### PR TITLE
fix(ansible): deliver build:slm to docs-referenced playbook (#9563 drift) (#9710)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -332,7 +332,11 @@
 
     - name: "[PLAY 1] SLM | Rebuild frontend production build"
       command:
-        cmd: npm run build
+        # build:slm = "VITE_API_URL=/slm vite build" — the SLM frontend is served
+        # under /slm, so a plain `npm run build` bakes in the wrong API base and
+        # the SLM dashboard calls the wrong endpoints (#9563, #9710). Matches the
+        # canonical ansible/update-all-nodes.yml.
+        cmd: npm run build:slm
         chdir: /opt/autobot/autobot-slm-frontend
       register: slm_build
       tags: [slm, slm-frontend]


### PR DESCRIPTION
## Thinking Path
Re-investigating the #9710 duplicate `update-all-nodes.yml` surfaced an urgent, concrete bug hidden inside the duplication: the **`playbooks/update-all-nodes.yml` that every operator doc points to** (CODE_UPDATE.md, CLAUDE_WORKFLOW.md, DEVELOPER_SETUP.md, UPDATE_FLOWS.md, ANSIBLE_PLAYBOOK_REFERENCE.md, slm-bash-execution.md) still rebuilt the SLM frontend with plain `npm run build`. The #9563 fix (`build:slm`) only landed in the *root* `ansible/update-all-nodes.yml`, which is referenced by CI, not operators — so **#9563 was never actually delivered for the documented deploy path.**

`build:slm` is `VITE_API_URL=/slm vite build`; the SLM frontend is served under `/slm`, so a plain build bakes in the wrong API base and the SLM dashboard hits the wrong endpoints.

## What Changed
- `autobot-slm-backend/ansible/playbooks/update-all-nodes.yml` PLAY 1 SLM frontend rebuild: `npm run build` → `npm run build:slm` (with a comment explaining why). Matches the canonical root playbook.
- Scope is exactly the SLM frontend task. The main `autobot-frontend` build (PLAY 2, `npx vite build`, root-served) is correctly left unchanged.

## Verification
- `yaml.safe_load_all` parses the playbook cleanly.
- Confirmed `build:slm` exists in `autobot-slm-frontend/package.json` (`"build:slm": "VITE_API_URL=/slm vite build"`).
- Diff is the single SLM build task; no other `run build` invocations affected.

## Scope note — does NOT close #9710
This delivers the urgent symptom fix only. The two playbooks have **diverged 1079 lines** and are both actively maintained (docs→playbooks/, CI→root); fully de-duplicating them needs a canonical decision + a deploy dry-run (analysis in #9710). Leaving #9710 open for that.

## Model Used
Opus 4.8.

Refs #9710, #9563