### PR TITLE
fix(ansible): suppress /sys/class/infiniband gather_facts warning on WSL2 (#9282)

### DIFF
--- a/autobot-slm-backend/ansible/ansible.cfg
+++ b/autobot-slm-backend/ansible/ansible.cfg
@@ -29,6 +29,8 @@ display_ok_hosts = True
 
 # Performance Optimization
 gathering = smart
+# WSL2: Exclude hardware facts to suppress /sys/class/infiniband warning (#9282)
+gather_subset = !hardware
 fact_caching = jsonfile
 fact_caching_connection = /tmp/ansible_fact_cache
 fact_caching_timeout = 86400


### PR DESCRIPTION
## Summary

Suppresses the `/sys/class/infiniband` warning on every WSL2 provision run. WSL2 does not expose InfiniBand hardware, so Ansible network facts collection warns on every run — pure noise.

Closes #9282

## Thinking Path

The warning comes from Ansible traversing `/sys/class/infiniband` during hardware fact collection. WSL2 does not expose that path as a directory. The cleanest fix is `gather_subset = !hardware` in `ansible.cfg` which excludes hardware facts globally for all playbooks, removing the collection attempt entirely. No playbook in AutoBot requires hardware facts.

## What Changed

- Added `gather_subset = !hardware` to `autobot-slm-backend/ansible/ansible.cfg`

## Verification

```bash
ansible-config dump | grep GATHER_SUBSET
# DEFAULT_GATHER_SUBSET = ["!hardware"]
```

Config recognized by Ansible; the setting applies to all playbooks with `gather_facts: true`. Warning no longer appears on WSL2 provision runs.

## Model Used

claude-sonnet-4-6

## Changelog fragment

N/A — internal infra noise fix, no user-visible behaviour change