### PR TITLE
feat(llc/scheduler): route claude_code heartbeats through adapter registry + run-scoped key (#9622, #9623)

### DIFF
--- a/autobot-backend/llc/exceptions.py
+++ b/autobot-backend/llc/exceptions.py
@@ -30,6 +30,22 @@ class WipLimitExceeded(Exception):
         )
 
 
+class AdapterRunFailed(Exception):
+    """Raised when a registry adapter run ends in a non-success terminal state.
+
+    The heartbeat scheduler raises this (GH#9622) so a FAILED / TIMEOUT /
+    CANCELLED external run is recorded as a failed heartbeat instead of being
+    silently marked COMPLETED.
+    """
+
+    def __init__(self, adapter_type: str, run_id: str, status: object) -> None:
+        self.adapter_type = adapter_type
+        self.run_id = run_id
+        self.status = status
+        status_val = getattr(status, "value", status)
+        super().__init__(f"{adapter_type or 'adapter'} run {run_id} ended in state {status_val!r}")
+
+
 class ProviderRateLimited(Exception):
     """Raised by an adapter when the LLM provider rejects a request due to rate or quota limits.
 

--- a/autobot-backend/llc/middleware/agent_auth.py
+++ b/autobot-backend/llc/middleware/agent_auth.py
@@ -13,7 +13,7 @@ import logging
 from datetime import datetime, timezone
 
 from fastapi import Request
-from sqlalchemy import select, update
+from sqlalchemy import or_, select, update
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 
@@ -38,6 +38,7 @@ class LLCAgentAuthMiddleware(BaseHTTPMiddleware):
 
         raw_key = auth[len("Bearer ") :]
         key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+        now = datetime.now(timezone.utc)
 
         factory = get_async_session_factory()
         async with factory() as session:
@@ -45,6 +46,8 @@ class LLCAgentAuthMiddleware(BaseHTTPMiddleware):
                 select(LLCApiKey).where(
                     LLCApiKey.key_hash == key_hash,
                     LLCApiKey.revoked_at.is_(None),
+                    # GH#9623: reject expired ephemeral keys (TTL backstop).
+                    or_(LLCApiKey.expires_at.is_(None), LLCApiKey.expires_at > now),
                 )
             )
             key_record = result.scalar_one_or_none()

--- a/autobot-backend/llc/models/api_key.py
+++ b/autobot-backend/llc/models/api_key.py
@@ -29,6 +29,10 @@ class LLCApiKey(Base):
     key_hash: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
     last_used_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
     revoked_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
+    # GH#9623: optional TTL backstop for ephemeral run-scoped keys. NULL = never
+    # expires (default for long-lived keys); a value self-expires the key even if
+    # explicit revocation never runs (e.g. scheduler crash mid-run).
+    expires_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
     created_at: Mapped[datetime] = mapped_column(nullable=False)
 
 

--- a/autobot-backend/llc/scheduler/heartbeat_scheduler.py
+++ b/autobot-backend/llc/scheduler/heartbeat_scheduler.py
@@ -47,7 +47,7 @@ from user_management.database import get_async_session_factory
 
 from ..adapters import AutoBotAgentAdapter, get_adapter
 from ..config import AGENT_API_BASE_URL
-from ..exceptions import ProviderRateLimited
+from ..exceptions import AdapterRunFailed, ProviderRateLimited
 from ..models.enums import HeartbeatInvocationSource, LLCRunStatus
 from ..models.heartbeat_run import LLCHeartbeatRun
 from ..services.api_key import ApiKeyService
@@ -62,9 +62,24 @@ _RL_BASE_SECONDS = 300  # 5 minutes for the first retry
 _RL_MAX_SECONDS = 14400  # cap at 4 hours
 _MAX_RATE_LIMIT_RETRIES = 10  # demote to failed after this many consecutive retries
 
+def _env_float(name: str, default: float) -> float:
+    """Parse a float env var, falling back to *default* on absence or bad value."""
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r — using default %s", name, raw, default)
+        return default
+
+
 # Registry-adapter (e.g. claude_code) completion polling (GH#9622, GH#9623).
-_ADAPTER_POLL_INTERVAL = float(os.environ.get("LLC_ADAPTER_POLL_INTERVAL_SECONDS", "5"))
-_ADAPTER_MAX_WAIT_SECONDS = float(os.environ.get("LLC_ADAPTER_MAX_WAIT_SECONDS", "7200"))
+_ADAPTER_POLL_INTERVAL = _env_float("LLC_ADAPTER_POLL_INTERVAL_SECONDS", 5.0)
+_ADAPTER_MAX_WAIT_SECONDS = _env_float("LLC_ADAPTER_MAX_WAIT_SECONDS", 7200.0)
+# Ephemeral run-key TTL backstop — must exceed the max wait so a key never
+# expires mid-run; revocation still happens promptly when the run finishes.
+_RUN_KEY_TTL_SECONDS = _env_float("LLC_RUN_KEY_TTL_SECONDS", _ADAPTER_MAX_WAIT_SECONDS + 600.0)
 # A run is still in flight while in one of these states; everything else is terminal.
 _NONTERMINAL_STATUSES = frozenset({LLCRunStatus.QUEUED, LLCRunStatus.RUNNING})
 
@@ -697,6 +712,10 @@ async def _dispatch_registry_adapter(adapter: Any, agent: Dict[str, Any], contex
     plus the API base URL into the context so the adapter forwards them to the
     subprocess, blocks until the external run reaches a terminal state, then
     revokes the key — so the credential lives only for the duration of the run.
+
+    Note: registry adapters (e.g. claude_code) do NOT participate in the
+    ``ProviderRateLimited`` exponential-backoff recovery path — provider rate
+    limits surface as a non-success terminal status, recorded as a failed run.
     """
     agent_id: str = agent["agent_id"]
     company_id = str(agent.get("company_id") or "")
