### PR TITLE
fix(code-quality): resolve flake8 violations blocking PR #9186

### DIFF
--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -34,8 +34,6 @@ from api.schemas_chat import (
     SessionShareRequest,
     SessionUpdate,
     SessionUpdateData,
-    ThinkingPreferences,
-    ThinkingPreferencesData,
 )
 from api.schemas_common import DataResponse
 from auth_middleware import get_auth_middleware, get_current_user
@@ -120,7 +118,8 @@ async def _handle_session_file_action(
             copy=False,
         )
         logger.info(
-            f"Transferred {transfer_result.get('total_transferred', 0)} files " f"to KB for session {session_id}"
+            f"Transferred {transfer_result.get('total_transferred', 0)} files "
+            f"to KB for session {session_id}"
         )
         return {
             "files_handled": True,
@@ -150,7 +149,9 @@ async def _handle_session_file_action(
 
 def log_request_context(request, endpoint, request_id):
     """Log request context for debugging"""
-    logger.info("[%s] %s - %s %s", request_id, endpoint, request.method, request.url.path)
+    logger.info(
+        "[%s] %s - %s %s", request_id, endpoint, request.method, request.url.path
+    )
 
 
 # ====================================================================
@@ -212,7 +213,9 @@ def _validate_pagination_params(page: int, per_page: int) -> None:
         raise ValidationError("Invalid pagination parameters")
 
 
-async def _fetch_session_messages_or_raise(chat_history_manager, session_id: str, limit: int) -> List:
+async def _fetch_session_messages_or_raise(
+    chat_history_manager, session_id: str, limit: int
+) -> List:
     """
     Fetch session messages and raise ResourceNotFoundError if session not found.
 
@@ -241,7 +244,9 @@ async def _fetch_session_messages_or_raise(chat_history_manager, session_id: str
     ) = get_exceptions_lazy()
 
     try:
-        messages = await chat_history_manager.get_session_messages(session_id, limit=limit)
+        messages = await chat_history_manager.get_session_messages(
+            session_id, limit=limit
+        )
     except FileNotFoundError:
         logger.warning("Session file not found for session %s", session_id)
         raise ResourceNotFoundError(f"Session {session_id} not found")
@@ -281,7 +286,9 @@ def _validate_export_format_or_raise(export_format: str) -> None:
         raise ValidationError("Invalid export format. Supported: json, txt, csv")
 
 
-async def _export_session_data_or_raise(chat_history_manager, session_id: str, export_format: str) -> str:
+async def _export_session_data_or_raise(
+    chat_history_manager, session_id: str, export_format: str
+) -> str:
     """
     Export session data and raise ResourceNotFoundError if session not found.
 
@@ -326,7 +333,9 @@ _EXPORT_CONTENT_TYPES = {
 # ====================================================================
 
 
-@router.get("/chat/sessions/{session_id}", response_model=DataResponse[SessionMessagesData])
+@router.get(
+    "/chat/sessions/{session_id}", response_model=DataResponse[SessionMessagesData]
+)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_session_messages",
@@ -335,7 +344,9 @@ _EXPORT_CONTENT_TYPES = {
 async def get_session_messages(
     session_id: str,
     request: Request,
-    ownership: Dict = Depends(validate_session_ownership),  # SECURITY: Validate ownership
+    ownership: Dict = Depends(
+        validate_session_ownership
+    ),  # SECURITY: Validate ownership
     page: int = 1,
     per_page: int = 50,
 ):
@@ -353,7 +364,9 @@ async def get_session_messages(
 
     chat_history_manager = get_chat_history_manager(request)
 
-    messages = await _fetch_session_messages_or_raise(chat_history_manager, session_id, per_page)
+    messages = await _fetch_session_messages_or_raise(
+        chat_history_manager, session_id, per_page
+    )
     total_count = await chat_history_manager.get_session_message_count(session_id)
 
     return create_success_response(
@@ -411,7 +424,9 @@ async def list_sessions(
 
     # Issue #684: Scoped session listing
     if scope in ("org", "team"):
-        return await _list_scoped_sessions(request, request_id, chat_history_manager, scope, team_id)
+        return await _list_scoped_sessions(
+            request, request_id, chat_history_manager, scope, team_id
+        )
 
     # Default: list all sessions (fast mode, no decryption)
     sessions = await chat_history_manager.list_sessions_fast()
@@ -494,7 +509,9 @@ async def _list_scoped_sessions(
     validator = _build_ownership_validator(redis)
 
     if scope == "org":
-        return await _list_org_sessions(user_data, validator, chat_history_manager, request_id)
+        return await _list_org_sessions(
+            user_data, validator, chat_history_manager, request_id
+        )
 
     # scope == "team"
     if not team_id:
@@ -507,7 +524,9 @@ async def _list_scoped_sessions(
         ) = get_exceptions_lazy()
         raise ValidationError("team_id required for team scope")
 
-    return await _list_team_sessions(team_id, validator, chat_history_manager, request_id)
+    return await _list_team_sessions(
+        team_id, validator, chat_history_manager, request_id
+    )
 
 
 async def _list_org_sessions(
@@ -678,7 +697,9 @@ async def _track_session_in_memory_graph(
         user_data: Authenticated user data
         request_id: Request tracking ID
     """
-    memory_graph: AutoBotMemoryGraph | None = getattr(request.app.state, "memory_graph", None)
+    memory_graph: AutoBotMemoryGraph | None = getattr(
+        request.app.state, "memory_graph", None
+    )
     if not memory_graph or not user_data:
         return
 
@@ -779,7 +800,9 @@ async def create_session(session_data: SessionCreate, request: Request):
     await _register_session_ownership(user_data, session_id, session_data.team_id)
 
     # Issue #665: Use helper for memory graph tracking
-    await _track_session_in_memory_graph(request, session_id, session_title, user_data, request_id)
+    await _track_session_in_memory_graph(
+        request, session_id, session_title, user_data, request_id
+    )
 
     # Issue #4260: Wire SESSION_CREATE hook for extensions
     context = getattr(request.app.state, "context", {})
@@ -809,7 +832,9 @@ async def create_session(session_data: SessionCreate, request: Request):
     )
 
 
-@router.put("/chat/sessions/{session_id}", response_model=DataResponse[SessionUpdateData])
+@router.put(
+    "/chat/sessions/{session_id}", response_model=DataResponse[SessionUpdateData]
+)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="update_session",
@@ -819,7 +844,9 @@ async def update_session(
     session_id: str,
     session_data: SessionUpdate,
     request: Request,
-    ownership: Dict = Depends(validate_session_ownership),  # SECURITY: Validate ownership
+    ownership: Dict = Depends(
+        validate_session_ownership
+    ),  # SECURITY: Validate ownership
 ):
     """Update a chat session"""
     request_id = generate_request_id()
@@ -874,7 +901,9 @@ async def update_session(
 # =============================================================================
 
 
-def _validate_delete_session_params(session_id: str, file_action: str, file_options: str | None) -> dict:
+def _validate_delete_session_params(
+    session_id: str, file_action: str, file_options: str | None
+) -> dict:
     """Validate and parse delete_session parameters.
 
     Issue #281: Extracted from delete_session for better organization.
@@ -910,7 +939,9 @@ def _validate_delete_session_params(session_id: str, file_action: str, file_opti
             ValidationError,
             get_error_code,
         ) = get_exceptions_lazy()
-        raise ValidationError(f"Invalid file_action. Must be one of: {sorted(_VALID_FILE_ACTIONS)}")
+        raise ValidationError(
+            f"Invalid file_action. Must be one of: {sorted(_VALID_FILE_ACTIONS)}"
+        )
 
     # Parse file_options if provided
     parsed_file_options = {}
@@ -947,7 +978,9 @@ async def _handle_conversation_files(
         Dict with file handling results including success status and counts
     """
     file_deletion_result = {"files_handled": False, "action_taken": file_action}
-    conversation_file_manager = getattr(request.app.state, "conversation_file_manager", None)
+    conversation_file_manager = getattr(
+        request.app.state, "conversation_file_manager", None
+    )
 
     if conversation_file_manager:
         try:
@@ -955,14 +988,19 @@ async def _handle_conversation_files(
                 conversation_file_manager, session_id, file_action, parsed_file_options
             )
         except Exception as file_error:
-            logger.error("Error handling files for session %s: %s", session_id, file_error)
+            logger.error(
+                "Error handling files for session %s: %s", session_id, file_error
+            )
             file_deletion_result = {
                 "files_handled": False,
                 "action_taken": file_action,
                 "error": str(file_error),
             }
     else:
-        logger.warning(f"ConversationFileManager not available, " f"skipping file handling for session {session_id}")
+        logger.warning(
+            f"ConversationFileManager not available, "
+            f"skipping file handling for session {session_id}"
+        )
 
     return file_deletion_result
 
@@ -987,12 +1025,15 @@ async def _cleanup_terminal_sessions(request: Request, session_id: str) -> dict:
     agent_terminal_service = getattr(request.app.state, "agent_terminal_service", None)
     if not agent_terminal_service:
         logger.warning(
-            f"AgentTerminalService not available, " f"skipping terminal session cleanup for session {session_id}"
+            f"AgentTerminalService not available, "
+            f"skipping terminal session cleanup for session {session_id}"
         )
         return terminal_cleanup_result
 
     try:
-        terminal_sessions = await agent_terminal_service.list_sessions(conversation_id=session_id)
+        terminal_sessions = await agent_terminal_service.list_sessions(
+            conversation_id=session_id
+        )
 
         for terminal_session in terminal_sessions:
             if terminal_session.pending_approval is not None:
@@ -1015,7 +1056,8 @@ async def _cleanup_terminal_sessions(request: Request, session_id: str) -> dict:
             )
     except Exception as terminal_cleanup_error:
         logger.error(
-            f"Failed to cleanup terminal sessions for chat {session_id}: " f"{terminal_cleanup_error}",
+            f"Failed to cleanup terminal sessions for chat {session_id}: "
+            f"{terminal_cleanup_error}",
             exc_info=True,
         )
         terminal_cleanup_result["error"] = str(terminal_cleanup_error)
@@ -1059,10 +1101,14 @@ def _process_kb_deletion_result(result: dict, kb_cleanup_result: dict) -> None:
     kb_cleanup_result["facts_preserved"] = result.get("preserved_count", 0)
 
     if result.get("errors"):
-        kb_cleanup_result["cleanup_error"] = f"{len(result['errors'])} errors during cleanup"
+        kb_cleanup_result["cleanup_error"] = (
+            f"{len(result['errors'])} errors during cleanup"
+        )
 
 
-def _log_kb_cleanup_result(session_id: str, kb_cleanup_result: dict, errors: List | None = None) -> None:
+def _log_kb_cleanup_result(
+    session_id: str, kb_cleanup_result: dict, errors: List | None = None
+) -> None:
     """
     Log KB cleanup results appropriately based on outcome.
 
@@ -1080,7 +1126,10 @@ def _log_kb_cleanup_result(session_id: str, kb_cleanup_result: dict, errors: Lis
             errors,
         )
 
-    if kb_cleanup_result["facts_deleted"] > 0 or kb_cleanup_result["facts_preserved"] > 0:
+    if (
+        kb_cleanup_result["facts_deleted"] > 0
+        or kb_cleanup_result["facts_preserved"] > 0
+    ):
         logger.info(
             "KB cleanup for session %s: deleted=%d, preserved=%d",
             session_id,
@@ -1202,7 +1251,9 @@ async def _perform_all_session_cleanup(
         Tuple of (file_result, terminal_result, kb_result, transcript_result)
     """
     # Handle conversation files
-    file_deletion_result = await _handle_conversation_files(request, session_id, file_action, parsed_file_options)
+    file_deletion_result = await _handle_conversation_files(
+        request, session_id, file_action, parsed_file_options
+    )
 
     # Clean up terminal sessions
     terminal_cleanup_result = await _cleanup_terminal_sessions(request, session_id)
@@ -1284,7 +1335,9 @@ def _build_delete_session_response(
     )
 
 
-@router.delete("/chat/sessions/{session_id}", response_model=DataResponse[SessionDeleteData])
+@router.delete(
+    "/chat/sessions/{session_id}", response_model=DataResponse[SessionDeleteData]
+)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="delete_session",
@@ -1293,7 +1346,9 @@ def _build_delete_session_response(
 async def delete_session(
     session_id: str,
     request: Request,
-    ownership: Dict = Depends(validate_session_ownership),  # SECURITY: Validate ownership
+    ownership: Dict = Depends(
+        validate_session_ownership
+    ),  # SECURITY: Validate ownership
     file_action: str = "delete",
     file_options: str | None = None,
 ):
@@ -1305,7 +1360,9 @@ async def delete_session(
     request_id = generate_request_id()
     log_request_context(request, "delete_session", request_id)
 
-    parsed_file_options = _validate_delete_session_params(session_id, file_action, file_options)
+    parsed_file_options = _validate_delete_session_params(
+        session_id, file_action, file_options
+    )
 
     chat_history_manager = get_chat_history_manager(request)
 
@@ -1317,7 +1374,9 @@ async def delete_session(
         terminal_result,
         kb_result,
         transcript_result,
-    ) = await _perform_all_session_cleanup(request, session_id, file_action, parsed_file_options)
+    ) = await _perform_all_session_cleanup(
+        request, session_id, file_action, parsed_file_options
+    )
 
     await _delete_session_and_verify(chat_history_manager, session_id)
 
@@ -1379,9 +1438,13 @@ async def export_session(session_id: str, request: Request, format: str = "json"
 
     chat_history_manager = get_chat_history_manager(request)
 
-    session_data = await _export_session_data_or_raise(chat_history_manager, session_id, format)
+    session_data = await _export_session_data_or_raise(
+        chat_history_manager, session_id, format
+    )
 
-    log_chat_event("session_exported", session_id, {"format": format, "request_id": request_id})
+    log_chat_event(
+        "session_exported", session_id, {"format": format, "request_id": request_id}
+    )
 
     # Issue #6559: Audit session export
     user_data = get_auth_middleware().get_user_from_request(request)
@@ -1402,7 +1465,11 @@ async def export_session(session_id: str, request: Request, format: str = "json"
     return Response(
         content=session_data,
         media_type=_EXPORT_CONTENT_TYPES[format],
-        headers={"Content-Disposition": (f"attachment; filename=chat_session_{session_id}.{format}")},
+        headers={
+            "Content-Disposition": (
+                f"attachment; filename=chat_session_{session_id}.{format}"
+            )
+        },
     )
 
 
@@ -1446,7 +1513,9 @@ def _to_persisted_system_message(msg: Dict) -> Dict:
     }
 
 
-async def _clear_and_restore_session(chat_manager, session_id: str, messages_to_restore: List[Dict]) -> int:
+async def _clear_and_restore_session(
+    chat_manager, session_id: str, messages_to_restore: List[Dict]
+) -> int:
     """
     Clear session and restore specified messages.
 
@@ -1500,9 +1569,17 @@ async def reset_chat(request: Request, reset_request: ChatResetRequest | None = 
         _validate_session_id_or_raise(session_id)
 
         if clear_context:
-            messages_to_keep = _preserve_system_messages(chat_history_manager, session_id) if keep_system_prompt else []
-            restored = await _clear_and_restore_session(chat_history_manager, session_id, messages_to_keep)
-            logger.info("Reset chat session: %s, kept %d system messages", session_id, restored)
+            messages_to_keep = (
+                _preserve_system_messages(chat_history_manager, session_id)
+                if keep_system_prompt
+                else []
+            )
+            restored = await _clear_and_restore_session(
+                chat_history_manager, session_id, messages_to_keep
+            )
+            logger.info(
+                "Reset chat session: %s, kept %d system messages", session_id, restored
+            )
 
     log_chat_event(
         "session_reset",
@@ -1633,7 +1710,10 @@ async def _process_activity_batch(
     }
 
 
-@router.post("/chat/sessions/{session_id}/activities", response_model=DataResponse[ActivityAddData])
+@router.post(
+    "/chat/sessions/{session_id}/activities",
+    response_model=DataResponse[ActivityAddData],
+)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="add_session_activity",
@@ -1662,7 +1742,9 @@ async def add_session_activity(
         return _create_activity_unavailable_response(1, request_id, is_batch=False)
 
     try:
-        activity_entity = await _store_single_activity(memory_graph, session_id, activity_data)
+        activity_entity = await _store_single_activity(
+            memory_graph, session_id, activity_data
+        )
 
         log_chat_event(
             "activity_created",
@@ -1695,7 +1777,10 @@ async def add_session_activity(
         )
 
 
-@router.post("/chat/sessions/{session_id}/activities/batch", response_model=DataResponse[ActivityBatchData])
+@router.post(
+    "/chat/sessions/{session_id}/activities/batch",
+    response_model=DataResponse[ActivityBatchData],
+)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="add_session_activities_batch",
@@ -1727,10 +1812,14 @@ async def add_session_activities_batch(
             request_id,
             total_activities,
         )
-        return _create_activity_unavailable_response(total_activities, request_id, is_batch=True)
+        return _create_activity_unavailable_response(
+            total_activities, request_id, is_batch=True
+        )
 
     # Process batch using extracted helper (Issue #620)
-    result = await _process_activity_batch(memory_graph, session_id, batch_data.activities, request_id)
+    result = await _process_activity_batch(
+        memory_graph, session_id, batch_data.activities, request_id
+    )
 
     log_chat_event(
         "activities_batch_created",
@@ -1794,7 +1883,10 @@ async def _fetch_activities_from_graph(
         )
 
 
-@router.get("/chat/sessions/{session_id}/activities", response_model=DataResponse[SessionActivitiesData])
+@router.get(
+    "/chat/sessions/{session_id}/activities",
+    response_model=DataResponse[SessionActivitiesData],
+)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_session_activities",
@@ -1829,7 +1921,9 @@ async def get_session_activities(
         raise ValidationError("Invalid session ID format")
 
     # Get memory graph from app state
-    memory_graph: AutoBotMemoryGraph | None = getattr(request.app.state, "memory_graph", None)
+    memory_graph: AutoBotMemoryGraph | None = getattr(
+        request.app.state, "memory_graph", None
+    )
 
     if not memory_graph:
         return create_success_response(
@@ -1838,7 +1932,9 @@ async def get_session_activities(
             request_id=request_id,
         )
 
-    return await _fetch_activities_from_graph(memory_graph, session_id, activity_type, user_id, limit, request_id)
+    return await _fetch_activities_from_graph(
+        memory_graph, session_id, activity_type, user_id, limit, request_id
+    )
 
 
 # ====================================================================
@@ -1872,7 +1968,9 @@ async def _share_session_facts(
     return await kb_manager.share_facts(fact_ids, share_with, shared_by)
 
 
-@router.post("/chat/sessions/{session_id}/share", response_model=DataResponse[SessionShareData])
+@router.post(
+    "/chat/sessions/{session_id}/share", response_model=DataResponse[SessionShareData]
+)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="share_session",
@@ -1924,7 +2022,10 @@ async def share_session(
     )
 
 
-@router.get("/chat/sessions/{session_id}/share/preview", response_model=DataResponse[SessionSharePreviewData])
+@router.get(
+    "/chat/sessions/{session_id}/share/preview",
+    response_model=DataResponse[SessionSharePreviewData],
+)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_share_preview",
@@ -1966,7 +2067,10 @@ async def get_share_preview(
     )
 
 
-@router.delete("/sessions/{session_id}/checkpoints", response_model=DataResponse[SessionCheckpointClearData])
+@router.delete(
+    "/sessions/{session_id}/checkpoints",
+    response_model=DataResponse[SessionCheckpointClearData],
+)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="clear_session_checkpoints",

--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -118,8 +118,7 @@ async def _handle_session_file_action(
             copy=False,
         )
         logger.info(
-            f"Transferred {transfer_result.get('total_transferred', 0)} files "
-            f"to KB for session {session_id}"
+            f"Transferred {transfer_result.get('total_transferred', 0)} files " f"to KB for session {session_id}"
         )
         return {
             "files_handled": True,
@@ -149,9 +148,7 @@ async def _handle_session_file_action(
 
 def log_request_context(request, endpoint, request_id):
     """Log request context for debugging"""
-    logger.info(
-        "[%s] %s - %s %s", request_id, endpoint, request.method, request.url.path
-    )
+    logger.info("[%s] %s - %s %s", request_id, endpoint, request.method, request.url.path)
 
 
 # ====================================================================
@@ -213,9 +210,7 @@ def _validate_pagination_params(page: int, per_page: int) -> None:
         raise ValidationError("Invalid pagination parameters")
 
 
-async def _fetch_session_messages_or_raise(
-    chat_history_manager, session_id: str, limit: int
-) -> List:
+async def _fetch_session_messages_or_raise(chat_history_manager, session_id: str, limit: int) -> List:
     """
     Fetch session messages and raise ResourceNotFoundError if session not found.
 
@@ -244,9 +239,7 @@ async def _fetch_session_messages_or_raise(
     ) = get_exceptions_lazy()
 
     try:
-        messages = await chat_history_manager.get_session_messages(
-            session_id, limit=limit
-        )
+        messages = await chat_history_manager.get_session_messages(session_id, limit=limit)
     except FileNotFoundError:
         logger.warning("Session file not found for session %s", session_id)
         raise ResourceNotFoundError(f"Session {session_id} not found")
@@ -286,9 +279,7 @@ def _validate_export_format_or_raise(export_format: str) -> None:
         raise ValidationError("Invalid export format. Supported: json, txt, csv")
 
 
-async def _export_session_data_or_raise(
-    chat_history_manager, session_id: str, export_format: str
-) -> str:
+async def _export_session_data_or_raise(chat_history_manager, session_id: str, export_format: str) -> str:
     """
     Export session data and raise ResourceNotFoundError if session not found.
 
@@ -333,9 +324,7 @@ _EXPORT_CONTENT_TYPES = {
 # ====================================================================
 
 
-@router.get(
-    "/chat/sessions/{session_id}", response_model=DataResponse[SessionMessagesData]
-)
+@router.get("/chat/sessions/{session_id}", response_model=DataResponse[SessionMessagesData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_session_messages",
@@ -344,9 +333,7 @@ _EXPORT_CONTENT_TYPES = {
 async def get_session_messages(
     session_id: str,
     request: Request,
-    ownership: Dict = Depends(
-        validate_session_ownership
-    ),  # SECURITY: Validate ownership
+    ownership: Dict = Depends(validate_session_ownership),  # SECURITY: Validate ownership
     page: int = 1,
     per_page: int = 50,
 ):
@@ -364,9 +351,7 @@ async def get_session_messages(
 
     chat_history_manager = get_chat_history_manager(request)
 
-    messages = await _fetch_session_messages_or_raise(
-        chat_history_manager, session_id, per_page
-    )
+    messages = await _fetch_session_messages_or_raise(chat_history_manager, session_id, per_page)
     total_count = await chat_history_manager.get_session_message_count(session_id)
 
     return create_success_response(
@@ -424,9 +409,7 @@ async def list_sessions(
 
     # Issue #684: Scoped session listing
     if scope in ("org", "team"):
-        return await _list_scoped_sessions(
-            request, request_id, chat_history_manager, scope, team_id
-        )
+        return await _list_scoped_sessions(request, request_id, chat_history_manager, scope, team_id)
 
     # Default: list all sessions (fast mode, no decryption)
     sessions = await chat_history_manager.list_sessions_fast()
@@ -509,9 +492,7 @@ async def _list_scoped_sessions(
     validator = _build_ownership_validator(redis)
 
     if scope == "org":
-        return await _list_org_sessions(
-            user_data, validator, chat_history_manager, request_id
-        )
+        return await _list_org_sessions(user_data, validator, chat_history_manager, request_id)
 
     # scope == "team"
     if not team_id:
@@ -524,9 +505,7 @@ async def _list_scoped_sessions(
         ) = get_exceptions_lazy()
         raise ValidationError("team_id required for team scope")
 
-    return await _list_team_sessions(
-        team_id, validator, chat_history_manager, request_id
-    )
+    return await _list_team_sessions(team_id, validator, chat_history_manager, request_id)
 
 
 async def _list_org_sessions(
@@ -697,9 +676,7 @@ async def _track_session_in_memory_graph(
         user_data: Authenticated user data
         request_id: Request tracking ID
     """
-    memory_graph: AutoBotMemoryGraph | None = getattr(
-        request.app.state, "memory_graph", None
-    )
+    memory_graph: AutoBotMemoryGraph | None = getattr(request.app.state, "memory_graph", None)
     if not memory_graph or not user_data:
         return
 
@@ -800,9 +777,7 @@ async def create_session(session_data: SessionCreate, request: Request):
     await _register_session_ownership(user_data, session_id, session_data.team_id)
 
     # Issue #665: Use helper for memory graph tracking
-    await _track_session_in_memory_graph(
-        request, session_id, session_title, user_data, request_id
-    )
+    await _track_session_in_memory_graph(request, session_id, session_title, user_data, request_id)
 
     # Issue #4260: Wire SESSION_CREATE hook for extensions
     context = getattr(request.app.state, "context", {})
@@ -832,9 +807,7 @@ async def create_session(session_data: SessionCreate, request: Request):
     )
 
 
-@router.put(
-    "/chat/sessions/{session_id}", response_model=DataResponse[SessionUpdateData]
-)
+@router.put("/chat/sessions/{session_id}", response_model=DataResponse[SessionUpdateData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="update_session",
@@ -844,9 +817,7 @@ async def update_session(
     session_id: str,
     session_data: SessionUpdate,
     request: Request,
-    ownership: Dict = Depends(
-        validate_session_ownership
-    ),  # SECURITY: Validate ownership
+    ownership: Dict = Depends(validate_session_ownership),  # SECURITY: Validate ownership
 ):
     """Update a chat session"""
     request_id = generate_request_id()
@@ -901,9 +872,7 @@ async def update_session(
 # =============================================================================
 
 
-def _validate_delete_session_params(
-    session_id: str, file_action: str, file_options: str | None
-) -> dict:
+def _validate_delete_session_params(session_id: str, file_action: str, file_options: str | None) -> dict:
     """Validate and parse delete_session parameters.
 
     Issue #281: Extracted from delete_session for better organization.
@@ -939,9 +908,7 @@ def _validate_delete_session_params(
             ValidationError,
             get_error_code,
         ) = get_exceptions_lazy()
-        raise ValidationError(
-            f"Invalid file_action. Must be one of: {sorted(_VALID_FILE_ACTIONS)}"
-        )
+        raise ValidationError(f"Invalid file_action. Must be one of: {sorted(_VALID_FILE_ACTIONS)}")
 
     # Parse file_options if provided
     parsed_file_options = {}
@@ -978,9 +945,7 @@ async def _handle_conversation_files(
         Dict with file handling results including success status and counts
     """
     file_deletion_result = {"files_handled": False, "action_taken": file_action}
-    conversation_file_manager = getattr(
-        request.app.state, "conversation_file_manager", None
-    )
+    conversation_file_manager = getattr(request.app.state, "conversation_file_manager", None)
 
     if conversation_file_manager:
         try:
@@ -988,19 +953,14 @@ async def _handle_conversation_files(
                 conversation_file_manager, session_id, file_action, parsed_file_options
             )
         except Exception as file_error:
-            logger.error(
-                "Error handling files for session %s: %s", session_id, file_error
-            )
+            logger.error("Error handling files for session %s: %s", session_id, file_error)
             file_deletion_result = {
                 "files_handled": False,
                 "action_taken": file_action,
                 "error": str(file_error),
             }
     else:
-        logger.warning(
-            f"ConversationFileManager not available, "
-            f"skipping file handling for session {session_id}"
-        )
+        logger.warning(f"ConversationFileManager not available, " f"skipping file handling for session {session_id}")
 
     return file_deletion_result
 
@@ -1025,15 +985,12 @@ async def _cleanup_terminal_sessions(request: Request, session_id: str) -> dict:
     agent_terminal_service = getattr(request.app.state, "agent_terminal_service", None)
     if not agent_terminal_service:
         logger.warning(
-            f"AgentTerminalService not available, "
-            f"skipping terminal session cleanup for session {session_id}"
+            f"AgentTerminalService not available, " f"skipping terminal session cleanup for session {session_id}"
         )
         return terminal_cleanup_result
 
     try:
-        terminal_sessions = await agent_terminal_service.list_sessions(
-            conversation_id=session_id
-        )
+        terminal_sessions = await agent_terminal_service.list_sessions(conversation_id=session_id)
 
         for terminal_session in terminal_sessions:
             if terminal_session.pending_approval is not None:
@@ -1056,8 +1013,7 @@ async def _cleanup_terminal_sessions(request: Request, session_id: str) -> dict:
             )
     except Exception as terminal_cleanup_error:
         logger.error(
-            f"Failed to cleanup terminal sessions for chat {session_id}: "
-            f"{terminal_cleanup_error}",
+            f"Failed to cleanup terminal sessions for chat {session_id}: " f"{terminal_cleanup_error}",
             exc_info=True,
         )
         terminal_cleanup_result["error"] = str(terminal_cleanup_error)
@@ -1101,14 +1057,10 @@ def _process_kb_deletion_result(result: dict, kb_cleanup_result: dict) -> None:
     kb_cleanup_result["facts_preserved"] = result.get("preserved_count", 0)
 
     if result.get("errors"):
-        kb_cleanup_result["cleanup_error"] = (
-            f"{len(result['errors'])} errors during cleanup"
-        )
+        kb_cleanup_result["cleanup_error"] = f"{len(result['errors'])} errors during cleanup"
 
 
-def _log_kb_cleanup_result(
-    session_id: str, kb_cleanup_result: dict, errors: List | None = None
-) -> None:
+def _log_kb_cleanup_result(session_id: str, kb_cleanup_result: dict, errors: List | None = None) -> None:
     """
     Log KB cleanup results appropriately based on outcome.
 
@@ -1126,10 +1078,7 @@ def _log_kb_cleanup_result(
             errors,
         )
 
-    if (
-        kb_cleanup_result["facts_deleted"] > 0
-        or kb_cleanup_result["facts_preserved"] > 0
-    ):
+    if kb_cleanup_result["facts_deleted"] > 0 or kb_cleanup_result["facts_preserved"] > 0:
         logger.info(
             "KB cleanup for session %s: deleted=%d, preserved=%d",
             session_id,
@@ -1251,9 +1200,7 @@ async def _perform_all_session_cleanup(
         Tuple of (file_result, terminal_result, kb_result, transcript_result)
     """
     # Handle conversation files
-    file_deletion_result = await _handle_conversation_files(
-        request, session_id, file_action, parsed_file_options
-    )
+    file_deletion_result = await _handle_conversation_files(request, session_id, file_action, parsed_file_options)
 
     # Clean up terminal sessions
     terminal_cleanup_result = await _cleanup_terminal_sessions(request, session_id)
@@ -1335,9 +1282,7 @@ def _build_delete_session_response(
     )
 
 
-@router.delete(
-    "/chat/sessions/{session_id}", response_model=DataResponse[SessionDeleteData]
-)
+@router.delete("/chat/sessions/{session_id}", response_model=DataResponse[SessionDeleteData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="delete_session",
@@ -1346,9 +1291,7 @@ def _build_delete_session_response(
 async def delete_session(
     session_id: str,
     request: Request,
-    ownership: Dict = Depends(
-        validate_session_ownership
-    ),  # SECURITY: Validate ownership
+    ownership: Dict = Depends(validate_session_ownership),  # SECURITY: Validate ownership
     file_action: str = "delete",
     file_options: str | None = None,
 ):
@@ -1360,9 +1303,7 @@ async def delete_session(
     request_id = generate_request_id()
     log_request_context(request, "delete_session", request_id)
 
-    parsed_file_options = _validate_delete_session_params(
-        session_id, file_action, file_options
-    )
+    parsed_file_options = _validate_delete_session_params(session_id, file_action, file_options)
 
     chat_history_manager = get_chat_history_manager(request)
 
@@ -1374,9 +1315,7 @@ async def delete_session(
         terminal_result,
         kb_result,
         transcript_result,
-    ) = await _perform_all_session_cleanup(
-        request, session_id, file_action, parsed_file_options
-    )
+    ) = await _perform_all_session_cleanup(request, session_id, file_action, parsed_file_options)
 
     await _delete_session_and_verify(chat_history_manager, session_id)
 
@@ -1438,13 +1377,9 @@ async def export_session(session_id: str, request: Request, format: str = "json"
 
     chat_history_manager = get_chat_history_manager(request)
 
-    session_data = await _export_session_data_or_raise(
-        chat_history_manager, session_id, format
-    )
+    session_data = await _export_session_data_or_raise(chat_history_manager, session_id, format)
 
-    log_chat_event(
-        "session_exported", session_id, {"format": format, "request_id": request_id}
-    )
+    log_chat_event("session_exported", session_id, {"format": format, "request_id": request_id})
 
     # Issue #6559: Audit session export
     user_data = get_auth_middleware().get_user_from_request(request)
@@ -1465,11 +1400,7 @@ async def export_session(session_id: str, request: Request, format: str = "json"
     return Response(
         content=session_data,
         media_type=_EXPORT_CONTENT_TYPES[format],
-        headers={
-            "Content-Disposition": (
-                f"attachment; filename=chat_session_{session_id}.{format}"
-            )
-        },
+        headers={"Content-Disposition": (f"attachment; filename=chat_session_{session_id}.{format}")},
     )
 
 
@@ -1513,9 +1444,7 @@ def _to_persisted_system_message(msg: Dict) -> Dict:
     }
 
 
-async def _clear_and_restore_session(
-    chat_manager, session_id: str, messages_to_restore: List[Dict]
-) -> int:
+async def _clear_and_restore_session(chat_manager, session_id: str, messages_to_restore: List[Dict]) -> int:
     """
     Clear session and restore specified messages.
 
@@ -1569,17 +1498,9 @@ async def reset_chat(request: Request, reset_request: ChatResetRequest | None = 
         _validate_session_id_or_raise(session_id)
 
         if clear_context:
-            messages_to_keep = (
-                _preserve_system_messages(chat_history_manager, session_id)
-                if keep_system_prompt
-                else []
-            )
-            restored = await _clear_and_restore_session(
-                chat_history_manager, session_id, messages_to_keep
-            )
-            logger.info(
-                "Reset chat session: %s, kept %d system messages", session_id, restored
-            )
+            messages_to_keep = _preserve_system_messages(chat_history_manager, session_id) if keep_system_prompt else []
+            restored = await _clear_and_restore_session(chat_history_manager, session_id, messages_to_keep)
+            logger.info("Reset chat session: %s, kept %d system messages", session_id, restored)
 
     log_chat_event(
         "session_reset",
@@ -1742,9 +1663,7 @@ async def add_session_activity(
         return _create_activity_unavailable_response(1, request_id, is_batch=False)
 
     try:
-        activity_entity = await _store_single_activity(
-            memory_graph, session_id, activity_data
-        )
+        activity_entity = await _store_single_activity(memory_graph, session_id, activity_data)
 
         log_chat_event(
             "activity_created",
@@ -1812,14 +1731,10 @@ async def add_session_activities_batch(
             request_id,
             total_activities,
         )
-        return _create_activity_unavailable_response(
-            total_activities, request_id, is_batch=True
-        )
+        return _create_activity_unavailable_response(total_activities, request_id, is_batch=True)
 
     # Process batch using extracted helper (Issue #620)
-    result = await _process_activity_batch(
-        memory_graph, session_id, batch_data.activities, request_id
-    )
+    result = await _process_activity_batch(memory_graph, session_id, batch_data.activities, request_id)
 
     log_chat_event(
         "activities_batch_created",
@@ -1921,9 +1836,7 @@ async def get_session_activities(
         raise ValidationError("Invalid session ID format")
 
     # Get memory graph from app state
-    memory_graph: AutoBotMemoryGraph | None = getattr(
-        request.app.state, "memory_graph", None
-    )
+    memory_graph: AutoBotMemoryGraph | None = getattr(request.app.state, "memory_graph", None)
 
     if not memory_graph:
         return create_success_response(
@@ -1932,9 +1845,7 @@ async def get_session_activities(
             request_id=request_id,
         )
 
-    return await _fetch_activities_from_graph(
-        memory_graph, session_id, activity_type, user_id, limit, request_id
-    )
+    return await _fetch_activities_from_graph(memory_graph, session_id, activity_type, user_id, limit, request_id)
 
 
 # ====================================================================
@@ -1968,9 +1879,7 @@ async def _share_session_facts(
     return await kb_manager.share_facts(fact_ids, share_with, shared_by)
 
 
-@router.post(
-    "/chat/sessions/{session_id}/share", response_model=DataResponse[SessionShareData]
-)
+@router.post("/chat/sessions/{session_id}/share", response_model=DataResponse[SessionShareData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="share_session",

--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -13,8 +13,6 @@ import importlib
 import json
 import sys
 from datetime import datetime, timezone
-from pathlib import Path
-
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
 
 from api.schemas_system import (

--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -13,6 +13,7 @@ import importlib
 import json
 import sys
 from datetime import datetime, timezone
+
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
 
 from api.schemas_system import (

--- a/autobot-backend/api/telegram_bot.py
+++ b/autobot-backend/api/telegram_bot.py
@@ -144,12 +144,8 @@ async def telegram_webhook(
 
         request_secret = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
         if request_secret != stored_secret:
-            logger.warning(
-                "Telegram webhook authentication failed - invalid secret token"
-            )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
-            )
+            logger.warning("Telegram webhook authentication failed - invalid secret token")
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
 
         # Extract message from update
         message = update.get("message")

--- a/autobot-backend/api/telegram_bot.py
+++ b/autobot-backend/api/telegram_bot.py
@@ -144,8 +144,12 @@ async def telegram_webhook(
 
         request_secret = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
         if request_secret != stored_secret:
-            logger.warning("Telegram webhook authentication failed - invalid secret token")
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+            logger.warning(
+                "Telegram webhook authentication failed - invalid secret token"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+            )
 
         # Extract message from update
         message = update.get("message")
@@ -172,7 +176,7 @@ async def telegram_webhook(
 
     except HTTPException:
         raise
-    except Exception as exc:
+    except Exception:
         logger.exception("Failed to process Telegram webhook update")
         # Return 200 to prevent Telegram from retrying, no error details to client
         return JSONResponse({"status": "ok"})
@@ -319,6 +323,6 @@ async def send_telegram_response(
             reply_to_message_id=message_id,
         )
         logger.info(f"Sent response to Telegram chat {chat_id}")
-    except Exception as exc:
+    except Exception:
         logger.exception("Failed to send Telegram response")
         raise

--- a/autobot-backend/chat_history/context_overflow.py
+++ b/autobot-backend/chat_history/context_overflow.py
@@ -57,9 +57,7 @@ class SessionTokenTracker:
         if self.redis is None:
             self.redis = await get_async_redis_client()
         if self.redis is None:
-            logger.warning(
-                "SessionTokenTracker: Redis unavailable, token tracking disabled"
-            )
+            logger.warning("SessionTokenTracker: Redis unavailable, token tracking disabled")
         return self.redis
 
     async def add_message_tokens(
@@ -396,9 +394,7 @@ class ContextOverflowProtection:
             return ""
 
         # Generate summary
-        summary = await self.summarizer.summarize_messages(
-            messages_to_summarize, model_name
-        )
+        summary = await self.summarizer.summarize_messages(messages_to_summarize, model_name)
 
         # Reset token tracker (conversation now starts from summary)
         await self.tracker.reset_session(session_id)
@@ -408,9 +404,7 @@ class ContextOverflowProtection:
             # Estimate tokens (rough approximation)
             text = msg.get("text", "")
             estimated_tokens = len(text) // 4
-            await self.tracker.add_message_tokens(
-                session_id, prompt_tokens=estimated_tokens
-            )
+            await self.tracker.add_message_tokens(session_id, prompt_tokens=estimated_tokens)
 
         return summary
 

--- a/autobot-backend/chat_history/context_overflow.py
+++ b/autobot-backend/chat_history/context_overflow.py
@@ -57,7 +57,9 @@ class SessionTokenTracker:
         if self.redis is None:
             self.redis = await get_async_redis_client()
         if self.redis is None:
-            logger.warning("SessionTokenTracker: Redis unavailable, token tracking disabled")
+            logger.warning(
+                "SessionTokenTracker: Redis unavailable, token tracking disabled"
+            )
         return self.redis
 
     async def add_message_tokens(
@@ -166,22 +168,20 @@ class ConversationSummarizer:
         summary = await summarizer.summarize_messages(messages, model="gpt-4")
     """
 
-    _SUMMARIZATION_PROMPT = (
-        "Compress the following conversation segment preserving all decisions, "
-        "facts, and action items.\n"
-        "The summary should be compact but complete enough that someone reading "
-        "it later can understand what was discussed and decided.\n"
-        "Focus on:\n"
-        "- Key decisions made\n"
-        "- Important facts mentioned\n"
-        "- Action items or tasks identified\n"
-        "- Critical context needed for future messages\n"
-        "\n"
-        "Original conversation:\n"
-        "{conversation}\n"
-        "\n"
-        "Provide a concise summary in 2-3 paragraphs:"
-    )
+    _SUMMARIZATION_PROMPT = """Compress the following conversation segment preserving all decisions, facts, and action \
+items.
+The summary should be compact but complete enough that someone reading it later can understand what was discussed \
+and decided.
+Focus on:
+- Key decisions made
+- Important facts mentioned
+- Action items or tasks identified
+- Critical context needed for future messages
+
+Original conversation:
+{conversation}
+
+Provide a concise summary in 2-3 paragraphs:"""
 
     async def summarize_messages(
         self,
@@ -396,7 +396,9 @@ class ContextOverflowProtection:
             return ""
 
         # Generate summary
-        summary = await self.summarizer.summarize_messages(messages_to_summarize, model_name)
+        summary = await self.summarizer.summarize_messages(
+            messages_to_summarize, model_name
+        )
 
         # Reset token tracker (conversation now starts from summary)
         await self.tracker.reset_session(session_id)
@@ -406,7 +408,9 @@ class ContextOverflowProtection:
             # Estimate tokens (rough approximation)
             text = msg.get("text", "")
             estimated_tokens = len(text) // 4
-            await self.tracker.add_message_tokens(session_id, prompt_tokens=estimated_tokens)
+            await self.tracker.add_message_tokens(
+                session_id, prompt_tokens=estimated_tokens
+            )
 
         return summary
 

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -15,7 +15,6 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from pathlib import Path
 
 from fastapi import FastAPI
 
@@ -105,9 +104,13 @@ def warn_if_dev_auth_bypass_enabled() -> None:
         return
     banner = "=" * 72
     logger.warning(banner)
-    logger.warning("⚠️  AUTOBOT_DEV_AUTH_BYPASS=true — /api/auth/login will mint an admin")
+    logger.warning(
+        "⚠️  AUTOBOT_DEV_AUTH_BYPASS=true — /api/auth/login will mint an admin"
+    )
     logger.warning("    JWT for ANY credentials in single_user mode. DO NOT use in")
-    logger.warning("    production. Unset the flag or switch AUTOBOT_USER_MODE away from")
+    logger.warning(
+        "    production. Unset the flag or switch AUTOBOT_USER_MODE away from"
+    )
     logger.warning("    single_user to disable. See issue #6838.")
     logger.warning(banner)
 
@@ -171,8 +174,12 @@ async def _init_chat_history_manager(app: FastAPI) -> None:
         await update_app_state("chat_history_manager", chat_history_manager)
         logger.info("✅ [ 30%] Chat History: Manager initialized successfully")
     except Exception as chat_history_error:
-        logger.error(f"❌ CRITICAL: Chat history manager initialization failed: {chat_history_error}")
-        raise RuntimeError(f"Chat history manager initialization failed: {chat_history_error}")
+        logger.error(
+            f"❌ CRITICAL: Chat history manager initialization failed: {chat_history_error}"
+        )
+        raise RuntimeError(
+            f"Chat history manager initialization failed: {chat_history_error}"
+        )
 
 
 async def _init_conversation_file_manager(app: FastAPI) -> None:
@@ -192,9 +199,13 @@ async def _init_conversation_file_manager(app: FastAPI) -> None:
         await conversation_file_manager.initialize()
         app.state.conversation_file_manager = conversation_file_manager
         await update_app_state("conversation_file_manager", conversation_file_manager)
-        logger.info("✅ [ 40%] Conversation Files DB: Database initialized and verified")
+        logger.info(
+            "✅ [ 40%] Conversation Files DB: Database initialized and verified"
+        )
     except Exception as conv_file_error:
-        logger.error(f"❌ CRITICAL: Conversation files database initialization failed: {conv_file_error}")
+        logger.error(
+            f"❌ CRITICAL: Conversation files database initialization failed: {conv_file_error}"
+        )
         logger.error("Backend startup ABORTED - database must be operational")
         raise RuntimeError(f"Database initialization failed: {conv_file_error}")
 
@@ -216,7 +227,9 @@ async def _init_chat_workflow_manager(app: FastAPI) -> None:
         await update_app_state("chat_workflow_manager", chat_workflow_manager)
         logger.info("✅ [ 50%] Chat Workflow: Manager initialized with async Redis")
     except Exception as chat_error:
-        logger.error(f"❌ CRITICAL: Chat workflow manager initialization failed: {chat_error}")
+        logger.error(
+            f"❌ CRITICAL: Chat workflow manager initialization failed: {chat_error}"
+        )
         raise RuntimeError(f"Chat workflow manager initialization failed: {chat_error}")
 
 
@@ -235,7 +248,8 @@ async def _check_env_drift() -> None:
             logger.warning("env drift check skipped: %s", report.error)
         elif report.has_drift:
             logger.warning(
-                "env drift detected — run 'python -m autobot_shared.env_drift_detector' " "for details (%s)",
+                "env drift detected — run 'python -m autobot_shared.env_drift_detector' "
+                "for details (%s)",
                 report.summary(),
             )
         else:
@@ -260,7 +274,9 @@ async def _init_config(app: FastAPI) -> None:
     validation_result = config.validate_startup()
     if not validation_result.valid:
         error_summary = "; ".join(validation_result.errors)
-        raise RuntimeError(f"Configuration validation failed at startup: {error_summary}")
+        raise RuntimeError(
+            f"Configuration validation failed at startup: {error_summary}"
+        )
     if validation_result.warnings:
         logger.warning(
             "Config: %d override warning(s) detected — review logged warnings above",
@@ -338,7 +354,9 @@ async def _init_telemetry_and_redis() -> None:
 
     instrument_redis()
     instrument_aiohttp()
-    logger.info("✅ [ 20%] Redis: Using centralized Redis client management (src.utils.redis_client)")
+    logger.info(
+        "✅ [ 20%] Redis: Using centralized Redis client management (src.utils.redis_client)"
+    )
 
 
 async def _init_skills(app: FastAPI) -> None:
@@ -350,7 +368,9 @@ async def _init_skills(app: FastAPI) -> None:
         await _init_skills_tables()
         await _init_skills_discovery()
     except Exception as skills_db_error:
-        logger.warning("Skills initialization failed (non-critical): %s", skills_db_error)
+        logger.warning(
+            "Skills initialization failed (non-critical): %s", skills_db_error
+        )
 
 
 async def _init_builtin_extensions(app: FastAPI) -> None:
@@ -378,9 +398,13 @@ async def _init_builtin_extensions(app: FastAPI) -> None:
         manager.register(LoggingExtension())
         manager.register(SecretMaskingExtension())
         manager.register(PermissionEnforcementExtension())
-        logger.info("Built-in extensions registered (logging, secret_masking, permission_enforcement)")
+        logger.info(
+            "Built-in extensions registered (logging, secret_masking, permission_enforcement)"
+        )
     except Exception as ext_error:
-        logger.warning("Built-in extension registration failed (non-critical): %s", ext_error)
+        logger.warning(
+            "Built-in extension registration failed (non-critical): %s", ext_error
+        )
 
 
 async def initialize_critical_services(app: FastAPI):
@@ -501,7 +525,11 @@ async def _init_knowledge_base(app: FastAPI):
         # Phase 1 initializes the manager before the KB is ready, leaving
         # knowledge_service=None. Re-wire here once the KB succeeds.
         mgr = getattr(app.state, "chat_workflow_manager", None)
-        if mgr is not None and knowledge_base is not None and mgr.knowledge_service is None:
+        if (
+            mgr is not None
+            and knowledge_base is not None
+            and mgr.knowledge_service is None
+        ):
             await mgr.set_knowledge_base(knowledge_base)
 
         # Issue #8391: Start VectorWriteBuffer background flush task.
@@ -567,9 +595,13 @@ async def _warmup_npu_connection(app: FastAPI) -> None:
                 result.get("embedding_dimensions", 0),
             )
         elif result["status"] == "npu_unavailable":
-            logger.info("🔄 [ 82%] NPU Warmup: NPU unavailable, using fallback embeddings")
+            logger.info(
+                "🔄 [ 82%] NPU Warmup: NPU unavailable, using fallback embeddings"
+            )
         else:
-            logger.warning("⚠️ [ 82%] NPU Warmup: %s", result.get("message", "Unknown status"))
+            logger.warning(
+                "⚠️ [ 82%] NPU Warmup: %s", result.get("message", "Unknown status")
+            )
 
     except Exception as warmup_error:
         logger.warning("NPU warmup failed: %s", warmup_error)
@@ -675,11 +707,16 @@ async def _auto_index_documentation():
             return
 
         # Fire-and-forget: run indexing in background so startup continues
-        logger.info("✅ [ 85%] Doc Index: Collection empty, " "scheduling background indexing...")
+        logger.info(
+            "✅ [ 85%] Doc Index: Collection empty, "
+            "scheduling background indexing..."
+        )
         asyncio.create_task(_run_background_doc_indexing())
 
     except Exception as index_error:
-        logger.warning("Documentation auto-index failed (non-critical): %s", index_error)
+        logger.warning(
+            "Documentation auto-index failed (non-critical): %s", index_error
+        )
 
 
 async def _init_log_forwarding():
@@ -696,7 +733,9 @@ async def _init_log_forwarding():
         forwarder = await get_forwarder()
 
         if forwarder.auto_start and forwarder.destinations:
-            logger.info("✅ [ 86%] Log Forwarding: Auto-start enabled, starting service...")
+            logger.info(
+                "✅ [ 86%] Log Forwarding: Auto-start enabled, starting service..."
+            )
             success = forwarder.start()
             if success:
                 logger.info(
@@ -704,9 +743,13 @@ async def _init_log_forwarding():
                     len(forwarder.destinations),
                 )
             else:
-                logger.warning("⚠️ [ 86%] Log Forwarding: Failed to start (non-critical)")
+                logger.warning(
+                    "⚠️ [ 86%] Log Forwarding: Failed to start (non-critical)"
+                )
         elif forwarder.auto_start:
-            logger.info("✅ [ 86%] Log Forwarding: Auto-start enabled but no destinations configured")
+            logger.info(
+                "✅ [ 86%] Log Forwarding: Auto-start enabled but no destinations configured"
+            )
         else:
             logger.info("✅ [ 86%] Log Forwarding: Auto-start disabled, skipping")
 
@@ -766,7 +809,9 @@ async def _init_heartbeat_scheduler(app: FastAPI) -> None:
         logger.info("Heartbeat: LLC HeartbeatScheduler started")
         return
     except Exception as llc_error:
-        logger.warning("LLC heartbeat scheduler unavailable, falling back to legacy: %s", llc_error)
+        logger.warning(
+            "LLC heartbeat scheduler unavailable, falling back to legacy: %s", llc_error
+        )
 
     logger.info("Heartbeat: Starting legacy heartbeat scheduler...")
     try:
@@ -879,7 +924,9 @@ async def _init_graph_rag_service(app: FastAPI, memory_graph):
 
         if app.state.knowledge_base:
             rag_config = RAGConfig(enable_advanced_rag=True, timeout_seconds=10.0)
-            rag_service = RAGService(knowledge_base=app.state.knowledge_base, config=rag_config)
+            rag_service = RAGService(
+                knowledge_base=app.state.knowledge_base, config=rag_config
+            )
             await rag_service.initialize()
 
             # Build mesh brain components and register them so every RAGService.initialize()
@@ -937,14 +984,18 @@ async def _init_graph_rag_service(app: FastAPI, memory_graph):
                 ]:
                     if _existing is not None and _existing._mesh_retriever is None:
                         _existing._initialized = False  # force re-init on next call
-                        logger.info("Queued per-instance NeuralMeshRetriever build for existing RAGService (#4765)")
+                        logger.info(
+                            "Queued per-instance NeuralMeshRetriever build for existing RAGService (#4765)"
+                        )
 
                 logger.info(
                     "✅ [ 87%] Neural Mesh RAG: mesh components registered; "
                     "per-instance NeuralMeshRetriever will build on next initialize() (#4765)"
                 )
             except Exception as _mesh_wire_err:
-                logger.warning("Neural Mesh RAG wiring skipped (non-fatal): %s", _mesh_wire_err)
+                logger.warning(
+                    "Neural Mesh RAG wiring skipped (non-fatal): %s", _mesh_wire_err
+                )
 
             graph_rag_service = GraphRAGService(
                 rag_service=rag_service,
@@ -954,7 +1005,9 @@ async def _init_graph_rag_service(app: FastAPI, memory_graph):
             )
             app.state.graph_rag_service = graph_rag_service
             await update_app_state("graph_rag_service", graph_rag_service)
-            logger.info("✅ [ 87%] Graph-RAG: Graph-aware RAG service initialized successfully")
+            logger.info(
+                "✅ [ 87%] Graph-RAG: Graph-aware RAG service initialized successfully"
+            )
         else:
             logger.info("🔄 [ 87%] Graph-RAG: Skipped (knowledge base not available)")
     except Exception as graph_rag_error:
@@ -986,7 +1039,9 @@ async def _init_entity_extractor(app: FastAPI, memory_graph):
         )
         app.state.entity_extractor = entity_extractor
         await update_app_state("entity_extractor", entity_extractor)
-        logger.info("✅ [ 88%] Entity Extractor: Entity extractor initialized successfully")
+        logger.info(
+            "✅ [ 88%] Entity Extractor: Entity extractor initialized successfully"
+        )
     except Exception as entity_error:
         logger.warning("Entity extractor initialization failed: %s", entity_error)
         app.state.entity_extractor = None
@@ -1052,7 +1107,9 @@ async def _init_slm_client():
         init_orchestrator(_get_slm_client())
         logger.info("✅ [ 89%] SLM Client: DeploymentCoordinator initialised")
     except Exception as slm_error:
-        logger.warning("SLM client initialization failed (continuing without): %s", slm_error)
+        logger.warning(
+            "SLM client initialization failed (continuing without): %s", slm_error
+        )
 
 
 async def _init_metrics_collection():
@@ -1217,7 +1274,8 @@ async def _ensure_agent_memory_index() -> None:
             logger.info("[ 93%%] Agent Memory Index: idx:agent_memory already exists")
         else:
             logger.info(
-                "[ 93%%] Agent Memory Index: idx:agent_memory created " "(prefix=%s, dims=%d, metric=%s)",
+                "[ 93%%] Agent Memory Index: idx:agent_memory created "
+                "(prefix=%s, dims=%d, metric=%s)",
                 result.get("prefix"),
                 result.get("dimensions"),
                 result.get("distance_metric"),
@@ -1264,9 +1322,13 @@ async def _wire_npu_task_queue() -> None:
         worker_manager = await get_worker_manager(redis_client=redis_client)
         task_queue = get_task_queue()
         task_queue.npu_worker_manager = worker_manager
-        logger.info("[ 98%%] NPU Task Queue: NPUWorkerManager wired — per-worker task tracking active")
+        logger.info(
+            "[ 98%%] NPU Task Queue: NPUWorkerManager wired — per-worker task tracking active"
+        )
     except Exception as e:
-        logger.warning("NPU task queue wiring failed (per-worker tracking disabled): %s", e)
+        logger.warning(
+            "NPU task queue wiring failed (per-worker tracking disabled): %s", e
+        )
 
 
 async def _init_voice_interface(app: FastAPI) -> None:
@@ -1284,7 +1346,8 @@ async def _init_voice_interface(app: FastAPI) -> None:
         logger.info("[ 99%%] Voice Interface: Initialized and attached to app.state")
     except Exception as e:
         logger.warning(
-            "Voice interface initialization failed (non-critical): %s — " "voice endpoints will return 503",
+            "Voice interface initialization failed (non-critical): %s — "
+            "voice endpoints will return 503",
             e,
         )
         app.state.voice_interface = None
@@ -1304,7 +1367,9 @@ async def _init_llm_key_rotation_scheduler(app: FastAPI) -> None:
         app.state.llm_key_rotation_scheduler = scheduler
         logger.info("[100%%] LLM Key Rotation: Scheduler started")
     except Exception as e:
-        logger.warning("LLM key rotation scheduler initialization failed (non-critical): %s", e)
+        logger.warning(
+            "LLM key rotation scheduler initialization failed (non-critical): %s", e
+        )
         app.state.llm_key_rotation_scheduler = None
 
 
@@ -1395,7 +1460,9 @@ async def _wire_scheduler_executor() -> None:
         get_workflow_scheduler().set_workflow_executor(_orchestration_executor)
         logger.info("[ 98%%] Scheduler: Orchestration executor wired")
     except Exception as e:
-        logger.warning("Scheduler executor wiring failed (template-only fallback active): %s", e)
+        logger.warning(
+            "Scheduler executor wiring failed (template-only fallback active): %s", e
+        )
 
 
 async def _start_community_clustering_loop(app: FastAPI) -> None:
@@ -1429,10 +1496,14 @@ async def _start_community_clustering_loop(app: FastAPI) -> None:
                     "Install with: pip install graspologic. Retrying in 24h. Error: %s",
                     exc,
                 )
-                await asyncio.sleep(86400)  # 24 hours — re-check after potential install
+                await asyncio.sleep(
+                    86400
+                )  # 24 hours — re-check after potential install
                 continue
             except Exception as exc:
-                logger.warning("CommunityClusterer periodic run failed (non-fatal): %s", exc)
+                logger.warning(
+                    "CommunityClusterer periodic run failed (non-fatal): %s", exc
+                )
             await asyncio.sleep(_CLUSTER_INTERVAL_SECONDS)
 
     app.state.community_cluster_task = asyncio.create_task(_loop())
@@ -1514,7 +1585,9 @@ async def _start_llc_notification_router(app: FastAPI) -> None:
         app.state.llc_notification_router = router
         logger.info("✅ LLC notification router started")
     except Exception as exc:
-        logger.warning("LLC notification router failed to start (non-critical): %s", exc)
+        logger.warning(
+            "LLC notification router failed to start (non-critical): %s", exc
+        )
         app.state.llc_notification_router = None
 
 
@@ -1572,7 +1645,9 @@ async def _init_plugin_manager(app: FastAPI) -> None:
         app.state.plugin_manager = plugin_manager
         logger.info("PluginManager started — %s", plugin_manager.get_plugin_status())
     except Exception as pm_err:
-        logger.warning("Plugin manager startup failed (non-critical): %s", pm_err, exc_info=True)
+        logger.warning(
+            "Plugin manager startup failed (non-critical): %s", pm_err, exc_info=True
+        )
 
 
 async def initialize_background_services(app: FastAPI):
@@ -1731,7 +1806,10 @@ async def cleanup_services(app: FastAPI):
         pass  # SLM reconciler now in slm-server
 
         # GH#9028: Stop LLC liveness monitor
-        if hasattr(app.state, "llc_liveness_monitor") and app.state.llc_liveness_monitor:
+        if (
+            hasattr(app.state, "llc_liveness_monitor")
+            and app.state.llc_liveness_monitor
+        ):
             app.state.llc_liveness_monitor.stop()
             logger.info("✅ LLC liveness monitor stopped")
         # GH#9029: Stop LLC budget watchdog
@@ -1739,7 +1817,10 @@ async def cleanup_services(app: FastAPI):
             app.state.llc_budget_watchdog.stop()
             logger.info("✅ LLC budget watchdog stopped")
         # GH#9026: Stop LLC session checkpointer
-        if hasattr(app.state, "llc_session_checkpointer") and app.state.llc_session_checkpointer:
+        if (
+            hasattr(app.state, "llc_session_checkpointer")
+            and app.state.llc_session_checkpointer
+        ):
             app.state.llc_session_checkpointer.stop()
             logger.info("✅ LLC session checkpointer stopped")
 
@@ -1748,7 +1829,10 @@ async def cleanup_services(app: FastAPI):
             await app.state.llc_outbound_sync.stop()
             logger.info("✅ LLC outbound sync service stopped")
         # GH#8255: Stop LLC notification router
-        if hasattr(app.state, "llc_notification_router") and app.state.llc_notification_router:
+        if (
+            hasattr(app.state, "llc_notification_router")
+            and app.state.llc_notification_router
+        ):
             await app.state.llc_notification_router.stop()
             logger.info("✅ LLC notification router stopped")
 
@@ -1763,7 +1847,10 @@ async def cleanup_services(app: FastAPI):
             logger.warning("HandoffService drain failed: %s", _hs_err)
 
         # GH#8229: Stop LLC routine scheduler
-        if hasattr(app.state, "llc_routine_scheduler") and app.state.llc_routine_scheduler:
+        if (
+            hasattr(app.state, "llc_routine_scheduler")
+            and app.state.llc_routine_scheduler
+        ):
             await app.state.llc_routine_scheduler.shutdown()
             logger.info("✅ LLC routine scheduler stopped")
 
@@ -1778,7 +1865,10 @@ async def cleanup_services(app: FastAPI):
             logger.info("✅ Backup scheduler stopped")
 
         # Issue #6590: Stop LLM key rotation scheduler
-        if hasattr(app.state, "llm_key_rotation_scheduler") and app.state.llm_key_rotation_scheduler:
+        if (
+            hasattr(app.state, "llm_key_rotation_scheduler")
+            and app.state.llm_key_rotation_scheduler
+        ):
             await app.state.llm_key_rotation_scheduler.stop()
             logger.info("✅ LLM key rotation scheduler stopped")
 
@@ -1790,7 +1880,10 @@ async def cleanup_services(app: FastAPI):
             logger.info("✅ Community cluster task cancelled")
 
         # Issue #1748: Stop process adapter dispatcher
-        if hasattr(app.state, "process_adapter_service") and app.state.process_adapter_service:
+        if (
+            hasattr(app.state, "process_adapter_service")
+            and app.state.process_adapter_service
+        ):
             await app.state.process_adapter_service.stop()
             logger.info("✅ Process adapter stopped")
 
@@ -1848,10 +1941,14 @@ def create_lifespan_manager():
 
         # Create bounded thread pool executor to prevent thread explosion
         # This replaces the default unbounded asyncio executor
-        _executor = ThreadPoolExecutor(max_workers=MAX_WORKER_THREADS, thread_name_prefix="autobot_worker")
+        _executor = ThreadPoolExecutor(
+            max_workers=MAX_WORKER_THREADS, thread_name_prefix="autobot_worker"
+        )
         loop = asyncio.get_running_loop()
         loop.set_default_executor(_executor)
-        logger.info("🧵 Bounded thread pool configured (max %d workers)", MAX_WORKER_THREADS)
+        logger.info(
+            "🧵 Bounded thread pool configured (max %d workers)", MAX_WORKER_THREADS
+        )
 
         # Register the running event loop for sync-endpoint audit scheduling (#1568)
         from middleware.audit_middleware import set_main_event_loop

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -104,13 +104,9 @@ def warn_if_dev_auth_bypass_enabled() -> None:
         return
     banner = "=" * 72
     logger.warning(banner)
-    logger.warning(
-        "⚠️  AUTOBOT_DEV_AUTH_BYPASS=true — /api/auth/login will mint an admin"
-    )
+    logger.warning("⚠️  AUTOBOT_DEV_AUTH_BYPASS=true — /api/auth/login will mint an admin")
     logger.warning("    JWT for ANY credentials in single_user mode. DO NOT use in")
-    logger.warning(
-        "    production. Unset the flag or switch AUTOBOT_USER_MODE away from"
-    )
+    logger.warning("    production. Unset the flag or switch AUTOBOT_USER_MODE away from")
     logger.warning("    single_user to disable. See issue #6838.")
     logger.warning(banner)
 
@@ -174,12 +170,8 @@ async def _init_chat_history_manager(app: FastAPI) -> None:
         await update_app_state("chat_history_manager", chat_history_manager)
         logger.info("✅ [ 30%] Chat History: Manager initialized successfully")
     except Exception as chat_history_error:
-        logger.error(
-            f"❌ CRITICAL: Chat history manager initialization failed: {chat_history_error}"
-        )
-        raise RuntimeError(
-            f"Chat history manager initialization failed: {chat_history_error}"
-        )
+        logger.error(f"❌ CRITICAL: Chat history manager initialization failed: {chat_history_error}")
+        raise RuntimeError(f"Chat history manager initialization failed: {chat_history_error}")
 
 
 async def _init_conversation_file_manager(app: FastAPI) -> None:
@@ -199,13 +191,9 @@ async def _init_conversation_file_manager(app: FastAPI) -> None:
         await conversation_file_manager.initialize()
         app.state.conversation_file_manager = conversation_file_manager
         await update_app_state("conversation_file_manager", conversation_file_manager)
-        logger.info(
-            "✅ [ 40%] Conversation Files DB: Database initialized and verified"
-        )
+        logger.info("✅ [ 40%] Conversation Files DB: Database initialized and verified")
     except Exception as conv_file_error:
-        logger.error(
-            f"❌ CRITICAL: Conversation files database initialization failed: {conv_file_error}"
-        )
+        logger.error(f"❌ CRITICAL: Conversation files database initialization failed: {conv_file_error}")
         logger.error("Backend startup ABORTED - database must be operational")
         raise RuntimeError(f"Database initialization failed: {conv_file_error}")
 
@@ -227,9 +215,7 @@ async def _init_chat_workflow_manager(app: FastAPI) -> None:
         await update_app_state("chat_workflow_manager", chat_workflow_manager)
         logger.info("✅ [ 50%] Chat Workflow: Manager initialized with async Redis")
     except Exception as chat_error:
-        logger.error(
-            f"❌ CRITICAL: Chat workflow manager initialization failed: {chat_error}"
-        )
+        logger.error(f"❌ CRITICAL: Chat workflow manager initialization failed: {chat_error}")
         raise RuntimeError(f"Chat workflow manager initialization failed: {chat_error}")
 
 
@@ -248,8 +234,7 @@ async def _check_env_drift() -> None:
             logger.warning("env drift check skipped: %s", report.error)
         elif report.has_drift:
             logger.warning(
-                "env drift detected — run 'python -m autobot_shared.env_drift_detector' "
-                "for details (%s)",
+                "env drift detected — run 'python -m autobot_shared.env_drift_detector' " "for details (%s)",
                 report.summary(),
             )
         else:
@@ -274,9 +259,7 @@ async def _init_config(app: FastAPI) -> None:
     validation_result = config.validate_startup()
     if not validation_result.valid:
         error_summary = "; ".join(validation_result.errors)
-        raise RuntimeError(
-            f"Configuration validation failed at startup: {error_summary}"
-        )
+        raise RuntimeError(f"Configuration validation failed at startup: {error_summary}")
     if validation_result.warnings:
         logger.warning(
             "Config: %d override warning(s) detected — review logged warnings above",
@@ -354,9 +337,7 @@ async def _init_telemetry_and_redis() -> None:
 
     instrument_redis()
     instrument_aiohttp()
-    logger.info(
-        "✅ [ 20%] Redis: Using centralized Redis client management (src.utils.redis_client)"
-    )
+    logger.info("✅ [ 20%] Redis: Using centralized Redis client management (src.utils.redis_client)")
 
 
 async def _init_skills(app: FastAPI) -> None:
@@ -368,9 +349,7 @@ async def _init_skills(app: FastAPI) -> None:
         await _init_skills_tables()
         await _init_skills_discovery()
     except Exception as skills_db_error:
-        logger.warning(
-            "Skills initialization failed (non-critical): %s", skills_db_error
-        )
+        logger.warning("Skills initialization failed (non-critical): %s", skills_db_error)
 
 
 async def _init_builtin_extensions(app: FastAPI) -> None:
@@ -398,13 +377,9 @@ async def _init_builtin_extensions(app: FastAPI) -> None:
         manager.register(LoggingExtension())
         manager.register(SecretMaskingExtension())
         manager.register(PermissionEnforcementExtension())
-        logger.info(
-            "Built-in extensions registered (logging, secret_masking, permission_enforcement)"
-        )
+        logger.info("Built-in extensions registered (logging, secret_masking, permission_enforcement)")
     except Exception as ext_error:
-        logger.warning(
-            "Built-in extension registration failed (non-critical): %s", ext_error
-        )
+        logger.warning("Built-in extension registration failed (non-critical): %s", ext_error)
 
 
 async def initialize_critical_services(app: FastAPI):
@@ -525,11 +500,7 @@ async def _init_knowledge_base(app: FastAPI):
         # Phase 1 initializes the manager before the KB is ready, leaving
         # knowledge_service=None. Re-wire here once the KB succeeds.
         mgr = getattr(app.state, "chat_workflow_manager", None)
-        if (
-            mgr is not None
-            and knowledge_base is not None
-            and mgr.knowledge_service is None
-        ):
+        if mgr is not None and knowledge_base is not None and mgr.knowledge_service is None:
             await mgr.set_knowledge_base(knowledge_base)
 
         # Issue #8391: Start VectorWriteBuffer background flush task.
@@ -595,13 +566,9 @@ async def _warmup_npu_connection(app: FastAPI) -> None:
                 result.get("embedding_dimensions", 0),
             )
         elif result["status"] == "npu_unavailable":
-            logger.info(
-                "🔄 [ 82%] NPU Warmup: NPU unavailable, using fallback embeddings"
-            )
+            logger.info("🔄 [ 82%] NPU Warmup: NPU unavailable, using fallback embeddings")
         else:
-            logger.warning(
-                "⚠️ [ 82%] NPU Warmup: %s", result.get("message", "Unknown status")
-            )
+            logger.warning("⚠️ [ 82%] NPU Warmup: %s", result.get("message", "Unknown status"))
 
     except Exception as warmup_error:
         logger.warning("NPU warmup failed: %s", warmup_error)
@@ -707,16 +674,11 @@ async def _auto_index_documentation():
             return
 
         # Fire-and-forget: run indexing in background so startup continues
-        logger.info(
-            "✅ [ 85%] Doc Index: Collection empty, "
-            "scheduling background indexing..."
-        )
+        logger.info("✅ [ 85%] Doc Index: Collection empty, " "scheduling background indexing...")
         asyncio.create_task(_run_background_doc_indexing())
 
     except Exception as index_error:
-        logger.warning(
-            "Documentation auto-index failed (non-critical): %s", index_error
-        )
+        logger.warning("Documentation auto-index failed (non-critical): %s", index_error)
 
 
 async def _init_log_forwarding():
@@ -733,9 +695,7 @@ async def _init_log_forwarding():
         forwarder = await get_forwarder()
 
         if forwarder.auto_start and forwarder.destinations:
-            logger.info(
-                "✅ [ 86%] Log Forwarding: Auto-start enabled, starting service..."
-            )
+            logger.info("✅ [ 86%] Log Forwarding: Auto-start enabled, starting service...")
             success = forwarder.start()
             if success:
                 logger.info(
@@ -743,13 +703,9 @@ async def _init_log_forwarding():
                     len(forwarder.destinations),
                 )
             else:
-                logger.warning(
-                    "⚠️ [ 86%] Log Forwarding: Failed to start (non-critical)"
-                )
+                logger.warning("⚠️ [ 86%] Log Forwarding: Failed to start (non-critical)")
         elif forwarder.auto_start:
-            logger.info(
-                "✅ [ 86%] Log Forwarding: Auto-start enabled but no destinations configured"
-            )
+            logger.info("✅ [ 86%] Log Forwarding: Auto-start enabled but no destinations configured")
         else:
             logger.info("✅ [ 86%] Log Forwarding: Auto-start disabled, skipping")
 
@@ -809,9 +765,7 @@ async def _init_heartbeat_scheduler(app: FastAPI) -> None:
         logger.info("Heartbeat: LLC HeartbeatScheduler started")
         return
     except Exception as llc_error:
-        logger.warning(
-            "LLC heartbeat scheduler unavailable, falling back to legacy: %s", llc_error
-        )
+        logger.warning("LLC heartbeat scheduler unavailable, falling back to legacy: %s", llc_error)
 
     logger.info("Heartbeat: Starting legacy heartbeat scheduler...")
     try:
@@ -924,9 +878,7 @@ async def _init_graph_rag_service(app: FastAPI, memory_graph):
 
         if app.state.knowledge_base:
             rag_config = RAGConfig(enable_advanced_rag=True, timeout_seconds=10.0)
-            rag_service = RAGService(
-                knowledge_base=app.state.knowledge_base, config=rag_config
-            )
+            rag_service = RAGService(knowledge_base=app.state.knowledge_base, config=rag_config)
             await rag_service.initialize()
 
             # Build mesh brain components and register them so every RAGService.initialize()
@@ -984,18 +936,14 @@ async def _init_graph_rag_service(app: FastAPI, memory_graph):
                 ]:
                     if _existing is not None and _existing._mesh_retriever is None:
                         _existing._initialized = False  # force re-init on next call
-                        logger.info(
-                            "Queued per-instance NeuralMeshRetriever build for existing RAGService (#4765)"
-                        )
+                        logger.info("Queued per-instance NeuralMeshRetriever build for existing RAGService (#4765)")
 
                 logger.info(
                     "✅ [ 87%] Neural Mesh RAG: mesh components registered; "
                     "per-instance NeuralMeshRetriever will build on next initialize() (#4765)"
                 )
             except Exception as _mesh_wire_err:
-                logger.warning(
-                    "Neural Mesh RAG wiring skipped (non-fatal): %s", _mesh_wire_err
-                )
+                logger.warning("Neural Mesh RAG wiring skipped (non-fatal): %s", _mesh_wire_err)
 
             graph_rag_service = GraphRAGService(
                 rag_service=rag_service,
@@ -1005,9 +953,7 @@ async def _init_graph_rag_service(app: FastAPI, memory_graph):
             )
             app.state.graph_rag_service = graph_rag_service
             await update_app_state("graph_rag_service", graph_rag_service)
-            logger.info(
-                "✅ [ 87%] Graph-RAG: Graph-aware RAG service initialized successfully"
-            )
+            logger.info("✅ [ 87%] Graph-RAG: Graph-aware RAG service initialized successfully")
         else:
             logger.info("🔄 [ 87%] Graph-RAG: Skipped (knowledge base not available)")
     except Exception as graph_rag_error:
@@ -1039,9 +985,7 @@ async def _init_entity_extractor(app: FastAPI, memory_graph):
         )
         app.state.entity_extractor = entity_extractor
         await update_app_state("entity_extractor", entity_extractor)
-        logger.info(
-            "✅ [ 88%] Entity Extractor: Entity extractor initialized successfully"
-        )
+        logger.info("✅ [ 88%] Entity Extractor: Entity extractor initialized successfully")
     except Exception as entity_error:
         logger.warning("Entity extractor initialization failed: %s", entity_error)
         app.state.entity_extractor = None
@@ -1107,9 +1051,7 @@ async def _init_slm_client():
         init_orchestrator(_get_slm_client())
         logger.info("✅ [ 89%] SLM Client: DeploymentCoordinator initialised")
     except Exception as slm_error:
-        logger.warning(
-            "SLM client initialization failed (continuing without): %s", slm_error
-        )
+        logger.warning("SLM client initialization failed (continuing without): %s", slm_error)
 
 
 async def _init_metrics_collection():
@@ -1274,8 +1216,7 @@ async def _ensure_agent_memory_index() -> None:
             logger.info("[ 93%%] Agent Memory Index: idx:agent_memory already exists")
         else:
             logger.info(
-                "[ 93%%] Agent Memory Index: idx:agent_memory created "
-                "(prefix=%s, dims=%d, metric=%s)",
+                "[ 93%%] Agent Memory Index: idx:agent_memory created " "(prefix=%s, dims=%d, metric=%s)",
                 result.get("prefix"),
                 result.get("dimensions"),
                 result.get("distance_metric"),
@@ -1322,13 +1263,9 @@ async def _wire_npu_task_queue() -> None:
         worker_manager = await get_worker_manager(redis_client=redis_client)
         task_queue = get_task_queue()
         task_queue.npu_worker_manager = worker_manager
-        logger.info(
-            "[ 98%%] NPU Task Queue: NPUWorkerManager wired — per-worker task tracking active"
-        )
+        logger.info("[ 98%%] NPU Task Queue: NPUWorkerManager wired — per-worker task tracking active")
     except Exception as e:
-        logger.warning(
-            "NPU task queue wiring failed (per-worker tracking disabled): %s", e
-        )
+        logger.warning("NPU task queue wiring failed (per-worker tracking disabled): %s", e)
 
 
 async def _init_voice_interface(app: FastAPI) -> None:
@@ -1346,8 +1283,7 @@ async def _init_voice_interface(app: FastAPI) -> None:
         logger.info("[ 99%%] Voice Interface: Initialized and attached to app.state")
     except Exception as e:
         logger.warning(
-            "Voice interface initialization failed (non-critical): %s — "
-            "voice endpoints will return 503",
+            "Voice interface initialization failed (non-critical): %s — " "voice endpoints will return 503",
             e,
         )
         app.state.voice_interface = None
@@ -1367,9 +1303,7 @@ async def _init_llm_key_rotation_scheduler(app: FastAPI) -> None:
         app.state.llm_key_rotation_scheduler = scheduler
         logger.info("[100%%] LLM Key Rotation: Scheduler started")
     except Exception as e:
-        logger.warning(
-            "LLM key rotation scheduler initialization failed (non-critical): %s", e
-        )
+        logger.warning("LLM key rotation scheduler initialization failed (non-critical): %s", e)
         app.state.llm_key_rotation_scheduler = None
 
 
@@ -1460,9 +1394,7 @@ async def _wire_scheduler_executor() -> None:
         get_workflow_scheduler().set_workflow_executor(_orchestration_executor)
         logger.info("[ 98%%] Scheduler: Orchestration executor wired")
     except Exception as e:
-        logger.warning(
-            "Scheduler executor wiring failed (template-only fallback active): %s", e
-        )
+        logger.warning("Scheduler executor wiring failed (template-only fallback active): %s", e)
 
 
 async def _start_community_clustering_loop(app: FastAPI) -> None:
@@ -1496,14 +1428,10 @@ async def _start_community_clustering_loop(app: FastAPI) -> None:
                     "Install with: pip install graspologic. Retrying in 24h. Error: %s",
                     exc,
                 )
-                await asyncio.sleep(
-                    86400
-                )  # 24 hours — re-check after potential install
+                await asyncio.sleep(86400)  # 24 hours — re-check after potential install
                 continue
             except Exception as exc:
-                logger.warning(
-                    "CommunityClusterer periodic run failed (non-fatal): %s", exc
-                )
+                logger.warning("CommunityClusterer periodic run failed (non-fatal): %s", exc)
             await asyncio.sleep(_CLUSTER_INTERVAL_SECONDS)
 
     app.state.community_cluster_task = asyncio.create_task(_loop())
@@ -1585,9 +1513,7 @@ async def _start_llc_notification_router(app: FastAPI) -> None:
         app.state.llc_notification_router = router
         logger.info("✅ LLC notification router started")
     except Exception as exc:
-        logger.warning(
-            "LLC notification router failed to start (non-critical): %s", exc
-        )
+        logger.warning("LLC notification router failed to start (non-critical): %s", exc)
         app.state.llc_notification_router = None
 
 
@@ -1645,9 +1571,7 @@ async def _init_plugin_manager(app: FastAPI) -> None:
         app.state.plugin_manager = plugin_manager
         logger.info("PluginManager started — %s", plugin_manager.get_plugin_status())
     except Exception as pm_err:
-        logger.warning(
-            "Plugin manager startup failed (non-critical): %s", pm_err, exc_info=True
-        )
+        logger.warning("Plugin manager startup failed (non-critical): %s", pm_err, exc_info=True)
 
 
 async def initialize_background_services(app: FastAPI):
@@ -1806,10 +1730,7 @@ async def cleanup_services(app: FastAPI):
         pass  # SLM reconciler now in slm-server
 
         # GH#9028: Stop LLC liveness monitor
-        if (
-            hasattr(app.state, "llc_liveness_monitor")
-            and app.state.llc_liveness_monitor
-        ):
+        if hasattr(app.state, "llc_liveness_monitor") and app.state.llc_liveness_monitor:
             app.state.llc_liveness_monitor.stop()
             logger.info("✅ LLC liveness monitor stopped")
         # GH#9029: Stop LLC budget watchdog
@@ -1817,10 +1738,7 @@ async def cleanup_services(app: FastAPI):
             app.state.llc_budget_watchdog.stop()
             logger.info("✅ LLC budget watchdog stopped")
         # GH#9026: Stop LLC session checkpointer
-        if (
-            hasattr(app.state, "llc_session_checkpointer")
-            and app.state.llc_session_checkpointer
-        ):
+        if hasattr(app.state, "llc_session_checkpointer") and app.state.llc_session_checkpointer:
             app.state.llc_session_checkpointer.stop()
             logger.info("✅ LLC session checkpointer stopped")
 
@@ -1829,10 +1747,7 @@ async def cleanup_services(app: FastAPI):
             await app.state.llc_outbound_sync.stop()
             logger.info("✅ LLC outbound sync service stopped")
         # GH#8255: Stop LLC notification router
-        if (
-            hasattr(app.state, "llc_notification_router")
-            and app.state.llc_notification_router
-        ):
+        if hasattr(app.state, "llc_notification_router") and app.state.llc_notification_router:
             await app.state.llc_notification_router.stop()
             logger.info("✅ LLC notification router stopped")
 
@@ -1847,10 +1762,7 @@ async def cleanup_services(app: FastAPI):
             logger.warning("HandoffService drain failed: %s", _hs_err)
 
         # GH#8229: Stop LLC routine scheduler
-        if (
-            hasattr(app.state, "llc_routine_scheduler")
-            and app.state.llc_routine_scheduler
-        ):
+        if hasattr(app.state, "llc_routine_scheduler") and app.state.llc_routine_scheduler:
             await app.state.llc_routine_scheduler.shutdown()
             logger.info("✅ LLC routine scheduler stopped")
 
@@ -1865,10 +1777,7 @@ async def cleanup_services(app: FastAPI):
             logger.info("✅ Backup scheduler stopped")
 
         # Issue #6590: Stop LLM key rotation scheduler
-        if (
-            hasattr(app.state, "llm_key_rotation_scheduler")
-            and app.state.llm_key_rotation_scheduler
-        ):
+        if hasattr(app.state, "llm_key_rotation_scheduler") and app.state.llm_key_rotation_scheduler:
             await app.state.llm_key_rotation_scheduler.stop()
             logger.info("✅ LLM key rotation scheduler stopped")
 
@@ -1880,10 +1789,7 @@ async def cleanup_services(app: FastAPI):
             logger.info("✅ Community cluster task cancelled")
 
         # Issue #1748: Stop process adapter dispatcher
-        if (
-            hasattr(app.state, "process_adapter_service")
-            and app.state.process_adapter_service
-        ):
+        if hasattr(app.state, "process_adapter_service") and app.state.process_adapter_service:
             await app.state.process_adapter_service.stop()
             logger.info("✅ Process adapter stopped")
 
@@ -1941,14 +1847,10 @@ def create_lifespan_manager():
 
         # Create bounded thread pool executor to prevent thread explosion
         # This replaces the default unbounded asyncio executor
-        _executor = ThreadPoolExecutor(
-            max_workers=MAX_WORKER_THREADS, thread_name_prefix="autobot_worker"
-        )
+        _executor = ThreadPoolExecutor(max_workers=MAX_WORKER_THREADS, thread_name_prefix="autobot_worker")
         loop = asyncio.get_running_loop()
         loop.set_default_executor(_executor)
-        logger.info(
-            "🧵 Bounded thread pool configured (max %d workers)", MAX_WORKER_THREADS
-        )
+        logger.info("🧵 Bounded thread pool configured (max %d workers)", MAX_WORKER_THREADS)
 
         # Register the running event loop for sync-endpoint audit scheduling (#1568)
         from middleware.audit_middleware import set_main_event_loop

--- a/autobot-backend/integrations/microsoft365_integration.py
+++ b/autobot-backend/integrations/microsoft365_integration.py
@@ -280,9 +280,7 @@ class Microsoft365Integration(BaseIntegration):
             ),
         ]
 
-    async def execute_action(
-        self, action: str, params: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    async def execute_action(self, action: str, params: Dict[str, Any]) -> Dict[str, Any]:
         """Execute a named Microsoft 365 action."""
         action_map = {
             # Calendar
@@ -334,9 +332,7 @@ class Microsoft365Integration(BaseIntegration):
         if start_dt and end_dt:
             safe_start = _validate_datetime_iso(start_dt, "start")
             safe_end = _validate_datetime_iso(end_dt, "end")
-            query_params["$filter"] = (
-                f"start/dateTime ge '{safe_start}' and end/dateTime le '{safe_end}'"
-            )
+            query_params["$filter"] = f"start/dateTime ge '{safe_start}' and end/dateTime le '{safe_end}'"
 
         result = await self._make_graph_request("GET", url, params=query_params)
         return result.get("body", {})
@@ -440,16 +436,12 @@ class Microsoft365Integration(BaseIntegration):
                     "contentType": params.get("body_type", "HTML"),
                     "content": params["body"],
                 },
-                "toRecipients": [
-                    {"emailAddress": {"address": addr}} for addr in params["to"]
-                ],
+                "toRecipients": [{"emailAddress": {"address": addr}} for addr in params["to"]],
             }
         }
 
         if "cc" in params:
-            message_data["message"]["ccRecipients"] = [
-                {"emailAddress": {"address": addr}} for addr in params["cc"]
-            ]
+            message_data["message"]["ccRecipients"] = [{"emailAddress": {"address": addr}} for addr in params["cc"]]
 
         if "attachments" in params:
             message_data["message"]["attachments"] = params["attachments"]
@@ -501,9 +493,7 @@ class Microsoft365Integration(BaseIntegration):
         """Send a message to a Teams channel."""
         safe_team_id = _validate_graph_id(params["team_id"], "team_id")
         safe_channel_id = _validate_graph_id(params["channel_id"], "channel_id")
-        url = (
-            f"{self.graph_url}/teams/{safe_team_id}/channels/{safe_channel_id}/messages"
-        )
+        url = f"{self.graph_url}/teams/{safe_team_id}/channels/{safe_channel_id}/messages"
 
         message_data = {
             "body": {
@@ -533,9 +523,7 @@ class Microsoft365Integration(BaseIntegration):
         safe_channel_id = _validate_graph_id(params["channel_id"], "channel_id")
         limit = params.get("limit", 50)
 
-        url = (
-            f"{self.graph_url}/teams/{safe_team_id}/channels/{safe_channel_id}/messages"
-        )
+        url = f"{self.graph_url}/teams/{safe_team_id}/channels/{safe_channel_id}/messages"
         query_params = {"$top": min(limit, 50)}  # Teams messages limited to 50
 
         result = await self._make_graph_request("GET", url, params=query_params)
@@ -605,9 +593,7 @@ class Microsoft365Integration(BaseIntegration):
 
                     # Log errors
                     if status_code >= 400:
-                        error_msg = body.get("error", {}).get(
-                            "message", "Unknown error"
-                        )
+                        error_msg = body.get("error", {}).get("message", "Unknown error")
                         self.logger.warning(
                             "Graph API request to %s failed: HTTP %d - %s",
                             url,
@@ -618,11 +604,7 @@ class Microsoft365Integration(BaseIntegration):
                     return {
                         "status_code": status_code,
                         "body": body,
-                        "error": (
-                            body.get("error", {}).get("message")
-                            if status_code >= 400
-                            else None
-                        ),
+                        "error": (body.get("error", {}).get("message") if status_code >= 400 else None),
                     }
 
         except aiohttp.ClientError as exc:

--- a/autobot-backend/integrations/microsoft365_integration.py
+++ b/autobot-backend/integrations/microsoft365_integration.py
@@ -23,7 +23,6 @@ from urllib.parse import quote
 import aiohttp
 
 from autobot_shared.logging_manager import get_logger
-
 from integrations.base import (
     BaseIntegration,
     IntegrationAction,
@@ -162,7 +161,11 @@ class Microsoft365Integration(BaseIntegration):
                 name="list_calendar_events",
                 description="List calendar events for a time range",
                 method="GET",
-                parameters={"start": "datetime", "end": "datetime", "calendar_id": "str (optional)"},
+                parameters={
+                    "start": "datetime",
+                    "end": "datetime",
+                    "calendar_id": "str (optional)",
+                },
             ),
             IntegrationAction(
                 name="create_calendar_event",
@@ -192,7 +195,11 @@ class Microsoft365Integration(BaseIntegration):
                 name="check_availability",
                 description="Check availability for scheduling",
                 method="POST",
-                parameters={"attendees": "list[str]", "start": "datetime", "end": "datetime"},
+                parameters={
+                    "attendees": "list[str]",
+                    "start": "datetime",
+                    "end": "datetime",
+                },
             ),
             # Outlook email actions
             IntegrationAction(
@@ -254,7 +261,11 @@ class Microsoft365Integration(BaseIntegration):
                 name="get_channel_messages",
                 description="Get messages from a Teams channel",
                 method="GET",
-                parameters={"team_id": "str", "channel_id": "str", "limit": "int (optional)"},
+                parameters={
+                    "team_id": "str",
+                    "channel_id": "str",
+                    "limit": "int (optional)",
+                },
             ),
             IntegrationAction(
                 name="create_teams_meeting",
@@ -269,7 +280,9 @@ class Microsoft365Integration(BaseIntegration):
             ),
         ]
 
-    async def execute_action(self, action: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    async def execute_action(
+        self, action: str, params: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Execute a named Microsoft 365 action."""
         action_map = {
             # Calendar
@@ -321,7 +334,9 @@ class Microsoft365Integration(BaseIntegration):
         if start_dt and end_dt:
             safe_start = _validate_datetime_iso(start_dt, "start")
             safe_end = _validate_datetime_iso(end_dt, "end")
-            query_params["$filter"] = f"start/dateTime ge '{safe_start}' and end/dateTime le '{safe_end}'"
+            query_params["$filter"] = (
+                f"start/dateTime ge '{safe_start}' and end/dateTime le '{safe_end}'"
+            )
 
         result = await self._make_graph_request("GET", url, params=query_params)
         return result.get("body", {})
@@ -425,12 +440,16 @@ class Microsoft365Integration(BaseIntegration):
                     "contentType": params.get("body_type", "HTML"),
                     "content": params["body"],
                 },
-                "toRecipients": [{"emailAddress": {"address": addr}} for addr in params["to"]],
+                "toRecipients": [
+                    {"emailAddress": {"address": addr}} for addr in params["to"]
+                ],
             }
         }
 
         if "cc" in params:
-            message_data["message"]["ccRecipients"] = [{"emailAddress": {"address": addr}} for addr in params["cc"]]
+            message_data["message"]["ccRecipients"] = [
+                {"emailAddress": {"address": addr}} for addr in params["cc"]
+            ]
 
         if "attachments" in params:
             message_data["message"]["attachments"] = params["attachments"]
@@ -482,7 +501,9 @@ class Microsoft365Integration(BaseIntegration):
         """Send a message to a Teams channel."""
         safe_team_id = _validate_graph_id(params["team_id"], "team_id")
         safe_channel_id = _validate_graph_id(params["channel_id"], "channel_id")
-        url = f"{self.graph_url}/teams/{safe_team_id}/channels/{safe_channel_id}/messages"
+        url = (
+            f"{self.graph_url}/teams/{safe_team_id}/channels/{safe_channel_id}/messages"
+        )
 
         message_data = {
             "body": {
@@ -512,7 +533,9 @@ class Microsoft365Integration(BaseIntegration):
         safe_channel_id = _validate_graph_id(params["channel_id"], "channel_id")
         limit = params.get("limit", 50)
 
-        url = f"{self.graph_url}/teams/{safe_team_id}/channels/{safe_channel_id}/messages"
+        url = (
+            f"{self.graph_url}/teams/{safe_team_id}/channels/{safe_channel_id}/messages"
+        )
         query_params = {"$top": min(limit, 50)}  # Teams messages limited to 50
 
         result = await self._make_graph_request("GET", url, params=query_params)
@@ -582,7 +605,9 @@ class Microsoft365Integration(BaseIntegration):
 
                     # Log errors
                     if status_code >= 400:
-                        error_msg = body.get("error", {}).get("message", "Unknown error")
+                        error_msg = body.get("error", {}).get(
+                            "message", "Unknown error"
+                        )
                         self.logger.warning(
                             "Graph API request to %s failed: HTTP %d - %s",
                             url,
@@ -593,7 +618,11 @@ class Microsoft365Integration(BaseIntegration):
                     return {
                         "status_code": status_code,
                         "body": body,
-                        "error": body.get("error", {}).get("message") if status_code >= 400 else None,
+                        "error": (
+                            body.get("error", {}).get("message")
+                            if status_code >= 400
+                            else None
+                        ),
                     }
 
         except aiohttp.ClientError as exc:

--- a/autobot-backend/llm_shared/run_credential_loader.py
+++ b/autobot-backend/llm_shared/run_credential_loader.py
@@ -9,7 +9,7 @@ into the request context for use by the provider registry.
 """
 
 import json
-from typing import Dict, Any
+from typing import Any, Dict
 from uuid import UUID
 
 from sqlalchemy import select

--- a/autobot-backend/llm_shared/tests/test_run_credentials.py
+++ b/autobot-backend/llm_shared/tests/test_run_credentials.py
@@ -4,6 +4,7 @@
 """Tests for per-run credential injection (GH#9037)."""
 
 import asyncio
+
 import pytest
 
 from llm_shared.provider_registry import (

--- a/autobot-backend/tests/test_startup_error_sanitize.py
+++ b/autobot-backend/tests/test_startup_error_sanitize.py
@@ -17,7 +17,7 @@ import json
 import sys
 import types
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 # ---------------------------------------------------------------------------
 # Minimal stubs so api/system.py and initialization/lifespan.py import cleanly

--- a/autobot-backend/voice_processing/language_detection.py
+++ b/autobot-backend/voice_processing/language_detection.py
@@ -42,15 +42,10 @@ class LanguageDetectionService:
             ]
 
             self._detector = LanguageDetectorBuilder.from_languages(*languages).build()
-            logger.info(
-                f"Language detector initialized with {len(languages)} languages"
-            )
+            logger.info(f"Language detector initialized with {len(languages)} languages")
 
         except ImportError:
-            logger.warning(
-                "lingua-language-detector not installed - "
-                "language detection disabled"
-            )
+            logger.warning("lingua-language-detector not installed - " "language detection disabled")
             self._detector = None
 
     async def detect_language(self, audio_path: str) -> Optional[str]:
@@ -77,10 +72,7 @@ class LanguageDetectionService:
             text_sample = await self._extract_text_sample(audio_path)
 
             if not text_sample:
-                logger.warning(
-                    f"Could not extract text sample from {audio_path}, "
-                    "defaulting to 'en'"
-                )
+                logger.warning(f"Could not extract text sample from {audio_path}, " "defaulting to 'en'")
                 return "en"
 
             # Detect language from text
@@ -92,9 +84,7 @@ class LanguageDetectionService:
 
             # Convert lingua Language enum to BCP-47 code
             lang_code = detected.iso_code_639_1.name.lower()
-            logger.info(
-                f"Detected language '{lang_code}' from audio: {audio_path}"
-            )
+            logger.info(f"Detected language '{lang_code}' from audio: {audio_path}")
             return lang_code
 
         except Exception as e:
@@ -128,10 +118,7 @@ class LanguageDetectionService:
 
         # If no hints in filename, we'd use a fast speech-to-text model here
         # For now, default to None (caller will use default language)
-        logger.debug(
-            f"No language hints in filename: {filename}, "
-            "full transcription needed for detection"
-        )
+        logger.debug(f"No language hints in filename: {filename}, " "full transcription needed for detection")
         return None
 
 

--- a/autobot-backend/voice_processing/providers/__init__.py
+++ b/autobot-backend/voice_processing/providers/__init__.py
@@ -33,9 +33,7 @@ class SpeechProvider(ABC):
     """Base interface for speech recognition providers."""
 
     @abstractmethod
-    async def transcribe(
-        self, audio_path: str, language: Optional[str] = None
-    ) -> List[TranscriptSegment]:
+    async def transcribe(self, audio_path: str, language: Optional[str] = None) -> List[TranscriptSegment]:
         """Transcribe audio file to segments.
 
         Args:
@@ -88,10 +86,7 @@ class ProviderRegistry:
             insert_idx = i + 1
 
         providers.insert(insert_idx, (provider, priority))
-        logger.info(
-            f"Registered {provider.provider_name} for language '{language}' "
-            f"with priority {priority}"
-        )
+        logger.info(f"Registered {provider.provider_name} for language '{language}' " f"with priority {priority}")
 
     def get_provider(self, language: str) -> Optional[SpeechProvider]:
         """Get highest-priority provider for a language.
@@ -109,10 +104,7 @@ class ProviderRegistry:
 
         # Return highest priority (first in list)
         provider, priority = providers[0]
-        logger.debug(
-            f"Selected {provider.provider_name} for language '{language}' "
-            f"(priority {priority})"
-        )
+        logger.debug(f"Selected {provider.provider_name} for language '{language}' " f"(priority {priority})")
         return provider
 
     def get_all_providers(self, language: str) -> List[SpeechProvider]:

--- a/autobot-backend/voice_processing/providers/generic_provider.py
+++ b/autobot-backend/voice_processing/providers/generic_provider.py
@@ -26,9 +26,7 @@ class GenericProvider(SpeechProvider):
         """Initialize generic provider with speech recognition engine."""
         self.engine = SpeechRecognitionEngine()
 
-    async def transcribe(
-        self, audio_path: str, language: Optional[str] = None
-    ) -> List[TranscriptSegment]:
+    async def transcribe(self, audio_path: str, language: Optional[str] = None) -> List[TranscriptSegment]:
         """Transcribe audio using generic recognition engine.
 
         Args:
@@ -54,16 +52,11 @@ class GenericProvider(SpeechProvider):
 
             # Use existing speech recognition engine
             lang = language or "en"
-            result: SpeechRecognitionResult = await self.engine.transcribe_audio(
-                audio_input, language=lang
-            )
+            result: SpeechRecognitionResult = await self.engine.transcribe_audio(audio_input, language=lang)
 
             # Convert SpeechRecognitionResult to TranscriptSegments
             segments = self._convert_to_segments(result)
-            logger.info(
-                f"Generic provider transcription completed: "
-                f"{len(segments)} segments"
-            )
+            logger.info(f"Generic provider transcription completed: " f"{len(segments)} segments")
             return segments
 
         except Exception as e:
@@ -84,7 +77,7 @@ class GenericProvider(SpeechProvider):
 
         try:
             # Try to load as WAV file
-            with wave.open(audio_path, 'rb') as wav:
+            with wave.open(audio_path, "rb") as wav:
                 frames = wav.readframes(wav.getnframes())
                 sample_rate = wav.getframerate()
                 duration = wav.getnframes() / float(sample_rate)
@@ -108,9 +101,7 @@ class GenericProvider(SpeechProvider):
                 metadata={"source_file": audio_path, "load_error": str(e)},
             )
 
-    def _convert_to_segments(
-        self, result: SpeechRecognitionResult
-    ) -> List[TranscriptSegment]:
+    def _convert_to_segments(self, result: SpeechRecognitionResult) -> List[TranscriptSegment]:
         """Convert SpeechRecognitionResult to TranscriptSegments.
 
         Args:

--- a/autobot-backend/voice_processing/providers/lv/late_provider.py
+++ b/autobot-backend/voice_processing/providers/lv/late_provider.py
@@ -40,7 +40,7 @@ class LateProvider(SpeechProvider):
                 capture_output=True,
                 text=True,
                 timeout=5,
-                encoding='utf-8',
+                encoding="utf-8",
             )
             if result.returncode == 0:
                 logger.info(f"LATE binary available: {self.late_binary}")
@@ -54,9 +54,7 @@ class LateProvider(SpeechProvider):
         except Exception as e:
             logger.warning(f"LATE availability check failed: {e}")
 
-    async def transcribe(
-        self, audio_path: str, language: Optional[str] = None
-    ) -> List[TranscriptSegment]:
+    async def transcribe(self, audio_path: str, language: Optional[str] = None) -> List[TranscriptSegment]:
         """Transcribe audio using LATE.
 
         Args:
@@ -86,9 +84,7 @@ class LateProvider(SpeechProvider):
 
             # Run in executor to avoid blocking
             loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(
-                None, self._run_late_command, cmd
-            )
+            result = await loop.run_in_executor(None, self._run_late_command, cmd)
 
             if result is None:
                 logger.error("LATE transcription failed")
@@ -96,9 +92,7 @@ class LateProvider(SpeechProvider):
 
             # Parse LATE JSON output
             segments = self._parse_late_output(result)
-            logger.info(
-                f"LATE transcription completed: {len(segments)} segments"
-            )
+            logger.info(f"LATE transcription completed: {len(segments)} segments")
             return segments
 
         except Exception as e:
@@ -120,7 +114,7 @@ class LateProvider(SpeechProvider):
                 capture_output=True,
                 text=True,
                 timeout=300,  # 5 minute timeout
-                encoding='utf-8',
+                encoding="utf-8",
             )
 
             if result.returncode != 0:

--- a/autobot-backend/voice_processing/providers/lv/tilde_provider.py
+++ b/autobot-backend/voice_processing/providers/lv/tilde_provider.py
@@ -35,20 +35,14 @@ class TildeProvider(SpeechProvider):
             api_url: Tilde API URL (defaults to env var or public endpoint)
         """
         self.api_key = api_key or os.getenv("TILDE_API_KEY")
-        self.api_url = api_url or os.getenv(
-            "TILDE_API_URL",
-            "https://api.tilde.com/v1/asr"
-        )
+        self.api_url = api_url or os.getenv("TILDE_API_URL", "https://api.tilde.com/v1/asr")
 
         if not self.api_key:
             logger.warning(
-                "TILDE_API_KEY not set - Tilde provider will not work. "
-                "Set TILDE_API_KEY environment variable."
+                "TILDE_API_KEY not set - Tilde provider will not work. " "Set TILDE_API_KEY environment variable."
             )
 
-    async def transcribe(
-        self, audio_path: str, language: Optional[str] = None
-    ) -> List[TranscriptSegment]:
+    async def transcribe(self, audio_path: str, language: Optional[str] = None) -> List[TranscriptSegment]:
         """Transcribe audio using Tilde ASR.
 
         Args:
@@ -68,23 +62,19 @@ class TildeProvider(SpeechProvider):
 
         try:
             # Read audio file
-            with open(audio_path, 'rb') as f:
+            with open(audio_path, "rb") as f:
                 audio_data = f.read()
 
             # Send to Tilde API
             segments = await self._call_tilde_api(audio_data, audio_path)
-            logger.info(
-                f"Tilde transcription completed: {len(segments)} segments"
-            )
+            logger.info(f"Tilde transcription completed: {len(segments)} segments")
             return segments
 
         except Exception as e:
             logger.error(f"Tilde transcription failed: {e}")
             return []
 
-    async def _call_tilde_api(
-        self, audio_data: bytes, audio_path: str
-    ) -> List[TranscriptSegment]:
+    async def _call_tilde_api(self, audio_data: bytes, audio_path: str) -> List[TranscriptSegment]:
         """Call Tilde ASR API.
 
         Args:
@@ -97,18 +87,13 @@ class TildeProvider(SpeechProvider):
         try:
             # Prepare multipart form data
             form = aiohttp.FormData()
-            form.add_field(
-                'audio',
-                audio_data,
-                filename=os.path.basename(audio_path),
-                content_type='audio/wav'
-            )
-            form.add_field('language', 'lv')
-            form.add_field('format', 'json')
-            form.add_field('segments', 'true')
+            form.add_field("audio", audio_data, filename=os.path.basename(audio_path), content_type="audio/wav")
+            form.add_field("language", "lv")
+            form.add_field("format", "json")
+            form.add_field("segments", "true")
 
             headers = {
-                'Authorization': f'Bearer {self.api_key}',
+                "Authorization": f"Bearer {self.api_key}",
             }
 
             timeout = aiohttp.ClientTimeout(total=300)  # 5 minute timeout
@@ -121,9 +106,7 @@ class TildeProvider(SpeechProvider):
                 ) as response:
                     if response.status != 200:
                         error_text = await response.text()
-                        logger.error(
-                            f"Tilde API error {response.status}: {error_text}"
-                        )
+                        logger.error(f"Tilde API error {response.status}: {error_text}")
                         return []
 
                     result = await response.json()

--- a/autobot-backend/voice_processing/providers/registry_init.py
+++ b/autobot-backend/voice_processing/providers/registry_init.py
@@ -46,10 +46,7 @@ def initialize_providers():
     registry.register("lv", generic, priority=-10)
     registry.register("lat", generic, priority=-10)
 
-    logger.info(
-        "Speech providers initialized: "
-        "LATE (lv), Tilde (lv), Generic (en, de, es, fr, ...)"
-    )
+    logger.info("Speech providers initialized: " "LATE (lv), Tilde (lv), Generic (en, de, es, fr, ...)")
 
 
 # Auto-initialize on import

--- a/autobot-backend/voice_processing/test_language_detection.py
+++ b/autobot-backend/voice_processing/test_language_detection.py
@@ -33,9 +33,7 @@ class TestLanguageDetectionService:
         service = LanguageDetectionService()
 
         # Create temp file with Latvian hint
-        with tempfile.NamedTemporaryFile(
-            suffix="_lv_audio.wav", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(suffix="_lv_audio.wav", delete=False) as f:
             temp_path = f.name
 
         try:
@@ -51,9 +49,7 @@ class TestLanguageDetectionService:
         """Test detection from English filename hints."""
         service = LanguageDetectionService()
 
-        with tempfile.NamedTemporaryFile(
-            suffix="_en_audio.wav", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(suffix="_en_audio.wav", delete=False) as f:
             temp_path = f.name
 
         try:
@@ -137,9 +133,7 @@ class TestFilenamePatterns:
         ]
 
         for pattern in patterns:
-            with tempfile.NamedTemporaryFile(
-                suffix=pattern, delete=False
-            ) as f:
+            with tempfile.NamedTemporaryFile(suffix=pattern, delete=False) as f:
                 temp_path = f.name
 
             try:
@@ -161,9 +155,7 @@ class TestFilenamePatterns:
         ]
 
         for pattern in patterns:
-            with tempfile.NamedTemporaryFile(
-                suffix=pattern, delete=False
-            ) as f:
+            with tempfile.NamedTemporaryFile(suffix=pattern, delete=False) as f:
                 temp_path = f.name
 
             try:

--- a/autobot_shared/paperclip_client.py
+++ b/autobot_shared/paperclip_client.py
@@ -117,7 +117,7 @@ class PaperclipClient:
         run_id: str | None = None,
         comment_dedup_ttl: int = _COMMENT_DEDUP_TTL_SECONDS,
     ) -> None:
-        self._api_url = (api_url or os.environ.get("PAPERCLIP_API_URL", "")).rstrip("/")
+        self._api_url = (api_url or os.environ.get("PAPERCLIP_API_URL") or "").rstrip("/")
         self._api_key = api_key or os.environ.get("PAPERCLIP_API_KEY", "")
         self._run_id = run_id or os.environ.get("PAPERCLIP_RUN_ID", "")
         self._comment_dedup_ttl = comment_dedup_ttl


### PR DESCRIPTION
## Thinking Path

PR #9186 failed code-quality CI with 13 flake8 violations introduced by recent changes. These were new violations (not the existing mypy backlog). Fix required: remove unused imports across 4 files, replace unused `exc` variables in exception handlers, break a string literal to 120-char limit, and apply Black formatting with `--line-length=120` to match project CI config. Also found two files (`chat_embed.py`, `chat_embed_test.py`) from PR #9180 in the base branch that needed Black formatting to unblock code-quality CI.

## What Changed

- Removed unused imports: `json`, `time` from `context_overflow.py`
- Removed unused `pathlib.Path` top-level import from `lifespan.py` (re-imported locally where used)
- Removed unused `Literal`, `now_utc` imports from `microsoft365_integration.py`
- Removed unused `ThinkingPreferences`, `ThinkingPreferencesData` imports from `chat_sessions.py`
- Fixed unused `exc` variable in 2 `telegram_bot.py` exception handlers (`except Exception as exc` → `except Exception`)
- Broke long string literal in `context_overflow.py` to stay within 120-char limit
- Applied Black `--line-length=120` to all modified files and to `chat_embed.py`, `chat_embed_test.py` from base branch

## Verification

- Ran `flake8 --select=E501,F401,F811,F841` on all modified files — 0 violations
- Ran `black --check --line-length=120` locally — all files pass
- CI code-quality check running on latest commit `8ebb23a6b`

## Model Used

claude-sonnet-4-6