### PR TITLE
fix(backend): declare watchdog in requirements — watch-folders 500 on fresh venvs (#10009)

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -89,6 +89,11 @@ scikit-learn>=1.8.0           # Issue #2027: RAPTOR clustering
 bleach>=6.0.0           # HTML sanitization for canvas HTML/PDF export (XSS prevention — security-critical)
 weasyprint>=69.0        # HTML→PDF rendering for canvas PDF export
 
+# Filesystem watching (#9000 KB watch-folders, docs watcher, hot reload) — #10009:
+# imported by kb_folder_watcher/documentation_watcher/hot_reload_manager but was
+# never declared; fresh venvs 500'd on /api/knowledge_base/watch-folders
+watchdog>=6.0.0
+
 # Media processing pipelines (Issue #932)
 aiohttp>=3.14.0         # Async HTTP client - SECURITY UPDATE
 httpx>=0.28.1           # Issue #4412: hub registry fetches (async HTTP)


### PR DESCRIPTION
## Thinking Path
Live 500 on the deployed manager: `/api/knowledge_base/watch-folders` → `ModuleNotFoundError: No module named 'watchdog'`. Three modules import it (since #9000) but it was never in `autobot-backend/requirements.txt` — fresh venvs always lacked it. The deployment was hot-fixed via `pip install watchdog` (endpoint 200 now); this is the codebase root fix.

## What Changed
One requirements entry: `watchdog>=6.0.0` (the verified-working version live), with a comment naming the three importers.

## Verification
- Deployed venv with watchdog 6.0.0: `/api/knowledge_base/watch-folders` → 200 (live)
- Importers: `utils/hot_reload_manager.py`, `services/documentation_watcher.py`, `services/kb_folder_watcher.py`

## Model Used
Claude Opus 4.8 (1M context)

Closes #10009
