### PR TITLE
feat(llc): add built-in company templates (#9042)

### DIFF
--- a/autobot-backend/llc/api/templates.py
+++ b/autobot-backend/llc/api/templates.py
@@ -30,6 +30,7 @@ from llc.models.template import (
     TemplateSearchResult,
 )
 from llc.services.template import (
+    BuiltInTemplateNotFoundError,
     TemplateAccessError,
     TemplateNotFoundError,
     TemplateSecretPlaceholderError,
@@ -139,3 +140,33 @@ async def delete_template(
         await svc.session.commit()
     except TemplateNotFoundError:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+
+
+@router.get("/built-in", response_model=List[Dict])
+async def list_built_in_templates() -> List[Dict]:
+    """List all built-in company templates (GH#9042).
+
+    Returns template metadata only (name, description, category, tags).
+    Does not require authentication or database access.
+    """
+    from typing import Dict
+
+    return TemplateService.list_built_in_templates()
+
+
+@router.get("/built-in/{template_key}", response_model=Dict)
+async def get_built_in_template(template_key: str) -> Dict:
+    """Fetch a specific built-in template by key (GH#9042).
+
+    Args:
+        template_key: Template identifier (e.g., 'software-team')
+
+    Returns:
+        Full template JSON including metadata, variables, agents, goals, work_items, kb_collections
+    """
+    from typing import Dict
+
+    try:
+        return TemplateService.get_built_in_template(template_key)
+    except BuiltInTemplateNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))

--- a/autobot-backend/llc/built_in_templates/content-team.json
+++ b/autobot-backend/llc/built_in_templates/content-team.json
@@ -1,0 +1,121 @@
+{
+  "metadata": {
+    "name": "Content Creation Team",
+    "description": "Complete content production workflow with strategist, writers, editors, and publishers",
+    "category": "company",
+    "version": "1.0",
+    "tags": ["content", "writing", "publishing", "marketing"]
+  },
+  "variables": {
+    "company_name": "{{COMPANY_NAME}}",
+    "brand_voice": "{{BRAND_VOICE}}",
+    "target_audience": "{{TARGET_AUDIENCE}}"
+  },
+  "agents": [
+    {
+      "name": "Content Strategist",
+      "role": "strategist",
+      "description": "Plans content strategy, defines topics, and ensures alignment with brand goals",
+      "capabilities": ["content_planning", "audience_research", "strategy_development"],
+      "instructions": "You are the content strategist. Research audience needs, plan content calendars, define topics that align with brand goals, and coordinate the content team.",
+      "model": "claude-sonnet-4-6",
+      "adapter_config": {
+        "type": "local",
+        "tools": ["read", "write", "web_search"]
+      }
+    },
+    {
+      "name": "Content Writer",
+      "role": "writer",
+      "description": "Creates engaging, high-quality content across various formats",
+      "capabilities": ["article_writing", "copywriting", "storytelling"],
+      "instructions": "You are a content writer. Create compelling, well-researched content that engages the target audience. Write in the brand voice, ensure clarity and accuracy, and optimize for readability.",
+      "model": "claude-sonnet-4-6",
+      "adapter_config": {
+        "type": "local",
+        "tools": ["read", "write", "web_search"]
+      }
+    },
+    {
+      "name": "Content Editor",
+      "role": "editor",
+      "description": "Reviews and polishes content for quality, consistency, and brand alignment",
+      "capabilities": ["editing", "quality_review", "brand_consistency"],
+      "instructions": "You are a content editor. Review drafts for clarity, grammar, tone, and brand consistency. Provide constructive feedback to improve quality and ensure content meets publication standards.",
+      "model": "claude-sonnet-4-6",
+      "adapter_config": {
+        "type": "local",
+        "tools": ["read", "write"]
+      }
+    },
+    {
+      "name": "Content Publisher",
+      "role": "publisher",
+      "description": "Formats, optimizes, and publishes content across distribution channels",
+      "capabilities": ["formatting", "seo_optimization", "multi_channel_distribution"],
+      "instructions": "You are the content publisher. Format approved content for different platforms, optimize for SEO, schedule publications, and ensure proper distribution across all channels.",
+      "model": "claude-haiku-4-5",
+      "adapter_config": {
+        "type": "local",
+        "tools": ["read", "write", "bash"]
+      }
+    }
+  ],
+  "goals": [
+    {
+      "title": "Define Content Strategy",
+      "description": "Establish brand voice, target personas, and content themes",
+      "priority": "high",
+      "status": "todo"
+    },
+    {
+      "title": "Build Content Pipeline",
+      "description": "Create efficient workflow from ideation to publication",
+      "priority": "high",
+      "status": "backlog"
+    },
+    {
+      "title": "Publish Quality Content",
+      "description": "Produce and distribute engaging content on consistent schedule",
+      "priority": "medium",
+      "status": "backlog"
+    }
+  ],
+  "work_items": [
+    {
+      "title": "Create brand style guide",
+      "description": "Document brand voice, tone, writing standards, and visual guidelines",
+      "assignee_role": "strategist",
+      "priority": "high",
+      "status": "todo"
+    },
+    {
+      "title": "Develop content calendar",
+      "description": "Plan publication schedule with topics, formats, and distribution channels",
+      "assignee_role": "strategist",
+      "priority": "high",
+      "status": "todo"
+    },
+    {
+      "title": "Setup editorial workflow",
+      "description": "Define process from draft to review to publication with quality gates",
+      "assignee_role": "editor",
+      "priority": "medium",
+      "status": "todo"
+    }
+  ],
+  "kb_collections": [
+    {
+      "name": "Brand Guidelines",
+      "description": "Brand voice, style guide, and content standards"
+    },
+    {
+      "name": "Content Library",
+      "description": "Published articles, drafts, and content assets"
+    },
+    {
+      "name": "SEO & Distribution",
+      "description": "SEO best practices, platform guidelines, and publishing checklists"
+    }
+  ]
+}

--- a/autobot-backend/llc/built_in_templates/customer-ops.json
+++ b/autobot-backend/llc/built_in_templates/customer-ops.json
@@ -1,0 +1,109 @@
+{
+  "metadata": {
+    "name": "Customer Operations Team",
+    "description": "Complete customer support workflow with triage, support specialists, and escalation handling",
+    "category": "company",
+    "version": "1.0",
+    "tags": ["customer-support", "ops", "triage", "escalation"]
+  },
+  "variables": {
+    "company_name": "{{COMPANY_NAME}}",
+    "support_email": "{{SUPPORT_EMAIL}}",
+    "escalation_contact": "{{ESCALATION_CONTACT}}"
+  },
+  "agents": [
+    {
+      "name": "Triage Agent",
+      "role": "triage",
+      "description": "First-line support agent that categorizes and routes customer inquiries",
+      "capabilities": ["ticket_categorization", "urgency_assessment", "routing"],
+      "instructions": "You are the triage agent. Quickly assess customer inquiries, categorize them by type and urgency, and route to the appropriate support agent or escalation path.",
+      "model": "claude-haiku-4-5",
+      "adapter_config": {
+        "type": "local",
+        "tools": ["read", "write"]
+      }
+    },
+    {
+      "name": "Support Specialist",
+      "role": "support",
+      "description": "Handles customer inquiries, troubleshoots issues, and provides solutions",
+      "capabilities": ["troubleshooting", "customer_communication", "issue_resolution"],
+      "instructions": "You are a support specialist. Handle customer inquiries with empathy and professionalism. Troubleshoot issues, provide clear solutions, and escalate complex cases when needed.",
+      "model": "claude-sonnet-4-6",
+      "adapter_config": {
+        "type": "local",
+        "tools": ["read", "write", "bash", "grep"]
+      }
+    },
+    {
+      "name": "Escalation Manager",
+      "role": "escalation",
+      "description": "Handles complex customer issues requiring human intervention or executive decisions",
+      "capabilities": ["complex_resolution", "human_handoff", "executive_communication"],
+      "instructions": "You are the escalation manager. Handle complex issues that require human judgment, coordinate with human staff for critical decisions, and ensure high-priority customers receive appropriate attention.",
+      "model": "claude-sonnet-4-6",
+      "adapter_config": {
+        "type": "local",
+        "tools": ["read", "write", "bash"]
+      }
+    }
+  ],
+  "goals": [
+    {
+      "title": "Establish Support Processes",
+      "description": "Define ticket workflows, SLAs, and escalation procedures",
+      "priority": "high",
+      "status": "todo"
+    },
+    {
+      "title": "Build Knowledge Base",
+      "description": "Create comprehensive support documentation and FAQ",
+      "priority": "high",
+      "status": "backlog"
+    },
+    {
+      "title": "Optimize Response Times",
+      "description": "Achieve and maintain target SLAs for all ticket categories",
+      "priority": "medium",
+      "status": "backlog"
+    }
+  ],
+  "work_items": [
+    {
+      "title": "Define ticket categories",
+      "description": "Establish taxonomy for issue types, urgency levels, and routing rules",
+      "assignee_role": "triage",
+      "priority": "high",
+      "status": "todo"
+    },
+    {
+      "title": "Create response templates",
+      "description": "Develop standard responses for common customer inquiries",
+      "assignee_role": "support",
+      "priority": "high",
+      "status": "todo"
+    },
+    {
+      "title": "Setup escalation criteria",
+      "description": "Define when and how to escalate issues to human staff",
+      "assignee_role": "escalation",
+      "priority": "high",
+      "status": "todo"
+    }
+  ],
+  "kb_collections": [
+    {
+      "name": "Support Knowledge Base",
+      "description": "Common issues, solutions, and troubleshooting guides"
+    },
+    {
+      "name": "Customer FAQ",
+      "description": "Frequently asked questions and self-service guides"
+    },
+    {
+      "name": "Escalation Procedures",
+      "description": "Guidelines for handling complex cases and human handoffs"
+    }
+  ]
+}

--- a/autobot-backend/llc/built_in_templates/research-team.json
+++ b/autobot-backend/llc/built_in_templates/research-team.json
@@ -1,0 +1,120 @@
+{
+  "metadata": {
+    "name": "Research Team",
+    "description": "Comprehensive research workflow with lead researcher, deep research specialists, summarizers, and technical writers",
+    "category": "company",
+    "version": "1.0",
+    "tags": ["research", "analysis", "writing", "documentation"]
+  },
+  "variables": {
+    "company_name": "{{COMPANY_NAME}}",
+    "research_domain": "{{RESEARCH_DOMAIN}}"
+  },
+  "agents": [
+    {
+      "name": "Research Lead",
+      "role": "research_lead",
+      "description": "Coordinates research projects, defines methodologies, and ensures quality of research outputs",
+      "capabilities": ["research_planning", "methodology_design", "quality_review"],
+      "instructions": "You are the research lead. Define research questions, design methodologies, coordinate the research team, and ensure findings are rigorous and well-documented.",
+      "model": "claude-opus-4-8",
+      "adapter_config": {
+        "type": "local",
+        "tools": ["read", "write", "bash", "grep"]
+      }
+    },
+    {
+      "name": "Deep Research Agent",
+      "role": "researcher",
+      "description": "Conducts in-depth research, analyzes sources, and extracts insights",
+      "capabilities": ["web_research", "source_analysis", "data_extraction", "fact_checking"],
+      "instructions": "You are a deep research specialist. Conduct thorough investigations, analyze multiple sources, verify facts, and extract meaningful insights. Focus on accuracy and comprehensiveness.",
+      "model": "claude-sonnet-4-6",
+      "adapter_config": {
+        "type": "local",
+        "tools": ["read", "write", "web_search", "web_fetch"]
+      }
+    },
+    {
+      "name": "Research Summarizer",
+      "role": "summarizer",
+      "description": "Synthesizes research findings into concise, actionable summaries",
+      "capabilities": ["synthesis", "summarization", "insight_extraction"],
+      "instructions": "You are a research summarizer. Take complex research findings and distill them into clear, concise summaries that highlight key insights and actionable recommendations.",
+      "model": "claude-sonnet-4-6",
+      "adapter_config": {
+        "type": "local",
+        "tools": ["read", "write"]
+      }
+    },
+    {
+      "name": "Technical Writer",
+      "role": "writer",
+      "description": "Creates polished research reports, documentation, and presentations",
+      "capabilities": ["technical_writing", "documentation", "report_creation"],
+      "instructions": "You are a technical writer. Transform research summaries into well-structured, professionally written reports and documentation. Ensure clarity, accuracy, and proper citations.",
+      "model": "claude-sonnet-4-6",
+      "adapter_config": {
+        "type": "local",
+        "tools": ["read", "write"]
+      }
+    }
+  ],
+  "goals": [
+    {
+      "title": "Establish Research Methodology",
+      "description": "Define research processes, quality standards, and documentation templates",
+      "priority": "high",
+      "status": "todo"
+    },
+    {
+      "title": "Build Knowledge Base",
+      "description": "Create structured repository of research findings and insights",
+      "priority": "high",
+      "status": "backlog"
+    },
+    {
+      "title": "Publish Research Reports",
+      "description": "Produce comprehensive research reports on key topics",
+      "priority": "medium",
+      "status": "backlog"
+    }
+  ],
+  "work_items": [
+    {
+      "title": "Define research workflow",
+      "description": "Document the end-to-end research process from question to published report",
+      "assignee_role": "research_lead",
+      "priority": "high",
+      "status": "todo"
+    },
+    {
+      "title": "Create research templates",
+      "description": "Develop templates for research briefs, findings, and final reports",
+      "assignee_role": "writer",
+      "priority": "high",
+      "status": "todo"
+    },
+    {
+      "title": "Setup source verification process",
+      "description": "Establish fact-checking and source validation procedures",
+      "assignee_role": "researcher",
+      "priority": "medium",
+      "status": "todo"
+    }
+  ],
+  "kb_collections": [
+    {
+      "name": "Research Methodology",
+      "description": "Research processes, quality standards, and best practices"
+    },
+    {
+      "name": "Source Library",
+      "description": "Curated collection of trusted sources and references"
+    },
+    {
+      "name": "Published Research",
+      "description": "Completed research reports and findings"
+    }
+  ]
+}

--- a/autobot-backend/llc/built_in_templates/software-team.json
+++ b/autobot-backend/llc/built_in_templates/software-team.json
@@ -1,0 +1,121 @@
+{
+  "metadata": {
+    "name": "Software Development Team",
+    "description": "Complete software development workflow with architect, developer, code reviewer, and QA agent",
+    "category": "company",
+    "version": "1.0",
+    "tags": ["software", "development", "engineering", "qa", "code-review"]
+  },
+  "variables": {
+    "company_name": "{{COMPANY_NAME}}",
+    "repo_url": "{{REPO_URL}}",
+    "main_branch": "{{MAIN_BRANCH}}"
+  },
+  "agents": [
+    {
+      "name": "Lead Architect",
+      "role": "architect",
+      "description": "Technical lead responsible for architecture decisions, system design, and code review standards",
+      "capabilities": ["architecture_design", "code_review", "technical_planning"],
+      "instructions": "You are the technical architect. Design scalable systems, establish coding standards, and guide the development team through architectural decisions.",
+      "model": "claude-sonnet-4-6",
+      "adapter_config": {
+        "type": "local",
+        "tools": ["read", "write", "bash", "grep", "glob"]
+      }
+    },
+    {
+      "name": "Senior Developer",
+      "role": "developer",
+      "description": "Full-stack developer implementing features, fixing bugs, and maintaining code quality",
+      "capabilities": ["feature_implementation", "bug_fixing", "refactoring"],
+      "instructions": "You are a senior developer. Implement features following best practices, write clean maintainable code, and collaborate with the architect on technical decisions.",
+      "model": "claude-sonnet-4-6",
+      "adapter_config": {
+        "type": "local",
+        "tools": ["read", "write", "edit", "bash", "grep", "glob"]
+      }
+    },
+    {
+      "name": "Code Reviewer",
+      "role": "code_reviewer",
+      "description": "Dedicated code reviewer ensuring quality, security, and maintainability",
+      "capabilities": ["code_review", "security_audit", "quality_assurance"],
+      "instructions": "You are a code reviewer. Review pull requests for correctness, security vulnerabilities, performance issues, and maintainability. Provide constructive feedback.",
+      "model": "claude-sonnet-4-6",
+      "adapter_config": {
+        "type": "local",
+        "tools": ["read", "bash", "grep", "glob"]
+      }
+    },
+    {
+      "name": "QA Engineer",
+      "role": "qa",
+      "description": "Quality assurance engineer writing tests and ensuring system reliability",
+      "capabilities": ["test_writing", "integration_testing", "bug_verification"],
+      "instructions": "You are a QA engineer. Write comprehensive tests, verify bug fixes, and ensure features work as expected. Focus on edge cases and integration scenarios.",
+      "model": "claude-haiku-4-5",
+      "adapter_config": {
+        "type": "local",
+        "tools": ["read", "write", "bash", "grep"]
+      }
+    }
+  ],
+  "goals": [
+    {
+      "title": "Establish Development Workflow",
+      "description": "Set up branching strategy, CI/CD pipeline, and code review process",
+      "priority": "high",
+      "status": "todo"
+    },
+    {
+      "title": "Build Core Features",
+      "description": "Implement the minimum viable product with essential features",
+      "priority": "high",
+      "status": "backlog"
+    },
+    {
+      "title": "Quality Assurance Setup",
+      "description": "Establish testing framework, coverage requirements, and QA processes",
+      "priority": "medium",
+      "status": "backlog"
+    }
+  ],
+  "work_items": [
+    {
+      "title": "Setup repository structure",
+      "description": "Initialize project structure, configure linters, and set up pre-commit hooks",
+      "assignee_role": "architect",
+      "priority": "high",
+      "status": "todo"
+    },
+    {
+      "title": "Define coding standards",
+      "description": "Document coding conventions, architecture patterns, and best practices",
+      "assignee_role": "architect",
+      "priority": "high",
+      "status": "todo"
+    },
+    {
+      "title": "Configure CI/CD pipeline",
+      "description": "Set up automated testing, linting, and deployment workflows",
+      "assignee_role": "developer",
+      "priority": "medium",
+      "status": "todo"
+    }
+  ],
+  "kb_collections": [
+    {
+      "name": "Architecture Docs",
+      "description": "System architecture, design decisions, and technical RFCs"
+    },
+    {
+      "name": "Development Guides",
+      "description": "Development setup, coding standards, and best practices"
+    },
+    {
+      "name": "Code Review Guidelines",
+      "description": "Code review checklists, security patterns, and quality standards"
+    }
+  ]
+}

--- a/autobot-backend/llc/services/template.py
+++ b/autobot-backend/llc/services/template.py
@@ -8,9 +8,11 @@ template library. All ChromaDB operations target the ``platform:template_kb``
 collection.
 """
 
+import json
 import logging
 import re
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import sqlalchemy as sa
@@ -35,6 +37,7 @@ logger = logging.getLogger(__name__)
 _PLATFORM_TEMPLATE_COLLECTION = "platform:template_kb"
 _SECRET_PLACEHOLDER_RE = re.compile(r"\{\{([A-Z0-9_]+)\}\}")
 _TEMPLATE_SEARCH_LIMIT = 10
+_BUILT_IN_TEMPLATES_DIR = Path(__file__).parent.parent / "built_in_templates"
 
 
 class TemplateNotFoundError(Exception):
@@ -51,6 +54,10 @@ class TemplateSecretPlaceholderError(Exception):
 
 class TemplateAccessError(Exception):
     """Raised when a company requests a private template it does not own."""
+
+
+class BuiltInTemplateNotFoundError(Exception):
+    """Raised when a built-in template key does not exist."""
 
 
 class TemplateService:
@@ -229,6 +236,34 @@ class TemplateService:
     async def search(self, query: str) -> List[TemplateSearchResult]:
         """Semantic search over platform:template_kb ChromaDB collection."""
         return await _search_template_kb(query)
+
+    # ------------------------------------------------------------------
+    # Built-in Templates (GH#9042)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def list_built_in_templates() -> List[Dict[str, Any]]:
+        """List all built-in company templates from disk (GH#9042).
+
+        Returns list of template metadata (name, description, category, tags).
+        Does not require a database session.
+        """
+        return _load_all_built_in_templates()
+
+    @staticmethod
+    def get_built_in_template(template_key: str) -> Dict[str, Any]:
+        """Fetch a specific built-in template by key (GH#9042).
+
+        Args:
+            template_key: Filename without extension (e.g., 'software-team')
+
+        Returns:
+            Full template JSON including metadata, variables, agents, goals, etc.
+
+        Raises:
+            BuiltInTemplateNotFoundError: If template_key does not exist
+        """
+        return _load_built_in_template(template_key)
 
 
 # ------------------------------------------------------------------
@@ -525,3 +560,77 @@ def _build_embed_text(
     if tags:
         parts.append(f"Tags: {', '.join(tags)}")
     return "\n".join(parts)
+
+
+# ------------------------------------------------------------------
+# Built-in template loaders (GH#9042)
+# ------------------------------------------------------------------
+
+
+def _load_all_built_in_templates() -> List[Dict[str, Any]]:
+    """Load metadata for all built-in templates from disk.
+
+    Returns list of template metadata (does not include full template_json).
+    """
+    templates = []
+    if not _BUILT_IN_TEMPLATES_DIR.exists():
+        logger.warning("Built-in templates directory not found: %s", _BUILT_IN_TEMPLATES_DIR)
+        return templates
+
+    for template_file in sorted(_BUILT_IN_TEMPLATES_DIR.glob("*.json")):
+        try:
+            with open(template_file, encoding="utf-8") as f:
+                data = json.load(f)
+                metadata = data.get("metadata", {})
+                templates.append(
+                    {
+                        "key": template_file.stem,
+                        "name": metadata.get("name", template_file.stem),
+                        "description": metadata.get("description"),
+                        "category": metadata.get("category", "company"),
+                        "version": metadata.get("version", "1.0"),
+                        "tags": metadata.get("tags", []),
+                    }
+                )
+        except Exception:
+            logger.exception("Failed to load built-in template: %s", template_file)
+            continue
+
+    return templates
+
+
+def _load_built_in_template(template_key: str) -> Dict[str, Any]:
+    """Load a specific built-in template by key.
+
+    Args:
+        template_key: Filename without extension (e.g., 'software-team')
+
+    Returns:
+        Full template JSON
+
+    Raises:
+        BuiltInTemplateNotFoundError: If template does not exist or key is invalid
+    """
+    # Validate template_key against strict allowlist to prevent path traversal
+    if not re.fullmatch(r"[a-z0-9_-]+", template_key):
+        raise BuiltInTemplateNotFoundError(
+            f"Invalid template key '{template_key}' — must contain only lowercase letters, numbers, hyphens, and underscores"
+        )
+
+    template_path = _BUILT_IN_TEMPLATES_DIR / f"{template_key}.json"
+
+    # Verify resolved path is within the built-in templates directory
+    resolved_path = template_path.resolve()
+    base_path = _BUILT_IN_TEMPLATES_DIR.resolve()
+    if base_path not in resolved_path.parents and resolved_path != base_path:
+        raise BuiltInTemplateNotFoundError(f"Template path outside allowed directory: {template_key}")
+
+    if not resolved_path.exists():
+        raise BuiltInTemplateNotFoundError(f"Built-in template '{template_key}' not found")
+
+    try:
+        with open(resolved_path, encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as exc:
+        logger.exception("Failed to load built-in template: %s", resolved_path)
+        raise BuiltInTemplateNotFoundError(f"Failed to load template '{template_key}'") from exc


### PR DESCRIPTION
## Summary

Add reference company templates for common agent team patterns. This implements the backend foundation for GH#9042, providing 4 pre-built organizational starter packs.

## Implementation

**Templates Created:**
- **Software Team**: Lead Architect → Developer → Code Reviewer → QA Engineer
- **Research Team**: Research Lead → Deep Research → Summarizer → Technical Writer
- **Customer Ops**: Triage → Support → Escalation Manager
- **Content Team**: Strategist → Writer → Editor → Publisher

**Backend Changes:**
- Created `autobot-backend/llc/built_in_templates/` directory
- Added 4 JSON template files with complete agent configurations
- Added `TemplateService.list_built_in_templates()` - returns template metadata
- Added `TemplateService.get_built_in_template(key)` - loads full template with path traversal protection
- Added `GET /llc/templates/built-in` endpoint
- Added `GET /llc/templates/built-in/{key}` endpoint

**Security:**
- Template keys validated with strict regex: `^[a-z0-9_-]+$`
- Resolved paths verified to be within `built_in_templates/` directory
- Protection against path traversal attacks

**Each Template Includes:**
- Pre-configured agents with roles, capabilities, and model assignments
- Starter goals and work items
- KB collection structure
- Variable placeholders for customization (`{{COMPANY_NAME}}`, `{{REPO_URL}}`, etc.)

## Testing

```bash
# Test syntax
python3 -m py_compile autobot-backend/llc/services/template.py
python3 -m py_compile autobot-backend/llc/api/templates.py

# Test API endpoints (manual)
curl http://localhost:8001/llc/templates/built-in
curl http://localhost:8001/llc/templates/built-in/software-team
```

## Follow-up Work

Frontend integration deferred to separate issue:
- Template browser UI component
- Company creation wizard integration
- Variable substitution form
- Template preview/comparison

## Related

- Closes #9042
- Builds on template infrastructure from #8260

🤖 Generated with Paperclip