### PR TITLE
refactor(llc/scheduler): extract PollLoopScheduler base for poll-loop schedulers (#9842)

### DIFF
--- a/autobot-backend/llc/scheduler/__init__.py
+++ b/autobot-backend/llc/scheduler/__init__.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """LLC scheduler package."""
 
+from .base import PollLoopScheduler
 from .budget_watchdog import BudgetWatchdog
 from .liveness_monitor import LivenessMonitor
 from .session_checkpointer import SessionCheckpointer
 
-__all__ = ["BudgetWatchdog", "LivenessMonitor", "SessionCheckpointer"]
+__all__ = ["PollLoopScheduler", "BudgetWatchdog", "LivenessMonitor", "SessionCheckpointer"]

--- a/autobot-backend/llc/scheduler/base.py
+++ b/autobot-backend/llc/scheduler/base.py
@@ -104,9 +104,7 @@ class PollLoopScheduler:
                 # per-module log-level filtering keeps working as it did
                 # before the extraction; the base logger only carries
                 # lifecycle events.
-                logging.getLogger(type(self).__module__).exception(
-                    "%s._tick() failed", type(self).__name__
-                )
+                logging.getLogger(type(self).__module__).exception("%s._tick() failed", type(self).__name__)
             await asyncio.sleep(self._poll_interval)
 
     # ------------------------------------------------------------------

--- a/autobot-backend/llc/scheduler/base.py
+++ b/autobot-backend/llc/scheduler/base.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""PollLoopScheduler — shared poll-loop scaffolding for LLC schedulers (GH#9842).
+
+Provides start/stop/is_running lifecycle management and the ``_loop`` coroutine
+that drives periodic execution.  Subclasses implement only ``_tick()`` — the
+per-poll unit of work.
+
+Error handling contract (preserved from the three concrete schedulers):
+  - ``asyncio.CancelledError`` breaks the loop (not re-raised; task exits cleanly).
+  - All other exceptions are caught, logged via ``logger.exception()``, and the
+    loop continues after the sleep.  This matches BudgetWatchdog, LivenessMonitor,
+    and SessionCheckpointer exactly.
+  - The sleep always runs, even when an exception occurs.
+
+stop() semantics (preserved):
+  - Sets ``_running = False`` first.
+  - Cancels the task if it exists and is not already done.
+  - Does NOT await the task (matches all three concrete schedulers).
+"""
+
+import asyncio
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class PollLoopScheduler:
+    """Base class for asyncio poll-loop schedulers.
+
+    Subclasses must:
+      - Call ``super().__init__(poll_interval)`` (or assign ``self._poll_interval``
+        directly before calling ``start()``).
+      - Implement ``async def _tick(self) -> None`` with the per-poll logic.
+      - Use their own module-level ``logger`` for per-tick log messages — the
+        base class only logs lifecycle events using its own logger.
+
+    The ``_task_name`` class variable controls the asyncio task name and defaults
+    to the concrete class name.  Override at the class level to keep the exact
+    task names that existed before extraction.
+    """
+
+    _task_name: str = ""  # set per subclass; falls back to class name if empty
+
+    def __init__(self, poll_interval: float) -> None:
+        self._poll_interval = poll_interval
+        self._running: bool = False
+        self._task: Optional[asyncio.Task[None]] = None
+
+    @property
+    def is_running(self) -> bool:
+        """True if the polling task is running and not yet done."""
+        return self._running and self._task is not None and not self._task.done()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the background polling loop (idempotent)."""
+        if self._running:
+            return
+        self._running = True
+        task_name = self._task_name or type(self).__name__
+        self._task = asyncio.create_task(self._loop(), name=task_name)
+
+    def stop(self) -> None:
+        """Stop the background polling loop.
+
+        Sets ``_running = False`` and cancels the task.  Does not await
+        the task — callers that need a clean drain must do so themselves.
+        """
+        self._running = False
+        if self._task and not self._task.done():
+            self._task.cancel()
+
+    # ------------------------------------------------------------------
+    # Internal loop
+    # ------------------------------------------------------------------
+
+    async def _loop(self) -> None:
+        """Drive periodic calls to ``_tick()``.
+
+        Catches and logs all exceptions from ``_tick()`` so that a single
+        failing tick does not kill the loop.  ``asyncio.CancelledError``
+        breaks the loop cleanly.  The sleep always runs after each tick
+        (or after an exception), matching the original concrete schedulers.
+        """
+        while self._running:
+            try:
+                await self._tick()
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.exception("%s._tick() failed", type(self).__name__)
+            await asyncio.sleep(self._poll_interval)
+
+    # ------------------------------------------------------------------
+    # Hook for subclasses
+    # ------------------------------------------------------------------
+
+    async def _tick(self) -> None:
+        """Per-poll unit of work.  Subclasses must override this method."""
+        raise NotImplementedError(f"{type(self).__name__} must implement _tick()")

--- a/autobot-backend/llc/scheduler/base.py
+++ b/autobot-backend/llc/scheduler/base.py
@@ -59,13 +59,18 @@ class PollLoopScheduler:
     # Lifecycle
     # ------------------------------------------------------------------
 
-    def start(self) -> None:
-        """Start the background polling loop (idempotent)."""
+    def start(self) -> bool:
+        """Start the background polling loop (idempotent).
+
+        Returns True when the task was created by this call, False on a
+        redundant start — so subclasses can log "started" exactly once.
+        """
         if self._running:
-            return
+            return False
         self._running = True
         task_name = self._task_name or type(self).__name__
         self._task = asyncio.create_task(self._loop(), name=task_name)
+        return True
 
     def stop(self) -> None:
         """Stop the background polling loop.
@@ -95,7 +100,13 @@ class PollLoopScheduler:
             except asyncio.CancelledError:
                 break
             except Exception:
-                logger.exception("%s._tick() failed", type(self).__name__)
+                # Attribute tick failures to the subclass's module logger so
+                # per-module log-level filtering keeps working as it did
+                # before the extraction; the base logger only carries
+                # lifecycle events.
+                logging.getLogger(type(self).__module__).exception(
+                    "%s._tick() failed", type(self).__name__
+                )
             await asyncio.sleep(self._poll_interval)
 
     # ------------------------------------------------------------------

--- a/autobot-backend/llc/scheduler/budget_watchdog.py
+++ b/autobot-backend/llc/scheduler/budget_watchdog.py
@@ -13,12 +13,10 @@ For soft-threshold agents: publishes a notification to
 For agents at or over 100%: calls BudgetService hard stop (idempotent).
 """
 
-import asyncio
 import json
 import logging
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Optional
 
 from sqlalchemy import or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -29,6 +27,7 @@ from user_management.models.organization import Organization
 
 from ..models.budget import LLCAgentBudget
 from ..services.budget import BudgetService
+from .base import PollLoopScheduler
 
 logger = logging.getLogger(__name__)
 
@@ -37,38 +36,23 @@ _HARD_THRESHOLD = Decimal("1.00")
 _POLL_INTERVAL_SECONDS = 300  # 5 minutes
 
 
-class BudgetWatchdog:
+class BudgetWatchdog(PollLoopScheduler):
     """Periodic watchdog that enforces company and agent budget limits."""
 
+    _task_name = "llc-budget-watchdog"
+
     def __init__(self, poll_interval: int = _POLL_INTERVAL_SECONDS) -> None:
-        self._poll_interval = poll_interval
-        self._running = False
-        self._task: Optional[asyncio.Task[None]] = None
+        super().__init__(poll_interval)
         self._budget_svc = BudgetService()
 
     def start(self) -> None:
         """Start the background polling loop."""
-        if self._running:
-            return
-        self._running = True
-        self._task = asyncio.create_task(self._loop(), name="llc-budget-watchdog")
-        logger.info("BudgetWatchdog started (poll interval: %ds)", self._poll_interval)
+        super().start()
+        if self._task is not None:
+            logger.info("BudgetWatchdog started (poll interval: %ds)", self._poll_interval)
 
-    def stop(self) -> None:
-        """Stop the background polling loop."""
-        self._running = False
-        if self._task and not self._task.done():
-            self._task.cancel()
-
-    async def _loop(self) -> None:
-        while self._running:
-            try:
-                await self._check_once()
-            except asyncio.CancelledError:
-                break
-            except Exception:
-                logger.exception("BudgetWatchdog._check_once failed")
-            await asyncio.sleep(self._poll_interval)
+    async def _tick(self) -> None:
+        await self._check_once()
 
     async def _check_once(self) -> None:
         """Single scan — find over-threshold agents and notify / hard-stop."""

--- a/autobot-backend/llc/scheduler/budget_watchdog.py
+++ b/autobot-backend/llc/scheduler/budget_watchdog.py
@@ -47,8 +47,7 @@ class BudgetWatchdog(PollLoopScheduler):
 
     def start(self) -> None:
         """Start the background polling loop."""
-        super().start()
-        if self._task is not None:
+        if super().start():
             logger.info("BudgetWatchdog started (poll interval: %ds)", self._poll_interval)
 
     async def _tick(self) -> None:

--- a/autobot-backend/llc/scheduler/liveness_monitor.py
+++ b/autobot-backend/llc/scheduler/liveness_monitor.py
@@ -15,7 +15,6 @@ For each stuck run:
   6. Writes an activity log entry
 """
 
-import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Optional
@@ -32,6 +31,7 @@ from ..models.heartbeat_run import LLCHeartbeatRun
 from ..models.work_item import LLCWorkItem
 from ..services.activity_log import LLCActivityLogService
 from ..services.work_item_service import WorkItemService
+from .base import PollLoopScheduler
 
 logger = logging.getLogger(__name__)
 
@@ -39,46 +39,27 @@ _DEFAULT_TIMEOUT_MINUTES = 30
 _POLL_INTERVAL_SECONDS = 60
 
 
-class LivenessMonitor:
+class LivenessMonitor(PollLoopScheduler):
     """Periodic monitor that detects and recovers stuck heartbeat runs."""
+
+    _task_name = "llc-liveness-monitor"
 
     def __init__(
         self,
         activity_log: Optional[LLCActivityLogService] = None,
         poll_interval: int = _POLL_INTERVAL_SECONDS,
     ) -> None:
+        super().__init__(poll_interval)
         self._activity_log = activity_log
-        self._poll_interval = poll_interval
-        self._running = False
-        self._task: Optional[asyncio.Task] = None  # type: ignore[type-arg]
-
-    @property
-    def is_running(self) -> bool:
-        return self._running and self._task is not None and not self._task.done()
 
     def start(self) -> None:
         """Start the background polling loop."""
-        if self._running:
-            return
-        self._running = True
-        self._task = asyncio.create_task(self._loop(), name="llc-liveness-monitor")
-        logger.info("LivenessMonitor started (poll interval: %ds)", self._poll_interval)
+        super().start()
+        if self._task is not None:
+            logger.info("LivenessMonitor started (poll interval: %ds)", self._poll_interval)
 
-    def stop(self) -> None:
-        """Stop the background polling loop."""
-        self._running = False
-        if self._task and not self._task.done():
-            self._task.cancel()
-
-    async def _loop(self) -> None:
-        while self._running:
-            try:
-                await self._check_once()
-            except asyncio.CancelledError:
-                break
-            except Exception:
-                logger.exception("LivenessMonitor._check_once failed")
-            await asyncio.sleep(self._poll_interval)
+    async def _tick(self) -> None:
+        await self._check_once()
 
     async def _check_once(self) -> None:
         """Single scan — find stuck runs and trigger recovery for each."""

--- a/autobot-backend/llc/scheduler/liveness_monitor.py
+++ b/autobot-backend/llc/scheduler/liveness_monitor.py
@@ -54,8 +54,7 @@ class LivenessMonitor(PollLoopScheduler):
 
     def start(self) -> None:
         """Start the background polling loop."""
-        super().start()
-        if self._task is not None:
+        if super().start():
             logger.info("LivenessMonitor started (poll interval: %ds)", self._poll_interval)
 
     async def _tick(self) -> None:

--- a/autobot-backend/llc/scheduler/session_checkpointer.py
+++ b/autobot-backend/llc/scheduler/session_checkpointer.py
@@ -14,13 +14,11 @@ scheduler begins dispatching.  For each ``status='running'`` run it:
   3. Re-queues agent in ``llc:heartbeat:schedule`` sorted set at score=now
 """
 
-import asyncio
 import json
 import logging
 import os
 import time
 from datetime import datetime, timezone
-from typing import Optional
 
 from sqlalchemy import select
 
@@ -29,6 +27,7 @@ from user_management.database import get_async_session_factory
 
 from ..models.enums import LLCRunStatus
 from ..models.heartbeat_run import LLCHeartbeatRun
+from .base import PollLoopScheduler
 
 logger = logging.getLogger(__name__)
 
@@ -62,41 +61,22 @@ logger.info(
 )
 
 
-class SessionCheckpointer:
+class SessionCheckpointer(PollLoopScheduler):
     """Periodic checkpointer that writes session state to Redis for crash recovery."""
 
-    def __init__(self, poll_interval: int = LLC_CHECKPOINT_INTERVAL_SECONDS) -> None:
-        self._poll_interval = poll_interval
-        self._running = False
-        self._task: Optional[asyncio.Task[None]] = None
+    _task_name = "llc-session-checkpointer"
 
-    @property
-    def is_running(self) -> bool:
-        return self._running and self._task is not None and not self._task.done()
+    def __init__(self, poll_interval: int = LLC_CHECKPOINT_INTERVAL_SECONDS) -> None:
+        super().__init__(poll_interval)
 
     def start(self) -> None:
         """Start the background polling loop."""
-        if self._running:
-            return
-        self._running = True
-        self._task = asyncio.create_task(self._loop(), name="llc-session-checkpointer")
-        logger.info("SessionCheckpointer started (poll interval: %ds)", self._poll_interval)
+        super().start()
+        if self._task is not None:
+            logger.info("SessionCheckpointer started (poll interval: %ds)", self._poll_interval)
 
-    def stop(self) -> None:
-        """Stop the background polling loop."""
-        self._running = False
-        if self._task and not self._task.done():
-            self._task.cancel()
-
-    async def _loop(self) -> None:
-        while self._running:
-            try:
-                await self._check_once()
-            except asyncio.CancelledError:
-                break
-            except Exception:
-                logger.exception("SessionCheckpointer._check_once failed")
-            await asyncio.sleep(self._poll_interval)
+    async def _tick(self) -> None:
+        await self._check_once()
 
     async def _check_once(self) -> None:
         """Single scan — write checkpoints for all currently running runs."""

--- a/autobot-backend/llc/scheduler/session_checkpointer.py
+++ b/autobot-backend/llc/scheduler/session_checkpointer.py
@@ -71,8 +71,7 @@ class SessionCheckpointer(PollLoopScheduler):
 
     def start(self) -> None:
         """Start the background polling loop."""
-        super().start()
-        if self._task is not None:
+        if super().start():
             logger.info("SessionCheckpointer started (poll interval: %ds)", self._poll_interval)
 
     async def _tick(self) -> None:

--- a/autobot-backend/llc/tests/test_poll_loop_scheduler.py
+++ b/autobot-backend/llc/tests/test_poll_loop_scheduler.py
@@ -5,7 +5,7 @@
 """Unit tests for PollLoopScheduler base class (GH#9842)."""
 
 import asyncio
-from unittest.mock import patch
+import logging
 
 import pytest
 
@@ -155,10 +155,10 @@ def test_task_name_falls_back_to_class_name_when_empty() -> None:
 
 
 @pytest.mark.asyncio
-async def test_tick_exception_does_not_kill_loop() -> None:
+async def test_tick_exception_does_not_kill_loop(caplog: pytest.LogCaptureFixture) -> None:
     """When _tick() raises, the loop continues (exception is caught and logged)."""
     sched = _ErrorScheduler(poll_interval=0.0)
-    with patch("llc.scheduler.base.logger") as mock_log:
+    with caplog.at_level(logging.ERROR, logger=_ErrorScheduler.__module__):
         sched.start()
         # Allow a couple of iterations — if the loop were killed by the first
         # exception, tick_count would stay at 1.
@@ -167,22 +167,24 @@ async def test_tick_exception_does_not_kill_loop() -> None:
         await asyncio.sleep(0)  # let cancellation propagate
 
     assert sched.tick_count >= 2, "loop must survive tick exceptions"
-    assert mock_log.exception.called, "exception must be logged"
+    assert any("_tick() failed" in r.message for r in caplog.records), "exception must be logged"
 
 
 @pytest.mark.asyncio
-async def test_tick_exception_logs_class_name() -> None:
-    """The exception log message includes the concrete class name."""
+async def test_tick_exception_logs_class_name(caplog: pytest.LogCaptureFixture) -> None:
+    """Tick failures log the concrete class name under the subclass's module logger."""
     sched = _ErrorScheduler(poll_interval=0.0)
-    with patch("llc.scheduler.base.logger") as mock_log:
+    with caplog.at_level(logging.ERROR, logger=_ErrorScheduler.__module__):
         sched.start()
         await asyncio.sleep(0.05)
         sched.stop()
         await asyncio.sleep(0)
 
-    # The format string contains the class name
-    call_args = mock_log.exception.call_args
-    assert "_ErrorScheduler" in call_args[0][0] % (call_args[0][1],)
+    failures = [r for r in caplog.records if "_tick() failed" in r.message]
+    assert failures, "exception must be logged"
+    # Attributed to the subclass's module logger, naming the concrete class
+    assert failures[0].name == _ErrorScheduler.__module__
+    assert "_ErrorScheduler" in failures[0].message
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llc/tests/test_poll_loop_scheduler.py
+++ b/autobot-backend/llc/tests/test_poll_loop_scheduler.py
@@ -1,0 +1,214 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for PollLoopScheduler base class (GH#9842)."""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from llc.scheduler.base import PollLoopScheduler
+
+
+# ---------------------------------------------------------------------------
+# Test double — concrete subclass with a controllable tick
+# ---------------------------------------------------------------------------
+
+
+class _CountingScheduler(PollLoopScheduler):
+    """Minimal subclass that counts tick invocations."""
+
+    _task_name = "test-counting-scheduler"
+
+    def __init__(self, poll_interval: float = 9999.0) -> None:
+        super().__init__(poll_interval)
+        self.tick_count = 0
+
+    async def _tick(self) -> None:
+        self.tick_count += 1
+
+
+class _ErrorScheduler(PollLoopScheduler):
+    """Subclass whose tick always raises a non-Cancelled exception."""
+
+    _task_name = "test-error-scheduler"
+
+    def __init__(self, poll_interval: float = 9999.0) -> None:
+        super().__init__(poll_interval)
+        self.tick_count = 0
+
+    async def _tick(self) -> None:
+        self.tick_count += 1
+        raise RuntimeError("tick exploded")
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: start / stop idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_start_creates_task_and_sets_running() -> None:
+    """start() creates the asyncio task and sets _running=True."""
+
+    async def _run() -> None:
+        sched = _CountingScheduler()
+        assert not sched.is_running
+        sched.start()
+        assert sched._running is True
+        assert sched._task is not None
+        assert not sched._task.done()
+        sched.stop()
+
+    asyncio.get_event_loop().run_until_complete(_run())
+
+
+def test_start_idempotent() -> None:
+    """Calling start() twice does not create a second task."""
+
+    async def _run() -> None:
+        sched = _CountingScheduler()
+        sched.start()
+        task_first = sched._task
+        sched.start()  # second call — must be a no-op
+        assert sched._task is task_first
+        sched.stop()
+
+    asyncio.get_event_loop().run_until_complete(_run())
+
+
+def test_stop_clears_running_flag_and_cancels() -> None:
+    """stop() sets _running=False and cancels the task."""
+
+    async def _run() -> None:
+        sched = _CountingScheduler()
+        sched.start()
+        assert sched._running is True
+        sched.stop()
+        assert sched._running is False
+        # Give the event loop a chance to deliver the cancellation
+        await asyncio.sleep(0)
+
+    asyncio.get_event_loop().run_until_complete(_run())
+
+
+def test_stop_before_start_is_safe() -> None:
+    """stop() on a never-started scheduler does not raise."""
+    sched = _CountingScheduler()
+    sched.stop()  # must not raise
+
+
+def test_is_running_false_after_stop() -> None:
+    """is_running is False after stop() even if the task hasn't exited yet."""
+
+    async def _run() -> None:
+        sched = _CountingScheduler()
+        sched.start()
+        sched.stop()
+        # _running=False → is_running must be False regardless of task state
+        assert not sched.is_running
+
+    asyncio.get_event_loop().run_until_complete(_run())
+
+
+# ---------------------------------------------------------------------------
+# Task naming
+# ---------------------------------------------------------------------------
+
+
+def test_task_name_uses_class_variable() -> None:
+    """The asyncio task gets the name from _task_name."""
+
+    async def _run() -> None:
+        sched = _CountingScheduler()
+        sched.start()
+        assert sched._task is not None
+        assert sched._task.get_name() == "test-counting-scheduler"
+        sched.stop()
+
+    asyncio.get_event_loop().run_until_complete(_run())
+
+
+def test_task_name_falls_back_to_class_name_when_empty() -> None:
+    """When _task_name is empty the task name is the class name."""
+
+    class _Unnamed(PollLoopScheduler):
+        _task_name = ""  # empty → fall back
+
+        async def _tick(self) -> None:
+            pass
+
+    async def _run() -> None:
+        sched = _Unnamed(poll_interval=9999.0)
+        sched.start()
+        assert sched._task is not None
+        assert sched._task.get_name() == "_Unnamed"
+        sched.stop()
+
+    asyncio.get_event_loop().run_until_complete(_run())
+
+
+# ---------------------------------------------------------------------------
+# Tick exception survival
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tick_exception_does_not_kill_loop() -> None:
+    """When _tick() raises, the loop continues (exception is caught and logged)."""
+    sched = _ErrorScheduler(poll_interval=0.0)
+    with patch("llc.scheduler.base.logger") as mock_log:
+        sched.start()
+        # Allow a couple of iterations — if the loop were killed by the first
+        # exception, tick_count would stay at 1.
+        await asyncio.sleep(0.05)
+        sched.stop()
+        await asyncio.sleep(0)  # let cancellation propagate
+
+    assert sched.tick_count >= 2, "loop must survive tick exceptions"
+    assert mock_log.exception.called, "exception must be logged"
+
+
+@pytest.mark.asyncio
+async def test_tick_exception_logs_class_name() -> None:
+    """The exception log message includes the concrete class name."""
+    sched = _ErrorScheduler(poll_interval=0.0)
+    with patch("llc.scheduler.base.logger") as mock_log:
+        sched.start()
+        await asyncio.sleep(0.05)
+        sched.stop()
+        await asyncio.sleep(0)
+
+    # The format string contains the class name
+    call_args = mock_log.exception.call_args
+    assert "_ErrorScheduler" in call_args[0][0] % (call_args[0][1],)
+
+
+# ---------------------------------------------------------------------------
+# Cancellation (CancelledError breaks the loop cleanly)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancellation_breaks_loop_cleanly() -> None:
+    """Cancelling the task does not produce an unhandled CancelledError."""
+    sched = _CountingScheduler(poll_interval=9999.0)
+    sched.start()
+    assert sched._task is not None
+    sched._task.cancel()
+    # Must not raise — CancelledError is caught inside _loop
+    await asyncio.gather(sched._task, return_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# Default _tick raises NotImplementedError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_base_tick_raises_not_implemented() -> None:
+    """Calling _tick() directly on the base raises NotImplementedError."""
+    sched = PollLoopScheduler(poll_interval=9999.0)
+    with pytest.raises(NotImplementedError):
+        await sched._tick()

--- a/autobot-backend/llc/tests/test_poll_loop_scheduler.py
+++ b/autobot-backend/llc/tests/test_poll_loop_scheduler.py
@@ -11,7 +11,6 @@ import pytest
 
 from llc.scheduler.base import PollLoopScheduler
 
-
 # ---------------------------------------------------------------------------
 # Test double — concrete subclass with a controllable tick
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path
BudgetWatchdog, LivenessMonitor, and SessionCheckpointer hand-rolled identical start/stop/_loop/is_running scaffolding. Extracted `PollLoopScheduler` (`llc/scheduler/base.py`) — subclasses keep only their per-tick logic — mirroring the #9834 SubprocessLifecycleAdapter consolidation. RoutineScheduler was deliberately excluded after inspection: async `startup()/shutdown()`, `ensure_future`, shutdown awaits the task with CancelledError suppression, different loop error handling — a different lifecycle contract where forced inheritance would change semantics. `heartbeat_scheduler` is richer and out of scope per the issue.

## What Changed
- NEW `llc/scheduler/base.py`: `PollLoopScheduler` — idempotent `start()` (returns created-flag so subclasses log 'started' exactly once), `stop()` (cancel without await, `_running=False` first), `_loop` (CancelledError breaks; other exceptions logged-and-continue with the sleep always running), per-subclass task names preserved; tick failures attributed to the subclass's module logger so per-module log filtering keeps working
- `budget_watchdog.py`, `liveness_monitor.py`, `session_checkpointer.py`: scaffolding removed, `_tick` hook wired; `_check_agent_budgets` and all tick bodies untouched (rebased cleanly over #9998's token-mode changes — 24/24 combined tests post-rebase)
- NEW `llc/tests/test_poll_loop_scheduler.py`: 11 tests (start idempotency, stop-before-start, task naming, tick-exception survival + logger attribution, clean cancellation, NotImplementedError guard)

## Verification
- 11/11 new base tests; scheduler suites byte-identical pre/post (4 pre-existing liveness failures = #9987, health-probe failures pre-existing on base — reviewer re-ran both sides)
- Independent review verdict APPROVE; its MEDIUM (double-start re-logging 'started') and LOW (base logger stealing tick-failure attribution) fixed in-PR
- BudgetWatchdog gains `is_running` additively (no prior callers — verified incl. health probe's getattr pattern); production wiring in lifespan.py unchanged
- flake8 + py_compile clean

## Model Used
Fable 5 (main session) + Sonnet sub-agents (implementation + independent review)

Fixes #9842

🤖 Generated with [Claude Code](https://claude.com/claude-code)