### PR TITLE
fix(ansible): use build:slm command for SLM frontend deployment (#9563)

### DIFF
--- a/autobot-slm-backend/ansible/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/update-all-nodes.yml
@@ -232,7 +232,7 @@
 
     - name: "[PLAY 1] SLM Frontend | Rebuild production dist"
       command:
-        cmd: npm run build
+        cmd: npm run build:slm
         chdir: "{{ code_base_dir }}/autobot-slm-frontend"
       tags: [slm, slm-frontend]
 


### PR DESCRIPTION
## Thinking Path

SLM frontend deployment was failing because Ansible used `npm run build` instead of `npm run build:slm`. The error message explicitly stated the fix, but the playbook wasn't updated. Checked package.json to confirm `build:slm` script exists and sets VITE_API_URL=/slm automatically.

## What Changed

`autobot-slm-backend/ansible/update-all-nodes.yml`:
- Line ~120: Changed build command from `npm run build` to `npm run build:slm`

## Verification

```bash
# Verify the script exists
grep "build:slm" autobot-slm-frontend/package.json

# Run playbook (staging)
ansible-playbook autobot-slm-backend/ansible/update-all-nodes.yml --limit staging

# Confirm build succeeds
journalctl -u autobot-slm-backend | grep "frontend build"
```

## Model Used

Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)

---

Closes #9563