### PR TITLE
feat(api): implement ChromaDB REST API endpoints (MVA-2046)

### DIFF
--- a/autobot-backend/api/knowledge_chroma.py
+++ b/autobot-backend/api/knowledge_chroma.py
@@ -37,9 +37,7 @@ class CollectionMetadata(BaseModel):
 
     name: str = Field(..., description="Collection name")
     count: int = Field(..., description="Number of documents in collection")
-    metadata: Optional[Dict[str, Any]] = Field(
-        default=None, description="Collection metadata"
-    )
+    metadata: Optional[Dict[str, Any]] = Field(default=None, description="Collection metadata")
 
 
 class CollectionListResponse(BaseModel):
@@ -64,9 +62,7 @@ class DocumentItem(BaseModel):
     id: str = Field(..., description="Document ID")
     document: Optional[str] = Field(None, description="Document text content")
     metadata: Optional[Dict[str, Any]] = Field(None, description="Document metadata")
-    embedding_dim: Optional[int] = Field(
-        None, description="Embedding vector dimensionality"
-    )
+    embedding_dim: Optional[int] = Field(None, description="Embedding vector dimensionality")
 
 
 class DocumentListResponse(BaseModel):
@@ -86,9 +82,7 @@ class SearchRequest(BaseModel):
 
     query: str = Field(..., description="Query text for similarity search")
     n_results: int = Field(10, ge=1, le=100, description="Number of results to return")
-    where: Optional[Dict[str, Any]] = Field(
-        None, description="Metadata filter (ChromaDB where clause)"
-    )
+    where: Optional[Dict[str, Any]] = Field(None, description="Metadata filter (ChromaDB where clause)")
 
 
 class SearchResultItem(BaseModel):
@@ -157,9 +151,7 @@ async def list_collections(
             except Exception as e:
                 logger.warning(f"Failed to get metadata for collection {name}: {e}")
                 # Include collection with partial data
-                collections_data.append(
-                    CollectionMetadata(name=name, count=0, metadata=None)
-                )
+                collections_data.append(CollectionMetadata(name=name, count=0, metadata=None))
 
         return CollectionListResponse(success=True, data=collections_data)
 

--- a/autobot-backend/api/knowledge_chroma.py
+++ b/autobot-backend/api/knowledge_chroma.py
@@ -200,7 +200,7 @@ async def get_collection_detail(
             ),
         )
 
