### PR TITLE
fix(deps): revert vega 6.x→5.x for vega-embed compatibility (#9577)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -100,6 +100,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "vega-lite"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "vega-functions"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/autobot-slm-frontend"

--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -32,7 +32,7 @@
         "pinia-plugin-persistedstate": "^4.7.1",
         "three": "^0.184.0",
         "three-spritetext": "^1.10.0",
-        "vega": "^6.2.0",
+        "vega": "^5.30.0",
         "vega-embed": "^6.29.0",
         "vega-lite": "5.23.0",
         "vue": "^3.5.34",
@@ -3342,9 +3342,9 @@
       "license": "MIT"
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.16",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "version": "7946.0.4",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.4.tgz",
+      "integrity": "sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q==",
       "license": "MIT"
     },
     "node_modules/@types/jsdom": {
@@ -9215,6 +9215,48 @@
       "version": "1.2.0",
       "license": "BSD-3-Clause"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "dev": true,
@@ -12117,82 +12159,67 @@
       "license": "MIT"
     },
     "node_modules/vega": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-6.2.0.tgz",
-      "integrity": "sha512-BIwalIcEGysJdQDjeVUmMWB3e50jPDNAMfLJscjEvpunU9bSt7X1OYnQxkg3uBwuRRI4nWfFZO9uIW910nLeGw==",
+      "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.33.1.tgz",
+      "integrity": "sha512-1fArfVDUqVbb5z8n+/nVQb+VNBzx8svY6CrsyTK4Ujm4yrd9I1auoKxBAPXLCavY1LcrbHUskQbGUP8gXOzyQw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-crossfilter": "~5.1.0",
-        "vega-dataflow": "~6.1.0",
-        "vega-encode": "~5.1.0",
-        "vega-event-selector": "~4.0.0",
-        "vega-expression": "~6.1.0",
-        "vega-force": "~5.1.0",
-        "vega-format": "~2.1.0",
-        "vega-functions": "~6.1.0",
-        "vega-geo": "~5.1.0",
-        "vega-hierarchy": "~5.1.0",
-        "vega-label": "~2.1.0",
-        "vega-loader": "~5.1.0",
-        "vega-parser": "~7.1.0",
-        "vega-projection": "~2.1.0",
-        "vega-regression": "~2.1.0",
-        "vega-runtime": "~7.1.0",
-        "vega-scale": "~8.1.0",
-        "vega-scenegraph": "~5.1.0",
-        "vega-statistics": "~2.0.0",
-        "vega-time": "~3.1.0",
-        "vega-transforms": "~5.1.0",
-        "vega-typings": "~2.1.0",
-        "vega-util": "~2.1.0",
-        "vega-view": "~6.1.0",
-        "vega-view-transforms": "~5.1.0",
-        "vega-voronoi": "~5.1.0",
-        "vega-wordcloud": "~5.1.0"
-      },
-      "funding": {
-        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+        "vega-crossfilter": "~4.1.4",
+        "vega-dataflow": "~5.7.8",
+        "vega-encode": "~4.10.3",
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.2.1",
+        "vega-force": "~4.2.3",
+        "vega-format": "~1.1.4",
+        "vega-functions": "~5.18.1",
+        "vega-geo": "~4.4.4",
+        "vega-hierarchy": "~4.1.4",
+        "vega-label": "~1.3.2",
+        "vega-loader": "~4.5.4",
+        "vega-parser": "~6.6.1",
+        "vega-projection": "~1.6.3",
+        "vega-regression": "~1.3.2",
+        "vega-runtime": "~6.2.2",
+        "vega-scale": "~7.4.3",
+        "vega-scenegraph": "~4.13.2",
+        "vega-statistics": "~1.9.0",
+        "vega-time": "~2.1.4",
+        "vega-transforms": "~4.12.2",
+        "vega-typings": "~1.5.1",
+        "vega-util": "~1.17.4",
+        "vega-view": "~5.16.1",
+        "vega-view-transforms": "~4.6.2",
+        "vega-voronoi": "~4.2.5",
+        "vega-wordcloud": "~4.1.7"
       }
     },
     "node_modules/vega-canvas": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-2.0.0.tgz",
