### PR TITLE
refactor(voice): consolidate VALID_BUNDLES and BundleAssignRequest into voice_bundle_constants.py (#9048)

### DIFF
--- a/autobot-backend/api/chat_embed.py
+++ b/autobot-backend/api/chat_embed.py
@@ -68,8 +68,7 @@ if _TRUSTED_PROXIES:
     )
 else:
     logger.info(
-        "Embed trusted proxies: none — rate limiting by direct connection IP only "
-        "(set %s if behind reverse proxy)",
+        "Embed trusted proxies: none — rate limiting by direct connection IP only " "(set %s if behind reverse proxy)",
         _TRUSTED_PROXIES_ENV,
     )
 

--- a/autobot-backend/api/chat_embed_test.py
+++ b/autobot-backend/api/chat_embed_test.py
@@ -139,9 +139,11 @@ async def test_origin_allowlist_blocks_disallowed_origin(client, mock_redis):
         # Need to reload the module to pick up new env var
         import importlib
         import api.chat_embed
+
         importlib.reload(api.chat_embed)
 
         from api.chat_embed import router as reloaded_router
+
         app = FastAPI()
         app.include_router(reloaded_router, prefix="/api")
         test_client = TestClient(app)
@@ -169,9 +171,11 @@ async def test_origin_allowlist_allows_configured_origin(client, mock_redis):
         # Reload module to pick up env var
         import importlib
         import api.chat_embed
+
         importlib.reload(api.chat_embed)
 
         from api.chat_embed import router as reloaded_router
+
         app = FastAPI()
         app.include_router(reloaded_router, prefix="/api")
         test_client = TestClient(app)
@@ -243,6 +247,7 @@ async def test_xff_ignored_when_peer_not_trusted(client, mock_redis):
         # Reload module to pick up env var
         import importlib
         import api.chat_embed
+
         importlib.reload(api.chat_embed)
 
         # Request from untrusted IP with spoofed X-Forwarded-For
@@ -271,6 +276,7 @@ async def test_xff_honored_when_peer_trusted(client, mock_redis):
         # Reload module to pick up env var
         import importlib
         import api.chat_embed
+
         importlib.reload(api.chat_embed)
 
         from api.chat_embed import _get_client_ip

--- a/autobot-backend/api/chat_embed_test.py
+++ b/autobot-backend/api/chat_embed_test.py
@@ -138,6 +138,7 @@ async def test_origin_allowlist_blocks_disallowed_origin(client, mock_redis):
     ):
         # Need to reload the module to pick up new env var
         import importlib
+
         import api.chat_embed
 
         importlib.reload(api.chat_embed)
@@ -170,6 +171,7 @@ async def test_origin_allowlist_allows_configured_origin(client, mock_redis):
     ):
         # Reload module to pick up env var
         import importlib
+
         import api.chat_embed
 
         importlib.reload(api.chat_embed)
@@ -246,14 +248,16 @@ async def test_xff_ignored_when_peer_not_trusted(client, mock_redis):
     ):
         # Reload module to pick up env var
         import importlib
+
         import api.chat_embed
 
         importlib.reload(api.chat_embed)
 
         # Request from untrusted IP with spoofed X-Forwarded-For
         # The rate limiter should use testclient's IP, not XFF value
-        from api.chat_embed import _get_client_ip
         from fastapi import Request
+
+        from api.chat_embed import _get_client_ip
 
         mock_request = MagicMock(spec=Request)
         mock_request.client = MagicMock()
@@ -275,12 +279,14 @@ async def test_xff_honored_when_peer_trusted(client, mock_redis):
     ):
         # Reload module to pick up env var
         import importlib
+
         import api.chat_embed
 
         importlib.reload(api.chat_embed)
 
-        from api.chat_embed import _get_client_ip
         from fastapi import Request
+
+        from api.chat_embed import _get_client_ip
 
         mock_request = MagicMock(spec=Request)
         mock_request.client = MagicMock()

--- a/autobot-backend/api/telegram_bot.py
+++ b/autobot-backend/api/telegram_bot.py
@@ -25,10 +25,10 @@ from autobot_shared.logging_manager import get_logger
 from services.gateway.gateway_manager import GatewayManager
 from services.telegram_bot_service import (
     TelegramBotService,
-    save_telegram_bot_token,
     get_telegram_bot_token,
-    save_telegram_webhook_secret,
     get_telegram_webhook_secret,
+    save_telegram_bot_token,
+    save_telegram_webhook_secret,
 )
 from utils.chat_utils import generate_request_id
 

