### PR TITLE
fix(llc/frontend): read companyId from route params across LLC dashboard views (#9626)

### DIFF
--- a/autobot-frontend/src/views/llc/ApprovalsInbox.vue
+++ b/autobot-frontend/src/views/llc/ApprovalsInbox.vue
@@ -26,126 +26,132 @@
       </div>
     </div>
 
-    <!-- Filters -->
-    <div class="inbox-filters">
-      <select v-model="filters.type" class="filter-select">
-        <option value="">All Types</option>
-        <option v-for="t in APPROVAL_TYPES" :key="t" :value="t">{{ formatType(t) }}</option>
-      </select>
-      <select v-if="activeTab === 'history'" v-model="filters.status" class="filter-select">
-        <option value="">All Statuses</option>
-        <option value="approved">Approved</option>
-        <option value="rejected">Rejected</option>
-        <option value="changes_requested">Changes Requested</option>
-      </select>
-      <input v-model="filters.search" class="filter-search" placeholder="Search..." type="text" />
-    </div>
+    <div v-if="!companyId" class="state-msg">Select a company to view approvals.</div>
 
-    <!-- Pending Tab -->
-    <div v-if="activeTab === 'pending'" class="approval-list">
-      <div v-if="isLoading" class="state-msg">Loading...</div>
-      <div v-else-if="filteredPending.length === 0" class="state-msg">No pending approvals.</div>
-      <div
-        v-for="item in filteredPending"
-        :key="item.id"
-        class="approval-card"
-      >
-        <div class="card-header">
-          <span class="type-badge" :class="`type-${item.type}`">{{ formatType(item.type) }}</span>
-          <span class="card-meta">Requested by: {{ item.requested_by_agent_id }}</span>
-          <span class="card-meta">{{ formatDate(item.created_at) }}</span>
-        </div>
+    <template v-else>
+      <!-- Filters -->
+      <div class="inbox-filters">
+        <select v-model="filters.type" class="filter-select">
+          <option value="">All Types</option>
+          <option v-for="t in APPROVAL_TYPES" :key="t" :value="t">{{ formatType(t) }}</option>
+        </select>
+        <select v-if="activeTab === 'history'" v-model="filters.status" class="filter-select">
+          <option value="">All Statuses</option>
+          <option value="approved">Approved</option>
+          <option value="rejected">Rejected</option>
+          <option value="changes_requested">Changes Requested</option>
+        </select>
+        <input v-model="filters.search" class="filter-search" placeholder="Search..." type="text" />
+      </div>
 
-        <div class="payload-section">
-          <button class="toggle-payload" @click="togglePayload(item.id)">
-            {{ expandedPayloads.has(item.id) ? 'Hide' : 'Show' }} Payload
-          </button>
-          <pre v-if="expandedPayloads.has(item.id)" class="payload-json">{{ formatJson(item.payload) }}</pre>
-        </div>
+      <!-- Pending Tab -->
+      <div v-if="activeTab === 'pending'" class="approval-list">
+        <div v-if="isLoading" class="state-msg">Loading...</div>
+        <div v-else-if="filteredPending.length === 0" class="state-msg">No pending approvals.</div>
+        <div
+          v-for="item in filteredPending"
+          :key="item.id"
+          class="approval-card"
+        >
+          <div class="card-header">
+            <span class="type-badge" :class="`type-${item.type}`">{{ formatType(item.type) }}</span>
+            <span class="card-meta">Requested by: {{ item.requested_by_agent_id }}</span>
+            <span class="card-meta">{{ formatDate(item.created_at) }}</span>
+          </div>
 
-        <div class="card-actions">
-          <button
-            class="btn-approve"
-            :disabled="processing.has(item.id)"
-            @click="decide(item.id, 'approved')"
-          >
-            Approve
-          </button>
-          <button
-            class="btn-reject"
-            :disabled="processing.has(item.id)"
-            @click="openDecisionNote(item.id, 'rejected')"
-          >
-            Reject
-          </button>
-          <button
-            class="btn-changes"
-            :disabled="processing.has(item.id)"
-            @click="openDecisionNote(item.id, 'changes_requested')"
-          >
-            Request Changes
-          </button>
-        </div>
-
-        <div v-if="noteTarget?.id === item.id" class="note-form">
-          <textarea
-            v-model="decisionNote"
-            class="note-textarea"
-            placeholder="Decision note (required)..."
-            rows="3"
-          />
-          <div class="note-actions">
-            <button class="btn-secondary" @click="noteTarget = null">Cancel</button>
-            <button
-              class="btn-primary"
-              :disabled="!decisionNote.trim() || processing.has(item.id)"
-              @click="submitWithNote(item.id)"
-            >
-              Confirm
+          <div class="payload-section">
+            <button class="toggle-payload" @click="togglePayload(item.id)">
+              {{ expandedPayloads.has(item.id) ? 'Hide' : 'Show' }} Payload
             </button>
+            <pre v-if="expandedPayloads.has(item.id)" class="payload-json">{{ formatJson(item.payload) }}</pre>
+          </div>
+
+          <div class="card-actions">
+            <button
+              class="btn-approve"
+              :disabled="processing.has(item.id)"
+              @click="decide(item.id, 'approved')"
+            >
+              Approve
+            </button>
+            <button
+              class="btn-reject"
+              :disabled="processing.has(item.id)"
+              @click="openDecisionNote(item.id, 'rejected')"
+            >
+              Reject
+            </button>
+            <button
+              class="btn-changes"
+              :disabled="processing.has(item.id)"
+              @click="openDecisionNote(item.id, 'changes_requested')"
+            >
+              Request Changes
+            </button>
+          </div>
+
+          <div v-if="noteTarget?.id === item.id" class="note-form">
+            <textarea
+              v-model="decisionNote"
+              class="note-textarea"
+              placeholder="Decision note (required)..."
+              rows="3"
+            />
+            <div class="note-actions">
+              <button class="btn-secondary" @click="noteTarget = null">Cancel</button>
+              <button
+                class="btn-primary"
+                :disabled="!decisionNote.trim() || processing.has(item.id)"
+                @click="submitWithNote(item.id)"
+              >
+                Confirm
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <!-- History Tab -->
-    <div v-if="activeTab === 'history'" class="approval-list">
-      <div v-if="isLoading" class="state-msg">Loading...</div>
-      <div v-else-if="filteredHistory.length === 0" class="state-msg">No history found.</div>
-      <div
-        v-for="item in filteredHistory"
-        :key="item.id"
-        class="approval-card history-card"
-      >
-        <div class="card-header">
-          <span class="type-badge" :class="`type-${item.type}`">{{ formatType(item.type) }}</span>
-          <span class="status-badge" :class="`status-${item.status}`">{{ formatType(item.status) }}</span>
-          <span class="card-meta">Decided by: {{ item.decided_by_agent_id ?? '—' }}</span>
-          <span class="card-meta">{{ formatDate(item.decided_at ?? item.updated_at) }}</span>
-        </div>
-        <div class="payload-section">
-          <button class="toggle-payload" @click="togglePayload(item.id)">
-            {{ expandedPayloads.has(item.id) ? 'Hide' : 'Show' }} Payload
-          </button>
-          <pre v-if="expandedPayloads.has(item.id)" class="payload-json">{{ formatJson(item.payload) }}</pre>
+      <!-- History Tab -->
+      <div v-if="activeTab === 'history'" class="approval-list">
+        <div v-if="isLoading" class="state-msg">Loading...</div>
+        <div v-else-if="filteredHistory.length === 0" class="state-msg">No history found.</div>
+        <div
+          v-for="item in filteredHistory"
+          :key="item.id"
+          class="approval-card history-card"
+        >
+          <div class="card-header">
+            <span class="type-badge" :class="`type-${item.type}`">{{ formatType(item.type) }}</span>
+            <span class="status-badge" :class="`status-${item.status}`">{{ formatType(item.status) }}</span>
+            <span class="card-meta">Decided by: {{ item.decided_by_agent_id ?? '—' }}</span>
+            <span class="card-meta">{{ formatDate(item.decided_at ?? item.updated_at) }}</span>
+          </div>
+          <div class="payload-section">
+            <button class="toggle-payload" @click="togglePayload(item.id)">
+              {{ expandedPayloads.has(item.id) ? 'Hide' : 'Show' }} Payload
+            </button>
+            <pre v-if="expandedPayloads.has(item.id)" class="payload-json">{{ formatJson(item.payload) }}</pre>
+          </div>
         </div>
       </div>
-    </div>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useRoute } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import { useUserStore } from '@/stores/useUserStore'
 
 const logger = createLogger('ApprovalsInbox')
 const api = useApiClient()
