### PR TITLE
fix(compose): stop single_user startup error spam — LLC scheduler gate + git_tracker guard (#9771)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1503,6 +1503,10 @@ async def _start_community_clustering_loop(app: FastAPI) -> None:
 
 async def _init_liveness_monitor(app: FastAPI) -> None:
     """Start LLC LivenessMonitor to recover stuck heartbeat runs (GH#9028)."""
+    if not _llc_postgres_available():
+        logger.info("LLC LivenessMonitor: skipped (Postgres disabled — single_user mode)")
+        app.state.llc_liveness_monitor = None
+        return
     logger.info("LLC LivenessMonitor: Starting...")
     try:
         from llc.scheduler.liveness_monitor import LivenessMonitor
@@ -1518,6 +1522,10 @@ async def _init_liveness_monitor(app: FastAPI) -> None:
 
 async def _init_budget_watchdog(app: FastAPI) -> None:
     """Start LLC BudgetWatchdog for per-agent budget enforcement (GH#9029)."""
+    if not _llc_postgres_available():
+        logger.info("LLC BudgetWatchdog: skipped (Postgres disabled — single_user mode)")
+        app.state.llc_budget_watchdog = None
+        return
     logger.info("LLC BudgetWatchdog: Starting...")
     try:
         from llc.scheduler.budget_watchdog import BudgetWatchdog

--- a/autobot-slm-backend/services/git_tracker.py
+++ b/autobot-slm-backend/services/git_tracker.py
@@ -81,6 +81,15 @@ class GitTracker:
         """
         cmd = ["git", "-C", self.repo_path, *args]
 
+        # Deployments without a local checkout (docker compose / rsync) have no
+        # code_source dir. Skip the git invocation and let callers fall back to
+        # the DB commit setting, instead of warn-spamming every reconcile cycle
+        # (#9716 guarded only version_check_task; the API/reconciler callers
+        # bypassed it — #9771).
+        if not _is_git_repo(self.repo_path):
+            logger.debug("git_tracker: %s is not a git repo — skipping 'git %s'", self.repo_path, " ".join(args))
+            return "", 1
+
         try:
             proc = await asyncio.create_subprocess_exec(
                 *cmd,

--- a/autobot-slm-backend/tests/services/git_tracker_test.py
+++ b/autobot-slm-backend/tests/services/git_tracker_test.py
@@ -32,42 +32,61 @@ class TestGitTracker:
         """Test getting current commit hash from local repo."""
         tracker = GitTracker(repo_path="${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
 
-        with patch("asyncio.create_subprocess_exec") as mock_exec:
-            mock_process = AsyncMock()
-            mock_process.communicate = AsyncMock(return_value=(b"abc123def456\n", b""))
-            mock_process.returncode = 0
-            mock_exec.return_value = mock_process
+        with patch.object(git_tracker, "_is_git_repo", return_value=True):
+            with patch("asyncio.create_subprocess_exec") as mock_exec:
+                mock_process = AsyncMock()
+                mock_process.communicate = AsyncMock(return_value=(b"abc123def456\n", b""))
+                mock_process.returncode = 0
+                mock_exec.return_value = mock_process
 
-            commit = await tracker.get_local_commit()
-            assert commit == "abc123def456"
+                commit = await tracker.get_local_commit()
+                assert commit == "abc123def456"
 
     @pytest.mark.asyncio
     async def test_fetch_from_remote(self):
         """Test fetching updates from remote."""
         tracker = GitTracker(repo_path="${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
 
-        with patch("asyncio.create_subprocess_exec") as mock_exec:
-            mock_process = AsyncMock()
-            mock_process.communicate = AsyncMock(return_value=(b"", b""))
-            mock_process.returncode = 0
-            mock_exec.return_value = mock_process
+        with patch.object(git_tracker, "_is_git_repo", return_value=True):
+            with patch("asyncio.create_subprocess_exec") as mock_exec:
+                mock_process = AsyncMock()
+                mock_process.communicate = AsyncMock(return_value=(b"", b""))
+                mock_process.returncode = 0
+                mock_exec.return_value = mock_process
 
-            success = await tracker.fetch_remote()
-            assert success is True
+                success = await tracker.fetch_remote()
+                assert success is True
 
     @pytest.mark.asyncio
     async def test_get_remote_commit_hash(self):
         """Test getting latest commit hash from remote."""
         tracker = GitTracker(repo_path="${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
 
-        with patch("asyncio.create_subprocess_exec") as mock_exec:
-            mock_process = AsyncMock()
-            mock_process.communicate = AsyncMock(return_value=(b"def789ghi012\n", b""))
-            mock_process.returncode = 0
-            mock_exec.return_value = mock_process
+        with patch.object(git_tracker, "_is_git_repo", return_value=True):
+            with patch("asyncio.create_subprocess_exec") as mock_exec:
+                mock_process = AsyncMock()
+                mock_process.communicate = AsyncMock(return_value=(b"def789ghi012\n", b""))
+                mock_process.returncode = 0
+                mock_exec.return_value = mock_process
 
-            commit = await tracker.get_remote_commit(branch="main")
-            assert commit == "def789ghi012"
+                commit = await tracker.get_remote_commit(branch="main")
+                assert commit == "def789ghi012"
+
+    @pytest.mark.asyncio
+    async def test_run_git_command_skips_when_not_a_repo(self):
+        """No local checkout → skip the git invocation entirely (#9771).
+
+        Callers must fall back to the DB commit setting instead of spawning
+        a doomed `git` subprocess (and warn-spamming) every reconcile cycle.
+        """
+        tracker = GitTracker(repo_path="/opt/autobot/code_source")
+
+        with patch.object(git_tracker, "_is_git_repo", return_value=False):
+            with patch("asyncio.create_subprocess_exec") as mock_exec:
+                output, returncode = await tracker._run_git_command("rev-parse", "HEAD")
+
+                assert (output, returncode) == ("", 1)
+                mock_exec.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_check_for_updates_no_update(self):


### PR DESCRIPTION
Closes #9771. Follow-up to #9720 / #9762.

## Thinking Path
The compose stack boots all-8-healthy, but `docker logs` revealed two background loops spamming errors every cycle in the default `single_user` mode. Both are mode/deployment mismatches in the same family as the #9712–#9719 fixes:
1. **LLC schedulers** call `get_async_session_factory()`, which hard-raises in `single_user` (no Postgres). Their siblings already gate on `_llc_postgres_available()` (#9713) — `_init_budget_watchdog` and `_init_liveness_monitor` were missed.
2. **git_tracker** #9716 guarded only `version_check_task` (300s); `api/code_sync.py` calls `get_local_commit()` directly, hit by the 60s reconciler, so the `git rev-parse HEAD` warn-flood continued against the missing `/opt/autobot/code_source`.

## What Changed
- **`autobot-backend/initialization/lifespan.py`** — add the `_llc_postgres_available()` gate to `_init_budget_watchdog` and `_init_liveness_monitor` (skip cleanly in single_user, mirrors `_init_session_checkpointer`).
- **`autobot-slm-backend/services/git_tracker.py`** — centralize the `_is_git_repo` guard inside `_run_git_command`: when there's no local checkout, skip the git invocation (debug log) and let callers fall back to the DB commit setting. Fixes all callers at once.
- **`git_tracker_test.py`** — patch `_is_git_repo` in the subprocess-mocking tests + add a regression test asserting the short-circuit never spawns a process.

## Verification
- `pytest tests/services/git_tracker_test.py` → **7 passed**.
- Rebuilt `autobot/slm:latest` from this branch + recreated container: **0** `rev-parse HEAD` warnings after a full 60s reconcile cycle; only the clean one-time `No local git code source … version checking disabled` INFO. slm healthy.
- Backend image rebuild + recreate (backend/worker/celery-beat) to confirm zero `BudgetWatchdog`/`LivenessMonitor` RuntimeErrors — _appending evidence to a comment once the build completes._

## Model Used
Claude Opus 4.8 (1M context)