### PR TITLE
fix(docker): install claude CLI from official signed apt repo (#9950)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,6 +184,12 @@ services:
     build:
       context: .
       dockerfile: docker/backend/Dockerfile
+      # claude CLI integrity pin (GH#9950): supplied via env so the image
+      # is built against a human-verified version + installer sha256.
+      # Empty default keeps the Dockerfile's required-arg guard active.
+      args:
+        CLAUDE_CLI_VERSION: "${CLAUDE_CLI_VERSION:-stable}"
+        CLAUDE_INSTALLER_SHA256: "${CLAUDE_INSTALLER_SHA256:-}"
     image: autobot/backend:latest
     container_name: autobot-backend
     restart: unless-stopped
@@ -301,6 +307,12 @@ services:
     build:
       context: .
       dockerfile: docker/backend/Dockerfile
+      # claude CLI integrity pin (GH#9950): supplied via env so the image
+      # is built against a human-verified version + installer sha256.
+      # Empty default keeps the Dockerfile's required-arg guard active.
+      args:
+        CLAUDE_CLI_VERSION: "${CLAUDE_CLI_VERSION:-stable}"
+        CLAUDE_INSTALLER_SHA256: "${CLAUDE_INSTALLER_SHA256:-}"
     image: autobot/backend:latest
     container_name: autobot-worker
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,12 +184,11 @@ services:
     build:
       context: .
       dockerfile: docker/backend/Dockerfile
-      # claude CLI integrity pin (GH#9950): supplied via env so the image
-      # is built against a human-verified version + installer sha256.
-      # Empty default keeps the Dockerfile's required-arg guard active.
+      # claude CLI version pin (GH#9950): optional exact package version for a
+      # reproducible build (e.g. 2.1.89). Empty default = current stable-channel
+      # build from Anthropic's signed apt repo (integrity verified by apt).
       args:
-        CLAUDE_CLI_VERSION: "${CLAUDE_CLI_VERSION:-stable}"
-        CLAUDE_INSTALLER_SHA256: "${CLAUDE_INSTALLER_SHA256:-}"
+        CLAUDE_CLI_VERSION: "${CLAUDE_CLI_VERSION:-}"
     image: autobot/backend:latest
     container_name: autobot-backend
     restart: unless-stopped
@@ -307,12 +306,11 @@ services:
     build:
       context: .
       dockerfile: docker/backend/Dockerfile
-      # claude CLI integrity pin (GH#9950): supplied via env so the image
-      # is built against a human-verified version + installer sha256.
-      # Empty default keeps the Dockerfile's required-arg guard active.
+      # claude CLI version pin (GH#9950): optional exact package version for a
+      # reproducible build (e.g. 2.1.89). Empty default = current stable-channel
+      # build from Anthropic's signed apt repo (integrity verified by apt).
       args:
-        CLAUDE_CLI_VERSION: "${CLAUDE_CLI_VERSION:-stable}"
-        CLAUDE_INSTALLER_SHA256: "${CLAUDE_INSTALLER_SHA256:-}"
+        CLAUDE_CLI_VERSION: "${CLAUDE_CLI_VERSION:-}"
     image: autobot/backend:latest
     container_name: autobot-worker
     restart: unless-stopped

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -40,60 +40,48 @@ FROM python:3.12-slim-bookworm AS production
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# --- claude CLI pinning + integrity (GH#9950) ---
-# Hardening of the prior unpinned `curl | bash` supply-chain risk:
-#   1. CLAUDE_CLI_VERSION pins an exact published release (not a moving channel).
-#   2. CLAUDE_INSTALLER_SHA256 pins the sha256 of the installer bootstrap script.
-#      The installer is downloaded to a file, its checksum verified, and ONLY
-#      THEN executed — no piping of an unverified stream into bash.
-#   3. The installer itself then fetches the version-pinned binary and verifies
-#      it against its own signed sha256 manifest (second integrity layer).
+# --- claude CLI install (GH#9950) ---
+# Replaces the prior unpinned `curl | bash` supply-chain risk with Anthropic's
+# official SIGNED apt repository — the same keyring + sources-list + apt-get
+# pattern used for `gh` below. apt verifies every package against the Claude Code
+# release signing key on every install, so there is no manual sha256 to supply
+# and no self-updating-installer hash to chase. The signing key (fingerprint
+# 31DD DE24 DDFA B679 F42D 7BD2 BAA9 29FF 1A7E CACE) is the stable trust anchor;
+# new releases are just newer signed packages, so the build never fails-closed on
+# an upstream installer refresh. apt installs do not auto-update (correct for an
+# immutable image — the native curl|bash installer auto-updates in the background).
 #
-# To update the pin:
-#   curl -fsSLO https://claude.ai/install.sh
-#   sha256sum install.sh        # -> paste into CLAUDE_INSTALLER_SHA256 below
-#   # pick the target version from https://github.com/anthropics/claude-code/releases
-# Build override (CI / release pipeline supplies the verified values):
-#   docker build --build-arg CLAUDE_CLI_VERSION=1.2.3 \
-#                --build-arg CLAUDE_INSTALLER_SHA256=<64-hex> ...
-ARG CLAUDE_CLI_VERSION=stable
-# REQUIRED: no default — the build MUST fail unless a real, human-verified
-# sha256 is supplied. A placeholder/empty value makes the verification step
-# (and therefore the build) fail loudly rather than silently piping to bash.
-ARG CLAUDE_INSTALLER_SHA256=""
+# CLAUDE_CLI_VERSION pins an exact package version for reproducible builds
+# (e.g. 2.1.89); leave empty to take the current build from the stable channel.
+ARG CLAUDE_CLI_VERSION=""
 
-# Install runtime deps + LLC agent CLIs (GH#9793).
-# gh: official GitHub apt repo (keyring + sources list + apt-get install) — signed apt, no pipe-to-bash.
-# claude: download-then-verify-then-run (GH#9950). The official installer ONLY
-#   installs to $HOME/.local/bin (CLAUDE_INSTALL_DIR is not honored — proven by
-#   the smoke-test build gate), so HOME is redirected to a world-readable prefix
-#   and the launcher symlinked into /usr/local/bin for the autobot user.
+# Install runtime deps + LLC agent CLIs (GH#9793) from signed apt repos — no
+# pipe-to-bash for either CLI. `claude` lands on the system PATH (no HOME
+# redirect / symlink needed); the build-time `--version` checks prove both
+# resolve, so an install regression fails the build instead of silently
+# breaking LLC dispatch.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates \
     && install -m 0755 -d /etc/apt/keyrings \
+    # gh — official GitHub signed apt repo
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
        | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
     && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
        > /etc/apt/sources.list.d/github-cli.list \
-    && apt-get update && apt-get install -y --no-install-recommends gh \
-    && install -m 0755 -d /opt/claude-cli \
-    # Fail early if the integrity pin was not supplied (no blind pipe-to-bash).
-    && if [ -z "$CLAUDE_INSTALLER_SHA256" ]; then \
-         echo "ERROR: CLAUDE_INSTALLER_SHA256 build-arg is required (GH#9950). See Dockerfile comment for how to compute it." >&2; \
-         exit 1; \
+    # claude-code — official Anthropic signed apt repo (stable channel)
+    && curl -fsSL https://downloads.claude.ai/keys/claude-code.asc \
+       -o /etc/apt/keyrings/claude-code.asc \
+    && chmod go+r /etc/apt/keyrings/claude-code.asc \
+    && echo "deb [signed-by=/etc/apt/keyrings/claude-code.asc] https://downloads.claude.ai/claude-code/apt/stable stable main" \
+       > /etc/apt/sources.list.d/claude-code.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && if [ -n "$CLAUDE_CLI_VERSION" ]; then \
+         apt-get install -y --no-install-recommends "claude-code=${CLAUDE_CLI_VERSION}"; \
+       else \
+         apt-get install -y --no-install-recommends claude-code; \
        fi \
-    # 1) download the installer to a file (do NOT execute the stream)
-    && curl -fsSL https://claude.ai/install.sh -o /tmp/claude-install.sh \
-    # 2) verify its sha256 against the pinned, human-verified value
-    && echo "${CLAUDE_INSTALLER_SHA256}  /tmp/claude-install.sh" | sha256sum -c - \
-    # 3) only now execute it, pinned to an exact version, HOME-redirected
-    && HOME=/opt/claude-cli bash /tmp/claude-install.sh "${CLAUDE_CLI_VERSION}" \
-    && rm -f /tmp/claude-install.sh \
-    && ln -s /opt/claude-cli/.local/bin/claude /usr/local/bin/claude \
-    && chmod -R a+rX /opt/claude-cli \
-    # Build-time proof both CLIs resolve on PATH — without this, an installer
-    # prefix change would silently break LLC dispatch (gate skips forever).
     && gh --version \
     && claude --version \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -40,15 +40,36 @@ FROM python:3.12-slim-bookworm AS production
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# --- claude CLI pinning + integrity (GH#9950) ---
+# Hardening of the prior unpinned `curl | bash` supply-chain risk:
+#   1. CLAUDE_CLI_VERSION pins an exact published release (not a moving channel).
+#   2. CLAUDE_INSTALLER_SHA256 pins the sha256 of the installer bootstrap script.
+#      The installer is downloaded to a file, its checksum verified, and ONLY
+#      THEN executed — no piping of an unverified stream into bash.
+#   3. The installer itself then fetches the version-pinned binary and verifies
+#      it against its own signed sha256 manifest (second integrity layer).
+#
+# To update the pin:
+#   curl -fsSLO https://claude.ai/install.sh
+#   sha256sum install.sh        # -> paste into CLAUDE_INSTALLER_SHA256 below
+#   # pick the target version from https://github.com/anthropics/claude-code/releases
+# Build override (CI / release pipeline supplies the verified values):
+#   docker build --build-arg CLAUDE_CLI_VERSION=1.2.3 \
+#                --build-arg CLAUDE_INSTALLER_SHA256=<64-hex> ...
+ARG CLAUDE_CLI_VERSION=stable
+# REQUIRED: no default — the build MUST fail unless a real, human-verified
+# sha256 is supplied. A placeholder/empty value makes the verification step
+# (and therefore the build) fail loudly rather than silently piping to bash.
+ARG CLAUDE_INSTALLER_SHA256=""
+
 # Install runtime deps + LLC agent CLIs (GH#9793).
-# gh: official GitHub apt repo (keyring + sources list + apt-get install).
-# claude: the official installer verifies a sha256 manifest but ONLY installs
-#   to $HOME/.local/bin (CLAUDE_INSTALL_DIR is not honored — proven by the
-#   smoke-test build gate). Redirect HOME to a world-readable prefix and
-#   symlink the launcher into /usr/local/bin so the autobot user can run it.
-#   "stable" pins the release channel (GH#9950 hardening).
+# gh: official GitHub apt repo (keyring + sources list + apt-get install) — signed apt, no pipe-to-bash.
+# claude: download-then-verify-then-run (GH#9950). The official installer ONLY
+#   installs to $HOME/.local/bin (CLAUDE_INSTALL_DIR is not honored — proven by
+#   the smoke-test build gate), so HOME is redirected to a world-readable prefix
+#   and the launcher symlinked into /usr/local/bin for the autobot user.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
+    curl ca-certificates \
     && install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
        | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
@@ -57,7 +78,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
        > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update && apt-get install -y --no-install-recommends gh \
     && install -m 0755 -d /opt/claude-cli \
-    && curl -fsSL https://claude.ai/install.sh | HOME=/opt/claude-cli bash -s -- stable \
+    # Fail early if the integrity pin was not supplied (no blind pipe-to-bash).
+    && if [ -z "$CLAUDE_INSTALLER_SHA256" ]; then \
+         echo "ERROR: CLAUDE_INSTALLER_SHA256 build-arg is required (GH#9950). See Dockerfile comment for how to compute it." >&2; \
+         exit 1; \
+       fi \
+    # 1) download the installer to a file (do NOT execute the stream)
+    && curl -fsSL https://claude.ai/install.sh -o /tmp/claude-install.sh \
+    # 2) verify its sha256 against the pinned, human-verified value
+    && echo "${CLAUDE_INSTALLER_SHA256}  /tmp/claude-install.sh" | sha256sum -c - \
+    # 3) only now execute it, pinned to an exact version, HOME-redirected
+    && HOME=/opt/claude-cli bash /tmp/claude-install.sh "${CLAUDE_CLI_VERSION}" \
+    && rm -f /tmp/claude-install.sh \
     && ln -s /opt/claude-cli/.local/bin/claude /usr/local/bin/claude \
     && chmod -R a+rX /opt/claude-cli \
     # Build-time proof both CLIs resolve on PATH — without this, an installer


### PR DESCRIPTION
## Thinking Path
The backend image installed the claude CLI via unverified, unpinned `curl -fsSL https://claude.ai/install.sh | bash` (added in #9948, `857cfaedc`) — a supply-chain risk. The interim draft hardened it with download→sha256-verify→run, but that required a human-supplied checksum and pinned a **self-updating bootstrap installer** whose hash drifts on every upstream refresh (build fails-closed each time). Per https://code.claude.com/docs/en/setup, Claude Code publishes an **official signed apt repository** — the correct root fix.

## What Changed
- `docker/backend/Dockerfile`: install `claude-code` from Anthropic's signed apt repo using the **same keyring + sources-list + apt-get pattern already used for `gh`**. apt verifies every package against the Claude Code release signing key (fingerprint `31DD DE24 DDFA B679 F42D 7BD2 BAA9 29FF 1A7E CACE`) on every install — no manual sha256, no installer-hash drift. Dropped the `/opt/claude-cli` HOME-redirect + `/usr/local/bin` symlink (apt puts `claude` on PATH) and the required-sha256 build-arg guard. Kept the build-time `gh --version && claude --version` proof.
- `docker-compose.yml`: removed the obsolete `CLAUDE_INSTALLER_SHA256` build-arg passthrough; `CLAUDE_CLI_VERSION` now optionally pins an exact package version (empty = current stable-channel build).

## Why this is the core fix
- **No human-supplied secret** — apt does signature verification automatically; the build no longer needs a checksum to proceed.
- **No drift / no fail-closed churn** — the signing key is the stable trust anchor; new releases are just newer signed packages.
- **Correct for an immutable image** — apt installs don't auto-update (the native `curl|bash` installer auto-updates in the background, which a container shouldn't).
- **Consistent** — one signed-apt pattern for both agent CLIs (`gh` + `claude`).

## Verification
- `docker-compose.yml` parses (`yaml.safe_load`); grep confirms zero `claude.ai/install.sh`, `CLAUDE_INSTALLER_SHA256`, or `/opt/claude-cli` references remain. Full image build (apt fetch + `claude --version`) runs in CI smoke-test.

## Model Used
Fable 5 (main session)

Fixes #9950 (part of #9919)