### PR TITLE
security(streams): sanitize remaining SSE exception leaks (#9410)

### DIFF
--- a/autobot-backend/agents/overseer/overseer_agent.py
+++ b/autobot-backend/agents/overseer/overseer_agent.py
@@ -462,7 +462,8 @@ Examples:
 
         except Exception as e:
             logger.error("[OverseerAgent] Step %d failed: %s", task.step_number, e)
-            yield ("update", _build_error_update(plan_id, task, str(e)))
+            # Issue #9410: Never leak exception details in SSE streams
+            yield ("update", _build_error_update(plan_id, task, "Task execution failed"))
 
     def _build_plan_update(self, plan: TaskPlan) -> OverseerUpdate:
         """

--- a/autobot-backend/api/chat_compare.py
+++ b/autobot-backend/api/chat_compare.py
@@ -111,7 +111,8 @@ async def _stream_single_model(
 
     except Exception as exc:
         logger.warning("compare stream error for %s: %s", model_spec, exc)
-        yield _sse({"model": model_spec, "error": str(exc), "done": True})
+        # Issue #9410: Never leak exception details in SSE streams
+        yield _sse({"model": model_spec, "error": "Model comparison failed", "done": True})
 
 
 def _sse(payload: Dict) -> str:

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -3128,7 +3128,8 @@ before summarizing.
             if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
                 error_content = "The model is taking too long to respond. Please try again."
             else:
-                error_content = str(exc) or f"{type(exc).__name__}: unexpected error"
+                # Issue #9410: Never leak exception details in SSE streams
+                error_content = "An unexpected error occurred. Please try again."
             queue.put_nowait(
                 {
                     "type": "error",

--- a/autobot-backend/llm_shared/adapters/ollama_adapter.py
+++ b/autobot-backend/llm_shared/adapters/ollama_adapter.py
@@ -143,7 +143,8 @@ class OllamaAdapter(AdapterBase):
                         logger.debug("OllamaAdapter.pull_model: non-JSON line: %s", line)
         except Exception as exc:
             logger.warning("OllamaAdapter.pull_model failed: %s", exc)
-            yield {"status": "error", "error": str(exc)}
+            # Issue #9410: Never leak exception details in SSE streams
+            yield {"status": "error", "error": "Model pull failed"}
 
 
 __all__ = ["OllamaAdapter"]


### PR DESCRIPTION
## Summary

Sanitizes 4 additional SSE exception detail leaks discovered during review of PR #9408. All locations now send generic error messages to clients while preserving full exception details for operators via logger calls.

**Fixed locations:**
1. `chat_workflow/manager.py:3131` - Graph execution errors
2. `api/chat_compare.py:114` - Multi-model comparison errors  
3. `agents/overseer/overseer_agent.py:465` - Task execution errors
4. `llm_shared/adapters/ollama_adapter.py:146` - Model pull errors

## Security Impact

- **Severity:** MEDIUM (information disclosure)
- **Attack vector:** Client observes internal exception details via SSE streams
- **Mitigation:** Replace `str(exc)` with generic error messages
- **Operator impact:** None - full details still logged via `logger.error()`/`logger.warning()`

## Test Plan

- ✅ Python syntax validation (`py_compile`) passes for all 4 files
- ✅ Code review confirms all SSE error handlers now use generic messages
- ✅ Verified `logger.error()`/`logger.warning()` calls preserve full exception details
- ✅ Searched for remaining `yield.*str(exc)` patterns → none in scope

## Related

- Issue #9410
- Related to PR #9408 (sanitized streaming providers)
- Same vulnerability class as #9360

🤖 Generated with [Claude Code](https://claude.com/claude-code)