### PR TITLE
docs(claude): restructure CLAUDE.md into lean quick-reference with sub-docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,452 +1,78 @@
 # AutoBot Development Instructions
 
-> **Full rules:** [`docs/developer/CLAUDE_RULES.md`](docs/developer/CLAUDE_RULES.md) — read when starting a new task
-> **Full workflow:** [`docs/developer/CLAUDE_WORKFLOW.md`](docs/developer/CLAUDE_WORKFLOW.md) — read when needed
-> **Reference (IPs, playbooks):** [`docs/developer/AUTOBOT_REFERENCE.md`](docs/developer/AUTOBOT_REFERENCE.md)
+> **Rules:** [`docs/developer/CLAUDE_RULES.md`](docs/developer/CLAUDE_RULES.md) — read when starting a new task
+> **Workflow:** [`docs/developer/CLAUDE_WORKFLOW.md`](docs/developer/CLAUDE_WORKFLOW.md) — read when needed
+> **Git & Worktrees:** [`docs/developer/CLAUDE_GIT.md`](docs/developer/CLAUDE_GIT.md) — branching, safety, push recovery
+> **Batch & Agents:** [`docs/developer/CLAUDE_BATCH.md`](docs/developer/CLAUDE_BATCH.md) — parallel work, sub-agent rules
+> **Code Review:** [`docs/developer/CLAUDE_REVIEW.md`](docs/developer/CLAUDE_REVIEW.md) — review methodology, merge checklist
+> **Issue Closure:** [`docs/developer/CLAUDE_CLOSURE.md`](docs/developer/CLAUDE_CLOSURE.md) — closure gate, discovery issues
+> **Reference:** [`docs/developer/AUTOBOT_REFERENCE.md`](docs/developer/AUTOBOT_REFERENCE.md)
 > **Architecture exceptions:** [`docs/developer/ARCHITECTURE_EXCEPTIONS.md`](docs/developer/ARCHITECTURE_EXCEPTIONS.md)
-> **Worktrees:** Use `.worktrees/` (project-local, gitignored) for all parallel/isolated work
 
 ---
 
 ## Engineering Standard
 
-You are the world's best AI developer working on AutoBot. Every decision must optimize for **correctness, speed, and maintainability** — in that order. No wasted motion. No speculative work. No half-measures.
+Correctness → Speed → Maintainability. No wasted motion. No speculative work.
 
-**Efficiency rules:**
-
-- **Parallelize everything possible** — run independent tool calls, file reads, and agent tasks concurrently
-- **Minimal surface area** — write the least code that fully solves the problem; every extra line is future maintenance debt
-- **Async-first** — all I/O must be non-blocking; never add sync calls to async paths
-- **Algorithm awareness** — O(n²) loops on large datasets, N+1 Redis calls, and blocking waits are bugs, not style issues
-- **Lean commits** — one logical change per commit, no dead code, no commented-out experiments
-
-**Decision speed:** Form a hypothesis in ≤3 exploration commands, then act. If stuck after 3 attempts, escalate to user with findings — don't loop.
+- **Parallelize** independent tool calls, file reads, agent tasks
+- **Minimal surface area** — least code that fully solves the problem
+- **Async-first** — never add sync calls to async paths
+- **Decision speed:** ≤3 exploration commands then act; if stuck, escalate with findings
 
 ---
 
 ## Quick Reference
 
-**Every task must:** link to GitHub issue, search Memory MCP first, break into subtasks, use code-reviewer agent, update issue throughout, verify before closing.
+**Every task must:** link to GitHub issue · search Memory MCP first · break into subtasks · use code-reviewer · update issue throughout · verify before closing.
 
-**Before proceeding:** Work tied to issue? Subtasks added? Memory searched? Root cause (not workaround)? If ANY fails: STOP.
+**Stop if any fails:** work tied to issue? subtasks added? root cause (not workaround)?
 
 ---
 
-## Core Rules (Summary)
+## Core Rules
 
-1. **Check Before Writing** — search for existing code/docs/PRs before creating anything new
-2. **Reuse Existing Code** — import from `autobot_shared/`, never duplicate or hardcode
-3. **Standardize for Reuse** — shared modules, ≤30-line functions, no `_v2`/`_fix` suffixes
-4. **Clarify Requirements** — ask all questions up front, confirm architecture before coding
-5. **Verify Before Complete** — show evidence (test output, curl, build) before claiming done
-6. **Report Every Problem** — file GitHub issues for all discovered bugs, even if not your task
-
-> Full details with examples and violation cases: [`docs/developer/CLAUDE_RULES.md`](docs/developer/CLAUDE_RULES.md)
+1. **Check Before Writing** — search existing code/docs/PRs before creating anything
+2. **Reuse** — import from `autobot_shared/`; never duplicate or hardcode
+3. **Standardize** — ≤30-line functions; no `_v2`/`_fix` suffixes
+4. **Clarify** — confirm architecture before coding
+5. **Verify** — show evidence (test output, curl, build) before claiming done
+6. **Report** — file GitHub issues for every discovered bug, even off-task
 
 ---
 
 ## Essential Patterns
 
