### PR TITLE
docs(frontend): clarify host composables scope and separation (#9063)

### DIFF
--- a/autobot-frontend/src/composables/useHostInventory.ts
+++ b/autobot-frontend/src/composables/useHostInventory.ts
@@ -4,6 +4,17 @@
 //
 // useHostInventory — SLM node/host management composable (GH#7513)
 // Calls the SLM backend /api/nodes endpoints.
+//
+// ⚠️ DISTINCT FROM useHostSelection (GH#9063 audit):
+// - useHostInventory: Ansible-managed fleet (SLM nodes with provisioning, roles, health metrics)
+//   → Admin dashboard for managing infrastructure nodes
+//   → Data source: SLM backend /api/nodes (node inventory, Ansible state)
+//
+// - useHostSelection: User-configured SSH targets (secrets.env infrastructure hosts)
+//   → Agent SSH actions + terminal selector
+//   → Data source: main backend /api/infrastructure/hosts (user secrets)
+//
+// These serve DIFFERENT purposes and MUST remain separate composables.
 
 import { ref } from 'vue'
 import { getSLMUrl } from '@/config/ssot-config'

--- a/autobot-frontend/src/composables/useHostSelection.ts
+++ b/autobot-frontend/src/composables/useHostSelection.ts
@@ -11,6 +11,17 @@
  * - Session-level host persistence
  * - API for agents to request host selection
  *
+ * ⚠️ DISTINCT FROM useHostInventory (GH#9063 audit):
+ * - useHostSelection: User-configured SSH targets from secrets.env
+ *   → Data source: main backend /api/infrastructure/hosts (user secrets)
+ *   → Used by: agent SSH actions, terminal selector, ui/HostSelector
+ *
+ * - useHostInventory: Ansible-managed fleet nodes
+ *   → Data source: SLM backend /api/nodes (Ansible inventory, provisioning)
+ *   → Used by: admin dashboard (HostsView.vue) for fleet management
+ *
+ * These serve DIFFERENT purposes and MUST remain separate composables.
+ *
  * fetchWithAuth replaced with useFetchEndpoint (Pattern A) for both
  * loadHosts and loadTerminalHosts (Issue #6089).
  */

--- a/autobot-frontend/src/composables/useHostSelector.ts
+++ b/autobot-frontend/src/composables/useHostSelector.ts
@@ -5,9 +5,16 @@
 /**
  * useHostSelector - Composable for the ui/HostSelector component
  *
- * GH#9063 consolidation: delegates host loading to useHostSelection
+ * ✅ GH#9063 consolidation COMPLETE: delegates host loading to useHostSelection
  * (same /api/infrastructure/hosts source) instead of making a separate
  * useFetchEndpoint call. Maps InfrastructureHost → SelectorHost shape.
+ *
+ * This composable is a THIN WRAPPER around useHostSelection that:
+ * - Provides the SelectorHost type shape for UI components
+ * - Applies client-side capability filtering
+ * - Maintains backward compatibility for components using the old API
+ *
+ * Data flow: useHostSelector → useHostSelection → /api/infrastructure/hosts
  *
  * Issue #6087
  */


### PR DESCRIPTION
## Summary

Resolves GH#9063 — audit of three host/node composables with overlapping scope.

**Investigation findings:**
- `useHostSelector` **already delegates** to `useHostSelection` (consolidation complete)
- `useHostInventory` and `useHostSelection` serve **legitimately different purposes**:
  - **useHostInventory**: SLM-managed Ansible fleet (`/api/nodes`) for admin provisioning
  - **useHostSelection**: User-configured SSH targets (`/api/infrastructure/hosts`) for agent actions

**Changes:**
- Added clear documentation headers to all three composables
- Explained data sources, use cases, and why they remain separate
- Marked useHostSelector consolidation as ✅ COMPLETE

## Evidence

**File changes:**
- `useHostInventory.ts`: Added distinction documentation
- `useHostSelection.ts`: Added distinction documentation  
- `useHostSelector.ts`: Marked consolidation complete

**Type check:** Documentation-only changes, no logic modified

## Test plan

- [x] Documentation headers added to all three composables
- [x] Clear explanation of separation rationale
- [x] No logic changes, purely clarifying comments

🤖 Generated with Paperclip