### PR TITLE
ci(gate): run frontend-test on PRs to Dev_new_gui (#10019)

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -10,7 +10,10 @@ on:
       - 'autobot-frontend/**'
       - '.github/workflows/frontend-test.yml'
   pull_request:
-    branches: [main, develop]
+    # 'Dev_*' covers the Dev_new_gui integration branch — every frontend PR
+    # merges here, so the suite must run pre-merge, not only post-merge on the
+    # push trigger (#10019). main/develop kept for promotion PRs.
+    branches: [main, develop, 'Dev_*']
     paths:
       - 'autobot-frontend/**'
       - '.github/workflows/frontend-test.yml'


### PR DESCRIPTION
## Thinking Path
`.github/workflows/frontend-test.yml` listed only `main`/`develop` under `pull_request.branches`, so every frontend PR merged into the `Dev_new_gui` integration branch with **zero** frontend tests run pre-merge — the suite only fired post-merge on the push trigger. Verified on the June PR wave: `frontend-tests` appeared on none of them. This is the structural hole that let #9724's icon-helper migration land a 19-test regression unseen.

## What Changed
- `frontend-test.yml` `pull_request.branches`: `[main, develop]` → `[main, develop, 'Dev_*']` (same glob the push trigger already uses).

## Verification
- YAML valid. The suite is green on Dev_new_gui as of #9724 (strict vue-tsc → 0) and #9693 (unit 1781 / integration 28 / lint 0), so enabling it on PRs adds a passing advisory check, not a red one.
- **Merge ordering:** land after #10078 (#9693) so the suite is green when the trigger goes live. Advisory (non-required), so no PR is blocked regardless.

## Path to required check
Tracked in #10022 — path-filtered workflows can't be required directly (they deadlock PRs that don't touch the paths); needs the always-report pattern.

## Model Used
Claude Opus 4.8 (main session)

Closes #10019. Part of umbrella #9924.