### PR TITLE
fix(code-sync): protect .env and data via shared exclude chokepoint (#9970)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -611,6 +611,21 @@ _SLM_COMPONENTS = [
 ]
 
 
+# #9970: secret/runtime paths that must survive every sync. The deployed .env
+# is the systemd EnvironmentFile (#2824) and exists only in the deployment --
+# a delete-style sync without these excludes removes it and the service cannot
+# start ("Failed to load environment files"). `data` holds per-service runtime
+# state with the same property. Applied at the rsync chokepoint so no caller
+# or future component list can forget them.
+_PROTECTED_EXCLUDES: List[str] = [".env", "data"]
+
+
+def _rsync_exclude_args(excludes: List[str]) -> List[str]:
+    """Build --exclude args from caller excludes plus protected paths (#9970)."""
+    merged = list(dict.fromkeys([*excludes, *_PROTECTED_EXCLUDES]))
+    return [f"--exclude={exc}" for exc in merged]
+
+
 async def _rsync_component(
     source_user: str,
     source_ip: str,
@@ -632,8 +647,7 @@ async def _rsync_component(
         ssh_opts,
         "--rsync-path=sudo rsync",  # source may need root to read e.g. /home/${USER:-autobot}/  # noqa
     ]
-    for exc in excludes:
-        cmd.append(f"--exclude={exc}")
+    cmd.extend(_rsync_exclude_args(excludes))
     cmd.append(f"{source_user}@{source_ip}:{source_path}/{component}/")
     cmd.append(f"/opt/autobot/{component}/")
 
@@ -666,8 +680,7 @@ async def _rsync_component_local(
     Used when source_ip matches the SLM server's own IP — no SSH needed.
     """
     cmd = ["rsync", "-avz", "--delete", "--no-group", "--no-owner"]
-    for exc in excludes:
-        cmd.append(f"--exclude={exc}")
+    cmd.extend(_rsync_exclude_args(excludes))
     cmd.append(f"{source_path}/{component}/")
     cmd.append(f"/opt/autobot/{component}/")
     try:

--- a/autobot-slm-backend/tests/api/test_code_sync_protected_excludes.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_protected_excludes.py
@@ -1,0 +1,54 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression tests for the protected rsync excludes (#9970).
+
+The deployed .env (systemd EnvironmentFile, #2824) and runtime data dirs
+exist only in the deployment — a delete-style rsync without these excludes
+removes them and the synced service cannot start. The protection is applied
+at the rsync chokepoint (_rsync_exclude_args) so no component list or
+caller can forget it.
+"""
+
+from __future__ import annotations
+
+# Add autobot-slm-backend to path so api.code_sync imports resolve.
+import sys
+from pathlib import Path
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+from api.code_sync import (  # noqa: E402
+    _PROTECTED_EXCLUDES,
+    _SLM_COMPONENTS,
+    _rsync_exclude_args,
+)
+
+
+def test_protected_excludes_cover_env_and_data() -> None:
+    assert ".env" in _PROTECTED_EXCLUDES
+    assert "data" in _PROTECTED_EXCLUDES
+
+
+def test_exclude_args_always_include_protected_paths() -> None:
+    args = _rsync_exclude_args([])
+    assert "--exclude=.env" in args
+    assert "--exclude=data" in args
+
+
+def test_exclude_args_for_every_component_list() -> None:
+    for component, excludes in _SLM_COMPONENTS:
+        args = _rsync_exclude_args(excludes)
+        assert "--exclude=.env" in args, f"{component} sync would delete .env"
+        assert "--exclude=data" in args, f"{component} sync would delete data"
+        # caller excludes are preserved
+        for exc in excludes:
+            assert f"--exclude={exc}" in args
+
+
+def test_exclude_args_deduplicate() -> None:
+    args = _rsync_exclude_args([".env", "venv", "venv"])
+    assert args.count("--exclude=.env") == 1
+    assert args.count("--exclude=venv") == 1


### PR DESCRIPTION
## Thinking Path
Operator ran Code Sync from the UI; `autobot-backend.service` died with `Failed to load environment files` — the sync removed the deployed `.env` (systemd EnvironmentFile, #2824), which exists only in the deployment, because no exclude list in `code_sync.py` contained it (or `data`). Recovery required restoring from `/etc/autobot/autobot-backend.env` + `systemctl reset-failed`.

## What Changed
- `_PROTECTED_EXCLUDES = [".env", "data"]` merged into the exclude args **inside both sync builders** (`_rsync_component`, `_rsync_component_local`) via a new `_rsync_exclude_args()` chokepoint — callers and future component lists cannot forget it; duplicates deduped.
- Regression tests (`tests/api/test_code_sync_protected_excludes.py`): protected paths present for empty excludes and for **every** `_SLM_COMPONENTS` entry; caller excludes preserved; dedupe.

## Verification
- All 4 test bodies pass (verified via segment-level execution locally; the full pytest collection needs CI's venv — pre-existing local python_multipart breakage)
- `py_compile` clean
- Mirrors the Ansible roles' exclusion behavior and the repo safety-hook contract

## Model Used
Claude Opus 4.8 (1M context)

Production-protective fix for today's live incident. Closes #9970
