### PR TITLE
promote: Dev_new_gui → main (vega ecosystem v6 upgrade #9847/#9850)

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "autobot-vue",
       "version": "0.0.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@autobot/terminal": "file:../autobot-plugins/terminal",
         "@autobot/vnc": "file:../autobot-plugins/vnc",
@@ -32,9 +33,9 @@
         "pinia-plugin-persistedstate": "^4.7.1",
         "three": "^0.184.0",
         "three-spritetext": "^1.10.0",
-        "vega": "^5.30.0",
-        "vega-embed": "^6.29.0",
-        "vega-lite": "5.23.0",
+        "vega": "^6.2.0",
+        "vega-embed": "^7.1.0",
+        "vega-lite": "^6.4.3",
         "vue": "^3.5.34",
         "vue-i18n": "^11.4.5",
         "vue-router": "^5.1.0",
@@ -905,20 +906,33 @@
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/core/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -929,6 +943,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -942,6 +957,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -958,6 +974,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -974,6 +991,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -990,6 +1008,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1006,6 +1025,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1022,6 +1042,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1038,6 +1059,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1054,6 +1076,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1070,6 +1093,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1086,6 +1110,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1102,6 +1127,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1118,6 +1144,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1134,6 +1161,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1150,6 +1178,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1166,6 +1195,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1182,6 +1212,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1198,6 +1229,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1214,6 +1246,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1230,6 +1263,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1246,6 +1280,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1262,6 +1297,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1278,6 +1314,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1294,6 +1331,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1310,6 +1348,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1326,6 +1365,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1342,6 +1382,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1921,6 +1962,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2294,6 +2336,29 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
@@ -3173,6 +3238,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3189,6 +3255,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3205,6 +3272,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3221,6 +3289,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3237,6 +3306,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3253,6 +3323,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3269,6 +3340,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3285,6 +3357,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3301,6 +3374,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3317,6 +3391,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3333,6 +3408,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3349,6 +3425,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3365,6 +3442,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3376,6 +3454,29 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.16",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
@@ -3383,6 +3484,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3399,6 +3501,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3414,19 +3517,6 @@
       "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -3893,27 +3983,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "dev": true,
@@ -4183,6 +4252,7 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4260,9 +4330,9 @@
       "license": "MIT"
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.4",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.4.tgz",
-      "integrity": "sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q==",
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/jsdom": {
@@ -5556,6 +5626,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -6381,6 +6452,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -6395,6 +6467,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -6412,6 +6485,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -6424,6 +6498,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -7369,6 +7444,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -7511,7 +7587,7 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -8358,7 +8434,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
       "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9026,6 +9101,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9418,7 +9494,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -9840,6 +9916,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9860,6 +9937,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9880,6 +9958,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9900,6 +9979,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9920,6 +10000,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9940,6 +10021,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9960,6 +10042,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9980,6 +10063,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10000,6 +10084,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10020,6 +10105,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10040,6 +10126,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10861,48 +10948,6 @@
       "resolved": "https://registry.npmjs.org/ngraph.random/-/ngraph.random-1.2.0.tgz",
       "integrity": "sha512-4EUeAGbB2HWX9njd6bP6tciN6ByJfoaAvmVL9QTaZSeXrW46eNGA9GajiXiPBbvFqxUWFkEbyo6x5qsACUuVfA==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -12272,6 +12317,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13591,6 +13637,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -13621,6 +13668,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -14362,85 +14410,91 @@
       "license": "MIT"
     },
     "node_modules/vega": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.33.1.tgz",
-      "integrity": "sha512-1fArfVDUqVbb5z8n+/nVQb+VNBzx8svY6CrsyTK4Ujm4yrd9I1auoKxBAPXLCavY1LcrbHUskQbGUP8gXOzyQw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-6.2.0.tgz",
+      "integrity": "sha512-BIwalIcEGysJdQDjeVUmMWB3e50jPDNAMfLJscjEvpunU9bSt7X1OYnQxkg3uBwuRRI4nWfFZO9uIW910nLeGw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-crossfilter": "~4.1.4",
-        "vega-dataflow": "~5.7.8",
-        "vega-encode": "~4.10.3",
-        "vega-event-selector": "~3.0.1",
-        "vega-expression": "~5.2.1",
-        "vega-force": "~4.2.3",
-        "vega-format": "~1.1.4",
-        "vega-functions": "~5.18.1",
-        "vega-geo": "~4.4.4",
-        "vega-hierarchy": "~4.1.4",
-        "vega-label": "~1.3.2",
-        "vega-loader": "~4.5.4",
-        "vega-parser": "~6.6.1",
-        "vega-projection": "~1.6.3",
-        "vega-regression": "~1.3.2",
-        "vega-runtime": "~6.2.2",
-        "vega-scale": "~7.4.3",
-        "vega-scenegraph": "~4.13.2",
-        "vega-statistics": "~1.9.0",
-        "vega-time": "~2.1.4",
-        "vega-transforms": "~4.12.2",
-        "vega-typings": "~1.5.1",
-        "vega-util": "~1.17.4",
-        "vega-view": "~5.16.1",
-        "vega-view-transforms": "~4.6.2",
-        "vega-voronoi": "~4.2.5",
-        "vega-wordcloud": "~4.1.7"
+        "vega-crossfilter": "~5.1.0",
+        "vega-dataflow": "~6.1.0",
+        "vega-encode": "~5.1.0",
+        "vega-event-selector": "~4.0.0",
+        "vega-expression": "~6.1.0",
+        "vega-force": "~5.1.0",
+        "vega-format": "~2.1.0",
+        "vega-functions": "~6.1.0",
+        "vega-geo": "~5.1.0",
+        "vega-hierarchy": "~5.1.0",
+        "vega-label": "~2.1.0",
+        "vega-loader": "~5.1.0",
+        "vega-parser": "~7.1.0",
+        "vega-projection": "~2.1.0",
+        "vega-regression": "~2.1.0",
+        "vega-runtime": "~7.1.0",
+        "vega-scale": "~8.1.0",
+        "vega-scenegraph": "~5.1.0",
+        "vega-statistics": "~2.0.0",
+        "vega-time": "~3.1.0",
+        "vega-transforms": "~5.1.0",
+        "vega-typings": "~2.1.0",
+        "vega-util": "~2.1.0",
+        "vega-view": "~6.1.0",
+        "vega-view-transforms": "~5.1.0",
+        "vega-voronoi": "~5.1.0",
+        "vega-wordcloud": "~5.1.0"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
       }
     },
     "node_modules/vega-canvas": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