-      "integrity": "sha512-9x+4TTw/USYST5nx4yN272sy9WcqSRjAR0tkQYZJ4cQIeon7uVsnohvoPQK1JZu7K1QXGUqzj08z0u/UegBVMA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
+      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-crossfilter": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-5.1.0.tgz",
-      "integrity": "sha512-EmVhfP3p6AM7o/lPan/QAoqjblI19BxWUlvl2TSs0xjQd8KbaYYbS4Ixt3cmEvl0QjRdBMF6CdJJ/cy9DTS4Fw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.4.tgz",
+      "integrity": "sha512-5E/i60Y80CUt+4O+U89X8ZnauaFuq0ztq/Hx4i4sT/crk4Lfn1oplRAjNOo7dFEZ04TahyBbYiJKIhR0yvmHpw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
-        "vega-dataflow": "^6.1.0",
-        "vega-util": "^2.1.0"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.8",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-crossfilter/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-dataflow": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-6.1.0.tgz",
-      "integrity": "sha512-JxumGlODtFbzoQ4c/jQK8Tb/68ih0lrexlCozcMfTAwQ12XhTqCvlafh7MAKKTMBizjOfaQTHm4Jkyb1H5CfyQ==",
+      "version": "5.7.8",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.8.tgz",
+      "integrity": "sha512-jrllcIjSYU5Jh130RDR44o/SbUbJndLuoiM9IsKWW+a7HayKnfmbdHWm7MvCrj/YLupFZVojRaS1tTs53EXTdA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-format": "^2.1.0",
-        "vega-loader": "^5.1.0",
-        "vega-util": "^2.1.0"
+        "vega-format": "^1.1.4",
+        "vega-loader": "^4.5.4",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-dataflow/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-embed": {
       "version": "6.29.0",
@@ -12223,23 +12250,17 @@
       }
     },
     "node_modules/vega-encode": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-5.1.0.tgz",
-      "integrity": "sha512-q26oI7B+MBQYcTQcr5/c1AMsX3FvjZLQOBi7yI0vV+GEn93fElDgvhQiYrgeYSD4Exi/jBPeUXuN6p4bLz16kA==",
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.10.3.tgz",
+      "integrity": "sha512-245ebBuN1TjwVVDFG7JZaZ/ExLAhZ4kDTK2zlIoXs/g2P5rRgL4Q6oRixr+Pgr43G7ISCEHrUBgUjRcSoG8eEA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
-        "vega-dataflow": "^6.1.0",
-        "vega-scale": "^8.1.0",
-        "vega-util": "^2.1.0"
+        "vega-dataflow": "^5.7.8",
+        "vega-scale": "^7.4.3",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-encode/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-event-selector": {
       "version": "3.0.1",
@@ -12254,114 +12275,84 @@
       }
     },
     "node_modules/vega-force": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-5.1.0.tgz",
-      "integrity": "sha512-wdnchOSeXpF9Xx8Yp0s6Do9F7YkFeOn/E/nENtsI7NOcyHpICJ5+UkgjUo9QaQ/Yu+dIDU+sP/4NXsUtq6SMaQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.3.tgz",
+      "integrity": "sha512-7Yp1uOPy3eyzK/hnAIU0v/yQ9mIhtoJ+tq8AMaZiWqy67SUYsE3olmgdllY6R9M81D/n/rv8K+8JjbHMU5/sUA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-force": "^3.0.0",
-        "vega-dataflow": "^6.1.0",
-        "vega-util": "^2.1.0"
+        "vega-dataflow": "^5.7.8",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-force/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-format": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-2.1.0.tgz",
-      "integrity": "sha512-i9Ht33IgqG36+S1gFDpAiKvXCPz+q+1vDhDGKK8YsgMxGOG4PzinKakI66xd7SdV4q97FgpR7odAXqtDN2wKqw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.4.tgz",
+      "integrity": "sha512-+oz6UvXjQSbweW9P8q+1o2qFYyBYPFax94j6a9PQMnCIWMovFSss1wEElljOT8CEpnHyS15yiGlmz4qbWTQwnQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
+        "d3-array": "^3.2.2",
         "d3-format": "^3.1.0",
         "d3-time-format": "^4.1.0",
