### PR TITLE
feat(llc/budget): token-based budget mode with shadow cost tracking (#8997)

### DIFF
--- a/autobot-backend/llc/api/budget.py
+++ b/autobot-backend/llc/api/budget.py
@@ -232,10 +232,24 @@ async def update_limit(
     # GH#8462: pass Decimal directly — Pydantic already validates it as Decimal,
     # no str() conversion needed (which would silently coerce to TEXT in the ORM).
     # GH#8997: support budget_mode and token_limit updates.
+    # Validate mode-appropriate fields (GH#8997 "not both"):
+    # - Setting token_limit while explicitly targeting dollars mode is rejected.
+    # - Setting budget_limit while explicitly targeting tokens mode is rejected.
+    effective_mode = body.budget_mode if body.budget_mode is not None else str(row.budget_mode)
+    if body.budget_mode is not None and body.budget_mode not in ("dollars", "tokens"):
+        raise HTTPException(status_code=400, detail="budget_mode must be 'dollars' or 'tokens'")
+    if effective_mode == "dollars" and body.token_limit is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="token_limit cannot be set when budget_mode is 'dollars'",
+        )
+    if effective_mode == "tokens" and body.budget_limit is not None and body.budget_mode == "tokens":
+        raise HTTPException(
+            status_code=400,
+            detail="budget_limit cannot be set when switching to budget_mode 'tokens'; set token_limit instead",
+        )
     values: dict = {}
     if body.budget_mode is not None:
-        if body.budget_mode not in ("dollars", "tokens"):
-            raise HTTPException(status_code=400, detail="budget_mode must be 'dollars' or 'tokens'")
         values["budget_mode"] = body.budget_mode
     if body.budget_limit is not None:
         values["budget_limit"] = body.budget_limit

--- a/autobot-backend/llc/api/budget.py
+++ b/autobot-backend/llc/api/budget.py
@@ -243,6 +243,10 @@ async def update_limit(
             status_code=400,
             detail="token_limit cannot be set when budget_mode is 'dollars'",
         )
+    # Asymmetry is deliberate: budget_limit on a row ALREADY in tokens mode is
+    # allowed — it adjusts the dollar fallback used when token_limit is unset
+    # (see watchdog/check_budget fallback semantics). Only the explicit switch
+    # to tokens mode rejects a simultaneous budget_limit.
     if effective_mode == "tokens" and body.budget_limit is not None and body.budget_mode == "tokens":
         raise HTTPException(
             status_code=400,
@@ -264,8 +268,11 @@ async def update_limit(
     await session.execute(update(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id).values(**values))
     await session.refresh(row)
 
-    svc = BudgetService()
-    remaining, is_over, alert = await svc.check_budget(session, agent_id)
+    # Drop the tracker cache so readers (watchdog, check_budget) see the new
+    # mode/limit immediately instead of the pre-PATCH state for up to its TTL,
+    # and derive the response from the freshly refreshed row.
+    await BudgetService.invalidate_cache(agent_id)
+    remaining, is_over, alert = _derive_status(row)
     return _build_response(row, remaining, is_over, alert)
 
 

--- a/autobot-backend/llc/scheduler/budget_watchdog.py
+++ b/autobot-backend/llc/scheduler/budget_watchdog.py
@@ -91,9 +91,7 @@ class BudgetWatchdog:
           BudgetService.check_budget / _derive_status semantics.
         """
         result = await session.execute(
-            select(LLCAgentBudget).where(
-                or_(LLCAgentBudget.budget_limit > 0, LLCAgentBudget.token_limit > 0)
-            )
+            select(LLCAgentBudget).where(or_(LLCAgentBudget.budget_limit > 0, LLCAgentBudget.token_limit > 0))
         )
         rows = list(result.scalars().all())
 

--- a/autobot-backend/llc/scheduler/budget_watchdog.py
+++ b/autobot-backend/llc/scheduler/budget_watchdog.py
@@ -82,16 +82,28 @@ class BudgetWatchdog:
     # ------------------------------------------------------------------
 
     async def _check_agent_budgets(self, session: AsyncSession) -> None:
-        """Check all agent budget rows for threshold violations."""
-        result = await session.execute(select(LLCAgentBudget).where(LLCAgentBudget.budget_limit > 0))
+        """Check all agent budget rows for threshold violations (GH#8997).
+
+        Evaluates each agent in its active budget mode:
+        - DOLLARS: ratio = budget_spent / budget_limit
+        - TOKENS: ratio = tokens_spent / token_limit (only when token_limit > 0)
+        """
+        result = await session.execute(select(LLCAgentBudget))
         rows = list(result.scalars().all())
 
         for row in rows:
-            spent = Decimal(str(row.budget_spent))
-            limit = Decimal(str(row.budget_limit))
-            if limit <= Decimal("0"):
-                continue
-            ratio = spent / limit
+            budget_mode = str(row.budget_mode)
+            if budget_mode == "tokens":
+                token_limit = int(row.token_limit) if row.token_limit is not None else 0
+                if token_limit <= 0:
+                    continue
+                tokens_spent = int(row.tokens_spent)
+                ratio = Decimal(str(tokens_spent)) / Decimal(str(token_limit))
+            else:
+                limit = Decimal(str(row.budget_limit))
+                if limit <= Decimal("0"):
+                    continue
+                ratio = Decimal(str(row.budget_spent)) / limit
 
             if ratio >= _HARD_THRESHOLD:
                 await self._hard_stop_agent(session, row)
@@ -99,25 +111,40 @@ class BudgetWatchdog:
                 await self._notify_agent_soft(row, ratio)
 
     async def _hard_stop_agent(self, session: AsyncSession, row: LLCAgentBudget) -> None:
-        """Idempotent hard stop: pause the agent if not already paused."""
+        """Idempotent hard stop: pause the agent if not already paused (GH#8997)."""
         try:
             # BudgetService.check_budget returns (remaining, is_over, alert)
             _, is_over, _ = await self._budget_svc.check_budget(session, row.agent_id)
             if not is_over:
                 return  # race condition — already under limit, skip
-            logger.warning(
-                "BudgetWatchdog: agent %s has exhausted budget (%.2f / %.2f) — hard stop",
-                row.agent_id,
-                float(row.budget_spent),
-                float(row.budget_limit),
-            )
+            budget_mode = str(row.budget_mode)
+            if budget_mode == "tokens":
+                spent_val = int(row.tokens_spent)
+                limit_val = int(row.token_limit) if row.token_limit is not None else 0
+                logger.warning(
+                    "BudgetWatchdog: agent %s exhausted token budget (%d / %d) — hard stop",
+                    row.agent_id,
+                    spent_val,
+                    limit_val,
+                )
+            else:
+                spent_val = float(row.budget_spent)
+                limit_val = float(row.budget_limit)
+                logger.warning(
+                    "BudgetWatchdog: agent %s exhausted dollar budget (%.2f / %.2f) — hard stop",
+                    row.agent_id,
+                    spent_val,
+                    limit_val,
+                )
             await self._notify(
                 company_id=row.company_id,
                 event_type="budget.hard_stop",
                 payload={
                     "agent_id": row.agent_id,
-                    "spent": float(row.budget_spent),
-                    "limit": float(row.budget_limit),
+                    "budget_mode": budget_mode,
+                    "spent": spent_val,
+                    "limit": limit_val,
+                    "shadow_cost_usd": float(row.budget_spent) if budget_mode == "tokens" else None,
                     "ts": datetime.now(tz=timezone.utc).isoformat(),
                 },
             )
@@ -127,20 +154,28 @@ class BudgetWatchdog:
             logger.exception("hard_stop_agent failed for %s (swallowed)", row.agent_id)
 
     async def _notify_agent_soft(self, row: LLCAgentBudget, ratio: Decimal) -> None:
-        """Publish soft-threshold notification."""
+        """Publish soft-threshold notification (GH#8997)."""
         try:
             logger.info(
                 "BudgetWatchdog: agent %s at %.0f%% of budget — soft alert",
                 row.agent_id,
                 float(ratio) * 100,
             )
+            budget_mode = str(row.budget_mode)
+            if budget_mode == "tokens":
+                spent_val = int(row.tokens_spent)
+                limit_val = int(row.token_limit) if row.token_limit is not None else 0
+            else:
+                spent_val = float(row.budget_spent)
+                limit_val = float(row.budget_limit)
             await self._notify(
                 company_id=row.company_id,
                 event_type="budget.soft_alert",
                 payload={
                     "agent_id": row.agent_id,
-                    "spent": float(row.budget_spent),
-                    "limit": float(row.budget_limit),
+                    "budget_mode": budget_mode,
+                    "spent": spent_val,
+                    "limit": limit_val,
                     "ratio": float(ratio),
                     "ts": datetime.now(tz=timezone.utc).isoformat(),
                 },

--- a/autobot-backend/llc/scheduler/budget_watchdog.py
+++ b/autobot-backend/llc/scheduler/budget_watchdog.py
@@ -20,7 +20,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Optional
 
-from sqlalchemy import select, text
+from sqlalchemy import or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.redis_client import get_async_redis_client
@@ -86,17 +86,21 @@ class BudgetWatchdog:
 
         Evaluates each agent in its active budget mode:
         - DOLLARS: ratio = budget_spent / budget_limit
-        - TOKENS: ratio = tokens_spent / token_limit (only when token_limit > 0)
+        - TOKENS: ratio = tokens_spent / token_limit; a tokens-mode row with no
+          token_limit falls back to dollar enforcement, matching
+          BudgetService.check_budget / _derive_status semantics.
         """
-        result = await session.execute(select(LLCAgentBudget))
+        result = await session.execute(
+            select(LLCAgentBudget).where(
+                or_(LLCAgentBudget.budget_limit > 0, LLCAgentBudget.token_limit > 0)
+            )
+        )
         rows = list(result.scalars().all())
 
         for row in rows:
             budget_mode = str(row.budget_mode)
-            if budget_mode == "tokens":
-                token_limit = int(row.token_limit) if row.token_limit is not None else 0
-                if token_limit <= 0:
-                    continue
+            token_limit = int(row.token_limit) if row.token_limit is not None else 0
+            if budget_mode == "tokens" and token_limit > 0:
                 tokens_spent = int(row.tokens_spent)
                 ratio = Decimal(str(tokens_spent)) / Decimal(str(token_limit))
             else:

--- a/autobot-backend/llc/services/budget.py
+++ b/autobot-backend/llc/services/budget.py
@@ -38,6 +38,11 @@ _tracker = AgentBudgetTracker()  # noqa: SRB001 — canonical SharedRuntimeBag c
 class BudgetService(LLCServiceBase):
     """Per-agent budget enforcement: cost ingest, hard stop, soft alert."""
 
+    @staticmethod
+    async def invalidate_cache(agent_id: str) -> None:
+        """Drop the tracker cache for an agent after its limits/mode change."""
+        await _tracker.invalidate(agent_id)
+
     async def provision_budget(
         self,
         session: AsyncSession,

--- a/autobot-backend/llc/tests/test_budget_token_mode.py
+++ b/autobot-backend/llc/tests/test_budget_token_mode.py
@@ -2,210 +2,563 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Tests for token-based budget mode (GH#8997)."""
+"""Tests for token-based budget mode (GH#8997).
+
+Covers:
+  - Token mode: enforcement, accumulation, hard stop, alert
+  - Dollar mode: unchanged behaviour (regression)
+  - Mode switch: remaining recalculated in new mode
+  - Both modes: tokens_spent always tracked (shadow cost)
+  - API validation: mode-appropriate field guard (400)
+  - Watchdog: token-mode hard stop fires; dollar-mode regression
+"""
+
+from __future__ import annotations
 
 import uuid
 from decimal import Decimal
+from typing import AsyncIterator
+from unittest.mock import AsyncMock, patch
 
+from sqlalchemy import select
+
+import httpx
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from llc.exceptions import BudgetExhausted
 from llc.models.budget import LLCAgentBudget
 from llc.models.enums import BudgetMode
 from llc.services.budget import BudgetService
+from llc.tests import _e2e_harness as harness
+
+
+# ---------------------------------------------------------------------------
+# DB fixtures — in-memory SQLite backed, reusing the e2e harness schema
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def engine():  # noqa: ANN201
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
+    await harness.create_loop_schema(eng)
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(engine):  # noqa: ANN001, ANN201
+    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+@pytest_asyncio.fixture
+async def session(session_factory) -> AsyncIterator[AsyncSession]:  # noqa: ANN001
+    async with session_factory() as s:
+        try:
+            yield s
+            await s.commit()
+        except Exception:
+            await s.rollback()
+            raise
 
 
 @pytest.fixture
-async def budget_service():
-    """Create a BudgetService instance."""
+def budget_service() -> BudgetService:
     return BudgetService()
 
 
-@pytest.fixture
-async def test_agent_id():
-    """Generate a unique agent ID for testing."""
-    return f"test-agent-{uuid.uuid4()}"
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-async def company_id():
-    """Generate a unique company ID for testing."""
-    return str(uuid.uuid4())
+def _make_budget(
+    agent_id: str,
+    company_id: str,
+    mode: str = BudgetMode.DOLLARS.value,
+    budget_limit: float = 100.0,
+    token_limit: int | None = None,
+    tokens_spent: int = 0,
+    budget_spent: float = 0.0,
+) -> LLCAgentBudget:
+    return LLCAgentBudget(
+        id=uuid.uuid4(),
+        company_id=company_id,
+        agent_id=agent_id,
+        budget_mode=mode,
+        budget_limit=Decimal(str(budget_limit)),
+        budget_spent=Decimal(str(budget_spent)),
+        token_limit=token_limit,
+        tokens_spent=tokens_spent,
+        alert_threshold=0.8,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Token mode: accumulation, alert, hard stop
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_token_mode_budget_enforcement(
-    session: AsyncSession,
-    budget_service: BudgetService,
-    test_agent_id: str,
-    company_id: str,
-):
-    """Test token-based budget enforcement (GH#8997)."""
-    # Create a token-mode budget with 1000 token limit
-    budget = LLCAgentBudget(
+async def test_token_mode_budget_enforcement(session: AsyncSession, budget_service: BudgetService) -> None:
+    """Token-based hard stop fires when tokens_spent > token_limit (GH#8997)."""
+    agent_id = f"ta-{uuid.uuid4().hex[:8]}"
+    company_id = str(uuid.uuid4())
+    session.add(_make_budget(agent_id, company_id, mode=BudgetMode.TOKENS.value, token_limit=1000))
+    await session.commit()
+
+    with patch("llc.services.budget.get_async_redis_client", new_callable=AsyncMock) as mock_redis:
+        mock_redis.return_value = None
+        # 300 in + 200 out = 500 total — under 1000 limit
+        cost = await budget_service.ingest_cost_event(
+            session, agent_id, tokens_in=300, tokens_out=200, model="claude-haiku-4-5-20251001"
+        )
+
+    # Cost is calculated for analytics even in token mode
+    assert cost > Decimal("0"), "Dollar cost should be tracked for shadow cost analytics"
+
+    remaining, is_over, alert = await budget_service.check_budget(session, agent_id)
+    assert remaining == Decimal("500")   # 1000 - 500
+    assert not is_over
+    assert not alert  # 500/1000 = 50% < 80%
+
+    with patch("llc.services.budget.get_async_redis_client", new_callable=AsyncMock) as mock_redis:
+        mock_redis.return_value = None
+        # 200 in + 150 out = 350 → total 850 (85%) — alert should fire
+        await budget_service.ingest_cost_event(
+            session, agent_id, tokens_in=200, tokens_out=150, model="claude-haiku-4-5-20251001"
+        )
+
+    remaining, is_over, alert = await budget_service.check_budget(session, agent_id)
+    assert remaining == Decimal("150")   # 1000 - 850
+    assert not is_over
+    assert alert  # 850/1000 = 85% >= 80%
+
+    # 200 in + 150 out = 350 → total 1200 > 1000 — hard stop
+    with pytest.raises(BudgetExhausted):
+        with patch("llc.services.budget.get_async_redis_client", new_callable=AsyncMock) as mock_redis:
+            mock_redis.return_value = None
+            await budget_service.ingest_cost_event(
+                session, agent_id, tokens_in=200, tokens_out=150, model="claude-haiku-4-5-20251001"
+            )
+
+
+@pytest.mark.asyncio
+async def test_token_ingest_accumulation(session: AsyncSession, budget_service: BudgetService) -> None:
+    """tokens_spent accumulates correctly across multiple ingest calls (GH#8997)."""
+    agent_id = f"ta-{uuid.uuid4().hex[:8]}"
+    company_id = str(uuid.uuid4())
+    session.add(_make_budget(agent_id, company_id, mode=BudgetMode.TOKENS.value, token_limit=5000))
+    await session.commit()
+
+    with patch("llc.services.budget.get_async_redis_client", new_callable=AsyncMock) as mock_redis:
+        mock_redis.return_value = None
+        await budget_service.ingest_cost_event(session, agent_id, 100, 50, "claude-haiku-4-5-20251001")
+        await budget_service.ingest_cost_event(session, agent_id, 200, 100, "claude-haiku-4-5-20251001")
+
+    remaining, _, _ = await budget_service.check_budget(session, agent_id)
+    # 150 + 300 = 450 tokens spent; remaining = 5000 - 450
+    assert remaining == Decimal("4550")
+
+
+# ---------------------------------------------------------------------------
+# Dollar mode: regression
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dollar_mode_budget_enforcement(session: AsyncSession, budget_service: BudgetService) -> None:
+    """Dollar-based hard stop fires when budget_spent > budget_limit (GH#8215 regression)."""
+    agent_id = f"ta-{uuid.uuid4().hex[:8]}"
+    company_id = str(uuid.uuid4())
+    # haiku-4-5: $0.80/1M input, $4.00/1M output
+    # 1M in + 200k out = $0.80 + $0.80 = $1.60; limit $2.00 leaves $0.40 remaining
+    session.add(_make_budget(agent_id, company_id, mode=BudgetMode.DOLLARS.value, budget_limit=2.0))
+    await session.commit()
+
+    with patch("llc.services.budget.get_async_redis_client", new_callable=AsyncMock) as mock_redis:
+        mock_redis.return_value = None
+        cost = await budget_service.ingest_cost_event(
+            session, agent_id, 1_000_000, 200_000, "claude-haiku-4-5-20251001"
+        )
+
+    assert cost == Decimal("1.60")
+    remaining, is_over, alert = await budget_service.check_budget(session, agent_id)
+    assert remaining == Decimal("0.40")   # $2.00 - $1.60
+    assert not is_over
+    assert alert  # 1.60/2.00 = 80% — threshold is >= 0.8, so alert fires at exactly 80%
+
+    with pytest.raises(BudgetExhausted):
+        with patch("llc.services.budget.get_async_redis_client", new_callable=AsyncMock) as mock_redis:
+            mock_redis.return_value = None
+            # 1M in + 500k out = $0.80 + $2.00 = $2.80 → total $4.40 > $2.00 limit
+            await budget_service.ingest_cost_event(
+                session, agent_id, 1_000_000, 500_000, "claude-haiku-4-5-20251001"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Shadow cost: tokens_spent tracked in both modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_both_modes_track_tokens(session: AsyncSession, budget_service: BudgetService) -> None:
+    """tokens_spent is always incremented regardless of active budget mode (GH#8997)."""
+    agent_id = f"ta-{uuid.uuid4().hex[:8]}"
+    company_id = str(uuid.uuid4())
+    session.add(_make_budget(agent_id, company_id, mode=BudgetMode.DOLLARS.value, budget_limit=100.0))
+    await session.commit()
+
+    with patch("llc.services.budget.get_async_redis_client", new_callable=AsyncMock) as mock_redis:
+        mock_redis.return_value = None
+        await budget_service.ingest_cost_event(session, agent_id, 1000, 500, "claude-haiku-4-5-20251001")
+
+    result = await session.execute(
+        select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id)
+    )
+    row = result.scalar_one()
+    assert row.tokens_spent == 1500  # shadow cost tracked in dollars mode
+    assert row.budget_spent > Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_token_mode_shadow_cost_usd(session: AsyncSession, budget_service: BudgetService) -> None:
+    """In token mode, budget_spent (USD) is updated as shadow cost (GH#8997)."""
+    agent_id = f"ta-{uuid.uuid4().hex[:8]}"
+    company_id = str(uuid.uuid4())
+    session.add(_make_budget(agent_id, company_id, mode=BudgetMode.TOKENS.value, token_limit=100_000))
+    await session.commit()
+
+    with patch("llc.services.budget.get_async_redis_client", new_callable=AsyncMock) as mock_redis:
+        mock_redis.return_value = None
+        cost = await budget_service.ingest_cost_event(session, agent_id, 1000, 500, "claude-haiku-4-5-20251001")
+
+    # USD shadow cost must be positive
+    assert cost > Decimal("0"), "Shadow cost must be calculated and returned in token mode"
+
+    result = await session.execute(
+        select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id)
+    )
+    row = result.scalar_one()
+    assert row.budget_spent > Decimal("0"), "budget_spent (USD shadow) must be tracked in token mode"
+
+
+# ---------------------------------------------------------------------------
+# Mode switch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mode_switch(session_factory, budget_service: BudgetService) -> None:  # noqa: ANN001
+    """Switching budget mode updates enforcement plane without losing analytics (GH#8997).
+
+    Uses separate sessions for write and read phases to ensure the ORM identity map
+    does not return stale tokens_spent after the raw-SQL UPDATE in ingest_cost_event.
+    """
+    agent_id = f"ta-{uuid.uuid4().hex[:8]}"
+    company_id = str(uuid.uuid4())
+
+    # Phase 1: insert the budget row in dollars mode
+    async with session_factory() as s:
+        s.add(_make_budget(agent_id, company_id, mode=BudgetMode.DOLLARS.value, budget_limit=100.0))
+        await s.commit()
+
+    # Phase 2: ingest tokens while in dollars mode
+    async with session_factory() as s:
+        with patch("llc.services.budget.get_async_redis_client", new_callable=AsyncMock) as mock_redis:
+            mock_redis.return_value = None
+            await budget_service.ingest_cost_event(s, agent_id, 1000, 500, "claude-haiku-4-5-20251001")
+        await s.commit()
+
+    # Phase 3: switch to token mode
+    async with session_factory() as s:
+        result = await s.execute(select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id))
+        budget = result.scalar_one()
+        budget.budget_mode = BudgetMode.TOKENS.value
+        budget.token_limit = 10000
+        await s.commit()
+
+    # Phase 4: fresh session for check_budget — sees updated DB state
+    async with session_factory() as s:
+        remaining, is_over, _ = await budget_service.check_budget(s, agent_id)
+        assert remaining == Decimal("8500")  # 10000 - 1500 tokens
+        assert not is_over
+
+        result = await s.execute(select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id))
+        row = result.scalar_one()
+        assert row.budget_spent > Decimal("0")
+        assert row.tokens_spent == 1500
+
+
+# ---------------------------------------------------------------------------
+# API validation: mode-appropriate field guard
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def app(session_factory):  # noqa: ANN001, ANN201
+    from fastapi import FastAPI
+
+    from llc.api import budget as budget_api
+    from user_management.database import get_async_session
+
+    application = FastAPI()
+    application.include_router(budget_api.router, prefix="/api/llc")
+
+    async def _override_session() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    application.dependency_overrides[get_async_session] = _override_session
+    return application
+
+
+@pytest_asyncio.fixture
+async def client(app) -> AsyncIterator[httpx.AsyncClient]:  # noqa: ANN001
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def _seed_budget(session_factory, mode: str = "dollars") -> str:  # noqa: ANN001
+    agent_id = f"va-{uuid.uuid4().hex[:8]}"
+    async with session_factory() as s:
+        s.add(
+            LLCAgentBudget(
+                id=uuid.uuid4(),
+                company_id=str(uuid.uuid4()),
+                agent_id=agent_id,
+                budget_mode=mode,
+                budget_limit=Decimal("50.00"),
+                budget_spent=Decimal("0"),
+                token_limit=1_000_000 if mode == "tokens" else None,
+                tokens_spent=0,
+                alert_threshold=0.8,
+            )
+        )
+        await s.commit()
+    return agent_id
+
+
+@pytest.mark.asyncio
+async def test_update_limit_rejects_token_limit_in_dollars_mode(
+    client: httpx.AsyncClient, session_factory
+) -> None:
+    """PATCH /limit must return 400 when token_limit is set and budget_mode is 'dollars' (GH#8997)."""
+    agent_id = await _seed_budget(session_factory, mode="dollars")
+
+    resp = await client.patch(
+        f"/api/llc/budget/{agent_id}/limit",
+        json={"token_limit": 500_000},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "token_limit" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_update_limit_rejects_budget_limit_when_switching_to_tokens(
+    client: httpx.AsyncClient, session_factory
+) -> None:
+    """PATCH /limit must return 400 when budget_limit is set and budget_mode is 'tokens' (GH#8997)."""
+    agent_id = await _seed_budget(session_factory, mode="dollars")
+
+    resp = await client.patch(
+        f"/api/llc/budget/{agent_id}/limit",
+        json={"budget_mode": "tokens", "budget_limit": "20.00"},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "budget_limit" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_update_limit_accepts_token_limit_in_tokens_mode(
+    client: httpx.AsyncClient, session_factory
+) -> None:
+    """PATCH /limit accepts token_limit when budget_mode is 'tokens' (GH#8997)."""
+    agent_id = await _seed_budget(session_factory, mode="dollars")
+
+    with patch("llc.services.budget._tracker.get_state", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = None
+        resp = await client.patch(
+            f"/api/llc/budget/{agent_id}/limit",
+            json={"budget_mode": "tokens", "token_limit": 2_000_000},
+        )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["budget_mode"] == "tokens"
+    assert data["token_limit"] == 2_000_000
+
+
+@pytest.mark.asyncio
+async def test_update_limit_accepts_budget_limit_in_dollars_mode(
+    client: httpx.AsyncClient, session_factory
+) -> None:
+    """PATCH /limit accepts budget_limit when budget_mode is 'dollars' (GH#8997)."""
+    agent_id = await _seed_budget(session_factory, mode="dollars")
+
+    with patch("llc.services.budget._tracker.get_state", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = None
+        resp = await client.patch(
+            f"/api/llc/budget/{agent_id}/limit",
+            json={"budget_limit": "75.00"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert Decimal(resp.json()["budget_limit"]) == Decimal("75.00")
+
+
+# ---------------------------------------------------------------------------
+# Watchdog: token-mode hard stop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watchdog_token_mode_hard_stop() -> None:
+    """BudgetWatchdog fires hard_stop for a token-mode agent at 100% (GH#8997)."""
+    import json
+
+    from llc.scheduler.budget_watchdog import BudgetWatchdog
+    from unittest.mock import MagicMock
+
+    company_id = str(uuid.uuid4())
+    row = LLCAgentBudget(
         id=uuid.uuid4(),
         company_id=company_id,
-        agent_id=test_agent_id,
+        agent_id=f"wa-{uuid.uuid4().hex[:6]}",
         budget_mode=BudgetMode.TOKENS.value,
-        budget_limit=Decimal("100.00"),  # Dollar limit (not enforced in token mode)
-        budget_spent=Decimal("0"),
+        budget_limit=Decimal("100.00"),
+        budget_spent=Decimal("0.05"),   # shadow cost
         token_limit=1000,
-        tokens_spent=0,
+        tokens_spent=1200,              # over 1000 limit
         alert_threshold=0.8,
     )
-    session.add(budget)
-    await session.commit()
 
-    # Ingest 500 tokens (under limit)
-    cost = await budget_service.ingest_cost_event(
-        session, test_agent_id, tokens_in=300, tokens_out=200, model="claude-sonnet-4-6"
-    )
+    mock_redis = AsyncMock()
+    mock_redis.publish = AsyncMock()
 
-    # Verify cost was calculated (for analytics)
-    assert cost > Decimal("0")
+    scalars = MagicMock()
+    scalars.all.return_value = [row]
+    execute_result = MagicMock()
+    execute_result.scalars.return_value = scalars
+    session = AsyncMock()
+    session.execute.return_value = execute_result
 
-    # Check budget status
-    remaining, is_over, alert = await budget_service.check_budget(session, test_agent_id)
-    assert remaining == Decimal("500")  # 1000 - 500 tokens
-    assert not is_over
-    assert not alert  # 500/1000 = 50% < 80% threshold
+    mock_svc = MagicMock()
+    mock_svc.check_budget = AsyncMock(return_value=(Decimal("-200"), True, True))
 
-    # Ingest more tokens to trigger alert (850 total, 85%)
-    await budget_service.ingest_cost_event(
-        session, test_agent_id, tokens_in=200, tokens_out=150, model="claude-sonnet-4-6"
-    )
+    with (
+        patch(
+            "llc.scheduler.budget_watchdog.get_async_redis_client",
+            new_callable=AsyncMock,
+            return_value=mock_redis,
+        ),
+        patch("llc.scheduler.budget_watchdog.get_async_session_factory") as mock_factory,
+    ):
+        factory = MagicMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        factory.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_factory.return_value = factory
 
-    remaining, is_over, alert = await budget_service.check_budget(session, test_agent_id)
-    assert remaining == Decimal("150")  # 1000 - 850 tokens
-    assert not is_over
-    assert alert  # 850/1000 = 85% > 80% threshold
+        watchdog = BudgetWatchdog(poll_interval=9999)
+        watchdog._budget_svc = mock_svc
+        await watchdog._check_agent_budgets(session)
 
-    # Ingest tokens to exceed limit (1200 total)
-    with pytest.raises(BudgetExhausted):
-        await budget_service.ingest_cost_event(
-            session, test_agent_id, tokens_in=200, tokens_out=150, model="claude-sonnet-4-6"
-        )
+    mock_redis.publish.assert_called_once()
+    channel, payload_json = mock_redis.publish.call_args[0]
+    assert channel == f"llc:notifications:{company_id}"
+    payload = json.loads(payload_json)
+    assert payload["event_type"] == "budget.hard_stop"
+    assert payload["budget_mode"] == "tokens"
+    assert payload["spent"] == 1200
+    assert payload["shadow_cost_usd"] == pytest.approx(0.05)
 
 
 @pytest.mark.asyncio
-async def test_dollar_mode_budget_enforcement(
-    session: AsyncSession,
-    budget_service: BudgetService,
-    test_agent_id: str,
-    company_id: str,
-):
-    """Test dollar-based budget enforcement still works (GH#8215)."""
-    # Create a dollar-mode budget with $10 limit
-    budget = LLCAgentBudget(
+async def test_watchdog_token_mode_soft_alert() -> None:
+    """BudgetWatchdog fires soft_alert for a token-mode agent at 85% (GH#8997)."""
+    import json
+
+    from llc.scheduler.budget_watchdog import BudgetWatchdog
+    from unittest.mock import MagicMock
+
+    company_id = str(uuid.uuid4())
+    row = LLCAgentBudget(
         id=uuid.uuid4(),
         company_id=company_id,
-        agent_id=test_agent_id,
-        budget_mode=BudgetMode.DOLLARS.value,
-        budget_limit=Decimal("10.00"),
-        budget_spent=Decimal("0"),
-        token_limit=None,  # Not used in dollar mode
-        tokens_spent=0,
-        alert_threshold=0.8,
-    )
-    session.add(budget)
-    await session.commit()
-
-    # Ingest tokens worth ~$5
-    # claude-sonnet-4-6: $3/1M input, $15/1M output
-    # 1M input + 200k output = $3 + $3 = $6
-    cost = await budget_service.ingest_cost_event(
-        session, test_agent_id, tokens_in=1_000_000, tokens_out=200_000, model="claude-sonnet-4-6"
-    )
-
-    assert cost == Decimal("6.00")
-
-    # Check budget status
-    remaining, is_over, alert = await budget_service.check_budget(session, test_agent_id)
-    assert remaining == Decimal("4.00")  # $10 - $6
-    assert not is_over
-    assert not alert  # $6/$10 = 60% < 80% threshold
-
-    # Ingest more to exceed limit
-    with pytest.raises(BudgetExhausted):
-        await budget_service.ingest_cost_event(
-            session, test_agent_id, tokens_in=1_000_000, tokens_out=500_000, model="claude-sonnet-4-6"
-        )
-
-
-@pytest.mark.asyncio
-async def test_mode_switch(
-    session: AsyncSession,
-    budget_service: BudgetService,
-    test_agent_id: str,
-    company_id: str,
-):
-    """Test switching between budget modes (GH#8997)."""
-    # Start with dollar mode
-    budget = LLCAgentBudget(
-        id=uuid.uuid4(),
-        company_id=company_id,
-        agent_id=test_agent_id,
-        budget_mode=BudgetMode.DOLLARS.value,
+        agent_id=f"wa-{uuid.uuid4().hex[:6]}",
+        budget_mode=BudgetMode.TOKENS.value,
         budget_limit=Decimal("100.00"),
-        budget_spent=Decimal("0"),
-        token_limit=None,
-        tokens_spent=0,
+        budget_spent=Decimal("0.03"),
+        token_limit=1000,
+        tokens_spent=850,  # 85% — triggers soft alert
         alert_threshold=0.8,
     )
-    session.add(budget)
-    await session.commit()
 
-    # Ingest some usage
-    await budget_service.ingest_cost_event(
-        session, test_agent_id, tokens_in=1000, tokens_out=500, model="claude-sonnet-4-6"
-    )
+    mock_redis = AsyncMock()
+    mock_redis.publish = AsyncMock()
 
-    # Switch to token mode
-    budget.budget_mode = BudgetMode.TOKENS.value
-    budget.token_limit = 10000
-    await session.commit()
+    scalars = MagicMock()
+    scalars.all.return_value = [row]
+    execute_result = MagicMock()
+    execute_result.scalars.return_value = scalars
+    session = AsyncMock()
+    session.execute.return_value = execute_result
 
-    # Check budget now uses token limit
-    remaining, is_over, alert = await budget_service.check_budget(session, test_agent_id)
-    assert remaining == Decimal("8500")  # 10000 - 1500 tokens
-    assert not is_over
+    with patch(
+        "llc.scheduler.budget_watchdog.get_async_redis_client",
+        new_callable=AsyncMock,
+        return_value=mock_redis,
+    ):
+        watchdog = BudgetWatchdog(poll_interval=9999)
+        await watchdog._check_agent_budgets(session)
 
-    # Verify dollar tracking continues (for analytics)
-    await session.refresh(budget)
-    assert budget.budget_spent > Decimal("0")
-    assert budget.tokens_spent == 1500
+    mock_redis.publish.assert_called_once()
+    _, payload_json = mock_redis.publish.call_args[0]
+    payload = json.loads(payload_json)
+    assert payload["event_type"] == "budget.soft_alert"
+    assert payload["budget_mode"] == "tokens"
 
 
 @pytest.mark.asyncio
-async def test_both_modes_track_tokens(
-    session: AsyncSession,
-    budget_service: BudgetService,
-    test_agent_id: str,
-    company_id: str,
-):
-    """Verify both modes track tokens_spent for analytics (GH#8997)."""
-    # Dollar mode agent
-    budget = LLCAgentBudget(
+async def test_watchdog_token_mode_under_threshold_no_alert() -> None:
+    """BudgetWatchdog does NOT alert for a token-mode agent at 50% (GH#8997)."""
+    from llc.scheduler.budget_watchdog import BudgetWatchdog
+    from unittest.mock import MagicMock
+
+    row = LLCAgentBudget(
         id=uuid.uuid4(),
-        company_id=company_id,
-        agent_id=test_agent_id,
-        budget_mode=BudgetMode.DOLLARS.value,
+        company_id=str(uuid.uuid4()),
+        agent_id=f"wa-{uuid.uuid4().hex[:6]}",
+        budget_mode=BudgetMode.TOKENS.value,
         budget_limit=Decimal("100.00"),
-        budget_spent=Decimal("0"),
-        token_limit=None,
-        tokens_spent=0,
+        budget_spent=Decimal("0.01"),
+        token_limit=1000,
+        tokens_spent=500,  # 50% — under 80% threshold
         alert_threshold=0.8,
     )
-    session.add(budget)
-    await session.commit()
 
-    # Ingest tokens
-    await budget_service.ingest_cost_event(
-        session, test_agent_id, tokens_in=1000, tokens_out=500, model="claude-sonnet-4-6"
-    )
+    mock_redis = AsyncMock()
+    mock_redis.publish = AsyncMock()
 
-    # Verify tokens_spent is tracked even in dollar mode
-    await session.refresh(budget)
-    assert budget.tokens_spent == 1500
-    assert budget.budget_spent > Decimal("0")
+    scalars = MagicMock()
+    scalars.all.return_value = [row]
+    execute_result = MagicMock()
+    execute_result.scalars.return_value = scalars
+    session = AsyncMock()
+    session.execute.return_value = execute_result
+
+    with patch(
+        "llc.scheduler.budget_watchdog.get_async_redis_client",
+        new_callable=AsyncMock,
+        return_value=mock_redis,
+    ):
+        watchdog = BudgetWatchdog(poll_interval=9999)
+        await watchdog._check_agent_budgets(session)
+
+    mock_redis.publish.assert_not_called()

--- a/autobot-backend/llc/tests/test_budget_token_mode.py
+++ b/autobot-backend/llc/tests/test_budget_token_mode.py
@@ -20,11 +20,10 @@ from decimal import Decimal
 from typing import AsyncIterator
 from unittest.mock import AsyncMock, patch
 
-from sqlalchemy import select
-
 import httpx
 import pytest
 import pytest_asyncio
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from llc.exceptions import BudgetExhausted
@@ -32,7 +31,6 @@ from llc.models.budget import LLCAgentBudget
 from llc.models.enums import BudgetMode
 from llc.services.budget import BudgetService
 from llc.tests import _e2e_harness as harness
-
 
 # ---------------------------------------------------------------------------
 # DB fixtures — in-memory SQLite backed, reusing the e2e harness schema
@@ -119,7 +117,7 @@ async def test_token_mode_budget_enforcement(session: AsyncSession, budget_servi
     assert cost > Decimal("0"), "Dollar cost should be tracked for shadow cost analytics"
 
     remaining, is_over, alert = await budget_service.check_budget(session, agent_id)
-    assert remaining == Decimal("500")   # 1000 - 500
+    assert remaining == Decimal("500")  # 1000 - 500
     assert not is_over
     assert not alert  # 500/1000 = 50% < 80%
 
@@ -131,7 +129,7 @@ async def test_token_mode_budget_enforcement(session: AsyncSession, budget_servi
         )
 
     remaining, is_over, alert = await budget_service.check_budget(session, agent_id)
-    assert remaining == Decimal("150")   # 1000 - 850
+    assert remaining == Decimal("150")  # 1000 - 850
     assert not is_over
     assert alert  # 850/1000 = 85% >= 80%
 
@@ -185,7 +183,7 @@ async def test_dollar_mode_budget_enforcement(session: AsyncSession, budget_serv
 
     assert cost == Decimal("1.60")
     remaining, is_over, alert = await budget_service.check_budget(session, agent_id)
-    assert remaining == Decimal("0.40")   # $2.00 - $1.60
+    assert remaining == Decimal("0.40")  # $2.00 - $1.60
     assert not is_over
     assert alert  # 1.60/2.00 = 80% — threshold is >= 0.8, so alert fires at exactly 80%
 
@@ -193,9 +191,7 @@ async def test_dollar_mode_budget_enforcement(session: AsyncSession, budget_serv
         with patch("llc.services.budget.get_async_redis_client", new_callable=AsyncMock) as mock_redis:
             mock_redis.return_value = None
             # 1M in + 500k out = $0.80 + $2.00 = $2.80 → total $4.40 > $2.00 limit
-            await budget_service.ingest_cost_event(
-                session, agent_id, 1_000_000, 500_000, "claude-haiku-4-5-20251001"
-            )
+            await budget_service.ingest_cost_event(session, agent_id, 1_000_000, 500_000, "claude-haiku-4-5-20251001")
 
 
 # ---------------------------------------------------------------------------
@@ -215,9 +211,7 @@ async def test_both_modes_track_tokens(session: AsyncSession, budget_service: Bu
         mock_redis.return_value = None
         await budget_service.ingest_cost_event(session, agent_id, 1000, 500, "claude-haiku-4-5-20251001")
 
-    result = await session.execute(
-        select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id)
-    )
+    result = await session.execute(select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id))
     row = result.scalar_one()
     assert row.tokens_spent == 1500  # shadow cost tracked in dollars mode
     assert row.budget_spent > Decimal("0")
@@ -238,9 +232,7 @@ async def test_token_mode_shadow_cost_usd(session: AsyncSession, budget_service:
     # USD shadow cost must be positive
     assert cost > Decimal("0"), "Shadow cost must be calculated and returned in token mode"
 
-    result = await session.execute(
-        select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id)
-    )
+    result = await session.execute(select(LLCAgentBudget).where(LLCAgentBudget.agent_id == agent_id))
     row = result.scalar_one()
     assert row.budget_spent > Decimal("0"), "budget_spent (USD shadow) must be tracked in token mode"
 
@@ -348,9 +340,7 @@ async def _seed_budget(session_factory, mode: str = "dollars") -> str:  # noqa: 
 
 
 @pytest.mark.asyncio
-async def test_update_limit_rejects_token_limit_in_dollars_mode(
-    client: httpx.AsyncClient, session_factory
-) -> None:
+async def test_update_limit_rejects_token_limit_in_dollars_mode(client: httpx.AsyncClient, session_factory) -> None:
     """PATCH /limit must return 400 when token_limit is set and budget_mode is 'dollars' (GH#8997)."""
     agent_id = await _seed_budget(session_factory, mode="dollars")
 
@@ -378,9 +368,7 @@ async def test_update_limit_rejects_budget_limit_when_switching_to_tokens(
 
 
 @pytest.mark.asyncio
-async def test_update_limit_accepts_token_limit_in_tokens_mode(
-    client: httpx.AsyncClient, session_factory
-) -> None:
+async def test_update_limit_accepts_token_limit_in_tokens_mode(client: httpx.AsyncClient, session_factory) -> None:
     """PATCH /limit accepts token_limit when budget_mode is 'tokens' (GH#8997)."""
     agent_id = await _seed_budget(session_factory, mode="dollars")
 
@@ -397,9 +385,7 @@ async def test_update_limit_accepts_token_limit_in_tokens_mode(
 
 
 @pytest.mark.asyncio
-async def test_update_limit_accepts_budget_limit_in_dollars_mode(
-    client: httpx.AsyncClient, session_factory
-) -> None:
+async def test_update_limit_accepts_budget_limit_in_dollars_mode(client: httpx.AsyncClient, session_factory) -> None:
     """PATCH /limit accepts budget_limit when budget_mode is 'dollars' (GH#8997)."""
     agent_id = await _seed_budget(session_factory, mode="dollars")
 
@@ -422,9 +408,9 @@ async def test_update_limit_accepts_budget_limit_in_dollars_mode(
 async def test_watchdog_token_mode_hard_stop() -> None:
     """BudgetWatchdog fires hard_stop for a token-mode agent at 100% (GH#8997)."""
     import json
+    from unittest.mock import MagicMock
 
     from llc.scheduler.budget_watchdog import BudgetWatchdog
-    from unittest.mock import MagicMock
 
     company_id = str(uuid.uuid4())
     row = LLCAgentBudget(
@@ -433,9 +419,9 @@ async def test_watchdog_token_mode_hard_stop() -> None:
         agent_id=f"wa-{uuid.uuid4().hex[:6]}",
         budget_mode=BudgetMode.TOKENS.value,
         budget_limit=Decimal("100.00"),
-        budget_spent=Decimal("0.05"),   # shadow cost
+        budget_spent=Decimal("0.05"),  # shadow cost
         token_limit=1000,
-        tokens_spent=1200,              # over 1000 limit
+        tokens_spent=1200,  # over 1000 limit
         alert_threshold=0.8,
     )
 
@@ -483,9 +469,9 @@ async def test_watchdog_token_mode_hard_stop() -> None:
 async def test_watchdog_token_mode_soft_alert() -> None:
     """BudgetWatchdog fires soft_alert for a token-mode agent at 85% (GH#8997)."""
     import json
+    from unittest.mock import MagicMock
 
     from llc.scheduler.budget_watchdog import BudgetWatchdog
-    from unittest.mock import MagicMock
 
     company_id = str(uuid.uuid4())
     row = LLCAgentBudget(
@@ -528,8 +514,9 @@ async def test_watchdog_token_mode_soft_alert() -> None:
 @pytest.mark.asyncio
 async def test_watchdog_token_mode_under_threshold_no_alert() -> None:
     """BudgetWatchdog does NOT alert for a token-mode agent at 50% (GH#8997)."""
-    from llc.scheduler.budget_watchdog import BudgetWatchdog
     from unittest.mock import MagicMock
+
+    from llc.scheduler.budget_watchdog import BudgetWatchdog
 
     row = LLCAgentBudget(
         id=uuid.uuid4(),


### PR DESCRIPTION
## Thinking Path
The schema (`budget_mode`/`token_limit`/`tokens_spent`, migration `20260604_036`) and the CostDashboard token UI shipped earlier; enforcement was the missing piece. Token counts already arrive via `POST /budget/{agent_id}/ingest` (`tokens_in`/`tokens_out`) — no upstream changes needed. The review round hardened two real gaps: the PATCH response/watchdog read a stale tracker cache for up to its TTL after a mode/limit change, and a tokens-mode row with no `token_limit` was silently skipped by the watchdog while the service still enforced its dollar fallback.

## What Changed
- `llc/api/budget.py`: cross-mode validation on `PATCH /budget/{agent_id}/limit` (400 setting the other mode's field; deliberate, documented asymmetry: `budget_limit` on an already-tokens row adjusts the dollar fallback); response now derived from the refreshed row + tracker cache invalidated on every PATCH
- `llc/services/budget.py`: `BudgetService.invalidate_cache()` helper
- `llc/scheduler/budget_watchdog.py`: token-mode branch (soft notify ≥80%, hard stop ≥100%, `shadow_cost_usd` in the payload); tokens-with-no-limit rows fall back to dollar enforcement (matches service semantics); SQL-level row filter restored (`budget_limit > 0 OR token_limit > 0`) instead of full-table scan
- `llc/tests/test_budget_token_mode.py`: 13 tests — mode-guard 400s, token accumulation, token hard stop, shadow cost, dollars-mode regression

## Verification
- 36/36 budget tests (token-mode, provision, service, watchdog) after the review fixes
- Independent code-reviewer verdict APPROVE (M1/M2 fixed in-PR, L1 documented, L2 fixed); reviewer confirmed ingest token enforcement and cents-mode backward-compat are pre-existing on base, migration chain linear
- flake8 + py_compile clean

## Model Used
Fable 5 (main session) + Sonnet sub-agents (implementation + independent review)

Fixes #8997

🤖 Generated with [Claude Code](https://claude.com/claude-code)