### PR TITLE
fix(router-registry): remove duplicate mobile_devices registration (MVA-3022)

### DIFF
--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -671,13 +671,8 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["voice", "rbac"],
         "voice_bundle_user",
     ),
-    # GH#4463: Mobile device pairing for push notifications and offline sync
-    (
-        "api.mobile_devices",
-        "/devices",
-        ["mobile-devices", "push-notifications"],
-        "mobile_devices",
-    ),
+    # NOTE (MVA-3022): mobile_devices removed — already registered in core_routers.py
+    # as a system router. Duplicate registration caused routes to appear twice.
     # GH#4459: Web push notification endpoints (subscribe/unsubscribe/vapid-key)
     ("api.push", "/push", ["push", "notifications"], "push"),
     # GH#9044: Transcriber module — project + recording CRUD under /api/transcriber


### PR DESCRIPTION
## Summary

- Removed duplicate `mobile_devices` router registration from `feature_routers.py`
- Router is already registered in `core_routers.py` as a system router
- Follows the de-duplication pattern from issue #4203

## Problem

The `mobile_devices` router was registered in both:
1. `core_routers.py` (line 127, added in commit 900c163d3)
2. `feature_routers.py` (lines 675-680)

This duplicate registration caused the same routes to appear twice in the OpenAPI schema, similar to the issue documented in #4203.

## Changes

- Removed the `mobile_devices` router entry from `feature_routers.py`
- Added a NOTE comment explaining the removal (following the pattern used for other de-duplicated routers)

## Verification

```bash
# Before: mobile_devices appears in both files
grep -c "api.mobile_devices" feature_routers.py core_routers.py
# feature_routers.py:1
# core_routers.py:1

# After: only in core_routers.py
grep -c "api.mobile_devices" feature_routers.py core_routers.py
# feature_routers.py:0
# core_routers.py:1
```

## Related Issues

- Fixes: [MVA-3022](/MVA/issues/MVA-3022)
- Parent: [MVA-2992](/MVA/issues/MVA-2992)
- Related pattern: #4203 (de-duplicating routers from feature_routers.py)

🤖 Generated with [Paperclip](https://paperclip.ing)