+const route = useRoute()
 const userStore = useUserStore()
 
 const props = defineProps<{ companyId?: string }>()
-const companyId = computed(() => props.companyId ?? '00000000-0000-0000-0000-000000000000')
+const companyId = computed(() => (route.params.companyId as string) ?? props.companyId ?? '')
 
 const APPROVAL_TYPES = [
   'budget_increase', 'agent_spawn', 'external_api', 'code_deploy',
@@ -259,6 +265,7 @@ async function submitWithNote(id: string) {
 }
 
 async function fetchApprovals() {
+  if (!companyId.value) return
   isLoading.value = true
   try {
     const data = await api.get<Approval[] | { items: Approval[] }>(
@@ -275,6 +282,7 @@ async function fetchApprovals() {
 let pollInterval: ReturnType<typeof setInterval> | null = null
 
 onMounted(() => {
+  if (!companyId.value) return
   fetchApprovals()
   pollInterval = setInterval(fetchApprovals, 30_000)
 })

--- a/autobot-frontend/src/views/llc/CeoChatView.vue
+++ b/autobot-frontend/src/views/llc/CeoChatView.vue
@@ -9,7 +9,8 @@
         <span class="sidebar-title">Threads</span>
         <button class="btn-new-thread" @click="showNewThread = true">+ New</button>
       </div>
-      <div v-if="threadsLoading" class="state-msg-sm">Loading...</div>
+      <div v-if="!companyId" class="state-msg-sm">Select a company to view threads.</div>
+      <div v-else-if="threadsLoading" class="state-msg-sm">Loading...</div>
       <div v-else-if="threads.length === 0" class="state-msg-sm">No threads yet.</div>
       <div class="thread-list">
         <div
@@ -113,14 +114,16 @@
 
 <script setup lang="ts">
 import { ref, computed, nextTick, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('CeoChatView')
 const api = useApiClient()
+const route = useRoute()
 
 const props = defineProps<{ companyId?: string }>()
-const companyId = computed(() => props.companyId ?? '00000000-0000-0000-0000-000000000000')
+const companyId = computed(() => (route.params.companyId as string) ?? props.companyId ?? '')
 
 interface ChatMessage {
   id: string
@@ -171,6 +174,7 @@ async function scrollToBottom() {
 }
 
 async function fetchThreads() {
+  if (!companyId.value) return
   threadsLoading.value = true
   try {
     const data = await api.get<ChatThread[] | { items: ChatThread[] }>(
@@ -239,7 +243,10 @@ async function createThread() {
   }
 }
 
-onMounted(fetchThreads)
+onMounted(() => {
+  if (!companyId.value) return
+  fetchThreads()
+})
 </script>
 
 <style scoped>

--- a/autobot-frontend/src/views/llc/CompanyDashboard.vue
+++ b/autobot-frontend/src/views/llc/CompanyDashboard.vue
@@ -8,11 +8,14 @@ import { useApiClient } from '@/plugins/api'
 import { useWebSocket } from '@/composables/useWebSocket'
 import { getBackendUrl } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 
 const logger = createLogger('CompanyDashboard')
 const api = useApiClient()
+const route = useRoute()
 const router = useRouter()
+
+const companyId = computed(() => route.params.companyId as string)
 
 interface AgentStatus {
   id: string
@@ -62,10 +65,9 @@ const activityFeed = ref<ActivityEvent[]>([])
 const isLoading = ref(false)
 const error = ref<string | null>(null)
 
-const wsUrl = computed(() => {
-  const companyId = 'default'
-  return `${getBackendUrl().replace(/^http/, 'ws')}/api/llc/ws/activity/${companyId}`
-})
+const wsUrl = computed(
+  () => `${getBackendUrl().replace(/^http/, 'ws')}/api/llc/ws/activity/${companyId.value}`
+)
 
 const { lastMessage, connect, disconnect } = useWebSocket(wsUrl.value, {
   autoConnect: false,
@@ -99,6 +101,7 @@ const budgetBarColor = (b: BudgetInfo) => {
 }
 
 async function fetchDashboardData() {
+  if (!companyId.value) return
   isLoading.value = true
   error.value = null
   try {
@@ -148,6 +151,7 @@ function formatTime(ts: string): string {
 }
 
 onMounted(async () => {
+  if (!companyId.value) return
   await fetchDashboardData()
   connect()
 })
@@ -174,150 +178,156 @@ watch(lastMessage, (msg) => {
       </button>
     </div>
 
-    <div v-if="error" class="rounded-lg bg-red-50 border border-red-200 p-4 text-red-700 text-sm">
-      {{ error }}
-      <button class="ml-4 underline" @click="fetchDashboardData">Retry</button>
+    <div v-if="!companyId" class="text-center py-12 text-gray-500">
+      Select a company to view its dashboard.
     </div>
 
-    <div v-if="isLoading" class="text-center py-12 text-gray-500">Loading…</div>
-
     <template v-else>
-      <!-- Pending Approvals -->
-      <section v-if="pendingApprovals.length > 0">
-        <div class="flex items-center gap-2 mb-3">
-          <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200">Pending Approvals</h2>
-          <span class="bg-amber-100 text-amber-800 text-xs font-semibold px-2 py-0.5 rounded-full">
-            {{ pendingApprovals.length }}
-          </span>
-        </div>
-        <div class="space-y-2">
-          <div
-            v-for="approval in pendingApprovals"
-            :key="approval.id"
-            class="flex items-center justify-between bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3"
-          >
-            <div>
-              <p class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ approval.title }}</p>
-              <p class="text-xs text-gray-500">Requested by {{ approval.requested_by }} · {{ formatTime(approval.created_at) }}</p>
-            </div>
-            <button
-              class="px-3 py-1.5 bg-green-600 text-white text-xs rounded hover:bg-green-700 transition-colors"
-              @click="quickApprove(approval.id)"
-            >
-              Approve
-            </button>
-          </div>
-        </div>
-      </section>
+      <div v-if="error" class="rounded-lg bg-red-50 border border-red-200 p-4 text-red-700 text-sm">
+        {{ error }}
+        <button class="ml-4 underline" @click="fetchDashboardData">Retry</button>
+      </div>
 
-      <!-- Budget Gauges -->
-      <section>
-        <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-3">Budget</h2>
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          <div
-            v-for="budget in budgets"
-            :key="budget.label"
-            class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4"
-          >
-            <div class="flex justify-between items-center mb-2">
-              <span class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ budget.label }}</span>
-              <span class="text-xs text-gray-500">{{ budgetPercent(budget) }}%</span>
-            </div>
-            <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
-              <div
-                class="h-2 rounded-full transition-all"
-                :class="budgetBarColor(budget)"
-                :style="{ width: `${budgetPercent(budget)}%` }"
-              />
-            </div>
-            <p class="text-xs text-gray-500 mt-1">{{ budget.spent }} / {{ budget.total }}</p>
-          </div>
-        </div>
-      </section>
+      <div v-if="isLoading" class="text-center py-12 text-gray-500">Loading…</div>
 
-      <!-- Agent Status Grid -->
-      <section>
-        <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-3">
-          Agents
-          <span class="text-sm font-normal text-gray-500 ml-1">({{ agents.length }})</span>
-        </h2>
-        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
-          <div
-            v-for="agent in agents"
-            :key="agent.id"
-            class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3 flex flex-col gap-1"
-          >
-            <div class="flex items-center gap-2">
-              <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" :class="statusColor(agent.status)" />
-              <span class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{{ agent.name }}</span>
-            </div>
-            <span class="text-xs text-gray-500 truncate">{{ agent.title }}</span>
-            <span class="text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded px-1.5 py-0.5 self-start">
-              {{ agent.adapter_type }}
+      <template v-else>
+        <!-- Pending Approvals -->
+        <section v-if="pendingApprovals.length > 0">
+          <div class="flex items-center gap-2 mb-3">
+            <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200">Pending Approvals</h2>
+            <span class="bg-amber-100 text-amber-800 text-xs font-semibold px-2 py-0.5 rounded-full">
+              {{ pendingApprovals.length }}
             </span>
           </div>
-        </div>
-      </section>
-
-      <!-- Live Heartbeat Runs -->
-      <section>
-        <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-3">Recent Heartbeat Runs</h2>
-        <div class="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
-          <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
-            <thead class="bg-gray-50 dark:bg-gray-900">
-              <tr>
-                <th class="px-4 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">Agent</th>
-                <th class="px-4 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">Status</th>
-                <th class="px-4 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">Started</th>
-                <th class="px-4 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">Duration</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-100 dark:divide-gray-800 bg-white dark:bg-gray-800">
-              <tr v-for="run in heartbeatRuns" :key="run.run_id">
-                <td class="px-4 py-2 text-gray-900 dark:text-gray-100 font-medium">{{ run.agent_name }}</td>
-                <td class="px-4 py-2">
-                  <span
-                    class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
-                    :class="{
-                      'bg-green-100 text-green-800': run.status === 'done',
-                      'bg-blue-100 text-blue-800': run.status === 'running',
-                      'bg-red-100 text-red-800': run.status === 'failed',
-                    }"
-                  >
-                    {{ run.status }}
-                  </span>
-                </td>
-                <td class="px-4 py-2 text-gray-500">{{ formatTime(run.started_at) }}</td>
-                <td class="px-4 py-2 text-gray-500">{{ formatDuration(run.duration_ms) }}</td>
-              </tr>
-              <tr v-if="heartbeatRuns.length === 0">
-                <td colspan="4" class="px-4 py-4 text-center text-gray-400 text-sm">No runs yet</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </section>
-
-      <!-- Activity Feed -->
-      <section>
-        <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-3">Live Activity</h2>
-        <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-700 max-h-72 overflow-y-auto">
-          <div
-            v-for="event in activityFeed"
-            :key="event.id"
-            class="px-4 py-2 flex items-start gap-3"
-          >
-            <span class="text-xs text-gray-400 w-16 flex-shrink-0 pt-0.5">{{ formatTime(event.timestamp) }}</span>
-            <div class="flex-1 min-w-0">
-              <span class="text-xs text-indigo-600 dark:text-indigo-400 font-medium mr-1">{{ event.agent_name ?? 'system' }}</span>
-              <span class="text-sm text-gray-700 dark:text-gray-300">{{ event.summary }}</span>
+          <div class="space-y-2">
+            <div
+              v-for="approval in pendingApprovals"
+              :key="approval.id"
+              class="flex items-center justify-between bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3"
+            >
+              <div>
+                <p class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ approval.title }}</p>
+                <p class="text-xs text-gray-500">Requested by {{ approval.requested_by }} · {{ formatTime(approval.created_at) }}</p>
+              </div>
+              <button
+                class="px-3 py-1.5 bg-green-600 text-white text-xs rounded hover:bg-green-700 transition-colors"
+                @click="quickApprove(approval.id)"
+              >
+                Approve
+              </button>
             </div>
           </div>
-          <div v-if="activityFeed.length === 0" class="px-4 py-4 text-center text-gray-400 text-sm">
-            Waiting for activity…
+        </section>
+
+        <!-- Budget Gauges -->
+        <section>
+          <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-3">Budget</h2>
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div
+              v-for="budget in budgets"
+              :key="budget.label"
+              class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4"
+            >
+              <div class="flex justify-between items-center mb-2">
+                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ budget.label }}</span>
+                <span class="text-xs text-gray-500">{{ budgetPercent(budget) }}%</span>
+              </div>
+              <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+                <div
+                  class="h-2 rounded-full transition-all"
+                  :class="budgetBarColor(budget)"
+                  :style="{ width: `${budgetPercent(budget)}%` }"
+                />
+              </div>
+              <p class="text-xs text-gray-500 mt-1">{{ budget.spent }} / {{ budget.total }}</p>
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+
+        <!-- Agent Status Grid -->
+        <section>
+          <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-3">
+            Agents
+            <span class="text-sm font-normal text-gray-500 ml-1">({{ agents.length }})</span>
+          </h2>
+          <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+            <div
+              v-for="agent in agents"
+              :key="agent.id"
+              class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3 flex flex-col gap-1"
+            >
+              <div class="flex items-center gap-2">
+                <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" :class="statusColor(agent.status)" />
+                <span class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{{ agent.name }}</span>
+              </div>
+              <span class="text-xs text-gray-500 truncate">{{ agent.title }}</span>
+              <span class="text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded px-1.5 py-0.5 self-start">
+                {{ agent.adapter_type }}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        <!-- Live Heartbeat Runs -->
+        <section>
+          <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-3">Recent Heartbeat Runs</h2>
+          <div class="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+              <thead class="bg-gray-50 dark:bg-gray-900">
+                <tr>
+                  <th class="px-4 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">Agent</th>
+                  <th class="px-4 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">Status</th>
+                  <th class="px-4 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">Started</th>
+                  <th class="px-4 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">Duration</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100 dark:divide-gray-800 bg-white dark:bg-gray-800">
+                <tr v-for="run in heartbeatRuns" :key="run.run_id">
+                  <td class="px-4 py-2 text-gray-900 dark:text-gray-100 font-medium">{{ run.agent_name }}</td>
+                  <td class="px-4 py-2">
+                    <span
+                      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                      :class="{
+                        'bg-green-100 text-green-800': run.status === 'done',
+                        'bg-blue-100 text-blue-800': run.status === 'running',
+                        'bg-red-100 text-red-800': run.status === 'failed',
+                      }"
+                    >
+                      {{ run.status }}
+                    </span>
+                  </td>
+                  <td class="px-4 py-2 text-gray-500">{{ formatTime(run.started_at) }}</td>
+                  <td class="px-4 py-2 text-gray-500">{{ formatDuration(run.duration_ms) }}</td>
+                </tr>
+                <tr v-if="heartbeatRuns.length === 0">
+                  <td colspan="4" class="px-4 py-4 text-center text-gray-400 text-sm">No runs yet</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <!-- Activity Feed -->
+        <section>
+          <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-3">Live Activity</h2>
+          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-700 max-h-72 overflow-y-auto">
+            <div
+              v-for="event in activityFeed"
+              :key="event.id"
+              class="px-4 py-2 flex items-start gap-3"
+            >
+              <span class="text-xs text-gray-400 w-16 flex-shrink-0 pt-0.5">{{ formatTime(event.timestamp) }}</span>
+              <div class="flex-1 min-w-0">
+                <span class="text-xs text-indigo-600 dark:text-indigo-400 font-medium mr-1">{{ event.agent_name ?? 'system' }}</span>
+                <span class="text-sm text-gray-700 dark:text-gray-300">{{ event.summary }}</span>
+              </div>
+            </div>
+            <div v-if="activityFeed.length === 0" class="px-4 py-4 text-center text-gray-400 text-sm">
+              Waiting for activity…
+            </div>
+          </div>
+        </section>
+      </template>
     </template>
   </div>
 </template>

--- a/autobot-frontend/src/views/llc/CompanyPortabilityView.vue
+++ b/autobot-frontend/src/views/llc/CompanyPortabilityView.vue
@@ -28,7 +28,7 @@
         <div class="export-buttons">
           <button
             class="btn-primary"
-            :disabled="exportingTemplate"
+            :disabled="exportingTemplate || !effectiveCompanyId"
             @click="exportTemplate"
           >
             <span v-if="exportingTemplate" class="spinner" />
@@ -37,7 +37,7 @@
 
           <button
             class="btn-secondary"
-            :disabled="exportingSnapshot"
+            :disabled="exportingSnapshot || !effectiveCompanyId"
             @click="exportSnapshot"
           >
             <span v-if="exportingSnapshot" class="spinner" />
@@ -45,6 +45,9 @@
           </button>
         </div>
 
+        <p v-if="!effectiveCompanyId" class="export-hint">
+          Select a company to enable exporting.
+        </p>
         <p class="export-hint">
           <strong>Template</strong> — agents, goals, routines, seed tasks (no sprint history, no secrets).<br />
           <strong>Snapshot</strong> — full backup including all work items and sprint history.
@@ -202,6 +205,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useRoute } from 'vue-router'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { getApiBase } from '@/config/ssot-config'
 import { useNotificationBus } from '@/composables/useNotificationBus'
@@ -209,10 +213,11 @@ import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('CompanyPortabilityView')
 const { showToast } = useNotificationBus()
+const route = useRoute()
 
 // ── props ────────────────────────────────────────────────────────────────────
 const props = defineProps<{ companyId?: string }>()
-const effectiveCompanyId = computed(() => props.companyId ?? '00000000-0000-0000-0000-000000000000')
+const effectiveCompanyId = computed(() => (route.params.companyId as string) ?? props.companyId ?? '')
 
 // ── state ────────────────────────────────────────────────────────────────────
 const globalError = ref<string | null>(null)
@@ -289,6 +294,7 @@ function extractSecretPlaceholders(json: unknown): string[] {
 
 // ── export ────────────────────────────────────────────────────────────────────
 async function exportTemplate(): Promise<void> {
+  if (!effectiveCompanyId.value) return
   exportingTemplate.value = true
   try {
     const res = await fetchWithAuth(
@@ -307,6 +313,7 @@ async function exportTemplate(): Promise<void> {
 }
 
 async function exportSnapshot(): Promise<void> {
+  if (!effectiveCompanyId.value) return
   exportingSnapshot.value = true
   try {
     const res = await fetchWithAuth(

--- a/autobot-frontend/src/views/llc/CostDashboard.vue
+++ b/autobot-frontend/src/views/llc/CostDashboard.vue
@@ -8,6 +8,9 @@
       <button class="btn-export" @click="exportCsv">Export CSV</button>
     </div>
 
+    <div v-if="!companyId" class="state-msg">Select a company to view costs.</div>
+
+    <template v-else>
     <!-- Summary cards -->
     <div class="summary-cards">
       <div class="summary-card">
@@ -214,19 +217,22 @@
         </tbody>
       </table>
     </div>
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, reactive, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('CostDashboard')
 const api = useApiClient()
+const route = useRoute()
 
 const props = defineProps<{ companyId?: string }>()
-const companyId = computed(() => props.companyId ?? '00000000-0000-0000-0000-000000000000')
+const companyId = computed(() => (route.params.companyId as string) ?? props.companyId ?? '')
 
 interface BudgetEntry {
   agent_id: string
@@ -429,6 +435,7 @@ async function saveBudgetSettings() {
 }
 
 async function fetchBudgets() {
+  if (!companyId.value) return
   try {
     const data = await api.get<BudgetEntry[] | { items: BudgetEntry[] }>(`/api/llc/budget?company_id=${companyId.value}`)
     budgets.value = Array.isArray(data) ? data : (data as { items: BudgetEntry[] }).items ?? []
@@ -438,6 +445,7 @@ async function fetchBudgets() {
 }
 
 async function fetchCostEvents() {
+  if (!companyId.value) return
   isLoading.value = true
   try {
     const data = await api.get<CostEvent[] | { items: CostEvent[] }>(`/api/llc/cost-events?company_id=${companyId.value}`)
@@ -456,6 +464,7 @@ async function fetchCostEvents() {
 }
 
 onMounted(async () => {
+  if (!companyId.value) return
   await Promise.all([fetchBudgets(), fetchCostEvents()])
 })
 </script>


### PR DESCRIPTION
## Thinking Path
`CompanyDashboard.vue` hardcoded `const companyId = 'default'` and 4 sibling LLC views (`ApprovalsInbox`, `CeoChatView`, `CostDashboard`, `CompanyPortabilityView`) fell back to the zero-UUID — so every API call on those dashboards used an invalid id and returned empty/404 data regardless of the company being viewed. The fix mirrors the views that already work correctly (`BacklogView`, `SprintBoardView`, `KanbanBoardView`), which read `route.params.companyId`.

## What Changed
- All 5 views now derive `companyId` from `useRoute().params.companyId` (route-prop fallback retained for the 3 routes that pass it as a prop), removing the hardcoded `'default'` and zero-UUID fallbacks.
- Every API call / `onMounted` / poll / WS connect is guarded on a falsy `companyId` and renders a 'Select a company' empty-state instead of firing an invalid request.

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json`: **0 errors in the 5 changed files** (project has a pre-existing 231-error type-check baseline tracked by #9693 — unrelated to this change; none in these files).
- Manual review: `useRoute` imported in all 5; no remaining hardcoded/zero-UUID values; all `.value` accesses and templates consistent.

## Model Used
Claude (frontend-engineer subagent), verified by Opus 4.8.

Closes #9626