### PR TITLE
fix(transcriber): replace @vue:updated with watch() for status changes (#9208)

### DIFF
--- a/autobot-frontend/src/components/transcriber/ProcessingProgress.vue
+++ b/autobot-frontend/src/components/transcriber/ProcessingProgress.vue
@@ -2,7 +2,7 @@
 <!-- AutoBot - AI-Powered Automation Platform -->
 <!-- Copyright (c) 2025 mrveiss -->
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { onMounted, watch } from 'vue'
 import { useSseProgress } from '@/composables/transcriber/useSseProgress'
 
 const props = defineProps<{ recordingId: number }>()
@@ -14,14 +14,14 @@ onMounted(() => {
   connect()
 })
 
-function onStatusChange() {
-  if (status.value === 'complete') emit('complete')
-  if (status.value === 'error') emit('error')
-}
+watch(status, (val) => {
+  if (val === 'complete') emit('complete')
+  if (val === 'error') emit('error')
+})
 </script>
 
 <template>
-  <div class="processing-progress" @vue:updated="onStatusChange">
+  <div class="processing-progress">
     <div class="progress-bar-track">
       <div class="progress-bar-fill" :style="{ width: `${percent}%` }" />
     </div>


### PR DESCRIPTION
## Thinking Path

ProcessingProgress.vue used `@vue:updated` lifecycle hook to detect status changes and emit events. This hook fires on **every re-render** (any reactive update), not just when `status` changes. This causes:
- Duplicate event emissions when other refs (percent, step) update
- Missed events if status changes without triggering a re-render

The canonical Vue 3 pattern is `watch()` on the specific ref (`status`) to trigger exactly once per value change.

## What Changed

- `autobot-frontend/src/components/transcriber/ProcessingProgress.vue`:
  - Imported `watch` from Vue
  - Replaced `@vue:updated="onStatusChange"` template binding with `watch(status, (val) => { ... })` in setup
  - Removed the event binding from template

## Verification

✅ Code follows canonical Vue 3 Composition API pattern
✅ `watch()` ensures events fire exactly once per status change
✅ No TypeScript errors introduced
✅ Event emissions now correctly tied to status changes only, not all re-renders

## Model Used

claude-sonnet-4-6

---

Fixes #9208 — part of #9044 (transcriber improvements).