### PR TITLE
fix(deps): upgrade vega ecosystem to v6 — stop recurring Dependabot break (#9847)

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -252,7 +252,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -797,7 +796,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -846,7 +844,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -924,6 +921,17 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4112,7 +4120,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4492,7 +4499,6 @@
       "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.61.0",
@@ -4532,7 +4538,6 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -4788,7 +4793,6 @@
       "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.8",
@@ -5022,7 +5026,6 @@
       "integrity": "sha512-RUS2ZU2TsduVrI+9c12uTNaKrNUTsm6yFt3fueEUB9iKvyC2UP83F+sqIz00HQIah4UOL1TMoDAki8K0NjGvsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.8",
         "fflate": "^0.8.2",
@@ -5181,7 +5184,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
       "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.34",
         "@vue/shared": "3.5.34"
@@ -5405,7 +5407,6 @@
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
       "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.5.34",
         "@vue/shared": "3.5.34"
@@ -5535,7 +5536,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5652,8 +5652,7 @@
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-5.14.0.tgz",
       "integrity": "sha512-hBLz5Gd8B5ZuocEzNUwEeKdw9vd7uy4OnqbDjAYyvwiAEyHk3OnO9+tGzAznpM6pnyCqWjPXUKKYoNIwdskeuQ==",
-      "license": "SEE LICENSE IN LICENSE",
-      "peer": true
+      "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/arch": {
       "version": "2.2.0",
@@ -6085,7 +6084,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6770,7 +6768,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7593,7 +7590,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7657,7 +7653,6 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7714,7 +7709,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7794,7 +7788,6 @@
       "integrity": "sha512-4g7ZP3pYcuqd7Zp0pzUKcos0W+RkjBz4EGdhJ92FcYk6v03Ti/GK5NwjgsjxHK+98eXDbHeK7VtX1az7/8doZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
@@ -8620,7 +8613,6 @@
       "integrity": "sha512-5p9Sxis3eowDJKqx90QCsgbNA02XXqJ59NOHvD4V6cxp+rP4d/xOyVx7uY3hS8hiUbY1VeiFH8lbJ81AyuDVLQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -11399,7 +11391,6 @@
       "integrity": "sha512-ypZkK/aDc5NQV8zIR6s2H2Tl3aNW8FmJ1m9+2qsaYuRenl8vgnHNCGwTHviWJdUQzglOlHFchgopdtGhSy17Rw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "oxlint": "bin/oxlint"
       },
@@ -11687,7 +11678,6 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -11878,7 +11868,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12215,7 +12204,6 @@
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12226,7 +12214,6 @@
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -13016,7 +13003,6 @@
       "integrity": "sha512-5Ax5vbHxFgMBGGhQDm75Rrumm/HZC4ICFhMcJaM0UlqnC/4FKj/IaZtImZFupknyiiyUEcWHPQFA2kX3/VSv1A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.2",
@@ -13837,8 +13823,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -13858,8 +13843,7 @@
       "version": "0.184.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
       "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-forcegraph": {
       "version": "1.43.1",
@@ -13994,7 +13978,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14223,7 +14206,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14432,7 +14414,6 @@
       "resolved": "https://registry.npmjs.org/vega/-/vega-6.2.0.tgz",
       "integrity": "sha512-BIwalIcEGysJdQDjeVUmMWB3e50jPDNAMfLJscjEvpunU9bSt7X1OYnQxkg3uBwuRRI4nWfFZO9uIW910nLeGw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "vega-crossfilter": "~5.1.0",
         "vega-dataflow": "~6.1.0",
@@ -14654,7 +14635,6 @@
       "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-6.4.3.tgz",
       "integrity": "sha512-d/7hPjfz560UERaQuTmGgIVfXAe3g2hJWeC+igDeaGohUdEoNrHLXgR/yTOBT8vV/lIuuKnw+0/xWWblkDwkMQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "json-stringify-pretty-compact": "~4.0.0",
         "tslib": "~2.8.1",
@@ -15049,7 +15029,6 @@
       "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -15340,7 +15319,6 @@
       "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.8",
         "@vitest/mocker": "4.1.8",
@@ -15460,7 +15438,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
       "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.34",
         "@vue/compiler-sfc": "3.5.34",

--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "autobot-vue",
       "version": "0.0.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@autobot/terminal": "file:../autobot-plugins/terminal",
         "@autobot/vnc": "file:../autobot-plugins/vnc",
@@ -32,9 +33,9 @@
         "pinia-plugin-persistedstate": "^4.7.1",
         "three": "^0.184.0",
         "three-spritetext": "^1.10.0",
-        "vega": "^5.30.0",
-        "vega-embed": "^6.29.0",
-        "vega-lite": "5.23.0",
+        "vega": "^6.2.0",
+        "vega-embed": "^7.1.0",
+        "vega-lite": "^6.4.3",
         "vue": "^3.5.34",
         "vue-i18n": "^11.4.5",
         "vue-router": "^5.1.0",
@@ -251,6 +252,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -795,6 +797,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -843,6 +846,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -905,20 +909,22 @@
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+    "node_modules/@emnapi/core/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -929,6 +935,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -942,6 +949,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -958,6 +966,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -974,6 +983,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -990,6 +1000,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1006,6 +1017,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1022,6 +1034,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1038,6 +1051,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1054,6 +1068,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1070,6 +1085,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1086,6 +1102,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1102,6 +1119,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1118,6 +1136,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1134,6 +1153,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1150,6 +1170,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1166,6 +1187,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1182,6 +1204,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1198,6 +1221,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1214,6 +1238,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1230,6 +1255,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1246,6 +1272,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1262,6 +1289,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1278,6 +1306,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1294,6 +1323,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1310,6 +1340,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1326,6 +1357,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1342,6 +1374,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1921,6 +1954,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2294,6 +2328,29 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
@@ -3173,6 +3230,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3189,6 +3247,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3205,6 +3264,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3221,6 +3281,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3237,6 +3298,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3253,6 +3315,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3269,6 +3332,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3285,6 +3349,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3301,6 +3366,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3317,6 +3383,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3333,6 +3400,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3349,6 +3417,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3365,6 +3434,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3376,6 +3446,29 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.16",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
@@ -3383,6 +3476,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3399,6 +3493,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3414,19 +3509,6 @@
       "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -3893,27 +3975,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "dev": true,
@@ -4051,6 +4112,7 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4183,6 +4245,7 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4260,9 +4323,9 @@
       "license": "MIT"
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.4",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.4.tgz",
-      "integrity": "sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q==",
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/jsdom": {
@@ -4429,6 +4492,7 @@
       "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.61.0",
@@ -4468,6 +4532,7 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -4723,6 +4788,7 @@
       "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.8",
@@ -4956,6 +5022,7 @@
       "integrity": "sha512-RUS2ZU2TsduVrI+9c12uTNaKrNUTsm6yFt3fueEUB9iKvyC2UP83F+sqIz00HQIah4UOL1TMoDAki8K0NjGvsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.8",
         "fflate": "^0.8.2",
@@ -5114,6 +5181,7 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
       "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.34",
         "@vue/shared": "3.5.34"
@@ -5337,6 +5405,7 @@
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
       "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.5.34",
         "@vue/shared": "3.5.34"
@@ -5466,6 +5535,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5556,6 +5626,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5581,7 +5652,8 @@
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-5.14.0.tgz",
       "integrity": "sha512-hBLz5Gd8B5ZuocEzNUwEeKdw9vd7uy4OnqbDjAYyvwiAEyHk3OnO9+tGzAznpM6pnyCqWjPXUKKYoNIwdskeuQ==",
-      "license": "SEE LICENSE IN LICENSE"
+      "license": "SEE LICENSE IN LICENSE",
+      "peer": true
     },
     "node_modules/arch": {
       "version": "2.2.0",
@@ -6013,6 +6085,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6381,6 +6454,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -6395,6 +6469,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -6412,6 +6487,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -6424,6 +6500,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -6693,6 +6770,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7369,6 +7447,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -7511,9 +7590,10 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7577,6 +7657,7 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7633,6 +7714,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7712,6 +7794,7 @@
       "integrity": "sha512-4g7ZP3pYcuqd7Zp0pzUKcos0W+RkjBz4EGdhJ92FcYk6v03Ti/GK5NwjgsjxHK+98eXDbHeK7VtX1az7/8doZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
@@ -8358,7 +8441,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
       "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8538,6 +8620,7 @@
       "integrity": "sha512-5p9Sxis3eowDJKqx90QCsgbNA02XXqJ59NOHvD4V6cxp+rP4d/xOyVx7uY3hS8hiUbY1VeiFH8lbJ81AyuDVLQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -9026,6 +9109,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9418,7 +9502,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -9840,6 +9924,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9860,6 +9945,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9880,6 +9966,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9900,6 +9987,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9920,6 +10008,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9940,6 +10029,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9960,6 +10050,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9980,6 +10071,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10000,6 +10092,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10020,6 +10113,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10040,6 +10134,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10862,48 +10957,6 @@
       "integrity": "sha512-4EUeAGbB2HWX9njd6bP6tciN6ByJfoaAvmVL9QTaZSeXrW46eNGA9GajiXiPBbvFqxUWFkEbyo6x5qsACUuVfA==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -11346,6 +11399,7 @@
       "integrity": "sha512-ypZkK/aDc5NQV8zIR6s2H2Tl3aNW8FmJ1m9+2qsaYuRenl8vgnHNCGwTHviWJdUQzglOlHFchgopdtGhSy17Rw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "oxlint": "bin/oxlint"
       },
@@ -11633,6 +11687,7 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -11823,6 +11878,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12159,6 +12215,7 @@
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12169,6 +12226,7 @@
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12272,6 +12330,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12957,6 +13016,7 @@
       "integrity": "sha512-5Ax5vbHxFgMBGGhQDm75Rrumm/HZC4ICFhMcJaM0UlqnC/4FKj/IaZtImZFupknyiiyUEcWHPQFA2kX3/VSv1A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.2",
@@ -13591,6 +13651,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -13621,6 +13682,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -13775,7 +13837,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -13795,7 +13858,8 @@
       "version": "0.184.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
       "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-forcegraph": {
       "version": "1.43.1",
@@ -13930,6 +13994,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14158,6 +14223,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14362,85 +14428,92 @@
       "license": "MIT"
     },
     "node_modules/vega": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.33.1.tgz",
-      "integrity": "sha512-1fArfVDUqVbb5z8n+/nVQb+VNBzx8svY6CrsyTK4Ujm4yrd9I1auoKxBAPXLCavY1LcrbHUskQbGUP8gXOzyQw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-6.2.0.tgz",
+      "integrity": "sha512-BIwalIcEGysJdQDjeVUmMWB3e50jPDNAMfLJscjEvpunU9bSt7X1OYnQxkg3uBwuRRI4nWfFZO9uIW910nLeGw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
-        "vega-crossfilter": "~4.1.4",
-        "vega-dataflow": "~5.7.8",
-        "vega-encode": "~4.10.3",
-        "vega-event-selector": "~3.0.1",
-        "vega-expression": "~5.2.1",
-        "vega-force": "~4.2.3",
-        "vega-format": "~1.1.4",
-        "vega-functions": "~5.18.1",
-        "vega-geo": "~4.4.4",
-        "vega-hierarchy": "~4.1.4",
-        "vega-label": "~1.3.2",
-        "vega-loader": "~4.5.4",
-        "vega-parser": "~6.6.1",
-        "vega-projection": "~1.6.3",
-        "vega-regression": "~1.3.2",
-        "vega-runtime": "~6.2.2",
-        "vega-scale": "~7.4.3",
-        "vega-scenegraph": "~4.13.2",
-        "vega-statistics": "~1.9.0",
-        "vega-time": "~2.1.4",
-        "vega-transforms": "~4.12.2",
-        "vega-typings": "~1.5.1",
-        "vega-util": "~1.17.4",
-        "vega-view": "~5.16.1",
-        "vega-view-transforms": "~4.6.2",
-        "vega-voronoi": "~4.2.5",
-        "vega-wordcloud": "~4.1.7"
+        "vega-crossfilter": "~5.1.0",
+        "vega-dataflow": "~6.1.0",
+        "vega-encode": "~5.1.0",
+        "vega-event-selector": "~4.0.0",
+        "vega-expression": "~6.1.0",
+        "vega-force": "~5.1.0",
+        "vega-format": "~2.1.0",
+        "vega-functions": "~6.1.0",
+        "vega-geo": "~5.1.0",
+        "vega-hierarchy": "~5.1.0",
+        "vega-label": "~2.1.0",
+        "vega-loader": "~5.1.0",
+        "vega-parser": "~7.1.0",
+        "vega-projection": "~2.1.0",
+        "vega-regression": "~2.1.0",
+        "vega-runtime": "~7.1.0",
+        "vega-scale": "~8.1.0",
+        "vega-scenegraph": "~5.1.0",
+        "vega-statistics": "~2.0.0",
+        "vega-time": "~3.1.0",
+        "vega-transforms": "~5.1.0",
+        "vega-typings": "~2.1.0",
+        "vega-util": "~2.1.0",
+        "vega-view": "~6.1.0",
+        "vega-view-transforms": "~5.1.0",
+        "vega-voronoi": "~5.1.0",
+        "vega-wordcloud": "~5.1.0"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
       }
     },
     "node_modules/vega-canvas": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
