### PR TITLE
fix(ansible): co-located wizard — frontend 4b nginx ordering + universal /slm API path (#9952 #9953)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/seed-fleet-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/seed-fleet-nodes.yml
@@ -21,7 +21,7 @@
 #   -e "slm_admin_user=myuser" -e "slm_admin_password=mypass"
 #
 # Override API URL:
-#   -e "slm_api_url=https://<slm-host>"
+#   -e "slm_api_url=https://<slm-host>/slm"
 ---
 - name: Seed Fleet Nodes into SLM Database
   hosts: localhost
@@ -29,7 +29,10 @@
   gather_facts: false
 
   vars:
-    slm_api_url: "https://{{ hostvars['00-SLM-Manager']['ansible_host'] | default('127.0.0.1') }}"
+    # #9953: /slm prefix is the UNIVERSAL SLM API path — served in both
+    # co-located and dedicated nginx modes (#3268). The bare /api/ path routes
+    # to the USER backend on co-located hosts, so SLM auth there returns 401.
+    slm_api_url: "https://{{ hostvars['00-SLM-Manager']['ansible_host'] | default('127.0.0.1') }}/slm"
     slm_admin_user: "admin"
     # Password comes from hostvars (set by slm_manager role) or override
     slm_admin_password: >-

--- a/autobot-slm-backend/ansible/roles/frontend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/frontend/tasks/main.yml
@@ -165,6 +165,28 @@
   when: package_json_path.stat.exists
   tags: ['frontend', 'build']
 
+# #9952: Resolve co-location from the filesystem BEFORE the nginx tasks.
+# The slm_colocated_frontend fact is otherwise only set in Phase 4c
+# (provision-fleet-roles.yml) — during Phase 4b it is undefined, so this role
+# used to enable the standalone site on a co-located manager, the restart
+# handler hit nginx's duplicate-upstream emerg, and the host was dropped
+# before 4c's cleanup. Same detection method Phase 4c uses.
+- name: "Frontend | Stat SLM nginx config to detect co-location (#9952)"
+  ansible.builtin.stat:
+    path: "/etc/nginx/sites-available/{{ slm_nginx_config | default('autobot-slm') }}"
+  register: _frontend_slm_nginx_stat
+  become: true
+  tags: ['frontend', 'nginx']
+
+- name: "Frontend | Set co-location flag from filesystem (#9952)"
+  ansible.builtin.set_fact:
+    slm_colocated_frontend: >-
+      {{
+        (slm_colocated_frontend | default(false) | bool) or
+        (_frontend_slm_nginx_stat.stat.exists | default(false) | bool)
+      }}
+  tags: ['frontend', 'nginx']
+
 # Skip nginx config when co-located with SLM — SLM nginx handles both (#2829)
 - name: "Frontend | Configure nginx"
   template:

--- a/autobot-slm-backend/ansible/roles/vnc/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/vnc/defaults/main.yml
@@ -29,6 +29,9 @@ websockify_service_name: vnc-websockify
 
 # SLM credential auto-registration (#2926)
 vnc_register_credentials: true
-slm_api_url: "https://{{ slm_host | default('127.0.0.1') }}"
+# #9953: /slm prefix is the UNIVERSAL SLM API path — served in both co-located
+# and dedicated nginx modes (#3268). The bare /api/ path routes to the USER
+# backend on co-located hosts, so SLM auth there returns 401.
+slm_api_url: "https://{{ slm_host | default('127.0.0.1') }}/slm"
 slm_admin_user: "admin"
 slm_admin_password: "{{ lookup('env', 'SLM_ADMIN_PASSWORD') | default('admin', true) }}"

--- a/autobot-slm-backend/ansible/roles/xrdp/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/xrdp/defaults/main.yml
@@ -18,6 +18,9 @@ xrdp_bitmap_compression: "true"
 
 # SLM credential auto-registration (mirrors vnc role pattern, #2926)
 xrdp_register_credentials: true
-slm_api_url: "https://{{ slm_host | default('127.0.0.1') }}"
+# #9953: /slm prefix is the UNIVERSAL SLM API path — served in both co-located
+# and dedicated nginx modes (#3268). The bare /api/ path routes to the USER
+# backend on co-located hosts, so SLM auth there returns 401.
+slm_api_url: "https://{{ slm_host | default('127.0.0.1') }}/slm"
 slm_admin_user: "admin"
 slm_admin_password: "{{ lookup('env', 'SLM_ADMIN_PASSWORD') | default('admin', true) }}"


### PR DESCRIPTION
## Thinking Path
The 2026-06-11 verification wizard run (after #9935 merged) got past Phase 4a for the first time — `LimitNOFILE` verified live, Errno-24 spam stopped — but exposed the two remaining failures in the 4a→4c chain (#9281): the frontend role's own Phase 4b nginx handler, and SLM auth hitting the wrong backend on co-located hosts.

## What Changed
**#9952 — frontend role 4b ordering (residual half of #9933):** `slm_colocated_frontend` is only resolved in Phase 4c, so in 4b the role enabled `sites-enabled/autobot-frontend` on the co-located manager → duplicate-upstream emerg → `restart nginx` handler failed → host dropped before 4c's cleanup (verified live: symlink re-created 13:50, manager failed=1). The role now stats `sites-available/autobot-slm` (4c's own detection method) and sets the flag before its nginx tasks — enable is skipped and the role's Disable task cleans up in 4b itself.

**#9953 — `slm_api_url` universal /slm prefix:** vnc/xrdp defaults + seed-fleet-nodes pointed at the bare host root; co-located nginx routes `/api/` to the **user backend** → SLM admin auth 401 on every node. `/slm/api/` is served in **both** nginx modes (#3268 alias, `autobot-slm.conf.j2:218-234`) — defaults now use it. (redis role's direct `:8000` URL is mode-independent — untouched.)

## Verification
- YAML parse OK ×4; `ansible-playbook --syntax-check` clean for `provision-fleet-roles.yml` + `seed-fleet-nodes.yml`
- Live co-located manager: `https://<host>/slm/api/health` → healthy JSON via nginx (the /slm prefix path works); the 4b failure mode reproduced + manually remediated on this host pending this fix

## Model Used
Claude Opus 4.8 (1M context)

Part of umbrella #9919; completes the #9281 4a→4c chain.
Closes #9952
Closes #9953
