### PR TITLE
refactor(llc/frontend): consolidate tree-build, status-color, run-status mapping (#9909)

### DIFF
--- a/autobot-frontend/src/composables/llc/__tests__/llcStatus.test.ts
+++ b/autobot-frontend/src/composables/llc/__tests__/llcStatus.test.ts
@@ -1,0 +1,69 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Author: mrveiss
+ *
+ * Unit tests for the shared LLC status mappings (#9909).
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  agentStatusColor,
+  companyStatusColor,
+  runStatusToAgentStatus,
+  runStatusToRunDisplayStatus,
+} from '../llcStatus'
+
+describe('agentStatusColor', () => {
+  it.each([
+    ['active', 'bg-green-500'],
+    ['idle', 'bg-yellow-400'],
+    ['error', 'bg-red-500'],
+    ['paused', 'bg-gray-400'],
+    ['unknown', 'bg-gray-400'],
+  ])('maps %s → %s', (status, expected) => {
+    expect(agentStatusColor(status)).toBe(expected)
+  })
+})
+
+describe('companyStatusColor', () => {
+  it.each([
+    ['active', 'bg-green-500'],
+    ['paused', 'bg-yellow-400'],
+    ['inactive', 'bg-gray-400'],
+    ['unknown', 'bg-gray-400'],
+  ])('maps %s → %s', (status, expected) => {
+    expect(companyStatusColor(status)).toBe(expected)
+  })
+
+  it('differs from agentStatusColor for paused (yellow vs gray)', () => {
+    expect(companyStatusColor('paused')).toBe('bg-yellow-400')
+    expect(agentStatusColor('paused')).toBe('bg-gray-400')
+  })
+})
+
+describe('runStatusToAgentStatus', () => {
+  it.each([
+    ['running', 'active'],
+    ['failed', 'error'],
+    ['timeout', 'error'],
+    ['interrupted', 'error'],
+    ['completed', 'idle'],
+    [null, 'idle'],
+  ])('maps %s → %s', (raw, expected) => {
+    expect(runStatusToAgentStatus(raw as string | null)).toBe(expected)
+  })
+})
+
+describe('runStatusToRunDisplayStatus', () => {
+  it.each([
+    ['completed', 'done'],
+    ['running', 'running'],
+    ['failed', 'failed'],
+    ['timeout', 'failed'],
+    ['anything-else', 'failed'],
+  ])('maps %s → %s', (raw, expected) => {
+    expect(runStatusToRunDisplayStatus(raw)).toBe(expected)
+  })
+})

--- a/autobot-frontend/src/composables/llc/__tests__/useLlcTree.test.ts
+++ b/autobot-frontend/src/composables/llc/__tests__/useLlcTree.test.ts
@@ -1,0 +1,119 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Author: mrveiss
+ *
+ * Unit tests for the shared LLC tree helpers (#9909).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { markExpanded, buildTreeFromParent, mapTree } from '../useLlcTree'
+
+interface TestNode {
+  id: string
+  children: TestNode[]
+  expanded?: boolean
+}
+
+interface FlatItem {
+  id: string
+  parent_id: string | null
+}
+
+const toNode = (item: FlatItem): TestNode => ({ id: item.id, children: [], expanded: false })
+
+describe('markExpanded', () => {
+  it('expands top-level nodes and collapses all descendants', () => {
+    const tree: TestNode[] = [
+      {
+        id: 'root',
+        expanded: false,
+        children: [
+          { id: 'child', expanded: true, children: [{ id: 'grandchild', expanded: true, children: [] }] },
+        ],
+      },
+    ]
+    markExpanded(tree, true)
+    expect(tree[0].expanded).toBe(true)
+    expect(tree[0].children[0].expanded).toBe(false)
+    expect(tree[0].children[0].children[0].expanded).toBe(false)
+  })
+
+  it('collapses everything when called with false', () => {
+    const tree: TestNode[] = [
+      { id: 'a', expanded: true, children: [{ id: 'b', expanded: true, children: [] }] },
+    ]
+    markExpanded(tree, false)
+    expect(tree[0].expanded).toBe(false)
+    expect(tree[0].children[0].expanded).toBe(false)
+  })
+
+  it('handles an empty forest', () => {
+    expect(() => markExpanded([], true)).not.toThrow()
+  })
+})
+
+describe('buildTreeFromParent', () => {
+  it('assembles a forest from flat parent edges', () => {
+    const flat: FlatItem[] = [
+      { id: 'r1', parent_id: null },
+      { id: 'c1', parent_id: 'r1' },
+      { id: 'c2', parent_id: 'r1' },
+      { id: 'g1', parent_id: 'c1' },
+      { id: 'r2', parent_id: null },
+    ]
+    const roots = buildTreeFromParent(flat, 'id', 'parent_id', toNode)
+    expect(roots.map((r) => r.id)).toEqual(['r1', 'r2'])
+    expect(roots[0].children.map((c) => c.id)).toEqual(['c1', 'c2'])
+    expect(roots[0].children[0].children.map((g) => g.id)).toEqual(['g1'])
+    expect(roots[1].children).toEqual([])
+  })
+
+  it('treats items with an unknown parent as roots', () => {
+    const flat: FlatItem[] = [{ id: 'a', parent_id: 'missing' }]
+    const roots = buildTreeFromParent(flat, 'id', 'parent_id', toNode)
+    expect(roots.map((r) => r.id)).toEqual(['a'])
+  })
+
+  it('treats self-referencing items as roots (no cycle)', () => {
+    const flat: FlatItem[] = [{ id: 'a', parent_id: 'a' }]
+    const roots = buildTreeFromParent(flat, 'id', 'parent_id', toNode)
+    expect(roots.map((r) => r.id)).toEqual(['a'])
+    expect(roots[0].children).toEqual([])
+  })
+
+  it('returns an empty forest for empty input', () => {
+    expect(buildTreeFromParent([] as FlatItem[], 'id', 'parent_id', toNode)).toEqual([])
+  })
+})
+
+describe('mapTree', () => {
+  interface RawNode {
+    name: string
+    children?: RawNode[]
+  }
+
+  it('recursively maps a nested raw tree', () => {
+    const raw: RawNode = {
+      name: 'root',
+      children: [{ name: 'child', children: [{ name: 'grandchild' }] }],
+    }
+    const mapped = mapTree(raw, (item, children: TestNode[]) => ({
+      id: item.name.toUpperCase(),
+      children,
+      expanded: false,
+    }))
+    expect(mapped.id).toBe('ROOT')
+    expect(mapped.children[0].id).toBe('CHILD')
+    expect(mapped.children[0].children[0].id).toBe('GRANDCHILD')
+  })
+
+  it('defaults missing children to an empty array', () => {
+    const mapped = mapTree({ name: 'leaf' } as RawNode, (item, children: TestNode[]) => ({
+      id: item.name,
+      children,
+    }))
+    expect(mapped.children).toEqual([])
+  })
+})

--- a/autobot-frontend/src/composables/llc/llcStatus.ts
+++ b/autobot-frontend/src/composables/llc/llcStatus.ts
@@ -1,0 +1,55 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * Shared LLC status types and display mappings (GH#9909).
+ *
+ * Consolidates the status unions, status-dot color maps, and raw
+ * run-status mappings previously duplicated across OrgTreeNode.vue,
+ * CompanyTreeNode.vue, and CompanyDashboard.vue.
+ *
+ * No generated LLC run-status type exists under src/types or src/api, so
+ * the unions below are the single source of truth for the frontend.
+ */
+
+/** Display status for an LLC agent (org-chart node / dashboard agent grid). */
+export type AgentDisplayStatus = 'active' | 'idle' | 'error' | 'paused'
+
+/** Display status for a heartbeat-run row. */
+export type RunDisplayStatus = 'running' | 'done' | 'failed'
+
+/**
+ * Agent status → tailwind status-dot color.
+ * Exact map shared verbatim by OrgTreeNode.vue and CompanyDashboard.vue
+ * ('paused' and any unknown status fall through to gray).
+ */
+export function agentStatusColor(status: string): string {
+  if (status === 'active') return 'bg-green-500'
+  if (status === 'idle') return 'bg-yellow-400'
+  if (status === 'error') return 'bg-red-500'
+  return 'bg-gray-400'
+}
+
+/**
+ * Company status → tailwind status-dot color (CompanyTreeNode.vue).
+ * NOTE: intentionally different from agentStatusColor — companies have no
+ * 'idle'/'error' states, 'paused' is yellow, and 'inactive'/unknown is gray.
+ */
+export function companyStatusColor(status: string): string {
+  if (status === 'active') return 'bg-green-500'
+  if (status === 'paused') return 'bg-yellow-400'
+  return 'bg-gray-400'
+}
+
+/** Raw heartbeat-run status → agent display status. */
+export function runStatusToAgentStatus(s: string | null): AgentDisplayStatus {
+  if (s === 'running') return 'active'
+  if (s === 'failed' || s === 'timeout' || s === 'interrupted') return 'error'
+  return 'idle'
+}
+
+/** Raw heartbeat-run status → run display status ('completed' → 'done'). */
+export function runStatusToRunDisplayStatus(s: string): RunDisplayStatus {
+  return s === 'completed' ? 'done' : s === 'running' ? 'running' : 'failed'
+}

--- a/autobot-frontend/src/composables/llc/useLlcTree.ts
+++ b/autobot-frontend/src/composables/llc/useLlcTree.ts
@@ -1,0 +1,65 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * Shared LLC tree helpers (GH#9909).
+ *
+ * Consolidates the recursive expand-marker and tree-assembly logic that was
+ * duplicated across GoalTree.vue and SubCompanyTree.vue.
+ */
+
+/** Minimal node shape required by markExpanded(). */
+export interface ExpandableNode {
+  expanded?: boolean
+  children?: ExpandableNode[]
+}
+
+/**
+ * Set the expanded flag on the given nodes; all descendants are collapsed.
+ * Calling with `expanded = true` expands the roots only (matches the
+ * previous per-view behavior in GoalTree.vue / SubCompanyTree.vue).
+ */
+export function markExpanded<T extends ExpandableNode>(nodes: T[], expanded: boolean): void {
+  for (const node of nodes) {
+    node.expanded = expanded
+    if (node.children) markExpanded(node.children, false)
+  }
+}
+
+/**
+ * Assemble a forest from a flat list using id → parent-id edges.
+ * Items with a falsy, unknown, or self-referencing parent become roots.
+ */
+export function buildTreeFromParent<TFlat, TNode extends { children: TNode[] }>(
+  items: TFlat[],
+  idKey: keyof TFlat,
+  parentKey: keyof TFlat,
+  toNode: (item: TFlat) => TNode,
+): TNode[] {
+  const byId = new Map<unknown, TNode>()
+  for (const item of items) byId.set(item[idKey], toNode(item))
+  const roots: TNode[] = []
+  for (const item of items) {
+    const node = byId.get(item[idKey])!
+    const parentId = item[parentKey]
+    const parent = parentId ? byId.get(parentId) : undefined
+    if (parent && parent !== node) parent.children.push(node)
+    else roots.push(node)
+  }
+  return roots
+}
+
+/**
+ * Recursively map an already-nested raw tree (e.g. the company /tree
+ * endpoint response) into a display-node tree.
+ */
+export function mapTree<TRaw extends { children?: TRaw[] }, TNode>(
+  raw: TRaw,
+  toNode: (item: TRaw, children: TNode[]) => TNode,
+): TNode {
+  return toNode(
+    raw,
+    (raw.children ?? []).map((child) => mapTree(child, toNode)),
+  )
+}

--- a/autobot-frontend/src/views/llc/CompanyDashboard.vue
+++ b/autobot-frontend/src/views/llc/CompanyDashboard.vue
@@ -8,12 +8,17 @@ import { useApiClient } from '@/plugins/api'
 import { useWebSocket } from '@/composables/useWebSocket'
 import { getBackendUrl } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import { useLlcCompanyContext } from '@/composables/llc/useLlcCompanyContext'
+import {
+  agentStatusColor,
+  runStatusToAgentStatus,
+  runStatusToRunDisplayStatus,
+} from '@/composables/llc/llcStatus'
+import type { AgentDisplayStatus, RunDisplayStatus } from '@/composables/llc/llcStatus'
 
 const logger = createLogger('CompanyDashboard')
 const api = useApiClient()
-const route = useRoute()
 const router = useRouter()
 const { resolveCompanyId } = useLlcCompanyContext()
 
@@ -25,7 +30,7 @@ interface AgentStatus {
   id: string
   name: string
   title: string
-  status: 'active' | 'idle' | 'error' | 'paused'
+  status: AgentDisplayStatus
   adapter_type: string
   last_heartbeat: string | null
 }
@@ -48,7 +53,7 @@ interface HeartbeatRun {
   agent_id: string
   agent_name: string
   run_id: string
-  status: 'running' | 'done' | 'failed'
+  status: RunDisplayStatus
   started_at: string
   duration_ms: number | null
 }
@@ -81,11 +86,6 @@ interface RawRunRow {
   finished_at: string | null
 }
 
-function runStatusToAgentStatus(s: string | null): AgentStatus['status'] {
-  if (s === 'running') return 'active'
-  if (s === 'failed' || s === 'timeout' || s === 'interrupted') return 'error'
-  return 'idle'
-}
 function mapAgent(r: RawAgentRow): AgentStatus {
   return {
     id: r.id,
@@ -104,8 +104,6 @@ function mapBudget(r: RawBudgetRow): BudgetInfo {
   }
 }
 function mapRun(r: RawRunRow): HeartbeatRun {
-  const status: HeartbeatRun['status'] =
-    r.status === 'completed' ? 'done' : r.status === 'running' ? 'running' : 'failed'
   const duration =
     r.started_at && r.finished_at
       ? new Date(r.finished_at).getTime() - new Date(r.started_at).getTime()
@@ -114,7 +112,7 @@ function mapRun(r: RawRunRow): HeartbeatRun {
     agent_id: r.agent_id,
     agent_name: r.agent_id,
     run_id: r.id,
-    status,
+    status: runStatusToRunDisplayStatus(r.status),
     started_at: r.started_at ?? '',
     duration_ms: duration,
   }
@@ -144,13 +142,6 @@ function handleWsMessage(raw: string) {
   } catch (err) {
     logger.warn('WS parse error', err)
   }
-}
-
-const statusColor = (status: string) => {
-  if (status === 'active') return 'bg-green-500'
-  if (status === 'idle') return 'bg-yellow-400'
-  if (status === 'error') return 'bg-red-500'
-  return 'bg-gray-400'
 }
 
 const budgetPercent = (b: BudgetInfo) =>
@@ -327,7 +318,7 @@ watch(lastMessage, (msg) => {
               class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3 flex flex-col gap-1"
             >
               <div class="flex items-center gap-2">
-                <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" :class="statusColor(agent.status)" />
+                <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" :class="agentStatusColor(agent.status)" />
                 <span class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{{ agent.name }}</span>
               </div>
               <span class="text-xs text-gray-500 truncate">{{ agent.title }}</span>

--- a/autobot-frontend/src/views/llc/CompanyTreeNode.vue
+++ b/autobot-frontend/src/views/llc/CompanyTreeNode.vue
@@ -3,6 +3,8 @@
 // Copyright (c) 2025 mrveiss
 // Author: mrveiss
 
+import { companyStatusColor } from '@/composables/llc/llcStatus'
+
 export interface CompanyNode {
   id: string
   name: string
@@ -26,12 +28,6 @@ const budgetBarColor = (node: CompanyNode) => {
   if (pct >= 70) return 'bg-yellow-400'
   return 'bg-green-500'
 }
-
-const statusColor = (status: string) => {
-  if (status === 'active') return 'bg-green-500'
-  if (status === 'paused') return 'bg-yellow-400'
-  return 'bg-gray-400'
-}
 </script>
 
 <template>
@@ -52,7 +48,7 @@ const statusColor = (status: string) => {
       </button>
       <span v-else class="w-5 flex-shrink-0" />
 
-      <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" :class="statusColor(node.status)" />
+      <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" :class="companyStatusColor(node.status)" />
       <span class="flex-1 font-semibold text-sm text-gray-900 dark:text-gray-100">{{ node.name }}</span>
 
       <div class="flex items-center gap-2 w-32">

--- a/autobot-frontend/src/views/llc/GoalTree.vue
+++ b/autobot-frontend/src/views/llc/GoalTree.vue
@@ -7,6 +7,7 @@ import { ref, onMounted } from 'vue'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import { useLlcCompanyContext } from '@/composables/llc/useLlcCompanyContext'
+import { markExpanded, buildTreeFromParent } from '@/composables/llc/useLlcTree'
 import GoalTreeNode from './GoalTreeNode.vue'
 import type { Goal } from './GoalTreeNode.vue'
 
@@ -27,27 +28,15 @@ interface FlatGoal {
   status: string
 }
 
-/** Assemble a tree from flat goals using parent_goal_id edges. */
-function buildGoalTree(flat: FlatGoal[]): Goal[] {
-  const byId = new Map<string, Goal>()
-  for (const g of flat) {
-    byId.set(g.id, {
-      id: g.id,
-      title: g.title,
-      status: g.status as Goal['status'],
-      linked_item_count: 0,
-      children: [],
-      expanded: false,
-    } as Goal)
-  }
-  const roots: Goal[] = []
-  for (const g of flat) {
-    const node = byId.get(g.id)!
-    const parent = g.parent_goal_id ? byId.get(g.parent_goal_id) : undefined
-    if (parent && parent.id !== node.id) parent.children.push(node)
-    else roots.push(node)
-  }
-  return roots
+function toGoalNode(g: FlatGoal): Goal {
+  return {
+    id: g.id,
+    title: g.title,
+    status: g.status as Goal['status'],
+    linked_item_count: 0,
+    children: [],
+    expanded: false,
+  } as Goal
 }
 
 async function fetchGoals() {
@@ -62,7 +51,7 @@ async function fetchGoals() {
     // No /goals/tree route — fetch flat goals and assemble the tree client-side
     // from parent_goal_id (#9861).
     const flat = await api.get<FlatGoal[]>(`/api/llc/goals?company_id=${cid}`)
-    goals.value = buildGoalTree(flat ?? [])
+    goals.value = buildTreeFromParent(flat ?? [], 'id', 'parent_goal_id', toGoalNode)
     markExpanded(goals.value, true)
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
@@ -70,13 +59,6 @@ async function fetchGoals() {
     error.value = msg
   } finally {
     isLoading.value = false
-  }
-}
-
-function markExpanded(nodes: Goal[], expanded: boolean) {
-  for (const node of nodes) {
-    node.expanded = expanded
-    if (node.children) markExpanded(node.children, false)
   }
 }
 

--- a/autobot-frontend/src/views/llc/OrgTreeNode.vue
+++ b/autobot-frontend/src/views/llc/OrgTreeNode.vue
@@ -3,13 +3,14 @@
 // Copyright (c) 2025 mrveiss
 // Author: mrveiss
 
-import { defineProps, defineEmits } from 'vue'
+import { agentStatusColor } from '@/composables/llc/llcStatus'
+import type { AgentDisplayStatus } from '@/composables/llc/llcStatus'
 
 export interface OrgNode {
   id: string
   name: string
   title: string
-  status: 'active' | 'idle' | 'error' | 'paused'
+  status: AgentDisplayStatus
   adapter_type: string
   is_human: boolean
   last_heartbeat: string | null
@@ -21,15 +22,8 @@ export interface OrgNode {
   expanded?: boolean
 }
 
-const props = defineProps<{ node: OrgNode; depth?: number }>()
+defineProps<{ node: OrgNode; depth?: number }>()
 const emit = defineEmits<{ select: [node: OrgNode] }>()
-
-const statusColor = (status: string) => {
-  if (status === 'active') return 'bg-green-500'
-  if (status === 'idle') return 'bg-yellow-400'
-  if (status === 'error') return 'bg-red-500'
-  return 'bg-gray-400'
-}
 </script>
 
 <template>
@@ -50,7 +44,7 @@ const statusColor = (status: string) => {
       <p class="text-xs font-semibold text-gray-900 dark:text-gray-100 truncate">{{ node.name }}</p>
       <p class="text-xs text-gray-500 truncate">{{ node.title }}</p>
       <div class="flex justify-center items-center gap-1 mt-1">
-        <span class="w-2 h-2 rounded-full" :class="statusColor(node.status)" />
+        <span class="w-2 h-2 rounded-full" :class="agentStatusColor(node.status)" />
         <span class="text-xs text-gray-400">{{ node.adapter_type }}</span>
       </div>
     </div>

--- a/autobot-frontend/src/views/llc/SubCompanyTree.vue
+++ b/autobot-frontend/src/views/llc/SubCompanyTree.vue
@@ -7,6 +7,7 @@ import { ref, onMounted } from 'vue'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import { useRouter } from 'vue-router'
+import { markExpanded, mapTree } from '@/composables/llc/useLlcTree'
 import CompanyTreeNode from './CompanyTreeNode.vue'
 import type { CompanyNode } from './CompanyTreeNode.vue'
 
@@ -33,7 +34,7 @@ function statusOf(llcStatus?: string): CompanyNode['status'] {
   return 'inactive'
 }
 
-function mapNode(raw: RawCompanyTreeNode): CompanyNode {
+function toCompanyNode(raw: RawCompanyTreeNode, children: CompanyNode[]): CompanyNode {
   return {
     id: raw.id,
     name: raw.name,
@@ -42,7 +43,7 @@ function mapNode(raw: RawCompanyTreeNode): CompanyNode {
     // budget-aware tree endpoint exists (#9861).
     budget_spent: 0,
     budget_total: 0,
-    children: (raw.children ?? []).map(mapNode),
+    children,
     expanded: false,
   }
 }
@@ -57,7 +58,7 @@ async function fetchTree() {
     const subtrees = await Promise.all(
       (roots ?? []).map((c) => api.get<RawCompanyTreeNode>(`/api/llc/companies/${c.id}/tree`)),
     )
-    tree.value = subtrees.filter(Boolean).map(mapNode)
+    tree.value = subtrees.filter(Boolean).map((subtree) => mapTree(subtree, toCompanyNode))
     markExpanded(tree.value, true)
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
@@ -65,13 +66,6 @@ async function fetchTree() {
     error.value = msg
   } finally {
     isLoading.value = false
-  }
-}
-
-function markExpanded(nodes: CompanyNode[], expanded: boolean) {
-  for (const node of nodes) {
-    node.expanded = expanded
-    if (node.children) markExpanded(node.children, false)
   }
 }
 


### PR DESCRIPTION
## Thinking Path
Retrospective of the LLC ship (#9861/PR #9902) surfaced copy-paste duplication across `views/llc/`: an identical recursive `markExpanded` in two trees, parent-pointer forest assembly in two shapes, a status→tailwind color map duplicated 3×, and two run-status translations inline in CompanyDashboard. Consolidated into two shared composables; one color map (`CompanyTreeNode`) is genuinely different (`paused→yellow`, no idle/error keys) so it stays a separate `companyStatusColor()` with a unit test pinning the divergence.

## What Changed
- NEW `src/composables/llc/useLlcTree.ts` — `markExpanded`, generic `buildTreeFromParent(items, idKey, parentKey, toNode)`, `mapTree`
- NEW `src/composables/llc/llcStatus.ts` — `AgentDisplayStatus`/`RunDisplayStatus` unions, `agentStatusColor`, `companyStatusColor`, `runStatusToAgentStatus`, `runStatusToRunDisplayStatus`
- Consumers rewired: `GoalTree.vue`, `SubCompanyTree.vue`, `OrgTreeNode.vue`, `CompanyTreeNode.vue`, `CompanyDashboard.vue`
- Zero-behavior cleanups in touched files: removed OrgTreeNode's invalid `import { defineProps, defineEmits } from 'vue'` (fixes 2 pre-existing TS2440) and CompanyDashboard's unused `useRoute`

NO behavior change — code-reviewer verified line-by-line parity of every replaced function (orderings, orphan handling, else-branches, null fallbacks).

## Verification
- `npx vitest run src/composables/llc/__tests__/` → 30/30 passed (orphan-parent, self-reference, empty input, paused-divergence, null run-status all pinned)
- `npx vue-tsc --noEmit -p tsconfig.app.json` → zero new errors; 2 pre-existing errors fixed
- eslint on all 9 touched files → clean
- grep audit: only the shared modules + import sites remain in LLC code

## Model Used
Fable 5 (main session) + Sonnet sub-agents (implementation + independent code review)

Fixes #9909

🤖 Generated with [Claude Code](https://claude.com/claude-code)