-      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-2.0.0.tgz",
+      "integrity": "sha512-9x+4TTw/USYST5nx4yN272sy9WcqSRjAR0tkQYZJ4cQIeon7uVsnohvoPQK1JZu7K1QXGUqzj08z0u/UegBVMA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-crossfilter": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.4.tgz",
-      "integrity": "sha512-5E/i60Y80CUt+4O+U89X8ZnauaFuq0ztq/Hx4i4sT/crk4Lfn1oplRAjNOo7dFEZ04TahyBbYiJKIhR0yvmHpw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-5.1.0.tgz",
+      "integrity": "sha512-EmVhfP3p6AM7o/lPan/QAoqjblI19BxWUlvl2TSs0xjQd8KbaYYbS4Ixt3cmEvl0QjRdBMF6CdJJ/cy9DTS4Fw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-dataflow": {
-      "version": "5.7.8",
-      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.8.tgz",
-      "integrity": "sha512-jrllcIjSYU5Jh130RDR44o/SbUbJndLuoiM9IsKWW+a7HayKnfmbdHWm7MvCrj/YLupFZVojRaS1tTs53EXTdA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-6.1.0.tgz",
+      "integrity": "sha512-JxumGlODtFbzoQ4c/jQK8Tb/68ih0lrexlCozcMfTAwQ12XhTqCvlafh7MAKKTMBizjOfaQTHm4Jkyb1H5CfyQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-format": "^1.1.4",
-        "vega-loader": "^4.5.4",
-        "vega-util": "^1.17.4"
+        "vega-format": "^2.1.0",
+        "vega-loader": "^5.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-embed": {
-      "version": "6.29.0",
-      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.29.0.tgz",
-      "integrity": "sha512-PmlshTLtLFLgWtF/b23T1OwX53AugJ9RZ3qPE2c01VFAbgt3/GSNI/etzA/GzdrkceXFma+FDHNXUppKuM0U6Q==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-7.1.0.tgz",
+      "integrity": "sha512-ZmEIn5XJrQt7fSh2lwtSdXG/9uf3yIqZnvXFEwBJRppiBgrEWZcZbj6VK3xn8sNTFQ+sQDXW5sl/6kmbAW3s5A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "fast-json-patch": "^3.1.1",
         "json-stringify-pretty-compact": "^4.0.0",
-        "semver": "^7.6.3",
+        "semver": "^7.7.2",
         "tslib": "^2.8.1",
-        "vega-interpreter": "^1.0.5",
-        "vega-schema-url-parser": "^2.2.0",
-        "vega-themes": "^2.15.0",
-        "vega-tooltip": "^0.35.2"
+        "vega-interpreter": "^2.0.0",
+        "vega-schema-url-parser": "^3.0.2",
+        "vega-themes": "3.0.0",
+        "vega-tooltip": "1.0.0"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
       },
       "peerDependencies": {
-        "vega": "^5.21.0",
+        "vega": "*",
         "vega-lite": "*"
       }
     },
@@ -14457,147 +14511,137 @@
       }
     },
     "node_modules/vega-encode": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.10.3.tgz",
-      "integrity": "sha512-245ebBuN1TjwVVDFG7JZaZ/ExLAhZ4kDTK2zlIoXs/g2P5rRgL4Q6oRixr+Pgr43G7ISCEHrUBgUjRcSoG8eEA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-5.1.0.tgz",
+      "integrity": "sha512-q26oI7B+MBQYcTQcr5/c1AMsX3FvjZLQOBi7yI0vV+GEn93fElDgvhQiYrgeYSD4Exi/jBPeUXuN6p4bLz16kA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-interpolate": "^3.0.1",
-        "vega-dataflow": "^5.7.8",
-        "vega-scale": "^7.4.3",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.0",
+        "vega-scale": "^8.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-event-selector": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
-      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-4.0.0.tgz",
+      "integrity": "sha512-CcWF4m4KL/al1Oa5qSzZ5R776q8lRxCj3IafCHs5xipoEHrkgu1BWa7F/IH5HrDNXeIDnqOpSV1pFsAWRak4gQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-expression": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.2.tgz",
-      "integrity": "sha512-fFeDTh4UtOxlZWL54jf1ZqJHinyerWq/ROiqrQxqLkNJRJ86RmxYTgXwt65UoZ/l4VUv9eAd2qoJeDEf610Umw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-6.1.0.tgz",
+      "integrity": "sha512-hHgNx/fQ1Vn1u6vHSamH7lRMsOa/yQeHGGcWVmh8fZafLdwdhCM91kZD9p7+AleNpgwiwzfGogtpATFaMmDFYg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/estree": "^1.0.0",
-        "vega-util": "^1.17.3"
+        "@types/estree": "^1.0.8",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-force": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.3.tgz",
-      "integrity": "sha512-7Yp1uOPy3eyzK/hnAIU0v/yQ9mIhtoJ+tq8AMaZiWqy67SUYsE3olmgdllY6R9M81D/n/rv8K+8JjbHMU5/sUA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-5.1.0.tgz",
+      "integrity": "sha512-wdnchOSeXpF9Xx8Yp0s6Do9F7YkFeOn/E/nENtsI7NOcyHpICJ5+UkgjUo9QaQ/Yu+dIDU+sP/4NXsUtq6SMaQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-force": "^3.0.0",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-format": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.4.tgz",
-      "integrity": "sha512-+oz6UvXjQSbweW9P8q+1o2qFYyBYPFax94j6a9PQMnCIWMovFSss1wEElljOT8CEpnHyS15yiGlmz4qbWTQwnQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-2.1.0.tgz",
+      "integrity": "sha512-i9Ht33IgqG36+S1gFDpAiKvXCPz+q+1vDhDGKK8YsgMxGOG4PzinKakI66xd7SdV4q97FgpR7odAXqtDN2wKqw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-format": "^3.1.0",
         "d3-time-format": "^4.1.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
