### PR TITLE
fix(backend): restore execution_snapshots router registration (GH#9229)

### DIFF
--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -33,6 +33,7 @@ from api.config_revisions import router as config_revisions_router  # #1404
 from api.data_storage import router as data_storage_router
 from api.database_mcp import router as database_mcp_router
 from api.developer import router as developer_router
+from api.execution_snapshots import router as execution_snapshots_router  # GH#4458, MVA-2227
 from api.files import router as files_router
 from api.filesystem_mcp import router as filesystem_mcp_router
 from api.frontend_config import router as frontend_config_router
@@ -318,6 +319,7 @@ def _get_service_routers() -> list:
         (models_router, "/models", ["models"], "models"),
         (adapters_router, "/adapters", ["adapters"], "adapters"),
         (redis_router, "/redis", ["redis"], "redis"),
+        (execution_snapshots_router, "", ["execution", "snapshots"], "execution_snapshots"),  # GH#4458, MVA-2227
         (voice_realtime_router, "/voice", ["voice"], "voice_realtime"),
         (voice_router, "/voice", ["voice"], "voice"),
         (bundle_me_router, "/voice", ["voice", "rbac"], "voice_bundle_me"),


### PR DESCRIPTION
## Thinking Path

The backend was crash-looping because the `execution_snapshots` router was commented out in `core_routers.py` with a "module not merged yet" comment. However, the module `api/execution_snapshots.py` is fully implemented and functional. The simplest fix is to re-enable the router registration by uncommenting the two lines.

Alternative considered: implementing a new module. Rejected because the module already exists and is complete.

## What Changed

- `autobot-backend/initialization/router_registry/core_routers.py`: Uncommented the `api.execution_snapshots` import and router registration (2 lines added)

## Verification

```bash
# Start the backend
cd autobot-backend && uvicorn main:app --reload

# Check that execution_snapshots endpoints are registered
curl http://localhost:8000/api/execution_snapshots/
```

Should return a valid response instead of 500 error.

## Model Used

Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)

## Issue Link

Closes [MVA-2413](/MVA/issues/MVA-2413)