--- a/autobot-backend/api/voice_bundle_admin.py
+++ b/autobot-backend/api/voice_bundle_admin.py
@@ -14,7 +14,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from api.redis_mcp.rbac import VALID_BUNDLES
+from api.voice_bundle_constants import VALID_BUNDLES, BundleAssignRequest
 from api.voice_bundle_user import _count_tools_for_bundle
 from auth_middleware import get_auth_middleware, get_current_user
 from autobot_shared.logging_manager import get_logger
@@ -60,10 +60,6 @@ class BundleAssignmentResponse(BaseModel):
     bundle_name: Optional[str]
 
 
-class BundleAssignRequest(BaseModel):
-    bundle_name: Optional[str] = None  # None = clear override
-
-
 # ---------------------------------------------------------------------------
 # GET /voice/realtime/bundle/me
 # ---------------------------------------------------------------------------
@@ -77,7 +73,11 @@ async def get_my_bundle(
     """Return the resolved voice bundle for the authenticated caller."""
     from api.redis_mcp.rbac import resolve_bundle_for_user  # noqa: PLC0415
 
-    user_id = current_user.get("user_id") or current_user.get("sub") or current_user.get("username")
+    user_id = (
+        current_user.get("user_id")
+        or current_user.get("sub")
+        or current_user.get("username")
+    )
     role = current_user.get("role", "user")
     is_admin = role == "admin"
 
@@ -96,7 +96,9 @@ async def get_my_bundle(
 # ---------------------------------------------------------------------------
 
 
-@bundle_admin_router.get("/voice/bundle/{user_id}", response_model=BundleAssignmentResponse)
+@bundle_admin_router.get(
+    "/voice/bundle/{user_id}", response_model=BundleAssignmentResponse
+)
 async def get_user_bundle(
     user_id: str,
     request: Request,
@@ -127,7 +129,9 @@ async def get_user_bundle(
 # ---------------------------------------------------------------------------
 
 
-@bundle_admin_router.put("/voice/bundle/{user_id}", response_model=BundleAssignmentResponse)
+@bundle_admin_router.put(
+    "/voice/bundle/{user_id}", response_model=BundleAssignmentResponse
+)
 async def set_user_bundle(
     user_id: str,
     body: BundleAssignRequest,
@@ -141,7 +145,12 @@ async def set_user_bundle(
             detail=f"Invalid bundle_name '{body.bundle_name}'. Valid: {sorted(VALID_BUNDLES)}",
         )
 
-    admin_id = admin_user.get("user_id") or admin_user.get("sub") or admin_user.get("username") or "unknown"
+    admin_id = (
+        admin_user.get("user_id")
+        or admin_user.get("sub")
+        or admin_user.get("username")
+        or "unknown"
+    )
 
     try:
         from sqlalchemy import text  # noqa: PLC0415

--- a/autobot-backend/api/voice_bundle_admin.py
+++ b/autobot-backend/api/voice_bundle_admin.py
@@ -73,11 +73,7 @@ async def get_my_bundle(
     """Return the resolved voice bundle for the authenticated caller."""
     from api.redis_mcp.rbac import resolve_bundle_for_user  # noqa: PLC0415
 
-    user_id = (
-        current_user.get("user_id")
-        or current_user.get("sub")
-        or current_user.get("username")
-    )
+    user_id = current_user.get("user_id") or current_user.get("sub") or current_user.get("username")
     role = current_user.get("role", "user")
     is_admin = role == "admin"
 
@@ -96,9 +92,7 @@ async def get_my_bundle(
 # ---------------------------------------------------------------------------
 
 
-@bundle_admin_router.get(
-    "/voice/bundle/{user_id}", response_model=BundleAssignmentResponse
-)
+@bundle_admin_router.get("/voice/bundle/{user_id}", response_model=BundleAssignmentResponse)
 async def get_user_bundle(
     user_id: str,
     request: Request,
@@ -129,9 +123,7 @@ async def get_user_bundle(
 # ---------------------------------------------------------------------------
 
 
-@bundle_admin_router.put(
-    "/voice/bundle/{user_id}", response_model=BundleAssignmentResponse
-)
+@bundle_admin_router.put("/voice/bundle/{user_id}", response_model=BundleAssignmentResponse)
 async def set_user_bundle(
     user_id: str,
     body: BundleAssignRequest,
@@ -145,12 +137,7 @@ async def set_user_bundle(
             detail=f"Invalid bundle_name '{body.bundle_name}'. Valid: {sorted(VALID_BUNDLES)}",
         )
 
-    admin_id = (
-        admin_user.get("user_id")
-        or admin_user.get("sub")
-        or admin_user.get("username")
-        or "unknown"
-    )
+    admin_id = admin_user.get("user_id") or admin_user.get("sub") or admin_user.get("username") or "unknown"
 
     try:
         from sqlalchemy import text  # noqa: PLC0415

--- a/autobot-backend/api/voice_bundle_constants.py
+++ b/autobot-backend/api/voice_bundle_constants.py
@@ -1,0 +1,49 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Consolidated voice bundle constants and schemas (GH#9048).
+
+This module serves as the single source of truth for voice bundle definitions,
+replacing duplicate constants previously scattered across voice_bundle_user.py
+and voice_bundle_admin.py.
+"""
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+from api.redis_mcp.rbac import VALID_BUNDLES as _VALID_BUNDLES
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Re-export VALID_BUNDLES from rbac.py as the canonical source
+VALID_BUNDLES: frozenset[str] = _VALID_BUNDLES
+
+# Bundle metadata: human-readable labels and descriptions
+BUNDLE_DEFINITIONS: dict[str, dict[str, str]] = {
+    "voice_safe": {
+        "label": "Voice Safe",
+        "description": "Basic voice commands for standard users",
+    },
+    "voice_extended": {
+        "label": "Voice Extended",
+        "description": "Extended voice commands with advanced features",
+    },
+    "voice_admin": {
+        "label": "Voice Admin",
+        "description": "Full voice command set for administrators",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class BundleAssignRequest(BaseModel):
+    """Request to assign or clear a bundle for a user."""
+
+    bundle_name: Optional[str] = None  # None = clear override

--- a/autobot-backend/api/voice_bundle_user.py
+++ b/autobot-backend/api/voice_bundle_user.py
@@ -68,9 +68,7 @@ async def _count_tools_for_bundle(bundle: str, is_admin: bool) -> int:
         )
 
         all_tools = list(TOOL_ACCESS_MATRIX.keys())
-        _tool_count_cache[key] = len(
-            filter_tools_for_bundle(all_tools, bundle=bundle, is_admin=is_admin)
-        )
+        _tool_count_cache[key] = len(filter_tools_for_bundle(all_tools, bundle=bundle, is_admin=is_admin))
     return _tool_count_cache[key]
 
 
@@ -83,9 +81,7 @@ def _get_user_id(user: dict) -> str:
     return user.get("user_id") or user.get("sub") or user.get("username") or "unknown"
 
 
-def _check_self_or_admin(
-    request: Request, current_user: dict, target_user_id: str
-) -> bool:
+def _check_self_or_admin(request: Request, current_user: dict, target_user_id: str) -> bool:
     """Verify user can access target_user_id (self or admin)."""
     current_user_id = _get_user_id(current_user)
     return current_user_id == target_user_id or _is_admin(current_user)
@@ -264,9 +260,7 @@ async def set_user_bundle(
                 )
             )
         except Exception:
-            logger.warning(
-                "set_user_bundle: failed to emit failure audit", exc_info=True
-            )
+            logger.warning("set_user_bundle: failed to emit failure audit", exc_info=True)
         logger.error("set_user_bundle: DB error: %s", exc)
         raise HTTPException(status_code=500, detail="Database error") from exc
 

--- a/autobot-backend/api/voice_bundle_user.py
+++ b/autobot-backend/api/voice_bundle_user.py
@@ -14,7 +14,11 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from api.redis_mcp.rbac import VALID_BUNDLES
+from api.voice_bundle_constants import (
+    BUNDLE_DEFINITIONS,
+    VALID_BUNDLES,
+    BundleAssignRequest,
+)
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -47,32 +51,6 @@ class UserBundleResponse(BaseModel):
     bundle_name: Optional[str] = None
 
 
-class BundleAssignRequest(BaseModel):
-    """Request to assign or clear a bundle for a user."""
-
-    bundle_name: Optional[str] = None  # None = clear override
-
-
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
-BUNDLE_DEFINITIONS: dict[str, dict[str, str]] = {
-    "voice_safe": {
-        "label": "Voice Safe",
-        "description": "Basic voice commands for standard users",
-    },
-    "voice_extended": {
-        "label": "Voice Extended",
-        "description": "Extended voice commands with advanced features",
-    },
-    "voice_admin": {
-        "label": "Voice Admin",
-        "description": "Full voice command set for administrators",
-    },
-}
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -84,10 +62,15 @@ async def _count_tools_for_bundle(bundle: str, is_admin: bool) -> int:
     """Return the number of tools available in this bundle (cached per bundle+role)."""
     key = (bundle, is_admin)
     if key not in _tool_count_cache:
-        from api.redis_mcp.rbac import TOOL_ACCESS_MATRIX, filter_tools_for_bundle  # noqa: PLC0415
+        from api.redis_mcp.rbac import (  # noqa: PLC0415
+            TOOL_ACCESS_MATRIX,
+            filter_tools_for_bundle,
+        )
 
         all_tools = list(TOOL_ACCESS_MATRIX.keys())
-        _tool_count_cache[key] = len(filter_tools_for_bundle(all_tools, bundle=bundle, is_admin=is_admin))
+        _tool_count_cache[key] = len(
+            filter_tools_for_bundle(all_tools, bundle=bundle, is_admin=is_admin)
+        )
     return _tool_count_cache[key]
 
 
@@ -100,7 +83,9 @@ def _get_user_id(user: dict) -> str:
     return user.get("user_id") or user.get("sub") or user.get("username") or "unknown"
 
 
-def _check_self_or_admin(request: Request, current_user: dict, target_user_id: str) -> bool:
+def _check_self_or_admin(
+    request: Request, current_user: dict, target_user_id: str
+) -> bool:
     """Verify user can access target_user_id (self or admin)."""
     current_user_id = _get_user_id(current_user)
     return current_user_id == target_user_id or _is_admin(current_user)
@@ -251,7 +236,11 @@ async def set_user_bundle(
                               assigned_by = EXCLUDED.assigned_by,
                               assigned_at = EXCLUDED.assigned_at
                         """),
-                    {"uid": user_id, "bundle": body.bundle_name, "by": str(current_user_id)},
+                    {
+                        "uid": user_id,
+                        "bundle": body.bundle_name,
+                        "by": str(current_user_id),
+                    },
                 )
             await session.commit()
             # Re-read after commit so response reflects actual stored value.
@@ -275,7 +264,9 @@ async def set_user_bundle(
                 )
             )
         except Exception:
-            logger.warning("set_user_bundle: failed to emit failure audit", exc_info=True)
+            logger.warning(
+                "set_user_bundle: failed to emit failure audit", exc_info=True
+            )
         logger.error("set_user_bundle: DB error: %s", exc)
         raise HTTPException(status_code=500, detail="Database error") from exc
 

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -30,7 +30,6 @@ from api.chat_embed import router as chat_embed_router  # GH#9047
 from api.chat_presets import router as chat_presets_router  # GH#8595
 from api.collaboration import router as collaboration_router
 from api.config_revisions import router as config_revisions_router  # #1404
-from api.telegram_bot import router as telegram_bot_router  # MVA-2074
 from api.data_storage import router as data_storage_router
 from api.database_mcp import router as database_mcp_router
 from api.developer import router as developer_router
@@ -83,6 +82,7 @@ from api.service_messages import router as service_messages_router
 from api.settings import router as settings_router
 from api.structured_thinking_mcp import router as structured_thinking_mcp_router
 from api.system import router as system_router
+from api.telegram_bot import router as telegram_bot_router  # MVA-2074
 from api.usage import router as usage_router  # Issue #1807
 from api.user_management.router import router as user_management_router  # Issue #1801
 from api.vnc_manager import router as vnc_router

--- a/autobot-backend/integrations/whatsapp_integration.py
+++ b/autobot-backend/integrations/whatsapp_integration.py
@@ -21,7 +21,6 @@ import json
 import time
 from typing import Any, Dict, List
 
-
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
 from integrations.base import (

--- a/autobot-backend/integrations/whatsapp_integration.py
+++ b/autobot-backend/integrations/whatsapp_integration.py
@@ -21,7 +21,6 @@ import json
 import time
 from typing import Any, Dict, List
 
-import aiohttp
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client

--- a/autobot-backend/integrations/whatsapp_integration_test.py
+++ b/autobot-backend/integrations/whatsapp_integration_test.py
@@ -5,13 +5,12 @@
 Tests for WhatsApp Business API Integration (Issue #9007)
 """
 
-import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
 from integrations.base import IntegrationConfig, IntegrationStatus
-from integrations.whatsapp_integration import WhatsAppIntegration, WhatsAppOptInStatus
+from integrations.whatsapp_integration import WhatsAppIntegration
 
 
 @pytest.fixture

--- a/autobot-backend/llc/services/template.py
+++ b/autobot-backend/llc/services/template.py
@@ -614,7 +614,8 @@ def _load_built_in_template(template_key: str) -> Dict[str, Any]:
     # Validate template_key against strict allowlist to prevent path traversal
     if not re.fullmatch(r"[a-z0-9_-]+", template_key):
         raise BuiltInTemplateNotFoundError(
-            f"Invalid template key '{template_key}' — must contain only lowercase letters, numbers, hyphens, and underscores"
+            f"Invalid template key '{template_key}' — must contain only lowercase letters, "
+            f"numbers, hyphens, and underscores"
         )
 
     template_path = _BUILT_IN_TEMPLATES_DIR / f"{template_key}.json"

--- a/autobot-backend/llm_shared/fallback_chain_test.py
+++ b/autobot-backend/llm_shared/fallback_chain_test.py
@@ -7,7 +7,6 @@ Tests for model fallback chain manager (GH#8998).
 
 import os
 
-import pytest
 
 from .fallback_chain import FallbackChain, FallbackChainManager, get_fallback_chain_manager
 

--- a/autobot-backend/llm_shared/fallback_chain_test.py
+++ b/autobot-backend/llm_shared/fallback_chain_test.py
@@ -7,7 +7,6 @@ Tests for model fallback chain manager (GH#8998).
 
 import os
 
-
 from .fallback_chain import FallbackChain, FallbackChainManager, get_fallback_chain_manager
 
 

--- a/autobot-backend/llm_shared/providers/bedrock.py
+++ b/autobot-backend/llm_shared/providers/bedrock.py
@@ -24,7 +24,6 @@ import time
 from typing import Any, AsyncIterator, Dict, List
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.ssot_config import config
 from llm_shared.models import LLMRequest, LLMResponse, ToolCall
 from llm_shared.types import ProviderType
 
@@ -534,7 +533,7 @@ class BedrockProvider(BaseProvider):
     async def is_available(self) -> bool:
         """Return True if Bedrock credentials are configured and the service is reachable."""
         try:
-            client = self._ensure_runtime_client()
+            self._ensure_runtime_client()  # Verify runtime client can be created
             # Simple health check - list foundation models (no cost)
             import boto3
 

--- a/autobot-backend/services/telegram_bot_service.py
+++ b/autobot-backend/services/telegram_bot_service.py
@@ -8,8 +8,9 @@ Manages Telegram bot instance, sends messages via Bot API,
 and handles webhook verification.
 """
 
-import aiohttp
 from typing import Any, Dict, Optional
+
+import aiohttp
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client


### PR DESCRIPTION
## Thinking Path

GitHub issue #9048 identified duplicate definitions of `VALID_BUNDLES` and `BundleAssignRequest` across three files:
- `voice_bundle_user.py` defined `BundleAssignRequest` and `BUNDLE_DEFINITIONS`
- `voice_bundle_admin.py` duplicated `BundleAssignRequest`
- `rbac.py` defined `_VALID_BUNDLES` as the source of truth

The duplication creates maintenance risk — adding or renaming bundles requires updates in multiple places. The fix: create a single constants module that re-exports `VALID_BUNDLES` from rbac.py and consolidates the schema and metadata.

## What Changed

- Created `autobot-backend/api/voice_bundle_constants.py` as the single source of truth for voice bundle constants
- Moved `BUNDLE_DEFINITIONS` from `voice_bundle_user.py` to the new constants module
- Deduplicated `BundleAssignRequest` Pydantic model (was independently defined in both `voice_bundle_user.py` and `voice_bundle_admin.py`)
- Re-exported `VALID_BUNDLES` from `api.redis_mcp.rbac` as the canonical import point
- Updated both `voice_bundle_user.py` and `voice_bundle_admin.py` to import from the new module

## Verification

- [x] Python syntax check passes on all three files
- [x] Import verification: `voice_bundle_constants`, `voice_bundle_user`, `voice_bundle_admin` all import cleanly
- [x] Test suite: 42/48 tests pass (6 failures are pre-existing, unrelated to this change — `database.session` module not available in test env)
- [ ] Verify bundle assignment endpoints work end-to-end in staging

## Model Used

Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)

## Related Issues

Closes #9048