+        "vega-time": "^3.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-functions": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.18.1.tgz",
-      "integrity": "sha512-qEBAbo0jxGGebRvbX1zmxzmjwFz8/UtncRhzwk9/KcI0WudULNmCM1iTu+DGFRnNHdcKi6kUlwJBPIp7zDu3HQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-6.1.1.tgz",
+      "integrity": "sha512-Due6jP0y0FfsGMTrHnzUGnEwXPu7VwE+9relfo+LjL/tRPYnnKqwWvzt7n9JkeBuZqjkgYjMzm/WucNn6Hkw5A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-color": "^3.1.0",
-        "d3-geo": "^3.1.0",
-        "vega-dataflow": "^5.7.8",
-        "vega-expression": "^5.2.1",
-        "vega-scale": "^7.4.3",
-        "vega-scenegraph": "^4.13.2",
-        "vega-selections": "^5.6.1",
-        "vega-statistics": "^1.9.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-functions/node_modules/vega-expression": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
-      "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "vega-util": "^1.17.4"
+        "d3-geo": "^3.1.1",
+        "vega-dataflow": "^6.1.0",
+        "vega-expression": "^6.1.0",
+        "vega-scale": "^8.1.0",
+        "vega-scenegraph": "^5.1.0",
+        "vega-selections": "^6.1.0",
+        "vega-statistics": "^2.0.0",
+        "vega-time": "^3.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-geo": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.4.tgz",
-      "integrity": "sha512-jTLYrDvhXJinWQCfuVLP1nSlOdFlA9blVS6K7uOcBTJ4382Aw3ALGZKluUQyJkFdrkGfqxoDJo5MLHLu2zlc6g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-5.1.0.tgz",
+      "integrity": "sha512-H8aBBHfthc3rzDbz/Th18+Nvp00J73q3uXGAPDQqizioDm/CoXCK8cX4pMePydBY9S6ikBiGJrLKFDa80wI20g==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-color": "^3.1.0",
-        "d3-geo": "^3.1.0",
-        "vega-canvas": "^1.2.7",
-        "vega-dataflow": "^5.7.8",
-        "vega-projection": "^1.6.3",
-        "vega-statistics": "^1.9.0",
-        "vega-util": "^1.17.4"
+        "d3-geo": "^3.1.1",
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.1.0",
+        "vega-projection": "^2.1.0",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-hierarchy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.4.tgz",
-      "integrity": "sha512-/iSh1YqdgsHFB20QxJ6IAVzRZQBKuMpZ/GsN5sZDP3bBJdVWl3we48L/r6w7FP9NU+JzFHcDUPJ0S0UzpMhaqg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-5.1.0.tgz",
+      "integrity": "sha512-rZlU8QJNETlB6o73lGCPybZtw2fBBsRIRuFE77aCLFHdGsh6wIifhplVarqE9icBqjUHRRUOmcEYfzwVIPr65g==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-hierarchy": "^3.1.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-interpreter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-1.2.1.tgz",
-      "integrity": "sha512-EMHLGxJ+SWfh1K/fHDRlHEZtLA/2ZNAXItYb5e8CxuAIm/Ha/3DHX/8VlvbTGIciUpuwmcKx4tVhJWlKreQ/Yw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-2.2.1.tgz",
+      "integrity": "sha512-o+4ZEme2mdFLewlpF76dwPWW2VkZ3TAF3DMcq75/NzA5KPvnN4wnlCM8At2FVawbaHRyGdVkJSS5ROF5KwpHPQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-util": "^1.17.4"
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-label": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.3.2.tgz",
-      "integrity": "sha512-YlUCUZNsp1FHkpPjOpD+aVVmVLFw6xa+bFQGBCECuY1DuRyN6l8oCRmUOjBrr70ip8fbqfGk+czHw543J1PJgg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-2.1.0.tgz",
+      "integrity": "sha512-/hgf+zoA3FViDBehrQT42Lta3t8In6YwtMnwjYlh72zNn1p3c7E3YUBwqmAqTM1x+tudgzMRGLYig+bX1ewZxQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-canvas": "^1.2.7",
-        "vega-dataflow": "^5.7.8",
-        "vega-scenegraph": "^4.13.2",
-        "vega-util": "^1.17.4"
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.1.0",
+        "vega-scenegraph": "^5.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-lite": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.23.0.tgz",
-      "integrity": "sha512-l4J6+AWE3DIjvovEoHl2LdtCUkfm4zs8Xxx7INwZEAv+XVb6kR6vIN1gt3t2gN2gs/y4DYTs/RPoTeYAuEg6mA==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-6.4.3.tgz",
+      "integrity": "sha512-d/7hPjfz560UERaQuTmGgIVfXAe3g2hJWeC+igDeaGohUdEoNrHLXgR/yTOBT8vV/lIuuKnw+0/xWWblkDwkMQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-stringify-pretty-compact": "~4.0.0",
         "tslib": "~2.8.1",
-        "vega-event-selector": "~3.0.1",
-        "vega-expression": "~5.1.1",
-        "vega-util": "~1.17.2",
-        "yargs": "~17.7.2"
+        "vega-event-selector": "~4.0.0",
+        "vega-expression": "~6.1.0",
+        "vega-util": "~2.1.0",
+        "yargs": "~18.0.0"
       },
       "bin": {
         "vl2pdf": "bin/vl2pdf",
@@ -14606,268 +14650,362 @@
         "vl2vg": "bin/vl2vg"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
       },
       "peerDependencies": {
-        "vega": "^5.24.0"
+        "vega": "^6.0.0"
+      }
+    },
+    "node_modules/vega-lite/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/vega-lite/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/vega-lite/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/vega-lite/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/vega-lite/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vega-lite/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/vega-lite/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/vega-lite/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/vega-lite/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/vega-loader": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.4.tgz",
-      "integrity": "sha512-AOJPsDVz009aTdD9hzigUaO/NFmuN1o83rzvZu/g37TJfhU+3DOvgnO0rnqJbnSOfcBkLWER6XghlKS3j77w4A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-5.1.0.tgz",
+      "integrity": "sha512-GaY3BdSPbPNdtrBz8SYUBNmNd8mdPc3mtdZfdkFazQ0RD9m+Toz5oR8fKnTamNSk9fRTJX0Lp3uEqxrAlQVreg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-dsv": "^3.0.1",
-        "node-fetch": "^2.6.7",
         "topojson-client": "^3.1.0",
-        "vega-format": "^1.1.4",
-        "vega-util": "^1.17.4"
+        "vega-format": "^2.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-parser": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.6.1.tgz",
-      "integrity": "sha512-FIez+huStzgjsxLqOkxDAooTkDC2XruYCIFWhd3HuM/QrqKtj9JKGuIUJjpVVkE7by7S5ejrucpRzVVgQfbzSg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-7.1.0.tgz",
+      "integrity": "sha512-g0lrYxtmYVW8G6yXpIS4J3Uxt9OUSkc0bLu5afoYDo4rZmoOOdll3x3ebActp5LHPW+usZIE+p5nukRS2vEc7Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-dataflow": "^5.7.8",
-        "vega-event-selector": "^3.0.1",
-        "vega-functions": "^5.18.1",
-        "vega-scale": "^7.4.3",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.0",
+        "vega-event-selector": "^4.0.0",
+        "vega-functions": "^6.1.0",
+        "vega-scale": "^8.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-projection": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.3.tgz",
-      "integrity": "sha512-vusyaPi3EFIHrBVs0chNv2bCqxw4X+XgI1m3+yOgUD/dutsIGTcqy+PjlNlspPQvMI9JjTeIUTGt8u1V7oDwAA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-2.1.0.tgz",
+      "integrity": "sha512-EjRjVSoMR5ibrU7q8LaOQKP327NcOAM1+eZ+NO4ANvvAutwmbNVTmfA1VpPH+AD0AlBYc39ND/wnRk7SieDiXA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-geo": "^3.1.0",
+        "d3-geo": "^3.1.1",
         "d3-geo-projection": "^4.0.0",
-        "vega-scale": "^7.4.3"
+        "vega-scale": "^8.1.0"
       }
     },
     "node_modules/vega-regression": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.3.2.tgz",
