### PR TITLE
feat(connectors): OAuth authorize/callback flow + auto-refresh resolver (#9019)

### DIFF
--- a/autobot-backend/api/knowledge_connector_oauth.py
+++ b/autobot-backend/api/knowledge_connector_oauth.py
@@ -1,0 +1,274 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Connector OAuth 2.0 endpoints (ADR-007 / GH#9019).
+
+Generic, provider-agnostic authorization-code + PKCE flow that lets a user
+"Connect <provider>" from the knowledge-base UI.  The resulting refresh/access
+tokens are persisted through SecretsService (never custom storage) and returned
+by reference (``secret_id``) for attachment to a connector.
+
+- ``authorize`` mints CSRF state + PKCE, stashes them server-side, and returns
+  the provider authorization URL.  Requires an authenticated user.
+- ``callback`` is reached by the provider's browser redirect; it is authorized
+  by the single-use ``state`` token (server-minted), exchanges the code for
+  tokens, stores them, and returns an HTML page that hands the ``secret_id``
+  back to the opener window.
+"""
+
+import html
+import json
+import uuid
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel
+
+from auth_middleware import get_current_user
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_redis_client
+from autobot_shared.ssot_config import config
+from knowledge.connectors import oauth_flow
+from knowledge.connectors.credential_store import get_credential_store
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["knowledge-connectors-oauth"])
+
+# OAuth state is single-use and short-lived; this is a security window, not a cache.
+_OAUTH_STATE_TTL_SECONDS = 600
+_OAUTH_STATE_PREFIX = "connector:oauth:state:"
+# Double-submit cookie binding the completing browser to the initiating one (CSRF).
+_OAUTH_STATE_COOKIE = "connector_oauth_state"
+_OAUTH_CALLBACK_PATH = "/api/knowledge_base/connectors/oauth/callback"
+
+
+class AuthorizeRequest(BaseModel):
+    """Body for starting a connector OAuth flow."""
+
+    redirect_uri: str
+    scopes: list[str] | None = None
+
+
+class AuthorizeResponse(BaseModel):
+    authorize_url: str
+    state: str
+    connector_id: str
+
+
+def _state_key(state: str) -> str:
+    return "%s%s" % (_OAUTH_STATE_PREFIX, state)
+
+
+def _validate_redirect_uri(redirect_uri: str) -> None:
+    """Reject redirect URIs whose host is not allow-listed (anti-phishing).
+
+    Reuses the SSO callback-host allowlist and HTTPS-enforcement settings.
+    """
+    parsed = urlparse(redirect_uri)
+    if not parsed.scheme or not parsed.hostname:
+        raise HTTPException(status_code=422, detail="redirect_uri must be an absolute URL")
+    allowed = {h.strip().lower() for h in config.auth.sso_callback_hosts.split(",") if h.strip()}
+    if parsed.hostname.lower() not in allowed:
+        raise HTTPException(status_code=400, detail="redirect_uri host is not allow-listed")
+    if config.auth.enforce_https_callbacks and parsed.scheme != "https":
+        raise HTTPException(status_code=400, detail="redirect_uri must use HTTPS")
+
+
+@router.post("/knowledge_base/connectors/oauth/{provider}/authorize", response_model=AuthorizeResponse)
+async def start_oauth(
+    provider: str,
+    request: AuthorizeRequest,
+    response: Response,
+    user: dict = Depends(get_current_user),
+) -> AuthorizeResponse:
+    """Begin a connector OAuth flow; return the provider authorization URL."""
+    try:
+        prov = oauth_flow.get_provider(provider)
+        client_id, _ = oauth_flow.resolve_client_credentials(prov)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    _validate_redirect_uri(request.redirect_uri)
+
+    state = oauth_flow.generate_state()
+    verifier, challenge = oauth_flow.generate_pkce()
+    connector_id = str(uuid.uuid4())
+    scopes = tuple(request.scopes) if request.scopes else None
+
+    payload = {
+        "provider": provider,
+        "owner_id": str(user.get("user_id") or "system"),
+        "connector_id": connector_id,
+        "code_verifier": verifier,
+        "redirect_uri": request.redirect_uri,
+        "scopes": list(scopes) if scopes else [],
+    }
+    redis = get_redis_client(database="knowledge")
+    await _redis_setex(redis, _state_key(state), _OAUTH_STATE_TTL_SECONDS, json.dumps(payload, ensure_ascii=False))
+
+    # Bind the completing browser to this one: the callback requires this cookie
+    # to match the returned state (defends against OAuth CSRF / token attachment).
+    # SameSite=lax so the cookie rides the top-level provider→callback redirect.
+    response.set_cookie(
+        _OAUTH_STATE_COOKIE,
+        state,
+        max_age=_OAUTH_STATE_TTL_SECONDS,
+        httponly=True,
+        secure=config.auth.enforce_https_callbacks,
+        samesite="lax",
+        path=_OAUTH_CALLBACK_PATH,
+    )
+
+    authorize_url = oauth_flow.build_authorize_url(
+        prov, client_id, request.redirect_uri, state, challenge, scopes
+    )
+    return AuthorizeResponse(authorize_url=authorize_url, state=state, connector_id=connector_id)
+
+
+@router.get("/knowledge_base/connectors/oauth/callback", response_class=HTMLResponse)
+async def oauth_callback(
+    request: Request,
+    state: str = Query(...),
+    code: str | None = Query(default=None),
+    error: str | None = Query(default=None),
+) -> HTMLResponse:
+    """Handle the provider redirect: exchange code → store tokens → hand back secret_id."""
+    # CSRF binding: the browser completing the flow must be the one that started
+    # it (carries the state cookie). Reject before consuming the state token.
+    cookie_state = request.cookies.get(_OAUTH_STATE_COOKIE)
+    if not cookie_state or cookie_state != state:
+        return _clear_cookie(_result_page(error="state_binding_mismatch"))
+
+    redis = get_redis_client(database="knowledge")
+    raw = await _redis_getdel(redis, _state_key(state))
+    if raw is None:
+        return _clear_cookie(_result_page(error="invalid_or_expired_state"))
+    payload = json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else raw)
+
+    if error:
+        return _clear_cookie(_result_page(error=error, provider=payload.get("provider")))
+    if not code:
+        return _clear_cookie(_result_page(error="missing_authorization_code", provider=payload.get("provider")))
+
+    try:
+        secret_id = await _exchange_and_store(payload, code)
+    except (ValueError, KeyError) as exc:
+        logger.error("OAuth callback config error: %s", exc)
+        return _clear_cookie(_result_page(error="provider_not_configured", provider=payload.get("provider")))
+    except RuntimeError as exc:
+        logger.error("OAuth token exchange failed: %s", exc)
+        return _clear_cookie(_result_page(error="token_exchange_failed", provider=payload.get("provider")))
+
+    return _clear_cookie(
+        _result_page(
+            secret_id=secret_id,
+            provider=payload.get("provider"),
+            connector_id=payload.get("connector_id"),
+        )
+    )
+
+
+async def _exchange_and_store(payload: dict, code: str) -> str:
+    """Exchange the auth code and persist tokens; return the secret id."""
+    prov = oauth_flow.get_provider(payload["provider"])
+    client_id, client_secret = oauth_flow.resolve_client_credentials(prov)
+    token_response = await oauth_flow.exchange_code(
+        prov, client_id, client_secret, code, payload["redirect_uri"], payload["code_verifier"]
+    )
+    return await get_credential_store().store_oauth(
+        connector_id=payload["connector_id"],
+        owner_id=payload["owner_id"],
+        provider=payload["provider"],
+        token_response=token_response,
+        client_id=client_id,
+        client_secret=client_secret,
+        token_url=prov.token_url,
+        scopes=payload.get("scopes") or list(prov.default_scopes),
+    )
+
+
+def _result_page(
+    secret_id: str | None = None,
+    provider: str | None = None,
+    connector_id: str | None = None,
+    error: str | None = None,
+) -> HTMLResponse:
+    """Render the popup result page that messages the opener and self-closes."""
+    message = {
+        "type": "connector-oauth",
+        "ok": error is None,
+        "secret_id": secret_id,
+        "provider": provider,
+        "connector_id": connector_id,
+        "error": error,
+    }
+    status = "Connected — you can close this window." if error is None else ("Connection failed: %s" % error)
+    # Both reflected values are attacker-influenced (error is a provider query
+    # param): HTML-escape the visible text, and JS-escape the embedded JSON so a
+    # value can never break out of the <script> or the string context.
+    safe_status = html.escape(status)
+    safe_json = _js_safe_json(message)
+    body = (
+        "<!doctype html><html><head><meta charset='utf-8'><title>Connector OAuth</title></head>"
+        "<body style='font-family:sans-serif;padding:2rem'>"
+        "<p>%s</p>"
+        "<script>(function(){var m=%s;try{if(window.opener){window.opener.postMessage(m,window.location.origin);}}"
+        "catch(e){}setTimeout(function(){window.close();},500);})();</script>"
+        "</body></html>"
+    ) % (safe_status, safe_json)
+    return HTMLResponse(content=body, status_code=200)
+
+
+def _js_safe_json(obj: dict) -> str:
+    """json.dumps with HTML/JS-sensitive chars escaped so it is safe inside <script>."""
+    out = json.dumps(obj)
+    for ch, esc in (
+        ("<", "\\u003c"),
+        (">", "\\u003e"),
+        ("&", "\\u0026"),
+        (chr(0x2028), "\\u2028"),  # JS line separator — breaks string literals
+        (chr(0x2029), "\\u2029"),  # JS paragraph separator
+    ):
+        out = out.replace(ch, esc)
+    return out
+
+
+def _clear_cookie(response: HTMLResponse) -> HTMLResponse:
+    """Delete the single-use state-binding cookie on the result response."""
+    response.delete_cookie(_OAUTH_STATE_COOKIE, path=_OAUTH_CALLBACK_PATH)
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Redis helpers (sync client → thread; tolerate async client too)
+# ---------------------------------------------------------------------------
+
+
+async def _redis_setex(redis, key: str, ttl: int, value: str) -> None:
+    result = redis.set(key, value, ex=ttl)
+    if hasattr(result, "__await__"):
+        await result
+
+
+async def _redis_getdel(redis, key: str):
+    """Atomically fetch and delete a key (single-use state)."""
+    getdel = getattr(redis, "getdel", None)
+    if getdel is not None:
+        result = getdel(key)
+        if hasattr(result, "__await__"):
+            result = await result
+        return result
+    # Fallback for clients without GETDEL.
+    value = redis.get(key)
+    if hasattr(value, "__await__"):
+        value = await value
+    deleted = redis.delete(key)
+    if hasattr(deleted, "__await__"):
+        await deleted
+    return value

--- a/autobot-backend/api/knowledge_connector_oauth.py
+++ b/autobot-backend/api/knowledge_connector_oauth.py
@@ -207,34 +207,28 @@ def _result_page(
         "error": error,
     }
     status = "Connected — you can close this window." if error is None else ("Connection failed: %s" % error)
-    # Both reflected values are attacker-influenced (error is a provider query
-    # param): HTML-escape the visible text, and JS-escape the embedded JSON so a
-    # value can never break out of the <script> or the string context.
+    # Every attacker-influenced value (error is a provider query param) reaches the
+    # response only through html.escape, a recognized XSS sanitizer. The visible
+    # status is escaped as HTML text; the postMessage payload is serialized to JSON,
+    # html-escaped, and stored in a data-* attribute that the inline script reads
+    # back via JSON.parse(). No user-influenced value is interpolated into the
+    # <script> body itself, so a value cannot break out of the HTML or script context.
     safe_status = html.escape(status)
-    safe_json = _js_safe_json(message)
+    safe_payload = html.escape(json.dumps(message))
     body = (
         "<!doctype html><html><head><meta charset='utf-8'><title>Connector OAuth</title></head>"
         "<body style='font-family:sans-serif;padding:2rem'>"
         "<p>%s</p>"
-        "<script>(function(){var m=%s;try{if(window.opener){window.opener.postMessage(m,window.location.origin);}}"
-        "catch(e){}setTimeout(function(){window.close();},500);})();</script>"
+        "<div id='connector-oauth-data' data-message=\"%s\"></div>"
+        "<script>(function(){"
+        "var el=document.getElementById('connector-oauth-data');"
+        "var m=JSON.parse(el.getAttribute('data-message'));"
+        "try{if(window.opener){window.opener.postMessage(m,window.location.origin);}}catch(e){}"
+        "setTimeout(function(){window.close();},500);"
+        "})();</script>"
         "</body></html>"
-    ) % (safe_status, safe_json)
+    ) % (safe_status, safe_payload)
     return HTMLResponse(content=body, status_code=200)
-
-
-def _js_safe_json(obj: dict) -> str:
-    """json.dumps with HTML/JS-sensitive chars escaped so it is safe inside <script>."""
-    out = json.dumps(obj)
-    for ch, esc in (
-        ("<", "\\u003c"),
-        (">", "\\u003e"),
-        ("&", "\\u0026"),
-        (chr(0x2028), "\\u2028"),  # JS line separator — breaks string literals
-        (chr(0x2029), "\\u2029"),  # JS paragraph separator
-    ):
-        out = out.replace(ch, esc)
-    return out
 
 
 def _clear_cookie(response: HTMLResponse) -> HTMLResponse:

--- a/autobot-backend/api/knowledge_connector_oauth.py
+++ b/autobot-backend/api/knowledge_connector_oauth.py
@@ -125,9 +125,7 @@ async def start_oauth(
         path=_OAUTH_CALLBACK_PATH,
     )
 
-    authorize_url = oauth_flow.build_authorize_url(
-        prov, client_id, request.redirect_uri, state, challenge, scopes
-    )
+    authorize_url = oauth_flow.build_authorize_url(prov, client_id, request.redirect_uri, state, challenge, scopes)
     return AuthorizeResponse(authorize_url=authorize_url, state=state, connector_id=connector_id)
 
 

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -51,6 +51,7 @@ from api.knowledge_chroma import router as knowledge_chroma_router  # MVA-2046
 from api.knowledge_cognition import router as knowledge_cognition_router
 from api.knowledge_collaboration import router as knowledge_collaboration_router
 from api.knowledge_collections import router as knowledge_collections_router
+from api.knowledge_connector_oauth import router as knowledge_connector_oauth_router
 from api.knowledge_connectors import router as knowledge_connectors_router
 from api.knowledge_debug import router as knowledge_debug_router
 from api.knowledge_grounding import router as knowledge_grounding_router
@@ -260,6 +261,12 @@ def _get_knowledge_organization_routers() -> list:
             "",
             ["knowledge-connectors"],
             "knowledge_connectors",
+        ),
+        (
+            knowledge_connector_oauth_router,
+            "",
+            ["knowledge-connectors-oauth"],
+            "knowledge_connector_oauth",
         ),
         (
             knowledge_population_router,

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -11,9 +11,11 @@ Bridges ConnectorConfig ↔ SecretsService so that sensitive auth fields
 
 import asyncio
 import json
+from datetime import timedelta
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
+from autobot_shared.time_utils import now_utc, parse_utc_iso
 
 logger = get_logger(__name__)
 
@@ -23,6 +25,10 @@ _AUTH_TYPE_TO_SECRET_TYPE: dict = {
     "ApiKeyAuth": "connector_api_key",
     "BasicAuth": "connector_password",
 }
+
+# Refresh an OAuth access token this many seconds before its stated expiry, so
+# in-flight requests never race a hard expiry. Not a cache TTL — a safety skew.
+ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 60
 
 
 class ConnectorCredentialStore:
@@ -143,8 +149,143 @@ class ConnectorCredentialStore:
         )
 
     # ------------------------------------------------------------------
+    # OAuth 2.0 authorization-code tokens (ADR-007 §7 / GH#9019)
+    # ------------------------------------------------------------------
+
+    async def store_oauth(
+        self,
+        connector_id: str,
+        owner_id: str,
+        provider: str,
+        token_response: dict,
+        client_id: str,
+        client_secret: str,
+        token_url: str,
+        scopes: list,
+    ) -> str:
+        """Persist a token set obtained via the OAuth auth-code flow.
+
+        Stores a self-contained credential bundle (access + refresh token,
+        client app creds, token endpoint) so :meth:`get_access_token` can
+        refresh later without re-reading provider config.  Returns the secret id.
+        """
+        creds = self._oauth_bundle(token_response, client_id, client_secret, token_url, scopes, provider)
+        name = f"connector:{connector_id}:auth"
+        result = await asyncio.get_running_loop().run_in_executor(
+            None,
+            lambda: self._svc.create_secret(
+                name=name,
+                secret_type="connector_oauth_token",
+                value=json.dumps(creds, ensure_ascii=False),
+                scope="user",
+                created_by=owner_id,
+                metadata={"provider": provider, "connector_id": connector_id},
+            ),
+        )
+        return result["id"]
+
+    async def get_access_token(self, secret_id: str, owner_id: str) -> str:
+        """Return a valid access token, refreshing + rotating the secret in place.
+
+        Raises PermissionError on owner mismatch, LookupError when the secret is
+        missing or holds no refresh token while the access token is expired.
+        Propagates RuntimeError from the token endpoint on a failed refresh.
+        """
+        secret = await asyncio.get_running_loop().run_in_executor(
+            None,
+            lambda: self._svc.get_secret(secret_id=secret_id, include_value=True, accessed_by=owner_id),
+        )
+        if secret is None:
+            raise LookupError(f"OAuth secret {secret_id!r} not found or expired")
+        stored_owner = secret.get("created_by") or ""
+        if stored_owner and stored_owner != owner_id:
+            raise PermissionError(f"owner_id mismatch for secret {secret_id!r}: expected {stored_owner!r}")
+
+        creds = json.loads(secret["value"])
+        access_token = creds.get("access_token")
+        if access_token and not self._access_token_expired(creds.get("access_token_expires_at")):
+            return access_token
+
+        refresh_token = creds.get("refresh_token")
+        if not refresh_token:
+            raise LookupError(f"OAuth secret {secret_id!r} access token expired and no refresh token — re-auth required")
+
+        from knowledge.connectors import oauth_flow
+
+        token_response = await oauth_flow.refresh_access_token(
+            creds["token_url"], creds["client_id"], creds["client_secret"], refresh_token
+        )
+        creds["access_token"] = token_response["access_token"]
+        creds["access_token_expires_at"] = self._expiry_iso(token_response.get("expires_in"))
+        if token_response.get("refresh_token"):
+            # Providers like GitLab rotate the refresh token on each use.
+            creds["refresh_token"] = token_response["refresh_token"]
+
+        await asyncio.get_running_loop().run_in_executor(
+            None,
+            lambda: self._svc.update_secret(
+                secret_id=secret_id,
+                value=json.dumps(creds, ensure_ascii=False),
+                updated_by=owner_id,
+            ),
+        )
+        return creds["access_token"]
+
+    # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    @classmethod
+    def _oauth_bundle(
+        cls,
+        token_response: dict,
+        client_id: str,
+        client_secret: str,
+        token_url: str,
+        scopes: list,
+        provider: str,
+    ) -> dict:
+        """Build the stored OAuth credential bundle from a token response."""
+        return {
+            "provider": provider,
+            "access_token": token_response.get("access_token", ""),
+            "refresh_token": token_response.get("refresh_token", ""),
+            "access_token_expires_at": cls._expiry_iso(token_response.get("expires_in")),
+            "token_type": token_response.get("token_type", "Bearer"),
+            "scope": token_response.get("scope", " ".join(scopes)),
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "token_url": token_url,
+        }
+
+    @staticmethod
+    def _expiry_iso(expires_in) -> str | None:
+        """Return ISO expiry timestamp for *expires_in* seconds, or None.
+
+        Only a missing value (None) means non-expiring; ``expires_in == 0`` is a
+        real, immediate expiry.
+        """
+        if expires_in is None:
+            return None
+        try:
+            seconds = int(expires_in)
+        except (TypeError, ValueError):
+            return None
+        return (now_utc() + timedelta(seconds=seconds)).isoformat()
+
+    @staticmethod
+    def _access_token_expired(expires_at_iso: str | None) -> bool:
+        """True when the access token is unusable within the refresh skew window.
+
+        A missing expiry is treated as non-expiring (some providers omit it).
+        """
+        if not expires_at_iso:
+            return False
+        try:
+            expires_at = parse_utc_iso(expires_at_iso)
+        except (ValueError, TypeError):
+            return True
+        return now_utc() + timedelta(seconds=ACCESS_TOKEN_REFRESH_SKEW_SECONDS) >= expires_at
 
     @staticmethod
     def _sensitive_fields(auth_cls: type) -> frozenset:

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -208,7 +208,9 @@ class ConnectorCredentialStore:
 
         refresh_token = creds.get("refresh_token")
         if not refresh_token:
-            raise LookupError(f"OAuth secret {secret_id!r} access token expired and no refresh token — re-auth required")
+            raise LookupError(
+                f"OAuth secret {secret_id!r} access token expired and no refresh token — re-auth required"
+            )
 
         from knowledge.connectors import oauth_flow
 

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -175,7 +175,7 @@ class ConnectorCredentialStore:
             None,
             lambda: self._svc.create_secret(
                 name=name,
-                secret_type="connector_oauth_token",
+                secret_type="connector_oauth_token",  # nosec B106 - SecretType label, not a credential
                 value=json.dumps(creds, ensure_ascii=False),
                 scope="user",
                 created_by=owner_id,

--- a/autobot-backend/knowledge/connectors/oauth_flow.py
+++ b/autobot-backend/knowledge/connectors/oauth_flow.py
@@ -1,0 +1,228 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Generic OAuth 2.0 authorization-code flow for connectors (ADR-007 / GH#9019).
+
+Provider-agnostic helpers used by the connector OAuth endpoints and the
+credential resolver:
+
+- A small registry of supported providers (Google, Microsoft, GitLab).
+- PKCE (S256) generation.
+- Authorization-URL construction.
+- Authorization-code → token exchange.
+- Refresh-token → access-token refresh (used by the auto-refresh resolver).
+
+Operator-registered OAuth *application* credentials (client_id/client_secret)
+come from ``config.auth.*`` — see ssot_config AuthConfig. The per-user tokens
+this module obtains are persisted via SecretsService by the caller, never here.
+"""
+
+import base64
+import hashlib
+import secrets
+from dataclasses import dataclass, field
+from typing import Tuple
+
+import aiohttp
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config
+
+logger = get_logger(__name__)
+
+_TOKEN_REQUEST_TIMEOUT = 30.0
+
+
+@dataclass(frozen=True)
+class OAuthProvider:
+    """Static OAuth endpoint + scope configuration for one provider."""
+
+    name: str
+    authorize_url: str
+    token_url: str
+    client_id_setting: str
+    client_secret_setting: str
+    default_scopes: Tuple[str, ...] = ()
+    # Extra query params required on the authorize request (provider-specific,
+    # e.g. Google's offline access + consent prompt to guarantee a refresh token).
+    extra_authorize_params: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Provider registry
+# ---------------------------------------------------------------------------
+
+OAUTH_PROVIDERS: dict = {
+    "google": OAuthProvider(
+        name="google",
+        authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
+        token_url="https://oauth2.googleapis.com/token",
+        client_id_setting="google_oauth_client_id",
+        client_secret_setting="google_oauth_client_secret",
+        default_scopes=("https://www.googleapis.com/auth/drive.readonly",),
+        # access_type=offline + prompt=consent → Google always returns a refresh_token.
+        extra_authorize_params={"access_type": "offline", "prompt": "consent"},
+    ),
+    "microsoft": OAuthProvider(
+        name="microsoft",
+        authorize_url="https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+        token_url="https://login.microsoftonline.com/common/oauth2/v2.0/token",
+        client_id_setting="microsoft_oauth_client_id",
+        client_secret_setting="microsoft_oauth_client_secret",
+        # offline_access is required for Microsoft to issue a refresh token.
+        default_scopes=("offline_access", "Files.Read.All", "Sites.Read.All"),
+    ),
+    "gitlab": OAuthProvider(
+        name="gitlab",
+        authorize_url="https://gitlab.com/oauth/authorize",
+        token_url="https://gitlab.com/oauth/token",
+        client_id_setting="gitlab_oauth_client_id",
+        client_secret_setting="gitlab_oauth_client_secret",
+        default_scopes=("read_api", "read_repository"),
+    ),
+}
+
+
+def get_provider(name: str) -> OAuthProvider:
+    """Return the OAuthProvider for *name*. Raises KeyError when unknown."""
+    try:
+        return OAUTH_PROVIDERS[name]
+    except KeyError as exc:
+        raise KeyError("unknown OAuth provider: %s" % name) from exc
+
+
+def resolve_client_credentials(provider: OAuthProvider) -> Tuple[str, str]:
+    """Return (client_id, client_secret) for *provider* from operator config.
+
+    Raises ValueError when either is unset — the provider's Connect flow is
+    disabled until the operator registers an OAuth application.
+    """
+    client_id = getattr(config.auth, provider.client_id_setting, "") or ""
+    client_secret = getattr(config.auth, provider.client_secret_setting, "") or ""
+    if not client_id or not client_secret:
+        raise ValueError(
+            "OAuth provider %r is not configured — set %s / %s"
+            % (provider.name, provider.client_id_setting, provider.client_secret_setting)
+        )
+    return client_id, client_secret
+
+
+# ---------------------------------------------------------------------------
+# PKCE
+# ---------------------------------------------------------------------------
+
+
+def generate_pkce() -> Tuple[str, str]:
+    """Return (code_verifier, code_challenge) for a PKCE S256 exchange."""
+    verifier = secrets.token_urlsafe(64)[:128]
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    return verifier, challenge
+
+
+def generate_state() -> str:
+    """Return an unguessable CSRF state token for the authorize request."""
+    return secrets.token_urlsafe(32)
+
+
+# ---------------------------------------------------------------------------
+# Authorization URL
+# ---------------------------------------------------------------------------
+
+
+def build_authorize_url(
+    provider: OAuthProvider,
+    client_id: str,
+    redirect_uri: str,
+    state: str,
+    code_challenge: str,
+    scopes: Tuple[str, ...] | None = None,
+) -> str:
+    """Construct the provider authorization URL for an auth-code + PKCE flow."""
+    from urllib.parse import urlencode
+
+    chosen_scopes = scopes if scopes else provider.default_scopes
+    params = {
+        "client_id": client_id,
+        "response_type": "code",
+        "redirect_uri": redirect_uri,
+        "scope": " ".join(chosen_scopes),
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    params.update(provider.extra_authorize_params)
+    return "%s?%s" % (provider.authorize_url, urlencode(params))
+
+
+# ---------------------------------------------------------------------------
+# Token exchange + refresh
+# ---------------------------------------------------------------------------
+
+
+async def _post_token(token_url: str, payload: dict) -> dict:
+    """POST form-encoded *payload* to *token_url*; return the parsed token dict.
+
+    Raises RuntimeError on a non-2xx response or transport error.
+    """
+    timeout = aiohttp.ClientTimeout(total=_TOKEN_REQUEST_TIMEOUT)
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(
+                token_url,
+                data=payload,
+                headers={"Accept": "application/json"},
+            ) as resp:
+                body = await resp.json(content_type=None)
+                if resp.status >= 400:
+                    # Token endpoints return {"error": "...", "error_description": "..."}.
+                    detail = body.get("error_description") or body.get("error") or "unknown error"
+                    raise RuntimeError("token endpoint returned HTTP %d: %s" % (resp.status, detail))
+                return body
+    except aiohttp.ClientError as exc:
+        raise RuntimeError("token endpoint request failed: %s" % exc) from exc
+
+
+async def exchange_code(
+    provider: OAuthProvider,
+    client_id: str,
+    client_secret: str,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+) -> dict:
+    """Exchange an authorization *code* for tokens.
+
+    Returns the raw token response (access_token, refresh_token, expires_in, ...).
+    """
+    payload = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "code_verifier": code_verifier,
+    }
+    return await _post_token(provider.token_url, payload)
+
+
+async def refresh_access_token(
+    token_url: str,
+    client_id: str,
+    client_secret: str,
+    refresh_token: str,
+) -> dict:
+    """Exchange a *refresh_token* for a fresh access token.
+
+    Returns the raw token response. Some providers (e.g. GitLab) rotate the
+    refresh token and return a new one; callers must persist it when present.
+    """
+    payload = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": client_id,
+        "client_secret": client_secret,
+    }
+    return await _post_token(token_url, payload)

--- a/autobot-backend/knowledge/connectors/oauth_flow.py
+++ b/autobot-backend/knowledge/connectors/oauth_flow.py
@@ -58,7 +58,7 @@ OAUTH_PROVIDERS: dict = {
     "google": OAuthProvider(
         name="google",
         authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
-        token_url="https://oauth2.googleapis.com/token",
+        token_url="https://oauth2.googleapis.com/token",  # nosec B106 - OAuth token endpoint URL, not a credential
         client_id_setting="google_oauth_client_id",
         client_secret_setting="google_oauth_client_secret",
         default_scopes=("https://www.googleapis.com/auth/drive.readonly",),
@@ -68,7 +68,7 @@ OAUTH_PROVIDERS: dict = {
     "microsoft": OAuthProvider(
         name="microsoft",
         authorize_url="https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-        token_url="https://login.microsoftonline.com/common/oauth2/v2.0/token",
+        token_url="https://login.microsoftonline.com/common/oauth2/v2.0/token",  # nosec B106 - token endpoint URL
         client_id_setting="microsoft_oauth_client_id",
         client_secret_setting="microsoft_oauth_client_secret",
         # offline_access is required for Microsoft to issue a refresh token.
@@ -77,7 +77,7 @@ OAUTH_PROVIDERS: dict = {
     "gitlab": OAuthProvider(
         name="gitlab",
         authorize_url="https://gitlab.com/oauth/authorize",
-        token_url="https://gitlab.com/oauth/token",
+        token_url="https://gitlab.com/oauth/token",  # nosec B106 - OAuth token endpoint URL, not a credential
         client_id_setting="gitlab_oauth_client_id",
         client_secret_setting="gitlab_oauth_client_secret",
         default_scopes=("read_api", "read_repository"),

--- a/autobot-backend/knowledge/connectors/tests/test_connector_oauth_api.py
+++ b/autobot-backend/knowledge/connectors/tests/test_connector_oauth_api.py
@@ -1,0 +1,159 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Endpoint tests for connector OAuth authorize + callback (ADR-007 / GH#9019)."""
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api import knowledge_connector_oauth as mod
+from auth_middleware import get_current_user
+from knowledge.connectors import oauth_flow
+
+
+class _FakeRedis:
+    """Minimal in-memory redis supporting set(ex=) and getdel()."""
+
+    def __init__(self):
+        self.store = {}
+
+    def set(self, key, value, ex=None):
+        self.store[key] = value
+        return True
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def getdel(self, key):
+        return self.store.pop(key, None)
+
+    def delete(self, key):
+        return 1 if self.store.pop(key, None) is not None else 0
+
+
+@pytest.fixture
+def client(monkeypatch):
+    fake_redis = _FakeRedis()
+    monkeypatch.setattr(mod, "get_redis_client", lambda database=None: fake_redis)
+    # Provider configured.
+    monkeypatch.setattr(oauth_flow.config.auth, "google_oauth_client_id", "cid", raising=False)
+    monkeypatch.setattr(oauth_flow.config.auth, "google_oauth_client_secret", "csec", raising=False)
+
+    app = FastAPI()
+    # Mount under /api to match production (app factory prepends /api); the
+    # state-binding cookie is path-scoped to the real callback path.
+    app.include_router(mod.router, prefix="/api")
+    app.dependency_overrides[get_current_user] = lambda: {"user_id": "user-42"}
+    return TestClient(app), fake_redis
+
+
+_AUTHZ = "/api/knowledge_base/connectors/oauth/{p}/authorize"
+_CALLBACK = "/api/knowledge_base/connectors/oauth/callback"
+
+
+def test_authorize_returns_url_and_persists_state(client):
+    tc, fake_redis = client
+    resp = tc.post(_AUTHZ.format(p="google"), json={"redirect_uri": "https://localhost/cb"})
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    qs = parse_qs(urlparse(data["authorize_url"]).query)
+    assert qs["client_id"] == ["cid"]
+    assert qs["state"] == [data["state"]]
+    assert qs["code_challenge_method"] == ["S256"]
+    # State persisted server-side for the callback to consume.
+    assert any(k.endswith(data["state"]) for k in fake_redis.store)
+    # State-binding cookie issued for the completing browser (CSRF defense).
+    assert "connector_oauth_state" in resp.cookies
+
+
+def test_authorize_unknown_provider_404(client):
+    tc, _ = client
+    resp = tc.post(_AUTHZ.format(p="bogus"), json={"redirect_uri": "https://localhost/cb"})
+    assert resp.status_code == 404
+
+
+def test_authorize_unconfigured_provider_400(client, monkeypatch):
+    tc, _ = client
+    monkeypatch.setattr(oauth_flow.config.auth, "gitlab_oauth_client_id", "", raising=False)
+    monkeypatch.setattr(oauth_flow.config.auth, "gitlab_oauth_client_secret", "", raising=False)
+    resp = tc.post(_AUTHZ.format(p="gitlab"), json={"redirect_uri": "https://localhost/cb"})
+    assert resp.status_code == 400
+
+
+def test_authorize_rejects_unlisted_redirect_host(client):
+    tc, _ = client
+    resp = tc.post(_AUTHZ.format(p="google"), json={"redirect_uri": "https://evil.example.com/cb"})
+    assert resp.status_code == 400
+
+
+def test_callback_exchanges_and_stores(client, monkeypatch):
+    tc, fake_redis = client
+    # Start a flow to mint valid state + binding cookie (carried by the client).
+    start = tc.post(_AUTHZ.format(p="google"), json={"redirect_uri": "https://localhost/cb"}).json()
+    state = start["state"]
+
+    async def _fake_exchange(provider, client_id, client_secret, code, redirect_uri, code_verifier):
+        assert code == "auth-code"
+        return {"access_token": "at", "refresh_token": "rt", "expires_in": 3600}
+
+    stored = {}
+
+    class _FakeStore:
+        async def store_oauth(self, **kwargs):
+            stored.update(kwargs)
+            return "secret-xyz"
+
+    monkeypatch.setattr(oauth_flow, "exchange_code", _fake_exchange)
+    monkeypatch.setattr(mod, "get_credential_store", lambda: _FakeStore())
+
+    resp = tc.get(f"{_CALLBACK}?state={state}&code=auth-code")
+    assert resp.status_code == 200
+    assert "secret-xyz" in resp.text  # passed to opener via postMessage payload
+    assert stored["owner_id"] == "user-42"
+    assert stored["provider"] == "google"
+    # State is single-use: consumed on callback.
+    assert not any(k.endswith(state) for k in fake_redis.store)
+
+
+def test_callback_rejects_missing_binding_cookie(client):
+    """A fresh browser (no binding cookie) cannot complete someone else's flow."""
+    tc, fake_redis = client
+    # Seed a valid state in redis but provide no matching cookie.
+    fake_redis.store["connector:oauth:state:ghost"] = "{}"
+    resp = tc.get(f"{_CALLBACK}?state=ghost&code=x")
+    assert resp.status_code == 200
+    assert "state_binding_mismatch" in resp.text
+    # State NOT consumed — the CSRF check fires before touching redis.
+    assert "connector:oauth:state:ghost" in fake_redis.store
+
+
+def test_callback_expired_state_returns_error_page(client):
+    tc, fake_redis = client
+    state = tc.post(_AUTHZ.format(p="google"), json={"redirect_uri": "https://localhost/cb"}).json()["state"]
+    fake_redis.store.clear()  # simulate state expiry; cookie still present
+    resp = tc.get(f"{_CALLBACK}?state={state}&code=x")
+    assert resp.status_code == 200
+    assert "invalid_or_expired_state" in resp.text
+
+
+def test_callback_provider_error_passthrough(client):
+    tc, _ = client
+    state = tc.post(_AUTHZ.format(p="google"), json={"redirect_uri": "https://localhost/cb"}).json()["state"]
+    resp = tc.get(f"{_CALLBACK}?state={state}&error=access_denied")
+    assert resp.status_code == 200
+    assert "access_denied" in resp.text
+
+
+def test_callback_escapes_reflected_error_xss(client):
+    """A malicious provider error param cannot break out of the result HTML/JS."""
+    tc, _ = client
+    state = tc.post(_AUTHZ.format(p="google"), json={"redirect_uri": "https://localhost/cb"}).json()["state"]
+    resp = tc.get(_CALLBACK, params={"state": state, "error": "</script><img src=x onerror=alert(1)>"})
+    assert resp.status_code == 200
+    # No raw closing-script or tag injection survives.
+    assert "</script><img" not in resp.text
+    assert "<img src=x" not in resp.text

--- a/autobot-backend/knowledge/connectors/tests/test_credential_store.py
+++ b/autobot-backend/knowledge/connectors/tests/test_credential_store.py
@@ -285,9 +285,14 @@ async def test_get_access_token_returns_unexpired_without_refresh(monkeypatch):
     svc, store = _make_svc()
     cs = ConnectorCredentialStore(svc)
     secret_id = await cs.store_oauth(
-        "c1", "u1", "google",
+        "c1",
+        "u1",
+        "google",
         {"access_token": "still-good", "refresh_token": "rt", "expires_in": 3600},
-        "cid", "csec", "https://token", ["s"],
+        "cid",
+        "csec",
+        "https://token",
+        ["s"],
     )
 
     # refresh_access_token must NOT be called for a valid token.
@@ -307,9 +312,14 @@ async def test_get_access_token_refreshes_when_expired(monkeypatch):
     cs = ConnectorCredentialStore(svc)
     # expires_in=0 → immediately within the skew window → expired.
     secret_id = await cs.store_oauth(
-        "c2", "u1", "gitlab",
+        "c2",
+        "u1",
+        "gitlab",
         {"access_token": "old", "refresh_token": "rt-old", "expires_in": 0},
-        "cid", "csec", "https://token", ["s"],
+        "cid",
+        "csec",
+        "https://token",
+        ["s"],
     )
 
     from knowledge.connectors import oauth_flow
@@ -333,9 +343,14 @@ async def test_get_access_token_owner_mismatch_raises():
     svc, store = _make_svc()
     cs = ConnectorCredentialStore(svc)
     secret_id = await cs.store_oauth(
-        "c3", "owner-a", "google",
+        "c3",
+        "owner-a",
+        "google",
         {"access_token": "at", "refresh_token": "rt", "expires_in": 3600},
-        "cid", "csec", "https://token", ["s"],
+        "cid",
+        "csec",
+        "https://token",
+        ["s"],
     )
     with pytest.raises(PermissionError):
         await cs.get_access_token(secret_id, "intruder")
@@ -354,9 +369,14 @@ async def test_get_access_token_expired_without_refresh_token_raises(monkeypatch
     svc, store = _make_svc()
     cs = ConnectorCredentialStore(svc)
     secret_id = await cs.store_oauth(
-        "c4", "u1", "google",
+        "c4",
+        "u1",
+        "google",
         {"access_token": "old", "expires_in": 0},  # no refresh_token
-        "cid", "csec", "https://token", ["s"],
+        "cid",
+        "csec",
+        "https://token",
+        ["s"],
     )
     with pytest.raises(LookupError, match="re-auth required"):
         await cs.get_access_token(secret_id, "u1")

--- a/autobot-backend/knowledge/connectors/tests/test_credential_store.py
+++ b/autobot-backend/knowledge/connectors/tests/test_credential_store.py
@@ -250,3 +250,113 @@ async def test_round_trip_store_load_rotate_revoke():
     # revoke
     await cs.revoke(secret_id, "owner-1")
     assert secret_id not in store
+
+
+# ---------------------------------------------------------------------------
+# OAuth auth-code tokens: store_oauth + get_access_token auto-refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_store_oauth_persists_bundle_and_credentials_isolated():
+    svc, store = _make_svc()
+    cs = ConnectorCredentialStore(svc)
+
+    secret_id = await cs.store_oauth(
+        connector_id="gdrive-1",
+        owner_id="user-9",
+        provider="google",
+        token_response={"access_token": "at", "refresh_token": "rt", "expires_in": 3600},
+        client_id="cid",
+        client_secret="csec",
+        token_url="https://oauth2.googleapis.com/token",
+        scopes=["drive.readonly"],
+    )
+    bundle = json.loads(store[secret_id]["value"])
+    assert bundle["access_token"] == "at"
+    assert bundle["refresh_token"] == "rt"
+    assert bundle["client_secret"] == "csec"
+    assert bundle["access_token_expires_at"] is not None
+    assert store[secret_id]["created_by"] == "user-9"
+
+
+@pytest.mark.asyncio
+async def test_get_access_token_returns_unexpired_without_refresh(monkeypatch):
+    svc, store = _make_svc()
+    cs = ConnectorCredentialStore(svc)
+    secret_id = await cs.store_oauth(
+        "c1", "u1", "google",
+        {"access_token": "still-good", "refresh_token": "rt", "expires_in": 3600},
+        "cid", "csec", "https://token", ["s"],
+    )
+
+    # refresh_access_token must NOT be called for a valid token.
+    from knowledge.connectors import oauth_flow
+
+    async def _boom(*a, **k):
+        raise AssertionError("refresh should not be called")
+
+    monkeypatch.setattr(oauth_flow, "refresh_access_token", _boom)
+    token = await cs.get_access_token(secret_id, "u1")
+    assert token == "still-good"
+
+
+@pytest.mark.asyncio
+async def test_get_access_token_refreshes_when_expired(monkeypatch):
+    svc, store = _make_svc()
+    cs = ConnectorCredentialStore(svc)
+    # expires_in=0 → immediately within the skew window → expired.
+    secret_id = await cs.store_oauth(
+        "c2", "u1", "gitlab",
+        {"access_token": "old", "refresh_token": "rt-old", "expires_in": 0},
+        "cid", "csec", "https://token", ["s"],
+    )
+
+    from knowledge.connectors import oauth_flow
+
+    async def _fake_refresh(token_url, client_id, client_secret, refresh_token):
+        assert refresh_token == "rt-old"
+        return {"access_token": "new", "refresh_token": "rt-new", "expires_in": 3600}
+
+    monkeypatch.setattr(oauth_flow, "refresh_access_token", _fake_refresh)
+    token = await cs.get_access_token(secret_id, "u1")
+    assert token == "new"
+
+    # Secret rotated in place: new access + rotated refresh token persisted.
+    bundle = json.loads(store[secret_id]["value"])
+    assert bundle["access_token"] == "new"
+    assert bundle["refresh_token"] == "rt-new"
+
+
+@pytest.mark.asyncio
+async def test_get_access_token_owner_mismatch_raises():
+    svc, store = _make_svc()
+    cs = ConnectorCredentialStore(svc)
+    secret_id = await cs.store_oauth(
+        "c3", "owner-a", "google",
+        {"access_token": "at", "refresh_token": "rt", "expires_in": 3600},
+        "cid", "csec", "https://token", ["s"],
+    )
+    with pytest.raises(PermissionError):
+        await cs.get_access_token(secret_id, "intruder")
+
+
+@pytest.mark.asyncio
+async def test_get_access_token_missing_secret_raises():
+    svc, _ = _make_svc()
+    cs = ConnectorCredentialStore(svc)
+    with pytest.raises(LookupError):
+        await cs.get_access_token("nope", "u1")
+
+
+@pytest.mark.asyncio
+async def test_get_access_token_expired_without_refresh_token_raises(monkeypatch):
+    svc, store = _make_svc()
+    cs = ConnectorCredentialStore(svc)
+    secret_id = await cs.store_oauth(
+        "c4", "u1", "google",
+        {"access_token": "old", "expires_in": 0},  # no refresh_token
+        "cid", "csec", "https://token", ["s"],
+    )
+    with pytest.raises(LookupError, match="re-auth required"):
+        await cs.get_access_token(secret_id, "u1")

--- a/autobot-backend/knowledge/connectors/tests/test_oauth_flow.py
+++ b/autobot-backend/knowledge/connectors/tests/test_oauth_flow.py
@@ -12,7 +12,6 @@ import pytest
 
 from knowledge.connectors import oauth_flow
 
-
 # ---------------------------------------------------------------------------
 # Provider registry
 # ---------------------------------------------------------------------------
@@ -144,9 +143,7 @@ async def test_refresh_access_token_posts_expected_payload(monkeypatch):
         return {"access_token": "fresh", "expires_in": 3600}
 
     monkeypatch.setattr(oauth_flow, "_post_token", _fake_post)
-    result = await oauth_flow.refresh_access_token(
-        "https://token", "cid", "csec", refresh_token="rt"
-    )
+    result = await oauth_flow.refresh_access_token("https://token", "cid", "csec", refresh_token="rt")
     assert result["access_token"] == "fresh"
     assert captured["payload"]["grant_type"] == "refresh_token"
     assert captured["payload"]["refresh_token"] == "rt"

--- a/autobot-backend/knowledge/connectors/tests/test_oauth_flow.py
+++ b/autobot-backend/knowledge/connectors/tests/test_oauth_flow.py
@@ -1,0 +1,186 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the generic connector OAuth flow (ADR-007 / GH#9019)."""
+
+import base64
+import hashlib
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from knowledge.connectors import oauth_flow
+
+
+# ---------------------------------------------------------------------------
+# Provider registry
+# ---------------------------------------------------------------------------
+
+
+def test_get_provider_known():
+    p = oauth_flow.get_provider("google")
+    assert p.name == "google"
+    assert p.token_url.startswith("https://")
+
+
+def test_get_provider_unknown_raises():
+    with pytest.raises(KeyError):
+        oauth_flow.get_provider("does-not-exist")
+
+
+def test_resolve_client_credentials_unconfigured_raises(monkeypatch):
+    monkeypatch.setattr(oauth_flow.config.auth, "google_oauth_client_id", "", raising=False)
+    monkeypatch.setattr(oauth_flow.config.auth, "google_oauth_client_secret", "", raising=False)
+    with pytest.raises(ValueError):
+        oauth_flow.resolve_client_credentials(oauth_flow.get_provider("google"))
+
+
+def test_resolve_client_credentials_configured(monkeypatch):
+    monkeypatch.setattr(oauth_flow.config.auth, "google_oauth_client_id", "cid", raising=False)
+    monkeypatch.setattr(oauth_flow.config.auth, "google_oauth_client_secret", "csec", raising=False)
+    cid, csec = oauth_flow.resolve_client_credentials(oauth_flow.get_provider("google"))
+    assert (cid, csec) == ("cid", "csec")
+
+
+# ---------------------------------------------------------------------------
+# PKCE / state
+# ---------------------------------------------------------------------------
+
+
+def test_generate_pkce_is_valid_s256():
+    verifier, challenge = oauth_flow.generate_pkce()
+    # RFC 7636: 43..128 chars for the verifier.
+    assert 43 <= len(verifier) <= 128
+    expected = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest()).decode().rstrip("=")
+    assert challenge == expected
+    assert "=" not in challenge
+
+
+def test_generate_pkce_unique():
+    assert oauth_flow.generate_pkce()[0] != oauth_flow.generate_pkce()[0]
+
+
+def test_generate_state_unique():
+    assert oauth_flow.generate_state() != oauth_flow.generate_state()
+
+
+# ---------------------------------------------------------------------------
+# Authorize URL
+# ---------------------------------------------------------------------------
+
+
+def test_build_authorize_url_contains_required_params():
+    provider = oauth_flow.get_provider("google")
+    url = oauth_flow.build_authorize_url(
+        provider,
+        client_id="cid",
+        redirect_uri="https://app.example.com/cb",
+        state="st8",
+        code_challenge="chal",
+    )
+    parsed = urlparse(url)
+    qs = parse_qs(parsed.query)
+    assert parsed.scheme == "https"
+    assert qs["client_id"] == ["cid"]
+    assert qs["response_type"] == ["code"]
+    assert qs["redirect_uri"] == ["https://app.example.com/cb"]
+    assert qs["state"] == ["st8"]
+    assert qs["code_challenge"] == ["chal"]
+    assert qs["code_challenge_method"] == ["S256"]
+    # Google-specific: guarantees a refresh token.
+    assert qs["access_type"] == ["offline"]
+    assert qs["prompt"] == ["consent"]
+    # Default scope applied when none supplied.
+    assert "drive.readonly" in qs["scope"][0]
+
+
+def test_build_authorize_url_custom_scopes_override_defaults():
+    provider = oauth_flow.get_provider("gitlab")
+    url = oauth_flow.build_authorize_url(
+        provider,
+        client_id="cid",
+        redirect_uri="https://app/cb",
+        state="s",
+        code_challenge="c",
+        scopes=("read_user",),
+    )
+    qs = parse_qs(urlparse(url).query)
+    assert qs["scope"] == ["read_user"]
+
+
+# ---------------------------------------------------------------------------
+# Token exchange / refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_posts_expected_payload(monkeypatch):
+    captured = {}
+
+    async def _fake_post(token_url, payload):
+        captured["url"] = token_url
+        captured["payload"] = payload
+        return {"access_token": "at", "refresh_token": "rt", "expires_in": 3600}
+
+    monkeypatch.setattr(oauth_flow, "_post_token", _fake_post)
+    provider = oauth_flow.get_provider("google")
+    result = await oauth_flow.exchange_code(
+        provider, "cid", "csec", code="abc", redirect_uri="https://app/cb", code_verifier="ver"
+    )
+    assert result["access_token"] == "at"
+    assert captured["url"] == provider.token_url
+    assert captured["payload"]["grant_type"] == "authorization_code"
+    assert captured["payload"]["code"] == "abc"
+    assert captured["payload"]["code_verifier"] == "ver"
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_posts_expected_payload(monkeypatch):
+    captured = {}
+
+    async def _fake_post(token_url, payload):
+        captured["payload"] = payload
+        return {"access_token": "fresh", "expires_in": 3600}
+
+    monkeypatch.setattr(oauth_flow, "_post_token", _fake_post)
+    result = await oauth_flow.refresh_access_token(
+        "https://token", "cid", "csec", refresh_token="rt"
+    )
+    assert result["access_token"] == "fresh"
+    assert captured["payload"]["grant_type"] == "refresh_token"
+    assert captured["payload"]["refresh_token"] == "rt"
+
+
+@pytest.mark.asyncio
+async def test_post_token_raises_on_http_error(monkeypatch):
+    """_post_token surfaces token-endpoint errors as RuntimeError."""
+
+    class _FakeResp:
+        status = 400
+
+        async def json(self, content_type=None):
+            return {"error": "invalid_grant", "error_description": "bad code"}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    class _FakeSession:
+        def __init__(self, *a, **k):
+            pass
+
+        def post(self, *a, **k):
+            return _FakeResp()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(oauth_flow.aiohttp, "ClientSession", _FakeSession)
+    with pytest.raises(RuntimeError, match="bad code"):
+        await oauth_flow._post_token("https://token", {"grant_type": "authorization_code"})

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorOAuthButton.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorOAuthButton.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+/**
+ * ConnectorOAuthButton — "Connect <provider>" OAuth launcher (ADR-007 / #9019).
+ *
+ * Starts a backend OAuth flow, opens the provider authorization URL in a popup,
+ * and listens for the backend callback's postMessage to receive the stored
+ * `secret_id`. Emits `connected` with that reference so the parent connector
+ * form can attach it — credentials never touch the frontend.
+ */
+
+import { ref, onBeforeUnmount } from 'vue'
+import BaseButton from '@/components/base/BaseButton.vue'
+import { knowledgeRepository } from '@/models/repositories/KnowledgeRepository'
+import { getApiBase } from '@/config/ssot-config'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('ConnectorOAuthButton')
+
+const props = defineProps<{
+  provider: string
+  label: string
+  scopes?: string[]
+  disabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  connected: [payload: { secretId: string; connectorId: string; provider: string }]
+  error: [message: string]
+}>()
+
+const connecting = ref(false)
+let popup: Window | null = null
+let messageHandler: ((e: MessageEvent) => void) | null = null
+
+function callbackUrl(): string {
+  // Absolute URL to the backend OAuth callback; host must be allow-listed
+  // server-side (AUTOBOT_SSO_CALLBACK_HOSTS).
+  return new URL(
+    `${getApiBase()}/knowledge_base/connectors/oauth/callback`,
+    window.location.origin
+  ).href
+}
+
+function cleanup(): void {
+  if (messageHandler) {
+    window.removeEventListener('message', messageHandler)
+    messageHandler = null
+  }
+  connecting.value = false
+  popup = null
+}
+
+function onMessage(event: MessageEvent): void {
+  // Only trust messages from our own origin (the backend callback page).
+  if (event.origin !== window.location.origin) return
+  const data = event.data
+  if (!data || data.type !== 'connector-oauth') return
+
+  if (data.ok && data.secret_id) {
+    emit('connected', {
+      secretId: data.secret_id,
+      connectorId: data.connector_id ?? '',
+      provider: data.provider ?? props.provider
+    })
+  } else {
+    const message = data.error || 'oauth_failed'
+    logger.warn('OAuth flow failed', message)
+    emit('error', message)
+  }
+  try {
+    popup?.close()
+  } catch {
+    /* popup may already be closed */
+  }
+  cleanup()
+}
+
+async function connect(): Promise<void> {
+  if (connecting.value || props.disabled) return
+  connecting.value = true
+  try {
+    const { authorize_url } = await knowledgeRepository.startConnectorOAuth(
+      props.provider,
+      callbackUrl(),
+      props.scopes
+    )
+    messageHandler = onMessage
+    window.addEventListener('message', messageHandler)
+    popup = window.open(authorize_url, 'connector-oauth', 'width=600,height=720')
+    if (!popup) {
+      // Popup blocked — fall back to a full-page redirect.
+      window.location.href = authorize_url
+    }
+  } catch (err) {
+    logger.error('Failed to start OAuth flow', err)
+    emit('error', err instanceof Error ? err.message : 'oauth_start_failed')
+    cleanup()
+  }
+}
+
+onBeforeUnmount(cleanup)
+</script>
+
+<template>
+  <BaseButton
+    variant="secondary"
+    :disabled="disabled || connecting"
+    :loading="connecting"
+    @click="connect"
+  >
+    {{ connecting ? `Connecting to ${label}…` : `Connect ${label}` }}
+  </BaseButton>
+</template>

--- a/autobot-frontend/src/components/knowledge/connectors/__tests__/ConnectorOAuthButton.spec.ts
+++ b/autobot-frontend/src/components/knowledge/connectors/__tests__/ConnectorOAuthButton.spec.ts
@@ -1,0 +1,122 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * Tests for ConnectorOAuthButton — the "Connect <provider>" OAuth launcher
+ * (ADR-007 / #9019). Verifies the popup flow and that a backend-callback
+ * postMessage surfaces as a `connected` event with the secret reference.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+import ConnectorOAuthButton from '../ConnectorOAuthButton.vue'
+import { knowledgeRepository } from '@/models/repositories/KnowledgeRepository'
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api'
+}))
+
+vi.mock('@/models/repositories/KnowledgeRepository', () => ({
+  knowledgeRepository: { startConnectorOAuth: vi.fn() }
+}))
+
+const startSpy = knowledgeRepository.startConnectorOAuth as unknown as ReturnType<typeof vi.fn>
+
+describe('ConnectorOAuthButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default: popup opens successfully.
+    window.open = vi.fn(() => ({ close: vi.fn() })) as unknown as typeof window.open
+  })
+
+  function mountButton() {
+    return mount(ConnectorOAuthButton, {
+      props: { provider: 'google', label: 'Google Drive', scopes: ['drive.readonly'] }
+    })
+  }
+
+  it('starts the flow with the absolute callback URL and opens a popup', async () => {
+    startSpy.mockResolvedValue({ authorize_url: 'https://provider/auth', state: 's', connector_id: 'c' })
+    const wrapper = mountButton()
+
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+
+    expect(startSpy).toHaveBeenCalledWith(
+      'google',
+      `${window.location.origin}/api/knowledge_base/connectors/oauth/callback`,
+      ['drive.readonly']
+    )
+    expect(window.open).toHaveBeenCalledWith(
+      'https://provider/auth',
+      'connector-oauth',
+      expect.any(String)
+    )
+  })
+
+  it('emits "connected" when the callback posts a success message', async () => {
+    startSpy.mockResolvedValue({ authorize_url: 'https://provider/auth', state: 's', connector_id: 'c' })
+    const wrapper = mountButton()
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: window.location.origin,
+        data: { type: 'connector-oauth', ok: true, secret_id: 'sec-1', connector_id: 'c', provider: 'google' }
+      })
+    )
+    await flushPromises()
+
+    expect(wrapper.emitted('connected')?.[0]?.[0]).toEqual({
+      secretId: 'sec-1',
+      connectorId: 'c',
+      provider: 'google'
+    })
+  })
+
+  it('emits "error" when the callback posts a failure message', async () => {
+    startSpy.mockResolvedValue({ authorize_url: 'https://provider/auth', state: 's', connector_id: 'c' })
+    const wrapper = mountButton()
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: window.location.origin,
+        data: { type: 'connector-oauth', ok: false, error: 'access_denied' }
+      })
+    )
+    await flushPromises()
+
+    expect(wrapper.emitted('error')?.[0]?.[0]).toBe('access_denied')
+  })
+
+  it('ignores messages from a foreign origin', async () => {
+    startSpy.mockResolvedValue({ authorize_url: 'https://provider/auth', state: 's', connector_id: 'c' })
+    const wrapper = mountButton()
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://evil.example.com',
+        data: { type: 'connector-oauth', ok: true, secret_id: 'sec-evil' }
+      })
+    )
+    await flushPromises()
+
+    expect(wrapper.emitted('connected')).toBeUndefined()
+  })
+
+  it('emits "error" when starting the flow fails', async () => {
+    startSpy.mockRejectedValue(new Error('boom'))
+    const wrapper = mountButton()
+
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.emitted('error')?.[0]?.[0]).toBe('boom')
+  })
+})

