### PR TITLE
refactor(llc/adapters): extract shared SubprocessLifecycleAdapter base (#9834)

### DIFF
--- a/autobot-backend/llc/adapters/claude_code_adapter.py
+++ b/autobot-backend/llc/adapters/claude_code_adapter.py
@@ -20,6 +20,9 @@ adapter_config schema::
 adapter retries without it and clears the config value for subsequent calls.
 ``streaming_watchdog_timeout_seconds`` configures per-agent silent-stream timeout
 (defaults to 120s global, overridable per adapter or per agent).
+
+The state-file / status / cancel lifecycle is shared via
+:class:`SubprocessLifecycleAdapter` (GH#9834).
 """
 
 from __future__ import annotations
@@ -27,9 +30,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import pathlib
 import shutil
-import signal
 import time
 import uuid
 from typing import Optional
@@ -37,40 +38,31 @@ from typing import Optional
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
 
-from ..models.enums import LLCRunStatus
-from .base import AdapterRunStatus
-from .subprocess_support import inject_agent_credentials, render_context_markdown, serialize_invoke_context
+from .subprocess_base import DEFAULT_OUTPUT_DIR as _DEFAULT_OUTPUT_DIR
+from .subprocess_base import SIGTERM_GRACE_SECONDS as _SIGTERM_GRACE_SECONDS
+from .subprocess_base import SubprocessLifecycleAdapter
+from .subprocess_base import resolve_timeout as _resolve_timeout
+from .subprocess_support import inject_agent_credentials, serialize_invoke_context
 
 logger = get_logger(__name__)
 
 _SESSION_TTL_SECONDS = 4 * 3600
-_SIGTERM_GRACE_SECONDS = 10
-_ADAPTER_TIMEOUT_SECONDS = 3600  # per-adapter default (preserves current behavior)
-_DEFAULT_TIMEOUT_SECONDS = 3600  # deprecated, use _ADAPTER_TIMEOUT_SECONDS
-_DEFAULT_OUTPUT_DIR = "/tmp"  # nosec B108 - test/controlled code uses tmpdir intentionally
 _SESSION_KEY = "llc:agent:{agent_id}:claude_session"
+
+# Re-exported for the import contract (subscription adapter + tests rely on these).
+__all__ = [
+    "ClaudeCodeAdapter",
+    "_output_path",
+    "_state_path",
+    "_resolve_claude_cli",
+    "_resolve_timeout",
+    "_SIGTERM_GRACE_SECONDS",
+    "_DEFAULT_OUTPUT_DIR",
+]
 
 
 def _redis_session_key(agent_id: str) -> str:
     return _SESSION_KEY.format(agent_id=agent_id)
-
-
-def _resolve_timeout(cfg: dict) -> int:
-    """Resolve timeout using 3-tier hierarchy:
-    1. Per-agent override via adapter_config.timeout_seconds
-    2. Per-adapter default (_ADAPTER_TIMEOUT_SECONDS)
-    3. Global default (LLC_DEFAULT_ADAPTER_TIMEOUT_SECONDS env var, default: 120s)
-    """
-    # Tier 1: per-agent override
-    if "timeout_seconds" in cfg:
-        return int(cfg["timeout_seconds"])
-
-    # Tier 2/3: global env var, fallback to per-adapter default
-    global_default = os.environ.get("LLC_DEFAULT_ADAPTER_TIMEOUT_SECONDS")
-    if global_default:
-        return int(global_default)
-
-    return _ADAPTER_TIMEOUT_SECONDS
 
 
 def _output_path(output_dir: str, agent_id: str, run_id: str) -> str:
@@ -90,15 +82,11 @@ def _resolve_claude_cli() -> str:
     return path
 
 
-class ClaudeCodeAdapter:
+class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
     """Adapter that manages agent runs as Claude Code CLI subprocess sessions."""
 
-    async def invoke(self, agent_config: dict, context: dict) -> str:
-        try:
-            return await self._invoke(agent_config, context)
-        except Exception as exc:
-            logger.exception("ClaudeCodeAdapter.invoke failed: %s", exc)
-            raise
+    _LOG_NAME = "ClaudeCodeAdapter"
+    _state_path = staticmethod(_state_path)
 
     async def _invoke(self, agent_config: dict, context: dict) -> str:
         cli = _resolve_claude_cli()
@@ -124,11 +112,7 @@ class ClaudeCodeAdapter:
         if resume_session_id:
             cmd += ["--resume", resume_session_id]
             session_id = resume_session_id
-            logger.info(
-                "ClaudeCodeAdapter: resuming session %s for agent %s",
-                session_id,
-                agent_id,
-            )
+            logger.info("ClaudeCodeAdapter: resuming session %s for agent %s", session_id, agent_id)
         else:
             if model:
                 cmd += ["--model", model]
@@ -168,10 +152,7 @@ class ClaudeCodeAdapter:
             except FileNotFoundError as e:
                 if not (workspace_dir and e.filename and os.path.abspath(e.filename) == os.path.abspath(workspace_dir)):
                     raise  # missing binary or unrelated path
-                logger.warning(
-                    "ClaudeCodeAdapter: workspace_dir %r missing, retrying without cwd",
-                    workspace_dir,
-                )
+                logger.warning("ClaudeCodeAdapter: workspace_dir %r missing, retrying without cwd", workspace_dir)
                 context.pop("workspace_dir", None)
                 env.pop("AUTOBOT_WORKSPACE_DIR", None)
                 env["LLC_INVOKE_CONTEXT"] = serialize_invoke_context(context)
@@ -208,114 +189,13 @@ class ClaudeCodeAdapter:
         await self._store_session(agent_id, session_id)
         return run_id
 
-    async def status(self, agent_config: dict, run_id: str) -> AdapterRunStatus:
-        try:
-            return await self._status(agent_config, run_id)
-        except Exception as exc:
-            logger.exception("ClaudeCodeAdapter.status failed: %s", exc)
-            return AdapterRunStatus(status=LLCRunStatus.FAILED, error=str(exc))
-
-    async def _status(self, agent_config: dict, run_id: str) -> AdapterRunStatus:
-        cfg = agent_config.get("adapter_config", {})
-        output_dir: str = cfg.get("output_dir", _DEFAULT_OUTPUT_DIR)
-        state = self._load_state(_state_path(output_dir, run_id), output_dir)
-
-        if state is None:
-            try:
-                pid = int(run_id.split("/")[0])
-            except (ValueError, IndexError):
-                return AdapterRunStatus(
-                    status=LLCRunStatus.FAILED,
-                    error=f"Unparseable run_id: {run_id!r}",
-                )
-            return self._probe_pid(pid)
-
-        pid: int = state["pid"]
-        timeout_sec: float = state.get("timeout_seconds", _DEFAULT_TIMEOUT_SECONDS)
-        started_at: float = state.get("started_at", 0.0)
-
-        if time.time() - started_at > timeout_sec:
-            logger.warning("ClaudeCodeAdapter: run_id %s timed out (%ss)", run_id, timeout_sec)
-            await self.cancel(agent_config, run_id)
-            return AdapterRunStatus(status=LLCRunStatus.TIMEOUT)
-
-        return self._probe_pid(pid)
-
-    def _probe_pid(self, pid: int) -> AdapterRunStatus:
-        try:
-            os.kill(pid, 0)
-            return AdapterRunStatus(status=LLCRunStatus.RUNNING)
-        except ProcessLookupError:
-            return AdapterRunStatus(status=LLCRunStatus.COMPLETED)
-        except PermissionError:
-            return AdapterRunStatus(status=LLCRunStatus.RUNNING)
-        except OSError as exc:
-            return AdapterRunStatus(status=LLCRunStatus.FAILED, error=str(exc))
-
-    async def cancel(self, agent_config: dict, run_id: str) -> None:
-        try:
-            await self._cancel(agent_config, run_id)
-        except Exception as exc:
-            logger.exception("ClaudeCodeAdapter.cancel failed: %s", exc)
-
-    async def _cancel(self, agent_config: dict, run_id: str) -> None:
-        cfg = agent_config.get("adapter_config", {})
-        output_dir: str = cfg.get("output_dir", _DEFAULT_OUTPUT_DIR)
-
-        try:
-            pid = int(run_id.split("/")[0])
-        except (ValueError, IndexError):
-            logger.error("ClaudeCodeAdapter.cancel: unparseable run_id %r", run_id)
-            return
-
-        try:
-            os.kill(pid, signal.SIGTERM)
-            logger.info("ClaudeCodeAdapter: SIGTERM -> PID %d", pid)
-        except ProcessLookupError:
-            pass
-        else:
-            for _ in range(_SIGTERM_GRACE_SECONDS * 10):
-                await asyncio.sleep(0.1)
-                try:
-                    os.kill(pid, 0)
-                except ProcessLookupError:
-                    break
-            else:
-                try:
-                    os.kill(pid, signal.SIGKILL)
-                    logger.warning("ClaudeCodeAdapter: SIGKILL -> PID %d", pid)
-                except ProcessLookupError:
-                    pass
-
+    async def _post_cancel(self, agent_config: dict, run_id: str) -> None:
+        """Clear the Redis resume session so the next run starts fresh (GH#9834)."""
         agent_id: str = agent_config.get("agent_id", "")
         if agent_id:
             await self._clear_session(agent_id)
 
-        try:
-            os.unlink(_state_path(output_dir, run_id))
-        except FileNotFoundError:
-            pass
-
-    def _build_prompt(self, context: dict) -> str:
-        """Render the agent prompt as structured Markdown (GH#9622).
-
-        Delegates to :func:`render_context_markdown` so the heartbeat fat
-        context becomes a readable brief instead of a raw ``json.dumps`` blob.
-        """
-        return render_context_markdown(context)
-
-    @staticmethod
-    def _load_state(state_file: str, safe_dir: str = _DEFAULT_OUTPUT_DIR) -> Optional[dict]:
-        try:
-            resolved = pathlib.Path(state_file).resolve()
-            base = pathlib.Path(safe_dir).resolve()
-            if not resolved.is_relative_to(base):
-                return None
-            with open(resolved, encoding="utf-8") as fh:
-                return json.load(fh)
-        except (FileNotFoundError, json.JSONDecodeError):
-            return None
-
+    # Redis resume-session management (claude-specific) ---------------------
     async def _get_resumable_session(self, agent_id: str) -> Optional[str]:
         redis = await get_async_redis_client(database="main")
         if redis is None:

--- a/autobot-backend/llc/adapters/copilot_local_adapter.py
+++ b/autobot-backend/llc/adapters/copilot_local_adapter.py
@@ -14,7 +14,8 @@ adapter_config schema::
     }
 
 ``run_id`` is ``"<pid>/<session_id>"`` where ``session_id`` is a UUID assigned at
-invoke time and used to locate the state file on disk (mirrors ClaudeCodeAdapter).
+invoke time and used to locate the state file on disk. The state-file / status /
+cancel lifecycle is shared via :class:`SubprocessLifecycleAdapter` (GH#9834).
 """
 
 from __future__ import annotations
@@ -22,26 +23,33 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import pathlib
 import shutil
-import signal
 import time
 import uuid
 from typing import Optional
 
 from autobot_shared.logging_manager import get_logger
 
-from ..models.enums import LLCRunStatus
-from .base import AdapterRunStatus
-from .subprocess_support import inject_agent_credentials, render_context_markdown, serialize_invoke_context
+from .subprocess_base import DEFAULT_OUTPUT_DIR as _DEFAULT_OUTPUT_DIR
+from .subprocess_base import SIGTERM_GRACE_SECONDS as _SIGTERM_GRACE_SECONDS
+from .subprocess_base import SubprocessLifecycleAdapter
+from .subprocess_base import resolve_timeout as _resolve_timeout
+from .subprocess_support import inject_agent_credentials, serialize_invoke_context
 
 logger = get_logger(__name__)
 
-_SIGTERM_GRACE_SECONDS = 10
-_ADAPTER_TIMEOUT_SECONDS = 3600  # per-adapter default (preserves current behavior)
-_DEFAULT_TIMEOUT_SECONDS = 3600  # deprecated, use _ADAPTER_TIMEOUT_SECONDS
-_DEFAULT_OUTPUT_DIR = "/tmp"  # nosec B108 - test/controlled code uses tmpdir intentionally
 _DEFAULT_COPILOT_MODEL = "copilot-4o"
+
+# Re-exported for the import contract (subscription adapter + tests rely on these).
+__all__ = [
+    "CopilotLocalAdapter",
+    "_output_path",
+    "_state_path",
+    "_resolve_gh_cli",
+    "_resolve_timeout",
+    "_SIGTERM_GRACE_SECONDS",
+    "_DEFAULT_OUTPUT_DIR",
+]
 
 
 def _resolve_gh_cli() -> str:
@@ -61,33 +69,11 @@ def _state_path(output_dir: str, run_id: str) -> str:
     return os.path.join(output_dir, f"llc_copilot_state_{safe_run}.json")
 
 
-def _resolve_timeout(cfg: dict) -> int:
-    """Resolve timeout using 3-tier hierarchy:
-    1. Per-agent override via adapter_config.timeout_seconds
-    2. Per-adapter default (_ADAPTER_TIMEOUT_SECONDS)
-    3. Global default (LLC_DEFAULT_ADAPTER_TIMEOUT_SECONDS env var, default: 120s)
-    """
-    # Tier 1: per-agent override
-    if "timeout_seconds" in cfg:
-        return int(cfg["timeout_seconds"])
-
-    # Tier 2/3: global env var, fallback to per-adapter default
-    global_default = os.environ.get("LLC_DEFAULT_ADAPTER_TIMEOUT_SECONDS")
-    if global_default:
-        return int(global_default)
-
-    return _ADAPTER_TIMEOUT_SECONDS
-
-
-class CopilotLocalAdapter:
+class CopilotLocalAdapter(SubprocessLifecycleAdapter):
     """Adapter that manages agent runs as local ``gh copilot`` CLI subprocess sessions."""
 
-    async def invoke(self, agent_config: dict, context: dict) -> str:
-        try:
-            return await self._invoke(agent_config, context)
-        except Exception as exc:
-            logger.exception("CopilotLocalAdapter.invoke failed: %s", exc)
-            raise
+    _LOG_NAME = "CopilotLocalAdapter"
+    _state_path = staticmethod(_state_path)
 
     async def _invoke(self, agent_config: dict, context: dict) -> str:
         gh_cli = _resolve_gh_cli()
@@ -131,10 +117,7 @@ class CopilotLocalAdapter:
                 )
             except FileNotFoundError as e:
                 if workspace_dir and e.filename and os.path.abspath(str(e.filename)) == os.path.abspath(workspace_dir):
-                    logger.warning(
-                        "CopilotLocalAdapter: workspace_dir %r missing, retrying without cwd",
-                        workspace_dir,
-                    )
+                    logger.warning("CopilotLocalAdapter: workspace_dir %r missing, retrying without cwd", workspace_dir)
                     env.pop("AUTOBOT_WORKSPACE_DIR", None)
                     workspace_dir = None
                     context.pop("workspace_dir", None)
@@ -171,107 +154,3 @@ class CopilotLocalAdapter:
             json.dump(state, fh)
 
         return run_id
-
-    async def status(self, agent_config: dict, run_id: str) -> AdapterRunStatus:
-        try:
-            return await self._status(agent_config, run_id)
-        except Exception as exc:
-            logger.exception("CopilotLocalAdapter.status failed: %s", exc)
-            return AdapterRunStatus(status=LLCRunStatus.FAILED, error=str(exc))
-
-    async def _status(self, agent_config: dict, run_id: str) -> AdapterRunStatus:
-        cfg = agent_config.get("adapter_config", {})
-        output_dir: str = cfg.get("output_dir", _DEFAULT_OUTPUT_DIR)
-        state = self._load_state(_state_path(output_dir, run_id), output_dir)
-
-        if state is None:
-            try:
-                pid = int(run_id.split("/")[0])
-            except (ValueError, IndexError):
-                return AdapterRunStatus(
-                    status=LLCRunStatus.FAILED,
-                    error=f"Unparseable run_id: {run_id!r}",
-                )
-            return self._probe_pid(pid)
-
-        pid: int = state["pid"]
-        timeout_sec: float = state.get("timeout_seconds", _DEFAULT_TIMEOUT_SECONDS)
-        started_at: float = state.get("started_at", 0.0)
-
-        if time.time() - started_at > timeout_sec:
-            logger.warning("CopilotLocalAdapter: run_id %s timed out (%ss)", run_id, timeout_sec)
-            await self.cancel(agent_config, run_id)
-            return AdapterRunStatus(status=LLCRunStatus.TIMEOUT)
-
-        return self._probe_pid(pid)
-
-    def _probe_pid(self, pid: int) -> AdapterRunStatus:
-        try:
-            os.kill(pid, 0)
-            return AdapterRunStatus(status=LLCRunStatus.RUNNING)
-        except ProcessLookupError:
-            return AdapterRunStatus(status=LLCRunStatus.COMPLETED)
-        except PermissionError:
-            return AdapterRunStatus(status=LLCRunStatus.RUNNING)
-        except OSError as exc:
-            return AdapterRunStatus(status=LLCRunStatus.FAILED, error=str(exc))
-
-    async def cancel(self, agent_config: dict, run_id: str) -> None:
-        try:
-            await self._cancel(agent_config, run_id)
-        except Exception as exc:
-            logger.exception("CopilotLocalAdapter.cancel failed: %s", exc)
-
-    async def _cancel(self, agent_config: dict, run_id: str) -> None:
-        cfg = agent_config.get("adapter_config", {})
-        output_dir: str = cfg.get("output_dir", _DEFAULT_OUTPUT_DIR)
-
-        try:
-            pid = int(run_id.split("/")[0])
-        except (ValueError, IndexError):
-            logger.error("CopilotLocalAdapter.cancel: unparseable run_id %r", run_id)
-            return
-
-        try:
-            os.kill(pid, signal.SIGTERM)
-            logger.info("CopilotLocalAdapter: SIGTERM -> PID %d", pid)
-        except ProcessLookupError:
-            pass
-        else:
-            for _ in range(_SIGTERM_GRACE_SECONDS * 10):
-                await asyncio.sleep(0.1)
-                try:
-                    os.kill(pid, 0)
-                except ProcessLookupError:
-                    break
-            else:
-                try:
-                    os.kill(pid, signal.SIGKILL)
-                    logger.warning("CopilotLocalAdapter: SIGKILL -> PID %d", pid)
-                except ProcessLookupError:
-                    pass
-
-        try:
-            os.unlink(_state_path(output_dir, run_id))
-        except FileNotFoundError:
-            pass
-
-    def _build_prompt(self, context: dict) -> str:
-        """Render the agent prompt as structured Markdown (GH#9769).
-
-        Shared with the other subprocess adapters via
-        :func:`render_context_markdown` — never a raw ``json.dumps`` blob.
-        """
-        return render_context_markdown(context)
-
-    @staticmethod
-    def _load_state(state_file: str, safe_dir: str = _DEFAULT_OUTPUT_DIR) -> Optional[dict]:
-        try:
-            resolved = pathlib.Path(state_file).resolve()
-            base = pathlib.Path(safe_dir).resolve()
-            if not resolved.is_relative_to(base):
-                return None
-            with open(resolved, encoding="utf-8") as fh:
-                return json.load(fh)
-        except (FileNotFoundError, json.JSONDecodeError):
-            return None

--- a/autobot-backend/llc/adapters/subprocess_base.py
+++ b/autobot-backend/llc/adapters/subprocess_base.py
@@ -1,0 +1,197 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Shared subprocess-lifecycle base for LLC CLI adapters (GH#9834).
+
+`ClaudeCodeAdapter` and `CopilotLocalAdapter` (and their subscription variants)
+ran the same external-CLI lifecycle — state-file management, PID probe, timeout
+resolution, status polling, and SIGTERM→SIGKILL cancellation — with the bodies
+duplicated near-verbatim (differing only in log name, file-name prefix, and a
+claude-only post-cancel session clear). `subprocess_support` already shares the
+prompt/credential layer (GH#9789); this base completes the consolidation for the
+lifecycle.
+
+A subclass provides:
+- ``_LOG_NAME`` — for log messages
+- ``_state_path`` — a staticmethod ``(output_dir, run_id) -> path`` (file-name
+  prefix differs per adapter; kept module-level for the import contract)
+- ``_invoke`` — command assembly + env + spawn (adapter-specific)
+- optionally ``_post_cancel`` — a hook run after the process is killed
+  (ClaudeCodeAdapter clears its Redis resume-session there)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import pathlib
+import signal
+import time
+from typing import Callable, Optional
+
+from autobot_shared.logging_manager import get_logger
+
+from ..models.enums import LLCRunStatus
+from .base import AdapterRunStatus
+from .subprocess_support import render_context_markdown
+
+logger = get_logger(__name__)
+
+SIGTERM_GRACE_SECONDS = 10
+ADAPTER_TIMEOUT_SECONDS = 3600  # per-adapter default (preserves current behavior)
+DEFAULT_TIMEOUT_SECONDS = 3600  # fallback when a state file omits timeout_seconds
+DEFAULT_OUTPUT_DIR = "/tmp"  # nosec B108 - test/controlled code uses tmpdir intentionally
+
+
+def resolve_timeout(cfg: dict) -> int:
+    """Resolve the run timeout via a 3-tier hierarchy:
+
+    1. per-agent override (``adapter_config.timeout_seconds``)
+    2. global env var ``LLC_DEFAULT_ADAPTER_TIMEOUT_SECONDS``
+    3. per-adapter default (:data:`ADAPTER_TIMEOUT_SECONDS`)
+    """
+    if "timeout_seconds" in cfg:
+        return int(cfg["timeout_seconds"])
+    global_default = os.environ.get("LLC_DEFAULT_ADAPTER_TIMEOUT_SECONDS")
+    if global_default:
+        return int(global_default)
+    return ADAPTER_TIMEOUT_SECONDS
+
+
+class SubprocessLifecycleAdapter:
+    """Common invoke-wrapper / status / cancel lifecycle for CLI subprocess adapters."""
+
+    # Subclass configuration ------------------------------------------------
+    _LOG_NAME: str = "SubprocessAdapter"
+    # staticmethod (output_dir, run_id) -> str; set by each subclass.
+    _state_path: Callable[[str, str], str]
+
+    # Invoke ----------------------------------------------------------------
+    async def invoke(self, agent_config: dict, context: dict) -> str:
+        try:
+            return await self._invoke(agent_config, context)
+        except Exception as exc:
+            logger.exception("%s.invoke failed: %s", self._LOG_NAME, exc)
+            raise
+
+    async def _invoke(self, agent_config: dict, context: dict) -> str:
+        raise NotImplementedError
+
+    def _build_prompt(self, context: dict) -> str:
+        """Render the heartbeat context as structured Markdown (GH#9622/GH#9769)."""
+        return render_context_markdown(context)
+
+    # Status ----------------------------------------------------------------
+    async def status(self, agent_config: dict, run_id: str) -> AdapterRunStatus:
+        try:
+            return await self._status(agent_config, run_id)
+        except Exception as exc:
+            logger.exception("%s.status failed: %s", self._LOG_NAME, exc)
+            return AdapterRunStatus(status=LLCRunStatus.FAILED, error=str(exc))
+
+    async def _status(self, agent_config: dict, run_id: str) -> AdapterRunStatus:
+        cfg = agent_config.get("adapter_config", {})
+        output_dir: str = cfg.get("output_dir", DEFAULT_OUTPUT_DIR)
+        state = self._load_state(self._state_path(output_dir, run_id), output_dir)
+
+        if state is None:
+            try:
+                pid = int(run_id.split("/")[0])
+            except (ValueError, IndexError):
+                return AdapterRunStatus(status=LLCRunStatus.FAILED, error=f"Unparseable run_id: {run_id!r}")
+            return self._probe_pid(pid)
+
+        pid: int = state["pid"]
+        timeout_sec: float = state.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
+        started_at: float = state.get("started_at", 0.0)
+
+        if time.time() - started_at > timeout_sec:
+            logger.warning("%s: run_id %s timed out (%ss)", self._LOG_NAME, run_id, timeout_sec)
+            await self.cancel(agent_config, run_id)
+            return AdapterRunStatus(status=LLCRunStatus.TIMEOUT)
+
+        return self._probe_pid(pid)
+
+    def _probe_pid(self, pid: int) -> AdapterRunStatus:
+        try:
+            os.kill(pid, 0)
+            return AdapterRunStatus(status=LLCRunStatus.RUNNING)
+        except ProcessLookupError:
+            return AdapterRunStatus(status=LLCRunStatus.COMPLETED)
+        except PermissionError:
+            return AdapterRunStatus(status=LLCRunStatus.RUNNING)
+        except OSError as exc:
+            return AdapterRunStatus(status=LLCRunStatus.FAILED, error=str(exc))
+
+    # Cancel ----------------------------------------------------------------
+    async def cancel(self, agent_config: dict, run_id: str) -> None:
+        try:
+            await self._cancel(agent_config, run_id)
+        except Exception as exc:
+            logger.exception("%s.cancel failed: %s", self._LOG_NAME, exc)
+
+    async def _cancel(self, agent_config: dict, run_id: str) -> None:
+        cfg = agent_config.get("adapter_config", {})
+        output_dir: str = cfg.get("output_dir", DEFAULT_OUTPUT_DIR)
+
+        try:
+            pid = int(run_id.split("/")[0])
+        except (ValueError, IndexError):
+            logger.error("%s.cancel: unparseable run_id %r", self._LOG_NAME, run_id)
+            return
+
+        try:
+            os.kill(pid, signal.SIGTERM)
+            logger.info("%s: SIGTERM -> PID %d", self._LOG_NAME, pid)
+        except ProcessLookupError:
+            pass
+        else:
+            for _ in range(SIGTERM_GRACE_SECONDS * 10):
+                await asyncio.sleep(0.1)
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    break
+            else:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                    logger.warning("%s: SIGKILL -> PID %d", self._LOG_NAME, pid)
+                except ProcessLookupError:
+                    pass
+
+        await self._post_cancel(agent_config, run_id)
+
+        try:
+            os.unlink(self._state_path(output_dir, run_id))
+        except FileNotFoundError:
+            pass
+
+    async def _post_cancel(self, agent_config: dict, run_id: str) -> None:
+        """Hook run after the process is killed, before the state file is removed.
+
+        Default no-op; ClaudeCodeAdapter overrides it to clear its resume session.
+        """
+
+    # State file ------------------------------------------------------------
+    @staticmethod
+    def _load_state(state_file: str, safe_dir: str = DEFAULT_OUTPUT_DIR) -> Optional[dict]:
+        try:
+            resolved = pathlib.Path(state_file).resolve()
+            base = pathlib.Path(safe_dir).resolve()
+            if not resolved.is_relative_to(base):
+                return None
+            with open(resolved, encoding="utf-8") as fh:
+                return json.load(fh)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+
+
+__all__ = [
+    "SubprocessLifecycleAdapter",
+    "SIGTERM_GRACE_SECONDS",
+    "ADAPTER_TIMEOUT_SECONDS",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "DEFAULT_OUTPUT_DIR",
+    "resolve_timeout",
+]

--- a/autobot-backend/llc/adapters/tests/test_subprocess_base.py
+++ b/autobot-backend/llc/adapters/tests/test_subprocess_base.py
@@ -1,0 +1,71 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for the shared SubprocessLifecycleAdapter base (GH#9834)."""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from llc.adapters.subprocess_base import (
+    ADAPTER_TIMEOUT_SECONDS,
+    SubprocessLifecycleAdapter,
+    resolve_timeout,
+)
+from llc.models.enums import LLCRunStatus
+
+
+def _state_path(output_dir: str, run_id: str) -> str:
+    return os.path.join(output_dir, f"base_state_{run_id.replace('/', '_')}.json")
+
+
+class _DummyAdapter(SubprocessLifecycleAdapter):
+    _LOG_NAME = "DummyAdapter"
+    _state_path = staticmethod(_state_path)
+
+    async def _invoke(self, agent_config, context):  # pragma: no cover - not exercised
+        return "1/x"
+
+
+class TestResolveTimeout:
+    def test_per_agent_override(self, monkeypatch) -> None:
+        monkeypatch.setenv("LLC_DEFAULT_ADAPTER_TIMEOUT_SECONDS", "250")
+        assert resolve_timeout({"timeout_seconds": 500}) == 500
+
+    def test_global_env(self, monkeypatch) -> None:
+        monkeypatch.setenv("LLC_DEFAULT_ADAPTER_TIMEOUT_SECONDS", "180")
+        assert resolve_timeout({}) == 180
+
+    def test_adapter_default(self, monkeypatch) -> None:
+        monkeypatch.delenv("LLC_DEFAULT_ADAPTER_TIMEOUT_SECONDS", raising=False)
+        assert resolve_timeout({}) == ADAPTER_TIMEOUT_SECONDS == 3600
+
+
+class TestLoadStatePathTraversal:
+    def test_rejects_outside_safe_dir(self) -> None:
+        # A path escaping safe_dir must be refused (returns None), not read.
+        assert SubprocessLifecycleAdapter._load_state("/etc/passwd", "/tmp") is None
+
+    def test_reads_valid_state(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, "s.json")
+            with open(p, "w", encoding="utf-8") as fh:
+                json.dump({"pid": 1}, fh)
+            assert SubprocessLifecycleAdapter._load_state(p, td) == {"pid": 1}
+
+
+@pytest.mark.asyncio
+class TestSharedLifecycle:
+    async def test_status_unparseable_run_id(self) -> None:
+        # No state file + non-numeric pid → FAILED via the shared base path.
+        with tempfile.TemporaryDirectory() as td:
+            result = await _DummyAdapter().status({"adapter_config": {"output_dir": td}}, "notapid/x")
+        assert result.status == LLCRunStatus.FAILED
+
+    async def test_status_completed_when_pid_gone(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            # No state file; run_id pid is an almost-certainly-dead PID.
+            result = await _DummyAdapter().status({"adapter_config": {"output_dir": td}}, "2147483646/x")
+        assert result.status in (LLCRunStatus.COMPLETED, LLCRunStatus.RUNNING)


### PR DESCRIPTION
## Thinking Path

The post-merge audit (after #9811 shared the prompt/credential layer) found the **subprocess lifecycle** still duplicated near-verbatim across `claude_code_adapter` (355 lines) and `copilot_local_adapter` (281 lines) — `_cancel` was byte-identical bar log strings + claude's session-clear. Filed as #9834; this addresses it.

## What Changed

New **`llc/adapters/subprocess_base.py` → `SubprocessLifecycleAdapter`** owns the shared lifecycle:
- `invoke` wrapper, `status`/`_status`, `_probe_pid`, `cancel`/`_cancel` (SIGTERM→grace→SIGKILL), `_load_state` (path-traversal-guarded), `_build_prompt`
- shared `resolve_timeout` (3-tier) + `SIGTERM_GRACE_SECONDS` / `ADAPTER_TIMEOUT_SECONDS` / `DEFAULT_*` constants
- a `_post_cancel(agent_config, run_id)` hook (default no-op)

Subclasses now only carry what actually differs:
- `ClaudeCodeAdapter` (355→**234**): `_invoke` (resume-session + stream-json), Redis session methods, `_post_cancel` → clear session
- `CopilotLocalAdapter` (281→**156**): `_invoke` (`gh copilot suggest`)

The legacy module-level symbols (`_output_path`/`_state_path`/`_resolve_claude_cli`/`_resolve_gh_cli`/`_resolve_timeout`/`_SIGTERM_GRACE_SECONDS`) are kept as re-exports, so the subscription adapters' imports and the existing test suite's import-contract are **unchanged**. The subscription subclasses inherit the shared lifecycle automatically.

Net: −246 duplicated lines for a 197-line single source of truth.

## Verification

```
$ python3 -m pytest llc/adapters/tests/ llc/tests/test_heartbeat_scheduler.py llc/tests/test_heartbeat_context.py -q
154 passed
```
The existing adapter suite is the behavior contract — **0 failures**, all unchanged. New `test_subprocess_base.py` covers `resolve_timeout` tiers, the `_load_state` path-traversal guard, and shared status. Registry wiring verified via the existing `TestRegistry` tests.

Closes #9834.

## Model Used

claude-opus-4-8 (1M context)
