### PR TITLE
security(slm/sso): encrypt SSO client secrets at rest with AES-256-GCM (#9501)

### DIFF
--- a/autobot-slm-backend/scripts/encrypt_sso_secrets.py
+++ b/autobot-slm-backend/scripts/encrypt_sso_secrets.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Migrate existing plaintext SSO provider secrets to AES-256-GCM encryption.
+
+Run once after deploying the encrypted SSOProvider model. Safe to re-run:
+rows whose sensitive fields already carry the ``enc:`` prefix are skipped.
+
+Usage:
+    AUTOBOT_FIELD_ENCRYPTION_KEY=<key> python scripts/encrypt_sso_secrets.py [--dry-run]
+
+Exit codes:
+    0  — success (all rows encrypted or already encrypted)
+    1  — error
+"""
+
+import argparse
+import logging
+import sys
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Encrypt plaintext SSO provider secrets in-place.")
+    p.add_argument("--dry-run", action="store_true", help="Report what would change without writing to DB.")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+
+    try:
+        from autobot_shared.field_encryption import encrypt_sso_config, is_sso_config_encrypted
+        from sqlalchemy import create_engine, text
+        from config import get_db_url  # autobot-slm-backend config helper
+        import json
+    except ImportError as exc:
+        logger.error("Import error: %s — run from autobot-slm-backend/ with its venv active.", exc)
+        return 1
+
+    engine = create_engine(get_db_url(), future=True)
+    updated = 0
+    skipped = 0
+    errors = 0
+
+    with engine.begin() as conn:
+        rows = conn.execute(text("SELECT id, config FROM sso_providers ORDER BY id")).fetchall()
+        logger.info("Found %d SSO provider row(s) to inspect.", len(rows))
+
+        for row in rows:
+            provider_id, config = row
+            if config is None:
+                skipped += 1
+                continue
+
+            if is_sso_config_encrypted(config):
+                logger.debug("Provider %s: already encrypted, skipping.", provider_id)
+                skipped += 1
+                continue
+
+            try:
+                encrypted = encrypt_sso_config(config)
+            except Exception as exc:
+                logger.error("Provider %s: encryption failed — %s", provider_id, exc)
+                errors += 1
+                continue
+
+            if args.dry_run:
+                logger.info("DRY-RUN provider %s: would encrypt sensitive fields.", provider_id)
+            else:
+                conn.execute(
+                    text("UPDATE sso_providers SET config = :cfg WHERE id = :id"),
+                    {"cfg": json.dumps(encrypted), "id": str(provider_id)},
+                )
+                logger.info("Provider %s: encrypted.", provider_id)
+            updated += 1
+
+    verb = "Would update" if args.dry_run else "Updated"
+    logger.info("%s %d row(s), skipped %d, errors %d.", verb, updated, skipped, errors)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/autobot-slm-backend/user_management/models/sso.py
+++ b/autobot-slm-backend/user_management/models/sso.py
@@ -18,6 +18,7 @@ from sqlalchemy import Boolean, DateTime, ForeignKey, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from autobot_shared.field_encryption import decrypt_sso_config, encrypt_sso_config
 from user_management.models.base import Base, TimestampMixin
 
 if TYPE_CHECKING:
@@ -79,9 +80,10 @@ class SSOProvider(Base, TimestampMixin):
         nullable=False,
     )
 
-    # Provider configuration (encrypted JSON)
-    # Contains client_id, client_secret, endpoints, etc.
-    config: Mapped[dict] = mapped_column(
+    # Provider configuration stored encrypted in DB.
+    # Access via the .config property which transparently decrypts sensitive fields.
+    _config: Mapped[dict] = mapped_column(
+        "config",
         JSONB,
         nullable=False,
     )
@@ -142,6 +144,16 @@ class SSOProvider(Base, TimestampMixin):
     def __repr__(self) -> str:
         scope = f"org:{self.org_id}" if self.org_id else "global"
         return f"<SSOProvider(type={self.provider_type}, name={self.name}, scope={scope})>"
+
+    @property
+    def config(self) -> dict:
+        """Return provider config with sensitive fields decrypted (plaintext in memory)."""
+        return decrypt_sso_config(self._config)
+
+    @config.setter
+    def config(self, value: dict) -> None:
+        """Encrypt sensitive fields before persisting to the DB."""
+        self._config = encrypt_sso_config(value)
 
     @property
     def is_enterprise(self) -> bool:

--- a/autobot_shared/field_encryption.py
+++ b/autobot_shared/field_encryption.py
@@ -57,3 +57,58 @@ def decrypt_field(ciphertext: str) -> str:
     ct = blob[_NONCE_LEN:]
     plaintext_bytes = AESGCM(key).decrypt(nonce, ct, None)
     return plaintext_bytes.decode("utf-8")
+
+
+# Sentinel prefix that distinguishes an encrypted value from a plaintext one.
+# Allows backward-compatible reads: if a stored value lacks the prefix it was
+# written before encryption was enabled and is returned as-is.
+_ENCRYPTED_PREFIX = "enc:"
+
+# Fields within sso_providers.config that hold credentials and must be
+# encrypted at rest.
+SSO_SENSITIVE_FIELDS: frozenset[str] = frozenset(
+    {
+        "client_secret",
+        "private_key",
+        "private_key_pem",
+        "bind_password",
+        "service_account_key",
+    }
+)
+
+
+def encrypt_sso_config(config: dict) -> dict:
+    """Return a copy of *config* with all sensitive fields encrypted.
+
+    Non-sensitive fields are copied verbatim. Already-encrypted values
+    (prefixed with ``enc:``) are left unchanged so the function is idempotent.
+    """
+    out = dict(config)
+    for field in SSO_SENSITIVE_FIELDS:
+        value = out.get(field)
+        if value and isinstance(value, str) and not value.startswith(_ENCRYPTED_PREFIX):
+            out[field] = _ENCRYPTED_PREFIX + encrypt_field(value)
+    return out
+
+
+def decrypt_sso_config(config: dict) -> dict:
+    """Return a copy of *config* with all encrypted sensitive fields decrypted.
+
+    Values that do not carry the ``enc:`` prefix are assumed plaintext (written
+    before encryption was rolled out) and are returned unchanged.
+    """
+    out = dict(config)
+    for field in SSO_SENSITIVE_FIELDS:
+        value = out.get(field)
+        if value and isinstance(value, str) and value.startswith(_ENCRYPTED_PREFIX):
+            out[field] = decrypt_field(value[len(_ENCRYPTED_PREFIX):])
+    return out
+
+
+def is_sso_config_encrypted(config: dict) -> bool:
+    """Return True if at least one sensitive field in *config* is encrypted."""
+    for field in SSO_SENSITIVE_FIELDS:
+        value = config.get(field)
+        if value and isinstance(value, str) and value.startswith(_ENCRYPTED_PREFIX):
+            return True
+    return False

--- a/autobot_shared/field_encryption_sso_test.py
+++ b/autobot_shared/field_encryption_sso_test.py
@@ -1,0 +1,101 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for SSO config field-level encryption helpers (GH#9501)."""
+
+import base64
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _encryption_key(monkeypatch):
+    """Inject a deterministic 32-byte test key."""
+    key = base64.urlsafe_b64encode(b"x" * 32).decode()
+    monkeypatch.setenv("AUTOBOT_FIELD_ENCRYPTION_KEY", key)
+    yield
+
+
+from autobot_shared.field_encryption import (  # noqa: E402
+    SSO_SENSITIVE_FIELDS,
+    _ENCRYPTED_PREFIX,
+    decrypt_sso_config,
+    encrypt_sso_config,
+    is_sso_config_encrypted,
+)
+
+
+class TestEncryptSsoConfig:
+    def test_sensitive_fields_are_encrypted(self):
+        cfg = {"client_id": "abc", "client_secret": "s3cr3t"}
+        enc = encrypt_sso_config(cfg)
+        assert enc["client_id"] == "abc"
+        assert enc["client_secret"].startswith(_ENCRYPTED_PREFIX)
+        assert enc["client_secret"] != "s3cr3t"
+
+    def test_non_sensitive_fields_are_unchanged(self):
+        cfg = {"auth_url": "https://example.com", "token_url": "https://t.example.com"}
+        enc = encrypt_sso_config(cfg)
+        assert enc == cfg
+
+    def test_all_sensitive_field_names_are_handled(self):
+        cfg = {f: "secret-value" for f in SSO_SENSITIVE_FIELDS}
+        enc = encrypt_sso_config(cfg)
+        for field in SSO_SENSITIVE_FIELDS:
+            assert enc[field].startswith(_ENCRYPTED_PREFIX), field
+
+    def test_idempotent_already_encrypted(self):
+        cfg = {"client_secret": "plaintext"}
+        enc1 = encrypt_sso_config(cfg)
+        enc2 = encrypt_sso_config(enc1)
+        assert enc1["client_secret"] == enc2["client_secret"]
+
+    def test_missing_sensitive_field_not_added(self):
+        cfg = {"client_id": "only"}
+        enc = encrypt_sso_config(cfg)
+        assert "client_secret" not in enc
+
+    def test_none_value_skipped(self):
+        cfg = {"client_secret": None}
+        enc = encrypt_sso_config(cfg)
+        assert enc["client_secret"] is None
+
+    def test_empty_string_skipped(self):
+        cfg = {"client_secret": ""}
+        enc = encrypt_sso_config(cfg)
+        assert enc["client_secret"] == ""
+
+
+class TestDecryptSsoConfig:
+    def test_roundtrip(self):
+        original = {"client_id": "id", "client_secret": "mysecret", "bind_password": "pass"}
+        assert decrypt_sso_config(encrypt_sso_config(original)) == original
+
+    def test_plaintext_passthrough_backward_compat(self):
+        """Rows written before encryption was enabled must still be readable."""
+        cfg = {"client_secret": "legacy-plaintext", "client_id": "id"}
+        assert decrypt_sso_config(cfg) == cfg
+
+    def test_mixed_encrypted_and_plaintext(self):
+        cfg = {"client_secret": _ENCRYPTED_PREFIX + "garbage"}
+        # Should raise on bad ciphertext
+        with pytest.raises(Exception):
+            decrypt_sso_config(cfg)
+
+
+class TestIsSsoConfigEncrypted:
+    def test_returns_true_when_any_field_encrypted(self):
+        cfg = {"client_secret": _ENCRYPTED_PREFIX + "data"}
+        assert is_sso_config_encrypted(cfg) is True
+
+    def test_returns_false_when_all_plaintext(self):
+        cfg = {"client_secret": "plain", "client_id": "id"}
+        assert is_sso_config_encrypted(cfg) is False
+
+    def test_returns_false_for_empty_config(self):
+        assert is_sso_config_encrypted({}) is False
+
+    def test_returns_true_after_encrypt(self):
+        cfg = {"client_secret": "s"}
+        assert is_sso_config_encrypted(encrypt_sso_config(cfg)) is True


### PR DESCRIPTION
## Summary

Resolves HIGH-severity finding H-2 from the SSO/OIDC security assessment (MVA-3388 / GitHub #9501).

- **`autobot_shared/field_encryption.py`** — extends the existing AES-256-GCM field encryption module with three SSO-specific helpers:
  - `encrypt_sso_config(config)` — returns a copy of the config dict with sensitive fields (`client_secret`, `private_key`, `private_key_pem`, `bind_password`, `service_account_key`) AES-256-GCM encrypted and prefixed with `enc:`. Idempotent: already-encrypted values are left unchanged.
  - `decrypt_sso_config(config)` — inverse; backward-compatible: plaintext values (no `enc:` prefix) are returned as-is for rows written before this change.
  - `is_sso_config_encrypted(config)` — predicate used by the migration script.

- **`autobot-slm-backend/user_management/models/sso.py`** — `SSOProvider` model updated:
  - Renames SQLAlchemy column attribute from `config` to `_config` (DB column name `config` unchanged — no schema migration required).
  - Adds `config` Python property: getter decrypts on read (plaintext in memory), setter encrypts on write. Fully transparent to all existing callers of `provider.config`.

- **`autobot-slm-backend/scripts/encrypt_sso_secrets.py`** — one-shot migration script to encrypt all existing plaintext rows. Supports `--dry-run`. Idempotent (skips already-encrypted rows).

- **`autobot_shared/field_encryption_sso_test.py`** — 14 unit tests covering roundtrip, idempotency, backward-compat passthrough, empty/None values, and all sensitive field names.

## Key Design Decisions

- Reuses existing `AUTOBOT_FIELD_ENCRYPTION_KEY` env var and AES-256-GCM infrastructure — no new cryptographic primitives introduced.
- Selective field encryption (not whole-config): non-sensitive fields like `client_id` and endpoint URLs stay readable for debugging.
- No DB schema change: column name stays `config`, only the SQLAlchemy attribute is renamed.

## Test plan

- [x] 14/14 unit tests passing (`python3 -m pytest autobot_shared/field_encryption_sso_test.py -v`)
- [x] Model syntax validated (`python3 -m py_compile autobot-slm-backend/user_management/models/sso.py`)
- [x] Run migration script with `--dry-run` before applying to staging DB
- [ ] Verify SSO login succeeds on staging after migration

## References

- Security assessment H-2: `SSO_OIDC_SECURITY_ASSESSMENT.md`
- GitHub issue: https://github.com/mrveiss/AutoBot-AI/issues/9501
- Paperclip issue: MVA-3395

🤖 Generated with [Claude Code](https://claude.com/claude-code)