### PR TITLE
feat(voice-bundle): register voice bundle routers (#8605)

### DIFF
--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -39,17 +39,20 @@ class MetricsWorkflowResponse(BaseModel):
     workflow_id: str
     metrics: Any | None = None
 
+
 class MetricsPerformanceSummaryResponse(BaseModel):
     """Response for GET /performance/summary."""
 
     success: bool
     performance_summary: Any | None = None
 
+
 class MetricsSystemCurrentResponse(BaseModel):
     """Response for GET /system/current."""
 
     success: bool
     system_metrics: Any | None = None
+
 
 class MetricsSystemHistoryResponse(BaseModel):
     """Response for GET /system/history."""
@@ -66,6 +69,7 @@ class MetricsSystemSummaryResponse(BaseModel):
     success: bool
     resource_summary: Any | None = None
 
+
 class MetricsExportResponse(BaseModel):
     """Response for GET /export/workflow and GET /export/system."""
 
@@ -73,12 +77,14 @@ class MetricsExportResponse(BaseModel):
     format: str
     data: Any | None = None
 
+
 class MetricsMonitoringStartResponse(BaseModel):
     """Response for POST /system/monitoring/start."""
 
     success: bool
     message: str
     collection_interval: Any | None = None
+
 
 class MetricsMonitoringStopResponse(SuccessMessageResponse):
     """Response for POST /system/monitoring/stop."""

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -145,6 +145,7 @@ class KnowledgeCollectionCreateResponse(BaseModel):
     collection: Dict[str, Any] | None = None
     message: str | None = None
 
+
 class KnowledgeCollectionListResponse(BaseModel):
     """Response for GET /collections."""
 
@@ -163,12 +164,14 @@ class KnowledgeCollectionDetailResponse(BaseModel):
     status: str
     collection: Dict[str, Any] | None = None
 
+
 class KnowledgeCollectionUpdateResponse(BaseModel):
     """Response for PUT /collections/{collection_id}."""
 
     status: str
     collection: Dict[str, Any] | None = None
     message: str | None = None
+
 
 class KnowledgeCollectionDeleteResponse(BaseModel):
     """Response for DELETE /collections/{collection_id}."""
@@ -178,6 +181,7 @@ class KnowledgeCollectionDeleteResponse(BaseModel):
     facts_in_collection: int
     facts_deleted: int
     message: str | None = None
+
 
 class KnowledgeCollectionAddFactsResponse(BaseModel):
     """Response for POST /collections/{collection_id}/facts."""
@@ -190,6 +194,7 @@ class KnowledgeCollectionAddFactsResponse(BaseModel):
     total_facts: int
     message: str | None = None
 
+
 class KnowledgeCollectionRemoveFactsResponse(BaseModel):
     """Response for DELETE /collections/{collection_id}/facts."""
 
@@ -199,6 +204,7 @@ class KnowledgeCollectionRemoveFactsResponse(BaseModel):
     not_in_collection: int
     total_facts: int
     message: str | None = None
+
 
 class KnowledgeCollectionFactsListResponse(BaseModel):
     """Response for GET /collections/{collection_id}/facts."""
@@ -232,6 +238,7 @@ class KnowledgeCollectionExportResponse(BaseModel):
     total_count: int
     exported_at: str | None = None
 
+
 class KnowledgeCollectionBulkDeleteResponse(BaseModel):
     """Response for POST /collections/{collection_id}/bulk-delete."""
 
@@ -255,6 +262,7 @@ class KnowledgeCategoryCreateResponse(BaseModel):
     category: Dict[str, Any] | None = None
     message: str | None = None
 
+
 class KnowledgeCategoryTreeResponse(BaseModel):
     """Response for GET /categories/tree."""
 
@@ -269,12 +277,14 @@ class KnowledgeCategoryDetailResponse(BaseModel):
     status: str
     category: Dict[str, Any] | None = None
 
+
 class KnowledgeCategoryUpdateResponse(BaseModel):
     """Response for PUT /categories/{category_id}."""
 
     status: str
     category: Dict[str, Any] | None = None
     message: str | None = None
+
 
 class KnowledgeCategoryDeleteResponse(BaseModel):
     """Response for DELETE /categories/{category_id}."""
@@ -283,6 +293,7 @@ class KnowledgeCategoryDeleteResponse(BaseModel):
     deleted_count: int
     facts_reassigned: int
     message: str | None = None
+
 
 class KnowledgeCategoryChildrenResponse(BaseModel):
     """Response for GET /categories/{category_id}/children."""
@@ -325,6 +336,7 @@ class KnowledgeFactAssignCategoryResponse(BaseModel):
     category_id: str | None = None
     category_path: str | None = None
     message: str | None = None
+
 
 class KnowledgeCategorySearchResponse(BaseModel):
     """Response for POST /categories/search."""
@@ -385,6 +397,7 @@ class KnowledgeDocumentationSearchResponse(BaseModel):
     total_results: int | None = None
     message: str | None = None
 
+
 class KnowledgeDocumentationStatsResponse(BaseModel):
     """Response for GET /unified/documentation/stats."""
 
@@ -394,6 +407,7 @@ class KnowledgeDocumentationStatsResponse(BaseModel):
     how_to_index: str | None = None
     collection_name: str | None = None
     document_count: int | None = None
+
 
 class KnowledgeUnifiedGraphResponse(BaseModel):
     """Response for POST /unified/graph and GET /unified/graph."""
@@ -437,6 +451,7 @@ class KnowledgeScopedFactsResponse(BaseModel):
     facts: List[Any]
     count: int
     total: int | None = None
+
 
 class KnowledgeShareResponse(BaseModel):
     """Response for POST /knowledge/collaboration/facts/{id}/share."""
@@ -497,6 +512,7 @@ class KnowledgeAuditEventsResponse(BaseModel):
     fact_id: str | None = None
     organization_id: str | None = None
 
+
 class KnowledgePermissionChangesResponse(BaseModel):
     """Response for GET /knowledge/audit/permission-changes."""
 
@@ -540,6 +556,7 @@ class KnowledgeVerificationApproveResponse(BaseModel):
     verified_at: str | None = None
     message: str | None = None
 
+
 class KnowledgeVerificationRejectResponse(BaseModel):
     """Response for POST /verification/{fact_id}/reject."""
 
@@ -547,6 +564,7 @@ class KnowledgeVerificationRejectResponse(BaseModel):
     fact_id: str
     deleted: bool
     message: str | None = None
+
 
 class KnowledgeVerificationConfigResponse(BaseModel):
     """Response for GET/PUT /verification/config."""
@@ -573,6 +591,7 @@ class KnowledgeSuggestionsTagsResponse(BaseModel):
     suggestions: List[Any] | None = None
     similar_docs_analyzed: int | None = None
 
+
 class KnowledgeSuggestionsCategoriesResponse(BaseModel):
     """Response for POST /suggestions/categories."""
 
@@ -581,6 +600,7 @@ class KnowledgeSuggestionsCategoriesResponse(BaseModel):
     success: bool
     suggestions: List[Any] | None = None
     similar_docs_analyzed: int | None = None
+
 
 class KnowledgeSuggestionsAllResponse(BaseModel):
     """Response for POST /suggestions/all."""
@@ -598,6 +618,7 @@ class KnowledgeSuggestionsContextResponse(BaseModel):
     success: bool
     suggestions: List[Any] | None = None
     total_candidates: int | None = None
+
 
 class KnowledgeAutoApplySuggestionsResponse(BaseModel):
     """Response for POST /facts/{fact_id}/auto-apply."""
@@ -620,6 +641,7 @@ class KnowledgeShareFactResponse(BaseModel):
     shared_with: List[Any]
     visibility: str | None = None
 
+
 class KnowledgeUnshareFactResponse(BaseModel):
     """Response for DELETE /api/knowledge/facts/{fact_id}/share/{user_id_to_remove}."""
 
@@ -628,12 +650,14 @@ class KnowledgeUnshareFactResponse(BaseModel):
     shared_with: List[Any]
     visibility: str | None = None
 
+
 class KnowledgeUpdateVisibilityResponse(BaseModel):
     """Response for PUT /api/knowledge/facts/{fact_id}/visibility."""
 
     success: bool
     fact_id: str
     visibility: str | None = None
+
 
 class KnowledgeMyFactsResponse(BaseModel):
     """Response for GET /api/knowledge/facts/mine."""
@@ -677,6 +701,7 @@ class KnowledgeVerifyClaimResponse(BaseModel):
     evidence: List[Any] | None = None
     verification_method: str | None = None
     kb_source: str | None = None
+
 
 class KnowledgeConflictsListResponse(BaseModel):
     """Response for GET /api/kb-conflicts."""
@@ -728,6 +753,7 @@ class KnowledgeOrganizationPolicyResponse(BaseModel):
     require_approval_for_system: bool
     retention_days: int | None = None
 
+
 class KnowledgeOrganizationStatsResponse(BaseModel):
     """Response for GET /knowledge/organization/stats."""
 
@@ -767,6 +793,7 @@ class KnowledgeScopedSearchResponse(BaseModel):
     mode: str | None = None
     user_id: str | None = None
     filtered_by_permissions: bool | None = None
+
 
 class KnowledgeAccessibleScopesResponse(BaseModel):
     """Response for GET /knowledge/search/accessible-scopes."""

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -169,6 +169,7 @@ class FeatureFlagStatusResponse(BaseModel):
     success: bool
     data: Any | None = None
 
+
 class FeatureFlagEnforcementModeResponse(SuccessDataResponse):
     """Response for PUT /feature-flags/enforcement-mode."""
 
@@ -377,6 +378,7 @@ class FilePreviewResponse(BaseModel):
     mime_type: str | None = None
     size: int | None = None
     name: str | None = None
+
 
 class FileDeleteResponse(BaseModel):
     """Response for DELETE /files/delete.
@@ -592,6 +594,7 @@ class VisionOCRResponse(BaseModel):
     text_regions: List[Any]
     total_text_regions: int
     region: Dict[str, Any] | None = None
+
 
 class VisionAutomationOpportunitiesResponse(BaseModel):
     """Response for GET /vision/automation-opportunities."""

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -121,6 +121,7 @@ class StateTrackingStatusResponse(BaseModel):
     change_count: Any | None = None
     latest_snapshot: Any | None = None
 
+
 class StateTrackingSummaryResponse(BaseModel):
     """Response for GET /summary."""
 
@@ -301,6 +302,7 @@ class RUMEventResponse(BaseModel):
     status: str
     message: str
     session_event_count: int | None = None
+
 
 class RUMDisableResponse(BaseModel):
     """Response for POST /rum/disable."""

--- a/autobot-backend/api/voice_bundle_admin.py
+++ b/autobot-backend/api/voice_bundle_admin.py
@@ -29,6 +29,11 @@ bundle_me_router = APIRouter(tags=["voice", "rbac"])
 # Router for admin operations
 bundle_admin_router = APIRouter(prefix="/admin", tags=["admin", "voice", "rbac"])
 
+# Combined router for feature_routers.py discovery (GH#8605)
+router = APIRouter()
+router.include_router(bundle_me_router, prefix="/voice")
+router.include_router(bundle_admin_router)
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -657,6 +657,20 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["voice", "realtime", "webrtc"],
         "realtime_session",
     ),
+    # GH#8605: Per-user voice bundle assignment (admin + user endpoints)
+    (
+        "api.voice_bundle_admin",
+        "",
+        ["voice", "rbac", "admin"],
+        "voice_bundle_admin",
+    ),
+    # GH#8605: Voice bundle management (user-facing endpoints)
+    (
+        "api.voice_bundle_user",
+        "/voice",
+        ["voice", "rbac"],
+        "voice_bundle_user",
+    ),
     # GH#4463: Mobile device pairing for push notifications and offline sync
     (
         "api.mobile_devices",


### PR DESCRIPTION
## Summary

Registers voice_bundle_admin and voice_bundle_user routers in `feature_routers.py` so the per-user voice bundle assignment endpoints are discoverable by FastAPI.

This completes GH#8605 by wiring the already-implemented backend endpoints to the router registry.

Closes #8605

## Changes

- Add `voice_bundle_admin` router registration for `/me` and admin endpoints
- Add `voice_bundle_user` router registration with `/voice` prefix  
- Export combined `router` from `voice_bundle_admin.py` for feature discovery

## Test plan

- [x] Router registration follows existing pattern in `feature_routers.py`
- [x] Endpoints match spec from GH#8605 issue description:
  - `GET /api/voice/realtime/bundle/me`
  - `GET /api/admin/voice/bundle/{user_id}`
  - `PUT /api/admin/voice/bundle/{user_id}`
- [x] Backend implementation already tested in PR #8862
- [x] Frontend implementation already merged in PR #8694 (`useVoiceBundle.ts`)

## Changelog fragment

- [x] N/A (internal router wiring, no user-visible API change - endpoints already implemented in #8862)