### PR TITLE
security(docker): remove static fallback JWT/session signing secrets from compose (#9775)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -500,3 +500,11 @@ AUTOBOT_TRACE_CONSOLE=false
 # ALERT_ERROR_RATE_THRESHOLD=0.05
 # ALERT_COOLDOWN_SECONDS=300
 # ALERT_CIRCUIT_BREAKER_FAILURE_WARNING=3
+
+# --- Signing secrets (GH#9775) ---
+# REQUIRED for docker-compose. No static fallback ships in docker-compose.yml.
+# Generate unique per-deployment values with:
+#   bash docker/generate-secrets.sh   (writes gitignored docker/.env.secrets)
+# or set them yourself (openssl rand -hex 32):
+# AUTOBOT_JWT_SECRET=
+# SECRET_KEY=

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -93,6 +93,14 @@ jobs:
           echo "Final disk space:"
           df -h
 
+      - name: Generate signing secrets (GH#9775)
+        run: |
+          # Base compose now fail-fasts on unset AUTOBOT_JWT_SECRET / SECRET_KEY
+          # (no static fallback). Generate them and expose to all later compose
+          # steps via $GITHUB_ENV so interpolation succeeds.
+          bash docker/generate-secrets.sh
+          cat docker/.env.secrets >> "$GITHUB_ENV"
+
       - name: Start services with Docker Compose
         run: docker compose --env-file docker/.env.docker up -d
 

--- a/.github/workflows/hardened-smoke-test.yml
+++ b/.github/workflows/hardened-smoke-test.yml
@@ -55,6 +55,14 @@ jobs:
           openssl rand -hex 32 > secrets/slm_jwt_secret.txt
           chmod 600 secrets/*.txt
 
+      - name: Generate signing secrets (GH#9775)
+        run: |
+          # Base compose now fail-fasts on unset AUTOBOT_JWT_SECRET / SECRET_KEY
+          # (no static fallback). Generate them and expose to all later compose
+          # steps via $GITHUB_ENV so interpolation succeeds.
+          bash docker/generate-secrets.sh
+          cat docker/.env.secrets >> "$GITHUB_ENV"
+
       - name: Build images with layer cache
         run: |
           echo "=== Building backend image ==="

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ config/*.yaml
 config/settings.json
 backend/config/settings.json
 .env
+docker/.env.secrets
 .env.local
 .env.development.local
 .env.test.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,16 @@
 # Requires Docker Compose v2+ for resource limits (deploy.resources).
 #
 # Usage:
-#   docker compose --env-file docker/.env.docker up -d          # Start all core services
-#   docker compose --env-file docker/.env.docker --profile monitoring up -d
-#   docker compose --env-file docker/.env.docker --profile ollama up -d
+#   bash docker/generate-secrets.sh                              # First run only — generate signing secrets
+#   docker compose --env-file docker/.env.docker --env-file docker/.env.secrets up -d          # Start all core services
+#   docker compose --env-file docker/.env.docker --env-file docker/.env.secrets --profile monitoring up -d
+#   docker compose --env-file docker/.env.docker --env-file docker/.env.secrets --profile ollama up -d
+#
+# SECRETS (GH#9775): AUTOBOT_JWT_SECRET / SECRET_KEY have NO static fallback —
+# a committed shared signing secret allows token forgery. Run
+# docker/generate-secrets.sh once to create a gitignored docker/.env.secrets with
+# unique random values, then pass it via --env-file (or set the vars yourself).
+# Compose fails fast with a clear message if they are unset.
 #
 # NOTE: --env-file docker/.env.docker is required when the root .env contains
 # fleet-specific paths (e.g. AUTOBOT_TLS_CERT_DIR=infrastructure/shared/certs)
@@ -201,8 +208,8 @@ services:
       - AUTOBOT_SLM_HOST=autobot-slm
       - AUTOBOT_SLM_PORT=8000
       # Shared signing secrets — must match SLM so the node JWT verifies (#9715)
-      - AUTOBOT_JWT_SECRET=${AUTOBOT_JWT_SECRET:-autobot-dev-shared-jwt-secret-change-me}
-      - SECRET_KEY=${SECRET_KEY:-autobot-dev-shared-secret-key-change-me}
+      - AUTOBOT_JWT_SECRET=${AUTOBOT_JWT_SECRET:?unset - run docker/generate-secrets.sh then add --env-file docker/.env.secrets (GH#9775)}
+      - SECRET_KEY=${SECRET_KEY:?unset - run docker/generate-secrets.sh then add --env-file docker/.env.secrets (GH#9775)}
     depends_on:
       autobot-redis:
         condition: service_healthy
@@ -276,8 +283,8 @@ services:
       - AUTOBOT_SLM_HOST=autobot-slm
       - AUTOBOT_SLM_PORT=8000
       # Shared signing secrets — must match SLM so the node JWT verifies (#9715)
-      - AUTOBOT_JWT_SECRET=${AUTOBOT_JWT_SECRET:-autobot-dev-shared-jwt-secret-change-me}
-      - SECRET_KEY=${SECRET_KEY:-autobot-dev-shared-secret-key-change-me}
+      - AUTOBOT_JWT_SECRET=${AUTOBOT_JWT_SECRET:?unset - run docker/generate-secrets.sh then add --env-file docker/.env.secrets (GH#9775)}
+      - SECRET_KEY=${SECRET_KEY:?unset - run docker/generate-secrets.sh then add --env-file docker/.env.secrets (GH#9775)}
     healthcheck:
       # $$HOSTNAME (escaped) expands inside the container at runtime. A single
       # $HOSTNAME is interpolated by Compose at parse time to an empty string,
@@ -397,8 +404,8 @@ services:
       # without a shared secret each service generates its own and SLM rejects
       # the node WS with 401, leaving the host shown offline (#9715). CHANGE in
       # production via AUTOBOT_JWT_SECRET / SECRET_KEY.
-      - AUTOBOT_JWT_SECRET=${AUTOBOT_JWT_SECRET:-autobot-dev-shared-jwt-secret-change-me}
-      - SECRET_KEY=${SECRET_KEY:-autobot-dev-shared-secret-key-change-me}
+      - AUTOBOT_JWT_SECRET=${AUTOBOT_JWT_SECRET:?unset - run docker/generate-secrets.sh then add --env-file docker/.env.secrets (GH#9775)}
+      - SECRET_KEY=${SECRET_KEY:?unset - run docker/generate-secrets.sh then add --env-file docker/.env.secrets (GH#9775)}
     depends_on:
       autobot-redis:
         condition: service_healthy

--- a/docker/generate-secrets.sh
+++ b/docker/generate-secrets.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Generate per-deployment signing secrets for the docker-compose stack (GH#9775).
+#
+# The compose file no longer ships static fallback values for AUTOBOT_JWT_SECRET
+# / SECRET_KEY — a committed shared signing secret allows JWT/session forgery
+# against any default deployment. This script writes unique, random secrets to a
+# gitignored docker/.env.secrets that you then pass to compose.
+#
+# Idempotent: existing values are preserved, never overwritten or printed.
+#
+# Usage:
+#   bash docker/generate-secrets.sh
+#   docker compose --env-file docker/.env.docker --env-file docker/.env.secrets up -d
+set -euo pipefail
+
+SECRETS_FILE="$(cd "$(dirname "$0")" && pwd)/.env.secrets"
+
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "ERROR: openssl is required to generate secrets." >&2
+    exit 1
+fi
+
+touch "$SECRETS_FILE"
+chmod 600 "$SECRETS_FILE"
+
+ensure_secret() {
+    local key="$1"
+    if grep -q "^${key}=" "$SECRETS_FILE" 2>/dev/null; then
+        echo "  ${key}: already set — keeping existing value"
+    else
+        printf '%s=%s\n' "$key" "$(openssl rand -hex 32)" >>"$SECRETS_FILE"
+        echo "  ${key}: generated"
+    fi
+}
+
+echo "Writing signing secrets to ${SECRETS_FILE}"
+ensure_secret AUTOBOT_JWT_SECRET
+ensure_secret SECRET_KEY
+
+echo ""
+echo "Done. Start the stack with both env files:"
+echo "  docker compose --env-file docker/.env.docker --env-file docker/.env.secrets up -d"


### PR DESCRIPTION
## Thinking Path

Automated security review (#9775) flagged `docker-compose.yml` shipping a static, committed shared signing secret (`autobot-dev-shared-*-change-me`) for `AUTOBOT_JWT_SECRET` / `SECRET_KEY` across 3 services — a known signing key enables JWT/session-token forgery against any default deployment. The env files (`docker/.env.docker`) don't set these, so the stack relied entirely on the YAML fallback. The fix must remove the static secret without silently shipping a new one, while keeping a clear path to a working stack.

## What Changed

- **All 6 occurrences fail fast** (`${VAR:?...}`) instead of a static default — compose refuses to start with a clear, actionable message if the secret is unset.
- **`docker/generate-secrets.sh`** — generates unique `openssl rand -hex 32` values into a **gitignored** `docker/.env.secrets`. Idempotent: existing values are kept, never overwritten or printed.
- **`.gitignore`** ignores `docker/.env.secrets`; **`.env.example`** documents the two vars + the generator; the compose header shows the new `generate → up` workflow (`--env-file docker/.env.secrets`).

## Verification (real `docker compose config`)

```
# unset → fail fast
$ docker compose --env-file docker/.env.docker config
error ... required variable AUTOBOT_JWT_SECRET is missing a value: unset - run docker/generate-secrets.sh ...   (exit 1)

# generate, then config parses cleanly
$ bash docker/generate-secrets.sh        # AUTOBOT_JWT_SECRET: generated / SECRET_KEY: generated
$ docker compose --env-file docker/.env.docker --env-file docker/.env.secrets config   # exit 0
$ grep -c autobot-dev-shared <config-output>   # 0 — static default gone
```
Generator is idempotent (second run: "already set — keeping existing"). `docker/.env.secrets` is `chmod 600` + gitignored.

## Scope note
This is a **UX change**: out-of-box startup now requires running the generator once (security-over-zero-config, exactly what the review asked for — "fails fast if unset"). It interacts with the zero-config goal of #9762, so flagged here for the review gate. Weaker non-signing defaults (`POSTGRES_PASSWORD`/`SLM_ADMIN_PASSWORD`/`GRAFANA_ADMIN_PASSWORD` on the internal network) are intentionally out of scope for this signing-secret fix.

Closes #9775.

## Model Used

claude-opus-4-8 (1M context)
