### PR TITLE
fix(provision): validate stale code_source has vega dep before build (#9284)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
+++ b/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
@@ -176,6 +176,30 @@
       when: github_sync is not failed
       tags: [always]
 
+    # GH#9284: When GitHub sync fails, validate that stale code_source
+    # has critical frontend dependencies (vega fix from 267b2044a).
+    # Prevents late build failures with cryptic Rolldown errors.
+    - name: "[PRE-FLIGHT] Validate stale code_source has critical dependencies"
+      block:
+        - name: "[PRE-FLIGHT] Check if package.json has vega dependency"
+          ansible.builtin.command:
+            cmd: jq -e '.dependencies.vega' {{ git_repo_root }}/autobot-frontend/package.json
+          register: vega_check
+          changed_when: false
+          failed_when: false
+
+        - name: "[PRE-FLIGHT] Abort if code_source missing critical frontend deps"
+          ansible.builtin.fail:
+            msg: >-
+              CRITICAL: Stale code_source missing vega dependency (GH#9284).
+              Frontend build will fail at Phase 4b with Rolldown import error.
+              Fix: Restore internet connectivity and re-run provisioning to sync latest code from {{ deploy_ref }}.
+              Current commit: {{ deploy_info.stdout }}
+              Required commit: 267b2044a or later (fix(frontend): add vega as explicit dep)
+          when: vega_check.rc != 0
+      when: github_sync is failed
+      tags: [always]
+
 # -------------------------------------------------------------------
 # Phase 0: Shared Dependencies (nginx, python312, nodejs)
 # Resolved from ROLE_DEPENDENCIES map via node_dependencies host var.


### PR DESCRIPTION
## Summary

Adds pre-flight validation to Ansible provisioning that aborts early with a clear error when:
- GitHub sync fails (no internet connectivity)
- Stale code_source is missing critical frontend dependencies (specifically the vega fix from commit 267b2044a)

This prevents cryptic Rolldown import errors at Phase 4b when provisioning continues with stale code.

## Root Cause

When provisioning runs offline and GitHub sync fails, it falls back to stale code_source. If that stale code is missing the vega-as-direct-dependency fix (GH#9218), the frontend build fails late at Phase 4b with:

```
[vite]: Rolldown failed to resolve import "vega" from "node_modules/vega-embed/build/vega-embed.module.js"
```

## Fix

Added a validation block in `provision-fleet-roles.yml` that:
1. Checks if package.json has the vega dependency when GitHub sync fails
2. Fails immediately with a clear error message pointing to the root cause
3. Instructs the operator to restore internet connectivity and retry

## Test Plan

- ✅ Rebased on latest Dev_new_gui (commit 084ded92a)
- ✅ Single-file change: only touches `provision-fleet-roles.yml`
- ✅ Syntax verified: playbook parses correctly

## Closes

- Paperclip: [MVA-2434](/MVA/issues/MVA-2434)
- GitHub: #9284

🤖 Generated with Paperclip
Co-Authored-By: Paperclip <noreply@paperclip.ing>