### PR TITLE
consolidation(migrations): shared alembic guard helpers — has_table/has_column/ensure_pg_enum (#10027)

### DIFF
--- a/.session/HANDOFF-issue-10027.md
+++ b/.session/HANDOFF-issue-10027.md
@@ -1,0 +1,13 @@
+# Handoff: issue-10027
+status: complete
+pr: #10072
+base_at_push: 7ccc67096 (rebased)
+gates: guards-unit=PASS(6) full-chain-DDL-parity=PASS(sha-identical) ruff=PASS migration-matrix=PASS(CI)
+needs_rebase_before_merge: no
+remaining: (none)
+notes: |
+  Shared alembic guard helpers (migrations/guards.py); refactored 002/018/022/027/030/031/032/036.
+  DDL byte-identical proven via pg_dump --schema-only diff (base vs branch) = same sha, 4040 lines.
+  Design: enum values literal in version scripts; NO shared registry (a migration is frozen history).
+  #9980 fixed model-side, not here. SLM psycopg2 utils.py deliberately untouched (#9785).
+worktree: .worktrees/issue-10027 (safe to remove after merge)

--- a/autobot-backend/migrations/guards.py
+++ b/autobot-backend/migrations/guards.py
@@ -1,0 +1,96 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shared schema-existence guards for Alembic version scripts (#10027).
+
+Every guard wraps the same two primitives the version scripts used to
+inline — ``sa.inspect(op.get_bind())`` lookups and the
+``postgresql.ENUM(create_type=False)`` + ``create(checkfirst=True)`` pair —
+so the emitted DDL is identical to the hand-written forms it replaces.
+
+Enum values stay literal inside each version script: a migration is frozen
+history, so it must never read a value list that later revisions (or model
+code) can change underneath it. ``pg_enum`` only removes the boilerplate of
+saying "this column references a type that op.create_table must not try to
+create" (generic ``sa.Enum`` silently ignores ``create_type`` and re-emitted
+unconditional ``CREATE TYPE``, aborting fresh-database upgrades — #9759).
+
+Usage in a version script::
+
+    from migrations.guards import ensure_pg_enum, has_table, pg_enum
+
+    _status = pg_enum("approvalstatus", "pending", "approved")
+
+    def upgrade() -> None:
+        ensure_pg_enum(_status)
+        if not has_table("approvals"):
+            ...
+
+Importable as ``migrations.guards`` because ``autobot-backend`` is on
+``sys.path`` both at Alembic runtime (env.py inserts it) and under pytest
+(``pythonpath`` in pytest.ini); ``migrations`` resolves as a namespace
+package, so no ``__init__.py`` is required.
+
+The SLM's psycopg2-based ``autobot-slm-backend/migrations/utils.py`` is a
+deliberate non-target: different driver and lifecycle (#10027, #9785).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import ENUM
+
+
+def _inspector() -> sa.engine.reflection.Inspector:
+    """Inspector bound to the in-flight migration connection."""
+    return sa.inspect(op.get_bind())
+
+
+def has_table(name: str) -> bool:
+    """True when ``name`` exists in the connected database."""
+    return _inspector().has_table(name)
+
+
+def has_column(table: str, column: str) -> bool:
+    """True when ``table`` exists and carries ``column``."""
+    inspector = _inspector()
+    if not inspector.has_table(table):
+        return False
+    return column in {c["name"] for c in inspector.get_columns(table)}
+
+
+def existing_columns(table: str) -> set[str]:
+    """Column names of ``table`` (empty set when the table is absent)."""
+    inspector = _inspector()
+    if not inspector.has_table(table):
+        return set()
+    return {c["name"] for c in inspector.get_columns(table)}
+
+
+def has_index(table: str, index: str) -> bool:
+    """True when ``table`` exists and carries an index named ``index``."""
+    inspector = _inspector()
+    if not inspector.has_table(table):
+        return False
+    return index in {i["name"] for i in inspector.get_indexes(table)}
+
+
+def pg_enum(name: str, *values: str) -> ENUM:
+    """A ``postgresql.ENUM`` reference that ``op.create_table`` never creates.
+
+    Use the returned object both in column definitions and as the argument
+    to :func:`ensure_pg_enum` / :func:`drop_pg_enum`. Values must be the
+    literal strings the migration historically wrote — never derived from
+    model code.
+    """
+    return ENUM(*values, name=name, create_type=False)
+
+
+def ensure_pg_enum(enum_type: ENUM) -> None:
+    """Emit ``CREATE TYPE`` for ``enum_type`` only when it does not exist."""
+    enum_type.create(op.get_bind(), checkfirst=True)
+
+
+def drop_pg_enum(enum_type: ENUM) -> None:
+    """Emit ``DROP TYPE`` for ``enum_type`` only when it exists."""
+    enum_type.drop(op.get_bind(), checkfirst=True)

--- a/autobot-backend/migrations/versions/20260216_002_secrets_hierarchical_access.py
+++ b/autobot-backend/migrations/versions/20260216_002_secrets_hierarchical_access.py
@@ -24,6 +24,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
+from migrations.guards import existing_columns, has_table
+
 # revision identifiers, used by Alembic.
 revision: str = "002"
 down_revision: str | None = "001"
@@ -93,17 +95,15 @@ def _create_secrets_table() -> None:
 
 def upgrade() -> None:
     """Ensure secrets table exists, then add org_id/team_ids for hierarchical access."""
-    inspector = sa.inspect(op.get_bind())
-
-    if not inspector.has_table("secrets"):
+    if not has_table("secrets"):
         _create_secrets_table()
-        existing_columns: set[str] = set()
+        present_columns: set[str] = set()
     else:
         # Table predates migration control (created via create_all) — it may
         # already carry any of the columns this revision adds.
-        existing_columns = {c["name"] for c in inspector.get_columns("secrets")}
+        present_columns = existing_columns("secrets")
 
-    if "org_id" not in existing_columns:
+    if "org_id" not in present_columns:
         op.add_column(
             "secrets",
             sa.Column(
@@ -119,7 +119,7 @@ def upgrade() -> None:
             ["org_id"],
         )
 
-    if "team_ids" not in existing_columns:
+    if "team_ids" not in present_columns:
         op.add_column(
             "secrets",
             sa.Column(

--- a/autobot-backend/migrations/versions/20260422_018_skills_process_run_timestamptz.py
+++ b/autobot-backend/migrations/versions/20260422_018_skills_process_run_timestamptz.py
@@ -23,6 +23,8 @@ from typing import Sequence
 import sqlalchemy as sa
 from alembic import op
 
+from migrations.guards import has_table
+
 revision: str = "20260422_018"
 down_revision: str | None = "20260324_017"
 branch_labels: str | Sequence[str] | None = None
@@ -42,9 +44,8 @@ _COLUMNS = [
 
 def upgrade() -> None:
     """Convert naive TIMESTAMP columns to TIMESTAMPTZ. Issue #5538."""
-    inspector = sa.inspect(op.get_bind())
     for table, column in _COLUMNS:
-        if not inspector.has_table(table):
+        if not has_table(table):
             continue
         op.alter_column(
             table,
@@ -56,9 +57,8 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Revert TIMESTAMPTZ columns back to naive TIMESTAMP. Issue #5538."""
-    inspector = sa.inspect(op.get_bind())
     for table, column in _COLUMNS:
-        if not inspector.has_table(table):
+        if not has_table(table):
             continue
         op.alter_column(
             table,

--- a/autobot-backend/migrations/versions/20260523_022_create_llc_work_items.py
+++ b/autobot-backend/migrations/versions/20260523_022_create_llc_work_items.py
@@ -20,18 +20,17 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects.postgresql import ENUM, JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from migrations.guards import drop_pg_enum, ensure_pg_enum, pg_enum
 
 revision: str = "20260523_022"
 down_revision: Union[str, None] = "20260522_021"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-# postgresql.ENUM with create_type=False: the enums are created explicitly in
-# upgrade() with checkfirst=True. Generic sa.Enum silently IGNORES
-# create_type, so op.create_table re-emitted an unconditional CREATE TYPE for
-# each enum column and aborted on fresh databases (#9759).
-_workitemtype = ENUM(
+_workitemtype = pg_enum(
+    "workitemtype",
     "epic",
     "feature",
     "pbi",
@@ -40,10 +39,9 @@ _workitemtype = ENUM(
     "subtask",
     "spike",
     "risk",
-    name="workitemtype",
-    create_type=False,
 )
-_workitemstatus = ENUM(
+_workitemstatus = pg_enum(
+    "workitemstatus",
     "backlog",
     "ready",
     "in_progress",
@@ -51,26 +49,23 @@ _workitemstatus = ENUM(
     "done",
     "cancelled",
     "blocked",
-    name="workitemstatus",
-    create_type=False,
 )
-_workitempriority = ENUM(
+_workitempriority = pg_enum(
+    "workitempriority",
     "critical",
     "high",
     "medium",
     "low",
-    name="workitempriority",
-    create_type=False,
 )
 
 
 def upgrade() -> None:
     bind = op.get_bind()
-    _workitemtype.create(bind, checkfirst=True)
-    _workitemstatus.create(bind, checkfirst=True)
+    ensure_pg_enum(_workitemtype)
+    ensure_pg_enum(_workitemstatus)
     # Ensure 'ready' exists even when workitemstatus was pre-created without it.
     bind.execute(sa.text("ALTER TYPE workitemstatus ADD VALUE IF NOT EXISTS 'ready'"))
-    _workitempriority.create(bind, checkfirst=True)
+    ensure_pg_enum(_workitempriority)
 
     op.create_table(
         "llc_work_items",
@@ -201,6 +196,6 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_table("llc_work_item_comments")
     op.drop_table("llc_work_items")
-    _workitempriority.drop(op.get_bind(), checkfirst=True)
-    _workitemstatus.drop(op.get_bind(), checkfirst=True)
-    _workitemtype.drop(op.get_bind(), checkfirst=True)
+    drop_pg_enum(_workitempriority)
+    drop_pg_enum(_workitemstatus)
+    drop_pg_enum(_workitemtype)

--- a/autobot-backend/migrations/versions/20260523_027_create_llc_approvals.py
+++ b/autobot-backend/migrations/versions/20260523_027_create_llc_approvals.py
@@ -14,40 +14,37 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects.postgresql import ENUM, JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from migrations.guards import drop_pg_enum, ensure_pg_enum, pg_enum
 
 revision: str = "20260523_027"
 down_revision: Union[str, None] = "20260523_026"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-# postgresql.ENUM with create_type=False: created explicitly in upgrade() with
-# checkfirst=True. Generic sa.Enum silently IGNORES create_type, so
-# op.create_table re-emitted CREATE TYPE and aborted on fresh databases (#9759).
-_approvaltype = ENUM(
+_approvaltype = pg_enum(
+    "approvaltype",
     "hire",
     "strategy",
     "budget_override",
     "sprint_close",
-    name="approvaltype",
-    create_type=False,
 )
 
-_approvalstatus = ENUM(
+_approvalstatus = pg_enum(
+    "approvalstatus",
     "pending",
     "approved",
     "rejected",
     "withdrawn",
     "expired",
-    name="approvalstatus",
-    create_type=False,
 )
 
 
 def upgrade() -> None:
     # Create enum types independently so they survive partial rollbacks.
-    _approvaltype.create(op.get_bind(), checkfirst=True)
-    _approvalstatus.create(op.get_bind(), checkfirst=True)
+    ensure_pg_enum(_approvaltype)
+    ensure_pg_enum(_approvalstatus)
 
     op.create_table(
         "llc_approvals",
@@ -114,5 +111,5 @@ def downgrade() -> None:
     op.drop_index("ix_llc_approvals_type", table_name="llc_approvals")
     op.drop_index("ix_llc_approvals_company_id", table_name="llc_approvals")
     op.drop_table("llc_approvals")
-    _approvalstatus.drop(op.get_bind(), checkfirst=True)
-    _approvaltype.drop(op.get_bind(), checkfirst=True)
+    drop_pg_enum(_approvalstatus)
+    drop_pg_enum(_approvaltype)

--- a/autobot-backend/migrations/versions/20260523_030_llc_sprint_hierarchy.py
+++ b/autobot-backend/migrations/versions/20260523_030_llc_sprint_hierarchy.py
@@ -22,46 +22,42 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects.postgresql import ENUM, JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from migrations.guards import drop_pg_enum, ensure_pg_enum, pg_enum
 
 revision: str = "20260523_030"
 down_revision: Union[str, None] = "20260523_029"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-# postgresql.ENUM with create_type=False: the enums are created explicitly in
-# upgrade() with checkfirst=True. Generic sa.Enum silently IGNORES
-# create_type, so op.create_table re-emitted an unconditional CREATE TYPE for
-# each enum column and aborted on fresh databases (#9759).
-_portfolio_status = ENUM("active", "paused", "archived", name="portfoliostatus", create_type=False)
-_program_status = ENUM("active", "paused", "archived", name="programstatus", create_type=False)
-_project_status = ENUM(
+_portfolio_status = pg_enum("portfoliostatus", "active", "paused", "archived")
+_program_status = pg_enum("programstatus", "active", "paused", "archived")
+_project_status = pg_enum(
+    "projectstatus",
     "backlog",
     "planned",
     "in_progress",
     "completed",
     "cancelled",
-    name="projectstatus",
-    create_type=False,
 )
-_sprint_status = ENUM(
+_sprint_status = pg_enum(
+    "sprintstatus",
     "planning",
     "active",
     "review",
     "retrospective",
     "closed",
     "cancelled",
-    name="sprintstatus",
-    create_type=False,
 )
 
 
 def upgrade() -> None:
     # -- Create ENUMs --
-    _portfolio_status.create(op.get_bind(), checkfirst=True)
-    _program_status.create(op.get_bind(), checkfirst=True)
-    _project_status.create(op.get_bind(), checkfirst=True)
-    _sprint_status.create(op.get_bind(), checkfirst=True)
+    ensure_pg_enum(_portfolio_status)
+    ensure_pg_enum(_program_status)
+    ensure_pg_enum(_project_status)
+    ensure_pg_enum(_sprint_status)
 
     # -- llc_portfolios --
     op.create_table(
@@ -213,7 +209,7 @@ def downgrade() -> None:
     op.drop_column("llc_work_items", "needs_triage")
     op.drop_column("llc_work_items", "backlog_position")
 
-    _sprint_status.drop(op.get_bind(), checkfirst=True)
-    _project_status.drop(op.get_bind(), checkfirst=True)
-    _program_status.drop(op.get_bind(), checkfirst=True)
-    _portfolio_status.drop(op.get_bind(), checkfirst=True)
+    drop_pg_enum(_sprint_status)
+    drop_pg_enum(_project_status)
+    drop_pg_enum(_program_status)
+    drop_pg_enum(_portfolio_status)

--- a/autobot-backend/migrations/versions/20260523_031_llc_company_memberships.py
+++ b/autobot-backend/migrations/versions/20260523_031_llc_company_memberships.py
@@ -16,16 +16,22 @@ Create Date: 2026-05-23
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects.postgresql import ENUM, UUID
+from sqlalchemy.dialects.postgresql import UUID
+
+from migrations.guards import drop_pg_enum, ensure_pg_enum, pg_enum
 
 revision = "20260523_031"
 down_revision = "20260523_030"
 branch_labels = None
 depends_on = None
 
+_membershiprole = pg_enum("membershiprole", "owner", "admin", "member", "guest")
+
 
 def upgrade() -> None:
-    op.execute("CREATE TYPE membershiprole AS ENUM ('owner', 'admin', 'member', 'guest')")
+    # Historically an unguarded ``op.execute("CREATE TYPE ...")``; the guard
+    # only skips creation when the type already exists (#10027).
+    ensure_pg_enum(_membershiprole)
 
     op.create_table(
         "llc_company_memberships",
@@ -39,17 +45,7 @@ def upgrade() -> None:
         sa.Column("user_id", UUID(as_uuid=True), nullable=False),
         sa.Column(
             "role",
-            # postgresql.ENUM: generic sa.Enum silently IGNORES create_type,
-            # re-emitting CREATE TYPE after the op.execute above and aborting
-            # fresh-database upgrades (#9759).
-            ENUM(
-                "owner",
-                "admin",
-                "member",
-                "guest",
-                name="membershiprole",
-                create_type=False,
-            ),
+            _membershiprole,
             nullable=False,
             server_default="member",
         ),
@@ -84,4 +80,4 @@ def downgrade() -> None:
     op.drop_index("ix_llc_company_memberships_user_id", table_name="llc_company_memberships")
     op.drop_index("ix_llc_company_memberships_company_id", table_name="llc_company_memberships")
     op.drop_table("llc_company_memberships")
-    op.execute("DROP TYPE IF EXISTS membershiprole")
+    drop_pg_enum(_membershiprole)

--- a/autobot-backend/migrations/versions/20260523_032_llc_boards.py
+++ b/autobot-backend/migrations/versions/20260523_032_llc_boards.py
@@ -16,22 +16,20 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects.postgresql import ENUM, JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from migrations.guards import drop_pg_enum, ensure_pg_enum, pg_enum
 
 revision: str = "20260523_032"
 down_revision: Union[str, None] = "20260523_031"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-# postgresql.ENUM with create_type=False: created explicitly in upgrade() with
-# checkfirst=True. Generic sa.Enum silently IGNORES create_type, so
-# op.create_table re-emitted CREATE TYPE and aborted on fresh databases (#9759).
-_boardtype = ENUM("kanban", "sprint", name="boardtype", create_type=False)
+_boardtype = pg_enum("boardtype", "kanban", "sprint")
 
 
 def upgrade() -> None:
-    bind = op.get_bind()
-    _boardtype.create(bind, checkfirst=True)
+    ensure_pg_enum(_boardtype)
 
     op.create_table(
         "llc_boards",
@@ -118,5 +116,4 @@ def downgrade() -> None:
     op.drop_index("ix_llc_boards_project_id", table_name="llc_boards")
     op.drop_index("ix_llc_boards_company_id", table_name="llc_boards")
     op.drop_table("llc_boards")
-    bind = op.get_bind()
-    _boardtype.drop(bind, checkfirst=True)
+    drop_pg_enum(_boardtype)

--- a/autobot-backend/migrations/versions/20260524_036_llc_review_gate_policies.py
+++ b/autobot-backend/migrations/versions/20260524_036_llc_review_gate_policies.py
@@ -14,12 +14,26 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects.postgresql import ENUM
+
+from migrations.guards import pg_enum
 
 revision: str = "20260524_036"
 down_revision: Union[str, None] = "20260523_035"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
+
+# The type already exists (created by 20260523_022); this is a reference only.
+_workitemtype = pg_enum(
+    "workitemtype",
+    "epic",
+    "feature",
+    "pbi",
+    "task",
+    "bug",
+    "subtask",
+    "spike",
+    "risk",
+)
 
 
 def upgrade() -> None:
@@ -34,21 +48,7 @@ def upgrade() -> None:
         sa.Column("company_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column(
             "item_type",
-            # postgresql.ENUM: the type already exists (created by 20260523_022);
-            # generic sa.Enum silently IGNORES create_type and re-emitted
-            # CREATE TYPE here, aborting fresh-database upgrades (#9759).
-            ENUM(
-                "epic",
-                "feature",
-                "pbi",
-                "task",
-                "bug",
-                "subtask",
-                "spike",
-                "risk",
-                name="workitemtype",
-                create_type=False,
-            ),
+            _workitemtype,
             nullable=False,
         ),
         sa.Column("requires_human_review", sa.Boolean(), nullable=False, server_default="false"),

--- a/autobot-backend/tests/migrations/test_guards.py
+++ b/autobot-backend/tests/migrations/test_guards.py
@@ -1,0 +1,80 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the shared Alembic guard helpers (#10027).
+
+The inspector-backed guards run against an in-memory SQLite database under a
+real ``Operations.context`` so ``op.get_bind()`` resolves exactly as it does
+inside a version script. ``ensure_pg_enum``/``drop_pg_enum`` are
+Postgres-only (``CREATE TYPE``) and are exercised by the fresh-database
+schema verification instead (see PR evidence and the #10002 migration gate).
+"""
+
+import pytest
+
+# Real alembic required: the backend conftest stubs alembic with a MagicMock
+# when it is not installed, which cannot drive an Operations context.
+_alembic_migration = pytest.importorskip("alembic.migration")
+_alembic_operations = pytest.importorskip("alembic.operations")
+
+import sqlalchemy as sa  # noqa: E402
+from sqlalchemy.dialects import postgresql  # noqa: E402
+
+from migrations.guards import (  # noqa: E402
+    existing_columns,
+    has_column,
+    has_index,
+    has_table,
+    pg_enum,
+)
+
+MigrationContext = _alembic_migration.MigrationContext
+Operations = _alembic_operations.Operations
+
+pytestmark = pytest.mark.migration_gate
+
+
+@pytest.fixture()
+def op_context():
+    """An installed ``op`` proxy bound to an in-memory SQLite schema."""
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        conn.execute(sa.text("CREATE TABLE sample (id INTEGER PRIMARY KEY, name TEXT)"))
+        conn.execute(sa.text("CREATE INDEX ix_sample_name ON sample (name)"))
+        context = MigrationContext.configure(conn)
+        with Operations.context(context):
+            yield
+
+
+class TestInspectorGuards:
+    def test_has_table(self, op_context) -> None:
+        assert has_table("sample") is True
+        assert has_table("absent") is False
+
+    def test_has_column(self, op_context) -> None:
+        assert has_column("sample", "name") is True
+        assert has_column("sample", "absent") is False
+        assert has_column("absent", "name") is False
+
+    def test_existing_columns(self, op_context) -> None:
+        assert existing_columns("sample") == {"id", "name"}
+        assert existing_columns("absent") == set()
+
+    def test_has_index(self, op_context) -> None:
+        assert has_index("sample", "ix_sample_name") is True
+        assert has_index("sample", "ix_absent") is False
+        assert has_index("absent", "ix_sample_name") is False
+
+
+class TestPgEnum:
+    def test_reference_shape(self) -> None:
+        enum_type = pg_enum("approvalstatus", "pending", "approved")
+        assert isinstance(enum_type, postgresql.ENUM)
+        assert enum_type.name == "approvalstatus"
+        assert list(enum_type.enums) == ["pending", "approved"]
+
+    def test_never_auto_created(self) -> None:
+        # create_type=False is the entire point: op.create_table must not
+        # emit CREATE TYPE for a column that references this type (#9759).
+        assert pg_enum("boardtype", "kanban", "sprint").create_type is False


### PR DESCRIPTION
## Thinking Path
Umbrella #9920 follow-up. Post-merge review of #9988 (#9759) found the same schema-existence guard logic re-implemented inline in three forms plus an enum-existence pattern copy-pasted across six LLC migrations. Writing guards ad-hoc per migration is exactly how the 002/018 divergence happened. This consolidates them into one importable module **without changing a single byte of emitted DDL**.

## What Changed
New module `autobot-backend/migrations/guards.py`:
- `has_table` / `has_column` / `existing_columns` / `has_index` — wrappers over `sa.inspect(op.get_bind())` (the inline form 002/018 hand-wrote).
- `pg_enum(name, *values)` — a `postgresql.ENUM(create_type=False)` reference so `op.create_table` never re-emits `CREATE TYPE` (the #9759 abort class).
- `ensure_pg_enum` / `drop_pg_enum` — the `.create/.drop(checkfirst=True)` pair the six LLC migrations each repeated by hand.

Refactored onto the helpers: `002` secrets, `018` timestamptz, `022` work_items, `027` approvals, `030` sprint_hierarchy, `031` company_memberships, `032` boards, `036` review_gate_policies.

**Design decision (deliberate):** enum values stay **literal** inside each version script. A migration is frozen history and must never read a value list that model code or a later revision can change underneath it, so `guards.py` holds **no shared value registry**. The #9980 model-side enum fix lives with the models, not here. `031`'s previously-unguarded raw `op.execute("CREATE TYPE …")` / `DROP TYPE IF EXISTS` become `ensure_pg_enum`/`drop_pg_enum` (checkfirst) — strictly safer, same #9759 class. SLM's psycopg2 `migrations/utils.py` is a deliberate non-target (#9785).

## Verification
- **Full-chain DDL parity (the load-bearing proof):** `alembic upgrade head` from empty on a disposable Postgres 16, base vs this branch, `pg_dump --schema-only` — **byte-identical, identical SHA** (4040 lines, sha `4359b02c1340838d` both sides) after stripping pg_dump's per-session `\restrict` tokens.
- 6 guard unit tests green (`test_guards.py`, SQLite-backed Operations context + `pg_enum` shape).
- ruff clean; no `print()`.

## Model Used
Claude Opus 4.8 (1M context)

Closes #10027