-        "vega-time": "^3.1.0",
-        "vega-util": "^2.1.0"
+        "vega-time": "^2.1.4",
+        "vega-util": "^1.17.4"
       }
     },
-    "node_modules/vega-format/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/vega-functions": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-6.1.1.tgz",
-      "integrity": "sha512-Due6jP0y0FfsGMTrHnzUGnEwXPu7VwE+9relfo+LjL/tRPYnnKqwWvzt7n9JkeBuZqjkgYjMzm/WucNn6Hkw5A==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.18.1.tgz",
+      "integrity": "sha512-qEBAbo0jxGGebRvbX1zmxzmjwFz8/UtncRhzwk9/KcI0WudULNmCM1iTu+DGFRnNHdcKi6kUlwJBPIp7zDu3HQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
+        "d3-array": "^3.2.2",
         "d3-color": "^3.1.0",
-        "d3-geo": "^3.1.1",
-        "vega-dataflow": "^6.1.0",
-        "vega-expression": "^6.1.0",
-        "vega-scale": "^8.1.0",
-        "vega-scenegraph": "^5.1.0",
-        "vega-selections": "^6.1.0",
-        "vega-statistics": "^2.0.0",
-        "vega-time": "^3.1.0",
-        "vega-util": "^2.1.0"
+        "d3-geo": "^3.1.0",
+        "vega-dataflow": "^5.7.8",
+        "vega-expression": "^5.2.1",
+        "vega-scale": "^7.4.3",
+        "vega-scenegraph": "^4.13.2",
+        "vega-selections": "^5.6.1",
+        "vega-statistics": "^1.9.0",
+        "vega-time": "^2.1.4",
+        "vega-util": "^1.17.4"
       }
     },
     "node_modules/vega-functions/node_modules/vega-expression": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-6.1.0.tgz",
-      "integrity": "sha512-hHgNx/fQ1Vn1u6vHSamH7lRMsOa/yQeHGGcWVmh8fZafLdwdhCM91kZD9p7+AleNpgwiwzfGogtpATFaMmDFYg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
+      "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/estree": "^1.0.8",
-        "vega-util": "^2.1.0"
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-functions/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-geo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-5.1.0.tgz",
-      "integrity": "sha512-H8aBBHfthc3rzDbz/Th18+Nvp00J73q3uXGAPDQqizioDm/CoXCK8cX4pMePydBY9S6ikBiGJrLKFDa80wI20g==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.4.tgz",
+      "integrity": "sha512-jTLYrDvhXJinWQCfuVLP1nSlOdFlA9blVS6K7uOcBTJ4382Aw3ALGZKluUQyJkFdrkGfqxoDJo5MLHLu2zlc6g==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
+        "d3-array": "^3.2.2",
         "d3-color": "^3.1.0",
-        "d3-geo": "^3.1.1",
-        "vega-canvas": "^2.0.0",
-        "vega-dataflow": "^6.1.0",
-        "vega-projection": "^2.1.0",
-        "vega-statistics": "^2.0.0",
-        "vega-util": "^2.1.0"
+        "d3-geo": "^3.1.0",
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.8",
+        "vega-projection": "^1.6.3",
+        "vega-statistics": "^1.9.0",
+        "vega-util": "^1.17.4"
       }
     },
