### PR TITLE
fix(docker): add /app/config tmpfs mount for hardened backend/worker (MVA-2798)

### DIFF
--- a/docker-compose.hardened.yml
+++ b/docker-compose.hardened.yml
@@ -113,6 +113,7 @@ services:
     read_only: true
     tmpfs:
       - /tmp
+      - /app/config:mode=1777  # config_manager creates config dir on init
       - /app/autobot-backend/.cache:mode=1777
       - /app/autobot-backend/logs:mode=1777  # logging_manager creates logs/backup dirs on init
     deploy:
@@ -126,6 +127,7 @@ services:
     read_only: true
     tmpfs:
       - /tmp
+      - /app/config:mode=1777  # config_manager creates config dir on init
       - /app/autobot-backend/.cache:mode=1777
       - /app/autobot-backend/logs:mode=1777  # logging_manager creates logs/backup dirs on init
     deploy:


### PR DESCRIPTION
## Problem

The `hardened-smoke-test` CI check is consistently failing across multiple unrelated PRs with the same error:

```
Container autobot-backend Error
Container autobot-slm Error
dependency failed to start: container autobot-backend is unhealthy
```

**Blocked PRs:**
- #9355 - execution_snapshots router fix
- #9345 - slm-agent update_url fix  
- #9352 - chat folders parent_id fix

## Root Cause

When running with the hardened Docker Compose overlay (`read_only: true`):

1. `ConfigManager.__init__` tries to create `/app/config` directory at startup
2. The hardened overlay sets `read_only: true` but didn't include `/app/config` in tmpfs mounts
3. Container crashes with: `OSError: [Errno 30] Read-only file system: '/app/config'`
4. Both backend and worker services are affected

See failure logs from [GH run 26915863483](https://github.com/mrveiss/AutoBot-AI/actions/runs/26915863483/job/79405339264)

## Solution

Add `/app/config:mode=1777` tmpfs mount to both `autobot-backend` and `autobot-worker` services in `docker-compose.hardened.yml`.

This follows the same pattern as existing tmpfs mounts for `.cache` and `logs` directories that also need write access under read-only filesystem constraints.

## Testing

- [x] Analyzed CI failure logs to identify root cause
- [ ] CI hardened-smoke-test will verify the fix

## Related Issues

Closes MVA-2798
Unblocks #9355, #9345, #9352