### PR TITLE
fix(api): allow setting nullable document fields to null (#9525)

### DIFF
--- a/autobot-backend/api/documents.py
+++ b/autobot-backend/api/documents.py
@@ -211,13 +211,13 @@ async def update_document(
         raise HTTPException(status_code=404, detail="Document not found")
     await _assert_ownership(doc, uid)
 
-    if body.title is not None:
+    if "title" in body.model_fields_set:
         doc.title = body.title
-    if body.content is not None:
+    if "content" in body.model_fields_set:
         doc.content = body.content
-    if body.tags is not None:
+    if "tags" in body.model_fields_set:
         doc.tags = body.tags
-    if body.metadata is not None:
+    if "metadata" in body.model_fields_set:
         doc.metadata = body.metadata
     doc.touch()
 

--- a/autobot-backend/tests/api/test_documents.py
+++ b/autobot-backend/tests/api/test_documents.py
@@ -157,6 +157,50 @@ class TestUpdateDocument:
         assert result["content"] == "original content"
         assert result["title"] == "New Title Only"
 
+    @pytest.mark.asyncio
+    async def test_can_set_nullable_fields_to_null(self, mock_redis):
+        """Test fix for #9525: nullable fields can be explicitly set to null."""
+        from api.documents import UpdateDocumentRequest, update_document
+
+        doc = _make_doc(
+            title="Original Title",
+            content="Original content",
+            tags=["tag1", "tag2"],
+            metadata={"key": "value"},
+        )
+        mock_redis.get = AsyncMock(return_value=doc.model_dump_json())
+
+        # Set all nullable fields to null
+        body = UpdateDocumentRequest(title=None, content=None, tags=None, metadata=None)
+        with patch("api.documents.get_async_redis_client", AsyncMock(return_value=mock_redis)):
+            result = await update_document(doc.id, body, current_user=_FAKE_USER)
+
+        # All fields should be null (not unchanged)
+        assert result["title"] is None
+        assert result["content"] is None
+        assert result["tags"] is None
+        assert result["metadata"] is None
+
+    @pytest.mark.asyncio
+    async def test_validation_still_enforced_when_not_null(self, mock_redis):
+        """Test fix for #9525: validation (e.g., title min_length) still works."""
+        from fastapi import HTTPException
+
+        from api.documents import UpdateDocumentRequest, update_document
+
+        doc = _make_doc()
+        mock_redis.get = AsyncMock(return_value=doc.model_dump_json())
+
+        # Empty string should fail validation (min_length=1)
+        with pytest.raises(Exception):  # Pydantic ValidationError
+            UpdateDocumentRequest(title="")
+
+        # But null should be allowed
+        body = UpdateDocumentRequest(title=None)
+        with patch("api.documents.get_async_redis_client", AsyncMock(return_value=mock_redis)):
+            result = await update_document(doc.id, body, current_user=_FAKE_USER)
+        assert result["title"] is None
+
 
 class TestDeleteDocument:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes bug in `PUT /documents/{doc_id}` endpoint where nullable fields couldn't be explicitly set to `null` to clear them.

**Root cause:** Used `is not None` checks instead of `in body.model_fields_set`

**Changes:**
- Replace all four `is not None` checks with `in body.model_fields_set` in documents.py:214-221
- Add comprehensive test coverage for null-setting behavior
- Verify validation still enforced for non-null values (title min_length)

## Test Plan

✅ Added `test_can_set_nullable_fields_to_null` - verifies all 4 nullable fields (title, content, tags, metadata) can be set to null
✅ Added `test_validation_still_enforced_when_not_null` - verifies title min_length=1 validation still works
✅ Existing tests still pass (partial updates, ownership checks)

## Verification

**Before:**
```bash
curl -X PUT /api/documents/123 -d '{"tags": null}' -H "Content-Type: application/json"
# Result: doc.tags unchanged (request silently ignored)
```

**After:**
```bash
curl -X PUT /api/documents/123 -d '{"tags": null}' -H "Content-Type: application/json"
# Result: doc.tags = null (field cleared as requested)
```

## Acceptance Criteria Met

- ✅ Replace all four `is not None` checks with `in body.model_fields_set`
- ✅ Add test case verifying `null` can be set for each field
- ✅ Verify no validation is skipped (title min_length still enforced when not null)

Closes #9525
Related to #9357 (MVA-3060) - parent audit issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)