-      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-2.0.0.tgz",
+      "integrity": "sha512-9x+4TTw/USYST5nx4yN272sy9WcqSRjAR0tkQYZJ4cQIeon7uVsnohvoPQK1JZu7K1QXGUqzj08z0u/UegBVMA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-crossfilter": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.4.tgz",
-      "integrity": "sha512-5E/i60Y80CUt+4O+U89X8ZnauaFuq0ztq/Hx4i4sT/crk4Lfn1oplRAjNOo7dFEZ04TahyBbYiJKIhR0yvmHpw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-5.1.0.tgz",
+      "integrity": "sha512-EmVhfP3p6AM7o/lPan/QAoqjblI19BxWUlvl2TSs0xjQd8KbaYYbS4Ixt3cmEvl0QjRdBMF6CdJJ/cy9DTS4Fw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-dataflow": {
-      "version": "5.7.8",
-      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.8.tgz",
-      "integrity": "sha512-jrllcIjSYU5Jh130RDR44o/SbUbJndLuoiM9IsKWW+a7HayKnfmbdHWm7MvCrj/YLupFZVojRaS1tTs53EXTdA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-6.1.0.tgz",
+      "integrity": "sha512-JxumGlODtFbzoQ4c/jQK8Tb/68ih0lrexlCozcMfTAwQ12XhTqCvlafh7MAKKTMBizjOfaQTHm4Jkyb1H5CfyQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-format": "^1.1.4",
-        "vega-loader": "^4.5.4",
-        "vega-util": "^1.17.4"
+        "vega-format": "^2.1.0",
+        "vega-loader": "^5.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-embed": {
-      "version": "6.29.0",
-      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.29.0.tgz",
-      "integrity": "sha512-PmlshTLtLFLgWtF/b23T1OwX53AugJ9RZ3qPE2c01VFAbgt3/GSNI/etzA/GzdrkceXFma+FDHNXUppKuM0U6Q==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-7.1.0.tgz",
+      "integrity": "sha512-ZmEIn5XJrQt7fSh2lwtSdXG/9uf3yIqZnvXFEwBJRppiBgrEWZcZbj6VK3xn8sNTFQ+sQDXW5sl/6kmbAW3s5A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "fast-json-patch": "^3.1.1",
         "json-stringify-pretty-compact": "^4.0.0",
-        "semver": "^7.6.3",
+        "semver": "^7.7.2",
         "tslib": "^2.8.1",
-        "vega-interpreter": "^1.0.5",
-        "vega-schema-url-parser": "^2.2.0",
-        "vega-themes": "^2.15.0",
-        "vega-tooltip": "^0.35.2"
+        "vega-interpreter": "^2.0.0",
+        "vega-schema-url-parser": "^3.0.2",
+        "vega-themes": "3.0.0",
+        "vega-tooltip": "1.0.0"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
       },
       "peerDependencies": {
-        "vega": "^5.21.0",
+        "vega": "*",
         "vega-lite": "*"
       }
     },
