### PR TITLE
fix(auth): repair ConfigManager.misc 500 breaking all nav API calls (#9781)

### DIFF
--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -696,7 +696,7 @@ async def get_current_user(request: Request) -> Dict:
     Raises HTTPException if authentication fails.
     """
     # Issue #1779: Allow trusted internal services via API key
-    _internal_key = config.misc.internal_api_key
+    _internal_key = ssot_config.misc.internal_api_key
     if _internal_key and request.headers.get("X-Internal-API-Key") == _internal_key:
         return {"username": "service:slm", "role": "admin", "service": True}
 
@@ -769,7 +769,7 @@ def check_admin_permission(request: Request) -> bool:
     """
     # Issue #1145: Allow trusted internal services (e.g. SLM backend) via API key.
     # The key is set via AUTOBOT_INTERNAL_API_KEY env var on both services.
-    _internal_key = config.misc.internal_api_key
+    _internal_key = ssot_config.misc.internal_api_key
     if _internal_key and request.headers.get("X-Internal-API-Key") == _internal_key:
         logger.debug("Internal API key auth: granting admin access")
         return True


### PR DESCRIPTION
Closes #9781.

## Thinking Path
Reported symptom: **frontend navigation does not respond.** Live evidence pinned it fast:
- nginx (frontend) logs: `GET /api/analytics/agents/tasks/recent` → **500 (×52 from /home)**, plus `/api/onboarding/presets`, `/api/onboarding/doctor`, `/api/settings/telemetry`, `/api/services/version` all **500**. The SPA mounts but every view's data call fails → nav looks dead.
- backend logs: `AttributeError: 'ConfigManager' object has no attribute 'misc'` — **192×**, raised in the auth path via `llm_awareness_middleware`.

## Root Cause
`auth_middleware.py` imports two config objects: `ssot_config` (the SSOT, has `.misc`, line 25) and `config = get_config_manager()` (a `ConfigManager`, **no** `.misc`, line 33). Lines **699** and **772** read `config.misc.internal_api_key` on the wrong object → `AttributeError` inside a request middleware → 500s a broad set of endpoints on every request. `internal_api_key` is defined on `MiscConfig` (`ssot_config.py:1264`, reached via `ssot_config.misc`), so the `.misc.internal_api_key` path was intentional — only the object was wrong.

## What Changed
`autobot-backend/auth_middleware.py:699,772` — `config.misc.internal_api_key` → `ssot_config.misc.internal_api_key`.

## Verification
- `py_compile` clean.
- Rebuilt the backend image with this fix and recreated the stack: the `ConfigManager has no attribute 'misc'` AttributeError count drops to **0** and the previously-500ing nav endpoints return non-500 (evidence appended as a comment).

## Model Used
Claude Opus 4.8 (1M context)