### PR TITLE
fix(ansible): add AUTOBOT_BACKEND_HOST to backend.env.j2 template

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -5,6 +5,7 @@
 
 # Server (Issue #858: Use SSOT config variable names)
 HOST={{ backend_host }}
+AUTOBOT_BACKEND_HOST={{ backend_host | default('0.0.0.0') }}
 AUTOBOT_BACKEND_PORT={{ backend_port }}
 
 # Application Paths (Issue #858: Database and schema paths)


### PR DESCRIPTION
## Summary

Adds missing `AUTOBOT_BACKEND_HOST` environment variable to the Ansible backend deployment template to prevent backend crash-loops on next deployment.

## Changes

- Added `AUTOBOT_BACKEND_HOST={{ backend_host | default('0.0.0.0') }}` to `autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2`
- Uses existing `backend_host` Ansible variable with `0.0.0.0` fallback
- Positioned in Server configuration section for logical grouping

## Context

- Required by `startup_validation.py` which validates `backend.server_host` config
- Discovered during incident resolution for MVA-2409 / GH#8926
- Without this variable, next Ansible deployment causes backend crash-loop

## Testing

- [x] Variable follows existing template patterns
- [x] Default value matches required server binding (0.0.0.0)
- [ ] Deployment verification needed post-merge

## Related

- Fixes #9276
- Parent incident: GH#8926
- Paperclip: MVA-2417

🤖 Generated with [Paperclip](https://paperclip.ing)