### PR TITLE
fix(ansible): make fresh-VM fleet provisioning work out-of-box (#9914 #9915)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -119,6 +119,25 @@
     backend_slm_auth_tok: "{{ _backend_slm_auth_tok.stdout | default('') | trim }}"
   tags: ['backend', 'config']
 
+# #9914: Deploy the systemd unit BEFORE any stop/start so a fresh VM provisions
+# out-of-box. Previously the unit was deployed after the MVA-1633 start task, so
+# first-run on a clean node failed: "Could not find the requested service
+# autobot-backend". Tagged backend,config so tag-filtered runs register it too.
+- name: "Backend | Deploy backend systemd service (#9914)"
+  ansible.builtin.template:
+    src: autobot-backend.service.j2
+    dest: /etc/systemd/system/autobot-backend.service
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart backend
+  tags: ['backend', 'config']
+
+- name: "Backend | Reload systemd so the unit is registered before start (#9914)"
+  ansible.builtin.systemd:
+    daemon_reload: true
+  tags: ['backend', 'config']
+
 # MVA-1633: Prevent systemd Restart=always race during env updates.
 # The backend service may restart BEFORE the new .env is written if we use
 # async notify. Stop explicitly, write env files, verify they exist, then start.
@@ -623,15 +642,6 @@
     state: started
     daemon_reload: false
   tags: ['backend', 'config']
-
-- name: Deploy backend systemd service
-  ansible.builtin.template:
-    src: autobot-backend.service.j2
-    dest: /etc/systemd/system/autobot-backend.service
-    mode: "0644"
-  notify:
-    - reload systemd
-    - restart backend
 
 - name: Enable and start backend service
   ansible.builtin.systemd:

--- a/autobot-slm-backend/ansible/roles/common/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/common/tasks/main.yml
@@ -180,13 +180,18 @@
   when: ufw_enabled | bool
   tags: ['common', 'firewall']
 
+# #9915: Sanitize to a valid DNS hostname (underscores etc. are rejected by
+# hostnamectl) and skip ANY SLM-Manager label variant — the wizard may label it
+# `node_00_SLM_Manager`, which the old literal `!= '00-SLM-Manager'` guard missed.
 - name: "Common | Set hostname"
   hostname:
-    name: "{{ inventory_hostname }}"
+    name: "{{ _hostname_sanitized }}"
   become: true
+  vars:
+    _hostname_sanitized: "{{ inventory_hostname | regex_replace('[^A-Za-z0-9-]', '-') | lower }}"
   when:
     - inventory_hostname is defined
-    - inventory_hostname != '00-SLM-Manager'
+    - "'slm-manager' not in _hostname_sanitized"
   tags: ['common', 'hostname']
 
 - name: "Common | Update /etc/hosts"


### PR DESCRIPTION
## Thinking Path
SLM-wizard provisioning of a fresh **native VM** failed and the cascade dropped the host, so every later phase (Frontend, AI Stack, NPU, TTS, LLM Nodes, Browser) ran as an empty play. The logs (`provision-wizard.log`, 2026-06-10 23:24) showed two distinct first-run bugs. Goal: provisioning must work out-of-box, every time, on a clean VM.

## What Changed
**#9914 — backend systemd unit deployed too late**
`roles/backend/tasks/main.yml` started `autobot-backend` (MVA-1633 start) *before* the unit file was templated 7 tasks later, so a fresh node failed with `Could not find the requested service autobot-backend`. The unit deploy + an explicit `daemon_reload` now run **before** the MVA-1633 stop/start bracket, tagged `backend,config` so `--tags backend,config` runs register the unit too. The duplicate late deploy was removed (no dead/dup task).

**#9915 — `Common | Set hostname` rejected the SLM-Manager label variant**
The task passed `inventory_hostname` verbatim — `node_00_SLM_Manager` has underscores, which `hostnamectl` rejects — and the skip guard only matched the literal `00-SLM-Manager`, missing the `node_00_*` variant. Now sanitizes to a valid DNS hostname (`regex_replace('[^A-Za-z0-9-]','-') | lower`) and skips **any** `slm-manager` variant.

## Verification
- `python3 yaml.safe_load` — both files parse OK
- `ansible-playbook --syntax-check playbooks/provision-fleet-roles.yml` → exit 0
- Hostname logic (Jinja-equivalent):
  - `node_00_SLM_Manager` → `node-00-slm-manager` → **skipped** (was failing)
  - `node1721616826` → unchanged → **not skipped**, valid hostname
  - `00-SLM-Manager` → `00-slm-manager` → **skipped** (intent preserved)
- Backend task order now: Deploy unit → Reload → Stop → write env → Start

## Model Used
Claude Opus 4.8 (1M context)

Closes #9914
Closes #9915