-    except ValueError as e:
+    except ValueError:
         # ChromaDB raises ValueError for missing collection
         logger.warning(f"Collection not found: {name}")
         raise HTTPException(
@@ -272,7 +272,7 @@ async def list_documents(
             total=total,
         )
 
-    except ValueError as e:
+    except ValueError:
         logger.warning(f"Collection not found: {name}")
         raise HTTPException(
             status_code=404,
@@ -359,7 +359,7 @@ async def search_collection(
 
     except HTTPException:
         raise
-    except ValueError as e:
+    except ValueError:
         logger.warning(f"Collection not found: {name}")
         raise HTTPException(
             status_code=404,

--- a/autobot-backend/api/knowledge_chroma.py
+++ b/autobot-backend/api/knowledge_chroma.py
@@ -1,0 +1,381 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+ChromaDB REST API endpoints for frontend explorer UI.
+
+Issue MVA-2046: Provides REST API to expose ChromaDB collections and documents.
+Endpoints support listing collections, getting details, browsing documents,
+and performing similarity searches.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from auth_middleware import get_current_user
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.logging_manager import get_logger
+from utils.async_chromadb_client import get_async_chromadb_client
+
+logger = get_logger(__name__)
+
+router = APIRouter(
+    prefix="/api/knowledge/chroma",
+    tags=["knowledge-chroma", "chroma"],
+)
+
+
+# ============================================================================
+# Pydantic Models
+# ============================================================================
+
+
+class CollectionMetadata(BaseModel):
+    """Metadata for a ChromaDB collection."""
+
+    name: str = Field(..., description="Collection name")
+    count: int = Field(..., description="Number of documents in collection")
+    metadata: Optional[Dict[str, Any]] = Field(
+        default=None, description="Collection metadata"
+    )
+
+
+class CollectionListResponse(BaseModel):
+    """Response for listing all collections."""
+
+    success: bool = True
+    data: List[CollectionMetadata]
+    error: Optional[str] = None
+
+
+class CollectionDetailResponse(BaseModel):
+    """Response for getting collection details."""
+
+    success: bool = True
+    data: Optional[CollectionMetadata] = None
+    error: Optional[str] = None
+
+
+class DocumentItem(BaseModel):
+    """A document in a collection."""
+
+    id: str = Field(..., description="Document ID")
+    document: Optional[str] = Field(None, description="Document text content")
+    metadata: Optional[Dict[str, Any]] = Field(None, description="Document metadata")
+    embedding_dim: Optional[int] = Field(
+        None, description="Embedding vector dimensionality"
+    )
+
+
+class DocumentListResponse(BaseModel):
+    """Response for listing documents in a collection."""
+
+    success: bool = True
+    data: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Documents with ids, documents, metadatas, embeddings summary",
+    )
+    total: Optional[int] = Field(None, description="Total document count")
+    error: Optional[str] = None
+
+
+class SearchRequest(BaseModel):
+    """Request for similarity search."""
+
+    query: str = Field(..., description="Query text for similarity search")
+    n_results: int = Field(10, ge=1, le=100, description="Number of results to return")
+    where: Optional[Dict[str, Any]] = Field(
+        None, description="Metadata filter (ChromaDB where clause)"
+    )
+
+
+class SearchResultItem(BaseModel):
+    """A single search result."""
+
+    id: str
+    document: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    distance: Optional[float] = Field(None, description="Similarity distance score")
+
+
+class SearchResponse(BaseModel):
+    """Response for similarity search."""
+
+    success: bool = True
+    data: Optional[List[SearchResultItem]] = None
+    query: Optional[str] = None
+    error: Optional[str] = None
+
+
+# ============================================================================
+# Endpoints
+# ============================================================================
+
+
+@router.get("/collections", response_model=CollectionListResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_chroma_collections",
+    error_code_prefix="CHROMA",
+)
+async def list_collections(
+    current_user: dict = Depends(get_current_user),
+) -> CollectionListResponse:
+    """
+    List all ChromaDB collections with metadata.
+
+    Returns collection names, document counts, and metadata for all collections
+    in the ChromaDB instance.
+
+    Args:
+        current_user: Authenticated user (injected by auth middleware)
+
+    Returns:
+        CollectionListResponse with list of collections and their metadata
+
+    Raises:
+        HTTPException: 500 if ChromaDB connection fails
+    """
+    try:
+        client = await get_async_chromadb_client()
+        collection_names = await client.list_collections()
+
+        collections_data = []
+        for name in collection_names:
+            try:
+                collection = await client.get_collection(name)
+                count = await collection.count()
+                collections_data.append(
+                    CollectionMetadata(
+                        name=name,
+                        count=count,
+                        metadata=collection.metadata,
+                    )
+                )
+            except Exception as e:
+                logger.warning(f"Failed to get metadata for collection {name}: {e}")
+                # Include collection with partial data
+                collections_data.append(
+                    CollectionMetadata(name=name, count=0, metadata=None)
+                )
+
+        return CollectionListResponse(success=True, data=collections_data)
+
+    except Exception as e:
+        logger.error(f"Failed to list ChromaDB collections: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"ChromaDB connection error: {str(e)}",
+        )
+
+
+@router.get("/collections/{name}", response_model=CollectionDetailResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_chroma_collection",
+    error_code_prefix="CHROMA",
+)
+async def get_collection_detail(
+    name: str,
+    current_user: dict = Depends(get_current_user),
+) -> CollectionDetailResponse:
+    """
+    Get detailed metadata for a specific collection.
+
+    Args:
+        name: Collection name
+        current_user: Authenticated user (injected by auth middleware)
+
+    Returns:
+        CollectionDetailResponse with collection metadata
+
+    Raises:
+        HTTPException: 404 if collection not found, 500 on connection error
+    """
+    try:
+        client = await get_async_chromadb_client()
+        collection = await client.get_collection(name)
+        count = await collection.count()
+
+        return CollectionDetailResponse(
+            success=True,
+            data=CollectionMetadata(
+                name=name,
+                count=count,
+                metadata=collection.metadata,
+            ),
+        )
+
+    except ValueError as e:
+        # ChromaDB raises ValueError for missing collection
+        logger.warning(f"Collection not found: {name}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Collection '{name}' not found",
+        )
+    except Exception as e:
+        logger.error(f"Failed to get collection {name}: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"ChromaDB error: {str(e)}",
+        )
+
+
+@router.get("/collections/{name}/documents", response_model=DocumentListResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_chroma_documents",
+    error_code_prefix="CHROMA",
+)
+async def list_documents(
+    name: str,
+    limit: int = Query(100, ge=1, le=1000, description="Maximum results to return"),
+    offset: int = Query(0, ge=0, description="Number of results to skip"),
+    current_user: dict = Depends(get_current_user),
+) -> DocumentListResponse:
+    """
+    List documents in a collection with pagination.
+
+    Args:
+        name: Collection name
+        limit: Maximum number of documents to return (1-1000)
+        offset: Number of documents to skip for pagination
+        current_user: Authenticated user (injected by auth middleware)
+
+    Returns:
+        DocumentListResponse with document data (ids, documents, metadatas, embeddings)
+
+    Raises:
+        HTTPException: 404 if collection not found, 500 on error
+    """
+    try:
+        client = await get_async_chromadb_client()
+        collection = await client.get_collection(name)
+
+        # Get documents with pagination
+        results = await collection.get(
+            limit=limit,
+            offset=offset,
+            include=["documents", "metadatas", "embeddings"],
+        )
+
+        # Add embedding dimensionality info
+        embedding_dim = None
+        if results.get("embeddings") and len(results["embeddings"]) > 0:
+            embedding_dim = len(results["embeddings"][0])
+
+        # Get total count
+        total = await collection.count()
+
+        return DocumentListResponse(
+            success=True,
+            data={
+                "ids": results.get("ids", []),
+                "documents": results.get("documents", []),
+                "metadatas": results.get("metadatas", []),
+                "embedding_dim": embedding_dim,
+            },
+            total=total,
+        )
+
+    except ValueError as e:
+        logger.warning(f"Collection not found: {name}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Collection '{name}' not found",
+        )
+    except Exception as e:
+        logger.error(f"Failed to list documents in collection {name}: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"ChromaDB error: {str(e)}",
+        )
+
+
+@router.post("/collections/{name}/search", response_model=SearchResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="search_chroma_collection",
+    error_code_prefix="CHROMA",
+)
+async def search_collection(
+    name: str,
+    request: SearchRequest,
+    current_user: dict = Depends(get_current_user),
+) -> SearchResponse:
+    """
+    Perform similarity search on a collection using query text.
+
+    Uses the collection's embedding function to convert query text to vectors
+    and performs similarity search.
+
+    Args:
+        name: Collection name
+        request: Search parameters (query, n_results, where filter)
+        current_user: Authenticated user (injected by auth middleware)
+
+    Returns:
+        SearchResponse with matching documents and similarity scores
+
+    Raises:
+        HTTPException: 400 for invalid parameters, 404 if collection not found,
+                      500 on search error
+    """
+    try:
+        if not request.query or not request.query.strip():
+            raise HTTPException(
+                status_code=400,
+                detail="Query text cannot be empty",
+            )
+
+        client = await get_async_chromadb_client()
+        collection = await client.get_collection(name)
+
+        # Perform search using query_texts (ChromaDB will handle embedding)
+        results = await collection.query(
+            query_texts=[request.query],
+            n_results=request.n_results,
+            where=request.where,
+            include=["documents", "metadatas", "distances"],
+        )
+
+        # Format results into flat list (query returns nested lists)
+        search_results = []
+        if results.get("ids") and len(results["ids"]) > 0:
+            ids = results["ids"][0]
+            documents = results.get("documents", [[]])[0]
+            metadatas = results.get("metadatas", [[]])[0]
+            distances = results.get("distances", [[]])[0]
+
+            for i, doc_id in enumerate(ids):
+                search_results.append(
+                    SearchResultItem(
+                        id=doc_id,
+                        document=documents[i] if i < len(documents) else None,
+                        metadata=metadatas[i] if i < len(metadatas) else None,
+                        distance=distances[i] if i < len(distances) else None,
+                    )
+                )
+
+        return SearchResponse(
+            success=True,
+            data=search_results,
+            query=request.query,
+        )
+
+    except HTTPException:
+        raise
+    except ValueError as e:
+        logger.warning(f"Collection not found: {name}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Collection '{name}' not found",
+        )
+    except Exception as e:
+        logger.error(f"Search failed in collection {name}: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"ChromaDB search error: {str(e)}",
+        )

--- a/autobot-backend/api/knowledge_chroma_test.py
+++ b/autobot-backend/api/knowledge_chroma_test.py
@@ -8,7 +8,7 @@ Tests all 4 endpoints with success cases, error cases, and edge cases.
 Uses pytest with async test support and mocks ChromaDB client.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import HTTPException

--- a/autobot-backend/api/knowledge_chroma_test.py
+++ b/autobot-backend/api/knowledge_chroma_test.py
@@ -160,12 +160,14 @@ async def test_get_collection_detail_connection_error(mock_current_user, mock_ch
 @pytest.mark.asyncio
 async def test_list_documents_success(mock_current_user, mock_chroma_client, mock_chroma_collection):
     """Test successful listing of documents with pagination."""
-    mock_chroma_collection.get = AsyncMock(return_value={
-        "ids": ["doc1", "doc2", "doc3"],
-        "documents": ["Text 1", "Text 2", "Text 3"],
-        "metadatas": [{"source": "a"}, {"source": "b"}, {"source": "c"}],
-        "embeddings": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]],
-    })
+    mock_chroma_collection.get = AsyncMock(
+        return_value={
+            "ids": ["doc1", "doc2", "doc3"],
+            "documents": ["Text 1", "Text 2", "Text 3"],
+            "metadatas": [{"source": "a"}, {"source": "b"}, {"source": "c"}],
+            "embeddings": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]],
+        }
+    )
 
     mock_chroma_client.get_collection = AsyncMock(return_value=mock_chroma_collection)
 
