### PR TITLE
perf(transcriber): add foreign key indexes for query optimization (MVA-2782)

### DIFF
--- a/autobot-backend/transcriber/database.py
+++ b/autobot-backend/transcriber/database.py
@@ -71,6 +71,14 @@ CREATE TABLE IF NOT EXISTS kb_pushes (
     pushed_by TEXT NOT NULL
 );
 """),
+    (2, """
+CREATE INDEX IF NOT EXISTS idx_recordings_project_id ON recordings(project_id);
+CREATE INDEX IF NOT EXISTS idx_speakers_recording_id ON speakers(recording_id);
+CREATE INDEX IF NOT EXISTS idx_segments_recording_id ON segments(recording_id);
+CREATE INDEX IF NOT EXISTS idx_segments_speaker_id ON segments(speaker_id);
+CREATE INDEX IF NOT EXISTS idx_notes_recording_id ON notes(recording_id);
+CREATE INDEX IF NOT EXISTS idx_notes_segment_id ON notes(segment_id);
+"""),
 ]
 
 

--- a/autobot-backend/transcriber/tests/test_database.py
+++ b/autobot-backend/transcriber/tests/test_database.py
@@ -105,7 +105,7 @@ async def test_migration_table_exists_and_version_recorded(tmp_path):
     async with aiosqlite.connect(db_path) as conn:
         cur = await conn.execute("SELECT version FROM _schema_migrations ORDER BY version")
         versions = [row[0] for row in await cur.fetchall()]
-    assert versions == [1]
+    assert versions == [1, 2]
 
 
 @pytest.mark.asyncio
@@ -120,7 +120,7 @@ async def test_migration_idempotent_on_reconnect(tmp_path):
     async with aiosqlite.connect(db_path) as conn:
         cur = await conn.execute("SELECT COUNT(*) FROM _schema_migrations")
         row = await cur.fetchone()
-    assert row[0] == 1  # version 1 recorded exactly once
+    assert row[0] == 2  # migrations 1 and 2 recorded exactly once each
 
 
 # ── GH#9058: close() uses is not None ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds migration 2 with 6 indexes on foreign key columns to prevent slow queries as transcriber data grows.

## Changes

- **Migration 2** — 6 CREATE INDEX statements:
  - `idx_recordings_project_id ON recordings(project_id)` (queried in list_recordings)
  - `idx_speakers_recording_id ON speakers(recording_id)` (queried in list_speakers)
  - `idx_segments_recording_id ON segments(recording_id)` (queried in list_segments)
  - `idx_segments_speaker_id ON segments(speaker_id)` (used in merge, FK)
  - `idx_notes_recording_id ON notes(recording_id)` (queried in list_notes)
  - `idx_notes_segment_id ON notes(segment_id)` (FK)
- **Test updates** — migration count expectations updated to [1, 2]

## Test Coverage

All 66 transcriber tests pass including:
- `test_migration_table_exists_and_version_recorded`
- `test_migration_idempotent_on_reconnect`

## Reference

- Issue: MVA-2782
- Parent: [MVA-2173](/MVA/issues/MVA-2173)
- Blocks: [MVA-2776](/MVA/issues/MVA-2776) (code review)
- Base PR: #9350

🤖 Generated with Paperclip