### PR TITLE
fix(ci): upgrade frontend-test to Node.js 22 to fix oxlint TypeScript config error (MVA-2804)

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 
 permissions:
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         working-directory: autobot-frontend
@@ -126,7 +126,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         working-directory: autobot-frontend
@@ -169,7 +169,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         working-directory: autobot-frontend


### PR DESCRIPTION
## Summary

Targeted 1-file fix for MVA-2804: oxlint rejects Node.js 20.20.2 when loading TypeScript config files, blocking all Dependabot PRs targeting `main`.

- Upgrades `NODE_VERSION` env and all three `node-version:` pins in `frontend-test.yml` from `'20'` → `'22'`
- Fixes jobs: `unit-tests`, `security-scan`, `build-test`

**Root cause:** Oxlint requires `^20.19.0 || >=22.18.0` for TypeScript config support. Node.js 20.20.2 satisfies the semver range but oxlint's internal semver parser misidentifies it as unsupported (upstream bug). Node.js 22 is a clean fix that avoids the parser edge case.

**Scope:** 1 file changed, 4 lines. No application code touched.

## Test plan

- [ ] `frontend-tests` CI check passes on this PR
- [ ] `frontend-tests` CI check passes on open Dependabot PRs (e.g. #9363) after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)