-    "node_modules/vega-geo/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/vega-hierarchy": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-5.1.0.tgz",
-      "integrity": "sha512-rZlU8QJNETlB6o73lGCPybZtw2fBBsRIRuFE77aCLFHdGsh6wIifhplVarqE9icBqjUHRRUOmcEYfzwVIPr65g==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.4.tgz",
+      "integrity": "sha512-/iSh1YqdgsHFB20QxJ6IAVzRZQBKuMpZ/GsN5sZDP3bBJdVWl3we48L/r6w7FP9NU+JzFHcDUPJ0S0UzpMhaqg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-hierarchy": "^3.1.2",
-        "vega-dataflow": "^6.1.0",
-        "vega-util": "^2.1.0"
+        "vega-dataflow": "^5.7.8",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-hierarchy/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-interpreter": {
       "version": "1.2.1",
@@ -12371,22 +12362,16 @@
       }
     },
     "node_modules/vega-label": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-2.1.0.tgz",
-      "integrity": "sha512-/hgf+zoA3FViDBehrQT42Lta3t8In6YwtMnwjYlh72zNn1p3c7E3YUBwqmAqTM1x+tudgzMRGLYig+bX1ewZxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.3.2.tgz",
+      "integrity": "sha512-YlUCUZNsp1FHkpPjOpD+aVVmVLFw6xa+bFQGBCECuY1DuRyN6l8oCRmUOjBrr70ip8fbqfGk+czHw543J1PJgg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-canvas": "^2.0.0",
-        "vega-dataflow": "^6.1.0",
-        "vega-scenegraph": "^5.1.0",
-        "vega-util": "^2.1.0"
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.8",
+        "vega-scenegraph": "^4.13.2",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-label/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-lite": {
       "version": "5.23.0",
@@ -12413,171 +12398,124 @@
       }
     },
     "node_modules/vega-loader": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-5.1.0.tgz",
-      "integrity": "sha512-GaY3BdSPbPNdtrBz8SYUBNmNd8mdPc3mtdZfdkFazQ0RD9m+Toz5oR8fKnTamNSk9fRTJX0Lp3uEqxrAlQVreg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.4.tgz",
+      "integrity": "sha512-AOJPsDVz009aTdD9hzigUaO/NFmuN1o83rzvZu/g37TJfhU+3DOvgnO0rnqJbnSOfcBkLWER6XghlKS3j77w4A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-dsv": "^3.0.1",
+        "node-fetch": "^2.6.7",
         "topojson-client": "^3.1.0",
-        "vega-format": "^2.1.0",
-        "vega-util": "^2.1.0"
+        "vega-format": "^1.1.4",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-loader/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-7.1.0.tgz",
-      "integrity": "sha512-g0lrYxtmYVW8G6yXpIS4J3Uxt9OUSkc0bLu5afoYDo4rZmoOOdll3x3ebActp5LHPW+usZIE+p5nukRS2vEc7Q==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.6.1.tgz",
+      "integrity": "sha512-FIez+huStzgjsxLqOkxDAooTkDC2XruYCIFWhd3HuM/QrqKtj9JKGuIUJjpVVkE7by7S5ejrucpRzVVgQfbzSg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-dataflow": "^6.1.0",
-        "vega-event-selector": "^4.0.0",
-        "vega-functions": "^6.1.0",
-        "vega-scale": "^8.1.0",
-        "vega-util": "^2.1.0"
+        "vega-dataflow": "^5.7.8",
+        "vega-event-selector": "^3.0.1",
+        "vega-functions": "^5.18.1",
+        "vega-scale": "^7.4.3",
+        "vega-util": "^1.17.4"
       }
     },
-    "node_modules/vega-parser/node_modules/vega-event-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-4.0.0.tgz",
-      "integrity": "sha512-CcWF4m4KL/al1Oa5qSzZ5R776q8lRxCj3IafCHs5xipoEHrkgu1BWa7F/IH5HrDNXeIDnqOpSV1pFsAWRak4gQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/vega-parser/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/vega-projection": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-2.1.0.tgz",
-      "integrity": "sha512-EjRjVSoMR5ibrU7q8LaOQKP327NcOAM1+eZ+NO4ANvvAutwmbNVTmfA1VpPH+AD0AlBYc39ND/wnRk7SieDiXA==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.3.tgz",
+      "integrity": "sha512-vusyaPi3EFIHrBVs0chNv2bCqxw4X+XgI1m3+yOgUD/dutsIGTcqy+PjlNlspPQvMI9JjTeIUTGt8u1V7oDwAA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-geo": "^3.1.1",
+        "d3-geo": "^3.1.0",
         "d3-geo-projection": "^4.0.0",
