### PR TITLE
fix(ansible): unblock co-located SLM Manager provisioning (#9933 #9934)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
+++ b/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
@@ -489,10 +489,26 @@
       changed_when: true
       tags: ['frontend', 'slm-nginx', 'provision']
 
+    # #9933: In co-located mode the SLM nginx config (autobot-slm) owns the
+    # `upstream autobot_backend` block. The frontend role (Phase 4b) runs before
+    # the co-location flag is set, so it enables a standalone `autobot-frontend`
+    # site that ALSO declares `upstream autobot_backend` → `nginx -t` fails with
+    # `duplicate upstream "autobot_backend"`. Remove the conflicting symlink here,
+    # where co-location is definitively known, before testing the config.
+    - name: "SLM | Disable standalone autobot-frontend site in co-located mode (#9933)"
+      ansible.builtin.file:
+        path: /etc/nginx/sites-enabled/autobot-frontend
+        state: absent
+      when: _is_slm_frontend_colocated | bool
+      register: _frontend_site_disabled
+      tags: ['frontend', 'slm-nginx', 'provision']
+
     - name: "SLM | Test nginx config after co-location update"
       ansible.builtin.command:
         cmd: nginx -t
-      when: _slm_nginx_rerendered is defined and _slm_nginx_rerendered is changed
+      when: >-
+        (_slm_nginx_rerendered is defined and _slm_nginx_rerendered is changed)
+        or (_frontend_site_disabled is defined and _frontend_site_disabled is changed)
       changed_when: false
       tags: ['frontend', 'slm-nginx', 'provision']
 
@@ -500,7 +516,9 @@
       ansible.builtin.systemd:
         name: nginx
         state: reloaded
-      when: _slm_nginx_rerendered is defined and _slm_nginx_rerendered is changed
+      when: >-
+        (_slm_nginx_rerendered is defined and _slm_nginx_rerendered is changed)
+        or (_frontend_site_disabled is defined and _frontend_site_disabled is changed)
       tags: ['frontend', 'slm-nginx', 'provision']
 
 # -------------------------------------------------------------------

--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-backend.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-backend.service.j2
@@ -24,6 +24,13 @@ Restart=always
 RestartSec=5
 StartLimitInterval=120
 StartLimitBurst=5
+# #9934: Raise the file-descriptor ceiling. The backend runs multiple uvicorn
+# workers with DB/Redis/ChromaDB pools + HTTP clients and exhausts the default
+# soft limit on busy/co-located hosts (OSError: [Errno 24] Too many open files →
+# socket.accept() out of system resource → #3687 health gate never goes green).
+# Matches the convention used by every other AutoBot unit (slm-agent, frontend,
+# ollama, browser, coordinator = 65535/65536).
+LimitNOFILE={{ backend_nofile_limit | default(65536) }}
 StandardOutput=append:{{ backend_log_dir }}/backend.log
 StandardError=append:{{ backend_log_dir }}/backend-error.log
 


### PR DESCRIPTION
## Thinking Path
After PR #9916 cleared the fresh-VM hostname/systemd bugs (#9914/#9915), I re-checked the wizard run: the native VM `node1721616826` is now fully green (failed=0, ok=177), and the co-located SLM Manager got 200 tasks further but hit two deeper failures. Both are pre-existing co-location bugs in umbrella #9919 (deployment-install) and are the concrete root causes of the 4a→4c chain in #9281.

## What Changed
**#9933 — nginx `duplicate upstream "autobot_backend"` (Phase 4c)**
The frontend role (Phase 4b) enables a standalone `autobot-frontend` site *before* the co-location flag is set (the flag is resolved later, in Phase 4c), so both `sites-enabled/autobot-frontend:6` and `sites-enabled/autobot-slm:6` declare `upstream autobot_backend`. `include sites-enabled/*` loads both → `nginx -t` emerg. Fix: in the Phase 4c co-location play (`provision-fleet-roles.yml`), remove the conflicting `sites-enabled/autobot-frontend` symlink when `_is_slm_frontend_colocated` is true — *before* `nginx -t` — and add that removal to the test/reload trigger conditions.

**#9934 — backend unhealthy: FD exhaustion**
`autobot-backend.service.j2` had **no `LimitNOFILE`** — the only AutoBot unit missing it. The multi-worker backend (DB/Redis/ChromaDB pools + HTTP clients) hit the default fd ceiling on the busy co-located host: `OSError: [Errno 24] Too many open files` → `socket.accept() out of system resource` → the `#3687` health gate never went green (120 retries / ~10 min). Fix: `LimitNOFILE={{ backend_nofile_limit | default(65536) }}`, matching the repo convention (slm-agent/frontend/ollama/browser/coordinator = 65535/65536).

## Verification
- `python3 yaml.safe_load_all` on the playbook → OK
- `ansible-playbook --syntax-check playbooks/provision-fleet-roles.yml` → exit 0
- Confirmed on the failing host that only `autobot-frontend` + `autobot-slm` declare the duplicate `upstream autobot_backend` (autobot-backend.conf does not)
- Backend unit now renders `LimitNOFILE=65536`

## Model Used
Claude Opus 4.8 (1M context)

Part of umbrella #9919. Related: #9281.
Closes #9933
Closes #9934
