### PR TITLE
fix(memory-graph): create FT index + data on DB 0 so semantic search leaves SCAN fallback (#9943)

### DIFF
--- a/autobot-backend/autobot_memory_graph/core.py
+++ b/autobot-backend/autobot_memory_graph/core.py
@@ -82,7 +82,7 @@ class Config:
     def __init__(self):
         self.redis_host = _ssot_config.vm.redis  # (#1148)
         self.redis_port = 6379
-        self.redis_db = DATABASE_MAPPING["knowledge"]  # (#2670)
+        self.redis_db = DATABASE_MAPPING["memory"]  # DB 0 — required for RediSearch FT.* (#9943)
         self.index_prefix = "autobot:entities"
         self.relations_prefix = "autobot:relations"
         self.embedding_model = "nomic-embed-text"
@@ -150,7 +150,13 @@ class AutoBotMemoryGraphCore:
 
             try:
                 # Initialize Redis client
-                self.redis_client = get_redis_client(async_client=True, database="knowledge")
+                # RediSearch FT.CREATE only operates on Redis logical DB 0.
+                # Both the FT indexes (memory_entity_idx, memory_fulltext_idx) and
+                # the data keys (memory:entity:*, memory:relations:*) must live on
+                # the same DB.  The "memory" alias maps to DB 0 for exactly this
+                # purpose — see autobot_shared/redis_management/types.py _ALIASES.
+                # Fixed by #9943 (same root cause as #9904).
+                self.redis_client = get_redis_client(async_client=True, database="memory")
 
                 # Create search indexes if they don't exist
                 await self._create_search_indexes()

--- a/autobot-backend/autobot_memory_graph/core.py
+++ b/autobot-backend/autobot_memory_graph/core.py
@@ -182,29 +182,24 @@ class AutoBotMemoryGraphCore:
 
     async def _create_search_indexes(self) -> None:
         """
-        Create Redis search indexes for entities if they don't exist.
+        Create the RediSearch FT indexes for entity/full-text search.
 
-        Issue #665: Helper for initialize()
+        Delegates to the canonical ``ensure_indexes`` coroutine in
+        ``semantic_search`` (the single source of the FT.CREATE schema for
+        ``memory_entity_idx`` / ``memory_fulltext_idx`` over ``memory:entity:*``
+        JSON keys).  Without this call the production init path created no
+        index, so FT.SEARCH always degraded to the slow SCAN fallback (#9943).
+
+        Imported lazily because ``semantic_search`` imports from this module
+        at import time (circular-import guard).
+
+        Issue #665 / #9943: Helper for initialize().
         """
-        try:
-            # Check if index exists
-            exists = await self._check_index_exists(self.index_name)
-            if exists:
-                logger.debug(f"Search index {self.index_name} already exists")
-                return
+        from .semantic_search import ensure_indexes
 
-            # Create index for entity search
-            # Note: This is a simplified version. Full implementation
-            # would include FT.CREATE with proper schema
-            logger.info(f"Creating search index: {self.index_name}")
-
-            # Index creation would go here
-            # Actual implementation depends on RedisSearch version and schema
-
-        except Exception as e:
-            logger.warning(f"Error creating search indexes: {e}")
-            # Don't fail initialization if index creation fails
-            # Index may already exist or be created manually
+        # ensure_indexes performs its own per-index existence check and swallows
+        # creation errors with a warning, so initialization is never blocked.
+        await ensure_indexes(self.redis_client)
 
     async def _check_index_exists(self, index_name: str) -> bool:
         """

--- a/autobot-backend/autobot_memory_graph/semantic_search.py
+++ b/autobot-backend/autobot_memory_graph/semantic_search.py
@@ -205,7 +205,9 @@ class MemoryGraphQueryProcessor:
     def __init__(self, redis_client: Any, embedding_model: str | None = None):
         """
         Args:
-            redis_client:    Async Redis client (already connected, knowledge DB).
+            redis_client:    Async Redis client (already connected, DB 0 / "memory"
+                             alias).  RediSearch FT.SEARCH requires DB 0; entity
+                             data keys also live on DB 0 after #9943.
             embedding_model: Ollama model name.  Falls back to
                              config["knowledge.embedding_model"] or
                              "nomic-embed-text".
@@ -583,7 +585,11 @@ async def ensure_indexes(redis_client: Any) -> None:
         memory_fulltext_idx — phonetic full-text index
 
     Args:
-        redis_client: Async Redis client connected to the knowledge database.
+        redis_client: Async Redis client connected to Redis logical DB 0.
+            RediSearch FT.CREATE only operates on DB 0; pass a client created
+            with ``database="memory"`` (the DB 0 alias).  The data keys
+            (``memory:entity:*``) written by ``AutoBotMemoryGraphCore`` also
+            live on DB 0 after the fix in #9943.
     """
     await asyncio.gather(
         _ensure_entity_idx(redis_client),

--- a/autobot-backend/autobot_memory_graph/semantic_search_test.py
+++ b/autobot-backend/autobot_memory_graph/semantic_search_test.py
@@ -382,3 +382,35 @@ class TestEnsureIndexes:
 
         calls = [str(c) for c in redis_mock.execute_command.call_args_list]
         assert not any("FT.CREATE" in c for c in calls)
+
+
+class TestCoreCreateSearchIndexes:
+    """Regression guard for #9943: the production init path must actually
+    create the FT indexes (it was a no-op stub, so search stayed on SCAN)."""
+
+    @pytest.mark.asyncio
+    async def test_create_search_indexes_delegates_to_ensure_indexes(
+        self, monkeypatch
+    ) -> None:
+        from autobot_memory_graph.core import AutoBotMemoryGraphCore
+
+        # Bypass the heavy __init__ (Config/Redis) — only the redis_client
+        # attribute matters for this wiring check.
+        inst = AutoBotMemoryGraphCore.__new__(AutoBotMemoryGraphCore)
+        fake_client = MagicMock()
+        inst.redis_client = fake_client
+
+        captured: Dict[str, Any] = {}
+
+        async def fake_ensure(client: Any) -> None:
+            captured["client"] = client
+
+        monkeypatch.setattr(
+            "autobot_memory_graph.semantic_search.ensure_indexes", fake_ensure
+        )
+
+        await inst._create_search_indexes()
+
+        # The stub used to create nothing; it must now pass the live client
+        # through to ensure_indexes so FT.CREATE actually runs.
+        assert captured.get("client") is fake_client

--- a/autobot-backend/autobot_memory_graph/semantic_search_test.py
+++ b/autobot-backend/autobot_memory_graph/semantic_search_test.py
@@ -389,9 +389,7 @@ class TestCoreCreateSearchIndexes:
     create the FT indexes (it was a no-op stub, so search stayed on SCAN)."""
 
     @pytest.mark.asyncio
-    async def test_create_search_indexes_delegates_to_ensure_indexes(
-        self, monkeypatch
-    ) -> None:
+    async def test_create_search_indexes_delegates_to_ensure_indexes(self, monkeypatch) -> None:
         from autobot_memory_graph.core import AutoBotMemoryGraphCore
 
         # Bypass the heavy __init__ (Config/Redis) — only the redis_client
@@ -405,9 +403,7 @@ class TestCoreCreateSearchIndexes:
         async def fake_ensure(client: Any) -> None:
             captured["client"] = client
 
-        monkeypatch.setattr(
-            "autobot_memory_graph.semantic_search.ensure_indexes", fake_ensure
-        )
+        monkeypatch.setattr("autobot_memory_graph.semantic_search.ensure_indexes", fake_ensure)
 
         await inst._create_search_indexes()
 


### PR DESCRIPTION
## Thinking Path
Two root causes kept memory-graph semantic search permanently on the slow SCAN path:
1. **Wrong DB:** the client was created with `database="knowledge"` (Redis DB 1), but RediSearch `FT.CREATE` only operates on DB 0 — index creation always failed (swallowed by `logger.warning`). Same class as #9904/PR #9939.
2. **Index never created in prod:** `core.py`'s `_create_search_indexes()` (called from `initialize()`) was a no-op stub; the real `ensure_indexes()` in `semantic_search.py` was exported but **never called at runtime**. So even on DB 0, no FT index would ever exist → FT.SEARCH fails → SCAN fallback.

## What Changed
- `core.py`: client + `Config.redis_db` now use the `"memory"` alias (DB 0). Both the FT indexes and the data keys (`memory:entity:*`, written via `json().set`) now share DB 0.
- `core.py`: `_create_search_indexes()` now delegates to the canonical `ensure_indexes()` (lazy import to avoid the `semantic_search → core` circular import).
- `semantic_search.py`: docstrings corrected (DB 0 / "memory" alias).
- Added regression test `TestCoreCreateSearchIndexes` asserting the init path actually invokes `ensure_indexes`.

## Verification
- `pytest autobot_memory_graph/semantic_search_test.py` → **38 passed** (incl. new test) ✅
- `py_compile` ✅

## Model Used
Opus 4.8

Fixes #9943