### PR TITLE
feat(plugins): add trust tier badges and capability API methods (MVA-1988)

### DIFF
--- a/autobot-frontend/src/components/plugins/TrustTierBadge.vue
+++ b/autobot-frontend/src/components/plugins/TrustTierBadge.vue
@@ -1,0 +1,77 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2025 mrveiss -->
+<!-- Author: mrveiss -->
+
+<!--
+  TrustTierBadge Component
+  Issue #9049 - Plugin capability system trust tier badges
+-->
+
+<template>
+  <span :class="['trust-tier-badge', `trust-tier-${tier}`]" :title="tooltipText">
+    {{ displayText }}
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface Props {
+  tier: 'official' | 'verified' | 'community' | 'unverified'
+}
+
+const props = defineProps<Props>()
+
+const displayText = computed(() => {
+  const textMap = {
+    official: 'Official',
+    verified: 'Verified',
+    community: 'Community',
+    unverified: 'Unverified',
+  }
+  return textMap[props.tier]
+})
+
+const tooltipText = computed(() => {
+  const tooltipMap = {
+    official: 'Built by AutoBot core team — capabilities auto-granted',
+    verified: 'Reviewed and approved by AutoBot team — requires operator approval',
+    community: 'Community-submitted plugin — requires operator approval',
+    unverified: 'Newly uploaded, not yet reviewed — requires operator approval',
+  }
+  return tooltipMap[props.tier]
+})
+</script>
+
+<style scoped>
+.trust-tier-badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  cursor: help;
+}
+
+.trust-tier-official {
+  background-color: #10b981;
+  color: #fff;
+}
+
+.trust-tier-verified {
+  background-color: #3b82f6;
+  color: #fff;
+}
+
+.trust-tier-community {
+  background-color: #f59e0b;
+  color: #fff;
+}
+
+.trust-tier-unverified {
+  background-color: #ef4444;
+  color: #fff;
+}
+</style>

--- a/autobot-frontend/src/views/PluginsView.vue
+++ b/autobot-frontend/src/views/PluginsView.vue
@@ -173,7 +173,10 @@
                   />
                 </svg>
               </div>
-              <span :class="['status-badge', `status-${plugin.status}`]">{{ plugin.status }}</span>
+              <div style="display: flex; gap: 0.5rem; align-items: center;">
+                <TrustTierBadge v-if="plugin.trust_tier" :tier="plugin.trust_tier" />
+                <span :class="['status-badge', `status-${plugin.status}`]">{{ plugin.status }}</span>
+              </div>
             </div>
 
             <div class="card-body">
@@ -288,7 +291,10 @@
                   />
                 </svg>
               </div>
-              <span class="status-badge status-unloaded">{{ $t('views.plugins.available') }}</span>
+              <div style="display: flex; gap: 0.5rem; align-items: center;">
+                <TrustTierBadge v-if="manifest.trust_tier" :tier="manifest.trust_tier" />
+                <span class="status-badge status-unloaded">{{ $t('views.plugins.available') }}</span>
+              </div>
             </div>
 
             <div class="card-body">
@@ -355,6 +361,10 @@
             <dt>{{ $t('views.plugins.name') }}</dt><dd>{{ selectedPlugin.name }}</dd>
             <dt>{{ $t('views.plugins.version') }}</dt><dd>{{ selectedPlugin.version }}</dd>
             <dt>{{ $t('views.plugins.author') }}</dt><dd>{{ selectedPlugin.author }}</dd>
+            <dt v-if="selectedPlugin.trust_tier">{{ $t('views.plugins.trustTier') }}</dt>
+            <dd v-if="selectedPlugin.trust_tier">
+              <TrustTierBadge :tier="selectedPlugin.trust_tier" />
+            </dd>
             <dt>{{ $t('views.plugins.status') }}</dt>
             <dd>
               <span :class="['status-badge', `status-${selectedPlugin.status}`]">
@@ -445,6 +455,7 @@ import { usePlugins, type PluginInfo, type PluginManifest } from '@/composables/
 import PluginInstallModal from '@/components/plugins/PluginInstallModal.vue'
 import CapabilityApprovalDialog from '@/components/plugins/CapabilityApprovalDialog.vue'
 import CapabilityAuditLog from '@/components/plugins/CapabilityAuditLog.vue'
+import TrustTierBadge from '@/components/plugins/TrustTierBadge.vue'
 
 const { t } = useI18n()
 const route = useRoute()


### PR DESCRIPTION
## Summary

Implements plugin trust tier badges and adds capability API methods to usePlugins composable.

Part of [MVA-1974](/MVA/issues/MVA-1974) — plugin capability approval UI (child issue 1/2).

## Changes

### 1. New Component: TrustTierBadge.vue
- Displays trust tier badge for plugins
- Color-coded: official (green), verified (blue), community (yellow), unverified (red)
- Tooltips explaining each tier

### 2. API Methods in usePlugins.ts
- `getCapabilities(name)` - GET /api/plugins/{name}/capabilities
- `approveCapabilities(name, capabilities)` - POST /api/plugins/{name}/approve-capabilities
- `getAuditLog(limit?)` - GET /api/plugins/audit

### 3. Badge Integration in PluginsView.vue
- Trust tier badges shown next to plugin names in installed/discovered lists

## Test Plan

- [ ] Trust tier badges render correctly with proper colors
- [ ] API methods successfully call backend endpoints
- [ ] Badges appear in plugin lists

## Related

- Parent: MVA-1974
- Sibling: MVA-1989 (already merged in #9159)
- Backend: PR #9151 (branch MVA-1955)

GH#9049