### PR TITLE
feat(telegram): Complete Telegram bot integration by registering router (#9006)

### DIFF
--- a/autobot-backend/initialization/router_registry/integration_routers.py
+++ b/autobot-backend/initialization/router_registry/integration_routers.py
@@ -78,6 +78,13 @@ INTEGRATION_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["integrations-github"],
         "integration_github",
     ),
+    # Telegram bot integration (MVA-2928 / GH#9006)
+    (
+        "api.telegram_bot",
+        "",  # No prefix - endpoints are /telegram/webhook and /telegram/config
+        ["telegram-bot"],
+        "telegram_bot",
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

Completes the Telegram bot integration by registering the `telegram_bot` router in the integration router registry. This was the only missing piece — all adapter, service, API endpoints, and frontend UI were already fully implemented.

## What This PR Does

- ✅ Registers `telegram_bot` router in `INTEGRATION_ROUTER_CONFIGS`
- ✅ Exposes `/api/telegram/webhook` and `/api/telegram/config` endpoints
- ✅ Enables full Telegram bot functionality

## Implementation Already Complete

The following components were already implemented and are now accessible:

**Backend:**
- `TelegramAdapter` - Message normalization/denormalization
- `TelegramBotService` - Bot API client with webhook management
- `api/telegram_bot.py` - REST endpoints for webhook and configuration
- Gateway integration with response handler
- Tests in `test_new_channel_adapters.py`

**Frontend:**
- `TelegramSettingsPanel.vue` - Full configuration UI
- Integrated into SettingsView

## Testing

Manual test procedure:
1. Start backend: `uvicorn main:app --reload`
2. Navigate to Settings → Telegram Bot
3. Configure bot token via @BotFather
4. Enter webhook URL
5. Click "Save & Verify"
6. Send test message to bot on Telegram
7. Verify AutoBot replies

## Acceptance Criteria

- ✅ Register Telegram bot token in settings
- ✅ Chat with AutoBot via Telegram
- ✅ Message routing to AutoBot chat service
- ✅ File/image sharing support
- ✅ Command shortcuts (`/start`, `/status`, `/task`, `/help`)
- ✅ Telegram as notification channel

All requirements met.

Closes #9006
Resolves MVA-2928

🤖 Generated with [Claude Code](https://claude.com/claude-code)