@@ -14457,147 +14530,138 @@
       }
     },
     "node_modules/vega-encode": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.10.3.tgz",
-      "integrity": "sha512-245ebBuN1TjwVVDFG7JZaZ/ExLAhZ4kDTK2zlIoXs/g2P5rRgL4Q6oRixr+Pgr43G7ISCEHrUBgUjRcSoG8eEA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-5.1.0.tgz",
+      "integrity": "sha512-q26oI7B+MBQYcTQcr5/c1AMsX3FvjZLQOBi7yI0vV+GEn93fElDgvhQiYrgeYSD4Exi/jBPeUXuN6p4bLz16kA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-interpolate": "^3.0.1",
-        "vega-dataflow": "^5.7.8",
-        "vega-scale": "^7.4.3",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.0",
+        "vega-scale": "^8.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-event-selector": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
-      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-4.0.0.tgz",
+      "integrity": "sha512-CcWF4m4KL/al1Oa5qSzZ5R776q8lRxCj3IafCHs5xipoEHrkgu1BWa7F/IH5HrDNXeIDnqOpSV1pFsAWRak4gQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-expression": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.2.tgz",
-      "integrity": "sha512-fFeDTh4UtOxlZWL54jf1ZqJHinyerWq/ROiqrQxqLkNJRJ86RmxYTgXwt65UoZ/l4VUv9eAd2qoJeDEf610Umw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-6.1.0.tgz",
+      "integrity": "sha512-hHgNx/fQ1Vn1u6vHSamH7lRMsOa/yQeHGGcWVmh8fZafLdwdhCM91kZD9p7+AleNpgwiwzfGogtpATFaMmDFYg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/estree": "^1.0.0",
-        "vega-util": "^1.17.3"
+        "@types/estree": "^1.0.8",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-force": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.3.tgz",
-      "integrity": "sha512-7Yp1uOPy3eyzK/hnAIU0v/yQ9mIhtoJ+tq8AMaZiWqy67SUYsE3olmgdllY6R9M81D/n/rv8K+8JjbHMU5/sUA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-5.1.0.tgz",
+      "integrity": "sha512-wdnchOSeXpF9Xx8Yp0s6Do9F7YkFeOn/E/nENtsI7NOcyHpICJ5+UkgjUo9QaQ/Yu+dIDU+sP/4NXsUtq6SMaQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-force": "^3.0.0",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-format": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.4.tgz",
-      "integrity": "sha512-+oz6UvXjQSbweW9P8q+1o2qFYyBYPFax94j6a9PQMnCIWMovFSss1wEElljOT8CEpnHyS15yiGlmz4qbWTQwnQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-2.1.0.tgz",
+      "integrity": "sha512-i9Ht33IgqG36+S1gFDpAiKvXCPz+q+1vDhDGKK8YsgMxGOG4PzinKakI66xd7SdV4q97FgpR7odAXqtDN2wKqw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-format": "^3.1.0",
         "d3-time-format": "^4.1.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
