### PR TITLE
fix(ci): restore symlink corrupted by relicense — repairs ansible-role-facts-test (#9936)

### DIFF
--- a/autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml
@@ -1,3 +1,1 @@
-# Copyright 2025-2026 mrveiss
-# SPDX-License-Identifier: Apache-2.0
 ../../../inventory/group_vars/all.yml


### PR DESCRIPTION
## Thinking Path
The `ansible-role-facts-test` CI job has been red on every ansible-path PR with `'role_backend_active' is undefined`. Local repro errored even earlier: `failed to combine variables … group_vars/all.yml`. Forensics found the real root cause: the Apache-2.0 relicense commit `e939daf30` (PR #9830) corrupted the repo's **only symlink** — `tests/inventory/group_vars/all.yml` kept git mode 120000 but its target blob had the SPDX header prepended, turning the link target into a 3-line copyright string. The synthetic test inventory therefore stopped loading the canonical `inventory/group_vars/all.yml`.

## What Changed
Restored the symlink to its original target `../../../inventory/group_vars/all.yml` (blob now byte-identical to the #7068 original). The `_no_group_vars` vars_files variant was never broken and is untouched — the group_vars mechanism itself is exercised again, as intended. Scanned all git symlinks repo-wide: this was the only one; no recurring SPDX tooling exists to re-corrupt it.

## Verification (all 4 CI steps run locally, exit 0)
- group_vars codepath: PLAY RECAP all 9 synthetic hosts `failed=0`
- vars_files codepath: all 9 hosts `failed=0`
- `check_role_facts_synced.py`: "OK — 11 role_*_active facts identical"
- `test_clean_yml_loops.yml`: `localhost: ok=80 failed=0`

## Model Used
Claude Opus 4.8 (1M context) + devops-engineer agent

Part of umbrella #9919.
Closes #9936
