### PR TITLE
security(telegram): encrypt bot token in Redis storage (#9606)

### DIFF
--- a/autobot-backend/services/telegram_bot_service.py
+++ b/autobot-backend/services/telegram_bot_service.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Optional
 
 import aiohttp
 
+from autobot_shared.field_encryption import decrypt_field, encrypt_field
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
 
@@ -20,6 +21,9 @@ logger = get_logger(__name__)
 # Redis keys for storing Telegram bot config
 TELEGRAM_BOT_TOKEN_KEY = "autobot:settings:telegram_bot_token"
 TELEGRAM_WEBHOOK_SECRET_KEY = "autobot:settings:telegram_webhook_secret"
+
+# Sentinel prefix for encrypted values (backward compatibility)
+_ENCRYPTED_PREFIX = "enc:"
 
 
 class TelegramBotService:
@@ -46,7 +50,17 @@ class TelegramBotService:
         bot_token = await redis.get(TELEGRAM_BOT_TOKEN_KEY)
         if bot_token:
             bot_token = bot_token.decode("utf-8") if isinstance(bot_token, bytes) else bot_token
-            logger.info("Loaded Telegram bot token from Redis")
+            # Decrypt if encrypted (backward compatible with plaintext tokens)
+            if bot_token.startswith(_ENCRYPTED_PREFIX):
+                try:
+                    bot_token = decrypt_field(bot_token[len(_ENCRYPTED_PREFIX) :])
+                    logger.info("Loaded and decrypted Telegram bot token from Redis")
+                except Exception as exc:
+                    logger.error(f"Failed to decrypt Telegram bot token: {exc}")
+                    return cls(bot_token=None)
+            else:
+                logger.warning("Telegram bot token is stored in plaintext (not encrypted)")
+                logger.info("Loaded Telegram bot token from Redis")
         else:
             logger.warning("No Telegram bot token found in Redis")
 
@@ -357,7 +371,7 @@ class TelegramBotService:
 
 async def save_telegram_bot_token(bot_token: str) -> None:
     """
-    Save Telegram bot token to Redis.
+    Save Telegram bot token to Redis (encrypted).
 
     Args:
         bot_token: Telegram Bot API token
@@ -366,13 +380,19 @@ async def save_telegram_bot_token(bot_token: str) -> None:
     if redis is None:
         raise RuntimeError("Redis client not available")
 
-    await redis.set(TELEGRAM_BOT_TOKEN_KEY, bot_token)
-    logger.info("Saved Telegram bot token to Redis")
+    # Encrypt the token before storing
+    try:
+        encrypted_token = _ENCRYPTED_PREFIX + encrypt_field(bot_token)
+        await redis.set(TELEGRAM_BOT_TOKEN_KEY, encrypted_token)
+        logger.info("Saved encrypted Telegram bot token to Redis")
+    except Exception as exc:
+        logger.error(f"Failed to encrypt Telegram bot token: {exc}")
+        raise
 
 
 async def get_telegram_bot_token() -> Optional[str]:
     """
-    Get Telegram bot token from Redis.
+    Get Telegram bot token from Redis (decrypted).
 
     Returns:
         Bot token or None if not configured
@@ -384,7 +404,17 @@ async def get_telegram_bot_token() -> Optional[str]:
 
     bot_token = await redis.get(TELEGRAM_BOT_TOKEN_KEY)
     if bot_token:
-        return bot_token.decode("utf-8") if isinstance(bot_token, bytes) else bot_token
+        bot_token = bot_token.decode("utf-8") if isinstance(bot_token, bytes) else bot_token
+        # Decrypt if encrypted (backward compatible with plaintext tokens)
+        if bot_token.startswith(_ENCRYPTED_PREFIX):
+            try:
+                return decrypt_field(bot_token[len(_ENCRYPTED_PREFIX) :])
+            except Exception as exc:
+                logger.error(f"Failed to decrypt Telegram bot token: {exc}")
+                return None
+        else:
+            logger.warning("Telegram bot token is stored in plaintext (not encrypted)")
+            return bot_token
     return None
 
 


### PR DESCRIPTION
## Summary

Implements encryption for Telegram bot token stored in Redis to address security gap discovered during CodeReviewer assessment of MVA-2074.

## Changes

- **Encrypted storage**: Bot token now encrypted using AES-256-GCM before Redis storage
- **Decryption on retrieval**: Tokens automatically decrypted when loaded from Redis
- **Backward compatibility**: Uses `enc:` prefix sentinel to detect encrypted vs plaintext tokens
- **Consistent pattern**: Follows same encryption approach as SSO config (field_encryption.py)

## Security Impact

### Before
```python
# Plaintext storage in Redis
await redis.set("autobot:settings:telegram_bot_token", "1234567890:ABC...")
```

### After
```python
# Encrypted storage with AES-256-GCM
encrypted_token = "enc:" + encrypt_field(bot_token)
await redis.set("autobot:settings:telegram_bot_token", encrypted_token)
```

## Requirements

Requires `AUTOBOT_FIELD_ENCRYPTION_KEY` environment variable (32-byte key, base64url encoded).

Generate with:
```bash
python -c "import secrets,base64; print(base64.urlsafe_b64encode(secrets.token_bytes(32)).decode())"
```

## Test Plan

- [x] Encryption/decryption roundtrip verified
- [x] Backward compatibility with plaintext tokens confirmed
- [x] Imports and syntax validated
- [ ] Integration test with live Redis (requires deployment)

## References

- Issue: #9606
- Parent: MVA-2074 (Telegram bot implementation)
- Pattern: MVA-1737 (SSO encryption implementation)
- Module: `autobot_shared/field_encryption.py`

🤖 Generated by SecurityEngineer agent via Paperclip