+        "vega-time": "^3.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-functions": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.18.1.tgz",
-      "integrity": "sha512-qEBAbo0jxGGebRvbX1zmxzmjwFz8/UtncRhzwk9/KcI0WudULNmCM1iTu+DGFRnNHdcKi6kUlwJBPIp7zDu3HQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-6.1.1.tgz",
+      "integrity": "sha512-Due6jP0y0FfsGMTrHnzUGnEwXPu7VwE+9relfo+LjL/tRPYnnKqwWvzt7n9JkeBuZqjkgYjMzm/WucNn6Hkw5A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-color": "^3.1.0",
-        "d3-geo": "^3.1.0",
-        "vega-dataflow": "^5.7.8",
-        "vega-expression": "^5.2.1",
-        "vega-scale": "^7.4.3",
-        "vega-scenegraph": "^4.13.2",
-        "vega-selections": "^5.6.1",
-        "vega-statistics": "^1.9.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-functions/node_modules/vega-expression": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
-      "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "vega-util": "^1.17.4"
+        "d3-geo": "^3.1.1",
+        "vega-dataflow": "^6.1.0",
+        "vega-expression": "^6.1.0",
+        "vega-scale": "^8.1.0",
+        "vega-scenegraph": "^5.1.0",
+        "vega-selections": "^6.1.0",
+        "vega-statistics": "^2.0.0",
+        "vega-time": "^3.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-geo": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.4.tgz",
-      "integrity": "sha512-jTLYrDvhXJinWQCfuVLP1nSlOdFlA9blVS6K7uOcBTJ4382Aw3ALGZKluUQyJkFdrkGfqxoDJo5MLHLu2zlc6g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-5.1.0.tgz",
+      "integrity": "sha512-H8aBBHfthc3rzDbz/Th18+Nvp00J73q3uXGAPDQqizioDm/CoXCK8cX4pMePydBY9S6ikBiGJrLKFDa80wI20g==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-color": "^3.1.0",
-        "d3-geo": "^3.1.0",
-        "vega-canvas": "^1.2.7",
-        "vega-dataflow": "^5.7.8",
-        "vega-projection": "^1.6.3",
-        "vega-statistics": "^1.9.0",
-        "vega-util": "^1.17.4"
+        "d3-geo": "^3.1.1",
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.1.0",
+        "vega-projection": "^2.1.0",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-hierarchy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.4.tgz",
-      "integrity": "sha512-/iSh1YqdgsHFB20QxJ6IAVzRZQBKuMpZ/GsN5sZDP3bBJdVWl3we48L/r6w7FP9NU+JzFHcDUPJ0S0UzpMhaqg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-5.1.0.tgz",
+      "integrity": "sha512-rZlU8QJNETlB6o73lGCPybZtw2fBBsRIRuFE77aCLFHdGsh6wIifhplVarqE9icBqjUHRRUOmcEYfzwVIPr65g==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-hierarchy": "^3.1.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-interpreter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-1.2.1.tgz",
-      "integrity": "sha512-EMHLGxJ+SWfh1K/fHDRlHEZtLA/2ZNAXItYb5e8CxuAIm/Ha/3DHX/8VlvbTGIciUpuwmcKx4tVhJWlKreQ/Yw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-2.2.1.tgz",
+      "integrity": "sha512-o+4ZEme2mdFLewlpF76dwPWW2VkZ3TAF3DMcq75/NzA5KPvnN4wnlCM8At2FVawbaHRyGdVkJSS5ROF5KwpHPQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-util": "^1.17.4"
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-label": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.3.2.tgz",
-      "integrity": "sha512-YlUCUZNsp1FHkpPjOpD+aVVmVLFw6xa+bFQGBCECuY1DuRyN6l8oCRmUOjBrr70ip8fbqfGk+czHw543J1PJgg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-2.1.0.tgz",
+      "integrity": "sha512-/hgf+zoA3FViDBehrQT42Lta3t8In6YwtMnwjYlh72zNn1p3c7E3YUBwqmAqTM1x+tudgzMRGLYig+bX1ewZxQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-canvas": "^1.2.7",
-        "vega-dataflow": "^5.7.8",
-        "vega-scenegraph": "^4.13.2",
-        "vega-util": "^1.17.4"
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.1.0",
+        "vega-scenegraph": "^5.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-lite": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.23.0.tgz",
-      "integrity": "sha512-l4J6+AWE3DIjvovEoHl2LdtCUkfm4zs8Xxx7INwZEAv+XVb6kR6vIN1gt3t2gN2gs/y4DYTs/RPoTeYAuEg6mA==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-6.4.3.tgz",
+      "integrity": "sha512-d/7hPjfz560UERaQuTmGgIVfXAe3g2hJWeC+igDeaGohUdEoNrHLXgR/yTOBT8vV/lIuuKnw+0/xWWblkDwkMQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "json-stringify-pretty-compact": "~4.0.0",
         "tslib": "~2.8.1",