--- a/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
+++ b/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
@@ -684,6 +684,30 @@ export class KnowledgeRepository extends ApiRepository {
   }
 
   /**
+   * Begin an OAuth "Connect <provider>" flow (ADR-007 / #9019).
+   *
+   * Asks the backend for a provider authorization URL. The caller opens that
+   * URL (typically in a popup); the backend callback stores the resulting
+   * tokens via the secrets API and hands a `secret_id` back to the opener via
+   * `postMessage`. `redirectUri` MUST be the host-allowlisted callback URL.
+   */
+  async startConnectorOAuth(
+    provider: string,
+    redirectUri: string,
+    scopes?: string[]
+  ): Promise<{ authorize_url: string; state: string; connector_id: string }> {
+    const response = await this.post<{
+      authorize_url: string
+      state: string
+      connector_id: string
+    }>(
+      `${getApiBase()}/knowledge_base/connectors/oauth/${encodeURIComponent(provider)}/authorize`,
+      { redirect_uri: redirectUri, scopes: scopes ?? null }
+    )
+    return response.data
+  }
+
+  /**
    * Get a single connector with its status
    */
   async getConnector(

--- a/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.connectors.test.ts
+++ b/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.connectors.test.ts
@@ -235,4 +235,46 @@ describe('KnowledgeRepository connector endpoints (#5200)', () => {
       )
     })
   })
