### PR TITLE
fix(ci): add missing tmpfs mounts for hardened-smoke-test (#9665)

### DIFF
--- a/docker-compose.hardened.yml
+++ b/docker-compose.hardened.yml
@@ -105,8 +105,10 @@ services:
     tmpfs:
       - /tmp
       - /app/config:mode=1777  # config_manager creates config dir on init
-      - /app/.config:mode=1777  # matplotlib creates this dir on init
+      - /app/.cache:mode=1777  # matplotlib writes to .cache
+      - /app/.config:mode=1777  # some libs create .config dir on init
       - /app/autobot-backend/.cache:mode=1777
+      - /app/autobot-backend/data:mode=1777  # conversation_file_manager creates data dir on init
       - /app/autobot-backend/logs:mode=1777  # logging_manager creates logs/backup dirs on init
     deploy:
       resources:
@@ -120,8 +122,10 @@ services:
     tmpfs:
       - /tmp
       - /app/config:mode=1777  # config_manager creates config dir on init
-      - /app/.config:mode=1777  # matplotlib creates this dir on init
+      - /app/.cache:mode=1777  # matplotlib writes to .cache
+      - /app/.config:mode=1777  # some libs create .config dir on init
       - /app/autobot-backend/.cache:mode=1777
+      - /app/autobot-backend/data:mode=1777  # conversation_file_manager creates data dir on init
       - /app/autobot-backend/logs:mode=1777  # logging_manager creates logs/backup dirs on init
     deploy:
       resources:


### PR DESCRIPTION
## Thinking Path

Investigated PM GitHub sweep report of PR #9452 hardened-smoke-test failure. Downloaded CI logs, found backend container unhealthy due to read-only filesystem errors on two paths not covered by existing tmpfs mounts.

## What Changed

Added missing tmpfs mounts to `docker-compose.hardened.yml`:
- `/app/.cache:mode=1777` — matplotlib cache writes
- `/app/autobot-backend/data:mode=1777` — conversation_file_manager database directory

Applied to both `autobot-backend` and `autobot-worker` services.

## Verification

**Root cause confirmed**: CI logs showed EROFS errors:
```
mkdir -p failed for path /app/.cache/matplotlib: Read-only file system
Conversation files database initialization failed: Read-only file system: '/app/autobot-backend/data/conversation_files'
Backend startup ABORTED - database must be operational
```

**Fix validated**: Paths now writable via tmpfs under `read_only: true` mode.

CI will verify hardened-smoke-test passes with this change.

## Model Used

Claude Sonnet 4.5