### PR TITLE
fix(config): merge YAML config with defaults to ensure required keys (#9232)

### DIFF
--- a/autobot-backend/config/loader.py
+++ b/autobot-backend/config/loader.py
@@ -72,19 +72,27 @@ ENV_VAR_MAPPINGS = {
 
 
 def load_yaml_config(config_file: Path) -> Dict[str, Any]:
-    """Load base configuration from YAML file"""
+    """Load base configuration from YAML file and merge with defaults.
+
+    Always starts with default config and merges the YAML on top.
+    This ensures all required config keys have sensible defaults even
+    if they're not present in the YAML file (Issue #9232).
+    """
+    defaults = get_default_config()
+
     if not config_file.exists():
         logger.info("Base configuration file not found: %s, using defaults", config_file)
-        return get_default_config()
+        return defaults
 
     try:
         with open(config_file, "r", encoding="utf-8") as f:
-            config = yaml.safe_load(f) or {}
+            yaml_config = yaml.safe_load(f) or {}
         logger.info("Base configuration loaded from %s", config_file)
-        return config
+        # Merge YAML config on top of defaults (YAML overrides defaults)
+        return deep_merge(defaults, yaml_config)
     except Exception as e:
         logger.error("Failed to load YAML configuration: %s", e)
-        return get_default_config()
+        return defaults
 
 
 def load_json_settings(settings_file: Path) -> Dict[str, Any]:


### PR DESCRIPTION
## Thinking Path

Backend startup fails because `load_yaml_config()` returned only YAML content — never merged with defaults. When `config.yaml` didn't contain `backend.server_host`, the loaded config dict was missing that key, and startup validation raised `RuntimeError`.

Root cause: The function returned raw YAML if the file existed, bypassing `get_default_config()`. The defaults path was only hit when the file was missing. Fix: always start from `get_default_config()` and merge YAML on top via `deep_merge()`.

## What Changed

- `autobot-backend/config/loader.py`: `load_yaml_config()` now calls `get_default_config()` unconditionally and merges YAML on top via `deep_merge()`. Ensures `backend.server_host=0.0.0.0` (and other required keys) are always present regardless of `config.yaml` content.

## Verification

Startup validation requires `backend.server_host` in the loaded config dict. After this change, `get_default_config()` provides it via `NetworkConstants.BIND_ALL_INTERFACES` (`0.0.0.0`), and any YAML overrides are merged on top.

Env var override: `AUTOBOT_BACKEND_HOST=<ip>` still works via `ENV_VAR_MAPPINGS` applied after YAML merge.

## Model Used

claude-sonnet-4-6

---

Closes #9232