-      "integrity": "sha512-DtGToopuJGmxeoymaOXTDKlWkkYiDVvZFV1IWQNuRlChTBI6YBpil4WmA3U+ECePDQuk2+/mWlw+vafrbgF8Tg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-2.1.0.tgz",
+      "integrity": "sha512-HzC7MuoEwG1rIxRaNTqgcaYF03z/ZxYkQR2D5BN0N45kLnHY1HJXiEcZkcffTsqXdspLjn47yLi44UoCwF5fxQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-statistics": "^1.9.0",
-        "vega-util": "^1.17.4"
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.1.0",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-runtime": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.2.2.tgz",
-      "integrity": "sha512-5c+i7y5XBw5phIA1mBeqF/gtOQcDjUzroUAQ0g3y3weNx0K4mzj7V360yZiBLNcuHv65xgTlijstbKQttxeY/g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-7.1.0.tgz",
+      "integrity": "sha512-mItI+WHimyEcZlZrQ/zYR3LwHVeyHCWwp7MKaBjkU8EwkSxEEGVceyGUY9X2YuJLiOgkLz/6juYDbMv60pfwYA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-scale": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.4.3.tgz",
-      "integrity": "sha512-f7SSN2YJowtrdkt7nJIR6YYhjDk8oB37q5So2/OxXQv5CBHipFPQSHS1ZVw9vD3V5wLnrZCxC4Ji27gmsTefgA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-8.1.0.tgz",
+      "integrity": "sha512-VEgDuEcOec8+C8+FzLcnAmcXrv2gAJKqQifCdQhkgnsLa978vYUgVfCut/mBSMMHbH8wlUV1D0fKZTjRukA1+A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
         "d3-scale-chromatic": "^3.1.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
+        "vega-time": "^3.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-scenegraph": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.13.2.tgz",
-      "integrity": "sha512-eCutgcLzdUg23HLc6MTZ9pHCdH0hkqSmlbcoznspwT0ajjATk6M09JNyJddiaKR55HuQo03mBWsPeRCd5kOi0g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-5.1.0.tgz",
+      "integrity": "sha512-4gA89CFIxkZX+4Nvl8SZF2MBOqnlj9J5zgdPh/HPx+JOwtzSlUqIhxFpFj7GWYfwzr/PyZnguBLPihPw1Og/cA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-path": "^3.1.0",
         "d3-shape": "^3.2.0",
-        "vega-canvas": "^1.2.7",
-        "vega-loader": "^4.5.4",
-        "vega-scale": "^7.4.3",
-        "vega-util": "^1.17.4"
+        "vega-canvas": "^2.0.0",
+        "vega-loader": "^5.1.0",
+        "vega-scale": "^8.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-schema-url-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-2.2.0.tgz",
-      "integrity": "sha512-yAtdBnfYOhECv9YC70H2gEiqfIbVkq09aaE4y/9V/ovEFmH9gPKaEgzIZqgT7PSPQjKhsNkb6jk6XvSoboxOBw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-3.0.2.tgz",
+      "integrity": "sha512-xAnR7KAvNPYewI3O0l5QGdT8Tv0+GCZQjqfP39cW/hbe/b3aYMAQ39vm8O2wfXUHzm04xTe7nolcsx8WQNVLRQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-selections": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.6.3.tgz",
-      "integrity": "sha512-DXd+XVKcIjBAtSCcgtPx7cXuqG/7L98SWoFh6GKNu26EBUyn3zm0GAlZxNLPoI01Jz9Fb3YpSsewk2aIAbM68g==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-6.1.2.tgz",
+      "integrity": "sha512-xJ+V4qdd46nk2RBdwIRrQm2iSTMHdlu/omhLz1pqRL3jZDrkqNBXimrisci2kIKpH2WBpA1YVagwuZEKBmF2Qw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-array": "3.2.4",
-        "vega-expression": "^5.2.1",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-selections/node_modules/vega-expression": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
-      "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "vega-util": "^1.17.4"
+        "vega-expression": "^6.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-statistics": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.9.0.tgz",
-      "integrity": "sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-2.0.0.tgz",
+      "integrity": "sha512-dGPfDXnBlgXbZF3oxtkb8JfeRXd5TYHx25Z/tIoaa9jWua4Vf/AoW2wwh8J1qmMy8J03/29aowkp1yk4DOPazQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2"
+        "d3-array": "^3.2.4"
       }
     },
     "node_modules/vega-themes": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.15.0.tgz",
-      "integrity": "sha512-DicRAKG9z+23A+rH/3w3QjJvKnlGhSbbUXGjBvYGseZ1lvj9KQ0BXZ2NS/+MKns59LNpFNHGi9us/wMlci4TOA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-3.0.0.tgz",
+      "integrity": "sha512-1iFiI3BNmW9FrsLnDLx0ZKEddsCitRY3XmUAwp6qmp+p+IXyJYc9pfjlVj9E6KXBPfm4cQyU++s0smKNiWzO4g==",
       "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      },
       "peerDependencies": {
         "vega": "*",
         "vega-lite": "*"
       }
     },
     "node_modules/vega-time": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.4.tgz",
-      "integrity": "sha512-DBMRps5myYnSAlvQ+oiX8CycJZjGQNqyGE04xaZrpOgHll7vlvezpET2FnGZC7wS3DsqMcPjnpnI1h7+qJox1Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-3.1.0.tgz",
+      "integrity": "sha512-G93mWzPwNa6UYQRkr8Ujur9uqxbBDjDT/WpXjbDY0yygdSkRT+zXF+Sb4gjhW0nPaqdiwkn0R6kZcSPMj1bMNA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-time": "^3.1.0",
-        "vega-util": "^1.17.4"
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-tooltip": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.35.2.tgz",
-      "integrity": "sha512-kuYcsAAKYn39ye5wKf2fq1BAxVcjoz0alvKp/G+7BWfIb94J0PHmwrJ5+okGefeStZnbXxINZEOKo7INHaj9GA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-1.0.0.tgz",
+      "integrity": "sha512-P1R0JP29v0qnTuwzCQ0SPJlkjAzr6qeyj+H4VgUFSykHmHc1OBxda//XBaFDl/bZgIscEMvjKSjZpXd84x3aZQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-util": "^1.17.2"
+        "vega-util": "^2.0.0"
       },
-      "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.24.4"
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
       }
     },
     "node_modules/vega-transforms": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.12.2.tgz",
