### PR TITLE
feat(execution): add snapshot interface to ExecutionBackend base class (MVA-2226)

### DIFF
--- a/autobot-backend/services/execution/base_backend.py
+++ b/autobot-backend/services/execution/base_backend.py
@@ -182,9 +182,7 @@ class ExecutionBackend(ABC):
             "last_health_check": self._last_health_check.isoformat(),
         }
 
-    async def snapshot(
-        self, container_id: str, session_id: str = "", user_id: str = ""
-    ) -> Any:
+    async def snapshot(self, container_id: str, session_id: str = "", user_id: str = "") -> Any:
         """Create a snapshot of an execution environment.
 
         Args:
@@ -200,9 +198,7 @@ class ExecutionBackend(ABC):
             NotImplementedError: If this backend does not support snapshots.
             RuntimeError: If snapshot creation fails.
         """
-        raise NotImplementedError(
-            f"{self.backend_type.value} backend does not support snapshots"
-        )
+        raise NotImplementedError(f"{self.backend_type.value} backend does not support snapshots")
 
     async def restore(self, snapshot_id: str, caller_user_id: str) -> str:
         """Restore an execution environment from a snapshot.
@@ -221,9 +217,7 @@ class ExecutionBackend(ABC):
             PermissionError: If caller_user_id does not own the snapshot.
             RuntimeError: If restore fails.
         """
-        raise NotImplementedError(
-            f"{self.backend_type.value} backend does not support snapshots"
-        )
+        raise NotImplementedError(f"{self.backend_type.value} backend does not support snapshots")
 
     async def delete_snapshot(self, snapshot_id: str, caller_user_id: str) -> bool:
         """Delete a snapshot and its associated resources.
@@ -240,9 +234,7 @@ class ExecutionBackend(ABC):
             NotImplementedError: If this backend does not support snapshots.
             PermissionError: If caller_user_id does not own the snapshot.
         """
-        raise NotImplementedError(
-            f"{self.backend_type.value} backend does not support snapshots"
-        )
+        raise NotImplementedError(f"{self.backend_type.value} backend does not support snapshots")
 
     async def get_snapshots_for_session(self, session_id: str) -> list:
         """List all snapshots for a given session.
@@ -257,6 +249,4 @@ class ExecutionBackend(ABC):
         Raises:
             NotImplementedError: If this backend does not support snapshots.
         """
-        raise NotImplementedError(
-            f"{self.backend_type.value} backend does not support snapshots"
-        )
+        raise NotImplementedError(f"{self.backend_type.value} backend does not support snapshots")

--- a/autobot-backend/services/execution/base_backend.py
+++ b/autobot-backend/services/execution/base_backend.py
@@ -181,3 +181,82 @@ class ExecutionBackend(ABC):
             "healthy": self._health_status,
             "last_health_check": self._last_health_check.isoformat(),
         }
+
+    async def snapshot(
+        self, container_id: str, session_id: str = "", user_id: str = ""
+    ) -> Any:
+        """Create a snapshot of an execution environment.
+
+        Args:
+            container_id: ID or name of the execution environment to snapshot.
+            session_id: Optional identifier for the agent session.
+            user_id: ID of the authenticated user creating the snapshot.
+                When non-empty, enables ownership validation on restore/delete.
+
+        Returns:
+            Backend-specific snapshot record with snapshot_id and metadata.
+
+        Raises:
+            NotImplementedError: If this backend does not support snapshots.
+            RuntimeError: If snapshot creation fails.
+        """
+        raise NotImplementedError(
+            f"{self.backend_type.value} backend does not support snapshots"
+        )
+
+    async def restore(self, snapshot_id: str, caller_user_id: str) -> str:
+        """Restore an execution environment from a snapshot.
+
+        Args:
+            snapshot_id: ID returned by a prior snapshot() call.
+            caller_user_id: ID of the user requesting restore.
+                Must match the snapshot's user_id when ownership validation is enabled.
+
+        Returns:
+            ID of the restored execution environment.
+
+        Raises:
+            NotImplementedError: If this backend does not support snapshots.
+            KeyError: If snapshot_id is not found.
+            PermissionError: If caller_user_id does not own the snapshot.
+            RuntimeError: If restore fails.
+        """
+        raise NotImplementedError(
+            f"{self.backend_type.value} backend does not support snapshots"
+        )
+
+    async def delete_snapshot(self, snapshot_id: str, caller_user_id: str) -> bool:
+        """Delete a snapshot and its associated resources.
+
+        Args:
+            snapshot_id: ID returned by a prior snapshot() call.
+            caller_user_id: ID of the user requesting deletion.
+                Must match the snapshot's user_id when ownership validation is enabled.
+
+        Returns:
+            True if the snapshot was found and removed, False if not found.
+
+        Raises:
+            NotImplementedError: If this backend does not support snapshots.
+            PermissionError: If caller_user_id does not own the snapshot.
+        """
+        raise NotImplementedError(
+            f"{self.backend_type.value} backend does not support snapshots"
+        )
+
+    async def get_snapshots_for_session(self, session_id: str) -> list:
+        """List all snapshots for a given session.
+
+        Args:
+            session_id: Session identifier to query snapshots for.
+
+        Returns:
+            List of backend-specific snapshot records for the session.
+            Returns empty list if no snapshots found.
+
+        Raises:
+            NotImplementedError: If this backend does not support snapshots.
+        """
+        raise NotImplementedError(
+            f"{self.backend_type.value} backend does not support snapshots"
+        )

