### PR TITLE
fix(ci): ensure Docker cache directory exists before build (MVA-2519)

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Create .env from .env.example
         run: cp .env.example .env
 
+      - name: Ensure cache directory exists
+        run: mkdir -p /tmp/.buildx-cache
+
       - name: Build images with layer cache
         run: |
           docker buildx build \


### PR DESCRIPTION
## Summary

Fixes intermittent smoke-test CI failures caused by Docker layer cache corruption when GitHub Actions cache misses.

## Root Cause

When GitHub Actions cache misses (new branches, cache expiration):
1. `/tmp/.buildx-cache` directory doesn't exist
2. Docker buildx `--cache-from type=local,src=/tmp/.buildx-cache` fails to lock non-existent directory
3. Layer cache becomes corrupted
4. COPY steps report cached "DONE 0.0s" but files aren't actually present
5. `npm ci` fails with "package-lock.json not found"

## Solution

Added cache directory initialization step before Docker builds:
```yaml
- name: Ensure cache directory exists
  run: mkdir -p /tmp/.buildx-cache
```

## Evidence

- **Failed runs**: 26847078957, 26849470789, 26849035175, 26846012779, 26845571814, 26845021126
- **Error pattern**: `could not lock /tmp/.buildx-cache/index.json.lock: no such file or directory`
- **Impact**: 7 failures in recent CI runs, affecting multiple PRs

## Test Plan

- [ ] Verify smoke-test passes on this PR
- [ ] Confirm cache directory is created before builds
- [ ] Check that subsequent cache hits work correctly

Closes MVA-2519

🤖 Generated with [Claude Code](https://claude.com/claude-code)