-        "vega-event-selector": "~3.0.1",
-        "vega-expression": "~5.1.1",
-        "vega-util": "~1.17.2",
-        "yargs": "~17.7.2"
+        "vega-event-selector": "~4.0.0",
+        "vega-expression": "~6.1.0",
+        "vega-util": "~2.1.0",
+        "yargs": "~18.0.0"
       },
       "bin": {
         "vl2pdf": "bin/vl2pdf",
@@ -14606,268 +14670,362 @@
         "vl2vg": "bin/vl2vg"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
       },
       "peerDependencies": {
-        "vega": "^5.24.0"
+        "vega": "^6.0.0"
+      }
+    },
+    "node_modules/vega-lite/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/vega-lite/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/vega-lite/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/vega-lite/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/vega-lite/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vega-lite/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/vega-lite/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/vega-lite/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/vega-lite/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/vega-loader": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.4.tgz",
-      "integrity": "sha512-AOJPsDVz009aTdD9hzigUaO/NFmuN1o83rzvZu/g37TJfhU+3DOvgnO0rnqJbnSOfcBkLWER6XghlKS3j77w4A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-5.1.0.tgz",
+      "integrity": "sha512-GaY3BdSPbPNdtrBz8SYUBNmNd8mdPc3mtdZfdkFazQ0RD9m+Toz5oR8fKnTamNSk9fRTJX0Lp3uEqxrAlQVreg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-dsv": "^3.0.1",
-        "node-fetch": "^2.6.7",
         "topojson-client": "^3.1.0",
