### PR TITLE
ci(test): co-located deployment smoke gate — the regression surface with zero coverage (#10023)

### DIFF
--- a/.github/workflows/co-located-smoke.yml
+++ b/.github/workflows/co-located-smoke.yml
@@ -1,0 +1,227 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+#
+# Co-located Deployment Smoke Gate (GH#10023, umbrella #9924)
+#
+# The 2026-06-11 bug-wave triage traced every true regression of the
+# post-June-10 wave to the co-located / deployment surface, which had zero
+# automated pre-merge coverage. This ADVISORY (not branch-protection-required)
+# gate asserts one test per regression class:
+#
+#   (a) nginx /slm prefix routing — HTTP + WS handshake reach the SLM behind
+#       the co-located nginx (#9967 / #9852 class)        -> colocated-stack
+#   (b) user frontend conforms to the strict co-located CSP (#9966 class)
+#       — static scan of the BUILT dist against the policy in
+#       autobot-security-headers-strict.conf.j2           -> colocated-stack
+#   (c) one-click update fleet selection sees the co-located self-node
+#       (#9996 class)                                     -> authz-and-selection
+#   (d) second user cannot read first user's transcriber rows
+#       (#9968 IDOR class)                                -> authz-and-selection
+#
+# KNOWN-RED while #9966 is open: the user frontend still ships an inline
+# script (index.html) and a Google Fonts @import (tailwind.css), so the CSP
+# step fails until #9966 lands. That red IS the gate catching the #9966
+# class — do not loosen the check; fix the frontend.
+#
+# Promote to required via the always-report pattern (#10022) once stable.
+
+name: Co-located Smoke
+
+on:
+  pull_request:
+    branches:
+      - Dev_new_gui
+    paths:
+      # nginx — compose flavor (live-tested here)
+      - 'docker/**'
+      - 'docker-compose*.yml'
+      # nginx — bare-metal co-located templates (same routing contract)
+      - 'autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm.conf.j2'
+      - 'autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-security-headers-strict.conf.j2'
+      - 'autobot-slm-backend/ansible/roles/slm_manager/templates/nginx-override.conf.j2'
+      - 'autobot-slm-backend/ansible/roles/frontend/templates/nginx-frontend.conf.j2'
+      # co-located client / update-selection logic
+      - 'autobot-backend/services/slm_client.py'
+      - 'autobot-slm-backend/api/code_sync.py'
+      - 'autobot-slm-backend/api/websocket.py'
+      # transcriber multi-user authz surface
+      - 'autobot-backend/transcriber/**'
+      # user-frontend CSP surface
+      - 'autobot-frontend/index.html'
+      - 'autobot-frontend/src/assets/**'
+      # the gate itself
+      - '.github/workflows/co-located-smoke.yml'
+      - 'scripts/check_colocated_csp.py'
+      - 'autobot-slm-backend/tests/api/test_collect_outdated_node_ids.py'
+      - 'autobot-backend/transcriber/tests/test_multiuser_authz.py'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Classes (c) + (d): pytest-shaped regression pins. Fast, no containers.
+  authz-and-selection:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements*.txt
+            autobot-backend/requirements*.txt
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r requirements-ci.txt --prefer-binary || true
+          # Hermetic essentials for both test files (no Postgres/Redis needed).
+          python -m pip install aiosqlite aiofiles pytest pytest-asyncio httpx python-multipart --prefer-binary
+
+      - name: (d) transcriber multi-user authz — #9968 IDOR class
+        run: |
+          python -m pytest autobot-backend/transcriber/tests/test_multiuser_authz.py -v --tb=short
+
+      - name: (c) one-click update self-node selection — #9996 class
+        # Separate pytest process: autobot-slm-backend/conftest.py stubs
+        # sys.modules globally and must not bleed into the transcriber run.
+        run: |
+          python -m pytest autobot-slm-backend/tests/api/test_collect_outdated_node_ids.py -v --tb=short
+
+  # Classes (a) + (b): live co-located compose stack (frontend at /, SLM at
+  # /slm — the same single-host topology as bare-metal co-located installs).
+  colocated-stack:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
+        with:
+          min-free-gb: '15'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
+
+      - name: Cache Docker layers
+        # Shares the docker-smoke-test cache prefix so layers stay warm.
+        uses: actions/cache@v5
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}-colocated
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Create .env from .env.example
+        run: cp .env.example .env
+
+      - name: Ensure cache directory exists
+        run: mkdir -p /tmp/.buildx-cache
+
+      - name: Build images with layer cache
+        run: |
+          for component in backend slm frontend; do
+            echo "=== Building ${component} image ==="
+            docker buildx build \
+              --cache-from type=local,src=/tmp/.buildx-cache \
+              --cache-to   type=local,dest=/tmp/.buildx-cache-new,mode=min \
+              --file "docker/${component}/Dockerfile" \
+              --tag "autobot/${component}:latest" \
+              --load \
+              .
+            df -h / | grep -v Filesystem
+          done
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Start co-located stack
+        run: docker compose --env-file docker/.env.docker up -d
+
+      - name: Wait for services to be healthy
+        run: |
+          echo "Waiting for frontend, backend, and SLM..."
+          for attempt in $(seq 1 90); do
+            frontend_ok=false; backend_ok=false; slm_ok=false
+            curl -s -f http://localhost > /dev/null 2>&1 && frontend_ok=true
+            curl -s -f http://localhost/api/system/health > /dev/null 2>&1 && backend_ok=true
+            curl -s -f http://localhost/slm/api/health > /dev/null 2>&1 && slm_ok=true
+            if $frontend_ok && $backend_ok && $slm_ok; then
+              echo "All services healthy after ${attempt} attempt(s)"
+              exit 0
+            fi
+            echo "attempt ${attempt}/90: frontend=$frontend_ok backend=$backend_ok slm=$slm_ok"
+            sleep 10
+          done
+          echo "Services failed to become healthy within 15 minutes"
+          docker compose --env-file docker/.env.docker logs
+          exit 1
+
+      - name: (a) nginx /slm prefix routing — HTTP (#9967/#9852 class)
+        run: |
+          set -euo pipefail
+          # Must be JSON from the SLM backend. If the /slm/api/ location is
+          # lost, the /slm/ SPA catch-all answers 200 text/html instead —
+          # so a bare 200 check would false-green; assert content-type too.
+          ctype=$(curl -fsS -o /tmp/slm-health.json -w '%{content_type}' http://localhost/slm/api/health)
+          echo "GET /slm/api/health -> ${ctype}: $(cat /tmp/slm-health.json)"
+          case "$ctype" in
+            application/json*) echo "OK: SLM API reachable under /slm" ;;
+            *) echo "FAIL: /slm/api/health did not reach the SLM (got ${ctype})"; exit 1 ;;
+          esac
+
+      - name: (a) nginx /slm prefix routing — WebSocket handshake (#9967 class)
+        run: |
+          set -uo pipefail
+          # slm_client connects to {SLM_URL}/api/ws/events; behind co-located
+          # nginx that is /slm/api/ws/events. The SLM accepts the WS before
+          # auth-closing (4001), so a correctly routed handshake returns 101.
+          # A missing /slm/api/ws/ location falls through to the plain /slm/api/
+          # proxy (no Upgrade headers -> 404) or the SPA catch-all (200).
+          code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 \
+            -H 'Connection: Upgrade' -H 'Upgrade: websocket' \
+            -H 'Sec-WebSocket-Version: 13' \
+            -H "Sec-WebSocket-Key: $(openssl rand -base64 16)" \
+            http://localhost/slm/api/ws/events || true)
+          echo "WS handshake /slm/api/ws/events -> HTTP ${code}"
+          if [ "$code" != "101" ]; then
+            echo "FAIL: SLM WebSocket not reachable under /slm (#9967 regression class)"
+            exit 1
+          fi
+          echo "OK: SLM WebSocket upgrades under /slm"
+
+      - name: (b) user frontend under strict co-located CSP (#9966 class)
+        run: |
+          set -euo pipefail
+          # Scan the BUILT user frontend (as served by nginx) against the CSP
+          # actually deployed on co-located installs (strict headers template).
+          docker compose --env-file docker/.env.docker cp \
+            autobot-frontend:/usr/share/nginx/html /tmp/colocated-html
+          python3 scripts/check_colocated_csp.py \
+            --csp-template autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-security-headers-strict.conf.j2 \
+            --dist /tmp/colocated-html
+
+      - name: Collect logs on failure
+        if: failure()
+        run: docker compose --env-file docker/.env.docker logs > colocated-failure-logs.txt
+
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: colocated-smoke-logs
+          path: colocated-failure-logs.txt
+
+      - name: Clean up
+        if: always()
+        run: docker compose --env-file docker/.env.docker down

--- a/autobot-backend/transcriber/tests/test_multiuser_authz.py
+++ b/autobot-backend/transcriber/tests/test_multiuser_authz.py
@@ -1,0 +1,149 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# autobot-backend/transcriber/tests/test_multiuser_authz.py
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Multi-user authorization regression tests for transcriber rows (#10023).
+
+Pins the #9968 IDOR fix: a second authenticated user must NOT be able to
+read, modify, or delete the first user's projects/recordings. All access
+goes through transcriber.deps.can_access (#9863 single ownership policy);
+if that policy is weakened or a route stops calling it, these tests go red.
+"""
+
+import io
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+
+from transcriber.database import Database
+from transcriber.deps import DEFAULT_USER, can_access, get_db
+from transcriber.routes.projects import router as projects_router
+from transcriber.routes.recordings import router as recordings_router
+
+USER_HEADER = "x-test-user"
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path):
+    """App with both routers and header-driven request.state.user identity."""
+    app = FastAPI()
+    db = Database(str(tmp_path / "test.db"))
+    upload_dir = tmp_path / "uploads"
+    upload_dir.mkdir()
+
+    async def override_db():
+        return db
+
+    @app.middleware("http")
+    async def set_user(request: Request, call_next):
+        uid = request.headers.get(USER_HEADER)
+        if uid:
+            request.state.user = SimpleNamespace(id=uid)
+        return await call_next(request)
+
+    await db.connect()
+    app.dependency_overrides[get_db] = override_db
+    app.state.transcriber_upload_dir = str(upload_dir)
+    app.include_router(projects_router, prefix="/api/transcriber")
+    app.include_router(recordings_router, prefix="/api/transcriber")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+async def _create_project(client, user: str) -> int:
+    r = await client.post(
+        "/api/transcriber/projects",
+        json={"name": f"{user}-project", "description": ""},
+        headers={USER_HEADER: user},
+    )
+    assert r.status_code == 201
+    return r.json()["id"]
+
+
+async def _upload_recording(client, user: str, pid: int) -> int:
+    r = await client.post(
+        f"/api/transcriber/projects/{pid}/recordings",
+        files={"file": ("a.wav", io.BytesIO(b"RIFF" + b"\x00" * 32), "audio/wav")},
+        headers={USER_HEADER: user},
+    )
+    assert r.status_code == 202
+    return r.json()["id"]
+
+
+def test_can_access_policy_unit():
+    """can_access: owner yes, other user no, legacy DEFAULT_USER rows shared."""
+    assert can_access({"user_id": "alice"}, "alice") is True
+    assert can_access({"user_id": "alice"}, "bob") is False
+    assert can_access({"user_id": DEFAULT_USER}, "bob") is True
+    # Rows from before auth wiring (no user_id stamp) stay readable.
+    assert can_access({}, "bob") is True
+
+
+@pytest.mark.asyncio
+async def test_second_user_cannot_read_first_users_project(client):
+    pid = await _create_project(client, "alice")
+    r = await client.get(f"/api/transcriber/projects/{pid}", headers={USER_HEADER: "bob"})
+    assert r.status_code == 404, "IDOR (#9968): bob read alice's project"
+    # Owner still sees it
+    r = await client.get(f"/api/transcriber/projects/{pid}", headers={USER_HEADER: "alice"})
+    assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_second_user_cannot_modify_or_delete_project(client):
+    pid = await _create_project(client, "alice")
+    r = await client.patch(
+        f"/api/transcriber/projects/{pid}",
+        json={"name": "hijacked"},
+        headers={USER_HEADER: "bob"},
+    )
+    assert r.status_code == 404, "IDOR (#9968): bob modified alice's project"
+    r = await client.delete(f"/api/transcriber/projects/{pid}", headers={USER_HEADER: "bob"})
+    assert r.status_code == 404, "IDOR (#9968): bob deleted alice's project"
+    # Row untouched
+    r = await client.get(f"/api/transcriber/projects/{pid}", headers={USER_HEADER: "alice"})
+    assert r.status_code == 200
+    assert r.json()["name"] == "alice-project"
+
+
+@pytest.mark.asyncio
+async def test_project_listing_is_scoped_per_user(client):
+    pid = await _create_project(client, "alice")
+    r = await client.get("/api/transcriber/projects", headers={USER_HEADER: "bob"})
+    assert r.status_code == 200
+    assert pid not in [p["id"] for p in r.json()], "bob's listing leaked alice's project"
+
+
+@pytest.mark.asyncio
+async def test_second_user_cannot_access_recordings(client):
+    pid = await _create_project(client, "alice")
+    rid = await _upload_recording(client, "alice", pid)
+
+    r = await client.get(f"/api/transcriber/projects/{pid}/recordings", headers={USER_HEADER: "bob"})
+    assert r.status_code == 404, "IDOR (#9968): bob listed alice's recordings"
+    r = await client.get(f"/api/transcriber/recordings/{rid}", headers={USER_HEADER: "bob"})
+    assert r.status_code == 404, "IDOR (#9968): bob read alice's recording"
+    r = await client.delete(f"/api/transcriber/recordings/{rid}", headers={USER_HEADER: "bob"})
+    assert r.status_code == 404, "IDOR (#9968): bob deleted alice's recording"
+    r = await client.post(
+        f"/api/transcriber/projects/{pid}/recordings",
+        files={"file": ("b.wav", io.BytesIO(b"RIFF" + b"\x00" * 8), "audio/wav")},
+        headers={USER_HEADER: "bob"},
+    )
+    assert r.status_code == 404, "IDOR (#9968): bob uploaded into alice's project"
+
+
+@pytest.mark.asyncio
+async def test_legacy_default_rows_stay_accessible(client):
+    """Pre-auth rows (stamped DEFAULT_USER) remain readable by any caller."""
+    r = await client.post(
+        "/api/transcriber/projects", json={"name": "legacy", "description": ""}
+    )  # no user header -> DEFAULT_USER
+    pid = r.json()["id"]
+    r = await client.get(f"/api/transcriber/projects/{pid}", headers={USER_HEADER: "bob"})
+    assert r.status_code == 200

--- a/autobot-slm-backend/conftest.py
+++ b/autobot-slm-backend/conftest.py
@@ -63,7 +63,11 @@ def _stub(name: str) -> MagicMock:
     a stubbed submodule on an older conftest.
     """
     if name not in sys.modules:
-        mod = MagicMock()
+        # unsafe=True: module stubs must expose arbitrary names, including
+        # ones starting with `assert` (e.g. services.fleet_sync_guard.
+        # assert_no_running_sync) which safe mocks block as typo-protection
+        # and turn into collection-time ImportError (#10023).
+        mod = MagicMock(unsafe=True)
         mod.__name__ = name
         mod.__package__ = name.split(".")[0]
         mod.__spec__ = None
@@ -130,6 +134,8 @@ for _m in [
 # being installed in the dev environment.  Issue: #3525
 _pm_mod = types.ModuleType("python_multipart")
 _pm_mod.__version__ = "9.9.99"  # type: ignore[attr-defined]  # high sentinel — immune to future FastAPI threshold bumps
+# Legacy `multipart` shim re-exports `from python_multipart import __all__` (#10023).
+_pm_mod.__all__ = []  # type: ignore[attr-defined]
 sys.modules.setdefault("python_multipart", _pm_mod)
 
 # ── user_management ───────────────────────────────────────────────────────────

--- a/autobot-slm-backend/tests/api/test_collect_outdated_node_ids.py
+++ b/autobot-slm-backend/tests/api/test_collect_outdated_node_ids.py
@@ -35,12 +35,44 @@ _mp_stub.multipart = types.ModuleType("multipart.multipart")  # type: ignore[att
 sys.modules.setdefault("multipart", _mp_stub)
 sys.modules.setdefault("multipart.multipart", _mp_stub.multipart)  # type: ignore[attr-defined]
 
+# When conftest.py stubs `models.schemas` as a MagicMock, FastAPI cannot build
+# response models from MagicMock schema types at router-decoration time
+# (`Invalid args for response field`) and api.code_sync fails to import. Swap a
+# benign `dict` in for every schema name api/code_sync.py references as a
+# response_model, before importing it. No-op when models.schemas is the real
+# module (#10023).
+_SCHEMA_NAMES = (
+    "CodeSyncRefreshResponse",
+    "CodeSyncStatusResponse",
+    "CodeVersionNotification",
+    "CodeVersionNotificationResponse",
+    "DriftResolveRequest",
+    "DriftResolveResponse",
+    "FileDriftReport",
+    "FleetSyncJobStatus",
+    "FleetSyncNodeStatus",
+    "FleetSyncRequest",
+    "FleetSyncResponse",
+    "NodeSyncRequest",
+    "NodeSyncResponse",
+    "PendingNodeResponse",
+    "PendingNodesResponse",
+    "ScheduleCreate",
+    "ScheduleResponse",
+    "ScheduleRunResponse",
+    "ScheduleUpdate",
+)
+_schemas_stub = sys.modules.get("models.schemas")
+if isinstance(_schemas_stub, MagicMock):
+    for _name in _SCHEMA_NAMES:
+        setattr(_schemas_stub, _name, dict)
+
 from api.code_sync import (  # noqa: E402
     UpdateAllJob,
     UpdateAllStage,
     _collect_outdated_node_ids,
 )
-from models.database import CodeStatus, Node  # noqa: E402
+from models.database import CodeStatus  # noqa: E402
 
 REMOTE_COMMIT = "deadbeef1234deadbeef1234"
 SLM_IP = "10.0.1.10"
@@ -61,17 +93,21 @@ def _job() -> UpdateAllJob:
     )
 
 
-def _node(node_id: str, ip: str, code_version: str | None, code_status: str) -> Node:
-    n = Node.__new__(Node)
-    n.node_id = node_id
-    n.hostname = f"host-{node_id}"
-    n.ip_address = ip
-    n.code_version = code_version
-    n.code_status = code_status
-    return n
+def _node(node_id: str, ip: str, code_version: str | None, code_status: str) -> Any:
+    # SimpleNamespace, not models.database.Node: the real ORM model needs
+    # autobot_shared on the path, which the conftest-stubbed unit env lacks.
+    # The impl (#9996-B) keys off code_version, so code_status is documentation
+    # only and never compared.
+    return types.SimpleNamespace(
+        node_id=node_id,
+        hostname=f"host-{node_id}",
+        ip_address=ip,
+        code_version=code_version,
+        code_status=code_status,
+    )
 
 
-def _db_service_mock(query_results: List[Node], slm_node: Node | None = None) -> Any:
+def _db_service_mock(query_results: List[Any], slm_node: Any | None = None) -> Any:
     """Build a db_service mock that returns query_results for the version query
     and slm_node for the self-node lookup."""
     db_service_ref = MagicMock()
@@ -205,6 +241,35 @@ async def test_a_self_node_added_when_code_version_is_none():
         result = await _collect_outdated_node_ids(job, REMOTE_COMMIT, db_svc)
 
     assert "slm-node-fresh" in result
+
+
+@pytest.mark.asyncio
+async def test_a_self_node_added_only_via_ip_match():
+    """#9996-A regression guard: the self-node ABSENT from the version query is
+    still added by the IP-match branch — the branch that actually fixed #9996.
+
+    The other facet-A tests place the self-node in the version-query results
+    too, so they pass even if the IP-append branch is removed; this one isolates
+    that branch (version query returns only the worker).
+    """
+    worker = _node("worker-1", OTHER_IP, "oldsha", CodeStatus.UP_TO_DATE.value)
+    self_node = _node("slm-node", SLM_IP, None, CodeStatus.UNKNOWN.value)
+
+    job = _job()
+    with (
+        patch("api.code_sync.settings") as mock_settings,
+        patch("api.code_sync._compute_deps_changed", new=AsyncMock(return_value=False)),
+    ):
+        mock_settings.external_url = f"http://{SLM_IP}"
+        # Version query returns ONLY the worker; the self-node is reachable only
+        # through the IP lookup.
+        db_svc = _db_service_mock(query_results=[worker], slm_node=self_node)
+        result = await _collect_outdated_node_ids(job, REMOTE_COMMIT, db_svc)
+
+    assert "slm-node" in result, (
+        "co-located self-node missing — #9996-A regression: self-node invisible "
+        "to _collect_outdated_node_ids when not in the version-comparison set"
+    )
 
 
 @pytest.mark.asyncio

--- a/scripts/check_colocated_csp.py
+++ b/scripts/check_colocated_csp.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Static CSP-conformance check for the user frontend under the strict
+co-located Content-Security-Policy (#10023, catches the #9966 class).
+
+On co-located deployments the user frontend is served behind the SLM nginx
+strict header set (autobot-security-headers-strict.conf.j2, #7737/#9933).
+This script parses the CSP from that template (single source of truth) and
+scans a BUILT frontend dist directory for content the policy would block:
+
+  * inline <script> without src      -> blocked by script-src 'self'
+  * external script/stylesheet URLs  -> blocked by script-src / style-src
+  * @import / url(http...) in CSS    -> blocked by style-src / font-src
+  * data: fonts in CSS               -> blocked when font-src lacks data:
+
+Exit code 0 = conformant, 1 = violations found, 2 = usage/parse error.
+Stdlib-only so it runs on a bare CI runner.
+"""
+
+import argparse
+import re
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+
+CSP_RE = re.compile(r'Content-Security-Policy\s+"([^"]+)"')
+EXTERNAL_URL_RE = re.compile(r"""url\(\s*['"]?(https?:)?//""", re.IGNORECASE)
+CSS_IMPORT_RE = re.compile(r"""@import\s+(?:url\(\s*)?['"]?(https?:)?//""", re.IGNORECASE)
+DATA_FONT_RE = re.compile(r"""url\(\s*['"]?data:(?:font|application/(?:x-)?font)""", re.IGNORECASE)
+
+
+def parse_csp(template_path: Path) -> dict[str, list[str]]:
+    """Extract the CSP directive map from the nginx header template."""
+    match = CSP_RE.search(template_path.read_text(encoding="utf-8"))
+    if not match:
+        sys.exit(f"ERROR: no Content-Security-Policy header found in {template_path}")
+    directives: dict[str, list[str]] = {}
+    for chunk in match.group(1).split(";"):
+        tokens = chunk.strip().split()
+        if tokens:
+            directives[tokens[0]] = tokens[1:]
+    return directives
+
+
+def _is_external(url: str) -> bool:
+    url = url.strip().lower()
+    return url.startswith(("http://", "https://", "//"))
+
+
+class _IndexHtmlScanner(HTMLParser):
+    """Collect CSP-relevant facts from index.html."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.inline_scripts: list[int] = []  # line numbers of inline <script>
+        self.external_scripts: list[str] = []
+        self.external_styles: list[str] = []
+        self._in_script_without_src = False
+        self._script_line = 0
+
+    def handle_starttag(self, tag: str, attrs: list) -> None:
+        attr_map = dict(attrs)
+        if tag == "script":
+            src = attr_map.get("src")
+            if src is None:
+                self._in_script_without_src = True
+                self._script_line = self.getpos()[0]
+            elif _is_external(src):
+                self.external_scripts.append(src)
+        elif tag == "link":
+            rel = (attr_map.get("rel") or "").lower()
+            href = attr_map.get("href") or ""
+            if rel in ("stylesheet", "preload") and _is_external(href):
+                self.external_styles.append(href)
+
+    def handle_data(self, data: str) -> None:
+        if self._in_script_without_src and data.strip():
+            self.inline_scripts.append(self._script_line)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "script":
+            self._in_script_without_src = False
+
+
+def check_index_html(path: Path, csp: dict[str, list[str]]) -> list[str]:
+    """Return violations the strict CSP would raise for index.html."""
+    scanner = _IndexHtmlScanner()
+    scanner.feed(path.read_text(encoding="utf-8"))
+    violations = []
+    script_src = csp.get("script-src", csp.get("default-src", []))
+    if "'unsafe-inline'" not in script_src:
+        for line in scanner.inline_scripts:
+            violations.append(f"{path}:{line}: inline <script> blocked by script-src {' '.join(script_src)}")
+    for src in scanner.external_scripts:
+        violations.append(f"{path}: external script '{src}' blocked by script-src 'self'")
+    for href in scanner.external_styles:
+        violations.append(f"{path}: external stylesheet '{href}' blocked by style-src 'self'")
+    return violations
+
+
+def check_css_file(path: Path, csp: dict[str, list[str]]) -> list[str]:
+    """Return violations the strict CSP would raise for one built CSS file."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    violations = []
+    if CSS_IMPORT_RE.search(text):
+        violations.append(f"{path}: external @import blocked by style-src 'self'")
+    elif EXTERNAL_URL_RE.search(text):
+        violations.append(f"{path}: external url(...) blocked by style-src/font-src 'self'")
+    font_src = csp.get("font-src", csp.get("default-src", []))
+    if "data:" not in font_src and DATA_FONT_RE.search(text):
+        violations.append(f"{path}: data: font blocked by font-src {' '.join(font_src)}")
+    return violations
+
+
+def scan_dist(dist: Path, csp: dict[str, list[str]]) -> list[str]:
+    """Scan the built user-frontend dist (excluding the /slm SLM-UI subtree)."""
+    slm_subtree = dist / "slm"
+    violations = []
+    index_html = dist / "index.html"
+    if not index_html.is_file():
+        sys.exit(f"ERROR: {index_html} not found — is --dist a built frontend?")
+    violations += check_index_html(index_html, csp)
+    for css in sorted(dist.rglob("*.css")):
+        if slm_subtree in css.parents:
+            continue
+        violations += check_css_file(css, csp)
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--csp-template", required=True, type=Path, help="nginx strict-headers template containing the CSP"
+    )
+    parser.add_argument("--dist", required=True, type=Path, help="built user-frontend dist directory")
+    args = parser.parse_args()
+
+    csp = parse_csp(args.csp_template)
+    print(f"Strict co-located CSP: {'; '.join(k + ' ' + ' '.join(v) for k, v in csp.items())}")
+    violations = scan_dist(args.dist, csp)
+    if violations:
+        print(
+            f"\nFAIL: {len(violations)} CSP violation(s) — user frontend would break "
+            "under the strict co-located CSP (#9966 class):"
+        )
+        for v in violations:
+            print(f"  - {v}")
+        return 1
+    print("OK: user frontend conforms to the strict co-located CSP")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Thinking Path
The 2026-06-11 bug-wave triage traced all 3 true regressions (of 33 bugs) to the co-located/deployment surface, which had **no** automated pre-merge gate. This adds an advisory `co-located-smoke` workflow with one assertion per regression class, path-filtered to that surface.

## What Changed
`.github/workflows/co-located-smoke.yml` — two jobs:
- **authz-and-selection** (fast pytest, no containers):
  - (c) #9996 self-node selection — reuses the canonical `tests/api/test_collect_outdated_node_ids.py`
  - (d) #9968 transcriber IDOR — `transcriber/tests/test_multiuser_authz.py` (6 tests, two header-driven identities through the projects + recordings routes)
- **colocated-stack** (compose, frontend at `/`, SLM at `/slm`):
  - (a) #9967/#9852 — `/slm/api/health` must answer `application/json` (not the SPA catch-all) + WS handshake on `/slm/api/ws/events` returns 101
  - (b) #9966 — built user frontend conforms to the strict co-located CSP via `scripts/check_colocated_csp.py` (#9966 has since landed via #10065, so this now guards regression)
- `scripts/check_colocated_csp.py` — stdlib-only CSP-conformance scan of a built dist against `autobot-security-headers-strict.conf.j2`
- `autobot-slm-backend/conftest.py` — `MagicMock(unsafe=True)` so `assert_*` stub names resolve (was a collection-time ImportError), + `__all__` for the multipart shim

**Canonical reuse (not duplication):** class (c) resurrects the pre-existing but dead `test_collect_outdated_node_ids.py` (it failed to import: stubbed `models.schemas` MagicMock rejected by FastAPI as a response_model; `Node.__new__` needs the real ORM the stubbed env can't load). Fixed by substituting `dict` for schema names pre-import and building nodes with `SimpleNamespace`. Added `test_a_self_node_added_only_via_ip_match` — the one case that isolates the IP-match branch (the others seed the self-node into the version query too, so they didn't actually red-proof #9996-A).

## Verification
- (c) `test_collect_outdated_node_ids.py` → 7 passed (isolated, as the workflow runs it). **Red-proof:** drop the self-node IP-append → only `test_a_self_node_added_only_via_ip_match` fails (1/7).
- (d) `test_multiuser_authz.py` → 6 passed. **Red-proof** (agent-verified): `can_access → True` fails the IDOR tests.
- Workflow YAML valid; all referenced paths exist (free-disk-space action, CSP template, Dockerfiles, compose env). The two pytest jobs run in **separate processes** because the SLM conftest stubs `sys.modules` globally.

## Model Used
Claude Fable 5 (devops-engineer agent — authored gate + tests) + Opus 4.8 (main session: canonical-reuse consolidation, isolating red-proof test, rebase, verification)

Closes #10023. Part of umbrella #9924.