### PR TITLE
fix(config): make backend.server_host optional with 0.0.0.0 default (GH#9232)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,7 @@ AUTOBOT_LOG_LEVEL=INFO
 #   VM5 Browser - YOUR_BROWSER_VM_IP - Web automation (Playwright)
 
 # Main Machine (WSL) - Backend API + VNC Desktop
+# Default: 0.0.0.0 (bind all interfaces). Override for specific interface binding.
 AUTOBOT_BACKEND_HOST=YOUR_BACKEND_IP
 
 # VM1 Frontend - Web interface (SINGLE FRONTEND SERVER)

--- a/autobot-backend/config/validation.py
+++ b/autobot-backend/config/validation.py
@@ -24,9 +24,8 @@ _PORT_MAX = 65535
 
 # Config keys that must resolve to a non-None value before serving requests.
 # Each entry is a dot-notation path checked via get_nested().
-_REQUIRED_CONFIG_KEYS: List[str] = [
-    "backend.server_host",
-]
+# GH#9232: backend.server_host removed — defaults to 0.0.0.0 in config/defaults.py
+_REQUIRED_CONFIG_KEYS: List[str] = []
 
 # Config keys required only when a feature flag is enabled.
 # Each tuple is (required_key, guard_path, guard_enabled_value).


### PR DESCRIPTION
## Thinking Path

Backend startup validation was failing when `AUTOBOT_BACKEND_HOST` was not set in `.env` files. Investigation revealed that `backend.server_host` was marked as required in `config/validation.py`, but a sensible default of `0.0.0.0` (bind all interfaces) already exists in `config/defaults.py`.

The solution is to remove it from the required keys list and let the default take effect.

## What Changed

- **config/validation.py**: Removed `"backend.server_host"` from `_REQUIRED_CONFIG_KEYS` list
- **.env.example**: Added clarifying comment documenting the `0.0.0.0` default value

## Verification

- Manually verified the backend starts successfully without `AUTOBOT_BACKEND_HOST` in `.env`
- Confirmed the default value `0.0.0.0` from `config/defaults.py` is used correctly
- No regression: backend still accepts explicit `AUTOBOT_BACKEND_HOST` values when provided

## Model Used

Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)

---

Fixes #9232
Related: MVA-2418 (DevOps deployment config follow-up)

🤖 Generated with [Paperclip](https://paperclip.ing)