### PR TITLE
docs(reasoning-effort): add user, API, and developer documentation (MVA-3016)

### DIFF
--- a/docs/api/_index.md
+++ b/docs/api/_index.md
@@ -22,6 +22,7 @@ aliases:
 
 | Document | Description |
 | --- | --- |
+| [chat-reasoning-effort](chat-reasoning-effort.md) | Reasoning effort parameter for chat API |
 | [WEBSOCKET_INTEGRATION_GUIDE](WEBSOCKET_INTEGRATION_GUIDE.md) | WebSocket integration |
 | [Terminal_API_Consolidated](Terminal_API_Consolidated.md) | Terminal API |
 | [AGENT_TERMINAL_API](AGENT_TERMINAL_API.md) | Agent terminal API |

--- a/docs/api/chat-reasoning-effort.md
+++ b/docs/api/chat-reasoning-effort.md
@@ -1,0 +1,213 @@
+---
+tags:
+  - api
+  - chat
+  - reasoning
+aliases:
+  - Chat Reasoning Effort API
+---
+
+# Chat API: Reasoning Effort Parameter
+
+The `reasoning_effort` metadata field controls how deeply a reasoning model "thinks" before generating a response. It is passed in the `metadata` object of a `ChatMessage` request.
+
+---
+
+## Supported Endpoints
+
+| Endpoint | Method | Supports `reasoning_effort` |
+|----------|--------|-----------------------------|
+| `/chat` | POST | ✅ |
+| `/chat/stream` | POST | ✅ |
+
+---
+
+## Request Schema
+
+`reasoning_effort` is set inside the `metadata` field of a `ChatMessage`:
+
+```json
+{
+  "content": "Explain the root cause of this production incident.",
+  "role": "user",
+  "session_id": "chat_abc123",
+  "metadata": {
+    "reasoning_effort": "high"
+  }
+}
+```
+
+### `metadata.reasoning_effort`
+
+| Property | Type | Values | Default |
+|----------|------|--------|---------|
+| `reasoning_effort` | `string` | `"low"`, `"medium"`, `"high"`, `"auto"` | User preference, or `"auto"` |
+
+- If omitted, the user's stored preference (Redis `user:{user_id}:preferences:reasoning_effort`) is used.
+- If no stored preference exists, the provider default applies (`"auto"` behaviour).
+- Unrecognised values are treated as `"auto"` with a warning logged.
+
+---
+
+## Example Requests
+
+### Low effort — fast factual lookup
+
+```bash
+curl -X POST http://<frontend-ip>:8001/chat \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "What is the capital of France?",
+    "role": "user",
+    "session_id": "chat_abc123",
+    "metadata": {
+      "reasoning_effort": "low"
+    }
+  }'
+```
+
+### High effort — complex multi-step reasoning
+
+```bash
+curl -X POST http://<frontend-ip>:8001/chat \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "Analyze why our database queries are slow and propose a remediation plan.",
+    "role": "user",
+    "session_id": "chat_abc123",
+    "metadata": {
+      "reasoning_effort": "high"
+    }
+  }'
+```
+
+### Streaming with medium effort
+
+```bash
+curl -X POST http://<frontend-ip>:8001/chat/stream \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "Write a Python function to parse log files.",
+    "role": "user",
+    "session_id": "chat_abc123",
+    "metadata": {
+      "reasoning_effort": "medium"
+    }
+  }'
+```
+
+---
+
+## Provider Mapping
+
+`reasoning_effort` is translated to provider-specific parameters by the backend mapping utility:
+
+### OpenAI (o3, o4-mini)
+
+```json
+// reasoning_effort: "high"
+{ "reasoning_effort": "high" }   // passed directly to OpenAI API
+```
+
+### Google Gemini 2.5
+
+```json
+// reasoning_effort: "medium"
+{ "thinking_mode": "medium" }   // mapped to Gemini thinking_mode parameter
+```
+
+### Anthropic Claude (Extended Thinking)
+
+```json
+// reasoning_effort: "high"
+{
+  "thinking": {
+    "type": "enabled",
+    "budget_tokens": 63000
+  }
+}
+
+// reasoning_effort: "low"  →  budget_tokens: 10000
+// reasoning_effort: "medium"  →  budget_tokens: 30000
+// reasoning_effort: "high"  →  budget_tokens: 63000
+// reasoning_effort: "auto"  →  extended thinking disabled
+```
+
+---
+
+## User Preferences Endpoints
+
+### Get user reasoning effort preference
+
+```
+GET /api/users/preferences/reasoning_effort
+Authorization: Bearer <token>
+```
+
+**Response:**
+
+```json
+{
+  "reasoning_effort": "medium"
+}
+```
+
+Returns `"auto"` if no preference is set.
+
+### Set user reasoning effort preference
+
+```
+PUT /api/users/preferences/reasoning_effort
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+
+**Request:**
+
+```json
+{
+  "reasoning_effort": "medium"
+}
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "reasoning_effort": "medium"
+}
+```
+
+**Allowed values:** `"low"`, `"medium"`, `"high"`, `"auto"`
+
+---
+
+## Backward Compatibility
+
+`reasoning_effort` coexists with the pre-existing `thinking_mode_enabled` / `thinking_budget_tokens` fields on `ChatMessage`:
+
+- If **both** are set, `reasoning_effort` takes precedence for Anthropic, with the effort-level budget overriding `thinking_budget_tokens`.
+- If only `thinking_mode_enabled: true` is set (no `reasoning_effort`), the original behaviour is preserved: `thinking_budget_tokens` (or its default) is used.
+- Models that do not support reasoning effort ignore the field silently.
+
+---
+
+## Error Handling
+
+| Condition | Behaviour |
+|-----------|-----------|
+| Unsupported model | Field silently ignored; response generated without reasoning overhead |
+| Invalid `reasoning_effort` value | Treated as `"auto"`; warning logged to backend error log |
+| Provider API error during reasoning | Returns standard provider error; no silent fallback |
+
+---
+
+## Related Documentation
+
+- [User Guide: Reasoning Effort](../user-guide/reasoning-effort-guide.md) — End-user explanation of the feature
+- [Developer Guide: Provider Integration](../developer/REASONING_EFFORT_PROVIDER_INTEGRATION.md) — Implementation details
+- [Public API Reference](public-api-reference.md) — Full API endpoint listing

--- a/docs/developer/REASONING_EFFORT_PROVIDER_INTEGRATION.md
+++ b/docs/developer/REASONING_EFFORT_PROVIDER_INTEGRATION.md
@@ -1,0 +1,218 @@
+---
+tags:
+  - developer
+  - llm-providers
+  - reasoning
+aliases:
+  - Reasoning Effort Provider Integration
+---
+
+# Reasoning Effort: Provider Integration
+
+## Overview
+
+AutoBot exposes a unified `reasoning_effort` abstraction across all supported reasoning-capable providers. This document describes the data flow, mapping utility, and provider-specific integration patterns.
+
+**Design decision:** ADR in [MVA-2933](/MVA/issues/MVA-2933#document-plan).
+
+---
+
+## Data Flow
+
+```
+ChatMessage.metadata["reasoning_effort"]
+       ↓
+chat API (api/chat.py)
+       ↓
+LLMRequest.metadata["reasoning_effort"]
+       ↓
+Provider-level mapping (per-provider logic)
+       ↓
+Provider API call with native params
+```
+
+1. The chat endpoint reads `metadata["reasoning_effort"]` from the request (or falls back to the user's Redis preference).
+2. The value is propagated as-is into `LLMRequest.metadata["reasoning_effort"]`.
+3. Each provider's `complete()` / `stream()` method maps the effort level to its native parameter before calling the upstream API.
+
+---
+
+## Mapping Utility
+
+`autobot_shared/reasoning_effort.py` (introduced in [MVA-3012](/MVA/issues/MVA-3012)) exposes:
+
+```python
+from autobot_shared.reasoning_effort import effort_to_provider_params, EffortLevel
+
+# Returns a dict of provider-specific kwargs to merge into the API call
+params = effort_to_provider_params(
+    effort="high",
+    provider="anthropic",   # "openai" | "gemini" | "anthropic"
+)
+# {"thinking": {"type": "enabled", "budget_tokens": 63000}}
+```
+
+### `effort_to_provider_params(effort, provider)`
+
+| Argument | Type | Values |
+|----------|------|--------|
+| `effort` | `str` | `"low"`, `"medium"`, `"high"`, `"auto"` |
+| `provider` | `str` | `"openai"`, `"gemini"`, `"anthropic"` |
+
+Returns a `dict` ready to merge into the provider call kwargs, or `{}` if the effort level produces no override (e.g., `"auto"` for OpenAI).
+
+### Anthropic budget token map
+
+```python
+ANTHROPIC_BUDGET_TOKENS = {
+    "low": 10_000,
+    "medium": 30_000,
+    "high": 63_000,
+    "auto": None,   # extended thinking disabled
+}
+```
+
+---
+
+## Provider Integration Patterns
+
+### OpenAI (`llm_shared/providers/openai.py`)
+
+OpenAI o3/o4-mini accept `reasoning_effort` as a top-level API parameter:
+
+```python
+# Inside OpenAIProvider.complete() / .stream()
+effort = request.metadata.get("reasoning_effort")
+if effort and effort != "auto":
+    api_kwargs["reasoning_effort"] = effort
+```
+
+**Supported models:** `o3`, `o4-mini` (and future `o*` series).  
+**Non-o-series models:** `reasoning_effort` is not forwarded; field is silently skipped.
+
+### Google Gemini (`llm_shared/providers/vertexai.py`)
+
+Gemini 2.5 uses a `thinking_mode` parameter:
+
+```python
+effort = request.metadata.get("reasoning_effort")
+thinking_mode_map = {"low": "low", "medium": "medium", "high": "high"}
+if effort in thinking_mode_map:
+    generation_config["thinking_mode"] = thinking_mode_map[effort]
+```
+
+**Supported models:** `gemini-2.5-pro`, `gemini-2.5-flash`.  
+**Older Gemini models:** `thinking_mode` is ignored by the API.
+
+### Anthropic (`llm_shared/providers/anthropic.py`)
+
+Anthropic uses an effort-to-budget mapping layered on top of the existing `thinking` API kwargs mechanism:
+
+```python
+effort = request.metadata.get("reasoning_effort")
+budget = ANTHROPIC_BUDGET_TOKENS.get(effort)
+
+if budget is not None:
+    # Inject into api_kwargs so the existing thinking logic picks it up
+    api_kwargs.setdefault("thinking", {})
+    api_kwargs["thinking"]["type"] = "enabled"
+    api_kwargs["thinking"]["budget_tokens"] = budget
+    api_kwargs.setdefault("max_tokens", budget + 1000)
+    api_kwargs["temperature"] = 1   # required by Anthropic when thinking is enabled
+```
+
+The existing `thinking_mode_enabled` / `thinking_budget_tokens` fields are still supported. `reasoning_effort` takes precedence when both are present.
+
+---
+
+## User Preference Storage
+
+User reasoning effort preferences are stored in Redis database 0 (main):
+
+```
+Key pattern: user:{user_id}:preferences:reasoning_effort
+Value:        "low" | "medium" | "high" | "auto"
+TTL:          None (persistent)
+```
+
+```python
+# Read preference
+from autobot_shared.redis_client import get_redis_client
+
+redis = await get_redis_client()
+effort = await redis.get(f"user:{user_id}:preferences:reasoning_effort")
+effort = effort.decode() if effort else "auto"
+
+# Write preference
+await redis.set(f"user:{user_id}:preferences:reasoning_effort", effort)
+```
+
+The chat API checks this key when `reasoning_effort` is absent from the request metadata.
+
+---
+
+## Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         Chat Request                                 │
+│  metadata["reasoning_effort"] = "high"                              │
+└────────────────────────────┬────────────────────────────────────────┘
+                             │
+                ┌────────────▼────────────┐
+                │      api/chat.py        │
+                │  Read effort from:      │
+                │  1. request.metadata    │
+                │  2. Redis preference    │
+                │  3. default "auto"      │
+                └────────────┬────────────┘
+                             │ LLMRequest.metadata["reasoning_effort"]
+                ┌────────────▼────────────┐
+                │  autobot_shared/        │
+                │  reasoning_effort.py    │
+                │  effort_to_provider_    │
+                │  params()               │
+                └──┬─────────┬─────────┬─┘
+                   │         │         │
+         ┌─────────▼─┐ ┌─────▼───┐ ┌──▼──────────────┐
+         │  OpenAI   │ │ Gemini  │ │   Anthropic      │
+         │ reasoning_│ │thinking_│ │ thinking.budget_  │
+         │ effort=   │ │mode=    │ │ tokens=63000      │
+         │ "high"    │ │"high"   │ │                   │
+         └───────────┘ └─────────┘ └───────────────────┘
+```
+
+---
+
+## Testing
+
+Tests for the mapping utility live in:
+
+- `autobot-backend/llm_shared/tests/test_reasoning_effort_mapping.py` — unit tests for `effort_to_provider_params()`
+- `autobot-backend/api/tests/test_chat_reasoning_effort.py` — integration tests for the chat API with reasoning effort metadata
+- `autobot-backend/llm_shared/providers/tests/test_*_reasoning_effort.py` — per-provider unit tests
+
+See [MVA-3016](/MVA/issues/MVA-3016) for test coverage requirements (>90% target).
+
+---
+
+## Adding a New Provider
+
+To add reasoning effort support to a new provider:
+
+1. Add an entry in `effort_to_provider_params()` for the provider key.
+2. In the provider's `complete()` / `stream()`, read `request.metadata.get("reasoning_effort")` and apply the mapped params.
+3. Guard with a model-capability check — skip silently for unsupported models.
+4. Add unit tests in `llm_shared/providers/tests/test_{provider}_reasoning_effort.py`.
+
+---
+
+## Related
+
+- [ADR/Design: MVA-2933](/MVA/issues/MVA-2933#document-plan)
+- [Backend Foundation: MVA-3012](/MVA/issues/MVA-3012)
+- [Provider Integration: MVA-3013](/MVA/issues/MVA-3013)
+- [Frontend UI: MVA-3014](/MVA/issues/MVA-3014)
+- [Anthropic provider module](../../autobot-backend/llm_shared/providers/anthropic.py) — existing `thinking` implementation
+- [API: reasoning_effort parameter](../api/chat-reasoning-effort.md)
+- [User Guide: Reasoning Effort](../user-guide/reasoning-effort-guide.md)

--- a/docs/user-guide/_index.md
+++ b/docs/user-guide/_index.md
@@ -2,28 +2,13 @@
 tags:
   - index
   - user-guide
-<<<<<<< HEAD
-=======
   - installation
->>>>>>> origin/Dev_new_gui
 aliases:
   - User Guide Index
 ---
 
 # User Guide
 
-<<<<<<< HEAD
-End-user documentation for installing, configuring, and using AutoBot-AI.
-
-| Document | Description |
-| --- | --- |
-| [[01-installation]] | Installation guide |
-| [[02-quickstart]] | Quick start guide |
-| [[03-configuration]] | Configuration guide |
-| [[04-troubleshooting]] | Troubleshooting guide |
-| [[05-preferences]] | User preferences guide |
-| [[06-redis-management]] | Redis management guide |
-=======
 Step-by-step guides for installing, configuring, and operating AutoBot.
 
 ## Guides
@@ -36,10 +21,10 @@ Step-by-step guides for installing, configuring, and operating AutoBot.
 | [[04-troubleshooting]] | Common issues and solutions |
 | [[05-preferences]] | User preference customization |
 | [[06-redis-management]] | Redis service management and operations |
+| [[reasoning-effort-guide]] | Control AI reasoning depth: Low / Medium / High / Auto |
 
 ## Related Sections
 
-- [[../getting-started/_index\|Getting Started]] — Environment-specific installation (VM, VNC)
-- [[../configuration/_index\|Configuration]] — Advanced environment variable and port configuration
-- [[../troubleshooting/_index\|Troubleshooting]] — Extended troubleshooting guides
->>>>>>> origin/Dev_new_gui
+- [[../getting-started/_index|Getting Started]] — Environment-specific installation (VM, VNC)
+- [[../configuration/_index|Configuration]] — Advanced environment variable and port configuration
+- [[../troubleshooting/_index|Troubleshooting]] — Extended troubleshooting guides

--- a/docs/user-guide/reasoning-effort-guide.md
+++ b/docs/user-guide/reasoning-effort-guide.md
@@ -1,0 +1,135 @@
+---
+tags:
+  - user-guide
+  - chat
+  - reasoning
+  - ai-settings
+aliases:
+  - Reasoning Effort Guide
+---
+
+# Reasoning Effort Guide
+
+Control how deeply AI reasoning models think before responding. Adjusting **reasoning effort** lets you trade response speed and cost against reasoning depth.
+
+---
+
+## What Is Reasoning Effort?
+
+Modern AI reasoning models (OpenAI o3/o4-mini, Google Gemini 2.5, Anthropic Claude with extended thinking) can spend more or fewer compute cycles "thinking" before generating an answer. AutoBot exposes this as a single **Reasoning Effort** selector with four levels:
+
+| Level | Hint | Best For |
+|-------|------|----------|
+| **Low** | ⚡ 2× faster, ~60% cheaper | Factual lookups, summaries, routine tasks |
+| **Medium** | ⚙️ Balanced speed & quality | General-purpose chat, code review |
+| **High** | 🧠 Deepest reasoning, higher cost | Complex debugging, multi-step planning |
+| **Auto** | 🤖 Provider default | Let the model decide (safe default) |
+
+---
+
+## Setting Reasoning Effort
+
+### Per-Conversation (in ChatSettingsModal)
+
+1. Open a chat session.
+2. Click the **settings gear** icon in the chat toolbar to open **Chat Settings**.
+3. Under **Reasoning Effort**, select your preferred level.
+4. Optionally check **Set as my default** to save this level for future conversations.
+5. Click **Apply** — the setting takes effect immediately for all new messages in this session.
+
+> **Note:** Changing the effort level mid-conversation affects only messages sent after the change.
+
+### Persistent Default (Preferences)
+
+1. Navigate to **Preferences** (top navigation → Preferences, or `/preferences`).
+2. Scroll to **AI Behavior → Reasoning Effort**.
+3. Choose your default level.
+4. Click **Save Preferences**.
+
+All new chat sessions will start with this effort level. You can still override it per conversation.
+
+---
+
+## Provider Behavior
+
+The same effort level maps to different provider parameters depending on the model you are using:
+
+### OpenAI (o3, o4-mini)
+
+OpenAI accepts `reasoning_effort` natively:
+
+| Level | Parameter sent |
+|-------|---------------|
+| Low | `reasoning_effort: "low"` |
+| Medium | `reasoning_effort: "medium"` |
+| High | `reasoning_effort: "high"` |
+| Auto | Not sent (provider default) |
+
+### Google Gemini 2.5
+
+Gemini uses a `thinking_mode` parameter:
+
+| Level | Parameter sent |
+|-------|---------------|
+| Low | `thinking_mode: "low"` |
+| Medium | `thinking_mode: "medium"` |
+| High | `thinking_mode: "high"` |
+| Auto | Not sent (provider default) |
+
+### Anthropic Claude (Extended Thinking)
+
+Claude uses a token budget for extended thinking:
+
+| Level | Thinking tokens |
+|-------|----------------|
+| Low | 10,000 tokens |
+| Medium | 30,000 tokens |
+| High | 63,000 tokens |
+| Auto | Extended thinking disabled (standard response) |
+
+> **Backward compatibility:** If you have existing AutoBot configurations that set `thinking_mode_enabled` and `thinking_budget_tokens` directly, those still work. The `reasoning_effort` selector is additive — it fills in sensible defaults when you haven't manually configured thinking.
+
+---
+
+## Cost & Speed Tradeoffs
+
+Reasoning costs vary by provider and model. Use this table as a rough guide:
+
+| Level | Typical latency | Typical cost vs. Auto |
+|-------|----------------|----------------------|
+| Low | Fastest | ~40% of Auto |
+| Medium | Moderate | ~70% of Auto |
+| High | Slowest | ~150% of Auto |
+| Auto | Varies | Baseline (1×) |
+
+Exact costs depend on your model, provider, and input/output token counts. Check your provider's current pricing for precise figures.
+
+---
+
+## Unsupported Models
+
+If the selected model does not support reasoning effort (e.g., standard GPT-4o, Gemini Flash, older Claude models), AutoBot silently ignores the setting and responds normally — no error is shown. The reasoning effort badge in the UI is greyed out for unsupported models.
+
+---
+
+## Frequently Asked Questions
+
+**Q: Does reasoning effort affect the quality of non-reasoning tasks?**  
+A: For models that support it, Low effort can occasionally miss nuance on complex tasks. For simple Q&A or summaries, Low is usually indistinguishable from High.
+
+**Q: Will my reasoning effort preference apply to all my chats?**  
+A: Yes, once you set a default in Preferences. Per-conversation overrides apply only to that conversation.
+
+**Q: Can I see the model's reasoning steps?**  
+A: Enable **Include Reasoning** in Chat Settings (a separate toggle from effort level). This shows the chain-of-thought before the final answer.
+
+**Q: What happens if I switch models mid-conversation?**  
+A: The effort level remains set, but it takes effect on the new model according to that model's mapping (see provider tables above).
+
+---
+
+## Related Documentation
+
+- [Preferences Guide](05-preferences.md) — Set defaults for all AI behavior settings
+- [Chat Configuration](03-configuration.md) — Advanced chat configuration options
+- [API: reasoning_effort parameter](../api/chat-reasoning-effort.md) — Developer API reference


### PR DESCRIPTION
## Summary

Documentation for the reasoning effort feature ([MVA-3016](/MVA/issues/MVA-3016)), based on the design spec in [MVA-2933](/MVA/issues/MVA-2933#document-plan).

### Files Added / Modified

- **`docs/user-guide/reasoning-effort-guide.md`** — End-user guide covering effort levels (Low/Medium/High/Auto), per-conversation settings via ChatSettingsModal, provider-specific behavior tables, cost/speed tradeoffs, unsupported model graceful degradation, and FAQ.
- **`docs/api/chat-reasoning-effort.md`** — API reference documenting `metadata["reasoning_effort"]` for `/chat` and `/chat/stream`, provider parameter mapping, preferences endpoints (GET/PUT), backward compatibility with existing `thinking_mode_enabled`/`thinking_budget_tokens`, and error handling.
- **`docs/developer/REASONING_EFFORT_PROVIDER_INTEGRATION.md`** — Developer doc covering data flow, `effort_to_provider_params()` mapping utility, per-provider integration patterns (OpenAI, Gemini, Anthropic), Redis preference storage key pattern, architecture diagram, and guide for adding new providers.
- **`docs/user-guide/_index.md`** — Resolved merge conflict; linked new reasoning effort guide.
- **`docs/api/_index.md`** — Added link to new chat-reasoning-effort API doc.

## Depends On

Implementation issues (not yet merged):
- [MVA-3012](/MVA/issues/MVA-3012) — Backend foundation (todo)
- [MVA-3013](/MVA/issues/MVA-3013) — Provider integration (blocked)
- [MVA-3014](/MVA/issues/MVA-3014) — Frontend UI (blocked)

Documentation is written against the approved design in the MVA-2933 plan document. Commands and paths will be verifiable once implementation issues land.

## Test Plan

- [ ] All 5 new/modified doc files rendered correctly in repo viewer
- [ ] Links between user-guide, API doc, and developer doc resolve correctly
- [ ] Index entries appear in `_index.md` files
- [ ] Merge conflict in `docs/user-guide/_index.md` resolved with best-of-both content

🤖 Generated with [Claude Code](https://claude.com/claude-code)