### PR TITLE
feat(tasks): implement snapshot cleanup Celery task (GH#4458)

### DIFF
--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -34,9 +34,7 @@ _celery_results_db = DATABASE_MAPPING["celery_results"]
 
 # Issue #725: Check if TLS is enabled for Redis connections
 _redis_tls_enabled = ssot_config.tls.redis_tls_enabled
-_redis_port = (
-    ssot_config.tls.redis_tls_port if _redis_tls_enabled else ssot_config.port.redis
-)
+_redis_port = ssot_config.tls.redis_tls_port if _redis_tls_enabled else ssot_config.port.redis
 _redis_scheme = "rediss" if _redis_tls_enabled else "redis"
 
 # Build SSL context for TLS connections - Issue #725, #164
@@ -59,9 +57,7 @@ if _redis_tls_enabled:
         _client_cert = str(_project_root / _cert_dir / "main-host" / "server-cert.pem")
         _client_key = str(_project_root / _cert_dir / "main-host" / "server-key.pem")
 
-    _ssl_context = get_internal_tls_context(
-        ca_path=_ca_cert, client_cert=_client_cert, client_key=_client_key
-    )
+    _ssl_context = get_internal_tls_context(ca_path=_ca_cert, client_cert=_client_cert, client_key=_client_key)
     _broker_ssl_options = {"ssl": _ssl_context}
     _backend_ssl_options = {"ssl": _ssl_context}
 
@@ -72,18 +68,12 @@ if _redis_password:
     _default_broker_url = f"{_redis_scheme}://:{_encoded_password}@{_redis_host}:{_redis_port}/{_celery_broker_db}"
     _default_backend_url = f"{_redis_scheme}://:{_encoded_password}@{_redis_host}:{_redis_port}/{_celery_results_db}"
 else:
-    _default_broker_url = (
-        f"{_redis_scheme}://{_redis_host}:{_redis_port}/{_celery_broker_db}"
-    )
-    _default_backend_url = (
-        f"{_redis_scheme}://{_redis_host}:{_redis_port}/{_celery_results_db}"
-    )
+    _default_broker_url = f"{_redis_scheme}://{_redis_host}:{_redis_port}/{_celery_broker_db}"
+    _default_backend_url = f"{_redis_scheme}://{_redis_host}:{_redis_port}/{_celery_results_db}"
 
 # Get Celery-specific configuration
 _celery_config = config.get("celery", {})
-_visibility_timeout = _celery_config.get(
-    "visibility_timeout", 43200
-)  # 12 hours default
+_visibility_timeout = _celery_config.get("visibility_timeout", 43200)  # 12 hours default
 _result_expires = _celery_config.get("result_expires", 86400)  # 24 hours default
 _worker_prefetch = _celery_config.get("worker_prefetch_multiplier", 1)
 _worker_max_tasks = _celery_config.get("worker_max_tasks_per_child", 100)
@@ -199,17 +189,13 @@ celery_app.conf.beat_schedule = {
     },
     "knowledge-cleanup-generated-files": {
         "task": "tasks.cleanup_generated_files",
-        "schedule": _crontab_from_string(
-            ssot_config.knowledge_generated_files_cleanup_schedule
-        ),
+        "schedule": _crontab_from_string(ssot_config.knowledge_generated_files_cleanup_schedule),
         "kwargs": {"dry_run": False},
     },
     # Issue #5081: prune expired entries from the doc_sync:queue:done zset
     "knowledge-sync-queue-prune": {
         "task": "tasks.prune_sync_queue_done",
-        "schedule": _crontab_from_string(
-            ssot_config.knowledge_sync_queue_prune_schedule
-        ),
+        "schedule": _crontab_from_string(ssot_config.knowledge_sync_queue_prune_schedule),
     },
     # GH#8224: detect expired active sprints and queue SPRINT_CLOSE approvals daily
     "llc-sprint-autoclose-daily": {
@@ -263,6 +249,4 @@ try:
 except ImportError:
     pass  # pywebpush not installed — push notifications disabled
 except Exception:
-    logger.warning(
-        "Push notification hook registration failed (GH#4459)", exc_info=True
-    )
+    logger.warning("Push notification hook registration failed (GH#4459)", exc_info=True)

--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -34,7 +34,9 @@ _celery_results_db = DATABASE_MAPPING["celery_results"]
 
 # Issue #725: Check if TLS is enabled for Redis connections
 _redis_tls_enabled = ssot_config.tls.redis_tls_enabled
-_redis_port = ssot_config.tls.redis_tls_port if _redis_tls_enabled else ssot_config.port.redis
+_redis_port = (
+    ssot_config.tls.redis_tls_port if _redis_tls_enabled else ssot_config.port.redis
+)
 _redis_scheme = "rediss" if _redis_tls_enabled else "redis"
 
 # Build SSL context for TLS connections - Issue #725, #164
@@ -57,7 +59,9 @@ if _redis_tls_enabled:
         _client_cert = str(_project_root / _cert_dir / "main-host" / "server-cert.pem")
         _client_key = str(_project_root / _cert_dir / "main-host" / "server-key.pem")
 
-    _ssl_context = get_internal_tls_context(ca_path=_ca_cert, client_cert=_client_cert, client_key=_client_key)
+    _ssl_context = get_internal_tls_context(
+        ca_path=_ca_cert, client_cert=_client_cert, client_key=_client_key
+    )
     _broker_ssl_options = {"ssl": _ssl_context}
     _backend_ssl_options = {"ssl": _ssl_context}
 
@@ -68,12 +72,18 @@ if _redis_password:
     _default_broker_url = f"{_redis_scheme}://:{_encoded_password}@{_redis_host}:{_redis_port}/{_celery_broker_db}"
     _default_backend_url = f"{_redis_scheme}://:{_encoded_password}@{_redis_host}:{_redis_port}/{_celery_results_db}"
 else:
-    _default_broker_url = f"{_redis_scheme}://{_redis_host}:{_redis_port}/{_celery_broker_db}"
-    _default_backend_url = f"{_redis_scheme}://{_redis_host}:{_redis_port}/{_celery_results_db}"
+    _default_broker_url = (
+        f"{_redis_scheme}://{_redis_host}:{_redis_port}/{_celery_broker_db}"
+    )
+    _default_backend_url = (
+        f"{_redis_scheme}://{_redis_host}:{_redis_port}/{_celery_results_db}"
+    )
 
 # Get Celery-specific configuration
 _celery_config = config.get("celery", {})
-_visibility_timeout = _celery_config.get("visibility_timeout", 43200)  # 12 hours default
+_visibility_timeout = _celery_config.get(
+    "visibility_timeout", 43200
+)  # 12 hours default
 _result_expires = _celery_config.get("result_expires", 86400)  # 24 hours default
 _worker_prefetch = _celery_config.get("worker_prefetch_multiplier", 1)
 _worker_max_tasks = _celery_config.get("worker_max_tasks_per_child", 100)
@@ -189,13 +199,17 @@ celery_app.conf.beat_schedule = {
     },
     "knowledge-cleanup-generated-files": {
         "task": "tasks.cleanup_generated_files",
-        "schedule": _crontab_from_string(ssot_config.knowledge_generated_files_cleanup_schedule),
+        "schedule": _crontab_from_string(
+            ssot_config.knowledge_generated_files_cleanup_schedule
+        ),
         "kwargs": {"dry_run": False},
     },
     # Issue #5081: prune expired entries from the doc_sync:queue:done zset
     "knowledge-sync-queue-prune": {
         "task": "tasks.prune_sync_queue_done",
-        "schedule": _crontab_from_string(ssot_config.knowledge_sync_queue_prune_schedule),
+        "schedule": _crontab_from_string(
+            ssot_config.knowledge_sync_queue_prune_schedule
+        ),
     },
     # GH#8224: detect expired active sprints and queue SPRINT_CLOSE approvals daily
     "llc-sprint-autoclose-daily": {
@@ -233,6 +247,11 @@ celery_app.conf.beat_schedule = {
         "schedule": crontab(hour=3, minute=30, day_of_week=0),  # Sunday 03:30 UTC
         "kwargs": {"dry_run": False},
     },
+    # MVA-2228: nightly snapshot cleanup (TTL-based eviction)
+    "snapshot-cleanup-daily": {
+        "task": "tasks.cleanup_expired_snapshots",
+        "schedule": crontab(hour=3, minute=0),
+    },
 }
 
 # GH#4459: Register web-push task_success signal so tasks that pass user_id
@@ -244,4 +263,6 @@ try:
 except ImportError:
     pass  # pywebpush not installed — push notifications disabled
 except Exception:
-    logger.warning("Push notification hook registration failed (GH#4459)", exc_info=True)
+    logger.warning(
+        "Push notification hook registration failed (GH#4459)", exc_info=True
+    )

--- a/autobot-backend/tasks/snapshot_cleanup.py
+++ b/autobot-backend/tasks/snapshot_cleanup.py
@@ -39,9 +39,7 @@ async def _async_cleanup_expired_snapshots(ttl_days: int) -> Dict[str, int]:
 
         if created < cutoff:
             try:
-                await backend.delete_snapshot(
-                    record.snapshot_id, caller_user_id=_SYSTEM_CALLER
-                )
+                await backend.delete_snapshot(record.snapshot_id, caller_user_id=_SYSTEM_CALLER)
                 deleted += 1
                 logger.info(
                     "Deleted snapshot %s (age: %d days, size: %d bytes)",
@@ -51,9 +49,7 @@ async def _async_cleanup_expired_snapshots(ttl_days: int) -> Dict[str, int]:
                 )
             except Exception as exc:
                 errors += 1
-                logger.error(
-                    "Failed to delete snapshot %s: %s", record.snapshot_id, exc
-                )
+                logger.error("Failed to delete snapshot %s: %s", record.snapshot_id, exc)
 
     logger.info(
         "Snapshot cleanup: deleted=%d, errors=%d, ttl_days=%d",

--- a/autobot-backend/tasks/snapshot_cleanup.py
+++ b/autobot-backend/tasks/snapshot_cleanup.py
@@ -1,0 +1,81 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Celery beat task: nightly snapshot cleanup based on TTL (GH#4458, MVA-2228).
+
+Removes Docker snapshots older than AUTOBOT_SNAPSHOT_TTL_DAYS to prevent
+unbounded storage growth in long-running deployments.
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Dict
+
+from autobot_shared.async_compat import run_or_schedule
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
+from celery_app import celery_app
+
+logger = get_logger(__name__)
+
+_DEFAULT_TTL_DAYS = 7
+
+
+async def _async_cleanup_expired_snapshots(ttl_days: int) -> Dict[str, int]:
+    """Remove snapshots older than TTL (async helper for Celery task)."""
+    from services.execution.docker_backend import _SYSTEM_CALLER, DockerBackend
+
+    backend = lazy_singleton(DockerBackend)
+    snapshots = backend._snapshot_index.list_all()
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=ttl_days)
+    deleted = 0
+    errors = 0
+
+    for record in snapshots:
+        created = datetime.fromisoformat(record.created_at)
+        age_days = (datetime.now(timezone.utc) - created).days
+
+        if created < cutoff:
+            try:
+                await backend.delete_snapshot(
+                    record.snapshot_id, caller_user_id=_SYSTEM_CALLER
+                )
+                deleted += 1
+                logger.info(
+                    "Deleted snapshot %s (age: %d days, size: %d bytes)",
+                    record.snapshot_id,
+                    age_days,
+                    record.size_bytes,
+                )
+            except Exception as exc:
+                errors += 1
+                logger.error(
+                    "Failed to delete snapshot %s: %s", record.snapshot_id, exc
+                )
+
+    logger.info(
+        "Snapshot cleanup: deleted=%d, errors=%d, ttl_days=%d",
+        deleted,
+        errors,
+        ttl_days,
+    )
+    return {"deleted": deleted, "errors": errors}
+
+
+@celery_app.task(bind=True, name="tasks.cleanup_expired_snapshots")
+def cleanup_expired_snapshots(self, ttl_days: int = None) -> Dict[str, int]:
+    """Remove snapshots older than TTL (GH#4458, MVA-2228).
+
+    Args:
+        ttl_days: Number of days to retain snapshots. Defaults to
+                  AUTOBOT_SNAPSHOT_TTL_DAYS env var or 7 days.
+
+    Returns:
+        Dict with "deleted" and "errors" counts.
+    """
+    if ttl_days is None:
+        ttl_days = int(os.getenv("AUTOBOT_SNAPSHOT_TTL_DAYS", _DEFAULT_TTL_DAYS))
+
+    return run_or_schedule(_async_cleanup_expired_snapshots(ttl_days))

--- a/autobot-backend/tests/test_snapshot_cleanup.py
+++ b/autobot-backend/tests/test_snapshot_cleanup.py
@@ -48,9 +48,7 @@ async def test_cleanup_expired_snapshots_ttl_filter():
 
     assert result["deleted"] == 1
     assert result["errors"] == 0
-    mock_backend.delete_snapshot.assert_called_once_with(
-        "old1", caller_user_id="__system__"
-    )
+    mock_backend.delete_snapshot.assert_called_once_with("old1", caller_user_id="__system__")
 
 
 @pytest.mark.asyncio
@@ -87,9 +85,7 @@ async def test_cleanup_expired_snapshots_env_var():
 
     assert result["deleted"] == 1
     assert result["errors"] == 0
-    mock_backend.delete_snapshot.assert_called_once_with(
-        "old1", caller_user_id="__system__"
-    )
+    mock_backend.delete_snapshot.assert_called_once_with("old1", caller_user_id="__system__")
 
 
 @pytest.mark.asyncio
@@ -119,9 +115,7 @@ async def test_cleanup_expired_snapshots_error_handling():
     mock_backend = MagicMock()
     mock_backend._snapshot_index.list_all.return_value = snapshots
     # First delete fails, second succeeds
-    mock_backend.delete_snapshot = AsyncMock(
-        side_effect=[Exception("Docker error"), True]
-    )
+    mock_backend.delete_snapshot = AsyncMock(side_effect=[Exception("Docker error"), True])
 
     with patch("tasks.snapshot_cleanup.lazy_singleton", return_value=mock_backend):
         result = cleanup_expired_snapshots(ttl_days=7)

--- a/autobot-backend/tests/test_snapshot_cleanup.py
+++ b/autobot-backend/tests/test_snapshot_cleanup.py
@@ -1,0 +1,131 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for snapshot cleanup Celery task (GH#4458, MVA-2228).
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.execution.snapshot_index import SnapshotRecord
+from tasks.snapshot_cleanup import cleanup_expired_snapshots
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired_snapshots_ttl_filter():
+    """Verify only snapshots older than TTL are deleted."""
+    now = datetime.now(timezone.utc)
+
+    snapshots = [
+        SnapshotRecord(
+            snapshot_id="old1",
+            session_id="s1",
+            container_id="c1",
+            image_name="img1",
+            created_at=(now - timedelta(days=10)).isoformat(),
+            size_bytes=1000,
+        ),
+        SnapshotRecord(
+            snapshot_id="recent1",
+            session_id="s2",
+            container_id="c2",
+            image_name="img2",
+            created_at=(now - timedelta(days=3)).isoformat(),
+            size_bytes=2000,
+        ),
+    ]
+
+    mock_backend = MagicMock()
+    mock_backend._snapshot_index.list_all.return_value = snapshots
+    mock_backend.delete_snapshot = AsyncMock(return_value=True)
+
+    with patch("tasks.snapshot_cleanup.lazy_singleton", return_value=mock_backend):
+        result = cleanup_expired_snapshots(ttl_days=7)
+
+    assert result["deleted"] == 1
+    assert result["errors"] == 0
+    mock_backend.delete_snapshot.assert_called_once_with(
+        "old1", caller_user_id="__system__"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired_snapshots_env_var():
+    """Verify AUTOBOT_SNAPSHOT_TTL_DAYS env var is respected."""
+    now = datetime.now(timezone.utc)
+
+    snapshots = [
+        SnapshotRecord(
+            snapshot_id="old1",
+            session_id="s1",
+            container_id="c1",
+            image_name="img1",
+            created_at=(now - timedelta(days=15)).isoformat(),
+            size_bytes=1000,
+        ),
+        SnapshotRecord(
+            snapshot_id="recent1",
+            session_id="s2",
+            container_id="c2",
+            image_name="img2",
+            created_at=(now - timedelta(days=10)).isoformat(),
+            size_bytes=2000,
+        ),
+    ]
+
+    mock_backend = MagicMock()
+    mock_backend._snapshot_index.list_all.return_value = snapshots
+    mock_backend.delete_snapshot = AsyncMock(return_value=True)
+
+    with patch.dict(os.environ, {"AUTOBOT_SNAPSHOT_TTL_DAYS": "14"}):
+        with patch("tasks.snapshot_cleanup.lazy_singleton", return_value=mock_backend):
+            result = cleanup_expired_snapshots()
+
+    assert result["deleted"] == 1
+    assert result["errors"] == 0
+    mock_backend.delete_snapshot.assert_called_once_with(
+        "old1", caller_user_id="__system__"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired_snapshots_error_handling():
+    """Verify errors are logged but don't stop cleanup."""
+    now = datetime.now(timezone.utc)
+
+    snapshots = [
+        SnapshotRecord(
+            snapshot_id="old1",
+            session_id="s1",
+            container_id="c1",
+            image_name="img1",
+            created_at=(now - timedelta(days=10)).isoformat(),
+            size_bytes=1000,
+        ),
+        SnapshotRecord(
+            snapshot_id="old2",
+            session_id="s2",
+            container_id="c2",
+            image_name="img2",
+            created_at=(now - timedelta(days=12)).isoformat(),
+            size_bytes=2000,
+        ),
+    ]
+
+    mock_backend = MagicMock()
+    mock_backend._snapshot_index.list_all.return_value = snapshots
+    # First delete fails, second succeeds
+    mock_backend.delete_snapshot = AsyncMock(
+        side_effect=[Exception("Docker error"), True]
+    )
+
+    with patch("tasks.snapshot_cleanup.lazy_singleton", return_value=mock_backend):
+        result = cleanup_expired_snapshots(ttl_days=7)
+
+    assert result["deleted"] == 1
+    assert result["errors"] == 1
+    assert mock_backend.delete_snapshot.call_count == 2


### PR DESCRIPTION
## Thinking Path

1. **Architectural review** — SeniorCodeArchitect approved pattern (follows existing `workspace_cleanup.py`)
2. **Implementation** — Created task file, registered beat schedule, wrote tests
3. **Verification** — All unit tests passing, follows existing patterns

## What Changed

### New Files
- **`autobot-backend/tasks/snapshot_cleanup.py`**
  - Async task `cleanup_expired_snapshots` with TTL-based filtering
  - Uses `run_or_schedule` pattern from existing memory tasks
  - Respects `AUTOBOT_SNAPSHOT_TTL_DAYS` env var (default: 7 days)
  - Continues cleanup on individual failures, logs errors

- **`autobot-backend/tests/test_snapshot_cleanup.py`**
  - TTL filter verification test
  - Environment variable handling test
  - Error recovery test (continues on partial failure)

### Modified Files
- **`autobot-backend/celery_app.py`**
  - Added `snapshot-cleanup-daily` to beat schedule (runs 3 AM UTC)

## Verification

- [x] All 3 unit tests passing (TTL filter, env var, error recovery)
- [x] Code follows existing `workspace_cleanup.py` pattern
- [x] Uses `_SYSTEM_CALLER` constant for system-level cleanup
- [x] Datetime handling verified (ISO 8601 parsing, timezone-aware comparison)
- [x] Error handling: continues on failures, logs all errors
- [ ] Manual test: `celery -A celery_app call tasks.cleanup_expired_snapshots` (requires deployment)

## Model Used

Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)

## Summary

Implements daily Celery Beat task to delete snapshots older than `AUTOBOT_SNAPSHOT_TTL_DAYS` (default: 7 days).

**Key features:**
- TTL-based filtering with configurable retention period
- System-level cleanup using `_SYSTEM_CALLER` constant
- Error resilience: continues cleanup on individual failures
- Monitoring-ready: returns `{"deleted": N, "errors": M}` dict
- Comprehensive logging: snapshot_id, age, size per deletion

## Deployment Notes

- Add `AUTOBOT_SNAPSHOT_TTL_DAYS=7` to `/etc/autobot/autobot-backend.env`
- Restart `celery-beat.service` after deployment

## Related Issues

Closes #4458  
Implements [MVA-2238](/MVA/issues/MVA-2238)  
Child of [MVA-2228](/MVA/issues/MVA-2228)  
Parent epic: [MVA-2222](/MVA/issues/MVA-2222)

🤖 Generated with [Paperclip](https://paperclip.ing)
