### PR TITLE
feat(ansible): include AUTOBOT_BACKEND_HOST in backend deployment config (MVA-2418)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -5,6 +5,7 @@
 
 # Server (Issue #858: Use SSOT config variable names)
 HOST={{ backend_host }}
+AUTOBOT_BACKEND_HOST={{ backend_host }}
 AUTOBOT_BACKEND_PORT={{ backend_port }}
 
 # Application Paths (Issue #858: Database and schema paths)

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -6,7 +6,7 @@ AutoBot supports comprehensive configuration through environment variables with 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AUTOBOT_BACKEND_HOST` | `0.0.0.0` | Backend server host |
+| `AUTOBOT_BACKEND_HOST` | `127.0.0.1` (or `0.0.0.0` on WSL2) | Backend server host — automatically configured by Ansible from `backend_host` variable (MVA-2418) |
 | `AUTOBOT_BACKEND_PORT` | `8001` | Backend server port |
 | `AUTOBOT_BACKEND_API_ENDPOINT` | `http://localhost:8001` | Full API endpoint URL |
 | `AUTOBOT_BACKEND_TIMEOUT` | `60` | Request timeout in seconds |

--- a/docs/runbooks/SINGLE_HOST_DEPLOYMENT.md
+++ b/docs/runbooks/SINGLE_HOST_DEPLOYMENT.md
@@ -144,6 +144,8 @@ AUTOBOT_LLM_TIMEOUT=120
 
 **Note:** Do NOT modify IPs after provisioning without re-running the role setup.
 
+**Updated (MVA-2418):** The `AUTOBOT_BACKEND_HOST` variable is now automatically configured by the Ansible backend role in `/etc/autobot/autobot-backend.env`. If using Ansible for deployment, this variable no longer needs manual configuration in the global `.env` file — it will be set from the `backend_host` Ansible variable (defaults to `127.0.0.1`, or `0.0.0.0` on WSL2).
+
 ---
 
 ## Step 3: Create Ansible Inventory for Single-Host


### PR DESCRIPTION
## Summary

- Add `AUTOBOT_BACKEND_HOST={{ backend_host }}` to the Ansible backend.env.j2 template so new deployments automatically include the variable
- Update environment-variables.md to document correct defaults and Ansible automation
- Update SINGLE_HOST_DEPLOYMENT.md with note that Ansible now manages this variable

## Context

[MVA-2412](/MVA/issues/MVA-2412) fixed the backend to default `backend.server_host` to `0.0.0.0`, but the Ansible deployment template was not emitting `AUTOBOT_BACKEND_HOST` at all. This PR adds explicit provisioning for clarity and production flexibility (related to the concurrent fix in PR #9279 from MVA-2417).

The Ansible `backend_host` variable already handles the WSL2 case (auto-set to `0.0.0.0` when WSL2 mirrored networking is detected), so this template line inherits all existing environment-specific logic.

## Test plan

- [ ] Verify `AUTOBOT_BACKEND_HOST` appears in deployed `.env` after running the backend Ansible role
- [ ] Confirm `backend_host` default (`127.0.0.1`) and WSL2 override (`0.0.0.0`) both propagate correctly

Closes MVA-2418

🤖 Generated with [Paperclip](https://paperclip.ing)