### PR TITLE
docs(arch): mark service-discovery modules as intentional unwired library (#9893)

### DIFF
--- a/autobot-backend/utils/distributed_service_discovery.py
+++ b/autobot-backend/utils/distributed_service_discovery.py
@@ -9,6 +9,11 @@ This module provides instant service resolution for the distributed VM architect
 by maintaining a local cache of service endpoints and implementing health-based routing.
 
 ROOT CAUSE FIX: Replaces DNS resolution delays with cached service endpoints
+
+Wiring status (#9893): This is an available library API. It is intentionally NOT
+wired into the production inter-service path, which uses SSOT-config endpoint
+resolution + ServiceMessageBus (Redis streams) + mTLS. Retained deliberately
+(not dead code); wire it in only with a concrete dynamic-node-resolution need.
 """
 
 import asyncio

--- a/autobot-backend/utils/service_discovery.py
+++ b/autobot-backend/utils/service_discovery.py
@@ -6,6 +6,13 @@
 """
 Service Discovery System for AutoBot Distributed Architecture
 Provides dynamic service resolution and health monitoring across 6 VMs
+
+Wiring status (#9893): This is an available library API for dynamic service
+discovery. It is intentionally NOT wired into the production inter-service path,
+which resolves endpoints via SSOT config and communicates over ServiceMessageBus
+(Redis streams) + mTLS (autobot_shared.tls.get_internal_tls_context). Retained
+deliberately (not dead code); wire it in only when a concrete dynamic-node-
+resolution requirement appears (e.g. dynamically-scaled fleet nodes).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Thinking Path

Discovery #9893 (from catalog verification): `utils/service_discovery.py` and `utils/distributed_service_discovery.py` are complete but have **zero production callers** — production inter-service comms use SSOT-config endpoint resolution + `ServiceMessageBus` (Redis streams) + mTLS instead. Rather than delete (against the never-delete rule) or wire in a second discovery mechanism with no driving requirement, document them as a deliberately-retained library API (the recommended option 2).

## What Changed

- Added a "Wiring status (#9893)" note to both module docstrings: available library, intentionally not wired, retained deliberately, wire in only on a concrete dynamic-node-resolution need.

Docstring-only — no behavior, imports, or signatures changed.

## Verification

- Confirmed zero production callers (only `distributed_service_discovery_test.py` references them).
- Confirmed production path uses `ServiceMessageBus` + `get_internal_tls_context` (celery_app, dag_executor, slm_client, notification_service, state_machine).

## Model Used

Claude Opus 4.8 (1M context)