### PR TITLE
fix(api): allow canvas title to be set to null (#9526)

### DIFF
--- a/autobot-backend/api/canvas.py
+++ b/autobot-backend/api/canvas.py
@@ -238,7 +238,7 @@ async def put_canvas(
             new_token = uuid.uuid4()
             now = datetime.now(tz=timezone.utc)
 
-            if body.title is not None:
+            if 'title' in body.model_fields_set:
                 canvas.title = body.title
             canvas.save_token = new_token
             canvas.updated_at = now

--- a/autobot-backend/tests/api/test_canvas.py
+++ b/autobot-backend/tests/api/test_canvas.py
@@ -214,6 +214,52 @@ class TestPutCanvas:
             resp = client.put(f"/api/canvas/{_CANVAS_ID}", json={"cells": []})
         assert resp.status_code == 403
 
+    def test_autosave_can_set_title_to_null(self, app):
+        """Test that title can be explicitly set to null (GH#9526)."""
+        canvas = _make_canvas()
+        canvas.title = "Existing Title"
+        session = _mock_session()
+        session.execute.return_value.scalar_one_or_none = MagicMock(return_value=canvas)
+
+        from auth_middleware import get_current_user
+        from user_management.database import get_async_session
+
+        app.dependency_overrides = {
+            get_async_session: lambda: session,
+            get_current_user: lambda: _USER_A,
+        }
+
+        with TestClient(app) as client:
+            resp = client.put(
+                f"/api/canvas/{_CANVAS_ID}",
+                json={"title": None, "cells": []},
+            )
+        assert resp.status_code == 200
+        assert canvas.title is None
+
+    def test_autosave_omitted_title_unchanged(self, app):
+        """Test that omitting title from request leaves it unchanged."""
+        canvas = _make_canvas()
+        canvas.title = "Existing Title"
+        session = _mock_session()
+        session.execute.return_value.scalar_one_or_none = MagicMock(return_value=canvas)
+
+        from auth_middleware import get_current_user
+        from user_management.database import get_async_session
+
+        app.dependency_overrides = {
+            get_async_session: lambda: session,
+            get_current_user: lambda: _USER_A,
+        }
+
+        with TestClient(app) as client:
+            resp = client.put(
+                f"/api/canvas/{_CANVAS_ID}",
+                json={"cells": []},
+            )
+        assert resp.status_code == 200
+        assert canvas.title == "Existing Title"
+
 
 # ---------------------------------------------------------------------------
 # POST /api/canvas/{id}/cells


### PR DESCRIPTION
## Summary
- Fixed canvas autosave endpoint to allow explicitly setting title to null
- Replaced `is not None` check with `model_fields_set` pattern

## What Changed
- **api/canvas.py:241**: Changed from `if body.title is not None:` to `if 'title' in body.model_fields_set:`
- **tests/api/test_canvas.py**: Added `test_autosave_can_set_title_to_null` to verify null works
- **tests/api/test_canvas.py**: Added `test_autosave_omitted_title_unchanged` to verify omitted field behavior

## Thinking Path
1. Read GH#9526 issue description - clear bug in canvas.py line 241
2. Located canvas.py and verified the problematic code
3. Applied the fix using `model_fields_set` pattern
4. Added two test cases to cover both null and omitted scenarios
5. Ran tests - all pass including new tests
6. Committed and pushed

## Verification
```bash
python3 -m pytest tests/api/test_canvas.py::TestPutCanvas -v
# All 4 tests passed (including 2 new tests)
```

## Test Coverage
- ✅ Title can be explicitly set to null
- ✅ Omitting title from request leaves it unchanged
- ✅ Existing autosave tests still pass

Closes #9526 (MVA-3450)

🤖 Generated with Claude Code