### PR TITLE
fix(ansible): Add missing autobot_shared symlink for SLM backend (#9565)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -254,6 +254,18 @@
       become: true
       tags: [slm, slm-agent, shared]
 
+    # Issue #9565: slm-backend needs autobot_shared in PYTHONPATH
+    - name: "[PLAY 1] SLM Backend | Create autobot_shared symlink for backend imports"
+      ansible.builtin.file:
+        src: /opt/autobot/autobot_shared
+        dest: /opt/autobot/autobot-slm-backend/autobot_shared
+        state: link
+        force: true
+        owner: autobot
+        group: autobot
+      become: true
+      tags: [slm, slm-backend, shared]
+
     # --- SLM custom migrations (#1630) ---
     - name: "[PLAY 1] SLM | Load db credentials for migration (#2293)"
       slurp:
@@ -826,6 +838,19 @@
       become: true
       when: slm_node_id is defined
       tags: [slm-agent, shared]
+
+    # Issue #9565: slm-backend needs autobot_shared in PYTHONPATH
+    - name: "[PLAY 2] SLM Backend | Create autobot_shared symlink for backend imports"
+      ansible.builtin.file:
+        src: /opt/autobot/autobot_shared
+        dest: /opt/autobot/autobot-slm-backend/autobot_shared
+        state: link
+        force: true
+        owner: autobot
+        group: autobot
+      become: true
+      when: slm_node_id is defined
+      tags: [slm-backend, shared]
 
     # ----- Mark synced -----
     - name: "[PLAY 2] Mark node as synced in SLM DB"


### PR DESCRIPTION
## Thinking Path

- Issue #9565 reported that the Ansible playbook creates an `autobot_shared` symlink for the SLM agent but not for the SLM backend
- This causes `ModuleNotFoundError: No module named 'autobot_shared'` when the backend tries to import from autobot_shared
- The fix mirrors the existing SLM agent symlink task pattern for the SLM backend

## What Changed

- Added `autobot_shared` symlink creation task for SLM backend in Play 1 (after line 255)
- Added `autobot_shared` symlink creation task for SLM backend in Play 2 (after line 828)
- Both tasks follow the same pattern as the existing SLM agent symlink tasks
- Symlink points from `/opt/autobot/autobot-slm-backend/autobot_shared` to `/opt/autobot/autobot_shared`

## Verification

- [x] Reviewed existing SLM agent symlink task pattern
- [x] Added matching tasks for SLM backend in both Play 1 and Play 2
- [x] Used correct tags: `[slm, slm-backend, shared]` for Play 1, `[slm-backend, shared]` for Play 2
- [x] Added `when: slm_node_id is defined` condition for Play 2 (matching agent pattern)
- [ ] Deploy via Ansible to verify symlink creation
- [ ] Confirm backend starts without import errors

## Model Used

Claude Sonnet 4.5

Closes #9565