### PR TITLE
fix(backend): remove deleted api.transcriber import from core_routers (#9384)

### DIFF
--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -86,7 +86,6 @@ from api.settings import router as settings_router
 from api.structured_thinking_mcp import router as structured_thinking_mcp_router
 from api.system import router as system_router
 from api.telegram_bot import router as telegram_bot_router  # MVA-2074
-from api.transcriber import router as transcriber_router  # Issue #9044, MVA-2186
 from api.usage import router as usage_router  # Issue #1807
 from api.user_management.router import router as user_management_router  # Issue #1801
 from api.vnc_manager import router as vnc_router
@@ -430,13 +429,6 @@ def _get_canvas_routers() -> list:
     ]
 
 
-def _get_transcriber_routers() -> list:
-    """Transcriber routers (MVA-2186, Issue #9044)."""
-    return [
-        (transcriber_router, "/transcriber", ["transcriber"], "transcriber"),
-    ]
-
-
 def load_core_routers():
     """
     Load and return core API routers (Issue #560: decomposed, #730: plugins).
@@ -459,5 +451,4 @@ def load_core_routers():
     routers.extend(_get_agent_routers())
     routers.extend(_get_plugin_routers())
     routers.extend(_get_canvas_routers())
-    routers.extend(_get_transcriber_routers())
     return routers


### PR DESCRIPTION
## Summary

Removed `api.transcriber` import and related router registration from `core_routers.py` after module deletion in #9371.

## Changes

- Removed import: `from api.transcriber import router as transcriber_router`
- Removed helper function: `_get_transcriber_routers()`
- Removed registration call: `routers.extend(_get_transcriber_routers())`

## Fixes

- Resolves #9384 (ModuleNotFoundError in startup-import-smoke CI check)

## Test Plan

- ✅ Verified `api.transcriber` module is deleted
- ✅ Confirmed no other references to `api.transcriber` in codebase
- ✅ Import smoke test passes (no ModuleNotFoundError)

🤖 Generated with Claude Code