### PR TITLE
fix(ansible): add REDIS_HOST env vars to slm-agent systemd unit (#9226)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/defaults/main.yml
@@ -58,3 +58,7 @@ node_exporter_port: 9100
 # Set this to override the git commit (e.g., for releases)
 # When empty, the current git commit hash is auto-detected
 slm_agent_version: ""
+
+# Redis connection (Issue #9226)
+# Agent imports from autobot_shared which requires REDIS_HOST set
+slm_agent_redis_host: "{{ redis_host | default('127.0.0.1') }}"

--- a/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
@@ -36,6 +36,9 @@ Environment=SLM_NODE_ID={{ slm_node_id }}
 Environment=SLM_ADMIN_URL={{ effective_admin_url }}
 Environment=PYTHONPATH={{ slm_agent_dir }}
 Environment=PYTHONUNBUFFERED=1
+# Issue #9226: Redis connection for autobot_shared imports
+Environment=REDIS_HOST={{ slm_agent_redis_host }}
+Environment=AUTOBOT_REDIS_HOST={{ slm_agent_redis_host }}
 
 # Agent execution — admin_url resolved from SLM_ADMIN_URL env var above,
 # not baked into CLI args, so re-provisioning updates it (#2833).


### PR DESCRIPTION
## Thinking Path

slm-agent imports from autobot_shared which expects REDIS_HOST env var to be set. Without it, the Redis client defaults to empty string host, causing connection failures. The autobot-backend systemd unit already sets these vars - this brings slm-agent into parity.

## What Changed

- Added `slm_agent_redis_host` variable to `slm_agent` role defaults (resolves from `redis_host`, defaults to `127.0.0.1`)
- Added `Environment=REDIS_HOST` and `Environment=AUTOBOT_REDIS_HOST` to `slm-agent.service.j2` systemd template
- Fixes Redis connection failure when slm-agent imports from `autobot_shared`

## Problem

The `slm-agent.service` systemd unit was missing `REDIS_HOST` and `AUTOBOT_REDIS_HOST`. The SLM agent imports from `autobot_shared` which defaults `REDIS_HOST` to `""` (empty string), causing:

```
Error -2 connecting to :6379. Name or service not known.
```

The `autobot-backend.service` already sets `AUTOBOT_REDIS_HOST=127.0.0.1` — this PR brings the SLM agent into parity.

## Verification

Manual test plan:
- Re-provision an SLM agent node with the updated role
- Confirm `systemctl show slm-agent.service | grep REDIS` shows both env vars set
- Confirm `slm-agent` starts without Redis connection errors

## Model Used

Claude Sonnet 4.5

## Files changed

- `autobot-slm-backend/ansible/roles/slm_agent/defaults/main.yml`
- `autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2`

Closes #9226

🤖 Generated with [Claude Code](https://claude.com/claude-code)