-        "vega-scale": "^8.1.0"
+        "vega-scale": "^7.4.3"
       }
     },
     "node_modules/vega-regression": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-2.1.0.tgz",
-      "integrity": "sha512-HzC7MuoEwG1rIxRaNTqgcaYF03z/ZxYkQR2D5BN0N45kLnHY1HJXiEcZkcffTsqXdspLjn47yLi44UoCwF5fxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.3.2.tgz",
+      "integrity": "sha512-DtGToopuJGmxeoymaOXTDKlWkkYiDVvZFV1IWQNuRlChTBI6YBpil4WmA3U+ECePDQuk2+/mWlw+vafrbgF8Tg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
-        "vega-dataflow": "^6.1.0",
-        "vega-statistics": "^2.0.0",
-        "vega-util": "^2.1.0"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.8",
+        "vega-statistics": "^1.9.0",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-regression/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-runtime": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-7.1.0.tgz",
-      "integrity": "sha512-mItI+WHimyEcZlZrQ/zYR3LwHVeyHCWwp7MKaBjkU8EwkSxEEGVceyGUY9X2YuJLiOgkLz/6juYDbMv60pfwYA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.2.2.tgz",
+      "integrity": "sha512-5c+i7y5XBw5phIA1mBeqF/gtOQcDjUzroUAQ0g3y3weNx0K4mzj7V360yZiBLNcuHv65xgTlijstbKQttxeY/g==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-dataflow": "^6.1.0",
-        "vega-util": "^2.1.0"
+        "vega-dataflow": "^5.7.8",
+        "vega-util": "^1.17.4"
       }
     },
-    "node_modules/vega-runtime/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/vega-scale": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-8.1.0.tgz",
-      "integrity": "sha512-VEgDuEcOec8+C8+FzLcnAmcXrv2gAJKqQifCdQhkgnsLa978vYUgVfCut/mBSMMHbH8wlUV1D0fKZTjRukA1+A==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.4.3.tgz",
+      "integrity": "sha512-f7SSN2YJowtrdkt7nJIR6YYhjDk8oB37q5So2/OxXQv5CBHipFPQSHS1ZVw9vD3V5wLnrZCxC4Ji27gmsTefgA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
         "d3-scale-chromatic": "^3.1.0",
-        "vega-time": "^3.1.0",
-        "vega-util": "^2.1.0"
+        "vega-time": "^2.1.4",
+        "vega-util": "^1.17.4"
       }
     },
-    "node_modules/vega-scale/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/vega-scenegraph": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-5.1.0.tgz",
-      "integrity": "sha512-4gA89CFIxkZX+4Nvl8SZF2MBOqnlj9J5zgdPh/HPx+JOwtzSlUqIhxFpFj7GWYfwzr/PyZnguBLPihPw1Og/cA==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.13.2.tgz",
+      "integrity": "sha512-eCutgcLzdUg23HLc6MTZ9pHCdH0hkqSmlbcoznspwT0ajjATk6M09JNyJddiaKR55HuQo03mBWsPeRCd5kOi0g==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-path": "^3.1.0",
         "d3-shape": "^3.2.0",
-        "vega-canvas": "^2.0.0",
-        "vega-loader": "^5.1.0",
-        "vega-scale": "^8.1.0",
-        "vega-util": "^2.1.0"
+        "vega-canvas": "^1.2.7",
+        "vega-loader": "^4.5.4",
+        "vega-scale": "^7.4.3",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-scenegraph/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-schema-url-parser": {
       "version": "2.2.0",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-selections": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-6.1.2.tgz",