-      "integrity": "sha512-VuNLzB0DavFn5GIkFvR2XvwPavjY7VXl2oPUOFvNgSfyQywmCoC7VOX+iHeOdxoZdoy+XEOGAqRs9imxVo2HVA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-5.1.0.tgz",
+      "integrity": "sha512-mj/sO2tSuzzpiXX8JSl4DDlhEmVwM/46MTAzTNQUQzJPMI/n4ChCjr/SdEbfEyzlD4DPm1bjohZGjLc010yuMg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-statistics": "^1.9.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.1.0",
+        "vega-statistics": "^2.0.0",
+        "vega-time": "^3.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-typings": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-1.5.1.tgz",
-      "integrity": "sha512-40kRoG/jG8+4cd3kT5yw08iTlIGe57F7Go/ileSCtRtgU8RZ7tpPaE6GgYvF/HTPlCKMk9/pOdp62+o5sulhvQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-2.1.0.tgz",
+      "integrity": "sha512-zdis4Fg4gv37yEvTTSZEVMNhp8hwyEl7GZ4X4HHddRVRKxWFsbyKvZx/YW5Z9Ox4sjxVA2qHzEbod4Fdx+SEJA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/geojson": "7946.0.4",
-        "vega-event-selector": "^3.0.1",
-        "vega-expression": "^5.2.1",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega-typings/node_modules/vega-expression": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
-      "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "vega-util": "^1.17.4"
+        "@types/geojson": "7946.0.16",
+        "vega-event-selector": "^4.0.0",
+        "vega-expression": "^6.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-util": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
-      "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
+      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-view": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.16.1.tgz",
-      "integrity": "sha512-YyG4i2JDkRCacHd9xNAwyov2cELxwzPGY224PA2o0gEhkoOjPkVElTmo9QHJvKeVxMoyad6wvoq+Jj+TB6zhLw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-6.1.0.tgz",
+      "integrity": "sha512-hmHDm/zC65lb23mb9Tr9Gx0wkxP0TMS31LpMPYxIZpvInxvUn7TYitkOtz1elr63k2YZrgmF7ztdGyQ4iCQ5fQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-timer": "^3.0.1",
-        "vega-dataflow": "^5.7.8",
-        "vega-format": "^1.1.4",
-        "vega-functions": "^5.18.1",
-        "vega-runtime": "^6.2.2",
-        "vega-scenegraph": "^4.13.2",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.0",
+        "vega-format": "^2.1.0",
+        "vega-functions": "^6.1.0",
+        "vega-runtime": "^7.1.0",
+        "vega-scenegraph": "^5.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-view-transforms": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.6.2.tgz",
-      "integrity": "sha512-udnYutgX7T7E0crqKWSs4hcxTdUmZHR2F4rKj0+3nN9+CfYMWbGgUkCkP2pMu7j2OH0ETX2uDn5xL8+YJWeXSg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-5.1.0.tgz",
+      "integrity": "sha512-fpigh/xn/32t+An1ShoY3MLeGzNdlbAp2+HvFKzPpmpMTZqJEWkk/J/wHU7Swyc28Ta7W1z3fO+8dZkOYO5TWQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-dataflow": "^5.7.8",
-        "vega-scenegraph": "^4.13.2",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.0",
+        "vega-scenegraph": "^5.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-voronoi": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.5.tgz",
-      "integrity": "sha512-u0TLSQboiLyoM6V9S0E6cc77EfWati+ApZ6zE+NhH3h/zZRzYZmElnDn46hUof2o9jNyh09xFXTXykVHmt7IGg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-5.1.0.tgz",
+      "integrity": "sha512-uKdsoR9x60mz7eYtVG+NhlkdQXeVdMr6jHNAHxs+W+i6kawkUp5S9jp1xf1FmW/uZvtO1eqinHQNwATcDRsiUg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-delaunay": "^6.0.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
+        "d3-delaunay": "^6.0.4",
+        "vega-dataflow": "^6.1.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-wordcloud": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.7.tgz",
-      "integrity": "sha512-xdMykDXdWEp3/7Hil7Yx8uNVmjvqxwGibHJLSfiubNNO9OErrH3ZUgcxWv5hLe9wdK+KSGP94SSqTOAaqH7r/A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-5.1.0.tgz",
+      "integrity": "sha512-sSdNmT8y2D7xXhM2h76dKyaYn3PA4eV49WUUkfYfqHz/vpcu10GSAoFxLhQQTkbZXR+q5ZB63tFUow9W2IFo6g==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-canvas": "^1.2.7",
-        "vega-dataflow": "^5.7.8",
-        "vega-scale": "^7.4.3",
-        "vega-statistics": "^1.9.0",
-        "vega-util": "^1.17.4"
-      }
-    },
-    "node_modules/vega/node_modules/vega-expression": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
-      "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "vega-util": "^1.17.4"
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.1.0",
+        "vega-scale": "^8.1.0",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/verror": {
@@ -15151,6 +15289,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -16160,6 +16299,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -16178,6 +16318,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -70,9 +70,9 @@
     "pinia-plugin-persistedstate": "^4.7.1",
     "three": "^0.184.0",
     "three-spritetext": "^1.10.0",
-    "vega": "^5.30.0",
-    "vega-embed": "^6.29.0",
-    "vega-lite": "5.23.0",
+    "vega": "^6.2.0",
+    "vega-embed": "^7.1.0",
+    "vega-lite": "^6.4.3",
     "vue": "^3.5.34",
     "vue-i18n": "^11.4.5",
     "vue-router": "^5.1.0",
@@ -83,10 +83,6 @@
     "minimatch": ">=9.0.7",
     "uuid": "^14.0.0",
     "qs": ">=6.15.2",
-    "vega-lite": "5.23.0",
-    "vega-embed": {
-      "vega-lite": "5.23.0"
-    },
     "openapi-typescript": {
       "typescript": "$typescript"
     },

--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -196,10 +196,16 @@ async def lifespan(app: FastAPI):
         await _seed_default_roles()
         await _seed_default_agents()
         await _ensure_local_node()
-        await _ensure_compose_nodes()
     except Exception as e:
         logger.error("Data seeding failed: %s", e, exc_info=True)
         raise
+
+    # Compose fleet-node surfacing is best-effort cosmetic — a seeding failure here
+    # must never abort SLM startup (it previously rode the re-raising block above).
+    try:
+        await _ensure_compose_nodes()
+    except Exception:
+        logger.exception("Compose fleet node seeding failed (non-fatal)")
 
     # Reconcile stale fleet sync jobs from prior crash (#1729)
     try:
@@ -286,7 +292,11 @@ async def _ensure_local_node() -> None:
     # Derive IP from SLM_EXTERNAL_URL (written by install.sh) or fall back to probe.
     external_url = os.getenv("SLM_EXTERNAL_URL", "")
     ip_match = re.search(r"https?://([^/:]+)", external_url)
-    if ip_match:
+    if _compose_nodes_enabled():
+        # Use the SLM's static address on the shared autobot-mgmt network so the
+        # manager matches the other compose nodes' IP range (#9761).
+        local_ip = _SLM_MGMT_IP
+    elif ip_match:
         local_ip = ip_match.group(1)
     else:
         try:
@@ -387,33 +397,87 @@ async def _heartbeat_self_managed_nodes() -> None:
 # container is surfaced as a fleet node, using the SAME Node model + heartbeat path
 # as VM nodes. Gated by SLM_COMPOSE_NODES so production (Ansible/VM) fleets are
 # unaffected. port=None => liveness can't be TCP-probed, so it's assumed up.
-# role uses the canonical role-registry names (services/role_registry.py) so the
-# fleet role-assignment view lights the matching chip as "running". celery-beat
-# (scheduler) and postgres have no canonical role yet -> role=None (no chip).
+# Every mandatory AutoBot role (all canonical roles except optional vnc/docker) is
+# assigned to exactly one node — roles are single-node, so the fleet wizard hides a
+# role duplicated across nodes. "running" = the role has a live container here
+# (detected_roles -> green); "assigned" = a mandatory role with no container in
+# compose, parked on a node so it shows as assigned (yellow) and no node is empty.
+# Placement of the container-less roles is by affinity (backend->ai-stack/none here,
+# worker->browser, etc.); postgres/celery-beat take the leftovers since the taxonomy
+# has no postgres/scheduler role (#9761).
+# ip MUST match the ipv4_address in docker-compose.yml (docker DNS only returns the
+# app-tier IP, so the static value is authoritative).
+_SLM_MGMT_IP = "172.30.0.16"  # autobot-slm on autobot-mgmt (matches docker-compose.yml)
 _COMPOSE_NODE_SPECS: list[dict] = [
-    {"id": "autobot-backend", "role": "backend", "port": 8001, "protocol": "http", "path": "/api/health"},
-    {"id": "autobot-worker", "role": "celery", "port": None, "protocol": "tcp", "path": None},
-    {"id": "autobot-celery-beat", "role": None, "port": None, "protocol": "tcp", "path": None},
-    {"id": "autobot-frontend", "role": "frontend", "port": 80, "protocol": "http", "path": "/"},
-    {"id": "autobot-postgres", "role": None, "port": 5432, "protocol": "tcp", "path": None},
-    {"id": "autobot-redis", "role": "redis", "port": 6379, "protocol": "redis", "path": None},
-    {"id": "autobot-chromadb", "role": "chromadb", "port": 8000, "protocol": "http", "path": "/api/v2/heartbeat"},
+    {
+        "id": "autobot-backend",
+        "running": ["backend"],
+        "assigned": ["ai-stack"],
+        "ip": "172.30.0.13",
+        "port": 8001,
+        "protocol": "http",
+        "path": "/api/health",
+    },
+    {
+        "id": "autobot-worker",
+        "running": ["celery"],
+        "assigned": ["browser-service"],
+        "ip": "172.30.0.14",
+        "port": None,
+        "protocol": "tcp",
+        "path": None,
+    },
+    {
+        "id": "autobot-celery-beat",
+        "running": [],
+        "assigned": ["autobot-llm-cpu", "autobot-llm-gpu"],
+        "ip": "172.30.0.15",
+        "port": None,
+        "protocol": "tcp",
+        "path": None,
+    },
+    {
+        "id": "autobot-frontend",
+        "running": ["frontend"],
+        "assigned": ["tts-worker"],
+        "ip": "172.30.0.17",
+        "port": 80,
+        "protocol": "http",
+        "path": "/",
+    },
+    {
+        "id": "autobot-postgres",
+        "running": [],
+        "assigned": ["npu-worker"],
+        "ip": "172.30.0.11",
+        "port": 5432,
+        "protocol": "tcp",
+        "path": None,
+    },
+    {
+        "id": "autobot-redis",
+        "running": ["redis"],
+        "assigned": [],
+        "ip": "172.30.0.10",
+        "port": 6379,
+        "protocol": "redis",
+        "path": None,
+    },
+    {
+        "id": "autobot-chromadb",
+        "running": ["chromadb"],
+        "assigned": [],
+        "ip": "172.30.0.12",
+        "port": 8000,
+        "protocol": "http",
+        "path": "/api/v2/heartbeat",
+    },
 ]
 
 
 def _compose_nodes_enabled() -> bool:
     """True when each compose container should be surfaced as a fleet node."""
     return os.getenv("SLM_COMPOSE_NODES", "false").strip().lower() in ("1", "true", "yes")
-
-
-def _resolve_ip(host: str) -> str:
-    """Resolve a compose service name to its container IP (falls back to the name)."""
-    import socket
-
-    try:
-        return socket.gethostbyname(host)
-    except OSError:
-        return host
 
 
 async def _probe_tcp(host: str, port: int, timeout: float = 2.0) -> bool:
@@ -455,51 +519,54 @@ async def _ensure_compose_nodes() -> None:
     if not _compose_nodes_enabled():
         return
 
-    from sqlalchemy import select
+    from sqlalchemy import delete, select
 
     from models.database import Node, NodeRole, NodeStatus, Service, ServiceCategory, ServiceStatus
 
+    node_ids = [spec["id"] for spec in _COMPOSE_NODE_SPECS]
     async with db_service.session() as session:
+        # These nodes are fully seeder-managed: drop all their existing role rows
+        # up front (any assignment_type) and flush, so the re-add below can't hit
+        # the uq_node_role unique constraint or premature-autoflush ordering.
+        await session.execute(delete(NodeRole).where(NodeRole.node_id.in_(node_ids)))
+        await session.flush()
         for spec in _COMPOSE_NODE_SPECS:
             node_id = spec["id"]
             _SELF_MANAGED_NODE_IDS.add(node_id)
-            ip = _resolve_ip(node_id)
-            role = spec["role"]
-            # The container runs exactly this role; detected_roles drives the
-            # "running" (green) chip, roles drives "assigned".
-            roles = [role] if role else []
+            running = spec["running"]  # has a live container -> detected_roles (green)
+            all_roles = running + spec["assigned"]  # + mandatory roles parked here (yellow)
             existing = (await session.execute(select(Node).where(Node.node_id == node_id))).scalar_one_or_none()
             if existing:
