### PR TITLE
test(circuit-breaker): add unit tests for reset_on_success modes

### DIFF
--- a/autobot-backend/circuit_breaker_test.py
+++ b/autobot-backend/circuit_breaker_test.py
@@ -86,6 +86,40 @@ class TestCircuitBreaker:
         assert state["name"] == "test_svc"
         assert "stats" in state
 
+    def test_reset_on_success_true_fully_resets(self):
+        """Test reset_on_success=True (default): failure_count resets to 0 on success in CLOSED."""
+        config = CircuitBreakerConfig(failure_threshold=5, reset_on_success=True)
+        cb = CircuitBreaker("test_svc", config)
+        # Accumulate 3 failures (below threshold)
+        for _ in range(3):
+            cb._record_failure(0.1, ConnectionError("test"))
+        assert cb.failure_count == 3
+        assert cb.state == CircuitState.CLOSED
+        # Record one success
+        cb._record_success(0.1)
+        # failure_count should be fully reset to 0
+        assert cb.failure_count == 0
+        assert cb.state == CircuitState.CLOSED
+
+    def test_reset_on_success_false_decrements(self):
+        """Test reset_on_success=False (legacy): failure_count decrements by 1 on success in CLOSED."""
+        config = CircuitBreakerConfig(failure_threshold=5, reset_on_success=False)
+        cb = CircuitBreaker("test_svc", config)
+        # Accumulate 3 failures (below threshold)
+        for _ in range(3):
+            cb._record_failure(0.1, ConnectionError("test"))
+        assert cb.failure_count == 3
+        assert cb.state == CircuitState.CLOSED
+        # Record one success
+        cb._record_success(0.1)
+        # failure_count should decrement by 1
+        assert cb.failure_count == 2
+        assert cb.state == CircuitState.CLOSED
+        # Record another success
+        cb._record_success(0.1)
+        # failure_count should decrement again
+        assert cb.failure_count == 1
+
 
 class TestCircuitBreakerAsync:
     """Tests for async operations."""


### PR DESCRIPTION
## Summary

Closes #9431

Added unit tests for the `reset_on_success` feature implemented in #9293.

## Changes

- Added `test_reset_on_success_true_fully_resets`: Verifies default mode (`reset_on_success=True`) fully resets `failure_count` to 0 on success in CLOSED state
- Added `test_reset_on_success_false_decrements`: Verifies legacy mode (`reset_on_success=False`) decrements `failure_count` by 1 on success in CLOSED state

## Test Evidence

```
============================= test session starts ==============================
circuit_breaker_test.py::TestCircuitBreaker::test_reset_on_success_true_fully_resets PASSED [ 50%]
circuit_breaker_test.py::TestCircuitBreaker::test_reset_on_success_false_decrements PASSED [100%]

============================== 2 passed in 0.37s ===============================
```

Full test suite: 23/23 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)