### PR TITLE
fix(voice): rename get_provider_registry to get_speech_provider_registry (#9231)

### DIFF
--- a/autobot-backend/tests/integration/test_transcriber_pipeline.py
+++ b/autobot-backend/tests/integration/test_transcriber_pipeline.py
@@ -19,7 +19,7 @@ from transcriber.database import TranscriberDatabase
 from transcriber.models import RecordingStatus
 from transcriber.orchestrator import TranscriberOrchestrator
 from voice_processing.language_detection import detect_language
-from voice_processing.providers import get_provider_registry
+from voice_processing.providers import get_speech_provider_registry
 
 
 @pytest.fixture
@@ -77,7 +77,7 @@ async def test_service_availability():
     assert diarization is not None
 
     # Speech provider registry
-    registry = get_provider_registry()
+    registry = get_speech_provider_registry()
     assert registry is not None
 
     # Check that language detection works

--- a/autobot-backend/transcriber/orchestrator.py
+++ b/autobot-backend/transcriber/orchestrator.py
@@ -17,7 +17,7 @@ from media.audio.ffmpeg_service import get_ffmpeg_service
 from transcriber.database import TranscriberDatabase, get_transcriber_db
 from transcriber.models import RecordingStatus, TranscriptionSegment
 from voice_processing.language_detection import detect_language
-from voice_processing.providers import get_provider_registry
+from voice_processing.providers import get_speech_provider_registry
 
 logger = get_logger(__name__)
 
@@ -34,7 +34,7 @@ class TranscriberOrchestrator:
         self.db = db
         self.ffmpeg_service = get_ffmpeg_service()
         self.diarization_service = get_diarization_service()
-        self.provider_registry = get_provider_registry()
+        self.provider_registry = get_speech_provider_registry()
 
     async def process_recording(self, recording_id: int) -> dict:
         """Process a recording through the full pipeline.

--- a/autobot-backend/voice_processing/providers/__init__.py
+++ b/autobot-backend/voice_processing/providers/__init__.py
@@ -124,8 +124,8 @@ class ProviderRegistry:
 _registry = ProviderRegistry()
 
 
-def get_provider_registry() -> ProviderRegistry:
-    """Get global provider registry instance."""
+def get_speech_provider_registry() -> ProviderRegistry:
+    """Get global speech provider registry instance."""
     return _registry
 
 

--- a/autobot-backend/voice_processing/providers/registry_init.py
+++ b/autobot-backend/voice_processing/providers/registry_init.py
@@ -9,7 +9,7 @@ Part of Issue MVA-2185.
 """
 
 from autobot_shared.logging_manager import get_logger
-from voice_processing.providers import get_provider_registry
+from voice_processing.providers import get_speech_provider_registry
 from voice_processing.providers.generic_provider import GenericProvider
 from voice_processing.providers.lv.late_provider import LateProvider
 from voice_processing.providers.lv.tilde_provider import TildeProvider
@@ -25,7 +25,7 @@ def initialize_providers():
     - LATE (priority 10) > Tilde (priority 5) for Latvian
     - Generic provider is fallback for all languages (priority 0)
     """
-    registry = get_provider_registry()
+    registry = get_speech_provider_registry()
 
     # Register Latvian providers
     late = LateProvider()

--- a/autobot-backend/voice_processing/providers/test_registry.py
+++ b/autobot-backend/voice_processing/providers/test_registry.py
@@ -23,7 +23,7 @@ from voice_processing.providers import (
     ProviderRegistry,
     SpeechProvider,
     TranscriptSegment,
-    get_provider_registry,
+    get_speech_provider_registry,
     get_speech_provider,
 )
 from voice_processing.providers.generic_provider import GenericProvider
@@ -221,10 +221,10 @@ class TestRealProviders:
 class TestGlobalRegistry:
     """Test global registry singleton."""
 
-    def test_get_provider_registry_singleton(self):
-        """Test that get_provider_registry returns same instance."""
-        registry1 = get_provider_registry()
-        registry2 = get_provider_registry()
+    def test_get_speech_provider_registry_singleton(self):
+        """Test that get_speech_provider_registry returns same instance."""
+        registry1 = get_speech_provider_registry()
+        registry2 = get_speech_provider_registry()
         assert registry1 is registry2
 
     def test_get_speech_provider_convenience(self):


### PR DESCRIPTION
## Summary
Resolves naming collision between two different `get_provider_registry()` functions:
- `llm_shared.provider_registry.get_provider_registry()` (LLM providers, 40+ callers)
- `voice_processing.providers.get_provider_registry()` (speech providers, 3 callers)

Renamed the speech one to `get_speech_provider_registry()` for clarity.

## Changes
- ✅ Renamed function in `voice_processing/providers/__init__.py`
- ✅ Updated all callers: `orchestrator.py`, `registry_init.py`, `test_transcriber_pipeline.py`
- ✅ Updated test file: `test_registry.py`

## Verification
- No remaining references to old name in voice_processing module
- Import paths are consistent
- 5 files changed: 13 insertions, 13 deletions (pure rename)

Closes #9231