### PR TITLE
fix(ci): apply .bandit config in security-tests bandit scan (#9726)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,8 +130,11 @@ jobs:
       run: |
         echo "🔒 Running security analysis..."
 
-        # Security vulnerability scan — fail on medium+ severity/confidence
-        bandit -r autobot-backend/ autobot-slm-backend/ autobot_shared/ \
+        # Security vulnerability scan — fail on medium+ severity/confidence.
+        # -c .bandit applies the centralized skip list (B101/B104/B105/B106/B108/...)
+        # so known false positives don't fail the gate, matching code-quality.yml
+        # and security.yml (#9694). Real medium+ findings still exit non-zero.
+        bandit -c .bandit -r autobot-backend/ autobot-slm-backend/ autobot_shared/ \
           --severity-level medium --confidence-level medium \
           -f json -o bandit-report.json
         if [ -f bandit-report.json ]; then


### PR DESCRIPTION
## Thinking Path
The `security-tests` job's "Run security analysis" step in `ci.yml` ran `bandit -r ... --severity-level medium --confidence-level medium -f json -o bandit-report.json` **without `-c .bandit`**. So bandit flagged the B104/B108/etc. findings that the centralized `.bandit` skip list exists to suppress and exited 1 → the step failed (`Process completed with exit code 1`) on every `Dev_new_gui` run. Same class of miss that #9694/#9708 fixed for `security.yml`; the `security-tests` workflow was overlooked.

## What Changed
- Added `-c .bandit` to the bandit invocation in `.github/workflows/ci.yml` (security-tests job), aligning it with `code-quality.yml` and `security.yml`.
- Kept gating intact (no `|| true`): real medium+ findings outside the skip list still fail the step.

## Verification
Ran both invocations against the full codebase locally (bandit 1.9.4):
```
# current (no -c)  → reproduces the failure
bandit -r autobot-backend/ autobot-slm-backend/ autobot_shared/ --severity-level medium --confidence-level medium
exit: 1
# with -c .bandit  → passes, false positives skipped
bandit -c .bandit -r autobot-backend/ autobot-slm-backend/ autobot_shared/ --severity-level medium --confidence-level medium
exit: 0
```
YAML validated (`yaml.safe_load`).

## Model Used
Opus 4.8.

Closes #9726