### PR TITLE
feat(llc-frontend): template browser UI for company creation wizard (#9164)

### DIFF
--- a/autobot-frontend/src/components/llc/TemplateBrowser.vue
+++ b/autobot-frontend/src/components/llc/TemplateBrowser.vue
@@ -1,0 +1,779 @@
+<template>
+  <div class="template-browser">
+    <div class="browser-header">
+      <div class="search-box">
+        <Icon name="search" />
+        <input
+          v-model="searchQuery"
+          :placeholder="$t('llc.templates.searchPlaceholder')"
+          class="search-input"
+        />
+      </div>
+      <div class="category-filters">
+        <button
+          v-for="cat in categories"
+          :key="cat"
+          class="filter-btn"
+          :class="{ active: selectedCategory === cat }"
+          @click="selectedCategory = cat"
+        >
+          {{ getCategoryLabel(cat) }}
+          <span v-if="getCategoryCount(cat)" class="count-badge">{{
+            getCategoryCount(cat)
+          }}</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Error State -->
+    <div v-if="error" class="error-state">
+      <Icon name="exclamation-triangle" />
+      <p>{{ error }}</p>
+      <button class="btn-secondary" @click="loadTemplates">
+        <Icon name="redo" /> {{ $t('common.retry') }}
+      </button>
+    </div>
+
+    <!-- Loading State -->
+    <div v-else-if="loading" class="loading-state">
+      <Icon name="spinner" spin />
+      <span>{{ $t('llc.templates.loading') }}</span>
+    </div>
+
+    <!-- Empty State -->
+    <div v-else-if="filteredTemplates.length === 0" class="empty-state">
+      <Icon name="building" />
+      <p>{{ $t('llc.templates.noMatch') }}</p>
+    </div>
+
+    <!-- Templates Grid -->
+    <div v-else class="templates-grid">
+      <div
+        v-for="template in filteredTemplates"
+        :key="template.key"
+        class="template-card"
+        :class="{ selected: selectedTemplate?.key === template.key }"
+        @click="selectTemplate(template)"
+      >
+        <div class="template-icon" :class="getCategoryClass(template.category)">
+          <Icon :name="template.icon || getDefaultIcon(template.category)" />
+        </div>
+        <div class="template-info">
+          <h4>{{ template.name }}</h4>
+          <p class="description">{{ template.description }}</p>
+          <div class="template-meta">
+            <span class="category-badge">{{ getCategoryLabel(template.category) }}</span>
+            <span v-if="template.estimated_agents" class="agents-count">
+              <Icon name="user-tie" /> {{ template.estimated_agents }} agents
+            </span>
+            <span v-if="template.estimated_monthly_cost_cents" class="cost">
+              <Icon name="dollar-sign" />
+              ${{ (template.estimated_monthly_cost_cents / 100).toFixed(0) }}/mo
+            </span>
+          </div>
+          <div v-if="template.tags?.length" class="template-tags">
+            <span v-for="tag in template.tags.slice(0, 3)" :key="tag" class="tag">{{ tag }}</span>
+            <span v-if="template.tags.length > 3" class="tag-more">
+              +{{ template.tags.length - 3 }}
+            </span>
+          </div>
+        </div>
+        <div class="template-actions">
+          <button
+            class="btn-icon"
+            @click.stop="openPreview(template)"
+            :title="$t('llc.templates.preview')"
+            :aria-label="$t('llc.templates.preview')"
+          >
+            <Icon name="eye" />
+          </button>
+          <button
+            v-if="!hideSelect"
+            class="btn-select"
+            :class="{ selected: selectedTemplate?.key === template.key }"
+            @click.stop="selectTemplate(template)"
+            :title="$t('llc.templates.select')"
+            :aria-label="$t('llc.templates.select')"
+          >
+            <Icon name="check" />
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Template Preview -->
+    <Transition name="slide">
+      <div v-if="previewTemplate" class="preview-panel">
+        <div class="preview-header">
+          <h3>{{ previewTemplate.name }}</h3>
+          <button @click="previewTemplate = null" :aria-label="$t('common.close')">
+            <Icon name="times" />
+          </button>
+        </div>
+        <div class="preview-body">
+          <p class="preview-desc">{{ previewTemplate.description }}</p>
+
+          <div class="preview-meta">
+            <div class="meta-item">
+              <Icon name="layer-group" />
+              <span>{{ getCategoryLabel(previewTemplate.category) }}</span>
+            </div>
+            <div v-if="previewTemplate.estimated_agents" class="meta-item">
+              <Icon name="user-tie" />
+              <span>{{ previewTemplate.estimated_agents }} agents</span>
+            </div>
+            <div v-if="previewTemplate.estimated_monthly_cost_cents" class="meta-item">
+              <Icon name="dollar-sign" />
+              <span>${{ (previewTemplate.estimated_monthly_cost_cents / 100).toFixed(0) }}/mo estimated</span>
+            </div>
+          </div>
+
+          <!-- Agents -->
+          <div v-if="previewTemplate.agents?.length" class="preview-section">
+            <h4><Icon name="user-tie" /> Agents Included</h4>
+            <div class="agent-list">
+              <div v-for="agent in previewTemplate.agents" :key="agent.name" class="agent-item">
+                <span class="agent-name">{{ agent.title }}</span>
+                <span class="agent-role">{{ agent.role }}</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Goals -->
+          <div v-if="previewTemplate.goals?.length" class="preview-section">
+            <h4><Icon name="bullseye" /> Goals</h4>
+            <div class="goal-list">
+              <div v-for="(goal, i) in previewTemplate.goals" :key="i" class="goal-item">
+                <span class="goal-level">{{ goal.level }}</span>
+                <span class="goal-title">{{ goal.title }}</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Knowledge Collections -->
+          <div v-if="previewTemplate.kb_collections?.length" class="preview-section">
+            <h4><Icon name="book" /> Knowledge Collections</h4>
+            <div class="kb-list">
+              <div v-for="(kb, i) in previewTemplate.kb_collections" :key="i" class="kb-item">
+                <Icon name="book-open" />
+                <div>
+                  <span class="kb-name">{{ kb.name }}</span>
+                  <p class="kb-desc">{{ kb.description }}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Work Items -->
+          <div v-if="previewTemplate.work_items?.length" class="preview-section">
+            <h4><Icon name="tasks" /> Initial Work Items</h4>
+            <div class="work-list">
+              <div v-for="(item, i) in previewTemplate.work_items.slice(0, 5)" :key="i" class="work-item">
+                <span class="work-type">{{ item.type }}</span>
+                <span class="work-title">{{ item.title }}</span>
+              </div>
+              <span v-if="previewTemplate.work_items.length > 5" class="work-more">
+                +{{ previewTemplate.work_items.length - 5 }} more
+              </span>
+            </div>
+          </div>
+        </div>
+        <div class="preview-actions">
+          <button class="btn-secondary" @click="previewTemplate = null">
+            <Icon name="times" /> {{ $t('common.close') }}
+          </button>
+          <button class="btn-primary" @click="selectAndClose(previewTemplate)">
+            <Icon name="check" /> {{ $t('llc.templates.useTemplate') }}
+          </button>
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+// GH#9164 - Template Browser UI for Company Creation Wizard
+
+import { ref, computed, onMounted } from 'vue'
+import { useCompanyTemplates, type CompanyTemplate, type TemplateCategory } from '@/composables/llc/useCompanyTemplates'
+import Icon from '@/components/ui/Icon.vue'
+
+const props = withDefaults(
+  defineProps<{
+    hideSelect?: boolean
+    modelValue?: CompanyTemplate | null
+  }>(),
+  {
+    hideSelect: false,
+    modelValue: null,
+  }
+)
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', template: CompanyTemplate | null): void
+  (e: 'select', template: CompanyTemplate): void
+}>()
+
+const { templates, loading, error, listBuiltInTemplates } = useCompanyTemplates()
+
+const searchQuery = ref('')
+const selectedCategory = ref<TemplateCategory | 'all'>('all')
+const selectedTemplate = ref<CompanyTemplate | null>(props.modelValue)
+const previewTemplate = ref<CompanyTemplate | null>(null)
+
+const categories = computed<Array<TemplateCategory | 'all'>>(() => [
+  'all',
+  'software-team',
+  'marketing-agency',
+  'consulting-firm',
+  'research-lab',
+  'startup',
+  'custom',
+])
+
+const filteredTemplates = computed(() => {
+  let result = templates.value
+
+  // Filter by category
+  if (selectedCategory.value !== 'all') {
+    result = result.filter(t => t.category === selectedCategory.value)
+  }
+
+  // Filter by search query
+  if (searchQuery.value.trim()) {
+    const q = searchQuery.value.toLowerCase()
+    result = result.filter(
+      t =>
+        t.name.toLowerCase().includes(q) ||
+        t.description.toLowerCase().includes(q) ||
+        t.tags?.some(tag => tag.toLowerCase().includes(q))
+    )
+  }
+
+  return result
+})
+
+function getCategoryLabel(cat: TemplateCategory | 'all'): string {
+  const labels: Record<string, string> = {
+    all: 'All Templates',
+    'software-team': 'Software Team',
+    'marketing-agency': 'Marketing Agency',
+    'consulting-firm': 'Consulting Firm',
+    'research-lab': 'Research Lab',
+    startup: 'Startup',
+    custom: 'Custom',
+  }
+  return labels[cat] || cat
+}
+
+function getCategoryCount(cat: TemplateCategory | 'all'): number {
+  if (cat === 'all') return templates.value.length
+  return templates.value.filter(t => t.category === cat).length
+}
+
+function getCategoryClass(cat: TemplateCategory): string {
+  return `category-${cat}`
+}
+
+function getDefaultIcon(cat: TemplateCategory): string {
+  const icons: Record<TemplateCategory, string> = {
+    'software-team': 'code',
+    'marketing-agency': 'bullhorn',
+    'consulting-firm': 'briefcase',
+    'research-lab': 'flask',
+    startup: 'rocket',
+    custom: 'wrench',
+  }
+  return icons[cat] || 'building'
+}
+
+function selectTemplate(template: CompanyTemplate) {
+  selectedTemplate.value = template
+  emit('update:modelValue', template)
+  emit('select', template)
+}
+
+function selectAndClose(template: CompanyTemplate) {
+  selectTemplate(template)
+  previewTemplate.value = null
+}
+
+function openPreview(template: CompanyTemplate) {
+  previewTemplate.value = template
+}
+
+async function loadTemplates() {
+  await listBuiltInTemplates()
+}
+
+onMounted(() => {
+  loadTemplates()
+})
+</script>
+
+<style scoped>
+.template-browser {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg-primary);
+}
+
+.browser-header {
+  padding: var(--spacing-4);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.search-box {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--spacing-3);
+}
+
+.search-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  outline: none;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+
+.category-filters {
+  display: flex;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.filter-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1-5);
+  padding: var(--spacing-1-5) var(--spacing-3);
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  cursor: pointer;
+  transition: all var(--duration-200);
+}
+
+.filter-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.filter-btn.active {
+  background: var(--color-primary);
+  color: white;
+  border-color: var(--color-primary);
+}
+
+.count-badge {
+  padding: 0 var(--spacing-1-5);
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.error-state,
+.loading-state,
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-8);
+  gap: var(--spacing-3);
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.templates-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: var(--spacing-4);
+  padding: var(--spacing-4);
+  overflow-y: auto;
+}
+
+.template-card {
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing-4);
+  background: var(--bg-secondary);
+  border: 2px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  transition: all var(--duration-200);
+}
+
+.template-card:hover {
+  border-color: var(--color-primary);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.template-card.selected {
+  border-color: var(--color-primary);
+  background: var(--bg-tertiary);
+}
+
+.template-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-md);
+  margin-bottom: var(--spacing-3);
+  font-size: var(--text-2xl);
+}
+
+.category-software-team {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+}
+
+.category-marketing-agency {
+  background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+  color: white;
+}
+
+.category-consulting-firm {
+  background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+  color: white;
+}
+
+.category-research-lab {
+  background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
+  color: white;
+}
+
+.category-startup {
+  background: linear-gradient(135deg, #fa709a 0%, #fee140 100%);
+  color: white;
+}
+
+.category-custom {
+  background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%);
+  color: white;
+}
+
+.template-info {
+  flex: 1;
+}
+
+.template-info h4 {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 var(--spacing-2);
+}
+
+.template-info .description {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  margin: 0 0 var(--spacing-3);
+  line-height: 1.5;
+}
+
+.template-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
+  font-size: var(--text-xs);
+}
+
+.category-badge,
+.agents-count,
+.cost {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-1) var(--spacing-2);
+  background: var(--bg-primary);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+}
+
+.template-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-1);
+}
+
+.tag {
+  padding: var(--spacing-0-5) var(--spacing-1-5);
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.tag-more {
+  padding: var(--spacing-0-5) var(--spacing-1-5);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.template-actions {
+  display: flex;
+  gap: var(--spacing-2);
+  margin-top: var(--spacing-3);
+  padding-top: var(--spacing-3);
+  border-top: 1px solid var(--border-color);
+}
+
+.btn-icon,
+.btn-select {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-2);
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--duration-200);
+}
+
+.btn-icon:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.btn-select {
+  flex: 1;
+}
+
+.btn-select:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.btn-select.selected {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: white;
+}
+
+/* Preview Panel */
+.preview-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 480px;
+  height: 100vh;
+  background: var(--bg-elevated);
+  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  z-index: 100;
+}
+
+.preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-4);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.preview-header h3 {
+  font-size: var(--text-xl);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.preview-header button {
+  padding: var(--spacing-2);
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-md);
+  transition: all var(--duration-200);
+}
+
+.preview-header button:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.preview-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--spacing-4);
+}
+
+.preview-desc {
+  font-size: var(--text-base);
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0 0 var(--spacing-4);
+}
+
+.preview-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-4);
+  padding-bottom: var(--spacing-4);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.meta-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.preview-section {
+  margin-bottom: var(--spacing-4);
+}
+
+.preview-section h4 {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 var(--spacing-3);
+}
+
+.agent-list,
+.goal-list,
+.kb-list,
+.work-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.agent-item,
+.goal-item,
+.work-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2);
+  background: var(--bg-secondary);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+}
+
+.agent-name,
+.goal-title,
+.work-title {
+  color: var(--text-primary);
+}
+
+.agent-role,
+.goal-level,
+.work-type {
+  padding: var(--spacing-0-5) var(--spacing-1-5);
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.kb-item {
+  display: flex;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2);
+  background: var(--bg-secondary);
+  border-radius: var(--radius-md);
+}
+
+.kb-name {
+  display: block;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--text-primary);
+  margin-bottom: var(--spacing-0-5);
+}
+
+.kb-desc {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.work-more {
+  padding: var(--spacing-2);
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
+.preview-actions {
+  display: flex;
+  gap: var(--spacing-2);
+  padding: var(--spacing-4);
+  border-top: 1px solid var(--border-color);
+}
+
+.btn-secondary,
+.btn-primary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2-5) var(--spacing-4);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--duration-200);
+}
+
+.btn-secondary {
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.btn-secondary:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.btn-primary {
+  flex: 1;
+  background: var(--color-primary);
+  color: white;
+}
+
+.btn-primary:hover {
+  opacity: 0.9;
+}
+
+/* Slide Transition */
+.slide-enter-active,
+.slide-leave-active {
+  transition: transform var(--duration-300) ease;
+}
+
+.slide-enter-from,
+.slide-leave-to {
+  transform: translateX(100%);
+}
+</style>

--- a/autobot-frontend/src/composables/llc/useCompanyTemplates.ts
+++ b/autobot-frontend/src/composables/llc/useCompanyTemplates.ts
@@ -1,0 +1,147 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+/**
+ * useCompanyTemplates composable (GH#9164)
+ *
+ * Provides API access to LLC company template library:
+ * - List built-in templates
+ * - Get template details
+ * - Search templates (custom templates from DB)
+ * - Import template into company
+ */
+
+import { ref } from 'vue'
+import { useApiClient } from '@/plugins/api'
+import { createLogger } from '@/utils/debugUtils'
+import type { AxiosError } from 'axios'
+
+const logger = createLogger('useCompanyTemplates')
+
+export type TemplateCategory =
+  | 'software-team'
+  | 'marketing-agency'
+  | 'consulting-firm'
+  | 'research-lab'
+  | 'startup'
+  | 'custom'
+
+export interface CompanyTemplate {
+  key: string
+  name: string
+  description: string
+  category: TemplateCategory
+  tags: string[]
+  icon?: string
+  estimated_agents?: number
+  estimated_monthly_cost_cents?: number
+  variables?: Record<string, { description: string; default?: string; required?: boolean }>
+  agents?: Array<{
+    name: string
+    title: string
+    role: string
+    adapter_type: string
+  }>
+  goals?: Array<{
+    level: string
+    title: string
+    description: string
+  }>
+  work_items?: Array<{
+    type: string
+    title: string
+    description: string
+  }>
+  kb_collections?: Array<{
+    name: string
+    description: string
+  }>
+}
+
+export interface TemplateImportRequest {
+  target_company_id: string
+  variable_values?: Record<string, string>
+  secret_mappings?: Record<string, string>
+}
+
+export interface TemplateImportResult {
+  company_id: string
+  agents_created: number
+  goals_created: number
+  work_items_created: number
+  kb_collections_created: number
+}
+
+export function useCompanyTemplates() {
+  const api = useApiClient()
+
+  const templates = ref<CompanyTemplate[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function listBuiltInTemplates(): Promise<CompanyTemplate[]> {
+    loading.value = true
+    error.value = null
+    try {
+      const response = await api.get<CompanyTemplate[]>('/api/llc/templates/built-in')
+      templates.value = response
+      return response
+    } catch (err) {
+      const msg = (err as AxiosError)?.message ?? String(err)
+      logger.error('Failed to list built-in templates', err)
+      error.value = `Failed to load templates: ${msg}`
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getBuiltInTemplate(templateKey: string): Promise<CompanyTemplate> {
+    loading.value = true
+    error.value = null
+    try {
+      const response = await api.get<CompanyTemplate>(
+        `/api/llc/templates/built-in/${encodeURIComponent(templateKey)}`
+      )
+      return response
+    } catch (err) {
+      const msg = (err as AxiosError)?.message ?? String(err)
+      logger.error(`Failed to get template ${templateKey}`, err)
+      error.value = `Failed to load template: ${msg}`
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function importTemplate(
+    templateId: string,
+    request: TemplateImportRequest
+  ): Promise<TemplateImportResult> {
+    loading.value = true
+    error.value = null
+    try {
+      const response = await api.post<TemplateImportResult>(
+        `/api/llc/templates/${encodeURIComponent(templateId)}/import`,
+        request
+      )
+      return response
+    } catch (err) {
+      const msg = (err as AxiosError)?.message ?? String(err)
+      logger.error(`Failed to import template ${templateId}`, err)
+      error.value = `Failed to import template: ${msg}`
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    templates,
+    loading,
+    error,
+    listBuiltInTemplates,
+    getBuiltInTemplate,
+    importTemplate,
+  }
+}

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -7401,5 +7401,53 @@
     "newCodeDesc": "Start a code analysis session",
     "newAnalysis": "New Analysis",
     "newAnalysisDesc": "Start an analysis session"
+  },
+  "llc": {
+    "templates": {
+      "searchPlaceholder": "Search templates...",
+      "loading": "Loading templates...",
+      "noMatch": "No templates found matching your search",
+      "preview": "Preview template",
+      "select": "Select template",
+      "useTemplate": "Use this template"
+    },
+    "wizard": {
+      "step1": {
+        "title": "Choose a Starting Point",
+        "description": "Start with a template or build from scratch",
+        "startFromScratch": "Start from Scratch",
+        "startFromScratchDesc": "Build your company structure from the ground up",
+        "useTemplate": "Use a Template",
+        "useTemplateDesc": "Start with a pre-configured company template"
+      },
+      "step2": {
+        "title": "Configure Your Company",
+        "description": "Set up your company details and preferences",
+        "companyName": "Company Name",
+        "companyNamePlaceholder": "e.g., Acme Corporation",
+        "issuePrefix": "Issue Prefix",
+        "issuePrefixPlaceholder": "e.g., ACM",
+        "issuePrefixHint": "2-10 uppercase letters for issue identifiers (e.g., ACM-123)",
+        "mission": "Mission Statement",
+        "missionPlaceholder": "What is your company's mission?",
+        "monthlyBudget": "Monthly Budget",
+        "monthlyBudgetPlaceholder": "100",
+        "estimatedCost": "Estimated cost",
+        "brandColor": "Brand Color",
+        "brandColorPlaceholder": "#667eea",
+        "templateVariables": "Template Configuration"
+      },
+      "step3": {
+        "title": "Review & Create",
+        "description": "Review your configuration and create your company",
+        "companyDetails": "Company Details",
+        "template": "Template",
+        "agents": "Agents",
+        "goals": "Goals",
+        "workItems": "Work Items",
+        "kbCollections": "Knowledge Collections",
+        "createCompany": "Create Company"
+      }
+    }
   }
 }

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -964,6 +964,13 @@ export const routes: RouteRecordRaw[] = [
     component: () => import('@/views/llc/SubCompanyTree.vue'),
     meta: { title: 'Company Hierarchy', requiresAuth: true, llcScope: true, hideInNav: true },
   },
+  // GH#9164: Company Creation Wizard with Template Browser
+  {
+    path: '/llc/companies/create',
+    name: 'llc-company-create',
+    component: () => import('@/views/llc/CompanyCreationWizard.vue'),
+    meta: { title: 'Create Company', requiresAuth: true, llcScope: true, hideInNav: true, hideFooter: true },
+  },
   // Issue #4465: Usage moved under /analytics/usage
   { path: '/usage', redirect: '/analytics/usage' },
   {

--- a/autobot-frontend/src/views/llc/CompanyCreationWizard.vue
+++ b/autobot-frontend/src/views/llc/CompanyCreationWizard.vue
@@ -1,0 +1,877 @@
+<template>
+  <div class="company-creation-wizard">
+    <!-- Step Indicator -->
+    <div class="wizard-header">
+      <div class="steps-indicator">
+        <div
+          v-for="(s, i) in STEPS"
+          :key="s.n"
+          class="step-item"
+          :class="{ active: step === s.n, completed: step > s.n }"
+        >
+          <div class="step-circle">
+            <Icon v-if="step > s.n" name="check" />
+            <span v-else>{{ s.n }}</span>
+          </div>
+          <span class="step-label">{{ s.label }}</span>
+          <div v-if="i < STEPS.length - 1" class="step-connector"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Wizard Content -->
+    <div class="wizard-content">
+      <!-- Step 1: Choose Template -->
+      <div v-if="step === 1" class="wizard-step">
+        <div class="step-header">
+          <h2>{{ $t('llc.wizard.step1.title') }}</h2>
+          <p>{{ $t('llc.wizard.step1.description') }}</p>
+        </div>
+
+        <div class="template-choice">
+          <button
+            class="choice-card"
+            :class="{ active: !useTemplate }"
+            @click="useTemplate = false"
+          >
+            <Icon name="plus-circle" class="choice-icon" />
+            <h3>{{ $t('llc.wizard.step1.startFromScratch') }}</h3>
+            <p>{{ $t('llc.wizard.step1.startFromScratchDesc') }}</p>
+          </button>
+          <button
+            class="choice-card"
+            :class="{ active: useTemplate }"
+            @click="useTemplate = true"
+          >
+            <Icon name="clone" class="choice-icon" />
+            <h3>{{ $t('llc.wizard.step1.useTemplate') }}</h3>
+            <p>{{ $t('llc.wizard.step1.useTemplateDesc') }}</p>
+          </button>
+        </div>
+
+        <div v-if="useTemplate" class="template-browser-container">
+          <TemplateBrowser v-model="selectedTemplate" />
+        </div>
+      </div>
+
+      <!-- Step 2: Configure Company -->
+      <div v-if="step === 2" class="wizard-step">
+        <div class="step-header">
+          <h2>{{ $t('llc.wizard.step2.title') }}</h2>
+          <p>{{ $t('llc.wizard.step2.description') }}</p>
+        </div>
+
+        <div class="company-form">
+          <div class="form-group">
+            <label for="companyName" class="form-label">
+              <span>{{ $t('llc.wizard.step2.companyName') }}</span>
+              <span class="required">*</span>
+            </label>
+            <input
+              id="companyName"
+              v-model="companyConfig.name"
+              type="text"
+              class="form-input"
+              :placeholder="$t('llc.wizard.step2.companyNamePlaceholder')"
+              required
+            />
+          </div>
+
+          <div class="form-group">
+            <label for="issuePrefix" class="form-label">
+              <span>{{ $t('llc.wizard.step2.issuePrefix') }}</span>
+              <span class="required">*</span>
+            </label>
+            <input
+              id="issuePrefix"
+              v-model="companyConfig.issue_prefix"
+              type="text"
+              class="form-input"
+              :placeholder="$t('llc.wizard.step2.issuePrefixPlaceholder')"
+              maxlength="10"
+              pattern="[A-Z]{2,10}"
+              required
+            />
+            <span class="form-hint">{{ $t('llc.wizard.step2.issuePrefixHint') }}</span>
+          </div>
+
+          <div class="form-group">
+            <label for="mission" class="form-label">
+              <span>{{ $t('llc.wizard.step2.mission') }}</span>
+            </label>
+            <textarea
+              id="mission"
+              v-model="companyConfig.mission"
+              class="form-textarea"
+              :placeholder="$t('llc.wizard.step2.missionPlaceholder')"
+              rows="4"
+            ></textarea>
+          </div>
+
+          <div class="form-group">
+            <label for="monthlyBudget" class="form-label">
+              <span>{{ $t('llc.wizard.step2.monthlyBudget') }}</span>
+            </label>
+            <div class="budget-input">
+              <span class="budget-currency">$</span>
+              <input
+                id="monthlyBudget"
+                v-model.number="budgetDollars"
+                type="number"
+                class="form-input"
+                min="0"
+                step="10"
+                :placeholder="$t('llc.wizard.step2.monthlyBudgetPlaceholder')"
+              />
+              <span class="budget-unit">/month</span>
+            </div>
+            <span v-if="selectedTemplate?.estimated_monthly_cost_cents" class="form-hint">
+              {{ $t('llc.wizard.step2.estimatedCost') }}:
+              ${{ (selectedTemplate.estimated_monthly_cost_cents / 100).toFixed(0) }}/mo
+            </span>
+          </div>
+
+          <div class="form-group">
+            <label for="brandColor" class="form-label">
+              <span>{{ $t('llc.wizard.step2.brandColor') }}</span>
+            </label>
+            <div class="color-input">
+              <input
+                id="brandColor"
+                v-model="companyConfig.brand_color"
+                type="color"
+                class="form-color"
+              />
+              <input
+                v-model="companyConfig.brand_color"
+                type="text"
+                class="form-input"
+                :placeholder="$t('llc.wizard.step2.brandColorPlaceholder')"
+                pattern="#[0-9A-Fa-f]{6}"
+              />
+            </div>
+          </div>
+
+          <!-- Template Variables (if using template) -->
+          <div v-if="selectedTemplate?.variables" class="form-section">
+            <h3>{{ $t('llc.wizard.step2.templateVariables') }}</h3>
+            <div
+              v-for="(varMeta, varKey) in selectedTemplate.variables"
+              :key="varKey"
+              class="form-group"
+            >
+              <label :for="`var-${varKey}`" class="form-label">
+                <span>{{ varMeta.description || varKey }}</span>
+                <span v-if="varMeta.required" class="required">*</span>
+              </label>
+              <input
+                :id="`var-${varKey}`"
+                v-model="templateVariables[varKey]"
+                type="text"
+                class="form-input"
+                :placeholder="varMeta.default"
+                :required="varMeta.required"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Step 3: Review & Create -->
+      <div v-if="step === 3" class="wizard-step">
+        <div class="step-header">
+          <h2>{{ $t('llc.wizard.step3.title') }}</h2>
+          <p>{{ $t('llc.wizard.step3.description') }}</p>
+        </div>
+
+        <div class="review-summary">
+          <div class="summary-section">
+            <h3>{{ $t('llc.wizard.step3.companyDetails') }}</h3>
+            <dl class="summary-list">
+              <div class="summary-item">
+                <dt>{{ $t('llc.wizard.step2.companyName') }}</dt>
+                <dd>{{ companyConfig.name }}</dd>
+              </div>
+              <div class="summary-item">
+                <dt>{{ $t('llc.wizard.step2.issuePrefix') }}</dt>
+                <dd>{{ companyConfig.issue_prefix }}</dd>
+              </div>
+              <div v-if="companyConfig.mission" class="summary-item">
+                <dt>{{ $t('llc.wizard.step2.mission') }}</dt>
+                <dd>{{ companyConfig.mission }}</dd>
+              </div>
+              <div class="summary-item">
+                <dt>{{ $t('llc.wizard.step2.monthlyBudget') }}</dt>
+                <dd>${{ budgetDollars }}/month</dd>
+              </div>
+              <div class="summary-item">
+                <dt>{{ $t('llc.wizard.step2.brandColor') }}</dt>
+                <dd>
+                  <div class="color-preview">
+                    <span
+                      class="color-swatch"
+                      :style="{ background: companyConfig.brand_color }"
+                    ></span>
+                    {{ companyConfig.brand_color }}
+                  </div>
+                </dd>
+              </div>
+            </dl>
+          </div>
+
+          <div v-if="selectedTemplate" class="summary-section">
+            <h3>{{ $t('llc.wizard.step3.template') }}</h3>
+            <div class="template-summary">
+              <div class="template-summary-header">
+                <div
+                  class="template-icon"
+                  :class="`category-${selectedTemplate.category}`"
+                >
+                  <Icon
+                    :name="
+                      selectedTemplate.icon || getDefaultIcon(selectedTemplate.category)
+                    "
+                  />
+                </div>
+                <div>
+                  <h4>{{ selectedTemplate.name }}</h4>
+                  <p>{{ selectedTemplate.description }}</p>
+                </div>
+              </div>
+              <dl class="summary-list">
+                <div v-if="selectedTemplate.agents?.length" class="summary-item">
+                  <dt>{{ $t('llc.wizard.step3.agents') }}</dt>
+                  <dd>{{ selectedTemplate.agents.length }} agents</dd>
+                </div>
+                <div v-if="selectedTemplate.goals?.length" class="summary-item">
+                  <dt>{{ $t('llc.wizard.step3.goals') }}</dt>
+                  <dd>{{ selectedTemplate.goals.length }} goals</dd>
+                </div>
+                <div v-if="selectedTemplate.work_items?.length" class="summary-item">
+                  <dt>{{ $t('llc.wizard.step3.workItems') }}</dt>
+                  <dd>{{ selectedTemplate.work_items.length }} work items</dd>
+                </div>
+                <div v-if="selectedTemplate.kb_collections?.length" class="summary-item">
+                  <dt>{{ $t('llc.wizard.step3.kbCollections') }}</dt>
+                  <dd>{{ selectedTemplate.kb_collections.length }} KB collections</dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+        </div>
+
+        <!-- Error -->
+        <div v-if="error" class="error-banner">
+          <Icon name="exclamation-triangle" />
+          <span>{{ error }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Wizard Actions -->
+    <div class="wizard-actions">
+      <button
+        v-if="step > 1"
+        class="btn-secondary"
+        @click="previousStep"
+        :disabled="loading"
+      >
+        <Icon name="arrow-left" /> {{ $t('common.back') }}
+      </button>
+      <button v-else class="btn-secondary" @click="$router.push('/llc/dashboard')">
+        <Icon name="times" /> {{ $t('common.cancel') }}
+      </button>
+
+      <button
+        v-if="step < 3"
+        class="btn-primary"
+        @click="nextStep"
+        :disabled="!canProceed"
+      >
+        {{ $t('common.next') }} <Icon name="arrow-right" />
+      </button>
+      <button v-else class="btn-primary" @click="createCompany" :disabled="loading">
+        <Icon v-if="loading" name="spinner" spin />
+        <Icon v-else name="check" />
+        {{ $t('llc.wizard.step3.createCompany') }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+// GH#9164 - Company Creation Wizard with Template Browser
+
+import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useApiClient } from '@/plugins/api'
+import { createLogger } from '@/utils/debugUtils'
+import { useCompanyTemplates, type CompanyTemplate, type TemplateCategory } from '@/composables/llc/useCompanyTemplates'
+import TemplateBrowser from '@/components/llc/TemplateBrowser.vue'
+import Icon from '@/components/ui/Icon.vue'
+
+const logger = createLogger('CompanyCreationWizard')
+const router = useRouter()
+const api = useApiClient()
+const { importTemplate } = useCompanyTemplates()
+
+const STEPS = [
+  { n: 1, label: 'Choose Template' },
+  { n: 2, label: 'Configure' },
+  { n: 3, label: 'Review' },
+]
+
+const step = ref(1)
+const useTemplate = ref(false)
+const selectedTemplate = ref<CompanyTemplate | null>(null)
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+interface CompanyConfig {
+  name: string
+  issue_prefix: string
+  mission: string
+  monthly_budget_cents: number
+  brand_color: string
+}
+
+const companyConfig = ref<CompanyConfig>({
+  name: '',
+  issue_prefix: '',
+  mission: '',
+  monthly_budget_cents: 10000, // $100 default
+  brand_color: '#667eea',
+})
+
+const budgetDollars = computed({
+  get: () => companyConfig.value.monthly_budget_cents / 100,
+  set: (val: number) => {
+    companyConfig.value.monthly_budget_cents = Math.round(val * 100)
+  },
+})
+
+const templateVariables = ref<Record<string, string>>({})
+
+const canProceed = computed(() => {
+  if (step.value === 1) {
+    return !useTemplate.value || selectedTemplate.value !== null
+  }
+  if (step.value === 2) {
+    const hasName = companyConfig.value.name.trim().length > 0
+    const hasPrefix = /^[A-Z]{2,10}$/.test(companyConfig.value.issue_prefix)
+    const hasRequiredVars =
+      !selectedTemplate.value?.variables ||
+      Object.entries(selectedTemplate.value.variables).every(
+        ([key, meta]) => !meta.required || templateVariables.value[key]?.trim()
+      )
+    return hasName && hasPrefix && hasRequiredVars
+  }
+  return true
+})
+
+function nextStep() {
+  if (canProceed.value && step.value < 3) {
+    step.value++
+  }
+}
+
+function previousStep() {
+  if (step.value > 1) {
+    step.value--
+    error.value = null
+  }
+}
+
+function getDefaultIcon(cat: TemplateCategory): string {
+  const icons: Record<TemplateCategory, string> = {
+    'software-team': 'code',
+    'marketing-agency': 'bullhorn',
+    'consulting-firm': 'briefcase',
+    'research-lab': 'flask',
+    startup: 'rocket',
+    custom: 'wrench',
+  }
+  return icons[cat] || 'building'
+}
+
+async function createCompany() {
+  loading.value = true
+  error.value = null
+
+  try {
+    // Step 1: Create the company
+    const companyPayload = {
+      name: companyConfig.value.name,
+      issue_prefix: companyConfig.value.issue_prefix,
+      mission: companyConfig.value.mission || undefined,
+      monthly_budget_cents: companyConfig.value.monthly_budget_cents,
+      brand_color: companyConfig.value.brand_color,
+      status: 'active',
+    }
+
+    logger.info('Creating company', companyPayload)
+    const createdCompany = await api.post<{ id: string }>('/api/llc/companies', companyPayload)
+
+    // Step 2: If template selected, import it
+    if (selectedTemplate.value) {
+      logger.info('Importing template', {
+        templateKey: selectedTemplate.value.key,
+        companyId: createdCompany.id,
+      })
+
+      const importPayload = {
+        target_company_id: createdCompany.id,
+        variable_values: templateVariables.value,
+      }
+
+      // For built-in templates, use the key as the template ID
+      await importTemplate(selectedTemplate.value.key, importPayload)
+    }
+
+    logger.info('Company created successfully', { companyId: createdCompany.id })
+
+    // Redirect to company dashboard
+    await router.push('/llc/dashboard')
+  } catch (err: any) {
+    logger.error('Failed to create company', err)
+    error.value = err?.response?.data?.detail || err?.message || 'Failed to create company'
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<style scoped>
+.company-creation-wizard {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background: var(--bg-primary);
+}
+
+.wizard-header {
+  padding: var(--spacing-6) var(--spacing-4);
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-elevated);
+}
+
+.steps-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.step-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  flex: 1;
+}
+
+.step-circle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  font-weight: 600;
+  margin-bottom: var(--spacing-2);
+  transition: all var(--duration-300);
+  z-index: 1;
+}
+
+.step-item.active .step-circle {
+  background: var(--color-primary);
+  color: white;
+  transform: scale(1.1);
+}
+
+.step-item.completed .step-circle {
+  background: var(--color-success);
+  color: white;
+}
+
+.step-label {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.step-item.active .step-label {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.step-connector {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  width: 100%;
+  height: 2px;
+  background: var(--border-color);
+  z-index: 0;
+}
+
+.wizard-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--spacing-6) var(--spacing-4);
+}
+
+.wizard-step {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.step-header {
+  text-align: center;
+  margin-bottom: var(--spacing-6);
+}
+
+.step-header h2 {
+  font-size: var(--text-3xl);
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 var(--spacing-2);
+}
+
+.step-header p {
+  font-size: var(--text-base);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.template-choice {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
+}
+
+.choice-card {
+  padding: var(--spacing-6);
+  background: var(--bg-secondary);
+  border: 2px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  text-align: center;
+  cursor: pointer;
+  transition: all var(--duration-200);
+}
+
+.choice-card:hover {
+  border-color: var(--color-primary);
+  transform: translateY(-2px);
+}
+
+.choice-card.active {
+  border-color: var(--color-primary);
+  background: var(--bg-tertiary);
+}
+
+.choice-icon {
+  font-size: 48px;
+  color: var(--color-primary);
+  margin-bottom: var(--spacing-3);
+}
+
+.choice-card h3 {
+  font-size: var(--text-xl);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 var(--spacing-2);
+}
+
+.choice-card p {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.template-browser-container {
+  height: 600px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.company-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.form-section {
+  padding-top: var(--spacing-4);
+  border-top: 1px solid var(--border-color);
+}
+
+.form-section h3 {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 var(--spacing-4);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1-5);
+}
+
+.form-label {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.required {
+  color: var(--color-error);
+}
+
+.form-input,
+.form-textarea {
+  padding: var(--spacing-2-5) var(--spacing-3);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  outline: none;
+  transition: all var(--duration-200);
+}
+
+.form-input:focus,
+.form-textarea:focus {
+  border-color: var(--color-primary);
+  background: var(--bg-tertiary);
+}
+
+.form-textarea {
+  resize: vertical;
+  font-family: inherit;
+}
+
+.form-hint {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.budget-input,
+.color-input {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.budget-currency,
+.budget-unit {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.form-color {
+  width: 48px;
+  height: 48px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.review-summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6);
+}
+
+.summary-section {
+  padding: var(--spacing-4);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+}
+
+.summary-section h3 {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 var(--spacing-4);
+}
+
+.summary-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  margin: 0;
+}
+
+.summary-item {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: var(--spacing-3);
+}
+
+.summary-item dt {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.summary-item dd {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.color-preview {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.color-swatch {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
+}
+
+.template-summary-header {
+  display: flex;
+  align-items: start;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-4);
+  padding-bottom: var(--spacing-4);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.template-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-md);
+  font-size: var(--text-2xl);
+  flex-shrink: 0;
+}
+
+.template-summary-header h4 {
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 var(--spacing-1);
+}
+
+.template-summary-header p {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.error-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error);
+  border-radius: var(--radius-md);
+  color: var(--color-error);
+  font-size: var(--text-sm);
+  margin-top: var(--spacing-4);
+}
+
+.wizard-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
+  border-top: 1px solid var(--border-color);
+  background: var(--bg-elevated);
+}
+
+.btn-secondary,
+.btn-primary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3) var(--spacing-6);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--duration-200);
+}
+
+.btn-secondary {
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.btn-primary {
+  background: var(--color-primary);
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.btn-primary:disabled,
+.btn-secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Template Icon Categories */
+.category-software-team {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+}
+
+.category-marketing-agency {
+  background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+  color: white;
+}
+
+.category-consulting-firm {
+  background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+  color: white;
+}
+
+.category-research-lab {
+  background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
+  color: white;
+}
+
+.category-startup {
+  background: linear-gradient(135deg, #fa709a 0%, #fee140 100%);
+  color: white;
+}
+
+.category-custom {
+  background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%);
+  color: white;
+}
+</style>


### PR DESCRIPTION
## Thinking Path

Issue GH#9164 requires a template browser UI for company creation wizard in the LLC module. The backend template endpoints (GH#8260) already exist, but there's no frontend UI to browse and select templates. Without this UI, users can't leverage the built-in company templates.

## What Changed

Implemented complete company creation wizard with template browser:

1. **TemplateBrowser.vue** - Template selection UI with grid view, category filtering, search, and side panel preview
2. **CompanyCreationWizard.vue** - 3-step wizard flow (choose template → configure details → review)
3. **useCompanyTemplates.ts** - Composable for template API operations
4. **Router** - Added `/llc/companies/create` route
5. **i18n** - Added LLC wizard and template translations

## Verification

- [x] TypeScript compilation passes (`vue-tsc --noEmit`)
- [x] No import errors
- [x] Router configuration valid
- [x] Translation keys added
- [x] Modeled after WorkflowTemplateGallery for UI consistency
- [ ] Manual test pending: navigate to `/llc/companies/create`, select template, create company

## Model Used

Claude Sonnet 4.5 via Paperclip

## Design Decisions

- Modeled after existing WorkflowTemplateGallery for UI consistency
- Template variables dynamically rendered based on template metadata
- Budget field suggests estimated cost from template
- Brand color picker with hex input
- Full TypeScript type safety with CompanyTemplate interface

## Backend Integration

- Uses existing `/api/llc/templates/built-in` endpoint (GH#8260)
- Creates company via `POST /api/llc/companies`
- Imports template via `POST /api/llc/templates/{key}/import`

Resolves GH#9164

🤖 Generated with Paperclip