### PR TITLE
fix(voice-rbac): guard success emit() to prevent audit failures crashing endpoint (GH#8982)

### DIFF
--- a/autobot-backend/api/voice_bundle_user.py
+++ b/autobot-backend/api/voice_bundle_user.py
@@ -264,17 +264,20 @@ async def set_user_bundle(
         logger.error("set_user_bundle: DB error: %s", exc)
         raise HTTPException(status_code=500, detail="Database error") from exc
 
-    emit(
-        AuditEvent(
-            category=AuditCategory.SECURITY,
-            action="voice_bundle_assignment_changed",
-            actor_id=str(current_user_id),
-            resource_type="user_voice_bundle",
-            resource_id=user_id,
-            outcome="success",
-            metadata={**_audit_meta, "bundle_name": stored_bundle_name},
+    try:
+        emit(
+            AuditEvent(
+                category=AuditCategory.SECURITY,
+                action="voice_bundle_assignment_changed",
+                actor_id=str(current_user_id),
+                resource_type="user_voice_bundle",
+                resource_id=user_id,
+                outcome="success",
+                metadata={**_audit_meta, "bundle_name": stored_bundle_name},
+            )
         )
-    )
+    except Exception:
+        logger.warning("set_user_bundle: failed to emit success audit", exc_info=True)
 
     logger.info(
         "voice_bundle user_id=%s target=%s bundle=%s",


### PR DESCRIPTION
## Summary

Security audit follow-up for GH#8982 / [MVA-2410](/MVA/issues/MVA-2410).

After GH#8969 fix (PR #8974), a secondary security gap remained:

- `emit()` for the **success** SECURITY audit event was **unguarded** outside the try block
- If `emit()` fails (e.g., Redis/audit system down), the endpoint crashes with 500 **even though the DB operation succeeded**
- An attacker who can disrupt the audit system could mask privilege escalations AND cause all bundle operations to appear to fail

**Root cause:** PR #9111 deliberately moved `emit(success)` outside the try block to prevent emit failures being misclassified as DB failures — but left it unguarded.

**Fix:** Wrap success `emit()` in try/except, matching the pattern already used for the failure `emit()`. If audit fails, log a warning but still return 200 (correct — DB operation DID succeed).

## Changes

- `autobot-backend/api/voice_bundle_user.py`: wrap success `emit()` in try/except

## Test plan

- [x] All 30 existing tests pass (`test_voice_bundle_user.py`)
- [x] `test_admin_assigns_bundle_to_user` passes
- [x] `test_admin_can_assign_admin_bundle` passes
- [x] `test_admin_clears_bundle_for_user` passes

## Security impact

| Scenario | Before | After |
|---|---|---|
| DB success + audit success | 200 ✅ | 200 ✅ |
| DB success + audit failure | 500 ❌ | 200 + warning log ✅ |
| DB failure | 500 + failure audit ✅ | 500 + failure audit ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)