@@ -193,12 +195,14 @@ async def test_list_documents_success(mock_current_user, mock_chroma_client, moc
 @pytest.mark.asyncio
 async def test_list_documents_pagination(mock_current_user, mock_chroma_client, mock_chroma_collection):
     """Test pagination parameters are correctly passed."""
-    mock_chroma_collection.get = AsyncMock(return_value={
-        "ids": ["doc4", "doc5"],
-        "documents": ["Text 4", "Text 5"],
-        "metadatas": [{}, {}],
-        "embeddings": [[0.1], [0.2]],
-    })
+    mock_chroma_collection.get = AsyncMock(
+        return_value={
+            "ids": ["doc4", "doc5"],
+            "documents": ["Text 4", "Text 5"],
+            "metadatas": [{}, {}],
+            "embeddings": [[0.1], [0.2]],
+        }
+    )
 
     mock_chroma_client.get_collection = AsyncMock(return_value=mock_chroma_collection)
 
@@ -219,12 +223,14 @@ async def test_list_documents_pagination(mock_current_user, mock_chroma_client, 
 @pytest.mark.asyncio
 async def test_list_documents_empty_collection(mock_current_user, mock_chroma_client, mock_chroma_collection):
     """Test listing documents from empty collection."""
-    mock_chroma_collection.get = AsyncMock(return_value={
-        "ids": [],
-        "documents": [],
-        "metadatas": [],
-        "embeddings": [],
-    })
+    mock_chroma_collection.get = AsyncMock(
+        return_value={
+            "ids": [],
+            "documents": [],
+            "metadatas": [],
+            "embeddings": [],
+        }
+    )
     mock_chroma_collection.count = AsyncMock(return_value=0)
 
     mock_chroma_client.get_collection = AsyncMock(return_value=mock_chroma_collection)
@@ -261,12 +267,14 @@ async def test_list_documents_not_found(mock_current_user, mock_chroma_client):
 @pytest.mark.asyncio
 async def test_search_collection_success(mock_current_user, mock_chroma_client, mock_chroma_collection):
     """Test successful similarity search."""
-    mock_chroma_collection.query = AsyncMock(return_value={
-        "ids": [["doc1", "doc2"]],
-        "documents": [["Match 1", "Match 2"]],
-        "metadatas": [[{"score": 0.9}, {"score": 0.8}]],
-        "distances": [[0.1, 0.2]],
-    })
+    mock_chroma_collection.query = AsyncMock(
+        return_value={
+            "ids": [["doc1", "doc2"]],
+            "documents": [["Match 1", "Match 2"]],
+            "metadatas": [[{"score": 0.9}, {"score": 0.8}]],
+            "distances": [[0.1, 0.2]],
+        }
+    )
 
     mock_chroma_client.get_collection = AsyncMock(return_value=mock_chroma_collection)
 
@@ -296,20 +304,18 @@ async def test_search_collection_success(mock_current_user, mock_chroma_client, 
 @pytest.mark.asyncio
 async def test_search_collection_with_filter(mock_current_user, mock_chroma_client, mock_chroma_collection):
     """Test search with metadata filter."""
-    mock_chroma_collection.query = AsyncMock(return_value={
-        "ids": [["doc1"]],
-        "documents": [["Filtered match"]],
-        "metadatas": [[{"category": "tech"}]],
-        "distances": [[0.1]],
-    })
+    mock_chroma_collection.query = AsyncMock(
+        return_value={
+            "ids": [["doc1"]],
+            "documents": [["Filtered match"]],
+            "metadatas": [[{"category": "tech"}]],
+            "distances": [[0.1]],
+        }
+    )
 
     mock_chroma_client.get_collection = AsyncMock(return_value=mock_chroma_collection)
 
-    search_req = SearchRequest(
-        query="test",
-        n_results=5,
-        where={"category": "tech"}
-    )
+    search_req = SearchRequest(query="test", n_results=5, where={"category": "tech"})
 
     with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
         response = await search_collection(
@@ -359,12 +365,14 @@ async def test_search_collection_whitespace_query(mock_current_user, mock_chroma
 @pytest.mark.asyncio
 async def test_search_collection_no_results(mock_current_user, mock_chroma_client, mock_chroma_collection):
     """Test search returning no results."""
-    mock_chroma_collection.query = AsyncMock(return_value={
-        "ids": [[]],
-        "documents": [[]],
-        "metadatas": [[]],
-        "distances": [[]],
-    })
+    mock_chroma_collection.query = AsyncMock(
+        return_value={
+            "ids": [[]],
+            "documents": [[]],
+            "metadatas": [[]],
+            "distances": [[]],
+        }
+    )
 
     mock_chroma_client.get_collection = AsyncMock(return_value=mock_chroma_collection)
 

--- a/autobot-backend/api/knowledge_chroma_test.py
+++ b/autobot-backend/api/knowledge_chroma_test.py
@@ -1,0 +1,399 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for ChromaDB REST API endpoints (MVA-2046).
+
+Tests all 4 endpoints with success cases, error cases, and edge cases.
+Uses pytest with async test support and mocks ChromaDB client.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.knowledge_chroma import (
+    SearchRequest,
+    get_collection_detail,
+    list_collections,
+    list_documents,
+    search_collection,
+)
+
+
+@pytest.fixture
+def mock_current_user():
+    """Mock authenticated user."""
+    return {"email": "test@example.com", "role": "user"}
+
+
+@pytest.fixture
+def mock_chroma_client():
+    """Mock AsyncChromaClient."""
+    client = AsyncMock()
+    client.list_collections = AsyncMock(return_value=["test_collection", "docs"])
+    return client
+
+
+@pytest.fixture
+def mock_chroma_collection():
+    """Mock AsyncChromaCollection."""
+    collection = AsyncMock()
+    collection.name = "test_collection"
+    collection.metadata = {"description": "Test collection"}
+    collection.count = AsyncMock(return_value=42)
+    return collection
+
+
+# =============================================================================
+# Test list_collections endpoint
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_collections_success(mock_current_user, mock_chroma_client, mock_chroma_collection):
+    """Test successful listing of all collections."""
+    mock_chroma_client.get_collection = AsyncMock(return_value=mock_chroma_collection)
+
+    with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
+        response = await list_collections(current_user=mock_current_user)
+
+    assert response.success is True
+    assert len(response.data) == 2
+    assert response.data[0].name == "test_collection"
+    assert response.data[0].count == 42
+    assert response.error is None
+
+
+@pytest.mark.asyncio
+async def test_list_collections_partial_failure(mock_current_user, mock_chroma_client):
+    """Test listing collections when one collection fails to load."""
+    # First collection succeeds, second fails
+    good_collection = AsyncMock()
+    good_collection.name = "good"
+    good_collection.metadata = {}
+    good_collection.count = AsyncMock(return_value=10)
+
+    async def get_collection_side_effect(name):
+        if name == "test_collection":
+            return good_collection
+        raise Exception("Collection unavailable")
+
+    mock_chroma_client.get_collection = AsyncMock(side_effect=get_collection_side_effect)
+
+    with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
+        response = await list_collections(current_user=mock_current_user)
+
+    # Should still return data with partial results
+    assert response.success is True
+    assert len(response.data) == 2
+    # First collection has full data
+    assert response.data[0].count == 10
+    # Second collection has partial data (count=0, no metadata)
+    assert response.data[1].count == 0
+    assert response.data[1].metadata is None
+
+
+@pytest.mark.asyncio
+async def test_list_collections_connection_error(mock_current_user):
+    """Test handling of ChromaDB connection failure."""
+    with patch("api.knowledge_chroma.get_async_chromadb_client", side_effect=Exception("Connection failed")):
+        with pytest.raises(HTTPException) as exc_info:
+            await list_collections(current_user=mock_current_user)
+
+    assert exc_info.value.status_code == 500
+    assert "ChromaDB connection error" in exc_info.value.detail
+
+
+# =============================================================================
+# Test get_collection_detail endpoint
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_collection_detail_success(mock_current_user, mock_chroma_client, mock_chroma_collection):
+    """Test successful retrieval of collection details."""
+    mock_chroma_client.get_collection = AsyncMock(return_value=mock_chroma_collection)
+
+    with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
+        response = await get_collection_detail(name="test_collection", current_user=mock_current_user)
+
+    assert response.success is True
+    assert response.data.name == "test_collection"
+    assert response.data.count == 42
+    assert response.data.metadata == {"description": "Test collection"}
+    assert response.error is None
+
+
+@pytest.mark.asyncio
+async def test_get_collection_detail_not_found(mock_current_user, mock_chroma_client):
+    """Test 404 when collection doesn't exist."""
+    mock_chroma_client.get_collection = AsyncMock(side_effect=ValueError("Collection not found"))
+
+    with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_collection_detail(name="nonexistent", current_user=mock_current_user)
+
+    assert exc_info.value.status_code == 404
+    assert "not found" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_get_collection_detail_connection_error(mock_current_user, mock_chroma_client):
+    """Test 500 on ChromaDB connection error."""
+    mock_chroma_client.get_collection = AsyncMock(side_effect=Exception("Connection lost"))
+
+    with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_collection_detail(name="test_collection", current_user=mock_current_user)
+
+    assert exc_info.value.status_code == 500
+    assert "ChromaDB error" in exc_info.value.detail
+
+
+# =============================================================================
+# Test list_documents endpoint
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_documents_success(mock_current_user, mock_chroma_client, mock_chroma_collection):
+    """Test successful listing of documents with pagination."""
+    mock_chroma_collection.get = AsyncMock(return_value={
+        "ids": ["doc1", "doc2", "doc3"],
+        "documents": ["Text 1", "Text 2", "Text 3"],
+        "metadatas": [{"source": "a"}, {"source": "b"}, {"source": "c"}],
+        "embeddings": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]],
+    })
+
+    mock_chroma_client.get_collection = AsyncMock(return_value=mock_chroma_collection)
+
+    with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
+        response = await list_documents(
+            name="test_collection",
+            limit=100,
+            offset=0,
+            current_user=mock_current_user,
+        )
+
+    assert response.success is True
+    assert response.total == 42  # From mock collection count
+    assert response.data["embedding_dim"] == 3
+    assert len(response.data["ids"]) == 3
+    assert response.data["ids"][0] == "doc1"
+
+    # Verify pagination parameters were passed
+    mock_chroma_collection.get.assert_called_once()
+    call_kwargs = mock_chroma_collection.get.call_args.kwargs
+    assert call_kwargs["limit"] == 100
+    assert call_kwargs["offset"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_documents_pagination(mock_current_user, mock_chroma_client, mock_chroma_collection):
+    """Test pagination parameters are correctly passed."""
+    mock_chroma_collection.get = AsyncMock(return_value={
+        "ids": ["doc4", "doc5"],
+        "documents": ["Text 4", "Text 5"],
+        "metadatas": [{}, {}],
+        "embeddings": [[0.1], [0.2]],
+    })
+
+    mock_chroma_client.get_collection = AsyncMock(return_value=mock_chroma_collection)
+
+    with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
+        response = await list_documents(
+            name="test_collection",
+            limit=50,
+            offset=100,
+            current_user=mock_current_user,
+        )
+
+    # Verify pagination was used
+    call_kwargs = mock_chroma_collection.get.call_args.kwargs
+    assert call_kwargs["limit"] == 50
+    assert call_kwargs["offset"] == 100
+
+
+@pytest.mark.asyncio
+async def test_list_documents_empty_collection(mock_current_user, mock_chroma_client, mock_chroma_collection):
+    """Test listing documents from empty collection."""
+    mock_chroma_collection.get = AsyncMock(return_value={
+        "ids": [],
+        "documents": [],
+        "metadatas": [],
+        "embeddings": [],
+    })
+    mock_chroma_collection.count = AsyncMock(return_value=0)
+
+    mock_chroma_client.get_collection = AsyncMock(return_value=mock_chroma_collection)
+
+    with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
+        response = await list_documents(
+            name="empty_collection",
+            current_user=mock_current_user,
+        )
+
+    assert response.success is True
+    assert response.total == 0
+    assert response.data["embedding_dim"] is None
+    assert len(response.data["ids"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_documents_not_found(mock_current_user, mock_chroma_client):
+    """Test 404 when collection doesn't exist."""
+    mock_chroma_client.get_collection = AsyncMock(side_effect=ValueError("Not found"))
+
+    with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
+        with pytest.raises(HTTPException) as exc_info:
+            await list_documents(name="nonexistent", current_user=mock_current_user)
+
+    assert exc_info.value.status_code == 404
+
+
+# =============================================================================
+# Test search_collection endpoint
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_search_collection_success(mock_current_user, mock_chroma_client, mock_chroma_collection):
+    """Test successful similarity search."""
+    mock_chroma_collection.query = AsyncMock(return_value={
+        "ids": [["doc1", "doc2"]],
+        "documents": [["Match 1", "Match 2"]],
+        "metadatas": [[{"score": 0.9}, {"score": 0.8}]],
+        "distances": [[0.1, 0.2]],
+    })
+
+    mock_chroma_client.get_collection = AsyncMock(return_value=mock_chroma_collection)
+
+    search_req = SearchRequest(query="test query", n_results=10)
+
+    with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
+        response = await search_collection(
+            name="test_collection",
+            request=search_req,
+            current_user=mock_current_user,
+        )
+
+    assert response.success is True
+    assert response.query == "test query"
+    assert len(response.data) == 2
+    assert response.data[0].id == "doc1"
+    assert response.data[0].document == "Match 1"
+    assert response.data[0].distance == 0.1
+
+    # Verify search parameters
+    mock_chroma_collection.query.assert_called_once()
+    call_kwargs = mock_chroma_collection.query.call_args.kwargs
+    assert call_kwargs["query_texts"] == ["test query"]
+    assert call_kwargs["n_results"] == 10
+
+
+@pytest.mark.asyncio
+async def test_search_collection_with_filter(mock_current_user, mock_chroma_client, mock_chroma_collection):
+    """Test search with metadata filter."""
+    mock_chroma_collection.query = AsyncMock(return_value={
+        "ids": [["doc1"]],
+        "documents": [["Filtered match"]],
+        "metadatas": [[{"category": "tech"}]],
+        "distances": [[0.1]],
+    })
+
+    mock_chroma_client.get_collection = AsyncMock(return_value=mock_chroma_collection)
+
+    search_req = SearchRequest(
+        query="test",
+        n_results=5,
+        where={"category": "tech"}
+    )
+
+    with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
+        response = await search_collection(
+            name="test_collection",
+            request=search_req,
+            current_user=mock_current_user,
+        )
+
+    # Verify filter was passed
+    call_kwargs = mock_chroma_collection.query.call_args.kwargs
+    assert call_kwargs["where"] == {"category": "tech"}
+
+
+@pytest.mark.asyncio
+async def test_search_collection_empty_query(mock_current_user, mock_chroma_client):
+    """Test 400 error for empty query."""
+    search_req = SearchRequest(query="", n_results=10)
+
+    with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
+        with pytest.raises(HTTPException) as exc_info:
+            await search_collection(
+                name="test_collection",
+                request=search_req,
+                current_user=mock_current_user,
+            )
+
+    assert exc_info.value.status_code == 400
+    assert "empty" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_search_collection_whitespace_query(mock_current_user, mock_chroma_client):
+    """Test 400 error for whitespace-only query."""
+    search_req = SearchRequest(query="   ", n_results=10)
+
+    with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
+        with pytest.raises(HTTPException) as exc_info:
+            await search_collection(
+                name="test_collection",
+                request=search_req,
+                current_user=mock_current_user,
+            )
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_search_collection_no_results(mock_current_user, mock_chroma_client, mock_chroma_collection):
+    """Test search returning no results."""
+    mock_chroma_collection.query = AsyncMock(return_value={
+        "ids": [[]],
+        "documents": [[]],
+        "metadatas": [[]],
+        "distances": [[]],
+    })
+
+    mock_chroma_client.get_collection = AsyncMock(return_value=mock_chroma_collection)
+
+    search_req = SearchRequest(query="no matches", n_results=10)
+
+    with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
+        response = await search_collection(
+            name="test_collection",
+            request=search_req,
+            current_user=mock_current_user,
+        )
+
+    assert response.success is True
+    assert response.data == []
+
+
+@pytest.mark.asyncio
+async def test_search_collection_not_found(mock_current_user, mock_chroma_client):
+    """Test 404 when collection doesn't exist."""
+    mock_chroma_client.get_collection = AsyncMock(side_effect=ValueError("Not found"))
+
+    search_req = SearchRequest(query="test", n_results=10)
+
+    with patch("api.knowledge_chroma.get_async_chromadb_client", return_value=mock_chroma_client):
+        with pytest.raises(HTTPException) as exc_info:
+            await search_collection(
+                name="nonexistent",
+                request=search_req,
+                current_user=mock_current_user,
+            )
+
+    assert exc_info.value.status_code == 404

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -45,6 +45,7 @@ from api.knowledge_ai_stack import router as knowledge_ai_stack_router
 from api.knowledge_audit import router as knowledge_audit_router
 from api.knowledge_boards import router as knowledge_boards_router
 from api.knowledge_categories import router as knowledge_categories_router
+from api.knowledge_chroma import router as knowledge_chroma_router  # MVA-2046
 from api.knowledge_cognition import router as knowledge_cognition_router
 from api.knowledge_collaboration import router as knowledge_collaboration_router
 from api.knowledge_collections import router as knowledge_collections_router
@@ -136,6 +137,7 @@ def _get_core_knowledge_routers() -> list:
     return [
         (knowledge_router, "/knowledge_base", ["knowledge"], "knowledge"),
         (knowledge_audit_router, "", ["knowledge-audit"], "knowledge_audit"),
+        (knowledge_chroma_router, "", ["knowledge-chroma"], "knowledge_chroma"),  # MVA-2046
         (
             knowledge_search_router,
             "/knowledge_base",

--- a/autobot-backend/llm_shared/observability/langfuse_observer.py
+++ b/autobot-backend/llm_shared/observability/langfuse_observer.py
@@ -26,9 +26,7 @@ class LangFuseObserver:
         try:
             from langfuse import Langfuse
         except ImportError as exc:
-            raise RuntimeError(
-                "langfuse package not installed — run: pip install langfuse>=2.0.0"
-            ) from exc
+            raise RuntimeError("langfuse package not installed — run: pip install langfuse>=2.0.0") from exc
 
         self._client = Langfuse(
             host=config.host,

--- a/autobot-backend/llm_shared/observability/langsmith_observer.py
+++ b/autobot-backend/llm_shared/observability/langsmith_observer.py
@@ -26,9 +26,7 @@ class LangSmithObserver:
         try:
             import langsmith
         except ImportError as exc:
-            raise RuntimeError(
-                "langsmith package not installed — run: pip install langsmith>=0.1.0"
-            ) from exc
+            raise RuntimeError("langsmith package not installed — run: pip install langsmith>=0.1.0") from exc
 
         self._client = langsmith.Client(api_url=config.api_url, api_key=config.api_key)
         self._project = config.project

--- a/autobot-backend/tests/llm_shared/test_langfuse_observer.py
+++ b/autobot-backend/tests/llm_shared/test_langfuse_observer.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Minimal LLMRequest / LLMResponse stand-ins so tests don't need the full
 # backend import chain.

--- a/autobot-backend/tests/llm_shared/test_langfuse_observer.py
+++ b/autobot-backend/tests/llm_shared/test_langfuse_observer.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/autobot-backend/tests/llm_shared/test_langsmith_observer.py
+++ b/autobot-backend/tests/llm_shared/test_langsmith_observer.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Minimal LLMRequest / LLMResponse stand-ins so tests don't need the full
 # backend import chain.
@@ -48,9 +47,7 @@ def mock_langsmith_module():
     fake_client.create_run = MagicMock()
     fake_client.update_run = MagicMock()
 
-    with patch.dict(
-        "sys.modules", {"langsmith": MagicMock(Client=MagicMock(return_value=fake_client))}
-    ):
+    with patch.dict("sys.modules", {"langsmith": MagicMock(Client=MagicMock(return_value=fake_client))}):
         yield fake_client
 
 


### PR DESCRIPTION
## Summary

Implements ChromaDB REST API endpoints to expose collections and documents for the frontend explorer UI. Closes #MVA-2046

## Thinking Path

Checked existing `async_chromadb_client.py` for client interface, then followed FastAPI async patterns used in other `api/knowledge_*.py` modules. Registered the new router in `core_routers.py` alongside existing knowledge routers.

## What Changed

- Added `autobot-backend/api/knowledge_chroma.py` — 4 REST endpoints (list collections, get collection, list documents, search)
- Added `autobot-backend/api/knowledge_chroma_test.py` — 16 unit tests covering success + error cases
- Updated `autobot-backend/initialization/core_routers.py` — registered `knowledge_chroma` router under `/api/knowledge/chroma`

## Changes

- Add `autobot-backend/api/knowledge_chroma.py` with 4 REST endpoints
- Add `autobot-backend/api/knowledge_chroma_test.py` with 16 unit tests
- Register `knowledge_chroma` router in `core_routers.py`

## Verification

- All 16 unit tests pass locally via pytest
- Flake8 clean on both new files
- Router registered and importable (smoke-import verified)
- OpenAPI docs auto-generated at /docs endpoint

## Model Used

claude-sonnet-4-6

## Test plan

- [x] All 16 unit tests pass
- [x] Error cases tested (missing collection, invalid params, connection failure)
- [x] OpenAPI docs auto-generated at /docs
- [x] Uses existing async_chromadb_client.py

## Changelog fragment

N/A — internal backend feature, no user-visible behaviour change yet (frontend integration in parent [MVA-2043](/MVA/issues/MVA-2043))