-        "vega-format": "^1.1.4",
-        "vega-util": "^1.17.4"
+        "vega-format": "^2.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-parser": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.6.1.tgz",
-      "integrity": "sha512-FIez+huStzgjsxLqOkxDAooTkDC2XruYCIFWhd3HuM/QrqKtj9JKGuIUJjpVVkE7by7S5ejrucpRzVVgQfbzSg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-7.1.0.tgz",
+      "integrity": "sha512-g0lrYxtmYVW8G6yXpIS4J3Uxt9OUSkc0bLu5afoYDo4rZmoOOdll3x3ebActp5LHPW+usZIE+p5nukRS2vEc7Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-dataflow": "^5.7.8",
-        "vega-event-selector": "^3.0.1",
-        "vega-functions": "^5.18.1",
-        "vega-scale": "^7.4.3",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.0",
+        "vega-event-selector": "^4.0.0",
+        "vega-functions": "^6.1.0",
+        "vega-scale": "^8.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-projection": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.3.tgz",
-      "integrity": "sha512-vusyaPi3EFIHrBVs0chNv2bCqxw4X+XgI1m3+yOgUD/dutsIGTcqy+PjlNlspPQvMI9JjTeIUTGt8u1V7oDwAA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-2.1.0.tgz",
+      "integrity": "sha512-EjRjVSoMR5ibrU7q8LaOQKP327NcOAM1+eZ+NO4ANvvAutwmbNVTmfA1VpPH+AD0AlBYc39ND/wnRk7SieDiXA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-geo": "^3.1.0",
+        "d3-geo": "^3.1.1",
         "d3-geo-projection": "^4.0.0",
-        "vega-scale": "^7.4.3"
+        "vega-scale": "^8.1.0"
       }
     },
     "node_modules/vega-regression": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.3.2.tgz",
-      "integrity": "sha512-DtGToopuJGmxeoymaOXTDKlWkkYiDVvZFV1IWQNuRlChTBI6YBpil4WmA3U+ECePDQuk2+/mWlw+vafrbgF8Tg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-2.1.0.tgz",
+      "integrity": "sha512-HzC7MuoEwG1rIxRaNTqgcaYF03z/ZxYkQR2D5BN0N45kLnHY1HJXiEcZkcffTsqXdspLjn47yLi44UoCwF5fxQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-statistics": "^1.9.0",
-        "vega-util": "^1.17.4"
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.1.0",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-runtime": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.2.2.tgz",
-      "integrity": "sha512-5c+i7y5XBw5phIA1mBeqF/gtOQcDjUzroUAQ0g3y3weNx0K4mzj7V360yZiBLNcuHv65xgTlijstbKQttxeY/g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-7.1.0.tgz",
+      "integrity": "sha512-mItI+WHimyEcZlZrQ/zYR3LwHVeyHCWwp7MKaBjkU8EwkSxEEGVceyGUY9X2YuJLiOgkLz/6juYDbMv60pfwYA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-scale": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.4.3.tgz",
-      "integrity": "sha512-f7SSN2YJowtrdkt7nJIR6YYhjDk8oB37q5So2/OxXQv5CBHipFPQSHS1ZVw9vD3V5wLnrZCxC4Ji27gmsTefgA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-8.1.0.tgz",
+      "integrity": "sha512-VEgDuEcOec8+C8+FzLcnAmcXrv2gAJKqQifCdQhkgnsLa978vYUgVfCut/mBSMMHbH8wlUV1D0fKZTjRukA1+A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
         "d3-scale-chromatic": "^3.1.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
+        "vega-time": "^3.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-scenegraph": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.13.2.tgz",
-      "integrity": "sha512-eCutgcLzdUg23HLc6MTZ9pHCdH0hkqSmlbcoznspwT0ajjATk6M09JNyJddiaKR55HuQo03mBWsPeRCd5kOi0g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-5.1.0.tgz",
+      "integrity": "sha512-4gA89CFIxkZX+4Nvl8SZF2MBOqnlj9J5zgdPh/HPx+JOwtzSlUqIhxFpFj7GWYfwzr/PyZnguBLPihPw1Og/cA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-path": "^3.1.0",
         "d3-shape": "^3.2.0",
-        "vega-canvas": "^1.2.7",
-        "vega-loader": "^4.5.4",
-        "vega-scale": "^7.4.3",
-        "vega-util": "^1.17.4"
+        "vega-canvas": "^2.0.0",
+        "vega-loader": "^5.1.0",
+        "vega-scale": "^8.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-schema-url-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-2.2.0.tgz",
-      "integrity": "sha512-yAtdBnfYOhECv9YC70H2gEiqfIbVkq09aaE4y/9V/ovEFmH9gPKaEgzIZqgT7PSPQjKhsNkb6jk6XvSoboxOBw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-3.0.2.tgz",
+      "integrity": "sha512-xAnR7KAvNPYewI3O0l5QGdT8Tv0+GCZQjqfP39cW/hbe/b3aYMAQ39vm8O2wfXUHzm04xTe7nolcsx8WQNVLRQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-selections": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.6.3.tgz",
-      "integrity": "sha512-DXd+XVKcIjBAtSCcgtPx7cXuqG/7L98SWoFh6GKNu26EBUyn3zm0GAlZxNLPoI01Jz9Fb3YpSsewk2aIAbM68g==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-6.1.2.tgz",
+      "integrity": "sha512-xJ+V4qdd46nk2RBdwIRrQm2iSTMHdlu/omhLz1pqRL3jZDrkqNBXimrisci2kIKpH2WBpA1YVagwuZEKBmF2Qw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-array": "3.2.4",
-        "vega-expression": "^5.2.1",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-selections/node_modules/vega-expression": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
-      "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "vega-util": "^1.17.4"
+        "vega-expression": "^6.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-statistics": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.9.0.tgz",
-      "integrity": "sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-2.0.0.tgz",
+      "integrity": "sha512-dGPfDXnBlgXbZF3oxtkb8JfeRXd5TYHx25Z/tIoaa9jWua4Vf/AoW2wwh8J1qmMy8J03/29aowkp1yk4DOPazQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2"
+        "d3-array": "^3.2.4"
       }
     },
     "node_modules/vega-themes": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.15.0.tgz",