-      "integrity": "sha512-xJ+V4qdd46nk2RBdwIRrQm2iSTMHdlu/omhLz1pqRL3jZDrkqNBXimrisci2kIKpH2WBpA1YVagwuZEKBmF2Qw==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.6.3.tgz",
+      "integrity": "sha512-DXd+XVKcIjBAtSCcgtPx7cXuqG/7L98SWoFh6GKNu26EBUyn3zm0GAlZxNLPoI01Jz9Fb3YpSsewk2aIAbM68g==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-array": "3.2.4",
-        "vega-expression": "^6.1.0",
-        "vega-util": "^2.1.0"
+        "vega-expression": "^5.2.1",
+        "vega-util": "^1.17.4"
       }
     },
     "node_modules/vega-selections/node_modules/vega-expression": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-6.1.0.tgz",
-      "integrity": "sha512-hHgNx/fQ1Vn1u6vHSamH7lRMsOa/yQeHGGcWVmh8fZafLdwdhCM91kZD9p7+AleNpgwiwzfGogtpATFaMmDFYg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
+      "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/estree": "^1.0.8",
-        "vega-util": "^2.1.0"
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.4"
       }
     },
-    "node_modules/vega-selections/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/vega-statistics": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-2.0.0.tgz",
-      "integrity": "sha512-dGPfDXnBlgXbZF3oxtkb8JfeRXd5TYHx25Z/tIoaa9jWua4Vf/AoW2wwh8J1qmMy8J03/29aowkp1yk4DOPazQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.9.0.tgz",
+      "integrity": "sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4"
+        "d3-array": "^3.2.2"
       }
     },
     "node_modules/vega-themes": {
@@ -12591,21 +12529,15 @@
       }
     },
     "node_modules/vega-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-3.1.0.tgz",
-      "integrity": "sha512-G93mWzPwNa6UYQRkr8Ujur9uqxbBDjDT/WpXjbDY0yygdSkRT+zXF+Sb4gjhW0nPaqdiwkn0R6kZcSPMj1bMNA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.4.tgz",
+      "integrity": "sha512-DBMRps5myYnSAlvQ+oiX8CycJZjGQNqyGE04xaZrpOgHll7vlvezpET2FnGZC7wS3DsqMcPjnpnI1h7+qJox1Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
+        "d3-array": "^3.2.2",
         "d3-time": "^3.1.0",
-        "vega-util": "^2.1.0"
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-time/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-tooltip": {
       "version": "0.35.2",
@@ -12618,158 +12550,104 @@
       }
     },
     "node_modules/vega-transforms": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-5.1.0.tgz",
-      "integrity": "sha512-mj/sO2tSuzzpiXX8JSl4DDlhEmVwM/46MTAzTNQUQzJPMI/n4ChCjr/SdEbfEyzlD4DPm1bjohZGjLc010yuMg==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.12.2.tgz",
+      "integrity": "sha512-VuNLzB0DavFn5GIkFvR2XvwPavjY7VXl2oPUOFvNgSfyQywmCoC7VOX+iHeOdxoZdoy+XEOGAqRs9imxVo2HVA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
-        "vega-dataflow": "^6.1.0",
-        "vega-statistics": "^2.0.0",
-        "vega-time": "^3.1.0",
-        "vega-util": "^2.1.0"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.8",
+        "vega-statistics": "^1.9.0",
+        "vega-time": "^2.1.4",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-transforms/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-typings": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-2.1.0.tgz",
-      "integrity": "sha512-zdis4Fg4gv37yEvTTSZEVMNhp8hwyEl7GZ4X4HHddRVRKxWFsbyKvZx/YW5Z9Ox4sjxVA2qHzEbod4Fdx+SEJA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-1.5.1.tgz",
+      "integrity": "sha512-40kRoG/jG8+4cd3kT5yw08iTlIGe57F7Go/ileSCtRtgU8RZ7tpPaE6GgYvF/HTPlCKMk9/pOdp62+o5sulhvQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/geojson": "7946.0.16",
-        "vega-event-selector": "^4.0.0",
-        "vega-expression": "^6.1.0",
-        "vega-util": "^2.1.0"
+        "@types/geojson": "7946.0.4",
+        "vega-event-selector": "^3.0.1",
+        "vega-expression": "^5.2.1",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-typings/node_modules/vega-event-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-4.0.0.tgz",
-      "integrity": "sha512-CcWF4m4KL/al1Oa5qSzZ5R776q8lRxCj3IafCHs5xipoEHrkgu1BWa7F/IH5HrDNXeIDnqOpSV1pFsAWRak4gQ==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-typings/node_modules/vega-expression": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-6.1.0.tgz",
-      "integrity": "sha512-hHgNx/fQ1Vn1u6vHSamH7lRMsOa/yQeHGGcWVmh8fZafLdwdhCM91kZD9p7+AleNpgwiwzfGogtpATFaMmDFYg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
+      "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/estree": "^1.0.8",
-        "vega-util": "^2.1.0"
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-typings/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-util": {
       "version": "1.17.4",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-view": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-6.1.0.tgz",
