### PR TITLE
fix(connectors): correct SourceInfo fields in OneDrive (GH#9004)

### DIFF
--- a/autobot-backend/knowledge/connectors/onedrive.py
+++ b/autobot-backend/knowledge/connectors/onedrive.py
@@ -530,17 +530,31 @@ class OneDriveConnector(AbstractConnector):
         last_modified_str = file_item.get("lastModifiedDateTime", "")
         last_modified = parse_utc_iso(last_modified_str) if last_modified_str else now_utc()
 
+        # Build path from parent reference
+        parent_ref = file_item.get("parentReference", {})
+        parent_path = parent_ref.get("path", "")
+        # Extract the actual folder path from the full path format
+        # e.g., "/drive/root:/Documents" -> "/Documents"
+        if "/root:" in parent_path:
+            folder_path = parent_path.split("/root:", 1)[1]
+        else:
+            folder_path = "/"
+        full_path = f"{folder_path}/{file_name}".replace("//", "/")
+
         return SourceInfo(
             source_id=source_id,
             name=file_name,
-            description=f"OneDrive file: {file_name}",
+            path=full_path,
+            content_type=self._get_content_type(file_ext),
+            size_bytes=file_item.get("size", 0),
             last_modified=last_modified,
             metadata={
                 "file_id": file_id,
                 "file_name": file_name,
                 "file_extension": file_ext,
                 "web_url": file_item.get("webUrl", ""),
-                "size": file_item.get("size", 0),
+                "drive_id": parent_ref.get("driveId", ""),
+                "site_id": self._site_id or "",
             },
         )
 
@@ -550,6 +564,19 @@ class OneDriveConnector(AbstractConnector):
         if "." in file_name:
             return "." + file_name.rsplit(".", 1)[-1]
         return ""
+
+    @staticmethod
+    def _get_content_type(file_ext: str) -> str:
+        """Map file extension to MIME type."""
+        content_type_map = {
+            ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ".pdf": "application/pdf",
+            ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            ".md": "text/markdown",
+            ".txt": "text/plain",
+        }
+        return content_type_map.get(file_ext.lower(), "application/octet-stream")
 
     async def _graph_request(
         self,

--- a/autobot-backend/knowledge/connectors/onedrive_test.py
+++ b/autobot-backend/knowledge/connectors/onedrive_test.py
@@ -168,6 +168,10 @@ class TestOneDriveConnector:
             "size": 12345,
             "lastModifiedDateTime": "2026-06-04T08:00:00Z",
             "webUrl": "https://onedrive.live.com/file-123",
+            "parentReference": {
+                "path": "/drive/root:/Documents",
+                "driveId": "drive-abc",
+            },
         }
 
         source_info = connector._file_to_source_info(file_item)
@@ -175,9 +179,13 @@ class TestOneDriveConnector:
         assert source_info is not None
         assert source_info.source_id == "onedrive:test-onedrive-1:file:file-123"
         assert source_info.name == "document.docx"
-        assert "document.docx" in source_info.description
+        assert source_info.path == "/Documents/document.docx"
+        assert source_info.content_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        assert source_info.size_bytes == 12345
         assert source_info.metadata["file_id"] == "file-123"
         assert source_info.metadata["file_extension"] == ".docx"
+        assert source_info.metadata["web_url"] == "https://onedrive.live.com/file-123"
+        assert source_info.metadata["drive_id"] == "drive-abc"
 
     @pytest.mark.asyncio
     async def test_file_to_source_info_unsupported_extension(self, onedrive_config):


### PR DESCRIPTION
Fixes field mapping bug in OneDrive connector.

## Changes
- Updated `_file_to_source_info()` to use correct SourceInfo fields
- Added `_get_mime_type()` helper
- Fixed test to verify correct fields

## Verification
All 16 OneDrive connector tests passing.

Fixes #9004
Replaces #9446 (scope violation - 140 files)

## Thinking Path
This is a clean recreation of the OneDrive fix from PR #9446. The previous PR had 140 files changed due to a stale branch with duplicate commits. This PR contains ONLY the OneDrive connector fix (commit f8c8d6506) cherry-picked onto a fresh Dev_new_gui branch.

## What Changed
- 2 files modified: `onedrive.py` and `onedrive_test.py`
- Fixed SourceInfo field mapping in OneDrive connector
- All changes are scoped to OneDrive connector only

## Model Used
Claude Sonnet 4.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>