### PR TITLE
style(formatting): fix black formatting on chat_workflow/manager.py

### DIFF
--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -1599,7 +1599,11 @@ class ChatWorkflowManager(
     ):
         """Stream LLM response chunks. Issue #620. Issue MVA-1993: Includes lightweight_mode_used."""
         state = self._initialize_stream_state(
-            selected_model, terminal_session_id, used_knowledge, rag_citations, lightweight_mode_used=lightweight_mode_used
+            selected_model,
+            terminal_session_id,
+            used_knowledge,
+            rag_citations,
+            lightweight_mode_used=lightweight_mode_used,
         )
         llm_response, current_segment, current_message_type = state[:3]
         tool_call_completed, streaming_msg = state[3:]
@@ -2754,20 +2758,21 @@ before summarizing.
                 # Trivial tier is the canonical lightweight signal (GH#9050).
                 # Fall back to simple tier when trivial is not configured.
                 is_trivial = complexity_result.tier == "trivial"
-                is_simple_fallback = (
-                    complexity_result.tier == "simple"
-                    and not getattr(tier_config.models, "trivial", "")
+                is_simple_fallback = complexity_result.tier == "simple" and not getattr(
+                    tier_config.models, "trivial", ""
                 )
                 lightweight_mode = is_trivial or is_simple_fallback
                 if lightweight_mode:
-                    logger.info("[MVA-1992] Lightweight mode enabled (tier=%s, score=%.1f)",
-                               complexity_result.tier, complexity_result.score)
+                    logger.info(
+                        "[MVA-1992] Lightweight mode enabled (tier=%s, score=%.1f)",
+                        complexity_result.tier,
+                        complexity_result.score,
+                    )
         except Exception as e:
             logger.warning("[MVA-1992] Complexity routing failed, defaulting to full mode: %s", e)
 
         llm_params = await self._prepare_llm_request_params(
-            session, message, use_knowledge=use_knowledge, language=language,
-            lightweight_mode=lightweight_mode
+            session, message, use_knowledge=use_knowledge, language=language, lightweight_mode=lightweight_mode
         )
         # MVA-1993: Store lightweight_mode in params for response metadata
         llm_params["lightweight_mode_used"] = lightweight_mode


### PR DESCRIPTION
## Summary
- Fixed black formatting violations in `autobot-backend/chat_workflow/manager.py`
- File was modified in PR#9176 (MVA-1993) and introduced formatting issues

## Context
- Original MVA-2118 tracked 3 files from GH#9116 that were failing black
- Those 3 files were already fixed in commit 269ab998c (May 31)
- During investigation, discovered this new file failing black --check

## Test plan
- [x] `black --check --line-length=120 autobot-backend/chat_workflow/manager.py` passes
- [x] No functional changes, formatting only

Closes MVA-2118
Refs: GH#9116

🤖 Generated with Paperclip