### PR TITLE
feat(frontend): add context overflow warning UI and preference settings (MVA-2006)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatHeader.vue
+++ b/autobot-frontend/src/components/chat/ChatHeader.vue
@@ -41,6 +41,15 @@
         <!-- Session Actions -->
         <button
           v-if="currentSessionId"
+          @click="$emit('open-settings')"
+          class="header-btn"
+          :title="$t('chat.openSettings')"
+        >
+          <Icon name="cog" />
+        </button>
+
+        <button
+          v-if="currentSessionId"
           @click="$emit('export-session')"
           class="header-btn"
           :title="$t('chat.exportChat')"
@@ -94,6 +103,7 @@ interface Emits {
   (e: 'export-session'): void
   (e: 'clear-session'): void
   (e: 'toggle-mobile-sidebar'): void
+  (e: 'open-settings'): void
 }
 
 const props = defineProps<Props>()

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -53,6 +53,7 @@
           @export-session="exportSession"
           @clear-session="clearSession"
           @toggle-mobile-sidebar="showMobileSidebar = !showMobileSidebar"
+          @open-settings="showChatSettings = true"
           class="shrink-0"
         >
           <!-- File Panel Toggle Button (injected into header) -->
@@ -257,6 +258,12 @@
       v-if="showVoiceOverlay"
       @close="showVoiceOverlay = false"
     />
+
+    <!-- Chat Settings Modal (MVA-2006) -->
+    <ChatSettingsModal
+      :show="showChatSettings"
+      @close="showChatSettings = false"
+    />
   </ErrorBoundary>
 </template>
 
@@ -278,6 +285,7 @@ import { useAppStore } from '@/stores/useAppStore'
 import { useNotificationBus } from '@/composables/useNotificationBus'
 import { usePreferences } from '@/composables/usePreferences'
 import { useOverseerAgent } from '@/composables/useOverseerAgent'
+import { useGlobalWebSocket } from '@/composables/useGlobalWebSocket'
 import ApiClient from '@/utils/ApiClient'
 import batchApiService from '@/services/BatchApiService'
 // MIGRATED: Using AppConfig.js for better configuration management
@@ -301,6 +309,7 @@ import CommandPermissionDialog from '@/components/ui/CommandPermissionDialog.vue
 import WorkflowProgressWidget from '@/components/workflow/WorkflowProgressWidget.vue'
 import VoiceConversationOverlay from './VoiceConversationOverlay.vue'
 import VoiceConversationPanel from './VoiceConversationPanel.vue'
+import ChatSettingsModal from './ChatSettingsModal.vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 // Issue #3232: chain-of-thought reasoning trace
 import ReasoningTrace from './ReasoningTrace.vue'
