### PR TITLE
fix(api-wiring): resolve frontend/backend contract drift (audit #9851)

### DIFF
--- a/.github/workflows/api-wiring.yml
+++ b/.github/workflows/api-wiring.yml
@@ -1,0 +1,75 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+#
+# API Wiring Audit (GH#9851)
+# Cross-references every /api/ path the frontend calls against the backend's
+# actual route table and flags router modules that exist but are never mounted.
+#
+# Authoritative mode builds the app and dumps app.openapi(); if the build fails
+# in CI it falls back to static (regex) mode so the job still reports.
+#
+# NOTE: the audit step is currently non-blocking (continue-on-error: true)
+# because known false positives remain — template-literal paths the normalizer
+# can't resolve (/api/{server}/mcp/*, /api/llc/agents/{id}/{sub}), bare base-URL
+# strings, websockets (absent from OpenAPI), and a handful of LLC views pending a
+# company-context redesign (tracked in #9851). Once those are cleared, DELETE the
+# `continue-on-error: true` line below to make this a blocking gate.
+
+name: API Wiring Audit
+
+on:
+  push:
+    branches: [ main, Dev_new_gui ]
+    paths: &paths
+      - 'autobot-backend/**/*.py'
+      - 'autobot-frontend/src/**'
+      - 'scripts/audit_api_wiring.py'
+      - 'requirements*.txt'
+      - '.github/workflows/api-wiring.yml'
+  pull_request:
+    branches: [ main, Dev_new_gui ]
+    paths: *paths
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  api-wiring:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements*.txt
+            autobot-backend/requirements*.txt
+
+      - name: Install backend dependencies (best-effort)
+        continue-on-error: true
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r requirements-ci.txt --prefer-binary || true
+
+      - name: Run API wiring audit
+        # Non-blocking until known false positives are cleared (see header).
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          export PYTHONPATH="$PWD:$PWD/autobot-backend:${PYTHONPATH:-}"
+          mkdir -p data logs static config
+          if python scripts/audit_api_wiring.py --dump-openapi openapi.json; then
+            echo "::notice::Authoritative OpenAPI dump succeeded — auditing against real route table."
+            python scripts/audit_api_wiring.py --openapi openapi.json --fail-on-unwired
+          else
+            echo "::warning::App build failed in CI — falling back to static (heuristic) audit."
+            python scripts/audit_api_wiring.py
+          fi

--- a/WIRING_AUDIT_REPORT.md
+++ b/WIRING_AUDIT_REPORT.md
@@ -1,0 +1,126 @@
+<!--
+Copyright 2025-2026 mrveiss
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# API Wiring Audit Report (#9851)
+
+Frontend/backend API contract remediation driven by `scripts/audit_api_wiring.py`
+in authoritative mode against a `app.openapi()` dump (2055 paths). Branch
+`api-wiring-fixes` → `Dev_new_gui`.
+
+## Headline
+
+| Metric | Before | After |
+|---|---:|---:|
+| Unwired frontend calls | 70 | 19 |
+| — of which false positives (audit-tool limits) | — | 14 |
+| — of which real, deferred (tracked) | — | 5 |
+| Unmounted router modules | 3 | 2 (both false positives) |
+
+51 real unwired calls resolved. The remaining 19 unwired / 2 unmounted are either
+audit-tool false positives or deferred items with a clear follow-up (below).
+
+## Fixed
+
+### Backend
+
+1. **`codebase_analytics` router silently unmounted → ~39 dead `/api/analytics/codebase/*` calls.**
+   `feature_routers` swallowed two import-time crashes:
+   - `ssot_config.codebase_index_embedding_mode` typed `int` (default `0`) but the
+     only consumer calls `.lower()` → `AttributeError`. Retyped to `str`
+     (`"precompute"`).
+   - `scanner.py` annotated `progress_callback: callable | None` using the builtin
+     `callable`; PEP-604 unions eval eagerly → `TypeError`. Use `typing.Callable`.
+
+   Result: router mounts 81 paths. (commit `9e87e34c`)
+
+2. **`user_provider_credentials` router never registered + unimportable.** It pulled
+   `get_current_user_id`/`get_db_session` from `auth_middleware` (neither exists).
+   Wired to `api.user_management.dependencies`; added a `get_current_user_id` UUID
+   dependency there; fixed the literal `/api`-doubled prefix; registered in
+   `core_routers`. (commit `5f73231c`)
+
+3. **Transcriber double-prefix.** Routes were mounted twice — correctly by
+   `core_routers` (`/api/transcriber/*`) and again by `feature_routers` via an
+   extension router carrying a full `/api/transcriber` prefix, yielding a dead
+   `/api/api/transcriber/*` duplicate. Removed the duplicate registration. (commit `9996f7c3`)
+
+4. **Two minimal LLC read endpoints** (genuinely cheap, mirror existing code):
+   - `GET /api/llc/heartbeat-runs` — org-scoped run feed (CompanyDashboard).
+   - `GET /api/llc/work-items/{id}/activity` — per-item audit trail (WorkItemDetail),
+     tenant-isolated via `require_org_context` (see Security). (commit `d4e658bb`)
+
+### Frontend
+
+5. **LLC views** — pointed at canonical routes, dropped the non-existent
+   `{data:{...}}` envelope (ApiClient returns parsed JSON directly):
+   CompanyDashboard (`agents/status`→`agents`, `approvals/pending`→`approvals`,
+   `budgets`→`budget`, `activity`→`companies/{id}/activity`, approve→`/decide`),
+   WorkItemDetail (`artifacts`→`products`, activity→`{items}`), GoalTree
+   (`goals/{id}/items`→`/tasks`). (commit `d33d38ba`)
+
+6. **Device pairing panel** — aligned with `mobile_devices.py`:
+   `devices/paired`→`/api/devices`, `pairing/generate-code`→`/api/devices/pair-qr`
+   (QR challenge token), and removed the dead `pairing/confirm` POST (pairing
+   completes mobile-side via `POST /api/devices/pair`; desktop refreshes the
+   list). (commit `c5eb9aec`)
+
+### CI
+
+7. **`.github/workflows/api-wiring.yml`** — dumps the spec and runs the audit on
+   backend/frontend route changes; static-mode fallback if the app build fails.
+   Currently non-blocking (`continue-on-error`) because false positives remain;
+   flip to blocking once the audit reaches exit 0.
+
+## Security
+
+The first cut of `GET /api/llc/work-items/{id}/activity` derived the tenant
+`company_id` from the requested resource — an IDOR (any user could read any
+tenant's work-item activity by guessing an id). Fixed before merge: scope is
+now taken from `require_org_context` and the item must belong to the caller's
+org (else 404). Flagged by the automated commit security review.
+
+## Deferred (tracked, not fixed here)
+
+These need backend implementation or a frontend redesign beyond path wiring;
+filed as **#9861** rather than patched blind. The UI elements should be
+feature-flagged off until implemented (no dead buttons).
+
+- **LLC company-context bug.** `CompanyDashboard`/`SubCompanyTree`/`GoalTree`/
+  `OrgChart` read `route.params.companyId` on routes that define no such param,
+  and there is no company store — so company context is unresolved and these
+  views can't drive the (company-scoped) backend. The path/shape fixes above are
+  prerequisites; the context plumbing is the blocker.
+- **`/api/llc/companies/tree`** (SubCompanyTree) — no global company-tree route;
+  build client-side from `/api/llc/companies/` once company context exists.
+- **`/api/llc/goals/tree`** (GoalTree) — assemble client-side from flat
+  `/api/llc/goals?company_id=` (`parent_goal_id` is present) once context exists.
+- **`/api/llc/org-chart`** (OrgChart) — no agent reporting-hierarchy is exposed;
+  needs a backend endpoint or a degraded flat-list view. The pause/resume control
+  also needs the company-scoped `/companies/{id}/controls/agents/{id}/pause|resume`.
+- **`/api/llc/companies/{id}/backlog/reorder`** — write endpoint; `backlog_position`
+  exists, needs a bulk-reorder route + ordering semantics.
+- **`/api/llc/work-items/suggest-ac`** — needs an LLM-backed acceptance-criteria
+  service; only the storage field exists.
+- **Pre-existing work_items routes lack tenant checks** (e.g. `/products`,
+  `get_work_item`) — noted by the security review; out of scope here, worth a
+  hardening pass.
+
+## Known false positives (no action)
+
+The audit's path normalizer flags these; all resolve at runtime:
+- Template-literal params: `/api/{server}/mcp/*`, `/api/llc/agents/{id}/{sub}`,
+  `/api/analytics/codebase/cross-language/{lang}`, `/api/analytics/codebase/patterns/report/*`.
+- Bare base-URL strings: `/api/orchestrator`, `/api/transcriber`, `/api/code-intelligence`.
+- Websockets (`/api/ws`, `/api/ws/live`) — FastAPI omits them from OpenAPI.
+- Unmounted-router flags for `analytics_engagement` (sub-included via `api.analytics`)
+  and `transcripts` (served via the transcriber extension) — both verified mounted.
+
+## Verification
+
+- `app.openapi()` builds: 2055 paths (all changed backend modules import cleanly).
+- LLC unit tests: `test_activity_log` + `test_work_item` — 30 passed.
+- Types: `npm run gen:types` must run against a fully-provisioned backend; a
+  constrained-env regen here was lossy for 77 endpoints (services unavailable),
+  so it was not committed. CI/dev should regenerate.

--- a/autobot-backend/api/codebase_analytics/scanner.py
+++ b/autobot-backend/api/codebase_analytics/scanner.py
@@ -29,7 +29,7 @@ import asyncio
 import threading
 from collections import deque
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Callable, Dict, List, Tuple
 
 from fastapi import HTTPException
 
@@ -258,7 +258,7 @@ _analyze_single_file = _analyze_single_file_bound
 
 async def scan_codebase(
     root_path: str | None = None,
-    progress_callback: callable | None = None,
+    progress_callback: Callable | None = None,
     immediate_store_collection=None,
     redis_client=None,
     source_id: str | None = None,

--- a/autobot-backend/api/user_management/dependencies.py
+++ b/autobot-backend/api/user_management/dependencies.py
@@ -71,6 +71,31 @@ def get_current_user(request: Request) -> dict:
     return user_data
 
 
+def get_current_user_id(
+    current_user: dict = Depends(get_current_user),
+) -> uuid.UUID:
+    """Resolve the authenticated user's UUID id.
+
+    GH#9037: per-user resources (e.g. provider credentials) key on the user's
+    UUID. Real authenticated users carry an ``id``/``user_id``/``sub`` claim;
+    service/internal principals do not, so they are rejected here. Deployment-
+    mode gating (single_user → 503) is handled by ``get_db_session``.
+    """
+    raw = current_user.get("id") or current_user.get("user_id") or current_user.get("sub")
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User identity required",
+        )
+    try:
+        return uuid.UUID(str(raw))
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User identity is not a valid id",
+        ) from exc
+
+
 def get_tenant_context(
     request: Request,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/api/user_provider_credentials.py
+++ b/autobot-backend/api/user_provider_credentials.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth_middleware import get_current_user_id, get_db_session
+from api.user_management.dependencies import get_current_user_id, get_db_session
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from models.secret import Secret, SecretScope, SecretType
@@ -26,7 +26,7 @@ from services.secrets_service import SecretsService
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/api/user/provider-credentials", tags=["user-provider-credentials"])
+router = APIRouter(prefix="/user/provider-credentials", tags=["user-provider-credentials"])
 
 
 class ProviderCredentialCreate(BaseModel):

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -129,7 +129,6 @@ def _get_system_routers() -> list:
         (usage_router, "/usage", ["usage", "analytics"], "usage"),  # Issue #1807
         (user_management_router, "", ["user-management"], "user_management"),  # Issue #1801
         (user_provider_credentials_router, "", ["user-provider-credentials"], "user_provider_credentials"),  # GH#9037
-
         (mobile_devices_router, "/devices", ["devices", "integrations"], "mobile_devices"),  # GH#4463
         (data_storage_router, "", ["data-storage"], "data_storage"),
         (prompts_router, "/prompts", ["prompts"], "prompts"),

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -91,6 +91,7 @@ from api.telegram_bot import router as telegram_bot_router  # MVA-2074
 from api.transcriber import router as transcriber_router  # Issue #9044, MVA-2186
 from api.usage import router as usage_router  # Issue #1807
 from api.user_management.router import router as user_management_router  # Issue #1801
+from api.user_provider_credentials import router as user_provider_credentials_router  # GH#9037
 from api.vnc_manager import router as vnc_router
 from api.vnc_mcp import router as vnc_mcp_router
 from api.vnc_proxy import router as vnc_proxy_router
@@ -127,6 +128,8 @@ def _get_system_routers() -> list:
         (settings_router, "/settings", ["settings"], "settings"),
         (usage_router, "/usage", ["usage", "analytics"], "usage"),  # Issue #1807
         (user_management_router, "", ["user-management"], "user_management"),  # Issue #1801
+        (user_provider_credentials_router, "", ["user-provider-credentials"], "user_provider_credentials"),  # GH#9037
+
         (mobile_devices_router, "/devices", ["devices", "integrations"], "mobile_devices"),  # GH#4463
         (data_storage_router, "", ["data-storage"], "data_storage"),
         (prompts_router, "/prompts", ["prompts"], "prompts"),

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -676,16 +676,12 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
     # as a system router. Duplicate registration caused routes to appear twice.
     # GH#4459: Web push notification endpoints (subscribe/unsubscribe/vapid-key)
     ("api.push", "/push", ["push", "notifications"], "push"),
-    # GH#9044: Transcriber module — project + recording CRUD under /api/transcriber
-    # Guarded by TRANSCRIBER_ENABLED env var (defaults to true).
-    # The combined router in transcriber_extension carries its own /api/transcriber
-    # prefix so we use "" here to avoid a double-prefix.
-    (
-        "extensions.builtin.transcriber_extension",
-        "",
-        ["transcriber"],
-        "transcriber",
-    ),
+    # GH#9044: Transcriber routes are mounted by core_routers via
+    # api.transcriber.router (prefix "/transcriber" → /api/transcriber/*).
+    # The transcriber_extension combined router carries a full "/api/transcriber"
+    # prefix, so registering it here mounted a duplicate at /api/api/transcriber/*
+    # (app_factory prepends "/api"). Removed to eliminate the double-prefix; the
+    # core registration already serves the full transcriber surface (incl. kb).
 ]
 
 

--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -27,6 +27,7 @@ from .labels import router as labels_router
 from .portability import router as portability_router
 from .review_gate_policies import router as review_gate_router
 from .routines import router as routines_router
+from .runs import heartbeat_runs_router
 from .runs import router as runs_router
 from .secrets import router as secrets_router
 from .sprints import router as sprints_router
@@ -53,6 +54,7 @@ router.include_router(agent_router)
 router.include_router(agents_router)
 router.include_router(agent_wiki_router)
 router.include_router(runs_router)
+router.include_router(heartbeat_runs_router)
 router.include_router(ceo_chat_router)
 router.include_router(decisions_router)
 router.include_router(routines_router)

--- a/autobot-backend/llc/api/runs.py
+++ b/autobot-backend/llc/api/runs.py
@@ -28,6 +28,11 @@ from ..models.heartbeat_run import LLCHeartbeatRun
 
 router = APIRouter(prefix="/agents", tags=["llc-runs"])
 
+# GH#9851: org-scoped heartbeat-run feed for the company dashboard. The
+# per-agent feed lives under /agents/{agent_id}/runs; this is the unfiltered
+# org view the dashboard's "recent runs" panel needs.
+heartbeat_runs_router = APIRouter(prefix="/heartbeat-runs", tags=["llc-runs"])
+
 
 def _run_to_dict(run: LLCHeartbeatRun) -> Dict[str, Any]:
     return {
@@ -60,6 +65,24 @@ async def list_runs(
         LLCHeartbeatRun.agent_id == agent_id,
         LLCHeartbeatRun.company_id == ctx.org_id,
     )
+    if status:
+        q = q.where(LLCHeartbeatRun.status == status)
+    q = q.order_by(LLCHeartbeatRun.created_at.desc()).limit(limit).offset(offset)
+    result = await session.execute(q)
+    return [_run_to_dict(r) for r in result.scalars().all()]
+
+
+@heartbeat_runs_router.get("", response_model=List[Dict[str, Any]])
+async def list_org_heartbeat_runs(
+    status: Optional[str] = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> List[Dict[str, Any]]:
+    """List heartbeat runs across the whole org, newest first (GH#9851)."""
+    q = select(LLCHeartbeatRun).where(LLCHeartbeatRun.company_id == ctx.org_id)
     if status:
         q = q.where(LLCHeartbeatRun.status == status)
     q = q.order_by(LLCHeartbeatRun.created_at.desc()).limit(limit).offset(offset)

--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -34,13 +34,14 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.user_management.dependencies import get_current_user
+from api.user_management.dependencies import get_current_user, require_org_context
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
 from models.agent_org import AgentOrgNode
 from user_management.database import get_async_session_factory
 from user_management.models.user import User
+from user_management.services import TenantContext
 
 from ..kb.collections import KbCollectionManager
 from ..models.enums import (
@@ -70,7 +71,9 @@ from ..services.work_item_service import (
     WorkItemService,
     resolve_actor_role,
 )
+from ..services.activity_log import ActivityLogQuery, LLCActivityLogService
 from ..services.work_product_service import WorkProductService
+from .activity import ActivityLogEntry, ActivityLogResponse
 
 
 class HumanClaimRequest(BaseModel):
@@ -108,6 +111,7 @@ _get_relation_service = lazy_singleton(WorkItemRelationService)
 _get_attachment_service = lazy_singleton(AttachmentService)
 _get_comment_wake_service = lazy_singleton(CommentWakeService)
 _get_heartbeat_scheduler = lazy_singleton(HeartbeatScheduler)
+_get_activity_service = lazy_singleton(LLCActivityLogService)
 
 
 def _service() -> WorkItemService:
@@ -866,6 +870,62 @@ async def list_work_products(
         ],
         "total": len(products),
     }
+
+
+@router.get("/{work_item_id}/activity", response_model=ActivityLogResponse)
+async def list_work_item_activity(
+    work_item_id: str,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
+    session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> ActivityLogResponse:
+    """Per-work-item activity trail (GH#9851).
+
+    Tenant scope is derived from the authenticated org context, never the
+    requested resource: the item must belong to the caller's org (else 404,
+    indistinguishable from "missing"), and the activity query is filtered by
+    ctx.org_id. Newest first.
+    """
+    item = await _service().get(session, work_item_id)
+    if item is None or str(item.company_id) != str(ctx.org_id):
+        raise HTTPException(status_code=404, detail="Work item not found")
+
+    params = ActivityLogQuery(
+        entity_type="work_item",
+        entity_id=work_item_id,
+        page=page,
+        page_size=page_size,
+    )
+    result = await _get_activity_service().query(
+        session=session, company_id=str(ctx.org_id), params=params
+    )
+
+    items = [
+        ActivityLogEntry(
+            id=str(row.id),
+            company_id=str(row.company_id),
+            actor_type=row.actor_type,
+            actor_agent_id=str(row.actor_agent_id) if row.actor_agent_id else None,
+            actor_user_id=str(row.actor_user_id) if row.actor_user_id else None,
+            entity_type=row.entity_type,
+            entity_id=str(row.entity_id),
+            action=row.action,
+            before_state=row.before_state,
+            after_state=row.after_state,
+            metadata=row.log_metadata,
+            occurred_at=row.occurred_at,
+        )
+        for row in result.items
+    ]
+    return ActivityLogResponse(
+        items=items,
+        page=result.page,
+        page_size=result.page_size,
+        total=result.total,
+        has_next=result.has_next,
+    )
 
 
 # ------------------------------------------------------------------

--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -51,6 +51,7 @@ from ..models.enums import (
     WorkItemType,
 )
 from ..scheduler.heartbeat_scheduler import HeartbeatScheduler
+from ..services.activity_log import ActivityLogQuery, LLCActivityLogService
 from ..services.attachment_service import (
     AttachmentNotFound,
     AttachmentService,
@@ -71,7 +72,6 @@ from ..services.work_item_service import (
     WorkItemService,
     resolve_actor_role,
 )
-from ..services.activity_log import ActivityLogQuery, LLCActivityLogService
 from ..services.work_product_service import WorkProductService
 from .activity import ActivityLogEntry, ActivityLogResponse
 
@@ -898,9 +898,7 @@ async def list_work_item_activity(
         page=page,
         page_size=page_size,
     )
-    result = await _get_activity_service().query(
-        session=session, company_id=str(ctx.org_id), params=params
-    )
+    result = await _get_activity_service().query(session=session, company_id=str(ctx.org_id), params=params)
 
     items = [
         ActivityLogEntry(

--- a/autobot-frontend/src/components/settings/DevicePairingSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/DevicePairingSettingsPanel.vue
@@ -229,8 +229,10 @@ onMounted(async () => {
 // Methods
 async function loadPairedDevices() {
   try {
-    const response = await apiClient.get('/api/devices/paired')
-    pairedDevices.value = response.data || []
+    // GH#9851: canonical list route is GET /api/devices → { devices: [...] }.
+    // ApiClient returns parsed JSON directly (no axios .data envelope).
+    const response = await apiClient.get<{ devices: typeof pairedDevices.value }>('/api/devices')
+    pairedDevices.value = response.devices || []
   } catch (error) {
     logger.error('Failed to load paired devices', error)
     showToast('Failed to load paired devices', 'error')
@@ -242,9 +244,10 @@ async function startPairingFlow() {
     pairingInProgress.value = true
     pairingError.value = ''
 
-    // Request pairing code from backend
-    const response = await apiClient.post('/api/devices/pairing/generate-code')
-    pairingCode.value = response.data.code
+    // GH#9851: backend issues a QR challenge token via GET /api/devices/pair-qr.
+    // The mobile app scans it and completes pairing by POSTing to /api/devices/pair.
+    const response = await apiClient.get<{ challenge_token: string }>('/api/devices/pair-qr')
+    pairingCode.value = response.challenge_token
 
     // Reset UI state
     pairingStep.value = 1
@@ -313,13 +316,10 @@ async function completePairing() {
   try {
     pairingInProgress.value = true
 
-    // Complete pairing with backend
-    const response = await apiClient.post('/api/devices/pairing/confirm', {
-      code: pairingCode.value,
-      deviceName: deviceName.value
-    })
-
-    // Update paired devices list
+    // GH#9851: there is no desktop-side "confirm" endpoint — pairing is completed
+    // by the mobile device POSTing the scanned challenge token to /api/devices/pair.
+    // The desktop confirms by refreshing the device list and checking the device
+    // now appears.
     await loadPairedDevices()
 
     // Show success message

--- a/autobot-frontend/src/views/llc/CompanyDashboard.vue
+++ b/autobot-frontend/src/views/llc/CompanyDashboard.vue
@@ -105,18 +105,22 @@ async function fetchDashboardData() {
   isLoading.value = true
   error.value = null
   try {
+    // GH#9851: align with canonical LLC routes. The api client returns parsed
+    // JSON directly (no {data:{...}} envelope); these endpoints return arrays
+    // (agents/approvals/budget/runs) or an ActivityLogResponse ({items}).
+    const cid = companyId.value
     const [agentsResp, approvalsResp, budgetsResp, runsResp, activityResp] = await Promise.all([
-      api.get<{ data: { agents: AgentStatus[] } }>('/api/llc/agents/status'),
-      api.get<{ data: { approvals: PendingApproval[] } }>('/api/llc/approvals/pending'),
-      api.get<{ data: { budgets: BudgetInfo[] } }>('/api/llc/budgets'),
-      api.get<{ data: { runs: HeartbeatRun[] } }>('/api/llc/heartbeat-runs?limit=20'),
-      api.get<{ data: { events: ActivityEvent[] } }>('/api/llc/activity?limit=50'),
+      api.get<AgentStatus[]>(`/api/llc/agents?company_id=${cid}`),
+      api.get<PendingApproval[]>(`/api/llc/approvals?company_id=${cid}`),
+      api.get<BudgetInfo[]>(`/api/llc/budget?company_id=${cid}`),
+      api.get<HeartbeatRun[]>('/api/llc/heartbeat-runs?limit=20'),
+      api.get<{ items: ActivityEvent[] }>(`/api/llc/companies/${cid}/activity?page_size=50`),
     ])
-    agents.value = (agentsResp as { data: { agents: AgentStatus[] } }).data?.agents ?? []
-    pendingApprovals.value = (approvalsResp as { data: { approvals: PendingApproval[] } }).data?.approvals ?? []
-    budgets.value = (budgetsResp as { data: { budgets: BudgetInfo[] } }).data?.budgets ?? []
-    heartbeatRuns.value = (runsResp as { data: { runs: HeartbeatRun[] } }).data?.runs ?? []
-    activityFeed.value = (activityResp as { data: { events: ActivityEvent[] } }).data?.events ?? []
+    agents.value = agentsResp ?? []
+    pendingApprovals.value = approvalsResp ?? []
+    budgets.value = budgetsResp ?? []
+    heartbeatRuns.value = runsResp ?? []
+    activityFeed.value = activityResp?.items ?? []
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
     logger.error('Failed to fetch dashboard data:', msg)
@@ -128,7 +132,7 @@ async function fetchDashboardData() {
 
 async function quickApprove(approvalId: string) {
   try {
-    await api.post(`/api/llc/approvals/${approvalId}/approve`, {})
+    await api.post(`/api/llc/approvals/${approvalId}/decide`, { decision: 'approved' })
     pendingApprovals.value = pendingApprovals.value.filter(a => a.id !== approvalId)
   } catch (err: unknown) {
     logger.error('Quick approve failed', err)

--- a/autobot-frontend/src/views/llc/GoalTree.vue
+++ b/autobot-frontend/src/views/llc/GoalTree.vue
@@ -53,8 +53,9 @@ async function selectGoal(goal: Goal) {
   if (!goal.linked_items && goal.linked_item_count > 0) {
     goal.loading_items = true
     try {
-      const resp = await api.get<{ data: { items: Goal['linked_items'] } }>(`/api/llc/goals/${goal.id}/items`)
-      goal.linked_items = (resp as { data: { items: Goal['linked_items'] } }).data?.items ?? []
+      // GH#9851: backend route is /tasks and returns an array directly.
+      const resp = await api.get<NonNullable<Goal['linked_items']>>(`/api/llc/goals/${goal.id}/tasks`)
+      goal.linked_items = resp ?? []
     } catch (err: unknown) {
       logger.error('Failed to fetch goal items', err)
       goal.linked_items = []

--- a/autobot-frontend/src/views/llc/WorkItemDetail.vue
+++ b/autobot-frontend/src/views/llc/WorkItemDetail.vue
@@ -435,8 +435,10 @@ async function fetchComments() {
 async function fetchArtifacts() {
   isLoadingArtifacts.value = true
   try {
-    const result = await api.get<{ artifacts: Artifact[] }>(`/api/llc/work-items/${props.item.id}/artifacts`)
-    artifacts.value = result.artifacts ?? []
+    // GH#9851: backend names these "products" (work products), returned as
+    // {products:[...]}. The api client returns parsed JSON directly.
+    const result = await api.get<{ products: Artifact[] }>(`/api/llc/work-items/${props.item.id}/products`)
+    artifacts.value = result.products ?? []
   } catch (err) {
     logger.error('Failed to load artifacts', err)
   } finally {
@@ -447,8 +449,9 @@ async function fetchArtifacts() {
 async function fetchActivity() {
   isLoadingActivity.value = true
   try {
-    const result = await api.get<{ events: ActivityEvent[] }>(`/api/llc/work-items/${props.item.id}/activity`)
-    activity.value = result.events ?? []
+    // GH#9851: /activity returns an ActivityLogResponse ({items:[...]}).
+    const result = await api.get<{ items: ActivityEvent[] }>(`/api/llc/work-items/${props.item.id}/activity`)
+    activity.value = result.items ?? []
   } catch (err) {
     logger.error('Failed to load activity', err)
   } finally {

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1354,7 +1354,9 @@ class MiscConfig(BaseSettings):
     celery_result_backend: str = Field(default="", alias="CELERY_RESULT_BACKEND")
     ci: str = Field(default="", alias="CI")
     codebase_index_batch_size: int = Field(default=0, alias="CODEBASE_INDEX_BATCH_SIZE")
-    codebase_index_embedding_mode: int = Field(default=0, alias="CODEBASE_INDEX_EMBEDDING_MODE")
+    codebase_index_embedding_mode: str = Field(
+        default="precompute", alias="CODEBASE_INDEX_EMBEDDING_MODE"
+    )
     codebase_index_embed_batch_size: int = Field(default=0, alias="CODEBASE_INDEX_EMBED_BATCH_SIZE")
     codebase_index_incremental: str = Field(default="", alias="CODEBASE_INDEX_INCREMENTAL")
     codebase_index_parallel_batches: str = Field(default="", alias="CODEBASE_INDEX_PARALLEL_BATCHES")

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1354,9 +1354,7 @@ class MiscConfig(BaseSettings):
     celery_result_backend: str = Field(default="", alias="CELERY_RESULT_BACKEND")
     ci: str = Field(default="", alias="CI")
     codebase_index_batch_size: int = Field(default=0, alias="CODEBASE_INDEX_BATCH_SIZE")
-    codebase_index_embedding_mode: str = Field(
-        default="precompute", alias="CODEBASE_INDEX_EMBEDDING_MODE"
-    )
+    codebase_index_embedding_mode: str = Field(default="precompute", alias="CODEBASE_INDEX_EMBEDDING_MODE")
     codebase_index_embed_batch_size: int = Field(default=0, alias="CODEBASE_INDEX_EMBED_BATCH_SIZE")
     codebase_index_incremental: str = Field(default="", alias="CODEBASE_INDEX_INCREMENTAL")
     codebase_index_parallel_batches: str = Field(default="", alias="CODEBASE_INDEX_PARALLEL_BATCHES")


### PR DESCRIPTION
Closes part of #9851. Follow-ups tracked in #9861.

## Thinking Path
The API wiring audit (authoritative, 2055-path OpenAPI dump) found 70 unwired frontend calls + 3 unmounted routers. Root-caused and fixed the real drift; deferred items that need backend implementation or a frontend redesign rather than patching blind. One commit per logical fix.

## What Changed
**Backend**
- `codebase_analytics` router silently unmounted (2 import-chain type bugs: `int`-typed embedding-mode `.lower()`, builtin `callable | None` eager eval) → now mounts 81 paths, resolving ~39 dead `/api/analytics/codebase/*` calls.
- `user_provider_credentials` mounted (was unregistered + importing phantom `auth_middleware` deps); added a `get_current_user_id` UUID dependency.
- Transcriber double-prefix removed (`/api/api/transcriber/*` dead duplicate).
- Two minimal LLC reads: `GET /api/llc/heartbeat-runs`, `GET /api/llc/work-items/{id}/activity` (tenant-isolated).

**Frontend**
- LLC views (CompanyDashboard, WorkItemDetail, GoalTree) → canonical routes, dropped the non-existent `{data:{...}}` envelope.
- Device pairing panel → canonical `mobile_devices.py` (QR-challenge flow); removed the dead confirm POST.

**CI**
- `.github/workflows/api-wiring.yml` (non-blocking until known FPs cleared).

**Result:** unwired 70→19 (14 false positives, 5 deferred → #9861); unmounted 3→2 (both verified-mounted FPs). Full write-up in `WIRING_AUDIT_REPORT.md`.

## Verification
- `app.openapi()` builds: 2055 paths (all changed backend modules import cleanly).
- LLC unit tests: `test_activity_log` + `test_work_item` — 30 passed.
- Authoritative audit re-run confirms 70→19.
- IDOR in the new `/activity` endpoint (caught by automated commit review) fixed before merge — tenant scope from `require_org_context`.
- Types: `gen:types` must run against a fully-provisioned backend (constrained-env regen was lossy for 77 endpoints; not committed).

## Model Used
Claude Opus 4.8 (1M context)