### PR TITLE
docs(nav): resolve conflict markers in 21 _index.md MOCs (#9887)

### DIFF
--- a/docs/audit/_index.md
+++ b/docs/audit/_index.md
@@ -15,7 +15,7 @@ Audit reports covering frontend components, code quality, and system reviews.
 | Document | Description |
 | --- | --- |
 | [[frontend-orphaned-components-4194]] | Frontend orphaned component audit (issue #4194) |
-| [[orphan-audit-2026-06-04]] | Vault orphan audit (2026-06-04) |
+| [Vault orphan audit (2026-06-04)](../orphan-audit-2026-06-04.md) | Vault orphan audit (2026-06-04) |
 
 ## Related Sections
 

--- a/docs/connectors/_index.md
+++ b/docs/connectors/_index.md
@@ -6,15 +6,6 @@ aliases:
   - Connectors Index
 ---
 
-<<<<<<< HEAD
-# Connectors
-
-Third-party integrations and connector development guides.
-
-| Document | Description |
-| --- | --- |
-| [[writing-a-connector]] | Guide for writing a new connector |
-=======
 # Connectors Documentation
 
 Guides for writing, configuring, and extending AutoBot connectors.
@@ -30,4 +21,3 @@ Guides for writing, configuring, and extending AutoBot connectors.
 - [[../plugins/_index\|Plugins]] — Plugin system and plugin development
 - [[../configuration/_index\|Configuration]] — Connector configuration
 - [[../examples/_index\|Examples]] — Example connector implementations
->>>>>>> origin/Dev_new_gui

--- a/docs/database/_index.md
+++ b/docs/database/_index.md
@@ -6,16 +6,6 @@ aliases:
   - Database Index
 ---
 
-<<<<<<< HEAD
-# Database
-
-Database schema, memory graph, and Redis specifications.
-
-| Document | Description |
-| --- | --- |
-| [[MEMORY_GRAPH_QUICK_REFERENCE]] | Memory graph quick reference |
-| [[REDIS_MEMORY_GRAPH_SPECIFICATION]] | Redis memory graph specification |
-=======
 # Database Documentation
 
 Database specifications, memory graph design, and quick reference guides.
@@ -32,4 +22,3 @@ Database specifications, memory graph design, and quick reference guides.
 - [[../configuration/_index\|Configuration]] — Database configuration
 - [[../migration/_index\|Migration]] — Database migration guides
 - [[../monitoring/_index\|Monitoring]] — Database monitoring
->>>>>>> origin/Dev_new_gui

--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -6,24 +6,15 @@ aliases:
   - Design Index
 ---
 
-<<<<<<< HEAD
-# Design
-
-Design documents for features, search architecture, and UI specifications.
-=======
 # Design Documentation
 
 Technical design documents covering architecture, UX specifications, and system design decisions.
 
 ## Documents
->>>>>>> origin/Dev_new_gui
 
 | Document | Description |
 | --- | --- |
 | [[MEMORY_GRAPH_SEARCH_ARCHITECTURE]] | Memory graph search architecture design |
-<<<<<<< HEAD
-| [[TECHNICAL_PRECISION_THEME]] | Technical precision theme design |
-=======
 | [[TECHNICAL_PRECISION_THEME]] | Technical precision theme and design guidelines |
 
 ## Related Sections
@@ -31,4 +22,3 @@ Technical design documents covering architecture, UX specifications, and system 
 - [[../designs/_index\|Designs]] — Design mockups and visual assets
 - [[../research/_index\|Research]] — Research informing design decisions
 - [[../superpowers/_index\|Superpowers]] — Feature design specs and plans
->>>>>>> origin/Dev_new_gui

--- a/docs/designs/_index.md
+++ b/docs/designs/_index.md
@@ -8,26 +8,16 @@ aliases:
 
 # Designs
 
-<<<<<<< HEAD
-UI and system design assets.
+Visual design assets and mockups for AutoBot UI and system components.
 
 ## Sub-sections
 
 | Section | Description |
 | --- | --- |
-| [[mockups/_index\|Mockups]] | UI mockups and visual design assets |
-=======
-Visual design assets and mockups for AutoBot UI and system components.
-
-## Directories
-
-| Directory | Description |
-| --- | --- |
-| `mockups/` | UI mockups and wireframes (empty — assets pending) |
+| [[mockups/_index\|Mockups]] | UI mockups and wireframes |
 
 ## Related Sections
 
 - [[../design/_index\|Design]] — Technical design documents
 - [[../screenshots/_index\|Screenshots]] — Application screenshots
 - [[../superpowers/_index\|Superpowers]] — Feature design specs
->>>>>>> origin/Dev_new_gui

--- a/docs/discovery/_index.md
+++ b/docs/discovery/_index.md
@@ -6,15 +6,6 @@ aliases:
   - Discovery Index
 ---
 
-<<<<<<< HEAD
-# Discovery
-
-Feature discovery and exploration audit documents.
-
-| Document | Description |
-| --- | --- |
-| [[frontend-orphaned-components-audit-4184]] | Frontend orphaned components discovery audit |
-=======
 # Discovery Documentation
 
 Discovery reports from codebase exploration and component auditing.
@@ -31,4 +22,3 @@ Discovery reports from codebase exploration and component auditing.
 - [[../analysis/_index\|Analysis]] — Analysis of discovered issues
 - [[../fixes/_index\|Fixes]] — Fixes applied after discovery
 - [[../research/_index\|Research]] — Research and investigation
->>>>>>> origin/Dev_new_gui

--- a/docs/examples/_index.md
+++ b/docs/examples/_index.md
@@ -8,27 +8,6 @@ aliases:
 
 # Examples
 
-<<<<<<< HEAD
-Example code and workflow samples demonstrating AutoBot-AI capabilities.
-
-## Sub-sections
-
-| Section | Description |
-| --- | --- |
-| [[mcp_agent_workflows/_index\|MCP Agent Workflows]] | Example MCP agent workflow implementations |
-
-## Code Examples
-
-| File | Description |
-| --- | --- |
-| before_after_optimization_comparison.py | Before/after optimization comparison example |
-| circuit_breaker_usage.py | Circuit breaker usage example |
-| parallel_fleet_workflow.py | Parallel fleet workflow example |
-| retry_mechanism_usage.py | Retry mechanism usage example |
-| service_failure_monitoring.py | Service failure monitoring example |
-| vllm_prefix_caching_usage.py | vLLM prefix caching usage example |
-| env_template.txt | Environment variables template |
-=======
 Code examples and sample workflows demonstrating AutoBot features.
 
 ## Python Examples
@@ -47,6 +26,7 @@ Code examples and sample workflows demonstrating AutoBot features.
 
 | Document | Description |
 | --- | --- |
+| [[mcp_agent_workflows/_index\|MCP Agent Workflows]] | MCP agent workflows index |
 | [[mcp_agent_workflows/README\|MCP Agent Workflows README]] | Overview of MCP agent workflow examples |
 | `mcp_agent_workflows/base.py` | Base MCP workflow class |
 | `mcp_agent_workflows/code_analysis.py` | Code analysis workflow |
@@ -58,4 +38,3 @@ Code examples and sample workflows demonstrating AutoBot features.
 - [[../how-to/_index\|How-To]] — Step-by-step how-to guides
 - [[../connectors/_index\|Connectors]] — Connector examples
 - [[../plugins/_index\|Plugins]] — Plugin examples
->>>>>>> origin/Dev_new_gui

--- a/docs/fixes/_index.md
+++ b/docs/fixes/_index.md
@@ -6,17 +6,6 @@ aliases:
   - Fixes Index
 ---
 
-<<<<<<< HEAD
-# Fixes
-
-Bug fix reports and consistency fix documentation.
-
-| Document | Description |
-| --- | --- |
-| [[CONVERSATION_TERMINATION_REPORT]] | Conversation termination fix report |
-| [[SESSION_ID_VALIDATION_REPORT]] | Session ID validation fix report |
-| [[terminal_input_consistency_fix]] | Terminal input consistency fix documentation |
-=======
 # Fixes Documentation
 
 Reports documenting applied bug fixes, session patches, and terminal corrections.
@@ -35,4 +24,3 @@ Reports documenting applied bug fixes, session patches, and terminal corrections
 - [[../audit/_index\|Audit]] — Audit reports that surface bugs
 - [[../discovery/_index\|Discovery]] — Discovery of issues requiring fixes
 - [[../migration/_index\|Migration]] — Migration-related fixes
->>>>>>> origin/Dev_new_gui

--- a/docs/how-to/_index.md
+++ b/docs/how-to/_index.md
@@ -8,39 +8,6 @@ aliases:
 
 # How-To Guides
 
-<<<<<<< HEAD
-Step-by-step instructions for common AutoBot-AI tasks.
-
-## Analytics & Monitoring
-
-| Document | Description |
-| --- | --- |
-| [[codebase-analytics-api-coverage-report]] | Codebase analytics API coverage report |
-| [[monitor-linux-service-failure-notifications]] | Monitor Linux service failure notifications |
-| [[llm-prompt-middleware-infra-telemetry]] | LLM prompt middleware infrastructure telemetry |
-
-## Configuration & Deployment
-
-| Document | Description |
-| --- | --- |
-| [[configure-autobot-chat-local-ollama-instance]] | Configure AutoBot chat with local Ollama instance |
-| [[deploy-docker-container-via-slm-ansible]] | Deploy Docker container via SLM Ansible |
-
-## Distributed Systems
-
-| Document | Description |
-| --- | --- |
-| [[distributed-execution-failover-redis-worker-nodes]] | Distributed execution failover with Redis worker nodes |
-| [[execute-bash-command-target-group-linux-nodes-slm]] | Execute bash commands on target group of Linux nodes via SLM |
-| [[parallel-shell-workflow-distributed-fleet]] | Parallel shell workflow on distributed fleet |
-
-## AI & Knowledge
-
-| Document | Description |
-| --- | --- |
-| [[rag-workflow-pdf-repository-context]] | RAG workflow with PDF repository context |
-| [[vision-module-vnc-detect-click-button]] | Vision module VNC detect and click button |
-=======
 Task-oriented guides covering common AutoBot operations and workflows.
 
 ## Guides
@@ -63,4 +30,3 @@ Task-oriented guides covering common AutoBot operations and workflows.
 - [[../examples/_index\|Examples]] — Code examples
 - [[../user-guide/_index\|User Guide]] — End-user guides
 - [[../configuration/_index\|Configuration]] — Configuration references
->>>>>>> origin/Dev_new_gui

--- a/docs/migration/_index.md
+++ b/docs/migration/_index.md
@@ -6,17 +6,6 @@ aliases:
   - Migration Index
 ---
 
-<<<<<<< HEAD
-# Migration
-
-Data, schema, and system migration guides.
-
-| Document | Description |
-| --- | --- |
-| [[Async_System_Migration]] | Async system migration guide |
-| [[ERROR_HANDLING_MIGRATION_GUIDE]] | Error handling migration guide |
-| [[LLM_Interface_Migration_Guide]] | LLM interface migration guide |
-=======
 # Migration Guides
 
 Step-by-step guides for migrating between system versions, APIs, and architectural patterns.
@@ -35,4 +24,3 @@ Step-by-step guides for migrating between system versions, APIs, and architectur
 - [[../configuration/_index\|Configuration]] — Configuration changes across versions
 - [[../fixes/_index\|Fixes]] — Fixes applied during migrations
 - [[../releases/_index\|Releases]] — Release notes with migration context
->>>>>>> origin/Dev_new_gui

--- a/docs/monitoring/_index.md
+++ b/docs/monitoring/_index.md
@@ -6,17 +6,6 @@ aliases:
   - Monitoring Index
 ---
 
-<<<<<<< HEAD
-# Monitoring
-
-Observability, distributed tracing, and metrics documentation.
-
-| Document | Description |
-| --- | --- |
-| [[DISTRIBUTED_TRACING]] | Distributed tracing setup and reference |
-| [[EPIC_80_COMPLETION]] | Epic 80 monitoring completion report |
-| [[QUICK_REFERENCE]] | Monitoring quick reference |
-=======
 # Monitoring Documentation
 
 Guides, references, and reports for distributed tracing, metrics, and system observability.
@@ -34,4 +23,3 @@ Guides, references, and reports for distributed tracing, metrics, and system obs
 - [[../configuration/_index\|Configuration]] — Monitoring configuration
 - [[../database/_index\|Database]] — Database monitoring
 - [[../how-to/_index\|How-To]] — Monitoring how-to guides (service failure notifications)
->>>>>>> origin/Dev_new_gui

--- a/docs/plugins/_index.md
+++ b/docs/plugins/_index.md
@@ -6,15 +6,6 @@ aliases:
   - Plugins Index
 ---
 
-<<<<<<< HEAD
-# Plugins
-
-Plugin architecture, capability system, and development guides.
-
-| Document | Description |
-| --- | --- |
-| [[capability-system]] | Plugin capability system documentation |
-=======
 # Plugins Documentation
 
 Plugin system architecture, capability definitions, and plugin development guides.
@@ -30,4 +21,3 @@ Plugin system architecture, capability definitions, and plugin development guide
 - [[../connectors/_index\|Connectors]] — Connector system (related to plugins)
 - [[../examples/_index\|Examples]] — Plugin usage examples
 - [[../configuration/_index\|Configuration]] — Plugin configuration
->>>>>>> origin/Dev_new_gui

--- a/docs/project/_index.md
+++ b/docs/project/_index.md
@@ -6,17 +6,6 @@ aliases:
   - Project Index
 ---
 
-<<<<<<< HEAD
-# Project
-
-Project management, remediation plans, and status documentation.
-
-| Document | Description |
-| --- | --- |
-| [[CONFIG_REMEDIATION_OVERVIEW]] | Configuration remediation overview |
-| [[CONFIG_REMEDIATION_PLAN]] | Configuration remediation plan |
-| [[DOCUMENTATION_INDEXING_PLAN]] | Documentation indexing plan |
-=======
 # Project Documentation
 
 Project-level planning, remediation overviews, and documentation indexing plans.
@@ -34,4 +23,3 @@ Project-level planning, remediation overviews, and documentation indexing plans.
 - [[../superpowers/_index\|Superpowers]] — Feature plans and specs
 - [[../releases/_index\|Releases]] — Release notes and milestones
 - [[../tasks/_index\|Tasks]] — Task tracking documentation
->>>>>>> origin/Dev_new_gui

--- a/docs/releases/_index.md
+++ b/docs/releases/_index.md
@@ -6,15 +6,6 @@ aliases:
   - Releases Index
 ---
 
-<<<<<<< HEAD
-# Releases
-
-Release notes and optimization documentation.
-
-| Document | Description |
-| --- | --- |
-| [[VLLM_OPTIMIZATION_RELEASE_NOTES]] | vLLM optimization release notes |
-=======
 # Release Notes
 
 Release notes and optimization reports for AutoBot versions.
@@ -30,4 +21,3 @@ Release notes and optimization reports for AutoBot versions.
 - [[../migration/_index\|Migration]] — Migration guides for version upgrades
 - [[../project/_index\|Project]] — Project-level planning and milestones
 - [[../superpowers/_index\|Superpowers]] — Feature plans that become releases
->>>>>>> origin/Dev_new_gui

--- a/docs/research/_index.md
+++ b/docs/research/_index.md
@@ -6,16 +6,6 @@ aliases:
   - Research Index
 ---
 
-<<<<<<< HEAD
-# Research
-
-Technical research documents and assessments.
-
-| Document | Description |
-| --- | --- |
-| [[INTEL_NPU_WINDOWS_DEPLOYMENT_ANALYSIS]] | Intel NPU Windows deployment analysis |
-| [[REDIS_OWNERSHIP_CONFLICT_RESEARCH_REPORT]] | Redis ownership conflict research report |
-=======
 # Research Documentation
 
 Research reports covering hardware integration, system conflicts, and technology evaluations.
@@ -32,4 +22,3 @@ Research reports covering hardware integration, system conflicts, and technology
 - [[../analysis/_index\|Analysis]] — Analysis based on research
 - [[../design/_index\|Design]] — Design informed by research
 - [[../discovery/_index\|Discovery]] — Discovery reports
->>>>>>> origin/Dev_new_gui

--- a/docs/screenshots/_index.md
+++ b/docs/screenshots/_index.md
@@ -8,12 +8,6 @@ aliases:
 
 # Screenshots
 
-<<<<<<< HEAD
-UI screenshots and visual documentation.
-
-This folder contains screenshots and visual assets used in documentation.
-See parent docs sections for context on where these images are referenced.
-=======
 Application screenshots showcasing AutoBot features and UI.
 
 ## Screenshots
@@ -31,4 +25,3 @@ Application screenshots showcasing AutoBot features and UI.
 
 - [[../designs/_index\|Designs]] — Design mockups and wireframes
 - [[../user-guide/_index\|User Guide]] — User guides referencing these screenshots
->>>>>>> origin/Dev_new_gui

--- a/docs/superpowers/_index.md
+++ b/docs/superpowers/_index.md
@@ -6,18 +6,6 @@ aliases:
   - Superpowers Index
 ---
 
-<<<<<<< HEAD
-# Superpowers
-
-Implementation plans and design specifications for AutoBot-AI features.
-
-## Sub-sections
-
-| Section | Description |
-| --- | --- |
-| [[plans/_index\|Plans]] | Feature implementation plans |
-| [[specs/_index\|Specs]] | Feature design specifications |
-=======
 # Superpowers Documentation
 
 Implementation plans and design specifications for AutoBot feature development.
@@ -63,9 +51,15 @@ Implementation plans and design specifications for AutoBot feature development.
 | [[specs/2026-05-29-resource-policy-design]] | Resource policy design spec |
 | [[specs/2026-05-30-transcriber-module-design]] | Transcriber module design spec |
 
+## Sub-sections
+
+| Section | Description |
+| --- | --- |
+| [[plans/_index\|Plans]] | Feature implementation plans |
+| [[specs/_index\|Specs]] | Feature design specifications |
+
 ## Related Sections
 
 - [[../design/_index\|Design]] — Technical design documents
 - [[../project/_index\|Project]] — Project-level plans
 - [[../releases/_index\|Releases]] — Releases resulting from these plans
->>>>>>> origin/Dev_new_gui

--- a/docs/superpowers/plans/_index.md
+++ b/docs/superpowers/plans/_index.md
@@ -4,14 +4,6 @@ tags:
   - superpowers
   - plans
 aliases:
-<<<<<<< HEAD
-  - Plans Index
----
-
-# Implementation Plans
-
-Feature implementation plans, ordered chronologically.
-=======
   - Superpowers Plans Index
 ---
 
@@ -20,36 +12,17 @@ Feature implementation plans, ordered chronologically.
 Implementation plans for AutoBot feature development.
 
 ## Plans
->>>>>>> origin/Dev_new_gui
 
 | Document | Description |
 | --- | --- |
 | [[2026-03-29-shared-dependency-roles]] | Shared dependency roles plan |
 | [[2026-03-31-platform-hardening]] | Platform hardening plan |
-<<<<<<< HEAD
-| [[2026-04-01-autoresearch-m3]] | Auto-research M3 plan |
-=======
 | [[2026-04-01-autoresearch-m3]] | AutoResearch M3 plan |
->>>>>>> origin/Dev_new_gui
 | [[2026-04-07-language-switcher]] | Language switcher plan |
 | [[2026-04-16-graphify-gaps]] | Graphify gaps plan |
 | [[2026-04-16-gui-audit-quick-fixes]] | GUI audit quick fixes plan |
 | [[2026-04-16-provisioning-gaps-fix]] | Provisioning gaps fix plan |
 | [[2026-04-17-responsive-nav]] | Responsive navigation plan |
-<<<<<<< HEAD
-| [[2026-04-26-composable-wave1-dead-code]] | Composable refactor wave 1: dead code |
-| [[2026-04-26-composable-wave2-fetchwithauth]] | Composable refactor wave 2: fetchWithAuth |
-| [[2026-04-26-composable-wave3-component-extraction]] | Composable refactor wave 3: component extraction |
-| [[2026-04-26-composable-wave4-confirm-dialog]] | Composable refactor wave 4: confirm dialog |
-| [[2026-05-05-plugin-sdk-required-env]] | Plugin SDK required environment plan |
-| [[2026-05-11-canonical-check-foundation]] | Canonical check foundation plan |
-| [[2026-05-16-live-canvas-phase1]] | Live canvas phase 1 plan |
-| [[2026-05-29-resource-policy]] | Resource policy plan |
-| [[2026-05-30-transcriber-plan-1-foundation]] | Transcriber plan 1: foundation |
-| [[2026-05-30-transcriber-plan-2-pipeline]] | Transcriber plan 2: pipeline |
-| [[2026-05-30-transcriber-plan-3-features]] | Transcriber plan 3: features |
-| [[2026-05-30-transcriber-plan-4-frontend]] | Transcriber plan 4: frontend |
-=======
 | [[2026-04-26-composable-wave1-dead-code]] | Composable refactor wave 1 — dead code |
 | [[2026-04-26-composable-wave2-fetchwithauth]] | Composable refactor wave 2 — fetchWithAuth |
 | [[2026-04-26-composable-wave3-component-extraction]] | Composable refactor wave 3 — component extraction |
@@ -68,4 +41,3 @@ Implementation plans for AutoBot feature development.
 - [[../_index|Superpowers]] — Parent superpowers section
 - [[../specs/_index|Specs]] — Design specifications for these plans
 - [[../../project/_index|Project]] — Project-level plans
->>>>>>> origin/Dev_new_gui

--- a/docs/superpowers/specs/_index.md
+++ b/docs/superpowers/specs/_index.md
@@ -4,14 +4,6 @@ tags:
   - superpowers
   - specs
 aliases:
-<<<<<<< HEAD
-  - Specs Index
----
-
-# Design Specifications
-
-Feature design specifications, ordered chronologically.
-=======
   - Superpowers Specs Index
 ---
 
@@ -20,23 +12,11 @@ Feature design specifications, ordered chronologically.
 Design specifications for AutoBot feature development.
 
 ## Specifications
->>>>>>> origin/Dev_new_gui
 
 | Document | Description |
 | --- | --- |
 | [[2026-03-29-shared-dependency-roles-design]] | Shared dependency roles design spec |
 | [[2026-03-31-platform-hardening-design]] | Platform hardening design spec |
-<<<<<<< HEAD
-| [[2026-04-01-autoresearch-m3-design]] | Auto-research M3 design spec |
-| [[2026-04-07-language-switcher-design]] | Language switcher design spec |
-| [[2026-04-16-provisioning-gaps-fix-design]] | Provisioning gaps fix design spec |
-| [[2026-04-26-composable-weakness-remediation-design]] | Composable weakness remediation design spec |
-| [[2026-05-05-arc-prize-plugin-design]] | ARC Prize plugin design spec |
-| [[2026-05-05-plugin-sdk-required-env-design]] | Plugin SDK required environment design spec |
-| [[2026-05-10-canonical-check-workflow-design]] | Canonical check workflow design spec |
-| [[2026-05-29-resource-policy-design]] | Resource policy design spec |
-| [[2026-05-30-transcriber-module-design]] | Transcriber module design spec |
-=======
 | [[2026-04-01-autoresearch-m3-design]] | AutoResearch M3 design spec |
 | [[2026-04-07-language-switcher-design]] | Language switcher design spec |
 | [[2026-04-16-provisioning-gaps-fix-design]] | Provisioning gaps fix design spec |
@@ -52,4 +32,3 @@ Design specifications for AutoBot feature development.
 - [[../_index|Superpowers]] — Parent superpowers section
 - [[../plans/_index|Plans]] — Implementation plans for these specs
 - [[../../design/_index|Design]] — Technical design documents
->>>>>>> origin/Dev_new_gui

--- a/docs/tasks/_index.md
+++ b/docs/tasks/_index.md
@@ -6,17 +6,6 @@ aliases:
   - Tasks Index
 ---
 
-<<<<<<< HEAD
-# Tasks
-
-Task documentation and implementation plans.
-
-## Sub-sections
-
-| Section | Description |
-| --- | --- |
-| [[security/_index\|Security]] | Security task documentation |
-=======
 # Tasks Documentation
 
 Task tracking and implementation documentation for ongoing workstreams.
@@ -27,9 +16,14 @@ Task tracking and implementation documentation for ongoing workstreams.
 | --- | --- |
 | [[security/tls-implementation\|TLS Implementation]] | TLS certificate implementation task |
 
+## Sub-sections
+
+| Section | Description |
+| --- | --- |
+| [[security/_index\|Security Tasks]] | Security implementation task documentation |
+
 ## Related Sections
 
 - [[../project/_index\|Project]] — Project-level planning
 - [[../superpowers/_index\|Superpowers]] — Feature implementation plans
 - [[../fixes/_index\|Fixes]] — Bug fix task documentation
->>>>>>> origin/Dev_new_gui

--- a/docs/tasks/security/_index.md
+++ b/docs/tasks/security/_index.md
@@ -9,13 +9,6 @@ aliases:
 
 # Security Tasks
 
-<<<<<<< HEAD
-Security implementation task documentation.
-
-| Document | Description |
-| --- | --- |
-| [[tls-implementation]] | TLS implementation task documentation |
-=======
 Security-related task documentation and implementation reports.
 
 ## Documents
@@ -29,4 +22,3 @@ Security-related task documentation and implementation reports.
 - [[../_index|Tasks]] — Parent tasks section
 - [[../../security/_index|Security]] — Security implementation documentation
 - [[../../audit/_index|Audit]] — Security audit reports
->>>>>>> origin/Dev_new_gui

--- a/docs/user-guide/_index.md
+++ b/docs/user-guide/_index.md
@@ -2,28 +2,13 @@
 tags:
   - index
   - user-guide
-<<<<<<< HEAD
-=======
   - installation
->>>>>>> origin/Dev_new_gui
 aliases:
   - User Guide Index
 ---
 
 # User Guide
 
-<<<<<<< HEAD
-End-user documentation for installing, configuring, and using AutoBot-AI.
-
-| Document | Description |
-| --- | --- |
-| [[01-installation]] | Installation guide |
-| [[02-quickstart]] | Quick start guide |
-| [[03-configuration]] | Configuration guide |
-| [[04-troubleshooting]] | Troubleshooting guide |
-| [[05-preferences]] | User preferences guide |
-| [[06-redis-management]] | Redis management guide |
-=======
 Step-by-step guides for installing, configuring, and operating AutoBot.
 
 ## Guides
@@ -42,4 +27,3 @@ Step-by-step guides for installing, configuring, and operating AutoBot.
 - [[../getting-started/_index\|Getting Started]] — Environment-specific installation (VM, VNC)
 - [[../configuration/_index\|Configuration]] — Advanced environment variable and port configuration
 - [[../troubleshooting/_index\|Troubleshooting]] — Extended troubleshooting guides
->>>>>>> origin/Dev_new_gui


### PR DESCRIPTION
## Thinking Path

Discovered during PR #9871 review: ~21 section MOC (`_index.md`) files on `Dev_new_gui` carried unresolved git conflict markers (`<<<<<<< / ======= / >>>>>>>`), breaking Jekyll rendering and Obsidian graph nav. Filed as #9887. Each conflict was the same shape — a terser HEAD side vs a richer `origin/Dev_new_gui` side (descriptive titles, fuller descriptions, "Related Sections").

## What Changed

- Resolved conflict markers in 21 `_index.md` MOCs, keeping the richer side.
- **Preserved sub-section `_index` links** the richer side dropped, to avoid re-orphaning: `designs→mockups`, `examples→mcp_agent_workflows`, `tasks→security`, `superpowers→plans/specs`.
- Re-applied the `design/_index.md` resolution + Jekyll-safe `audit/_index.md` link that were **lost when #9871's final commit was dropped by the squash merge** (merged while GitHub's mergeState was still recomputing).

## Verification

- `grep -rIn '^<<<<<<<\|^>>>>>>> ' docs --include='*.md'` → no matches (0 conflict markers).
- Orphan scan (sources include root `CLAUDE.md`) → **0 orphaned md files** across docs/.
- Excluded from scope: 2 vendored third-party prompt `.txt` files under `external_apps/` containing literal marker text, and `docs/.obsidian/workspace.json`.

## Model Used

Claude Opus 4.8 (1M context)