### PR TITLE
fix(tests): correct mock target for is_encryption_enabled after get_nested removal (#8954)

### DIFF
--- a/autobot-backend/security/encryption_service_test.py
+++ b/autobot-backend/security/encryption_service_test.py
@@ -191,19 +191,17 @@ class TestConvenienceFunctions(unittest.TestCase):
 class TestConfigurationIntegration(unittest.TestCase):
     """Test integration with configuration system."""
 
-    @patch("config.config")
+    @patch("encryption_service.config")
     def test_is_encryption_enabled_true(self, mock_config):
-        """Test encryption enabled check returns True."""
-        mock_config.get_nested.return_value = True
+        """Encryption is enabled when an encryption key is configured."""
+        mock_config.misc.encryption_key = "test-encryption-key"
         self.assertTrue(is_encryption_enabled())
-        mock_config.get_nested.assert_called_with("security.enable_encryption", False)
 
-    @patch("config.config")
+    @patch("encryption_service.config")
     def test_is_encryption_enabled_false(self, mock_config):
-        """Test encryption enabled check returns False."""
-        mock_config.get_nested.return_value = False
+        """Encryption is disabled when no encryption key is configured."""
+        mock_config.misc.encryption_key = ""
         self.assertFalse(is_encryption_enabled())
-        mock_config.get_nested.assert_called_with("security.enable_encryption", False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Thinking Path
`security/encryption_service_test.py` patched `config.config` and asserted `mock_config.get_nested.assert_called_with("security.enable_encryption", False)`. But production `encryption_service.is_encryption_enabled()` now reads `bool(config.misc.encryption_key)` (config imported as `from autobot_shared.ssot_config import config`) — it never calls `get_nested`. So the tests mocked the wrong object and asserted a method that is never invoked: a false-green that validated nothing.

## What Changed
- Patch target → `encryption_service.config` (the exact symbol the function resolves).
- Drive the real code path: set `mock_config.misc.encryption_key` to a value (→ `True`) and to `""` (→ `False`); dropped the obsolete `get_nested` assertion.

## Verification
```
$ python3 -m pytest security/encryption_service_test.py::TestConfigurationIntegration -q
2 passed
$ python3 -m flake8 security/encryption_service_test.py
0
```
The tests now genuinely fail if `is_encryption_enabled` regresses.

## Model Used
Opus 4.8.

Closes #8954