### PR TITLE
refactor(frontend): complete useGlobalWebSocket migration to useEventBus

### DIFF
--- a/autobot-frontend/OPTIMIZATION_OPPORTUNITIES.md
+++ b/autobot-frontend/OPTIMIZATION_OPPORTUNITIES.md
@@ -194,13 +194,6 @@ Comprehensive `useWebSocket.ts` composable with features:
    - **After**: useWebSocket with callbacks
    - **Saved**: ~45 lines of boilerplate
 
-### Components Using Global WebSocket
-
-These components use the existing GlobalWebSocketService (different pattern):
-- `MCPDashboard.vue` - Uses useGlobalWebSocket
-- `OptimizedRumDashboard.vue` - Uses useGlobalWebSocket
-- `NPUWorkersSettings.vue` - Uses useGlobalWebSocket
-
 ### Components with Specialized Patterns
 
 These components have unique WebSocket patterns that may benefit from custom implementation:

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -285,7 +285,9 @@ import { useAppStore } from '@/stores/useAppStore'
 import { useNotificationBus } from '@/composables/useNotificationBus'
 import { usePreferences } from '@/composables/usePreferences'
 import { useOverseerAgent } from '@/composables/useOverseerAgent'
-import { useGlobalWebSocket } from '@/composables/useGlobalWebSocket'
+// GH#9062: migrated from useGlobalWebSocket — context events flow through
+// LiveEventManager (global channel), so useEventBus is the correct subscriber
+import { useEventBus } from '@/composables/useEventBus'
 import ApiClient from '@/utils/ApiClient'
 import batchApiService from '@/services/BatchApiService'
 // MIGRATED: Using AppConfig.js for better configuration management
@@ -464,34 +466,36 @@ const notify = (message: string, type: 'info' | 'success' | 'warning' | 'error' 
 }
 
 // MVA-2006: Context window overflow WebSocket listeners
-const ws = useGlobalWebSocket()
+// GH#9062: migrated to useEventBus for channel-based event subscriptions
+const { subscribe } = useEventBus()
 const contextWarningShown = ref(false)
 
 // Listen for context_warning events (80% threshold)
-ws.on('context_warning', (data: any) => {
-  logger.debug('[ContextWindow] Warning event received:', data)
+subscribe('global', (event) => {
+  if (event.event_type === 'context_warning') {
+    const data = event.payload as any
+    logger.debug('[ContextWindow] Warning event received:', data)
 
-  // Only show toast if mode is 'auto' or 'warn', and not already shown
-  if (contextOverflowMode.value !== 'disabled' && !contextWarningShown.value) {
-    const percent = data.usage_percent ?? _ctxWindow.usagePercent.value
-    notify(
-      t('chat.contextWindow.warningToast', { percent: percent.toFixed(1) }),
-      'warning'
-    )
-    contextWarningShown.value = true
-  }
-})
+    // Only show toast if mode is 'auto' or 'warn', and not already shown
+    if (contextOverflowMode.value !== 'disabled' && !contextWarningShown.value) {
+      const percent = data.usage_percent ?? _ctxWindow.usagePercent.value
+      notify(
+        t('chat.contextWindow.warningToast', { percent: percent.toFixed(1) }),
+        'warning'
+      )
+      contextWarningShown.value = true
+    }
+  } else if (event.event_type === 'context_compressed') {
+    const data = event.payload as any
+    logger.info('[ContextWindow] Context compressed:', data)
 
-// Listen for context_compressed events (summary injected)
-ws.on('context_compressed', (data: any) => {
-  logger.info('[ContextWindow] Context compressed:', data)
+    // Reset warning flag so next session can show it again
+    contextWarningShown.value = false
 
-  // Reset warning flag so next session can show it again
-  contextWarningShown.value = false
-
-  // Notify user that compression occurred
-  if (contextOverflowMode.value === 'auto') {
-    notify(t('chat.contextWindow.compressedToast'), 'info')
+    // Notify user that compression occurred
+    if (contextOverflowMode.value === 'auto') {
+      notify(t('chat.contextWindow.compressedToast'), 'info')
+    }
   }
 })
 


### PR DESCRIPTION
## Thinking Path

The deprecated `useGlobalWebSocket` composable had two remaining callers using `ws.on()` for event subscriptions after Phase 1 of the #6488 migration:
- `useCaptchaStatus.ts` — already migrated in a previous PR (#9121)
- `ChatInterface.vue` — context window overflow events (`context_warning`, `context_compressed`) still using the old pattern

Both event types flow through the LiveEventManager global channel, making `useEventBus.subscribe('global', ...)` the correct replacement. The migration is purely structural — same events, same handlers, new subscription API.

The `useGlobalWebSocket` composable itself is preserved because `send()` and `state` access still require it until backend endpoint unification (#8291) is complete.

## What Changed

**`autobot-frontend/src/components/chat/ChatInterface.vue`**
- Replaced `useGlobalWebSocket` import with `useEventBus`
- Combined two separate `ws.on()` handlers into a single `subscribe('global', ...)` callback with `event.event_type` dispatch
- Context events now extracted from `event.payload` following Phase 2 pattern

**`autobot-frontend/OPTIMIZATION_OPPORTUNITIES.md`**
- Removed outdated WebSocket composables migration list (now complete)

## Verification

- ✅ Rebased onto latest Dev_new_gui (0950e1118) — no conflicts
- ✅ Only 2 files changed (focused scope matching issue description)
- ✅ Migration pattern matches `useCaptchaStatus.ts` reference implementation (already reviewed and merged)
- ✅ All functional callers of `useGlobalWebSocket.on()` migrated — only doc references remain in `useWebSocket.ts` and `useEventBus.ts`
- ✅ Deprecated composable preserved for `send()`/`state` callers until #8291

Closes #9062

## Model Used

claude-sonnet-4-6