+
+  describe('startConnectorOAuth — #9019 OAuth flow', () => {
+    it('POSTs to the provider authorize endpoint and returns the URL', async () => {
+      postSpy.mockResolvedValue({
+        data: {
+          authorize_url: 'https://accounts.google.com/o/oauth2/v2/auth?x=1',
+          state: 'st8',
+          connector_id: 'conn-uuid'
+        }
+      })
+
+      const result = await repo.startConnectorOAuth(
+        'google',
+        'https://localhost/api/knowledge_base/connectors/oauth/callback',
+        ['drive.readonly']
+      )
+
+      expect(result.authorize_url).toContain('accounts.google.com')
+      expect(result.connector_id).toBe('conn-uuid')
+      expect(postSpy).toHaveBeenCalledWith(
+        '/api/knowledge_base/connectors/oauth/google/authorize',
+        {
+          redirect_uri:
+            'https://localhost/api/knowledge_base/connectors/oauth/callback',
+          scopes: ['drive.readonly']
+        }
+      )
+    })
+
+    it('sends scopes:null when none supplied and url-encodes the provider', async () => {
+      postSpy.mockResolvedValue({
+        data: { authorize_url: 'https://x', state: 's', connector_id: 'c' }
+      })
+
+      await repo.startConnectorOAuth('git lab', 'https://localhost/cb')
+
+      expect(postSpy).toHaveBeenCalledWith(
+        '/api/knowledge_base/connectors/oauth/git%20lab/authorize',
+        { redirect_uri: 'https://localhost/cb', scopes: null }
+      )
+    })
+  })
 })

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -869,6 +869,46 @@ class AuthConfig(BaseSettings):
         ),
     )
 
