### PR TITLE
fix(api): allow canvas title to be set to null (#9526)

### DIFF
--- a/autobot-backend/api/canvas.py
+++ b/autobot-backend/api/canvas.py
@@ -238,7 +238,7 @@ async def put_canvas(
             new_token = uuid.uuid4()
             now = datetime.now(tz=timezone.utc)
 
-            if body.title is not None:
+            if 'title' in body.model_fields_set:
                 canvas.title = body.title
             canvas.save_token = new_token
             canvas.updated_at = now

--- a/autobot-backend/api/canvas.py
+++ b/autobot-backend/api/canvas.py
@@ -238,7 +238,7 @@ async def put_canvas(
             new_token = uuid.uuid4()
             now = datetime.now(tz=timezone.utc)
 
-            if 'title' in body.model_fields_set:
+            if "title" in body.model_fields_set:
                 canvas.title = body.title
             canvas.save_token = new_token
             canvas.updated_at = now

--- a/autobot-backend/tests/api/test_canvas.py
+++ b/autobot-backend/tests/api/test_canvas.py
@@ -214,6 +214,52 @@ class TestPutCanvas:
             resp = client.put(f"/api/canvas/{_CANVAS_ID}", json={"cells": []})
         assert resp.status_code == 403
 
+    def test_autosave_can_set_title_to_null(self, app):
+        """Test that title can be explicitly set to null (GH#9526)."""
+        canvas = _make_canvas()
+        canvas.title = "Existing Title"
+        session = _mock_session()
+        session.execute.return_value.scalar_one_or_none = MagicMock(return_value=canvas)
+
+        from auth_middleware import get_current_user
+        from user_management.database import get_async_session
+
+        app.dependency_overrides = {
+            get_async_session: lambda: session,
+            get_current_user: lambda: _USER_A,
+        }
+
+        with TestClient(app) as client:
+            resp = client.put(
+                f"/api/canvas/{_CANVAS_ID}",
+                json={"title": None, "cells": []},
+            )
+        assert resp.status_code == 200
+        assert canvas.title is None
+
+    def test_autosave_omitted_title_unchanged(self, app):
+        """Test that omitting title from request leaves it unchanged."""
+        canvas = _make_canvas()
+        canvas.title = "Existing Title"
+        session = _mock_session()
+        session.execute.return_value.scalar_one_or_none = MagicMock(return_value=canvas)
+
+        from auth_middleware import get_current_user
+        from user_management.database import get_async_session
+
+        app.dependency_overrides = {
+            get_async_session: lambda: session,
+            get_current_user: lambda: _USER_A,
+        }
+
+        with TestClient(app) as client:
+            resp = client.put(
+                f"/api/canvas/{_CANVAS_ID}",
+                json={"cells": []},
+            )
+        assert resp.status_code == 200
+        assert canvas.title == "Existing Title"
+
 
 # ---------------------------------------------------------------------------
 # POST /api/canvas/{id}/cells


### PR DESCRIPTION
## Thinking Path
The canvas API was rejecting PATCH requests that set `title` to `null`, even though `null` is a valid value meaning 'clear the title'. The validation was treating null as an invalid value rather than an intentional clear operation.

## What Changed
- Updated canvas PATCH handler to allow `title` to be set to `null` (GH#9526)
- Allows clients to explicitly clear the canvas title field

## Verification
- PATCH /api/canvas/{id} with `{"title": null}` succeeds and clears the title
- Non-null title updates continue to work

## Model Used
claude-sonnet-4-6