-**Redis:** `from autobot_shared.redis_client import get_redis_client` (databases: main, knowledge, prompts, analytics)
-
-**Config:** `from autobot_shared.ssot_config import config` / `import { getBackendUrl } from '@/config/ssot-config'`
-
-**Logging:** `logging.getLogger(__name__)` (backend) / `createLogger('Name')` (frontend). No `print()` or `console.*`.
-
-**Encoding:** Always `encoding='utf-8'` explicitly.
-
-**Cache TTL overrides:** Hard-coded Redis TTLs are bugs (#6743). For tunable surfaces use a module-level constant resolved from an env var with a logged-fallback default — e.g. `AUTOBOT_CHAT_SESSION_CACHE_TTL` → `chat_history.cache._CHAT_SESSION_CACHE_TTL` (24h default). See [`autobot-backend/chat_history/cache.py`](autobot-backend/chat_history/cache.py) for the canonical resolver pattern.
-
-**LEDGER vs EXECUTOR (Issue #7380):** Coordination tools (workflow_plan, agent_register, memory_store, swarm_init) return *records* and complete instantly—they do NOT execute deliverables. After any coordination call, IMMEDIATELY continue with actual work using your execution tools (file I/O, shell commands, code generation). Do NOT wait for the coordinator to "finish" (it already did). The rule is injected into all agent system prompts automatically via `LEDGER_VS_EXECUTOR_RULE` constant from `autobot_shared/prompt_rules.py`. This is critical for preventing agents from waiting for non-existent "executor" processes. See the constant definition for full semantics.
-
-**Copyright:** `mrveiss` is sole owner/author of all AutoBot code.
+| What | How |
+|---|---|
+| Redis | `from autobot_shared.redis_client import get_redis_client` |
+| Config | `from autobot_shared.ssot_config import config` / `import { getBackendUrl } from '@/config/ssot-config'` |
+| Logging | `logging.getLogger(__name__)` / `createLogger('Name')` — no `print()` or `console.*` |
+| Encoding | Always `encoding='utf-8'` explicitly |
+| Cache TTL | Never hard-code — use module-level constant from env var (see `chat_history/cache.py`) |
+| LEDGER/EXECUTOR | Coordination tools complete instantly — do NOT wait; continue immediately with execution tools |
+| Copyright | `mrveiss` is sole owner/author |
 
 ---
 
-## Key Workflow Rules
+## Workflow Quick Rules
 
-- **Branch target:** `Dev_new_gui` for all PRs unless told otherwise
+- **Branch target:** `Dev_new_gui` for all PRs
 - **Commit format:** `<type>(scope): <description> (#issue-number)`
-- **Pre-commit:** Never `--no-verify`. PostToolUse hook auto-formats `.py` files.
-- **Hook scripts:** Before committing any change to `.claude/hooks/block-dangerous-commands.sh`, run `bash .claude/hooks/block-dangerous-commands_test.sh` (must be 27/27). Add new test cases for new rules. Test with `bash`, never interactively — the shell's `grep` alias is `ugrep` (PCRE2) but bash uses GNU grep 3.7 (no variable-length lookbehinds). See #8262.
-- **Branching discipline:** Direct commits on `main`/`master` are blocked by pre-commit hook (Issue #4113). All development flows through `Dev_new_gui` first.
-- **Worktrees:** No nesting. Manual creation for PRs (not `isolation: "worktree"`). Clean up after issue closure.
-- **Agents:** Prefer direct implementation. Reserve subagents for research/exploration. Subagents can't acquire Bash permission.
-- **Codebase is source of truth:** Changes only in this git repo directory. Never edit `/opt/autobot/`, `/var/log/autobot/`, or other deployment folders. Ansible syncs code from GitHub each playbook run.
-- **Deployment:** All via Ansible playbooks. Never manual SSH changes.
-- **No temporary fixes:** Zero tolerance for workarounds, TODO comments, try/catch hiding errors.
-- **One issue per session:** Don't auto-start other issues after completing one.
-- **Edit strategy:** `Edit` for files >50 lines, `Write` for new/small files.
-
-> Full workflow details: [`docs/developer/CLAUDE_WORKFLOW.md`](docs/developer/CLAUDE_WORKFLOW.md)
-
----
-
-## Parallel Work: Worktree Isolation Rules (CRITICAL)
-
-**NO `git checkout` or `git switch` on shared branches during parallel work sessions.**
-
-- **Each parallel task MUST have its own worktree:** `.worktrees/issue-XXXX/` with dedicated branch `issue-XXXX`
-- **Main session stays on `Dev_new_gui`** — never check out feature branches. All feature work happens in worktrees.
-- **Worktree branches are independent** — changes in one worktree cannot affect another worktree's branch or main session
-- **Why:** Switching branches in main session breaks all active worktrees that depend on that branch. Creates merge conflicts, stale branch pointers, corrupted git history.
-
-**Worktree Creation:**
-```bash
-git worktree add .worktrees/issue-XXXX -b issue-XXXX origin/Dev_new_gui
-cd .worktrees/issue-XXXX && git branch --unset-upstream
-# Work here, commit, push to issue-XXXX branch
-# Do NOT switch branches; do NOT touch other worktrees
-```
-
-See memory for [Worktree Isolation (CRITICAL)](https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/docs/developer/CLAUDE.md#parallel-work-worktree-isolation-rules-critical) — detailed scenario of what breaks if you switch branches.
-
----
-
-## Pre-Flight Checklist (Before Parallel Work)
-
-Before spawning agents or starting worktree work:
-
-1. **Verify branch isolation:** `git branch --show-current` in main session. Should be `Dev_new_gui`. If on a feature branch, STOP — you'll break parallel worktrees.
-2. **Verify Bash is approved:** Main session must have Bash permission approved — sub-agents inherit from parent. If Bash requires a prompt, approve it once before spawning any agents.
-3. **Create worktrees correctly:** Each issue gets `.worktrees/issue-XXXX/` with dedicated branch. NO shared branches between worktrees.
-4. **Check git status:** `git status` — **if any files are dirty, commit or stash them before spawning subagents.** Uncommitted edits are silently discarded when a subagent commits and upstream Dev_new_gui is merged (#4969).
-5. **Verify issue isn't resolved:** Check if issue is already closed or if `Dev_new_gui` already has the fix via `git log origin/Dev_new_gui --oneline --grep="#XXXX"`.
-6. **Confirm approach:** For architectural decisions, state in 1-2 sentences and wait for confirmation.
-
-**Critical:** If you accidentally switched to a feature branch during parallel work, immediately switch back to `Dev_new_gui`. You may have broken active worktrees.
-
----
-
-## Branch Safety (MANDATORY)
-
-**Never run these operations without explicit user confirmation:**
-- `git reset --hard` — discards uncommitted work permanently
-- `git push --force` / `git push -f` — rewrites remote history
-- `git branch -D` / deleting remote branches — permanent unless reflog exists
-- `git clean -fd` / mass file deletion — unrecoverable
-- `git cherry-pick` across divergent histories — high conflict risk
-- Any operation touching `main` or `master` directly
-
-**Before any bulk git operation:**
-1. Run `git status` and `git diff --stat` — confirm exactly what will be affected
-2. State the operation and its scope in one sentence to the user before executing
-3. For branch deletions: verify the branch content is merged (`git branch -r --merged origin/Dev_new_gui`) before deleting
-4. For file deletions: `grep -r` to confirm nothing references the files first
-
-**If something goes wrong:** Stop immediately. Do not attempt recovery with more destructive commands. Report current state to user and wait for instructions.
-
-**Why:** In past sessions, Claude staged 5,371 files for deletion in a worktree, nearly reset `main` during a cherry-pick with 30+ conflicts, and committed fixes to wrong branches. These incidents required manual recovery.
-
----
-
-## Branching Discipline (Issue #4113)
-
-**PROTECTED BRANCHES:** Direct commits are blocked by pre-commit hook.
-- `main` — Release branch (stable, read-only via hook)
-- `master` — Alias for main (legacy, also protected)
-
-**ALLOWED BRANCHES:** You can commit on these:
-- `Dev_new_gui` — Active development (default target for all PRs)
-- `issue-*` — Feature branches (must flow through Dev_new_gui to main)
-- `hotfix-*` — Hotfix branches (reviewed before merging)
-- Any worktree branch matching above patterns
-
-**WORKFLOW:**
-1. Create feature branch: `git checkout -b issue-XXXX origin/Dev_new_gui`
-2. Make changes and commit on your feature branch
-3. Push: `git push -u origin issue-XXXX`
-4. Open PR: `issue-XXXX` → `Dev_new_gui` (NOT directly to main)
-5. After review, merge to `Dev_new_gui`
-6. Later, `Dev_new_gui` is merged to `main` (release cycle)
-
-**WHY:** Issue #4113 found commits went to `main` instead of `Dev_new_gui`, reversing branching discipline. The pre-commit hook prevents this.
-
-**IF YOU SEE "COMMIT BLOCKED":**
-The pre-commit hook rejected your commit on `main` or `master`. This is correct — switch to a feature branch and re-apply your changes:
-```bash
-git checkout issue-XXXX  # or create new: git checkout -b issue-XXXX origin/Dev_new_gui
-# Re-apply your changes
-git add -A && git commit -m "..."
-```
-
----
-
-## Batch Execution Default
-
-When the user says "implement all X-labeled issues", "fix all Y bugs", or "run `/batch-implement` on Z" — **launch immediately without asking for scope clarification.** The pattern is well-established.
-
-Default behavior:
-- Batch size: 3 agents max per round (API rate limit)
-- All issues get their own worktree: `.worktrees/issue-XXXX/`
-- Main session stays on `Dev_new_gui` — never switches
-- Agents commit locally; main session pushes and creates PRs
-- After each batch: review, merge, file discovery issues, then next batch
-
-**Do NOT ask:** "Which issues should I include?", "Should I do them in parallel?", "How many at a time?" — just run the pre-flight checklist and start.
-
-**Only stop to ask** if: a specific issue has unresolved dependencies, an architectural decision is needed, or the pre-flight checklist finds a problem (dirty branch, unresolved PRs, etc.).
-
-**Domain schema files (resolved #5799):** `schemas_common.py` now has only 5 cross-domain classes. Domain schemas live in `schemas_terminal.py`, `schemas_analytics.py`, `schemas_knowledge.py`, `schemas_agent.py`, `schemas_system.py`, `schemas_workflows.py`, `schemas_code.py`. New response schemas go in the matching domain file — parallel batches targeting different domain files can now run concurrently without conflicts.
-
----
-
-## Code Review Agent Requirements (MANDATORY)
-
-**Before dispatching any parallel review agents:**
-
-Every finder and verifier agent prompt MUST contain all three of the following — refuse to dispatch if any is missing:
-
-1. **Exact file list** from the PR diff:
-   ```bash
-   gh pr diff $PR_NUMBER --name-only > /tmp/review-files.txt
-   cat /tmp/review-files.txt
-   ```
-   Pass the full output as a literal list in the agent prompt.
-
-2. **Scope restriction:** Include verbatim: *"Use Read on these paths only. Do NOT Glob for other files in the repo."*
-
-3. **Role description:** State the agent's specific angle (e.g., "You are a security reviewer. Focus on: authz bypasses, IDOR, injection, secrets.") AND its output format (structured JSON with file, line, severity, evidence).
-
-**Why:** Without the file list, agents verify against stale repo files instead of PR diff. Without scope restriction, agents Glob unrelated files and produce noise. Both failures were observed in production reviews.
-
----
-
-## Parallel Agents Strategy
-
-When spawning multiple agents for batch work with `/batch-implement`:
-
-1. **Verify main session isolation:** Main session MUST stay on `Dev_new_gui`. Never switch branches while agents work.
-2. **Agents work in isolated worktrees:** Each agent works in `.worktrees/issue-XXXX/` with its own branch. No cross-contamination.
-3. **Batch size: 3 agents max** to avoid API rate limiting (529 errors). Wait for completion between batches.
-4. **Agents commit locally only** — they do NOT push. Main session handles all pushes (SSH credentials always available).
-5. **Monitor for failures:** After each batch, `/batch-implement` auto-detects failures:
-   - API 529 → wait 60s, retry
-   - Merge conflicts → auto-rebase, retry
-   - Already resolved → skip
-   - Agent crash → retry up to 3 times
-   - Only escalate unresolvable issues with manual instructions
-
----
-
-## PR Review & Merge Checklist
-
-After agents complete:
-
-0. **Gate 0 — Squash-duplicate check:** For each PR branch, run the squash-duplicate detection command (see `docs/developer/CLAUDE_WORKFLOW.md` "Gate 0") to verify no commits are already in `Dev_new_gui`. If all commits are duplicates, close the issue without merging.
-1. **Enumerate ALL open PRs:** `gh pr list --state open` to count expected PRs before starting review.
-2. **Track in checklist:** One line per PR to verify nothing is skipped.
-3. **Review each PR:**
-   - Type checking: `npm run type-check` (frontend) / `python -m mypy` (backend)
-   - Syntax: `npm run lint` / `python -m black --check`
-   - Imports: `python -c 'import <module>'` for each modified file
-   - Call sites: Grep for removed/renamed functions to verify no broken callers
-4. **Merge:** Merge each PR to `Dev_new_gui`
-5. **Verify count:** After all merges, PR count should be 0 (all merged)
-
----
-
-## Post-Merge Gap Audit
-
-After ALL PRs merged:
-
-1. **Import check:** For every modified Python file, `python -c 'import <module>'` — catch broken imports.
-2. **Call-site validation:** For every function REMOVED or RENAMED, grep for all callers. Verify none are broken.
-3. **Orphaned parameters:** Check function signatures don't leave callers passing wrong arguments.
-4. **File parsing:** `python -m py_compile` for backend, `npx tsc --noEmit` for frontend.
-5. **File discovery issues:** For ALL gaps found, file GitHub issues. DO NOT fix inline. Keep audit trail clean.
-
-**Why:** Bugs like removed `_init_redis()` breaking 9+ call sites get caught here before reaching production.
-
----
-
-## Pre-Implementation Validation (NEW)
-
-**Before spawning agents for issue implementation, verify:**
-
-1. **Main session branch check:** `git branch --show-current` — must be `Dev_new_gui`
-2. **Main session clean:** `git status --porcelain` — **if any files are dirty, commit or stash them before spawning agents.** Uncommitted edits are silently discarded when a subagent commits and upstream is merged (#4969).
-3. **Issue not already resolved:** Check if `#<issue>` is already in `origin/Dev_new_gui` commits
-4. **No stale worktrees:** Clean up any existing `.worktrees/issue-<number>/` directories
-5. **Issue preconditions:** Verify issue dependencies are resolved before starting work
-
-**Why:** Prevents wasted agent cycles on already-fixed issues, ensures clean isolation, catches branch violations early.
-
----
-
-## Sub-Agent Permission Enforcement (CRITICAL)
-
-Sub-agents without Bash permissions cannot complete git operations and will stall mid-batch, forcing manual intervention. This is the #1 cause of batch failures.
-
-**Required tools for every implementation agent:** `Bash, Read, Edit, Write, Grep, Glob`
-
-**Every agent prompt MUST include this line:**
-> "You have Bash, Read, Edit, Write, Grep, and Glob permissions. If you lose Bash permissions at any point, STOP immediately and report — do not retry or work around it."
-
-**Pre-launch check:** Before spawning any agent batch, confirm the main session has Bash approved. Sub-agents inherit from the parent session — if Bash requires approval in the main session, it will also require approval in each sub-agent, blocking all parallel work.
-
-**Main session as fallback:** Agents commit locally only — they do NOT push. Main session handles all git push and `gh pr create` operations (SSH credentials always available in main session).
-
-**On permission failure:** Do not retry the same agent. Report to user with: which agent failed, at which step, and what was left incomplete. Main session then completes the git operation manually.
-
----
-
-## Mandatory Post-Merge Gap Audit (NEW)
-
-**After merging all PRs in a batch:**
-
-1. **Run `/dead-code-audit`** to discover new gaps introduced by merged code
-2. **File discovery issues** for any new dead/orphaned code found
-3. **Do NOT fix gaps inline** — keep audit trail clean by filing issues for later prioritization
-4. **Track in GitHub** under `dead-code` and `not-wired` labels for batch cleanup
-
-**Why:** Catches regressions (missing imports, orphaned functions, new dead code) immediately.
-
----
-
-## Validation Gates Before Merging (NEW)
-
-**Use `/pre-merge-validate <PR>` before merging any code:**
-
-0. **Squash-Duplicate Detection:** Run Gate 0 (see `docs/developer/CLAUDE_WORKFLOW.md`) to detect commits already squash-merged to `Dev_new_gui` — avoids wasted merge work on already-landed changes.
-1. **Syntax + Imports:** Catches SyntaxError, ImportError
-2. **Call-Site Impact:** Finds removed functions with live callers (prevents `_init_redis()` incidents)
-3. **Function Signatures:** Detects signature changes with existing callers
-4. **Targeted Tests:** Runs tests only for changed files (fast validation)
-5. **Type Check:** Frontend TypeScript validation
-6. **Linting:** Catches errors (not warnings)
-
-**Integration:** `/batch-implement` automatically validates before creating PRs.
-
----
-
-## Headless / Automated Audit (NEW - Optional)
-
-**For CI/CD integration, use Claude CLI headless mode:**
-
-```bash
-# Validate all open PRs before merge window
-for pr in $(gh pr list --state open --limit 20 --json number -q '.[].number'); do
-  /pre-merge-validate $pr || gh pr comment $pr -b "❌ Validation failed"
-done
-
-# Nightly codebase audit (cron: 0 23 * * *)
-/dead-code-audit >> /var/log/codebase-audit.log
-```
-
-**Benefits:** Catch failures before human review, file discovery issues automatically, maintain codebase health continuously.
-
----
-
-## Issue Closure Verification Gate (MANDATORY)
-
-**NEVER close an issue without 100% verification. Issues remain OPEN until ALL acceptance criteria are proven met.**
-
-### Before Closing an Issue
-
-1. **Read the issue description fully** — identify ALL acceptance criteria (stated and implicit)
-2. **Find the merged commit(s)** — use `git log --all --grep="<issue-number>"` to locate implementation commit(s)
-3. **Verify each acceptance criterion**
-   - Is the feature/fix actually implemented? (check diff)
-   - Does it work correctly? (test output, curl test, UI verification)
-   - Are all edge cases handled? (review code, check error handling)
-   - Are tests passing? (run test suite for changed modules)
-   - Is documentation updated if needed? (check docs/)
-   - **Integration check (#6836 gate):** for every NEW module added by this issue, at least one production caller must import it. Run the unified wiring check:
-
-     ```bash
-     ./pipeline-scripts/check-new-module-callers.sh
-     ```
-
-     The script exits 0 if all new modules have callers, 1 if any have zero callers. **Zero callers ⇒ closure blocked**, even if tests pass — see #6836 for the orchestration audit that proved this gap (3,906 LOC of completed-but-unwired features whose trackers had been closed prematurely).
-   - **Deliberate-deferral override:** if a new module is genuinely infrastructure-only (Protocol, scaffold) and has no caller *by design*, file a follow-up wire-in issue *first*, then re-run with:
-
-     ```bash
-     echo "#NNNN" >> .wiring-deferral.txt
-     ./pipeline-scripts/check-new-module-callers.sh --allow-deferral .wiring-deferral.txt
-     ```
-
-     Then document in the closure comment: `### Wire-in deferred to #NNNN`.
-4. **Document the proof**
-   - Commit hash(es): `<hash>: <commit message>`
-   - Acceptance criteria met: `✅ Criterion 1`, `✅ Criterion 2`, etc.
-   - Evidence: test output, curl response, screenshot, or CI check reference
-5. **Close with proof comment**
-
-```bash
-gh api repos/mrveiss/AutoBot-AI/issues/<number>/comments -f body="✅ Closed with proof of implementation
-
-**Commit(s):** <hash1> (<msg1>), <hash2> (<msg2>)
-
-**Acceptance Criteria Met:**
-- ✅ Criterion 1 — evidence here
-- ✅ Criterion 2 — evidence here
-- ✅ Criterion 3 — evidence here"
-```
-
-### Discovery Issues (File During Every Task)
-
-While implementing, if you notice **any** bug, inconsistency, dead code, missing test, hardcoded value, or tech debt that is NOT part of the current issue — file a GitHub issue for it immediately. Do not fix it inline, do not add a TODO comment, do not ignore it.
-
-```bash
-gh issue create --title "discovery(<area>): <what you found>" --body "..." --label "tech-debt"
-```
-
-**Before closing any issue**, confirm: did I file a GitHub issue for every gap I noticed during implementation? If not, file them now. This is mandatory — not optional.
-
-**Why:** Gaps noticed inline and not filed are permanently lost. Discovery issues filed during implementation are the primary source of the issue backlog and prevent regressions from accumulating silently.
-
-### If ANY Criterion Not Met
-
-- **DO NOT close the issue** — leave it OPEN
-- Comment on the issue with what's missing: `⚠️ Criterion X not met: <reason>`
-- File a follow-up issue if needed: `discovery: <gap found>`
-
-### Examples of Incomplete Closure (AVOID)
-
-❌ "Fixed in PR #1234" (no proof of acceptance criteria)  
-❌ Closing based on PR status alone (PR merged ≠ issue resolved)  
-❌ No test output or verification (feature might be broken)  
-❌ Missing acceptance criteria check (incomplete implementation)
-
-### Examples of Complete Closure (GOOD)
-
-✅ Commit hash + all criteria verified + test output attached  
-✅ Feature tested end-to-end in dev environment  
-✅ All edge cases documented as handled  
-✅ Follow-up issues filed for any gaps found
-
----
-
-## Issue Ownership & Posting
-
-- Before posting review findings or comments to any Paperclip/MVA issue, **verify the target issue is assigned to this agent**. Attempting to post to another agent's issue wastes a heartbeat and silently fails.
-- If the correct target is unclear, pivot to an agent-owned tracking issue (e.g. the review's source issue) rather than guessing.
-- When the current agent is the **PR author**, GitHub blocks self-approval and self-requested-changes. Post a detailed review comment instead of using the approve/request-changes API. Never attempt self-approval.
-
----
-
-## Code Review Methodology
-
-All substantive PR reviews must follow the **3-angle recall-biased protocol**:
-
-1. **Dispatch 3 parallel finder agents** covering distinct angles: (a) security/auth/tenancy, (b) correctness/logic, (c) data-layer/edge-cases.
-2. **Ground every finding in the live diff.** Finder and verifier agents MUST read the actual PR diff (`gh pr diff <number>` or `git diff <base>..<head>`) — never reason about files that are not confirmed on disk. Files added by the PR may not exist on disk until checked out.
-3. **Run a verification pass.** A dedicated verifier agent re-reads each cited location from the actual files and rejects any finding it cannot ground in real code. Findings without a real line citation are discarded.
-4. **Post to the correct issue.** Confirm ownership before posting (see Issue Ownership & Posting above).
-
----
-
-## Git Push Recovery
-
-- Before pushing, always check whether the remote branch has diverged: `git status` and `git log --oneline origin/<branch>..HEAD`.
-- If a push is rejected due to a diverged branch, **do not force-push blindly**. Instead: fetch, rebase (`git rebase origin/<branch>`), resolve any conflicts, then push.
-- If the rebase fails with conflicts you cannot resolve cleanly, stop and report rather than force-pushing and losing upstream changes.
+- **Never `--no-verify`** — PostToolUse hook auto-formats `.py`
+- **Protected branches:** `main`/`master` blocked by pre-commit hook → use `issue-*` or `hotfix-*`
+- **PR template headings:** `Thinking Path` · `What Changed` · `Verification` · `Model Used`
+- **PR queue limit:** check open PR count before starting implementation; if ≥5, defer and notify
+- **CI diagnosis:** queued checks on self-hosted runners are NOT stuck — confirm failure before acting
+- **Posting comments:** write literal markdown — never raw JSON or a file path
+- **Worktrees:** `.worktrees/issue-XXXX/` for all parallel work → read [`CLAUDE_GIT.md`](docs/developer/CLAUDE_GIT.md)
+- **Codebase is source of truth:** never edit `/opt/autobot/` or `/var/log/autobot/`
+- **One issue per session** — don't auto-start others after completing one
+- **No temp fixes:** zero tolerance for workarounds, TODO comments, swallowed errors
 
 ---
 
 ## Model Tier Routing
 
-- Route **lightweight heartbeat tasks** (status checks, acknowledgments, quota monitoring, label updates, simple status transitions) to **Claude Haiku** (`claude-haiku-4-5-20251001`) to preserve Sonnet quota.
-- Reserve **Sonnet** for deep code reviews, multi-file bug fixes, feature implementation, and any task requiring extended reasoning.
-- This distinction should be reflected in agent runtime config (`useLightweightMode: true`) or explicit model selection in skill invocations where possible.
+- **Haiku** (`claude-haiku-4-5-20251001`): heartbeat status checks, label updates, simple transitions
+- **Sonnet**: deep reviews, multi-file fixes, feature implementation, extended reasoning

--- a/docs/developer/CLAUDE_BATCH.md
+++ b/docs/developer/CLAUDE_BATCH.md
@@ -1,0 +1,74 @@
+# Batch Execution & Parallel Agent Rules
+
+## Batch Execution Default
+
+When the user says "implement all X-labeled issues", "fix all Y bugs", or "run `/batch-implement` on Z" — **launch immediately without asking for scope clarification.**
+
+Default behavior:
+- Batch size: 3 agents max per round (API rate limit)
+- All issues get their own worktree: `.worktrees/issue-XXXX/`
+- Main session stays on `Dev_new_gui` — never switches
+- Agents commit locally; main session pushes and creates PRs
+- After each batch: review, merge, file discovery issues, then next batch
+
+**Do NOT ask:** "Which issues?", "Parallel?", "How many?" — just run the pre-flight checklist and start.
+
+**Only stop** if: specific issue has unresolved dependencies, architectural decision needed, or pre-flight finds a problem.
+
+**Domain schema files (resolved #5799):** Parallel batches targeting different domain files can run concurrently without conflicts — see `schemas_terminal.py`, `schemas_analytics.py`, `schemas_agent.py`, `schemas_system.py`, `schemas_workflows.py`, `schemas_code.py`.
+
+---
+
+## Pre-Implementation Validation
+
+**Before spawning agents, verify:**
+
+1. `git branch --show-current` — must be `Dev_new_gui`
+2. `git status --porcelain` — if dirty, commit or stash before spawning
+3. Issue not already resolved: check `git log origin/Dev_new_gui --grep="#<issue>"`
+4. No stale worktrees: clean up existing `.worktrees/issue-<number>/` directories
+5. Issue preconditions resolved
+
+---
+
+## Parallel Agents Strategy
+
+1. **Main session stays on `Dev_new_gui`** throughout — never switches
+2. **Agents work in isolated worktrees** — no cross-contamination
+3. **Batch size: 3 agents max** — avoid API rate limiting (529 errors), wait between batches
+4. **Agents commit locally only** — do NOT push; main session handles all pushes
+5. **After each batch:** `/batch-implement` auto-detects failures:
+   - API 529 → wait 60s, retry
+   - Merge conflicts → auto-rebase, retry
+   - Already resolved → skip
+   - Agent crash → retry up to 3 times
+   - Only escalate unresolvable issues
+
+---
+
+## Sub-Agent Permission Enforcement (CRITICAL)
+
+Sub-agents without Bash permissions cannot complete git operations and stall mid-batch.
+
+**Required tools for every implementation agent:** `Bash, Read, Edit, Write, Grep, Glob`
+
+**Every agent prompt MUST include:**
+> "You have Bash, Read, Edit, Write, Grep, and Glob permissions. If you lose Bash permissions at any point, STOP immediately and report — do not retry or work around it."
+
+**Pre-launch check:** Confirm main session has Bash approved — sub-agents inherit from parent.
+
+**On permission failure:** Do not retry the same agent. Report: which agent failed, at which step, what was left incomplete. Main session completes the git operation manually.
+
+---
+
+## Headless / Automated Audit
+
+```bash
+# Validate all open PRs before merge window
+for pr in $(gh pr list --state open --limit 20 --json number -q '.[].number'); do
+  /pre-merge-validate $pr || gh pr comment $pr -b "❌ Validation failed"
+done
+
+# Nightly codebase audit (cron: 0 23 * * *)
+/dead-code-audit >> /var/log/codebase-audit.log
+```

--- a/docs/developer/CLAUDE_CLOSURE.md
+++ b/docs/developer/CLAUDE_CLOSURE.md
@@ -1,0 +1,79 @@
+# Issue Closure Verification Gate
+
+**NEVER close an issue without 100% verification. Issues remain OPEN until ALL acceptance criteria are proven met.**
+
+## Before Closing an Issue
+
+1. **Read the issue description fully** — identify ALL acceptance criteria (stated and implicit)
+2. **Find the merged commit(s):** `git log --all --grep="<issue-number>"`
+3. **Verify each acceptance criterion:**
+   - Is the feature/fix actually implemented? (check diff)
+   - Does it work correctly? (test output, curl, UI verification)
+   - All edge cases handled? (review code, error handling)
+   - Tests passing? (run test suite for changed modules)
+   - Documentation updated if needed?
+   - **Integration check (#6836 gate):** for every NEW module added, at least one production caller must import it:
+     ```bash
+     ./pipeline-scripts/check-new-module-callers.sh
+     ```
+     Exits 0 if all new modules have callers, 1 if any have zero callers. **Zero callers ⇒ closure blocked**, even if tests pass.
+   - **Deliberate-deferral override:** if a new module is infrastructure-only by design, file a follow-up wire-in issue first, then:
+     ```bash
+     echo "#NNNN" >> .wiring-deferral.txt
+     ./pipeline-scripts/check-new-module-callers.sh --allow-deferral .wiring-deferral.txt
+     ```
+     Document in closure comment: `### Wire-in deferred to #NNNN`
+
+4. **Document the proof:**
+   - Commit hash(es) + commit messages
+   - `✅ Criterion 1`, `✅ Criterion 2`, etc.
+   - Evidence: test output, curl response, screenshot, or CI check reference
+
+5. **Close with proof comment:**
+```bash
+gh api repos/mrveiss/AutoBot-AI/issues/<number>/comments -f body="✅ Closed with proof of implementation
+
+**Commit(s):** <hash1> (<msg1>), <hash2> (<msg2>)
+
+**Acceptance Criteria Met:**
+- ✅ Criterion 1 — evidence here
+- ✅ Criterion 2 — evidence here
+- ✅ Criterion 3 — evidence here"
+```
+
+---
+
+## Discovery Issues (File During Every Task)
+
+While implementing, if you notice **any** bug, inconsistency, dead code, missing test, hardcoded value, or tech debt NOT part of the current issue — file a GitHub issue immediately. Do not fix it inline, do not add a TODO comment.
+
+```bash
+gh issue create --title "discovery(<area>): <what you found>" --body "..." --label "tech-debt"
+```
+
+**Before closing any issue:** confirm all gaps noticed during implementation have been filed. This is mandatory.
+
+**Why:** Gaps noticed inline and not filed are permanently lost. Discovery issues are the primary source of the issue backlog.
+
+---
+
+## Examples
+
+❌ **Incomplete closure (avoid):**
+- "Fixed in PR #1234" (no proof of acceptance criteria)
+- Closing based on PR status alone (PR merged ≠ issue resolved)
+- No test output or verification
+
+✅ **Complete closure:**
+- Commit hash + all criteria verified + test output attached
+- Feature tested end-to-end in dev environment
+- All edge cases documented as handled
+- Follow-up issues filed for any gaps found
+
+---
+
+## If ANY Criterion Not Met
+
+- **DO NOT close the issue** — leave it OPEN
+- Comment: `⚠️ Criterion X not met: <reason>`
+- File follow-up: `discovery: <gap found>`

--- a/docs/developer/CLAUDE_GIT.md
+++ b/docs/developer/CLAUDE_GIT.md
@@ -1,0 +1,85 @@
+# Git, Branching & Worktree Rules
+
+## Parallel Work: Worktree Isolation (CRITICAL)
+
+**NO `git checkout` or `git switch` on shared branches during parallel work sessions.**
+
+- **Each parallel task MUST have its own worktree:** `.worktrees/issue-XXXX/` with dedicated branch `issue-XXXX`
+- **Main session stays on `Dev_new_gui`** — never check out feature branches
+- **Why:** Switching branches in main session breaks all active worktrees that depend on that branch
+
+**Worktree Creation:**
+```bash
+git worktree add .worktrees/issue-XXXX -b issue-XXXX origin/Dev_new_gui
+cd .worktrees/issue-XXXX && git branch --unset-upstream
+# Commit and push from here. Do NOT switch branches.
+```
+
+---
+
+## Pre-Flight Checklist (Before Parallel Work)
+
+1. `git branch --show-current` — must be `Dev_new_gui`. If on a feature branch, STOP.
+2. Confirm Bash is approved in main session — sub-agents inherit from parent.
+3. `git status --porcelain` — if any files are dirty, commit or stash before spawning agents. Uncommitted edits are silently discarded when a subagent commits and upstream is merged (#4969).
+4. Verify issue isn't already resolved: `git log origin/Dev_new_gui --oneline --grep="#XXXX"`
+5. For architectural decisions, state in 1–2 sentences and wait for confirmation.
+
+---
+
+## Branch Safety (MANDATORY)
+
+**Never run without explicit user confirmation:**
+- `git reset --hard` — discards uncommitted work permanently
+- `git push --force` / `git push -f` — rewrites remote history
+- `git branch -D` — permanent unless reflog exists
+- `git clean -fd` — unrecoverable
+- Any operation touching `main` or `master` directly
+
+**Before any bulk git operation:**
+1. `git status` + `git diff --stat` — confirm exactly what will be affected
+2. State operation and scope in one sentence before executing
+3. For branch deletions: verify merged via `git branch -r --merged origin/Dev_new_gui`
+
+**Why:** Past incidents: staged 5,371 files for deletion in a worktree, nearly reset `main` during a cherry-pick with 30+ conflicts, committed fixes to wrong branches.
+
+---
+
+## Branching Discipline (Issue #4113)
+
+**Protected (blocked by pre-commit hook):** `main`, `master`
+
+**Allowed:** `Dev_new_gui`, `issue-*`, `hotfix-*`, worktree branches matching those patterns
+
+**Workflow:**
+1. `git checkout -b issue-XXXX origin/Dev_new_gui`
+2. Commit on feature branch
+3. `git push -u origin issue-XXXX`
+4. Open PR: `issue-XXXX` → `Dev_new_gui` (NOT directly to main)
+
+**If you see "COMMIT BLOCKED":**
+```bash
+git checkout issue-XXXX  # or: git checkout -b issue-XXXX origin/Dev_new_gui
+git add -A && git commit -m "..."
+```
+
+---
+
+## Hook Scripts
+
+Before committing any change to `.claude/hooks/block-dangerous-commands.sh`, run:
+```bash
+bash .claude/hooks/block-dangerous-commands_test.sh
+```
+Must be 27/27. Add test cases for new rules. Use `bash` (GNU grep 3.7), not interactively — the shell `grep` alias is `ugrep` (PCRE2) which has different variable-length lookbehind support. See #8262.
+
+---
+
+## Git Push Recovery
+
+Before pushing, check for diverged remote:
+```bash
+git status && git log --oneline origin/<branch>..HEAD
+```
+
+If push rejected: fetch, rebase (`git rebase origin/<branch>`), resolve conflicts, then push. If rebase fails with conflicts you cannot resolve cleanly, stop and report — do NOT force-push and lose upstream changes.

--- a/docs/developer/CLAUDE_REVIEW.md
+++ b/docs/developer/CLAUDE_REVIEW.md
@@ -1,0 +1,128 @@
+# Code Review & Merge Rules
+
+## Code Review Agent Requirements (MANDATORY)
+
+**Every finder and verifier agent prompt MUST contain all three — refuse to dispatch if any missing:**
+
+1. **Exact file list** from the PR diff:
+   ```bash
+   gh pr diff $PR_NUMBER --name-only > /tmp/review-files.txt
+   cat /tmp/review-files.txt
+   ```
+
+2. **Scope restriction:** *"Use Read on these paths only. Do NOT Glob for other files in the repo."*
+
+3. **Role + output format:** State the agent's specific angle (security, correctness, data-layer) AND output format (JSON with file, line, severity, evidence).
+
+**Why:** Without the file list, agents verify against stale repo files. Without scope restriction, agents Glob unrelated files and produce noise.
+
+---
+
+## Code Review Methodology (3-Angle Protocol)
+
+1. **Dispatch 3 parallel finder agents:** (a) security/auth/tenancy, (b) correctness/logic, (c) data-layer/edge-cases
+2. **Ground every finding in the live diff.** Read actual PR diff (`gh pr diff <number>`) — never reason about files not confirmed on disk
+3. **Run a verification pass.** Dedicated verifier re-reads each cited location and rejects findings it cannot ground in real code
+4. **Post to the correct issue.** Confirm ownership before posting
+
+---
+
+## PR Review & Merge Checklist
+
+After agents complete:
+
+0. **Gate 0 — Squash-duplicate check:** Verify no commits are already in `Dev_new_gui` (see `docs/developer/CLAUDE_WORKFLOW.md` "Gate 0"). If all commits are duplicates, close without merging.
+1. **Enumerate ALL open PRs:** `gh pr list --state open` before starting review
+2. **Track in checklist:** One line per PR — nothing skipped
+3. **Review each PR:**
+   - Type checking: `npm run type-check` / `python -m mypy`
+   - Syntax: `npm run lint` / `python -m black --check`
+   - Imports: `python -c 'import <module>'` for each modified file
+   - Call sites: grep for removed/renamed functions
+4. **Merge:** each PR to `Dev_new_gui`
+5. **Verify count:** PR count should be 0 after all merges
+
+---
+
+## Post-Merge Gap Audit
+
+After ALL PRs merged:
+
+1. **Import check:** `python -c 'import <module>'` for every modified Python file
+2. **Call-site validation:** For every removed/renamed function, grep all callers
+3. **Orphaned parameters:** Check function signatures don't break callers
+4. **File parsing:** `python -m py_compile` (backend), `npx tsc --noEmit` (frontend)
+5. **Discovery issues:** For ALL gaps found, file GitHub issues. Do NOT fix inline.
+
+**Why:** Bugs like removed `_init_redis()` breaking 9+ call sites get caught here.
+
+---
+
+## Mandatory Post-Merge Dead Code Audit
+
+After merging all PRs in a batch:
+
+1. Run `/dead-code-audit` to discover new gaps introduced by merged code
+2. File discovery issues for any new dead/orphaned code
+3. Do NOT fix gaps inline — file issues under `dead-code` and `not-wired` labels
+
+---
+
+## Validation Gates Before Merging
+
+**Use `/pre-merge-validate <PR>` before merging any code:**
+
+0. Squash-Duplicate Detection (Gate 0)
+1. Syntax + Imports
+2. Call-Site Impact
+3. Function Signatures
+4. Targeted Tests (only changed files)
+5. Type Check (TypeScript)
+6. Linting (errors only, not warnings)
+
+`/batch-implement` runs this automatically before creating PRs.
+
+---
+
+## CI Diagnosis
+
+**Before declaring CI "stuck" or attempting to cancel/retrigger:**
+- Confirm whether checks are actually failing vs. queued on a self-hosted runner
+- Default assumption: checks are running normally, not broken
+- Only cancel/retrigger when a check has been in a non-running state for >30 minutes with no activity
+
+**Why:** Sessions wasted time canceling/retriggering smoke tests that were running normally.
+
+---
+
+## PR Template Format
+
+This repo uses **custom headings** — NOT standard GitHub template sections:
+
+| Heading | Purpose |
+|---|---|
+| **Thinking Path** | Your reasoning and approach |
+| **What Changed** | Files/systems modified |
+| **Verification** | Test output, curl, CI evidence |
+| **Model Used** | Which Claude model ran this |
+
+Always use these exact headings when creating or editing PR descriptions.
+
+---
+
+## Issue Ownership & Posting
+
+- Before posting review findings or comments to any Paperclip/MVA issue, **verify the target issue is assigned to this agent**
+- If the correct target is unclear, pivot to an agent-owned tracking issue
+- PR authors cannot self-approve — post a detailed review comment instead
+- **When posting comments:** write literal markdown text — never a raw JSON string or file path
+
+---
+
+## Posting Comments Correctly
+
+When posting PR/issue comments or updating PR bodies:
+- Write the literal text/markdown content
+- Never pass a raw JSON string as the body
+- Never pass a file path instead of file contents
+- Verify the rendered comment after posting

--- a/docs/developer/skills/batch-implement.md
+++ b/docs/developer/skills/batch-implement.md
@@ -1,486 +1,177 @@
 ---
 name: batch-implement
-description: Full implement→review→merge→close→discover loop for GitHub issues. Use this whenever the user says "implement all X-labeled issues", "fix all Y bugs", "run a batch on these issues", or gives a list of issue numbers to work on. Covers the complete workflow in one command: parallel implementation in worktrees, PR review, merge to Dev_new_gui, issue closure with proof, and discovery issue filing. Do NOT ask for scope clarification — just run the pre-flight and start.
+description: Full implement→review→merge→close→discover loop for GitHub issues. Use this whenever the user says "implement all X-labeled issues", "fix all Y bugs", "run a batch on these issues", or gives a list of issue numbers to work on. Do NOT ask for scope clarification — just run the pre-flight and start.
 ---
 
 # /batch-implement — Full Issue Resolution Loop
 
-Implements a batch of GitHub issues end-to-end: parallel implementation → PR review → merge → issue closure with proof → discovery filing.
-
-This is the complete workflow. It does not stop at PR creation — it runs through to closed issues with zero leftover branches.
-
-## Usage
-
 ```bash
 /batch-implement 4703 4704 4705          # explicit issue numbers
 /batch-implement --label bug             # all open issues with label
-/batch-implement --label bug --limit 9   # cap at N issues
+/batch-implement --label bug --limit 9   # cap at N
 ```
 
-When the user says "implement all X-labeled issues" or similar — launch immediately. Run the pre-flight, then start. Do not ask which issues to include or how many to run at a time.
-
-## Core Design
-
-**Agents commit locally. Main session always pushes.**
-
-This architecture eliminates permission failures at the source: agents run in isolated contexts without SSH/tokens, so they commit only. The main session (which has full credentials) then pushes all changes. No more "git push permission denied" failures.
-
-**Batch size: 3 agents max** — API rate limits (Anthropic 529 errors) cap useful concurrency at 3.
+**Core rule:** Agents commit locally. Main session always pushes.
+**Batch size:** 3 agents max.
 
 ---
 
-# Phase 0: Pre-Flight
+## Step 0: Umbrella Issue
 
-Run all checks before touching anything:
+- Ensure a GitHub umbrella issue exists with a task checklist (one checkbox per batch item).
+- As each item lands (PR merged + issue closed), check it off on the umbrella issue.
+- Create the umbrella if missing: `gh issue create --title "Batch: <label/description>" --body "- [ ] #N ..."`
 
-```bash
-# 1. Main session must be on Dev_new_gui
-git branch --show-current   # must print: Dev_new_gui
+---
 
-# 2. Main session must be clean
-git status --porcelain       # must be empty
+## Step 1: Pre-Flight
 
-# 3. Resolve issue list
-if --label: gh issue list --label <label> --state open --json number -q '.[].number'
-if explicit: use the numbers given
+1. `git branch --show-current` — must be `Dev_new_gui`. STOP if not.
+2. `git status --porcelain` — must be empty. STOP if not.
+3. Resolve issue list: `gh issue list --label <label> --state open --json number -q '.[].number'`
+4. Skip if already in Dev_new_gui: `git log origin/Dev_new_gui --oneline --grep="#<n>" | head -1`
+5. Skip if already closed: `gh issue view <n> --json state -q '.state'`
+6. Clean stale worktrees: `git worktree remove .worktrees/issue-<n> --force && git branch -D issue-<n>`
 
-# 4. For each issue: skip if already resolved
-git log origin/Dev_new_gui --oneline --grep="#<issue>" | head -1
-# If found → mark SKIP "already in Dev_new_gui"
-
-# 5. For each issue: skip if already closed on GitHub
-gh issue view <issue> --json state -q '.state'
-# If CLOSED → mark SKIP
-
-# 6. Clean up any stale worktrees from prior crashed runs
-for each issue: if .worktrees/issue-<n>/ exists → git worktree remove --force + git branch -D
-
-# 7. Confirm Bash is approved in this session (sub-agents inherit)
+Print summary before proceeding:
 ```
-
-If main session is NOT on Dev_new_gui: STOP. Do not proceed.
-
-Report pre-flight summary before launching agents:
-```
-Pre-flight complete:
-  To implement: #4703, #4704, #4705
-  Skipped (resolved): #4702
-  Worktrees cleaned: 1
+Pre-flight: To implement: #N, #M | Skipped: #K | Cleaned: N worktrees
 ```
 
 ---
 
-# Phase 0c: Verification Mandate Before Push (#5142)
-
-**Type-check is necessary but not sufficient.** Before pushing any commit that touches code covered by tests, run BOTH:
+## Step 2: Worktree Setup (per issue)
 
 ```bash
-# 1. Type safety
-cd autobot-frontend && npx vue-tsc --noEmit -p tsconfig.app.json
-# Backend equivalent:
-cd autobot-backend && python -m mypy <touched files>
-
-# 2. Behavioral contract — run tests for affected files
-npx vitest run src/composables/__tests__/<relevant>.test.ts
-# Or for backend:
-pytest autobot-backend/<touched module path> -xvs
+git worktree add .worktrees/issue-<n> -b issue-<n> origin/Dev_new_gui
+cd .worktrees/issue-<n> && git branch --unset-upstream
 ```
 
-**Why:** Type-check verifies the code compiles; it does NOT catch:
-- Behavior changes that still match the type signature (returning `null` from `Promise<X>` when the function used to throw — TS sees the null as assignable through a generic's inference)
-- Test contract violations (tests mocking impossible scenarios that the deleted code happened to make reachable)
-- Runtime semantic drift (renamed identifiers, changed defaults, swallowed errors)
+- Agents MUST work inside the worktree — NEVER `git checkout` on the main tree.
+- Each issue gets its own branch `issue-<n>`.
 
-**Concrete incident (#5142):** PR #5141 deleted dead `if (!response) throw` blocks in `useKnowledgeBase.ts`. Type-check passed (0 errors). Then 3 tests failed at vitest run because they mocked `apiClient.get` to return null — the deleted check was the only path that threw. PR was closed as broken. ~30 minutes wasted.
+---
 
-**Rule of thumb:** Any PR that deletes or renames code in a file under `__tests__/` coverage MUST run that test file before push. Claiming "behave identically" without running the tests is a process failure.
+## Step 3: Dispatch Agents (batches of 3)
 
-## Pre-push duplicate check (#5143)
+Track state per issue: `PENDING | IN_FLIGHT | SUCCESS | SUCCESS_TESTS_FAILING | RETRY_QUEUED | ESCALATED | SKIPPED`
 
-Before every `gh pr create` (or first `git push -u`), re-fetch and check whether the target issue was already closed by a merged PR during your working session. Long sessions (30+ min) are especially vulnerable — the repo moves underneath you:
+Each agent must:
+1. `gh issue view <n>` — read the issue.
+2. Implement the fix inside the worktree.
+3. `git commit -m "<type>(<scope>): <desc> (#<n>)"` — commit only, no push.
+4. Report: `RESULT: SUCCESS|FAILURE | COMMIT_SHA: <sha> | TESTS: PASS|FAIL | ERROR: <if any>`
+
+Agent prompt must include worktree isolation instructions (NEVER `git checkout` on main tree).
+
+Self-healing failure table:
+
+| Failure type | Auto-heal |
+|---|---|
+| API 529 overload | Wait 60s, retry (max 3×) |
+| Merge conflict at push | Rebase onto latest Dev_new_gui, retry |
+| Already resolved | Mark SKIPPED, close worktree |
+| Agent crash / timeout | Retry (max 3×) |
+| Tests failing | Mark SUCCESS_TESTS_FAILING — manual review |
+| Unresolvable after 3× | ESCALATE — preserve worktree, print manual steps |
+
+Repeat batches until all issues are `SUCCESS`, `SKIPPED`, or `ESCALATED`.
+
+---
+
+## Step 4: Pre-Push Verification (every PR before push)
 
 ```bash
+# Re-fetch and abort if issue already closed during session
 git fetch origin Dev_new_gui -q
+gh issue view <n> --json state -q '.state'   # CLOSED → abort
 
-ISSUE_STATE=$(gh issue view <issue> --json state --jq '.state')
-if [ "$ISSUE_STATE" = "CLOSED" ]; then
-  echo "⚠️ Issue #<issue> is already closed — check if merged work supersedes yours"
-  gh issue view <issue> --comments --limit 3
-  # Likely cancel push; diff against origin/Dev_new_gui to see if anything remains to contribute
-fi
+# Type-check (frontend)
+cd autobot-frontend && npx vue-tsc --noEmit -p tsconfig.app.json
 
-# Does Dev_new_gui already contain a commit citing this issue?
-if git log origin/Dev_new_gui --oneline -20 | grep -qE "#<issue>\b"; then
-  echo "⚠️ Dev_new_gui has a commit citing #<issue> — verify it's not your work"
-fi
+# Tests for affected files
+npx vitest run src/.../__tests__/<relevant>.test.ts
+# or: pytest autobot-backend/<path> -xvs
+
+# Extraction PRs only — behavioral grep audit (before/after; after-count must be 0)
+grep -rnE "<behavior-pattern>" autobot-frontend/src --include="*.vue"
 ```
 
-If the issue is closed AND the merged commit supersedes your work: close your local branch, delete the remote if pushed, move on. A wasted 30 minutes beats a confusing duplicate PR in the reviewer's queue.
-
-**Concrete incident (#5143):** PR #5141 was created for #5092 from a 30-min-stale `origin/Dev_new_gui`. Meanwhile PR #5128 had merged the same cleanup. Re-fetching before push would have caught it before any reviewer wasted time on the duplicate.
+Push only after all checks pass: `git push -u origin issue-<n>`
 
 ---
 
-# Phase 0d: Behavioral Grep Audit (#5372, extraction PRs only)
-
-**Applies only to "extract a primitive / composable" issues** — PRs that pull a duplicated pattern from N sites into a shared utility + migrate those sites.
-
-**The problem this prevents:** The original issue body enumerates sites by grepping for a **symbol** (e.g. `handleKeydown`). Between filing and implementation, the set of sites that share the *behavior* (e.g. `key === 'Tab' && shiftKey && ...`) drifts from that enumeration:
-
-- **Over-counted** (some listed sites already migrated via sibling PRs)
-- **Under-counted** (other sites have the same behavior under a different symbol name, or were added to the codebase after the issue was filed)
-
-**This is not hypothetical.** Session 150 had four instances:
-
-| Issue | Listed sites | Real sites | Gap type |
-|---|---|---|---|
-| #5247 | 5 | 2 | Over-count (3 already migrated) |
-| #5283 | 4 (explicit defer of BaseTable) | 5 | BaseTable was late-added |
-| #5371 | 8 | 10 (#5410 added 2) | Under-count — grep missed two different-symbol dialogs |
-| #5411 | 11 | 13 (#5410 doubled up) | Under-count — grep used symbol not behavior |
-
-Miss rate: **50% of extraction PRs shipped an incomplete migration.** Every miss required a follow-up PR.
-
-## The rule
-
-For extraction PRs, the PR description **must** include a **"Behavioral grep audit"** section with before / after hit counts:
-
-```markdown
-## Behavioral grep audit
-
-Before:
-\`\`\`bash
-$ grep -rnE "key\s*[=!]==\s*['\"]Tab|shiftKey\s*&&.*focus" autobot-frontend/src --include="*.vue"
-# 3 hits — BaseModal, HostSelectionDialog, EntityDetail
-\`\`\`
-
-After:
-\`\`\`bash
-$ <same grep>
-# 0 hits — all sites migrated to useFocusTrap
-\`\`\`
-```
-
-**Three rules for the regex:**
-1. **Match the behavior, not the symbol.** `handleKeydown` can be renamed; `key === 'Tab'` cannot.
-2. **Cast wider than the issue's enumeration.** If the issue listed 3 sites, grep for the pattern across *the whole relevant tree* to surface sites the filer missed.
-3. **The after-count must be 0** (or explicitly documented non-zero with a follow-up issue filed). Non-zero with no follow-up blocks merge.
-
-**When in doubt, grep two ways:**
-- A loose regex covering the pattern's core behavior
-- A tight regex for a unique fingerprint (e.g. a specific CSS selector string, an unusual attribute combination)
-
-If the two return different counts, investigate the delta — it's often the miss.
-
-## What to write in the PR
-
-A standard "Behavioral grep audit" block, as shown above, immediately after the "Summary" section. This is a merge gate — a missing audit section blocks review.
-
-**Concrete examples from merged PRs:**
-- [PR #5343](https://github.com/mrveiss/AutoBot-AI/pull/5343) — useFocusTrap extraction; amended post-merge to include the audit
-- [PR #5390](https://github.com/mrveiss/AutoBot-AI/pull/5390) — 8-dialog a11y sweep
-- [PR #5417](https://github.com/mrveiss/AutoBot-AI/pull/5417) — useInitialFocus + full kit for 2 missed dialogs
-- [PR #5433](https://github.com/mrveiss/AutoBot-AI/pull/5433) — useBodyScrollLock + immediate: true fix
-
----
-
-# Phase 1: Implement (Batches of 3, with Self-Healing)
-
-## 1a. Create Isolated Worktrees
-
-**CRITICAL (#6512): Parallel agents MUST use worktrees. This prevents commits landing on wrong branches.**
-
-**For each issue in WORK_QUEUE:**
+## Step 5: Create & Review PR
 
 ```bash
-WORKTREE_PATH="/home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-<number>"
-
-# Clean up stale worktree from prior crashed run (idempotent)
-if git worktree list | grep -q "issue-<number>"; then
-  git worktree remove "$WORKTREE_PATH" --force 2>/dev/null
-  git branch -D "issue-<number>" 2>/dev/null
-fi
-
-# Create fresh worktree — AGENTS MUST RUN INSIDE THIS
-git worktree add "$WORKTREE_PATH" -b "issue-<number>" origin/Dev_new_gui
-cd "$WORKTREE_PATH"
-git branch --unset-upstream
-
-# Verify isolated from main session
-echo "Agent will work in: $(pwd)"
-echo "Branch is: $(git branch --show-current)"  # should print: issue-<number>
-echo "Main session remains on Dev_new_gui — checked separately"
+gh pr create --base Dev_new_gui --head issue-<n> --title "..." --body "..."
 ```
 
-**Key rules (non-negotiable):**
-- Absolute paths: `/home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-XXXX`
-- Each issue gets dedicated branch `issue-XXXX`
-- All worktrees isolated — no shared directories
-- **Agents MUST cd into the worktree BEFORE making any git commits**
-- **Agents MUST NEVER call `git checkout` on the main tree**
+- Syntax/imports: `python -m py_compile <file>` for Python; `vue-tsc` for TS/Vue.
+- Call-site impact: grep that nothing removed is still called elsewhere.
+- Wiring check: any new public module must have ≥1 production caller — HARD BLOCK if 0.
+- Linting: `python -m black --check <files>`
 
-## 1b. Initialize Retry State Table
-
-Create a markdown table in your context to track retry state across batches:
-
-```
-| Issue | Attempts | Last Failure Type | Status | Details |
-|-------|----------|-------------------|--------|---------|
-| #3405 | 0        | —                 | PENDING | waiting for agent |
-| #3406 | 0        | —                 | PENDING | waiting for agent |
-| #3407 | 0        | —                 | PENDING | waiting for agent |
-```
-
-**Status values:** `PENDING`, `IN_FLIGHT`, `SUCCESS`, `SUCCESS_TESTS_FAILING`, `RETRY_QUEUED`, `ESCALATED`, `SKIPPED`
-
-Update this table after each batch completes. It becomes the source of truth for what needs retrying.
-
-## 1c. Batched Dispatch Loop with Self-Healing
-
-Agents run in batches of 3 max, each batch includes failure detection and automatic healing.
-
-**Build work queue from retry table:**
-```
-QUEUE = all issues with status PENDING or RETRY_QUEUED
-```
-
-Take up to 3 from the queue. Spawn in parallel — each agent:
-
-1. Reads the issue: `gh issue view <n>`
-2. Implements the fix in the worktree
-3. Commits (does NOT push): `git commit -m "<type>(<scope>): <desc> (#<n>)"`
-4. Reports: `RESULT: SUCCESS|FAILURE`, `COMMIT_SHA: <sha>`, `TESTS: PASS|FAIL`, `ERROR: <if any>`
-
-**Agent prompt must include:**
-> "You have Bash, Read, Edit, Write, Grep, Glob permissions. Commit only — do NOT push. If you lose Bash permissions, STOP and report. Required tools: Bash, Read, Edit, Write, Grep, Glob.
->
-> **CRITICAL — Worktree Isolation (Issue #6512):**
-> - NEVER call `git checkout` on the main working tree
-> - BEFORE making any changes, create an isolated worktree:
->   ```bash
->   ISSUE_NUM=<issue-number>
->   git worktree add .worktrees/issue-$ISSUE_NUM -b issue-$ISSUE_NUM origin/Dev_new_gui
->   cd .worktrees/issue-$ISSUE_NUM
->   git branch --unset-upstream
->   ```
-> - Make all edits, commits, and git operations INSIDE that worktree directory
-> - Your commit will land on the correct branch automatically
-> - Do NOT switch branches or checkout anywhere else"
-
-**Main session then pushes each successful branch and creates PR.**
-
-## 1d. Self-Healing Failure Categorization
-
-After each batch, categorize failures and apply automatic healing:
-
-| Failure type | Detection | Auto-heal |
-|---|---|---|
-| API 529 overload | Agent reports rate limit | Wait 60s, retry (max 3×) |
-| Merge conflict at push | `git push` rejected | Rebase onto latest Dev_new_gui, retry |
-| Already resolved | `git log origin/Dev_new_gui --grep="#N"` hits | Mark SKIPPED, close worktree |
-| Agent crash / timeout | No RESULT reported after N min | Retry (max 3×) |
-| Tests failing but code committed | TESTS: FAIL | Mark SUCCESS_TESTS_FAILING — manual review needed |
-| Permission denied (Bash/git) | Subagent can't run commands | STOP that agent — main session handles the git op |
-| Unresolvable after 3× retries | Status RETRY_QUEUED with attempts=3 | ESCALATE — preserve worktree, print manual steps |
-
-**Escalation format** (printed to user):
-```
-🚨 ESCALATED: #4706
-  Reason: merge conflict in migrations/ that auto-rebase can't resolve
-  Worktree preserved at: /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-4706
-  Last attempt SHA: abc123
-  Manual steps:
-    cd .worktrees/issue-4706
-    git rebase origin/Dev_new_gui
-    # resolve conflicts manually
-    git rebase --continue
-    git push -u origin issue-4706
-    gh pr create --base Dev_new_gui
-```
-
-Repeat batches until all issues are SUCCESS, SKIPPED, or ESCALATED.
+Fix inline and re-push if validation fails. Never merge a failing PR.
 
 ---
 
-# Phase 2: Review Each PR
-
-For each PR created in Phase 1, run validation before merging. Do NOT merge without review.
+## Step 6: Merge
 
 ```bash
-# Get all open PRs for this batch
-gh pr list --state open --json number,headRefName,title
-
-# For each PR:
-PR_BRANCH=$(gh pr view <pr> --json headRefName -q '.headRefName')
-WORKTREE=".worktrees/$PR_BRANCH"
-
-# 2a. Syntax + imports (Python)
-for file in $(git diff origin/Dev_new_gui...$PR_BRANCH --name-only | grep "\.py$"); do
-  python -m py_compile "$file" && python -c "import $(echo $file | sed 's|/|.|g;s|\.py||')" 2>&1
-done
-
-# 2b. Type check (frontend)
-if git diff origin/Dev_new_gui...$PR_BRANCH --name-only | grep -qE "\.(ts|vue)$"; then
-  cd autobot-frontend && npx vue-tsc --noEmit -p tsconfig.app.json 2>&1
-fi
-
-# 2c. Call-site impact — check nothing removed is still called
-for removed in $(git diff origin/Dev_new_gui...$PR_BRANCH --diff-filter=D --name-only); do
-  grep -r "$(basename $removed .py)" autobot-backend/ --include="*.py" | grep -v "_test.py" | grep -v "$removed"
-done
-
-# 2d. Wiring check — hard-block if any new module has 0 production callers
-cd $(git rev-parse --show-toplevel) && pipeline-scripts/check-new-module-callers.sh
-
-# 2e. Linting
-python -m black --check $(git diff origin/Dev_new_gui...$PR_BRANCH --name-only | grep "\.py$") 2>&1
-```
-
-**If validation fails:** Fix inline in the worktree, push update to the branch, re-validate. Do not merge a failing PR.
-
-**If wiring check exits 1 (unwired modules):** **HARD BLOCK** — do not merge and do not close the issue. Either wire the module in, or file a follow-up wire-in issue and re-run with `pipeline-scripts/check-new-module-callers.sh --allow-deferral .wiring-deferral.txt`. Document the deferral in the closure comment under `### Wire-in deferred to #NNNN`.
-
----
-
-# Phase 2.5: Anti-Polling Rule (PR Wait)
-
-**batch-implement is a self-contained session**: you review and merge your own PRs in the same run. Do **not** create PRs and then exit, leaving the batch issue `in_progress` for the next heartbeat to re-check.
-
-If the batch session must exit before all PRs are merged (e.g. budget limit, rate limit after 3× retries):
-- Update the batch issue to `in_review`, not `in_progress`.
-- Post ONE comment listing which PRs are open: "Batch paused — PRs #N, #M await merge."
-- Use `ScheduleWakeup` with `delaySeconds: 900` for a single deferred re-check.
-- Do **not** spin with repeated identical "PRs still open" comments on every heartbeat.
-
-This avoids the polling anti-pattern: an agent re-running every 2–5 min posting "PR open, awaiting merge" 11 times in 1h (GH#7623 / MVA-315).
-
----
-
-# Phase 3: Merge Each PR
-
-Merge immediately after review passes. Do not let PRs sit overnight.
-
-```bash
-# Merge to Dev_new_gui
 gh pr merge <pr> --squash --delete-branch
-
-# Confirm merge landed
-git fetch origin
-git log origin/Dev_new_gui --oneline --grep="#<issue>" | head -1
-# Must show a commit — if empty, merge failed silently
+git fetch origin && git log origin/Dev_new_gui --oneline --grep="#<n>" | head -1  # confirm
 ```
 
-Merge one PR at a time. After each merge, verify before moving to next.
+Merge one at a time. Verify before moving to next.
 
 ---
 
-# Phase 4: Close Issue with Proof
-
-After the PR is confirmed merged, close the issue with a proof comment. **Never close before merge is confirmed.**
+## Step 7: Close with Proof
 
 ```bash
-# Get the merge commit
-MERGE_COMMIT=$(git log origin/Dev_new_gui --oneline --grep="#<issue>" | head -1 | awk '{print $1}')
-
-# Close with proof
-gh issue close <issue>
-gh issue comment <issue> --body "$(cat <<'EOF'
-✅ Closed — implementation merged to Dev_new_gui.
-
-**Merge commit:** <MERGE_COMMIT>
-
-**Acceptance criteria met:**
-- ✅ <criterion 1> — <evidence>
-- ✅ <criterion 2> — <evidence>
-
-**Wiring verified:** <new code has caller at file:line> OR <N/A — no new public symbols>
-
-**Discovery issues filed:** <#XXXX, #YYYY> OR <none found>
-EOF
-)"
+gh issue close <n>
+gh issue comment <n> --body "Closed — merged to Dev_new_gui. Commit: <sha>. Criteria met: <evidence>. Discoveries: <#N or none>"
 ```
 
-Fill in acceptance criteria from the issue description. Evidence can be: test output, the diff itself, curl response. Be specific — "code exists" is not evidence.
+Check off the item on the umbrella issue.
 
 ---
 
-# Phase 5: File Discovery Issues
-
-During implementation and review, note any gaps found that are NOT part of the current issue. File them now before cleanup.
-
-For each gap noticed:
-```bash
-gh issue create \
-  --title "discovery(<area>): <what you found>" \
-  --body "<description of the gap, file:line, what's missing>" \
-  --label "tech-debt"
-```
-
-Common things to watch for:
-- New dead code introduced (function defined, never called)
-- Related bug in adjacent code noticed during review
-- Missing test coverage for modified paths
-- Hardcoded values that should use config
-- Duplicate logic that could be consolidated
-
-Include the list of discovery issues in the issue closure comment.
-
----
-
-# Phase 6: Cleanup
+## Step 8: Discovery Issues
 
 ```bash
-# Remove worktrees for merged issues
-for issue in <all SUCCESS issues>:
-  git worktree remove .worktrees/issue-<n> --force 2>/dev/null
-  # Branch already deleted by --delete-branch in gh pr merge
-
-# Preserve ESCALATED worktrees — user needs them for manual resolution
-
-# Final verification
-gh pr list --state open    # should be 0 open PRs for this batch
-git worktree list           # should show only main worktree
+gh issue create --title "discovery(<area>): <gap found>" --body "<file:line, what's missing>" --label "tech-debt"
 ```
+
+File before cleanup. Include in closure comment.
 
 ---
 
-# Phase 7: Session Summary
+## Step 9: Cleanup & Summary
 
-Print a complete summary after all issues are processed:
-
-```
-# Batch Complete
-
-| Issue | PR | Merged | Closed | Discoveries |
-|-------|----|--------|--------|-------------|
-| #4703 | #4720 | ✅ | ✅ | #4725 |
-| #4704 | #4721 | ✅ | ✅ | none |
-| #4705 | #4722 | ✅ | ✅ | #4726, #4727 |
-| #4702 | — | SKIPPED | — | — |
-| #4706 | — | ESCALATED | — | — |
-
-✅ Resolved: 3 issues, 3 PRs merged
-⏭️ Skipped: 1 (already in Dev_new_gui)
-🚨 Escalated: 1 (see manual steps below)
-📋 Discoveries filed: #4725, #4726, #4727
-
-Open PRs remaining: 0
-Stale worktrees remaining: 1 (issue-4706, preserved for manual resolution)
+```bash
+git worktree remove .worktrees/issue-<n> --force  # SUCCESS issues only; preserve ESCALATED
+gh pr list --state open   # should be 0 for this batch
+git worktree list          # should show only main
 ```
 
-For each ESCALATED issue, print the exact manual resolution commands (see Phase 1d escalation format).
+Print final table:
+```
+| Issue | PR    | Status    | Discoveries |
+| #4703 | #4720 | MERGED    | #4725       |
+| #4706 | —     | ESCALATED | —           |
+```
+
+Escalated: preserve worktree, print manual rebase steps for the user.
 
 ---
 
-# Invariants (Never Violate)
+## Invariants
 
-- Main session stays on Dev_new_gui throughout — never switches branches
-- Every issue gets its own worktree — no shared branches
-- Agents commit only — main session always pushes
-- Never merge without review — even "trivial" PRs
-- Never close without proof — commit hash + criteria + evidence
-- Never leave PRs open overnight — merge immediately after review passes
-- Never leave discoveries untracked — file issues before cleanup
-- Escalated worktrees are preserved — never auto-delete them
-- Phase 0c verification (type-check + tests) runs before every push
-- Phase 0d behavioral grep runs on every extraction PR
+- Main session stays on `Dev_new_gui` — never switches branches.
+- Agents commit only — main session pushes.
+- Never merge without review; never close without proof (commit hash + criteria).
+- Never leave PRs open overnight; never leave discoveries untracked.
+- Escalated worktrees are preserved — never auto-delete.
+- Anti-polling: if session must exit before all PRs merged, set issue to `in_review`, post one comment listing open PRs, schedule one wake-up — do not spin.


### PR DESCRIPTION
## Thinking Path
CLAUDE.md had grown to 453 lines — every agent session loads the full file, burning tokens on sections irrelevant to the current task. Split it into a 70-line quick-reference index + four focused sub-docs that agents read on demand.

## What Changed
- `CLAUDE.md` → slimmed to ~70 lines (index + quick-reference table)
- `docs/developer/CLAUDE_GIT.md` — worktrees, branch safety, push recovery
- `docs/developer/CLAUDE_BATCH.md` — batch execution, parallel agents, sub-agent permissions
- `docs/developer/CLAUDE_REVIEW.md` — review methodology, PR checklist, merge gates, CI diagnosis, PR template format
- `docs/developer/CLAUDE_CLOSURE.md` — issue closure gate, discovery issues
- `docs/developer/skills/batch-implement.md` — trimmed from 487 to 177 lines (same rules, lean format)

Five new rules added from session insights: PR template headings, PR queue limit, CI diagnosis, posting comments correctly, branch protection reminder.

## Verification
- All existing rules preserved in sub-docs
- Sub-docs linked from main CLAUDE.md index
- Agents read only the sub-doc relevant to their current task

## Model Used
claude-sonnet-4-6