### PR TITLE
fix(slm-docker): parameterize Python version — unbreak SLM image on 3.14 (#9949)

### DIFF
--- a/docker/slm/Dockerfile
+++ b/docker/slm/Dockerfile
@@ -1,12 +1,15 @@
 # AutoBot SLM Backend - Service Lifecycle Manager (#1809, #1836)
-# python:3.12-slim-bookworm base — eliminates deadsnakes PPA cold build overhead (#6213)
+# python:${PYTHON_VERSION}-slim-bookworm base — eliminates deadsnakes PPA cold build overhead (#6213)
+# PYTHON_VERSION build ARG keeps the interpreter minor in one place so a 3.14 bump
+# only changes one value and the COPY site-packages path tracks it (#9949).
 #
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 
 # ---- Dependencies stage ----
-FROM python:3.12-slim-bookworm AS deps
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim-bookworm AS deps
 
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /app
@@ -29,7 +32,9 @@ RUN grep -v -E "(autobot_shared|^-r )" /tmp/requirements.txt > /app/requirements
 
 
 # ---- Production stage ----
-FROM python:3.12-slim-bookworm AS production
+FROM python:${PYTHON_VERSION}-slim-bookworm AS production
+# Re-declare after FROM so it is in scope for the COPY paths below.
+ARG PYTHON_VERSION=3.12
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -43,7 +48,7 @@ RUN groupadd -r --gid 999 autobot && useradd -r --uid 999 -g autobot -d /app aut
 WORKDIR /app
 
 # Copy Python packages from deps stage
-COPY --from=deps /usr/local/lib/python3.12/ /usr/local/lib/python3.12/
+COPY --from=deps /usr/local/lib/python${PYTHON_VERSION}/ /usr/local/lib/python${PYTHON_VERSION}/
 COPY --from=deps /usr/local/bin/ /usr/local/bin/
 
 # Copy shared module

--- a/docker/slm/dev-entrypoint.sh
+++ b/docker/slm/dev-entrypoint.sh
@@ -18,10 +18,10 @@ pip install -e /app/autobot_shared --quiet 2>/dev/null || true
 
 echo "[dev-entrypoint] Running SLM database migrations..."
 cd /app/autobot-slm-backend
-python3.12 -m migrations.runner || {
+python3 -m migrations.runner || {
     echo "ERROR: Migration failed -- retrying in 5s..."
     sleep 5
-    python3.12 -m migrations.runner || {
+    python3 -m migrations.runner || {
         echo "FATAL: Migration failed after retry. Aborting."
         exit 1
     }

--- a/docker/slm/entrypoint.sh
+++ b/docker/slm/entrypoint.sh
@@ -10,10 +10,10 @@ set -e
 cd /app/autobot-slm-backend
 
 echo "Running SLM database migrations..."
-python3.12 -m migrations.runner || {
+python3 -m migrations.runner || {
     echo "ERROR: Migration failed — retrying in 5s..."
     sleep 5
-    python3.12 -m migrations.runner || {
+    python3 -m migrations.runner || {
         echo "FATAL: Migration failed after retry. Aborting."
         exit 1
     }


### PR DESCRIPTION
## Thinking Path
Static analysis of the SLM image (no network/Docker here to capture a live 3.14 traceback). Found two deterministic, image-breaking hardcodes that explain the "container unhealthy, no traceback" symptom from #9825 — not a missing-wheel problem.

## What Changed
- `docker/slm/entrypoint.sh` + `dev-entrypoint.sh`: `python3.12 -m migrations.runner` → `python3`. On a 3.14 base `python3.12` is absent; with `set -e` the entrypoint exits 127 (`command not found`) on the first migration line before uvicorn starts — surfaces only as "unhealthy", matching the no-traceback symptom.
- `docker/slm/Dockerfile`: hardcoded `COPY --from=deps /usr/local/lib/python3.12/` → parameterized via the `PYTHON_VERSION` build ARG so the site-packages path never drifts from the base image. **Default stays 3.12** — nothing changes until the bump is intentional (`--build-arg PYTHON_VERSION=3.14`).

## Dependency cp314 audit
All `requirements.txt` floors already admit cp314-capable releases (pydantic/-core, asyncpg, psycopg2-binary, cryptography/bcrypt rust-abi3; rest pure-Python, zero removed-stdlib imports). No speculative floor bumps.

## Verification
- `py_compile`/shell syntax clean. Full 3.14 health requires CI/Docker — repro recipe in the issue. This is PARTIAL: the deterministic defects are fixed; CI must confirm the container reaches healthy on 3.14.

## Model Used
Fable 5 (main) + Sonnet sub-agent

Refs #9949 (part of #9919) — keeping open until CI verifies 3.14 health