### PR TITLE
refactor(llc/adapters): share probe_pid/terminate_pid primitives in subprocess_support (#9839)

### DIFF
--- a/autobot-backend/llc/adapters/process_adapter.py
+++ b/autobot-backend/llc/adapters/process_adapter.py
@@ -18,15 +18,16 @@ The ``run_id`` is the string-encoded PID of the spawned process.
 import asyncio
 import json
 import os
-import signal
 
 from autobot_shared.logging_manager import get_logger
 
 from ..models.enums import LLCRunStatus
 from .base import AdapterRunStatus
+from .subprocess_support import probe_pid, terminate_pid
 
 logger = get_logger(__name__)
 
+_LOG_NAME = "ProcessAdapter"
 _SIGTERM_GRACE_SECONDS = 5
 
 
@@ -56,38 +57,13 @@ class ProcessAdapter:
             pid = int(run_id)
         except ValueError as exc:
             return AdapterRunStatus(status=LLCRunStatus.FAILED, error=str(exc))
-        try:
-            # Signal 0 checks existence without delivering a signal.
-            os.kill(pid, 0)
-            return AdapterRunStatus(status=LLCRunStatus.RUNNING)
-        except ProcessLookupError:
-            # PID gone — we cannot recover exit code after the fact without
-            # holding a Popen handle, so report completed.
-            return AdapterRunStatus(status=LLCRunStatus.COMPLETED)
-        except PermissionError:
-            # Process exists but we can't signal it (different uid).
-            return AdapterRunStatus(status=LLCRunStatus.RUNNING)
-        except OSError as exc:
-            return AdapterRunStatus(status=LLCRunStatus.FAILED, error=str(exc))
+        return probe_pid(pid)
 
     async def cancel(self, agent_config: dict, run_id: str) -> None:
         pid = int(run_id)
-        try:
-            os.kill(pid, signal.SIGTERM)
-            logger.info("ProcessAdapter: sent SIGTERM to PID %d", pid)
-        except ProcessLookupError:
-            return  # already gone
-
-        # Wait for graceful exit; escalate to SIGKILL if needed.
-        for _ in range(_SIGTERM_GRACE_SECONDS * 10):
-            await asyncio.sleep(0.1)
-            try:
-                os.kill(pid, 0)
-            except ProcessLookupError:
-                return
-
-        try:
-            os.kill(pid, signal.SIGKILL)
-            logger.warning("ProcessAdapter: SIGKILL sent to PID %d (did not exit after SIGTERM)", pid)
-        except ProcessLookupError:
-            pass
+        # terminate_pid returns True when the process was already gone
+        # (SIGTERM raised ProcessLookupError) — match the original early-return
+        # behavior: no further action needed when the process is already dead.
+        already_gone = await terminate_pid(pid, _SIGTERM_GRACE_SECONDS, _LOG_NAME)
+        if already_gone:
+            return

--- a/autobot-backend/llc/adapters/subprocess_base.py
+++ b/autobot-backend/llc/adapters/subprocess_base.py
@@ -22,12 +22,10 @@ A subclass provides:
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 import pathlib
 import shutil
-import signal
 import time
 from typing import Callable, Optional
 
@@ -35,7 +33,7 @@ from autobot_shared.logging_manager import get_logger
 
 from ..models.enums import LLCRunStatus
 from .base import AdapterRunStatus
-from .subprocess_support import render_context_markdown
+from .subprocess_support import probe_pid, render_context_markdown, terminate_pid
 
 logger = get_logger(__name__)
 
@@ -117,7 +115,7 @@ class SubprocessLifecycleAdapter:
                 pid = int(run_id.split("/")[0])
             except (ValueError, IndexError):
                 return AdapterRunStatus(status=LLCRunStatus.FAILED, error=f"Unparseable run_id: {run_id!r}")
-            return self._probe_pid(pid)
+            return probe_pid(pid)
 
         pid: int = state["pid"]
         timeout_sec: float = state.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
@@ -128,18 +126,7 @@ class SubprocessLifecycleAdapter:
             await self.cancel(agent_config, run_id)
             return AdapterRunStatus(status=LLCRunStatus.TIMEOUT)
 
-        return self._probe_pid(pid)
-
-    def _probe_pid(self, pid: int) -> AdapterRunStatus:
-        try:
-            os.kill(pid, 0)
-            return AdapterRunStatus(status=LLCRunStatus.RUNNING)
-        except ProcessLookupError:
-            return AdapterRunStatus(status=LLCRunStatus.COMPLETED)
-        except PermissionError:
-            return AdapterRunStatus(status=LLCRunStatus.RUNNING)
-        except OSError as exc:
-            return AdapterRunStatus(status=LLCRunStatus.FAILED, error=str(exc))
+        return probe_pid(pid)
 
     # Cancel ----------------------------------------------------------------
     async def cancel(self, agent_config: dict, run_id: str) -> None:
@@ -158,24 +145,11 @@ class SubprocessLifecycleAdapter:
             logger.error("%s.cancel: unparseable run_id %r", self._LOG_NAME, run_id)
             return
 
-        try:
-            os.kill(pid, signal.SIGTERM)
-            logger.info("%s: SIGTERM -> PID %d", self._LOG_NAME, pid)
-        except ProcessLookupError:
-            pass
-        else:
-            for _ in range(SIGTERM_GRACE_SECONDS * 10):
-                await asyncio.sleep(0.1)
-                try:
-                    os.kill(pid, 0)
-                except ProcessLookupError:
-                    break
-            else:
-                try:
-                    os.kill(pid, signal.SIGKILL)
-                    logger.warning("%s: SIGKILL -> PID %d", self._LOG_NAME, pid)
-                except ProcessLookupError:
-                    pass
+        # terminate_pid returns True when the process was already gone
+        # (SIGTERM raised ProcessLookupError); we still continue to
+        # _post_cancel and state-file cleanup regardless — the process
+        # must be fully cleaned up whether or not it was already dead.
+        await terminate_pid(pid, SIGTERM_GRACE_SECONDS, self._LOG_NAME)
 
         await self._post_cancel(agent_config, run_id)
 

--- a/autobot-backend/llc/adapters/subprocess_support.py
+++ b/autobot-backend/llc/adapters/subprocess_support.py
@@ -29,9 +29,9 @@ from typing import Any
 
 from autobot_shared.logging_manager import get_logger
 
+from ..config import AGENT_API_BASE_URL, AGENT_API_KEY_PLACEHOLDER
 from ..models.enums import LLCRunStatus
 from .base import AdapterRunStatus
-from ..config import AGENT_API_BASE_URL, AGENT_API_KEY_PLACEHOLDER
 
 _logger = get_logger(__name__)
 

--- a/autobot-backend/llc/adapters/subprocess_support.py
+++ b/autobot-backend/llc/adapters/subprocess_support.py
@@ -21,10 +21,19 @@ prompts, no API key, and a leaked key in the context blob.
 
 from __future__ import annotations
 
+import asyncio
 import json
+import os
+import signal
 from typing import Any
 
+from autobot_shared.logging_manager import get_logger
+
+from ..models.enums import LLCRunStatus
+from .base import AdapterRunStatus
 from ..config import AGENT_API_BASE_URL, AGENT_API_KEY_PLACEHOLDER
+
+_logger = get_logger(__name__)
 
 # Context keys rendered by dedicated prompt sections or consumed as env vars —
 # excluded from the generic "Additional Context" catch-all.
@@ -154,9 +163,66 @@ def inject_agent_credentials(env: dict, context: dict) -> None:
         env["AUTOBOT_LLC_API_BASE"] = api_base
 
 
+def probe_pid(pid: int) -> AdapterRunStatus:
+    """Return an :class:`AdapterRunStatus` reflecting the liveness of *pid*.
+
+    Uses ``os.kill(pid, 0)`` (signal 0 — existence check, no delivery):
+
+    * RUNNING    — process exists and is signallable
+    * COMPLETED  — ``ProcessLookupError`` (PID gone; we have no exit code)
+    * RUNNING    — ``PermissionError`` (process exists, different uid)
+    * FAILED     — any other ``OSError``
+    """
+    try:
+        os.kill(pid, 0)
+        return AdapterRunStatus(status=LLCRunStatus.RUNNING)
+    except ProcessLookupError:
+        return AdapterRunStatus(status=LLCRunStatus.COMPLETED)
+    except PermissionError:
+        return AdapterRunStatus(status=LLCRunStatus.RUNNING)
+    except OSError as exc:
+        return AdapterRunStatus(status=LLCRunStatus.FAILED, error=str(exc))
+
+
+async def terminate_pid(pid: int, grace_seconds: int, log_name: str) -> bool:
+    """Send SIGTERM to *pid*, poll for exit, then SIGKILL if needed.
+
+    Returns ``True`` if the process was already gone when SIGTERM was sent
+    (``ProcessLookupError`` on the initial signal), ``False`` otherwise.
+    Callers that want to short-circuit on an already-dead process should
+    check the return value; callers with post-cancel cleanup to do can
+    ignore it.
+
+    The grace poll uses 0.1 s intervals for *grace_seconds* seconds before
+    escalating to SIGKILL.
+    """
+    try:
+        os.kill(pid, signal.SIGTERM)
+        _logger.info("%s: SIGTERM -> PID %d", log_name, pid)
+    except ProcessLookupError:
+        return True
+
+    for _ in range(grace_seconds * 10):
+        await asyncio.sleep(0.1)
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+
+    try:
+        os.kill(pid, signal.SIGKILL)
+        _logger.warning("%s: SIGKILL -> PID %d", log_name, pid)
+    except ProcessLookupError:
+        pass
+
+    return False
+
+
 __all__ = [
     "AGENT_API_KEY_PLACEHOLDER",
     "render_context_markdown",
     "serialize_invoke_context",
     "inject_agent_credentials",
+    "probe_pid",
+    "terminate_pid",
 ]

--- a/autobot-backend/llc/adapters/tests/test_subprocess_support.py
+++ b/autobot-backend/llc/adapters/tests/test_subprocess_support.py
@@ -1,16 +1,23 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Tests for shared subprocess-adapter helpers (GH#9789, GH#9769, GH#9777)."""
+"""Tests for shared subprocess-adapter helpers (GH#9789, GH#9769, GH#9777, GH#9839)."""
 
 import json
+import signal
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from llc.adapters.subprocess_support import (
     AGENT_API_KEY_PLACEHOLDER,
     inject_agent_credentials,
+    probe_pid,
     render_context_markdown,
     serialize_invoke_context,
+    terminate_pid,
 )
+from llc.models.enums import LLCRunStatus
 
 
 class TestRenderContextMarkdown:
@@ -79,3 +86,107 @@ class TestInjectAgentCredentials:
         assert "AUTOBOT_LLC_API_KEY" not in env
         # api_base falls back to the module default
         assert env.get("AUTOBOT_LLC_API_BASE")
+
+
+# ---------------------------------------------------------------------------
+# probe_pid (GH#9839)
+# ---------------------------------------------------------------------------
+
+
+class TestProbePid:
+    def test_running_when_kill_succeeds(self) -> None:
+        with patch("os.kill", return_value=None):
+            result = probe_pid(12345)
+        assert result.status is LLCRunStatus.RUNNING
+
+    def test_completed_on_process_lookup_error(self) -> None:
+        with patch("os.kill", side_effect=ProcessLookupError):
+            result = probe_pid(99999)
+        assert result.status is LLCRunStatus.COMPLETED
+
+    def test_running_on_permission_error(self) -> None:
+        with patch("os.kill", side_effect=PermissionError):
+            result = probe_pid(1)
+        assert result.status is LLCRunStatus.RUNNING
+
+    def test_failed_on_oserror(self) -> None:
+        with patch("os.kill", side_effect=OSError("bad fd")):
+            result = probe_pid(12345)
+        assert result.status is LLCRunStatus.FAILED
+        assert "bad fd" in (result.error or "")
+
+    def test_uses_signal_zero(self) -> None:
+        calls = []
+
+        def capture(pid, sig):
+            calls.append((pid, sig))
+
+        with patch("os.kill", side_effect=capture):
+            probe_pid(42)
+
+        assert calls == [(42, 0)]
+
+
+# ---------------------------------------------------------------------------
+# terminate_pid (GH#9839)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestTerminatePid:
+    async def test_returns_true_when_already_gone(self) -> None:
+        # SIGTERM immediately raises ProcessLookupError → process was already dead.
+        with patch("os.kill", side_effect=ProcessLookupError):
+            result = await terminate_pid(99999, grace_seconds=1, log_name="Test")
+        assert result is True
+
+    async def test_returns_false_when_process_exits_during_grace(self) -> None:
+        # SIGTERM succeeds; first poll raises ProcessLookupError (process gone).
+        kill_calls = []
+
+        def smart_kill(pid, sig):
+            kill_calls.append(sig)
+            if sig == 0:
+                raise ProcessLookupError  # gone after SIGTERM
+
+        with patch("os.kill", side_effect=smart_kill):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                result = await terminate_pid(12345, grace_seconds=1, log_name="Test")
+
+        assert result is False
+        assert signal.SIGTERM in kill_calls
+        assert signal.SIGKILL not in kill_calls
+
+    async def test_sigkill_sent_when_grace_expires(self) -> None:
+        # SIGTERM succeeds; signal-0 always succeeds (process never exits).
+        kill_calls = []
+
+        def stubborn_kill(pid, sig):
+            kill_calls.append(sig)
+            # signal 0 always returns (process alive); SIGKILL succeeds too.
+
+        with patch("os.kill", side_effect=stubborn_kill):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                result = await terminate_pid(12345, grace_seconds=1, log_name="Test")
+
+        assert result is False
+        assert signal.SIGTERM in kill_calls
+        assert signal.SIGKILL in kill_calls
+
+    async def test_sigkill_tolerates_already_gone(self) -> None:
+        # SIGTERM succeeds; signal-0 always succeeds (never exits); SIGKILL raises
+        # ProcessLookupError — should not propagate.
+        sigkill_count = [0]
+
+        def kill_fn(pid, sig):
+            if sig == signal.SIGKILL:
+                sigkill_count[0] += 1
+                raise ProcessLookupError
+            # SIGTERM: pass; signal-0: pass (alive)
+
+        with patch("os.kill", side_effect=kill_fn):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                result = await terminate_pid(12345, grace_seconds=1, log_name="Test")
+
+        assert result is False
+        assert sigkill_count[0] == 1  # SIGKILL was attempted once


### PR DESCRIPTION
## Thinking Path
PR #9835 extracted `SubprocessLifecycleAdapter` for the CLI adapters, but `process_adapter.py` still hand-rolled the same two primitives: the `os.kill(pid, 0)` status probe and the SIGTERM → grace-poll → SIGKILL loop. ProcessAdapter can't inherit the full lifecycle base (no state file — run_id is a bare PID), but the two pure primitives are shareable. The one real semantic difference between the originals — ProcessAdapter early-returns when SIGTERM finds the process already gone, while the lifecycle base always continues to state-file cleanup — is preserved via `terminate_pid`'s `already_gone` return value, which ProcessAdapter checks and the lifecycle base deliberately ignores.

## What Changed
- `llc/adapters/subprocess_support.py`: new `probe_pid(pid) -> AdapterRunStatus` and `async terminate_pid(pid, grace_seconds, log_name) -> bool`
- `llc/adapters/subprocess_base.py`: `_probe_pid` + inline cancel loop replaced with shared calls (grace 10, unchanged)
- `llc/adapters/process_adapter.py`: inline probe + cancel loop replaced (grace 5, unchanged)
- `llc/adapters/tests/test_subprocess_support.py`: 9 new tests — all probe branches, already-gone, exit-during-grace, grace-expiry SIGKILL, SIGKILL-tolerates-gone

## Verification
- 128/128 full adapter suite (reviewer re-ran independently); 19/19 in the new test file, 0.31s (asyncio.sleep mocked — no real sleeps)
- Independent code-reviewer verdict APPROVE: probe/terminate parity EXACT vs both originals (exception clause order, 0.1s poll, SIGKILL conditions, PermissionError propagation); existing caller-level tests pin the ProcessLookupError contract
- grep: SIGTERM/SIGKILL/os.kill logic now exists only in subprocess_support.py
- Known accepted delta: SIGTERM/SIGKILL log lines now emit under the shared module's logger (adapter identity preserved in message text via log_name)

## Model Used
Fable 5 (main session) + Sonnet sub-agents (implementation + independent review)

Fixes #9839

🤖 Generated with [Claude Code](https://claude.com/claude-code)