### PR TITLE
fix(redis): agent-memory RediSearch index on DB 0 via 'memory' alias (#9904)

### DIFF
--- a/autobot-backend/api/redis_mcp/router.py
+++ b/autobot-backend/api/redis_mcp/router.py
@@ -312,7 +312,7 @@ async def _wrap_vector_create_index(args: dict) -> Metadata:
         dimensions=args.get("dimensions", 1536),
         distance_metric=args.get("distance_metric", "COSINE"),
         extra_fields=args.get("extra_fields"),
-        database=args.get("database", "vectors"),
+        database=args.get("database", "memory"),
     )
 
 
@@ -323,7 +323,7 @@ async def _wrap_vector_search(args: dict) -> Metadata:
         index_name=args.get("index_name", "idx:agent_memory"),
         top_k=args.get("top_k", 10),
         return_fields=args.get("return_fields"),
-        database=args.get("database", "vectors"),
+        database=args.get("database", "memory"),
     )
 
 
@@ -335,14 +335,14 @@ async def _wrap_hybrid_search(args: dict) -> Metadata:
         index_name=args.get("index_name", "idx:agent_memory"),
         top_k=args.get("top_k", 10),
         return_fields=args.get("return_fields"),
-        database=args.get("database", "vectors"),
+        database=args.get("database", "memory"),
     )
 
 
 async def _wrap_vector_index_info(args: dict) -> Metadata:
     return await handle_redis_vector_index_info(
         index_name=args.get("index_name", "idx:agent_memory"),
-        database=args.get("database", "vectors"),
+        database=args.get("database", "memory"),
     )
 
 

--- a/autobot-backend/api/redis_mcp/tools.py
+++ b/autobot-backend/api/redis_mcp/tools.py
@@ -368,7 +368,9 @@ def _tool_redis_vector_create_index() -> MCPTool:
         name="redis_vector_create_index",
         description=(
             "Create a RediSearch vector index on hash keys using HNSW algorithm. "
-            "Default: idx:agent_memory on autobot:agent:memory:* with 1536 dims."
+            "Default: idx:agent_memory on autobot:agent:memory:* with 1536 dims. "
+            "RediSearch FT.CREATE requires DB 0; use database='memory' (DB 0 alias) "
+            "for agent-memory indexes."
         ),
         input_schema={
             "type": "object",
@@ -414,7 +416,7 @@ def _tool_redis_vector_create_index() -> MCPTool:
                     },
                     "description": "Additional schema fields (TEXT, TAG, NUMERIC)",
                 },
-                "database": {"type": "string", "default": "vectors"},
+                "database": {"type": "string", "default": "memory"},
             },
         },
     )
@@ -454,7 +456,7 @@ def _tool_redis_vector_search() -> MCPTool:
                     "items": {"type": "string"},
                     "description": "Fields to return (default: all)",
                 },
-                "database": {"type": "string", "default": "vectors"},
+                "database": {"type": "string", "default": "memory"},
             },
         },
     )
@@ -492,7 +494,7 @@ def _tool_redis_hybrid_search() -> MCPTool:
                     "type": "array",
                     "items": {"type": "string"},
                 },
-                "database": {"type": "string", "default": "vectors"},
+                "database": {"type": "string", "default": "memory"},
             },
             "required": ["filter_expression"],
         },
@@ -510,7 +512,7 @@ def _tool_redis_vector_index_info() -> MCPTool:
                     "type": "string",
                     "default": "idx:agent_memory",
                 },
-                "database": {"type": "string", "default": "vectors"},
+                "database": {"type": "string", "default": "memory"},
             },
         },
     )

--- a/autobot-backend/api/redis_mcp/vector_search.py
+++ b/autobot-backend/api/redis_mcp/vector_search.py
@@ -38,8 +38,14 @@ async def _text_to_embedding(text: str) -> List[float]:
     return await _generate_embedding_with_npu_fallback(text)
 
 
-async def _get_client(database: str = "vectors"):
-    """Get an async Redis client for vector operations."""
+async def _get_client(database: str = "memory"):
+    """Get an async Redis client for vector operations.
+
+    Defaults to the "memory" database (DB 0) — RediSearch FT.* commands only
+    operate on logical DB 0, and agent-memory data keys are written to DB 0
+    by the MCP data-access layer.  Callers may pass a different database name
+    for indexes that live on other DBs.
+    """
     return await get_async_redis_client(database=database)
 
 
@@ -88,9 +94,15 @@ async def handle_redis_vector_create_index(
     dimensions: int = 1536,
     distance_metric: str = "COSINE",
     extra_fields: List[Dict[str, str]] | None = None,
-    database: str = "vectors",
+    database: str = "memory",
 ) -> Metadata:
