### PR TITLE
feat(chat): add org-wide preset support (GH#4449)

### DIFF
--- a/autobot-backend/api/chat_presets.py
+++ b/autobot-backend/api/chat_presets.py
@@ -2,22 +2,30 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-Slash command presets API (GH#8595).
+Slash command presets API (GH#4449, GH#8595).
 
 GET    /api/chat/presets        -> SlashCommandPreset[]
 POST   /api/chat/presets        -> SlashCommandPreset
 PUT    /api/chat/presets/{id}   -> SlashCommandPreset
 DELETE /api/chat/presets/{id}   -> 204
 
-Storage: Redis hash `chat:presets:{user_id}` in the sessions database.
+Storage: Redis hashes in the sessions database:
+- Personal: `chat:presets:user:{user_id}`
+- Org-wide: `chat:presets:org:{org_id}`
+
 Each field in the hash is a preset ID whose value is a JSON-encoded preset.
+
+Permissions:
+- Any user can create/update/delete personal presets
+- Only org admins can create/update/delete org-wide presets
+- All org members can read org-wide presets
 
 Frontend contract: plain JSON, no envelope wrapper.
 """
 
 import json
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Literal, Optional
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -35,18 +43,29 @@ router = APIRouter(tags=["chat"])
 REDIS_DB = "sessions"
 
 
-def _hash_key(user_id: str) -> str:
-    return f"chat:presets:{user_id}"
+def _user_hash_key(user_id: str) -> str:
+    return f"chat:presets:user:{user_id}"
+
+
+def _org_hash_key(org_id: str) -> str:
+    return f"chat:presets:org:{org_id}"
 
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _is_org_admin(current_user: dict) -> bool:
+    """Check if user has org admin privileges."""
+    role = current_user.get("role", "").lower()
+    return role in ["admin", "org_admin", "owner"]
+
+
 class PresetCreate(BaseModel):
     name: str
     description: str
     content: str
+    scope: Literal["personal", "org"] = "personal"
 
 
 class PresetUpdate(BaseModel):
@@ -59,19 +78,33 @@ class PresetUpdate(BaseModel):
 async def list_presets(
     current_user: dict = Depends(get_current_user),
 ) -> JSONResponse:
-    """Return all presets for the authenticated user."""
+    """Return all presets for the authenticated user (personal + org-wide)."""
     user_id = current_user.get("username", "")
+    org_id = current_user.get("org_id")
     redis = await get_async_redis_client(database=REDIS_DB)
     if redis is None:
         logger.warning("chat_presets: Redis unavailable for user %s", user_id)
         raise HTTPException(status_code=503, detail="Service temporarily unavailable")
-    raw = await redis.hgetall(_hash_key(user_id))
+
     presets = []
-    for value in raw.values():
+
+    # Fetch personal presets
+    user_raw = await redis.hgetall(_user_hash_key(user_id))
+    for value in user_raw.values():
         try:
             presets.append(json.loads(value))
         except (json.JSONDecodeError, TypeError):
-            logger.warning("Skipping corrupt preset entry for user %s", user_id)
+            logger.warning("Skipping corrupt personal preset entry for user %s", user_id)
+
+    # Fetch org-wide presets if user belongs to an org
+    if org_id:
+        org_raw = await redis.hgetall(_org_hash_key(org_id))
+        for value in org_raw.values():
+            try:
+                presets.append(json.loads(value))
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Skipping corrupt org preset entry for org %s", org_id)
+
     presets.sort(key=lambda p: p.get("createdAt", ""))
     return JSONResponse(content=presets)
 
@@ -81,23 +114,52 @@ async def create_preset(
     payload: PresetCreate,
     current_user: dict = Depends(get_current_user),
 ) -> JSONResponse:
-    """Create a new preset for the authenticated user."""
+    """Create a new preset (personal or org-wide).
+
+    Org-wide presets require admin privileges.
+    """
     user_id = current_user.get("username", "")
+    org_id = current_user.get("org_id")
+
+    # Permission check for org presets
+    if payload.scope == "org":
+        if not org_id:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot create org preset: user not associated with an organization"
+            )
+        if not _is_org_admin(current_user):
+            raise HTTPException(
+                status_code=403,
+                detail="Only org admins can create org-wide presets"
+            )
+
     now = _now_iso()
     preset = {
         "id": str(uuid4()),
         "name": payload.name,
         "description": payload.description,
         "content": payload.content,
+        "scope": payload.scope,
         "createdAt": now,
         "updatedAt": now,
     }
+
     redis = await get_async_redis_client(database=REDIS_DB)
     if redis is None:
         logger.warning("chat_presets: Redis unavailable for user %s", user_id)
         raise HTTPException(status_code=503, detail="Service temporarily unavailable")
-    await redis.hset(_hash_key(user_id), preset["id"], json.dumps(preset))
-    logger.info("Created preset %s for user %s", preset["id"], user_id)
+
+    # Store in appropriate hash based on scope
+    hash_key = _org_hash_key(org_id) if payload.scope == "org" else _user_hash_key(user_id)
+    await redis.hset(hash_key, preset["id"], json.dumps(preset))
+
+    logger.info(
+        "Created %s preset %s for %s",
+        payload.scope,
+        preset["id"],
+        f"org {org_id}" if payload.scope == "org" else f"user {user_id}"
+    )
     return JSONResponse(content=preset, status_code=201)
 
 
@@ -107,15 +169,40 @@ async def update_preset(
     payload: PresetUpdate,
     current_user: dict = Depends(get_current_user),
 ) -> JSONResponse:
-    """Update an existing preset owned by the authenticated user."""
+    """Update an existing preset.
+
+    Users can update their own personal presets.
+    Only org admins can update org-wide presets.
+    """
     user_id = current_user.get("username", "")
+    org_id = current_user.get("org_id")
     redis = await get_async_redis_client(database=REDIS_DB)
     if redis is None:
         logger.warning("chat_presets: Redis unavailable for user %s", user_id)
         raise HTTPException(status_code=503, detail="Service temporarily unavailable")
-    raw = await redis.hget(_hash_key(user_id), preset_id)
+
+    # Try to find the preset in user's personal presets first
+    raw = await redis.hget(_user_hash_key(user_id), preset_id)
+    hash_key = _user_hash_key(user_id)
+    is_org_preset = False
+
+    # If not found in personal presets, try org presets
+    if raw is None and org_id:
+        raw = await redis.hget(_org_hash_key(org_id), preset_id)
+        if raw is not None:
+            hash_key = _org_hash_key(org_id)
+            is_org_preset = True
+
     if raw is None:
         raise HTTPException(status_code=404, detail="Preset not found")
+
+    # Permission check for org presets
+    if is_org_preset and not _is_org_admin(current_user):
+        raise HTTPException(
+            status_code=403,
+            detail="Only org admins can update org-wide presets"
+        )
+
     try:
         preset = json.loads(raw)
     except (json.JSONDecodeError, TypeError):
@@ -129,8 +216,12 @@ async def update_preset(
         preset["content"] = payload.content
     preset["updatedAt"] = _now_iso()
 
-    await redis.hset(_hash_key(user_id), preset_id, json.dumps(preset))
-    logger.info("Updated preset %s for user %s", preset_id, user_id)
+    await redis.hset(hash_key, preset_id, json.dumps(preset))
+    logger.info(
+        "Updated %s preset %s",
+        "org" if is_org_preset else "personal",
+        preset_id
+    )
     return JSONResponse(content=preset)
 
 
@@ -139,14 +230,37 @@ async def delete_preset(
     preset_id: str,
     current_user: dict = Depends(get_current_user),
 ) -> Response:
-    """Delete a preset owned by the authenticated user."""
+    """Delete a preset.
+
+    Users can delete their own personal presets.
+    Only org admins can delete org-wide presets.
+    """
     user_id = current_user.get("username", "")
+    org_id = current_user.get("org_id")
     redis = await get_async_redis_client(database=REDIS_DB)
     if redis is None:
         logger.warning("chat_presets: Redis unavailable for user %s", user_id)
         raise HTTPException(status_code=503, detail="Service temporarily unavailable")
-    deleted = await redis.hdel(_hash_key(user_id), preset_id)
-    if deleted == 0:
-        raise HTTPException(status_code=404, detail="Preset not found")
-    logger.info("Deleted preset %s for user %s", preset_id, user_id)
-    return Response(status_code=204)
+
+    # Try to delete from user's personal presets first
+    deleted = await redis.hdel(_user_hash_key(user_id), preset_id)
+    if deleted > 0:
+        logger.info("Deleted personal preset %s for user %s", preset_id, user_id)
+        return Response(status_code=204)
+
+    # If not found in personal presets, try org presets
+    if org_id:
+        # Check if preset exists in org presets
+        raw = await redis.hget(_org_hash_key(org_id), preset_id)
+        if raw is not None:
+            # Permission check for org presets
+            if not _is_org_admin(current_user):
+                raise HTTPException(
+                    status_code=403,
+                    detail="Only org admins can delete org-wide presets"
+                )
+            await redis.hdel(_org_hash_key(org_id), preset_id)
+            logger.info("Deleted org preset %s for org %s", preset_id, org_id)
+            return Response(status_code=204)
+
+    raise HTTPException(status_code=404, detail="Preset not found")

--- a/autobot-backend/api/chat_presets.py
+++ b/autobot-backend/api/chat_presets.py
@@ -125,14 +125,10 @@ async def create_preset(
     if payload.scope == "org":
         if not org_id:
             raise HTTPException(
-                status_code=400,
-                detail="Cannot create org preset: user not associated with an organization"
+                status_code=400, detail="Cannot create org preset: user not associated with an organization"
             )
         if not _is_org_admin(current_user):
-            raise HTTPException(
-                status_code=403,
-                detail="Only org admins can create org-wide presets"
-            )
+            raise HTTPException(status_code=403, detail="Only org admins can create org-wide presets")
 
     now = _now_iso()
     preset = {
@@ -158,7 +154,7 @@ async def create_preset(
         "Created %s preset %s for %s",
         payload.scope,
         preset["id"],
-        f"org {org_id}" if payload.scope == "org" else f"user {user_id}"
+        f"org {org_id}" if payload.scope == "org" else f"user {user_id}",
     )
     return JSONResponse(content=preset, status_code=201)
 
@@ -198,10 +194,7 @@ async def update_preset(
 
     # Permission check for org presets
     if is_org_preset and not _is_org_admin(current_user):
-        raise HTTPException(
-            status_code=403,
-            detail="Only org admins can update org-wide presets"
-        )
+        raise HTTPException(status_code=403, detail="Only org admins can update org-wide presets")
 
     try:
         preset = json.loads(raw)
@@ -217,11 +210,7 @@ async def update_preset(
     preset["updatedAt"] = _now_iso()
 
     await redis.hset(hash_key, preset_id, json.dumps(preset))
-    logger.info(
-        "Updated %s preset %s",
-        "org" if is_org_preset else "personal",
-        preset_id
-    )
+    logger.info("Updated %s preset %s", "org" if is_org_preset else "personal", preset_id)
     return JSONResponse(content=preset)
 
 
@@ -255,10 +244,7 @@ async def delete_preset(
         if raw is not None:
             # Permission check for org presets
             if not _is_org_admin(current_user):
-                raise HTTPException(
-                    status_code=403,
-                    detail="Only org admins can delete org-wide presets"
-                )
+                raise HTTPException(status_code=403, detail="Only org admins can delete org-wide presets")
             await redis.hdel(_org_hash_key(org_id), preset_id)
             logger.info("Deleted org preset %s for org %s", preset_id, org_id)
             return Response(status_code=204)

--- a/autobot-backend/api/chat_presets_test.py
+++ b/autobot-backend/api/chat_presets_test.py
@@ -70,6 +70,7 @@ class TestListPresets:
             "createdAt": "2025-01-01T00:00:00+00:00",
             "updatedAt": "2025-01-01T00:00:00+00:00",
         }
+
         async def mock_hgetall(key):
             if key == USER_HASH_KEY:
                 return {"a": json.dumps(p1)}
@@ -101,6 +102,7 @@ class TestListPresets:
             "createdAt": "2025-01-02T00:00:00+00:00",
             "updatedAt": "2025-01-02T00:00:00+00:00",
         }
+
         async def mock_hgetall(key):
             if key == USER_HASH_KEY:
                 return {"a": json.dumps(p1)}
@@ -164,6 +166,7 @@ class TestUpdatePreset:
             "createdAt": "2025-01-01T00:00:00+00:00",
             "updatedAt": "2025-01-01T00:00:00+00:00",
         }
+
         async def mock_hget(key, preset_id):
             if key == USER_HASH_KEY and preset_id == "abc":
                 return json.dumps(existing)
@@ -187,6 +190,7 @@ class TestUpdatePreset:
             "createdAt": "2025-01-01T00:00:00+00:00",
             "updatedAt": "2025-01-01T00:00:00+00:00",
         }
+
         async def mock_hget(key, preset_id):
             if key == ORG_HASH_KEY and preset_id == "xyz":
                 return json.dumps(existing)
@@ -209,6 +213,7 @@ class TestUpdatePreset:
             "createdAt": "2025-01-01T00:00:00+00:00",
             "updatedAt": "2025-01-01T00:00:00+00:00",
         }
+
         async def mock_hget(key, preset_id):
             if key == ORG_HASH_KEY and preset_id == "xyz":
                 return json.dumps(existing)
@@ -236,6 +241,7 @@ class TestDeletePreset:
             "name": "org preset",
             "scope": "org",
         }
+
         async def mock_hdel(key, preset_id):
             return 0  # Not found in personal presets
 
@@ -255,6 +261,7 @@ class TestDeletePreset:
             "name": "org preset",
             "scope": "org",
         }
+
         async def mock_hdel(key, preset_id):
             return 0  # Not found in personal presets
 

--- a/autobot-backend/api/chat_presets_test.py
+++ b/autobot-backend/api/chat_presets_test.py
@@ -1,7 +1,7 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Unit tests for slash command presets API (GH#8595)."""
+"""Unit tests for slash command presets API (GH#4449, GH#8595)."""
 
 import json
 from unittest.mock import AsyncMock, patch
@@ -12,15 +12,17 @@ from fastapi.testclient import TestClient
 
 from api.chat_presets import router
 
-USER = {"username": "testuser", "role": "user"}
-HASH_KEY = "chat:presets:testuser"
+USER = {"username": "testuser", "role": "user", "org_id": "org123"}
+ADMIN = {"username": "adminuser", "role": "admin", "org_id": "org123"}
+USER_HASH_KEY = "chat:presets:user:testuser"
+ORG_HASH_KEY = "chat:presets:org:org123"
 
 
-def _make_app() -> FastAPI:
+def _make_app(current_user=None) -> FastAPI:
     app = FastAPI()
 
     async def _override_user():
-        return USER
+        return current_user or USER
 
     from auth_middleware import get_current_user
 
@@ -46,6 +48,11 @@ def client(mock_redis):
     return TestClient(_make_app())
 
 
+@pytest.fixture
+def admin_client(mock_redis):
+    return TestClient(_make_app(current_user=ADMIN))
+
+
 class TestListPresets:
     def test_empty(self, client, mock_redis):
         mock_redis.hgetall.return_value = {}
@@ -53,64 +60,163 @@ class TestListPresets:
         assert resp.status_code == 200
         assert resp.json() == []
 
-    def test_returns_sorted_by_created_at(self, client, mock_redis):
+    def test_returns_personal_presets_only(self, client, mock_redis):
         p1 = {
             "id": "a",
             "name": "A",
             "description": "",
             "content": "x",
+            "scope": "personal",
+            "createdAt": "2025-01-01T00:00:00+00:00",
+            "updatedAt": "2025-01-01T00:00:00+00:00",
+        }
+        async def mock_hgetall(key):
+            if key == USER_HASH_KEY:
+                return {"a": json.dumps(p1)}
+            return {}
+
+        mock_redis.hgetall.side_effect = mock_hgetall
+        resp = client.get("/chat/presets")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["id"] == "a"
+
+    def test_returns_personal_and_org_presets(self, client, mock_redis):
+        p1 = {
+            "id": "a",
+            "name": "Personal",
+            "description": "",
+            "content": "x",
+            "scope": "personal",
             "createdAt": "2025-01-01T00:00:00+00:00",
             "updatedAt": "2025-01-01T00:00:00+00:00",
         }
         p2 = {
             "id": "b",
-            "name": "B",
+            "name": "Org",
             "description": "",
             "content": "y",
+            "scope": "org",
             "createdAt": "2025-01-02T00:00:00+00:00",
             "updatedAt": "2025-01-02T00:00:00+00:00",
         }
-        mock_redis.hgetall.return_value = {"b": json.dumps(p2), "a": json.dumps(p1)}
+        async def mock_hgetall(key):
+            if key == USER_HASH_KEY:
+                return {"a": json.dumps(p1)}
+            elif key == ORG_HASH_KEY:
+                return {"b": json.dumps(p2)}
+            return {}
+
+        mock_redis.hgetall.side_effect = mock_hgetall
         resp = client.get("/chat/presets")
         assert resp.status_code == 200
         data = resp.json()
+        assert len(data) == 2
         assert [d["id"] for d in data] == ["a", "b"]
 
 
 class TestCreatePreset:
-    def test_creates_with_id(self, client, mock_redis):
+    def test_creates_personal_preset(self, client, mock_redis):
         mock_redis.hset.return_value = 1
         resp = client.post(
             "/chat/presets",
-            json={"name": "greet", "description": "Greeting", "content": "Hello!"},
+            json={"name": "greet", "description": "Greeting", "content": "Hello!", "scope": "personal"},
         )
         assert resp.status_code == 201
         data = resp.json()
         assert data["name"] == "greet"
         assert data["content"] == "Hello!"
+        assert data["scope"] == "personal"
         assert "id" in data
         assert "createdAt" in data
         assert "updatedAt" in data
         mock_redis.hset.assert_awaited_once()
 
+    def test_creates_org_preset_as_admin(self, admin_client, mock_redis):
+        mock_redis.hset.return_value = 1
+        resp = admin_client.post(
+            "/chat/presets",
+            json={"name": "standup", "description": "Team standup", "content": "Daily standup", "scope": "org"},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == "standup"
+        assert data["scope"] == "org"
+
+    def test_rejects_org_preset_for_non_admin(self, client, mock_redis):
+        resp = client.post(
+            "/chat/presets",
+            json={"name": "standup", "description": "Team standup", "content": "Daily standup", "scope": "org"},
+        )
+        assert resp.status_code == 403
+        assert "admin" in resp.json()["detail"].lower()
+
 
 class TestUpdatePreset:
-    def test_updates_existing(self, client, mock_redis):
+    def test_updates_personal_preset(self, client, mock_redis):
         existing = {
             "id": "abc",
             "name": "old",
             "description": "d",
             "content": "c",
+            "scope": "personal",
             "createdAt": "2025-01-01T00:00:00+00:00",
             "updatedAt": "2025-01-01T00:00:00+00:00",
         }
-        mock_redis.hget.return_value = json.dumps(existing)
+        async def mock_hget(key, preset_id):
+            if key == USER_HASH_KEY and preset_id == "abc":
+                return json.dumps(existing)
+            return None
+
+        mock_redis.hget.side_effect = mock_hget
         mock_redis.hset.return_value = 0
         resp = client.put("/chat/presets/abc", json={"name": "new"})
         assert resp.status_code == 200
         data = resp.json()
         assert data["name"] == "new"
         assert data["content"] == "c"
+
+    def test_admin_updates_org_preset(self, admin_client, mock_redis):
+        existing = {
+            "id": "xyz",
+            "name": "old org",
+            "description": "d",
+            "content": "c",
+            "scope": "org",
+            "createdAt": "2025-01-01T00:00:00+00:00",
+            "updatedAt": "2025-01-01T00:00:00+00:00",
+        }
+        async def mock_hget(key, preset_id):
+            if key == ORG_HASH_KEY and preset_id == "xyz":
+                return json.dumps(existing)
+            return None
+
+        mock_redis.hget.side_effect = mock_hget
+        mock_redis.hset.return_value = 0
+        resp = admin_client.put("/chat/presets/xyz", json={"name": "new org"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "new org"
+
+    def test_non_admin_cannot_update_org_preset(self, client, mock_redis):
+        existing = {
+            "id": "xyz",
+            "name": "org preset",
+            "description": "d",
+            "content": "c",
+            "scope": "org",
+            "createdAt": "2025-01-01T00:00:00+00:00",
+            "updatedAt": "2025-01-01T00:00:00+00:00",
+        }
+        async def mock_hget(key, preset_id):
+            if key == ORG_HASH_KEY and preset_id == "xyz":
+                return json.dumps(existing)
+            return None
+
+        mock_redis.hget.side_effect = mock_hget
+        resp = client.put("/chat/presets/xyz", json={"name": "hacked"})
+        assert resp.status_code == 403
 
     def test_404_if_missing(self, client, mock_redis):
         mock_redis.hget.return_value = None
@@ -119,12 +225,51 @@ class TestUpdatePreset:
 
 
 class TestDeletePreset:
-    def test_deletes(self, client, mock_redis):
+    def test_deletes_personal_preset(self, client, mock_redis):
         mock_redis.hdel.return_value = 1
         resp = client.delete("/chat/presets/abc")
         assert resp.status_code == 204
 
+    def test_admin_deletes_org_preset(self, admin_client, mock_redis):
+        existing = {
+            "id": "xyz",
+            "name": "org preset",
+            "scope": "org",
+        }
+        async def mock_hdel(key, preset_id):
+            return 0  # Not found in personal presets
+
+        async def mock_hget(key, preset_id):
+            if key == ORG_HASH_KEY and preset_id == "xyz":
+                return json.dumps(existing)
+            return None
+
+        mock_redis.hdel.side_effect = mock_hdel
+        mock_redis.hget.side_effect = mock_hget
+        resp = admin_client.delete("/chat/presets/xyz")
+        assert resp.status_code == 204
+
+    def test_non_admin_cannot_delete_org_preset(self, client, mock_redis):
+        existing = {
+            "id": "xyz",
+            "name": "org preset",
+            "scope": "org",
+        }
+        async def mock_hdel(key, preset_id):
+            return 0  # Not found in personal presets
+
+        async def mock_hget(key, preset_id):
+            if key == ORG_HASH_KEY and preset_id == "xyz":
+                return json.dumps(existing)
+            return None
+
+        mock_redis.hdel.side_effect = mock_hdel
+        mock_redis.hget.side_effect = mock_hget
+        resp = client.delete("/chat/presets/xyz")
+        assert resp.status_code == 403
+
     def test_404_if_missing(self, client, mock_redis):
         mock_redis.hdel.return_value = 0
+        mock_redis.hget.return_value = None
         resp = client.delete("/chat/presets/missing")
         assert resp.status_code == 404


### PR DESCRIPTION
## Thinking Path

GitHub issue #4449 requires both personal and org-wide slash command presets. PR #8948 already shipped the frontend UI and PR #8595 shipped personal preset backend, but org-wide presets were missing. This PR completes the feature by extending the backend API to support org-wide presets with proper permission checks.

Design choice: reuse existing Redis storage pattern with separate hash keys (`chat:presets:user:{user_id}` for personal, `chat:presets:org:{org_id}` for org-wide) rather than migrating to a DB table. This keeps the implementation lightweight and leverages existing Redis infrastructure.

Permission model: any user can manage their personal presets; only org admins (`role` in `[admin, org_admin, owner]`) can create/update/delete org-wide presets. All org members can read org-wide presets.

## What Changed

- `autobot-backend/api/chat_presets.py`:
  - Add `scope` field to `PresetCreate` model (defaults to `personal`)
  - Add `_org_hash_key()` for org preset storage pattern
  - Add `_is_org_admin()` permission check helper
  - Update `list_presets()` to fetch both personal and org presets
  - Update `create_preset()` with org scope support and admin permission check
  - Update `update_preset()` to handle org presets with permission check
  - Update `delete_preset()` to handle org presets with permission check
- `autobot-backend/api/chat_presets_test.py`:
  - Add `ADMIN` user fixture with admin role
  - Add `admin_client` test fixture
  - Update all test cases to use new hash key patterns
  - Add tests for org preset creation, update, and delete
  - Add tests for permission denial (non-admin trying to manage org presets)
  - All 14 tests passing

## Verification

1. Unit tests: `python3 -m pytest autobot-backend/api/chat_presets_test.py -v` → 14/14 passed
2. Permission checks verified:
   - Regular user can create/update/delete personal presets ✓
   - Admin can create/update/delete org presets ✓
   - Regular user cannot create/update/delete org presets (403) ✓
3. List endpoint returns both personal and org presets for org members ✓
4. Presets are properly scoped by `org_id` and `user_id` ✓

## Risks

- Frontend may need updates to support the new `scope` field when creating presets (likely needs a toggle or separate UI for org admins to create org presets)
- Current implementation assumes `org_id` is present in the auth context; if a deployment doesn't use orgs, org presets will be unavailable (graceful degradation)

## Model Used

Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)

## Issue Link

Closes #4449
Paperclip: MVA-2221

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added and passing (14/14)
- [x] Documentation updated (API docstrings)
- [x] Pre-commit hooks will run on commit
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff