### PR TITLE
feat(voice-bundle): wire voice bundle routers (#8605)

### DIFF
--- a/autobot-backend/api/voice_bundle_admin.py
+++ b/autobot-backend/api/voice_bundle_admin.py
@@ -29,6 +29,11 @@ bundle_me_router = APIRouter(tags=["voice", "rbac"])
 # Router for admin operations
 bundle_admin_router = APIRouter(prefix="/admin", tags=["admin", "voice", "rbac"])
 
+# Combined router for feature_routers.py discovery (GH#8605)
+router = APIRouter()
+router.include_router(bundle_me_router, prefix="/voice")
+router.include_router(bundle_admin_router)
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -657,6 +657,20 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["voice", "realtime", "webrtc"],
         "realtime_session",
     ),
+    # GH#8605: Per-user voice bundle assignment (admin + user endpoints)
+    (
+        "api.voice_bundle_admin",
+        "",
+        ["voice", "rbac", "admin"],
+        "voice_bundle_admin",
+    ),
+    # GH#8605: Voice bundle management (user-facing endpoints)
+    (
+        "api.voice_bundle_user",
+        "/voice",
+        ["voice", "rbac"],
+        "voice_bundle_user",
+    ),
     # GH#4463: Mobile device pairing for push notifications and offline sync
     (
         "api.mobile_devices",


### PR DESCRIPTION
## Summary

Implements missing router registration for voice bundle RBAC endpoints in `feature_routers.py`.

Closes #8605

## Changes

- Add `api.voice_bundle_admin` router registration for `/me` and admin endpoints
- Add `api.voice_bundle_user` router registration with `/voice` prefix
- Update `voice_bundle_admin.py` to export combined router for feature discovery

## Test plan

- [x] Router registration follows existing patterns in `feature_routers.py`
- [x] Endpoints match spec from GH#8605 issue description
- [x] Backend implementation already tested in prior PRs (#8862)

## Changelog fragment

- [x] N/A (internal router wiring, no user-visible API change - endpoints already implemented in #8862)