### PR TITLE
fix(config): replace non-existent flat config attrs with canonical vm/port refs (#9912)

### DIFF
--- a/autobot-backend/services/captcha_human_loop.py
+++ b/autobot-backend/services/captcha_human_loop.py
@@ -123,7 +123,7 @@ class CaptchaHumanLoop:
         self.auto_skip_on_timeout = auto_skip_on_timeout
         # Use environment variable or NetworkConstants for VNC URL
         vnc_host = config.vnc_host
-        vnc_port = config.vnc_port
+        vnc_port = config.port.vnc
         self.vnc_url = vnc_url or f"http://{vnc_host}:{vnc_port}/vnc.html"
         self.enable_auto_solve = enable_auto_solve
         self._auto_solver = None

--- a/autobot-backend/services/playwright_service.py
+++ b/autobot-backend/services/playwright_service.py
@@ -425,7 +425,7 @@ async def get_playwright_service() -> PlaywrightService:
             # Double-check after acquiring lock
             if _playwright_service is None:
                 # Use correct Playwright container IP address
-                container_host = config.browser_service_host
+                container_host = config.vm.browser
                 if not container_host:
                     raise ValueError("AUTOBOT_BROWSER_SERVICE_HOST environment variable must be set")
                 _playwright_service = PlaywrightService(container_host=container_host)


### PR DESCRIPTION
## Thinking Path
Gap from the #9832 bug-sweep audit: two more files used non-existent flat config attributes (same class #9832 fixed in audit_logger/enterprise_feature_manager), crashing at runtime with AttributeError.

## What Changed
- `services/playwright_service.py:428`: `config.browser_service_host` → `config.vm.browser` (alias `AUTOBOT_BROWSER_SERVICE_HOST`)
- `services/captcha_human_loop.py:126`: `config.vnc_port` → `config.port.vnc` (alias `AUTOBOT_VNC_PORT`)
Follows the #9832 pattern (canonical nested refs, no new flat aliases).

## Verification
- `py_compile` both files OK
- Runtime probe: `config.vm.browser` / `config.port.vnc` resolve; old paths confirmed AttributeError
- Adjacent `config.vnc_host` verified as a REAL field (`ssot_config.py:1349`) — not part of the bug class
- Repo grep: no other production uses of the dead attributes (test-suite dataclass has its own `vnc_port` — unrelated)

## Model Used
Claude Opus 4.8 (1M context) + senior-backend-engineer agent

Part of umbrella #9919.
Closes #9912