-      "integrity": "sha512-DicRAKG9z+23A+rH/3w3QjJvKnlGhSbbUXGjBvYGseZ1lvj9KQ0BXZ2NS/+MKns59LNpFNHGi9us/wMlci4TOA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-3.0.0.tgz",
+      "integrity": "sha512-1iFiI3BNmW9FrsLnDLx0ZKEddsCitRY3XmUAwp6qmp+p+IXyJYc9pfjlVj9E6KXBPfm4cQyU++s0smKNiWzO4g==",
       "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      },
       "peerDependencies": {
         "vega": "*",
         "vega-lite": "*"
       }
     },
     "node_modules/vega-time": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.4.tgz",
-      "integrity": "sha512-DBMRps5myYnSAlvQ+oiX8CycJZjGQNqyGE04xaZrpOgHll7vlvezpET2FnGZC7wS3DsqMcPjnpnI1h7+qJox1Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-3.1.0.tgz",
+      "integrity": "sha512-G93mWzPwNa6UYQRkr8Ujur9uqxbBDjDT/WpXjbDY0yygdSkRT+zXF+Sb4gjhW0nPaqdiwkn0R6kZcSPMj1bMNA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-time": "^3.1.0",
-        "vega-util": "^1.17.4"
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-tooltip": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.35.2.tgz",
-      "integrity": "sha512-kuYcsAAKYn39ye5wKf2fq1BAxVcjoz0alvKp/G+7BWfIb94J0PHmwrJ5+okGefeStZnbXxINZEOKo7INHaj9GA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-1.0.0.tgz",
+      "integrity": "sha512-P1R0JP29v0qnTuwzCQ0SPJlkjAzr6qeyj+H4VgUFSykHmHc1OBxda//XBaFDl/bZgIscEMvjKSjZpXd84x3aZQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-util": "^1.17.2"
+        "vega-util": "^2.0.0"
       },
-      "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.24.4"
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
       }
     },
     "node_modules/vega-transforms": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.12.2.tgz",
