### PR TITLE
feat(mcp): implement resource/prompt infrastructure in filesystem bridge (MVA-2164)

### DIFF
--- a/autobot-backend/api/filesystem_mcp.py
+++ b/autobot-backend/api/filesystem_mcp.py
@@ -11,6 +11,8 @@ Provides comprehensive file operations with robust security boundaries:
 - Write operations (create, edit)
 - Directory management (create, list, move)
 - Discovery/analysis (search, tree, metadata)
+- MCP Resources (Issue MVA-2164): Expose filesystem paths as browseable resources
+- MCP Prompts (Issue MVA-2164): Predefined prompt templates for common tasks
 
 Security Model:
 - Whitelist-based directory access control
@@ -20,6 +22,82 @@ Security Model:
 
 Issue #718: Uses dedicated thread pool for file I/O to prevent blocking
 when the main asyncio thread pool is saturated by indexing operations.
+
+MCP Resources and Prompts Architecture (Issue MVA-2164)
+========================================================
+
+Resources:
+----------
+MCP resources provide a standardized way to expose filesystem paths as
+browseable, addressable resources using the file:// URI scheme.
+
+Endpoints:
+  - GET  /mcp/resources       - List available file resources
+  - POST /mcp/resources/read  - Read a resource by URI (file:// scheme)
+
+Resource URIs follow the pattern: file:///absolute/path/to/resource
+
+Implementation Details:
+  - Resources are generated from ALLOWED_DIRECTORIES
+  - Only directories that exist are exposed as resources
+  - URI-to-path conversion validates against security boundaries
+  - MIME type detection for proper content handling
+  - Same size limits apply as for regular file reads (MAX_FILE_SIZE)
+
+Prompts:
+--------
+MCP prompt templates provide predefined, parameterized prompts for common
+filesystem analysis tasks. Templates interpolate arguments to generate
+contextual instructions for LLMs.
+
+Endpoints:
+  - GET  /mcp/prompts     - List available prompt templates
+  - POST /mcp/prompts/get - Get a specific prompt with arguments
+
+Available Templates:
+  1. analyze_directory - Analyze directory structure and contents
+     Arguments: path (required)
+
+  2. summarize_file - Generate a summary of file contents
+     Arguments: path (required), focus (optional)
+
+  3. search_pattern - Search for files matching a pattern with context
+     Arguments: directory (required), pattern (required)
+
+Implementation Details:
+  - Templates are defined in-code for type safety and validation
+  - Arguments are validated at runtime before interpolation
+  - Generated prompts follow the messages format (role + content)
+  - Templates can be extended by adding new cases to get_prompt_mcp
+
+Usage Example:
+--------------
+    # List available resources
+    GET /api/filesystem/mcp/resources
+
+    # Read a resource
+    POST /api/filesystem/mcp/resources/read
+    {"uri": "file:///tmp/autobot/data.json"}
+
+    # List prompt templates
+    GET /api/filesystem/mcp/prompts
+
+    # Get a prompt template
+    POST /api/filesystem/mcp/prompts/get
+    {
+      "name": "analyze_directory",
+      "arguments": {"path": "/tmp/autobot/logs"}
+    }
+
+Future Extensions:
+------------------
+Other MCP bridges can follow this pattern by:
+  1. Implementing GET /<bridge>/mcp/resources endpoint
+  2. Implementing POST /<bridge>/mcp/resources/read endpoint
+  3. Implementing GET /<bridge>/mcp/prompts endpoint
+  4. Implementing POST /<bridge>/mcp/prompts/get endpoint
+  5. Using appropriate URI schemes for their resource types
+  6. Defining domain-specific prompt templates
 """
 
 import asyncio
@@ -84,18 +162,26 @@ from api.schemas_code import (
     FilesystemListDirectoryResponse,
     FilesystemListDirectoryWithSizesResponse,
     FilesystemMoveFileResponse,
+    FilesystemPromptGetResponse,
+    FilesystemPromptsListResponse,
     FilesystemReadMediaResponse,
     FilesystemReadMultipleResponse,
     FilesystemReadTextResponse,
+    FilesystemResourceReadResponse,
+    FilesystemResourcesListResponse,
     FilesystemSearchFilesResponse,
     FilesystemWriteFileResponse,
     GetFileInfoRequest,
+    GetPromptRequest,
     ListDirectoryRequest,
     ListDirectoryWithSizesRequest,
+    MCPPromptTemplate,
+    MCPResource,
     MCPTool,
     MoveFileRequest,
     ReadMediaFileRequest,
     ReadMultipleFilesRequest,
+    ReadResourceRequest,
     ReadTextFileRequest,
     SearchFilesRequest,
     WriteFileRequest,
@@ -1329,3 +1415,286 @@ async def list_allowed_directories_mcp(
             "max_file_size_bytes": MAX_FILE_SIZE,
         },
     }
+
+
+# ---------------------------------------------------------------------------
+# MCP Resources and Prompts (Issue MVA-2164)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/mcp/resources", response_model=FilesystemResourcesListResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_resources_mcp",
+    error_code_prefix="FILESYSTEM_MCP",
+)
+async def list_resources_mcp(
+    admin_check: bool = Depends(check_admin_permission),
+) -> Metadata:
+    """
+    List available file resources as MCP resources.
+
+    Issue MVA-2164: Exposes allowed directories as browseable resources.
+    Issue #744: Requires admin authentication.
+
+    Resources use file:// URI scheme for accessing filesystem paths.
+    Each allowed directory is exposed as a resource that can be read
+    via the /mcp/resources/read endpoint.
+    """
+    resources = []
+
+    for allowed_dir in ALLOWED_DIRECTORIES:
+        # Check if directory exists
+        dir_exists = await run_in_file_executor(os.path.exists, allowed_dir)
+        if dir_exists:
+            is_dir = await run_in_file_executor(os.path.isdir, allowed_dir)
+            if is_dir:
+                # Create resource for directory
+                dir_name = os.path.basename(allowed_dir.rstrip("/")) or "root"
+                resources.append(
+                    {
+                        "uri": f"file://{allowed_dir}",
+                        "name": dir_name,
+                        "description": f"Directory: {allowed_dir}",
+                        "mime_type": "inode/directory",
+                    }
+                )
+
+    return {
+        "success": True,
+        "resources": resources,
+        "total": len(resources),
+    }
+
+
+@router.post("/mcp/resources/read", response_model=FilesystemResourceReadResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="read_resource_mcp",
+    error_code_prefix="FILESYSTEM_MCP",
+)
+async def read_resource_mcp(
+    request: ReadResourceRequest,
+    admin_check: bool = Depends(check_admin_permission),
+) -> Metadata:
+    """
+    Read a resource by its URI.
+
+    Issue MVA-2164: Implements MCP resource reading via file:// URIs.
+    Issue #744: Requires admin authentication.
+
+    Supports file:// URI scheme for accessing filesystem paths.
+    The URI is converted to a filesystem path and validated against
+    allowed directories before reading.
+    """
+    # Parse file:// URI
+    if not request.uri.startswith("file://"):
+        raise_invalid_input("uri", "Only file:// URIs are supported")
+
+    # Extract path from URI
+    path = request.uri[7:]  # Remove 'file://'
+
+    # Validate path
+    safe_path = _validated_path(path)
+
+    # Check if path exists
+    path_exists = await run_in_file_executor(os.path.exists, safe_path)
+    if not path_exists:
+        raise_not_found("Resource", request.uri)
+
+    # Check if it's a file
+    is_file = await run_in_file_executor(os.path.isfile, safe_path)
+    if not is_file:
+        raise_invalid_input("uri", f"Resource is not a file: {request.uri}")
+
+    # Check file size
+    file_size = await run_in_file_executor(os.path.getsize, safe_path)
+    if file_size > MAX_FILE_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Resource too large: {file_size} bytes (max {MAX_FILE_SIZE})",
+        )
+
+    # Detect MIME type
+    mime_type, _ = mimetypes.guess_type(safe_path)
+    if mime_type is None:
+        mime_type = "text/plain"
+
+    try:
+        async with aiofiles.open(safe_path, "r", encoding="utf-8") as f:  # codeql[py/path-injection]
+            content = await f.read()
+
+        return {
+            "success": True,
+            "uri": request.uri,
+            "content": content,
+            "mime_type": mime_type,
+            "size_bytes": file_size,
+        }
+    except UnicodeDecodeError:
+        raise_invalid_input("uri", "Resource is not a text file")
+    except OSError:
+        raise_internal_error("Failed to read resource")
+
+
+@router.get("/mcp/prompts", response_model=FilesystemPromptsListResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_prompts_mcp",
+    error_code_prefix="FILESYSTEM_MCP",
+)
+async def list_prompts_mcp(
+    admin_check: bool = Depends(check_admin_permission),
+) -> Metadata:
+    """
+    List available prompt templates.
+
+    Issue MVA-2164: Exposes predefined prompt templates for common
+    filesystem analysis tasks.
+    Issue #744: Requires admin authentication.
+
+    Templates can be invoked via the /mcp/prompts/get endpoint with
+    appropriate arguments to generate contextual prompts.
+    """
+    prompts = [
+        {
+            "name": "analyze_directory",
+            "description": "Analyze directory structure and contents",
+            "arguments": [
+                {
+                    "name": "path",
+                    "description": "Directory path to analyze",
+                    "required": True,
+                }
+            ],
+        },
+        {
+            "name": "summarize_file",
+            "description": "Generate a summary of a file's contents",
+            "arguments": [
+                {
+                    "name": "path",
+                    "description": "File path to summarize",
+                    "required": True,
+                },
+                {
+                    "name": "focus",
+                    "description": "Aspect to focus on (e.g., 'structure', 'security', 'performance')",
+                    "required": False,
+                },
+            ],
+        },
+        {
+            "name": "search_pattern",
+            "description": "Search for files matching a pattern with context",
+            "arguments": [
+                {
+                    "name": "directory",
+                    "description": "Directory to search in",
+                    "required": True,
+                },
+                {
+                    "name": "pattern",
+                    "description": "File pattern to search for",
+                    "required": True,
+                },
+            ],
+        },
+    ]
+
+    return {
+        "success": True,
+        "prompts": prompts,
+        "total": len(prompts),
+    }
+
+
+@router.post("/mcp/prompts/get", response_model=FilesystemPromptGetResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_prompt_mcp",
+    error_code_prefix="FILESYSTEM_MCP",
+)
+async def get_prompt_mcp(
+    request: GetPromptRequest,
+    admin_check: bool = Depends(check_admin_permission),
+) -> Metadata:
+    """
+    Get a specific prompt template with arguments interpolated.
+
+    Issue MVA-2164: Returns formatted prompt messages for common
+    filesystem analysis tasks.
+    Issue #744: Requires admin authentication.
+
+    The template arguments are validated and interpolated into the
+    prompt to generate contextual instructions for LLMs.
+    """
+    if request.name == "analyze_directory":
+        path = request.arguments.get("path")
+        if not path:
+            raise_invalid_input("arguments", "Missing required argument: path")
+
+        return {
+            "success": True,
+            "name": request.name,
+            "description": "Analyze directory structure and contents",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": f"Please analyze the directory at {path}. "
+                    f"Provide insights on:\n"
+                    f"- Directory structure and organization\n"
+                    f"- File types and distributions\n"
+                    f"- Potential issues or improvements\n"
+                    f"- Overall code quality indicators",
+                }
+            ],
+        }
+
+    elif request.name == "summarize_file":
+        path = request.arguments.get("path")
+        if not path:
+            raise_invalid_input("arguments", "Missing required argument: path")
+
+        focus = request.arguments.get("focus", "general overview")
+        return {
+            "success": True,
+            "name": request.name,
+            "description": "Generate a summary of a file's contents",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": f"Please summarize the file at {path}. "
+                    f"Focus on: {focus}.\n"
+                    f"Provide a concise but comprehensive summary.",
+                }
+            ],
+        }
+
+    elif request.name == "search_pattern":
+        directory = request.arguments.get("directory")
+        pattern = request.arguments.get("pattern")
+
+        if not directory:
+            raise_invalid_input("arguments", "Missing required argument: directory")
+        if not pattern:
+            raise_invalid_input("arguments", "Missing required argument: pattern")
+
+        return {
+            "success": True,
+            "name": request.name,
+            "description": "Search for files matching a pattern with context",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": f"Search for files in {directory} matching pattern '{pattern}'.\n"
+                    f"For each match, provide:\n"
+                    f"- File location and purpose\n"
+                    f"- Key contents or functionality\n"
+                    f"- Relationships to other files",
+                }
+            ],
+        }
+
+    else:
+        raise_invalid_input("name", f"Unknown prompt template: {request.name}")

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -1481,6 +1481,71 @@ class FilesystemListAllowedResponse(BaseModel):
     security_info: FilesystemSecurityInfo
 
 
+class MCPResource(BaseModel):
+    """MCP resource definition."""
+
+    uri: str = Field(..., description="Resource URI (e.g., file:///path/to/file)")
+    name: str = Field(..., description="Human-readable resource name")
+    description: str | None = Field(None, description="Resource description")
+    mime_type: str | None = Field(None, description="MIME type of the resource")
+
+
+class MCPPromptTemplate(BaseModel):
+    """MCP prompt template definition."""
+
+    name: str = Field(..., description="Prompt template name")
+    description: str | None = Field(None, description="Template description")
+    arguments: List[Dict[str, Any]] = Field(default_factory=list, description="Template arguments schema")
+
+
+class FilesystemResourcesListResponse(BaseModel):
+    """Response for GET /mcp/resources."""
+
+    success: bool
+    resources: List[MCPResource]
+    total: int
+
+
+class ReadResourceRequest(BaseModel):
+    """Request model for reading a resource by URI."""
+
+    uri: str = Field(..., description="Resource URI (file:// scheme)")
+
+
+class FilesystemResourceReadResponse(BaseModel):
+    """Response for POST /mcp/resources/read."""
+
+    success: bool
+    uri: str
+    content: str
+    mime_type: str | None = None
+    size_bytes: int
+
+
+class FilesystemPromptsListResponse(BaseModel):
+    """Response for GET /mcp/prompts."""
+
+    success: bool
+    prompts: List[MCPPromptTemplate]
+    total: int
+
+
+class GetPromptRequest(BaseModel):
+    """Request model for getting a prompt template."""
+
+    name: str = Field(..., description="Prompt template name")
+    arguments: Dict[str, Any] = Field(default_factory=dict, description="Template arguments")
+
+
+class FilesystemPromptGetResponse(BaseModel):
+    """Response for POST /mcp/prompts/get."""
+
+    success: bool
+    name: str
+    description: str | None = None
+    messages: List[Dict[str, str]]
+
+
 class MCPTool(BaseModel):
     """Standard MCP tool definition (shared across all MCP endpoint files)."""
 

--- a/autobot-backend/tests/api/test_filesystem_mcp_resources_prompts.py
+++ b/autobot-backend/tests/api/test_filesystem_mcp_resources_prompts.py
@@ -1,0 +1,262 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for MCP Resources and Prompts endpoints (Issue MVA-2164)
+
+Tests the filesystem MCP bridge's resource and prompt template functionality,
+ensuring proper URI handling, validation, and template rendering.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def test_file(tmp_path):
+    """Create a test file for resource reading tests."""
+    test_file = tmp_path / "test_resource.txt"
+    test_file.write_text("Test resource content\nLine 2\nLine 3")
+    return str(test_file)
+
+
+class TestMCPResources:
+    """Tests for MCP resource endpoints."""
+
+    def test_list_resources_success(self, client: TestClient, admin_headers):
+        """Test listing available MCP resources."""
+        response = client.get("/api/filesystem/mcp/resources", headers=admin_headers)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["success"] is True
+        assert "resources" in data
+        assert "total" in data
+        assert isinstance(data["resources"], list)
+        assert data["total"] >= 0
+
+        # Verify resource structure if any exist
+        if data["resources"]:
+            resource = data["resources"][0]
+            assert "uri" in resource
+            assert "name" in resource
+            assert resource["uri"].startswith("file://")
+
+    def test_list_resources_requires_auth(self, client: TestClient):
+        """Test that listing resources requires admin authentication."""
+        response = client.get("/api/filesystem/mcp/resources")
+        assert response.status_code == 401
+
+    def test_read_resource_success(self, client: TestClient, admin_headers, test_file, monkeypatch):
+        """Test reading a resource by URI."""
+        # Mock is_path_allowed to accept test file
+        from api import filesystem_mcp
+
+        original_allowed = filesystem_mcp.ALLOWED_DIRECTORIES
+        monkeypatch.setattr(filesystem_mcp, "ALLOWED_DIRECTORIES", [str(test_file.rsplit("/", 1)[0]) + "/"])
+
+        uri = f"file://{test_file}"
+        response = client.post(
+            "/api/filesystem/mcp/resources/read",
+            headers=admin_headers,
+            json={"uri": uri},
+        )
+
+        # Restore original
+        monkeypatch.setattr(filesystem_mcp, "ALLOWED_DIRECTORIES", original_allowed)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["uri"] == uri
+        assert "Test resource content" in data["content"]
+        assert data["size_bytes"] > 0
+        assert "mime_type" in data
+
+    def test_read_resource_invalid_uri_scheme(self, client: TestClient, admin_headers):
+        """Test that non-file:// URIs are rejected."""
+        response = client.post(
+            "/api/filesystem/mcp/resources/read",
+            headers=admin_headers,
+            json={"uri": "http://example.com/file"},
+        )
+        assert response.status_code == 400
+        data = response.json()
+        assert "Only file:// URIs are supported" in data["detail"]
+
+    def test_read_resource_not_found(self, client: TestClient, admin_headers, monkeypatch):
+        """Test reading a non-existent resource."""
+        from api import filesystem_mcp
+
+        original_allowed = filesystem_mcp.ALLOWED_DIRECTORIES
+        monkeypatch.setattr(filesystem_mcp, "ALLOWED_DIRECTORIES", ["/tmp/"])
+
+        response = client.post(
+            "/api/filesystem/mcp/resources/read",
+            headers=admin_headers,
+            json={"uri": "file:///tmp/nonexistent_file.txt"},
+        )
+
+        monkeypatch.setattr(filesystem_mcp, "ALLOWED_DIRECTORIES", original_allowed)
+
+        assert response.status_code == 404
+
+    def test_read_resource_requires_auth(self, client: TestClient, test_file):
+        """Test that reading resources requires admin authentication."""
+        uri = f"file://{test_file}"
+        response = client.post("/api/filesystem/mcp/resources/read", json={"uri": uri})
+        assert response.status_code == 401
+
+
+class TestMCPPrompts:
+    """Tests for MCP prompt template endpoints."""
+
+    def test_list_prompts_success(self, client: TestClient, admin_headers):
+        """Test listing available prompt templates."""
+        response = client.get("/api/filesystem/mcp/prompts", headers=admin_headers)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["success"] is True
+        assert "prompts" in data
+        assert "total" in data
+        assert isinstance(data["prompts"], list)
+        assert data["total"] >= 2  # Should have at least 2 prompts
+
+        # Verify prompt structure
+        prompt = data["prompts"][0]
+        assert "name" in prompt
+        assert "description" in prompt
+        assert "arguments" in prompt
+
+    def test_list_prompts_requires_auth(self, client: TestClient):
+        """Test that listing prompts requires admin authentication."""
+        response = client.get("/api/filesystem/mcp/prompts")
+        assert response.status_code == 401
+
+    def test_get_prompt_analyze_directory(self, client: TestClient, admin_headers):
+        """Test getting the analyze_directory prompt template."""
+        response = client.post(
+            "/api/filesystem/mcp/prompts/get",
+            headers=admin_headers,
+            json={
+                "name": "analyze_directory",
+                "arguments": {"path": "/tmp/test_dir"},
+            },
+        )
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["success"] is True
+        assert data["name"] == "analyze_directory"
+        assert "messages" in data
+        assert len(data["messages"]) > 0
+
+        message = data["messages"][0]
+        assert message["role"] == "user"
+        assert "/tmp/test_dir" in message["content"]
+        assert "analyze" in message["content"].lower()
+
+    def test_get_prompt_summarize_file(self, client: TestClient, admin_headers):
+        """Test getting the summarize_file prompt template."""
+        response = client.post(
+            "/api/filesystem/mcp/prompts/get",
+            headers=admin_headers,
+            json={
+                "name": "summarize_file",
+                "arguments": {"path": "/tmp/test.py", "focus": "security"},
+            },
+        )
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["success"] is True
+        assert data["name"] == "summarize_file"
+        assert len(data["messages"]) > 0
+
+        message = data["messages"][0]
+        assert "/tmp/test.py" in message["content"]
+        assert "security" in message["content"]
+
+    def test_get_prompt_search_pattern(self, client: TestClient, admin_headers):
+        """Test getting the search_pattern prompt template."""
+        response = client.post(
+            "/api/filesystem/mcp/prompts/get",
+            headers=admin_headers,
+            json={
+                "name": "search_pattern",
+                "arguments": {"directory": "/tmp/src", "pattern": "*.py"},
+            },
+        )
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["success"] is True
+        assert data["name"] == "search_pattern"
+        assert len(data["messages"]) > 0
+
+        message = data["messages"][0]
+        assert "/tmp/src" in message["content"]
+        assert "*.py" in message["content"]
+
+    def test_get_prompt_missing_arguments(self, client: TestClient, admin_headers):
+        """Test that missing required arguments are rejected."""
+        response = client.post(
+            "/api/filesystem/mcp/prompts/get",
+            headers=admin_headers,
+            json={"name": "analyze_directory", "arguments": {}},
+        )
+        assert response.status_code == 400
+        data = response.json()
+        assert "Missing required argument" in data["detail"]
+
+    def test_get_prompt_unknown_template(self, client: TestClient, admin_headers):
+        """Test that unknown template names are rejected."""
+        response = client.post(
+            "/api/filesystem/mcp/prompts/get",
+            headers=admin_headers,
+            json={"name": "unknown_template", "arguments": {}},
+        )
+        assert response.status_code == 400
+        data = response.json()
+        assert "Unknown prompt template" in data["detail"]
+
+    def test_get_prompt_requires_auth(self, client: TestClient):
+        """Test that getting prompts requires admin authentication."""
+        response = client.post(
+            "/api/filesystem/mcp/prompts/get",
+            json={
+                "name": "analyze_directory",
+                "arguments": {"path": "/tmp/test"},
+            },
+        )
+        assert response.status_code == 401
+
+
+class TestMCPIntegration:
+    """Integration tests for MCP resources and prompts."""
+
+    def test_resources_and_prompts_workflow(self, client: TestClient, admin_headers):
+        """Test a complete workflow: list resources, list prompts, get prompt."""
+        # List resources
+        resources_response = client.get("/api/filesystem/mcp/resources", headers=admin_headers)
+        assert resources_response.status_code == 200
+
+        # List prompts
+        prompts_response = client.get("/api/filesystem/mcp/prompts", headers=admin_headers)
+        assert prompts_response.status_code == 200
+
+        prompts_data = prompts_response.json()
+        assert prompts_data["total"] >= 1
+
+        # Get a prompt
+        prompt_response = client.post(
+            "/api/filesystem/mcp/prompts/get",
+            headers=admin_headers,
+            json={
+                "name": prompts_data["prompts"][0]["name"],
+                "arguments": {"path": "/tmp/test", "directory": "/tmp", "pattern": "*.txt"},
+            },
+        )
+        # Should succeed or return 400 for missing args, but not 500
+        assert prompt_response.status_code in [200, 400]


### PR DESCRIPTION
## Thinking Path

Paperclip issue MVA-2164 requested MCP resource/prompt infrastructure. Analyzed MCP spec → identified 4 core endpoints → implemented in filesystem bridge as reference → added tests → documented pattern for other bridges.

## What Changed

- Added 4 new MCP endpoints to filesystem bridge:
  - `GET /mcp/resources` - list available file resources
  - `POST /mcp/resources/read` - read file resource by URI
  - `GET /mcp/prompts` - list available prompt templates
  - `POST /mcp/prompts/get` - get specific prompt template
- Implemented file:// URI scheme for resource access with path validation
- Provided 3 parameterized prompt templates: `analyze_directory`, `summarize_file`, `search_pattern`
- Added 15 unit tests in `autobot-backend/tests/api/test_filesystem_mcp_resources_prompts.py`

## Verification

- ✅ All 15 unit tests pass
- ✅ `GET /mcp/resources` returns allowed directories as file:// URIs
- ✅ `POST /mcp/resources/read` reads file content by URI, rejects non-file:// URIs, returns 404 for missing files
- ✅ `GET /mcp/prompts` returns 3 prompt templates with argument schemas
- ✅ `POST /mcp/prompts/get` interpolates arguments, returns 400 for missing required args and unknown templates
- ✅ All endpoints require admin auth (401 without credentials)
- ✅ startup-import-smoke passed
- ✅ smoke-test passed

## Model Used

Claude Sonnet 4.5

Closes #MVA-2164

🤖 Generated with [Claude Code](https://claude.com/claude-code)