### PR TITLE
fix(lint): resolve oxlint errors blocking frontend-tests CI (#9541)

### DIFF
--- a/autobot-frontend/src/components/terminal/__tests__/BaseXTerminal.spec.ts
+++ b/autobot-frontend/src/components/terminal/__tests__/BaseXTerminal.spec.ts
@@ -23,7 +23,8 @@ function createTerminalMock(this: Record<string, any>) {
   this.cols = 80
   this.rows = 24
   this.options = {}
-   
+
+  // eslint-disable-next-line @typescript-eslint/no-this-alias -- Mock: capturing instance for test assertions
   lastTerminalInstance = this
 }
 

--- a/autobot-frontend/src/composables/__tests__/useTimeout.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useTimeout.test.ts
@@ -326,7 +326,7 @@ describe('useTimeout Composable', () => {
     it('should preserve function context', async () => {
       let capturedThis: any = null
       const callback = function (this: any) {
-         
+        // eslint-disable-next-line @typescript-eslint/no-this-alias -- Test: capturing 'this' to verify context preservation
         capturedThis = this
       }
 

--- a/autobot-frontend/src/composables/useTimeout.ts
+++ b/autobot-frontend/src/composables/useTimeout.ts
@@ -234,7 +234,8 @@ export function useDebounce<T extends (...args: any[]) => any>(
     } else if (!leading) {
       // Only save args for trailing edge execution (not in leading mode)
       lastArgs = args
-       
+
+      // eslint-disable-next-line @typescript-eslint/no-this-alias -- Intentional: preserving 'this' context for debounced callback
       lastThis = this
     }
 

--- a/autobot-frontend/tests/monitoring-integration-test.js
+++ b/autobot-frontend/tests/monitoring-integration-test.js
@@ -74,7 +74,7 @@ async function runMonitoringTests() {
     testResults.healthMonitor = testResults.healthMonitor &&
       updatedBudget.recentOperations.length > 0;
 
-  } catch (error) {
+  } catch {
     testResults.healthMonitor = false;
   }
 
@@ -89,7 +89,7 @@ async function runMonitoringTests() {
     const optimalInterval = smartMonitoringController.getOptimalInterval(120000); // 2 minutes base
     testResults.smartController = testResults.smartController && optimalInterval > 0;
 
-  } catch (error) {
+  } catch {
     testResults.smartController = false;
   }
 


### PR DESCRIPTION
## Thinking Path

PR #9518 (dependabot hono bump) was merged, but frontend-tests continue failing on Dev_new_gui due to pre-existing oxlint errors unrelated to the dependency update.

## What Changed

Fixed 5 oxlint correctness violations:
- Removed unused `error` parameters in 2 catch blocks (`monitoring-integration-test.js`)
- Added suppression comments for 3 intentional `this` alias patterns:
  - `useTimeout.ts` line 238: preserving context for debounced callback
  - `useTimeout.test.ts` line 330: test verifying context preservation
  - `BaseXTerminal.spec.ts` line 27: capturing mock instance for assertions

All `this`-aliasing instances are legitimate patterns for preserving function context in debounce implementation and test mocks.

## Verification

```bash
cd autobot-frontend && npx oxlint . -D correctness --ignore-path .gitignore
# Exit 0, no errors
```

Closes #9541

## Model Used

Claude Sonnet 4.5