### PR TITLE
feat(llm): quota-triggered model fallback (#8998)

### DIFF
--- a/autobot-backend/llm_shared/__init__.py
+++ b/autobot-backend/llm_shared/__init__.py
@@ -41,6 +41,9 @@ from .base_provider import BaseProvider
 # Issue #551: L1/L2 dual-tier caching
 from .cache import CachedResponse, LLMResponseCache, get_llm_cache
 
+# GH#8998: Model fallback chains for quota/rate limit handling
+from .fallback_chain import FallbackChain, FallbackChainManager, get_fallback_chain_manager
+
 # Hardware detection
 from .hardware import TORCH_AVAILABLE, HardwareDetector
 
@@ -99,6 +102,10 @@ __all__ = [
     "get_llm_cache",
     # Semantic cache (Issue #8168)
     "SemanticLLMCache",
+    # Fallback chains (GH#8998)
+    "FallbackChain",
+    "FallbackChainManager",
+    "get_fallback_chain_manager",
     # Mock providers
     "LocalLLM",
     "MockPalm",

--- a/autobot-backend/llm_shared/fallback_chain.py
+++ b/autobot-backend/llm_shared/fallback_chain.py
@@ -1,0 +1,235 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Model fallback chain manager — auto-route to backup models on quota/rate limit.
+
+GH#8998: When a primary model returns 429 or quota exceeded, automatically
+try fallback models in sequence before failing.
+
+Design:
+  - Fallback chains are configurable per provider
+  - Chains can span multiple providers (e.g., Claude → OpenAI → Ollama)
+  - Exhausted chains fall back to the existing retry-with-backoff logic
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class FallbackChain:
+    """Defines a fallback chain for a primary model."""
+
+    primary_model: str
+    fallback_models: List[str]
+    primary_provider: Optional[str] = None
+    fallback_providers: Optional[List[str]] = None
+
+    def get_next_fallback(self, current_model: str) -> Optional[tuple[str, Optional[str]]]:
+        """
+        Get the next fallback model after the current one.
+
+        Args:
+            current_model: The model that just failed.
+
+        Returns:
+            Tuple of (next_model, next_provider) or None if chain exhausted.
+        """
+        if current_model == self.primary_model:
+            # Primary failed, try first fallback
+            if self.fallback_models:
+                next_model = self.fallback_models[0]
+                next_provider = self.fallback_providers[0] if self.fallback_providers else None
+                return next_model, next_provider
+            return None
+
+        # Check if we're in the fallback chain
+        try:
+            idx = self.fallback_models.index(current_model)
+            if idx < len(self.fallback_models) - 1:
+                # There's a next fallback
+                next_model = self.fallback_models[idx + 1]
+                next_provider = (
+                    self.fallback_providers[idx + 1] if self.fallback_providers and idx + 1 < len(self.fallback_providers) else None
+                )
+                return next_model, next_provider
+        except ValueError:
+            # Current model not in chain
+            pass
+
+        return None
+
+
+class FallbackChainManager:
+    """
+    Manages fallback chains for LLM models.
+
+    Fallback chains allow graceful degradation when a primary model hits
+    rate limits or quota caps.
+    """
+
+    def __init__(self) -> None:
+        self._chains: Dict[str, FallbackChain] = {}
+        self._load_default_chains()
+        self._load_env_chains()
+
+    def _load_default_chains(self) -> None:
+        """Load default fallback chains for common models."""
+        # Anthropic Claude fallback chain
+        self.register_chain(
+            FallbackChain(
+                primary_model="claude-opus-4",
+                fallback_models=["claude-sonnet-4", "claude-haiku-4"],
+                primary_provider="anthropic",
+                fallback_providers=["anthropic", "anthropic"],
+            )
+        )
+
+        self.register_chain(
+            FallbackChain(
+                primary_model="claude-sonnet-4",
+                fallback_models=["claude-haiku-4"],
+                primary_provider="anthropic",
+                fallback_providers=["anthropic"],
+            )
+        )
+
+        # OpenAI GPT fallback chain
+        self.register_chain(
+            FallbackChain(
+                primary_model="gpt-4",
+                fallback_models=["gpt-4o", "gpt-4o-mini"],
+                primary_provider="openai",
+                fallback_providers=["openai", "openai"],
+            )
+        )
+
+        self.register_chain(
+            FallbackChain(
+                primary_model="gpt-4o",
+                fallback_models=["gpt-4o-mini"],
+                primary_provider="openai",
+                fallback_providers=["openai"],
+            )
+        )
+
+        # Cross-provider fallback: expensive cloud → cheaper cloud → local
+        self.register_chain(
+            FallbackChain(
+                primary_model="claude-opus-4-cross",
+                fallback_models=["gpt-4o", "ollama/llama3"],
+                primary_provider="anthropic",
+                fallback_providers=["openai", "ollama"],
+            )
+        )
+
+        logger.info("Loaded %d default fallback chains", len(self._chains))
+
+    def _load_env_chains(self) -> None:
+        """
+        Load fallback chains from environment variables.
+
+        Env format:
+          AUTOBOT_FALLBACK_CHAIN_<PRIMARY_MODEL>=fallback1,fallback2,fallback3
+
+        Provider can be specified with provider:model format:
+          AUTOBOT_FALLBACK_CHAIN_CLAUDE_OPUS=anthropic:claude-sonnet-4,openai:gpt-4o
+        """
+        for key, value in os.environ.items():
+            if not key.startswith("AUTOBOT_FALLBACK_CHAIN_"):
+                continue
+
+            primary_model_key = key.replace("AUTOBOT_FALLBACK_CHAIN_", "").lower().replace("_", "-")
+            fallback_spec = value.strip()
+
+            if not fallback_spec:
+                continue
+
+            # Parse fallback spec: "provider1:model1,provider2:model2,model3"
+            fallback_models = []
+            fallback_providers = []
+
+            for part in fallback_spec.split(","):
+                part = part.strip()
+                if ":" in part:
+                    provider, model = part.split(":", 1)
+                    fallback_providers.append(provider.strip())
+                    fallback_models.append(model.strip())
+                else:
+                    fallback_providers.append(None)  # type: ignore[arg-type]
+                    fallback_models.append(part)
+
+            chain = FallbackChain(
+                primary_model=primary_model_key,
+                fallback_models=fallback_models,
+                fallback_providers=fallback_providers if any(fallback_providers) else None,
+            )
+
+            self.register_chain(chain)
+            logger.info(
+                "Loaded env fallback chain for %s: %s",
+                primary_model_key,
+                " → ".join(fallback_models),
+            )
+
+    def register_chain(self, chain: FallbackChain) -> None:
+        """Register a fallback chain."""
+        self._chains[chain.primary_model.lower()] = chain
+
+    def get_chain(self, model: str) -> Optional[FallbackChain]:
+        """Get fallback chain for a model."""
+        return self._chains.get(model.lower())
+
+    def get_next_fallback(
+        self, current_model: str, current_provider: Optional[str] = None
+    ) -> Optional[tuple[str, Optional[str]]]:
+        """
+        Get the next fallback model for the given current model.
+
+        Args:
+            current_model: The model that just failed with rate limit.
+            current_provider: The provider of the current model (optional).
+
+        Returns:
+            Tuple of (next_model, next_provider) or None if no fallback available.
+        """
+        # Try exact match first
+        chain = self.get_chain(current_model)
+        if chain:
+            return chain.get_next_fallback(current_model)
+
+        # Try provider:model format
+        if current_provider:
+            qualified_name = f"{current_provider}:{current_model}"
+            chain = self.get_chain(qualified_name)
+            if chain:
+                return chain.get_next_fallback(qualified_name)
+
+        return None
+
+    def list_chains(self) -> Dict[str, List[str]]:
+        """List all registered fallback chains."""
+        return {primary: chain.fallback_models for primary, chain in self._chains.items()}
+
+
+# Global singleton instance
+_fallback_manager: Optional[FallbackChainManager] = None
+
+
+def get_fallback_chain_manager() -> FallbackChainManager:
+    """Get the global fallback chain manager (lazy singleton)."""
+    global _fallback_manager
+    if _fallback_manager is None:
+        _fallback_manager = FallbackChainManager()
+    return _fallback_manager
+
+
+__all__ = ["FallbackChain", "FallbackChainManager", "get_fallback_chain_manager"]

--- a/autobot-backend/llm_shared/fallback_chain_test.py
+++ b/autobot-backend/llm_shared/fallback_chain_test.py
@@ -1,0 +1,185 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for model fallback chain manager (GH#8998).
+"""
+
+import os
+
+import pytest
+
+from .fallback_chain import FallbackChain, FallbackChainManager, get_fallback_chain_manager
+
+
+class TestFallbackChain:
+    """Tests for FallbackChain dataclass."""
+
+    def test_get_next_fallback_from_primary(self):
+        """Primary model failure returns first fallback."""
+        chain = FallbackChain(
+            primary_model="claude-opus-4",
+            fallback_models=["claude-sonnet-4", "claude-haiku-4"],
+            primary_provider="anthropic",
+            fallback_providers=["anthropic", "anthropic"],
+        )
+
+        result = chain.get_next_fallback("claude-opus-4")
+        assert result == ("claude-sonnet-4", "anthropic")
+
+    def test_get_next_fallback_from_middle(self):
+        """Fallback from middle of chain returns next model."""
+        chain = FallbackChain(
+            primary_model="claude-opus-4",
+            fallback_models=["claude-sonnet-4", "claude-haiku-4"],
+            primary_provider="anthropic",
+            fallback_providers=["anthropic", "anthropic"],
+        )
+
+        result = chain.get_next_fallback("claude-sonnet-4")
+        assert result == ("claude-haiku-4", "anthropic")
+
+    def test_get_next_fallback_chain_exhausted(self):
+        """Last model in chain returns None."""
+        chain = FallbackChain(
+            primary_model="claude-opus-4",
+            fallback_models=["claude-sonnet-4", "claude-haiku-4"],
+            primary_provider="anthropic",
+            fallback_providers=["anthropic", "anthropic"],
+        )
+
+        result = chain.get_next_fallback("claude-haiku-4")
+        assert result is None
+
+    def test_get_next_fallback_unknown_model(self):
+        """Model not in chain returns None."""
+        chain = FallbackChain(
+            primary_model="claude-opus-4",
+            fallback_models=["claude-sonnet-4"],
+        )
+
+        result = chain.get_next_fallback("gpt-4")
+        assert result is None
+
+    def test_get_next_fallback_no_providers(self):
+        """Chain without providers returns None for provider."""
+        chain = FallbackChain(
+            primary_model="claude-opus-4",
+            fallback_models=["claude-sonnet-4"],
+        )
+
+        result = chain.get_next_fallback("claude-opus-4")
+        assert result == ("claude-sonnet-4", None)
+
+
+class TestFallbackChainManager:
+    """Tests for FallbackChainManager."""
+
+    def test_default_chains_loaded(self):
+        """Default fallback chains are loaded on init."""
+        manager = FallbackChainManager()
+        chains = manager.list_chains()
+
+        # Check that common models have default chains
+        assert "claude-opus-4" in chains
+        assert "claude-sonnet-4" in chains
+        assert "gpt-4" in chains
+        assert "gpt-4o" in chains
+
+    def test_get_chain_by_model(self):
+        """Get fallback chain by primary model name."""
+        manager = FallbackChainManager()
+        chain = manager.get_chain("claude-opus-4")
+
+        assert chain is not None
+        assert chain.primary_model == "claude-opus-4"
+        assert "claude-sonnet-4" in chain.fallback_models
+
+    def test_get_chain_case_insensitive(self):
+        """Model names are case-insensitive."""
+        manager = FallbackChainManager()
+        chain1 = manager.get_chain("claude-opus-4")
+        chain2 = manager.get_chain("CLAUDE-OPUS-4")
+
+        assert chain1 is chain2
+
+    def test_get_next_fallback_success(self):
+        """Get next fallback model for a registered chain."""
+        manager = FallbackChainManager()
+        result = manager.get_next_fallback("claude-opus-4", "anthropic")
+
+        assert result is not None
+        next_model, next_provider = result
+        assert next_model == "claude-sonnet-4"
+        assert next_provider == "anthropic"
+
+    def test_get_next_fallback_no_chain(self):
+        """No fallback for unregistered model."""
+        manager = FallbackChainManager()
+        result = manager.get_next_fallback("unknown-model", "unknown-provider")
+
+        assert result is None
+
+    def test_register_custom_chain(self):
+        """Can register a custom fallback chain."""
+        manager = FallbackChainManager()
+        custom_chain = FallbackChain(
+            primary_model="my-custom-model",
+            fallback_models=["fallback-1", "fallback-2"],
+        )
+
+        manager.register_chain(custom_chain)
+        chain = manager.get_chain("my-custom-model")
+
+        assert chain is not None
+        assert chain.primary_model == "my-custom-model"
+        assert chain.fallback_models == ["fallback-1", "fallback-2"]
+
+    def test_env_chain_loading(self):
+        """Fallback chains can be loaded from environment variables."""
+        os.environ["AUTOBOT_FALLBACK_CHAIN_TEST_MODEL"] = "anthropic:fallback-1,openai:fallback-2"
+
+        manager = FallbackChainManager()
+        chain = manager.get_chain("test-model")
+
+        assert chain is not None
+        assert chain.fallback_models == ["fallback-1", "fallback-2"]
+        assert chain.fallback_providers == ["anthropic", "openai"]
+
+        # Cleanup
+        del os.environ["AUTOBOT_FALLBACK_CHAIN_TEST_MODEL"]
+
+    def test_env_chain_without_providers(self):
+        """Env chains can specify models without providers."""
+        os.environ["AUTOBOT_FALLBACK_CHAIN_ENV_MODEL"] = "fallback-1,fallback-2,fallback-3"
+
+        manager = FallbackChainManager()
+        chain = manager.get_chain("env-model")
+
+        assert chain is not None
+        assert chain.fallback_models == ["fallback-1", "fallback-2", "fallback-3"]
+        assert chain.fallback_providers is None
+
+        # Cleanup
+        del os.environ["AUTOBOT_FALLBACK_CHAIN_ENV_MODEL"]
+
+    def test_cross_provider_fallback(self):
+        """Fallback chains can span multiple providers."""
+        manager = FallbackChainManager()
+        chain = manager.get_chain("claude-opus-4-cross")
+
+        assert chain is not None
+        assert chain.primary_provider == "anthropic"
+        assert "gpt-4o" in chain.fallback_models
+        assert "openai" in (chain.fallback_providers or [])
+
+
+class TestSingleton:
+    """Tests for the global singleton."""
+
+    def test_get_fallback_chain_manager_singleton(self):
+        """get_fallback_chain_manager returns the same instance."""
+        manager1 = get_fallback_chain_manager()
+        manager2 = get_fallback_chain_manager()
+
+        assert manager1 is manager2

--- a/autobot-backend/services/llm_service.py
+++ b/autobot-backend/services/llm_service.py
@@ -43,7 +43,9 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.tracing import get_tracer
 from llm_shared import ProviderRegistry, get_provider_registry
 from llm_shared.cache import CachedResponse, get_llm_cache
+from llm_shared.fallback_chain import get_fallback_chain_manager
 from llm_shared.models import LLMRequest, LLMResponse
+from llm_shared.rate_limit_backoff import extract_rate_limit_info
 from llm_shared.tiered_routing import TierConfig, TieredModelRouter
 from llm_shared.types import LLMType
 
@@ -170,6 +172,10 @@ class LLMService:
         """
         Execute a non-streaming chat completion.
 
+        GH#8998: Supports quota-triggered fallback chains. When a model hits
+        rate limit (429) or quota exceeded, automatically tries fallback models
+        from the configured chain before failing.
+
         Args:
             messages: OpenAI-format message list
                 (``[{"role": "user", "content": "…"}, …]``).
@@ -200,21 +206,109 @@ class LLMService:
             **kwargs,
         )
 
-        provider = await self._registry.get_provider_for_request(
-            provider_name=provider_name,
-            conversation_id=conversation_id,
-        )
-        if provider is None:
-            self._error_count += 1
-            logger.error("No available provider for chat request")
-            return _build_error_response(request, "No available LLM provider", "none")
+        # GH#8998: Track attempted models to avoid infinite loops
+        attempted_models = []
+        fallback_manager = get_fallback_chain_manager()
+        current_provider_name = provider_name
+        current_model = model_name
+        max_fallback_attempts = 10  # Safety limit
 
-        response = await provider.chat_completion(request)
-        if response.error:
+        while len(attempted_models) < max_fallback_attempts:
+            provider = await self._registry.get_provider_for_request(
+                provider_name=current_provider_name,
+                conversation_id=conversation_id,
+            )
+            if provider is None:
+                self._error_count += 1
+                logger.error("No available provider for chat request")
+                return _build_error_response(request, "No available LLM provider", "none")
+
+            # Update request with current model
+            request.model_name = current_model
+
+            # Track this attempt
+            attempt_key = f"{provider.provider_name}:{current_model or 'default'}"
+            if attempt_key in attempted_models:
+                # Avoid infinite loop - this model was already tried
+                logger.warning(
+                    "Fallback chain loop detected at %s, breaking",
+                    attempt_key,
+                )
+                break
+            attempted_models.append(attempt_key)
+
+            logger.debug(
+                "Attempting chat completion with %s (attempt %d/%d)",
+                attempt_key,
+                len(attempted_models),
+                max_fallback_attempts,
+            )
+
+            response = await provider.chat_completion(request)
+
+            # Success case
+            if not response.error:
+                if len(attempted_models) > 1:
+                    logger.info(
+                        "Fallback successful: %s worked after %d attempts (tried: %s)",
+                        attempt_key,
+                        len(attempted_models),
+                        " → ".join(attempted_models),
+                    )
+                self._track_usage(response, conversation_id)
+                return response
+
+            # GH#8998: Check if this is a rate limit error that should trigger fallback
+            is_rate_limited, _ = extract_rate_limit_info(response)
+
+            if is_rate_limited:
+                # Try to find a fallback model
+                fallback_result = fallback_manager.get_next_fallback(
+                    current_model or provider.provider_name,
+                    provider.provider_name,
+                )
+
+                if fallback_result:
+                    next_model, next_provider = fallback_result
+                    logger.info(
+                        "Rate limit hit on %s, falling back to %s:%s",
+                        attempt_key,
+                        next_provider or current_provider_name,
+                        next_model,
+                    )
+                    current_model = next_model
+                    if next_provider:
+                        current_provider_name = next_provider
+                    continue
+                else:
+                    logger.warning(
+                        "Rate limit hit on %s but no fallback chain configured, returning error",
+                        attempt_key,
+                    )
+
+            # Non-rate-limit error or no fallback available
             self._error_count += 1
-            logger.warning("Provider %s returned error: %s", provider.provider_name, response.error)
-        self._track_usage(response, conversation_id)
-        return response
+            logger.warning(
+                "Provider %s returned error: %s (attempted: %s)",
+                provider.provider_name,
+                response.error,
+                " → ".join(attempted_models),
+            )
+            self._track_usage(response, conversation_id)
+            return response
+
+        # Max attempts reached
+        self._error_count += 1
+        logger.error(
+            "Exhausted fallback chain after %d attempts: %s",
+            len(attempted_models),
+            " → ".join(attempted_models),
+        )
+        return _build_error_response(
+            request,
+            f"All fallback models exhausted ({len(attempted_models)} attempts)",
+            attempted_models[-1] if attempted_models else "none",
+        )
 
     async def stream(
         self,


### PR DESCRIPTION
"## Summary\n\nImplements automatic model fallback when primary model hits rate limits or quota caps (GH#8998).\n\nAddresses Paperclip #3317 and #2101 — AutoBot's complexity router now gracefully handles 429 errors by automatically trying fallback models instead of hard failures.\n\n## Thinking Path\n\nWhen a user's primary LLM model hits rate limits or quota caps, AutoBot should gracefully fall back to alternative models rather than returning errors. The approach:\n\n1. Created a centralized `FallbackChainManager` to define fallback sequences per model\n2. Integrated rate limit detection into `LLMService.chat()` to catch 429 errors\n3. On rate limit, query the manager for the next model in the chain and retry\n4. Track attempted models to prevent infinite loops (max 10 attempts)\n5. Support both environment variable and programmatic chain configuration\n\nThis allows operators to define custom fallback chains (e.g., opus → sonnet → haiku, or even cross-provider fallbacks).\n\n## What Changed\n\n### Core Implementation\n\n**`llm_shared/fallback_chain.py`**\n- `FallbackChain` dataclass for defining fallback sequences\n- `FallbackChainManager` singleton with default chains:\n  - Anthropic: `claude-opus-4 → claude-sonnet-4 → claude-haiku-4`\n  - OpenAI: `gpt-4 → gpt-4o → gpt-4o-mini`\n  - Cross-provider: `claude-opus-4-cross → gpt-4o → ollama/llama3`\n- Environment variable configuration: `AUTOBOT_FALLBACK_CHAIN_<MODEL>=fallback1,fallback2`\n- Provider-qualified chains: `AUTOBOT_FALLBACK_CHAIN_OPUS=anthropic:claude-sonnet-4,openai:gpt-4o`\n\n**`services/llm_service.py`**\n- Modified `LLMService.chat()` to detect rate limit errors via `extract_rate_limit_info()`\n- On 429/quota error, queries `FallbackChainManager` for next fallback model\n- Retries with fallback model instead of failing immediately\n- Tracks attempted models to prevent infinite loops (max 10 fallback attempts)\n- Logs full fallback chain on success: `\"Fallback successful: anthropic:claude-sonnet-4 worked after 2 attempts (tried: anthropic:claude-opus-4 → anthropic:claude-sonnet-4)\"`\n\n**`llm_shared/__init__.py`**\n- Exported `FallbackChain`, `FallbackChainManager`, `get_fallback_chain_manager`\n\n### Tests\n\n**`llm_shared/fallback_chain_test.py`**\n- Full test coverage for `FallbackChain` dataclass\n- Default chain loading verification\n- Environment variable configuration tests\n- Cross-provider fallback validation\n- Singleton behavior tests\n\n## Verification\n\nRun tests with:\n```bash\npytest autobot-backend/llm_shared/fallback_chain_test.py -v\n```\n\nManual integration test:\n```python\nfrom services.llm_service import get_llm_service\n\nsvc = get_llm_service()\nresponse = await svc.chat(\n    messages=[{\"role\": \"user\", \"content\": \"Hello\"}],\n    model_name=\"claude-opus-4\",  # Will fall back to sonnet/haiku on 429\n)\n```\n\n**Test results:**\n- ✅ All unit tests pass (fallback_chain_test.py)\n- ✅ Default chains load correctly\n- ✅ Environment variable configuration works\n- ✅ Cross-provider fallback validation passes\n- ✅ Singleton behavior verified\n\n## Model Used\n\nClaude Sonnet 4.5\n\n---\n\n## How It Works\n\n1. User calls `LLMService.chat()` with primary model (e.g., `claude-opus-4`)\n2. Primary model returns 429 rate limit error\n3. `LLMService` checks `FallbackChainManager` for registered fallback chain\n4. If fallback exists, retries with next model in chain (e.g., `claude-sonnet-4`)\n5. Continues through fallback chain until success or exhaustion\n6. Logs full chain on success; returns error if all models exhausted\n\n## Configuration Examples\n\n### Environment Variables\n\n```bash\n# Single-provider fallback\nexport AUTOBOT_FALLBACK_CHAIN_CLAUDE_OPUS=claude-sonnet-4,claude-haiku-4\n\n# Cross-provider fallback with explicit provider prefixes\nexport AUTOBOT_FALLBACK_CHAIN_MY_MODEL=anthropic:claude-sonnet-4,openai:gpt-4o,ollama:llama3\n\n# Simple model-only fallback (uses same provider)\nexport AUTOBOT_FALLBACK_CHAIN_GPT4=gpt-4o,gpt-4o-mini\n```\n\n### Programmatic Registration\n\n```python\nfrom llm_shared.fallback_chain import FallbackChain, get_fallback_chain_manager\n\nmanager = get_fallback_chain_manager()\nmanager.register_chain(FallbackChain(\n    primary_model=\"my-custom-model\",\n    fallback_models=[\"fallback-1\", \"fallback-2\"],\n    primary_provider=\"openai\",\n    fallback_providers=[\"openai\", \"ollama\"]\n))\n```\n\n## Acceptance Criteria\n\n- ✅ FallbackChainManager with default chains for Anthropic and OpenAI\n- ✅ Environment variable configuration support\n- ✅ Cross-provider fallback chains\n- ✅ Integration with LLMService.chat()\n"