### PR TITLE
fix(llm): ensure tier field matches selected model [MVA-2022]

### DIFF
--- a/autobot-backend/llm_shared/tiered_routing/complexity_router.py
+++ b/autobot-backend/llm_shared/tiered_routing/complexity_router.py
@@ -92,10 +92,23 @@ class ComplexityRouter:
         # GH#9050: Trivial tier for ultra-simple queries
         elif result.is_trivial and self.config.models.trivial:
             selected_model = self.config.models.trivial
+            # Tier already matches "trivial" from scorer
         elif result.is_simple:
             selected_model = self.config.models.simple
+            # Tier already matches "simple" from scorer
         else:
             selected_model = self.config.models.complex
+            # MVA-2022: Update tier to match selected model.
+            # This handles cases where scorer assigned "trivial" or "simple"
+            # but we're routing to complex (e.g., trivial model not configured).
+            if result.tier != "complex":
+                result = ComplexityResult(
+                    score=result.score,
+                    factors=result.factors,
+                    tier="complex",
+                    reasoning=result.reasoning,
+                    input_tokens=result.input_tokens,
+                )
 
         self._metrics.record(result)
 

--- a/autobot-backend/tests/llm_interface_pkg/tier_routing_test.py
+++ b/autobot-backend/tests/llm_interface_pkg/tier_routing_test.py
@@ -51,16 +51,23 @@ _LONG_COMPLEX = [
 
 
 def _make_router(long_context_threshold: int = 16_000) -> ComplexityRouter:
-    cfg = TierConfig(
-        enabled=True,
-        complexity_threshold=3.0,
-        long_context_threshold=long_context_threshold,
-        models=TierModels(
+    # MVA-2022: Set trivial_threshold=0.0 to disable trivial tier for legacy tests.
+    # This maintains backward compatibility for tests written before GH#9050.
+    cfg_kwargs = {
+        "enabled": True,
+        "complexity_threshold": 3.0,
+        "long_context_threshold": long_context_threshold,
+        "models": TierModels(
             simple="cheap-model",
             complex="capable-model",
             long_context="long-model",
         ),
-    )
+    }
+    # Only set trivial_threshold if it exists (GH#9050+)
+    if hasattr(TierConfig, "trivial_threshold"):
+        cfg_kwargs["trivial_threshold"] = 0.0  # Disable trivial tier for these tests
+
+    cfg = TierConfig(**cfg_kwargs)
     return ComplexityRouter(cfg)
 
 
@@ -122,3 +129,43 @@ def test_tier_models_has_long_context_field():
     assert hasattr(models, "long_context")
     assert isinstance(models.long_context, str)
     assert models.long_context  # non-empty default
+
+
+# ─── MVA-2022: Tier mismatch fix ──────────────────────────────────────────────
+
+
+def test_trivial_without_model_configured_routes_to_complex_with_correct_tier():
+    """MVA-2022: When scorer assigns trivial but trivial model is not configured,
+    router should select complex model AND update tier to 'complex'.
+
+    Prevents metrics corruption from tier/model mismatch.
+    """
+    # hasattr guard: trivial tier only exists after GH#9050
+    if not hasattr(TierConfig, "trivial_threshold"):
+        return  # Skip on branches without trivial tier
+
+    cfg = TierConfig(
+        enabled=True,
+        complexity_threshold=3.0,
+        trivial_threshold=1.0,
+        long_context_threshold=16_000,
+        models=TierModels(
+            trivial="",  # NOT CONFIGURED - empty string
+            simple="cheap-model",
+            complex="capable-model",
+            long_context="long-model",
+        ),
+    )
+    router = ComplexityRouter(cfg)
+
+    # Ultra-simple query that would score < 1.0 → tier="trivial"
+    trivial_query = [{"role": "user", "content": "hi"}]
+    model, result = router.route(trivial_query)
+
+    # Without trivial model configured, should fall back to complex
+    assert model == "capable-model", f"expected complex model, got {model}"
+    # MVA-2022 FIX: tier must match the selected model
+    assert result.tier == "complex", (
+        f"Tier mismatch: selected complex model but tier is '{result.tier}'. "
+        "This causes metrics corruption."
+    )

--- a/autobot-backend/tests/llm_interface_pkg/tier_routing_test.py
+++ b/autobot-backend/tests/llm_interface_pkg/tier_routing_test.py
@@ -166,6 +166,5 @@ def test_trivial_without_model_configured_routes_to_complex_with_correct_tier():
     assert model == "capable-model", f"expected complex model, got {model}"
     # MVA-2022 FIX: tier must match the selected model
     assert result.tier == "complex", (
-        f"Tier mismatch: selected complex model but tier is '{result.tier}'. "
-        "This causes metrics corruption."
+        f"Tier mismatch: selected complex model but tier is '{result.tier}'. " "This causes metrics corruption."
     )


### PR DESCRIPTION
## Thinking Path

The ComplexityRouter had a tier mismatch bug where `result.tier` didn't always reflect the selected model. When the scorer assigned one tier but the router selected a different model (e.g., trivial tier not configured), the tier field was left unchanged, causing metrics corruption.

## What Changed

- **`complexity_router.py`**: In the final `else` branch (complex tier), added logic to create a new ComplexityResult with `tier="complex"` when the existing tier doesn't match
- **`tier_routing_test.py`**: 
  - Added `test_trivial_without_model_configured_routes_to_complex_with_correct_tier` to verify tier is updated correctly
  - Updated `_make_router` helper to set `trivial_threshold=0.0` for legacy tests (backward compatibility)

## Verification

```bash
# Run tier routing tests
pytest autobot-backend/tests/llm_interface_pkg/tier_routing_test.py -v
# Result: 7/8 pass (1 pre-existing failure unrelated to this fix)

# Specifically verify the tier mismatch fix
pytest autobot-backend/tests/llm_interface_pkg/tier_routing_test.py::test_trivial_without_model_configured_routes_to_complex_with_correct_tier -v
# Result: PASSED
```

## Risks

Low - only affects the `else` branch when complex tier is selected. Creates a new ComplexityResult object to ensure tier consistency. No behavior change for correctly configured systems.

## Model Used

Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)

## Issue Link

Closes #MVA-2022
Unblocks PR #9158 (issue-9050 trivial tier)

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added (tier mismatch scenario)
- [x] Documentation updated (inline comments)
- [x] Pre-commit hooks pass
- [x] PR targets `issue-9050` (trivial tier branch where bug manifests)
- [x] No secrets or credentials in the diff