### PR TITLE
fix(ansible): add AUTOBOT_BACKEND_HOST with default to backend.env.j2 template

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -5,7 +5,7 @@
 
 # Server (Issue #858: Use SSOT config variable names)
 HOST={{ backend_host }}
-AUTOBOT_BACKEND_HOST={{ backend_host }}
+AUTOBOT_BACKEND_HOST={{ backend_host | default('0.0.0.0') }}
 AUTOBOT_BACKEND_PORT={{ backend_port }}
 
 # Application Paths (Issue #858: Database and schema paths)


### PR DESCRIPTION
## Thinking Path
Backend service crashes in a loop when Ansible deploys without the `backend_host` inventory variable set. The `backend.env.j2` template references `{{ backend_host }}` without a fallback, causing the service to fail to start. This fix adds a sensible default (`0.0.0.0`) so the service binds to all interfaces when the variable is unset, preventing the crash-loop and allowing deployments to succeed even with incomplete inventory.

## What Changed
- `ansible/templates/backend.env.j2`: Added `| default('0.0.0.0')` filter to `AUTOBOT_BACKEND_HOST` variable assignment

## Verification
1. Deploy with Ansible inventory missing `backend_host` variable:
   ```bash
   ansible-playbook -i inventory/staging site.yml
   ```
2. Verify backend service starts successfully and binds to `0.0.0.0:8000`
3. Check service logs show no crash-loop errors

## Risks
None identified. The default `0.0.0.0` is the standard binding address for services in containerized environments and maintains backward compatibility with existing inventory files that do set `backend_host`.

## Model Used
Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)

## Issue Link
Closes #9276

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A - deployment config change)
- [x] Documentation updated if behavior changed (N/A - internal deployment fix)
- [x] Pre-commit hooks pass
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff