### PR TITLE
fix(transcriber): add missing transcript route models (startup-import-smoke fix)

### DIFF
--- a/autobot-backend/transcriber/models.py
+++ b/autobot-backend/transcriber/models.py
@@ -172,3 +172,69 @@ class KbPushStatus(BaseModel):
     pushed_at: Optional[datetime] = Field(None, description="Timestamp of KB push")
     kb_collection_id: Optional[str] = Field(None, description="KB collection ID")
     pushed_by: Optional[str] = Field(None, description="User who pushed to KB")
+
+
+# Transcript route models (transcriber/routes/transcripts.py)
+
+
+class SpeakerOut(BaseModel):
+    """Response schema for speaker."""
+
+    id: int
+    recording_id: int
+    speaker_label: str
+    display_name: Optional[str] = None
+
+
+class SpeakerUpdate(BaseModel):
+    """Request schema for updating speaker display name."""
+
+    display_name: str
+
+
+class SegmentOut(BaseModel):
+    """Response schema for transcription segment."""
+
+    id: int
+    recording_id: int
+    speaker_label: str
+    start_time: float
+    end_time: float
+    text: str
+    confidence: float
+    created_at: datetime
+
+
+class SegmentUpdate(BaseModel):
+    """Request schema for updating segment text."""
+
+    text: str
+
+
+class NoteCreate(BaseModel):
+    """Request schema for creating a note."""
+
+    content: str
+
+
+class NoteOut(BaseModel):
+    """Response schema for note."""
+
+    id: int
+    segment_id: int
+    recording_id: int
+    content: str
+
+
+class NoteUpdate(BaseModel):
+    """Request schema for updating note content."""
+
+    content: str
+
+
+class TranscriptOut(BaseModel):
+    """Response schema for full transcript."""
+
+    recording: RecordingOut
+    speakers: list[SpeakerOut]
+    segments: list[SegmentOut]


### PR DESCRIPTION
## Thinking Path

PR #9631 (the main CI fix for MVA-3524) was merged before the final round of missing model fixes could be included. The `startup-import-smoke` check is still failing on main because `transcriber/routes/transcripts.py` imports models that don't exist in `transcriber/models.py`.

The missing models were identified by analyzing CI logs showing `ImportError: cannot import name 'NoteCreate' from 'transcriber.models'`.

## What Changed

Added missing Pydantic models to `autobot-backend/transcriber/models.py`:
- `SpeakerOut` — response schema for speaker objects
- `SpeakerUpdate` — request schema for updating speaker display names
- `SegmentOut` — response schema for transcription segments
- `SegmentUpdate` — request schema for editing segment text
- `NoteCreate` — request schema for creating notes
- `NoteOut` — response schema for notes
- `NoteUpdate` — request schema for updating notes
- `TranscriptOut` — composite response schema used by `GET /recordings/{id}/transcript`

These are all required by `transcriber/routes/transcripts.py` which is included in the startup import tests.

## Verification

- All imports in `transcriber/routes/transcripts.py` should now resolve
- `startup-import-smoke` CI check should pass after this merge

## Model Used

Claude Sonnet 4.5 (DevOpsEngineer agent) — follow-up to MVA-3524 / PR #9631

---

**Closes:** startup-import-smoke CI failure on main  
**Follow-up to:** #9631 (MVA-3524 initial fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)