### PR TITLE
fix(docker): make compose stack run all-healthy out of the box (#9720)

### DIFF
--- a/autobot-backend/ai_hardware_accelerator.py
+++ b/autobot-backend/ai_hardware_accelerator.py
@@ -290,7 +290,10 @@ class AIHardwareAccelerator:
                     logger.warning(f"NPU Worker health check failed: {response.status}")
                     self.device_status[HardwareDevice.NPU]["available"] = False
         except Exception as e:
-            logger.warning("NPU Worker connection failed: %s", e)
+            # An NPU worker is optional hardware; its absence is the normal case
+            # (e.g. docker compose, no Intel NPU). Record unavailable and log at
+            # debug so we don't spam warnings every poll cycle (#9715).
+            logger.debug("NPU Worker unavailable: %s", e)
             self.device_status[HardwareDevice.NPU]["available"] = False
 
     async def _check_gpu_availability(self):

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1531,8 +1531,22 @@ async def _init_budget_watchdog(app: FastAPI) -> None:
         app.state.llc_budget_watchdog = None
 
 
+def _llc_postgres_available() -> bool:
+    """LLC persistence requires Postgres (single_company+). In single_user mode
+    it is intentionally unavailable, so callers skip rather than error (#9713)."""
+    try:
+        from user_management.config import get_deployment_config
+
+        return get_deployment_config().postgres_enabled
+    except Exception:
+        return False
+
+
 async def _recover_agent_sessions(app: FastAPI) -> None:
     """Re-queue runs that were interrupted by a previous server crash (GH#9026)."""
+    if not _llc_postgres_available():
+        logger.info("LLC SessionCheckpointer: skipped (Postgres disabled — single_user mode)")
+        return
     logger.info("LLC SessionCheckpointer: recovering incomplete runs...")
     try:
         from llc.scheduler.session_checkpointer import recover_incomplete_runs
@@ -1545,6 +1559,10 @@ async def _recover_agent_sessions(app: FastAPI) -> None:
 
 async def _init_session_checkpointer(app: FastAPI) -> None:
     """Start LLC SessionCheckpointer for periodic session state persistence (GH#9026)."""
+    if not _llc_postgres_available():
+        logger.info("LLC SessionCheckpointer: skipped (Postgres disabled — single_user mode)")
+        app.state.llc_session_checkpointer = None
+        return
     logger.info("LLC SessionCheckpointer: Starting...")
     try:
         from llc.scheduler.session_checkpointer import SessionCheckpointer

--- a/autobot-backend/migrations/env.py
+++ b/autobot-backend/migrations/env.py
@@ -44,18 +44,20 @@ target_metadata = [Base.metadata, LLCBase.metadata]
 
 def get_url() -> str:
     """Get database URL from deployment config or environment."""
-    # Try environment variable first
-    url = config.database_url
+    # Try environment variable first. NOTE: `config` here is the Alembic Config
+    # object, which has no `database_url`/`db_host` attributes — reading them
+    # raised AttributeError and broke migrations entirely. Read the env directly.
+    url = os.environ.get("AUTOBOT_DATABASE_URL", "")
     if url:
         return url
 
-    # Fall back to deployment config
+    # Fall back to deployment config (Postgres-backed user modes)
     try:
         deployment_config = get_deployment_config()
         return deployment_config.postgres_sync_url
     except Exception:
         # Default fallback for development
-        db_host = config.db_host
+        db_host = os.environ.get("AUTOBOT_POSTGRES_HOST", "autobot-postgres")
         return f"postgresql://autobot:autobot@{db_host}:5432/autobot"
 
 

--- a/autobot-backend/migrations/versions/20260216_003_code_patterns_table.py
+++ b/autobot-backend/migrations/versions/20260216_003_code_patterns_table.py
@@ -13,7 +13,11 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "20260216_003"
-down_revision = "20260216_002"
+# Parent is the secrets migration, whose revision id is the short "002"
+# (20260216_002_secrets_hierarchical_access.py declares revision = "002").
+# It was previously "20260216_002", which no revision defined → broken chain
+# (KeyError) blocking every fresh-DB upgrade (#9759).
+down_revision = "002"
 branch_labels = None
 depends_on = None
 

--- a/autobot-backend/migrations/versions/20260608_052_merge_heads.py
+++ b/autobot-backend/migrations/versions/20260608_052_merge_heads.py
@@ -1,0 +1,32 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""merge divergent heads (036b, 046, 051) into a single head
+
+Three parallel migration branches were never merged, leaving the chain with
+multiple heads so ``alembic upgrade head`` could not resolve a single target.
+This no-op merge unifies them (#9759).
+
+Revision ID: 20260608_052
+Revises: 20260524_036b, 20260527_046, 20260604_051
+Create Date: 2026-06-08
+"""
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "20260608_052"
+down_revision: Union[str, Sequence[str], None] = (
+    "20260524_036b",
+    "20260527_046",
+    "20260604_051",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """No schema change — merge node only."""
+
+
+def downgrade() -> None:
+    """No schema change — merge node only."""

--- a/autobot-backend/migrations/versions/20260608_052_merge_heads.py
+++ b/autobot-backend/migrations/versions/20260608_052_merge_heads.py
@@ -11,6 +11,7 @@ Revision ID: 20260608_052
 Revises: 20260524_036b, 20260527_046, 20260604_051
 Create Date: 2026-06-08
 """
+
 from typing import Sequence, Union
 
 # revision identifiers, used by Alembic.

--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -19,6 +19,7 @@ psutil>=7.2.2  # Issue #927: CPU monitoring for wake word optimization
 sqlalchemy>=2.0.50
 alembic>=1.18.4
 aiosqlite>=0.21.0
+asyncpg>=0.31.0  # Async PostgreSQL driver — required for RBAC user modes (single_company+) (#9713)
 
 # Document Generation (MVA-2174)
 python-docx>=1.1.0  # DOCX export for transcripts

--- a/autobot-backend/utils/system_metrics.py
+++ b/autobot-backend/utils/system_metrics.py
@@ -317,7 +317,11 @@ class SystemMetricsCollector:
                     category="performance",
                 )
         except Exception as e:
-            self.logger.warning("Health check failed for %s: %s", service_name, e)
+            # This is a periodic health probe: a down/unreachable service is an
+            # expected state that consumers read from the *_health metric (0.0),
+            # not from logs. Log at debug to avoid per-cycle spam for optional
+            # services like Ollama that aren't running out of the box (#9715).
+            self.logger.debug("Health check failed for %s: %s", service_name, e)
             error_msg = str(e)
 
         metrics[f"{service_name}_health"] = self._create_health_metric(service_name, health_value, timestamp, error_msg)

--- a/autobot-slm-backend/services/git_tracker.py
+++ b/autobot-slm-backend/services/git_tracker.py
@@ -32,6 +32,14 @@ VERSION_CHECK_INTERVAL = 300  # 5 minutes
 DEFAULT_REPO_PATH = os.environ.get("SLM_REPO_PATH", "/opt/autobot/code_source")
 DEFAULT_BRANCH = os.environ.get("SLM_REPO_BRANCH", "Dev_new_gui")
 
+# Log the "no local code source" condition once, not every interval (#9716).
+_missing_repo_warned = False
+
+
+def _is_git_repo(repo_path: str) -> bool:
+    """Return True if repo_path is a usable git working tree."""
+    return bool(repo_path) and os.path.isdir(os.path.join(repo_path, ".git"))
+
 
 class GitTracker:
     """
@@ -314,9 +322,27 @@ async def version_check_task(
     """
     logger.info("Starting version check task (interval: %ds)", interval)
 
+    global _missing_repo_warned
+
     while True:
         try:
             repo_path, branch = await _get_active_code_source_config()
+
+            # Deployments without a local checkout (e.g. docker compose) have no
+            # code_source dir. Skip quietly instead of spamming git failures
+            # every interval; log the condition exactly once (#9716).
+            if not _is_git_repo(repo_path):
+                if not _missing_repo_warned:
+                    logger.info(
+                        "No local git code source at %s — version checking disabled "
+                        "for this deployment.",
+                        repo_path,
+                    )
+                    _missing_repo_warned = True
+                await asyncio.sleep(interval)
+                continue
+
+            _missing_repo_warned = False
             tracker = get_git_tracker(repo_path=repo_path, branch=branch)
             result = await tracker.check_for_updates()
 

--- a/autobot-slm-backend/services/git_tracker.py
+++ b/autobot-slm-backend/services/git_tracker.py
@@ -334,8 +334,7 @@ async def version_check_task(
             if not _is_git_repo(repo_path):
                 if not _missing_repo_warned:
                     logger.info(
-                        "No local git code source at %s — version checking disabled "
-                        "for this deployment.",
+                        "No local git code source at %s — version checking disabled " "for this deployment.",
                         repo_path,
                     )
                     _missing_repo_warned = True

--- a/autobot_shared/http_client.py
+++ b/autobot_shared/http_client.py
@@ -227,7 +227,11 @@ class HTTPClientManager:
                 self._error_count += 1
                 # Also decrement active on error since we're not returning response
                 self._active_requests = max(0, self._active_requests - 1)
-            logger.error("HTTP request failed: %s", e)
+            # The exception is re-raised, so the caller logs it at the severity
+            # that fits its context. Logging error here too double-logs and
+            # spams for expected failures (e.g. health probes to optional,
+            # not-running services like Ollama) (#9715).
+            logger.debug("HTTP request failed: %s", e)
             raise
 
     async def decrement_active(self) -> None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -339,6 +339,15 @@ services:
         condition: service_healthy
       autobot-chromadb:
         condition: service_healthy
+    healthcheck:
+      # Beat serves no HTTP port, so it can't use the backend image's inherited
+      # curl healthcheck (which always failed → false "unhealthy"). Check the
+      # beat process (PID 1) is alive via procfs — no extra tools needed.
+      test: ["CMD-SHELL", "grep -q celery /proc/1/cmdline"]
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,9 @@ services:
       - POSTGRES_PASSWORD=${AUTOBOT_DB_PASSWORD:-autobot}
       - POSTGRES_DB=${AUTOBOT_DB_NAME:-autobot_slm}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${AUTOBOT_DB_USER:-autobot}"]
+      # -d targets an existing DB; without it pg_isready connects to db=user
+      # ("autobot"), which is never created → FATAL spam every interval (#9713).
+      test: ["CMD-SHELL", "pg_isready -U ${AUTOBOT_DB_USER:-autobot} -d ${AUTOBOT_DB_NAME:-autobot_slm}"]
       interval: 10s
       timeout: 3s
       retries: 5
@@ -107,18 +109,23 @@ services:
       - autobot-data
 
   autobot-chromadb:
-    image: chromadb/chroma:0.5.23
+    # Match the v1 client (chromadb>=1.5.9 in autobot-backend/requirements.txt).
+    # The old 0.5.23 server couldn't parse v1 client requests → KeyError '_type'
+    # spam (#9717). v1.x persists to /data (was /chroma/chroma in 0.5.x).
+    image: chromadb/chroma:1.5.9
     container_name: autobot-chromadb
     restart: unless-stopped
     ports:
       - "127.0.0.1:8100:8000"
     volumes:
-      - chroma_data:/chroma/chroma
+      - chroma_data:/data
     environment:
       - ANONYMIZED_TELEMETRY=False
       - IS_PERSISTENT=TRUE
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v2/heartbeat"]
+      # The chroma 1.x image is minimal (no curl/wget); use bash /dev/tcp to hit
+      # the v2 heartbeat and confirm a 200 (#9717).
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/8000; printf 'GET /api/v2/heartbeat HTTP/1.0\r\n\r\n' >&3; grep -q '200 OK' <&3"]
       interval: 15s
       timeout: 5s
       retries: 3
@@ -177,6 +184,22 @@ services:
       - AUTOBOT_LLAMAINDEX_LLM_ENDPOINT=http://${AUTOBOT_OLLAMA_HOST:-autobot-ollama}:11434
       - AUTOBOT_LLAMAINDEX_EMBEDDING_ENDPOINT=http://${AUTOBOT_OLLAMA_HOST:-autobot-ollama}:11434
       - AUTOBOT_AUDIT_LOG_FILE=/app/logs/audit.log
+      # User mode defaults to single_user (no Postgres schema bootstrap needed).
+      # RBAC (single_company → first user becomes admin) is wired and ready — set
+      # AUTOBOT_USER_MODE=single_company once the fresh-DB schema bootstrap lands
+      # (#9759). The Postgres env below is kept so that flip is a single var.
+      - AUTOBOT_USER_MODE=${AUTOBOT_USER_MODE:-single_user}
+      - AUTOBOT_POSTGRES_HOST=autobot-postgres
+      - AUTOBOT_POSTGRES_PORT=5432
+      - AUTOBOT_POSTGRES_DB=${AUTOBOT_USERS_DB_NAME:-autobot_users}
+      - AUTOBOT_POSTGRES_USER=${AUTOBOT_DB_USER:-autobot}
+      - AUTOBOT_POSTGRES_PASSWORD=${AUTOBOT_DB_PASSWORD:-autobot}
+      - AUTOBOT_ENCRYPTION_KEY=${AUTOBOT_ENCRYPTION_KEY:-}
+      # config.slm_url builds from AUTOBOT_SLM_HOST/PORT. The 127.0.0.1 default
+      # left the node unable to reach SLM → connection spam + host shown offline
+      # in the SLM dashboard. Point it at the service name (#9715).
+      - AUTOBOT_SLM_HOST=autobot-slm
+      - AUTOBOT_SLM_PORT=8000
     depends_on:
       autobot-redis:
         condition: service_healthy
@@ -238,8 +261,22 @@ services:
       - AUTOBOT_CHROMADB_HOST=autobot-chromadb
       - AUTOBOT_CHROMADB_PORT=8000
       - AUTOBOT_AUDIT_LOG_FILE=/app/logs/audit.log
+      # User-mgmt/RBAC tasks need the same Postgres + mode wiring as the backend.
+      # Defaults to single_user; flip AUTOBOT_USER_MODE once #9759 lands.
+      - AUTOBOT_USER_MODE=${AUTOBOT_USER_MODE:-single_user}
+      - AUTOBOT_POSTGRES_HOST=autobot-postgres
+      - AUTOBOT_POSTGRES_PORT=5432
+      - AUTOBOT_POSTGRES_DB=${AUTOBOT_USERS_DB_NAME:-autobot_users}
+      - AUTOBOT_POSTGRES_USER=${AUTOBOT_DB_USER:-autobot}
+      - AUTOBOT_POSTGRES_PASSWORD=${AUTOBOT_DB_PASSWORD:-autobot}
+      - AUTOBOT_ENCRYPTION_KEY=${AUTOBOT_ENCRYPTION_KEY:-}
+      - AUTOBOT_SLM_HOST=autobot-slm
+      - AUTOBOT_SLM_PORT=8000
     healthcheck:
-      test: ["CMD-SHELL", "python3.12 -m celery -A celery_app inspect ping --destination celery@$HOSTNAME --timeout 5"]
+      # $$HOSTNAME (escaped) expands inside the container at runtime. A single
+      # $HOSTNAME is interpolated by Compose at parse time to an empty string,
+      # making --destination "celery@" match no node → false unhealthy (#9714).
+      test: ["CMD-SHELL", "python3.12 -m celery -A celery_app inspect ping --destination celery@$$HOSTNAME --timeout 5"]
       interval: 30s
       timeout: 10s
       start_period: 30s
@@ -278,14 +315,15 @@ services:
       python3.12 -m celery -A celery_app beat
       --loglevel=info
       --scheduler celery.beat.PersistentScheduler
-      --schedule /var/lib/autobot/celerybeat-schedule
+      --schedule /app/data/celerybeat-schedule
     working_dir: /app/autobot-backend
     env_file:
       - docker/.env.docker
     volumes:
+      # Schedule db lives on the writable backend_data volume. The old
+      # /var/lib/autobot mount was root-owned → gdbm EACCES crash loop (#9712).
       - backend_data:/app/data
       - backend_logs:/app/logs
-      - celerybeat_schedule:/var/lib/autobot
     environment:
       - AUTOBOT_ENVIRONMENT=production
       - AUTOBOT_DEPLOYMENT_MODE=local
@@ -421,6 +459,9 @@ services:
       - /var/run
       - /var/cache/nginx
       - /var/lib/nginx
+      # nginx opens its compiled-in default error log before parsing config;
+      # on a read_only rootfs this path must be writable or it alerts (#9718).
+      - /var/log/nginx
     security_opt:
       - no-new-privileges:true
     networks:
@@ -552,7 +593,6 @@ volumes:
   chroma_data:
   backend_data:
   backend_logs:
-  celerybeat_schedule:
   slm_data:
   slm_logs:
   ollama_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,6 +200,9 @@ services:
       # in the SLM dashboard. Point it at the service name (#9715).
       - AUTOBOT_SLM_HOST=autobot-slm
       - AUTOBOT_SLM_PORT=8000
+      # Shared signing secrets — must match SLM so the node JWT verifies (#9715)
+      - AUTOBOT_JWT_SECRET=${AUTOBOT_JWT_SECRET:-autobot-dev-shared-jwt-secret-change-me}
+      - SECRET_KEY=${SECRET_KEY:-autobot-dev-shared-secret-key-change-me}
     depends_on:
       autobot-redis:
         condition: service_healthy
@@ -272,6 +275,9 @@ services:
       - AUTOBOT_ENCRYPTION_KEY=${AUTOBOT_ENCRYPTION_KEY:-}
       - AUTOBOT_SLM_HOST=autobot-slm
       - AUTOBOT_SLM_PORT=8000
+      # Shared signing secrets — must match SLM so the node JWT verifies (#9715)
+      - AUTOBOT_JWT_SECRET=${AUTOBOT_JWT_SECRET:-autobot-dev-shared-jwt-secret-change-me}
+      - SECRET_KEY=${SECRET_KEY:-autobot-dev-shared-secret-key-change-me}
     healthcheck:
       # $$HOSTNAME (escaped) expands inside the container at runtime. A single
       # $HOSTNAME is interpolated by Compose at parse time to an empty string,
@@ -387,6 +393,12 @@ services:
       - SLM_POSTGRES_HOST=autobot-postgres
       - SLM_ADMIN_PASSWORD=${SLM_ADMIN_PASSWORD:-admin}
       - SLM_DATA_DIR=/app/data
+      # Shared signing secrets so the backend node's JWT verifies on SLM —
+      # without a shared secret each service generates its own and SLM rejects
+      # the node WS with 401, leaving the host shown offline (#9715). CHANGE in
+      # production via AUTOBOT_JWT_SECRET / SECRET_KEY.
+      - AUTOBOT_JWT_SECRET=${AUTOBOT_JWT_SECRET:-autobot-dev-shared-jwt-secret-change-me}
+      - SECRET_KEY=${SECRET_KEY:-autobot-dev-shared-secret-key-change-me}
     depends_on:
       autobot-redis:
         condition: service_healthy


### PR DESCRIPTION
## Thinking Path
A log audit of a fresh `docker compose up -d --build` (#9720 umbrella) surfaced 8 faults (#9712–#9719): two crash/false-unhealthy containers, per-cycle FATAL/permission/connection/KeyError spam, and a stale ChromaDB. This PR fixes all of them so the stack comes up **all-healthy out of the box** (verified: 8/8 healthy, 0 unhealthy).

Two deeper items were uncovered and split out as tracked follow-ups rather than expanded here:
- **RBAC-by-default (#9759):** enabling Postgres for the backend needs a fresh-DB schema bootstrap that doesn't exist (migration chain was also broken). Per owner decision, the default ships as `single_user` with the LLC checkpointer gated; all RBAC wiring stays behind `AUTOBOT_USER_MODE`. Migration chain repaired here as partial progress.
- **SLM host-offline (#9761):** the node↔SLM auth (JWT token issuance + node provisioning) is an Ansible-only flow with no compose equivalent. Transport fixed (service-name + shared secret); full node auth tracked separately.

## What Changed
**Compose**
- Postgres healthcheck `-d <db>` → ends the every-10s `database "autobot" does not exist` FATAL (#9713)
- ChromaDB `0.5.23 → 1.5.9` (matches v1 client; fixes `KeyError '_type'`), persist `/data`, bash `/dev/tcp` heartbeat (image has no curl) (#9717)
- celery-beat schedule → writable `/app/data` (was root-owned `/var/lib/autobot` → gdbm crash loop) + proc-based healthcheck (was false-unhealthy from inherited curl) (#9712, #9714)
- worker healthcheck `$$HOSTNAME` (escaped) so it expands in-container, not to `""` (#9714)
- frontend tmpfs `/var/log/nginx` (read_only rootfs) (#9718)
- backend/worker `AUTOBOT_SLM_HOST=autobot-slm` (kills `127.0.0.1:8000` spam) + shared `AUTOBOT_JWT_SECRET`/`SECRET_KEY` (#9715)
- backend/worker Postgres + `AUTOBOT_USER_MODE` wiring (default `single_user`, ready to flip)

**Backend**
- `requirements.txt`: add `asyncpg` (Postgres user modes) (#9713)
- `system_metrics` / `ai_hardware_accelerator` / `http_client`: log expected health-probe failures (optional Ollama/NPU) at debug, not error/warning (#9715)
- `lifespan`: gate LLC SessionCheckpointer to skip cleanly when Postgres disabled

**SLM**
- `git_tracker`: skip + log-once when `/opt/autobot/code_source` is absent (was per-minute git-failure spam) (#9716)

**Migrations (partial progress on #9759)**
- `env.py get_url()`: read env vars (was AttributeError off the Alembic Config → migrations unrunnable)
- repair broken chain `20260216_003` down_revision → `"002"`; add merge migration unifying 3 divergent heads

## Verification
Clean `down -v` + `up -d --build` from this branch:
```
NAMES                 STATUS
autobot-backend       Up (healthy)
autobot-worker        Up (healthy)
autobot-slm           Up (healthy)
autobot-celery-beat   Up (healthy)
autobot-frontend      Up (healthy)
autobot-postgres      Up (healthy)
autobot-redis         Up (healthy)
autobot-chromadb      Up (healthy)
unhealthy: 0
```
Log scan: postgres FATAL, celery-beat permission, worker false-unhealthy, slm git_tracker, nginx error.log, chromadb KeyError, backend SLM `127.0.0.1` spam — **all eliminated**. Residual lines are one-time/non-fatal (single_user feature-gating notices + throttled optional AI-Stack/8080 warning).

Closes #9712, #9713, #9714, #9716, #9717, #9718, #9719
Partially addresses #9715 (SLM transport fixed; node auth → #9761), #9720 (umbrella)
Follow-ups: #9759 (RBAC schema bootstrap), #9761 (SLM node auth / host-offline)

## Model Used
Claude Opus 4.8 (1M context)
