### PR TITLE
fix(ansible): Add missing autobot_shared symlink for SLM backend (#9565)

### DIFF
--- a/autobot-slm-backend/ansible/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/update-all-nodes.yml
@@ -255,6 +255,16 @@
       become: true
       tags: [shared, library, slm-agent]
 
+    # Issue #9565: slm-backend also needs autobot_shared in PYTHONPATH
+    - name: "[PLAY 1] SLM Backend | Create autobot_shared symlink for backend imports"
+      ansible.builtin.file:
+        src: "{{ code_base_dir }}/autobot_shared"
+        dest: "{{ code_base_dir }}/autobot-slm-backend/autobot_shared"
+        state: link
+        force: true
+      become: true
+      tags: [shared, library, slm-backend]
+
     # =========================================================================
     # SLM AGENT - Issue #1164: Keep agent code in sync on every fleet update
     # =========================================================================


### PR DESCRIPTION
## Problem

The `update-all-nodes.yml` playbook creates an `autobot_shared` symlink for the SLM agent but **not** for the SLM backend. This causes import failures when the backend tries to import from `autobot_shared`.

## Error

```
ModuleNotFoundError: No module named 'autobot_shared'
```

## Fix

Added a new task in the playbook to create the `autobot_shared` symlink for the SLM backend, identical to the existing task for the SLM agent:

```yaml
- name: "[PLAY 1] SLM Backend | Create autobot_shared symlink for backend imports"
  ansible.builtin.file:
    src: "{{ code_base_dir }}/autobot_shared"
    dest: "{{ code_base_dir }}/autobot-slm-backend/autobot_shared"
    state: link
    force: true
  become: true
  tags: [shared, library, slm-backend]
```

## Impact

**High** - Resolves backend startup failures after Ansible deployment.

## Testing

After deployment, the symlink will be created automatically at:
`/opt/autobot/autobot-slm-backend/autobot_shared -> /opt/autobot/autobot_shared`

Closes #9565