### PR TITLE
fix(docker): dev-override entrypoints chain with-secrets.sh (#9910)

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -30,7 +30,10 @@ services:
   autobot-backend:
     # Dev entrypoint restores symlinks and pip packages before starting
     # the application. See docker/backend/dev-entrypoint.sh for details.
-    entrypoint: ["/app/docker/backend/dev-entrypoint.sh"]
+    # GH#9910: chained through with-secrets.sh so dev mode also loads the
+    # auto-provisioned signing secret (GH#9905); the /secrets volume and
+    # with-secrets.sh mounts are inherited from the base compose file.
+    entrypoint: ["/bin/sh", "/usr/local/bin/with-secrets.sh", "/app/docker/backend/dev-entrypoint.sh"]
     volumes:
       - ./autobot-backend:/app/autobot-backend
       - ./autobot_shared:/app/autobot_shared
@@ -66,7 +69,10 @@ services:
   autobot-slm:
     # Dev entrypoint restores symlinks, pip packages, and runs migrations
     # before starting the application. Replaces the production entrypoint.
-    entrypoint: ["/app/docker/slm/dev-entrypoint.sh"]
+    # GH#9910: chained through with-secrets.sh so dev mode also loads the
+    # auto-provisioned signing secret (GH#9905); the /secrets volume and
+    # with-secrets.sh mounts are inherited from the base compose file.
+    entrypoint: ["/bin/sh", "/usr/local/bin/with-secrets.sh", "/app/docker/slm/dev-entrypoint.sh"]
     volumes:
       - ./autobot-slm-backend:/app/autobot-slm-backend
       - ./autobot_shared:/app/autobot_shared


### PR DESCRIPTION
## Thinking Path
#9906 auto-provisions signing secrets via the `with-secrets.sh` entrypoint wrapper, but the dev override replaces the entrypoint entirely, bypassing the secret. `with-secrets.sh` ends with `exec "$@"` — purpose-built for chaining — so the fix is to chain the dev entrypoints through it rather than duplicate sourcing logic.

## What Changed
`docker-compose.override.example.yml` (only file): backend + slm dev entrypoints now chain `["/bin/sh", "/usr/local/bin/with-secrets.sh", "<dev-entrypoint>"]`, the same pattern the base compose uses for SLM. No volume/depends_on additions needed — verified the base file's `autobot_secrets:/secrets:ro` mount, `with-secrets.sh` mount, and `service_completed_successfully` dependency survive the override merge.

## Verification
- `docker compose -f docker-compose.yml -f docker-compose.override.example.yml config` parses; merged output inspected (chained entrypoints, secret mounts, depends_on, dev `--reload` command all present)
- `bash -n`/`sh -n` on all entrypoint scripts pass
- Runtime chain simulation (path-rewritten with-secrets.sh): generated secrets propagate through dev-entrypoint to the final command; operator-set values win
- Known gap (per #9906 lessons: `compose config` ≠ `up`): full proof needs a real `docker compose up` + cross-container `printenv AUTOBOT_JWT_SECRET` match — not run here (would boot the 8-service stack)

## Model Used
Claude Opus 4.8 (1M context) + devops-engineer agent

Part of umbrella #9919.
Closes #9910
