### PR TITLE
fix(provisioning): remove env vars with defaults from validation manifest

### DIFF
--- a/autobot-backend/startup_validation.py
+++ b/autobot-backend/startup_validation.py
@@ -34,9 +34,7 @@ def _load_required_vars() -> list[str]:
         "AUTOBOT_REDIS_URL",  # redis://host:port — composed by Ansible from backend_redis_host/port
         "AUTOBOT_AI_STACK_HOST",  # required Ansible inventory var (backend_ai_stack_host)
         "AUTOBOT_CHROMADB_HOST",  # required Ansible inventory var (backend_chromadb_host)
-        "AUTOBOT_JWT_SECRET",  # required Ansible inventory var (backend_jwt_secret)
         "AUTOBOT_DEFAULT_LLM_MODEL",  # required Ansible inventory var (backend_llm_model)
-        "AUTOBOT_EMBEDDING_MODEL",  # light-processing model tier — emitted from backend_light_model
     ]
 
 

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -278,9 +278,7 @@
       AUTOBOT_REDIS_URL
       AUTOBOT_AI_STACK_HOST
       AUTOBOT_CHROMADB_HOST
-      AUTOBOT_JWT_SECRET
       AUTOBOT_DEFAULT_LLM_MODEL
-      AUTOBOT_EMBEDDING_MODEL
   tags: ['backend', 'deploy']
 
 - name: Sync backend config directory from code_source


### PR DESCRIPTION
## Summary

Fixes GH#9084 — autobot-backend fails to start after provision due to startup_validation.py checking environment variables that have default values.

## Changes

Removed `AUTOBOT_JWT_SECRET` and `AUTOBOT_EMBEDDING_MODEL` from the validation manifest because both have `| default()` guards in `backend.env.j2` and are always set.

**Files modified:**
- `autobot-backend/startup_validation.py` — updated fallback list
- `autobot-slm-backend/ansible/roles/backend/tasks/main.yml` — updated manifest task

## Problem

The validation manifest was checking for vars that have defaults in the Ansible template:
- `AUTOBOT_JWT_SECRET` has `| default(backend_secret_key)` (line 30 of backend.env.j2)
- `AUTOBOT_EMBEDDING_MODEL` has `| default('phi3:mini')` (line 123 of backend.env.j2)

This caused false validation passes when required inventory vars were missing.

## Solution

The validation now only checks vars that must be explicitly set in inventory:
- `AUTOBOT_REDIS_URL`
- `AUTOBOT_AI_STACK_HOST`
- `AUTOBOT_CHROMADB_HOST`
- `AUTOBOT_DEFAULT_LLM_MODEL`

## Test plan

- [ ] Verify startup_validation.py passes with all required vars present
- [ ] Verify startup_validation.py fails when AUTOBOT_AI_STACK_HOST is missing
- [ ] Verify startup_validation.py passes even when AUTOBOT_JWT_SECRET is not in inventory (falls back to backend_secret_key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)