### PR TITLE
fix(frontend): green the unit+integration suite — 89 failures, 3 uncaught errors, 7 lint errors (#9693)

### DIFF
--- a/autobot-frontend/eslint.config.ts
+++ b/autobot-frontend/eslint.config.ts
@@ -23,6 +23,13 @@ export default defineConfigWithVueTs(
     '**/dist/**',
     '**/dist-ssr/**',
     '**/coverage/**',
+    // #9693: Storybook build output is an untracked artifact (gitignored);
+    // ignore it here too so local `npm run lint` matches CI.
+    '**/storybook-static/**',
+    // #9693: generated code is not hand-maintained; eslint --fix strips the
+    // generator's /* eslint-disable */ banner, breaking the
+    // frontend-codegen-drift sync check (#7122).
+    'src/types/_generated/**',
     // Issue #6784: ESLint rule fixtures contain intentional rule violations
     // (deny.test.ts) and counter-examples (allow.test.ts). Excluded from
     // production lint; verify manually with `npx eslint --no-ignore eslint-tests/`.

--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -36,7 +36,7 @@
     "check:i18n": "node scripts/check-i18n-keys.mjs",
     "check:locales": "python3 scripts/check-locale-completeness.py",
     "check-ts-delta": "bash scripts/check-ts-delta.sh",
-    "lint:oxlint": "oxlint . --fix -D correctness --ignore-path .gitignore",
+    "lint:oxlint": "oxlint . --fix -D correctness --ignore-path .gitignore --ignore-pattern 'src/types/_generated/**'",
     "lint:eslint": "eslint . --fix",
     "lint": "run-s lint:*",
     "format": "prettier --write src/",

--- a/autobot-frontend/src/components/__tests__/ChatInterface.test.ts
+++ b/autobot-frontend/src/components/__tests__/ChatInterface.test.ts
@@ -234,7 +234,7 @@ describe('ChatInterface', () => {
 
   describe('Rendering', () => {
     it('renders the main chat interface', async () => {
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       // i18n keys render as-is since test i18n has empty messages
       await waitFor(() => {
@@ -250,7 +250,7 @@ describe('ChatInterface', () => {
     })
 
     it('renders with collapsed sidebar when toggle is clicked', async () => {
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       await waitFor(() => {
         // #5456: ChatSidebar's mobile header no longer duplicates the
@@ -277,7 +277,7 @@ describe('ChatInterface', () => {
         settings: { data: {} },
       })
 
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       // The sessions are synced to the Pinia store via syncSessionsWithBackend
       // With createTestingPinia, the store actions are spied on
@@ -292,7 +292,7 @@ describe('ChatInterface', () => {
         () => new Promise(resolve => setTimeout(resolve, 5000))
       )
 
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       // Sidebar should still render with refresh button available
       expect(screen.getByLabelText('chat.sidebar.refreshList')).toBeInTheDocument()
@@ -301,7 +301,7 @@ describe('ChatInterface', () => {
 
   describe('Chat Management', () => {
     it('creates a new chat session', async () => {
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       await waitFor(() => {
         expect(screen.getByLabelText('chat.sidebar.createNew')).toBeInTheDocument()
@@ -323,7 +323,7 @@ describe('ChatInterface', () => {
         settings: { data: {} },
       })
 
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       // Verify initialization was called with session data
       await waitFor(() => {
@@ -338,7 +338,7 @@ describe('ChatInterface', () => {
         settings: { data: {} },
       })
 
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       await waitFor(() => {
         expect(mockInitializeChatInterface).toHaveBeenCalled()
@@ -350,7 +350,7 @@ describe('ChatInterface', () => {
     })
 
     it('resets current chat session button is disabled without active session', async () => {
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       await waitFor(() => {
         expect(screen.getByLabelText('chat.sidebar.resetChat')).toBeInTheDocument()
@@ -362,7 +362,7 @@ describe('ChatInterface', () => {
     })
 
     it('refreshes chat list', async () => {
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       await waitFor(() => {
         expect(screen.getByLabelText('chat.sidebar.refreshList')).toBeInTheDocument()
@@ -380,7 +380,7 @@ describe('ChatInterface', () => {
 
   describe('Message Handling', () => {
     it('renders the message input area', async () => {
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       await waitFor(() => {
         // ChatInput placeholder renders as i18n key
@@ -390,7 +390,7 @@ describe('ChatInterface', () => {
     })
 
     it('sends a message to the chat', async () => {
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       await waitFor(() => {
         expect(screen.getByPlaceholderText('chat.input.typeMessage')).toBeInTheDocument()
@@ -415,7 +415,7 @@ describe('ChatInterface', () => {
     })
 
     it('handles message input with keyboard shortcuts', async () => {
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       await waitFor(() => {
         expect(screen.getByPlaceholderText('chat.input.typeMessage')).toBeInTheDocument()
@@ -436,7 +436,7 @@ describe('ChatInterface', () => {
     })
 
     it('prevents sending empty messages', async () => {
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       await waitFor(() => {
         expect(screen.getByPlaceholderText('chat.input.typeMessage')).toBeInTheDocument()
@@ -451,7 +451,7 @@ describe('ChatInterface', () => {
     })
 
     it('displays chat messages area', async () => {
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       // The chat interface should render the content area
       await waitFor(() => {
@@ -462,7 +462,7 @@ describe('ChatInterface', () => {
 
   describe('WebSocket Integration', () => {
     it('handles incoming WebSocket messages', async () => {
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       // Simulate WebSocket connection
       const ws = webSocketTestUtil.connect(ServiceURLs.WEBSOCKET_LOCAL)
@@ -476,7 +476,7 @@ describe('ChatInterface', () => {
     })
 
     it('handles WebSocket connection errors', async () => {
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       const ws = webSocketTestUtil.connect(ServiceURLs.WEBSOCKET_LOCAL)
       webSocketTestUtil.simulateError('Connection failed')
@@ -486,7 +486,7 @@ describe('ChatInterface', () => {
     })
 
     it('handles workflow notifications via WebSocket', async () => {
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       webSocketTestUtil.connect(ServiceURLs.WEBSOCKET_LOCAL)
       webSocketTestUtil.simulateWorkflowUpdate('workflow-123', 'running', 2)
@@ -498,7 +498,7 @@ describe('ChatInterface', () => {
 
   describe('Knowledge Persistence Dialog', () => {
     it('opens knowledge persistence dialog when triggered', async () => {
-      const { container } = renderComponent(ChatInterface, { pinia: true })
+      const { container } = renderComponent(ChatInterface, { pinia: true, router: true })
 
       // Verify the component renders without errors
       expect(container).toBeInTheDocument()
@@ -510,7 +510,7 @@ describe('ChatInterface', () => {
       // Make initialization fail
       mockInitializeChatInterface.mockRejectedValue(new Error('Network error'))
 
-      const { container } = renderComponent(ChatInterface, { pinia: true })
+      const { container } = renderComponent(ChatInterface, { pinia: true, router: true })
 
       // Component should render despite error
       await waitFor(() => {
@@ -525,7 +525,7 @@ describe('ChatInterface', () => {
         settings: { data: {} },
       })
 
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       await waitFor(() => {
         // Should handle empty state - sidebar title still renders
@@ -539,7 +539,7 @@ describe('ChatInterface', () => {
 
   describe('Accessibility', () => {
     it('has proper ARIA labels', async () => {
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       await waitFor(() => {
         expect(screen.getByLabelText('chat.sidebar.createNew')).toBeInTheDocument()
@@ -558,7 +558,7 @@ describe('ChatInterface', () => {
         settings: { data: {} },
       })
 
-      renderComponent(ChatInterface, { pinia: true })
+      renderComponent(ChatInterface, { pinia: true, router: true })
 
       await waitFor(() => {
         expect(mockInitializeChatInterface).toHaveBeenCalledTimes(1)
@@ -584,7 +584,7 @@ describe('ChatInterface', () => {
         settings: { data: {} },
       })
 
-      const { container } = renderComponent(ChatInterface, { pinia: true })
+      const { container } = renderComponent(ChatInterface, { pinia: true, router: true })
 
       // Component should render without performance issues
       expect(container).toBeInTheDocument()

--- a/autobot-frontend/src/components/__tests__/SettingsPanel.test.ts
+++ b/autobot-frontend/src/components/__tests__/SettingsPanel.test.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { screen, waitFor } from '@testing-library/vue'
-import userEvent from '@testing-library/user-event'
 import SettingsPanel from '../settings/SettingsPanel.vue'
 import { renderComponent } from '../../test/utils/test-utils'
 import axios from 'axios'
@@ -119,10 +118,7 @@ function setupAxiosMocks() {
 }
 
 describe('SettingsPanel', () => {
-  let _user: ReturnType<typeof userEvent.setup>
-
   beforeEach(() => {
-    user = userEvent.setup()
     // Re-configure axios mocks after global vi.clearAllMocks() wipes them
     setupAxiosMocks()
   })

--- a/autobot-frontend/src/components/analytics/__tests__/DeclarationsSection.test.ts
+++ b/autobot-frontend/src/components/analytics/__tests__/DeclarationsSection.test.ts
@@ -83,7 +83,8 @@ describe('DeclarationsSection (#5369)', () => {
       const w = mountSection([], true)
       expect(w.find('.section-loading').exists()).toBe(true)
       expect(w.find('.empty-state').exists()).toBe(false)
-      expect(w.find('.fa-spinner').exists()).toBe(true)
+      // Icon.vue renders an SVG with `icon-spin` (no FontAwesome classes)
+      expect(w.find('.icon-spin').exists()).toBe(true)
     })
 
     it('renders spinner (not empty-state) with declarations when loading=true', () => {

--- a/autobot-frontend/src/components/canvas/CodeCell.spec.ts
+++ b/autobot-frontend/src/components/canvas/CodeCell.spec.ts
@@ -32,8 +32,10 @@ describe('CodeCell.vue', () => {
     const wrapper = mount(CodeCell, {
       props: { richPayload: null },
     })
-    expect(wrapper.find('[aria-busy="true"]').exists()).toBe(true)
-    expect(wrapper.text()).toContain('Loading code')
+    const skeleton = wrapper.find('[aria-busy="true"]')
+    expect(skeleton.exists()).toBe(true)
+    // Loading state is a visual skeleton; text lives in the aria-label
+    expect(skeleton.attributes('aria-label')).toContain('Loading code')
   })
 
   it('renders code block when payload provided', async () => {

--- a/autobot-frontend/src/components/knowledge/ChromaDBExplorer.vue
+++ b/autobot-frontend/src/components/knowledge/ChromaDBExplorer.vue
@@ -141,7 +141,7 @@
               <button @click="clearSearch" class="clear-btn">Clear</button>
             </div>
             <div
-              v-for="(result, idx) in searchResults"
+              v-for="result in searchResults"
               :key="result.id"
               class="search-result-item"
             >

--- a/autobot-frontend/src/components/knowledge/modals/__tests__/BulkEditModal.test.ts
+++ b/autobot-frontend/src/components/knowledge/modals/__tests__/BulkEditModal.test.ts
@@ -24,12 +24,15 @@ describe('BulkEditModal with Scope Support', () => {
     expect(modes).toContain('scope')
   })
 
+  // Dynamically compiles the real SFC; under full-suite load (last of 100+
+  // files) the on-demand Vue compile can exceed the 10s default, so give the
+  // import-resolution a realistic bound. The assertion itself is instant.
   it('should have KnowledgeScopeSelector imported in BulkEditModal', async () => {
     // This test verifies the component import is correct
     // The import statement in BulkEditModal should reference KnowledgeScopeSelector
     const content = await import('../BulkEditModal.vue')
     expect(content).toBeDefined()
-  })
+  }, 30000)
 
   it('should initialize scope state correctly', () => {
     // Scope state initialization check

--- a/autobot-frontend/src/components/modals/TelemetryConsentModal.vue
+++ b/autobot-frontend/src/components/modals/TelemetryConsentModal.vue
@@ -76,12 +76,12 @@ Issue #9035: Operator-controlled local usage metrics (never transmitted)
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import { useApi } from '@/composables/useApi'
+import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import Icon from '@/components/ui/Icon.vue'
 
 const logger = createLogger('TelemetryConsentModal')
-const api = useApi()
+const api = useApiClient()
 
 const isVisible = ref(false)
 const isProcessing = ref(false)

--- a/autobot-frontend/src/components/services/__tests__/RedisServiceControl.spec.js
+++ b/autobot-frontend/src/components/services/__tests__/RedisServiceControl.spec.js
@@ -207,7 +207,7 @@ describe('RedisServiceControl.vue', () => {
       wrapper = mountWithPlugins();
 
       const buttons = wrapper.findAllComponents({ name: 'BaseButton' });
-      const stopButton = buttons.find((b) => b.props('variant') === 'danger');
+      const stopButton = buttons.find((b) => b.props('variant') === 'error');
       expect(stopButton.exists()).toBe(true);
       expect(stopButton.props('disabled')).toBe(false);
     });
@@ -221,7 +221,7 @@ describe('RedisServiceControl.vue', () => {
       // Start, Restart, Stop buttons should all be disabled when loading
       const startBtn = buttons.find((b) => b.props('variant') === 'success');
       const restartBtn = buttons.find((b) => b.props('variant') === 'warning');
-      const stopBtn = buttons.find((b) => b.props('variant') === 'danger');
+      const stopBtn = buttons.find((b) => b.props('variant') === 'error');
 
       expect(startBtn.props('disabled')).toBe(true);
       expect(restartBtn.props('disabled')).toBe(true);
@@ -268,7 +268,7 @@ describe('RedisServiceControl.vue', () => {
       wrapper = mountWithPlugins();
 
       const stopButton = wrapper.findAllComponents({ name: 'BaseButton' }).find(
-        (b) => b.props('variant') === 'danger',
+        (b) => b.props('variant') === 'error',
       );
       await stopButton.trigger('click');
       await wrapper.vm.$nextTick();
@@ -320,7 +320,7 @@ describe('RedisServiceControl.vue', () => {
       // is the last BaseButton rendered by the #actions slot
       const allButtons = wrapper.findAllComponents({ name: 'BaseButton' });
       // The confirm button in the dialog has variant 'primary' (for restart, type='warning')
-      // but actually the template uses: :variant="confirmDialog.type === 'danger' ? 'danger' : 'primary'"
+      // but actually the template uses: :variant="confirmDialog.type === 'error' ? 'error' : 'primary'"
       // For restart, type='warning', so confirm button variant='primary'
       const confirmBtn = allButtons.find(
         (b) => b.props('variant') === 'primary',
@@ -366,7 +366,7 @@ describe('RedisServiceControl.vue', () => {
       wrapper = mountWithPlugins();
 
       const stopButton = wrapper.findAllComponents({ name: 'BaseButton' }).find(
-        (b) => b.props('variant') === 'danger',
+        (b) => b.props('variant') === 'error',
       );
       await stopButton.trigger('click');
       await wrapper.vm.$nextTick();
@@ -626,7 +626,7 @@ describe('RedisServiceControl.vue', () => {
       wrapper = mountWithPlugins();
 
       const stopBtn = wrapper.findAllComponents({ name: 'BaseButton' }).find(
-        (b) => b.props('variant') === 'danger',
+        (b) => b.props('variant') === 'error',
       );
       expect(stopBtn.props('disabled')).toBe(true);
     });

--- a/autobot-frontend/src/components/settings/TelemetrySettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/TelemetrySettingsPanel.vue
@@ -88,12 +88,12 @@ Issue #9035: Operator-controlled local usage metrics (never transmitted)
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import { useApi } from '@/composables/useApi'
+import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import Icon from '@/components/ui/Icon.vue'
 
 const logger = createLogger('TelemetrySettingsPanel')
-const api = useApi()
+const api = useApiClient()
 
 const telemetryEnabled = ref(true)
 const announcement = ref('')

--- a/autobot-frontend/src/components/terminal/__tests__/BaseXTerminal.spec.ts
+++ b/autobot-frontend/src/components/terminal/__tests__/BaseXTerminal.spec.ts
@@ -9,25 +9,28 @@ import BaseXTerminal from '../BaseXTerminal.vue'
 let lastTerminalInstance: Record<string, any> | null = null
 
 // Factory that creates a fresh Terminal mock instance.
-// Must be a regular function (not arrow) so it can be used as a constructor with `new`.
-function createTerminalMock(this: Record<string, any>) {
-  this.loadAddon = vi.fn()
-  this.open = vi.fn()
-  this.onData = vi.fn()
-  this.onResize = vi.fn()
-  this.dispose = vi.fn()
-  this.write = vi.fn()
-  this.writeln = vi.fn()
-  this.clear = vi.fn()
-  this.reset = vi.fn()
-  this.focus = vi.fn()
-  this.blur = vi.fn()
-  this.cols = 80
-  this.rows = 24
-  this.options = {}
-
-  // eslint-disable-next-line @typescript-eslint/no-this-alias -- Mock: capturing instance for test assertions
-  lastTerminalInstance = this
+// Returning an object from the constructor makes `new` yield it directly,
+// so no `this` mutation/aliasing is needed.
+function createTerminalMock(): Record<string, any> {
+  const instance: Record<string, any> = {
+    loadAddon: vi.fn(),
+    open: vi.fn(),
+    onData: vi.fn(),
+    onResize: vi.fn(),
+    dispose: vi.fn(),
+    write: vi.fn(),
+    writeln: vi.fn(),
+    clear: vi.fn(),
+    reset: vi.fn(),
+    focus: vi.fn(),
+    blur: vi.fn(),
+    cols: 80,
+    rows: 24,
+    options: {},
+  }
+  // Capture instance for test assertions
+  lastTerminalInstance = instance
+  return instance
 }
 
 // Import the mocked Terminal constructor so we can re-apply the implementation

--- a/autobot-frontend/src/composables/__tests__/useKnowledgeBase.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeBase.test.ts
@@ -116,10 +116,10 @@ describe('useKnowledgeBase (BC shim)', () => {
   it('should keep behavior for key icon helpers', () => {
     const { getCategoryIcon, getOSBadgeClass, getMessageIcon } = useKnowledgeBase()
 
-    expect(getCategoryIcon('security')).toBe('fas fa-shield-alt')
-    expect(getCategoryIcon('unknown')).toBe('fas fa-folder')
+    expect(getCategoryIcon('security')).toBe('shield-alt')
+    expect(getCategoryIcon('unknown')).toBe('folder')
     expect(getOSBadgeClass('linux')).toBe('badge-success')
     expect(getOSBadgeClass('macos')).toBe('badge-warning')
-    expect(getMessageIcon('error')).toContain('fas fa-times-circle')
+    expect(getMessageIcon('error')).toBe('times-circle')
   })
 })

--- a/autobot-frontend/src/composables/__tests__/useKnowledgeCategories.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeCategories.test.ts
@@ -214,28 +214,28 @@ describe('useKnowledgeCategories', () => {
   describe('getCategoryIcon', () => {
     it('should return correct icon for security category', () => {
       const { getCategoryIcon } = useKnowledgeCategories()
-      expect(getCategoryIcon('security')).toBe('fas fa-shield-alt')
+      expect(getCategoryIcon('security')).toBe('shield-alt')
     })
 
     it('should return correct icon for architecture category', () => {
       const { getCategoryIcon } = useKnowledgeCategories()
-      expect(getCategoryIcon('architecture')).toBe('fas fa-drafting-compass')
+      expect(getCategoryIcon('architecture')).toBe('sitemap')
     })
 
     it('should return correct icon for devops category', () => {
       const { getCategoryIcon } = useKnowledgeCategories()
-      expect(getCategoryIcon('devops')).toBe('fas fa-cogs')
+      expect(getCategoryIcon('devops')).toBe('cogs')
     })
 
     it('should return default folder icon for unknown category', () => {
       const { getCategoryIcon } = useKnowledgeCategories()
-      expect(getCategoryIcon('unknown')).toBe('fas fa-folder')
+      expect(getCategoryIcon('unknown')).toBe('folder')
     })
 
     it('should handle case-insensitive matching', () => {
       const { getCategoryIcon } = useKnowledgeCategories()
-      expect(getCategoryIcon('SECURITY')).toBe('fas fa-shield-alt')
-      expect(getCategoryIcon('SeCuRiTy')).toBe('fas fa-shield-alt')
+      expect(getCategoryIcon('SECURITY')).toBe('shield-alt')
+      expect(getCategoryIcon('SeCuRiTy')).toBe('shield-alt')
     })
   })
 

--- a/autobot-frontend/src/composables/__tests__/useKnowledgeIcons.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeIcons.test.ts
@@ -4,36 +4,53 @@
  * useKnowledgeIcons Composable Tests
  *
  * Split from useKnowledgeBase.test.ts (#5122).
+ *
+ * #9724: the icon helpers were migrated to return canonical SVG IconName
+ * values (e.g. "file-pdf") instead of Font Awesome class strings
+ * (e.g. "fas fa-file-pdf"), because consumers render via <Icon :name="...">.
+ * Expectations below assert the IconName the helper actually returns.
  */
 
 import { describe, it, expect, vi } from 'vitest'
 import { useKnowledgeIcons } from '../knowledge/useKnowledgeIcons'
 
+// getFileIcon delegates to getFileIconName (#9724 IconName migration).
+// Both are stubbed so the test exercises the helper, not the real mapping.
 vi.mock('@/utils/iconMappings', () => ({
   getFileIcon: () => 'fas fa-file',
+  getFileIconName: (name: string, isDir = false): string => {
+    if (isDir) return 'folder'
+    const ext = name.split('.').pop()?.toLowerCase()
+    const map: Record<string, string> = {
+      js: 'file-code',
+      py: 'file-code',
+      pdf: 'file-pdf',
+    }
+    return (ext && map[ext]) || 'file'
+  },
 }))
 
 describe('useKnowledgeIcons', () => {
   describe('getTypeIcon', () => {
     it('should return PDF icon for PDF documents', () => {
       const { getTypeIcon } = useKnowledgeIcons()
-      expect(getTypeIcon('pdf')).toBe('fas fa-file-pdf')
+      expect(getTypeIcon('pdf')).toBe('file-pdf')
     })
 
     it('should return code icon for JSON types', () => {
       const { getTypeIcon } = useKnowledgeIcons()
-      expect(getTypeIcon('json')).toBe('fas fa-file-code')
+      expect(getTypeIcon('json')).toBe('file-code')
     })
 
     it('should return image icon for image types', () => {
       const { getTypeIcon } = useKnowledgeIcons()
-      expect(getTypeIcon('png')).toBe('fas fa-file-image')
-      expect(getTypeIcon('jpg')).toBe('fas fa-file-image')
+      expect(getTypeIcon('png')).toBe('file-image')
+      expect(getTypeIcon('jpg')).toBe('file-image')
     })
 
     it('should return default file icon for unknown type', () => {
       const { getTypeIcon } = useKnowledgeIcons()
-      expect(getTypeIcon('unknown')).toBe('fas fa-file')
+      expect(getTypeIcon('unknown')).toBe('file')
     })
   })
 
@@ -41,23 +58,23 @@ describe('useKnowledgeIcons', () => {
     it('should return folder icon for directories', () => {
       const { getFileIcon } = useKnowledgeIcons()
       const icon = getFileIcon('mydir', true)
-      expect(icon).toContain('fas fa-folder')
+      expect(icon).toBe('folder')
     })
 
-    it('should return styled icon for file with color class', () => {
+    it('should return a file-code icon name for a script file', () => {
       const { getFileIcon } = useKnowledgeIcons()
       const icon = getFileIcon('script.js', false)
-      expect(icon).toContain('text-')
+      expect(icon).toBe('file-code')
     })
 
-    it('should apply different colors for different file types', () => {
+    it('should map distinct extensions to their IconName', () => {
       const { getFileIcon } = useKnowledgeIcons()
       const jsIcon = getFileIcon('app.js', false)
-      const pyIcon = getFileIcon('script.py', false)
       const pdfIcon = getFileIcon('document.pdf', false)
 
-      expect(jsIcon).not.toEqual(pyIcon)
-      expect(pyIcon).not.toEqual(pdfIcon)
+      expect(jsIcon).toBe('file-code')
+      expect(pdfIcon).toBe('file-pdf')
+      expect(jsIcon).not.toEqual(pdfIcon)
     })
   })
 
@@ -86,36 +103,27 @@ describe('useKnowledgeIcons', () => {
   describe('getMessageIcon', () => {
     it('should return info icon for info type', () => {
       const { getMessageIcon } = useKnowledgeIcons()
-      const icon = getMessageIcon('info')
-      expect(icon).toContain('fas fa-info-circle')
-      expect(icon).toContain('text-blue-500')
+      expect(getMessageIcon('info')).toBe('info-circle')
     })
 
     it('should return success icon for success type', () => {
       const { getMessageIcon } = useKnowledgeIcons()
-      const icon = getMessageIcon('success')
-      expect(icon).toContain('fas fa-check-circle')
-      expect(icon).toContain('text-green-500')
+      expect(getMessageIcon('success')).toBe('check-circle')
     })
 
     it('should return warning icon for warning type', () => {
       const { getMessageIcon } = useKnowledgeIcons()
-      const icon = getMessageIcon('warning')
-      expect(icon).toContain('fas fa-exclamation-triangle')
-      expect(icon).toContain('text-yellow-500')
+      expect(getMessageIcon('warning')).toBe('exclamation-triangle')
     })
 
     it('should return error icon for error type', () => {
       const { getMessageIcon } = useKnowledgeIcons()
-      const icon = getMessageIcon('error')
-      expect(icon).toContain('fas fa-times-circle')
-      expect(icon).toContain('text-red-500')
+      expect(getMessageIcon('error')).toBe('times-circle')
     })
 
     it('should default to info icon for unknown type', () => {
       const { getMessageIcon } = useKnowledgeIcons()
-      const icon = getMessageIcon('unknown')
-      expect(icon).toContain('fas fa-info-circle')
+      expect(getMessageIcon('unknown')).toBe('info-circle')
     })
   })
 

--- a/autobot-frontend/src/composables/__tests__/useNetworkStatus.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useNetworkStatus.test.ts
@@ -35,13 +35,10 @@ describe('isFeatureAvailable', () => {
 })
 
 describe('useNetworkStatus - browser events', () => {
-  let _originalNavigator: Navigator
   const onlineHandlers: EventListener[] = []
   const offlineHandlers: EventListener[] = []
 
   beforeEach(() => {
-    originalNavigator = window.navigator
-
     vi.spyOn(window, 'addEventListener').mockImplementation(
       (type: string, handler: EventListenerOrEventListenerObject) => {
         if (type === 'online') onlineHandlers.push(handler as EventListener)

--- a/autobot-frontend/src/composables/__tests__/useRealtimeVoice.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useRealtimeVoice.test.ts
@@ -75,7 +75,13 @@ vi.stubGlobal('window', { isSecureContext: true })
 // ─── Helpers ─────────────────────────────────────────────
 
 function makeJsonResponse(body: unknown, ok = true): Response {
-  return { ok, status: ok ? 200 : 500, json: async () => body } as unknown as Response
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+    // #7421: connect() reads X-Realtime-Session-Id from response headers
+    headers: { get: (_name: string) => null },
+  } as unknown as Response
 }
 
 function setFetchMock(overrides: Record<string, unknown> = {}) {

--- a/autobot-frontend/src/composables/__tests__/useTimeout.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useTimeout.test.ts
@@ -326,11 +326,8 @@ describe('useTimeout Composable', () => {
     })
 
     it('should preserve function context', async () => {
-      let capturedThis: any = null
-      const callback = function (this: any) {
-        // eslint-disable-next-line @typescript-eslint/no-this-alias -- Test: capturing 'this' to verify context preservation
-        capturedThis = this
-      }
+      // vi.fn records invocation contexts — no manual `this` capture needed
+      const callback = vi.fn(function (this: any) {})
 
       const context = { value: 'test-context' }
       const TestComponent = defineComponent({
@@ -347,7 +344,8 @@ describe('useTimeout Composable', () => {
       debounced.call(ctx)
       vi.advanceTimersByTime(500)
 
-      expect(capturedThis).toBeDefined()
+      expect(callback).toHaveBeenCalledOnce()
+      expect(callback.mock.contexts[0]).toBeDefined()
     })
   })
 

--- a/autobot-frontend/src/composables/__tests__/useToolApproval.spec.ts
+++ b/autobot-frontend/src/composables/__tests__/useToolApproval.spec.ts
@@ -43,21 +43,20 @@ vi.mock('@/config/ssot-config', () => ({
   getApiBase: vi.fn(() => '/api'),
 }))
 
-let mockFetchResponse: { ok: boolean; status: number; text: () => Promise<string> } = {
-  ok: true,
-  status: 200,
-  text: async () => '',
-}
+// useToolApproval submits via apiClient.post (parsed-JSON contract), not raw
+// fetchWithAuth. vi.fn(impl) keeps its implementation across mockReset.
+const mockPost = vi.fn(async (..._args: unknown[]) => ({}))
 
-vi.mock('@/utils/fetchWithAuth', () => ({
-  fetchWithAuth: vi.fn(async () => mockFetchResponse),
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    post: (...args: unknown[]) => mockPost(...args),
+  },
 }))
 
 // ---------------------------------------------------------------------------
 // Import the composable AFTER mocks are in place
 // ---------------------------------------------------------------------------
 import { useToolApproval } from '../useToolApproval'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -84,7 +83,6 @@ const validPayload = {
 describe('useToolApproval', () => {
   beforeEach(() => {
     capturedGlobalListener = null
-    mockFetchResponse = { ok: true, status: 200, text: async () => '' }
     vi.clearAllMocks()
   })
 
@@ -121,12 +119,9 @@ describe('useToolApproval', () => {
 
     await submitToolApproval(true, 'looks safe')
 
-    expect(fetchWithAuth).toHaveBeenCalledWith(
-      'http://backend/api/agent-terminal/tools/approve/test-uuid-1234',
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ approved: true, comment: 'looks safe', task_id: 'task-abc' }),
-      })
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/agent-terminal/tools/approve/test-uuid-1234',
+      { approved: true, comment: 'looks safe', task_id: 'task-abc' }
     )
     // Cleared after success
     expect(pendingToolApproval.value).toBeNull()
@@ -138,16 +133,14 @@ describe('useToolApproval', () => {
 
     await submitToolApproval(false)
 
-    expect(fetchWithAuth).toHaveBeenCalledWith(
+    expect(mockPost).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({
-        body: JSON.stringify({ approved: false, comment: null, task_id: 'task-abc' }),
-      })
+      expect.objectContaining({ approved: false, comment: null, task_id: 'task-abc' })
     )
   })
 
   it('throws and keeps pendingToolApproval when HTTP POST fails', async () => {
-    mockFetchResponse = { ok: false, status: 500, text: async () => 'internal error' }
+    mockPost.mockRejectedValueOnce(new Error('HTTP 500: internal error'))
     const { pendingToolApproval, submitToolApproval } = useToolApproval()
     capturedGlobalListener!(makeLiveEvent('APPROVAL_REQUIRED', validPayload))
 
@@ -164,6 +157,6 @@ describe('useToolApproval', () => {
     clearToolApproval()
 
     expect(pendingToolApproval.value).toBeNull()
-    expect(fetchWithAuth).not.toHaveBeenCalled()
+    expect(mockPost).not.toHaveBeenCalled()
   })
 })

--- a/autobot-frontend/src/composables/api/useFetchEndpoint.test.ts
+++ b/autobot-frontend/src/composables/api/useFetchEndpoint.test.ts
@@ -77,7 +77,9 @@ describe('useFetchEndpoint (rehomed)', () => {
       onSuccess,
     })
     await load()
-    expect(onSuccess).toHaveBeenCalledWith(7, rawEnvelope)
+    // Third arg is the optional request context (undefined when load() is
+    // called without one) — see onSuccess?: (data, raw, context) in the API.
+    expect(onSuccess).toHaveBeenCalledWith(7, rawEnvelope, undefined)
   })
 
   it('DELETE method routes correctly and supports a body', async () => {

--- a/autobot-frontend/src/composables/useConnectionTester.ts
+++ b/autobot-frontend/src/composables/useConnectionTester.ts
@@ -323,17 +323,26 @@ export function useConnectionTester(
     } catch (error) {
       clearTimeout(timeoutId)
 
-      // Handle different error types
+      // Handle different error types.
+      // #9693: fetch abort raises a DOMException, which does not inherit
+      // Error on every platform (jsdom, older browsers) — check it explicitly.
       let errorMessage: string
 
-      if (error instanceof Error && error.name === 'AbortError') {
+      const isAbortError =
+        (error instanceof DOMException || error instanceof Error) &&
+        error.name === 'AbortError'
+
+      if (isAbortError) {
         errorMessage = `Connection timeout (>${timeout}ms)`
         await updateStatus('disconnected', errorMessage)
       } else if (error instanceof TypeError) {
         errorMessage = `Network error: ${error.message}`
         await updateStatus('error', errorMessage)
       } else {
-        errorMessage = error instanceof Error ? error.message : 'Unknown connection error'
+        errorMessage =
+          error instanceof DOMException || error instanceof Error
+            ? error.message
+            : 'Unknown connection error'
         await updateStatus('error', errorMessage)
       }
 

--- a/autobot-frontend/src/composables/useTimeout.ts
+++ b/autobot-frontend/src/composables/useTimeout.ts
@@ -179,8 +179,9 @@ export function useDebounce<T extends (...args: any[]) => any>(
   let timeoutId: ReturnType<typeof setTimeout> | null = null
   let maxWaitTimeoutId: ReturnType<typeof setTimeout> | null = null
   let lastCallTime: number | null = null
-  let lastArgs: Parameters<T> | null = null
-  let lastThis: unknown = null
+  // Pending trailing-edge invocation: args + caller context bundled in one
+  // record (avoids aliasing `this` into a standalone variable).
+  let pending: { args: Parameters<T>; ctx: unknown } | null = null
 
   const cancel = (): void => {
     if (timeoutId) {
@@ -192,21 +193,20 @@ export function useDebounce<T extends (...args: any[]) => any>(
       maxWaitTimeoutId = null
     }
     lastCallTime = null
-    lastArgs = null
-    lastThis = null
+    pending = null
   }
 
   const invokeFunction = (): void => {
-    if (lastArgs) {
+    if (pending) {
+      const { args, ctx } = pending
       try {
-        fn.apply(lastThis, lastArgs)
+        fn.apply(ctx, args)
       } catch (error) {
         logger.error('Callback error:', error)
         throw error // Re-throw to preserve error behavior
       } finally {
-        lastArgs = null
+        pending = null
         lastCallTime = null
-        lastThis = null
       }
     }
   }
@@ -234,11 +234,9 @@ export function useDebounce<T extends (...args: any[]) => any>(
       }
       // Don't save args/this - no trailing edge in leading-only mode
     } else if (!leading) {
-      // Only save args for trailing edge execution (not in leading mode)
-      lastArgs = args
-
-      // eslint-disable-next-line @typescript-eslint/no-this-alias -- Intentional: preserving 'this' context for debounced callback
-      lastThis = this
+      // Only save args + caller context for trailing edge execution
+      // (not in leading mode)
+      pending = { args, ctx: this }
     }
 
     // Cancel previous timeout

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -82,7 +82,27 @@
     "hasMore": "Load more",
     "previous": "Previous",
     "optional": "اختياري",
-    "remove": "إزالة"
+    "remove": "إزالة",
+    "dismiss": "Dismiss",
+    "forward": "Forward",
+    "saving": "Saving...",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "fitToView": "Fit to view",
+    "toggleLayout": "Toggle layout",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "copyToClipboard": "Copy to clipboard",
+    "sortAscending": "Sort ascending",
+    "sortDescending": "Sort descending",
+    "moreOptions": "More options",
+    "exportJson": "Export as JSON",
+    "exportCsv": "Export as CSV",
+    "download": "Download",
+    "filterByCategory": "Filter by category",
+    "copied": "Copied"
   },
   "chat": {
     "sendMessage": "أرسل رسالة...",
@@ -112,6 +132,10 @@
         "overseer": "المشرف",
         "tool-code": "الكود",
         "tool-output": "الناتج"
+      },
+      "thinking": {
+        "badge": "🧠 Extended thinking ({count} tokens)",
+        "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
       }
     },
     "response": "استجابة",
@@ -252,7 +276,21 @@
       "sendingMessage": "Sending message...",
       "aiResponding": "AI is responding...",
       "typeMessage": "Type a message...",
-      "overseerLabel": "Overseer"
+      "overseerLabel": "Overseer",
+      "managePresets": "Manage slash command presets",
+      "generate": "Generate",
+      "generateImage": "Generate image",
+      "generateImageTitle": "generate Image",
+      "generating": "Generating",
+      "imagePromptLabel": "image Prompt",
+      "imagePromptPlaceholder": "Enter image prompt...",
+      "imageProvider": "Image provider",
+      "selectPromptTemplate": "Select prompt template",
+      "thinkingBudget": "Thinking budget",
+      "thinkingOff": "Thinking off",
+      "thinkingOffLabel": "thinking Off",
+      "thinkingOn": "Thinking on",
+      "thinkingOnLabel": "thinking On"
     },
     "translate": {
       "title": "Translate Text",
@@ -295,7 +333,8 @@
       "statusSending": "جارٍ الإرسال...",
       "statusSent": "تم الإرسال",
       "statusFailed": "فشل الإرسال",
-      "confirmDelete": "Delete this message? This action cannot be undone."
+      "confirmDelete": "Delete this message? This action cannot be undone.",
+      "thinkingUsed": "Thinking used"
     },
     "approval": {
       "autoApproved": "Auto-Approved",
@@ -481,7 +520,35 @@
       "selectAll": "تحديد الكل",
       "deselectAll": "إلغاء تحديد الكل",
       "share": "مشاركة",
-      "sharing": "Sharing..."
+      "sharing": "Sharing...",
+      "createAnother": "Create another",
+      "createLink": "Create link",
+      "creating": "Creating",
+      "emptyConversation": "Empty conversation",
+      "enterPassword": "Enter password",
+      "expiry": "Expiry",
+      "expiry1d": "Expiry1d",
+      "expiry1h": "Expiry1h",
+      "expiry30d": "Expiry30d",
+      "expiry7d": "Expiry7d",
+      "expiryNever": "Expiry never",
+      "linkExpired": "Link expired",
+      "linkExpires": "Link expires",
+      "linkNotFound": "Link not found",
+      "linkPasswordProtected": "Link password protected",
+      "linkReady": "Link ready",
+      "optionalPassword": "Optional password",
+      "passwordGate": "Password gate",
+      "passwordGateHint": "Password gate hint",
+      "passwordPlaceholder": "Enter password...",
+      "publicLink": "Public link",
+      "publicView": "Public view",
+      "readOnlyNote": "Read only note",
+      "revokeLink": "Revoke link",
+      "revoking": "Revoking",
+      "shareWithUsers": "Share with users",
+      "unlock": "Unlock",
+      "wrongPassword": "Wrong password"
     },
     "vision": {
       "title": "Image Analysis",
@@ -525,7 +592,8 @@
       "navigationFailed": "Navigation failed",
       "backFailed": "Back navigation failed",
       "forwardFailed": "Forward navigation failed",
-      "reloadFailed": "Reload failed"
+      "reloadFailed": "Reload failed",
+      "go": "Navigate"
     },
     "voice": {
       "title": "محادثة صوتية",
@@ -560,7 +628,10 @@
       "hintResponding": "AutoBot is responding...",
       "hintRespondingShort": "Responding...",
       "hintAutoStart": "Listening will start automatically",
-      "hintTapToSpeak": "Tap to speak"
+      "hintTapToSpeak": "Tap to speak",
+      "realtimeWebrtc": "Realtime WebRTC",
+      "realtimeConnecting": "Connecting to Realtime...",
+      "realtimeConnected": "Realtime — speak anytime"
     },
     "typing": {
       "aiAssistant": "المساعد الذكي",
@@ -585,7 +656,64 @@
       "streaming": "Streaming…",
       "done": "Done",
       "error": "Error"
-    }
+    },
+    "contextWindow": {
+      "ariaLabel": "{used} of {max} tokens used",
+      "tooltip": "{used} / {max} tokens used ({percent}% of context window)",
+      "warningToast": "Conversation approaching context limit ({percent}%). Older messages may be summarized.",
+      "compressedToast": "Context window optimized - older messages summarized",
+      "summaryTitle": "Context Summary",
+      "summaryToggle": "Show details",
+      "summarizing": "Summarizing..."
+    },
+    "openSettings": "Chat settings",
+    "settings": {
+      "title": "Chat Settings",
+      "contextOverflowLabel": "Context Overflow Protection",
+      "contextOverflowDescription": "Choose how to handle conversations approaching the context limit",
+      "contextOverflowAuto": "Auto-summarize",
+      "contextOverflowWarn": "Warn only",
+      "contextOverflowDisabled": "Disabled"
+    },
+    "folders": {
+      "folders": "Folders",
+      "newFolder": "New folder",
+      "folderName": "Folder name",
+      "rename": "Rename folder",
+      "addSubfolder": "Add subfolder",
+      "pin": "Pin folder",
+      "unpin": "Unpin folder",
+      "assignToFolder": "Move to folder",
+      "removeFromFolder": "Remove from folder",
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+    },
+    "presets": {
+      "modalTitle": "Slash Command Presets",
+      "newPreset": "New Preset",
+      "editPreset": "Edit Preset",
+      "fieldName": "Name",
+      "namePlaceholder": "my-preset",
+      "fieldDescription": "Description",
+      "descriptionPlaceholder": "What this preset does",
+      "fieldContent": "Content",
+      "contentPlaceholder": "Enter the prompt text...",
+      "cancel": "Cancel",
+      "create": "Create",
+      "update": "Update",
+      "delete": "Delete",
+      "listLabel": "Your presets",
+      "loading": "Loading presets...",
+      "empty": "No presets yet. Create one above.",
+      "editAriaLabel": "Edit preset {name}",
+      "deleteAriaLabel": "Delete preset {name}",
+      "deleteConfirmTitle": "Delete preset",
+      "deleteConfirmMessage": "Delete /{name}? This cannot be undone.",
+      "nameRequired": "Name is required",
+      "nameInvalid": "Only letters, numbers, hyphens, and underscores are allowed",
+      "contentRequired": "Content is required"
+    },
+    "lightweightMode": "Lightweight mode",
+    "lightweightModeTooltip": "lightweight Mode tooltip"
   },
   "settings": {
     "title": "الإعدادات",
@@ -664,7 +792,22 @@
     },
     "connection": {
       "title": "Connection",
-      "desc": "Configure backend connection settings"
+      "desc": "Configure backend connection settings",
+      "backendCheck": {
+        "title": "Backend reachability",
+        "description": "Run a one-shot ping to verify that the AutoBot backend is reachable from this browser. No periodic polling — manual only.",
+        "button": "Test backend connection",
+        "checking": "Checking…",
+        "reachable": "Reachable",
+        "unreachable": "Unreachable",
+        "latency": "Latency",
+        "lastTested": "Last tested",
+        "neverTested": "Not yet tested"
+      }
+    },
+    "presets": {
+      "title": "Slash Presets",
+      "description": "Create reusable slash commands that expand into full prompts in the chat input. Type / followed by the preset name to trigger them."
     }
   },
   "voice": {
@@ -1247,7 +1390,13 @@
         "usage": "الاستخدام",
         "usageAria": "الاستخدام والتكاليف",
         "operations": "العمليات",
-        "operationsAria": "العمليات طويلة الأمد"
+        "operationsAria": "العمليات طويلة الأمد",
+        "devTools": "Dev Tools",
+        "devToolsAria": "Developer tools and utilities",
+        "errors": "Errors",
+        "errorsAria": "Error monitoring",
+        "diagnostics": "Diagnostics",
+        "diagnosticsAria": "Failure analysis and causal inference"
       }
     },
     "header": {
@@ -1615,7 +1764,8 @@
       "file": "File",
       "score": "Score",
       "topIssue": "Top Issue",
-      "close": "إغلاق"
+      "close": "إغلاق",
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",
@@ -2190,6 +2340,38 @@
         "scanning": "Scanning...",
         "scanFile": "Scan File"
       }
+    },
+    "failureAnalysis": {
+      "title": "Failure Analysis",
+      "subtitle": "Root-cause analysis powered by the causal inference engine",
+      "empty": "Enter a task ID above to run a failure analysis.",
+      "form": {
+        "title": "Analyze a Failure",
+        "taskId": "Task ID",
+        "taskIdPlaceholder": "e.g. task-abc123",
+        "errorDescription": "Error Description",
+        "errorDescriptionPlaceholder": "Optional: describe the error or paste a stack trace",
+        "analyze": "Analyze",
+        "analyzing": "Analyzing...",
+        "clear": "Clear"
+      },
+      "result": {
+        "taskId": "Task ID",
+        "confidence": "Confidence",
+        "status": "Status",
+        "duration": "Duration",
+        "rootCause": "Root Cause",
+        "causalChain": "Causal Chain",
+        "interventions": "Interventions",
+        "confounders": "Confounders",
+        "recommendations": "Recommendations",
+        "participants": "Participants",
+        "mechanism": "Mechanism",
+        "successRate": "Success Rate",
+        "cost": "Cost",
+        "risk": "Risk",
+        "confoundingStrength": "Confounding Strength"
+      }
     }
   },
   "knowledge": {
@@ -2241,7 +2423,14 @@
       "visShared": "Vis shared",
       "visSystem": "Vis system",
       "visibility": "Visibility",
-      "visibilityHint": "Visibility hint"
+      "visibilityHint": "Visibility hint",
+      "errorAddText": "Failed to add text to knowledge base",
+      "errorFileTooLarge": "File \"{name}\" exceeds the maximum size limit",
+      "errorImportUrl": "Failed to import URL content",
+      "errorUnsupportedFormat": "File \"{name}\" has an unsupported format",
+      "errorUploadFiles": "Failed to upload files",
+      "successTextAdded": "Text added to knowledge base successfully",
+      "successUrlImported": "URL content imported successfully"
     },
     "documents": "Documents",
     "categories": {
@@ -2291,7 +2480,11 @@
       "maintenance": "Maintenance",
       "maintenanceAriaLabel": "Knowledge base maintenance",
       "analytics": "التحليلات",
-      "statistics": "Statistics"
+      "statistics": "Statistics",
+      "webResearch": "Web Research",
+      "webResearchAriaLabel": "4-tab web research panel",
+      "openSidebar": "Open navigation menu",
+      "closeSidebar": "Close navigation menu"
     },
     "backup": {
       "title": "Backup & Restore",
@@ -2787,7 +2980,9 @@
         "sourcesCount": "{count} sources"
       },
       "noEntities3D": "لا توجد كيانات للعرض",
-      "loading3dVisualization": "Loading3d visualization"
+      "loading3dVisualization": "Loading3d visualization",
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "connectors": {
       "title": "Source Connectors",
@@ -3159,7 +3354,8 @@
       "vectorFramework": "Vector framework",
       "vectorIndexHealth": "Vector index health",
       "vectorNotGenerated": "Vector not generated",
-      "vectorizedForRag": "Vectorized for rag"
+      "vectorizedForRag": "Vectorized for rag",
+      "confirmOptimize": "This will optimize the database. Continue?"
     },
     "summaries": {
       "search": {
@@ -3290,7 +3486,11 @@
       "decisionsApplied": "{count} decision(s) applied successfully",
       "compiledSuccess": "Chat compiled successfully",
       "failedToLoad": "Failed to load knowledge items",
-      "decisionsApplyFailed": "Failed to apply decisions"
+      "decisionsApplyFailed": "Failed to apply decisions",
+      "compileFailed": "Failed to compile conversation",
+      "suggestionAddToKb": "Suggested: Add to Knowledge Base",
+      "suggestionDelete": "Suggested: Delete",
+      "suggestionKeepTemporary": "Suggested: Keep Temporarily"
     },
     "systemKnowledge": {
       "vectorizeTooltip": "Generate vector embeddings for all knowledge base entries to enable semantic search",
@@ -3323,7 +3523,14 @@
       "success": "Success",
       "targetHost": "Target host",
       "totalFacts": "Total facts",
-      "vectorizing": "Vectorizing"
+      "vectorizing": "Vectorizing",
+      "confirmIndexDocs": "Do you want to force reindex existing documents?",
+      "confirmInitialize": "This will initialize system knowledge for the selected host. This may take several minutes. Continue?",
+      "confirmRefreshManPages": "This will refresh man pages for the selected host. Continue?",
+      "confirmReindex": "This will reindex all documents for the selected host. Continue?",
+      "confirmVectorize": "This will vectorize {totalFacts} facts. Currently {totalVectors} vectors exist, {needsVectorization} need vectorization. Continue?",
+      "vectorizeComplete": "Vectorize Facts (✓ {vectors} vectors from {facts} facts)",
+      "vectorizePending": "Vectorize Facts ({pending} pending)"
     },
     "vectorization": {
       "actionVectorize": "Vectorize",
@@ -3342,7 +3549,15 @@
       "noDocuments": "No documents",
       "progressTitle": "Progress title",
       "retryFailed": "Retry failed",
-      "total": "Total"
+      "total": "Total",
+      "statusFailed": "Failed",
+      "statusPending": "Pending",
+      "statusUnknown": "Unknown",
+      "statusVectorized": "Vectorized",
+      "tooltipFailed": "Vectorization failed for this document",
+      "tooltipPending": "Document is pending vectorization",
+      "tooltipUnknown": "Vectorization status unknown",
+      "tooltipVectorized": "Document has been vectorized and is searchable via RAG"
     },
     "batchSelection": {
       "selected": "{count} selected",
@@ -3382,7 +3597,8 @@
       "shareWith": "Share with",
       "team": "Team",
       "user": "User",
-      "write": "Write"
+      "write": "Write",
+      "unsavedConfirm": "You have unsaved changes. Are you sure you want to close?"
     },
     "memoryOrphan": {
       "entitiesToClean": "Entities to clean",
@@ -3430,7 +3646,11 @@
       "rejectedToday": "Rejected today",
       "selectAll": "Select all",
       "title": "Title",
-      "untitled": "Untitled"
+      "untitled": "Untitled",
+      "typeConnector": "Connector",
+      "typeResearch": "Web Research",
+      "typeUpload": "Manual Upload",
+      "typeUrl": "URL Fetch"
     },
     "sessionOrphan": {
       "moreOrphans": "More orphans",
@@ -3499,7 +3719,15 @@
       "warnings": "Warnings"
     },
     "manager": {
-      "errorFallback": "Error fallback"
+      "errorFallback": "Error fallback",
+      "tabAdvanced": "Advanced",
+      "tabCategories": "Categories",
+      "tabManage": "Manage",
+      "tabPromptEditor": "Prompts",
+      "tabSearch": "Search",
+      "tabStatistics": "Statistics",
+      "tabSystemDocs": "System Docs",
+      "tabUpload": "Upload"
     },
     "promptEditor": {
       "allCategories": "All categories",
@@ -3605,7 +3833,138 @@
       "selectDocument": "Select document",
       "subtitle": "Subtitle",
       "title": "Title",
-      "words": "Words"
+      "words": "Words",
+      "errorCopy": "Failed to copy to clipboard",
+      "errorExport": "Failed to export document",
+      "errorExportAll": "Failed to export all documents",
+      "errorLoadCategories": "Failed to load documentation categories",
+      "errorLoadContent": "Failed to load document content",
+      "errorLoadDocs": "Failed to load documents"
+    },
+    "search": {
+      "aiSynthesis": "Ai synthesis",
+      "allCategories": "All categories",
+      "autoEnhanceQuery": "Auto enhance query",
+      "clear": "Clear",
+      "clearAccessLevelFilter": "Clear access level filter",
+      "clearCategoryFilter": "Clear category filter",
+      "confidence": "Confidence",
+      "enableReranking": "Enable reranking",
+      "enhancedQuery": "Enhanced query",
+      "fallbackNote": "Fallback note",
+      "filterByAccessLevel": "Filter by access level",
+      "filterByCategory": "Filter by category",
+      "filtering": "Filtering",
+      "indexHelpAfter": "Index help after",
+      "indexHelpBefore": "Index help before",
+      "indexHelpLink": "Index help link",
+      "needToIndex": "Need to index",
+      "noResults": "No results",
+      "noResultsHint": "No results hint",
+      "noResultsRagHint": "No results rag hint",
+      "ragDesc": "Rag desc",
+      "ragEnhanced": "Rag enhanced",
+      "ragPlaceholder": "Rag placeholder",
+      "ragUnavailable": "Rag unavailable",
+      "rerankingBadge": "Reranking badge",
+      "resultsLimit": "Results limit",
+      "retry": "Retry",
+      "searchBtn": "Search btn",
+      "searchPlaceholder": "Search placeholder",
+      "searching": "Searching",
+      "sourcesCount": "Sources count",
+      "subtitle": "Subtitle",
+      "title": "Title",
+      "traditionalDesc": "Traditional desc",
+      "traditionalSearch": "Traditional search",
+      "accessPlatform": "Platform",
+      "accessPublic": "Public",
+      "accessSystem": "System",
+      "accessUser": "User",
+      "clickToView": "Click to view full document",
+      "close": "Close",
+      "copyContent": "Copy Content",
+      "defaultDocTitle": "Untitled Document",
+      "foundResults": "Found {count} results for \"{query}\"",
+      "loadingDocument": "Loading document content...",
+      "matchScore": "{value}% match",
+      "noContent": "No content available",
+      "rerankScore": "{value}% rerank"
+    },
+    "webResearch": {
+      "title": "Web Research",
+      "subtitle": "Fetch, crawl, discover, and extract data from the web",
+      "navLabel": "Web Research",
+      "navAriaLabel": "Web research panel",
+      "settingsNavLabel": "Research Settings",
+      "settingsNavAriaLabel": "Web research settings",
+      "tabListAriaLabel": "Web research tabs",
+      "renderLabel": "Render Mode",
+      "renderAuto": "Auto",
+      "renderFast": "Fast (no JS)",
+      "renderPlaywright": "Full JS (Playwright)",
+      "ingestLabel": "Save to Knowledge Base",
+      "respectRobotsLabel": "Respect robots.txt",
+      "reset": "Clear",
+      "retry": "Retry",
+      "fetching": "Fetching…",
+      "crawling": "Crawling…",
+      "discovering": "Discovering…",
+      "extracting": "Extracting…",
+      "indexed": "Saved to KB",
+      "failed": "Failed",
+      "schemaValid": "Schema Valid",
+      "schemaInvalid": "Schema Invalid",
+      "filterPlaceholder": "Filter URLs…",
+      "filterLabel": "Filter URLs",
+      "noFilterResults": "No URLs match the current filter.",
+      "depthLabel": "Depth {depth}",
+      "errorGeneric": "An unexpected error occurred. Please try again.",
+      "tabs": {
+        "scrape": "Fetch Page",
+        "scrapeAriaLabel": "Fetch Page — extract text from a single URL",
+        "crawl": "Crawl Site",
+        "crawlAriaLabel": "Crawl Site — follow links and index multiple pages",
+        "siteMap": "Find Pages",
+        "siteMapAriaLabel": "Find Pages — discover all URLs on a domain",
+        "extract": "Get Data",
+        "extractAriaLabel": "Get Data — extract structured data using a schema"
+      },
+      "scrape": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "formatLabel": "Output Format",
+        "submitLabel": "Fetch Page",
+        "emptyState": "Enter a URL above and click Fetch Page to extract its text content."
+      },
+      "crawl": {
+        "seedLabel": "Seed URL",
+        "seedPlaceholder": "https://example.com",
+        "depthLabel": "Max Depth",
+        "maxPagesLabel": "Max Pages",
+        "sameOriginLabel": "Same origin only",
+        "submitLabel": "Crawl Site",
+        "emptyState": "Enter a starting URL and click Crawl Site to follow its links.",
+        "resultTitle": "{count} pages crawled",
+        "urlListLabel": "Crawled pages"
+      },
+      "siteMap": {
+        "domainLabel": "Domain",
+        "domainPlaceholder": "example.com",
+        "maxUrlsLabel": "Max URLs",
+        "submitLabel": "Find Pages",
+        "emptyState": "Enter a domain name and click Find Pages to discover its URLs.",
+        "resultTitle": "{count} URLs found on {domain}",
+        "urlListLabel": "Discovered URLs"
+      },
+      "extract": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "schemaLabel": "JSON Schema",
+        "submitLabel": "Get Data",
+        "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
+        "resultTitle": "Extracted Data"
+      }
     }
   },
   "workflow": {
@@ -3725,7 +4084,10 @@
       "screenAnalysisAriaLabel": "Screen Analysis - capture and analyze screen content",
       "sectionDescVideoProcessing": "Process and analyze video frames",
       "screenAnalysis": "Screen Analysis",
-      "vision": "VISION"
+      "vision": "VISION",
+      "historyAriaLabel": "Workflow execution history",
+      "visualizerAriaLabel": "Orchestration visualizer",
+      "agentsAriaLabel": "Agent capabilities"
     },
     "modal": {
       "executeStep": "Execute This Step",
@@ -3829,7 +4191,15 @@
       "visionWait": "Wait for Element",
       "visionClick": "Click Element",
       "vision": "Vision",
-      "visionFindElement": "Find Element"
+      "visionFindElement": "Find Element",
+      "addCase": "Add case",
+      "addSwitch": "Add switch",
+      "conditionCompare": "Condition compare",
+      "conditionExpr": "Condition expr",
+      "switch": "Switch",
+      "switchDefaultHint": "Switch default hint",
+      "switchLabel": "switch",
+      "switchOnPlaceholder": "Enter switch on..."
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -4057,6 +4427,12 @@
       "resetDefaults": "Reset to Defaults",
       "saving": "Saving...",
       "tabTitle": "Settings"
+    },
+    "nav": {
+      "label": "Agents navigation",
+      "registry": "Registry",
+      "activity": "Activity",
+      "heartbeat": "Heartbeat"
     }
   },
   "errors": {
@@ -4066,7 +4442,8 @@
     "notFound": "Not found.",
     "serverError": "Server error. Please try again later.",
     "timeout": "Request timed out.",
-    "validation": "Please check your input."
+    "validation": "Please check your input.",
+    "genericError": "Generic error"
   },
   "status": {
     "online": "Online",
@@ -4348,7 +4725,8 @@
     "never": "Never",
     "themeLight": "Light",
     "themeDark": "Dark",
-    "themeAuto": "Auto"
+    "themeAuto": "Auto",
+    "tabDevices": "Tab devices"
   },
   "redis": {
     "title": "Redis Service",
@@ -4447,7 +4825,9 @@
         "showingOf": "Showing {showing} of {total} functions (scroll for more)",
         "noMatch": "No orphaned functions match your filter",
         "allConnected": "No orphaned functions detected - all functions are connected!"
-      }
+      },
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "importTree": {
       "title": "File Import Tree",
@@ -4557,7 +4937,12 @@
       "seriesName": "Problems",
       "xAxisTitle": "Number of Problems",
       "tooltipProblems": "problems"
-    }
+    },
+    "ariaLabel": "Accessible label",
+    "cellPlaceholder": "Loading...",
+    "defaultAriaLabel": "default (accessible)",
+    "renderError": "Render error",
+    "viewData": "View data"
   },
   "_meta": {
     "dir": "rtl",
@@ -5214,7 +5599,8 @@
       "aiAssistant": "المساعد الذكي",
       "knowledgeBase": "قاعدة المعرفة",
       "automation": "Automation",
-      "analytics": "التحليلات"
+      "analytics": "التحليلات",
+      "goHome": "Go Home"
     },
     "secrets": {
       "noticeTitle": "Security Notice",
@@ -5436,7 +5822,9 @@
       "widgetAgents": "Agent Activity",
       "widgetAgentsDesc": "Real-time agent activity monitoring",
       "widgetArchitecture": "System Architecture",
-      "widgetArchitectureDesc": "Interactive system architecture diagram"
+      "widgetArchitectureDesc": "Interactive system architecture diagram",
+      "saved": "Saved",
+      "dashboardSaved": "Dashboard saved"
     },
     "devSpeedup": {
       "title": "Developer Speedup",
@@ -5534,7 +5922,9 @@
       "noConfig": "No configuration stored for this plugin.",
       "invalidJson": "Invalid JSON — please fix before saving.",
       "saveFailed": "Failed to save configuration.",
-      "marketplace": "السوق"
+      "marketplace": "السوق",
+      "auditLog": "Audit log",
+      "trustTier": "Trust tier"
     },
     "marketplace": {
       "title": "Plugin Marketplace",
@@ -5636,6 +6026,22 @@
       "createBrowserSession": "Create Browser Session",
       "startingUrl": "Starting URL",
       "cancel": "إلغاء"
+    },
+    "scrapeTemplates": {
+      "title": "Scrape Templates",
+      "refresh": "Refresh templates",
+      "emptyTitle": "No Saved Templates",
+      "emptyMessage": "Mark regions on a page and save a template to see it here.",
+      "run": "Re-run template",
+      "duplicate": "Duplicate template",
+      "delete": "Delete template",
+      "deleteConfirm": "Delete \"{name}\"? This cannot be undone.",
+      "targetUrl": "Target URL",
+      "runButton": "Run",
+      "running": "Running...",
+      "extractedResults": "Extracted results",
+      "noValue": "(not found)",
+      "noResults": "No regions extracted."
     }
   },
   "collaboration": {
@@ -6276,6 +6682,65 @@
       "toastSavedToGallery": "Saved to gallery",
       "errorNoFrames": "No frames could be processed",
       "errorInvalidFile": "Please drop a valid video file"
+    },
+    "visionAutomation": {
+      "title": "Vision Automation",
+      "subtitle": "Screen analysis, UI element detection, OCR, and automation opportunity discovery",
+      "serviceStatus": "Service",
+      "sessionContext": "Session Context (optional)",
+      "sessionIdPlaceholder": "Session ID for context",
+      "tabsAriaLabel": "Vision automation tabs",
+      "analyzing": "Analyzing...",
+      "detecting": "Detecting...",
+      "extracting": "Extracting...",
+      "scanning": "Scanning...",
+      "errorLabel": "Error",
+      "tabs": {
+        "analysis": "Screen Analysis",
+        "elements": "Element Detection",
+        "ocr": "OCR",
+        "opportunities": "Automation Opportunities"
+      },
+      "columns": {
+        "id": "ID",
+        "type": "Type",
+        "confidence": "Confidence",
+        "text": "Text",
+        "interactions": "Interactions",
+        "position": "Center"
+      },
+      "analysis": {
+        "cardTitle": "Capture & Analyze Screen",
+        "trigger": "Capture & Analyze",
+        "elementsFound": "Elements",
+        "textRegions": "Text Regions",
+        "confidence": "Confidence",
+        "automationOpps": "Opportunities",
+        "detectedElements": "Detected UI Elements",
+        "empty": "Press Capture and Analyze to analyze the current screen"
+      },
+      "elements": {
+        "cardTitle": "Detect UI Elements",
+        "trigger": "Detect Elements",
+        "typePlaceholder": "Filter by element type (e.g. button)",
+        "minConfidence": "Min Confidence",
+        "results": "{filtered} of {total} elements",
+        "empty": "No elements match the current filter"
+      },
+      "ocr": {
+        "cardTitle": "OCR Text Extraction",
+        "trigger": "Extract Text",
+        "regionsFound": "{count} text region(s) found",
+        "noRegions": "No text regions detected",
+        "empty": "Press Extract Text to run OCR on the current screen"
+      },
+      "opportunities": {
+        "cardTitle": "Automation Opportunities",
+        "trigger": "Scan for Opportunities",
+        "total": "Total Opportunities",
+        "empty": "No automation opportunities found",
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+      }
     }
   },
   "visualizations": {
@@ -6293,7 +6758,8 @@
       "recentTasks": "Recent Tasks",
       "detailsBtn": "Details",
       "pauseBtn": "Pause",
-      "liveActivityFeed": "Live Activity Feed"
+      "liveActivityFeed": "Live Activity Feed",
+      "abstained": "Abstained"
     },
     "resourceHeatmap": {
       "defaultTitle": "Resource Utilization Heatmap",
@@ -6317,7 +6783,8 @@
       "rangeMedium": "Medium",
       "rangeHigh": "High",
       "rangeCritical": "Critical",
-      "usage": "الاستخدام"
+      "usage": "الاستخدام",
+      "noData": "No metrics available yet"
     },
     "systemArchitecture": {
       "defaultTitle": "System Architecture",
@@ -6616,7 +7083,8 @@
       "noEndpointData": "No endpoint data available",
       "noUserData": "No user data available",
       "noTrendData": "No trend data available",
-      "noRecentViolations": "No recent violations"
+      "noRecentViolations": "No recent violations",
+      "last14Days": "Last 14 days"
     },
     "enforcement": {
       "title": "Endpoint Overrides",
@@ -6953,7 +7421,10 @@
       "launchDesc": "This will open a live browser that you can control directly",
       "initializingSession": "Initializing browser session...",
       "sessionId": "Session ID: {id}",
-      "notAvailable": "Not available"
+      "notAvailable": "Not available",
+      "templates": "Scrape Templates",
+      "exitRegionMode": "Exit region mode",
+      "markRegions": "Mark regions"
     }
   },
   "serviceMessages": {
@@ -7018,7 +7489,28 @@
     "llcPortability": "Portability",
     "settingsAndTools": "Settings & Tools",
     "adminPanel": "Admin Panel",
-    "documents": "AI Documents"
+    "documents": "AI Documents",
+    "canvas": "Canvas",
+    "visionAutomation": "Vision",
+    "llmApiKeys": "LLM API Keys",
+    "llmProviders": "LLM Providers",
+    "adminHosts": "Host Inventory",
+    "adminSandbox": "Sandbox",
+    "budgetPolicies": "Budget Policies",
+    "companyOs": "Company OS",
+    "llcDashboard": "Dashboard",
+    "llcOrgChart": "Org Chart",
+    "llcGoals": "Goals",
+    "llcCompanies": "Companies",
+    "llcBacklog": "Backlog",
+    "llcApprovals": "Approvals",
+    "llcCosts": "Costs & Budget",
+    "llcHeartbeat": "Heartbeat",
+    "llcCeoChat": "CEO Chat",
+    "llcSelectCompany": "Switch Company",
+    "llcSelectCompanyPrompt": "Select a company to open its dashboard, backlog, and tools.",
+    "llcNoCompanies": "No companies yet.",
+    "llcCreateCompany": "Create a company"
   },
   "reasoningTrace": {
     "title": "Reasoning trace",
@@ -7060,6 +7552,176 @@
       "expired": "انتهت صلاحيته",
       "refresh": "الحصول على رمز جديد",
       "retry": "حاول مرة أخرى"
+    }
+  },
+  "llmKeys": {
+    "title": "LLM API Keys",
+    "issueKey": "Issue Key",
+    "revoke": "Revoke",
+    "rotate": "Rotate",
+    "unlimited": "Unlimited",
+    "empty": "No API keys found.",
+    "rawKeyWarning": "Copy this key now — it will not be shown again.",
+    "col": {
+      "prefix": "Key Prefix",
+      "team": "Team",
+      "label": "Label",
+      "budget": "Monthly Budget",
+      "spend": "Spend (MTD)",
+      "models": "Allowed Models",
+      "status": "Status",
+      "expires": "Expires"
+    },
+    "status": {
+      "active": "Active",
+      "revoked": "Revoked"
+    },
+    "form": {
+      "teamId": "Team ID",
+      "label": "Label",
+      "budget": "Monthly Budget (USD)",
+      "budgetHint": "Set to 0 for unlimited.",
+      "models": "Allowed Models (JSON array)",
+      "modelsHint": "E.g. [\"gpt-4\", \"claude-*\"]. Leave blank to allow all.",
+      "expiresAt": "Expires At (optional)"
+    },
+    "revokeConfirm": {
+      "title": "Revoke API Key",
+      "body": "Are you sure you want to revoke key {id}? This cannot be undone."
+    }
+  },
+  "llc": {
+    "templates": {
+      "searchPlaceholder": "Search templates...",
+      "loading": "Loading templates...",
+      "noMatch": "No templates found matching your search",
+      "preview": "Preview template",
+      "select": "Select template",
+      "useTemplate": "Use this template"
+    },
+    "wizard": {
+      "step1": {
+        "title": "Choose a Starting Point",
+        "description": "Start with a template or build from scratch",
+        "startFromScratch": "Start from Scratch",
+        "startFromScratchDesc": "Build your company structure from the ground up",
+        "useTemplate": "Use a Template",
+        "useTemplateDesc": "Start with a pre-configured company template"
+      },
+      "step2": {
+        "title": "Configure Your Company",
+        "description": "Set up your company details and preferences",
+        "companyName": "Company Name",
+        "companyNamePlaceholder": "e.g., Acme Corporation",
+        "issuePrefix": "Issue Prefix",
+        "issuePrefixPlaceholder": "e.g., ACM",
+        "issuePrefixHint": "2-10 uppercase letters for issue identifiers (e.g., ACM-123)",
+        "mission": "Mission Statement",
+        "missionPlaceholder": "What is your company's mission?",
+        "monthlyBudget": "Monthly Budget",
+        "monthlyBudgetPlaceholder": "100",
+        "estimatedCost": "Estimated cost",
+        "brandColor": "Brand Color",
+        "brandColorPlaceholder": "#667eea",
+        "templateVariables": "Template Configuration"
+      },
+      "step3": {
+        "title": "Review & Create",
+        "description": "Review your configuration and create your company",
+        "companyDetails": "Company Details",
+        "template": "Template",
+        "agents": "Agents",
+        "goals": "Goals",
+        "workItems": "Work Items",
+        "kbCollections": "Knowledge Collections",
+        "createCompany": "Create Company"
+      }
+    }
+  },
+  "code": {
+    "cellPlaceholder": "Loading...",
+    "copied": "Copied",
+    "copy": "Copy",
+    "copyCodeAriaLabel": "copy Code (accessible)",
+    "copyFailed": "Copy failed"
+  },
+  "devices": {
+    "addDevice": "Add device",
+    "confirmDelete": "Confirm delete",
+    "daysAgo": "Days ago",
+    "error": "Error",
+    "hoursAgo": "Hours ago",
+    "justNow": "Just now",
+    "lastSeen": "Last seen",
+    "loading": "Loading",
+    "minutesAgo": "Minutes ago",
+    "noDevices": "No devices",
+    "pairDevice": "Pair device",
+    "pairFirst": "Pair first",
+    "pairNewDevice": "Pair new device",
+    "paired": "Paired",
+    "pairedDevices": "Paired devices",
+    "pairingInstructions": "Pairing instructions",
+    "pairingNote": "Pairing note",
+    "step1": "Step1",
+    "step2": "Step2",
+    "step3": "Step3",
+    "step4": "Step4",
+    "unpair": "Unpair"
+  },
+  "imageCell": {
+    "copyUrl": "Copy url",
+    "download": "Download",
+    "downloadLabel": "download",
+    "generated": "Generated",
+    "lightbox": "Lightbox",
+    "loadError": "Load error",
+    "placeholder": "Placeholder",
+    "viewFull": "View full"
+  },
+  "plugins": {
+    "capabilities": {
+      "approvalDescription": "Approval description",
+      "approvalTitle": "approval",
+      "approveAll": "Approve all",
+      "approveSelected": "Approve selected",
+      "approving": "Approving",
+      "auditLogTitle": "audit Log",
+      "capability": "Capability",
+      "denied": "Denied",
+      "filterByPlugin": "Filter by plugin",
+      "granted": "Granted",
+      "loading": "Loading",
+      "loadingAudit": "Loading audit",
+      "noAuditEntries": "No audit entries",
+      "noPending": "No pending",
+      "operation": "Operation",
+      "plugin": "Plugin",
+      "status": "Status",
+      "timestamp": "Timestamp"
+    }
+  },
+  "errorMonitoring": {
+    "title": "Error Monitoring",
+    "subtitle": "System-wide error statistics, recent errors, and component breakdown",
+    "lastUpdate": "Last updated",
+    "noMessage": "(no message)",
+    "cards": {
+      "totalErrors": "Total Errors"
+    },
+    "filters": {
+      "category": "Category",
+      "component": "Component",
+      "all": "All"
+    },
+    "sections": {
+      "recentErrors": "Recent Errors",
+      "categories": "Errors by Category",
+      "components": "Errors by Component"
+    },
+    "empty": {
+      "noErrors": "No errors recorded",
+      "noData": "No data available"
     }
   }
 }

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -82,7 +82,27 @@
     "hasMore": "Load more",
     "previous": "Previous",
     "optional": "optional",
-    "remove": "Entfernen"
+    "remove": "Entfernen",
+    "dismiss": "Dismiss",
+    "forward": "Forward",
+    "saving": "Saving...",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "fitToView": "Fit to view",
+    "toggleLayout": "Toggle layout",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "copyToClipboard": "Copy to clipboard",
+    "sortAscending": "Sort ascending",
+    "sortDescending": "Sort descending",
+    "moreOptions": "More options",
+    "exportJson": "Export as JSON",
+    "exportCsv": "Export as CSV",
+    "download": "Download",
+    "filterByCategory": "Filter by category",
+    "copied": "Copied"
   },
   "chat": {
     "sendMessage": "Senden Sie eine Nachricht...",
@@ -112,6 +132,10 @@
         "overseer": "Aufseher",
         "tool-code": "Code",
         "tool-output": "Ausgabe"
+      },
+      "thinking": {
+        "badge": "🧠 Extended thinking ({count} tokens)",
+        "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
       }
     },
     "response": "Antwort",
@@ -252,7 +276,21 @@
       "sendingMessage": "Nachricht wird gesendet...",
       "aiResponding": "KI reagiert...",
       "typeMessage": "Geben Sie eine Nachricht ein...",
-      "overseerLabel": "Overseer"
+      "overseerLabel": "Overseer",
+      "managePresets": "Manage slash command presets",
+      "generate": "Generate",
+      "generateImage": "Generate image",
+      "generateImageTitle": "generate Image",
+      "generating": "Generating",
+      "imagePromptLabel": "image Prompt",
+      "imagePromptPlaceholder": "Enter image prompt...",
+      "imageProvider": "Image provider",
+      "selectPromptTemplate": "Select prompt template",
+      "thinkingBudget": "Thinking budget",
+      "thinkingOff": "Thinking off",
+      "thinkingOffLabel": "thinking Off",
+      "thinkingOn": "Thinking on",
+      "thinkingOnLabel": "thinking On"
     },
     "translate": {
       "title": "Text übersetzen",
@@ -295,7 +333,8 @@
       "statusSending": "Senden...",
       "statusSent": "Gesendet",
       "statusFailed": "Senden fehlgeschlagen",
-      "confirmDelete": "Diese Nachricht löschen? Diese Aktion kann nicht rückgängig gemacht werden."
+      "confirmDelete": "Diese Nachricht löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+      "thinkingUsed": "Thinking used"
     },
     "approval": {
       "autoApproved": "Automatisch genehmigt",
@@ -481,7 +520,35 @@
       "selectAll": "Wählen Sie „Alle“ aus",
       "deselectAll": "Alle abwählen",
       "share": "Aktie",
-      "sharing": "Teilen..."
+      "sharing": "Teilen...",
+      "createAnother": "Create another",
+      "createLink": "Create link",
+      "creating": "Creating",
+      "emptyConversation": "Empty conversation",
+      "enterPassword": "Enter password",
+      "expiry": "Expiry",
+      "expiry1d": "Expiry1d",
+      "expiry1h": "Expiry1h",
+      "expiry30d": "Expiry30d",
+      "expiry7d": "Expiry7d",
+      "expiryNever": "Expiry never",
+      "linkExpired": "Link expired",
+      "linkExpires": "Link expires",
+      "linkNotFound": "Link not found",
+      "linkPasswordProtected": "Link password protected",
+      "linkReady": "Link ready",
+      "optionalPassword": "Optional password",
+      "passwordGate": "Password gate",
+      "passwordGateHint": "Password gate hint",
+      "passwordPlaceholder": "Enter password...",
+      "publicLink": "Public link",
+      "publicView": "Public view",
+      "readOnlyNote": "Read only note",
+      "revokeLink": "Revoke link",
+      "revoking": "Revoking",
+      "shareWithUsers": "Share with users",
+      "unlock": "Unlock",
+      "wrongPassword": "Wrong password"
     },
     "vision": {
       "title": "Bildanalyse",
@@ -525,7 +592,8 @@
       "navigationFailed": "Die Navigation ist fehlgeschlagen",
       "backFailed": "Die Rücknavigation ist fehlgeschlagen",
       "forwardFailed": "Die Vorwärtsnavigation ist fehlgeschlagen",
-      "reloadFailed": "Neuladen fehlgeschlagen"
+      "reloadFailed": "Neuladen fehlgeschlagen",
+      "go": "Navigate"
     },
     "voice": {
       "title": "Sprachchat",
@@ -560,7 +628,10 @@
       "hintResponding": "AutoBot antwortet...",
       "hintRespondingShort": "Antworten...",
       "hintAutoStart": "Das Zuhören beginnt automatisch",
-      "hintTapToSpeak": "Tippen Sie, um zu sprechen"
+      "hintTapToSpeak": "Tippen Sie, um zu sprechen",
+      "realtimeWebrtc": "Realtime WebRTC",
+      "realtimeConnecting": "Connecting to Realtime...",
+      "realtimeConnected": "Realtime — speak anytime"
     },
     "typing": {
       "aiAssistant": "KI-Assistent",
@@ -585,7 +656,64 @@
       "streaming": "Streaming…",
       "done": "Done",
       "error": "Error"
-    }
+    },
+    "contextWindow": {
+      "ariaLabel": "{used} of {max} tokens used",
+      "tooltip": "{used} / {max} tokens used ({percent}% of context window)",
+      "warningToast": "Conversation approaching context limit ({percent}%). Older messages may be summarized.",
+      "compressedToast": "Context window optimized - older messages summarized",
+      "summaryTitle": "Context Summary",
+      "summaryToggle": "Show details",
+      "summarizing": "Summarizing..."
+    },
+    "openSettings": "Chat settings",
+    "settings": {
+      "title": "Chat Settings",
+      "contextOverflowLabel": "Context Overflow Protection",
+      "contextOverflowDescription": "Choose how to handle conversations approaching the context limit",
+      "contextOverflowAuto": "Auto-summarize",
+      "contextOverflowWarn": "Warn only",
+      "contextOverflowDisabled": "Disabled"
+    },
+    "folders": {
+      "folders": "Folders",
+      "newFolder": "New folder",
+      "folderName": "Folder name",
+      "rename": "Rename folder",
+      "addSubfolder": "Add subfolder",
+      "pin": "Pin folder",
+      "unpin": "Unpin folder",
+      "assignToFolder": "Move to folder",
+      "removeFromFolder": "Remove from folder",
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+    },
+    "presets": {
+      "modalTitle": "Slash Command Presets",
+      "newPreset": "New Preset",
+      "editPreset": "Edit Preset",
+      "fieldName": "Name",
+      "namePlaceholder": "my-preset",
+      "fieldDescription": "Description",
+      "descriptionPlaceholder": "What this preset does",
+      "fieldContent": "Content",
+      "contentPlaceholder": "Enter the prompt text...",
+      "cancel": "Cancel",
+      "create": "Create",
+      "update": "Update",
+      "delete": "Delete",
+      "listLabel": "Your presets",
+      "loading": "Loading presets...",
+      "empty": "No presets yet. Create one above.",
+      "editAriaLabel": "Edit preset {name}",
+      "deleteAriaLabel": "Delete preset {name}",
+      "deleteConfirmTitle": "Delete preset",
+      "deleteConfirmMessage": "Delete /{name}? This cannot be undone.",
+      "nameRequired": "Name is required",
+      "nameInvalid": "Only letters, numbers, hyphens, and underscores are allowed",
+      "contentRequired": "Content is required"
+    },
+    "lightweightMode": "Lightweight mode",
+    "lightweightModeTooltip": "lightweight Mode tooltip"
   },
   "settings": {
     "title": "Einstellungen",
@@ -664,7 +792,22 @@
     },
     "connection": {
       "title": "Connection",
-      "desc": "Configure backend connection settings"
+      "desc": "Configure backend connection settings",
+      "backendCheck": {
+        "title": "Backend reachability",
+        "description": "Run a one-shot ping to verify that the AutoBot backend is reachable from this browser. No periodic polling — manual only.",
+        "button": "Test backend connection",
+        "checking": "Checking…",
+        "reachable": "Reachable",
+        "unreachable": "Unreachable",
+        "latency": "Latency",
+        "lastTested": "Last tested",
+        "neverTested": "Not yet tested"
+      }
+    },
+    "presets": {
+      "title": "Slash Presets",
+      "description": "Create reusable slash commands that expand into full prompts in the chat input. Type / followed by the preset name to trigger them."
     }
   },
   "voice": {
@@ -1247,7 +1390,13 @@
         "usage": "Nutzung",
         "usageAria": "Nutzung & Kosten",
         "operations": "Operationen",
-        "operationsAria": "Lang laufende Operationen"
+        "operationsAria": "Lang laufende Operationen",
+        "devTools": "Dev Tools",
+        "devToolsAria": "Developer tools and utilities",
+        "errors": "Errors",
+        "errorsAria": "Error monitoring",
+        "diagnostics": "Diagnostics",
+        "diagnosticsAria": "Failure analysis and causal inference"
       }
     },
     "header": {
@@ -1615,7 +1764,8 @@
       "file": "Datei",
       "score": "Bewertung",
       "topIssue": "Hauptproblem",
-      "close": "Schließen"
+      "close": "Schließen",
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
     },
     "bugPrediction": {
       "title": "Fehlervorhersage",
@@ -2190,6 +2340,38 @@
         "scanning": "Scanne...",
         "scanFile": "Scan File"
       }
+    },
+    "failureAnalysis": {
+      "title": "Failure Analysis",
+      "subtitle": "Root-cause analysis powered by the causal inference engine",
+      "empty": "Enter a task ID above to run a failure analysis.",
+      "form": {
+        "title": "Analyze a Failure",
+        "taskId": "Task ID",
+        "taskIdPlaceholder": "e.g. task-abc123",
+        "errorDescription": "Error Description",
+        "errorDescriptionPlaceholder": "Optional: describe the error or paste a stack trace",
+        "analyze": "Analyze",
+        "analyzing": "Analyzing...",
+        "clear": "Clear"
+      },
+      "result": {
+        "taskId": "Task ID",
+        "confidence": "Confidence",
+        "status": "Status",
+        "duration": "Duration",
+        "rootCause": "Root Cause",
+        "causalChain": "Causal Chain",
+        "interventions": "Interventions",
+        "confounders": "Confounders",
+        "recommendations": "Recommendations",
+        "participants": "Participants",
+        "mechanism": "Mechanism",
+        "successRate": "Success Rate",
+        "cost": "Cost",
+        "risk": "Risk",
+        "confoundingStrength": "Confounding Strength"
+      }
     }
   },
   "knowledge": {
@@ -2241,7 +2423,14 @@
       "visShared": "Vis shared",
       "visSystem": "Vis system",
       "visibility": "Visibility",
-      "visibilityHint": "Visibility hint"
+      "visibilityHint": "Visibility hint",
+      "errorAddText": "Failed to add text to knowledge base",
+      "errorFileTooLarge": "File \"{name}\" exceeds the maximum size limit",
+      "errorImportUrl": "Failed to import URL content",
+      "errorUnsupportedFormat": "File \"{name}\" has an unsupported format",
+      "errorUploadFiles": "Failed to upload files",
+      "successTextAdded": "Text added to knowledge base successfully",
+      "successUrlImported": "URL content imported successfully"
     },
     "documents": "Dokumente",
     "categories": {
@@ -2291,7 +2480,11 @@
       "maintenance": "Wartung",
       "maintenanceAriaLabel": "Wissensdatenbank-Wartung",
       "analytics": "Analysen",
-      "statistics": "Statistiken"
+      "statistics": "Statistiken",
+      "webResearch": "Web Research",
+      "webResearchAriaLabel": "4-tab web research panel",
+      "openSidebar": "Open navigation menu",
+      "closeSidebar": "Close navigation menu"
     },
     "backup": {
       "title": "Sicherung & Wiederherstellung",
@@ -2787,7 +2980,9 @@
         "sourcesCount": "{count} Quellen"
       },
       "noEntities3D": "Keine Entitäten zum Anzeigen",
-      "loading3dVisualization": "Loading3d visualization"
+      "loading3dVisualization": "Loading3d visualization",
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "connectors": {
       "title": "Quell-Konnektoren",
@@ -3159,7 +3354,8 @@
       "vectorFramework": "Vector framework",
       "vectorIndexHealth": "Vector index health",
       "vectorNotGenerated": "Vector not generated",
-      "vectorizedForRag": "Vectorized for rag"
+      "vectorizedForRag": "Vectorized for rag",
+      "confirmOptimize": "This will optimize the database. Continue?"
     },
     "summaries": {
       "search": {
@@ -3290,7 +3486,11 @@
       "decisionsApplied": "{count} decision(s) applied successfully",
       "compiledSuccess": "Chat compiled successfully",
       "failedToLoad": "Failed to load knowledge items",
-      "decisionsApplyFailed": "Failed to apply decisions"
+      "decisionsApplyFailed": "Failed to apply decisions",
+      "compileFailed": "Failed to compile conversation",
+      "suggestionAddToKb": "Suggested: Add to Knowledge Base",
+      "suggestionDelete": "Suggested: Delete",
+      "suggestionKeepTemporary": "Suggested: Keep Temporarily"
     },
     "systemKnowledge": {
       "vectorizeTooltip": "Vektor-Embeddings für alle Wissensdatenbank-Einträge generieren, um semantische Suche zu ermöglichen",
@@ -3323,7 +3523,14 @@
       "success": "Success",
       "targetHost": "Target host",
       "totalFacts": "Total facts",
-      "vectorizing": "Vectorizing"
+      "vectorizing": "Vectorizing",
+      "confirmIndexDocs": "Do you want to force reindex existing documents?",
+      "confirmInitialize": "This will initialize system knowledge for the selected host. This may take several minutes. Continue?",
+      "confirmRefreshManPages": "This will refresh man pages for the selected host. Continue?",
+      "confirmReindex": "This will reindex all documents for the selected host. Continue?",
+      "confirmVectorize": "This will vectorize {totalFacts} facts. Currently {totalVectors} vectors exist, {needsVectorization} need vectorization. Continue?",
+      "vectorizeComplete": "Vectorize Facts (✓ {vectors} vectors from {facts} facts)",
+      "vectorizePending": "Vectorize Facts ({pending} pending)"
     },
     "vectorization": {
       "actionVectorize": "Vektorisieren",
@@ -3342,7 +3549,15 @@
       "noDocuments": "No documents",
       "progressTitle": "Progress title",
       "retryFailed": "Retry failed",
-      "total": "Total"
+      "total": "Total",
+      "statusFailed": "Failed",
+      "statusPending": "Pending",
+      "statusUnknown": "Unknown",
+      "statusVectorized": "Vectorized",
+      "tooltipFailed": "Vectorization failed for this document",
+      "tooltipPending": "Document is pending vectorization",
+      "tooltipUnknown": "Vectorization status unknown",
+      "tooltipVectorized": "Document has been vectorized and is searchable via RAG"
     },
     "batchSelection": {
       "selected": "{count} ausgewählt",
@@ -3382,7 +3597,8 @@
       "shareWith": "Share with",
       "team": "Team",
       "user": "User",
-      "write": "Write"
+      "write": "Write",
+      "unsavedConfirm": "You have unsaved changes. Are you sure you want to close?"
     },
     "memoryOrphan": {
       "entitiesToClean": "Entities to clean",
@@ -3430,7 +3646,11 @@
       "rejectedToday": "Rejected today",
       "selectAll": "Select all",
       "title": "Title",
-      "untitled": "Untitled"
+      "untitled": "Untitled",
+      "typeConnector": "Connector",
+      "typeResearch": "Web Research",
+      "typeUpload": "Manual Upload",
+      "typeUrl": "URL Fetch"
     },
     "sessionOrphan": {
       "moreOrphans": "More orphans",
@@ -3499,7 +3719,15 @@
       "warnings": "Warnings"
     },
     "manager": {
-      "errorFallback": "Error fallback"
+      "errorFallback": "Error fallback",
+      "tabAdvanced": "Advanced",
+      "tabCategories": "Categories",
+      "tabManage": "Manage",
+      "tabPromptEditor": "Prompts",
+      "tabSearch": "Search",
+      "tabStatistics": "Statistics",
+      "tabSystemDocs": "System Docs",
+      "tabUpload": "Upload"
     },
     "promptEditor": {
       "allCategories": "All categories",
@@ -3605,7 +3833,138 @@
       "selectDocument": "Select document",
       "subtitle": "Subtitle",
       "title": "Title",
-      "words": "Words"
+      "words": "Words",
+      "errorCopy": "Failed to copy to clipboard",
+      "errorExport": "Failed to export document",
+      "errorExportAll": "Failed to export all documents",
+      "errorLoadCategories": "Failed to load documentation categories",
+      "errorLoadContent": "Failed to load document content",
+      "errorLoadDocs": "Failed to load documents"
+    },
+    "search": {
+      "aiSynthesis": "Ai synthesis",
+      "allCategories": "All categories",
+      "autoEnhanceQuery": "Auto enhance query",
+      "clear": "Clear",
+      "clearAccessLevelFilter": "Clear access level filter",
+      "clearCategoryFilter": "Clear category filter",
+      "confidence": "Confidence",
+      "enableReranking": "Enable reranking",
+      "enhancedQuery": "Enhanced query",
+      "fallbackNote": "Fallback note",
+      "filterByAccessLevel": "Filter by access level",
+      "filterByCategory": "Filter by category",
+      "filtering": "Filtering",
+      "indexHelpAfter": "Index help after",
+      "indexHelpBefore": "Index help before",
+      "indexHelpLink": "Index help link",
+      "needToIndex": "Need to index",
+      "noResults": "No results",
+      "noResultsHint": "No results hint",
+      "noResultsRagHint": "No results rag hint",
+      "ragDesc": "Rag desc",
+      "ragEnhanced": "Rag enhanced",
+      "ragPlaceholder": "Rag placeholder",
+      "ragUnavailable": "Rag unavailable",
+      "rerankingBadge": "Reranking badge",
+      "resultsLimit": "Results limit",
+      "retry": "Retry",
+      "searchBtn": "Search btn",
+      "searchPlaceholder": "Search placeholder",
+      "searching": "Searching",
+      "sourcesCount": "Sources count",
+      "subtitle": "Subtitle",
+      "title": "Title",
+      "traditionalDesc": "Traditional desc",
+      "traditionalSearch": "Traditional search",
+      "accessPlatform": "Platform",
+      "accessPublic": "Public",
+      "accessSystem": "System",
+      "accessUser": "User",
+      "clickToView": "Click to view full document",
+      "close": "Close",
+      "copyContent": "Copy Content",
+      "defaultDocTitle": "Untitled Document",
+      "foundResults": "Found {count} results for \"{query}\"",
+      "loadingDocument": "Loading document content...",
+      "matchScore": "{value}% match",
+      "noContent": "No content available",
+      "rerankScore": "{value}% rerank"
+    },
+    "webResearch": {
+      "title": "Web Research",
+      "subtitle": "Fetch, crawl, discover, and extract data from the web",
+      "navLabel": "Web Research",
+      "navAriaLabel": "Web research panel",
+      "settingsNavLabel": "Research Settings",
+      "settingsNavAriaLabel": "Web research settings",
+      "tabListAriaLabel": "Web research tabs",
+      "renderLabel": "Render Mode",
+      "renderAuto": "Auto",
+      "renderFast": "Fast (no JS)",
+      "renderPlaywright": "Full JS (Playwright)",
+      "ingestLabel": "Save to Knowledge Base",
+      "respectRobotsLabel": "Respect robots.txt",
+      "reset": "Clear",
+      "retry": "Retry",
+      "fetching": "Fetching…",
+      "crawling": "Crawling…",
+      "discovering": "Discovering…",
+      "extracting": "Extracting…",
+      "indexed": "Saved to KB",
+      "failed": "Failed",
+      "schemaValid": "Schema Valid",
+      "schemaInvalid": "Schema Invalid",
+      "filterPlaceholder": "Filter URLs…",
+      "filterLabel": "Filter URLs",
+      "noFilterResults": "No URLs match the current filter.",
+      "depthLabel": "Depth {depth}",
+      "errorGeneric": "An unexpected error occurred. Please try again.",
+      "tabs": {
+        "scrape": "Fetch Page",
+        "scrapeAriaLabel": "Fetch Page — extract text from a single URL",
+        "crawl": "Crawl Site",
+        "crawlAriaLabel": "Crawl Site — follow links and index multiple pages",
+        "siteMap": "Find Pages",
+        "siteMapAriaLabel": "Find Pages — discover all URLs on a domain",
+        "extract": "Get Data",
+        "extractAriaLabel": "Get Data — extract structured data using a schema"
+      },
+      "scrape": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "formatLabel": "Output Format",
+        "submitLabel": "Fetch Page",
+        "emptyState": "Enter a URL above and click Fetch Page to extract its text content."
+      },
+      "crawl": {
+        "seedLabel": "Seed URL",
+        "seedPlaceholder": "https://example.com",
+        "depthLabel": "Max Depth",
+        "maxPagesLabel": "Max Pages",
+        "sameOriginLabel": "Same origin only",
+        "submitLabel": "Crawl Site",
+        "emptyState": "Enter a starting URL and click Crawl Site to follow its links.",
+        "resultTitle": "{count} pages crawled",
+        "urlListLabel": "Crawled pages"
+      },
+      "siteMap": {
+        "domainLabel": "Domain",
+        "domainPlaceholder": "example.com",
+        "maxUrlsLabel": "Max URLs",
+        "submitLabel": "Find Pages",
+        "emptyState": "Enter a domain name and click Find Pages to discover its URLs.",
+        "resultTitle": "{count} URLs found on {domain}",
+        "urlListLabel": "Discovered URLs"
+      },
+      "extract": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "schemaLabel": "JSON Schema",
+        "submitLabel": "Get Data",
+        "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
+        "resultTitle": "Extracted Data"
+      }
     }
   },
   "workflow": {
@@ -3725,7 +4084,10 @@
       "screenAnalysisAriaLabel": "Screen Analysis - capture and analyze screen content",
       "sectionDescVideoProcessing": "Process and analyze video frames",
       "screenAnalysis": "Screen Analysis",
-      "vision": "VISION"
+      "vision": "VISION",
+      "historyAriaLabel": "Workflow execution history",
+      "visualizerAriaLabel": "Orchestration visualizer",
+      "agentsAriaLabel": "Agent capabilities"
     },
     "modal": {
       "executeStep": "Execute This Step",
@@ -3829,7 +4191,15 @@
       "visionWait": "Wait for Element",
       "visionClick": "Click Element",
       "vision": "Vision",
-      "visionFindElement": "Find Element"
+      "visionFindElement": "Find Element",
+      "addCase": "Add case",
+      "addSwitch": "Add switch",
+      "conditionCompare": "Condition compare",
+      "conditionExpr": "Condition expr",
+      "switch": "Switch",
+      "switchDefaultHint": "Switch default hint",
+      "switchLabel": "switch",
+      "switchOnPlaceholder": "Enter switch on..."
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -4057,6 +4427,12 @@
       "resetDefaults": "Reset to Defaults",
       "saving": "Saving...",
       "tabTitle": "Settings"
+    },
+    "nav": {
+      "label": "Agents navigation",
+      "registry": "Registry",
+      "activity": "Activity",
+      "heartbeat": "Heartbeat"
     }
   },
   "errors": {
@@ -4066,7 +4442,8 @@
     "notFound": "Nicht gefunden.",
     "serverError": "Serverfehler. Bitte versuchen Sie es später erneut.",
     "timeout": "Zeitüberschreitung der Anfrage.",
-    "validation": "Bitte überprüfen Sie Ihre Eingabe."
+    "validation": "Bitte überprüfen Sie Ihre Eingabe.",
+    "genericError": "Generic error"
   },
   "status": {
     "online": "Online",
@@ -4348,7 +4725,8 @@
     "never": "Nie",
     "themeLight": "Hell",
     "themeDark": "Dunkel",
-    "themeAuto": "Automatisch"
+    "themeAuto": "Automatisch",
+    "tabDevices": "Tab devices"
   },
   "redis": {
     "title": "Redis-Dienst",
@@ -4447,7 +4825,9 @@
         "showingOf": "Showing {showing} of {total} functions (scroll for more)",
         "noMatch": "No orphaned functions match your filter",
         "allConnected": "No orphaned functions detected - all functions are connected!"
-      }
+      },
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "importTree": {
       "title": "File Import Tree",
@@ -4557,7 +4937,12 @@
       "seriesName": "Problems",
       "xAxisTitle": "Number of Problems",
       "tooltipProblems": "problems"
-    }
+    },
+    "ariaLabel": "Accessible label",
+    "cellPlaceholder": "Loading...",
+    "defaultAriaLabel": "default (accessible)",
+    "renderError": "Render error",
+    "viewData": "View data"
   },
   "_meta": {
     "dir": "ltr",
@@ -5214,7 +5599,8 @@
       "aiAssistant": "AI Assistant",
       "knowledgeBase": "Knowledge Base",
       "automation": "Automation",
-      "analytics": "Analytics"
+      "analytics": "Analytics",
+      "goHome": "Go Home"
     },
     "secrets": {
       "noticeTitle": "Security Notice",
@@ -5436,7 +5822,9 @@
       "widgetAgents": "Agent Activity",
       "widgetAgentsDesc": "Real-time agent activity monitoring",
       "widgetArchitecture": "System Architecture",
-      "widgetArchitectureDesc": "Interactive system architecture diagram"
+      "widgetArchitectureDesc": "Interactive system architecture diagram",
+      "saved": "Saved",
+      "dashboardSaved": "Dashboard saved"
     },
     "devSpeedup": {
       "title": "Developer Speedup",
@@ -5534,7 +5922,9 @@
       "noConfig": "No configuration stored for this plugin.",
       "invalidJson": "Invalid JSON — please fix before saving.",
       "saveFailed": "Failed to save configuration.",
-      "marketplace": "Marktplatz"
+      "marketplace": "Marktplatz",
+      "auditLog": "Audit log",
+      "trustTier": "Trust tier"
     },
     "marketplace": {
       "title": "Plugin Marketplace",
@@ -5636,6 +6026,22 @@
       "createBrowserSession": "Browsersitzung erstellen",
       "startingUrl": "Start-URL",
       "cancel": "Abbrechen"
+    },
+    "scrapeTemplates": {
+      "title": "Scrape Templates",
+      "refresh": "Refresh templates",
+      "emptyTitle": "No Saved Templates",
+      "emptyMessage": "Mark regions on a page and save a template to see it here.",
+      "run": "Re-run template",
+      "duplicate": "Duplicate template",
+      "delete": "Delete template",
+      "deleteConfirm": "Delete \"{name}\"? This cannot be undone.",
+      "targetUrl": "Target URL",
+      "runButton": "Run",
+      "running": "Running...",
+      "extractedResults": "Extracted results",
+      "noValue": "(not found)",
+      "noResults": "No regions extracted."
     }
   },
   "collaboration": {
@@ -6276,6 +6682,65 @@
       "toastSavedToGallery": "Saved to gallery",
       "errorNoFrames": "No frames could be processed",
       "errorInvalidFile": "Please drop a valid video file"
+    },
+    "visionAutomation": {
+      "title": "Vision Automation",
+      "subtitle": "Screen analysis, UI element detection, OCR, and automation opportunity discovery",
+      "serviceStatus": "Service",
+      "sessionContext": "Session Context (optional)",
+      "sessionIdPlaceholder": "Session ID for context",
+      "tabsAriaLabel": "Vision automation tabs",
+      "analyzing": "Analyzing...",
+      "detecting": "Detecting...",
+      "extracting": "Extracting...",
+      "scanning": "Scanning...",
+      "errorLabel": "Error",
+      "tabs": {
+        "analysis": "Screen Analysis",
+        "elements": "Element Detection",
+        "ocr": "OCR",
+        "opportunities": "Automation Opportunities"
+      },
+      "columns": {
+        "id": "ID",
+        "type": "Type",
+        "confidence": "Confidence",
+        "text": "Text",
+        "interactions": "Interactions",
+        "position": "Center"
+      },
+      "analysis": {
+        "cardTitle": "Capture & Analyze Screen",
+        "trigger": "Capture & Analyze",
+        "elementsFound": "Elements",
+        "textRegions": "Text Regions",
+        "confidence": "Confidence",
+        "automationOpps": "Opportunities",
+        "detectedElements": "Detected UI Elements",
+        "empty": "Press Capture and Analyze to analyze the current screen"
+      },
+      "elements": {
+        "cardTitle": "Detect UI Elements",
+        "trigger": "Detect Elements",
+        "typePlaceholder": "Filter by element type (e.g. button)",
+        "minConfidence": "Min Confidence",
+        "results": "{filtered} of {total} elements",
+        "empty": "No elements match the current filter"
+      },
+      "ocr": {
+        "cardTitle": "OCR Text Extraction",
+        "trigger": "Extract Text",
+        "regionsFound": "{count} text region(s) found",
+        "noRegions": "No text regions detected",
+        "empty": "Press Extract Text to run OCR on the current screen"
+      },
+      "opportunities": {
+        "cardTitle": "Automation Opportunities",
+        "trigger": "Scan for Opportunities",
+        "total": "Total Opportunities",
+        "empty": "No automation opportunities found",
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+      }
     }
   },
   "visualizations": {
@@ -6293,7 +6758,8 @@
       "recentTasks": "Recent Tasks",
       "detailsBtn": "Details",
       "pauseBtn": "Pause",
-      "liveActivityFeed": "Live Activity Feed"
+      "liveActivityFeed": "Live Activity Feed",
+      "abstained": "Abstained"
     },
     "resourceHeatmap": {
       "defaultTitle": "Resource Utilization Heatmap",
@@ -6317,7 +6783,8 @@
       "rangeMedium": "Medium",
       "rangeHigh": "High",
       "rangeCritical": "Critical",
-      "usage": "Usage"
+      "usage": "Usage",
+      "noData": "No metrics available yet"
     },
     "systemArchitecture": {
       "defaultTitle": "System Architecture",
@@ -6616,7 +7083,8 @@
       "noEndpointData": "No endpoint data available",
       "noUserData": "No user data available",
       "noTrendData": "No trend data available",
-      "noRecentViolations": "No recent violations"
+      "noRecentViolations": "No recent violations",
+      "last14Days": "Last 14 days"
     },
     "enforcement": {
       "title": "Endpoint Overrides",
@@ -6953,7 +7421,10 @@
       "launchDesc": "This will open a live browser that you can control directly",
       "initializingSession": "Initializing browser session...",
       "sessionId": "Session ID: {id}",
-      "notAvailable": "Not available"
+      "notAvailable": "Not available",
+      "templates": "Scrape Templates",
+      "exitRegionMode": "Exit region mode",
+      "markRegions": "Mark regions"
     }
   },
   "serviceMessages": {
@@ -7018,7 +7489,28 @@
     "llcPortability": "Portability",
     "settingsAndTools": "Settings & Tools",
     "adminPanel": "Admin Panel",
-    "documents": "AI Documents"
+    "documents": "AI Documents",
+    "canvas": "Canvas",
+    "visionAutomation": "Vision",
+    "llmApiKeys": "LLM API Keys",
+    "llmProviders": "LLM Providers",
+    "adminHosts": "Host Inventory",
+    "adminSandbox": "Sandbox",
+    "budgetPolicies": "Budget Policies",
+    "companyOs": "Company OS",
+    "llcDashboard": "Dashboard",
+    "llcOrgChart": "Org Chart",
+    "llcGoals": "Goals",
+    "llcCompanies": "Companies",
+    "llcBacklog": "Backlog",
+    "llcApprovals": "Approvals",
+    "llcCosts": "Costs & Budget",
+    "llcHeartbeat": "Heartbeat",
+    "llcCeoChat": "CEO Chat",
+    "llcSelectCompany": "Switch Company",
+    "llcSelectCompanyPrompt": "Select a company to open its dashboard, backlog, and tools.",
+    "llcNoCompanies": "No companies yet.",
+    "llcCreateCompany": "Create a company"
   },
   "reasoningTrace": {
     "title": "Reasoning-Trace",
@@ -7060,6 +7552,176 @@
       "expired": "Abgelaufen",
       "refresh": "Neuen Code erhalten",
       "retry": "Erneut versuchen"
+    }
+  },
+  "llmKeys": {
+    "title": "LLM API Keys",
+    "issueKey": "Issue Key",
+    "revoke": "Revoke",
+    "rotate": "Rotate",
+    "unlimited": "Unlimited",
+    "empty": "No API keys found.",
+    "rawKeyWarning": "Copy this key now — it will not be shown again.",
+    "col": {
+      "prefix": "Key Prefix",
+      "team": "Team",
+      "label": "Label",
+      "budget": "Monthly Budget",
+      "spend": "Spend (MTD)",
+      "models": "Allowed Models",
+      "status": "Status",
+      "expires": "Expires"
+    },
+    "status": {
+      "active": "Active",
+      "revoked": "Revoked"
+    },
+    "form": {
+      "teamId": "Team ID",
+      "label": "Label",
+      "budget": "Monthly Budget (USD)",
+      "budgetHint": "Set to 0 for unlimited.",
+      "models": "Allowed Models (JSON array)",
+      "modelsHint": "E.g. [\"gpt-4\", \"claude-*\"]. Leave blank to allow all.",
+      "expiresAt": "Expires At (optional)"
+    },
+    "revokeConfirm": {
+      "title": "Revoke API Key",
+      "body": "Are you sure you want to revoke key {id}? This cannot be undone."
+    }
+  },
+  "llc": {
+    "templates": {
+      "searchPlaceholder": "Search templates...",
+      "loading": "Loading templates...",
+      "noMatch": "No templates found matching your search",
+      "preview": "Preview template",
+      "select": "Select template",
+      "useTemplate": "Use this template"
+    },
+    "wizard": {
+      "step1": {
+        "title": "Choose a Starting Point",
+        "description": "Start with a template or build from scratch",
+        "startFromScratch": "Start from Scratch",
+        "startFromScratchDesc": "Build your company structure from the ground up",
+        "useTemplate": "Use a Template",
+        "useTemplateDesc": "Start with a pre-configured company template"
+      },
+      "step2": {
+        "title": "Configure Your Company",
+        "description": "Set up your company details and preferences",
+        "companyName": "Company Name",
+        "companyNamePlaceholder": "e.g., Acme Corporation",
+        "issuePrefix": "Issue Prefix",
+        "issuePrefixPlaceholder": "e.g., ACM",
+        "issuePrefixHint": "2-10 uppercase letters for issue identifiers (e.g., ACM-123)",
+        "mission": "Mission Statement",
+        "missionPlaceholder": "What is your company's mission?",
+        "monthlyBudget": "Monthly Budget",
+        "monthlyBudgetPlaceholder": "100",
+        "estimatedCost": "Estimated cost",
+        "brandColor": "Brand Color",
+        "brandColorPlaceholder": "#667eea",
+        "templateVariables": "Template Configuration"
+      },
+      "step3": {
+        "title": "Review & Create",
+        "description": "Review your configuration and create your company",
+        "companyDetails": "Company Details",
+        "template": "Template",
+        "agents": "Agents",
+        "goals": "Goals",
+        "workItems": "Work Items",
+        "kbCollections": "Knowledge Collections",
+        "createCompany": "Create Company"
+      }
+    }
+  },
+  "code": {
+    "cellPlaceholder": "Loading...",
+    "copied": "Copied",
+    "copy": "Copy",
+    "copyCodeAriaLabel": "copy Code (accessible)",
+    "copyFailed": "Copy failed"
+  },
+  "devices": {
+    "addDevice": "Add device",
+    "confirmDelete": "Confirm delete",
+    "daysAgo": "Days ago",
+    "error": "Error",
+    "hoursAgo": "Hours ago",
+    "justNow": "Just now",
+    "lastSeen": "Last seen",
+    "loading": "Loading",
+    "minutesAgo": "Minutes ago",
+    "noDevices": "No devices",
+    "pairDevice": "Pair device",
+    "pairFirst": "Pair first",
+    "pairNewDevice": "Pair new device",
+    "paired": "Paired",
+    "pairedDevices": "Paired devices",
+    "pairingInstructions": "Pairing instructions",
+    "pairingNote": "Pairing note",
+    "step1": "Step1",
+    "step2": "Step2",
+    "step3": "Step3",
+    "step4": "Step4",
+    "unpair": "Unpair"
+  },
+  "imageCell": {
+    "copyUrl": "Copy url",
+    "download": "Download",
+    "downloadLabel": "download",
+    "generated": "Generated",
+    "lightbox": "Lightbox",
+    "loadError": "Load error",
+    "placeholder": "Placeholder",
+    "viewFull": "View full"
+  },
+  "plugins": {
+    "capabilities": {
+      "approvalDescription": "Approval description",
+      "approvalTitle": "approval",
+      "approveAll": "Approve all",
+      "approveSelected": "Approve selected",
+      "approving": "Approving",
+      "auditLogTitle": "audit Log",
+      "capability": "Capability",
+      "denied": "Denied",
+      "filterByPlugin": "Filter by plugin",
+      "granted": "Granted",
+      "loading": "Loading",
+      "loadingAudit": "Loading audit",
+      "noAuditEntries": "No audit entries",
+      "noPending": "No pending",
+      "operation": "Operation",
+      "plugin": "Plugin",
+      "status": "Status",
+      "timestamp": "Timestamp"
+    }
+  },
+  "errorMonitoring": {
+    "title": "Error Monitoring",
+    "subtitle": "System-wide error statistics, recent errors, and component breakdown",
+    "lastUpdate": "Last updated",
+    "noMessage": "(no message)",
+    "cards": {
+      "totalErrors": "Total Errors"
+    },
+    "filters": {
+      "category": "Category",
+      "component": "Component",
+      "all": "All"
+    },
+    "sections": {
+      "recentErrors": "Recent Errors",
+      "categories": "Errors by Category",
+      "components": "Errors by Component"
+    },
+    "empty": {
+      "noErrors": "No errors recorded",
+      "noData": "No data available"
     }
   }
 }

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -82,7 +82,27 @@
     "hasMore": "Load more",
     "previous": "Previous",
     "optional": "opcional",
-    "remove": "Eliminar"
+    "remove": "Eliminar",
+    "dismiss": "Dismiss",
+    "forward": "Forward",
+    "saving": "Saving...",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "fitToView": "Fit to view",
+    "toggleLayout": "Toggle layout",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "copyToClipboard": "Copy to clipboard",
+    "sortAscending": "Sort ascending",
+    "sortDescending": "Sort descending",
+    "moreOptions": "More options",
+    "exportJson": "Export as JSON",
+    "exportCsv": "Export as CSV",
+    "download": "Download",
+    "filterByCategory": "Filter by category",
+    "copied": "Copied"
   },
   "chat": {
     "sendMessage": "Enviar un mensaje...",
@@ -112,6 +132,10 @@
         "overseer": "Capataz",
         "tool-code": "Código",
         "tool-output": "Producción"
+      },
+      "thinking": {
+        "badge": "🧠 Extended thinking ({count} tokens)",
+        "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
       }
     },
     "response": "respuesta",
@@ -252,7 +276,21 @@
       "sendingMessage": "Enviando mensaje...",
       "aiResponding": "La IA está respondiendo...",
       "typeMessage": "Escribe un mensaje...",
-      "overseerLabel": "Overseer"
+      "overseerLabel": "Overseer",
+      "managePresets": "Manage slash command presets",
+      "generate": "Generate",
+      "generateImage": "Generate image",
+      "generateImageTitle": "generate Image",
+      "generating": "Generating",
+      "imagePromptLabel": "image Prompt",
+      "imagePromptPlaceholder": "Enter image prompt...",
+      "imageProvider": "Image provider",
+      "selectPromptTemplate": "Select prompt template",
+      "thinkingBudget": "Thinking budget",
+      "thinkingOff": "Thinking off",
+      "thinkingOffLabel": "thinking Off",
+      "thinkingOn": "Thinking on",
+      "thinkingOnLabel": "thinking On"
     },
     "translate": {
       "title": "Traducir texto",
@@ -295,7 +333,8 @@
       "statusSending": "Envío...",
       "statusSent": "Enviado",
       "statusFailed": "No se pudo enviar",
-      "confirmDelete": "¿Eliminar este mensaje? Esta acción no se puede deshacer."
+      "confirmDelete": "¿Eliminar este mensaje? Esta acción no se puede deshacer.",
+      "thinkingUsed": "Thinking used"
     },
     "approval": {
       "autoApproved": "Aprobado automáticamente",
@@ -481,7 +520,35 @@
       "selectAll": "Seleccionar todo",
       "deselectAll": "Deseleccionar todo",
       "share": "Compartir",
-      "sharing": "Intercambio..."
+      "sharing": "Intercambio...",
+      "createAnother": "Create another",
+      "createLink": "Create link",
+      "creating": "Creating",
+      "emptyConversation": "Empty conversation",
+      "enterPassword": "Enter password",
+      "expiry": "Expiry",
+      "expiry1d": "Expiry1d",
+      "expiry1h": "Expiry1h",
+      "expiry30d": "Expiry30d",
+      "expiry7d": "Expiry7d",
+      "expiryNever": "Expiry never",
+      "linkExpired": "Link expired",
+      "linkExpires": "Link expires",
+      "linkNotFound": "Link not found",
+      "linkPasswordProtected": "Link password protected",
+      "linkReady": "Link ready",
+      "optionalPassword": "Optional password",
+      "passwordGate": "Password gate",
+      "passwordGateHint": "Password gate hint",
+      "passwordPlaceholder": "Enter password...",
+      "publicLink": "Public link",
+      "publicView": "Public view",
+      "readOnlyNote": "Read only note",
+      "revokeLink": "Revoke link",
+      "revoking": "Revoking",
+      "shareWithUsers": "Share with users",
+      "unlock": "Unlock",
+      "wrongPassword": "Wrong password"
     },
     "vision": {
       "title": "Análisis de imágenes",
@@ -525,7 +592,8 @@
       "navigationFailed": "Error de navegación",
       "backFailed": "Falló la navegación hacia atrás",
       "forwardFailed": "Falló la navegación hacia adelante",
-      "reloadFailed": "Recarga fallida"
+      "reloadFailed": "Recarga fallida",
+      "go": "Navigate"
     },
     "voice": {
       "title": "Chat de voz",
@@ -560,7 +628,10 @@
       "hintResponding": "AutoBot está respondiendo...",
       "hintRespondingShort": "Respondiendo...",
       "hintAutoStart": "La escucha comenzará automáticamente",
-      "hintTapToSpeak": "Toca para hablar"
+      "hintTapToSpeak": "Toca para hablar",
+      "realtimeWebrtc": "Realtime WebRTC",
+      "realtimeConnecting": "Connecting to Realtime...",
+      "realtimeConnected": "Realtime — speak anytime"
     },
     "typing": {
       "aiAssistant": "Asistente de IA",
@@ -585,7 +656,64 @@
       "streaming": "Streaming…",
       "done": "Done",
       "error": "Error"
-    }
+    },
+    "contextWindow": {
+      "ariaLabel": "{used} of {max} tokens used",
+      "tooltip": "{used} / {max} tokens used ({percent}% of context window)",
+      "warningToast": "Conversation approaching context limit ({percent}%). Older messages may be summarized.",
+      "compressedToast": "Context window optimized - older messages summarized",
+      "summaryTitle": "Context Summary",
+      "summaryToggle": "Show details",
+      "summarizing": "Summarizing..."
+    },
+    "openSettings": "Chat settings",
+    "settings": {
+      "title": "Chat Settings",
+      "contextOverflowLabel": "Context Overflow Protection",
+      "contextOverflowDescription": "Choose how to handle conversations approaching the context limit",
+      "contextOverflowAuto": "Auto-summarize",
+      "contextOverflowWarn": "Warn only",
+      "contextOverflowDisabled": "Disabled"
+    },
+    "folders": {
+      "folders": "Folders",
+      "newFolder": "New folder",
+      "folderName": "Folder name",
+      "rename": "Rename folder",
+      "addSubfolder": "Add subfolder",
+      "pin": "Pin folder",
+      "unpin": "Unpin folder",
+      "assignToFolder": "Move to folder",
+      "removeFromFolder": "Remove from folder",
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+    },
+    "presets": {
+      "modalTitle": "Slash Command Presets",
+      "newPreset": "New Preset",
+      "editPreset": "Edit Preset",
+      "fieldName": "Name",
+      "namePlaceholder": "my-preset",
+      "fieldDescription": "Description",
+      "descriptionPlaceholder": "What this preset does",
+      "fieldContent": "Content",
+      "contentPlaceholder": "Enter the prompt text...",
+      "cancel": "Cancel",
+      "create": "Create",
+      "update": "Update",
+      "delete": "Delete",
+      "listLabel": "Your presets",
+      "loading": "Loading presets...",
+      "empty": "No presets yet. Create one above.",
+      "editAriaLabel": "Edit preset {name}",
+      "deleteAriaLabel": "Delete preset {name}",
+      "deleteConfirmTitle": "Delete preset",
+      "deleteConfirmMessage": "Delete /{name}? This cannot be undone.",
+      "nameRequired": "Name is required",
+      "nameInvalid": "Only letters, numbers, hyphens, and underscores are allowed",
+      "contentRequired": "Content is required"
+    },
+    "lightweightMode": "Lightweight mode",
+    "lightweightModeTooltip": "lightweight Mode tooltip"
   },
   "settings": {
     "title": "Ajustes",
@@ -664,7 +792,22 @@
     },
     "connection": {
       "title": "Connection",
-      "desc": "Configure backend connection settings"
+      "desc": "Configure backend connection settings",
+      "backendCheck": {
+        "title": "Backend reachability",
+        "description": "Run a one-shot ping to verify that the AutoBot backend is reachable from this browser. No periodic polling — manual only.",
+        "button": "Test backend connection",
+        "checking": "Checking…",
+        "reachable": "Reachable",
+        "unreachable": "Unreachable",
+        "latency": "Latency",
+        "lastTested": "Last tested",
+        "neverTested": "Not yet tested"
+      }
+    },
+    "presets": {
+      "title": "Slash Presets",
+      "description": "Create reusable slash commands that expand into full prompts in the chat input. Type / followed by the preset name to trigger them."
     }
   },
   "voice": {
@@ -1247,7 +1390,13 @@
         "usage": "Uso",
         "usageAria": "Uso & Costos",
         "operations": "Operaciones",
-        "operationsAria": "Operaciones de larga duración"
+        "operationsAria": "Operaciones de larga duración",
+        "devTools": "Dev Tools",
+        "devToolsAria": "Developer tools and utilities",
+        "errors": "Errors",
+        "errorsAria": "Error monitoring",
+        "diagnostics": "Diagnostics",
+        "diagnosticsAria": "Failure analysis and causal inference"
       }
     },
     "header": {
@@ -1615,7 +1764,8 @@
       "file": "Archivo",
       "score": "Puntuación",
       "topIssue": "Problema principal",
-      "close": "Cerrar"
+      "close": "Cerrar",
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
     },
     "bugPrediction": {
       "title": "Predicción de errores",
@@ -2190,6 +2340,38 @@
         "scanning": "Escaneando...",
         "scanFile": "Scan File"
       }
+    },
+    "failureAnalysis": {
+      "title": "Failure Analysis",
+      "subtitle": "Root-cause analysis powered by the causal inference engine",
+      "empty": "Enter a task ID above to run a failure analysis.",
+      "form": {
+        "title": "Analyze a Failure",
+        "taskId": "Task ID",
+        "taskIdPlaceholder": "e.g. task-abc123",
+        "errorDescription": "Error Description",
+        "errorDescriptionPlaceholder": "Optional: describe the error or paste a stack trace",
+        "analyze": "Analyze",
+        "analyzing": "Analyzing...",
+        "clear": "Clear"
+      },
+      "result": {
+        "taskId": "Task ID",
+        "confidence": "Confidence",
+        "status": "Status",
+        "duration": "Duration",
+        "rootCause": "Root Cause",
+        "causalChain": "Causal Chain",
+        "interventions": "Interventions",
+        "confounders": "Confounders",
+        "recommendations": "Recommendations",
+        "participants": "Participants",
+        "mechanism": "Mechanism",
+        "successRate": "Success Rate",
+        "cost": "Cost",
+        "risk": "Risk",
+        "confoundingStrength": "Confounding Strength"
+      }
     }
   },
   "knowledge": {
@@ -2241,7 +2423,14 @@
       "visShared": "Vis shared",
       "visSystem": "Vis system",
       "visibility": "Visibility",
-      "visibilityHint": "Visibility hint"
+      "visibilityHint": "Visibility hint",
+      "errorAddText": "Failed to add text to knowledge base",
+      "errorFileTooLarge": "File \"{name}\" exceeds the maximum size limit",
+      "errorImportUrl": "Failed to import URL content",
+      "errorUnsupportedFormat": "File \"{name}\" has an unsupported format",
+      "errorUploadFiles": "Failed to upload files",
+      "successTextAdded": "Text added to knowledge base successfully",
+      "successUrlImported": "URL content imported successfully"
     },
     "documents": "Documentos",
     "categories": {
@@ -2291,7 +2480,11 @@
       "maintenance": "Mantenimiento",
       "maintenanceAriaLabel": "Mantenimiento de la base de conocimientos",
       "analytics": "Analíticas",
-      "statistics": "Estadísticas"
+      "statistics": "Estadísticas",
+      "webResearch": "Web Research",
+      "webResearchAriaLabel": "4-tab web research panel",
+      "openSidebar": "Open navigation menu",
+      "closeSidebar": "Close navigation menu"
     },
     "backup": {
       "title": "Copia de seguridad y restauración",
@@ -2787,7 +2980,9 @@
         "sourcesCount": "{count} fuentes"
       },
       "noEntities3D": "No hay entidades para mostrar",
-      "loading3dVisualization": "Loading3d visualization"
+      "loading3dVisualization": "Loading3d visualization",
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "connectors": {
       "title": "Conectores de fuentes",
@@ -3159,7 +3354,8 @@
       "vectorFramework": "Vector framework",
       "vectorIndexHealth": "Vector index health",
       "vectorNotGenerated": "Vector not generated",
-      "vectorizedForRag": "Vectorized for rag"
+      "vectorizedForRag": "Vectorized for rag",
+      "confirmOptimize": "This will optimize the database. Continue?"
     },
     "summaries": {
       "search": {
@@ -3290,7 +3486,11 @@
       "decisionsApplied": "{count} decision(s) applied successfully",
       "compiledSuccess": "Chat compiled successfully",
       "failedToLoad": "Failed to load knowledge items",
-      "decisionsApplyFailed": "Failed to apply decisions"
+      "decisionsApplyFailed": "Failed to apply decisions",
+      "compileFailed": "Failed to compile conversation",
+      "suggestionAddToKb": "Suggested: Add to Knowledge Base",
+      "suggestionDelete": "Suggested: Delete",
+      "suggestionKeepTemporary": "Suggested: Keep Temporarily"
     },
     "systemKnowledge": {
       "vectorizeTooltip": "Generate vector embeddings for all knowledge base entries to enable semantic search",
@@ -3323,7 +3523,14 @@
       "success": "Success",
       "targetHost": "Target host",
       "totalFacts": "Total facts",
-      "vectorizing": "Vectorizing"
+      "vectorizing": "Vectorizing",
+      "confirmIndexDocs": "Do you want to force reindex existing documents?",
+      "confirmInitialize": "This will initialize system knowledge for the selected host. This may take several minutes. Continue?",
+      "confirmRefreshManPages": "This will refresh man pages for the selected host. Continue?",
+      "confirmReindex": "This will reindex all documents for the selected host. Continue?",
+      "confirmVectorize": "This will vectorize {totalFacts} facts. Currently {totalVectors} vectors exist, {needsVectorization} need vectorization. Continue?",
+      "vectorizeComplete": "Vectorize Facts (✓ {vectors} vectors from {facts} facts)",
+      "vectorizePending": "Vectorize Facts ({pending} pending)"
     },
     "vectorization": {
       "actionVectorize": "Vectorizar",
@@ -3342,7 +3549,15 @@
       "noDocuments": "No documents",
       "progressTitle": "Progress title",
       "retryFailed": "Retry failed",
-      "total": "Total"
+      "total": "Total",
+      "statusFailed": "Failed",
+      "statusPending": "Pending",
+      "statusUnknown": "Unknown",
+      "statusVectorized": "Vectorized",
+      "tooltipFailed": "Vectorization failed for this document",
+      "tooltipPending": "Document is pending vectorization",
+      "tooltipUnknown": "Vectorization status unknown",
+      "tooltipVectorized": "Document has been vectorized and is searchable via RAG"
     },
     "batchSelection": {
       "selected": "{count} seleccionado(s)",
@@ -3382,7 +3597,8 @@
       "shareWith": "Share with",
       "team": "Team",
       "user": "User",
-      "write": "Write"
+      "write": "Write",
+      "unsavedConfirm": "You have unsaved changes. Are you sure you want to close?"
     },
     "memoryOrphan": {
       "entitiesToClean": "Entities to clean",
@@ -3430,7 +3646,11 @@
       "rejectedToday": "Rejected today",
       "selectAll": "Select all",
       "title": "Title",
-      "untitled": "Untitled"
+      "untitled": "Untitled",
+      "typeConnector": "Connector",
+      "typeResearch": "Web Research",
+      "typeUpload": "Manual Upload",
+      "typeUrl": "URL Fetch"
     },
     "sessionOrphan": {
       "moreOrphans": "More orphans",
@@ -3499,7 +3719,15 @@
       "warnings": "Warnings"
     },
     "manager": {
-      "errorFallback": "Error fallback"
+      "errorFallback": "Error fallback",
+      "tabAdvanced": "Advanced",
+      "tabCategories": "Categories",
+      "tabManage": "Manage",
+      "tabPromptEditor": "Prompts",
+      "tabSearch": "Search",
+      "tabStatistics": "Statistics",
+      "tabSystemDocs": "System Docs",
+      "tabUpload": "Upload"
     },
     "promptEditor": {
       "allCategories": "All categories",
@@ -3605,7 +3833,138 @@
       "selectDocument": "Select document",
       "subtitle": "Subtitle",
       "title": "Title",
-      "words": "Words"
+      "words": "Words",
+      "errorCopy": "Failed to copy to clipboard",
+      "errorExport": "Failed to export document",
+      "errorExportAll": "Failed to export all documents",
+      "errorLoadCategories": "Failed to load documentation categories",
+      "errorLoadContent": "Failed to load document content",
+      "errorLoadDocs": "Failed to load documents"
+    },
+    "search": {
+      "aiSynthesis": "Ai synthesis",
+      "allCategories": "All categories",
+      "autoEnhanceQuery": "Auto enhance query",
+      "clear": "Clear",
+      "clearAccessLevelFilter": "Clear access level filter",
+      "clearCategoryFilter": "Clear category filter",
+      "confidence": "Confidence",
+      "enableReranking": "Enable reranking",
+      "enhancedQuery": "Enhanced query",
+      "fallbackNote": "Fallback note",
+      "filterByAccessLevel": "Filter by access level",
+      "filterByCategory": "Filter by category",
+      "filtering": "Filtering",
+      "indexHelpAfter": "Index help after",
+      "indexHelpBefore": "Index help before",
+      "indexHelpLink": "Index help link",
+      "needToIndex": "Need to index",
+      "noResults": "No results",
+      "noResultsHint": "No results hint",
+      "noResultsRagHint": "No results rag hint",
+      "ragDesc": "Rag desc",
+      "ragEnhanced": "Rag enhanced",
+      "ragPlaceholder": "Rag placeholder",
+      "ragUnavailable": "Rag unavailable",
+      "rerankingBadge": "Reranking badge",
+      "resultsLimit": "Results limit",
+      "retry": "Retry",
+      "searchBtn": "Search btn",
+      "searchPlaceholder": "Search placeholder",
+      "searching": "Searching",
+      "sourcesCount": "Sources count",
+      "subtitle": "Subtitle",
+      "title": "Title",
+      "traditionalDesc": "Traditional desc",
+      "traditionalSearch": "Traditional search",
+      "accessPlatform": "Platform",
+      "accessPublic": "Public",
+      "accessSystem": "System",
+      "accessUser": "User",
+      "clickToView": "Click to view full document",
+      "close": "Close",
+      "copyContent": "Copy Content",
+      "defaultDocTitle": "Untitled Document",
+      "foundResults": "Found {count} results for \"{query}\"",
+      "loadingDocument": "Loading document content...",
+      "matchScore": "{value}% match",
+      "noContent": "No content available",
+      "rerankScore": "{value}% rerank"
+    },
+    "webResearch": {
+      "title": "Web Research",
+      "subtitle": "Fetch, crawl, discover, and extract data from the web",
+      "navLabel": "Web Research",
+      "navAriaLabel": "Web research panel",
+      "settingsNavLabel": "Research Settings",
+      "settingsNavAriaLabel": "Web research settings",
+      "tabListAriaLabel": "Web research tabs",
+      "renderLabel": "Render Mode",
+      "renderAuto": "Auto",
+      "renderFast": "Fast (no JS)",
+      "renderPlaywright": "Full JS (Playwright)",
+      "ingestLabel": "Save to Knowledge Base",
+      "respectRobotsLabel": "Respect robots.txt",
+      "reset": "Clear",
+      "retry": "Retry",
+      "fetching": "Fetching…",
+      "crawling": "Crawling…",
+      "discovering": "Discovering…",
+      "extracting": "Extracting…",
+      "indexed": "Saved to KB",
+      "failed": "Failed",
+      "schemaValid": "Schema Valid",
+      "schemaInvalid": "Schema Invalid",
+      "filterPlaceholder": "Filter URLs…",
+      "filterLabel": "Filter URLs",
+      "noFilterResults": "No URLs match the current filter.",
+      "depthLabel": "Depth {depth}",
+      "errorGeneric": "An unexpected error occurred. Please try again.",
+      "tabs": {
+        "scrape": "Fetch Page",
+        "scrapeAriaLabel": "Fetch Page — extract text from a single URL",
+        "crawl": "Crawl Site",
+        "crawlAriaLabel": "Crawl Site — follow links and index multiple pages",
+        "siteMap": "Find Pages",
+        "siteMapAriaLabel": "Find Pages — discover all URLs on a domain",
+        "extract": "Get Data",
+        "extractAriaLabel": "Get Data — extract structured data using a schema"
+      },
+      "scrape": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "formatLabel": "Output Format",
+        "submitLabel": "Fetch Page",
+        "emptyState": "Enter a URL above and click Fetch Page to extract its text content."
+      },
+      "crawl": {
+        "seedLabel": "Seed URL",
+        "seedPlaceholder": "https://example.com",
+        "depthLabel": "Max Depth",
+        "maxPagesLabel": "Max Pages",
+        "sameOriginLabel": "Same origin only",
+        "submitLabel": "Crawl Site",
+        "emptyState": "Enter a starting URL and click Crawl Site to follow its links.",
+        "resultTitle": "{count} pages crawled",
+        "urlListLabel": "Crawled pages"
+      },
+      "siteMap": {
+        "domainLabel": "Domain",
+        "domainPlaceholder": "example.com",
+        "maxUrlsLabel": "Max URLs",
+        "submitLabel": "Find Pages",
+        "emptyState": "Enter a domain name and click Find Pages to discover its URLs.",
+        "resultTitle": "{count} URLs found on {domain}",
+        "urlListLabel": "Discovered URLs"
+      },
+      "extract": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "schemaLabel": "JSON Schema",
+        "submitLabel": "Get Data",
+        "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
+        "resultTitle": "Extracted Data"
+      }
     }
   },
   "workflow": {
@@ -3725,7 +4084,10 @@
       "screenAnalysisAriaLabel": "Screen Analysis - capture and analyze screen content",
       "sectionDescVideoProcessing": "Process and analyze video frames",
       "screenAnalysis": "Screen Analysis",
-      "vision": "VISION"
+      "vision": "VISION",
+      "historyAriaLabel": "Workflow execution history",
+      "visualizerAriaLabel": "Orchestration visualizer",
+      "agentsAriaLabel": "Agent capabilities"
     },
     "modal": {
       "executeStep": "Execute This Step",
@@ -3829,7 +4191,15 @@
       "visionWait": "Wait for Element",
       "visionClick": "Click Element",
       "vision": "Vision",
-      "visionFindElement": "Find Element"
+      "visionFindElement": "Find Element",
+      "addCase": "Add case",
+      "addSwitch": "Add switch",
+      "conditionCompare": "Condition compare",
+      "conditionExpr": "Condition expr",
+      "switch": "Switch",
+      "switchDefaultHint": "Switch default hint",
+      "switchLabel": "switch",
+      "switchOnPlaceholder": "Enter switch on..."
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -4057,6 +4427,12 @@
       "resetDefaults": "Reset to Defaults",
       "saving": "Saving...",
       "tabTitle": "Settings"
+    },
+    "nav": {
+      "label": "Agents navigation",
+      "registry": "Registry",
+      "activity": "Activity",
+      "heartbeat": "Heartbeat"
     }
   },
   "errors": {
@@ -4066,7 +4442,8 @@
     "notFound": "No encontrado.",
     "serverError": "Error del servidor. Inténtelo de nuevo más tarde.",
     "timeout": "La solicitud ha expirado.",
-    "validation": "Verifique los datos introducidos."
+    "validation": "Verifique los datos introducidos.",
+    "genericError": "Generic error"
   },
   "status": {
     "online": "En línea",
@@ -4348,7 +4725,8 @@
     "never": "Nunca",
     "themeLight": "Claro",
     "themeDark": "Oscuro",
-    "themeAuto": "Automático"
+    "themeAuto": "Automático",
+    "tabDevices": "Tab devices"
   },
   "redis": {
     "title": "Servicio Redis",
@@ -4447,7 +4825,9 @@
         "showingOf": "Showing {showing} of {total} functions (scroll for more)",
         "noMatch": "No orphaned functions match your filter",
         "allConnected": "No orphaned functions detected - all functions are connected!"
-      }
+      },
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "importTree": {
       "title": "File Import Tree",
@@ -4557,7 +4937,12 @@
       "seriesName": "Problems",
       "xAxisTitle": "Number of Problems",
       "tooltipProblems": "problems"
-    }
+    },
+    "ariaLabel": "Accessible label",
+    "cellPlaceholder": "Loading...",
+    "defaultAriaLabel": "default (accessible)",
+    "renderError": "Render error",
+    "viewData": "View data"
   },
   "_meta": {
     "dir": "ltr",
@@ -5214,7 +5599,8 @@
       "aiAssistant": "AI Assistant",
       "knowledgeBase": "Knowledge Base",
       "automation": "Automation",
-      "analytics": "Analytics"
+      "analytics": "Analytics",
+      "goHome": "Go Home"
     },
     "secrets": {
       "noticeTitle": "Security Notice",
@@ -5436,7 +5822,9 @@
       "widgetAgents": "Agent Activity",
       "widgetAgentsDesc": "Real-time agent activity monitoring",
       "widgetArchitecture": "System Architecture",
-      "widgetArchitectureDesc": "Interactive system architecture diagram"
+      "widgetArchitectureDesc": "Interactive system architecture diagram",
+      "saved": "Saved",
+      "dashboardSaved": "Dashboard saved"
     },
     "devSpeedup": {
       "title": "Developer Speedup",
@@ -5534,7 +5922,9 @@
       "noConfig": "No configuration stored for this plugin.",
       "invalidJson": "Invalid JSON — please fix before saving.",
       "saveFailed": "Failed to save configuration.",
-      "marketplace": "Marketplace"
+      "marketplace": "Marketplace",
+      "auditLog": "Audit log",
+      "trustTier": "Trust tier"
     },
     "marketplace": {
       "title": "Plugin Marketplace",
@@ -5636,6 +6026,22 @@
       "createBrowserSession": "Crear sesión de navegador",
       "startingUrl": "URL de inicio",
       "cancel": "Cancelar"
+    },
+    "scrapeTemplates": {
+      "title": "Scrape Templates",
+      "refresh": "Refresh templates",
+      "emptyTitle": "No Saved Templates",
+      "emptyMessage": "Mark regions on a page and save a template to see it here.",
+      "run": "Re-run template",
+      "duplicate": "Duplicate template",
+      "delete": "Delete template",
+      "deleteConfirm": "Delete \"{name}\"? This cannot be undone.",
+      "targetUrl": "Target URL",
+      "runButton": "Run",
+      "running": "Running...",
+      "extractedResults": "Extracted results",
+      "noValue": "(not found)",
+      "noResults": "No regions extracted."
     }
   },
   "collaboration": {
@@ -6276,6 +6682,65 @@
       "toastSavedToGallery": "Saved to gallery",
       "errorNoFrames": "No frames could be processed",
       "errorInvalidFile": "Please drop a valid video file"
+    },
+    "visionAutomation": {
+      "title": "Vision Automation",
+      "subtitle": "Screen analysis, UI element detection, OCR, and automation opportunity discovery",
+      "serviceStatus": "Service",
+      "sessionContext": "Session Context (optional)",
+      "sessionIdPlaceholder": "Session ID for context",
+      "tabsAriaLabel": "Vision automation tabs",
+      "analyzing": "Analyzing...",
+      "detecting": "Detecting...",
+      "extracting": "Extracting...",
+      "scanning": "Scanning...",
+      "errorLabel": "Error",
+      "tabs": {
+        "analysis": "Screen Analysis",
+        "elements": "Element Detection",
+        "ocr": "OCR",
+        "opportunities": "Automation Opportunities"
+      },
+      "columns": {
+        "id": "ID",
+        "type": "Type",
+        "confidence": "Confidence",
+        "text": "Text",
+        "interactions": "Interactions",
+        "position": "Center"
+      },
+      "analysis": {
+        "cardTitle": "Capture & Analyze Screen",
+        "trigger": "Capture & Analyze",
+        "elementsFound": "Elements",
+        "textRegions": "Text Regions",
+        "confidence": "Confidence",
+        "automationOpps": "Opportunities",
+        "detectedElements": "Detected UI Elements",
+        "empty": "Press Capture and Analyze to analyze the current screen"
+      },
+      "elements": {
+        "cardTitle": "Detect UI Elements",
+        "trigger": "Detect Elements",
+        "typePlaceholder": "Filter by element type (e.g. button)",
+        "minConfidence": "Min Confidence",
+        "results": "{filtered} of {total} elements",
+        "empty": "No elements match the current filter"
+      },
+      "ocr": {
+        "cardTitle": "OCR Text Extraction",
+        "trigger": "Extract Text",
+        "regionsFound": "{count} text region(s) found",
+        "noRegions": "No text regions detected",
+        "empty": "Press Extract Text to run OCR on the current screen"
+      },
+      "opportunities": {
+        "cardTitle": "Automation Opportunities",
+        "trigger": "Scan for Opportunities",
+        "total": "Total Opportunities",
+        "empty": "No automation opportunities found",
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+      }
     }
   },
   "visualizations": {
@@ -6293,7 +6758,8 @@
       "recentTasks": "Recent Tasks",
       "detailsBtn": "Details",
       "pauseBtn": "Pause",
-      "liveActivityFeed": "Live Activity Feed"
+      "liveActivityFeed": "Live Activity Feed",
+      "abstained": "Abstained"
     },
     "resourceHeatmap": {
       "defaultTitle": "Resource Utilization Heatmap",
@@ -6317,7 +6783,8 @@
       "rangeMedium": "Medium",
       "rangeHigh": "High",
       "rangeCritical": "Critical",
-      "usage": "Usage"
+      "usage": "Usage",
+      "noData": "No metrics available yet"
     },
     "systemArchitecture": {
       "defaultTitle": "System Architecture",
@@ -6616,7 +7083,8 @@
       "noEndpointData": "No endpoint data available",
       "noUserData": "No user data available",
       "noTrendData": "No trend data available",
-      "noRecentViolations": "No recent violations"
+      "noRecentViolations": "No recent violations",
+      "last14Days": "Last 14 days"
     },
     "enforcement": {
       "title": "Endpoint Overrides",
@@ -6953,7 +7421,10 @@
       "launchDesc": "This will open a live browser that you can control directly",
       "initializingSession": "Initializing browser session...",
       "sessionId": "Session ID: {id}",
-      "notAvailable": "Not available"
+      "notAvailable": "Not available",
+      "templates": "Scrape Templates",
+      "exitRegionMode": "Exit region mode",
+      "markRegions": "Mark regions"
     }
   },
   "serviceMessages": {
@@ -7018,7 +7489,28 @@
     "llcPortability": "Portability",
     "settingsAndTools": "Settings & Tools",
     "adminPanel": "Admin Panel",
-    "documents": "AI Documents"
+    "documents": "AI Documents",
+    "canvas": "Canvas",
+    "visionAutomation": "Vision",
+    "llmApiKeys": "LLM API Keys",
+    "llmProviders": "LLM Providers",
+    "adminHosts": "Host Inventory",
+    "adminSandbox": "Sandbox",
+    "budgetPolicies": "Budget Policies",
+    "companyOs": "Company OS",
+    "llcDashboard": "Dashboard",
+    "llcOrgChart": "Org Chart",
+    "llcGoals": "Goals",
+    "llcCompanies": "Companies",
+    "llcBacklog": "Backlog",
+    "llcApprovals": "Approvals",
+    "llcCosts": "Costs & Budget",
+    "llcHeartbeat": "Heartbeat",
+    "llcCeoChat": "CEO Chat",
+    "llcSelectCompany": "Switch Company",
+    "llcSelectCompanyPrompt": "Select a company to open its dashboard, backlog, and tools.",
+    "llcNoCompanies": "No companies yet.",
+    "llcCreateCompany": "Create a company"
   },
   "reasoningTrace": {
     "title": "Traza de razonamiento",
@@ -7060,6 +7552,176 @@
       "expired": "Expirado",
       "refresh": "Obtener nuevo código",
       "retry": "Intentar de nuevo"
+    }
+  },
+  "llmKeys": {
+    "title": "LLM API Keys",
+    "issueKey": "Issue Key",
+    "revoke": "Revoke",
+    "rotate": "Rotate",
+    "unlimited": "Unlimited",
+    "empty": "No API keys found.",
+    "rawKeyWarning": "Copy this key now — it will not be shown again.",
+    "col": {
+      "prefix": "Key Prefix",
+      "team": "Team",
+      "label": "Label",
+      "budget": "Monthly Budget",
+      "spend": "Spend (MTD)",
+      "models": "Allowed Models",
+      "status": "Status",
+      "expires": "Expires"
+    },
+    "status": {
+      "active": "Active",
+      "revoked": "Revoked"
+    },
+    "form": {
+      "teamId": "Team ID",
+      "label": "Label",
+      "budget": "Monthly Budget (USD)",
+      "budgetHint": "Set to 0 for unlimited.",
+      "models": "Allowed Models (JSON array)",
+      "modelsHint": "E.g. [\"gpt-4\", \"claude-*\"]. Leave blank to allow all.",
+      "expiresAt": "Expires At (optional)"
+    },
+    "revokeConfirm": {
+      "title": "Revoke API Key",
+      "body": "Are you sure you want to revoke key {id}? This cannot be undone."
+    }
+  },
+  "llc": {
+    "templates": {
+      "searchPlaceholder": "Search templates...",
+      "loading": "Loading templates...",
+      "noMatch": "No templates found matching your search",
+      "preview": "Preview template",
+      "select": "Select template",
+      "useTemplate": "Use this template"
+    },
+    "wizard": {
+      "step1": {
+        "title": "Choose a Starting Point",
+        "description": "Start with a template or build from scratch",
+        "startFromScratch": "Start from Scratch",
+        "startFromScratchDesc": "Build your company structure from the ground up",
+        "useTemplate": "Use a Template",
+        "useTemplateDesc": "Start with a pre-configured company template"
+      },
+      "step2": {
+        "title": "Configure Your Company",
+        "description": "Set up your company details and preferences",
+        "companyName": "Company Name",
+        "companyNamePlaceholder": "e.g., Acme Corporation",
+        "issuePrefix": "Issue Prefix",
+        "issuePrefixPlaceholder": "e.g., ACM",
+        "issuePrefixHint": "2-10 uppercase letters for issue identifiers (e.g., ACM-123)",
+        "mission": "Mission Statement",
+        "missionPlaceholder": "What is your company's mission?",
+        "monthlyBudget": "Monthly Budget",
+        "monthlyBudgetPlaceholder": "100",
+        "estimatedCost": "Estimated cost",
+        "brandColor": "Brand Color",
+        "brandColorPlaceholder": "#667eea",
+        "templateVariables": "Template Configuration"
+      },
+      "step3": {
+        "title": "Review & Create",
+        "description": "Review your configuration and create your company",
+        "companyDetails": "Company Details",
+        "template": "Template",
+        "agents": "Agents",
+        "goals": "Goals",
+        "workItems": "Work Items",
+        "kbCollections": "Knowledge Collections",
+        "createCompany": "Create Company"
+      }
+    }
+  },
+  "code": {
+    "cellPlaceholder": "Loading...",
+    "copied": "Copied",
+    "copy": "Copy",
+    "copyCodeAriaLabel": "copy Code (accessible)",
+    "copyFailed": "Copy failed"
+  },
+  "devices": {
+    "addDevice": "Add device",
+    "confirmDelete": "Confirm delete",
+    "daysAgo": "Days ago",
+    "error": "Error",
+    "hoursAgo": "Hours ago",
+    "justNow": "Just now",
+    "lastSeen": "Last seen",
+    "loading": "Loading",
+    "minutesAgo": "Minutes ago",
+    "noDevices": "No devices",
+    "pairDevice": "Pair device",
+    "pairFirst": "Pair first",
+    "pairNewDevice": "Pair new device",
+    "paired": "Paired",
+    "pairedDevices": "Paired devices",
+    "pairingInstructions": "Pairing instructions",
+    "pairingNote": "Pairing note",
+    "step1": "Step1",
+    "step2": "Step2",
+    "step3": "Step3",
+    "step4": "Step4",
+    "unpair": "Unpair"
+  },
+  "imageCell": {
+    "copyUrl": "Copy url",
+    "download": "Download",
+    "downloadLabel": "download",
+    "generated": "Generated",
+    "lightbox": "Lightbox",
+    "loadError": "Load error",
+    "placeholder": "Placeholder",
+    "viewFull": "View full"
+  },
+  "plugins": {
+    "capabilities": {
+      "approvalDescription": "Approval description",
+      "approvalTitle": "approval",
+      "approveAll": "Approve all",
+      "approveSelected": "Approve selected",
+      "approving": "Approving",
+      "auditLogTitle": "audit Log",
+      "capability": "Capability",
+      "denied": "Denied",
+      "filterByPlugin": "Filter by plugin",
+      "granted": "Granted",
+      "loading": "Loading",
+      "loadingAudit": "Loading audit",
+      "noAuditEntries": "No audit entries",
+      "noPending": "No pending",
+      "operation": "Operation",
+      "plugin": "Plugin",
+      "status": "Status",
+      "timestamp": "Timestamp"
+    }
+  },
+  "errorMonitoring": {
+    "title": "Error Monitoring",
+    "subtitle": "System-wide error statistics, recent errors, and component breakdown",
+    "lastUpdate": "Last updated",
+    "noMessage": "(no message)",
+    "cards": {
+      "totalErrors": "Total Errors"
+    },
+    "filters": {
+      "category": "Category",
+      "component": "Component",
+      "all": "All"
+    },
+    "sections": {
+      "recentErrors": "Recent Errors",
+      "categories": "Errors by Category",
+      "components": "Errors by Component"
+    },
+    "empty": {
+      "noErrors": "No errors recorded",
+      "noData": "No data available"
     }
   }
 }

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -82,7 +82,27 @@
     "hasMore": "Load more",
     "previous": "Previous",
     "optional": "اختیاری",
-    "remove": "حذف"
+    "remove": "حذف",
+    "dismiss": "Dismiss",
+    "forward": "Forward",
+    "saving": "Saving...",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "fitToView": "Fit to view",
+    "toggleLayout": "Toggle layout",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "copyToClipboard": "Copy to clipboard",
+    "sortAscending": "Sort ascending",
+    "sortDescending": "Sort descending",
+    "moreOptions": "More options",
+    "exportJson": "Export as JSON",
+    "exportCsv": "Export as CSV",
+    "download": "Download",
+    "filterByCategory": "Filter by category",
+    "copied": "Copied"
   },
   "nav": {
     "chat": "گفتگو",
@@ -128,7 +148,28 @@
     "llcPortability": "Portability",
     "settingsAndTools": "Settings & Tools",
     "adminPanel": "Admin Panel",
-    "documents": "AI Documents"
+    "documents": "AI Documents",
+    "canvas": "Canvas",
+    "visionAutomation": "Vision",
+    "llmApiKeys": "LLM API Keys",
+    "llmProviders": "LLM Providers",
+    "adminHosts": "Host Inventory",
+    "adminSandbox": "Sandbox",
+    "budgetPolicies": "Budget Policies",
+    "companyOs": "Company OS",
+    "llcDashboard": "Dashboard",
+    "llcOrgChart": "Org Chart",
+    "llcGoals": "Goals",
+    "llcCompanies": "Companies",
+    "llcBacklog": "Backlog",
+    "llcApprovals": "Approvals",
+    "llcCosts": "Costs & Budget",
+    "llcHeartbeat": "Heartbeat",
+    "llcCeoChat": "CEO Chat",
+    "llcSelectCompany": "Switch Company",
+    "llcSelectCompanyPrompt": "Select a company to open its dashboard, backlog, and tools.",
+    "llcNoCompanies": "No companies yet.",
+    "llcCreateCompany": "Create a company"
   },
   "agent": {
     "registry": {
@@ -198,7 +239,13 @@
     "title": "Agents",
     "orchestrator": "Orchestrator",
     "config": "Agent Configuration",
-    "status": "Agent Status"
+    "status": "Agent Status",
+    "nav": {
+      "label": "Agents navigation",
+      "registry": "Registry",
+      "activity": "Activity",
+      "heartbeat": "Heartbeat"
+    }
   },
   "_meta": {
     "dir": "rtl",
@@ -762,7 +809,13 @@
         "usage": "استفاده",
         "usageAria": "استفاده و هزینه‌ها",
         "operations": "عملیات",
-        "operationsAria": "عملیات طولانی‌مدت"
+        "operationsAria": "عملیات طولانی‌مدت",
+        "devTools": "Dev Tools",
+        "devToolsAria": "Developer tools and utilities",
+        "errors": "Errors",
+        "errorsAria": "Error monitoring",
+        "diagnostics": "Diagnostics",
+        "diagnosticsAria": "Failure analysis and causal inference"
       }
     },
     "header": {
@@ -1130,7 +1183,8 @@
       "file": "File",
       "score": "Score",
       "topIssue": "Top Issue",
-      "close": "Close"
+      "close": "Close",
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",
@@ -1705,6 +1759,38 @@
         "scanning": "Scanning...",
         "scanFile": "Scan File"
       }
+    },
+    "failureAnalysis": {
+      "title": "Failure Analysis",
+      "subtitle": "Root-cause analysis powered by the causal inference engine",
+      "empty": "Enter a task ID above to run a failure analysis.",
+      "form": {
+        "title": "Analyze a Failure",
+        "taskId": "Task ID",
+        "taskIdPlaceholder": "e.g. task-abc123",
+        "errorDescription": "Error Description",
+        "errorDescriptionPlaceholder": "Optional: describe the error or paste a stack trace",
+        "analyze": "Analyze",
+        "analyzing": "Analyzing...",
+        "clear": "Clear"
+      },
+      "result": {
+        "taskId": "Task ID",
+        "confidence": "Confidence",
+        "status": "Status",
+        "duration": "Duration",
+        "rootCause": "Root Cause",
+        "causalChain": "Causal Chain",
+        "interventions": "Interventions",
+        "confounders": "Confounders",
+        "recommendations": "Recommendations",
+        "participants": "Participants",
+        "mechanism": "Mechanism",
+        "successRate": "Success Rate",
+        "cost": "Cost",
+        "risk": "Risk",
+        "confoundingStrength": "Confounding Strength"
+      }
     }
   },
   "knowledge": {
@@ -1802,7 +1888,9 @@
       "toggleLayout": "Toggle layout",
       "typeConversation": "Conversation",
       "create": "Create",
-      "loading3dVisualization": "Loading3d visualization"
+      "loading3dVisualization": "Loading3d visualization",
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "vectorization": {
       "actionVectorize": "Vectorize",
@@ -2690,7 +2778,11 @@
       "graphAriaLabel": "View knowledge graph",
       "title": "Knowledge Base",
       "analytics": "Analytics",
-      "entities": "Entities"
+      "entities": "Entities",
+      "webResearch": "Web Research",
+      "webResearchAriaLabel": "4-tab web research panel",
+      "openSidebar": "Open navigation menu",
+      "closeSidebar": "Close navigation menu"
     },
     "upload": {
       "selectCategory": "Select category...",
@@ -3201,7 +3293,9 @@
       "tabManage": "Manage",
       "tabSearch": "Search",
       "tabStatistics": "Statistics",
-      "tabUpload": "Upload"
+      "tabUpload": "Upload",
+      "tabPromptEditor": "Prompts",
+      "tabSystemDocs": "System Docs"
     },
     "emptyState": {
       "title": "Your knowledge base is empty",
@@ -3215,6 +3309,81 @@
     "categoriesError": {
       "title": "Knowledge base is unreachable",
       "description": "Redis connection failed. Check that the backend has Redis running."
+    },
+    "webResearch": {
+      "title": "Web Research",
+      "subtitle": "Fetch, crawl, discover, and extract data from the web",
+      "navLabel": "Web Research",
+      "navAriaLabel": "Web research panel",
+      "settingsNavLabel": "Research Settings",
+      "settingsNavAriaLabel": "Web research settings",
+      "tabListAriaLabel": "Web research tabs",
+      "renderLabel": "Render Mode",
+      "renderAuto": "Auto",
+      "renderFast": "Fast (no JS)",
+      "renderPlaywright": "Full JS (Playwright)",
+      "ingestLabel": "Save to Knowledge Base",
+      "respectRobotsLabel": "Respect robots.txt",
+      "reset": "Clear",
+      "retry": "Retry",
+      "fetching": "Fetching…",
+      "crawling": "Crawling…",
+      "discovering": "Discovering…",
+      "extracting": "Extracting…",
+      "indexed": "Saved to KB",
+      "failed": "Failed",
+      "schemaValid": "Schema Valid",
+      "schemaInvalid": "Schema Invalid",
+      "filterPlaceholder": "Filter URLs…",
+      "filterLabel": "Filter URLs",
+      "noFilterResults": "No URLs match the current filter.",
+      "depthLabel": "Depth {depth}",
+      "errorGeneric": "An unexpected error occurred. Please try again.",
+      "tabs": {
+        "scrape": "Fetch Page",
+        "scrapeAriaLabel": "Fetch Page — extract text from a single URL",
+        "crawl": "Crawl Site",
+        "crawlAriaLabel": "Crawl Site — follow links and index multiple pages",
+        "siteMap": "Find Pages",
+        "siteMapAriaLabel": "Find Pages — discover all URLs on a domain",
+        "extract": "Get Data",
+        "extractAriaLabel": "Get Data — extract structured data using a schema"
+      },
+      "scrape": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "formatLabel": "Output Format",
+        "submitLabel": "Fetch Page",
+        "emptyState": "Enter a URL above and click Fetch Page to extract its text content."
+      },
+      "crawl": {
+        "seedLabel": "Seed URL",
+        "seedPlaceholder": "https://example.com",
+        "depthLabel": "Max Depth",
+        "maxPagesLabel": "Max Pages",
+        "sameOriginLabel": "Same origin only",
+        "submitLabel": "Crawl Site",
+        "emptyState": "Enter a starting URL and click Crawl Site to follow its links.",
+        "resultTitle": "{count} pages crawled",
+        "urlListLabel": "Crawled pages"
+      },
+      "siteMap": {
+        "domainLabel": "Domain",
+        "domainPlaceholder": "example.com",
+        "maxUrlsLabel": "Max URLs",
+        "submitLabel": "Find Pages",
+        "emptyState": "Enter a domain name and click Find Pages to discover its URLs.",
+        "resultTitle": "{count} URLs found on {domain}",
+        "urlListLabel": "Discovered URLs"
+      },
+      "extract": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "schemaLabel": "JSON Schema",
+        "submitLabel": "Get Data",
+        "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
+        "resultTitle": "Extracted Data"
+      }
     }
   },
   "reasoningTrace": {
@@ -3370,7 +3539,10 @@
       "refresh": "Refresh",
       "availableAgents": "Available Agents",
       "min": "min",
-      "overviewAriaLabel": "View workflow overview"
+      "overviewAriaLabel": "View workflow overview",
+      "historyAriaLabel": "Workflow execution history",
+      "visualizerAriaLabel": "Orchestration visualizer",
+      "agentsAriaLabel": "Agent capabilities"
     },
     "runner": {
       "completed": "Completed",
@@ -3477,7 +3649,15 @@
       "visionWait": "Wait for Element",
       "conditionPlaceholder": "Condition (e.g., $? -eq 0)",
       "save": "Save",
-      "confirm": "Confirm"
+      "confirm": "Confirm",
+      "addCase": "Add case",
+      "addSwitch": "Add switch",
+      "conditionCompare": "Condition compare",
+      "conditionExpr": "Condition expr",
+      "switch": "Switch",
+      "switchDefaultHint": "Switch default hint",
+      "switchLabel": "switch",
+      "switchOnPlaceholder": "Enter switch on..."
     },
     "notifications": {
       "emailRecipients": "Email Recipients",
@@ -3996,7 +4176,10 @@
       "noSession": "No active browser session. Launch a session to start browsing.",
       "testButton": "Test",
       "getStarted": "Use automation controls above to get started",
-      "sessionId": "Session ID: {id}"
+      "sessionId": "Session ID: {id}",
+      "templates": "Scrape Templates",
+      "exitRegionMode": "Exit region mode",
+      "markRegions": "Mark regions"
     },
     "interface": {
       "typeText": "Type Text",
@@ -4160,7 +4343,9 @@
       "networkView": "Network View (Cytoscape)",
       "title": "Function Call Graph",
       "orphanedView": "Orphaned Functions (unused)",
-      "allModules": "All Modules"
+      "allModules": "All Modules",
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "moduleImports": {
       "tooltipFunctions": "functions",
@@ -4286,7 +4471,12 @@
       "loading": "Loading chart...",
       "total": "Total",
       "noData": "No data available"
-    }
+    },
+    "ariaLabel": "Accessible label",
+    "cellPlaceholder": "Loading...",
+    "defaultAriaLabel": "default (accessible)",
+    "renderError": "Render error",
+    "viewData": "View data"
   },
   "profile": {
     "confirmNewPassword": "Confirm new password",
@@ -4329,7 +4519,8 @@
     "closeAria": "Close profile",
     "themeAuto": "Auto",
     "pwChanged": "Password changed successfully!",
-    "username": "Username:"
+    "username": "Username:",
+    "tabDevices": "Tab devices"
   },
   "ui": {
     "themeToggle": {
@@ -4743,7 +4934,10 @@
       "you": "You",
       "silenceTimeout": "Silence timeout",
       "hintResponding": "AutoBot is responding...",
-      "title": "Voice Chat"
+      "title": "Voice Chat",
+      "realtimeWebrtc": "Realtime WebRTC",
+      "realtimeConnecting": "Connecting to Realtime...",
+      "realtimeConnected": "Realtime — speak anytime"
     },
     "filePanel": {
       "listView": "List view",
@@ -4787,7 +4981,35 @@
       "factsSelected": "{selected} of {total} facts selected",
       "share": "Share",
       "selectAll": "Select All",
-      "deselectAll": "Deselect All"
+      "deselectAll": "Deselect All",
+      "createAnother": "Create another",
+      "createLink": "Create link",
+      "creating": "Creating",
+      "emptyConversation": "Empty conversation",
+      "enterPassword": "Enter password",
+      "expiry": "Expiry",
+      "expiry1d": "Expiry1d",
+      "expiry1h": "Expiry1h",
+      "expiry30d": "Expiry30d",
+      "expiry7d": "Expiry7d",
+      "expiryNever": "Expiry never",
+      "linkExpired": "Link expired",
+      "linkExpires": "Link expires",
+      "linkNotFound": "Link not found",
+      "linkPasswordProtected": "Link password protected",
+      "linkReady": "Link ready",
+      "optionalPassword": "Optional password",
+      "passwordGate": "Password gate",
+      "passwordGateHint": "Password gate hint",
+      "passwordPlaceholder": "Enter password...",
+      "publicLink": "Public link",
+      "publicView": "Public view",
+      "readOnlyNote": "Read only note",
+      "revokeLink": "Revoke link",
+      "revoking": "Revoking",
+      "shareWithUsers": "Share with users",
+      "unlock": "Unlock",
+      "wrongPassword": "Wrong password"
     },
     "typing": {
       "understanding": "Understanding your request...",
@@ -4928,7 +5150,21 @@
       "attachFile": "Attach file",
       "retryUpload": "Retry upload",
       "removeFile": "Remove file",
-      "overseerLabel": "Overseer"
+      "overseerLabel": "Overseer",
+      "managePresets": "Manage slash command presets",
+      "generate": "Generate",
+      "generateImage": "Generate image",
+      "generateImageTitle": "generate Image",
+      "generating": "Generating",
+      "imagePromptLabel": "image Prompt",
+      "imagePromptPlaceholder": "Enter image prompt...",
+      "imageProvider": "Image provider",
+      "selectPromptTemplate": "Select prompt template",
+      "thinkingBudget": "Thinking budget",
+      "thinkingOff": "Thinking off",
+      "thinkingOffLabel": "thinking Off",
+      "thinkingOn": "Thinking on",
+      "thinkingOnLabel": "thinking On"
     },
     "visualBrowser": {
       "disconnected": "Disconnected",
@@ -4947,7 +5183,8 @@
       "reload": "Reload",
       "captureScreenshot": "Capture Screenshot",
       "urlPlaceholder": "Enter URL or search…",
-      "reloadFailed": "Reload failed"
+      "reloadFailed": "Reload failed",
+      "go": "Navigate"
     },
     "browser": {
       "connectingStatus": "Connecting",
@@ -5049,7 +5286,8 @@
       "senderSystem": "System",
       "statusSent": "Sent",
       "ctrlEnterToSave": "Press Ctrl+Enter (Cmd+Enter on Mac) to save",
-      "badgePlanning": "Planning"
+      "badgePlanning": "Planning",
+      "thinkingUsed": "Thinking used"
     },
     "stopGenerating": "Stop generating",
     "thinking": "Thinking...",
@@ -5070,7 +5308,11 @@
       "delete": "Delete message",
       "copy": "Copy message",
       "tokens": "{count} tokens",
-      "edit": "Edit message"
+      "edit": "Edit message",
+      "thinking": {
+        "badge": "🧠 Extended thinking ({count} tokens)",
+        "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
+      }
     },
     "docResult": {
       "copyContent": "Copy content",
@@ -5133,7 +5375,64 @@
       "streaming": "Streaming…",
       "done": "Done",
       "error": "Error"
-    }
+    },
+    "contextWindow": {
+      "ariaLabel": "{used} of {max} tokens used",
+      "tooltip": "{used} / {max} tokens used ({percent}% of context window)",
+      "warningToast": "Conversation approaching context limit ({percent}%). Older messages may be summarized.",
+      "compressedToast": "Context window optimized - older messages summarized",
+      "summaryTitle": "Context Summary",
+      "summaryToggle": "Show details",
+      "summarizing": "Summarizing..."
+    },
+    "openSettings": "Chat settings",
+    "settings": {
+      "title": "Chat Settings",
+      "contextOverflowLabel": "Context Overflow Protection",
+      "contextOverflowDescription": "Choose how to handle conversations approaching the context limit",
+      "contextOverflowAuto": "Auto-summarize",
+      "contextOverflowWarn": "Warn only",
+      "contextOverflowDisabled": "Disabled"
+    },
+    "folders": {
+      "folders": "Folders",
+      "newFolder": "New folder",
+      "folderName": "Folder name",
+      "rename": "Rename folder",
+      "addSubfolder": "Add subfolder",
+      "pin": "Pin folder",
+      "unpin": "Unpin folder",
+      "assignToFolder": "Move to folder",
+      "removeFromFolder": "Remove from folder",
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+    },
+    "presets": {
+      "modalTitle": "Slash Command Presets",
+      "newPreset": "New Preset",
+      "editPreset": "Edit Preset",
+      "fieldName": "Name",
+      "namePlaceholder": "my-preset",
+      "fieldDescription": "Description",
+      "descriptionPlaceholder": "What this preset does",
+      "fieldContent": "Content",
+      "contentPlaceholder": "Enter the prompt text...",
+      "cancel": "Cancel",
+      "create": "Create",
+      "update": "Update",
+      "delete": "Delete",
+      "listLabel": "Your presets",
+      "loading": "Loading presets...",
+      "empty": "No presets yet. Create one above.",
+      "editAriaLabel": "Edit preset {name}",
+      "deleteAriaLabel": "Delete preset {name}",
+      "deleteConfirmTitle": "Delete preset",
+      "deleteConfirmMessage": "Delete /{name}? This cannot be undone.",
+      "nameRequired": "Name is required",
+      "nameInvalid": "Only letters, numbers, hyphens, and underscores are allowed",
+      "contentRequired": "Content is required"
+    },
+    "lightweightMode": "Lightweight mode",
+    "lightweightModeTooltip": "lightweight Mode tooltip"
   },
   "serviceMessages": {
     "metadata": "Metadata",
@@ -5518,6 +5817,65 @@
       "confidenceLabel": "Confidence",
       "fixedInterval": "Fixed Interval",
       "toastProcessed": "Processed {count} frames successfully"
+    },
+    "visionAutomation": {
+      "title": "Vision Automation",
+      "subtitle": "Screen analysis, UI element detection, OCR, and automation opportunity discovery",
+      "serviceStatus": "Service",
+      "sessionContext": "Session Context (optional)",
+      "sessionIdPlaceholder": "Session ID for context",
+      "tabsAriaLabel": "Vision automation tabs",
+      "analyzing": "Analyzing...",
+      "detecting": "Detecting...",
+      "extracting": "Extracting...",
+      "scanning": "Scanning...",
+      "errorLabel": "Error",
+      "tabs": {
+        "analysis": "Screen Analysis",
+        "elements": "Element Detection",
+        "ocr": "OCR",
+        "opportunities": "Automation Opportunities"
+      },
+      "columns": {
+        "id": "ID",
+        "type": "Type",
+        "confidence": "Confidence",
+        "text": "Text",
+        "interactions": "Interactions",
+        "position": "Center"
+      },
+      "analysis": {
+        "cardTitle": "Capture & Analyze Screen",
+        "trigger": "Capture & Analyze",
+        "elementsFound": "Elements",
+        "textRegions": "Text Regions",
+        "confidence": "Confidence",
+        "automationOpps": "Opportunities",
+        "detectedElements": "Detected UI Elements",
+        "empty": "Press Capture and Analyze to analyze the current screen"
+      },
+      "elements": {
+        "cardTitle": "Detect UI Elements",
+        "trigger": "Detect Elements",
+        "typePlaceholder": "Filter by element type (e.g. button)",
+        "minConfidence": "Min Confidence",
+        "results": "{filtered} of {total} elements",
+        "empty": "No elements match the current filter"
+      },
+      "ocr": {
+        "cardTitle": "OCR Text Extraction",
+        "trigger": "Extract Text",
+        "regionsFound": "{count} text region(s) found",
+        "noRegions": "No text regions detected",
+        "empty": "Press Extract Text to run OCR on the current screen"
+      },
+      "opportunities": {
+        "cardTitle": "Automation Opportunities",
+        "trigger": "Scan for Opportunities",
+        "total": "Total Opportunities",
+        "empty": "No automation opportunities found",
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+      }
     }
   },
   "views": {
@@ -5686,7 +6044,9 @@
       "widgetTitle": "Title",
       "bar": "Bar",
       "create": "Create",
-      "area": "Area"
+      "area": "Area",
+      "saved": "Saved",
+      "dashboardSaved": "Dashboard saved"
     },
     "devSpeedup": {
       "after": "After",
@@ -5785,7 +6145,8 @@
       "goToChat": "Go to Chat",
       "analytics": "Analytics",
       "knowledgeBase": "Knowledge Base",
-      "goBack": "Go Back"
+      "goBack": "Go Back",
+      "goHome": "Go Home"
     },
     "plugins": {
       "requires": "Requires",
@@ -5835,7 +6196,9 @@
       "reload": "Reload",
       "version": "Version",
       "configuration": "Configuration",
-      "marketplace": "بازار"
+      "marketplace": "بازار",
+      "auditLog": "Audit log",
+      "trustTier": "Trust tier"
     },
     "vision": {
       "serviceOffline": "Service Offline",
@@ -5934,7 +6297,8 @@
       "noEndpointData": "No endpoint data available",
       "daysAnalyzed": "Days Analyzed",
       "vsYesterday": "vs yesterday",
-      "byEndpoint": "By Endpoint"
+      "byEndpoint": "By Endpoint",
+      "last14Days": "Last 14 days"
     },
     "modeSelector": {
       "modeDisabled": "Disabled",
@@ -6121,7 +6485,22 @@
     "backendOffline": "Backend offline — showing cached settings",
     "connection": {
       "title": "Connection",
-      "desc": "Configure backend connection settings"
+      "desc": "Configure backend connection settings",
+      "backendCheck": {
+        "title": "Backend reachability",
+        "description": "Run a one-shot ping to verify that the AutoBot backend is reachable from this browser. No periodic polling — manual only.",
+        "button": "Test backend connection",
+        "checking": "Checking…",
+        "reachable": "Reachable",
+        "unreachable": "Unreachable",
+        "latency": "Latency",
+        "lastTested": "Last tested",
+        "neverTested": "Not yet tested"
+      }
+    },
+    "presets": {
+      "title": "Slash Presets",
+      "description": "Create reusable slash commands that expand into full prompts in the chat input. Type / followed by the preset name to trigger them."
     }
   },
   "visualizations": {
@@ -6208,7 +6587,8 @@
       "minimum": "Minimum",
       "memoryUsage": "Memory Usage",
       "average": "Average",
-      "networkIo": "Network I/O"
+      "networkIo": "Network I/O",
+      "noData": "No metrics available yet"
     },
     "agentActivity": {
       "activeCount": "{count} active",
@@ -6224,7 +6604,8 @@
       "pauseBtn": "Pause",
       "liveActivityFeed": "Live Activity Feed",
       "defaultTitle": "Agent Activity Monitor",
-      "timelineView": "Timeline view"
+      "timelineView": "Timeline view",
+      "abstained": "Abstained"
     }
   },
   "audit": {
@@ -6508,6 +6889,22 @@
       "statTotal": "Total",
       "startingUrl": "Starting URL",
       "pause": "Pause"
+    },
+    "scrapeTemplates": {
+      "title": "Scrape Templates",
+      "refresh": "Refresh templates",
+      "emptyTitle": "No Saved Templates",
+      "emptyMessage": "Mark regions on a page and save a template to see it here.",
+      "run": "Re-run template",
+      "duplicate": "Duplicate template",
+      "delete": "Delete template",
+      "deleteConfirm": "Delete \"{name}\"? This cannot be undone.",
+      "targetUrl": "Target URL",
+      "runButton": "Run",
+      "running": "Running...",
+      "extractedResults": "Extracted results",
+      "noValue": "(not found)",
+      "noResults": "No regions extracted."
     }
   },
   "secrets": {
@@ -6666,7 +7063,8 @@
     "generic": "Something went wrong. Please try again.",
     "notFound": "Not found.",
     "unauthorized": "Unauthorized. Please log in.",
-    "serverError": "Server error. Please try again later."
+    "serverError": "Server error. Please try again later.",
+    "genericError": "Generic error"
   },
   "status": {
     "error": "Error",
@@ -7154,6 +7552,176 @@
       "expired": "منقضی شده",
       "refresh": "دریافت کد جدید",
       "retry": "تلاش مجدد"
+    }
+  },
+  "llmKeys": {
+    "title": "LLM API Keys",
+    "issueKey": "Issue Key",
+    "revoke": "Revoke",
+    "rotate": "Rotate",
+    "unlimited": "Unlimited",
+    "empty": "No API keys found.",
+    "rawKeyWarning": "Copy this key now — it will not be shown again.",
+    "col": {
+      "prefix": "Key Prefix",
+      "team": "Team",
+      "label": "Label",
+      "budget": "Monthly Budget",
+      "spend": "Spend (MTD)",
+      "models": "Allowed Models",
+      "status": "Status",
+      "expires": "Expires"
+    },
+    "status": {
+      "active": "Active",
+      "revoked": "Revoked"
+    },
+    "form": {
+      "teamId": "Team ID",
+      "label": "Label",
+      "budget": "Monthly Budget (USD)",
+      "budgetHint": "Set to 0 for unlimited.",
+      "models": "Allowed Models (JSON array)",
+      "modelsHint": "E.g. [\"gpt-4\", \"claude-*\"]. Leave blank to allow all.",
+      "expiresAt": "Expires At (optional)"
+    },
+    "revokeConfirm": {
+      "title": "Revoke API Key",
+      "body": "Are you sure you want to revoke key {id}? This cannot be undone."
+    }
+  },
+  "llc": {
+    "templates": {
+      "searchPlaceholder": "Search templates...",
+      "loading": "Loading templates...",
+      "noMatch": "No templates found matching your search",
+      "preview": "Preview template",
+      "select": "Select template",
+      "useTemplate": "Use this template"
+    },
+    "wizard": {
+      "step1": {
+        "title": "Choose a Starting Point",
+        "description": "Start with a template or build from scratch",
+        "startFromScratch": "Start from Scratch",
+        "startFromScratchDesc": "Build your company structure from the ground up",
+        "useTemplate": "Use a Template",
+        "useTemplateDesc": "Start with a pre-configured company template"
+      },
+      "step2": {
+        "title": "Configure Your Company",
+        "description": "Set up your company details and preferences",
+        "companyName": "Company Name",
+        "companyNamePlaceholder": "e.g., Acme Corporation",
+        "issuePrefix": "Issue Prefix",
+        "issuePrefixPlaceholder": "e.g., ACM",
+        "issuePrefixHint": "2-10 uppercase letters for issue identifiers (e.g., ACM-123)",
+        "mission": "Mission Statement",
+        "missionPlaceholder": "What is your company's mission?",
+        "monthlyBudget": "Monthly Budget",
+        "monthlyBudgetPlaceholder": "100",
+        "estimatedCost": "Estimated cost",
+        "brandColor": "Brand Color",
+        "brandColorPlaceholder": "#667eea",
+        "templateVariables": "Template Configuration"
+      },
+      "step3": {
+        "title": "Review & Create",
+        "description": "Review your configuration and create your company",
+        "companyDetails": "Company Details",
+        "template": "Template",
+        "agents": "Agents",
+        "goals": "Goals",
+        "workItems": "Work Items",
+        "kbCollections": "Knowledge Collections",
+        "createCompany": "Create Company"
+      }
+    }
+  },
+  "code": {
+    "cellPlaceholder": "Loading...",
+    "copied": "Copied",
+    "copy": "Copy",
+    "copyCodeAriaLabel": "copy Code (accessible)",
+    "copyFailed": "Copy failed"
+  },
+  "devices": {
+    "addDevice": "Add device",
+    "confirmDelete": "Confirm delete",
+    "daysAgo": "Days ago",
+    "error": "Error",
+    "hoursAgo": "Hours ago",
+    "justNow": "Just now",
+    "lastSeen": "Last seen",
+    "loading": "Loading",
+    "minutesAgo": "Minutes ago",
+    "noDevices": "No devices",
+    "pairDevice": "Pair device",
+    "pairFirst": "Pair first",
+    "pairNewDevice": "Pair new device",
+    "paired": "Paired",
+    "pairedDevices": "Paired devices",
+    "pairingInstructions": "Pairing instructions",
+    "pairingNote": "Pairing note",
+    "step1": "Step1",
+    "step2": "Step2",
+    "step3": "Step3",
+    "step4": "Step4",
+    "unpair": "Unpair"
+  },
+  "imageCell": {
+    "copyUrl": "Copy url",
+    "download": "Download",
+    "downloadLabel": "download",
+    "generated": "Generated",
+    "lightbox": "Lightbox",
+    "loadError": "Load error",
+    "placeholder": "Placeholder",
+    "viewFull": "View full"
+  },
+  "plugins": {
+    "capabilities": {
+      "approvalDescription": "Approval description",
+      "approvalTitle": "approval",
+      "approveAll": "Approve all",
+      "approveSelected": "Approve selected",
+      "approving": "Approving",
+      "auditLogTitle": "audit Log",
+      "capability": "Capability",
+      "denied": "Denied",
+      "filterByPlugin": "Filter by plugin",
+      "granted": "Granted",
+      "loading": "Loading",
+      "loadingAudit": "Loading audit",
+      "noAuditEntries": "No audit entries",
+      "noPending": "No pending",
+      "operation": "Operation",
+      "plugin": "Plugin",
+      "status": "Status",
+      "timestamp": "Timestamp"
+    }
+  },
+  "errorMonitoring": {
+    "title": "Error Monitoring",
+    "subtitle": "System-wide error statistics, recent errors, and component breakdown",
+    "lastUpdate": "Last updated",
+    "noMessage": "(no message)",
+    "cards": {
+      "totalErrors": "Total Errors"
+    },
+    "filters": {
+      "category": "Category",
+      "component": "Component",
+      "all": "All"
+    },
+    "sections": {
+      "recentErrors": "Recent Errors",
+      "categories": "Errors by Category",
+      "components": "Errors by Component"
+    },
+    "empty": {
+      "noErrors": "No errors recorded",
+      "noData": "No data available"
     }
   }
 }

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -82,7 +82,27 @@
     "hasMore": "Load more",
     "previous": "Previous",
     "optional": "facultatif",
-    "remove": "Supprimer"
+    "remove": "Supprimer",
+    "dismiss": "Dismiss",
+    "forward": "Forward",
+    "saving": "Saving...",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "fitToView": "Fit to view",
+    "toggleLayout": "Toggle layout",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "copyToClipboard": "Copy to clipboard",
+    "sortAscending": "Sort ascending",
+    "sortDescending": "Sort descending",
+    "moreOptions": "More options",
+    "exportJson": "Export as JSON",
+    "exportCsv": "Export as CSV",
+    "download": "Download",
+    "filterByCategory": "Filter by category",
+    "copied": "Copied"
   },
   "chat": {
     "sendMessage": "Envoyer un message...",
@@ -112,6 +132,10 @@
         "overseer": "Surveillant",
         "tool-code": "Code",
         "tool-output": "Sortir"
+      },
+      "thinking": {
+        "badge": "🧠 Extended thinking ({count} tokens)",
+        "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
       }
     },
     "response": "réponse",
@@ -252,7 +276,21 @@
       "sendingMessage": "Envoi d'un message...",
       "aiResponding": "L'IA répond...",
       "typeMessage": "Tapez un message...",
-      "overseerLabel": "Overseer"
+      "overseerLabel": "Overseer",
+      "managePresets": "Manage slash command presets",
+      "generate": "Generate",
+      "generateImage": "Generate image",
+      "generateImageTitle": "generate Image",
+      "generating": "Generating",
+      "imagePromptLabel": "image Prompt",
+      "imagePromptPlaceholder": "Enter image prompt...",
+      "imageProvider": "Image provider",
+      "selectPromptTemplate": "Select prompt template",
+      "thinkingBudget": "Thinking budget",
+      "thinkingOff": "Thinking off",
+      "thinkingOffLabel": "thinking Off",
+      "thinkingOn": "Thinking on",
+      "thinkingOnLabel": "thinking On"
     },
     "translate": {
       "title": "Traduire le texte",
@@ -295,7 +333,8 @@
       "statusSending": "Envoi...",
       "statusSent": "Envoyé",
       "statusFailed": "Échec de l'envoi",
-      "confirmDelete": "Supprimer ce message ? Cette action ne peut pas être annulée."
+      "confirmDelete": "Supprimer ce message ? Cette action ne peut pas être annulée.",
+      "thinkingUsed": "Thinking used"
     },
     "approval": {
       "autoApproved": "Approuvé automatiquement",
@@ -481,7 +520,35 @@
       "selectAll": "Sélectionner tout",
       "deselectAll": "Désélectionner tout",
       "share": "Partager",
-      "sharing": "Partage..."
+      "sharing": "Partage...",
+      "createAnother": "Create another",
+      "createLink": "Create link",
+      "creating": "Creating",
+      "emptyConversation": "Empty conversation",
+      "enterPassword": "Enter password",
+      "expiry": "Expiry",
+      "expiry1d": "Expiry1d",
+      "expiry1h": "Expiry1h",
+      "expiry30d": "Expiry30d",
+      "expiry7d": "Expiry7d",
+      "expiryNever": "Expiry never",
+      "linkExpired": "Link expired",
+      "linkExpires": "Link expires",
+      "linkNotFound": "Link not found",
+      "linkPasswordProtected": "Link password protected",
+      "linkReady": "Link ready",
+      "optionalPassword": "Optional password",
+      "passwordGate": "Password gate",
+      "passwordGateHint": "Password gate hint",
+      "passwordPlaceholder": "Enter password...",
+      "publicLink": "Public link",
+      "publicView": "Public view",
+      "readOnlyNote": "Read only note",
+      "revokeLink": "Revoke link",
+      "revoking": "Revoking",
+      "shareWithUsers": "Share with users",
+      "unlock": "Unlock",
+      "wrongPassword": "Wrong password"
     },
     "vision": {
       "title": "Analyse d'images",
@@ -525,7 +592,8 @@
       "navigationFailed": "Échec de la navigation",
       "backFailed": "La navigation arrière a échoué",
       "forwardFailed": "Échec de la navigation vers l'avant",
-      "reloadFailed": "Le rechargement a échoué"
+      "reloadFailed": "Le rechargement a échoué",
+      "go": "Navigate"
     },
     "voice": {
       "title": "Chat vocal",
@@ -560,7 +628,10 @@
       "hintResponding": "AutoBot répond...",
       "hintRespondingShort": "Répondre...",
       "hintAutoStart": "L'écoute démarrera automatiquement",
-      "hintTapToSpeak": "Appuyez pour parler"
+      "hintTapToSpeak": "Appuyez pour parler",
+      "realtimeWebrtc": "Realtime WebRTC",
+      "realtimeConnecting": "Connecting to Realtime...",
+      "realtimeConnected": "Realtime — speak anytime"
     },
     "typing": {
       "aiAssistant": "Assistant IA",
@@ -585,7 +656,64 @@
       "streaming": "Streaming…",
       "done": "Done",
       "error": "Error"
-    }
+    },
+    "contextWindow": {
+      "ariaLabel": "{used} of {max} tokens used",
+      "tooltip": "{used} / {max} tokens used ({percent}% of context window)",
+      "warningToast": "Conversation approaching context limit ({percent}%). Older messages may be summarized.",
+      "compressedToast": "Context window optimized - older messages summarized",
+      "summaryTitle": "Context Summary",
+      "summaryToggle": "Show details",
+      "summarizing": "Summarizing..."
+    },
+    "openSettings": "Chat settings",
+    "settings": {
+      "title": "Chat Settings",
+      "contextOverflowLabel": "Context Overflow Protection",
+      "contextOverflowDescription": "Choose how to handle conversations approaching the context limit",
+      "contextOverflowAuto": "Auto-summarize",
+      "contextOverflowWarn": "Warn only",
+      "contextOverflowDisabled": "Disabled"
+    },
+    "folders": {
+      "folders": "Folders",
+      "newFolder": "New folder",
+      "folderName": "Folder name",
+      "rename": "Rename folder",
+      "addSubfolder": "Add subfolder",
+      "pin": "Pin folder",
+      "unpin": "Unpin folder",
+      "assignToFolder": "Move to folder",
+      "removeFromFolder": "Remove from folder",
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+    },
+    "presets": {
+      "modalTitle": "Slash Command Presets",
+      "newPreset": "New Preset",
+      "editPreset": "Edit Preset",
+      "fieldName": "Name",
+      "namePlaceholder": "my-preset",
+      "fieldDescription": "Description",
+      "descriptionPlaceholder": "What this preset does",
+      "fieldContent": "Content",
+      "contentPlaceholder": "Enter the prompt text...",
+      "cancel": "Cancel",
+      "create": "Create",
+      "update": "Update",
+      "delete": "Delete",
+      "listLabel": "Your presets",
+      "loading": "Loading presets...",
+      "empty": "No presets yet. Create one above.",
+      "editAriaLabel": "Edit preset {name}",
+      "deleteAriaLabel": "Delete preset {name}",
+      "deleteConfirmTitle": "Delete preset",
+      "deleteConfirmMessage": "Delete /{name}? This cannot be undone.",
+      "nameRequired": "Name is required",
+      "nameInvalid": "Only letters, numbers, hyphens, and underscores are allowed",
+      "contentRequired": "Content is required"
+    },
+    "lightweightMode": "Lightweight mode",
+    "lightweightModeTooltip": "lightweight Mode tooltip"
   },
   "settings": {
     "title": "Paramètres",
@@ -664,7 +792,22 @@
     },
     "connection": {
       "title": "Connection",
-      "desc": "Configure backend connection settings"
+      "desc": "Configure backend connection settings",
+      "backendCheck": {
+        "title": "Backend reachability",
+        "description": "Run a one-shot ping to verify that the AutoBot backend is reachable from this browser. No periodic polling — manual only.",
+        "button": "Test backend connection",
+        "checking": "Checking…",
+        "reachable": "Reachable",
+        "unreachable": "Unreachable",
+        "latency": "Latency",
+        "lastTested": "Last tested",
+        "neverTested": "Not yet tested"
+      }
+    },
+    "presets": {
+      "title": "Slash Presets",
+      "description": "Create reusable slash commands that expand into full prompts in the chat input. Type / followed by the preset name to trigger them."
     }
   },
   "voice": {
@@ -1247,7 +1390,13 @@
         "usage": "Utilisation",
         "usageAria": "Utilisation & Coûts",
         "operations": "Opérations",
-        "operationsAria": "Opérations de longue durée"
+        "operationsAria": "Opérations de longue durée",
+        "devTools": "Dev Tools",
+        "devToolsAria": "Developer tools and utilities",
+        "errors": "Errors",
+        "errorsAria": "Error monitoring",
+        "diagnostics": "Diagnostics",
+        "diagnosticsAria": "Failure analysis and causal inference"
       }
     },
     "header": {
@@ -1615,7 +1764,8 @@
       "file": "File",
       "score": "Score",
       "topIssue": "Top Issue",
-      "close": "Close"
+      "close": "Close",
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",
@@ -2190,6 +2340,38 @@
         "scanning": "Scan en cours...",
         "scanFile": "Scan File"
       }
+    },
+    "failureAnalysis": {
+      "title": "Failure Analysis",
+      "subtitle": "Root-cause analysis powered by the causal inference engine",
+      "empty": "Enter a task ID above to run a failure analysis.",
+      "form": {
+        "title": "Analyze a Failure",
+        "taskId": "Task ID",
+        "taskIdPlaceholder": "e.g. task-abc123",
+        "errorDescription": "Error Description",
+        "errorDescriptionPlaceholder": "Optional: describe the error or paste a stack trace",
+        "analyze": "Analyze",
+        "analyzing": "Analyzing...",
+        "clear": "Clear"
+      },
+      "result": {
+        "taskId": "Task ID",
+        "confidence": "Confidence",
+        "status": "Status",
+        "duration": "Duration",
+        "rootCause": "Root Cause",
+        "causalChain": "Causal Chain",
+        "interventions": "Interventions",
+        "confounders": "Confounders",
+        "recommendations": "Recommendations",
+        "participants": "Participants",
+        "mechanism": "Mechanism",
+        "successRate": "Success Rate",
+        "cost": "Cost",
+        "risk": "Risk",
+        "confoundingStrength": "Confounding Strength"
+      }
     }
   },
   "knowledge": {
@@ -2241,7 +2423,14 @@
       "visShared": "Vis shared",
       "visSystem": "Vis system",
       "visibility": "Visibility",
-      "visibilityHint": "Visibility hint"
+      "visibilityHint": "Visibility hint",
+      "errorAddText": "Failed to add text to knowledge base",
+      "errorFileTooLarge": "File \"{name}\" exceeds the maximum size limit",
+      "errorImportUrl": "Failed to import URL content",
+      "errorUnsupportedFormat": "File \"{name}\" has an unsupported format",
+      "errorUploadFiles": "Failed to upload files",
+      "successTextAdded": "Text added to knowledge base successfully",
+      "successUrlImported": "URL content imported successfully"
     },
     "documents": "Documents",
     "categories": {
@@ -2291,7 +2480,11 @@
       "maintenance": "Maintenance",
       "maintenanceAriaLabel": "Maintenance de la base de connaissances",
       "analytics": "Analytique",
-      "statistics": "Statistiques"
+      "statistics": "Statistiques",
+      "webResearch": "Web Research",
+      "webResearchAriaLabel": "4-tab web research panel",
+      "openSidebar": "Open navigation menu",
+      "closeSidebar": "Close navigation menu"
     },
     "backup": {
       "title": "Sauvegarde et restauration",
@@ -2787,7 +2980,9 @@
         "sourcesCount": "{count} sources"
       },
       "noEntities3D": "Aucune entité à afficher",
-      "loading3dVisualization": "Loading3d visualization"
+      "loading3dVisualization": "Loading3d visualization",
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "connectors": {
       "title": "Connecteurs source",
@@ -3159,7 +3354,8 @@
       "vectorFramework": "Vector framework",
       "vectorIndexHealth": "Vector index health",
       "vectorNotGenerated": "Vector not generated",
-      "vectorizedForRag": "Vectorized for rag"
+      "vectorizedForRag": "Vectorized for rag",
+      "confirmOptimize": "This will optimize the database. Continue?"
     },
     "summaries": {
       "search": {
@@ -3290,7 +3486,11 @@
       "decisionsApplied": "{count} decision(s) applied successfully",
       "compiledSuccess": "Chat compiled successfully",
       "failedToLoad": "Failed to load knowledge items",
-      "decisionsApplyFailed": "Failed to apply decisions"
+      "decisionsApplyFailed": "Failed to apply decisions",
+      "compileFailed": "Failed to compile conversation",
+      "suggestionAddToKb": "Suggested: Add to Knowledge Base",
+      "suggestionDelete": "Suggested: Delete",
+      "suggestionKeepTemporary": "Suggested: Keep Temporarily"
     },
     "systemKnowledge": {
       "vectorizeTooltip": "Générer des embeddings vectoriels pour toutes les entrées de la base de connaissances afin d'activer la recherche sémantique",
@@ -3323,7 +3523,14 @@
       "success": "Success",
       "targetHost": "Target host",
       "totalFacts": "Total facts",
-      "vectorizing": "Vectorizing"
+      "vectorizing": "Vectorizing",
+      "confirmIndexDocs": "Do you want to force reindex existing documents?",
+      "confirmInitialize": "This will initialize system knowledge for the selected host. This may take several minutes. Continue?",
+      "confirmRefreshManPages": "This will refresh man pages for the selected host. Continue?",
+      "confirmReindex": "This will reindex all documents for the selected host. Continue?",
+      "confirmVectorize": "This will vectorize {totalFacts} facts. Currently {totalVectors} vectors exist, {needsVectorization} need vectorization. Continue?",
+      "vectorizeComplete": "Vectorize Facts (✓ {vectors} vectors from {facts} facts)",
+      "vectorizePending": "Vectorize Facts ({pending} pending)"
     },
     "vectorization": {
       "actionVectorize": "Vectoriser",
@@ -3342,7 +3549,15 @@
       "noDocuments": "No documents",
       "progressTitle": "Progress title",
       "retryFailed": "Retry failed",
-      "total": "Total"
+      "total": "Total",
+      "statusFailed": "Failed",
+      "statusPending": "Pending",
+      "statusUnknown": "Unknown",
+      "statusVectorized": "Vectorized",
+      "tooltipFailed": "Vectorization failed for this document",
+      "tooltipPending": "Document is pending vectorization",
+      "tooltipUnknown": "Vectorization status unknown",
+      "tooltipVectorized": "Document has been vectorized and is searchable via RAG"
     },
     "batchSelection": {
       "selected": "{count} sélectionné(s)",
@@ -3382,7 +3597,8 @@
       "shareWith": "Share with",
       "team": "Team",
       "user": "User",
-      "write": "Write"
+      "write": "Write",
+      "unsavedConfirm": "You have unsaved changes. Are you sure you want to close?"
     },
     "memoryOrphan": {
       "entitiesToClean": "Entities to clean",
@@ -3430,7 +3646,11 @@
       "rejectedToday": "Rejected today",
       "selectAll": "Select all",
       "title": "Title",
-      "untitled": "Untitled"
+      "untitled": "Untitled",
+      "typeConnector": "Connector",
+      "typeResearch": "Web Research",
+      "typeUpload": "Manual Upload",
+      "typeUrl": "URL Fetch"
     },
     "sessionOrphan": {
       "moreOrphans": "More orphans",
@@ -3499,7 +3719,15 @@
       "warnings": "Warnings"
     },
     "manager": {
-      "errorFallback": "Error fallback"
+      "errorFallback": "Error fallback",
+      "tabAdvanced": "Advanced",
+      "tabCategories": "Categories",
+      "tabManage": "Manage",
+      "tabPromptEditor": "Prompts",
+      "tabSearch": "Search",
+      "tabStatistics": "Statistics",
+      "tabSystemDocs": "System Docs",
+      "tabUpload": "Upload"
     },
     "promptEditor": {
       "allCategories": "All categories",
@@ -3605,7 +3833,138 @@
       "selectDocument": "Select document",
       "subtitle": "Subtitle",
       "title": "Title",
-      "words": "Words"
+      "words": "Words",
+      "errorCopy": "Failed to copy to clipboard",
+      "errorExport": "Failed to export document",
+      "errorExportAll": "Failed to export all documents",
+      "errorLoadCategories": "Failed to load documentation categories",
+      "errorLoadContent": "Failed to load document content",
+      "errorLoadDocs": "Failed to load documents"
+    },
+    "search": {
+      "aiSynthesis": "Ai synthesis",
+      "allCategories": "All categories",
+      "autoEnhanceQuery": "Auto enhance query",
+      "clear": "Clear",
+      "clearAccessLevelFilter": "Clear access level filter",
+      "clearCategoryFilter": "Clear category filter",
+      "confidence": "Confidence",
+      "enableReranking": "Enable reranking",
+      "enhancedQuery": "Enhanced query",
+      "fallbackNote": "Fallback note",
+      "filterByAccessLevel": "Filter by access level",
+      "filterByCategory": "Filter by category",
+      "filtering": "Filtering",
+      "indexHelpAfter": "Index help after",
+      "indexHelpBefore": "Index help before",
+      "indexHelpLink": "Index help link",
+      "needToIndex": "Need to index",
+      "noResults": "No results",
+      "noResultsHint": "No results hint",
+      "noResultsRagHint": "No results rag hint",
+      "ragDesc": "Rag desc",
+      "ragEnhanced": "Rag enhanced",
+      "ragPlaceholder": "Rag placeholder",
+      "ragUnavailable": "Rag unavailable",
+      "rerankingBadge": "Reranking badge",
+      "resultsLimit": "Results limit",
+      "retry": "Retry",
+      "searchBtn": "Search btn",
+      "searchPlaceholder": "Search placeholder",
+      "searching": "Searching",
+      "sourcesCount": "Sources count",
+      "subtitle": "Subtitle",
+      "title": "Title",
+      "traditionalDesc": "Traditional desc",
+      "traditionalSearch": "Traditional search",
+      "accessPlatform": "Platform",
+      "accessPublic": "Public",
+      "accessSystem": "System",
+      "accessUser": "User",
+      "clickToView": "Click to view full document",
+      "close": "Close",
+      "copyContent": "Copy Content",
+      "defaultDocTitle": "Untitled Document",
+      "foundResults": "Found {count} results for \"{query}\"",
+      "loadingDocument": "Loading document content...",
+      "matchScore": "{value}% match",
+      "noContent": "No content available",
+      "rerankScore": "{value}% rerank"
+    },
+    "webResearch": {
+      "title": "Web Research",
+      "subtitle": "Fetch, crawl, discover, and extract data from the web",
+      "navLabel": "Web Research",
+      "navAriaLabel": "Web research panel",
+      "settingsNavLabel": "Research Settings",
+      "settingsNavAriaLabel": "Web research settings",
+      "tabListAriaLabel": "Web research tabs",
+      "renderLabel": "Render Mode",
+      "renderAuto": "Auto",
+      "renderFast": "Fast (no JS)",
+      "renderPlaywright": "Full JS (Playwright)",
+      "ingestLabel": "Save to Knowledge Base",
+      "respectRobotsLabel": "Respect robots.txt",
+      "reset": "Clear",
+      "retry": "Retry",
+      "fetching": "Fetching…",
+      "crawling": "Crawling…",
+      "discovering": "Discovering…",
+      "extracting": "Extracting…",
+      "indexed": "Saved to KB",
+      "failed": "Failed",
+      "schemaValid": "Schema Valid",
+      "schemaInvalid": "Schema Invalid",
+      "filterPlaceholder": "Filter URLs…",
+      "filterLabel": "Filter URLs",
+      "noFilterResults": "No URLs match the current filter.",
+      "depthLabel": "Depth {depth}",
+      "errorGeneric": "An unexpected error occurred. Please try again.",
+      "tabs": {
+        "scrape": "Fetch Page",
+        "scrapeAriaLabel": "Fetch Page — extract text from a single URL",
+        "crawl": "Crawl Site",
+        "crawlAriaLabel": "Crawl Site — follow links and index multiple pages",
+        "siteMap": "Find Pages",
+        "siteMapAriaLabel": "Find Pages — discover all URLs on a domain",
+        "extract": "Get Data",
+        "extractAriaLabel": "Get Data — extract structured data using a schema"
+      },
+      "scrape": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "formatLabel": "Output Format",
+        "submitLabel": "Fetch Page",
+        "emptyState": "Enter a URL above and click Fetch Page to extract its text content."
+      },
+      "crawl": {
+        "seedLabel": "Seed URL",
+        "seedPlaceholder": "https://example.com",
+        "depthLabel": "Max Depth",
+        "maxPagesLabel": "Max Pages",
+        "sameOriginLabel": "Same origin only",
+        "submitLabel": "Crawl Site",
+        "emptyState": "Enter a starting URL and click Crawl Site to follow its links.",
+        "resultTitle": "{count} pages crawled",
+        "urlListLabel": "Crawled pages"
+      },
+      "siteMap": {
+        "domainLabel": "Domain",
+        "domainPlaceholder": "example.com",
+        "maxUrlsLabel": "Max URLs",
+        "submitLabel": "Find Pages",
+        "emptyState": "Enter a domain name and click Find Pages to discover its URLs.",
+        "resultTitle": "{count} URLs found on {domain}",
+        "urlListLabel": "Discovered URLs"
+      },
+      "extract": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "schemaLabel": "JSON Schema",
+        "submitLabel": "Get Data",
+        "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
+        "resultTitle": "Extracted Data"
+      }
     }
   },
   "workflow": {
@@ -3725,7 +4084,10 @@
       "screenAnalysisAriaLabel": "Screen Analysis - capture and analyze screen content",
       "sectionDescVideoProcessing": "Process and analyze video frames",
       "screenAnalysis": "Screen Analysis",
-      "vision": "VISION"
+      "vision": "VISION",
+      "historyAriaLabel": "Workflow execution history",
+      "visualizerAriaLabel": "Orchestration visualizer",
+      "agentsAriaLabel": "Agent capabilities"
     },
     "modal": {
       "executeStep": "Execute This Step",
@@ -3829,7 +4191,15 @@
       "visionWait": "Wait for Element",
       "visionClick": "Click Element",
       "vision": "Vision",
-      "visionFindElement": "Find Element"
+      "visionFindElement": "Find Element",
+      "addCase": "Add case",
+      "addSwitch": "Add switch",
+      "conditionCompare": "Condition compare",
+      "conditionExpr": "Condition expr",
+      "switch": "Switch",
+      "switchDefaultHint": "Switch default hint",
+      "switchLabel": "switch",
+      "switchOnPlaceholder": "Enter switch on..."
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -4057,6 +4427,12 @@
       "resetDefaults": "Reset to Defaults",
       "saving": "Saving...",
       "tabTitle": "Settings"
+    },
+    "nav": {
+      "label": "Agents navigation",
+      "registry": "Registry",
+      "activity": "Activity",
+      "heartbeat": "Heartbeat"
     }
   },
   "errors": {
@@ -4066,7 +4442,8 @@
     "notFound": "Non trouvé.",
     "serverError": "Erreur du serveur. Veuillez réessayer plus tard.",
     "timeout": "La requête a expiré.",
-    "validation": "Veuillez vérifier vos données."
+    "validation": "Veuillez vérifier vos données.",
+    "genericError": "Generic error"
   },
   "status": {
     "online": "En ligne",
@@ -4348,7 +4725,8 @@
     "never": "Jamais",
     "themeLight": "Clair",
     "themeDark": "Sombre",
-    "themeAuto": "Automatique"
+    "themeAuto": "Automatique",
+    "tabDevices": "Tab devices"
   },
   "redis": {
     "title": "Service Redis",
@@ -4447,7 +4825,9 @@
         "showingOf": "Showing {showing} of {total} functions (scroll for more)",
         "noMatch": "No orphaned functions match your filter",
         "allConnected": "No orphaned functions detected - all functions are connected!"
-      }
+      },
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "importTree": {
       "title": "File Import Tree",
@@ -4557,7 +4937,12 @@
       "seriesName": "Problems",
       "xAxisTitle": "Number of Problems",
       "tooltipProblems": "problems"
-    }
+    },
+    "ariaLabel": "Accessible label",
+    "cellPlaceholder": "Loading...",
+    "defaultAriaLabel": "default (accessible)",
+    "renderError": "Render error",
+    "viewData": "View data"
   },
   "_meta": {
     "dir": "ltr",
@@ -5214,7 +5599,8 @@
       "aiAssistant": "AI Assistant",
       "knowledgeBase": "Knowledge Base",
       "automation": "Automation",
-      "analytics": "Analytics"
+      "analytics": "Analytics",
+      "goHome": "Go Home"
     },
     "secrets": {
       "noticeTitle": "Security Notice",
@@ -5436,7 +5822,9 @@
       "widgetAgents": "Agent Activity",
       "widgetAgentsDesc": "Real-time agent activity monitoring",
       "widgetArchitecture": "System Architecture",
-      "widgetArchitectureDesc": "Interactive system architecture diagram"
+      "widgetArchitectureDesc": "Interactive system architecture diagram",
+      "saved": "Saved",
+      "dashboardSaved": "Dashboard saved"
     },
     "devSpeedup": {
       "title": "Developer Speedup",
@@ -5534,7 +5922,9 @@
       "noConfig": "No configuration stored for this plugin.",
       "invalidJson": "Invalid JSON — please fix before saving.",
       "saveFailed": "Failed to save configuration.",
-      "marketplace": "Marketplace"
+      "marketplace": "Marketplace",
+      "auditLog": "Audit log",
+      "trustTier": "Trust tier"
     },
     "marketplace": {
       "title": "Plugin Marketplace",
@@ -5636,6 +6026,22 @@
       "createBrowserSession": "Créer une session de navigateur",
       "startingUrl": "URL de départ",
       "cancel": "Annuler"
+    },
+    "scrapeTemplates": {
+      "title": "Scrape Templates",
+      "refresh": "Refresh templates",
+      "emptyTitle": "No Saved Templates",
+      "emptyMessage": "Mark regions on a page and save a template to see it here.",
+      "run": "Re-run template",
+      "duplicate": "Duplicate template",
+      "delete": "Delete template",
+      "deleteConfirm": "Delete \"{name}\"? This cannot be undone.",
+      "targetUrl": "Target URL",
+      "runButton": "Run",
+      "running": "Running...",
+      "extractedResults": "Extracted results",
+      "noValue": "(not found)",
+      "noResults": "No regions extracted."
     }
   },
   "collaboration": {
@@ -6276,6 +6682,65 @@
       "toastSavedToGallery": "Saved to gallery",
       "errorNoFrames": "No frames could be processed",
       "errorInvalidFile": "Please drop a valid video file"
+    },
+    "visionAutomation": {
+      "title": "Vision Automation",
+      "subtitle": "Screen analysis, UI element detection, OCR, and automation opportunity discovery",
+      "serviceStatus": "Service",
+      "sessionContext": "Session Context (optional)",
+      "sessionIdPlaceholder": "Session ID for context",
+      "tabsAriaLabel": "Vision automation tabs",
+      "analyzing": "Analyzing...",
+      "detecting": "Detecting...",
+      "extracting": "Extracting...",
+      "scanning": "Scanning...",
+      "errorLabel": "Error",
+      "tabs": {
+        "analysis": "Screen Analysis",
+        "elements": "Element Detection",
+        "ocr": "OCR",
+        "opportunities": "Automation Opportunities"
+      },
+      "columns": {
+        "id": "ID",
+        "type": "Type",
+        "confidence": "Confidence",
+        "text": "Text",
+        "interactions": "Interactions",
+        "position": "Center"
+      },
+      "analysis": {
+        "cardTitle": "Capture & Analyze Screen",
+        "trigger": "Capture & Analyze",
+        "elementsFound": "Elements",
+        "textRegions": "Text Regions",
+        "confidence": "Confidence",
+        "automationOpps": "Opportunities",
+        "detectedElements": "Detected UI Elements",
+        "empty": "Press Capture and Analyze to analyze the current screen"
+      },
+      "elements": {
+        "cardTitle": "Detect UI Elements",
+        "trigger": "Detect Elements",
+        "typePlaceholder": "Filter by element type (e.g. button)",
+        "minConfidence": "Min Confidence",
+        "results": "{filtered} of {total} elements",
+        "empty": "No elements match the current filter"
+      },
+      "ocr": {
+        "cardTitle": "OCR Text Extraction",
+        "trigger": "Extract Text",
+        "regionsFound": "{count} text region(s) found",
+        "noRegions": "No text regions detected",
+        "empty": "Press Extract Text to run OCR on the current screen"
+      },
+      "opportunities": {
+        "cardTitle": "Automation Opportunities",
+        "trigger": "Scan for Opportunities",
+        "total": "Total Opportunities",
+        "empty": "No automation opportunities found",
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+      }
     }
   },
   "visualizations": {
@@ -6293,7 +6758,8 @@
       "recentTasks": "Recent Tasks",
       "detailsBtn": "Details",
       "pauseBtn": "Pause",
-      "liveActivityFeed": "Live Activity Feed"
+      "liveActivityFeed": "Live Activity Feed",
+      "abstained": "Abstained"
     },
     "resourceHeatmap": {
       "defaultTitle": "Resource Utilization Heatmap",
@@ -6317,7 +6783,8 @@
       "rangeMedium": "Medium",
       "rangeHigh": "High",
       "rangeCritical": "Critical",
-      "usage": "Usage"
+      "usage": "Usage",
+      "noData": "No metrics available yet"
     },
     "systemArchitecture": {
       "defaultTitle": "System Architecture",
@@ -6616,7 +7083,8 @@
       "noEndpointData": "No endpoint data available",
       "noUserData": "No user data available",
       "noTrendData": "No trend data available",
-      "noRecentViolations": "No recent violations"
+      "noRecentViolations": "No recent violations",
+      "last14Days": "Last 14 days"
     },
     "enforcement": {
       "title": "Endpoint Overrides",
@@ -6953,7 +7421,10 @@
       "launchDesc": "This will open a live browser that you can control directly",
       "initializingSession": "Initializing browser session...",
       "sessionId": "Session ID: {id}",
-      "notAvailable": "Not available"
+      "notAvailable": "Not available",
+      "templates": "Scrape Templates",
+      "exitRegionMode": "Exit region mode",
+      "markRegions": "Mark regions"
     }
   },
   "serviceMessages": {
@@ -7018,7 +7489,28 @@
     "llcPortability": "Portability",
     "settingsAndTools": "Settings & Tools",
     "adminPanel": "Admin Panel",
-    "documents": "AI Documents"
+    "documents": "AI Documents",
+    "canvas": "Canvas",
+    "visionAutomation": "Vision",
+    "llmApiKeys": "LLM API Keys",
+    "llmProviders": "LLM Providers",
+    "adminHosts": "Host Inventory",
+    "adminSandbox": "Sandbox",
+    "budgetPolicies": "Budget Policies",
+    "companyOs": "Company OS",
+    "llcDashboard": "Dashboard",
+    "llcOrgChart": "Org Chart",
+    "llcGoals": "Goals",
+    "llcCompanies": "Companies",
+    "llcBacklog": "Backlog",
+    "llcApprovals": "Approvals",
+    "llcCosts": "Costs & Budget",
+    "llcHeartbeat": "Heartbeat",
+    "llcCeoChat": "CEO Chat",
+    "llcSelectCompany": "Switch Company",
+    "llcSelectCompanyPrompt": "Select a company to open its dashboard, backlog, and tools.",
+    "llcNoCompanies": "No companies yet.",
+    "llcCreateCompany": "Create a company"
   },
   "reasoningTrace": {
     "title": "Trace de raisonnement",
@@ -7060,6 +7552,176 @@
       "expired": "Expiré",
       "refresh": "Obtenir un nouveau code",
       "retry": "Réessayer"
+    }
+  },
+  "llmKeys": {
+    "title": "LLM API Keys",
+    "issueKey": "Issue Key",
+    "revoke": "Revoke",
+    "rotate": "Rotate",
+    "unlimited": "Unlimited",
+    "empty": "No API keys found.",
+    "rawKeyWarning": "Copy this key now — it will not be shown again.",
+    "col": {
+      "prefix": "Key Prefix",
+      "team": "Team",
+      "label": "Label",
+      "budget": "Monthly Budget",
+      "spend": "Spend (MTD)",
+      "models": "Allowed Models",
+      "status": "Status",
+      "expires": "Expires"
+    },
+    "status": {
+      "active": "Active",
+      "revoked": "Revoked"
+    },
+    "form": {
+      "teamId": "Team ID",
+      "label": "Label",
+      "budget": "Monthly Budget (USD)",
+      "budgetHint": "Set to 0 for unlimited.",
+      "models": "Allowed Models (JSON array)",
+      "modelsHint": "E.g. [\"gpt-4\", \"claude-*\"]. Leave blank to allow all.",
+      "expiresAt": "Expires At (optional)"
+    },
+    "revokeConfirm": {
+      "title": "Revoke API Key",
+      "body": "Are you sure you want to revoke key {id}? This cannot be undone."
+    }
+  },
+  "llc": {
+    "templates": {
+      "searchPlaceholder": "Search templates...",
+      "loading": "Loading templates...",
+      "noMatch": "No templates found matching your search",
+      "preview": "Preview template",
+      "select": "Select template",
+      "useTemplate": "Use this template"
+    },
+    "wizard": {
+      "step1": {
+        "title": "Choose a Starting Point",
+        "description": "Start with a template or build from scratch",
+        "startFromScratch": "Start from Scratch",
+        "startFromScratchDesc": "Build your company structure from the ground up",
+        "useTemplate": "Use a Template",
+        "useTemplateDesc": "Start with a pre-configured company template"
+      },
+      "step2": {
+        "title": "Configure Your Company",
+        "description": "Set up your company details and preferences",
+        "companyName": "Company Name",
+        "companyNamePlaceholder": "e.g., Acme Corporation",
+        "issuePrefix": "Issue Prefix",
+        "issuePrefixPlaceholder": "e.g., ACM",
+        "issuePrefixHint": "2-10 uppercase letters for issue identifiers (e.g., ACM-123)",
+        "mission": "Mission Statement",
+        "missionPlaceholder": "What is your company's mission?",
+        "monthlyBudget": "Monthly Budget",
+        "monthlyBudgetPlaceholder": "100",
+        "estimatedCost": "Estimated cost",
+        "brandColor": "Brand Color",
+        "brandColorPlaceholder": "#667eea",
+        "templateVariables": "Template Configuration"
+      },
+      "step3": {
+        "title": "Review & Create",
+        "description": "Review your configuration and create your company",
+        "companyDetails": "Company Details",
+        "template": "Template",
+        "agents": "Agents",
+        "goals": "Goals",
+        "workItems": "Work Items",
+        "kbCollections": "Knowledge Collections",
+        "createCompany": "Create Company"
+      }
+    }
+  },
+  "code": {
+    "cellPlaceholder": "Loading...",
+    "copied": "Copied",
+    "copy": "Copy",
+    "copyCodeAriaLabel": "copy Code (accessible)",
+    "copyFailed": "Copy failed"
+  },
+  "devices": {
+    "addDevice": "Add device",
+    "confirmDelete": "Confirm delete",
+    "daysAgo": "Days ago",
+    "error": "Error",
+    "hoursAgo": "Hours ago",
+    "justNow": "Just now",
+    "lastSeen": "Last seen",
+    "loading": "Loading",
+    "minutesAgo": "Minutes ago",
+    "noDevices": "No devices",
+    "pairDevice": "Pair device",
+    "pairFirst": "Pair first",
+    "pairNewDevice": "Pair new device",
+    "paired": "Paired",
+    "pairedDevices": "Paired devices",
+    "pairingInstructions": "Pairing instructions",
+    "pairingNote": "Pairing note",
+    "step1": "Step1",
+    "step2": "Step2",
+    "step3": "Step3",
+    "step4": "Step4",
+    "unpair": "Unpair"
+  },
+  "imageCell": {
+    "copyUrl": "Copy url",
+    "download": "Download",
+    "downloadLabel": "download",
+    "generated": "Generated",
+    "lightbox": "Lightbox",
+    "loadError": "Load error",
+    "placeholder": "Placeholder",
+    "viewFull": "View full"
+  },
+  "plugins": {
+    "capabilities": {
+      "approvalDescription": "Approval description",
+      "approvalTitle": "approval",
+      "approveAll": "Approve all",
+      "approveSelected": "Approve selected",
+      "approving": "Approving",
+      "auditLogTitle": "audit Log",
+      "capability": "Capability",
+      "denied": "Denied",
+      "filterByPlugin": "Filter by plugin",
+      "granted": "Granted",
+      "loading": "Loading",
+      "loadingAudit": "Loading audit",
+      "noAuditEntries": "No audit entries",
+      "noPending": "No pending",
+      "operation": "Operation",
+      "plugin": "Plugin",
+      "status": "Status",
+      "timestamp": "Timestamp"
+    }
+  },
+  "errorMonitoring": {
+    "title": "Error Monitoring",
+    "subtitle": "System-wide error statistics, recent errors, and component breakdown",
+    "lastUpdate": "Last updated",
+    "noMessage": "(no message)",
+    "cards": {
+      "totalErrors": "Total Errors"
+    },
+    "filters": {
+      "category": "Category",
+      "component": "Component",
+      "all": "All"
+    },
+    "sections": {
+      "recentErrors": "Recent Errors",
+      "categories": "Errors by Category",
+      "components": "Errors by Component"
+    },
+    "empty": {
+      "noErrors": "No errors recorded",
+      "noData": "No data available"
     }
   }
 }

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -82,7 +82,27 @@
     "hasMore": "Load more",
     "previous": "Previous",
     "optional": "אופציונלי",
-    "remove": "הסר"
+    "remove": "הסר",
+    "dismiss": "Dismiss",
+    "forward": "Forward",
+    "saving": "Saving...",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "fitToView": "Fit to view",
+    "toggleLayout": "Toggle layout",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "copyToClipboard": "Copy to clipboard",
+    "sortAscending": "Sort ascending",
+    "sortDescending": "Sort descending",
+    "moreOptions": "More options",
+    "exportJson": "Export as JSON",
+    "exportCsv": "Export as CSV",
+    "download": "Download",
+    "filterByCategory": "Filter by category",
+    "copied": "Copied"
   },
   "nav": {
     "chat": "צ'אט",
@@ -128,7 +148,28 @@
     "llcPortability": "Portability",
     "settingsAndTools": "Settings & Tools",
     "adminPanel": "Admin Panel",
-    "documents": "AI Documents"
+    "documents": "AI Documents",
+    "canvas": "Canvas",
+    "visionAutomation": "Vision",
+    "llmApiKeys": "LLM API Keys",
+    "llmProviders": "LLM Providers",
+    "adminHosts": "Host Inventory",
+    "adminSandbox": "Sandbox",
+    "budgetPolicies": "Budget Policies",
+    "companyOs": "Company OS",
+    "llcDashboard": "Dashboard",
+    "llcOrgChart": "Org Chart",
+    "llcGoals": "Goals",
+    "llcCompanies": "Companies",
+    "llcBacklog": "Backlog",
+    "llcApprovals": "Approvals",
+    "llcCosts": "Costs & Budget",
+    "llcHeartbeat": "Heartbeat",
+    "llcCeoChat": "CEO Chat",
+    "llcSelectCompany": "Switch Company",
+    "llcSelectCompanyPrompt": "Select a company to open its dashboard, backlog, and tools.",
+    "llcNoCompanies": "No companies yet.",
+    "llcCreateCompany": "Create a company"
   },
   "agent": {
     "registry": {
@@ -198,7 +239,13 @@
     "title": "Agents",
     "orchestrator": "Orchestrator",
     "config": "Agent Configuration",
-    "status": "Agent Status"
+    "status": "Agent Status",
+    "nav": {
+      "label": "Agents navigation",
+      "registry": "Registry",
+      "activity": "Activity",
+      "heartbeat": "Heartbeat"
+    }
   },
   "_meta": {
     "dir": "rtl",
@@ -762,7 +809,13 @@
         "usage": "שימוש",
         "usageAria": "שימוש & עלויות",
         "operations": "תפעול",
-        "operationsAria": "פעולות ארוכות טווח"
+        "operationsAria": "פעולות ארוכות טווח",
+        "devTools": "Dev Tools",
+        "devToolsAria": "Developer tools and utilities",
+        "errors": "Errors",
+        "errorsAria": "Error monitoring",
+        "diagnostics": "Diagnostics",
+        "diagnosticsAria": "Failure analysis and causal inference"
       }
     },
     "header": {
@@ -1130,7 +1183,8 @@
       "file": "File",
       "score": "Score",
       "topIssue": "Top Issue",
-      "close": "Close"
+      "close": "Close",
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",
@@ -1705,6 +1759,38 @@
         "scanning": "Scanning...",
         "scanFile": "Scan File"
       }
+    },
+    "failureAnalysis": {
+      "title": "Failure Analysis",
+      "subtitle": "Root-cause analysis powered by the causal inference engine",
+      "empty": "Enter a task ID above to run a failure analysis.",
+      "form": {
+        "title": "Analyze a Failure",
+        "taskId": "Task ID",
+        "taskIdPlaceholder": "e.g. task-abc123",
+        "errorDescription": "Error Description",
+        "errorDescriptionPlaceholder": "Optional: describe the error or paste a stack trace",
+        "analyze": "Analyze",
+        "analyzing": "Analyzing...",
+        "clear": "Clear"
+      },
+      "result": {
+        "taskId": "Task ID",
+        "confidence": "Confidence",
+        "status": "Status",
+        "duration": "Duration",
+        "rootCause": "Root Cause",
+        "causalChain": "Causal Chain",
+        "interventions": "Interventions",
+        "confounders": "Confounders",
+        "recommendations": "Recommendations",
+        "participants": "Participants",
+        "mechanism": "Mechanism",
+        "successRate": "Success Rate",
+        "cost": "Cost",
+        "risk": "Risk",
+        "confoundingStrength": "Confounding Strength"
+      }
     }
   },
   "knowledge": {
@@ -1802,7 +1888,9 @@
       "toggleLayout": "Toggle layout",
       "typeConversation": "Conversation",
       "create": "Create",
-      "loading3dVisualization": "Loading3d visualization"
+      "loading3dVisualization": "Loading3d visualization",
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "vectorization": {
       "actionVectorize": "Vectorize",
@@ -2690,7 +2778,11 @@
       "graphAriaLabel": "View knowledge graph",
       "title": "Knowledge Base",
       "analytics": "Analytics",
-      "entities": "Entities"
+      "entities": "Entities",
+      "webResearch": "Web Research",
+      "webResearchAriaLabel": "4-tab web research panel",
+      "openSidebar": "Open navigation menu",
+      "closeSidebar": "Close navigation menu"
     },
     "upload": {
       "selectCategory": "Select category...",
@@ -3201,7 +3293,9 @@
       "tabManage": "Manage",
       "tabSearch": "Search",
       "tabStatistics": "Statistics",
-      "tabUpload": "Upload"
+      "tabUpload": "Upload",
+      "tabPromptEditor": "Prompts",
+      "tabSystemDocs": "System Docs"
     },
     "emptyState": {
       "title": "Your knowledge base is empty",
@@ -3215,6 +3309,81 @@
     "categoriesError": {
       "title": "Knowledge base is unreachable",
       "description": "Redis connection failed. Check that the backend has Redis running."
+    },
+    "webResearch": {
+      "title": "Web Research",
+      "subtitle": "Fetch, crawl, discover, and extract data from the web",
+      "navLabel": "Web Research",
+      "navAriaLabel": "Web research panel",
+      "settingsNavLabel": "Research Settings",
+      "settingsNavAriaLabel": "Web research settings",
+      "tabListAriaLabel": "Web research tabs",
+      "renderLabel": "Render Mode",
+      "renderAuto": "Auto",
+      "renderFast": "Fast (no JS)",
+      "renderPlaywright": "Full JS (Playwright)",
+      "ingestLabel": "Save to Knowledge Base",
+      "respectRobotsLabel": "Respect robots.txt",
+      "reset": "Clear",
+      "retry": "Retry",
+      "fetching": "Fetching…",
+      "crawling": "Crawling…",
+      "discovering": "Discovering…",
+      "extracting": "Extracting…",
+      "indexed": "Saved to KB",
+      "failed": "Failed",
+      "schemaValid": "Schema Valid",
+      "schemaInvalid": "Schema Invalid",
+      "filterPlaceholder": "Filter URLs…",
+      "filterLabel": "Filter URLs",
+      "noFilterResults": "No URLs match the current filter.",
+      "depthLabel": "Depth {depth}",
+      "errorGeneric": "An unexpected error occurred. Please try again.",
+      "tabs": {
+        "scrape": "Fetch Page",
+        "scrapeAriaLabel": "Fetch Page — extract text from a single URL",
+        "crawl": "Crawl Site",
+        "crawlAriaLabel": "Crawl Site — follow links and index multiple pages",
+        "siteMap": "Find Pages",
+        "siteMapAriaLabel": "Find Pages — discover all URLs on a domain",
+        "extract": "Get Data",
+        "extractAriaLabel": "Get Data — extract structured data using a schema"
+      },
+      "scrape": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "formatLabel": "Output Format",
+        "submitLabel": "Fetch Page",
+        "emptyState": "Enter a URL above and click Fetch Page to extract its text content."
+      },
+      "crawl": {
+        "seedLabel": "Seed URL",
+        "seedPlaceholder": "https://example.com",
+        "depthLabel": "Max Depth",
+        "maxPagesLabel": "Max Pages",
+        "sameOriginLabel": "Same origin only",
+        "submitLabel": "Crawl Site",
+        "emptyState": "Enter a starting URL and click Crawl Site to follow its links.",
+        "resultTitle": "{count} pages crawled",
+        "urlListLabel": "Crawled pages"
+      },
+      "siteMap": {
+        "domainLabel": "Domain",
+        "domainPlaceholder": "example.com",
+        "maxUrlsLabel": "Max URLs",
+        "submitLabel": "Find Pages",
+        "emptyState": "Enter a domain name and click Find Pages to discover its URLs.",
+        "resultTitle": "{count} URLs found on {domain}",
+        "urlListLabel": "Discovered URLs"
+      },
+      "extract": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "schemaLabel": "JSON Schema",
+        "submitLabel": "Get Data",
+        "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
+        "resultTitle": "Extracted Data"
+      }
     }
   },
   "reasoningTrace": {
@@ -3370,7 +3539,10 @@
       "refresh": "Refresh",
       "availableAgents": "Available Agents",
       "min": "min",
-      "overviewAriaLabel": "View workflow overview"
+      "overviewAriaLabel": "View workflow overview",
+      "historyAriaLabel": "Workflow execution history",
+      "visualizerAriaLabel": "Orchestration visualizer",
+      "agentsAriaLabel": "Agent capabilities"
     },
     "runner": {
       "completed": "Completed",
@@ -3477,7 +3649,15 @@
       "visionWait": "Wait for Element",
       "conditionPlaceholder": "Condition (e.g., $? -eq 0)",
       "save": "Save",
-      "confirm": "Confirm"
+      "confirm": "Confirm",
+      "addCase": "Add case",
+      "addSwitch": "Add switch",
+      "conditionCompare": "Condition compare",
+      "conditionExpr": "Condition expr",
+      "switch": "Switch",
+      "switchDefaultHint": "Switch default hint",
+      "switchLabel": "switch",
+      "switchOnPlaceholder": "Enter switch on..."
     },
     "notifications": {
       "emailRecipients": "Email Recipients",
@@ -3996,7 +4176,10 @@
       "noSession": "No active browser session. Launch a session to start browsing.",
       "testButton": "Test",
       "getStarted": "Use automation controls above to get started",
-      "sessionId": "Session ID: {id}"
+      "sessionId": "Session ID: {id}",
+      "templates": "Scrape Templates",
+      "exitRegionMode": "Exit region mode",
+      "markRegions": "Mark regions"
     },
     "interface": {
       "typeText": "Type Text",
@@ -4160,7 +4343,9 @@
       "networkView": "Network View (Cytoscape)",
       "title": "Function Call Graph",
       "orphanedView": "Orphaned Functions (unused)",
-      "allModules": "All Modules"
+      "allModules": "All Modules",
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "moduleImports": {
       "tooltipFunctions": "functions",
@@ -4286,7 +4471,12 @@
       "loading": "Loading chart...",
       "total": "Total",
       "noData": "No data available"
-    }
+    },
+    "ariaLabel": "Accessible label",
+    "cellPlaceholder": "Loading...",
+    "defaultAriaLabel": "default (accessible)",
+    "renderError": "Render error",
+    "viewData": "View data"
   },
   "profile": {
     "confirmNewPassword": "Confirm new password",
@@ -4329,7 +4519,8 @@
     "closeAria": "Close profile",
     "themeAuto": "Auto",
     "pwChanged": "Password changed successfully!",
-    "username": "Username:"
+    "username": "Username:",
+    "tabDevices": "Tab devices"
   },
   "ui": {
     "themeToggle": {
@@ -4743,7 +4934,10 @@
       "you": "You",
       "silenceTimeout": "Silence timeout",
       "hintResponding": "AutoBot is responding...",
-      "title": "Voice Chat"
+      "title": "Voice Chat",
+      "realtimeWebrtc": "Realtime WebRTC",
+      "realtimeConnecting": "Connecting to Realtime...",
+      "realtimeConnected": "Realtime — speak anytime"
     },
     "filePanel": {
       "listView": "List view",
@@ -4787,7 +4981,35 @@
       "factsSelected": "{selected} of {total} facts selected",
       "share": "Share",
       "selectAll": "Select All",
-      "deselectAll": "Deselect All"
+      "deselectAll": "Deselect All",
+      "createAnother": "Create another",
+      "createLink": "Create link",
+      "creating": "Creating",
+      "emptyConversation": "Empty conversation",
+      "enterPassword": "Enter password",
+      "expiry": "Expiry",
+      "expiry1d": "Expiry1d",
+      "expiry1h": "Expiry1h",
+      "expiry30d": "Expiry30d",
+      "expiry7d": "Expiry7d",
+      "expiryNever": "Expiry never",
+      "linkExpired": "Link expired",
+      "linkExpires": "Link expires",
+      "linkNotFound": "Link not found",
+      "linkPasswordProtected": "Link password protected",
+      "linkReady": "Link ready",
+      "optionalPassword": "Optional password",
+      "passwordGate": "Password gate",
+      "passwordGateHint": "Password gate hint",
+      "passwordPlaceholder": "Enter password...",
+      "publicLink": "Public link",
+      "publicView": "Public view",
+      "readOnlyNote": "Read only note",
+      "revokeLink": "Revoke link",
+      "revoking": "Revoking",
+      "shareWithUsers": "Share with users",
+      "unlock": "Unlock",
+      "wrongPassword": "Wrong password"
     },
     "typing": {
       "understanding": "Understanding your request...",
@@ -4928,7 +5150,21 @@
       "attachFile": "Attach file",
       "retryUpload": "Retry upload",
       "removeFile": "Remove file",
-      "overseerLabel": "Overseer"
+      "overseerLabel": "Overseer",
+      "managePresets": "Manage slash command presets",
+      "generate": "Generate",
+      "generateImage": "Generate image",
+      "generateImageTitle": "generate Image",
+      "generating": "Generating",
+      "imagePromptLabel": "image Prompt",
+      "imagePromptPlaceholder": "Enter image prompt...",
+      "imageProvider": "Image provider",
+      "selectPromptTemplate": "Select prompt template",
+      "thinkingBudget": "Thinking budget",
+      "thinkingOff": "Thinking off",
+      "thinkingOffLabel": "thinking Off",
+      "thinkingOn": "Thinking on",
+      "thinkingOnLabel": "thinking On"
     },
     "visualBrowser": {
       "disconnected": "Disconnected",
@@ -4947,7 +5183,8 @@
       "reload": "Reload",
       "captureScreenshot": "Capture Screenshot",
       "urlPlaceholder": "Enter URL or search…",
-      "reloadFailed": "Reload failed"
+      "reloadFailed": "Reload failed",
+      "go": "Navigate"
     },
     "browser": {
       "connectingStatus": "Connecting",
@@ -5049,7 +5286,8 @@
       "senderSystem": "System",
       "statusSent": "Sent",
       "ctrlEnterToSave": "Press Ctrl+Enter (Cmd+Enter on Mac) to save",
-      "badgePlanning": "Planning"
+      "badgePlanning": "Planning",
+      "thinkingUsed": "Thinking used"
     },
     "stopGenerating": "Stop generating",
     "thinking": "Thinking...",
@@ -5070,7 +5308,11 @@
       "delete": "Delete message",
       "copy": "Copy message",
       "tokens": "{count} tokens",
-      "edit": "Edit message"
+      "edit": "Edit message",
+      "thinking": {
+        "badge": "🧠 Extended thinking ({count} tokens)",
+        "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
+      }
     },
     "docResult": {
       "copyContent": "Copy content",
@@ -5133,7 +5375,64 @@
       "streaming": "Streaming…",
       "done": "Done",
       "error": "Error"
-    }
+    },
+    "contextWindow": {
+      "ariaLabel": "{used} of {max} tokens used",
+      "tooltip": "{used} / {max} tokens used ({percent}% of context window)",
+      "warningToast": "Conversation approaching context limit ({percent}%). Older messages may be summarized.",
+      "compressedToast": "Context window optimized - older messages summarized",
+      "summaryTitle": "Context Summary",
+      "summaryToggle": "Show details",
+      "summarizing": "Summarizing..."
+    },
+    "openSettings": "Chat settings",
+    "settings": {
+      "title": "Chat Settings",
+      "contextOverflowLabel": "Context Overflow Protection",
+      "contextOverflowDescription": "Choose how to handle conversations approaching the context limit",
+      "contextOverflowAuto": "Auto-summarize",
+      "contextOverflowWarn": "Warn only",
+      "contextOverflowDisabled": "Disabled"
+    },
+    "folders": {
+      "folders": "Folders",
+      "newFolder": "New folder",
+      "folderName": "Folder name",
+      "rename": "Rename folder",
+      "addSubfolder": "Add subfolder",
+      "pin": "Pin folder",
+      "unpin": "Unpin folder",
+      "assignToFolder": "Move to folder",
+      "removeFromFolder": "Remove from folder",
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+    },
+    "presets": {
+      "modalTitle": "Slash Command Presets",
+      "newPreset": "New Preset",
+      "editPreset": "Edit Preset",
+      "fieldName": "Name",
+      "namePlaceholder": "my-preset",
+      "fieldDescription": "Description",
+      "descriptionPlaceholder": "What this preset does",
+      "fieldContent": "Content",
+      "contentPlaceholder": "Enter the prompt text...",
+      "cancel": "Cancel",
+      "create": "Create",
+      "update": "Update",
+      "delete": "Delete",
+      "listLabel": "Your presets",
+      "loading": "Loading presets...",
+      "empty": "No presets yet. Create one above.",
+      "editAriaLabel": "Edit preset {name}",
+      "deleteAriaLabel": "Delete preset {name}",
+      "deleteConfirmTitle": "Delete preset",
+      "deleteConfirmMessage": "Delete /{name}? This cannot be undone.",
+      "nameRequired": "Name is required",
+      "nameInvalid": "Only letters, numbers, hyphens, and underscores are allowed",
+      "contentRequired": "Content is required"
+    },
+    "lightweightMode": "Lightweight mode",
+    "lightweightModeTooltip": "lightweight Mode tooltip"
   },
   "serviceMessages": {
     "metadata": "Metadata",
@@ -5518,6 +5817,65 @@
       "confidenceLabel": "Confidence",
       "fixedInterval": "Fixed Interval",
       "toastProcessed": "Processed {count} frames successfully"
+    },
+    "visionAutomation": {
+      "title": "Vision Automation",
+      "subtitle": "Screen analysis, UI element detection, OCR, and automation opportunity discovery",
+      "serviceStatus": "Service",
+      "sessionContext": "Session Context (optional)",
+      "sessionIdPlaceholder": "Session ID for context",
+      "tabsAriaLabel": "Vision automation tabs",
+      "analyzing": "Analyzing...",
+      "detecting": "Detecting...",
+      "extracting": "Extracting...",
+      "scanning": "Scanning...",
+      "errorLabel": "Error",
+      "tabs": {
+        "analysis": "Screen Analysis",
+        "elements": "Element Detection",
+        "ocr": "OCR",
+        "opportunities": "Automation Opportunities"
+      },
+      "columns": {
+        "id": "ID",
+        "type": "Type",
+        "confidence": "Confidence",
+        "text": "Text",
+        "interactions": "Interactions",
+        "position": "Center"
+      },
+      "analysis": {
+        "cardTitle": "Capture & Analyze Screen",
+        "trigger": "Capture & Analyze",
+        "elementsFound": "Elements",
+        "textRegions": "Text Regions",
+        "confidence": "Confidence",
+        "automationOpps": "Opportunities",
+        "detectedElements": "Detected UI Elements",
+        "empty": "Press Capture and Analyze to analyze the current screen"
+      },
+      "elements": {
+        "cardTitle": "Detect UI Elements",
+        "trigger": "Detect Elements",
+        "typePlaceholder": "Filter by element type (e.g. button)",
+        "minConfidence": "Min Confidence",
+        "results": "{filtered} of {total} elements",
+        "empty": "No elements match the current filter"
+      },
+      "ocr": {
+        "cardTitle": "OCR Text Extraction",
+        "trigger": "Extract Text",
+        "regionsFound": "{count} text region(s) found",
+        "noRegions": "No text regions detected",
+        "empty": "Press Extract Text to run OCR on the current screen"
+      },
+      "opportunities": {
+        "cardTitle": "Automation Opportunities",
+        "trigger": "Scan for Opportunities",
+        "total": "Total Opportunities",
+        "empty": "No automation opportunities found",
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+      }
     }
   },
   "views": {
@@ -5686,7 +6044,9 @@
       "widgetTitle": "Title",
       "bar": "Bar",
       "create": "Create",
-      "area": "Area"
+      "area": "Area",
+      "saved": "Saved",
+      "dashboardSaved": "Dashboard saved"
     },
     "devSpeedup": {
       "after": "After",
@@ -5785,7 +6145,8 @@
       "goToChat": "Go to Chat",
       "analytics": "Analytics",
       "knowledgeBase": "Knowledge Base",
-      "goBack": "Go Back"
+      "goBack": "Go Back",
+      "goHome": "Go Home"
     },
     "plugins": {
       "requires": "Requires",
@@ -5835,7 +6196,9 @@
       "reload": "Reload",
       "version": "Version",
       "configuration": "Configuration",
-      "marketplace": "מרקטפלייס"
+      "marketplace": "מרקטפלייס",
+      "auditLog": "Audit log",
+      "trustTier": "Trust tier"
     },
     "vision": {
       "serviceOffline": "Service Offline",
@@ -5934,7 +6297,8 @@
       "noEndpointData": "No endpoint data available",
       "daysAnalyzed": "Days Analyzed",
       "vsYesterday": "vs yesterday",
-      "byEndpoint": "By Endpoint"
+      "byEndpoint": "By Endpoint",
+      "last14Days": "Last 14 days"
     },
     "modeSelector": {
       "modeDisabled": "Disabled",
@@ -6121,7 +6485,22 @@
     "backendOffline": "Backend offline — showing cached settings",
     "connection": {
       "title": "Connection",
-      "desc": "Configure backend connection settings"
+      "desc": "Configure backend connection settings",
+      "backendCheck": {
+        "title": "Backend reachability",
+        "description": "Run a one-shot ping to verify that the AutoBot backend is reachable from this browser. No periodic polling — manual only.",
+        "button": "Test backend connection",
+        "checking": "Checking…",
+        "reachable": "Reachable",
+        "unreachable": "Unreachable",
+        "latency": "Latency",
+        "lastTested": "Last tested",
+        "neverTested": "Not yet tested"
+      }
+    },
+    "presets": {
+      "title": "Slash Presets",
+      "description": "Create reusable slash commands that expand into full prompts in the chat input. Type / followed by the preset name to trigger them."
     }
   },
   "visualizations": {
@@ -6208,7 +6587,8 @@
       "minimum": "Minimum",
       "memoryUsage": "Memory Usage",
       "average": "Average",
-      "networkIo": "Network I/O"
+      "networkIo": "Network I/O",
+      "noData": "No metrics available yet"
     },
     "agentActivity": {
       "activeCount": "{count} active",
@@ -6224,7 +6604,8 @@
       "pauseBtn": "Pause",
       "liveActivityFeed": "Live Activity Feed",
       "defaultTitle": "Agent Activity Monitor",
-      "timelineView": "Timeline view"
+      "timelineView": "Timeline view",
+      "abstained": "Abstained"
     }
   },
   "audit": {
@@ -6508,6 +6889,22 @@
       "statTotal": "Total",
       "startingUrl": "Starting URL",
       "pause": "Pause"
+    },
+    "scrapeTemplates": {
+      "title": "Scrape Templates",
+      "refresh": "Refresh templates",
+      "emptyTitle": "No Saved Templates",
+      "emptyMessage": "Mark regions on a page and save a template to see it here.",
+      "run": "Re-run template",
+      "duplicate": "Duplicate template",
+      "delete": "Delete template",
+      "deleteConfirm": "Delete \"{name}\"? This cannot be undone.",
+      "targetUrl": "Target URL",
+      "runButton": "Run",
+      "running": "Running...",
+      "extractedResults": "Extracted results",
+      "noValue": "(not found)",
+      "noResults": "No regions extracted."
     }
   },
   "secrets": {
@@ -6666,7 +7063,8 @@
     "generic": "Something went wrong. Please try again.",
     "notFound": "Not found.",
     "unauthorized": "Unauthorized. Please log in.",
-    "serverError": "Server error. Please try again later."
+    "serverError": "Server error. Please try again later.",
+    "genericError": "Generic error"
   },
   "status": {
     "error": "Error",
@@ -7154,6 +7552,176 @@
       "expired": "פג תוקף",
       "refresh": "קבל קוד חדש",
       "retry": "נסה שוב"
+    }
+  },
+  "llmKeys": {
+    "title": "LLM API Keys",
+    "issueKey": "Issue Key",
+    "revoke": "Revoke",
+    "rotate": "Rotate",
+    "unlimited": "Unlimited",
+    "empty": "No API keys found.",
+    "rawKeyWarning": "Copy this key now — it will not be shown again.",
+    "col": {
+      "prefix": "Key Prefix",
+      "team": "Team",
+      "label": "Label",
+      "budget": "Monthly Budget",
+      "spend": "Spend (MTD)",
+      "models": "Allowed Models",
+      "status": "Status",
+      "expires": "Expires"
+    },
+    "status": {
+      "active": "Active",
+      "revoked": "Revoked"
+    },
+    "form": {
+      "teamId": "Team ID",
+      "label": "Label",
+      "budget": "Monthly Budget (USD)",
+      "budgetHint": "Set to 0 for unlimited.",
+      "models": "Allowed Models (JSON array)",
+      "modelsHint": "E.g. [\"gpt-4\", \"claude-*\"]. Leave blank to allow all.",
+      "expiresAt": "Expires At (optional)"
+    },
+    "revokeConfirm": {
+      "title": "Revoke API Key",
+      "body": "Are you sure you want to revoke key {id}? This cannot be undone."
+    }
+  },
+  "llc": {
+    "templates": {
+      "searchPlaceholder": "Search templates...",
+      "loading": "Loading templates...",
+      "noMatch": "No templates found matching your search",
+      "preview": "Preview template",
+      "select": "Select template",
+      "useTemplate": "Use this template"
+    },
+    "wizard": {
+      "step1": {
+        "title": "Choose a Starting Point",
+        "description": "Start with a template or build from scratch",
+        "startFromScratch": "Start from Scratch",
+        "startFromScratchDesc": "Build your company structure from the ground up",
+        "useTemplate": "Use a Template",
+        "useTemplateDesc": "Start with a pre-configured company template"
+      },
+      "step2": {
+        "title": "Configure Your Company",
+        "description": "Set up your company details and preferences",
+        "companyName": "Company Name",
+        "companyNamePlaceholder": "e.g., Acme Corporation",
+        "issuePrefix": "Issue Prefix",
+        "issuePrefixPlaceholder": "e.g., ACM",
+        "issuePrefixHint": "2-10 uppercase letters for issue identifiers (e.g., ACM-123)",
+        "mission": "Mission Statement",
+        "missionPlaceholder": "What is your company's mission?",
+        "monthlyBudget": "Monthly Budget",
+        "monthlyBudgetPlaceholder": "100",
+        "estimatedCost": "Estimated cost",
+        "brandColor": "Brand Color",
+        "brandColorPlaceholder": "#667eea",
+        "templateVariables": "Template Configuration"
+      },
+      "step3": {
+        "title": "Review & Create",
+        "description": "Review your configuration and create your company",
+        "companyDetails": "Company Details",
+        "template": "Template",
+        "agents": "Agents",
+        "goals": "Goals",
+        "workItems": "Work Items",
+        "kbCollections": "Knowledge Collections",
+        "createCompany": "Create Company"
+      }
+    }
+  },
+  "code": {
+    "cellPlaceholder": "Loading...",
+    "copied": "Copied",
+    "copy": "Copy",
+    "copyCodeAriaLabel": "copy Code (accessible)",
+    "copyFailed": "Copy failed"
+  },
+  "devices": {
+    "addDevice": "Add device",
+    "confirmDelete": "Confirm delete",
+    "daysAgo": "Days ago",
+    "error": "Error",
+    "hoursAgo": "Hours ago",
+    "justNow": "Just now",
+    "lastSeen": "Last seen",
+    "loading": "Loading",
+    "minutesAgo": "Minutes ago",
+    "noDevices": "No devices",
+    "pairDevice": "Pair device",
+    "pairFirst": "Pair first",
+    "pairNewDevice": "Pair new device",
+    "paired": "Paired",
+    "pairedDevices": "Paired devices",
+    "pairingInstructions": "Pairing instructions",
+    "pairingNote": "Pairing note",
+    "step1": "Step1",
+    "step2": "Step2",
+    "step3": "Step3",
+    "step4": "Step4",
+    "unpair": "Unpair"
+  },
+  "imageCell": {
+    "copyUrl": "Copy url",
+    "download": "Download",
+    "downloadLabel": "download",
+    "generated": "Generated",
+    "lightbox": "Lightbox",
+    "loadError": "Load error",
+    "placeholder": "Placeholder",
+    "viewFull": "View full"
+  },
+  "plugins": {
+    "capabilities": {
+      "approvalDescription": "Approval description",
+      "approvalTitle": "approval",
+      "approveAll": "Approve all",
+      "approveSelected": "Approve selected",
+      "approving": "Approving",
+      "auditLogTitle": "audit Log",
+      "capability": "Capability",
+      "denied": "Denied",
+      "filterByPlugin": "Filter by plugin",
+      "granted": "Granted",
+      "loading": "Loading",
+      "loadingAudit": "Loading audit",
+      "noAuditEntries": "No audit entries",
+      "noPending": "No pending",
+      "operation": "Operation",
+      "plugin": "Plugin",
+      "status": "Status",
+      "timestamp": "Timestamp"
+    }
+  },
+  "errorMonitoring": {
+    "title": "Error Monitoring",
+    "subtitle": "System-wide error statistics, recent errors, and component breakdown",
+    "lastUpdate": "Last updated",
+    "noMessage": "(no message)",
+    "cards": {
+      "totalErrors": "Total Errors"
+    },
+    "filters": {
+      "category": "Category",
+      "component": "Component",
+      "all": "All"
+    },
+    "sections": {
+      "recentErrors": "Recent Errors",
+      "categories": "Errors by Category",
+      "components": "Errors by Component"
+    },
+    "empty": {
+      "noErrors": "No errors recorded",
+      "noData": "No data available"
     }
   }
 }

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -82,7 +82,27 @@
     "hasMore": "Load more",
     "previous": "Previous",
     "optional": "pēc izvēles",
-    "remove": "Noņemt"
+    "remove": "Noņemt",
+    "dismiss": "Dismiss",
+    "forward": "Forward",
+    "saving": "Saving...",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "fitToView": "Fit to view",
+    "toggleLayout": "Toggle layout",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "copyToClipboard": "Copy to clipboard",
+    "sortAscending": "Sort ascending",
+    "sortDescending": "Sort descending",
+    "moreOptions": "More options",
+    "exportJson": "Export as JSON",
+    "exportCsv": "Export as CSV",
+    "download": "Download",
+    "filterByCategory": "Filter by category",
+    "copied": "Copied"
   },
   "chat": {
     "sendMessage": "Nosūtīt ziņu...",
@@ -112,6 +132,10 @@
         "overseer": "Pārraugs",
         "tool-code": "Kods",
         "tool-output": "Izvade"
+      },
+      "thinking": {
+        "badge": "🧠 Extended thinking ({count} tokens)",
+        "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
       }
     },
     "response": "atbildi",
@@ -252,7 +276,21 @@
       "sendingMessage": "Notiek ziņas sūtīšana...",
       "aiResponding": "AI reaģē...",
       "typeMessage": "Ierakstiet ziņojumu...",
-      "overseerLabel": "Overseer"
+      "overseerLabel": "Overseer",
+      "managePresets": "Manage slash command presets",
+      "generate": "Generate",
+      "generateImage": "Generate image",
+      "generateImageTitle": "generate Image",
+      "generating": "Generating",
+      "imagePromptLabel": "image Prompt",
+      "imagePromptPlaceholder": "Enter image prompt...",
+      "imageProvider": "Image provider",
+      "selectPromptTemplate": "Select prompt template",
+      "thinkingBudget": "Thinking budget",
+      "thinkingOff": "Thinking off",
+      "thinkingOffLabel": "thinking Off",
+      "thinkingOn": "Thinking on",
+      "thinkingOnLabel": "thinking On"
     },
     "translate": {
       "title": "Tulkot tekstu",
@@ -295,7 +333,8 @@
       "statusSending": "Notiek sūtīšana...",
       "statusSent": "Nosūtīts",
       "statusFailed": "Neizdevās nosūtīt",
-      "confirmDelete": "Vai dzēst šo ziņojumu? Šo darbību nevar atsaukt."
+      "confirmDelete": "Vai dzēst šo ziņojumu? Šo darbību nevar atsaukt.",
+      "thinkingUsed": "Thinking used"
     },
     "approval": {
       "autoApproved": "Automātiski apstiprināts",
@@ -481,7 +520,35 @@
       "selectAll": "Atlasiet visu",
       "deselectAll": "Noņemiet atlasi Visi",
       "share": "Dalīties",
-      "sharing": "Kopīgošana..."
+      "sharing": "Kopīgošana...",
+      "createAnother": "Create another",
+      "createLink": "Create link",
+      "creating": "Creating",
+      "emptyConversation": "Empty conversation",
+      "enterPassword": "Enter password",
+      "expiry": "Expiry",
+      "expiry1d": "Expiry1d",
+      "expiry1h": "Expiry1h",
+      "expiry30d": "Expiry30d",
+      "expiry7d": "Expiry7d",
+      "expiryNever": "Expiry never",
+      "linkExpired": "Link expired",
+      "linkExpires": "Link expires",
+      "linkNotFound": "Link not found",
+      "linkPasswordProtected": "Link password protected",
+      "linkReady": "Link ready",
+      "optionalPassword": "Optional password",
+      "passwordGate": "Password gate",
+      "passwordGateHint": "Password gate hint",
+      "passwordPlaceholder": "Enter password...",
+      "publicLink": "Public link",
+      "publicView": "Public view",
+      "readOnlyNote": "Read only note",
+      "revokeLink": "Revoke link",
+      "revoking": "Revoking",
+      "shareWithUsers": "Share with users",
+      "unlock": "Unlock",
+      "wrongPassword": "Wrong password"
     },
     "vision": {
       "title": "Attēlu analīze",
@@ -525,7 +592,8 @@
       "navigationFailed": "Navigācija neizdevās",
       "backFailed": "Navigācija atpakaļ neizdevās",
       "forwardFailed": "Navigācija uz priekšu neizdevās",
-      "reloadFailed": "Atkārtota ielāde neizdevās"
+      "reloadFailed": "Atkārtota ielāde neizdevās",
+      "go": "Navigate"
     },
     "voice": {
       "title": "Balss tērzēšana",
@@ -560,7 +628,10 @@
       "hintResponding": "AutoBot reaģē...",
       "hintRespondingShort": "Atbildot...",
       "hintAutoStart": "Klausīšanās sāksies automātiski",
-      "hintTapToSpeak": "Pieskarieties, lai runātu"
+      "hintTapToSpeak": "Pieskarieties, lai runātu",
+      "realtimeWebrtc": "Realtime WebRTC",
+      "realtimeConnecting": "Connecting to Realtime...",
+      "realtimeConnected": "Realtime — speak anytime"
     },
     "typing": {
       "aiAssistant": "AI palīgs",
@@ -585,7 +656,64 @@
       "streaming": "Streaming…",
       "done": "Done",
       "error": "Error"
-    }
+    },
+    "contextWindow": {
+      "ariaLabel": "{used} of {max} tokens used",
+      "tooltip": "{used} / {max} tokens used ({percent}% of context window)",
+      "warningToast": "Conversation approaching context limit ({percent}%). Older messages may be summarized.",
+      "compressedToast": "Context window optimized - older messages summarized",
+      "summaryTitle": "Context Summary",
+      "summaryToggle": "Show details",
+      "summarizing": "Summarizing..."
+    },
+    "openSettings": "Chat settings",
+    "settings": {
+      "title": "Chat Settings",
+      "contextOverflowLabel": "Context Overflow Protection",
+      "contextOverflowDescription": "Choose how to handle conversations approaching the context limit",
+      "contextOverflowAuto": "Auto-summarize",
+      "contextOverflowWarn": "Warn only",
+      "contextOverflowDisabled": "Disabled"
+    },
+    "folders": {
+      "folders": "Folders",
+      "newFolder": "New folder",
+      "folderName": "Folder name",
+      "rename": "Rename folder",
+      "addSubfolder": "Add subfolder",
+      "pin": "Pin folder",
+      "unpin": "Unpin folder",
+      "assignToFolder": "Move to folder",
+      "removeFromFolder": "Remove from folder",
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+    },
+    "presets": {
+      "modalTitle": "Slash Command Presets",
+      "newPreset": "New Preset",
+      "editPreset": "Edit Preset",
+      "fieldName": "Name",
+      "namePlaceholder": "my-preset",
+      "fieldDescription": "Description",
+      "descriptionPlaceholder": "What this preset does",
+      "fieldContent": "Content",
+      "contentPlaceholder": "Enter the prompt text...",
+      "cancel": "Cancel",
+      "create": "Create",
+      "update": "Update",
+      "delete": "Delete",
+      "listLabel": "Your presets",
+      "loading": "Loading presets...",
+      "empty": "No presets yet. Create one above.",
+      "editAriaLabel": "Edit preset {name}",
+      "deleteAriaLabel": "Delete preset {name}",
+      "deleteConfirmTitle": "Delete preset",
+      "deleteConfirmMessage": "Delete /{name}? This cannot be undone.",
+      "nameRequired": "Name is required",
+      "nameInvalid": "Only letters, numbers, hyphens, and underscores are allowed",
+      "contentRequired": "Content is required"
+    },
+    "lightweightMode": "Lightweight mode",
+    "lightweightModeTooltip": "lightweight Mode tooltip"
   },
   "settings": {
     "title": "Iestatījumi",
@@ -664,7 +792,22 @@
     },
     "connection": {
       "title": "Connection",
-      "desc": "Configure backend connection settings"
+      "desc": "Configure backend connection settings",
+      "backendCheck": {
+        "title": "Backend reachability",
+        "description": "Run a one-shot ping to verify that the AutoBot backend is reachable from this browser. No periodic polling — manual only.",
+        "button": "Test backend connection",
+        "checking": "Checking…",
+        "reachable": "Reachable",
+        "unreachable": "Unreachable",
+        "latency": "Latency",
+        "lastTested": "Last tested",
+        "neverTested": "Not yet tested"
+      }
+    },
+    "presets": {
+      "title": "Slash Presets",
+      "description": "Create reusable slash commands that expand into full prompts in the chat input. Type / followed by the preset name to trigger them."
     }
   },
   "voice": {
@@ -1247,7 +1390,13 @@
         "usage": "Lietojums",
         "usageAria": "Lietojums & Izmaksas",
         "operations": "Operācijas",
-        "operationsAria": "Ilgstošas operācijas"
+        "operationsAria": "Ilgstošas operācijas",
+        "devTools": "Dev Tools",
+        "devToolsAria": "Developer tools and utilities",
+        "errors": "Errors",
+        "errorsAria": "Error monitoring",
+        "diagnostics": "Diagnostics",
+        "diagnosticsAria": "Failure analysis and causal inference"
       }
     },
     "header": {
@@ -1615,7 +1764,8 @@
       "file": "File",
       "score": "Score",
       "topIssue": "Top Issue",
-      "close": "Close"
+      "close": "Close",
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",
@@ -2190,6 +2340,38 @@
         "scanning": "Scanning...",
         "scanFile": "Scan File"
       }
+    },
+    "failureAnalysis": {
+      "title": "Failure Analysis",
+      "subtitle": "Root-cause analysis powered by the causal inference engine",
+      "empty": "Enter a task ID above to run a failure analysis.",
+      "form": {
+        "title": "Analyze a Failure",
+        "taskId": "Task ID",
+        "taskIdPlaceholder": "e.g. task-abc123",
+        "errorDescription": "Error Description",
+        "errorDescriptionPlaceholder": "Optional: describe the error or paste a stack trace",
+        "analyze": "Analyze",
+        "analyzing": "Analyzing...",
+        "clear": "Clear"
+      },
+      "result": {
+        "taskId": "Task ID",
+        "confidence": "Confidence",
+        "status": "Status",
+        "duration": "Duration",
+        "rootCause": "Root Cause",
+        "causalChain": "Causal Chain",
+        "interventions": "Interventions",
+        "confounders": "Confounders",
+        "recommendations": "Recommendations",
+        "participants": "Participants",
+        "mechanism": "Mechanism",
+        "successRate": "Success Rate",
+        "cost": "Cost",
+        "risk": "Risk",
+        "confoundingStrength": "Confounding Strength"
+      }
     }
   },
   "knowledge": {
@@ -2241,7 +2423,14 @@
       "visShared": "Vis shared",
       "visSystem": "Vis system",
       "visibility": "Visibility",
-      "visibilityHint": "Visibility hint"
+      "visibilityHint": "Visibility hint",
+      "errorAddText": "Failed to add text to knowledge base",
+      "errorFileTooLarge": "File \"{name}\" exceeds the maximum size limit",
+      "errorImportUrl": "Failed to import URL content",
+      "errorUnsupportedFormat": "File \"{name}\" has an unsupported format",
+      "errorUploadFiles": "Failed to upload files",
+      "successTextAdded": "Text added to knowledge base successfully",
+      "successUrlImported": "URL content imported successfully"
     },
     "documents": "Dokumenti",
     "categories": {
@@ -2291,7 +2480,11 @@
       "maintenance": "Uzturēšana",
       "maintenanceAriaLabel": "Zināšanu bāzes uzturēšana",
       "analytics": "Analītika",
-      "statistics": "Statistika"
+      "statistics": "Statistika",
+      "webResearch": "Web Research",
+      "webResearchAriaLabel": "4-tab web research panel",
+      "openSidebar": "Open navigation menu",
+      "closeSidebar": "Close navigation menu"
     },
     "backup": {
       "title": "Dublēšana un atjaunošana",
@@ -2787,7 +2980,9 @@
         "sourcesCount": "{count} avoti"
       },
       "noEntities3D": "Nav entītiju, ko parādīt",
-      "loading3dVisualization": "Loading3d visualization"
+      "loading3dVisualization": "Loading3d visualization",
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "connectors": {
       "title": "Avotu savienotāji",
@@ -3159,7 +3354,8 @@
       "vectorFramework": "Vector framework",
       "vectorIndexHealth": "Vector index health",
       "vectorNotGenerated": "Vector not generated",
-      "vectorizedForRag": "Vectorized for rag"
+      "vectorizedForRag": "Vectorized for rag",
+      "confirmOptimize": "This will optimize the database. Continue?"
     },
     "summaries": {
       "search": {
@@ -3290,7 +3486,11 @@
       "decisionsApplied": "{count} decision(s) applied successfully",
       "compiledSuccess": "Chat compiled successfully",
       "failedToLoad": "Failed to load knowledge items",
-      "decisionsApplyFailed": "Failed to apply decisions"
+      "decisionsApplyFailed": "Failed to apply decisions",
+      "compileFailed": "Failed to compile conversation",
+      "suggestionAddToKb": "Suggested: Add to Knowledge Base",
+      "suggestionDelete": "Suggested: Delete",
+      "suggestionKeepTemporary": "Suggested: Keep Temporarily"
     },
     "systemKnowledge": {
       "vectorizeTooltip": "Ģenerēt vektoru iegulšanas visiem zināšanu bāzes ierakstiem, lai iespējotu semantisko meklēšanu",
@@ -3323,7 +3523,14 @@
       "success": "Success",
       "targetHost": "Target host",
       "totalFacts": "Total facts",
-      "vectorizing": "Vectorizing"
+      "vectorizing": "Vectorizing",
+      "confirmIndexDocs": "Do you want to force reindex existing documents?",
+      "confirmInitialize": "This will initialize system knowledge for the selected host. This may take several minutes. Continue?",
+      "confirmRefreshManPages": "This will refresh man pages for the selected host. Continue?",
+      "confirmReindex": "This will reindex all documents for the selected host. Continue?",
+      "confirmVectorize": "This will vectorize {totalFacts} facts. Currently {totalVectors} vectors exist, {needsVectorization} need vectorization. Continue?",
+      "vectorizeComplete": "Vectorize Facts (✓ {vectors} vectors from {facts} facts)",
+      "vectorizePending": "Vectorize Facts ({pending} pending)"
     },
     "vectorization": {
       "actionVectorize": "Vektorizēt",
@@ -3342,7 +3549,15 @@
       "noDocuments": "No documents",
       "progressTitle": "Progress title",
       "retryFailed": "Retry failed",
-      "total": "Total"
+      "total": "Total",
+      "statusFailed": "Failed",
+      "statusPending": "Pending",
+      "statusUnknown": "Unknown",
+      "statusVectorized": "Vectorized",
+      "tooltipFailed": "Vectorization failed for this document",
+      "tooltipPending": "Document is pending vectorization",
+      "tooltipUnknown": "Vectorization status unknown",
+      "tooltipVectorized": "Document has been vectorized and is searchable via RAG"
     },
     "batchSelection": {
       "selected": "Izvēlēti {count}",
@@ -3382,7 +3597,8 @@
       "shareWith": "Share with",
       "team": "Team",
       "user": "User",
-      "write": "Write"
+      "write": "Write",
+      "unsavedConfirm": "You have unsaved changes. Are you sure you want to close?"
     },
     "memoryOrphan": {
       "entitiesToClean": "Entities to clean",
@@ -3430,7 +3646,11 @@
       "rejectedToday": "Rejected today",
       "selectAll": "Select all",
       "title": "Title",
-      "untitled": "Untitled"
+      "untitled": "Untitled",
+      "typeConnector": "Connector",
+      "typeResearch": "Web Research",
+      "typeUpload": "Manual Upload",
+      "typeUrl": "URL Fetch"
     },
     "sessionOrphan": {
       "moreOrphans": "More orphans",
@@ -3499,7 +3719,15 @@
       "warnings": "Warnings"
     },
     "manager": {
-      "errorFallback": "Error fallback"
+      "errorFallback": "Error fallback",
+      "tabAdvanced": "Advanced",
+      "tabCategories": "Categories",
+      "tabManage": "Manage",
+      "tabPromptEditor": "Prompts",
+      "tabSearch": "Search",
+      "tabStatistics": "Statistics",
+      "tabSystemDocs": "System Docs",
+      "tabUpload": "Upload"
     },
     "promptEditor": {
       "allCategories": "All categories",
@@ -3605,7 +3833,138 @@
       "selectDocument": "Select document",
       "subtitle": "Subtitle",
       "title": "Title",
-      "words": "Words"
+      "words": "Words",
+      "errorCopy": "Failed to copy to clipboard",
+      "errorExport": "Failed to export document",
+      "errorExportAll": "Failed to export all documents",
+      "errorLoadCategories": "Failed to load documentation categories",
+      "errorLoadContent": "Failed to load document content",
+      "errorLoadDocs": "Failed to load documents"
+    },
+    "search": {
+      "aiSynthesis": "Ai synthesis",
+      "allCategories": "All categories",
+      "autoEnhanceQuery": "Auto enhance query",
+      "clear": "Clear",
+      "clearAccessLevelFilter": "Clear access level filter",
+      "clearCategoryFilter": "Clear category filter",
+      "confidence": "Confidence",
+      "enableReranking": "Enable reranking",
+      "enhancedQuery": "Enhanced query",
+      "fallbackNote": "Fallback note",
+      "filterByAccessLevel": "Filter by access level",
+      "filterByCategory": "Filter by category",
+      "filtering": "Filtering",
+      "indexHelpAfter": "Index help after",
+      "indexHelpBefore": "Index help before",
+      "indexHelpLink": "Index help link",
+      "needToIndex": "Need to index",
+      "noResults": "No results",
+      "noResultsHint": "No results hint",
+      "noResultsRagHint": "No results rag hint",
+      "ragDesc": "Rag desc",
+      "ragEnhanced": "Rag enhanced",
+      "ragPlaceholder": "Rag placeholder",
+      "ragUnavailable": "Rag unavailable",
+      "rerankingBadge": "Reranking badge",
+      "resultsLimit": "Results limit",
+      "retry": "Retry",
+      "searchBtn": "Search btn",
+      "searchPlaceholder": "Search placeholder",
+      "searching": "Searching",
+      "sourcesCount": "Sources count",
+      "subtitle": "Subtitle",
+      "title": "Title",
+      "traditionalDesc": "Traditional desc",
+      "traditionalSearch": "Traditional search",
+      "accessPlatform": "Platform",
+      "accessPublic": "Public",
+      "accessSystem": "System",
+      "accessUser": "User",
+      "clickToView": "Click to view full document",
+      "close": "Close",
+      "copyContent": "Copy Content",
+      "defaultDocTitle": "Untitled Document",
+      "foundResults": "Found {count} results for \"{query}\"",
+      "loadingDocument": "Loading document content...",
+      "matchScore": "{value}% match",
+      "noContent": "No content available",
+      "rerankScore": "{value}% rerank"
+    },
+    "webResearch": {
+      "title": "Web Research",
+      "subtitle": "Fetch, crawl, discover, and extract data from the web",
+      "navLabel": "Web Research",
+      "navAriaLabel": "Web research panel",
+      "settingsNavLabel": "Research Settings",
+      "settingsNavAriaLabel": "Web research settings",
+      "tabListAriaLabel": "Web research tabs",
+      "renderLabel": "Render Mode",
+      "renderAuto": "Auto",
+      "renderFast": "Fast (no JS)",
+      "renderPlaywright": "Full JS (Playwright)",
+      "ingestLabel": "Save to Knowledge Base",
+      "respectRobotsLabel": "Respect robots.txt",
+      "reset": "Clear",
+      "retry": "Retry",
+      "fetching": "Fetching…",
+      "crawling": "Crawling…",
+      "discovering": "Discovering…",
+      "extracting": "Extracting…",
+      "indexed": "Saved to KB",
+      "failed": "Failed",
+      "schemaValid": "Schema Valid",
+      "schemaInvalid": "Schema Invalid",
+      "filterPlaceholder": "Filter URLs…",
+      "filterLabel": "Filter URLs",
+      "noFilterResults": "No URLs match the current filter.",
+      "depthLabel": "Depth {depth}",
+      "errorGeneric": "An unexpected error occurred. Please try again.",
+      "tabs": {
+        "scrape": "Fetch Page",
+        "scrapeAriaLabel": "Fetch Page — extract text from a single URL",
+        "crawl": "Crawl Site",
+        "crawlAriaLabel": "Crawl Site — follow links and index multiple pages",
+        "siteMap": "Find Pages",
+        "siteMapAriaLabel": "Find Pages — discover all URLs on a domain",
+        "extract": "Get Data",
+        "extractAriaLabel": "Get Data — extract structured data using a schema"
+      },
+      "scrape": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "formatLabel": "Output Format",
+        "submitLabel": "Fetch Page",
+        "emptyState": "Enter a URL above and click Fetch Page to extract its text content."
+      },
+      "crawl": {
+        "seedLabel": "Seed URL",
+        "seedPlaceholder": "https://example.com",
+        "depthLabel": "Max Depth",
+        "maxPagesLabel": "Max Pages",
+        "sameOriginLabel": "Same origin only",
+        "submitLabel": "Crawl Site",
+        "emptyState": "Enter a starting URL and click Crawl Site to follow its links.",
+        "resultTitle": "{count} pages crawled",
+        "urlListLabel": "Crawled pages"
+      },
+      "siteMap": {
+        "domainLabel": "Domain",
+        "domainPlaceholder": "example.com",
+        "maxUrlsLabel": "Max URLs",
+        "submitLabel": "Find Pages",
+        "emptyState": "Enter a domain name and click Find Pages to discover its URLs.",
+        "resultTitle": "{count} URLs found on {domain}",
+        "urlListLabel": "Discovered URLs"
+      },
+      "extract": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "schemaLabel": "JSON Schema",
+        "submitLabel": "Get Data",
+        "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
+        "resultTitle": "Extracted Data"
+      }
     }
   },
   "workflow": {
@@ -3725,7 +4084,10 @@
       "screenAnalysisAriaLabel": "Screen Analysis - capture and analyze screen content",
       "sectionDescVideoProcessing": "Process and analyze video frames",
       "screenAnalysis": "Screen Analysis",
-      "vision": "VISION"
+      "vision": "VISION",
+      "historyAriaLabel": "Workflow execution history",
+      "visualizerAriaLabel": "Orchestration visualizer",
+      "agentsAriaLabel": "Agent capabilities"
     },
     "modal": {
       "executeStep": "Execute This Step",
@@ -3829,7 +4191,15 @@
       "visionWait": "Wait for Element",
       "visionClick": "Click Element",
       "vision": "Vision",
-      "visionFindElement": "Find Element"
+      "visionFindElement": "Find Element",
+      "addCase": "Add case",
+      "addSwitch": "Add switch",
+      "conditionCompare": "Condition compare",
+      "conditionExpr": "Condition expr",
+      "switch": "Switch",
+      "switchDefaultHint": "Switch default hint",
+      "switchLabel": "switch",
+      "switchOnPlaceholder": "Enter switch on..."
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -4057,6 +4427,12 @@
       "resetDefaults": "Reset to Defaults",
       "saving": "Saving...",
       "tabTitle": "Settings"
+    },
+    "nav": {
+      "label": "Agents navigation",
+      "registry": "Registry",
+      "activity": "Activity",
+      "heartbeat": "Heartbeat"
     }
   },
   "errors": {
@@ -4066,7 +4442,8 @@
     "notFound": "Nav atrasts.",
     "serverError": "Servera kļūda. Lūdzu, mēģiniet vēlāk.",
     "timeout": "Pieprasījuma noildze.",
-    "validation": "Lūdzu, pārbaudiet ievadītos datus."
+    "validation": "Lūdzu, pārbaudiet ievadītos datus.",
+    "genericError": "Generic error"
   },
   "status": {
     "online": "Tiešsaistē",
@@ -4348,7 +4725,8 @@
     "never": "Nekad",
     "themeLight": "Gaišs",
     "themeDark": "Tumšs",
-    "themeAuto": "Automātisks"
+    "themeAuto": "Automātisks",
+    "tabDevices": "Tab devices"
   },
   "redis": {
     "title": "Redis serviss",
@@ -4447,7 +4825,9 @@
         "showingOf": "Showing {showing} of {total} functions (scroll for more)",
         "noMatch": "No orphaned functions match your filter",
         "allConnected": "No orphaned functions detected - all functions are connected!"
-      }
+      },
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "importTree": {
       "title": "File Import Tree",
@@ -4557,7 +4937,12 @@
       "seriesName": "Problems",
       "xAxisTitle": "Number of Problems",
       "tooltipProblems": "problems"
-    }
+    },
+    "ariaLabel": "Accessible label",
+    "cellPlaceholder": "Loading...",
+    "defaultAriaLabel": "default (accessible)",
+    "renderError": "Render error",
+    "viewData": "View data"
   },
   "_meta": {
     "dir": "ltr",
@@ -5214,7 +5599,8 @@
       "aiAssistant": "AI Assistant",
       "knowledgeBase": "Knowledge Base",
       "automation": "Automation",
-      "analytics": "Analytics"
+      "analytics": "Analytics",
+      "goHome": "Go Home"
     },
     "secrets": {
       "noticeTitle": "Security Notice",
@@ -5436,7 +5822,9 @@
       "widgetAgents": "Agent Activity",
       "widgetAgentsDesc": "Real-time agent activity monitoring",
       "widgetArchitecture": "System Architecture",
-      "widgetArchitectureDesc": "Interactive system architecture diagram"
+      "widgetArchitectureDesc": "Interactive system architecture diagram",
+      "saved": "Saved",
+      "dashboardSaved": "Dashboard saved"
     },
     "devSpeedup": {
       "title": "Developer Speedup",
@@ -5534,7 +5922,9 @@
       "noConfig": "No configuration stored for this plugin.",
       "invalidJson": "Invalid JSON — please fix before saving.",
       "saveFailed": "Failed to save configuration.",
-      "marketplace": "Tirgus"
+      "marketplace": "Tirgus",
+      "auditLog": "Audit log",
+      "trustTier": "Trust tier"
     },
     "marketplace": {
       "title": "Plugin Marketplace",
@@ -5636,6 +6026,22 @@
       "createBrowserSession": "Izveidot pārlūka sesiju",
       "startingUrl": "Sākuma URL",
       "cancel": "Atcelt"
+    },
+    "scrapeTemplates": {
+      "title": "Scrape Templates",
+      "refresh": "Refresh templates",
+      "emptyTitle": "No Saved Templates",
+      "emptyMessage": "Mark regions on a page and save a template to see it here.",
+      "run": "Re-run template",
+      "duplicate": "Duplicate template",
+      "delete": "Delete template",
+      "deleteConfirm": "Delete \"{name}\"? This cannot be undone.",
+      "targetUrl": "Target URL",
+      "runButton": "Run",
+      "running": "Running...",
+      "extractedResults": "Extracted results",
+      "noValue": "(not found)",
+      "noResults": "No regions extracted."
     }
   },
   "collaboration": {
@@ -6276,6 +6682,65 @@
       "toastSavedToGallery": "Saved to gallery",
       "errorNoFrames": "No frames could be processed",
       "errorInvalidFile": "Please drop a valid video file"
+    },
+    "visionAutomation": {
+      "title": "Vision Automation",
+      "subtitle": "Screen analysis, UI element detection, OCR, and automation opportunity discovery",
+      "serviceStatus": "Service",
+      "sessionContext": "Session Context (optional)",
+      "sessionIdPlaceholder": "Session ID for context",
+      "tabsAriaLabel": "Vision automation tabs",
+      "analyzing": "Analyzing...",
+      "detecting": "Detecting...",
+      "extracting": "Extracting...",
+      "scanning": "Scanning...",
+      "errorLabel": "Error",
+      "tabs": {
+        "analysis": "Screen Analysis",
+        "elements": "Element Detection",
+        "ocr": "OCR",
+        "opportunities": "Automation Opportunities"
+      },
+      "columns": {
+        "id": "ID",
+        "type": "Type",
+        "confidence": "Confidence",
+        "text": "Text",
+        "interactions": "Interactions",
+        "position": "Center"
+      },
+      "analysis": {
+        "cardTitle": "Capture & Analyze Screen",
+        "trigger": "Capture & Analyze",
+        "elementsFound": "Elements",
+        "textRegions": "Text Regions",
+        "confidence": "Confidence",
+        "automationOpps": "Opportunities",
+        "detectedElements": "Detected UI Elements",
+        "empty": "Press Capture and Analyze to analyze the current screen"
+      },
+      "elements": {
+        "cardTitle": "Detect UI Elements",
+        "trigger": "Detect Elements",
+        "typePlaceholder": "Filter by element type (e.g. button)",
+        "minConfidence": "Min Confidence",
+        "results": "{filtered} of {total} elements",
+        "empty": "No elements match the current filter"
+      },
+      "ocr": {
+        "cardTitle": "OCR Text Extraction",
+        "trigger": "Extract Text",
+        "regionsFound": "{count} text region(s) found",
+        "noRegions": "No text regions detected",
+        "empty": "Press Extract Text to run OCR on the current screen"
+      },
+      "opportunities": {
+        "cardTitle": "Automation Opportunities",
+        "trigger": "Scan for Opportunities",
+        "total": "Total Opportunities",
+        "empty": "No automation opportunities found",
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+      }
     }
   },
   "visualizations": {
@@ -6293,7 +6758,8 @@
       "recentTasks": "Recent Tasks",
       "detailsBtn": "Details",
       "pauseBtn": "Pause",
-      "liveActivityFeed": "Live Activity Feed"
+      "liveActivityFeed": "Live Activity Feed",
+      "abstained": "Abstained"
     },
     "resourceHeatmap": {
       "defaultTitle": "Resource Utilization Heatmap",
@@ -6317,7 +6783,8 @@
       "rangeMedium": "Medium",
       "rangeHigh": "High",
       "rangeCritical": "Critical",
-      "usage": "Usage"
+      "usage": "Usage",
+      "noData": "No metrics available yet"
     },
     "systemArchitecture": {
       "defaultTitle": "System Architecture",
@@ -6616,7 +7083,8 @@
       "noEndpointData": "No endpoint data available",
       "noUserData": "No user data available",
       "noTrendData": "No trend data available",
-      "noRecentViolations": "No recent violations"
+      "noRecentViolations": "No recent violations",
+      "last14Days": "Last 14 days"
     },
     "enforcement": {
       "title": "Endpoint Overrides",
@@ -6953,7 +7421,10 @@
       "launchDesc": "This will open a live browser that you can control directly",
       "initializingSession": "Initializing browser session...",
       "sessionId": "Session ID: {id}",
-      "notAvailable": "Not available"
+      "notAvailable": "Not available",
+      "templates": "Scrape Templates",
+      "exitRegionMode": "Exit region mode",
+      "markRegions": "Mark regions"
     }
   },
   "serviceMessages": {
@@ -7018,7 +7489,28 @@
     "llcPortability": "Portability",
     "settingsAndTools": "Settings & Tools",
     "adminPanel": "Admin Panel",
-    "documents": "AI Documents"
+    "documents": "AI Documents",
+    "canvas": "Canvas",
+    "visionAutomation": "Vision",
+    "llmApiKeys": "LLM API Keys",
+    "llmProviders": "LLM Providers",
+    "adminHosts": "Host Inventory",
+    "adminSandbox": "Sandbox",
+    "budgetPolicies": "Budget Policies",
+    "companyOs": "Company OS",
+    "llcDashboard": "Dashboard",
+    "llcOrgChart": "Org Chart",
+    "llcGoals": "Goals",
+    "llcCompanies": "Companies",
+    "llcBacklog": "Backlog",
+    "llcApprovals": "Approvals",
+    "llcCosts": "Costs & Budget",
+    "llcHeartbeat": "Heartbeat",
+    "llcCeoChat": "CEO Chat",
+    "llcSelectCompany": "Switch Company",
+    "llcSelectCompanyPrompt": "Select a company to open its dashboard, backlog, and tools.",
+    "llcNoCompanies": "No companies yet.",
+    "llcCreateCompany": "Create a company"
   },
   "reasoningTrace": {
     "title": "Reasoning trace",
@@ -7060,6 +7552,176 @@
       "expired": "Beidzies",
       "refresh": "Saņemt jauno kodu",
       "retry": "Mēģiniet vēlreiz"
+    }
+  },
+  "llmKeys": {
+    "title": "LLM API Keys",
+    "issueKey": "Issue Key",
+    "revoke": "Revoke",
+    "rotate": "Rotate",
+    "unlimited": "Unlimited",
+    "empty": "No API keys found.",
+    "rawKeyWarning": "Copy this key now — it will not be shown again.",
+    "col": {
+      "prefix": "Key Prefix",
+      "team": "Team",
+      "label": "Label",
+      "budget": "Monthly Budget",
+      "spend": "Spend (MTD)",
+      "models": "Allowed Models",
+      "status": "Status",
+      "expires": "Expires"
+    },
+    "status": {
+      "active": "Active",
+      "revoked": "Revoked"
+    },
+    "form": {
+      "teamId": "Team ID",
+      "label": "Label",
+      "budget": "Monthly Budget (USD)",
+      "budgetHint": "Set to 0 for unlimited.",
+      "models": "Allowed Models (JSON array)",
+      "modelsHint": "E.g. [\"gpt-4\", \"claude-*\"]. Leave blank to allow all.",
+      "expiresAt": "Expires At (optional)"
+    },
+    "revokeConfirm": {
+      "title": "Revoke API Key",
+      "body": "Are you sure you want to revoke key {id}? This cannot be undone."
+    }
+  },
+  "llc": {
+    "templates": {
+      "searchPlaceholder": "Search templates...",
+      "loading": "Loading templates...",
+      "noMatch": "No templates found matching your search",
+      "preview": "Preview template",
+      "select": "Select template",
+      "useTemplate": "Use this template"
+    },
+    "wizard": {
+      "step1": {
+        "title": "Choose a Starting Point",
+        "description": "Start with a template or build from scratch",
+        "startFromScratch": "Start from Scratch",
+        "startFromScratchDesc": "Build your company structure from the ground up",
+        "useTemplate": "Use a Template",
+        "useTemplateDesc": "Start with a pre-configured company template"
+      },
+      "step2": {
+        "title": "Configure Your Company",
+        "description": "Set up your company details and preferences",
+        "companyName": "Company Name",
+        "companyNamePlaceholder": "e.g., Acme Corporation",
+        "issuePrefix": "Issue Prefix",
+        "issuePrefixPlaceholder": "e.g., ACM",
+        "issuePrefixHint": "2-10 uppercase letters for issue identifiers (e.g., ACM-123)",
+        "mission": "Mission Statement",
+        "missionPlaceholder": "What is your company's mission?",
+        "monthlyBudget": "Monthly Budget",
+        "monthlyBudgetPlaceholder": "100",
+        "estimatedCost": "Estimated cost",
+        "brandColor": "Brand Color",
+        "brandColorPlaceholder": "#667eea",
+        "templateVariables": "Template Configuration"
+      },
+      "step3": {
+        "title": "Review & Create",
+        "description": "Review your configuration and create your company",
+        "companyDetails": "Company Details",
+        "template": "Template",
+        "agents": "Agents",
+        "goals": "Goals",
+        "workItems": "Work Items",
+        "kbCollections": "Knowledge Collections",
+        "createCompany": "Create Company"
+      }
+    }
+  },
+  "code": {
+    "cellPlaceholder": "Loading...",
+    "copied": "Copied",
+    "copy": "Copy",
+    "copyCodeAriaLabel": "copy Code (accessible)",
+    "copyFailed": "Copy failed"
+  },
+  "devices": {
+    "addDevice": "Add device",
+    "confirmDelete": "Confirm delete",
+    "daysAgo": "Days ago",
+    "error": "Error",
+    "hoursAgo": "Hours ago",
+    "justNow": "Just now",
+    "lastSeen": "Last seen",
+    "loading": "Loading",
+    "minutesAgo": "Minutes ago",
+    "noDevices": "No devices",
+    "pairDevice": "Pair device",
+    "pairFirst": "Pair first",
+    "pairNewDevice": "Pair new device",
+    "paired": "Paired",
+    "pairedDevices": "Paired devices",
+    "pairingInstructions": "Pairing instructions",
+    "pairingNote": "Pairing note",
+    "step1": "Step1",
+    "step2": "Step2",
+    "step3": "Step3",
+    "step4": "Step4",
+    "unpair": "Unpair"
+  },
+  "imageCell": {
+    "copyUrl": "Copy url",
+    "download": "Download",
+    "downloadLabel": "download",
+    "generated": "Generated",
+    "lightbox": "Lightbox",
+    "loadError": "Load error",
+    "placeholder": "Placeholder",
+    "viewFull": "View full"
+  },
+  "plugins": {
+    "capabilities": {
+      "approvalDescription": "Approval description",
+      "approvalTitle": "approval",
+      "approveAll": "Approve all",
+      "approveSelected": "Approve selected",
+      "approving": "Approving",
+      "auditLogTitle": "audit Log",
+      "capability": "Capability",
+      "denied": "Denied",
+      "filterByPlugin": "Filter by plugin",
+      "granted": "Granted",
+      "loading": "Loading",
+      "loadingAudit": "Loading audit",
+      "noAuditEntries": "No audit entries",
+      "noPending": "No pending",
+      "operation": "Operation",
+      "plugin": "Plugin",
+      "status": "Status",
+      "timestamp": "Timestamp"
+    }
+  },
+  "errorMonitoring": {
+    "title": "Error Monitoring",
+    "subtitle": "System-wide error statistics, recent errors, and component breakdown",
+    "lastUpdate": "Last updated",
+    "noMessage": "(no message)",
+    "cards": {
+      "totalErrors": "Total Errors"
+    },
+    "filters": {
+      "category": "Category",
+      "component": "Component",
+      "all": "All"
+    },
+    "sections": {
+      "recentErrors": "Recent Errors",
+      "categories": "Errors by Category",
+      "components": "Errors by Component"
+    },
+    "empty": {
+      "noErrors": "No errors recorded",
+      "noData": "No data available"
     }
   }
 }

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -82,7 +82,27 @@
     "hasMore": "Load more",
     "previous": "Previous",
     "optional": "opcjonalne",
-    "remove": "Usuń"
+    "remove": "Usuń",
+    "dismiss": "Dismiss",
+    "forward": "Forward",
+    "saving": "Saving...",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "fitToView": "Fit to view",
+    "toggleLayout": "Toggle layout",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "copyToClipboard": "Copy to clipboard",
+    "sortAscending": "Sort ascending",
+    "sortDescending": "Sort descending",
+    "moreOptions": "More options",
+    "exportJson": "Export as JSON",
+    "exportCsv": "Export as CSV",
+    "download": "Download",
+    "filterByCategory": "Filter by category",
+    "copied": "Copied"
   },
   "chat": {
     "sendMessage": "Wyślij wiadomość...",
@@ -112,6 +132,10 @@
         "overseer": "Nadzorca",
         "tool-code": "Kod",
         "tool-output": "Wyjście"
+      },
+      "thinking": {
+        "badge": "🧠 Extended thinking ({count} tokens)",
+        "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
       }
     },
     "response": "odpowiedź",
@@ -252,7 +276,21 @@
       "sendingMessage": "Wysyłam wiadomość...",
       "aiResponding": "AI reaguje...",
       "typeMessage": "Wpisz wiadomość...",
-      "overseerLabel": "Overseer"
+      "overseerLabel": "Overseer",
+      "managePresets": "Manage slash command presets",
+      "generate": "Generate",
+      "generateImage": "Generate image",
+      "generateImageTitle": "generate Image",
+      "generating": "Generating",
+      "imagePromptLabel": "image Prompt",
+      "imagePromptPlaceholder": "Enter image prompt...",
+      "imageProvider": "Image provider",
+      "selectPromptTemplate": "Select prompt template",
+      "thinkingBudget": "Thinking budget",
+      "thinkingOff": "Thinking off",
+      "thinkingOffLabel": "thinking Off",
+      "thinkingOn": "Thinking on",
+      "thinkingOnLabel": "thinking On"
     },
     "translate": {
       "title": "Przetłumacz tekst",
@@ -295,7 +333,8 @@
       "statusSending": "Przesyłka...",
       "statusSent": "Wysłano",
       "statusFailed": "Nie udało się wysłać",
-      "confirmDelete": "Usunąć tę wiadomość? Tej akcji nie można cofnąć."
+      "confirmDelete": "Usunąć tę wiadomość? Tej akcji nie można cofnąć.",
+      "thinkingUsed": "Thinking used"
     },
     "approval": {
       "autoApproved": "Zatwierdzone automatycznie",
@@ -481,7 +520,35 @@
       "selectAll": "Wybierz wszystko",
       "deselectAll": "Odznacz wszystko",
       "share": "Udział",
-      "sharing": "Partycypujący..."
+      "sharing": "Partycypujący...",
+      "createAnother": "Create another",
+      "createLink": "Create link",
+      "creating": "Creating",
+      "emptyConversation": "Empty conversation",
+      "enterPassword": "Enter password",
+      "expiry": "Expiry",
+      "expiry1d": "Expiry1d",
+      "expiry1h": "Expiry1h",
+      "expiry30d": "Expiry30d",
+      "expiry7d": "Expiry7d",
+      "expiryNever": "Expiry never",
+      "linkExpired": "Link expired",
+      "linkExpires": "Link expires",
+      "linkNotFound": "Link not found",
+      "linkPasswordProtected": "Link password protected",
+      "linkReady": "Link ready",
+      "optionalPassword": "Optional password",
+      "passwordGate": "Password gate",
+      "passwordGateHint": "Password gate hint",
+      "passwordPlaceholder": "Enter password...",
+      "publicLink": "Public link",
+      "publicView": "Public view",
+      "readOnlyNote": "Read only note",
+      "revokeLink": "Revoke link",
+      "revoking": "Revoking",
+      "shareWithUsers": "Share with users",
+      "unlock": "Unlock",
+      "wrongPassword": "Wrong password"
     },
     "vision": {
       "title": "Analiza obrazu",
@@ -525,7 +592,8 @@
       "navigationFailed": "Nawigacja nie powiodła się",
       "backFailed": "Nawigacja wsteczna nie powiodła się",
       "forwardFailed": "Nawigacja do przodu nie powiodła się",
-      "reloadFailed": "Ponowne załadowanie nie powiodło się"
+      "reloadFailed": "Ponowne załadowanie nie powiodło się",
+      "go": "Navigate"
     },
     "voice": {
       "title": "Czat głosowy",
@@ -560,7 +628,10 @@
       "hintResponding": "AutoBot odpowiada...",
       "hintRespondingShort": "Odpowiadanie...",
       "hintAutoStart": "Słuchanie rozpocznie się automatycznie",
-      "hintTapToSpeak": "Kliknij, aby mówić"
+      "hintTapToSpeak": "Kliknij, aby mówić",
+      "realtimeWebrtc": "Realtime WebRTC",
+      "realtimeConnecting": "Connecting to Realtime...",
+      "realtimeConnected": "Realtime — speak anytime"
     },
     "typing": {
       "aiAssistant": "Asystent AI",
@@ -585,7 +656,64 @@
       "streaming": "Streaming…",
       "done": "Done",
       "error": "Error"
-    }
+    },
+    "contextWindow": {
+      "ariaLabel": "{used} of {max} tokens used",
+      "tooltip": "{used} / {max} tokens used ({percent}% of context window)",
+      "warningToast": "Conversation approaching context limit ({percent}%). Older messages may be summarized.",
+      "compressedToast": "Context window optimized - older messages summarized",
+      "summaryTitle": "Context Summary",
+      "summaryToggle": "Show details",
+      "summarizing": "Summarizing..."
+    },
+    "openSettings": "Chat settings",
+    "settings": {
+      "title": "Chat Settings",
+      "contextOverflowLabel": "Context Overflow Protection",
+      "contextOverflowDescription": "Choose how to handle conversations approaching the context limit",
+      "contextOverflowAuto": "Auto-summarize",
+      "contextOverflowWarn": "Warn only",
+      "contextOverflowDisabled": "Disabled"
+    },
+    "folders": {
+      "folders": "Folders",
+      "newFolder": "New folder",
+      "folderName": "Folder name",
+      "rename": "Rename folder",
+      "addSubfolder": "Add subfolder",
+      "pin": "Pin folder",
+      "unpin": "Unpin folder",
+      "assignToFolder": "Move to folder",
+      "removeFromFolder": "Remove from folder",
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+    },
+    "presets": {
+      "modalTitle": "Slash Command Presets",
+      "newPreset": "New Preset",
+      "editPreset": "Edit Preset",
+      "fieldName": "Name",
+      "namePlaceholder": "my-preset",
+      "fieldDescription": "Description",
+      "descriptionPlaceholder": "What this preset does",
+      "fieldContent": "Content",
+      "contentPlaceholder": "Enter the prompt text...",
+      "cancel": "Cancel",
+      "create": "Create",
+      "update": "Update",
+      "delete": "Delete",
+      "listLabel": "Your presets",
+      "loading": "Loading presets...",
+      "empty": "No presets yet. Create one above.",
+      "editAriaLabel": "Edit preset {name}",
+      "deleteAriaLabel": "Delete preset {name}",
+      "deleteConfirmTitle": "Delete preset",
+      "deleteConfirmMessage": "Delete /{name}? This cannot be undone.",
+      "nameRequired": "Name is required",
+      "nameInvalid": "Only letters, numbers, hyphens, and underscores are allowed",
+      "contentRequired": "Content is required"
+    },
+    "lightweightMode": "Lightweight mode",
+    "lightweightModeTooltip": "lightweight Mode tooltip"
   },
   "settings": {
     "title": "Ustawienia",
@@ -664,7 +792,22 @@
     },
     "connection": {
       "title": "Connection",
-      "desc": "Configure backend connection settings"
+      "desc": "Configure backend connection settings",
+      "backendCheck": {
+        "title": "Backend reachability",
+        "description": "Run a one-shot ping to verify that the AutoBot backend is reachable from this browser. No periodic polling — manual only.",
+        "button": "Test backend connection",
+        "checking": "Checking…",
+        "reachable": "Reachable",
+        "unreachable": "Unreachable",
+        "latency": "Latency",
+        "lastTested": "Last tested",
+        "neverTested": "Not yet tested"
+      }
+    },
+    "presets": {
+      "title": "Slash Presets",
+      "description": "Create reusable slash commands that expand into full prompts in the chat input. Type / followed by the preset name to trigger them."
     }
   },
   "voice": {
@@ -1247,7 +1390,13 @@
         "usage": "Użycie",
         "usageAria": "Użycie i Koszty",
         "operations": "Operacje",
-        "operationsAria": "Operacje długotrwałe"
+        "operationsAria": "Operacje długotrwałe",
+        "devTools": "Dev Tools",
+        "devToolsAria": "Developer tools and utilities",
+        "errors": "Errors",
+        "errorsAria": "Error monitoring",
+        "diagnostics": "Diagnostics",
+        "diagnosticsAria": "Failure analysis and causal inference"
       }
     },
     "header": {
@@ -1615,7 +1764,8 @@
       "file": "File",
       "score": "Score",
       "topIssue": "Top Issue",
-      "close": "Close"
+      "close": "Close",
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",
@@ -2190,6 +2340,38 @@
         "scanning": "Scanning...",
         "scanFile": "Scan File"
       }
+    },
+    "failureAnalysis": {
+      "title": "Failure Analysis",
+      "subtitle": "Root-cause analysis powered by the causal inference engine",
+      "empty": "Enter a task ID above to run a failure analysis.",
+      "form": {
+        "title": "Analyze a Failure",
+        "taskId": "Task ID",
+        "taskIdPlaceholder": "e.g. task-abc123",
+        "errorDescription": "Error Description",
+        "errorDescriptionPlaceholder": "Optional: describe the error or paste a stack trace",
+        "analyze": "Analyze",
+        "analyzing": "Analyzing...",
+        "clear": "Clear"
+      },
+      "result": {
+        "taskId": "Task ID",
+        "confidence": "Confidence",
+        "status": "Status",
+        "duration": "Duration",
+        "rootCause": "Root Cause",
+        "causalChain": "Causal Chain",
+        "interventions": "Interventions",
+        "confounders": "Confounders",
+        "recommendations": "Recommendations",
+        "participants": "Participants",
+        "mechanism": "Mechanism",
+        "successRate": "Success Rate",
+        "cost": "Cost",
+        "risk": "Risk",
+        "confoundingStrength": "Confounding Strength"
+      }
     }
   },
   "knowledge": {
@@ -2241,7 +2423,14 @@
       "visShared": "Vis shared",
       "visSystem": "Vis system",
       "visibility": "Visibility",
-      "visibilityHint": "Visibility hint"
+      "visibilityHint": "Visibility hint",
+      "errorAddText": "Failed to add text to knowledge base",
+      "errorFileTooLarge": "File \"{name}\" exceeds the maximum size limit",
+      "errorImportUrl": "Failed to import URL content",
+      "errorUnsupportedFormat": "File \"{name}\" has an unsupported format",
+      "errorUploadFiles": "Failed to upload files",
+      "successTextAdded": "Text added to knowledge base successfully",
+      "successUrlImported": "URL content imported successfully"
     },
     "documents": "Dokumenty",
     "categories": {
@@ -2291,7 +2480,11 @@
       "maintenance": "Konserwacja",
       "maintenanceAriaLabel": "Konserwacja bazy wiedzy",
       "analytics": "Analityka",
-      "statistics": "Statystyki"
+      "statistics": "Statystyki",
+      "webResearch": "Web Research",
+      "webResearchAriaLabel": "4-tab web research panel",
+      "openSidebar": "Open navigation menu",
+      "closeSidebar": "Close navigation menu"
     },
     "backup": {
       "title": "Kopia zapasowa i przywracanie",
@@ -2787,7 +2980,9 @@
         "sourcesCount": "{count} źródeł"
       },
       "noEntities3D": "Brak encji do wyświetlenia",
-      "loading3dVisualization": "Loading3d visualization"
+      "loading3dVisualization": "Loading3d visualization",
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "connectors": {
       "title": "Konektory źródeł",
@@ -3159,7 +3354,8 @@
       "vectorFramework": "Vector framework",
       "vectorIndexHealth": "Vector index health",
       "vectorNotGenerated": "Vector not generated",
-      "vectorizedForRag": "Vectorized for rag"
+      "vectorizedForRag": "Vectorized for rag",
+      "confirmOptimize": "This will optimize the database. Continue?"
     },
     "summaries": {
       "search": {
@@ -3290,7 +3486,11 @@
       "decisionsApplied": "{count} decision(s) applied successfully",
       "compiledSuccess": "Chat compiled successfully",
       "failedToLoad": "Failed to load knowledge items",
-      "decisionsApplyFailed": "Failed to apply decisions"
+      "decisionsApplyFailed": "Failed to apply decisions",
+      "compileFailed": "Failed to compile conversation",
+      "suggestionAddToKb": "Suggested: Add to Knowledge Base",
+      "suggestionDelete": "Suggested: Delete",
+      "suggestionKeepTemporary": "Suggested: Keep Temporarily"
     },
     "systemKnowledge": {
       "vectorizeTooltip": "Generuj osadzenia wektorowe dla wszystkich wpisów bazy wiedzy, aby umożliwić wyszukiwanie semantyczne",
@@ -3323,7 +3523,14 @@
       "success": "Success",
       "targetHost": "Target host",
       "totalFacts": "Total facts",
-      "vectorizing": "Vectorizing"
+      "vectorizing": "Vectorizing",
+      "confirmIndexDocs": "Do you want to force reindex existing documents?",
+      "confirmInitialize": "This will initialize system knowledge for the selected host. This may take several minutes. Continue?",
+      "confirmRefreshManPages": "This will refresh man pages for the selected host. Continue?",
+      "confirmReindex": "This will reindex all documents for the selected host. Continue?",
+      "confirmVectorize": "This will vectorize {totalFacts} facts. Currently {totalVectors} vectors exist, {needsVectorization} need vectorization. Continue?",
+      "vectorizeComplete": "Vectorize Facts (✓ {vectors} vectors from {facts} facts)",
+      "vectorizePending": "Vectorize Facts ({pending} pending)"
     },
     "vectorization": {
       "actionVectorize": "Wektoryzuj",
@@ -3342,7 +3549,15 @@
       "noDocuments": "No documents",
       "progressTitle": "Progress title",
       "retryFailed": "Retry failed",
-      "total": "Total"
+      "total": "Total",
+      "statusFailed": "Failed",
+      "statusPending": "Pending",
+      "statusUnknown": "Unknown",
+      "statusVectorized": "Vectorized",
+      "tooltipFailed": "Vectorization failed for this document",
+      "tooltipPending": "Document is pending vectorization",
+      "tooltipUnknown": "Vectorization status unknown",
+      "tooltipVectorized": "Document has been vectorized and is searchable via RAG"
     },
     "batchSelection": {
       "selected": "Wybrano {count}",
@@ -3382,7 +3597,8 @@
       "shareWith": "Share with",
       "team": "Team",
       "user": "User",
-      "write": "Write"
+      "write": "Write",
+      "unsavedConfirm": "You have unsaved changes. Are you sure you want to close?"
     },
     "memoryOrphan": {
       "entitiesToClean": "Entities to clean",
@@ -3430,7 +3646,11 @@
       "rejectedToday": "Rejected today",
       "selectAll": "Select all",
       "title": "Title",
-      "untitled": "Untitled"
+      "untitled": "Untitled",
+      "typeConnector": "Connector",
+      "typeResearch": "Web Research",
+      "typeUpload": "Manual Upload",
+      "typeUrl": "URL Fetch"
     },
     "sessionOrphan": {
       "moreOrphans": "More orphans",
@@ -3499,7 +3719,15 @@
       "warnings": "Warnings"
     },
     "manager": {
-      "errorFallback": "Error fallback"
+      "errorFallback": "Error fallback",
+      "tabAdvanced": "Advanced",
+      "tabCategories": "Categories",
+      "tabManage": "Manage",
+      "tabPromptEditor": "Prompts",
+      "tabSearch": "Search",
+      "tabStatistics": "Statistics",
+      "tabSystemDocs": "System Docs",
+      "tabUpload": "Upload"
     },
     "promptEditor": {
       "allCategories": "All categories",
@@ -3605,7 +3833,138 @@
       "selectDocument": "Select document",
       "subtitle": "Subtitle",
       "title": "Title",
-      "words": "Words"
+      "words": "Words",
+      "errorCopy": "Failed to copy to clipboard",
+      "errorExport": "Failed to export document",
+      "errorExportAll": "Failed to export all documents",
+      "errorLoadCategories": "Failed to load documentation categories",
+      "errorLoadContent": "Failed to load document content",
+      "errorLoadDocs": "Failed to load documents"
+    },
+    "search": {
+      "aiSynthesis": "Ai synthesis",
+      "allCategories": "All categories",
+      "autoEnhanceQuery": "Auto enhance query",
+      "clear": "Clear",
+      "clearAccessLevelFilter": "Clear access level filter",
+      "clearCategoryFilter": "Clear category filter",
+      "confidence": "Confidence",
+      "enableReranking": "Enable reranking",
+      "enhancedQuery": "Enhanced query",
+      "fallbackNote": "Fallback note",
+      "filterByAccessLevel": "Filter by access level",
+      "filterByCategory": "Filter by category",
+      "filtering": "Filtering",
+      "indexHelpAfter": "Index help after",
+      "indexHelpBefore": "Index help before",
+      "indexHelpLink": "Index help link",
+      "needToIndex": "Need to index",
+      "noResults": "No results",
+      "noResultsHint": "No results hint",
+      "noResultsRagHint": "No results rag hint",
+      "ragDesc": "Rag desc",
+      "ragEnhanced": "Rag enhanced",
+      "ragPlaceholder": "Rag placeholder",
+      "ragUnavailable": "Rag unavailable",
+      "rerankingBadge": "Reranking badge",
+      "resultsLimit": "Results limit",
+      "retry": "Retry",
+      "searchBtn": "Search btn",
+      "searchPlaceholder": "Search placeholder",
+      "searching": "Searching",
+      "sourcesCount": "Sources count",
+      "subtitle": "Subtitle",
+      "title": "Title",
+      "traditionalDesc": "Traditional desc",
+      "traditionalSearch": "Traditional search",
+      "accessPlatform": "Platform",
+      "accessPublic": "Public",
+      "accessSystem": "System",
+      "accessUser": "User",
+      "clickToView": "Click to view full document",
+      "close": "Close",
+      "copyContent": "Copy Content",
+      "defaultDocTitle": "Untitled Document",
+      "foundResults": "Found {count} results for \"{query}\"",
+      "loadingDocument": "Loading document content...",
+      "matchScore": "{value}% match",
+      "noContent": "No content available",
+      "rerankScore": "{value}% rerank"
+    },
+    "webResearch": {
+      "title": "Web Research",
+      "subtitle": "Fetch, crawl, discover, and extract data from the web",
+      "navLabel": "Web Research",
+      "navAriaLabel": "Web research panel",
+      "settingsNavLabel": "Research Settings",
+      "settingsNavAriaLabel": "Web research settings",
+      "tabListAriaLabel": "Web research tabs",
+      "renderLabel": "Render Mode",
+      "renderAuto": "Auto",
+      "renderFast": "Fast (no JS)",
+      "renderPlaywright": "Full JS (Playwright)",
+      "ingestLabel": "Save to Knowledge Base",
+      "respectRobotsLabel": "Respect robots.txt",
+      "reset": "Clear",
+      "retry": "Retry",
+      "fetching": "Fetching…",
+      "crawling": "Crawling…",
+      "discovering": "Discovering…",
+      "extracting": "Extracting…",
+      "indexed": "Saved to KB",
+      "failed": "Failed",
+      "schemaValid": "Schema Valid",
+      "schemaInvalid": "Schema Invalid",
+      "filterPlaceholder": "Filter URLs…",
+      "filterLabel": "Filter URLs",
+      "noFilterResults": "No URLs match the current filter.",
+      "depthLabel": "Depth {depth}",
+      "errorGeneric": "An unexpected error occurred. Please try again.",
+      "tabs": {
+        "scrape": "Fetch Page",
+        "scrapeAriaLabel": "Fetch Page — extract text from a single URL",
+        "crawl": "Crawl Site",
+        "crawlAriaLabel": "Crawl Site — follow links and index multiple pages",
+        "siteMap": "Find Pages",
+        "siteMapAriaLabel": "Find Pages — discover all URLs on a domain",
+        "extract": "Get Data",
+        "extractAriaLabel": "Get Data — extract structured data using a schema"
+      },
+      "scrape": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "formatLabel": "Output Format",
+        "submitLabel": "Fetch Page",
+        "emptyState": "Enter a URL above and click Fetch Page to extract its text content."
+      },
+      "crawl": {
+        "seedLabel": "Seed URL",
+        "seedPlaceholder": "https://example.com",
+        "depthLabel": "Max Depth",
+        "maxPagesLabel": "Max Pages",
+        "sameOriginLabel": "Same origin only",
+        "submitLabel": "Crawl Site",
+        "emptyState": "Enter a starting URL and click Crawl Site to follow its links.",
+        "resultTitle": "{count} pages crawled",
+        "urlListLabel": "Crawled pages"
+      },
+      "siteMap": {
+        "domainLabel": "Domain",
+        "domainPlaceholder": "example.com",
+        "maxUrlsLabel": "Max URLs",
+        "submitLabel": "Find Pages",
+        "emptyState": "Enter a domain name and click Find Pages to discover its URLs.",
+        "resultTitle": "{count} URLs found on {domain}",
+        "urlListLabel": "Discovered URLs"
+      },
+      "extract": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "schemaLabel": "JSON Schema",
+        "submitLabel": "Get Data",
+        "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
+        "resultTitle": "Extracted Data"
+      }
     }
   },
   "workflow": {
@@ -3725,7 +4084,10 @@
       "screenAnalysisAriaLabel": "Screen Analysis - capture and analyze screen content",
       "sectionDescVideoProcessing": "Process and analyze video frames",
       "screenAnalysis": "Screen Analysis",
-      "vision": "VISION"
+      "vision": "VISION",
+      "historyAriaLabel": "Workflow execution history",
+      "visualizerAriaLabel": "Orchestration visualizer",
+      "agentsAriaLabel": "Agent capabilities"
     },
     "modal": {
       "executeStep": "Execute This Step",
@@ -3829,7 +4191,15 @@
       "visionWait": "Wait for Element",
       "visionClick": "Click Element",
       "vision": "Vision",
-      "visionFindElement": "Find Element"
+      "visionFindElement": "Find Element",
+      "addCase": "Add case",
+      "addSwitch": "Add switch",
+      "conditionCompare": "Condition compare",
+      "conditionExpr": "Condition expr",
+      "switch": "Switch",
+      "switchDefaultHint": "Switch default hint",
+      "switchLabel": "switch",
+      "switchOnPlaceholder": "Enter switch on..."
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -4057,6 +4427,12 @@
       "resetDefaults": "Reset to Defaults",
       "saving": "Saving...",
       "tabTitle": "Settings"
+    },
+    "nav": {
+      "label": "Agents navigation",
+      "registry": "Registry",
+      "activity": "Activity",
+      "heartbeat": "Heartbeat"
     }
   },
   "errors": {
@@ -4066,7 +4442,8 @@
     "notFound": "Nie znaleziono.",
     "serverError": "Błąd serwera. Spróbuj ponownie później.",
     "timeout": "Przekroczono limit czasu żądania.",
-    "validation": "Sprawdź wprowadzone dane."
+    "validation": "Sprawdź wprowadzone dane.",
+    "genericError": "Generic error"
   },
   "status": {
     "online": "Online",
@@ -4348,7 +4725,8 @@
     "never": "Nigdy",
     "themeLight": "Jasny",
     "themeDark": "Ciemny",
-    "themeAuto": "Automatyczny"
+    "themeAuto": "Automatyczny",
+    "tabDevices": "Tab devices"
   },
   "redis": {
     "title": "Usługa Redis",
@@ -4447,7 +4825,9 @@
         "showingOf": "Showing {showing} of {total} functions (scroll for more)",
         "noMatch": "No orphaned functions match your filter",
         "allConnected": "No orphaned functions detected - all functions are connected!"
-      }
+      },
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "importTree": {
       "title": "File Import Tree",
@@ -4557,7 +4937,12 @@
       "seriesName": "Problems",
       "xAxisTitle": "Number of Problems",
       "tooltipProblems": "problems"
-    }
+    },
+    "ariaLabel": "Accessible label",
+    "cellPlaceholder": "Loading...",
+    "defaultAriaLabel": "default (accessible)",
+    "renderError": "Render error",
+    "viewData": "View data"
   },
   "_meta": {
     "dir": "ltr",
@@ -5214,7 +5599,8 @@
       "aiAssistant": "AI Assistant",
       "knowledgeBase": "Knowledge Base",
       "automation": "Automation",
-      "analytics": "Analytics"
+      "analytics": "Analytics",
+      "goHome": "Go Home"
     },
     "secrets": {
       "noticeTitle": "Security Notice",
@@ -5436,7 +5822,9 @@
       "widgetAgents": "Agent Activity",
       "widgetAgentsDesc": "Real-time agent activity monitoring",
       "widgetArchitecture": "System Architecture",
-      "widgetArchitectureDesc": "Interactive system architecture diagram"
+      "widgetArchitectureDesc": "Interactive system architecture diagram",
+      "saved": "Saved",
+      "dashboardSaved": "Dashboard saved"
     },
     "devSpeedup": {
       "title": "Developer Speedup",
@@ -5534,7 +5922,9 @@
       "noConfig": "No configuration stored for this plugin.",
       "invalidJson": "Invalid JSON — please fix before saving.",
       "saveFailed": "Failed to save configuration.",
-      "marketplace": "Marketplace"
+      "marketplace": "Marketplace",
+      "auditLog": "Audit log",
+      "trustTier": "Trust tier"
     },
     "marketplace": {
       "title": "Plugin Marketplace",
@@ -5636,6 +6026,22 @@
       "createBrowserSession": "Utwórz sesję przeglądarki",
       "startingUrl": "Początkowy URL",
       "cancel": "Anuluj"
+    },
+    "scrapeTemplates": {
+      "title": "Scrape Templates",
+      "refresh": "Refresh templates",
+      "emptyTitle": "No Saved Templates",
+      "emptyMessage": "Mark regions on a page and save a template to see it here.",
+      "run": "Re-run template",
+      "duplicate": "Duplicate template",
+      "delete": "Delete template",
+      "deleteConfirm": "Delete \"{name}\"? This cannot be undone.",
+      "targetUrl": "Target URL",
+      "runButton": "Run",
+      "running": "Running...",
+      "extractedResults": "Extracted results",
+      "noValue": "(not found)",
+      "noResults": "No regions extracted."
     }
   },
   "collaboration": {
@@ -6276,6 +6682,65 @@
       "toastSavedToGallery": "Saved to gallery",
       "errorNoFrames": "No frames could be processed",
       "errorInvalidFile": "Please drop a valid video file"
+    },
+    "visionAutomation": {
+      "title": "Vision Automation",
+      "subtitle": "Screen analysis, UI element detection, OCR, and automation opportunity discovery",
+      "serviceStatus": "Service",
+      "sessionContext": "Session Context (optional)",
+      "sessionIdPlaceholder": "Session ID for context",
+      "tabsAriaLabel": "Vision automation tabs",
+      "analyzing": "Analyzing...",
+      "detecting": "Detecting...",
+      "extracting": "Extracting...",
+      "scanning": "Scanning...",
+      "errorLabel": "Error",
+      "tabs": {
+        "analysis": "Screen Analysis",
+        "elements": "Element Detection",
+        "ocr": "OCR",
+        "opportunities": "Automation Opportunities"
+      },
+      "columns": {
+        "id": "ID",
+        "type": "Type",
+        "confidence": "Confidence",
+        "text": "Text",
+        "interactions": "Interactions",
+        "position": "Center"
+      },
+      "analysis": {
+        "cardTitle": "Capture & Analyze Screen",
+        "trigger": "Capture & Analyze",
+        "elementsFound": "Elements",
+        "textRegions": "Text Regions",
+        "confidence": "Confidence",
+        "automationOpps": "Opportunities",
+        "detectedElements": "Detected UI Elements",
+        "empty": "Press Capture and Analyze to analyze the current screen"
+      },
+      "elements": {
+        "cardTitle": "Detect UI Elements",
+        "trigger": "Detect Elements",
+        "typePlaceholder": "Filter by element type (e.g. button)",
+        "minConfidence": "Min Confidence",
+        "results": "{filtered} of {total} elements",
+        "empty": "No elements match the current filter"
+      },
+      "ocr": {
+        "cardTitle": "OCR Text Extraction",
+        "trigger": "Extract Text",
+        "regionsFound": "{count} text region(s) found",
+        "noRegions": "No text regions detected",
+        "empty": "Press Extract Text to run OCR on the current screen"
+      },
+      "opportunities": {
+        "cardTitle": "Automation Opportunities",
+        "trigger": "Scan for Opportunities",
+        "total": "Total Opportunities",
+        "empty": "No automation opportunities found",
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+      }
     }
   },
   "visualizations": {
@@ -6293,7 +6758,8 @@
       "recentTasks": "Recent Tasks",
       "detailsBtn": "Details",
       "pauseBtn": "Pause",
-      "liveActivityFeed": "Live Activity Feed"
+      "liveActivityFeed": "Live Activity Feed",
+      "abstained": "Abstained"
     },
     "resourceHeatmap": {
       "defaultTitle": "Resource Utilization Heatmap",
@@ -6317,7 +6783,8 @@
       "rangeMedium": "Medium",
       "rangeHigh": "High",
       "rangeCritical": "Critical",
-      "usage": "Usage"
+      "usage": "Usage",
+      "noData": "No metrics available yet"
     },
     "systemArchitecture": {
       "defaultTitle": "System Architecture",
@@ -6616,7 +7083,8 @@
       "noEndpointData": "No endpoint data available",
       "noUserData": "No user data available",
       "noTrendData": "No trend data available",
-      "noRecentViolations": "No recent violations"
+      "noRecentViolations": "No recent violations",
+      "last14Days": "Last 14 days"
     },
     "enforcement": {
       "title": "Endpoint Overrides",
@@ -6953,7 +7421,10 @@
       "launchDesc": "This will open a live browser that you can control directly",
       "initializingSession": "Initializing browser session...",
       "sessionId": "Session ID: {id}",
-      "notAvailable": "Not available"
+      "notAvailable": "Not available",
+      "templates": "Scrape Templates",
+      "exitRegionMode": "Exit region mode",
+      "markRegions": "Mark regions"
     }
   },
   "serviceMessages": {
@@ -7018,7 +7489,28 @@
     "llcPortability": "Portability",
     "settingsAndTools": "Settings & Tools",
     "adminPanel": "Admin Panel",
-    "documents": "AI Documents"
+    "documents": "AI Documents",
+    "canvas": "Canvas",
+    "visionAutomation": "Vision",
+    "llmApiKeys": "LLM API Keys",
+    "llmProviders": "LLM Providers",
+    "adminHosts": "Host Inventory",
+    "adminSandbox": "Sandbox",
+    "budgetPolicies": "Budget Policies",
+    "companyOs": "Company OS",
+    "llcDashboard": "Dashboard",
+    "llcOrgChart": "Org Chart",
+    "llcGoals": "Goals",
+    "llcCompanies": "Companies",
+    "llcBacklog": "Backlog",
+    "llcApprovals": "Approvals",
+    "llcCosts": "Costs & Budget",
+    "llcHeartbeat": "Heartbeat",
+    "llcCeoChat": "CEO Chat",
+    "llcSelectCompany": "Switch Company",
+    "llcSelectCompanyPrompt": "Select a company to open its dashboard, backlog, and tools.",
+    "llcNoCompanies": "No companies yet.",
+    "llcCreateCompany": "Create a company"
   },
   "reasoningTrace": {
     "title": "Slad rozumowania",
@@ -7060,6 +7552,176 @@
       "expired": "Wygasło",
       "refresh": "Uzyskaj nowy kod",
       "retry": "Spróbuj ponownie"
+    }
+  },
+  "llmKeys": {
+    "title": "LLM API Keys",
+    "issueKey": "Issue Key",
+    "revoke": "Revoke",
+    "rotate": "Rotate",
+    "unlimited": "Unlimited",
+    "empty": "No API keys found.",
+    "rawKeyWarning": "Copy this key now — it will not be shown again.",
+    "col": {
+      "prefix": "Key Prefix",
+      "team": "Team",
+      "label": "Label",
+      "budget": "Monthly Budget",
+      "spend": "Spend (MTD)",
+      "models": "Allowed Models",
+      "status": "Status",
+      "expires": "Expires"
+    },
+    "status": {
+      "active": "Active",
+      "revoked": "Revoked"
+    },
+    "form": {
+      "teamId": "Team ID",
+      "label": "Label",
+      "budget": "Monthly Budget (USD)",
+      "budgetHint": "Set to 0 for unlimited.",
+      "models": "Allowed Models (JSON array)",
+      "modelsHint": "E.g. [\"gpt-4\", \"claude-*\"]. Leave blank to allow all.",
+      "expiresAt": "Expires At (optional)"
+    },
+    "revokeConfirm": {
+      "title": "Revoke API Key",
+      "body": "Are you sure you want to revoke key {id}? This cannot be undone."
+    }
+  },
+  "llc": {
+    "templates": {
+      "searchPlaceholder": "Search templates...",
+      "loading": "Loading templates...",
+      "noMatch": "No templates found matching your search",
+      "preview": "Preview template",
+      "select": "Select template",
+      "useTemplate": "Use this template"
+    },
+    "wizard": {
+      "step1": {
+        "title": "Choose a Starting Point",
+        "description": "Start with a template or build from scratch",
+        "startFromScratch": "Start from Scratch",
+        "startFromScratchDesc": "Build your company structure from the ground up",
+        "useTemplate": "Use a Template",
+        "useTemplateDesc": "Start with a pre-configured company template"
+      },
+      "step2": {
+        "title": "Configure Your Company",
+        "description": "Set up your company details and preferences",
+        "companyName": "Company Name",
+        "companyNamePlaceholder": "e.g., Acme Corporation",
+        "issuePrefix": "Issue Prefix",
+        "issuePrefixPlaceholder": "e.g., ACM",
+        "issuePrefixHint": "2-10 uppercase letters for issue identifiers (e.g., ACM-123)",
+        "mission": "Mission Statement",
+        "missionPlaceholder": "What is your company's mission?",
+        "monthlyBudget": "Monthly Budget",
+        "monthlyBudgetPlaceholder": "100",
+        "estimatedCost": "Estimated cost",
+        "brandColor": "Brand Color",
+        "brandColorPlaceholder": "#667eea",
+        "templateVariables": "Template Configuration"
+      },
+      "step3": {
+        "title": "Review & Create",
+        "description": "Review your configuration and create your company",
+        "companyDetails": "Company Details",
+        "template": "Template",
+        "agents": "Agents",
+        "goals": "Goals",
+        "workItems": "Work Items",
+        "kbCollections": "Knowledge Collections",
+        "createCompany": "Create Company"
+      }
+    }
+  },
+  "code": {
+    "cellPlaceholder": "Loading...",
+    "copied": "Copied",
+    "copy": "Copy",
+    "copyCodeAriaLabel": "copy Code (accessible)",
+    "copyFailed": "Copy failed"
+  },
+  "devices": {
+    "addDevice": "Add device",
+    "confirmDelete": "Confirm delete",
+    "daysAgo": "Days ago",
+    "error": "Error",
+    "hoursAgo": "Hours ago",
+    "justNow": "Just now",
+    "lastSeen": "Last seen",
+    "loading": "Loading",
+    "minutesAgo": "Minutes ago",
+    "noDevices": "No devices",
+    "pairDevice": "Pair device",
+    "pairFirst": "Pair first",
+    "pairNewDevice": "Pair new device",
+    "paired": "Paired",
+    "pairedDevices": "Paired devices",
+    "pairingInstructions": "Pairing instructions",
+    "pairingNote": "Pairing note",
+    "step1": "Step1",
+    "step2": "Step2",
+    "step3": "Step3",
+    "step4": "Step4",
+    "unpair": "Unpair"
+  },
+  "imageCell": {
+    "copyUrl": "Copy url",
+    "download": "Download",
+    "downloadLabel": "download",
+    "generated": "Generated",
+    "lightbox": "Lightbox",
+    "loadError": "Load error",
+    "placeholder": "Placeholder",
+    "viewFull": "View full"
+  },
+  "plugins": {
+    "capabilities": {
+      "approvalDescription": "Approval description",
+      "approvalTitle": "approval",
+      "approveAll": "Approve all",
+      "approveSelected": "Approve selected",
+      "approving": "Approving",
+      "auditLogTitle": "audit Log",
+      "capability": "Capability",
+      "denied": "Denied",
+      "filterByPlugin": "Filter by plugin",
+      "granted": "Granted",
+      "loading": "Loading",
+      "loadingAudit": "Loading audit",
+      "noAuditEntries": "No audit entries",
+      "noPending": "No pending",
+      "operation": "Operation",
+      "plugin": "Plugin",
+      "status": "Status",
+      "timestamp": "Timestamp"
+    }
+  },
+  "errorMonitoring": {
+    "title": "Error Monitoring",
+    "subtitle": "System-wide error statistics, recent errors, and component breakdown",
+    "lastUpdate": "Last updated",
+    "noMessage": "(no message)",
+    "cards": {
+      "totalErrors": "Total Errors"
+    },
+    "filters": {
+      "category": "Category",
+      "component": "Component",
+      "all": "All"
+    },
+    "sections": {
+      "recentErrors": "Recent Errors",
+      "categories": "Errors by Category",
+      "components": "Errors by Component"
+    },
+    "empty": {
+      "noErrors": "No errors recorded",
+      "noData": "No data available"
     }
   }
 }

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -82,7 +82,27 @@
     "hasMore": "Load more",
     "previous": "Previous",
     "optional": "opcional",
-    "remove": "Remover"
+    "remove": "Remover",
+    "dismiss": "Dismiss",
+    "forward": "Forward",
+    "saving": "Saving...",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "fitToView": "Fit to view",
+    "toggleLayout": "Toggle layout",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "copyToClipboard": "Copy to clipboard",
+    "sortAscending": "Sort ascending",
+    "sortDescending": "Sort descending",
+    "moreOptions": "More options",
+    "exportJson": "Export as JSON",
+    "exportCsv": "Export as CSV",
+    "download": "Download",
+    "filterByCategory": "Filter by category",
+    "copied": "Copied"
   },
   "chat": {
     "sendMessage": "Envie uma mensagem...",
@@ -112,6 +132,10 @@
         "overseer": "Supervisor",
         "tool-code": "Código",
         "tool-output": "Saída"
+      },
+      "thinking": {
+        "badge": "🧠 Extended thinking ({count} tokens)",
+        "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
       }
     },
     "response": "resposta",
@@ -252,7 +276,21 @@
       "sendingMessage": "Enviando mensagem...",
       "aiResponding": "A IA está respondendo...",
       "typeMessage": "Digite uma mensagem...",
-      "overseerLabel": "Overseer"
+      "overseerLabel": "Overseer",
+      "managePresets": "Manage slash command presets",
+      "generate": "Generate",
+      "generateImage": "Generate image",
+      "generateImageTitle": "generate Image",
+      "generating": "Generating",
+      "imagePromptLabel": "image Prompt",
+      "imagePromptPlaceholder": "Enter image prompt...",
+      "imageProvider": "Image provider",
+      "selectPromptTemplate": "Select prompt template",
+      "thinkingBudget": "Thinking budget",
+      "thinkingOff": "Thinking off",
+      "thinkingOffLabel": "thinking Off",
+      "thinkingOn": "Thinking on",
+      "thinkingOnLabel": "thinking On"
     },
     "translate": {
       "title": "Traduzir texto",
@@ -295,7 +333,8 @@
       "statusSending": "Enviando...",
       "statusSent": "Enviado",
       "statusFailed": "Falha ao enviar",
-      "confirmDelete": "Excluir esta mensagem? Esta ação não pode ser desfeita."
+      "confirmDelete": "Excluir esta mensagem? Esta ação não pode ser desfeita.",
+      "thinkingUsed": "Thinking used"
     },
     "approval": {
       "autoApproved": "Aprovado automaticamente",
@@ -481,7 +520,35 @@
       "selectAll": "Selecionar tudo",
       "deselectAll": "Desmarcar tudo",
       "share": "Compartilhar",
-      "sharing": "Compartilhamento..."
+      "sharing": "Compartilhamento...",
+      "createAnother": "Create another",
+      "createLink": "Create link",
+      "creating": "Creating",
+      "emptyConversation": "Empty conversation",
+      "enterPassword": "Enter password",
+      "expiry": "Expiry",
+      "expiry1d": "Expiry1d",
+      "expiry1h": "Expiry1h",
+      "expiry30d": "Expiry30d",
+      "expiry7d": "Expiry7d",
+      "expiryNever": "Expiry never",
+      "linkExpired": "Link expired",
+      "linkExpires": "Link expires",
+      "linkNotFound": "Link not found",
+      "linkPasswordProtected": "Link password protected",
+      "linkReady": "Link ready",
+      "optionalPassword": "Optional password",
+      "passwordGate": "Password gate",
+      "passwordGateHint": "Password gate hint",
+      "passwordPlaceholder": "Enter password...",
+      "publicLink": "Public link",
+      "publicView": "Public view",
+      "readOnlyNote": "Read only note",
+      "revokeLink": "Revoke link",
+      "revoking": "Revoking",
+      "shareWithUsers": "Share with users",
+      "unlock": "Unlock",
+      "wrongPassword": "Wrong password"
     },
     "vision": {
       "title": "Análise de imagem",
@@ -525,7 +592,8 @@
       "navigationFailed": "Falha na navegação",
       "backFailed": "Falha na navegação de volta",
       "forwardFailed": "Falha na navegação para frente",
-      "reloadFailed": "Falha ao recarregar"
+      "reloadFailed": "Falha ao recarregar",
+      "go": "Navigate"
     },
     "voice": {
       "title": "Bate-papo por voz",
@@ -560,7 +628,10 @@
       "hintResponding": "O AutoBot está respondendo...",
       "hintRespondingShort": "Respondendo...",
       "hintAutoStart": "A escuta começará automaticamente",
-      "hintTapToSpeak": "Toque para falar"
+      "hintTapToSpeak": "Toque para falar",
+      "realtimeWebrtc": "Realtime WebRTC",
+      "realtimeConnecting": "Connecting to Realtime...",
+      "realtimeConnected": "Realtime — speak anytime"
     },
     "typing": {
       "aiAssistant": "Assistente de IA",
@@ -585,7 +656,64 @@
       "streaming": "Streaming…",
       "done": "Done",
       "error": "Error"
-    }
+    },
+    "contextWindow": {
+      "ariaLabel": "{used} of {max} tokens used",
+      "tooltip": "{used} / {max} tokens used ({percent}% of context window)",
+      "warningToast": "Conversation approaching context limit ({percent}%). Older messages may be summarized.",
+      "compressedToast": "Context window optimized - older messages summarized",
+      "summaryTitle": "Context Summary",
+      "summaryToggle": "Show details",
+      "summarizing": "Summarizing..."
+    },
+    "openSettings": "Chat settings",
+    "settings": {
+      "title": "Chat Settings",
+      "contextOverflowLabel": "Context Overflow Protection",
+      "contextOverflowDescription": "Choose how to handle conversations approaching the context limit",
+      "contextOverflowAuto": "Auto-summarize",
+      "contextOverflowWarn": "Warn only",
+      "contextOverflowDisabled": "Disabled"
+    },
+    "folders": {
+      "folders": "Folders",
+      "newFolder": "New folder",
+      "folderName": "Folder name",
+      "rename": "Rename folder",
+      "addSubfolder": "Add subfolder",
+      "pin": "Pin folder",
+      "unpin": "Unpin folder",
+      "assignToFolder": "Move to folder",
+      "removeFromFolder": "Remove from folder",
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+    },
+    "presets": {
+      "modalTitle": "Slash Command Presets",
+      "newPreset": "New Preset",
+      "editPreset": "Edit Preset",
+      "fieldName": "Name",
+      "namePlaceholder": "my-preset",
+      "fieldDescription": "Description",
+      "descriptionPlaceholder": "What this preset does",
+      "fieldContent": "Content",
+      "contentPlaceholder": "Enter the prompt text...",
+      "cancel": "Cancel",
+      "create": "Create",
+      "update": "Update",
+      "delete": "Delete",
+      "listLabel": "Your presets",
+      "loading": "Loading presets...",
+      "empty": "No presets yet. Create one above.",
+      "editAriaLabel": "Edit preset {name}",
+      "deleteAriaLabel": "Delete preset {name}",
+      "deleteConfirmTitle": "Delete preset",
+      "deleteConfirmMessage": "Delete /{name}? This cannot be undone.",
+      "nameRequired": "Name is required",
+      "nameInvalid": "Only letters, numbers, hyphens, and underscores are allowed",
+      "contentRequired": "Content is required"
+    },
+    "lightweightMode": "Lightweight mode",
+    "lightweightModeTooltip": "lightweight Mode tooltip"
   },
   "settings": {
     "title": "Configurações",
@@ -664,7 +792,22 @@
     },
     "connection": {
       "title": "Connection",
-      "desc": "Configure backend connection settings"
+      "desc": "Configure backend connection settings",
+      "backendCheck": {
+        "title": "Backend reachability",
+        "description": "Run a one-shot ping to verify that the AutoBot backend is reachable from this browser. No periodic polling — manual only.",
+        "button": "Test backend connection",
+        "checking": "Checking…",
+        "reachable": "Reachable",
+        "unreachable": "Unreachable",
+        "latency": "Latency",
+        "lastTested": "Last tested",
+        "neverTested": "Not yet tested"
+      }
+    },
+    "presets": {
+      "title": "Slash Presets",
+      "description": "Create reusable slash commands that expand into full prompts in the chat input. Type / followed by the preset name to trigger them."
     }
   },
   "voice": {
@@ -1247,7 +1390,13 @@
         "usage": "Uso",
         "usageAria": "Uso & Custos",
         "operations": "Operações",
-        "operationsAria": "Operações de longa duração"
+        "operationsAria": "Operações de longa duração",
+        "devTools": "Dev Tools",
+        "devToolsAria": "Developer tools and utilities",
+        "errors": "Errors",
+        "errorsAria": "Error monitoring",
+        "diagnostics": "Diagnostics",
+        "diagnosticsAria": "Failure analysis and causal inference"
       }
     },
     "header": {
@@ -1615,7 +1764,8 @@
       "file": "File",
       "score": "Score",
       "topIssue": "Top Issue",
-      "close": "Close"
+      "close": "Close",
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",
@@ -2190,6 +2340,38 @@
         "scanning": "Scanning...",
         "scanFile": "Scan File"
       }
+    },
+    "failureAnalysis": {
+      "title": "Failure Analysis",
+      "subtitle": "Root-cause analysis powered by the causal inference engine",
+      "empty": "Enter a task ID above to run a failure analysis.",
+      "form": {
+        "title": "Analyze a Failure",
+        "taskId": "Task ID",
+        "taskIdPlaceholder": "e.g. task-abc123",
+        "errorDescription": "Error Description",
+        "errorDescriptionPlaceholder": "Optional: describe the error or paste a stack trace",
+        "analyze": "Analyze",
+        "analyzing": "Analyzing...",
+        "clear": "Clear"
+      },
+      "result": {
+        "taskId": "Task ID",
+        "confidence": "Confidence",
+        "status": "Status",
+        "duration": "Duration",
+        "rootCause": "Root Cause",
+        "causalChain": "Causal Chain",
+        "interventions": "Interventions",
+        "confounders": "Confounders",
+        "recommendations": "Recommendations",
+        "participants": "Participants",
+        "mechanism": "Mechanism",
+        "successRate": "Success Rate",
+        "cost": "Cost",
+        "risk": "Risk",
+        "confoundingStrength": "Confounding Strength"
+      }
     }
   },
   "knowledge": {
@@ -2241,7 +2423,14 @@
       "visShared": "Vis shared",
       "visSystem": "Vis system",
       "visibility": "Visibility",
-      "visibilityHint": "Visibility hint"
+      "visibilityHint": "Visibility hint",
+      "errorAddText": "Failed to add text to knowledge base",
+      "errorFileTooLarge": "File \"{name}\" exceeds the maximum size limit",
+      "errorImportUrl": "Failed to import URL content",
+      "errorUnsupportedFormat": "File \"{name}\" has an unsupported format",
+      "errorUploadFiles": "Failed to upload files",
+      "successTextAdded": "Text added to knowledge base successfully",
+      "successUrlImported": "URL content imported successfully"
     },
     "documents": "Documentos",
     "categories": {
@@ -2291,7 +2480,11 @@
       "maintenance": "Manutenção",
       "maintenanceAriaLabel": "Manutenção da base de conhecimento",
       "analytics": "Análises",
-      "statistics": "Estatísticas"
+      "statistics": "Estatísticas",
+      "webResearch": "Web Research",
+      "webResearchAriaLabel": "4-tab web research panel",
+      "openSidebar": "Open navigation menu",
+      "closeSidebar": "Close navigation menu"
     },
     "backup": {
       "title": "Backup e restauração",
@@ -2787,7 +2980,9 @@
         "sourcesCount": "{count} fontes"
       },
       "noEntities3D": "Nenhuma entidade para exibir",
-      "loading3dVisualization": "Loading3d visualization"
+      "loading3dVisualization": "Loading3d visualization",
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "connectors": {
       "title": "Conectores de fontes",
@@ -3159,7 +3354,8 @@
       "vectorFramework": "Vector framework",
       "vectorIndexHealth": "Vector index health",
       "vectorNotGenerated": "Vector not generated",
-      "vectorizedForRag": "Vectorized for rag"
+      "vectorizedForRag": "Vectorized for rag",
+      "confirmOptimize": "This will optimize the database. Continue?"
     },
     "summaries": {
       "search": {
@@ -3290,7 +3486,11 @@
       "decisionsApplied": "{count} decision(s) applied successfully",
       "compiledSuccess": "Chat compiled successfully",
       "failedToLoad": "Failed to load knowledge items",
-      "decisionsApplyFailed": "Failed to apply decisions"
+      "decisionsApplyFailed": "Failed to apply decisions",
+      "compileFailed": "Failed to compile conversation",
+      "suggestionAddToKb": "Suggested: Add to Knowledge Base",
+      "suggestionDelete": "Suggested: Delete",
+      "suggestionKeepTemporary": "Suggested: Keep Temporarily"
     },
     "systemKnowledge": {
       "vectorizeTooltip": "Gerar embeddings vetoriais para todas as entradas da base de conhecimento para habilitar busca semântica",
@@ -3323,7 +3523,14 @@
       "success": "Success",
       "targetHost": "Target host",
       "totalFacts": "Total facts",
-      "vectorizing": "Vectorizing"
+      "vectorizing": "Vectorizing",
+      "confirmIndexDocs": "Do you want to force reindex existing documents?",
+      "confirmInitialize": "This will initialize system knowledge for the selected host. This may take several minutes. Continue?",
+      "confirmRefreshManPages": "This will refresh man pages for the selected host. Continue?",
+      "confirmReindex": "This will reindex all documents for the selected host. Continue?",
+      "confirmVectorize": "This will vectorize {totalFacts} facts. Currently {totalVectors} vectors exist, {needsVectorization} need vectorization. Continue?",
+      "vectorizeComplete": "Vectorize Facts (✓ {vectors} vectors from {facts} facts)",
+      "vectorizePending": "Vectorize Facts ({pending} pending)"
     },
     "vectorization": {
       "actionVectorize": "Vetorizar",
@@ -3342,7 +3549,15 @@
       "noDocuments": "No documents",
       "progressTitle": "Progress title",
       "retryFailed": "Retry failed",
-      "total": "Total"
+      "total": "Total",
+      "statusFailed": "Failed",
+      "statusPending": "Pending",
+      "statusUnknown": "Unknown",
+      "statusVectorized": "Vectorized",
+      "tooltipFailed": "Vectorization failed for this document",
+      "tooltipPending": "Document is pending vectorization",
+      "tooltipUnknown": "Vectorization status unknown",
+      "tooltipVectorized": "Document has been vectorized and is searchable via RAG"
     },
     "batchSelection": {
       "selected": "{count} selecionado(s)",
@@ -3382,7 +3597,8 @@
       "shareWith": "Share with",
       "team": "Team",
       "user": "User",
-      "write": "Write"
+      "write": "Write",
+      "unsavedConfirm": "You have unsaved changes. Are you sure you want to close?"
     },
     "memoryOrphan": {
       "entitiesToClean": "Entities to clean",
@@ -3430,7 +3646,11 @@
       "rejectedToday": "Rejected today",
       "selectAll": "Select all",
       "title": "Title",
-      "untitled": "Untitled"
+      "untitled": "Untitled",
+      "typeConnector": "Connector",
+      "typeResearch": "Web Research",
+      "typeUpload": "Manual Upload",
+      "typeUrl": "URL Fetch"
     },
     "sessionOrphan": {
       "moreOrphans": "More orphans",
@@ -3499,7 +3719,15 @@
       "warnings": "Warnings"
     },
     "manager": {
-      "errorFallback": "Error fallback"
+      "errorFallback": "Error fallback",
+      "tabAdvanced": "Advanced",
+      "tabCategories": "Categories",
+      "tabManage": "Manage",
+      "tabPromptEditor": "Prompts",
+      "tabSearch": "Search",
+      "tabStatistics": "Statistics",
+      "tabSystemDocs": "System Docs",
+      "tabUpload": "Upload"
     },
     "promptEditor": {
       "allCategories": "All categories",
@@ -3605,7 +3833,138 @@
       "selectDocument": "Select document",
       "subtitle": "Subtitle",
       "title": "Title",
-      "words": "Words"
+      "words": "Words",
+      "errorCopy": "Failed to copy to clipboard",
+      "errorExport": "Failed to export document",
+      "errorExportAll": "Failed to export all documents",
+      "errorLoadCategories": "Failed to load documentation categories",
+      "errorLoadContent": "Failed to load document content",
+      "errorLoadDocs": "Failed to load documents"
+    },
+    "search": {
+      "aiSynthesis": "Ai synthesis",
+      "allCategories": "All categories",
+      "autoEnhanceQuery": "Auto enhance query",
+      "clear": "Clear",
+      "clearAccessLevelFilter": "Clear access level filter",
+      "clearCategoryFilter": "Clear category filter",
+      "confidence": "Confidence",
+      "enableReranking": "Enable reranking",
+      "enhancedQuery": "Enhanced query",
+      "fallbackNote": "Fallback note",
+      "filterByAccessLevel": "Filter by access level",
+      "filterByCategory": "Filter by category",
+      "filtering": "Filtering",
+      "indexHelpAfter": "Index help after",
+      "indexHelpBefore": "Index help before",
+      "indexHelpLink": "Index help link",
+      "needToIndex": "Need to index",
+      "noResults": "No results",
+      "noResultsHint": "No results hint",
+      "noResultsRagHint": "No results rag hint",
+      "ragDesc": "Rag desc",
+      "ragEnhanced": "Rag enhanced",
+      "ragPlaceholder": "Rag placeholder",
+      "ragUnavailable": "Rag unavailable",
+      "rerankingBadge": "Reranking badge",
+      "resultsLimit": "Results limit",
+      "retry": "Retry",
+      "searchBtn": "Search btn",
+      "searchPlaceholder": "Search placeholder",
+      "searching": "Searching",
+      "sourcesCount": "Sources count",
+      "subtitle": "Subtitle",
+      "title": "Title",
+      "traditionalDesc": "Traditional desc",
+      "traditionalSearch": "Traditional search",
+      "accessPlatform": "Platform",
+      "accessPublic": "Public",
+      "accessSystem": "System",
+      "accessUser": "User",
+      "clickToView": "Click to view full document",
+      "close": "Close",
+      "copyContent": "Copy Content",
+      "defaultDocTitle": "Untitled Document",
+      "foundResults": "Found {count} results for \"{query}\"",
+      "loadingDocument": "Loading document content...",
+      "matchScore": "{value}% match",
+      "noContent": "No content available",
+      "rerankScore": "{value}% rerank"
+    },
+    "webResearch": {
+      "title": "Web Research",
+      "subtitle": "Fetch, crawl, discover, and extract data from the web",
+      "navLabel": "Web Research",
+      "navAriaLabel": "Web research panel",
+      "settingsNavLabel": "Research Settings",
+      "settingsNavAriaLabel": "Web research settings",
+      "tabListAriaLabel": "Web research tabs",
+      "renderLabel": "Render Mode",
+      "renderAuto": "Auto",
+      "renderFast": "Fast (no JS)",
+      "renderPlaywright": "Full JS (Playwright)",
+      "ingestLabel": "Save to Knowledge Base",
+      "respectRobotsLabel": "Respect robots.txt",
+      "reset": "Clear",
+      "retry": "Retry",
+      "fetching": "Fetching…",
+      "crawling": "Crawling…",
+      "discovering": "Discovering…",
+      "extracting": "Extracting…",
+      "indexed": "Saved to KB",
+      "failed": "Failed",
+      "schemaValid": "Schema Valid",
+      "schemaInvalid": "Schema Invalid",
+      "filterPlaceholder": "Filter URLs…",
+      "filterLabel": "Filter URLs",
+      "noFilterResults": "No URLs match the current filter.",
+      "depthLabel": "Depth {depth}",
+      "errorGeneric": "An unexpected error occurred. Please try again.",
+      "tabs": {
+        "scrape": "Fetch Page",
+        "scrapeAriaLabel": "Fetch Page — extract text from a single URL",
+        "crawl": "Crawl Site",
+        "crawlAriaLabel": "Crawl Site — follow links and index multiple pages",
+        "siteMap": "Find Pages",
+        "siteMapAriaLabel": "Find Pages — discover all URLs on a domain",
+        "extract": "Get Data",
+        "extractAriaLabel": "Get Data — extract structured data using a schema"
+      },
+      "scrape": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "formatLabel": "Output Format",
+        "submitLabel": "Fetch Page",
+        "emptyState": "Enter a URL above and click Fetch Page to extract its text content."
+      },
+      "crawl": {
+        "seedLabel": "Seed URL",
+        "seedPlaceholder": "https://example.com",
+        "depthLabel": "Max Depth",
+        "maxPagesLabel": "Max Pages",
+        "sameOriginLabel": "Same origin only",
+        "submitLabel": "Crawl Site",
+        "emptyState": "Enter a starting URL and click Crawl Site to follow its links.",
+        "resultTitle": "{count} pages crawled",
+        "urlListLabel": "Crawled pages"
+      },
+      "siteMap": {
+        "domainLabel": "Domain",
+        "domainPlaceholder": "example.com",
+        "maxUrlsLabel": "Max URLs",
+        "submitLabel": "Find Pages",
+        "emptyState": "Enter a domain name and click Find Pages to discover its URLs.",
+        "resultTitle": "{count} URLs found on {domain}",
+        "urlListLabel": "Discovered URLs"
+      },
+      "extract": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "schemaLabel": "JSON Schema",
+        "submitLabel": "Get Data",
+        "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
+        "resultTitle": "Extracted Data"
+      }
     }
   },
   "workflow": {
@@ -3725,7 +4084,10 @@
       "screenAnalysisAriaLabel": "Screen Analysis - capture and analyze screen content",
       "sectionDescVideoProcessing": "Process and analyze video frames",
       "screenAnalysis": "Screen Analysis",
-      "vision": "VISION"
+      "vision": "VISION",
+      "historyAriaLabel": "Workflow execution history",
+      "visualizerAriaLabel": "Orchestration visualizer",
+      "agentsAriaLabel": "Agent capabilities"
     },
     "modal": {
       "executeStep": "Execute This Step",
@@ -3829,7 +4191,15 @@
       "visionWait": "Wait for Element",
       "visionClick": "Click Element",
       "vision": "Vision",
-      "visionFindElement": "Find Element"
+      "visionFindElement": "Find Element",
+      "addCase": "Add case",
+      "addSwitch": "Add switch",
+      "conditionCompare": "Condition compare",
+      "conditionExpr": "Condition expr",
+      "switch": "Switch",
+      "switchDefaultHint": "Switch default hint",
+      "switchLabel": "switch",
+      "switchOnPlaceholder": "Enter switch on..."
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -4057,6 +4427,12 @@
       "resetDefaults": "Reset to Defaults",
       "saving": "Saving...",
       "tabTitle": "Settings"
+    },
+    "nav": {
+      "label": "Agents navigation",
+      "registry": "Registry",
+      "activity": "Activity",
+      "heartbeat": "Heartbeat"
     }
   },
   "errors": {
@@ -4066,7 +4442,8 @@
     "notFound": "Não encontrado.",
     "serverError": "Erro do servidor. Tente novamente mais tarde.",
     "timeout": "O pedido expirou.",
-    "validation": "Verifique os dados introduzidos."
+    "validation": "Verifique os dados introduzidos.",
+    "genericError": "Generic error"
   },
   "status": {
     "online": "Online",
@@ -4348,7 +4725,8 @@
     "never": "Nunca",
     "themeLight": "Claro",
     "themeDark": "Escuro",
-    "themeAuto": "Automático"
+    "themeAuto": "Automático",
+    "tabDevices": "Tab devices"
   },
   "redis": {
     "title": "Serviço Redis",
@@ -4447,7 +4825,9 @@
         "showingOf": "Showing {showing} of {total} functions (scroll for more)",
         "noMatch": "No orphaned functions match your filter",
         "allConnected": "No orphaned functions detected - all functions are connected!"
-      }
+      },
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "importTree": {
       "title": "File Import Tree",
@@ -4557,7 +4937,12 @@
       "seriesName": "Problems",
       "xAxisTitle": "Number of Problems",
       "tooltipProblems": "problems"
-    }
+    },
+    "ariaLabel": "Accessible label",
+    "cellPlaceholder": "Loading...",
+    "defaultAriaLabel": "default (accessible)",
+    "renderError": "Render error",
+    "viewData": "View data"
   },
   "_meta": {
     "dir": "ltr",
@@ -5214,7 +5599,8 @@
       "aiAssistant": "AI Assistant",
       "knowledgeBase": "Knowledge Base",
       "automation": "Automation",
-      "analytics": "Analytics"
+      "analytics": "Analytics",
+      "goHome": "Go Home"
     },
     "secrets": {
       "noticeTitle": "Security Notice",
@@ -5436,7 +5822,9 @@
       "widgetAgents": "Agent Activity",
       "widgetAgentsDesc": "Real-time agent activity monitoring",
       "widgetArchitecture": "System Architecture",
-      "widgetArchitectureDesc": "Interactive system architecture diagram"
+      "widgetArchitectureDesc": "Interactive system architecture diagram",
+      "saved": "Saved",
+      "dashboardSaved": "Dashboard saved"
     },
     "devSpeedup": {
       "title": "Developer Speedup",
@@ -5534,7 +5922,9 @@
       "noConfig": "No configuration stored for this plugin.",
       "invalidJson": "Invalid JSON — please fix before saving.",
       "saveFailed": "Failed to save configuration.",
-      "marketplace": "Marketplace"
+      "marketplace": "Marketplace",
+      "auditLog": "Audit log",
+      "trustTier": "Trust tier"
     },
     "marketplace": {
       "title": "Plugin Marketplace",
@@ -5636,6 +6026,22 @@
       "createBrowserSession": "Criar sessão do navegador",
       "startingUrl": "URL inicial",
       "cancel": "Cancelar"
+    },
+    "scrapeTemplates": {
+      "title": "Scrape Templates",
+      "refresh": "Refresh templates",
+      "emptyTitle": "No Saved Templates",
+      "emptyMessage": "Mark regions on a page and save a template to see it here.",
+      "run": "Re-run template",
+      "duplicate": "Duplicate template",
+      "delete": "Delete template",
+      "deleteConfirm": "Delete \"{name}\"? This cannot be undone.",
+      "targetUrl": "Target URL",
+      "runButton": "Run",
+      "running": "Running...",
+      "extractedResults": "Extracted results",
+      "noValue": "(not found)",
+      "noResults": "No regions extracted."
     }
   },
   "collaboration": {
@@ -6276,6 +6682,65 @@
       "toastSavedToGallery": "Saved to gallery",
       "errorNoFrames": "No frames could be processed",
       "errorInvalidFile": "Please drop a valid video file"
+    },
+    "visionAutomation": {
+      "title": "Vision Automation",
+      "subtitle": "Screen analysis, UI element detection, OCR, and automation opportunity discovery",
+      "serviceStatus": "Service",
+      "sessionContext": "Session Context (optional)",
+      "sessionIdPlaceholder": "Session ID for context",
+      "tabsAriaLabel": "Vision automation tabs",
+      "analyzing": "Analyzing...",
+      "detecting": "Detecting...",
+      "extracting": "Extracting...",
+      "scanning": "Scanning...",
+      "errorLabel": "Error",
+      "tabs": {
+        "analysis": "Screen Analysis",
+        "elements": "Element Detection",
+        "ocr": "OCR",
+        "opportunities": "Automation Opportunities"
+      },
+      "columns": {
+        "id": "ID",
+        "type": "Type",
+        "confidence": "Confidence",
+        "text": "Text",
+        "interactions": "Interactions",
+        "position": "Center"
+      },
+      "analysis": {
+        "cardTitle": "Capture & Analyze Screen",
+        "trigger": "Capture & Analyze",
+        "elementsFound": "Elements",
+        "textRegions": "Text Regions",
+        "confidence": "Confidence",
+        "automationOpps": "Opportunities",
+        "detectedElements": "Detected UI Elements",
+        "empty": "Press Capture and Analyze to analyze the current screen"
+      },
+      "elements": {
+        "cardTitle": "Detect UI Elements",
+        "trigger": "Detect Elements",
+        "typePlaceholder": "Filter by element type (e.g. button)",
+        "minConfidence": "Min Confidence",
+        "results": "{filtered} of {total} elements",
+        "empty": "No elements match the current filter"
+      },
+      "ocr": {
+        "cardTitle": "OCR Text Extraction",
+        "trigger": "Extract Text",
+        "regionsFound": "{count} text region(s) found",
+        "noRegions": "No text regions detected",
+        "empty": "Press Extract Text to run OCR on the current screen"
+      },
+      "opportunities": {
+        "cardTitle": "Automation Opportunities",
+        "trigger": "Scan for Opportunities",
+        "total": "Total Opportunities",
+        "empty": "No automation opportunities found",
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+      }
     }
   },
   "visualizations": {
@@ -6293,7 +6758,8 @@
       "recentTasks": "Recent Tasks",
       "detailsBtn": "Details",
       "pauseBtn": "Pause",
-      "liveActivityFeed": "Live Activity Feed"
+      "liveActivityFeed": "Live Activity Feed",
+      "abstained": "Abstained"
     },
     "resourceHeatmap": {
       "defaultTitle": "Resource Utilization Heatmap",
@@ -6317,7 +6783,8 @@
       "rangeMedium": "Medium",
       "rangeHigh": "High",
       "rangeCritical": "Critical",
-      "usage": "Usage"
+      "usage": "Usage",
+      "noData": "No metrics available yet"
     },
     "systemArchitecture": {
       "defaultTitle": "System Architecture",
@@ -6616,7 +7083,8 @@
       "noEndpointData": "No endpoint data available",
       "noUserData": "No user data available",
       "noTrendData": "No trend data available",
-      "noRecentViolations": "No recent violations"
+      "noRecentViolations": "No recent violations",
+      "last14Days": "Last 14 days"
     },
     "enforcement": {
       "title": "Endpoint Overrides",
@@ -6953,7 +7421,10 @@
       "launchDesc": "This will open a live browser that you can control directly",
       "initializingSession": "Initializing browser session...",
       "sessionId": "Session ID: {id}",
-      "notAvailable": "Not available"
+      "notAvailable": "Not available",
+      "templates": "Scrape Templates",
+      "exitRegionMode": "Exit region mode",
+      "markRegions": "Mark regions"
     }
   },
   "serviceMessages": {
@@ -7018,7 +7489,28 @@
     "llcPortability": "Portability",
     "settingsAndTools": "Settings & Tools",
     "adminPanel": "Admin Panel",
-    "documents": "AI Documents"
+    "documents": "AI Documents",
+    "canvas": "Canvas",
+    "visionAutomation": "Vision",
+    "llmApiKeys": "LLM API Keys",
+    "llmProviders": "LLM Providers",
+    "adminHosts": "Host Inventory",
+    "adminSandbox": "Sandbox",
+    "budgetPolicies": "Budget Policies",
+    "companyOs": "Company OS",
+    "llcDashboard": "Dashboard",
+    "llcOrgChart": "Org Chart",
+    "llcGoals": "Goals",
+    "llcCompanies": "Companies",
+    "llcBacklog": "Backlog",
+    "llcApprovals": "Approvals",
+    "llcCosts": "Costs & Budget",
+    "llcHeartbeat": "Heartbeat",
+    "llcCeoChat": "CEO Chat",
+    "llcSelectCompany": "Switch Company",
+    "llcSelectCompanyPrompt": "Select a company to open its dashboard, backlog, and tools.",
+    "llcNoCompanies": "No companies yet.",
+    "llcCreateCompany": "Create a company"
   },
   "reasoningTrace": {
     "title": "Rastro de raciocinio",
@@ -7060,6 +7552,176 @@
       "expired": "Expirado",
       "refresh": "Obter novo código",
       "retry": "Tentar novamente"
+    }
+  },
+  "llmKeys": {
+    "title": "LLM API Keys",
+    "issueKey": "Issue Key",
+    "revoke": "Revoke",
+    "rotate": "Rotate",
+    "unlimited": "Unlimited",
+    "empty": "No API keys found.",
+    "rawKeyWarning": "Copy this key now — it will not be shown again.",
+    "col": {
+      "prefix": "Key Prefix",
+      "team": "Team",
+      "label": "Label",
+      "budget": "Monthly Budget",
+      "spend": "Spend (MTD)",
+      "models": "Allowed Models",
+      "status": "Status",
+      "expires": "Expires"
+    },
+    "status": {
+      "active": "Active",
+      "revoked": "Revoked"
+    },
+    "form": {
+      "teamId": "Team ID",
+      "label": "Label",
+      "budget": "Monthly Budget (USD)",
+      "budgetHint": "Set to 0 for unlimited.",
+      "models": "Allowed Models (JSON array)",
+      "modelsHint": "E.g. [\"gpt-4\", \"claude-*\"]. Leave blank to allow all.",
+      "expiresAt": "Expires At (optional)"
+    },
+    "revokeConfirm": {
+      "title": "Revoke API Key",
+      "body": "Are you sure you want to revoke key {id}? This cannot be undone."
+    }
+  },
+  "llc": {
+    "templates": {
+      "searchPlaceholder": "Search templates...",
+      "loading": "Loading templates...",
+      "noMatch": "No templates found matching your search",
+      "preview": "Preview template",
+      "select": "Select template",
+      "useTemplate": "Use this template"
+    },
+    "wizard": {
+      "step1": {
+        "title": "Choose a Starting Point",
+        "description": "Start with a template or build from scratch",
+        "startFromScratch": "Start from Scratch",
+        "startFromScratchDesc": "Build your company structure from the ground up",
+        "useTemplate": "Use a Template",
+        "useTemplateDesc": "Start with a pre-configured company template"
+      },
+      "step2": {
+        "title": "Configure Your Company",
+        "description": "Set up your company details and preferences",
+        "companyName": "Company Name",
+        "companyNamePlaceholder": "e.g., Acme Corporation",
+        "issuePrefix": "Issue Prefix",
+        "issuePrefixPlaceholder": "e.g., ACM",
+        "issuePrefixHint": "2-10 uppercase letters for issue identifiers (e.g., ACM-123)",
+        "mission": "Mission Statement",
+        "missionPlaceholder": "What is your company's mission?",
+        "monthlyBudget": "Monthly Budget",
+        "monthlyBudgetPlaceholder": "100",
+        "estimatedCost": "Estimated cost",
+        "brandColor": "Brand Color",
+        "brandColorPlaceholder": "#667eea",
+        "templateVariables": "Template Configuration"
+      },
+      "step3": {
+        "title": "Review & Create",
+        "description": "Review your configuration and create your company",
+        "companyDetails": "Company Details",
+        "template": "Template",
+        "agents": "Agents",
+        "goals": "Goals",
+        "workItems": "Work Items",
+        "kbCollections": "Knowledge Collections",
+        "createCompany": "Create Company"
+      }
+    }
+  },
+  "code": {
+    "cellPlaceholder": "Loading...",
+    "copied": "Copied",
+    "copy": "Copy",
+    "copyCodeAriaLabel": "copy Code (accessible)",
+    "copyFailed": "Copy failed"
+  },
+  "devices": {
+    "addDevice": "Add device",
+    "confirmDelete": "Confirm delete",
+    "daysAgo": "Days ago",
+    "error": "Error",
+    "hoursAgo": "Hours ago",
+    "justNow": "Just now",
+    "lastSeen": "Last seen",
+    "loading": "Loading",
+    "minutesAgo": "Minutes ago",
+    "noDevices": "No devices",
+    "pairDevice": "Pair device",
+    "pairFirst": "Pair first",
+    "pairNewDevice": "Pair new device",
+    "paired": "Paired",
+    "pairedDevices": "Paired devices",
+    "pairingInstructions": "Pairing instructions",
+    "pairingNote": "Pairing note",
+    "step1": "Step1",
+    "step2": "Step2",
+    "step3": "Step3",
+    "step4": "Step4",
+    "unpair": "Unpair"
+  },
+  "imageCell": {
+    "copyUrl": "Copy url",
+    "download": "Download",
+    "downloadLabel": "download",
+    "generated": "Generated",
+    "lightbox": "Lightbox",
+    "loadError": "Load error",
+    "placeholder": "Placeholder",
+    "viewFull": "View full"
+  },
+  "plugins": {
+    "capabilities": {
+      "approvalDescription": "Approval description",
+      "approvalTitle": "approval",
+      "approveAll": "Approve all",
+      "approveSelected": "Approve selected",
+      "approving": "Approving",
+      "auditLogTitle": "audit Log",
+      "capability": "Capability",
+      "denied": "Denied",
+      "filterByPlugin": "Filter by plugin",
+      "granted": "Granted",
+      "loading": "Loading",
+      "loadingAudit": "Loading audit",
+      "noAuditEntries": "No audit entries",
+      "noPending": "No pending",
+      "operation": "Operation",
+      "plugin": "Plugin",
+      "status": "Status",
+      "timestamp": "Timestamp"
+    }
+  },
+  "errorMonitoring": {
+    "title": "Error Monitoring",
+    "subtitle": "System-wide error statistics, recent errors, and component breakdown",
+    "lastUpdate": "Last updated",
+    "noMessage": "(no message)",
+    "cards": {
+      "totalErrors": "Total Errors"
+    },
+    "filters": {
+      "category": "Category",
+      "component": "Component",
+      "all": "All"
+    },
+    "sections": {
+      "recentErrors": "Recent Errors",
+      "categories": "Errors by Category",
+      "components": "Errors by Component"
+    },
+    "empty": {
+      "noErrors": "No errors recorded",
+      "noData": "No data available"
     }
   }
 }

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -82,7 +82,27 @@
     "hasMore": "Load more",
     "previous": "Previous",
     "optional": "اختیاری",
-    "remove": "ہٹائیں"
+    "remove": "ہٹائیں",
+    "dismiss": "Dismiss",
+    "forward": "Forward",
+    "saving": "Saving...",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "fitToView": "Fit to view",
+    "toggleLayout": "Toggle layout",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "copyToClipboard": "Copy to clipboard",
+    "sortAscending": "Sort ascending",
+    "sortDescending": "Sort descending",
+    "moreOptions": "More options",
+    "exportJson": "Export as JSON",
+    "exportCsv": "Export as CSV",
+    "download": "Download",
+    "filterByCategory": "Filter by category",
+    "copied": "Copied"
   },
   "nav": {
     "chat": "چیٹ",
@@ -128,7 +148,28 @@
     "llcPortability": "Portability",
     "settingsAndTools": "Settings & Tools",
     "adminPanel": "Admin Panel",
-    "documents": "AI Documents"
+    "documents": "AI Documents",
+    "canvas": "Canvas",
+    "visionAutomation": "Vision",
+    "llmApiKeys": "LLM API Keys",
+    "llmProviders": "LLM Providers",
+    "adminHosts": "Host Inventory",
+    "adminSandbox": "Sandbox",
+    "budgetPolicies": "Budget Policies",
+    "companyOs": "Company OS",
+    "llcDashboard": "Dashboard",
+    "llcOrgChart": "Org Chart",
+    "llcGoals": "Goals",
+    "llcCompanies": "Companies",
+    "llcBacklog": "Backlog",
+    "llcApprovals": "Approvals",
+    "llcCosts": "Costs & Budget",
+    "llcHeartbeat": "Heartbeat",
+    "llcCeoChat": "CEO Chat",
+    "llcSelectCompany": "Switch Company",
+    "llcSelectCompanyPrompt": "Select a company to open its dashboard, backlog, and tools.",
+    "llcNoCompanies": "No companies yet.",
+    "llcCreateCompany": "Create a company"
   },
   "agent": {
     "registry": {
@@ -198,7 +239,13 @@
     "title": "Agents",
     "orchestrator": "Orchestrator",
     "config": "Agent Configuration",
-    "status": "Agent Status"
+    "status": "Agent Status",
+    "nav": {
+      "label": "Agents navigation",
+      "registry": "Registry",
+      "activity": "Activity",
+      "heartbeat": "Heartbeat"
+    }
   },
   "_meta": {
     "dir": "rtl",
@@ -762,7 +809,13 @@
         "usage": "استعمال",
         "usageAria": "استعمال اور اخراجات",
         "operations": "آپریشنز",
-        "operationsAria": "طویل مدتی آپریشنز"
+        "operationsAria": "طویل مدتی آپریشنز",
+        "devTools": "Dev Tools",
+        "devToolsAria": "Developer tools and utilities",
+        "errors": "Errors",
+        "errorsAria": "Error monitoring",
+        "diagnostics": "Diagnostics",
+        "diagnosticsAria": "Failure analysis and causal inference"
       }
     },
     "header": {
@@ -1130,7 +1183,8 @@
       "file": "File",
       "score": "Score",
       "topIssue": "Top Issue",
-      "close": "Close"
+      "close": "Close",
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",
@@ -1705,6 +1759,38 @@
         "scanning": "Scanning...",
         "scanFile": "Scan File"
       }
+    },
+    "failureAnalysis": {
+      "title": "Failure Analysis",
+      "subtitle": "Root-cause analysis powered by the causal inference engine",
+      "empty": "Enter a task ID above to run a failure analysis.",
+      "form": {
+        "title": "Analyze a Failure",
+        "taskId": "Task ID",
+        "taskIdPlaceholder": "e.g. task-abc123",
+        "errorDescription": "Error Description",
+        "errorDescriptionPlaceholder": "Optional: describe the error or paste a stack trace",
+        "analyze": "Analyze",
+        "analyzing": "Analyzing...",
+        "clear": "Clear"
+      },
+      "result": {
+        "taskId": "Task ID",
+        "confidence": "Confidence",
+        "status": "Status",
+        "duration": "Duration",
+        "rootCause": "Root Cause",
+        "causalChain": "Causal Chain",
+        "interventions": "Interventions",
+        "confounders": "Confounders",
+        "recommendations": "Recommendations",
+        "participants": "Participants",
+        "mechanism": "Mechanism",
+        "successRate": "Success Rate",
+        "cost": "Cost",
+        "risk": "Risk",
+        "confoundingStrength": "Confounding Strength"
+      }
     }
   },
   "knowledge": {
@@ -1802,7 +1888,9 @@
       "toggleLayout": "Toggle layout",
       "typeConversation": "Conversation",
       "create": "Create",
-      "loading3dVisualization": "Loading3d visualization"
+      "loading3dVisualization": "Loading3d visualization",
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "vectorization": {
       "actionVectorize": "Vectorize",
@@ -2690,7 +2778,11 @@
       "graphAriaLabel": "View knowledge graph",
       "title": "Knowledge Base",
       "analytics": "Analytics",
-      "entities": "Entities"
+      "entities": "Entities",
+      "webResearch": "Web Research",
+      "webResearchAriaLabel": "4-tab web research panel",
+      "openSidebar": "Open navigation menu",
+      "closeSidebar": "Close navigation menu"
     },
     "upload": {
       "selectCategory": "Select category...",
@@ -3201,7 +3293,9 @@
       "tabManage": "Manage",
       "tabSearch": "Search",
       "tabStatistics": "Statistics",
-      "tabUpload": "Upload"
+      "tabUpload": "Upload",
+      "tabPromptEditor": "Prompts",
+      "tabSystemDocs": "System Docs"
     },
     "emptyState": {
       "title": "Your knowledge base is empty",
@@ -3215,6 +3309,81 @@
     "categoriesError": {
       "title": "Knowledge base is unreachable",
       "description": "Redis connection failed. Check that the backend has Redis running."
+    },
+    "webResearch": {
+      "title": "Web Research",
+      "subtitle": "Fetch, crawl, discover, and extract data from the web",
+      "navLabel": "Web Research",
+      "navAriaLabel": "Web research panel",
+      "settingsNavLabel": "Research Settings",
+      "settingsNavAriaLabel": "Web research settings",
+      "tabListAriaLabel": "Web research tabs",
+      "renderLabel": "Render Mode",
+      "renderAuto": "Auto",
+      "renderFast": "Fast (no JS)",
+      "renderPlaywright": "Full JS (Playwright)",
+      "ingestLabel": "Save to Knowledge Base",
+      "respectRobotsLabel": "Respect robots.txt",
+      "reset": "Clear",
+      "retry": "Retry",
+      "fetching": "Fetching…",
+      "crawling": "Crawling…",
+      "discovering": "Discovering…",
+      "extracting": "Extracting…",
+      "indexed": "Saved to KB",
+      "failed": "Failed",
+      "schemaValid": "Schema Valid",
+      "schemaInvalid": "Schema Invalid",
+      "filterPlaceholder": "Filter URLs…",
+      "filterLabel": "Filter URLs",
+      "noFilterResults": "No URLs match the current filter.",
+      "depthLabel": "Depth {depth}",
+      "errorGeneric": "An unexpected error occurred. Please try again.",
+      "tabs": {
+        "scrape": "Fetch Page",
+        "scrapeAriaLabel": "Fetch Page — extract text from a single URL",
+        "crawl": "Crawl Site",
+        "crawlAriaLabel": "Crawl Site — follow links and index multiple pages",
+        "siteMap": "Find Pages",
+        "siteMapAriaLabel": "Find Pages — discover all URLs on a domain",
+        "extract": "Get Data",
+        "extractAriaLabel": "Get Data — extract structured data using a schema"
+      },
+      "scrape": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "formatLabel": "Output Format",
+        "submitLabel": "Fetch Page",
+        "emptyState": "Enter a URL above and click Fetch Page to extract its text content."
+      },
+      "crawl": {
+        "seedLabel": "Seed URL",
+        "seedPlaceholder": "https://example.com",
+        "depthLabel": "Max Depth",
+        "maxPagesLabel": "Max Pages",
+        "sameOriginLabel": "Same origin only",
+        "submitLabel": "Crawl Site",
+        "emptyState": "Enter a starting URL and click Crawl Site to follow its links.",
+        "resultTitle": "{count} pages crawled",
+        "urlListLabel": "Crawled pages"
+      },
+      "siteMap": {
+        "domainLabel": "Domain",
+        "domainPlaceholder": "example.com",
+        "maxUrlsLabel": "Max URLs",
+        "submitLabel": "Find Pages",
+        "emptyState": "Enter a domain name and click Find Pages to discover its URLs.",
+        "resultTitle": "{count} URLs found on {domain}",
+        "urlListLabel": "Discovered URLs"
+      },
+      "extract": {
+        "urlLabel": "URL",
+        "urlPlaceholder": "https://example.com/page",
+        "schemaLabel": "JSON Schema",
+        "submitLabel": "Get Data",
+        "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
+        "resultTitle": "Extracted Data"
+      }
     }
   },
   "reasoningTrace": {
@@ -3370,7 +3539,10 @@
       "refresh": "Refresh",
       "availableAgents": "Available Agents",
       "min": "min",
-      "overviewAriaLabel": "View workflow overview"
+      "overviewAriaLabel": "View workflow overview",
+      "historyAriaLabel": "Workflow execution history",
+      "visualizerAriaLabel": "Orchestration visualizer",
+      "agentsAriaLabel": "Agent capabilities"
     },
     "runner": {
       "completed": "Completed",
@@ -3477,7 +3649,15 @@
       "visionWait": "Wait for Element",
       "conditionPlaceholder": "Condition (e.g., $? -eq 0)",
       "save": "Save",
-      "confirm": "Confirm"
+      "confirm": "Confirm",
+      "addCase": "Add case",
+      "addSwitch": "Add switch",
+      "conditionCompare": "Condition compare",
+      "conditionExpr": "Condition expr",
+      "switch": "Switch",
+      "switchDefaultHint": "Switch default hint",
+      "switchLabel": "switch",
+      "switchOnPlaceholder": "Enter switch on..."
     },
     "notifications": {
       "emailRecipients": "Email Recipients",
@@ -3996,7 +4176,10 @@
       "noSession": "No active browser session. Launch a session to start browsing.",
       "testButton": "Test",
       "getStarted": "Use automation controls above to get started",
-      "sessionId": "Session ID: {id}"
+      "sessionId": "Session ID: {id}",
+      "templates": "Scrape Templates",
+      "exitRegionMode": "Exit region mode",
+      "markRegions": "Mark regions"
     },
     "interface": {
       "typeText": "Type Text",
@@ -4160,7 +4343,9 @@
       "networkView": "Network View (Cytoscape)",
       "title": "Function Call Graph",
       "orphanedView": "Orphaned Functions (unused)",
-      "allModules": "All Modules"
+      "allModules": "All Modules",
+      "loadingVisualization": "Loading visualization library...",
+      "retry": "Retry"
     },
     "moduleImports": {
       "tooltipFunctions": "functions",
@@ -4286,7 +4471,12 @@
       "loading": "Loading chart...",
       "total": "Total",
       "noData": "No data available"
-    }
+    },
+    "ariaLabel": "Accessible label",
+    "cellPlaceholder": "Loading...",
+    "defaultAriaLabel": "default (accessible)",
+    "renderError": "Render error",
+    "viewData": "View data"
   },
   "profile": {
     "confirmNewPassword": "Confirm new password",
@@ -4329,7 +4519,8 @@
     "closeAria": "Close profile",
     "themeAuto": "Auto",
     "pwChanged": "Password changed successfully!",
-    "username": "Username:"
+    "username": "Username:",
+    "tabDevices": "Tab devices"
   },
   "ui": {
     "themeToggle": {
@@ -4743,7 +4934,10 @@
       "you": "You",
       "silenceTimeout": "Silence timeout",
       "hintResponding": "AutoBot is responding...",
-      "title": "Voice Chat"
+      "title": "Voice Chat",
+      "realtimeWebrtc": "Realtime WebRTC",
+      "realtimeConnecting": "Connecting to Realtime...",
+      "realtimeConnected": "Realtime — speak anytime"
     },
     "filePanel": {
       "listView": "List view",
@@ -4787,7 +4981,35 @@
       "factsSelected": "{selected} of {total} facts selected",
       "share": "Share",
       "selectAll": "Select All",
-      "deselectAll": "Deselect All"
+      "deselectAll": "Deselect All",
+      "createAnother": "Create another",
+      "createLink": "Create link",
+      "creating": "Creating",
+      "emptyConversation": "Empty conversation",
+      "enterPassword": "Enter password",
+      "expiry": "Expiry",
+      "expiry1d": "Expiry1d",
+      "expiry1h": "Expiry1h",
+      "expiry30d": "Expiry30d",
+      "expiry7d": "Expiry7d",
+      "expiryNever": "Expiry never",
+      "linkExpired": "Link expired",
+      "linkExpires": "Link expires",
+      "linkNotFound": "Link not found",
+      "linkPasswordProtected": "Link password protected",
+      "linkReady": "Link ready",
+      "optionalPassword": "Optional password",
+      "passwordGate": "Password gate",
+      "passwordGateHint": "Password gate hint",
+      "passwordPlaceholder": "Enter password...",
+      "publicLink": "Public link",
+      "publicView": "Public view",
+      "readOnlyNote": "Read only note",
+      "revokeLink": "Revoke link",
+      "revoking": "Revoking",
+      "shareWithUsers": "Share with users",
+      "unlock": "Unlock",
+      "wrongPassword": "Wrong password"
     },
     "typing": {
       "understanding": "Understanding your request...",
@@ -4928,7 +5150,21 @@
       "attachFile": "Attach file",
       "retryUpload": "Retry upload",
       "removeFile": "Remove file",
-      "overseerLabel": "Overseer"
+      "overseerLabel": "Overseer",
+      "managePresets": "Manage slash command presets",
+      "generate": "Generate",
+      "generateImage": "Generate image",
+      "generateImageTitle": "generate Image",
+      "generating": "Generating",
+      "imagePromptLabel": "image Prompt",
+      "imagePromptPlaceholder": "Enter image prompt...",
+      "imageProvider": "Image provider",
+      "selectPromptTemplate": "Select prompt template",
+      "thinkingBudget": "Thinking budget",
+      "thinkingOff": "Thinking off",
+      "thinkingOffLabel": "thinking Off",
+      "thinkingOn": "Thinking on",
+      "thinkingOnLabel": "thinking On"
     },
     "visualBrowser": {
       "disconnected": "Disconnected",
@@ -4947,7 +5183,8 @@
       "reload": "Reload",
       "captureScreenshot": "Capture Screenshot",
       "urlPlaceholder": "Enter URL or search…",
-      "reloadFailed": "Reload failed"
+      "reloadFailed": "Reload failed",
+      "go": "Navigate"
     },
     "browser": {
       "connectingStatus": "Connecting",
@@ -5049,7 +5286,8 @@
       "senderSystem": "System",
       "statusSent": "Sent",
       "ctrlEnterToSave": "Press Ctrl+Enter (Cmd+Enter on Mac) to save",
-      "badgePlanning": "Planning"
+      "badgePlanning": "Planning",
+      "thinkingUsed": "Thinking used"
     },
     "stopGenerating": "Stop generating",
     "thinking": "Thinking...",
@@ -5070,7 +5308,11 @@
       "delete": "Delete message",
       "copy": "Copy message",
       "tokens": "{count} tokens",
-      "edit": "Edit message"
+      "edit": "Edit message",
+      "thinking": {
+        "badge": "🧠 Extended thinking ({count} tokens)",
+        "tooltip": "This response used extended thinking mode to reason through the problem step-by-step"
+      }
     },
     "docResult": {
       "copyContent": "Copy content",
@@ -5133,7 +5375,64 @@
       "streaming": "Streaming…",
       "done": "Done",
       "error": "Error"
-    }
+    },
+    "contextWindow": {
+      "ariaLabel": "{used} of {max} tokens used",
+      "tooltip": "{used} / {max} tokens used ({percent}% of context window)",
+      "warningToast": "Conversation approaching context limit ({percent}%). Older messages may be summarized.",
+      "compressedToast": "Context window optimized - older messages summarized",
+      "summaryTitle": "Context Summary",
+      "summaryToggle": "Show details",
+      "summarizing": "Summarizing..."
+    },
+    "openSettings": "Chat settings",
+    "settings": {
+      "title": "Chat Settings",
+      "contextOverflowLabel": "Context Overflow Protection",
+      "contextOverflowDescription": "Choose how to handle conversations approaching the context limit",
+      "contextOverflowAuto": "Auto-summarize",
+      "contextOverflowWarn": "Warn only",
+      "contextOverflowDisabled": "Disabled"
+    },
+    "folders": {
+      "folders": "Folders",
+      "newFolder": "New folder",
+      "folderName": "Folder name",
+      "rename": "Rename folder",
+      "addSubfolder": "Add subfolder",
+      "pin": "Pin folder",
+      "unpin": "Unpin folder",
+      "assignToFolder": "Move to folder",
+      "removeFromFolder": "Remove from folder",
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+    },
+    "presets": {
+      "modalTitle": "Slash Command Presets",
+      "newPreset": "New Preset",
+      "editPreset": "Edit Preset",
+      "fieldName": "Name",
+      "namePlaceholder": "my-preset",
+      "fieldDescription": "Description",
+      "descriptionPlaceholder": "What this preset does",
+      "fieldContent": "Content",
+      "contentPlaceholder": "Enter the prompt text...",
+      "cancel": "Cancel",
+      "create": "Create",
+      "update": "Update",
+      "delete": "Delete",
+      "listLabel": "Your presets",
+      "loading": "Loading presets...",
+      "empty": "No presets yet. Create one above.",
+      "editAriaLabel": "Edit preset {name}",
+      "deleteAriaLabel": "Delete preset {name}",
+      "deleteConfirmTitle": "Delete preset",
+      "deleteConfirmMessage": "Delete /{name}? This cannot be undone.",
+      "nameRequired": "Name is required",
+      "nameInvalid": "Only letters, numbers, hyphens, and underscores are allowed",
+      "contentRequired": "Content is required"
+    },
+    "lightweightMode": "Lightweight mode",
+    "lightweightModeTooltip": "lightweight Mode tooltip"
   },
   "serviceMessages": {
     "metadata": "Metadata",
@@ -5518,6 +5817,65 @@
       "confidenceLabel": "Confidence",
       "fixedInterval": "Fixed Interval",
       "toastProcessed": "Processed {count} frames successfully"
+    },
+    "visionAutomation": {
+      "title": "Vision Automation",
+      "subtitle": "Screen analysis, UI element detection, OCR, and automation opportunity discovery",
+      "serviceStatus": "Service",
+      "sessionContext": "Session Context (optional)",
+      "sessionIdPlaceholder": "Session ID for context",
+      "tabsAriaLabel": "Vision automation tabs",
+      "analyzing": "Analyzing...",
+      "detecting": "Detecting...",
+      "extracting": "Extracting...",
+      "scanning": "Scanning...",
+      "errorLabel": "Error",
+      "tabs": {
+        "analysis": "Screen Analysis",
+        "elements": "Element Detection",
+        "ocr": "OCR",
+        "opportunities": "Automation Opportunities"
+      },
+      "columns": {
+        "id": "ID",
+        "type": "Type",
+        "confidence": "Confidence",
+        "text": "Text",
+        "interactions": "Interactions",
+        "position": "Center"
+      },
+      "analysis": {
+        "cardTitle": "Capture & Analyze Screen",
+        "trigger": "Capture & Analyze",
+        "elementsFound": "Elements",
+        "textRegions": "Text Regions",
+        "confidence": "Confidence",
+        "automationOpps": "Opportunities",
+        "detectedElements": "Detected UI Elements",
+        "empty": "Press Capture and Analyze to analyze the current screen"
+      },
+      "elements": {
+        "cardTitle": "Detect UI Elements",
+        "trigger": "Detect Elements",
+        "typePlaceholder": "Filter by element type (e.g. button)",
+        "minConfidence": "Min Confidence",
+        "results": "{filtered} of {total} elements",
+        "empty": "No elements match the current filter"
+      },
+      "ocr": {
+        "cardTitle": "OCR Text Extraction",
+        "trigger": "Extract Text",
+        "regionsFound": "{count} text region(s) found",
+        "noRegions": "No text regions detected",
+        "empty": "Press Extract Text to run OCR on the current screen"
+      },
+      "opportunities": {
+        "cardTitle": "Automation Opportunities",
+        "trigger": "Scan for Opportunities",
+        "total": "Total Opportunities",
+        "empty": "No automation opportunities found",
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+      }
     }
   },
   "views": {
@@ -5686,7 +6044,9 @@
       "widgetTitle": "Title",
       "bar": "Bar",
       "create": "Create",
-      "area": "Area"
+      "area": "Area",
+      "saved": "Saved",
+      "dashboardSaved": "Dashboard saved"
     },
     "devSpeedup": {
       "after": "After",
@@ -5785,7 +6145,8 @@
       "goToChat": "Go to Chat",
       "analytics": "Analytics",
       "knowledgeBase": "Knowledge Base",
-      "goBack": "Go Back"
+      "goBack": "Go Back",
+      "goHome": "Go Home"
     },
     "plugins": {
       "requires": "Requires",
@@ -5835,7 +6196,9 @@
       "reload": "Reload",
       "version": "Version",
       "configuration": "Configuration",
-      "marketplace": "مارکیٹ پلیس"
+      "marketplace": "مارکیٹ پلیس",
+      "auditLog": "Audit log",
+      "trustTier": "Trust tier"
     },
     "vision": {
       "serviceOffline": "Service Offline",
@@ -5934,7 +6297,8 @@
       "noEndpointData": "No endpoint data available",
       "daysAnalyzed": "Days Analyzed",
       "vsYesterday": "vs yesterday",
-      "byEndpoint": "By Endpoint"
+      "byEndpoint": "By Endpoint",
+      "last14Days": "Last 14 days"
     },
     "modeSelector": {
       "modeDisabled": "Disabled",
@@ -6121,7 +6485,22 @@
     "backendOffline": "Backend offline — showing cached settings",
     "connection": {
       "title": "Connection",
-      "desc": "Configure backend connection settings"
+      "desc": "Configure backend connection settings",
+      "backendCheck": {
+        "title": "Backend reachability",
+        "description": "Run a one-shot ping to verify that the AutoBot backend is reachable from this browser. No periodic polling — manual only.",
+        "button": "Test backend connection",
+        "checking": "Checking…",
+        "reachable": "Reachable",
+        "unreachable": "Unreachable",
+        "latency": "Latency",
+        "lastTested": "Last tested",
+        "neverTested": "Not yet tested"
+      }
+    },
+    "presets": {
+      "title": "Slash Presets",
+      "description": "Create reusable slash commands that expand into full prompts in the chat input. Type / followed by the preset name to trigger them."
     }
   },
   "visualizations": {
@@ -6208,7 +6587,8 @@
       "minimum": "Minimum",
       "memoryUsage": "Memory Usage",
       "average": "Average",
-      "networkIo": "Network I/O"
+      "networkIo": "Network I/O",
+      "noData": "No metrics available yet"
     },
     "agentActivity": {
       "activeCount": "{count} active",
@@ -6224,7 +6604,8 @@
       "pauseBtn": "Pause",
       "liveActivityFeed": "Live Activity Feed",
       "defaultTitle": "Agent Activity Monitor",
-      "timelineView": "Timeline view"
+      "timelineView": "Timeline view",
+      "abstained": "Abstained"
     }
   },
   "audit": {
@@ -6508,6 +6889,22 @@
       "statTotal": "Total",
       "startingUrl": "Starting URL",
       "pause": "Pause"
+    },
+    "scrapeTemplates": {
+      "title": "Scrape Templates",
+      "refresh": "Refresh templates",
+      "emptyTitle": "No Saved Templates",
+      "emptyMessage": "Mark regions on a page and save a template to see it here.",
+      "run": "Re-run template",
+      "duplicate": "Duplicate template",
+      "delete": "Delete template",
+      "deleteConfirm": "Delete \"{name}\"? This cannot be undone.",
+      "targetUrl": "Target URL",
+      "runButton": "Run",
+      "running": "Running...",
+      "extractedResults": "Extracted results",
+      "noValue": "(not found)",
+      "noResults": "No regions extracted."
     }
   },
   "secrets": {
@@ -6666,7 +7063,8 @@
     "generic": "Something went wrong. Please try again.",
     "notFound": "Not found.",
     "unauthorized": "Unauthorized. Please log in.",
-    "serverError": "Server error. Please try again later."
+    "serverError": "Server error. Please try again later.",
+    "genericError": "Generic error"
   },
   "status": {
     "error": "Error",
@@ -7154,6 +7552,176 @@
       "expired": "ختم شدہ",
       "refresh": "نیا کوڈ حاصل کریں",
       "retry": "دوبارہ کوشش کریں"
+    }
+  },
+  "llmKeys": {
+    "title": "LLM API Keys",
+    "issueKey": "Issue Key",
+    "revoke": "Revoke",
+    "rotate": "Rotate",
+    "unlimited": "Unlimited",
+    "empty": "No API keys found.",
+    "rawKeyWarning": "Copy this key now — it will not be shown again.",
+    "col": {
+      "prefix": "Key Prefix",
+      "team": "Team",
+      "label": "Label",
+      "budget": "Monthly Budget",
+      "spend": "Spend (MTD)",
+      "models": "Allowed Models",
+      "status": "Status",
+      "expires": "Expires"
+    },
+    "status": {
+      "active": "Active",
+      "revoked": "Revoked"
+    },
+    "form": {
+      "teamId": "Team ID",
+      "label": "Label",
+      "budget": "Monthly Budget (USD)",
+      "budgetHint": "Set to 0 for unlimited.",
+      "models": "Allowed Models (JSON array)",
+      "modelsHint": "E.g. [\"gpt-4\", \"claude-*\"]. Leave blank to allow all.",
+      "expiresAt": "Expires At (optional)"
+    },
+    "revokeConfirm": {
+      "title": "Revoke API Key",
+      "body": "Are you sure you want to revoke key {id}? This cannot be undone."
+    }
+  },
+  "llc": {
+    "templates": {
+      "searchPlaceholder": "Search templates...",
+      "loading": "Loading templates...",
+      "noMatch": "No templates found matching your search",
+      "preview": "Preview template",
+      "select": "Select template",
+      "useTemplate": "Use this template"
+    },
+    "wizard": {
+      "step1": {
+        "title": "Choose a Starting Point",
+        "description": "Start with a template or build from scratch",
+        "startFromScratch": "Start from Scratch",
+        "startFromScratchDesc": "Build your company structure from the ground up",
+        "useTemplate": "Use a Template",
+        "useTemplateDesc": "Start with a pre-configured company template"
+      },
+      "step2": {
+        "title": "Configure Your Company",
+        "description": "Set up your company details and preferences",
+        "companyName": "Company Name",
+        "companyNamePlaceholder": "e.g., Acme Corporation",
+        "issuePrefix": "Issue Prefix",
+        "issuePrefixPlaceholder": "e.g., ACM",
+        "issuePrefixHint": "2-10 uppercase letters for issue identifiers (e.g., ACM-123)",
+        "mission": "Mission Statement",
+        "missionPlaceholder": "What is your company's mission?",
+        "monthlyBudget": "Monthly Budget",
+        "monthlyBudgetPlaceholder": "100",
+        "estimatedCost": "Estimated cost",
+        "brandColor": "Brand Color",
+        "brandColorPlaceholder": "#667eea",
+        "templateVariables": "Template Configuration"
+      },
+      "step3": {
+        "title": "Review & Create",
+        "description": "Review your configuration and create your company",
+        "companyDetails": "Company Details",
+        "template": "Template",
+        "agents": "Agents",
+        "goals": "Goals",
+        "workItems": "Work Items",
+        "kbCollections": "Knowledge Collections",
+        "createCompany": "Create Company"
+      }
+    }
+  },
+  "code": {
+    "cellPlaceholder": "Loading...",
+    "copied": "Copied",
+    "copy": "Copy",
+    "copyCodeAriaLabel": "copy Code (accessible)",
+    "copyFailed": "Copy failed"
+  },
+  "devices": {
+    "addDevice": "Add device",
+    "confirmDelete": "Confirm delete",
+    "daysAgo": "Days ago",
+    "error": "Error",
+    "hoursAgo": "Hours ago",
+    "justNow": "Just now",
+    "lastSeen": "Last seen",
+    "loading": "Loading",
+    "minutesAgo": "Minutes ago",
+    "noDevices": "No devices",
+    "pairDevice": "Pair device",
+    "pairFirst": "Pair first",
+    "pairNewDevice": "Pair new device",
+    "paired": "Paired",
+    "pairedDevices": "Paired devices",
+    "pairingInstructions": "Pairing instructions",
+    "pairingNote": "Pairing note",
+    "step1": "Step1",
+    "step2": "Step2",
+    "step3": "Step3",
+    "step4": "Step4",
+    "unpair": "Unpair"
+  },
+  "imageCell": {
+    "copyUrl": "Copy url",
+    "download": "Download",
+    "downloadLabel": "download",
+    "generated": "Generated",
+    "lightbox": "Lightbox",
+    "loadError": "Load error",
+    "placeholder": "Placeholder",
+    "viewFull": "View full"
+  },
+  "plugins": {
+    "capabilities": {
+      "approvalDescription": "Approval description",
+      "approvalTitle": "approval",
+      "approveAll": "Approve all",
+      "approveSelected": "Approve selected",
+      "approving": "Approving",
+      "auditLogTitle": "audit Log",
+      "capability": "Capability",
+      "denied": "Denied",
+      "filterByPlugin": "Filter by plugin",
+      "granted": "Granted",
+      "loading": "Loading",
+      "loadingAudit": "Loading audit",
+      "noAuditEntries": "No audit entries",
+      "noPending": "No pending",
+      "operation": "Operation",
+      "plugin": "Plugin",
+      "status": "Status",
+      "timestamp": "Timestamp"
+    }
+  },
+  "errorMonitoring": {
+    "title": "Error Monitoring",
+    "subtitle": "System-wide error statistics, recent errors, and component breakdown",
+    "lastUpdate": "Last updated",
+    "noMessage": "(no message)",
+    "cards": {
+      "totalErrors": "Total Errors"
+    },
+    "filters": {
+      "category": "Category",
+      "component": "Component",
+      "all": "All"
+    },
+    "sections": {
+      "recentErrors": "Recent Errors",
+      "categories": "Errors by Category",
+      "components": "Errors by Component"
+    },
+    "empty": {
+      "noErrors": "No errors recorded",
+      "noData": "No data available"
     }
   }
 }

--- a/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.stats.test.ts
+++ b/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.stats.test.ts
@@ -132,8 +132,11 @@ describe('KnowledgeRepository stats endpoints (#5215)', () => {
 
       expect(result.status).toBe('unknown')
       expect(result.basic_stats).toEqual({
+        total_documents: 0,
+        total_chunks: 0,
         total_facts: 0,
         total_vectors: 0,
+        db_size: 0,
         categories: [],
         status: 'unknown'
       })

--- a/autobot-frontend/src/services/GlobalWebSocketService.ts
+++ b/autobot-frontend/src/services/GlobalWebSocketService.ts
@@ -18,6 +18,7 @@ import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
 import { buildAuthenticatedWsUrl } from '@/utils/buildAuthenticatedWsUrl'
 import { useUserStore } from '@/stores/useUserStore'
+import { whenPiniaReady } from '@/utils/whenPiniaReady'
 
 // ---------------------------------------------------------------------------
 // Types & Interfaces
@@ -754,7 +755,10 @@ if (typeof window !== 'undefined') {
       }
     }
 
-    setTimeout(() => {
+    // #9693: whenPiniaReady guards against the timer firing before
+    // app.use(pinia) (slow mount) or after Pinia is gone (test teardown),
+    // where useUserStore() would throw an uncaught "no active Pinia" error.
+    whenPiniaReady(() => {
       const userStore = useUserStore()
       tryConnect()
       // #6692: react to login (token appears) and logout (token cleared) so a

--- a/autobot-frontend/src/services/LiveEventService.ts
+++ b/autobot-frontend/src/services/LiveEventService.ts
@@ -15,6 +15,7 @@ import { createLogger } from '@/utils/debugUtils'
 import config from '@/config/ssot-config'
 import { buildAuthenticatedWsUrl } from '@/utils/buildAuthenticatedWsUrl'
 import { useUserStore } from '@/stores/useUserStore'
+import { whenPiniaReady } from '@/utils/whenPiniaReady'
 import type { ConnectionState } from '@/services/GlobalWebSocketService'
 
 // (#6488) Canonical type lives in GlobalWebSocketService; re-export under the
@@ -367,7 +368,10 @@ if (typeof window !== 'undefined') {
       }
     }
 
-    setTimeout(() => {
+    // #9693: whenPiniaReady guards against the timer firing before
+    // app.use(pinia) (slow mount) or after Pinia is gone (test teardown),
+    // where useUserStore() would throw an uncaught "no active Pinia" error.
+    whenPiniaReady(() => {
       const userStore = useUserStore()
       tryConnect()
       // React to login (token appears) and logout (token cleared).

--- a/autobot-frontend/src/services/__tests__/api.integration.test.ts
+++ b/autobot-frontend/src/services/__tests__/api.integration.test.ts
@@ -1,7 +1,6 @@
 // Copyright 2025-2026 mrveiss
 // SPDX-License-Identifier: Apache-2.0
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
-import { setupServer } from 'msw/node'
+import { describe, it, expect } from 'vitest'
 import { http, HttpResponse } from 'msw'
 import { apiService } from '../api.js'
 import {
@@ -12,8 +11,9 @@ import {
   createMockSettings,
 } from '../../test/utils/test-utils'
 
-// Setup MSW server for integration tests
-const server = setupServer()
+// #9693: reuse the shared MSW server from integration-setup.ts — a second
+// setupServer() stacks interceptors and every request is handled twice.
+import { server } from '../../test/integration-setup'
 
 // ApiClient in test env (jsdom) uses proxy mode (empty baseUrl).
 // The vitest-setup.ts fetch wrapper prepends relative URLs with the jsdom origin.
@@ -21,17 +21,8 @@ const server = setupServer()
 const API_BASE = 'http://localhost:3000'
 
 describe('API Service Integration Tests', () => {
-  beforeAll(() => {
-    server.listen({ onUnhandledRequest: 'warn' })
-  })
-
-  afterAll(() => {
-    server.close()
-  })
-
-  beforeEach(() => {
-    server.resetHandlers()
-  })
+  // Server lifecycle (listen/resetHandlers/close) is managed globally by
+  // src/test/integration-setup.ts.
 
   describe('Chat API Integration', () => {
     it('sends message and receives response', async () => {

--- a/autobot-frontend/src/test/integration-setup.ts
+++ b/autobot-frontend/src/test/integration-setup.ts
@@ -4,8 +4,12 @@ import { beforeAll, afterAll } from 'vitest'
 import { setupServer } from 'msw/node'
 import { handlers } from './mocks/api-handlers'
 
-// Setup MSW server for integration tests
-const server = setupServer(...handlers)
+// Setup MSW server for integration tests.
+// #9693: exported so test files can register per-test handlers via
+// server.use(). Creating a SECOND setupServer() in a test file stacks two
+// fetch interceptors, so every request hits matching handlers twice —
+// which silently doubles stateful handler counters.
+export const server = setupServer(...handlers)
 
 beforeAll(() => {
   // Start the server before running integration tests

--- a/autobot-frontend/src/test/vitest-setup.ts
+++ b/autobot-frontend/src/test/vitest-setup.ts
@@ -38,19 +38,24 @@ class MockResizeObserver {
 }
 global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
 
-// Mock window.matchMedia (not available in jsdom)
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: vi.fn().mockImplementation((query: string) => ({
+// Mock window.matchMedia (not available in jsdom).
+// #9693: MUST be a plain function, not vi.fn() — `mockReset: true` in
+// vitest.config.ts wipes vi.fn() implementations after the first test,
+// making matchMedia() return undefined for every subsequent mount.
+const createMatchMediaStub = (query: string): MediaQueryList =>
+  ({
     matches: false,
     media: query,
     onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }) as unknown as MediaQueryList
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: createMatchMediaStub,
 })
 
 // Mock WebSocket

--- a/autobot-frontend/src/utils/whenPiniaReady.ts
+++ b/autobot-frontend/src/utils/whenPiniaReady.ts
@@ -1,0 +1,23 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+import { getActivePinia } from 'pinia'
+
+/**
+ * Run `callback` once Pinia is installed (#9693).
+ *
+ * Module-level singleton services (LiveEventService, GlobalWebSocketService)
+ * auto-connect via a delayed timer that reads the user store. If that timer
+ * fires before `app.use(pinia)` has run (slow app mount) — or after the Pinia
+ * instance is gone (test teardown, HMR dispose) — `useUserStore()` throws an
+ * uncaught "no active Pinia" error. Instead of assuming a fixed delay is
+ * always long enough, poll until a Pinia instance is actually active.
+ */
+export function whenPiniaReady(callback: () => void, delayMs = 1000): void {
+  setTimeout(() => {
+    if (getActivePinia()) {
+      callback()
+    } else {
+      whenPiniaReady(callback, delayMs)
+    }
+  }, delayMs)
+}

--- a/autobot-frontend/src/views/LLMProvidersView.vue
+++ b/autobot-frontend/src/views/LLMProvidersView.vue
@@ -161,6 +161,9 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
 import { getBackendUrl } from '@/config/ssot-config'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('LLMProvidersView')
 
 interface FallbackChain {
   primary_model: string
@@ -201,7 +204,7 @@ const fetchFallbackStatus = async () => {
     activeFallbacks.value = data.active_fallbacks || []
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Failed to fetch fallback status'
-    console.error('Error fetching fallback status:', err)
+    logger.error('Error fetching fallback status:', err)
   } finally {
     loading.value = false
   }

--- a/autobot-frontend/tests/e2e/thinking-mode.spec.ts
+++ b/autobot-frontend/tests/e2e/thinking-mode.spec.ts
@@ -145,7 +145,12 @@ test.describe('Thinking Mode E2E', () => {
     // The badge should exist if the backend supports it
     // (may be 0 in test environment without real Anthropic API)
     const count = await thinkingBadges.count();
-    console.log(`Found ${count} thinking badges`);
+    // Surface the observed badge count in the report instead of console noise
+    test.info().annotations.push({
+      type: 'info',
+      description: `Found ${count} thinking badges`,
+    });
+    expect(count).toBeGreaterThanOrEqual(0);
   });
 
   test('TC6: should toggle OFF and not send thinking params', async ({ page }) => {

--- a/autobot-frontend/tests/monitoring-integration-test.js
+++ b/autobot-frontend/tests/monitoring-integration-test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /**
  * Integration Test for Optimized Monitoring System
  * Tests the performance and functionality of the new monitoring architecture

--- a/autobot-frontend/vitest.integration.config.ts
+++ b/autobot-frontend/vitest.integration.config.ts
@@ -1,8 +1,14 @@
-import { mergeConfig, defineConfig, configDefaults } from 'vitest/config'
+import { mergeConfig, defineConfig, configDefaults, type UserConfig } from 'vitest/config'
 import viteConfig from './vite.config'
 
+// #9693: vite.config exports a function (Vite 7) — mergeConfig cannot merge a
+// callback, so resolve it first (same pattern as vitest.config.ts).
+const resolvedViteConfig = typeof viteConfig === 'function'
+  ? viteConfig({ command: 'serve', mode: 'test' })
+  : viteConfig
+
 export default mergeConfig(
-  viteConfig,
+  resolvedViteConfig as UserConfig,
   defineConfig({
     test: {
       // Integration test environment
@@ -24,7 +30,7 @@ export default mergeConfig(
         reporter: ['text', 'json', 'html'],
         reportsDirectory: 'coverage/integration',
         exclude: [
-          ...configDefaults.coverage.exclude,
+          ...(configDefaults.coverage?.exclude || []),
           'src/test/**',
           'src/**/*.d.ts',
           'src/**/*.config.ts',
@@ -32,12 +38,10 @@ export default mergeConfig(
       },
 
       // Sequential execution for integration tests
+      // (Vitest 4 removed poolOptions.forks.singleFork — maxWorkers: 1 is
+      // the top-level equivalent.)
       pool: 'forks',
-      poolOptions: {
-        forks: {
-          singleFork: true,
-        },
-      },
+      maxWorkers: 1,
 
       // Mock options
       clearMocks: true,
@@ -45,10 +49,10 @@ export default mergeConfig(
       restoreMocks: true,
 
       // Reporter configuration
-      reporter: process.env.CI ? ['junit', 'default'] : ['default'],
+      reporters: process.env.CI ? ['junit', 'default'] : ['default'],
       outputFile: {
         junit: 'test-results/integration-junit.xml',
       },
     },
-  }),
+  }) as UserConfig,
 )


### PR DESCRIPTION
## Thinking Path
The Unit & Integration Tests job has been red since the #9512 uv-deps era: 89 failing tests across 11 files, 3 uncaught exceptions bleeding across test files, a dead integration config, and 7 real eslint errors. Each failure was classified test-stale vs real-bug; 8 real runtime bugs surfaced and were fixed at root cause.

## What Changed
**Real bugs fixed:**
- `LiveEventService`/`GlobalWebSocketService`: module-level auto-connect timers called `useUserStore()` with no active Pinia (slow mount / teardown) → new shared `src/utils/whenPiniaReady.ts` guard (root cause of the 3 uncaught "no active Pinia" errors)
- `useConnectionTester`: DOMException-based AbortErrors misclassified as unknown errors
- `vitest-setup.ts`: matchMedia stub was a `vi.fn()` wiped by `mockReset:true` after the first test (root cause of SettingsPanel/ChatInterface cascades)
- `vitest.integration.config.ts`: dead since Vite 7 (`mergeConfig` vs function-style config) — the integration job never even loaded; migrated removed Vitest 4 options
- double MSW interception in `api.integration.test.ts` corrupting stateful retry handlers
- two ReferenceErrors from underscore-renamed declarations; `useTimeout` this-aliasing
- generated `src/types/_generated/` + untracked `storybook-static/` now lint-ignored (lint --fix kept stripping the codegen banner, which would break the #7122 drift check)

**Stale tests repaired** (component changed legitimately): ChatInterface (#6415 deep-link), CodeCell, DeclarationsSection (SVG Icon migration), RedisServiceControl, useToolApproval (apiClient migration), useRealtimeVoice (#7421), useFetchEndpoint. i18n: 474 missing keys backfilled across 10 locales (English passthrough per #7874).

**Flake bound:** BulkEditModal SFC-import test given a 30s timeout (compiles a real SFC; starved as file 105/105 under load — passes 4s isolated).

**Lint:** 7 errors fixed without suppressions (useApi→useApiClient in telemetry files — local-only framing kept, console→logger, unused vars).

## Verification
`npm run test:unit` → **105 files, 1781 passed / 1 skipped / 0 failed / 0 unhandled errors** (re-verified after rebase onto current Dev_new_gui). `npm run test:integration` → 28/28. `npm run lint` → exit 0.

## Model Used
Claude Fable 5 (frontend-engineer agent) + Opus 4.8 (main session: rebase, flake bound, re-verification)

Closes #9693. Part of umbrella #9924.