--- a/autobot-backend/services/execution/docker_backend.py
+++ b/autobot-backend/services/execution/docker_backend.py
@@ -386,6 +386,8 @@ class DockerBackend(ExecutionBackend):
     async def snapshot(self, container_id: str, session_id: str = "", user_id: str = "") -> SnapshotRecord:
         """Commit a running container's filesystem to a named image and record metadata.
 
+        Implements ExecutionBackend.snapshot() for Docker containers (GH#4458).
+
         Args:
             container_id: ID or name of the Docker container to snapshot.
             session_id: Caller-supplied identifier for the agent session.
@@ -453,6 +455,8 @@ class DockerBackend(ExecutionBackend):
     async def restore(self, snapshot_id: str, caller_user_id: str) -> str:
         """Start a new detached container from a previously saved snapshot.
 
+        Implements ExecutionBackend.restore() for Docker containers (GH#4458).
+
         Args:
             snapshot_id: ID returned by a prior ``snapshot()`` call.
             caller_user_id: ID of the user requesting restore.  When the snapshot has a
@@ -503,6 +507,8 @@ class DockerBackend(ExecutionBackend):
     async def delete_snapshot(self, snapshot_id: str, caller_user_id: str) -> bool:
         """Remove the snapshot image and its index entry.
 
+        Implements ExecutionBackend.delete_snapshot() for Docker containers (GH#4458).
+
         Args:
             snapshot_id: ID returned by a prior ``snapshot()`` call.
             caller_user_id: ID of the user requesting deletion.  When the snapshot has a
@@ -537,7 +543,16 @@ class DockerBackend(ExecutionBackend):
         return removed
 
     async def get_snapshots_for_session(self, session_id: str) -> list:
-        """Return all SnapshotRecords for the given session_id."""
+        """Return all SnapshotRecords for the given session_id.
+
+        Implements ExecutionBackend.get_snapshots_for_session() for Docker containers (GH#4458).
+
+        Args:
+            session_id: Session identifier to query snapshots for.
+
+        Returns:
+            List of SnapshotRecord objects for the session.
+        """
         return await asyncio.to_thread(self._snapshot_index.list_by_session, session_id)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path

Snapshot/restore methods needed to be added to the `ExecutionBackend` ABC so that callers can type-check against the base interface rather than reaching for `DockerBackend` directly. Default `NotImplementedError` with the backend type embedded in the message satisfies the GH#4458 acceptance criterion ("raise NotImplementedError by default") and gives non-Docker backends a clear upgrade path.

No behaviour change for Docker — only docstrings updated on the concrete implementation.

## What Changed

- `autobot-backend/services/execution/base_backend.py`: Added 4 async snapshot methods to `ExecutionBackend` base class with `NotImplementedError` defaults and comprehensive docstrings:
  - `snapshot(container_id, session_id, user_id) -> Any`
  - `restore(snapshot_id, caller_user_id) -> str`
  - `delete_snapshot(snapshot_id, caller_user_id) -> bool`
  - `get_snapshots_for_session(session_id) -> list`
- `autobot-backend/services/execution/docker_backend.py`: Updated docstrings to reference base class interface (no logic changes)

## Verification

- All 55 existing execution backend tests pass with zero regressions
- Both modules import cleanly
- `NotImplementedError` message format verified: `"local backend does not support snapshots"` etc.
- Black formatting applied, isort clean

## Model Used

claude-sonnet-4-6

## Related

- Closes [MVA-2226](/MVA/issues/MVA-2226)
- Parent: [MVA-2222](/MVA/issues/MVA-2222)
- GH#4458: https://github.com/mrveiss/AutoBot-AI/issues/4458