-      "integrity": "sha512-hmHDm/zC65lb23mb9Tr9Gx0wkxP0TMS31LpMPYxIZpvInxvUn7TYitkOtz1elr63k2YZrgmF7ztdGyQ4iCQ5fQ==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.16.1.tgz",
+      "integrity": "sha512-YyG4i2JDkRCacHd9xNAwyov2cELxwzPGY224PA2o0gEhkoOjPkVElTmo9QHJvKeVxMoyad6wvoq+Jj+TB6zhLw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.4",
+        "d3-array": "^3.2.2",
         "d3-timer": "^3.0.1",
-        "vega-dataflow": "^6.1.0",
-        "vega-format": "^2.1.0",
-        "vega-functions": "^6.1.0",
-        "vega-runtime": "^7.1.0",
-        "vega-scenegraph": "^5.1.0",
-        "vega-util": "^2.1.0"
+        "vega-dataflow": "^5.7.8",
+        "vega-format": "^1.1.4",
+        "vega-functions": "^5.18.1",
+        "vega-runtime": "^6.2.2",
+        "vega-scenegraph": "^4.13.2",
+        "vega-util": "^1.17.4"
       }
     },
     "node_modules/vega-view-transforms": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-5.1.0.tgz",
-      "integrity": "sha512-fpigh/xn/32t+An1ShoY3MLeGzNdlbAp2+HvFKzPpmpMTZqJEWkk/J/wHU7Swyc28Ta7W1z3fO+8dZkOYO5TWQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.6.2.tgz",
+      "integrity": "sha512-udnYutgX7T7E0crqKWSs4hcxTdUmZHR2F4rKj0+3nN9+CfYMWbGgUkCkP2pMu7j2OH0ETX2uDn5xL8+YJWeXSg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-dataflow": "^6.1.0",
-        "vega-scenegraph": "^5.1.0",
-        "vega-util": "^2.1.0"
+        "vega-dataflow": "^5.7.8",
+        "vega-scenegraph": "^4.13.2",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-view-transforms/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/vega-view/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-voronoi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-5.1.0.tgz",
-      "integrity": "sha512-uKdsoR9x60mz7eYtVG+NhlkdQXeVdMr6jHNAHxs+W+i6kawkUp5S9jp1xf1FmW/uZvtO1eqinHQNwATcDRsiUg==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.5.tgz",
+      "integrity": "sha512-u0TLSQboiLyoM6V9S0E6cc77EfWati+ApZ6zE+NhH3h/zZRzYZmElnDn46hUof2o9jNyh09xFXTXykVHmt7IGg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-delaunay": "^6.0.4",
-        "vega-dataflow": "^6.1.0",
-        "vega-util": "^2.1.0"
+        "d3-delaunay": "^6.0.2",
+        "vega-dataflow": "^5.7.8",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-voronoi/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega-wordcloud": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-5.1.0.tgz",
-      "integrity": "sha512-sSdNmT8y2D7xXhM2h76dKyaYn3PA4eV49WUUkfYfqHz/vpcu10GSAoFxLhQQTkbZXR+q5ZB63tFUow9W2IFo6g==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.7.tgz",
+      "integrity": "sha512-xdMykDXdWEp3/7Hil7Yx8uNVmjvqxwGibHJLSfiubNNO9OErrH3ZUgcxWv5hLe9wdK+KSGP94SSqTOAaqH7r/A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-canvas": "^2.0.0",
-        "vega-dataflow": "^6.1.0",
-        "vega-scale": "^8.1.0",
-        "vega-statistics": "^2.0.0",
-        "vega-util": "^2.1.0"
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.8",
+        "vega-scale": "^7.4.3",
+        "vega-statistics": "^1.9.0",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega-wordcloud/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/vega/node_modules/vega-event-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-4.0.0.tgz",
-      "integrity": "sha512-CcWF4m4KL/al1Oa5qSzZ5R776q8lRxCj3IafCHs5xipoEHrkgu1BWa7F/IH5HrDNXeIDnqOpSV1pFsAWRak4gQ==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/vega/node_modules/vega-expression": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-6.1.0.tgz",
-      "integrity": "sha512-hHgNx/fQ1Vn1u6vHSamH7lRMsOa/yQeHGGcWVmh8fZafLdwdhCM91kZD9p7+AleNpgwiwzfGogtpATFaMmDFYg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
+      "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/estree": "^1.0.8",
-        "vega-util": "^2.1.0"
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.4"
       }
