### PR TITLE
security(frontend): patch shell-quote critical (GHSA-w7jw-789q-3m8p) → npm audit 0 (#9857)

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -12671,9 +12671,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -83,6 +83,7 @@
     "minimatch": ">=9.0.7",
     "uuid": "^14.0.0",
     "qs": ">=6.15.2",
+    "shell-quote": ">=1.8.4",
     "openapi-typescript": {
       "typescript": "$typescript"
     },


### PR DESCRIPTION
## Thinking Path
While auditing deps during the vega-6 upgrade (#9850), found the remaining critical: `shell-quote@1.8.3` (transitive via `npm-run-all2@9.0.1`). It's also the likely trigger for the recurring main-targeted Dependabot *security* PRs (#9833/#9838) that bypassed `ignore:`/`target-branch` and dragged vega along.

## What Changed
- `autobot-frontend/package.json`: add `overrides.shell-quote >=1.8.4`
- Regenerated `package-lock.json` (shell-quote → 1.8.4)

## Verification
- `npm audit` = **0 vulnerabilities** (was 1 critical; vega-6 had already taken it 9→1)
- `npm-run-all2@9.0.1` peer `^1.7.3` satisfied by 1.8.4; resolves with strict peers
- Build via CI: smoke-test + vue-tsc-baseline

## Model Used
Claude Opus 4.8 (1M context)

Closes #9857