-    """Create a RediSearch vector index using HNSW."""
+    """Create a RediSearch vector index using HNSW.
+
+    The ``database`` parameter must resolve to Redis logical DB 0 because
+    RediSearch FT.CREATE is only supported on DB 0.  The "memory" alias
+    (DB 0) is the correct value for the agent-memory index; the legacy
+    default of "vectors" (DB 8) caused the startup warning fixed by #9904.
+    """
     client = await _get_client(database)
     schema_args = _build_index_schema(vector_field, dimensions, distance_metric, extra_fields)
     try:
@@ -181,7 +193,7 @@ async def handle_redis_vector_search(
     index_name: str = "idx:agent_memory",
     top_k: int = 10,
     return_fields: List[str] | None = None,
-    database: str = "vectors",
+    database: str = "memory",
 ) -> Metadata:
     """Similarity search by embedding vector or text (Issue #2623)."""
     top_k = min(max(1, top_k), _MAX_TOP_K)
@@ -204,7 +216,7 @@ async def handle_redis_hybrid_search(
     index_name: str = "idx:agent_memory",
     top_k: int = 10,
     return_fields: List[str] | None = None,
-    database: str = "vectors",
+    database: str = "memory",
 ) -> Metadata:
     """Vector + filter combined query (Issue #2623: accepts query_text)."""
     if filter_expression and not _SAFE_FILTER_PATTERN.match(filter_expression):
@@ -230,7 +242,7 @@ async def handle_redis_hybrid_search(
 
 async def handle_redis_vector_index_info(
     index_name: str = "idx:agent_memory",
-    database: str = "vectors",
+    database: str = "memory",
 ) -> Metadata:
     """Get index schema and stats."""
     client = await _get_client(database)

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1274,8 +1274,12 @@ async def _ensure_agent_memory_index() -> None:
 
     Idempotent — safe to call on every startup. If the index already exists,
     handle_redis_vector_create_index returns immediately without error.
-    Uses the vectors database (Redis DB 8) with default agent-memory schema:
-    HNSW, FLOAT32, 1536 dimensions, COSINE distance.
+
+    RediSearch FT.CREATE only operates on Redis logical DB 0.  Agent memory
+    data keys (autobot:agent:memory:*) are written to DB 0 ("main") by the
+    MCP data-access layer, so the index must live on the same DB.  The
+    "memory" database alias resolves to DB 0 and documents this constraint
+    explicitly (see autobot_shared/redis_management/types.py _ALIASES).
     """
     logger.info("[ 93%%] Agent Memory Index: Ensuring idx:agent_memory exists...")
     try:
@@ -1287,7 +1291,7 @@ async def _ensure_agent_memory_index() -> None:
             vector_field="embedding",
             dimensions=1536,
             distance_metric="COSINE",
-            database="vectors",
+            database="memory",
         )
         if result.get("message") == "Index already exists":
             logger.info("[ 93%%] Agent Memory Index: idx:agent_memory already exists")


### PR DESCRIPTION
## Thinking Path
Compose/single_user boot warned `Agent memory index creation failed: Cannot create index on db != 0`. RediSearch FT.CREATE only operates on Redis logical DB 0; `_ensure_agent_memory_index()` passed `database="vectors"` which maps to DB 8 (`redis_management/types.py:113`). The `"memory"` alias (DB 0) exists precisely for RediSearch (`types.py:112`), and agent-memory data writes default to `"main"` (DB 0) — so index and data now share DB 0.

## What Changed
- `initialization/lifespan.py` — `_ensure_agent_memory_index()` uses `database="memory"`
- `api/redis_mcp/vector_search.py` — public function + `_get_client` defaults `"vectors"`→`"memory"` with docstrings
- `api/redis_mcp/tools.py` — MCP tool schema defaults corrected (create_index, vector_search, hybrid_search, vector_index_info)
- `api/redis_mcp/router.py` — four `_wrap_*` functions corrected
("vectors"/DB 8 remains for LlamaIndex vector-store data, which writes directly to DB 8 — unchanged.)

## Verification
- `py_compile` all touched files OK; 37/37 semantic_search tests PASS
- Static trace: data keys (`autobot:agent:memory:*`) → DB 0 ("main"); index → DB 0 ("memory") — consistent
- Live Redis unavailable in this env (host placeholder) — runtime FT.CREATE proof deferred to deployed stack

## Model Used
Claude Opus 4.8 (1M context) + senior-backend-engineer agent

Part of umbrella #9919.
Closes #9904