@@ -432,7 +441,7 @@ const {
 const voiceConversation = useVoiceConversation()
 const showVoiceOverlay = ref(false)
 const showVoicePanel = ref(false)
-const { voiceDisplayMode } = usePreferences()
+const { voiceDisplayMode, contextOverflowMode } = usePreferences()
 
 function openVoiceConversation(): void {
   if (voiceDisplayMode.value === 'sidepanel') {
@@ -454,6 +463,43 @@ const notify = (message: string, type: 'info' | 'success' | 'warning' | 'error' 
   showToast(message, type, type === 'error' ? 0 : type === 'warning' ? 6000 : 4000)
 }
 
+// MVA-2006: Context window overflow WebSocket listeners
+const ws = useGlobalWebSocket()
+const contextWarningShown = ref(false)
+
+// Listen for context_warning events (80% threshold)
+ws.on('context_warning', (data: any) => {
+  logger.debug('[ContextWindow] Warning event received:', data)
+
+  // Only show toast if mode is 'auto' or 'warn', and not already shown
+  if (contextOverflowMode.value !== 'disabled' && !contextWarningShown.value) {
+    const percent = data.usage_percent ?? _ctxWindow.usagePercent.value
+    notify(
+      t('chat.contextWindow.warningToast', { percent: percent.toFixed(1) }),
+      'warning'
+    )
+    contextWarningShown.value = true
+  }
+})
+
+// Listen for context_compressed events (summary injected)
+ws.on('context_compressed', (data: any) => {
+  logger.info('[ContextWindow] Context compressed:', data)
+
+  // Reset warning flag so next session can show it again
+  contextWarningShown.value = false
+
+  // Notify user that compression occurred
+  if (contextOverflowMode.value === 'auto') {
+    notify(t('chat.contextWindow.compressedToast'), 'info')
+  }
+})
+
+// Reset warning flag when session changes
+watch(() => store.currentSessionId, () => {
+  contextWarningShown.value = false
+})
+
 // Issue #4414: multi-model compare panel toggle
 const showComparePanel = ref(false)
 
@@ -464,6 +510,8 @@ const showWorkflowProgress = ref(false)
 const showFilePanel = ref(false)
 // Mobile sidebar overlay (#1804)
 const showMobileSidebar = ref(false)
+// Chat settings modal (MVA-2006)
+const showChatSettings = ref(false)
 
 // Dialog data
 const currentChatContext = ref<any>(null)

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -143,6 +143,23 @@
           :rich-payload="(message.metadata.image_payload as Record<string, unknown>)"
         />
 
+        <!-- MVA-2006: Context summary message -->
+        <div
+          v-else-if="message.type === 'summary' || message.metadata?.is_summary"
+          class="message-content summary-message"
+        >
+          <div class="summary-header">
+            <span class="summary-icon">📝</span>
+            <span class="summary-title">{{ $t('chat.contextWindow.summaryTitle') }}</span>
+          </div>
+          <details class="summary-details">
+            <summary class="summary-toggle">
+              {{ $t('chat.contextWindow.summaryToggle') }}
+            </summary>
+            <div class="summary-content message-text" v-html="formatMessageContent(message.content, message.id)"></div>
+          </details>
+        </div>
+
         <!-- Message Content -->
         <div v-else class="message-content" :class="getContentClass(message)">
           <!-- Streaming content with typing indicator -->
@@ -1234,6 +1251,50 @@ onMounted(async () => {
   @apply bg-autobot-bg-tertiary border-autobot-border mx-auto text-autobot-text-secondary;
   max-width: 70%;
   border-radius: var(--radius-xl);
+}
+
+/* MVA-2006: SUMMARY MESSAGES - Context compression indicator */
+.summary-message {
+  @apply bg-blue-50 border border-blue-200 rounded-lg p-3 mb-2;
+}
+
+.summary-header {
+  @apply flex items-center gap-2 font-semibold text-blue-900 mb-2;
+}
+
+.summary-icon {
+  @apply text-xl;
+}
+
+.summary-title {
+  @apply text-sm;
+}
+
+.summary-details {
+  @apply mt-2;
+}
+
+.summary-toggle {
+  @apply cursor-pointer text-sm text-blue-700 hover:text-blue-900 select-none;
+  list-style: none;
+}
+
+.summary-toggle::marker {
+  display: none;
+}
+
+.summary-toggle::before {
+  content: '▶ ';
+  display: inline-block;
+  transition: transform 0.2s;
+}
+
+.summary-details[open] .summary-toggle::before {
+  transform: rotate(90deg);
+}
+
+.summary-content {
+  @apply mt-2 pt-2 border-t border-blue-200 text-sm text-gray-700;
 }
 
 /* ============================================

--- a/autobot-frontend/src/components/chat/ChatSettingsModal.vue
+++ b/autobot-frontend/src/components/chat/ChatSettingsModal.vue
@@ -1,0 +1,165 @@
+<template>
+  <div v-if="show" class="settings-modal-overlay" @click="$emit('close')">
+    <div class="settings-modal" @click.stop>
+      <div class="settings-header">
+        <h3>{{ $t('chat.settings.title') }}</h3>
+        <button @click="$emit('close')" class="close-btn" :aria-label="$t('common.close')">
+          <Icon name="times" />
+        </button>
+      </div>
+
+      <div class="settings-body">
+        <!-- Context Overflow Protection Setting -->
+        <div class="setting-group">
+          <label class="setting-label">
+            {{ $t('chat.settings.contextOverflowLabel') }}
+          </label>
+          <p class="setting-description">
+            {{ $t('chat.settings.contextOverflowDescription') }}
+          </p>
+          <select
+            v-model="localMode"
+            @change="updateMode"
+            class="setting-select"
+          >
+            <option value="auto">{{ $t('chat.settings.contextOverflowAuto') }}</option>
+            <option value="warn">{{ $t('chat.settings.contextOverflowWarn') }}</option>
+            <option value="disabled">{{ $t('chat.settings.contextOverflowDisabled') }}</option>
+          </select>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import Icon from '@/components/ui/Icon.vue'
+import { usePreferences } from '@/composables/usePreferences'
+
+interface Props {
+  show: boolean
+}
+
+interface Emits {
+  (e: 'close'): void
+}
+
+const props = defineProps<Props>()
+defineEmits<Emits>()
+
+const { contextOverflowMode, setContextOverflowMode } = usePreferences()
+const localMode = ref(contextOverflowMode.value)
+
+watch(() => props.show, (isShown) => {
+  if (isShown) {
+    localMode.value = contextOverflowMode.value
+  }
+})
+
+function updateMode() {
+  setContextOverflowMode(localMode.value)
+}
+</script>
+
+<style scoped>
+.settings-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.settings-modal {
+  background: var(--bg-primary);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  width: 90%;
+  max-width: 500px;
+  max-height: 80vh;
+  overflow: auto;
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.settings-header h3 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 0.5rem;
+  border-radius: var(--radius-md);
+  transition: all 0.2s;
+}
+
+.close-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.settings-body {
+  padding: 1.5rem;
+}
+
+.setting-group {
+  margin-bottom: 1.5rem;
+}
+
+.setting-group:last-child {
+  margin-bottom: 0;
+}
+
+.setting-label {
+  display: block;
+  font-weight: 500;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.setting-description {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.75rem;
+}
+
+.setting-select {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.setting-select:hover {
+  border-color: var(--color-primary);
+}
+
+.setting-select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+</style>

--- a/autobot-frontend/src/composables/usePreferences.ts
+++ b/autobot-frontend/src/composables/usePreferences.ts
@@ -20,6 +20,7 @@ export type FontSize = 'small' | 'medium' | 'large'
 export type AccentColor = 'teal' | 'emerald' | 'blue' | 'purple' | 'orange'
 export type LayoutDensity = 'compact' | 'comfortable' | 'spacious'
 export type VoiceDisplayMode = 'modal' | 'sidepanel'
+export type ContextOverflowMode = 'auto' | 'warn' | 'disabled'
 
 export interface UserPreferences {
   fontSize: FontSize
@@ -27,6 +28,7 @@ export interface UserPreferences {
   layoutDensity: LayoutDensity
   voiceDisplayMode: VoiceDisplayMode
   language: string
+  contextOverflowMode: ContextOverflowMode
 }
 
 // Default preferences
@@ -35,7 +37,8 @@ const DEFAULT_PREFERENCES: UserPreferences = {
   accentColor: 'teal',
   layoutDensity: 'comfortable',
   voiceDisplayMode: 'modal',
-  language: 'en'
+  language: 'en',
+  contextOverflowMode: 'auto'
 }
 
 // Reactive preferences state
@@ -44,6 +47,7 @@ const accentColor = ref<AccentColor>('teal')
 const layoutDensity = ref<LayoutDensity>('comfortable')
 const voiceDisplayMode = ref<VoiceDisplayMode>('modal')
 const language = ref<string>('en')
+const contextOverflowMode = ref<ContextOverflowMode>('auto')
 
 // Local storage key
 const STORAGE_KEY = 'autobot-preferences'
@@ -64,6 +68,7 @@ function loadPreferences(): void {
       layoutDensity.value = parsed.layoutDensity || DEFAULT_PREFERENCES.layoutDensity
       voiceDisplayMode.value = parsed.voiceDisplayMode || DEFAULT_PREFERENCES.voiceDisplayMode
       language.value = parsed.language || localStorage.getItem('autobot-language') || DEFAULT_PREFERENCES.language
+      contextOverflowMode.value = parsed.contextOverflowMode || DEFAULT_PREFERENCES.contextOverflowMode
 
       logger.debug('Preferences loaded from localStorage', {
         fontSize: fontSize.value,
@@ -88,7 +93,8 @@ function savePreferences(): void {
       accentColor: accentColor.value,
       layoutDensity: layoutDensity.value,
       voiceDisplayMode: voiceDisplayMode.value,
-      language: language.value
+      language: language.value,
+      contextOverflowMode: contextOverflowMode.value
     }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences))
     logger.debug('Preferences saved to localStorage', preferences)
@@ -192,6 +198,10 @@ export function usePreferences() {
     watch(voiceDisplayMode, () => {
       savePreferences()
     })
+
+    watch(contextOverflowMode, () => {
+      savePreferences()
+    })
   }
 
   /**
@@ -219,6 +229,10 @@ export function usePreferences() {
     voiceDisplayMode.value = mode
   }
 
+  function setContextOverflowMode(mode: ContextOverflowMode): void {
+    contextOverflowMode.value = mode
+  }
+
   async function setLanguage(code: string): Promise<void> {
     language.value = code
     await setLocale(code)
@@ -235,6 +249,7 @@ export function usePreferences() {
     layoutDensity.value = DEFAULT_PREFERENCES.layoutDensity
     voiceDisplayMode.value = DEFAULT_PREFERENCES.voiceDisplayMode
     language.value = DEFAULT_PREFERENCES.language
+    contextOverflowMode.value = DEFAULT_PREFERENCES.contextOverflowMode
     setLocale(DEFAULT_PREFERENCES.language)
     logger.debug('Preferences reset to defaults')
   }
@@ -247,6 +262,7 @@ export function usePreferences() {
     layoutDensity,
     voiceDisplayMode,
     language,
+    contextOverflowMode,
 
     // Actions
     setFontSize,
@@ -254,6 +270,7 @@ export function usePreferences() {
     setLayoutDensity,
     setVoiceDisplayMode,
     setLanguage,
+    setContextOverflowMode,
     loadLanguageFromBackend,
     resetPreferences
   }

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -106,13 +106,26 @@
   "chat": {
     "contextWindow": {
       "ariaLabel": "{used} of {max} tokens used",
-      "tooltip": "{used} / {max} tokens used ({percent}% of context window)"
+      "tooltip": "{used} / {max} tokens used ({percent}% of context window)",
+      "warningToast": "Conversation approaching context limit ({percent}%). Older messages may be summarized.",
+      "compressedToast": "Context window optimized - older messages summarized",
+      "summaryTitle": "Context Summary",
+      "summaryToggle": "Show details"
     },
     "sendMessage": "Send a message...",
     "newChat": "New Chat",
     "clearChat": "Clear chat",
     "exportChat": "Export chat",
     "deleteChat": "Delete chat",
+    "openSettings": "Chat settings",
+    "settings": {
+      "title": "Chat Settings",
+      "contextOverflowLabel": "Context Overflow Protection",
+      "contextOverflowDescription": "Choose how to handle conversations approaching the context limit",
+      "contextOverflowAuto": "Auto-summarize",
+      "contextOverflowWarn": "Warn only",
+      "contextOverflowDisabled": "Disabled"
+    },
     "editName": "Edit Name",
     "copyMessage": "Copy message",
     "editMessage": "Edit message",


### PR DESCRIPTION
## Summary

Implements context overflow warning UI and user preference controls for MVA-2006.

## Changes

- **usePreferences extension**: Added `contextOverflowMode` preference (auto/warn/disabled) with localStorage persistence
- **WebSocket listeners**: Listen for `context_warning` (80% threshold) and `context_compressed` events  
- **Toast notifications**: Warning toast at 80% threshold, respects user preference
- **Summary message styling**: Blue background with 📝 icon, expandable details section
- **ChatSettingsModal**: New settings modal for context overflow preference
- **Chat header**: Added settings icon button to open modal
- **i18n**: All UI text properly translated

## Acceptance Criteria

- ✅ Context fill percentage visible in chat header (via existing ContextWindowIndicator from #8990)
- ✅ Warning shown when >80% full (toast notification with user preference control)
- ✅ Summary messages styled distinctly (blue background, 📝 icon, expandable)
- ✅ User can change protection mode (ChatSettingsModal with 3 options)
- ✅ Settings persist across sessions (localStorage via usePreferences)

## Test Plan

1. Open chat and send messages to approach context limit
2. Verify toast appears at 80% threshold
3. Click settings icon in chat header
4. Change context overflow mode and verify it persists
5. Verify summary messages display with special styling
6. Verify WebSocket events trigger appropriate UI updates

🤖 Generated with Paperclip