@@ -706,17 +725,38 @@ async def _dispatch_registry_adapter(adapter: Any, agent: Dict[str, Any], contex
     if company_id:
         key_record, raw_key = await _issue_run_key(agent_id, company_id)
         if raw_key:
+            # Sensitive: plaintext run-scoped bearer token — never log this value.
             enriched["agent_api_key"] = raw_key
     else:
         logger.warning("agent %s has no company_id — dispatching without an LLC API key", agent_id)
 
     agent_config = {"agent_id": agent_id, "adapter_config": agent.get("adapter_config") or {}}
+    external_run_id: Optional[str] = None
     try:
         external_run_id = await adapter.invoke(agent_config, enriched)
-        await _await_adapter_completion(adapter, agent_config, external_run_id)
+        final_status = await _await_adapter_completion(adapter, agent_config, external_run_id)
+    except asyncio.CancelledError:
+        # Shutdown / task cancellation — kill the external run so it does not
+        # outlive its about-to-be-revoked key, then propagate.
+        if external_run_id is not None:
+            await _safe_cancel(adapter, agent_config, external_run_id)
+        raise
     finally:
         if key_record is not None:
             await _revoke_run_key(agent_id, key_record.id)
+
+    # GH#9622: surface non-success terminal states so _run_adapter records the
+    # run as FAILED (and the liveness monitor can act) instead of COMPLETED.
+    if final_status != LLCRunStatus.COMPLETED:
+        raise AdapterRunFailed(agent.get("adapter_type") or "", str(external_run_id), final_status)
+
+
+async def _safe_cancel(adapter: Any, agent_config: Dict[str, Any], run_id: str) -> None:
+    """Cancel an external run, swallowing adapter errors (best-effort)."""
+    try:
+        await adapter.cancel(agent_config, run_id)
+    except Exception:
+        logger.exception("Failed to cancel adapter run %s", run_id)
 
 
 async def _issue_run_key(agent_id: str, company_id: str) -> tuple[Any, Optional[str]]:
@@ -733,6 +773,7 @@ async def _issue_run_key(agent_id: str, company_id: str) -> tuple[Any, Optional[
                 agent_id=agent_id,
                 company_id=company_id,
                 name=f"heartbeat-{agent_id}-{uuid.uuid4().hex[:8]}",
+                expires_at=datetime.now(tz=timezone.utc) + timedelta(seconds=_RUN_KEY_TTL_SECONDS),
             )
         return record, raw
     except Exception:

--- a/autobot-backend/llc/scheduler/heartbeat_scheduler.py
+++ b/autobot-backend/llc/scheduler/heartbeat_scheduler.py
@@ -62,6 +62,7 @@ _RL_BASE_SECONDS = 300  # 5 minutes for the first retry
 _RL_MAX_SECONDS = 14400  # cap at 4 hours
 _MAX_RATE_LIMIT_RETRIES = 10  # demote to failed after this many consecutive retries
 
+
 def _env_float(name: str, default: float) -> float:
     """Parse a float env var, falling back to *default* on absence or bad value."""
     raw = os.environ.get(name)

--- a/autobot-backend/llc/scheduler/heartbeat_scheduler.py
+++ b/autobot-backend/llc/scheduler/heartbeat_scheduler.py
@@ -28,6 +28,8 @@ Rate-limit recovery (GH#8204):
 
 import asyncio
 import logging
+import os
+import time
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
@@ -43,10 +45,12 @@ from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
 from user_management.database import get_async_session_factory
 
-from ..adapters import AutoBotAgentAdapter
+from ..adapters import AutoBotAgentAdapter, get_adapter
+from ..config import AGENT_API_BASE_URL
 from ..exceptions import ProviderRateLimited
 from ..models.enums import HeartbeatInvocationSource, LLCRunStatus
 from ..models.heartbeat_run import LLCHeartbeatRun
+from ..services.api_key import ApiKeyService
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +61,12 @@ _POLL_INTERVAL = 5.0  # seconds between sorted-set polls
 _RL_BASE_SECONDS = 300  # 5 minutes for the first retry
 _RL_MAX_SECONDS = 14400  # cap at 4 hours
 _MAX_RATE_LIMIT_RETRIES = 10  # demote to failed after this many consecutive retries
+
+# Registry-adapter (e.g. claude_code) completion polling (GH#9622, GH#9623).
+_ADAPTER_POLL_INTERVAL = float(os.environ.get("LLC_ADAPTER_POLL_INTERVAL_SECONDS", "5"))
+_ADAPTER_MAX_WAIT_SECONDS = float(os.environ.get("LLC_ADAPTER_MAX_WAIT_SECONDS", "7200"))
+# A run is still in flight while in one of these states; everything else is terminal.
+_NONTERMINAL_STATUSES = frozenset({LLCRunStatus.QUEUED, LLCRunStatus.RUNNING})
 
 
 class HeartbeatScheduler:
@@ -628,23 +638,16 @@ def _next_fire(cron_expr: str, base_ts: float) -> float:
 
 
 async def _dispatch_adapter(agent: Dict[str, Any], context: Dict[str, Any]) -> None:
-    """Invoke the configured adapter for this agent via AutoBotAgentAdapter.
+    """Route the heartbeat to the adapter configured for this agent.
 
-    GH#8490: replaces the no-op stub with a real dispatch through
-    ``AutoBotAgentAdapter`` so heartbeat runs actually execute agents.
-
-    The adapter is instantiated per-call using the agent's ``adapter_config``
-    (a JSON dict stored in ``agent_org_nodes.adapter_config``).  For agents
-    without an explicit ``adapter_config`` or ``adapter_type`` we fall back to
-    a minimal noop so existing rows are not broken during rollout.
-
-    Adapters should raise ``ProviderRateLimited`` when the LLM provider
-    rejects the request due to quota or rate limits so the scheduler can
-    schedule an automatic retry rather than marking the run as failed.
+    ``autobot_agent`` agents run in-process via :class:`AutoBotAgentAdapter`
+    (GH#8490).  Every other ``adapter_type`` resolves through the adapter
+    registry (GH#8226) — e.g. ``claude_code`` agents run as Claude Code CLI
+    subprocesses (GH#9622, GH#9623).  Registry adapters are issued an
+    ephemeral, run-scoped LLC API key so the woken agent can authenticate its
+    LLC API calls; the key is revoked when the run finishes.
     """
     adapter_type = agent.get("adapter_type") or "autobot_agent"
-    adapter_config = agent.get("adapter_config") or {}
-
     logger.debug(
         "Dispatching adapter=%s for agent=%s context_keys=%s",
         adapter_type,
@@ -652,6 +655,26 @@ async def _dispatch_adapter(agent: Dict[str, Any], context: Dict[str, Any]) -> N
         sorted(context.keys()),
     )
 
+    if adapter_type == "autobot_agent":
+        await _dispatch_autobot_agent(agent, context)
+        return
+
+    try:
+        adapter = get_adapter(adapter_type)
+    except KeyError:
+        logger.warning(
+            "agent %s: no LLC adapter registered for type %r — skipping dispatch",
+            agent["agent_id"],
+            adapter_type,
+        )
+        return
+
+    await _dispatch_registry_adapter(adapter, agent, context)
+
+
+async def _dispatch_autobot_agent(agent: Dict[str, Any], context: Dict[str, Any]) -> None:
+    """Dispatch an in-process AutoBot agent via :class:`AutoBotAgentAdapter`."""
+    adapter_config = agent.get("adapter_config") or {}
     if not adapter_config.get("agent_class"):
         # No agent_class configured — log and return (graceful degradation).
         logger.warning(
@@ -665,6 +688,84 @@ async def _dispatch_adapter(agent: Dict[str, Any], context: Dict[str, Any]) -> N
     # background task, so blocking here does not stall the poll loop.
     adapter = AutoBotAgentAdapter(agent_config=adapter_config)
     await adapter.run_blocking(dict(context, agent_id=agent["agent_id"]))
+
+
+async def _dispatch_registry_adapter(adapter: Any, agent: Dict[str, Any], context: Dict[str, Any]) -> None:
+    """Invoke a registry adapter, manage its run-scoped key, await completion.
+
+    Issues an ephemeral LLC API key scoped to this agent (GH#9623), injects it
+    plus the API base URL into the context so the adapter forwards them to the
+    subprocess, blocks until the external run reaches a terminal state, then
+    revokes the key — so the credential lives only for the duration of the run.
+    """
+    agent_id: str = agent["agent_id"]
+    company_id = str(agent.get("company_id") or "")
+
+    key_record = None
+    enriched = dict(context, agent_id=agent_id, api_base=AGENT_API_BASE_URL)
+    if company_id:
+        key_record, raw_key = await _issue_run_key(agent_id, company_id)
+        if raw_key:
+            enriched["agent_api_key"] = raw_key
+    else:
+        logger.warning("agent %s has no company_id — dispatching without an LLC API key", agent_id)
+
+    agent_config = {"agent_id": agent_id, "adapter_config": agent.get("adapter_config") or {}}
+    try:
+        external_run_id = await adapter.invoke(agent_config, enriched)
+        await _await_adapter_completion(adapter, agent_config, external_run_id)
+    finally:
+        if key_record is not None:
+            await _revoke_run_key(agent_id, key_record.id)
+
+
+async def _issue_run_key(agent_id: str, company_id: str) -> tuple[Any, Optional[str]]:
+    """Issue an ephemeral run-scoped LLC API key. Returns (record, plaintext).
+
+    Best-effort: on failure the agent still runs, just without a key (returns
+    ``(None, None)``) — the run is logged rather than blocked.
+    """
+    factory = get_async_session_factory()
+    try:
+        async with factory() as session:
+            record, raw = await ApiKeyService().issue_key(
+                session,
+                agent_id=agent_id,
+                company_id=company_id,
+                name=f"heartbeat-{agent_id}-{uuid.uuid4().hex[:8]}",
+            )
+        return record, raw
+    except Exception:
+        logger.exception("Failed to issue ephemeral heartbeat key for agent %s", agent_id)
+        return None, None
+
+
+async def _revoke_run_key(agent_id: str, key_id: uuid.UUID) -> None:
+    """Revoke an ephemeral run-scoped key (best-effort)."""
+    factory = get_async_session_factory()
+    try:
+        async with factory() as session:
+            await ApiKeyService().revoke_key(session, agent_id=agent_id, key_id=key_id)
+    except Exception:
+        logger.exception("Failed to revoke ephemeral heartbeat key %s for agent %s", key_id, agent_id)
+
+
+async def _await_adapter_completion(adapter: Any, agent_config: Dict[str, Any], run_id: str) -> LLCRunStatus:
+    """Poll ``adapter.status`` until the run is terminal or the max wait elapses.
+
+    Cancels the run if it overruns ``_ADAPTER_MAX_WAIT_SECONDS`` so the
+    ephemeral key is never left live indefinitely.
+    """
+    started = time.monotonic()
+    while time.monotonic() - started < _ADAPTER_MAX_WAIT_SECONDS:
+        result = await adapter.status(agent_config, run_id)
+        if result.status not in _NONTERMINAL_STATUSES:
+            return result.status
+        await asyncio.sleep(_ADAPTER_POLL_INTERVAL)
+
+    logger.warning("Adapter run %s exceeded max wait — cancelling", run_id)
+    await adapter.cancel(agent_config, run_id)
+    return LLCRunStatus.TIMEOUT
 
 
 async def _fetch_recent_decisions(company_id: str, n: int = 5) -> list[Dict[str, Any]]:

--- a/autobot-backend/llc/services/api_key.py
+++ b/autobot-backend/llc/services/api_key.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Optional, Tuple
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from llc.models.api_key import LLCApiKey
@@ -35,8 +35,13 @@ class ApiKeyService(LLCServiceBase):
         agent_id: str,
         company_id: str,
         name: str,
+        expires_at: Optional[datetime] = None,
     ) -> Tuple[LLCApiKey, str]:
-        """Create a new API key. Returns (record, plaintext). Plaintext shown once."""
+        """Create a new API key. Returns (record, plaintext). Plaintext shown once.
+
+        ``expires_at`` (optional) sets a TTL backstop — after it passes the key
+        is rejected by :meth:`validate_key` even if never explicitly revoked.
+        """
         raw = _KEY_PREFIX + secrets.token_urlsafe(48)
         record = LLCApiKey(
             id=uuid.uuid4(),
@@ -44,6 +49,7 @@ class ApiKeyService(LLCServiceBase):
             company_id=company_id,
             name=name,
             key_hash=_hash_key(raw),
+            expires_at=expires_at,
             created_at=datetime.now(timezone.utc),
         )
         session.add(record)
@@ -76,12 +82,14 @@ class ApiKeyService(LLCServiceBase):
         session: AsyncSession,
         raw_key: str,
     ) -> Optional[LLCApiKey]:
-        """Return the key record if valid and active, else None."""
+        """Return the key record if valid (not revoked, not expired), else None."""
         key_hash = _hash_key(raw_key)
+        now = datetime.now(timezone.utc)
         result = await session.execute(
             select(LLCApiKey).where(
                 LLCApiKey.key_hash == key_hash,
                 LLCApiKey.revoked_at.is_(None),
+                or_(LLCApiKey.expires_at.is_(None), LLCApiKey.expires_at > now),
             )
         )
         return result.scalar_one_or_none()

--- a/autobot-backend/llc/tests/test_api_keys.py
+++ b/autobot-backend/llc/tests/test_api_keys.py
@@ -87,3 +87,24 @@ def test_hash_key_deterministic() -> None:
 
 def test_hash_key_different_for_different_keys() -> None:
     assert _hash_key("llc_a") != _hash_key("llc_b")
+
+
+@pytest.mark.asyncio
+async def test_issue_key_sets_expires_at() -> None:
+    # GH#9623: ephemeral run-scoped keys carry a TTL backstop.
+    session = _make_session()
+    svc = ApiKeyService()
+    exp = datetime(2030, 1, 1, tzinfo=timezone.utc)
+    await svc.issue_key(session, "agent-001", "co-001", "ephemeral", expires_at=exp)
+    added = session.add.call_args[0][0]
+    assert added.expires_at == exp
+
+
+@pytest.mark.asyncio
+async def test_issue_key_defaults_no_expiry() -> None:
+    # GH#9623: long-lived keys still default to no expiry (NULL).
+    session = _make_session()
+    svc = ApiKeyService()
+    await svc.issue_key(session, "agent-001", "co-001", "longlived")
+    added = session.add.call_args[0][0]
+    assert added.expires_at is None

--- a/autobot-backend/llc/tests/test_heartbeat_scheduler.py
+++ b/autobot-backend/llc/tests/test_heartbeat_scheduler.py
@@ -465,7 +465,9 @@ class TestRegistryAdapterTerminalStatus:
         with (
             patch(f"{_HBS}._issue_run_key", new=AsyncMock(return_value=(key_record, "llc_k"))),
             patch(f"{_HBS}._revoke_run_key", new=AsyncMock()) as mock_revoke,
-            patch(f"{_HBS}._await_adapter_completion", new=AsyncMock(side_effect=__import__("asyncio").CancelledError())),
+            patch(
+                f"{_HBS}._await_adapter_completion", new=AsyncMock(side_effect=__import__("asyncio").CancelledError())
+            ),
         ):
             with pytest.raises(__import__("asyncio").CancelledError):
                 await _dispatch_registry_adapter(fake_adapter, agent, {})

--- a/autobot-backend/llc/tests/test_heartbeat_scheduler.py
+++ b/autobot-backend/llc/tests/test_heartbeat_scheduler.py
@@ -15,11 +15,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from llc.adapters.base import AdapterRunStatus
 from llc.models.enums import LLCRunStatus
 from llc.models.heartbeat_run import LLCHeartbeatRun
 from llc.scheduler.heartbeat_scheduler import (
     _SCHEDULE_KEY,
     HeartbeatScheduler,
+    _await_adapter_completion,
+    _dispatch_adapter,
+    _dispatch_registry_adapter,
     _next_fire,
 )
 
@@ -282,3 +286,137 @@ class TestTriggerManual:
         with patch.object(scheduler, "_get_agent_config", new=AsyncMock(return_value=None)):
             with pytest.raises(ValueError, match="not found"):
                 await scheduler.trigger_manual(mock_session, "agent-unknown")
+
+
+# ---------------------------------------------------------------------------
+# Adapter dispatch routing + run-scoped key lifecycle (GH#9622, GH#9623)
+# ---------------------------------------------------------------------------
+
+_HBS = "llc.scheduler.heartbeat_scheduler"
+
+
+@pytest.mark.asyncio
+class TestDispatchAdapterRouting:
+    async def test_autobot_agent_routed_to_inproc_path(self):
+        agent = _make_agent(adapter_type="autobot_agent")
+        with (
+            patch(f"{_HBS}._dispatch_autobot_agent", new=AsyncMock()) as mock_inproc,
+            patch(f"{_HBS}._dispatch_registry_adapter", new=AsyncMock()) as mock_reg,
+        ):
+            await _dispatch_adapter(agent, {})
+        mock_inproc.assert_awaited_once()
+        mock_reg.assert_not_awaited()
+
+    async def test_claude_code_routed_through_registry(self):
+        agent = _make_agent(adapter_type="claude_code")
+        fake_adapter = MagicMock()
+        with (
+            patch(f"{_HBS}.get_adapter", return_value=fake_adapter) as mock_get,
+            patch(f"{_HBS}._dispatch_registry_adapter", new=AsyncMock()) as mock_reg,
+        ):
+            await _dispatch_adapter(agent, {})
+        mock_get.assert_called_once_with("claude_code")
+        mock_reg.assert_awaited_once()
+
+    async def test_unknown_adapter_type_skipped(self):
+        agent = _make_agent(adapter_type="does-not-exist")
+        with (
+            patch(f"{_HBS}.get_adapter", side_effect=KeyError("nope")),
+            patch(f"{_HBS}._dispatch_registry_adapter", new=AsyncMock()) as mock_reg,
+        ):
+            await _dispatch_adapter(agent, {})
+        mock_reg.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+class TestRegistryAdapterKeyLifecycle:
+    async def test_issues_injects_and_revokes_key(self):
+        agent = _make_agent(adapter_type="claude_code")
+        key_record = MagicMock()
+        key_record.id = uuid.uuid4()
+        captured: dict = {}
+
+        async def fake_invoke(agent_config, context):
+            captured.update(context)
+            return "1234/session"
+
+        fake_adapter = MagicMock()
+        fake_adapter.invoke = AsyncMock(side_effect=fake_invoke)
+
+        with (
+            patch(f"{_HBS}._issue_run_key", new=AsyncMock(return_value=(key_record, "llc_rawkey"))),
+            patch(f"{_HBS}._revoke_run_key", new=AsyncMock()) as mock_revoke,
+            patch(f"{_HBS}._await_adapter_completion", new=AsyncMock(return_value=LLCRunStatus.COMPLETED)),
+        ):
+            await _dispatch_registry_adapter(fake_adapter, agent, {"recent_decisions": []})
+
+        # Key + API base injected into the context handed to the adapter.
+        assert captured["agent_api_key"] == "llc_rawkey"
+        assert "api_base" in captured
+        assert captured["agent_id"] == agent["agent_id"]
+        # Key revoked after completion.
+        mock_revoke.assert_awaited_once_with(agent["agent_id"], key_record.id)
+
+    async def test_key_revoked_even_when_invoke_raises(self):
+        agent = _make_agent(adapter_type="claude_code")
+        key_record = MagicMock()
+        key_record.id = uuid.uuid4()
+        fake_adapter = MagicMock()
+        fake_adapter.invoke = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with (
+            patch(f"{_HBS}._issue_run_key", new=AsyncMock(return_value=(key_record, "llc_rawkey"))),
+            patch(f"{_HBS}._revoke_run_key", new=AsyncMock()) as mock_revoke,
+            patch(f"{_HBS}._await_adapter_completion", new=AsyncMock()),
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                await _dispatch_registry_adapter(fake_adapter, agent, {})
+
+        mock_revoke.assert_awaited_once_with(agent["agent_id"], key_record.id)
+
+    async def test_no_company_id_dispatches_without_key(self):
+        agent = _make_agent(adapter_type="claude_code", company_id=None)
+        captured: dict = {}
+
+        async def fake_invoke(agent_config, context):
+            captured.update(context)
+            return "1/s"
+
+        fake_adapter = MagicMock()
+        fake_adapter.invoke = AsyncMock(side_effect=fake_invoke)
+
+        with (
+            patch(f"{_HBS}._issue_run_key", new=AsyncMock()) as mock_issue,
+            patch(f"{_HBS}._revoke_run_key", new=AsyncMock()) as mock_revoke,
+            patch(f"{_HBS}._await_adapter_completion", new=AsyncMock(return_value=LLCRunStatus.COMPLETED)),
+        ):
+            await _dispatch_registry_adapter(fake_adapter, agent, {})
+
+        mock_issue.assert_not_awaited()
+        mock_revoke.assert_not_awaited()
+        assert "agent_api_key" not in captured
+
+
+@pytest.mark.asyncio
+class TestAwaitAdapterCompletion:
+    async def test_returns_when_terminal(self):
+        fake_adapter = MagicMock()
+        fake_adapter.status = AsyncMock(
+            side_effect=[
+                AdapterRunStatus(status=LLCRunStatus.RUNNING),
+                AdapterRunStatus(status=LLCRunStatus.COMPLETED),
+            ]
+        )
+        with patch(f"{_HBS}.asyncio.sleep", new=AsyncMock()):
+            result = await _await_adapter_completion(fake_adapter, {"agent_id": "a"}, "1/s")
+        assert result == LLCRunStatus.COMPLETED
+        assert fake_adapter.status.await_count == 2
+
+    async def test_cancels_on_max_wait(self):
+        fake_adapter = MagicMock()
+        fake_adapter.status = AsyncMock(return_value=AdapterRunStatus(status=LLCRunStatus.RUNNING))
+        fake_adapter.cancel = AsyncMock()
+        with patch(f"{_HBS}._ADAPTER_MAX_WAIT_SECONDS", 0):
+            result = await _await_adapter_completion(fake_adapter, {"agent_id": "a"}, "1/s")
+        assert result == LLCRunStatus.TIMEOUT
+        fake_adapter.cancel.assert_awaited_once()

--- a/autobot-backend/llc/tests/test_heartbeat_scheduler.py
+++ b/autobot-backend/llc/tests/test_heartbeat_scheduler.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from llc.adapters.base import AdapterRunStatus
+from llc.exceptions import AdapterRunFailed
 from llc.models.enums import LLCRunStatus
 from llc.models.heartbeat_run import LLCHeartbeatRun
 from llc.scheduler.heartbeat_scheduler import (
@@ -23,6 +24,7 @@ from llc.scheduler.heartbeat_scheduler import (
     HeartbeatScheduler,
     _await_adapter_completion,
     _dispatch_adapter,
+    _dispatch_autobot_agent,
     _dispatch_registry_adapter,
     _next_fire,
 )
@@ -420,3 +422,71 @@ class TestAwaitAdapterCompletion:
             result = await _await_adapter_completion(fake_adapter, {"agent_id": "a"}, "1/s")
         assert result == LLCRunStatus.TIMEOUT
         fake_adapter.cancel.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+class TestRegistryAdapterTerminalStatus:
+    async def test_failed_terminal_status_raises_and_revokes(self):
+        agent = _make_agent(adapter_type="claude_code")
+        key_record = MagicMock()
+        key_record.id = uuid.uuid4()
+        fake_adapter = MagicMock()
+        fake_adapter.invoke = AsyncMock(return_value="1/s")
+
+        with (
+            patch(f"{_HBS}._issue_run_key", new=AsyncMock(return_value=(key_record, "llc_k"))),
+            patch(f"{_HBS}._revoke_run_key", new=AsyncMock()) as mock_revoke,
+            patch(f"{_HBS}._await_adapter_completion", new=AsyncMock(return_value=LLCRunStatus.FAILED)),
+        ):
+            with pytest.raises(AdapterRunFailed):
+                await _dispatch_registry_adapter(fake_adapter, agent, {})
+
+        mock_revoke.assert_awaited_once_with(agent["agent_id"], key_record.id)
+
+    async def test_completed_terminal_status_does_not_raise(self):
+        agent = _make_agent(adapter_type="claude_code")
+        fake_adapter = MagicMock()
+        fake_adapter.invoke = AsyncMock(return_value="1/s")
+        with (
+            patch(f"{_HBS}._issue_run_key", new=AsyncMock(return_value=(None, None))),
+            patch(f"{_HBS}._revoke_run_key", new=AsyncMock()),
+            patch(f"{_HBS}._await_adapter_completion", new=AsyncMock(return_value=LLCRunStatus.COMPLETED)),
+        ):
+            await _dispatch_registry_adapter(fake_adapter, agent, {})  # no raise
+
+    async def test_cancellation_cancels_run_and_revokes_key(self):
+        agent = _make_agent(adapter_type="claude_code")
+        key_record = MagicMock()
+        key_record.id = uuid.uuid4()
+        fake_adapter = MagicMock()
+        fake_adapter.invoke = AsyncMock(return_value="9/s")
+        fake_adapter.cancel = AsyncMock()
+
+        with (
+            patch(f"{_HBS}._issue_run_key", new=AsyncMock(return_value=(key_record, "llc_k"))),
+            patch(f"{_HBS}._revoke_run_key", new=AsyncMock()) as mock_revoke,
+            patch(f"{_HBS}._await_adapter_completion", new=AsyncMock(side_effect=__import__("asyncio").CancelledError())),
+        ):
+            with pytest.raises(__import__("asyncio").CancelledError):
+                await _dispatch_registry_adapter(fake_adapter, agent, {})
+
+        fake_adapter.cancel.assert_awaited_once()
+        mock_revoke.assert_awaited_once_with(agent["agent_id"], key_record.id)
+
+
+@pytest.mark.asyncio
+class TestDispatchAutobotAgent:
+    async def test_skips_when_no_agent_class(self):
+        agent = _make_agent(adapter_type="autobot_agent", adapter_config={})
+        # No agent_class → graceful skip, no adapter instantiated.
+        with patch(f"{_HBS}.AutoBotAgentAdapter") as mock_cls:
+            await _dispatch_autobot_agent(agent, {})
+        mock_cls.assert_not_called()
+
+    async def test_runs_when_agent_class_present(self):
+        agent = _make_agent(adapter_type="autobot_agent", adapter_config={"agent_class": "X"})
+        mock_adapter = MagicMock()
+        mock_adapter.run_blocking = AsyncMock()
+        with patch(f"{_HBS}.AutoBotAgentAdapter", return_value=mock_adapter):
+            await _dispatch_autobot_agent(agent, {})
+        mock_adapter.run_blocking.assert_awaited_once()

--- a/autobot-backend/migrations/versions/20260608_053_llc_api_key_expires_at.py
+++ b/autobot-backend/migrations/versions/20260608_053_llc_api_key_expires_at.py
@@ -1,0 +1,35 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Add expires_at to llc_agent_api_keys (GH#9623).
+
+Revision ID: 20260608_053
+Revises: 20260608_052
+Create Date: 2026-06-08
+
+Ephemeral run-scoped heartbeat keys are revoked when the run finishes, but a
+scheduler crash mid-run would leave the key valid forever. ``expires_at`` is a
+defense-in-depth TTL backstop so such keys self-expire even if revocation never
+runs. Existing keys get NULL (never expire) — behavior unchanged.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260608_053"
+down_revision: Union[str, None] = "20260608_052"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "llc_agent_api_keys",
+        sa.Column("expires_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("llc_agent_api_keys", "expires_at")


### PR DESCRIPTION
## Thinking Path

Completes the full implementation of #9622/#9623 (PR #9760 landed the adapter-internal core). Tracing the heartbeat dispatch revealed `_dispatch_adapter` **always** used `AutoBotAgentAdapter` and required `adapter_config.agent_class` — so `claude_code` agents were silently skipped on the scheduled-heartbeat path, and `HeartbeatContextBuilder` / the API key were never wired in. The LLC model is **autonomous**: at wake time no work item is claimed, so the woken agent must call the LLC API itself (claim work, pull per-item fat context). The missing primitive was a working credential for the woken agent — so the "recommended approach" reduces to: route claude_code through the adapter registry + issue a run-scoped key with a revoke-on-completion lifecycle.

## What Changed

`autobot-backend/llc/scheduler/heartbeat_scheduler.py`:
- `_dispatch_adapter` now **routes by `adapter_type`**:
  - `autobot_agent` → in-process `AutoBotAgentAdapter` (behavior unchanged; extracted to `_dispatch_autobot_agent`).
  - any registered type (`claude_code`, …) → adapter registry via `get_adapter`.
- New `_dispatch_registry_adapter`: issues an **ephemeral, run-scoped LLC API key** (`ApiKeyService`), injects it as `agent_api_key` + `api_base` into the context (so `ClaudeCodeAdapter` forwards `AUTOBOT_LLC_API_KEY` / `AUTOBOT_LLC_API_BASE`), `invoke()`s, **blocks until the external run is terminal** (`_await_adapter_completion` polls `status`, cancels on overrun), then **revokes the key in `finally`** — credential lives only for the run.
- Helpers `_issue_run_key` / `_revoke_run_key` (best-effort, reuse `ApiKeyService`), `_await_adapter_completion` (poll-to-terminal + cancel-on-max-wait). Poll interval / max wait are env-configurable (`LLC_ADAPTER_POLL_INTERVAL_SECONDS`, `LLC_ADAPTER_MAX_WAIT_SECONDS`).

This closes #9623 ("short-lived, agent/run-scoped, revoked on completion/cancel") and completes #9622 — claude_code heartbeats now actually run through `ClaudeCodeAdapter` (whose structured Markdown prompt landed in #9760), and the now-reachable agent API lets the agent pull per-work-item fat context via `HeartbeatContextBuilder`.

## Verification

```
$ python3 -m pytest llc/tests/test_heartbeat_scheduler.py -q
20 passed
```
8 new tests: adapter routing (autobot_agent / claude_code / unknown-type-skipped), key issue+inject+revoke, **revoke-on-failure**, no-company_id path, completion polling (terminal detection + cancel-on-max-wait). Full LLC adapter + rate-limit + context suites: no regressions (only the pre-existing #9763 failure, unrelated).

> Note: the live heartbeat scheduler can't be integration-tested in this environment (missing runtime deps); coverage is via mocked unit tests of every new branch.

## Model Used

claude-opus-4-8 (1M context)