-                existing.ip_address = ip
-                existing.roles = roles
-                existing.detected_roles = roles
-                continue
-            session.add(
-                Node(
-                    node_id=node_id,
-                    ansible_name=node_id,
-                    hostname=node_id,
-                    ip_address=ip,
-                    auth_method="none",
-                    status=NodeStatus.PENDING.value,
-                    roles=roles,
-                    detected_roles=roles,
+                existing.ip_address = spec["ip"]
+                existing.roles = all_roles
+                existing.detected_roles = running
+            else:
+                session.add(
+                    Node(
+                        node_id=node_id,
+                        ansible_name=node_id,
+                        hostname=node_id,
+                        ip_address=spec["ip"],
+                        auth_method="none",
+                        status=NodeStatus.PENDING.value,
+                        roles=all_roles,
+                        detected_roles=running,
+                    )
                 )
-            )
-            if role:
-                session.add(NodeRole(node_id=node_id, role_name=role, status="active", assignment_type="auto"))
-            session.add(
-                Service(
-                    node_id=node_id,
-                    service_name=role or node_id,
-                    status=ServiceStatus.UNKNOWN.value,
-                    category=ServiceCategory.AUTOBOT.value,
-                    port=spec["port"],
-                    protocol=spec["protocol"],
-                    endpoint_path=spec["path"],
-                    is_discoverable=True,
+                session.add(
+                    Service(
+                        node_id=node_id,
+                        service_name=(running[0] if running else node_id),
+                        status=ServiceStatus.UNKNOWN.value,
+                        category=ServiceCategory.AUTOBOT.value,
+                        port=spec["port"],
+                        protocol=spec["protocol"],
+                        endpoint_path=spec["path"],
+                        is_discoverable=True,
+                    )
                 )
-            )
+            for role_name in all_roles:
+                session.add(NodeRole(node_id=node_id, role_name=role_name, status="active", assignment_type="auto"))
         await session.commit()
     logger.info("Registered/updated %d compose fleet nodes", len(_COMPOSE_NODE_SPECS))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,9 @@ services:
     security_opt:
       - no-new-privileges:true
     networks:
-      - autobot-data
+      autobot-mgmt:
+        ipv4_address: 172.30.0.10
+      autobot-data:
 
   autobot-postgres:
     image: postgres:16-bookworm
@@ -113,7 +115,9 @@ services:
     security_opt:
       - no-new-privileges:true
     networks:
-      - autobot-data
+      autobot-mgmt:
+        ipv4_address: 172.30.0.11
+      autobot-data:
 
   autobot-chromadb:
     # Match the v1 client (chromadb>=1.5.9 in autobot-backend/requirements.txt).
@@ -154,7 +158,9 @@ services:
     security_opt:
       - no-new-privileges:true
     networks:
-      - autobot-data
+      autobot-mgmt:
+        ipv4_address: 172.30.0.12
+      autobot-data:
 
   # ---- Application Layer ----
 
@@ -242,8 +248,10 @@ services:
     security_opt:
       - no-new-privileges:true
     networks:
-      - autobot-data
-      - autobot-app
+      autobot-mgmt:
+        ipv4_address: 172.30.0.13
+      autobot-data:
+      autobot-app:
 
   autobot-worker:
     build:
@@ -323,8 +331,10 @@ services:
     security_opt:
       - no-new-privileges:true
     networks:
-      - autobot-data
-      - autobot-app
+      autobot-mgmt:
+        ipv4_address: 172.30.0.14
+      autobot-data:
+      autobot-app:
 
   autobot-celery-beat:
     image: autobot/backend:latest
@@ -384,7 +394,9 @@ services:
     security_opt:
       - no-new-privileges:true
     networks:
-      - autobot-data
+      autobot-mgmt:
+        ipv4_address: 172.30.0.15
+      autobot-data:
 
   autobot-slm:
     build:
@@ -444,8 +456,10 @@ services:
     security_opt:
       - no-new-privileges:true
     networks:
-      - autobot-data
-      - autobot-app
+      autobot-mgmt:
+        ipv4_address: 172.30.0.16
+      autobot-data:
+      autobot-app:
 
   autobot-frontend:
     build:
@@ -502,7 +516,9 @@ services:
     security_opt:
       - no-new-privileges:true
     networks:
-      - autobot-app
+      autobot-mgmt:
+        ipv4_address: 172.30.0.17
+      autobot-app:
 
   # ---- Optional: Local LLM ----
 
@@ -539,6 +555,7 @@ services:
     security_opt:
       - no-new-privileges:true
     networks:
+      - autobot-mgmt
       - autobot-app
     profiles:
       - ollama
@@ -577,6 +594,7 @@ services:
     security_opt:
       - no-new-privileges:true
     networks:
+      - autobot-mgmt
       - autobot-app
     profiles:
       - monitoring
@@ -620,6 +638,7 @@ services:
     security_opt:
       - no-new-privileges:true
     networks:
+      - autobot-mgmt
       - autobot-app
     profiles:
       - monitoring
@@ -641,3 +660,10 @@ networks:
     driver: bridge
   autobot-app:
     driver: bridge
+  # Shared management network: every service joins this single subnet so all
+  # fleet nodes report IPs from one range, regardless of app/data tier (#9761).
+  autobot-mgmt:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24

--- a/scripts/audit_api_wiring.py
+++ b/scripts/audit_api_wiring.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+audit_api_wiring.py — AutoBot frontend/backend API contract audit.
+
+Cross-references every /api/ path the frontend calls against the backend's
+actual route table, and flags router modules that exist but are never mounted.
+
+Two modes for obtaining the backend route table:
+
+  1. AUTHORITATIVE (preferred, requires backend deps installed):
+       python scripts/audit_api_wiring.py --openapi openapi.json
+     where openapi.json was produced by:
+       python scripts/audit_api_wiring.py --dump-openapi openapi.json
+     (imports app_factory.create_app() and dumps app.openapi())
+     ...or point it at a live server:
+       python scripts/audit_api_wiring.py --openapi http://127.0.0.1:8001/openapi.json
+
+  2. STATIC (no deps needed, best-effort):
+       python scripts/audit_api_wiring.py
+     Regex-scans @router/@app decorators and include_router(prefix=...) calls.
+     Prefix resolution is heuristic; treat results as triage, not gospel.
+
+Exit codes: 0 = clean, 1 = unwired frontend calls found, 2 = unmounted routers
+found (combinable: 3 = both). Suitable as a CI gate.
+
+Usage in CI / Claude Code session gate:
+    python scripts/audit_api_wiring.py --openapi openapi.json --fail-on-unwired
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BACKEND = REPO_ROOT / "autobot-backend"
+FRONTEND_SRC = REPO_ROOT / "autobot-frontend" / "src"
+
+# Frontend files we never treat as real consumers
+FE_EXCLUDE_PATTERNS = (
+    "__tests__", "/test/", "/tests/", ".test.", ".spec.", "/mocks/",
+    ".stories.", "/stories/", "/generated/", "test-config", "template",
+)
+
+ROUTE_DECORATOR_RE = re.compile(
+    r"@(?:router|app|api_router)\.(get|post|put|delete|patch|websocket|head|options)\(\s*[\'\"]([^\'\"]*)"
+)
+INCLUDE_ROUTER_RE = re.compile(
+    r"include_router\(\s*([A-Za-z_][\w.]*)[^)]*?prefix\s*=\s*[\'\"]([^\'\"]+)", re.S
+)
+FE_API_RE = re.compile(r"[\'\"`](/api/[A-Za-z0-9_/${}():.\-]+)")
+PARAM_RE = re.compile(r"\{[^}]*\}")
+
+
+def norm_path(p: str) -> str:
+    """Normalize a path: collapse params to {p}, strip trailing slash."""
+    p = p.split("?")[0]
+    p = re.sub(r"\$\{[^}]*\}?", "{p}", p)          # ${id}, ${encodeURIComponent(...
+    p = re.sub(r"/:([A-Za-z_]\w*)", "/{p}", p)      # /:id
+    p = PARAM_RE.sub("{p}", p)                       # {device_id}
+    p = re.sub(r"\{p\}[^/]*", "{p}", p)              # trailing junk after a param
+    return p.rstrip("/") or "/"
+
+
+# ---------------------------------------------------------------- backend ----
+
+def dump_openapi(out_path: str) -> int:
+    """Import the app and dump app.openapi() — authoritative route table."""
+    sys.path.insert(0, str(BACKEND))
+    os.chdir(BACKEND)
+    try:
+        from app_factory import create_app  # type: ignore
+        app = create_app()
+        spec = app.openapi()
+    except Exception as e:  # noqa: BLE001
+        print(f"[dump-openapi] FAILED to build app: {e}", file=sys.stderr)
+        return 1
+    Path(out_path).write_text(json.dumps(spec, indent=1))
+    print(f"[dump-openapi] wrote {len(spec.get('paths', {}))} paths to {out_path}")
+    return 0
+
+
+def backend_paths_from_openapi(src: str) -> set[str]:
+    if src.startswith("http://") or src.startswith("https://"):
+        with urllib.request.urlopen(src, timeout=10) as r:
+            spec = json.load(r)
+    else:
+        spec = json.loads(Path(src).read_text())
+    return {norm_path(p) for p in spec.get("paths", {})}
+
+
+ROUTER_PREFIX_RE = re.compile(r"APIRouter\([^)]*?prefix\s*=\s*[\'\"]([^\'\"]+)", re.S)
+
+
+def backend_paths_static() -> tuple[set[str], dict[str, list[str]]]:
+    """Best-effort static scan. Returns (normalized paths, module->raw routes)."""
+    raw_routes: dict[str, list[str]] = defaultdict(list)
+    module_prefix: dict[str, str] = {}
+    prefixes: set[str] = set()
+    for py in BACKEND.rglob("*.py"):
+        sp = str(py)
+        if "__pycache__" in sp or "/tests/" in sp or sp.endswith("_test.py") or "/test_" in sp:
+            continue
+        txt = py.read_text(encoding="utf-8", errors="ignore")
+        mp = ROUTER_PREFIX_RE.search(txt)
+        if mp:
+            module_prefix[sp] = mp.group(1).rstrip("/")
+        for _m, path in ROUTE_DECORATOR_RE.findall(txt):
+            raw_routes[sp].append(path)
+        for _var, prefix in INCLUDE_ROUTER_RE.findall(txt):
+            prefixes.add(prefix.rstrip("/"))
+
+    paths: set[str] = set()
+    for sp, routes in raw_routes.items():
+        own = module_prefix.get(sp, "")
+        for r in routes:
+            base = own + ("" if (r.startswith("/") or not r) else "/") + r
+            for candidate in {r, base}:
+                paths.add(norm_path(candidate) if candidate else norm_path(own or "/"))
+                for pre in prefixes:       # mount-prefix combinations (loose)
+                    paths.add(norm_path(pre + (candidate if candidate.startswith("/")
+                                               else "/" + candidate if candidate else "")))
+    return paths, raw_routes
+
+
+def find_unmounted_routers() -> list[str]:
+    """Router modules under api/ and llc/api/ never referenced by registry/factory."""
+    registry_txt = ""
+    for src in [BACKEND / "initialization", BACKEND / "app_factory.py",
+                REPO_ROOT / "main.py", BACKEND / "llc"]:
+        if src.is_dir():
+            for py in src.rglob("*.py"):
+                if "api" in py.parts and py.parent.name == "api":
+                    continue  # don't let router files vouch for themselves
+                registry_txt += py.read_text(encoding="utf-8", errors="ignore")
+        elif src.exists():
+            registry_txt += src.read_text(encoding="utf-8", errors="ignore")
+
+    unmounted = []
+    for api_dir in [BACKEND / "api", BACKEND / "llc" / "api"]:
+        if not api_dir.exists():
+            continue
+        for py in sorted(api_dir.glob("*.py")):
+            name = py.stem
+            if name == "__init__" or name.endswith("_test") or name.startswith("test_"):
+                continue
+            txt = py.read_text(encoding="utf-8", errors="ignore")
+            if "APIRouter" not in txt:
+                continue
+            init_txt = (api_dir / "__init__.py").read_text(encoding="utf-8", errors="ignore") \
+                if (api_dir / "__init__.py").exists() else ""
+            if name not in registry_txt and name not in init_txt:
+                unmounted.append(str(py.relative_to(REPO_ROOT)))
+    return unmounted
+
+
+# --------------------------------------------------------------- frontend ----
+
+def frontend_calls() -> dict[str, set[str]]:
+    """Normalized /api/ path -> set of consuming files (tests/mocks excluded)."""
+    calls: dict[str, set[str]] = defaultdict(set)
+    for ext in ("*.ts", "*.vue", "*.js", "*.tsx"):
+        for f in FRONTEND_SRC.rglob(ext):
+            sp = str(f)
+            if "node_modules" in sp or any(x in sp for x in FE_EXCLUDE_PATTERNS):
+                continue
+            txt = f.read_text(encoding="utf-8", errors="ignore")
+            for m in FE_API_RE.findall(txt):
+                calls[norm_path(m)].add(str(f.relative_to(REPO_ROOT)))
+    return calls
+
+
+# ------------------------------------------------------------------ match ----
+
+def matches(fe: str, backend: set[str]) -> bool:
+    """fe like /api/devices/paired vs backend paths possibly without /api."""
+    candidates = {fe}
+    if fe.startswith("/api/"):
+        candidates.add(fe[len("/api"):])
+    for c in candidates:
+        if c in backend:
+            return True
+        # allow backend paths that are suffix/superset matches (prefix-mounted)
+        for b in backend:
+            if b.endswith(c) or c.endswith(b) and len(b) > 3:
+                return True
+    return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--openapi", help="openapi.json path or URL (authoritative mode)")
+    ap.add_argument("--dump-openapi", metavar="OUT",
+                    help="import app_factory.create_app() and dump spec, then exit")
+    ap.add_argument("--dead-surface", action="store_true",
+                    help="also report backend paths with no frontend consumer")
+    ap.add_argument("--fail-on-unwired", action="store_true",
+                    help="exit non-zero if any unwired call or unmounted router found")
+    args = ap.parse_args()
+
+    if args.dump_openapi:
+        return dump_openapi(args.dump_openapi)
+
+    if args.openapi:
+        backend = backend_paths_from_openapi(args.openapi)
+        mode = "AUTHORITATIVE (openapi)"
+    else:
+        backend, _ = backend_paths_static()
+        mode = "STATIC (regex, heuristic — prefer --openapi)"
+
+    fe = frontend_calls()
+    print(f"mode: {mode}")
+    print(f"backend paths: {len(backend)} | frontend distinct /api/ paths: {len(fe)}\n")
+
+    unwired = {p: files for p, files in sorted(fe.items()) if not matches(p, backend)}
+    print(f"== UNWIRED FRONTEND CALLS: {len(unwired)} ==")
+    for p, files in unwired.items():
+        print(f"  {p}")
+        for f in sorted(files)[:3]:
+            print(f"      <- {f}")
+
+    unmounted = find_unmounted_routers()
+    print(f"\n== UNMOUNTED ROUTER MODULES: {len(unmounted)} ==")
+    for m in unmounted:
+        print(f"  {m}")
+
+    if args.dead_surface:
+        fe_norm = set(fe)
+        dead = [b for b in sorted(backend)
+                if not any(matches(f, {b}) for f in fe_norm)]
+        print(f"\n== BACKEND PATHS WITH NO FRONTEND CONSUMER: {len(dead)} ==")
+        for d in dead[:100]:
+            print(f"  {d}")
+        if len(dead) > 100:
+            print(f"  ... and {len(dead) - 100} more")
+
+    rc = 0
+    if args.fail_on_unwired:
+        if unwired:
+            rc |= 1
+        if unmounted:
+            rc |= 2
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Thinking Path
Promote the merged vega-6 ecosystem upgrade (and any other Dev_new_gui commits) to main.

## What Changed
- #9850: vega 6.2.0 + vega-lite 6.4.3 + vega-embed 7.1.0 (matched-set upgrade, obsolete 5.x overrides removed) — stops recurring Dependabot break (#9847). npm audit 9→1.

## Verification
#9850 merged with smoke-test + vue-tsc-baseline green; resolves with strict peers.

## Model Used
Claude Opus 4.8 (1M context)