### PR TITLE
fix(ansible): universal /slm prefix for all SLM API calls in playbooks (#9957)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
+++ b/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
@@ -677,7 +677,7 @@
 
     - name: "Mark-synced | Login to SLM API"
       ansible.builtin.uri:
-        url: "https://{{ hostvars['00-SLM-Manager']['ansible_host'] | default('127.0.0.1') }}/api/auth/login"
+        url: "https://{{ hostvars['00-SLM-Manager']['ansible_host'] | default('127.0.0.1') }}/slm/api/auth/login"
         method: POST
         body_format: json
         body:
@@ -705,7 +705,7 @@
 
     - name: "Mark-synced | POST to /api/code-sync/nodes/{{ inventory_hostname }}/mark-synced"
       ansible.builtin.uri:
-        url: "https://{{ hostvars['00-SLM-Manager']['ansible_host'] | default('127.0.0.1') }}/api/code-sync/nodes/{{ inventory_hostname }}/mark-synced"
+        url: "https://{{ hostvars['00-SLM-Manager']['ansible_host'] | default('127.0.0.1') }}/slm/api/code-sync/nodes/{{ inventory_hostname }}/mark-synced"
         method: POST
         headers:
           Authorization: "Bearer {{ _slm_login.json.access_token | default('') }}"

--- a/autobot-slm-backend/ansible/playbooks/setup-internal-ca.yml
+++ b/autobot-slm-backend/ansible/playbooks/setup-internal-ca.yml
@@ -48,7 +48,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    slm_admin_url: "{{ lookup('env', 'AUTOBOT_SLM_URL') | default('https://' ~ {{ slm_host | default(hostvars[groups.get('slm_manager', groups.get('slm', ['localhost']))[0]]['ansible_host'] | default('127.0.0.1')) }}, true) }}"
+    slm_admin_url: "{{ lookup('env', 'AUTOBOT_SLM_URL') | default('https://' ~ (slm_host | default(hostvars[groups.get('slm_manager', groups.get('slm', ['localhost']))[0]]['ansible_host'] | default('127.0.0.1'))) ~ '/slm', true) }}"
     slm_admin_password: "{{ lookup('env', 'AUTOBOT_SLM_ADMIN_PASSWORD') | default('admin', true) }}"
 
   tasks:

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -360,7 +360,7 @@
 
     - name: "[PLAY 1] SLM | Wait for API to be ready"
       uri:
-        url: "https://{{ ansible_host }}/api/health"
+        url: "https://{{ ansible_host }}/slm/api/health"
         validate_certs: false
         status_code: 200
       register: slm_health_check
@@ -372,7 +372,7 @@
 
     - name: "[PLAY 1] SLM | Login to get auth token"
       uri:
-        url: "https://{{ ansible_host }}/api/auth/login"
+        url: "https://{{ ansible_host }}/slm/api/auth/login"
         method: POST
         body_format: json
         body:
@@ -394,7 +394,7 @@
 
     - name: "[PLAY 1] SLM | Mark node as synced in DB"
       uri:
-        url: "https://{{ ansible_host }}/api/code-sync/nodes/00-SLM-Manager/mark-synced"
+        url: "https://{{ ansible_host }}/slm/api/code-sync/nodes/00-SLM-Manager/mark-synced"
         method: POST
         headers:
           Authorization: "Bearer {{ slm_login_play1.json.access_token | default('') }}"
@@ -429,7 +429,7 @@
   pre_tasks:
     - name: "[PLAY 2] Login to SLM API"
       uri:
-        url: "https://{{ slm_host }}/api/auth/login"
+        url: "https://{{ slm_host }}/slm/api/auth/login"
         method: POST
         body_format: json
         body:
@@ -861,7 +861,7 @@
     # ----- Mark synced -----
     - name: "[PLAY 2] Mark node as synced in SLM DB"
       uri:
-        url: "https://{{ slm_host }}/api/code-sync/nodes/{{ inventory_hostname }}/mark-synced"
+        url: "https://{{ slm_host }}/slm/api/code-sync/nodes/{{ inventory_hostname }}/mark-synced"
         method: POST
         headers:
           Authorization: "Bearer {{ slm_token }}"
@@ -893,7 +893,7 @@
 
     - name: Check SLM health
       uri:
-        url: "https://{{ slm_host }}/api/health"
+        url: "https://{{ slm_host }}/slm/api/health"
         validate_certs: false
       register: slm_health
       ignore_errors: true

--- a/autobot-slm-backend/ansible/playbooks/update-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-node.yml
@@ -35,7 +35,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    slm_admin_url: "{{ lookup('env', 'AUTOBOT_SLM_URL') | default('https://' ~ {{ slm_host | default(hostvars[groups.get('slm_manager', groups.get('slm', ['localhost']))[0]]['ansible_host'] | default('127.0.0.1')) }}, true) }}"
+    slm_admin_url: "{{ lookup('env', 'AUTOBOT_SLM_URL') | default('https://' ~ (slm_host | default(hostvars[groups.get('slm_manager', groups.get('slm', ['localhost']))[0]]['ansible_host'] | default('127.0.0.1'))) ~ '/slm', true) }}"
 
   tasks:
     - name: "Login to SLM API"
@@ -216,7 +216,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    slm_admin_url: "{{ lookup('env', 'AUTOBOT_SLM_URL') | default('https://' ~ {{ slm_host | default(hostvars[groups.get('slm_manager', groups.get('slm', ['localhost']))[0]]['ansible_host'] | default('127.0.0.1')) }}, true) }}"
+    slm_admin_url: "{{ lookup('env', 'AUTOBOT_SLM_URL') | default('https://' ~ (slm_host | default(hostvars[groups.get('slm_manager', groups.get('slm', ['localhost']))[0]]['ansible_host'] | default('127.0.0.1'))) ~ '/slm', true) }}"
 
   tasks:
     - name: "Pause for services to stabilise"


### PR DESCRIPTION
## Thinking Path
The #9953 class, completed: 11 remaining SLM API calls across four playbooks used the bare host `/api/` path — on co-located managers nginx routes that to the **user backend**, so SLM auth 401s. This is why mark-synced always warn-skipped (#7103), why the Code Sync UI showed nodes as "unknown/outdated", and why the one-click fleet selection couldn't see real `code_status` (#9996 facet 2).

## What Changed
- `update-all-nodes.yml` — 6 urls (SLM health/login/mark-synced via `ansible_host` and `slm_host`) → `/slm/api/...`
- `provision-fleet-roles.yml` — the Phase 6.5 mark-synced login + POST → `/slm/api/...`
- `update-node.yml` (×2) + `setup-internal-ca.yml` (×1) — `slm_admin_url` defaults gain the `/slm` suffix **and** their malformed nested-`{{ }}` Jinja (invalid template-in-template) is corrected to parenthesized expressions
- `AUTOBOT_SLM_URL` env override untouched (operator provides a full base URL)

## Verification
- YAML parse OK ×4; `ansible-playbook --syntax-check` clean ×4 (`update-node.yml` with its required `-e node_id`, bare-check failure is the documented pre-existing design)
- Residual grep: 0 bare-host SLM `/api/` calls remain in these playbooks
- `/slm/api/` serving verified live on this co-located host throughout today (#9953/#9944)

## Model Used
Claude Opus 4.8 (1M context)

Closes #9957. Unblocks truthful mark-synced → feeds #9996 (one-click fleet selection) and the Code Sync UI state.
