### PR TITLE
fix(frontend): re-wire nav featureFlag filtering with fail-safe per-item defaults (#9984)

### DIFF
--- a/autobot-frontend/.env.example
+++ b/autobot-frontend/.env.example
@@ -22,11 +22,3 @@ VITE_ENABLE_RUM=true
 # VITE_BACKEND_PORT=8001
 # VITE_API_BASE_URL=http://localhost:8001
 # VITE_WS_BASE_URL=ws://localhost:8001/ws
-
-# Feature flags — gate nav items defined in src/config/navItems.ts.
-# An item with a `featureFlag` is shown ONLY when its VITE_FEATURE_<NAME>='true'.
-# Defaults below keep currently-shipped nav items visible (#9984).
-# Transcriber primary-nav item (#9044): set to 'false' to hide it.
-VITE_FEATURE_TRANSCRIBER=true
-# Live Canvas profile-menu item (GH#8758): opt-in, defaults off.
-# VITE_FEATURE_CANVAS=true

--- a/autobot-frontend/.env.example
+++ b/autobot-frontend/.env.example
@@ -22,3 +22,11 @@ VITE_ENABLE_RUM=true
 # VITE_BACKEND_PORT=8001
 # VITE_API_BASE_URL=http://localhost:8001
 # VITE_WS_BASE_URL=ws://localhost:8001/ws
+
+# Feature flags — gate nav items defined in src/config/navItems.ts.
+# An item with a `featureFlag` is shown ONLY when its VITE_FEATURE_<NAME>='true'.
+# Defaults below keep currently-shipped nav items visible (#9984).
+# Transcriber primary-nav item (#9044): set to 'false' to hide it.
+VITE_FEATURE_TRANSCRIBER=true
+# Live Canvas profile-menu item (GH#8758): opt-in, defaults off.
+# VITE_FEATURE_CANVAS=true

--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -217,7 +217,7 @@
           class="lg:hidden absolute top-full left-0 right-0 bg-autobot-bg-secondary border-b border-autobot-border shadow-lg z-20"
         >
           <div class="px-4 py-3 space-y-2">
-            <template v-for="item in navItems" :key="item.to">
+            <template v-for="item in filteredNavItems" :key="item.to">
             <router-link
               :to="item.to"
               @click="closeMobileNav"
@@ -974,7 +974,7 @@ export default {
     // Nav overflow: ref for container, filtered/visible/overflow computed slices
     const navContainerRef = ref<HTMLElement | null>(null)
 
-    const filteredNavItems = computed(() => navItems)
+    const filteredNavItems = computed(() => filterByFeatureFlag(navItems))
 
     const filteredProfileMenuItems = computed(() =>
       filterByFeatureFlag(profileMenuItems)
@@ -1022,6 +1022,7 @@ export default {
       showAuthChrome,
       hideFooter,
       navItems,
+      filteredNavItems,
       profileMenuItems,
       filteredProfileMenuItems,
       adminMenuItems,

--- a/autobot-frontend/src/__tests__/nav-items-coverage.test.ts
+++ b/autobot-frontend/src/__tests__/nav-items-coverage.test.ts
@@ -148,6 +148,30 @@ describe('navItems coverage (#6499)', () => {
     expect(canvasItem?.featureFlag).toBe('canvas')
   })
 
+  // #9984: filterByFeatureFlag must gate the PRIMARY nav too (was a no-op before —
+  // App.vue used `computed(() => navItems)` so flagged primary items always showed).
+  it('transcriber primary navItem has featureFlag set to "transcriber"', () => {
+    const transcriber = navItems.find((i) => i.to === '/transcriber')
+    expect(transcriber?.featureFlag).toBe('transcriber')
+  })
+
+  it('transcriber is hidden in navItems when VITE_FEATURE_TRANSCRIBER is unset', () => {
+    const result = filterByFeatureFlag(navItems, {})
+    expect(result.map((i) => i.to)).not.toContain('/transcriber')
+  })
+
+  it('transcriber is visible in navItems when VITE_FEATURE_TRANSCRIBER=true', () => {
+    const result = filterByFeatureFlag(navItems, { VITE_FEATURE_TRANSCRIBER: 'true' })
+    expect(result.map((i) => i.to)).toContain('/transcriber')
+  })
+
+  it('unflagged primary navItems are always visible regardless of env', () => {
+    const result = filterByFeatureFlag(navItems, {})
+    expect(result.map((i) => i.to)).toEqual(
+      expect.arrayContaining(['/home', '/chat', '/knowledge', '/automation']),
+    )
+  })
+
   it('allowlist size and route counts (regression sentinel)', () => {
     const allowlistSize = Object.keys(INTENTIONALLY_HIDDEN).length
     const checkedCount = topLevelRoutes().filter(

--- a/autobot-frontend/src/__tests__/nav-items-coverage.test.ts
+++ b/autobot-frontend/src/__tests__/nav-items-coverage.test.ts
@@ -150,19 +150,27 @@ describe('navItems coverage (#6499)', () => {
 
   // #9984: filterByFeatureFlag must gate the PRIMARY nav too (was a no-op before —
   // App.vue used `computed(() => navItems)` so flagged primary items always showed).
-  it('transcriber primary navItem has featureFlag set to "transcriber"', () => {
+  it('transcriber primary navItem is flagged and fails OPEN (shipped feature)', () => {
     const transcriber = navItems.find((i) => i.to === '/transcriber')
     expect(transcriber?.featureFlag).toBe('transcriber')
+    expect(transcriber?.featureDefaultVisible).toBe(true)
   })
 
-  it('transcriber is hidden in navItems when VITE_FEATURE_TRANSCRIBER is unset', () => {
+  it('transcriber stays VISIBLE when VITE_FEATURE_TRANSCRIBER is unset (fail-open)', () => {
     const result = filterByFeatureFlag(navItems, {})
+    expect(result.map((i) => i.to)).toContain('/transcriber')
+  })
+
+  it('transcriber is hidden only when VITE_FEATURE_TRANSCRIBER is explicitly "false"', () => {
+    const result = filterByFeatureFlag(navItems, { VITE_FEATURE_TRANSCRIBER: 'false' })
     expect(result.map((i) => i.to)).not.toContain('/transcriber')
   })
 
-  it('transcriber is visible in navItems when VITE_FEATURE_TRANSCRIBER=true', () => {
-    const result = filterByFeatureFlag(navItems, { VITE_FEATURE_TRANSCRIBER: 'true' })
-    expect(result.map((i) => i.to)).toContain('/transcriber')
+  it('canvas fails CLOSED — hidden when its flag is unset, shown only on "true"', () => {
+    const hidden = filterByFeatureFlag(profileMenuItems, {})
+    expect(hidden.map((i) => i.to)).not.toContain('/canvas')
+    const shown = filterByFeatureFlag(profileMenuItems, { VITE_FEATURE_CANVAS: 'true' })
+    expect(shown.map((i) => i.to)).toContain('/canvas')
   })
 
   it('unflagged primary navItems are always visible regardless of env', () => {

--- a/autobot-frontend/src/config/navItems.ts
+++ b/autobot-frontend/src/config/navItems.ts
@@ -69,8 +69,9 @@ export const navItems: NavItem[] = [
     featureFlag: 'transcriber',
   },
   // Issue #9890: Vision Automation is reachable via Workflow Builder sidebar + direct route.
-  // It is NOT in the primary nav rail — the featureFlag mechanism is dead (App.vue:977,
-  // #8820 stopped filtering), so a flag-gated entry would never hide the item.
+  // It is NOT in the primary nav rail. To gate a future entry, set its `featureFlag`
+  // and add a matching `VITE_FEATURE_<NAME>` default to the env templates (#9984 re-wired
+  // filterByFeatureFlag into both desktop and mobile nav in App.vue).
 ];
 
 // ─── Profile/settings menu items (GH#8748) ───────────────────────────────────

--- a/autobot-frontend/src/config/navItems.ts
+++ b/autobot-frontend/src/config/navItems.ts
@@ -27,21 +27,41 @@ export interface NavItem {
   iconPaths?: string[];
   iconRule?: SvgFillRule;
   iconStroke?: boolean;
-  /** VITE_FEATURE_<featureFlag.toUpperCase()> must equal 'true' to show this item. */
+  /**
+   * Gate this item behind `VITE_FEATURE_<featureFlag.toUpperCase()>`.
+   * The flag is a UX visibility toggle only — never a security boundary
+   * (route/API access is enforced server-side via RBAC). Explicit
+   * `'true'` shows, explicit `'false'` hides; when the env var is unset the
+   * item falls back to `featureDefaultVisible` (see below).
+   */
   featureFlag?: string;
+  /**
+   * Visibility when the feature flag's env var is UNSET (fail-safe default).
+   * Shipped features should set `true` (fail-open — stay visible even if the
+   * flag never reaches the build); experimental/preview features omit it so
+   * they fail closed (hidden until explicitly enabled). Default: `false`.
+   */
+  featureDefaultVisible?: boolean;
 }
 
 /**
- * Returns items whose featureFlag (if any) is enabled in the given env object.
- * Pass `import.meta.env` in production; pass a plain object in tests.
+ * Returns items whose featureFlag (if any) resolves to visible in the given
+ * env object. Resolution per item: no flag → always visible; flag `'true'` →
+ * visible; flag `'false'` → hidden; flag unset → `featureDefaultVisible`
+ * (fail-safe, default hidden). Pass `import.meta.env` in production; pass a
+ * plain object in tests.
  */
 export function filterByFeatureFlag(
   items: NavItem[],
   env: Record<string, string | boolean | undefined> = import.meta.env,
 ): NavItem[] {
-  return items.filter(
-    (item) => !item.featureFlag || env[`VITE_FEATURE_${item.featureFlag.toUpperCase()}`] === 'true',
-  );
+  return items.filter((item) => {
+    if (!item.featureFlag) return true;
+    const value = env[`VITE_FEATURE_${item.featureFlag.toUpperCase()}`];
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return item.featureDefaultVisible ?? false;
+  });
 }
 
 // ─── Primary nav (≤7 items for non-admin users at 1440 px) ───────────────────
@@ -60,25 +80,29 @@ export const navItems: NavItem[] = [
   // GH#9627: entry point is the company selector; LLC sub-views are reached
   // via the contextual LLC sidebar once a company is selected.
   { to: '/llc/select-company', labelKey: 'nav.companyOs', icon: 'M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4', iconStroke: true },
-  // Issue #9044: Transcriber — audio/video transcription module
+  // Issue #9044: Transcriber — audio/video transcription module.
+  // Shipped feature: fails OPEN (stays visible if VITE_FEATURE_TRANSCRIBER is
+  // unset); set the env var to 'false' to hide it.
   {
     to: '/transcriber',
     labelKey: 'nav.transcriber',
     icon: 'M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z',
     iconStroke: true,
     featureFlag: 'transcriber',
+    featureDefaultVisible: true,
   },
   // Issue #9890: Vision Automation is reachable via Workflow Builder sidebar + direct route.
-  // It is NOT in the primary nav rail. To gate a future entry, set its `featureFlag`
-  // and add a matching `VITE_FEATURE_<NAME>` default to the env templates (#9984 re-wired
-  // filterByFeatureFlag into both desktop and mobile nav in App.vue).
+  // It is NOT in the primary nav rail. To gate a future entry, add a `featureFlag`
+  // (and `featureDefaultVisible: true` only if it should ship visible by default).
+  // #9984 re-wired filterByFeatureFlag into both desktop and mobile nav in App.vue.
 ];
 
 // ─── Profile/settings menu items (GH#8748) ───────────────────────────────────
 // Shown in the profile dropdown — not in the primary nav rail.
 // Routes must carry hideInNav: true in router/index.ts.
 export const profileMenuItems: NavItem[] = [
-  // MVA-360: Live Canvas — gated by VITE_FEATURE_CANVAS (GH#8758)
+  // MVA-360: Live Canvas — experimental, gated by VITE_FEATURE_CANVAS (GH#8758).
+  // Fails CLOSED (hidden) unless the env var is explicitly 'true'.
   { to: '/canvas', labelKey: 'nav.canvas', icon: 'M3 3h7v7H3V3zm0 11h7v7H3v-7zm11-11h7v7h-7V3zm0 11h7v7h-7v-7z', iconStroke: true, featureFlag: 'canvas' },
   // Issue #929: Plugin Manager
   { to: '/plugins', labelKey: 'nav.plugins', icon: 'M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z', iconStroke: true },

--- a/autobot-slm-backend/ansible/roles/frontend/templates/frontend.env.j2
+++ b/autobot-slm-backend/ansible/roles/frontend/templates/frontend.env.j2
@@ -10,7 +10,9 @@ VITE_BACKEND_PORT={{ backend_port | default(8443) }}
 # Alternative API base URL (legacy compatibility)
 VITE_API_BASE_URL={{ frontend_backend_url }}
 
-# Feature flags — gate nav items defined in src/config/navItems.ts (#9984).
-# An item with a `featureFlag` shows ONLY when VITE_FEATURE_<NAME>='true'.
-# Defaults keep currently-shipped nav items visible.
+# Feature flags — UX visibility toggles for nav items in src/config/navItems.ts
+# (#9984). Value 'true' shows / 'false' hides. When a flag is unset the item
+# applies its own fail-safe default in code (shipped items stay visible,
+# experimental items stay hidden), so this is an explicit operator override —
+# not a security control (route/API access is enforced server-side via RBAC).
 VITE_FEATURE_TRANSCRIBER={{ frontend_feature_transcriber | default(true) | string | lower }}

--- a/autobot-slm-backend/ansible/roles/frontend/templates/frontend.env.j2
+++ b/autobot-slm-backend/ansible/roles/frontend/templates/frontend.env.j2
@@ -9,3 +9,8 @@ VITE_BACKEND_PORT={{ backend_port | default(8443) }}
 
 # Alternative API base URL (legacy compatibility)
 VITE_API_BASE_URL={{ frontend_backend_url }}
+
+# Feature flags — gate nav items defined in src/config/navItems.ts (#9984).
+# An item with a `featureFlag` shows ONLY when VITE_FEATURE_<NAME>='true'.
+# Defaults keep currently-shipped nav items visible.
+VITE_FEATURE_TRANSCRIBER={{ frontend_feature_transcriber | default(true) | string | lower }}


### PR DESCRIPTION
## Thinking Path
`filterByFeatureFlag()` was only applied to `profileMenuItems`; `filteredNavItems` was `computed(() => navItems)` (identity) and the mobile nav iterated raw `navItems`, so the primary-nav `featureFlag` field was a dead no-op (#8820). Re-wiring it naively was risky: the rigid `=== 'true'` (opt-in) semantics means an **undefined** flag hides the item, so the always-visible transcriber could vanish in any build that doesn't plumb the flag (and `vite.config` loads env from project-root `.env`, while the deployed env lands at `/etc/autobot/autobot-frontend.env` — see discovery).

Solution: keep the filter **wired** but give each item an explicit **fail-safe default**, treating the flag honestly as a UX toggle (real access control stays server-side via RBAC):
- **Shipped features fail OPEN** — transcriber stays visible unless explicitly `'false'`.
- **Experimental features fail CLOSED** — canvas hidden unless explicitly `'true'`.

## What Changed
- `config/navItems.ts`: `filterByFeatureFlag` resolves `'true'`→show / `'false'`→hide / unset→`featureDefaultVisible` (default false). Added `featureDefaultVisible?: boolean` to `NavItem`. Transcriber → `featureDefaultVisible: true`; canvas stays fail-closed.
- `App.vue`: `filteredNavItems = computed(() => filterByFeatureFlag(navItems))`; mobile nav now iterates `filteredNavItems`.
- `frontend.env.j2`: documented flags as UX overrides, not security controls.
- Tests: fail-open transcriber, fail-closed canvas, unflagged-always-visible.

## Verification
- `vue-tsc --noEmit` → **0 errors** (new strict baseline) ✅
- `vitest nav-items-coverage` → **12 passed** ✅
- (Pre-existing unrelated unhandled timer error from `LiveEventService.ts` surfaced by router import — filed as discovery.)

## Model Used
Opus 4.8

Fixes #9984