### PR TITLE
fix(captcha): use canonical config.vnc_url to avoid empty-host VNC URL (#9942)

### DIFF
--- a/autobot-backend/services/captcha_human_loop.py
+++ b/autobot-backend/services/captcha_human_loop.py
@@ -121,10 +121,8 @@ class CaptchaHumanLoop:
         """
         self.timeout_seconds = timeout_seconds
         self.auto_skip_on_timeout = auto_skip_on_timeout
-        # Use environment variable or NetworkConstants for VNC URL
-        vnc_host = config.vnc_host
-        vnc_port = config.port.vnc
-        self.vnc_url = vnc_url or f"http://{vnc_host}:{vnc_port}/vnc.html"
+        # Use canonical config property to avoid empty-host URL when AUTOBOT_VNC_HOST is unset
+        self.vnc_url = vnc_url or config.vnc_url
         self.enable_auto_solve = enable_auto_solve
         self._auto_solver = None
 


### PR DESCRIPTION
## Thinking Path
`captcha_human_loop.py` hand-assembled the VNC URL from `config.vnc_host`, which defaults to `""` when `AUTOBOT_VNC_HOST` is unset → `http://:6080/vnc.html`. The canonical `config.vnc_url` property builds from `vm.main` (always populated) + `port.vnc`, same URL shape. Sibling of #9912/#9832.

## What Changed
- `autobot-backend/services/captcha_human_loop.py`: replaced the 3-line hand-assembled URL with `config.vnc_url` (still honoring an explicit `vnc_url` override).

## Verification
- `py_compile` ✅ · `black --check` ✅ (no changes)
- `config.vnc_url` returns `http://{vm.main}:{port.vnc}/vnc.html` — identical shape, non-empty host.

## Model Used
Opus 4.8

Fixes #9942