### PR TITLE
feat(llm): extract thinking_tokens from Anthropic response (MVA-3089)

### DIFF
--- a/autobot-backend/llm_shared/providers/anthropic.py
+++ b/autobot-backend/llm_shared/providers/anthropic.py
@@ -256,6 +256,18 @@ class AnthropicProvider(BaseProvider):
                     )
             finish_reason = "tool_calls" if tool_calls else response.stop_reason
 
+            # MVA-3089: Extract thinking metadata from Anthropic response
+            usage_dict = {
+                "prompt_tokens": response.usage.input_tokens,
+                "completion_tokens": response.usage.output_tokens,
+                "total_tokens": total_tokens,
+            }
+            output_details = getattr(response.usage, "output_tokens_details", None)
+            if output_details:
+                thinking_tokens = getattr(output_details, "thinking_tokens", None)
+                if thinking_tokens is not None and thinking_tokens > 0:
+                    usage_dict["thinking_tokens"] = thinking_tokens
+
             return LLMResponse(
                 content=content,
                 model=response.model,
@@ -263,11 +275,7 @@ class AnthropicProvider(BaseProvider):
                 processing_time=processing_time,
                 request_id=request.request_id,
                 finish_reason=finish_reason,
-                usage={
-                    "prompt_tokens": response.usage.input_tokens,
-                    "completion_tokens": response.usage.output_tokens,
-                    "total_tokens": total_tokens,
-                },
+                usage=usage_dict,
                 tool_calls=tool_calls or None,
                 provider_metadata=self._build_provider_metadata(
                     model_api_name=response.model,


### PR DESCRIPTION
## Thinking Path

Completes MVA-3089 by extracting thinking_tokens from Anthropic response usage metadata to enable the thinking mode badge in the UI.

Without this extraction, the thinking badge added in MVA-3091 would never display because `thinking_tokens` was never populated in the LLM response.

Parent: MVA-3043 (GH#8993) thinking mode toggle
Depends on: MVA-3090 (schema), MVA-3091 (UI badge)

## What Changed

**Modified: autobot-backend/llm_shared/providers/anthropic.py**
- Extract `thinking_tokens` from `response.usage.output_tokens_details.thinking_tokens`
- Add to usage dict when present and > 0
- Use safe attribute access with getattr and None defaults

## Verification

```bash
python3 -m py_compile autobot-backend/llm_shared/providers/anthropic.py
```
✅ Syntax valid

## Model Used

Claude Sonnet 4.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)