### PR TITLE
fix(frontend): convert vite.config.ts to .js to resolve oxlint parsing error

### DIFF
--- a/autobot-frontend/vite.config.js
+++ b/autobot-frontend/vite.config.js
@@ -6,7 +6,6 @@ import { fileURLToPath, URL } from 'node:url'
 import { copyFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { defineConfig, loadEnv } from 'vite'
-import type { Plugin } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 import pkg from './package.json'
@@ -18,8 +17,8 @@ import pkg from './package.json'
  * MicVAD (@ricky0123/vad-web) fetches these files at runtime via fetch()
  * from a configurable baseAssetPath. They must be served as static files.
  */
-function vadAssetsPlugin(): Plugin {
-  const assets: [string, string][] = [
+function vadAssetsPlugin() {
+  const assets = [
     ['node_modules/@ricky0123/vad-web/dist/vad.worklet.bundle.min.js', 'vad.worklet.bundle.min.js'],
     ['node_modules/@ricky0123/vad-web/dist/silero_vad_legacy.onnx', 'silero_vad_legacy.onnx'],
     ['node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.mjs', 'ort-wasm-simd-threaded.mjs'],
@@ -63,12 +62,6 @@ export default defineConfig(({ mode }) => {
     },
     css: { devSourcemap: true, postcss: './postcss.config.js' },
     resolve: {
-      // preserveSymlinks: true resolves modules relative to the symlink path
-      // (node_modules/@autobot/terminal) not the real path (../../autobot-plugins/…).
-      // Without this, rolldown walks up from the real plugin path and misses
-      // pinia/vue in the frontend's node_modules. Required for file: workspace
-      // packages (same fix applied to slm-frontend in #8482 / MVA-893).
-      preserveSymlinks: true,
       alias: { '@': fileURLToPath(new URL('./src', import.meta.url)), 'vue': 'vue/dist/vue.esm-bundler.js' }
     },
     server: {

--- a/autobot-frontend/vite.config.js
+++ b/autobot-frontend/vite.config.js
@@ -62,6 +62,10 @@ export default defineConfig(({ mode }) => {
     },
     css: { devSourcemap: true, postcss: './postcss.config.js' },
     resolve: {
+      // preserveSymlinks resolves modules relative to the symlink path
+      // (node_modules/@autobot/terminal) not the real path (../../autobot-plugins/…).
+      // Required for file: workspace packages — see #8482 / MVA-893.
+      preserveSymlinks: true,
       alias: { '@': fileURLToPath(new URL('./src', import.meta.url)), 'vue': 'vue/dist/vue.esm-bundler.js' }
     },
     server: {


### PR DESCRIPTION
## Problem

Oxlint fails to parse TypeScript config files with Node.js v20.20.2, blocking all Dependabot PRs and frontend-tests:

```
TypeScript config files require Node.js ^20.19.0 || >=22.18.0.
```

Even though v20.20.2 satisfies the semver requirement, this appears to be an oxlint bug or configuration issue.

## Solution

Convert `autobot-frontend/vite.config.ts` to `vite.config.js` (pure JavaScript). This resolves the parsing error and allows CI to proceed.

## Thinking Path

Oxlint semver check for Node.js TS config support has a parsing edge case with v20.20.2. Options: (1) upgrade CI Node to v22, (2) convert config to .js, (3) pin oxlint. Converting to .js is the smallest change with no risk — vite.config is not imported by app code and does not need TypeScript. Restored `preserveSymlinks: true` which was accidentally dropped (required for @autobot/terminal workspace symlink).

## What Changed

- Renamed `autobot-frontend/vite.config.ts` → `vite.config.js`
- Removed `import type { Plugin }` and explicit TS return type from `vadAssetsPlugin()`
- Restored `preserveSymlinks: true` in resolve config (required for file: workspace packages, see #8482)

## Verification

- CI `frontend-tests` check was failing on PR #9361 with the oxlint Node.js error
- After this change, oxlint will not attempt to load vite.config as a TypeScript file
- No functional change to the Vite build configuration

## Model Used

claude-sonnet-4-6

## Impact

- Fixes frontend-tests CI failures on all Dependabot PRs targeting main
- No functional changes to Vite configuration

Closes MVA-2804