-    },
-    "node_modules/vega/node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/verror": {
       "version": "1.10.0",

--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -69,7 +69,7 @@
     "pinia-plugin-persistedstate": "^4.7.1",
     "three": "^0.184.0",
     "three-spritetext": "^1.10.0",
-    "vega": "^6.2.0",
+    "vega": "^5.30.0",
     "vega-embed": "^6.29.0",
     "vega-lite": "5.23.0",
     "vue": "^3.5.34",


### PR DESCRIPTION
## Thinking Path

Investigated visual regression CI failures on main:
1. Traced failure to `npm ci` peer dependency conflict (vega 6.x vs vega-embed 6.x)
2. Found PR #9702 (Dependabot vega-functions bump) merged to main on 2026-06-05
3. Confirmed vega-functions 6.x requires vega 6.x ecosystem, breaking vega-embed 6.29.0
4. Dev_new_gui already has correct vega 5.x versions

## What Changed

**autobot-frontend/package.json:**
- Downgrade `vega` from `^6.2.0` → `^5.30.0`

**autobot-frontend/package-lock.json:**
- Regenerate with vega 5.33.1 and compatible vega-* dependencies

**.github/dependabot.yml:**
- Add `vega-functions` to ignore list for major version updates

## Root Cause

PR #9702 was a Dependabot PR that bumped vega-functions from 5.18.1 to 6.1.1. This PR:
- Targeted main instead of Dev_new_gui (Dependabot ignores `target-branch` config)
- Transitively upgraded vega to 6.x through vega-functions dependencies
- Broke visual regression workflow with peer dependency conflict:
  ```
  npm error While resolving: vega-embed@6.29.0
  npm error Found: vega@6.2.0
  npm error Could not resolve dependency:
  npm error peer vega@"^5.21.0" from vega-embed@6.29.0
  ```

## Verification

- ✅ `npm ls vega vega-embed vega-lite` shows correct 5.x versions
- ✅ Package-lock.json has vega 5.33.1 with vega-embed 6.29.0 compatible
- ✅ Dependabot will not bump vega-functions to 6.x in future

**CI Check:** Visual regression workflow will pass once merged.

## Model Used

Claude Sonnet 4.5

Closes #9577

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>