### PR TITLE
fix(ci): use .bandit config in security.yml bandit scans (#9694)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -156,8 +156,8 @@ jobs:
     - name: Bandit Security Linter
       run: |
         echo "## Bandit Security Analysis" >> "$GITHUB_STEP_SUMMARY"
-        python3 -m bandit -r autobot-backend/ autobot-slm-backend/ autobot_shared/ -f json -o bandit-report.json || true
-        python3 -m bandit -r autobot-backend/ autobot-slm-backend/ autobot_shared/ -f txt || true
+        python3 -m bandit -c .bandit -r autobot-backend/ autobot-slm-backend/ autobot_shared/ -f json -o bandit-report.json || true
+        python3 -m bandit -c .bandit -r autobot-backend/ autobot-slm-backend/ autobot_shared/ -f txt || true
 
     - name: Semgrep SAST Scan
       # Blocking: exits non-zero when ERROR-severity findings are present.


### PR DESCRIPTION
## Thinking Path

PR #9701 intended to add `-c .bandit` to the Bandit step in `security.yml`, but its branch (MVA-3885) had diverged across 6,335 files and was unmergeable. Recreated the change cleanly off current Dev_new_gui.

## What Changed

`.github/workflows/security.yml` — Bandit Security Linter step now passes `-c .bandit` on both invocations (JSON + txt), matching `code-quality.yml`. This applies the centralized B104/B108/B608 skip rules so known false positives no longer appear in the step summary.

## Verification

- `.bandit` config confirmed present at repo root on Dev_new_gui.
- Both bandit commands already use `|| true`, so this is a consistency/clarity improvement to the summary output (no CI gating behavior change).
- Diff is 2 lines (+2/-2).

## Model Used

claude-opus-4-8

Supersedes #9701.