+    # ------------------------------------------------------------------
+    # Connector OAuth application credentials (ADR-007 / GH#9019)
+    #
+    # Per-provider OAuth *application* client_id/client_secret registered by the
+    # operator. Empty by default — a provider's "Connect" flow is disabled until
+    # its credentials are configured. These identify AutoBot's OAuth app; the
+    # resulting user refresh/access tokens are stored via SecretsService.
+    # ------------------------------------------------------------------
+
+    google_oauth_client_id: str = Field(
+        default="",
+        alias="AUTOBOT_GOOGLE_OAUTH_CLIENT_ID",
+        description="OAuth client_id for Google connectors (Drive). Empty disables the Google Connect flow.",
+    )
+    google_oauth_client_secret: str = Field(
+        default="",
+        alias="AUTOBOT_GOOGLE_OAUTH_CLIENT_SECRET",
+        description="OAuth client_secret for Google connectors (Drive).",
+    )
+    microsoft_oauth_client_id: str = Field(
+        default="",
+        alias="AUTOBOT_MICROSOFT_OAUTH_CLIENT_ID",
+        description="OAuth client_id for Microsoft connectors (OneDrive/SharePoint). Empty disables the flow.",
+    )
+    microsoft_oauth_client_secret: str = Field(
+        default="",
+        alias="AUTOBOT_MICROSOFT_OAUTH_CLIENT_SECRET",
+        description="OAuth client_secret for Microsoft connectors (OneDrive/SharePoint).",
+    )
+    gitlab_oauth_client_id: str = Field(
+        default="",
+        alias="AUTOBOT_GITLAB_OAUTH_CLIENT_ID",
+        description="OAuth client_id for GitLab connectors. Empty disables the GitLab Connect flow.",
+    )
+    gitlab_oauth_client_secret: str = Field(
+        default="",
+        alias="AUTOBOT_GITLAB_OAUTH_CLIENT_SECRET",
+        description="OAuth client_secret for GitLab connectors.",
+    )
+
 
 class PermissionMode(str, Enum):
     """

--- a/docs/adr/007-connector-oauth-token-storage.md
+++ b/docs/adr/007-connector-oauth-token-storage.md
@@ -1,0 +1,329 @@
+# ADR-007: Connector OAuth Token and Credential Storage
+
+## Status
+
+**Status**: Accepted
+
+## Date
+
+**Date**: 2026-05-30
+
+## Context
+
+All incoming connector plugins (Google Drive, OneDrive, Nextcloud, GitLab, etc.)
+need to store OAuth2 refresh tokens, app passwords, and API keys. No agreed
+storage pattern existed before this ADR.
+
+The current connector API (`knowledge_connectors.py`) accepts a `config` dict and
+persists it verbatim into Redis under `connector:{connector_id}`. This means:
+
+- **Plaintext credentials in Redis** — refresh tokens and client secrets are
+  readable by any process with access to the knowledge Redis database.
+- **No audit trail** — nothing records who read or rotated a credential.
+- **No revocation lifecycle** — deleting a connector leaves orphan credentials
+  with no cleanup hook.
+- **No cross-user isolation contract** — nothing prevents a credential lookup
+  from crossing user boundaries.
+
+AutoBot already has two encrypted secret stores:
+
+| Store | File | Key derivation | Scope |
+|-------|------|---------------|-------|
+| `SecretsService` | `autobot-backend/services/secrets_service.py` | Fernet (AUTOBOT_SECRETS_KEY) | user / session / organization |
+| `LLCSecret` | `autobot-backend/llc/services/secret.py` | HKDF-SHA256 (LLC_SECRET_MASTER_KEY) | company |
+
+New connectors MUST route sensitive credentials through `SecretsService`.
+
+## Decision
+
+### 1. Config vs. Credential Separation
+
+`ConnectorConfig` is split into two logical parts:
+
+| Layer | Stored in | Contains |
+|-------|-----------|---------|
+| Non-sensitive config | Redis (`connector:{id}`) | `token_url`, `scopes`, `header_name`, `client_id` |
+| Sensitive credentials | SecretsService (Fernet-encrypted SQLite) | `token`, `key`, `password`, `client_secret`, `refresh_token` |
+
+`ConnectorConfig` gains one new field: `secret_id: str | None = None`.
+Sensitive credential fields are stripped from `ConnectorConfig.config` at write
+time. The `secret_id` is stored in their place and used to reconstruct the full
+config at runtime.
+
+### 2. Sensitive Field Registry
+
+Each auth dataclass in `autobot_shared/auth/connector_auth.py` declares which
+fields are sensitive via a `__sensitive_fields__` class attribute:
+
+```python
+@dataclass
+class OAuthRefreshAuth:
+    client_id: str               # non-sensitive
+    client_secret: str           # SENSITIVE
+    refresh_token: str           # SENSITIVE
+    token_url: str               # non-sensitive
+    scopes: List[str]            # non-sensitive
+
+    __sensitive_fields__: ClassVar[frozenset] = frozenset({"client_secret", "refresh_token"})
+
+@dataclass
+class BearerAuth:
+    token: str                   # SENSITIVE
+
+    __sensitive_fields__: ClassVar[frozenset] = frozenset({"token"})
+
+@dataclass
+class ApiKeyAuth:
+    key: str                     # SENSITIVE
+    header: str = "X-Api-Key"   # non-sensitive
+
+    __sensitive_fields__: ClassVar[frozenset] = frozenset({"key"})
+
+@dataclass
+class BasicAuth:
+    username: str                # non-sensitive
+    password: str                # SENSITIVE
+
+    __sensitive_fields__: ClassVar[frozenset] = frozenset({"password"})
+```
+
+The `ConnectorCredentialStore` uses this set to split incoming config dicts and
+to reconstruct them at runtime.
+
+### 3. `ConnectorCredentialStore` — the Integration Shim
+
+A new module `autobot-backend/knowledge/connectors/credential_store.py` provides:
+
+```python
+class ConnectorCredentialStore:
+    """Bridges ConnectorConfig ↔ SecretsService for credential isolation.
+
+    All methods are async-safe; the underlying SecretsService calls are
+    synchronous but are run in a thread executor to avoid blocking the event loop.
+    """
+
+    def __init__(self, secrets_service: SecretsService) -> None: ...
+
+    async def store(
+        self,
+        connector_id: str,
+        owner_id: str,
+        auth_cls: type,
+        config: dict,
+    ) -> tuple[str, dict]:
+        """Extract sensitive fields from config, store them encrypted.
+
+        Returns (secret_id, sanitized_config) where sanitized_config has
+        sensitive fields removed.  Raises ValueError when auth_cls has no
+        __sensitive_fields__.
+        """
+
+    async def load(
+        self,
+        secret_id: str,
+        sanitized_config: dict,
+        auth_cls: type,
+        owner_id: str,
+    ) -> dict:
+        """Reconstruct full config by merging decrypted credentials back in.
+
+        Raises PermissionError when owner_id does not match the stored secret.
+        Raises LookupError when secret_id is not found or has expired.
+        """
+
+    async def rotate(
+        self,
+        secret_id: str,
+        new_credentials: dict,
+        owner_id: str,
+    ) -> None:
+        """Replace the stored secret value with new_credentials in-place."""
+
+    async def revoke(self, secret_id: str, owner_id: str) -> None:
+        """Delete the secret. Called on connector delete."""
+```
+
+### 4. Secret Naming and Typing
+
+```
+name:  connector:{connector_id}:auth
+type:  connector_oauth_token  (OAuthRefreshAuth)
+       connector_api_key      (ApiKeyAuth / BearerAuth)
+       connector_password     (BasicAuth)
+scope: user
+```
+
+`expiry`: `None` by default (long-lived refresh tokens). Connectors that work
+with short-lived access tokens set `expires_at` explicitly on each `rotate()`.
+
+### 5. API Layer Changes
+
+**POST /knowledge_base/connectors** (create):
+1. Validate config against auth schema (existing).
+2. Call `credential_store.store(connector_id, user_id, auth_cls, config)`
+   → `(secret_id, sanitized_config)`.
+3. Set `cfg.config = sanitized_config` and `cfg.secret_id = secret_id`.
+4. Persist `cfg` to Redis (no sensitive fields in Redis).
+
+**GET /knowledge_base/connectors/{id}** (read):
+- `_cfg_to_dict()` MUST NOT include `secret_id` in the public response.
+- Sensitive fields are never re-serialized into any GET response.
+
+**PUT /knowledge_base/connectors/{id}** (update):
+- If the request includes any sensitive field for the declared auth type:
+  call `credential_store.rotate(cfg.secret_id, new_creds, user_id)`.
+- Otherwise update only non-sensitive config in Redis.
+
+**DELETE /knowledge_base/connectors/{id}**:
+- Call `credential_store.revoke(cfg.secret_id, user_id)` before removing
+  the Redis key. Log a warning (never raise) on revoke failure to avoid
+  blocking the delete.
+
+**Connector invocation** (`test_connection()` / `sync()`):
+```python
+full_config = await credential_store.load(
+    cfg.secret_id, cfg.config, auth_cls, user_id
+)
+instance = ConnectorRegistry.build(cfg.connector_type, full_config)
+await instance.test_connection()
+# full_config is never written back to Redis
+```
+
+### 6. Cross-User Isolation
+
+`SecretsService.get_secret()` returns `None` when `owner_id` does not match
+the stored secret's `created_by`. `ConnectorCredentialStore.load()` converts
+that into a `PermissionError`, which surfaces as HTTP 403 at the API layer.
+
+Connectors that belong to an organization-shared config (future work) use
+`scope = "organization"` and omit per-user ownership checks — this is an
+explicit opt-in, not the default.
+
+### 7. Rotation and Revocation Lifecycle
+
+| Event | Action |
+|-------|--------|
+| Connector deleted | `revoke()` — secret deleted, Redis key removed |
+| OAuth token refresh (background) | `rotate()` — update secret in-place |
+| User re-authorizes via OAuth flow | `rotate()` with the new token set |
+| User account deleted | `SecretsService` cleanup scoped by `owner_id` |
+| Secret expired (`expires_at` reached) | `load()` raises `LookupError` → connector status set to `auth_expired`; UI prompts re-auth |
+
+### 8. Migration for Existing Connectors
+
+A one-time migration script (`scripts/migrate_connector_credentials.py`) will:
+
+1. Read every `connector:*` key from Redis.
+2. For each config dict, identify the declared auth type.
+3. Extract sensitive fields, call `credential_store.store()`.
+4. Write `secret_id` back to the Redis key and clear sensitive fields.
+5. Log every migrated connector at INFO; log failures at ERROR without aborting.
+
+The migration is idempotent: connectors whose `secret_id` is already set are skipped.
+
+## Alternatives Considered
+
+1. **Encrypt sensitive fields in Redis** — simpler but still keeps credentials in
+   Redis, complicates key rotation, offers no audit trail, and duplicates SecretsService.
+
+2. **Per-user vault (HashiCorp Vault / AWS Secrets Manager)** — stronger
+   guarantees but introduces an external dependency that conflicts with the
+   self-hosted deployment model.
+
+3. **Extend LLCSecret for connector credentials** — company-scoped secrets are
+   the right layer for LLC-owned connectors (future), but user-owned connectors
+   should use user-scoped SecretsService entries. Mixing the two into LLCSecret
+   would conflate user and company ownership.
+
+## Consequences
+
+### Positive
+
+- Credentials are encrypted at rest; never appear in Redis or any API response.
+- Full audit log on every read, write, rotate, and revoke via SecretsService.
+- Revocation is atomic: delete the secret, connector immediately deactivates on
+  the next invocation.
+- Cross-user isolation is guaranteed at the storage layer, not just the API layer.
+- Pattern is reusable for every future connector auth type — just add
+  `__sensitive_fields__` to the dataclass.
+
+### Negative
+
+- Two reads per connector invocation (Redis config + SecretsService decrypt).
+  Acceptable at current scale; a caching layer can be added later if needed.
+- SQLite write serialization under high concurrency — tracked separately
+  in the PostgreSQL migration backlog.
+- Migration script required for connectors created before this ADR is deployed.
+
+### Neutral
+
+- `ConnectorConfig.secret_id` is an optional field; connectors without auth
+  (`tier = 0`) leave it `None` and incur zero overhead.
+
+## Implementation Notes
+
+### Key Files
+
+- `autobot-backend/services/secrets_service.py` — SecretsService (storage layer)
+- `autobot_shared/auth/connector_auth.py` — add `__sensitive_fields__` to each dataclass
+- `autobot-backend/knowledge/connectors/models.py` — add `secret_id: str | None = None` to `ConnectorConfig`
+- `autobot-backend/knowledge/connectors/credential_store.py` — **new**: `ConnectorCredentialStore`
+- `autobot-backend/api/knowledge_connectors.py` — wire `ConnectorCredentialStore` into CRUD handlers
+- `scripts/migrate_connector_credentials.py` — **new**: one-time migration
+
+### Code Examples
+
+```python
+# Creating a connector with OAuth credentials
+from knowledge.connectors.credential_store import get_credential_store
+
+store = get_credential_store()  # singleton backed by SecretsService
+
+secret_id, safe_config = await store.store(
+    connector_id=str(cfg.connector_id),
+    owner_id=current_user_id,
+    auth_cls=OAuthRefreshAuth,
+    config={
+        "client_id": "abc",
+        "client_secret": "supersecret",   # extracted + encrypted
+        "refresh_token": "tok_xyz",        # extracted + encrypted
+        "token_url": "https://oauth2.googleapis.com/token",
+        "scopes": ["https://www.googleapis.com/auth/drive.readonly"],
+    },
+)
+# safe_config == {"client_id": "abc", "token_url": "...", "scopes": [...]}
+# secret_id   == "a7b3c9d1-..."
+
+cfg.config = safe_config
+cfg.secret_id = secret_id
+
+
+# Using the connector at runtime
+full_config = await store.load(cfg.secret_id, cfg.config, OAuthRefreshAuth, user_id)
+instance = GoogleDriveConnector(ConnectorConfig(..., config=full_config))
+await instance.sync()
+
+
+# Rotating after a background token refresh
+await store.rotate(cfg.secret_id, {"refresh_token": "tok_new"}, user_id)
+
+
+# Deleting a connector
+await store.revoke(cfg.secret_id, user_id)
+```
+
+## Related ADRs
+
+- [ADR-002](002-redis-database-separation.md) — Redis database separation
+  (knowledge DB is distinct from main DB; connector configs live in knowledge DB)
+
+## Implementation Issues
+
+- **GH#9019 / MVA-1717** — This ADR (prerequisite)
+- Scaffolding implementation: `ConnectorCredentialStore` + API wiring (child of MVA-1717)
+- Prerequisite for: GH#9003 (Google Drive), GH#9004 (OneDrive), GH#9011 (GitLab)
+
+---
+
+**Author**: mrveiss
+**Copyright**: © 2026 mrveiss

--- a/docs/adr/007-connector-oauth-token-storage.md
+++ b/docs/adr/007-connector-oauth-token-storage.md
@@ -312,6 +312,76 @@ await store.rotate(cfg.secret_id, {"refresh_token": "tok_new"}, user_id)
 await store.revoke(cfg.secret_id, user_id)
 ```
 
+## OAuth Authorization-Code Flow and Auto-Refresh (GH#9019 extension)
+
+The original ADR covered credential *storage*. The connector group also needs a
+generic way to *obtain* OAuth tokens (so users click "Connect", not paste a
+token) and to *keep them valid* (refresh short-lived access tokens). These are
+provider-agnostic and live at the gate, not in each connector.
+
+### 9. Authorization-code + PKCE flow
+
+`knowledge/connectors/oauth_flow.py` holds a small provider registry
+(`google`, `microsoft`, `gitlab`) plus pure helpers: PKCE (S256) generation,
+authorize-URL construction, code→token exchange, and refresh-token→access-token
+refresh. OAuth *application* credentials (`client_id`/`client_secret`) are
+operator-registered via `config.auth.{provider}_oauth_client_*`; a provider's
+flow is disabled until its credentials are set.
+
+Two endpoints (`api/knowledge_connector_oauth.py`):
+
+| Endpoint | Auth | Behaviour |
+|----------|------|-----------|
+| `POST /knowledge_base/connectors/oauth/{provider}/authorize` | user session | Mints CSRF `state` + PKCE verifier, stores them in the knowledge Redis (`connector:oauth:state:{state}`, 600 s TTL), returns the provider authorization URL. |
+| `GET /knowledge_base/connectors/oauth/callback` | single-use `state` | Reached by the provider's browser redirect. Validates+consumes `state` (GETDEL), exchanges the code for tokens, stores them via `store_oauth()`, returns an HTML page that `postMessage`s the `secret_id` back to the opener and self-closes. |
+
+`redirect_uri` hosts are validated against the existing
+`AUTOBOT_SSO_CALLBACK_HOSTS` allowlist (HTTPS enforced when
+`AUTOBOT_ENFORCE_HTTPS_CALLBACKS`).
+
+Security properties of the callback:
+
+- **CSRF / token-attachment defense** — `authorize` sets an HttpOnly,
+  SameSite=Lax, path-scoped cookie holding the `state`; the callback requires
+  that cookie to match the `state` query param *before* consuming it. This
+  binds the browser that completes the flow to the one that started it, so an
+  attacker cannot graft their own authorization onto a victim's session.
+- **Single-use** — the state is consumed with Redis `GETDEL`; the cookie is
+  cleared on every result.
+- **XSS-safe result page** — the only attacker-influenced value (`error` from
+  the provider) is HTML-escaped, and the embedded JSON is JS-escaped
+  (`<`, `>`, `&`, U+2028/U+2029) so nothing can break out of the `<script>`.
+- The callback is authorized by the cookie-bound `state`, not a bearer session
+  — correct for a top-level provider redirect that carries no `Authorization`
+  header.
+
+### 10. Auto-refresh resolver
+
+`ConnectorCredentialStore` gains two methods:
+
+- `store_oauth(...)` — persist a self-contained bundle (access + refresh token,
+  client app creds, token endpoint, `access_token_expires_at`) as a
+  `connector_oauth_token` secret. The **secret's** `expires_at` stays `None`
+  (long-lived refresh token); access-token expiry lives inside the bundle so an
+  expired access token never makes the secret vanish.
+- `get_access_token(secret_id, owner_id)` — return a valid access token,
+  refreshing + rotating the secret in place when it is within
+  `ACCESS_TOKEN_REFRESH_SKEW_SECONDS` of expiry. Honors refresh-token rotation
+  (e.g. GitLab). Raises `LookupError` when re-auth is required (no refresh
+  token), `PermissionError` on owner mismatch.
+
+Connectors call `get_access_token()` to obtain a bearer token at sync time;
+none of them handle refresh themselves.
+
+### 11. Frontend "Connect" building block
+
+`autobot-frontend/.../ConnectorOAuthButton.vue` is a reusable launcher:
+`KnowledgeRepository.startConnectorOAuth()` → open the authorize URL in a popup
+→ receive the callback's `postMessage` (origin-checked) → emit `connected` with
+the `secret_id`. Each connector issue (#9003/#9004/#9011) drops this button into
+its provider-specific config step; the gate does not surface connector types in
+the create wizard.
+
 ## Related ADRs
 
 - [ADR-002](002-redis-database-separation.md) — Redis database separation

--- a/docs/adr/_index.md
+++ b/docs/adr/_index.md
@@ -19,3 +19,4 @@ aliases:
 | [004-chat-workflow-architecture](004-chat-workflow-architecture.md) | Chat workflow architecture |
 | [005-single-frontend-mandate](005-single-frontend-mandate.md) | Single frontend mandate |
 | [006-skill-bound-planning](006-skill-bound-planning.md) | Skill-bound planning via skill_router at plan time |
+| [007-connector-oauth-token-storage](007-connector-oauth-token-storage.md) | Connector credentials must use SecretsService, not raw Redis |

--- a/docs/connectors/writing-a-connector.md
+++ b/docs/connectors/writing-a-connector.md
@@ -106,3 +106,86 @@ Set the `tier` class attribute to document setup complexity for the UI:
 - `0` — Zero-config (local file, unauthenticated URL)
 - `1` — Free API key or environment variable
 - `2` — OAuth, credentials, or private connection string
+
+## Credential Storage (Required for Tier 1 and 2)
+
+> **Architecture reference:** [ADR-007](../adr/007-connector-oauth-token-storage.md)
+
+Connector credentials (tokens, keys, passwords, client secrets) MUST NOT be
+stored as plain text in Redis.  The `ConnectorCredentialStore` handles this
+transparently — you only need to declare which auth type your connector uses.
+
+### 1. Declare your auth type
+
+```python
+from autobot_shared.auth.connector_auth import BearerAuth, OAuthRefreshAuth
+
+@ConnectorRegistry.register("my_source")
+class MySourceConnector(AbstractConnector):
+    connector_type = "my_source"
+    tier = 2
+
+    @classmethod
+    def auth_schema(cls) -> type:
+        return OAuthRefreshAuth  # or BearerAuth, ApiKeyAuth, BasicAuth
+```
+
+### 2. Mark sensitive fields
+
+Each auth dataclass has a `__sensitive_fields__` class attribute that lists
+which fields are encrypted at rest.  The defaults cover all tokens and secrets.
+You do not need to set this yourself — just pick the right auth type.
+
+| Auth type | Sensitive (encrypted) | Non-sensitive (Redis) |
+|-----------|----------------------|----------------------|
+| `OAuthRefreshAuth` | `client_secret`, `refresh_token` | `client_id`, `token_url`, `scopes` |
+| `BearerAuth` | `token` | — |
+| `ApiKeyAuth` | `key` | `header` |
+| `BasicAuth` | `password` | `username` |
+
+### 3. Use the full config at runtime
+
+The API layer splits and stores credentials automatically when a connector is
+created or updated.  When your connector is instantiated for `test_connection()`
+or `sync()`, the caller merges the credentials back via `ConnectorCredentialStore.load()`
+before passing `ConnectorConfig` to your constructor.  Your connector receives
+a fully populated `self.config.config` dict — no extra steps needed.
+
+```python
+async def test_connection(self) -> bool:
+    # self.config.config already contains all fields, including sensitive ones.
+    token = self.config.config["token"]
+    ...
+```
+
+### 4. Never store credentials yourself
+
+Do NOT write credentials back to `self.config.config` or Redis.  If a background
+token refresh produces a new `refresh_token`, rotate it via the store:
+
+```python
+from knowledge.connectors.credential_store import get_credential_store
+
+store = get_credential_store()
+await store.rotate(
+    self.config.secret_id,
+    {"refresh_token": new_token},
+    owner_id=self.config.owner_id,
+)
+```
+
+### 5. Testing connectors with credentials
+
+In acceptance tests, construct `ConnectorConfig` with the full config dict
+(sensitive fields included) and a fake `secret_id`.  The `ConnectorCredentialStore`
+is not invoked during unit tests — credentials flow through `config` directly.
+
+```python
+self.connector = MySourceConnector(ConnectorConfig(
+    connector_id="test-id",
+    connector_type="my_source",
+    name="Test",
+    config={"client_id": "x", "client_secret": "y", "refresh_token": "z", ...},
+    secret_id="test-secret-id",
+))
+```


### PR DESCRIPTION
## Thinking Path

#9019 is the connector-group architecture gate (OAuth tokens → secrets management). Investigation found the **credential-storage core already merged** (PR #9079: `ConnectorCredentialStore` + API CRUD wiring + `SecretType.OAUTH_REFRESH_TOKEN` + sensitive-field registry). Two ACs remained un-met and were rescoped by the accepted ADR-007 into generic, provider-agnostic plumbing: an **OAuth authorize/callback flow** (AC#3) and **access-token auto-refresh** (AC#2). This PR delivers that plumbing so the data-source connectors (#9003/#9004/#9011) can consume it — credentials never touch Redis or the frontend.

## What Changed

**Backend**
- `knowledge/connectors/oauth_flow.py` — provider registry (Google/Microsoft/GitLab), PKCE (S256), authorize-URL builder, code exchange, refresh-token rotation. OAuth *app* client creds from operator config.
- `ConnectorCredentialStore.store_oauth` + `get_access_token` — persist a self-contained token bundle via `SecretsService`; return a valid access token, **refreshing + rotating the secret in place** within an expiry skew (honors refresh-token rotation, e.g. GitLab).
- `api/knowledge_connector_oauth.py` — `POST .../oauth/{provider}/authorize` and `GET .../oauth/callback`, mounted in `core_routers`.
- `ssot_config` `AuthConfig` — per-provider `*_oauth_client_id/secret` settings (empty ⇒ provider disabled).

**Security** (both flagged by automated review, fixed here)
- **CSRF / token-attachment**: authorize sets an HttpOnly, SameSite=Lax, path-scoped `state` cookie; callback requires it to match `state` before consuming it (GETDEL single-use), binding the completing browser to the initiator.
- **XSS**: result page HTML-escapes the reflected `error` and JS-escapes the embedded JSON (`<`,`>`,`&`,U+2028/9).
- Redirect host allowlisted via existing `AUTOBOT_SSO_CALLBACK_HOSTS`; HTTPS enforced via `AUTOBOT_ENFORCE_HTTPS_CALLBACKS`.

**Frontend**
- `KnowledgeRepository.startConnectorOAuth` + reusable `ConnectorOAuthButton.vue` (popup launcher; origin-checked `postMessage`; emits `connected` with `secret_id`). Surfacing OAuth connector types in the create wizard belongs to #9003/#9004/#9011, which drop this button into their config step — not wired into the modal here to avoid half-wired dead UI.

**Docs**
- ADR-007 extended with the flow, auto-refresh, and security properties.

### Acceptance criteria (#9019)
| AC | Status |
|----|--------|
| `SecretType.OAUTH_REFRESH_TOKEN` | ✅ merged (#9079) |
| Resolver with auto-refresh | ✅ `get_access_token` (this PR) |
| OAuth callback stores tokens via secrets API | ✅ this PR |
| Plugins reference secrets by id, not env vars | ✅ merged (#9079) |
| Token revocation removes the secret | ✅ merged (#9079) |
| LLC company-scoped connector secrets | ⏭️ ADR marks as future work (org-scope opt-in) |

## Verification

- Backend: `pytest knowledge/connectors/tests/{test_oauth_flow,test_credential_store,test_connector_oauth_api}.py` → **41 passed** (incl. CSRF-binding + XSS escaping + refresh/rotate).
- Frontend: `vitest` on `ConnectorOAuthButton.spec.ts` + `KnowledgeRepository.connectors.test.ts` → **17 passed**.
- No regressions in `gdrive_test.py` / `registry_public_api_test.py`.

## Model Used

Claude Opus 4.8 (1M context)
