### PR TITLE
fix(ci): keep pr-queue-gate.yml valid YAML — build comment via indented printf (#9722)

### DIFF
--- a/.github/workflows/pr-queue-gate.yml
+++ b/.github/workflows/pr-queue-gate.yml
@@ -35,23 +35,24 @@ jobs:
               --jq --argjson skip "$PR_NUMBER" \
               '[.[] | select(.number != $skip) | "- #\(.number) \(.title)"] | join("\n")')
 
-            BODY=$(cat <<EOF
-## ⚠️ PR Queue Warning: $EXISTING/$LIMIT PRs Already Open
-
-This PR was opened while the queue is at capacity. **Please do not merge new work until existing PRs are reviewed and merged first.**
-
-**Open PRs to clear:**
-$OPEN_LIST
-
-**Action required (agent or author):**
-1. Check CI status on each open PR above
-2. Merge any that are green: \`gh pr merge <number> --squash --delete-branch\`
-3. Fix CI on failing ones if straightforward
-4. Only then should this PR proceed to review/merge
-
-> Queue gate enforced by \`.github/workflows/pr-queue-gate.yml\`
-EOF
-)
+            # Build the comment with an indented printf rather than a column-0
+            # heredoc: an unindented heredoc body breaks out of the `run: |` YAML
+            # block scalar, making the whole workflow invalid YAML (#9722).
+            BODY=$(printf '%s\n' \
+              "## ⚠️ PR Queue Warning: $EXISTING/$LIMIT PRs Already Open" \
+              "" \
+              "This PR was opened while the queue is at capacity. **Please do not merge new work until existing PRs are reviewed and merged first.**" \
+              "" \
+              "**Open PRs to clear:**" \
+              "$OPEN_LIST" \
+              "" \
+              "**Action required (agent or author):**" \
+              "1. Check CI status on each open PR above" \
+              '2. Merge any that are green: `gh pr merge <number> --squash --delete-branch`' \
+              "3. Fix CI on failing ones if straightforward" \
+              "4. Only then should this PR proceed to review/merge" \
+              "" \
+              '> Queue gate enforced by `.github/workflows/pr-queue-gate.yml`')
 
             gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
           else

--- a/.github/workflows/pr-queue-gate.yml
+++ b/.github/workflows/pr-queue-gate.yml
@@ -38,6 +38,7 @@ jobs:
             # Build the comment with an indented printf rather than a column-0
             # heredoc: an unindented heredoc body breaks out of the `run: |` YAML
             # block scalar, making the whole workflow invalid YAML (#9722).
+            # shellcheck disable=SC2016  # backticks/$ in single-quoted lines are intentionally literal
             BODY=$(printf '%s\n' \
               "## ⚠️ PR Queue Warning: $EXISTING/$LIMIT PRs Already Open" \
               "" \


### PR DESCRIPTION
## Thinking Path
The `lint` job (actionlint) was **red on every Dev_new_gui PR**:
```
.github/workflows/pr-queue-gate.yml:41:0: could not parse as YAML: could not find expected ':'
```
Root cause isn't actionlint — the file is **genuinely invalid YAML** (Python's `yaml.safe_load` rejects it identically). The `BODY=$(cat <<EOF … EOF)` heredoc body was written at **column 0**. A `run: |` literal block scalar ends at the first non-blank line indented *less* than the block, so the column-0 markdown terminated the scalar early and YAML then tried to parse the markdown (`This PR was opened … :` , `**Open PRs to clear:**`) as mappings → scanner error.

Indenting the heredoc body would satisfy YAML but `<<EOF` (not `<<-`) keeps the leading spaces, polluting every line of the posted comment — and YAML block scalars require *space* indentation while `<<-` only strips tabs. So the heredoc can't cleanly satisfy both. Fix: drop the heredoc, build `BODY` with an indented `printf '%s\n'` that stays inside the block scalar.

## What Changed
- `.github/workflows/pr-queue-gate.yml`: replaced the column-0 heredoc with an indented `printf '%s\n' …` (double-quoted lines interpolate `$EXISTING`/`$LIMIT`/`$OPEN_LIST`; lines containing backticks are single-quoted to keep them literal). Behaviour/output of the posted comment is unchanged.
- Side benefit: the workflow is now valid YAML for the first time, so GitHub Actions can actually load it (it would have failed to parse before).

## Verification
```
$ actionlint .github/workflows/pr-queue-gate.yml      # → clean, exit 0 (was: 41:0 parse error)
$ python3 -c 'import yaml; yaml.safe_load(open("..."))'  # → YAML OK
```
Ran the exact `printf` with sample values — renders the identical markdown (heading, bold warning, open-PR list, numbered actions, footer) with correct blank lines and literal backticks.

## Model Used
Opus 4.8.

Closes #9722