-      "integrity": "sha512-VuNLzB0DavFn5GIkFvR2XvwPavjY7VXl2oPUOFvNgSfyQywmCoC7VOX+iHeOdxoZdoy+XEOGAqRs9imxVo2HVA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-5.1.0.tgz",
+      "integrity": "sha512-mj/sO2tSuzzpiXX8JSl4DDlhEmVwM/46MTAzTNQUQzJPMI/n4ChCjr/SdEbfEyzlD4DPm1bjohZGjLc010yuMg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-statistics": "^1.9.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.1.0",
+        "vega-statistics": "^2.0.0",
+        "vega-time": "^3.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-typings": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-1.5.1.tgz",
-      "integrity": "sha512-40kRoG/jG8+4cd3kT5yw08iTlIGe57F7Go/ileSCtRtgU8RZ7tpPaE6GgYvF/HTPlCKMk9/pOdp62+o5sulhvQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-2.1.0.tgz",
+      "integrity": "sha512-zdis4Fg4gv37yEvTTSZEVMNhp8hwyEl7GZ4X4HHddRVRKxWFsbyKvZx/YW5Z9Ox4sjxVA2qHzEbod4Fdx+SEJA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/geojson": "7946.0.4",
-        "vega-event-selector": "^3.0.1",
-        "vega-expression": "^5.2.1",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-typings/node_modules/vega-expression": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
-      "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "vega-util": "^1.17.4"
+        "@types/geojson": "7946.0.16",
+        "vega-event-selector": "^4.0.0",
+        "vega-expression": "^6.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-util": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
-      "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
+      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-view": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.16.1.tgz",
-      "integrity": "sha512-YyG4i2JDkRCacHd9xNAwyov2cELxwzPGY224PA2o0gEhkoOjPkVElTmo9QHJvKeVxMoyad6wvoq+Jj+TB6zhLw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-6.1.0.tgz",
+      "integrity": "sha512-hmHDm/zC65lb23mb9Tr9Gx0wkxP0TMS31LpMPYxIZpvInxvUn7TYitkOtz1elr63k2YZrgmF7ztdGyQ4iCQ5fQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-timer": "^3.0.1",
-        "vega-dataflow": "^5.7.8",
-        "vega-format": "^1.1.4",
-        "vega-functions": "^5.18.1",
-        "vega-runtime": "^6.2.2",
-        "vega-scenegraph": "^4.13.2",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.0",
+        "vega-format": "^2.1.0",
+        "vega-functions": "^6.1.0",
+        "vega-runtime": "^7.1.0",
+        "vega-scenegraph": "^5.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-view-transforms": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.6.2.tgz",
-      "integrity": "sha512-udnYutgX7T7E0crqKWSs4hcxTdUmZHR2F4rKj0+3nN9+CfYMWbGgUkCkP2pMu7j2OH0ETX2uDn5xL8+YJWeXSg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-5.1.0.tgz",
+      "integrity": "sha512-fpigh/xn/32t+An1ShoY3MLeGzNdlbAp2+HvFKzPpmpMTZqJEWkk/J/wHU7Swyc28Ta7W1z3fO+8dZkOYO5TWQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-dataflow": "^5.7.8",
-        "vega-scenegraph": "^4.13.2",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.0",
+        "vega-scenegraph": "^5.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-voronoi": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.5.tgz",
-      "integrity": "sha512-u0TLSQboiLyoM6V9S0E6cc77EfWati+ApZ6zE+NhH3h/zZRzYZmElnDn46hUof2o9jNyh09xFXTXykVHmt7IGg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-5.1.0.tgz",
+      "integrity": "sha512-uKdsoR9x60mz7eYtVG+NhlkdQXeVdMr6jHNAHxs+W+i6kawkUp5S9jp1xf1FmW/uZvtO1eqinHQNwATcDRsiUg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-delaunay": "^6.0.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
+        "d3-delaunay": "^6.0.4",
+        "vega-dataflow": "^6.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-wordcloud": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.7.tgz",
-      "integrity": "sha512-xdMykDXdWEp3/7Hil7Yx8uNVmjvqxwGibHJLSfiubNNO9OErrH3ZUgcxWv5hLe9wdK+KSGP94SSqTOAaqH7r/A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-5.1.0.tgz",
+      "integrity": "sha512-sSdNmT8y2D7xXhM2h76dKyaYn3PA4eV49WUUkfYfqHz/vpcu10GSAoFxLhQQTkbZXR+q5ZB63tFUow9W2IFo6g==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-canvas": "^1.2.7",
-        "vega-dataflow": "^5.7.8",
-        "vega-scale": "^7.4.3",
-        "vega-statistics": "^1.9.0",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega/node_modules/vega-expression": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
-      "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "vega-util": "^1.17.4"
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.1.0",
+        "vega-scale": "^8.1.0",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/verror": {
@@ -14891,6 +15049,7 @@
       "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -15151,6 +15310,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -15180,6 +15340,7 @@
       "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.8",
         "@vitest/mocker": "4.1.8",
@@ -15299,6 +15460,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
       "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.34",
         "@vue/compiler-sfc": "3.5.34",
@@ -16160,6 +16322,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -16178,6 +16341,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -70,9 +70,9 @@
     "pinia-plugin-persistedstate": "^4.7.1",
     "three": "^0.184.0",
     "three-spritetext": "^1.10.0",
-    "vega": "^5.30.0",
-    "vega-embed": "^6.29.0",
-    "vega-lite": "5.23.0",
+    "vega": "^6.2.0",
+    "vega-embed": "^7.1.0",
+    "vega-lite": "^6.4.3",
     "vue": "^3.5.34",
     "vue-i18n": "^11.4.5",
     "vue-router": "^5.1.0",
@@ -83,10 +83,6 @@
     "minimatch": ">=9.0.7",
     "uuid": "^14.0.0",
     "qs": ">=6.15.2",
-    "vega-lite": "5.23.0",
-    "vega-embed": {
-      "vega-lite": "5.23.0"
-    },
     "openapi-typescript": {
       "typescript": "$typescript"
     },


### PR DESCRIPTION
## Thinking Path
Dependabot keeps proposing `vega` 5→6 (major) and it breaks CI every time (#9833, #9838 today; #9218/#9219/#9221 historically) because `vega-embed@6.29` peer-deps vega **5.x** and the `overrides` pinned `vega-lite` to 5.23.0. Per policy (track newest versions; we'll have to upgrade eventually), fix the root cause by moving the **whole ecosystem to v6 as a matched set** instead of pinning back.

## What Changed
`autobot-frontend/package.json` + regenerated `package-lock.json`:
- `vega` `^5.30.0` → `^6.2.0`
- `vega-lite` `5.23.0` → `^6.4.3` (peer `vega ^6.0.0` ✓)
- `vega-embed` `^6.29.0` → `^7.1.0` (v7 = vega 6 + vega-lite 6 compatible)
- Removed obsolete 5.x-era `vega-lite` overrides (root + nested under vega-embed)

## Verification
- Lockfile regenerated and **resolves cleanly with strict peers** (no `--legacy-peer-deps`); minimal-repro of the trio confirmed compatible.
- **Security improves:** frontend `npm audit` drops from **9 vulns (1 critical / 7 high / 1 moderate)** → **1 pre-existing critical** (unrelated to vega, present before this change).
- Sole consumer `ChartCell.vue` uses the stable `embed(el, spec, {renderer, actions})` API (unchanged in v7); test mocks vega-embed; no direct vega/vega-lite imports elsewhere.
- Final build/typecheck via CI gates: `frontend-tests`, `vue-tsc-baseline`, `smoke-test`.

## Model Used
Claude Opus 4.8 (1M context)

Closes #9847