### PR TITLE
fix(code-quality): remove unused imports and fix E501 in context_overflow and microsoft365

### DIFF
--- a/autobot-backend/chat_history/context_overflow.py
+++ b/autobot-backend/chat_history/context_overflow.py
@@ -13,8 +13,6 @@ Provides automatic context window management:
 Builds on #8990 (token usage tracking) and #3770 (compression service).
 """
 
-import json
-import time
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.logging_manager import get_logger
@@ -168,18 +166,22 @@ class ConversationSummarizer:
         summary = await summarizer.summarize_messages(messages, model="gpt-4")
     """
 
-    _SUMMARIZATION_PROMPT = """Compress the following conversation segment preserving all decisions, facts, and action items.
-The summary should be compact but complete enough that someone reading it later can understand what was discussed and decided.
-Focus on:
-- Key decisions made
-- Important facts mentioned
-- Action items or tasks identified
-- Critical context needed for future messages
-
-Original conversation:
-{conversation}
-
-Provide a concise summary in 2-3 paragraphs:"""
+    _SUMMARIZATION_PROMPT = (
+        "Compress the following conversation segment preserving all decisions, "
+        "facts, and action items.\n"
+        "The summary should be compact but complete enough that someone reading "
+        "it later can understand what was discussed and decided.\n"
+        "Focus on:\n"
+        "- Key decisions made\n"
+        "- Important facts mentioned\n"
+        "- Action items or tasks identified\n"
+        "- Critical context needed for future messages\n"
+        "\n"
+        "Original conversation:\n"
+        "{conversation}\n"
+        "\n"
+        "Provide a concise summary in 2-3 paragraphs:"
+    )
 
     async def summarize_messages(
         self,

--- a/autobot-backend/integrations/microsoft365_integration.py
+++ b/autobot-backend/integrations/microsoft365_integration.py
@@ -17,13 +17,13 @@ All operations use Microsoft Graph API v1.0 endpoints.
 import re
 import time
 from datetime import datetime
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List
 from urllib.parse import quote
 
 import aiohttp
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.time_utils import now_utc
+
 from integrations.base import (
     BaseIntegration,
     IntegrationAction,


### PR DESCRIPTION
## Thinking Path

code-quality CI was failing on PR #9186 due to flake8 violations and Black formatting issues in files recently landed on Dev_new_gui. These are pre-existing violations not introduced by #9186 itself, but they surface in the merged CI run. Fixed here so the base branch is clean.

- `context_overflow.py` and `microsoft365_integration.py`: unused imports (`json`, `time`, `Literal`, `now_utc`) removed. `now_utc` flagged as possible unwired datetime-normalisation feature (MVA-2181).
- `context_overflow.py`: `_SUMMARIZATION_PROMPT` exceeded 120 chars — refactored to concatenated string literals, content identical.
- `chat_embed.py` / `chat_embed_test.py`: Black formatting violations from PR #9180 — applied Black.

## What Changed

- **chat_history/context_overflow.py**: removed unused `json`, `time`; reformatted prompt string within line-length limit
- **integrations/microsoft365_integration.py**: removed unused `Literal`, `now_utc`
- **api/chat_embed.py** + **chat_embed_test.py**: Black formatting applied

## Verification

- `flake8` returns 0 on all changed files
- `python3.12 -m black --check` passes on all 2845 backend files
- No functional change — unused imports only, string reformatting preserves content

## Model Used

claude-sonnet-4-6