### PR TITLE
fix(ci): add /app/autobot-backend/logs tmpfs for hardened config

### DIFF
--- a/docker-compose.hardened.yml
+++ b/docker-compose.hardened.yml
@@ -114,6 +114,7 @@ services:
     tmpfs:
       - /tmp
       - /app/autobot-backend/.cache:mode=1777
+      - /app/autobot-backend/logs:mode=1777  # logging_manager creates logs/backup dirs on init
     deploy:
       resources:
         limits:
@@ -126,6 +127,7 @@ services:
     tmpfs:
       - /tmp
       - /app/autobot-backend/.cache:mode=1777
+      - /app/autobot-backend/logs:mode=1777  # logging_manager creates logs/backup dirs on init
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Thinking Path

The `hardened-smoke-test` CI was failing across multiple PRs with identical errors: backend container unhealthy. Investigation path:

1. Checked docker-compose.hardened.yml config → backend has `read_only: true` 
2. Examined similar fixes (ChromaDB) → found pattern of adding tmpfs mounts for write-needed dirs
3. Traced backend startup → logging_manager.py calls `mkdir()` on log directory
4. Identified gap: `/app/autobot-backend/logs` not in volumes or tmpfs
5. Solution: add tmpfs mount following ChromaDB pattern from existing config

Why this approach: Minimal change, follows established pattern in same file, preserves read-only security hardening.

## What Changed

- `docker-compose.hardened.yml`: Added `/app/autobot-backend/logs:mode=1777` tmpfs mount to `autobot-backend` service (line 117)
- `docker-compose.hardened.yml`: Added `/app/autobot-backend/logs:mode=1777` tmpfs mount to `autobot-worker` service (line 130)

## Verification

CI `hardened-smoke-test` check should pass. Specifically:
```bash
docker compose -f docker-compose.yml -f docker-compose.hardened.yml --env-file docker/.env.docker up -d
# Backend container should start successfully
docker ps | grep autobot-backend  # should show as healthy
curl http://localhost/api/system/health  # should return 200 OK
```

Manual verification:
```bash
# In hardened container, verify logs dir is writable tmpfs
docker exec autobot-backend mount | grep /app/autobot-backend/logs
# Should show: tmpfs on /app/autobot-backend/logs type tmpfs
```

## Risks

Low risk. Logs are ephemeral in tmpfs (lost on container restart), but:
- Structured logs already go to stdout (captured by Docker)
- Volume-mounted `/app/logs` still persists important logs
- This only affects hardened-smoke-test CI environment, not production deploys

Rollback: revert the two tmpfs lines if issues arise.

## Model Used

Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)

## Issue Link

Closes MVA-2798

Unblocks:
- MVA-2413 (#9355) - execution_snapshots router fix
- MVA-2449 (#9345) - slm-agent update_url fix
- MVA-1745 (#9352) - chat folders parent_id fix

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (CI hardened-smoke-test validates the fix)
- [x] Documentation updated if behavior changed (inline comment added)
- [x] Pre-commit hooks pass (YAML-only change, no hooks triggered)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff
