### PR TITLE
fix(llc/adapters): structured Markdown prompt + inject AUTOBOT_LLC_API_KEY env (#9622, #9623)

### DIFF
--- a/autobot-backend/llc/adapters/claude_code_adapter.py
+++ b/autobot-backend/llc/adapters/claude_code_adapter.py
@@ -118,6 +118,18 @@ _RENDERED_CONTEXT_KEYS = frozenset(
 )
 
 
+def _serialize_invoke_context(context: dict) -> str:
+    """Serialize context for ``LLC_INVOKE_CONTEXT`` with the API key redacted.
+
+    The real ``agent_api_key`` is forwarded only via the dedicated
+    ``AUTOBOT_LLC_API_KEY`` env var (GH#9623); it must not be duplicated inside
+    the JSON context blob, which is broader and more likely to be logged.
+    """
+    if context.get("agent_api_key") and context["agent_api_key"] != _AGENT_API_KEY_PLACEHOLDER:
+        context = {**context, "agent_api_key": _AGENT_API_KEY_PLACEHOLDER}
+    return json.dumps(context, default=str)
+
+
 def _render_kb_chunks(label: str, ctx: object) -> str:
     """Render a ``{chunks, sources}`` RAG context block, or '' when empty."""
     if not isinstance(ctx, dict):
@@ -243,7 +255,7 @@ class ClaudeCodeAdapter:
         cmd.append(prompt)
 
         workspace_dir: str | None = context.get("workspace_dir")
-        env = {**os.environ, "LLC_INVOKE_CONTEXT": json.dumps(context, default=str)}
+        env = {**os.environ, "LLC_INVOKE_CONTEXT": _serialize_invoke_context(context)}
         if workspace_dir:
             env["AUTOBOT_WORKSPACE_DIR"] = workspace_dir
 
@@ -284,7 +296,7 @@ class ClaudeCodeAdapter:
                 )
                 context.pop("workspace_dir", None)
                 env.pop("AUTOBOT_WORKSPACE_DIR", None)
-                env["LLC_INVOKE_CONTEXT"] = json.dumps(context, default=str)
+                env["LLC_INVOKE_CONTEXT"] = _serialize_invoke_context(context)
                 workspace_dir = None
                 proc = await asyncio.create_subprocess_exec(
                     *cmd,

--- a/autobot-backend/llc/adapters/claude_code_adapter.py
+++ b/autobot-backend/llc/adapters/claude_code_adapter.py
@@ -89,6 +89,110 @@ def _resolve_claude_cli() -> str:
     return path
 
 
+# Placeholder written by HeartbeatContextBuilder before a real key is issued at
+# dispatch time — never forwarded to the agent subprocess (GH#9623).
+_AGENT_API_KEY_PLACEHOLDER = "<injected-at-runtime>"
+
+# Keys rendered by dedicated prompt sections or consumed as env vars — excluded
+# from the generic "Additional Context" catch-all in _render_context_markdown.
+_RENDERED_CONTEXT_KEYS = frozenset(
+    {
+        "rag_brief",
+        "work_item_detail",
+        "work_item_id",
+        "goal_ancestry",
+        "company_context",
+        "project_context",
+        "agent_memory",
+        "agent_wiki",
+        "similar_past_work",
+        "recent_decisions",
+        "task_id",
+        "api_base",
+        "api_base_url",
+        "agent_api_key",
+        "workspace_dir",
+        "wake_reason",
+        "wake_comment_id",
+    }
+)
+
+
+def _render_kb_chunks(label: str, ctx: object) -> str:
+    """Render a ``{chunks, sources}`` RAG context block, or '' when empty."""
+    if not isinstance(ctx, dict):
+        return ""
+    chunks = [str(c).strip() for c in ctx.get("chunks") or [] if str(c).strip()]
+    if not chunks:
+        return ""
+    return f"## {label}\n" + "\n\n".join(chunks)
+
+
+def _render_work_item(detail: object) -> str:
+    """Render the ``work_item_detail`` block as a Markdown header + sections."""
+    if not isinstance(detail, dict):
+        return ""
+    lines = [f"# Work Item: {detail.get('title') or 'Untitled'}"]
+    meta = [f"**{k}:** {detail[v]}" for k, v in (("Status", "status"), ("Priority", "priority")) if detail.get(v)]
+    if meta:
+        lines.append(" | ".join(meta))
+    if detail.get("description"):
+        lines.append(f"\n## Description\n{detail['description']}")
+    if detail.get("acceptance_criteria"):
+        lines.append(f"\n## Acceptance Criteria\n{detail['acceptance_criteria']}")
+    return "\n".join(lines)
+
+
+def _render_list_section(label: str, items: object, key: str = "title") -> str:
+    """Render a list of dicts/strings as a bulleted Markdown section, or ''."""
+    if not isinstance(items, (list, tuple)) or not items:
+        return ""
+    bullets = []
+    for item in items:
+        if isinstance(item, dict):
+            text = item.get(key) or item.get("summary") or item.get("description")
+            bullets.append(f"- {text}" if text else f"- {item}")
+        else:
+            bullets.append(f"- {item}")
+    return f"## {label}\n" + "\n".join(bullets)
+
+
+def _render_extra_scalars(context: dict) -> str:
+    """Render leftover scalar context keys as bullets (never a raw JSON dump)."""
+    extras = [
+        f"- {k}: {v}"
+        for k, v in context.items()
+        if k not in _RENDERED_CONTEXT_KEYS and isinstance(v, (str, int, float, bool))
+    ]
+    return "## Additional Context\n" + "\n".join(extras) if extras else ""
+
+
+def _render_context_markdown(context: dict) -> str:
+    """Assemble the agent prompt from recognised context sections (GH#9622).
+
+    Renders the heartbeat fat context (work item, goal ancestry, KB context,
+    agent memory, past work) as readable Markdown.  Never serialises the raw
+    context dict as JSON — unrecognised scalar keys become a bulleted block.
+    """
+    api_base = context.get("api_base") or context.get("api_base_url")
+    sections = [
+        str(context["rag_brief"]) if context.get("rag_brief") else "",
+        _render_work_item(context.get("work_item_detail")),
+        _render_list_section("Goal Ancestry", context.get("goal_ancestry")),
+        _render_kb_chunks("Company Knowledge Base", context.get("company_context")),
+        _render_kb_chunks("Project Knowledge Base", context.get("project_context")),
+        _render_kb_chunks("Agent Memory", context.get("agent_memory")),
+        f"## Agent Wiki\n{context['agent_wiki']}" if context.get("agent_wiki") else "",
+        _render_list_section("Similar Past Work", context.get("similar_past_work")),
+        _render_list_section("Recent Decisions", context.get("recent_decisions"), key="summary"),
+        f"Task ID: {context['task_id']}" if context.get("task_id") else "",
+        f"API base URL: {api_base}" if api_base else "",
+        _render_extra_scalars(context),
+    ]
+    body = "\n\n".join(s for s in sections if s)
+    return body or "Heartbeat invocation: no additional context was provided."
+
+
 class ClaudeCodeAdapter:
     """Adapter that manages agent runs as Claude Code CLI subprocess sessions."""
 
@@ -150,6 +254,16 @@ class ClaudeCodeAdapter:
         wake_comment_id = context.get("wake_comment_id")
         if wake_comment_id:
             env["AUTOBOT_LLC_WAKE_COMMENT_ID"] = wake_comment_id
+
+        # GH#9623: surface the agent's LLC API bearer token + base URL so the
+        # subprocess can authenticate LLC API calls. The build-time placeholder
+        # is skipped — only a real injected key is forwarded.
+        api_key = context.get("agent_api_key")
+        if api_key and api_key != _AGENT_API_KEY_PLACEHOLDER:
+            env["AUTOBOT_LLC_API_KEY"] = api_key
+        api_base_env = context.get("api_base") or context.get("api_base_url")
+        if api_base_env:
+            env["AUTOBOT_LLC_API_BASE"] = api_base_env
 
         out_fh = open(output_file, "w", encoding="utf-8")
         try:
@@ -293,16 +407,12 @@ class ClaudeCodeAdapter:
             pass
 
     def _build_prompt(self, context: dict) -> str:
-        parts: list[str] = []
-        if rag_brief := context.get("rag_brief"):
-            parts.append(rag_brief)
-        if task_id := context.get("task_id", ""):
-            parts.append(f"Task ID: {task_id}")
-        if api_base := context.get("api_base_url", ""):
-            parts.append(f"API base URL: {api_base}")
-        if not parts:
-            parts.append(json.dumps(context, default=str))
-        return "\n\n".join(parts)
+        """Render the agent prompt as structured Markdown (GH#9622).
+
+        Delegates to :func:`_render_context_markdown` so the heartbeat fat
+        context becomes a readable brief instead of a raw ``json.dumps`` blob.
+        """
+        return _render_context_markdown(context)
 
     @staticmethod
     def _load_state(state_file: str, safe_dir: str = _DEFAULT_OUTPUT_DIR) -> Optional[dict]:

--- a/autobot-backend/llc/adapters/tests/test_claude_code_adapter.py
+++ b/autobot-backend/llc/adapters/tests/test_claude_code_adapter.py
@@ -66,13 +66,53 @@ class TestBuildPrompt:
         assert "Task ID: t2" in p
         assert "API base URL: http://api" in p
 
-    def test_empty_context_falls_back_to_json(self) -> None:
+    def test_empty_context_returns_nonempty_placeholder(self) -> None:
+        # GH#9622: empty context must not produce a raw JSON dump.
         p = self._prompt({})
         assert p  # non-empty
+        assert p.strip() != "{}"
+        assert not p.lstrip().startswith("{")
 
-    def test_unknown_keys_serialised_as_json(self) -> None:
+    def test_unknown_scalar_keys_rendered_as_bullets_not_json(self) -> None:
+        # GH#9622: unknown scalar keys are bulleted, never json.dumps(context).
         p = self._prompt({"foo": "bar"})
-        assert "bar" in p
+        assert "- foo: bar" in p
+        assert '"foo"' not in p  # not JSON-serialised
+
+    def test_fat_context_renders_structured_markdown(self) -> None:
+        # GH#9622: heartbeat fat context becomes a readable Markdown brief.
+        p = self._prompt(
+            {
+                "work_item_detail": {
+                    "title": "Fix login",
+                    "status": "in_progress",
+                    "priority": "high",
+                    "description": "Users cannot log in.",
+                    "acceptance_criteria": "Login works.",
+                },
+                "goal_ancestry": [{"title": "Improve auth"}],
+                "company_context": {"chunks": ["Company uses OAuth."], "sources": []},
+                "agent_memory": {"chunks": ["Tried fix A."], "sources": []},
+                "similar_past_work": [{"title": "Past auth fix"}],
+                "agent_api_key": "<injected-at-runtime>",
+            }
+        )
+        assert "# Work Item: Fix login" in p
+        assert "**Status:** in_progress" in p
+        assert "## Acceptance Criteria" in p
+        assert "## Goal Ancestry" in p
+        assert "- Improve auth" in p
+        assert "Company uses OAuth." in p
+        assert "Tried fix A." in p
+        assert "Past auth fix" in p
+        # The build-time API-key placeholder must never leak into the prompt.
+        assert "<injected-at-runtime>" not in p
+
+    def test_never_emits_raw_json_dump(self) -> None:
+        # GH#9622: regression guard — a dict-valued unknown key is not dumped.
+        p = self._prompt({"work_item_detail": {"title": "T"}, "raw": {"a": 1}})
+        assert '{"a": 1}' not in p
+        assert '"a": 1' not in p
 
 
 # ---------------------------------------------------------------------------
@@ -189,6 +229,55 @@ class TestInvoke:
         assert "--allowedTools" in captured_cmd
         tools_idx = captured_cmd.index("--allowedTools")
         assert captured_cmd[tools_idx + 1] == "Bash,Read"
+
+    async def test_invoke_injects_agent_api_key_env(self) -> None:
+        # GH#9623: a real agent_api_key is forwarded as AUTOBOT_LLC_API_KEY.
+        adapter = ClaudeCodeAdapter()
+        fake_proc = _make_fake_proc(33)
+        captured_env: dict = {}
+
+        async def fake_exec(*args, **kwargs):
+            captured_env.update(kwargs.get("env") or {})
+            return fake_proc
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg = _agent_cfg(output_dir=td)
+            with (
+                patch("llc.adapters.claude_code_adapter.shutil.which", return_value="/usr/bin/claude"),
+                patch(
+                    "llc.adapters.claude_code_adapter.get_async_redis_client", new_callable=AsyncMock, return_value=None
+                ),
+                patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+                patch("builtins.open", MagicMock(return_value=MagicMock())),
+            ):
+                await adapter.invoke(cfg, {"agent_api_key": "real-key-123", "api_base": "http://api/llc"})
+
+        assert captured_env.get("AUTOBOT_LLC_API_KEY") == "real-key-123"
+        assert captured_env.get("AUTOBOT_LLC_API_BASE") == "http://api/llc"
+
+    async def test_invoke_skips_placeholder_api_key(self) -> None:
+        # GH#9623: the build-time placeholder is never forwarded to the subprocess.
+        adapter = ClaudeCodeAdapter()
+        fake_proc = _make_fake_proc(34)
+        captured_env: dict = {}
+
+        async def fake_exec(*args, **kwargs):
+            captured_env.update(kwargs.get("env") or {})
+            return fake_proc
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg = _agent_cfg(output_dir=td)
+            with (
+                patch("llc.adapters.claude_code_adapter.shutil.which", return_value="/usr/bin/claude"),
+                patch(
+                    "llc.adapters.claude_code_adapter.get_async_redis_client", new_callable=AsyncMock, return_value=None
+                ),
+                patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+                patch("builtins.open", MagicMock(return_value=MagicMock())),
+            ):
+                await adapter.invoke(cfg, {"agent_api_key": "<injected-at-runtime>"})
+
+        assert "AUTOBOT_LLC_API_KEY" not in captured_env
 
     async def test_fd_closed_when_exec_raises(self) -> None:
         """out_fh must be closed even if create_subprocess_exec raises (GH#6471 follow-up)."""

--- a/autobot-backend/llc/adapters/tests/test_claude_code_adapter.py
+++ b/autobot-backend/llc/adapters/tests/test_claude_code_adapter.py
@@ -114,6 +114,27 @@ class TestBuildPrompt:
         assert '{"a": 1}' not in p
         assert '"a": 1' not in p
 
+    def test_wrong_type_fields_handled_gracefully(self) -> None:
+        # GH#9622: helpers guard against mistyped fat-context values.
+        p = self._prompt(
+            {
+                "work_item_detail": "not-a-dict",
+                "goal_ancestry": {"not": "a-list"},
+                "company_context": "not-a-dict",
+                "task_id": "t-ok",
+            }
+        )
+        assert "# Work Item" not in p  # string detail skipped
+        assert "## Goal Ancestry" not in p  # dict ancestry skipped
+        assert "Task ID: t-ok" in p  # valid field still rendered
+
+    def test_kb_chunks_filters_empty_and_nonstring(self) -> None:
+        # GH#9622: blank/whitespace chunks are dropped; an all-empty block is omitted.
+        p = self._prompt({"company_context": {"chunks": ["  ", "", "Real chunk"], "sources": []}})
+        assert "Real chunk" in p
+        empty = self._prompt({"agent_memory": {"chunks": ["", "   "], "sources": []}})
+        assert "## Agent Memory" not in empty
+
 
 # ---------------------------------------------------------------------------
 # invoke
@@ -254,6 +275,10 @@ class TestInvoke:
 
         assert captured_env.get("AUTOBOT_LLC_API_KEY") == "real-key-123"
         assert captured_env.get("AUTOBOT_LLC_API_BASE") == "http://api/llc"
+        # GH#9623: the real key must NOT be duplicated inside the broader
+        # LLC_INVOKE_CONTEXT blob — it is redacted to the placeholder there.
+        assert "real-key-123" not in captured_env.get("LLC_INVOKE_CONTEXT", "")
+        assert "<injected-at-runtime>" in captured_env.get("LLC_INVOKE_CONTEXT", "")
 
     async def test_invoke_skips_placeholder_api_key(self) -> None:
         # GH#9623: the build-time placeholder is never forwarded to the subprocess.


### PR DESCRIPTION
## Thinking Path

Verifying the LLC epic (#8204) surfaced two still-valid adapter follow-ups. I traced the heartbeat dispatch path and found that `_dispatch_adapter` currently always routes through `AutoBotAgentAdapter` (GH#8490), so `ClaudeCodeAdapter` is invoked off the scheduled-heartbeat path. The two issues each have a **self-contained, fully unit-testable adapter-internal core** and a **dispatch-side wiring** part. This PR delivers the adapter-internal core (correct and forward-compatible regardless of the eventual dispatch-routing decision) and explicitly defers the dispatch-side work, which touches a critical scheduler that cannot be integration-tested in this environment.

## What Changed

**#9622 — structured Markdown prompt (no raw JSON):**
- `ClaudeCodeAdapter._build_prompt` → delegates to a new `_render_context_markdown` helper that renders the heartbeat fat context (`work_item_detail`, `goal_ancestry`, `company_context`/`project_context`, `agent_memory`, `agent_wiki`, `similar_past_work`, `recent_decisions`) as readable Markdown sections.
- Unrecognised **scalar** keys → bulleted "Additional Context" block; **dict-valued** keys are never `json.dumps`-ed to the agent. Empty context yields a non-empty placeholder.

**#9623 — inject LLC API bearer token:**
- `invoke()` forwards `context["agent_api_key"]` as `AUTOBOT_LLC_API_KEY` (and `api_base` as `AUTOBOT_LLC_API_BASE`) into the subprocess env. The build-time `"<injected-at-runtime>"` placeholder is skipped — only a real key is forwarded.

## Verification

```
$ python3 -m pytest llc/adapters/tests/test_claude_code_adapter.py -q
33 passed, 1 failed
```
The single failure (`test_invoke_writes_state_file`) is **pre-existing** — it fails identically on unmodified origin (it patches `builtins.open` globally then asserts the state file exists on disk). Filed separately as a discovery issue; unrelated to this change. All 8 new/changed tests pass:
- `TestBuildPrompt`: rag_brief+task_id, thin task/url, empty→placeholder, scalar-keys-as-bullets-not-JSON, fat-context structured render, no-raw-JSON regression guard.
- `TestInvoke`: real key forwarded as env var, placeholder skipped.

## Remaining (deferred — tracked on the issues, NOT closed by this PR)

- **#9622:** assemble `HeartbeatContextBuilder.build()` output into the dispatch `context` dict so the fat fields actually reach `_build_prompt` at runtime (requires routing `claude_code` agents through `ClaudeCodeAdapter`).
- **#9623:** issue a short-lived JWT scoped to agent+run at dispatch time (replacing the `<injected-at-runtime>` placeholder) with revoke-on-completion lifecycle.

Both require integration testing of the heartbeat scheduler and an architectural decision on adapter routing.

## Model Used

claude-opus-4-8 (1M context)
