### PR TITLE
feat(sso): add OKTA provider type and endpoint templates

### DIFF
--- a/autobot-slm-backend/api/sso.py
+++ b/autobot-slm-backend/api/sso.py
@@ -10,7 +10,7 @@ Admin endpoints for managing SSO provider configurations.
 import logging
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.auth.permissions import Permission
@@ -178,3 +178,13 @@ async def test_provider(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Internal server error",
         ) from e
+
+
+@router.get("/provider-templates/{provider_type}", response_model=dict)
+async def get_provider_template(
+    provider_type: str,
+    domain: str = Query("", description="Domain or tenant ID for endpoint URL construction"),
+    current_user: dict = Depends(require_permission(Permission.SECURITY_MANAGE)),
+) -> dict:
+    """Get pre-filled endpoint template for a known SSO provider type."""
+    return SSOService.get_provider_endpoint_template(provider_type, domain)

--- a/autobot-slm-backend/user_management/models/sso.py
+++ b/autobot-slm-backend/user_management/models/sso.py
@@ -31,6 +31,7 @@ class SSOProviderType(str, Enum):
     # Enterprise SSO
     LDAP = "ldap"
     ACTIVE_DIRECTORY = "active_directory"
+    OKTA = "okta"
     SAML = "saml"
     MICROSOFT_ENTRA = "microsoft_entra"
     GOOGLE_WORKSPACE = "google_workspace"

--- a/autobot-slm-backend/user_management/services/sso_service.py
+++ b/autobot-slm-backend/user_management/services/sso_service.py
@@ -56,6 +56,37 @@ class SSOAuthenticationError(SSOServiceError):
 class SSOService(BaseService):
     """SSO provider management and authentication service."""
 
+    @staticmethod
+    def get_provider_endpoint_template(provider_type: str, domain: str = "") -> dict[str, str]:
+        """Return pre-filled OIDC endpoint config for known provider types."""
+        templates = {
+            SSOProviderType.OKTA.value: {
+                "authorize_url": f"https://{domain}/oauth2/v1/authorize",
+                "token_url": f"https://{domain}/oauth2/v1/token",
+                "userinfo_url": f"https://{domain}/oauth2/v1/userinfo",
+                "scope": "openid email profile groups",
+            },
+            SSOProviderType.MICROSOFT_ENTRA.value: {
+                "authorize_url": f"https://login.microsoftonline.com/{domain}/oauth2/v2.0/authorize",
+                "token_url": f"https://login.microsoftonline.com/{domain}/oauth2/v2.0/token",
+                "userinfo_url": "https://graph.microsoft.com/oidc/userinfo",
+                "scope": "openid email profile",
+            },
+            SSOProviderType.GOOGLE_WORKSPACE.value: {
+                "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+                "token_url": "https://oauth2.googleapis.com/token",
+                "userinfo_url": "https://openidconnect.googleapis.com/v1/userinfo",
+                "scope": "openid email profile",
+            },
+            SSOProviderType.GITHUB.value: {
+                "authorize_url": "https://github.com/login/oauth/authorize",
+                "token_url": "https://github.com/login/oauth/access_token",
+                "userinfo_url": "https://api.github.com/user",
+                "scope": "user:email read:user",
+            },
+        }
+        return templates.get(provider_type, {})
+
     async def create_provider(self, data: SSOProviderCreate) -> SSOProvider:
         """Create a new SSO provider."""
         provider = SSOProvider(


### PR DESCRIPTION
## Thinking Path

Added OKTA as a supported SSO provider type with pre-filled endpoint templates for admin UI auto-population.

## What Changed

- **Enum**: Added `SSOProviderType.OKTA = "okta"` to `user_management/models/sso.py`
- **Service**: Added `SSOService.get_provider_endpoint_template()` static method with templates for:
  - Okta (with domain parameter)
  - Microsoft Entra (with tenant ID parameter)
  - Google Workspace
  - GitHub
- **API**: Added `GET /api/sso-providers/provider-templates/{provider_type}` endpoint with optional `domain` query param

## Verification

- Python syntax validation passed
- All files compile without errors
- Endpoint returns pre-filled configs for known providers, empty dict for unknown

## Model Used

Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)

---

Resolves MVA-1736
Parent: MVA-1730 (OIDC/SSO federation)