### PR TITLE
feat(secrets): envelope-crypto core — root key, per-vault KEK, DEK wrapping (#10089)

### DIFF
--- a/autobot_shared/secrets_envelope.py
+++ b/autobot_shared/secrets_envelope.py
@@ -36,6 +36,11 @@ from dataclasses import dataclass
 
 ROOT_KEY_ENV = "AUTOBOT_SECRETS_ROOT_KEY"
 
+# On-disk crypto format. Every persisted blob carries this so the algorithm can
+# change later without guessing: a future v2 (different AEAD/KDF) is detected by
+# the tag, not by trial decryption. Bump only when the wire format changes.
+FORMAT_VERSION = 1
+
 _KEY_LEN = 32  # AES-256
 _NONCE_LEN = 12  # AES-GCM standard nonce
 _HKDF_INFO_PREFIX = b"autobot-secrets-vault:"
@@ -43,6 +48,16 @@ _HKDF_INFO_PREFIX = b"autobot-secrets-vault:"
 
 class DecryptionError(Exception):
     """Raised when an AEAD open fails — wrong key, wrong grantee, or tampering."""
+
+
+class UnsupportedFormatError(Exception):
+    """Raised when a serialized blob carries a crypto-format version we can't read."""
+
+
+def _check_version(data: dict[str, object]) -> None:
+    version = data.get("v")
+    if version != FORMAT_VERSION:
+        raise UnsupportedFormatError(f"unsupported secrets crypto format v={version!r} (expected {FORMAT_VERSION})")
 
 
 def _b64e(raw: bytes) -> str:
@@ -107,12 +122,13 @@ class SealedSecret:
     nonce: bytes
     ciphertext: bytes
 
-    def to_dict(self) -> dict[str, str]:
-        return {"nonce": _b64e(self.nonce), "ciphertext": _b64e(self.ciphertext)}
+    def to_dict(self) -> dict[str, str | int]:
+        return {"v": FORMAT_VERSION, "nonce": _b64e(self.nonce), "ciphertext": _b64e(self.ciphertext)}
 
     @classmethod
-    def from_dict(cls, data: dict[str, str]) -> SealedSecret:
-        return cls(nonce=_b64d(data["nonce"]), ciphertext=_b64d(data["ciphertext"]))
+    def from_dict(cls, data: dict[str, str | int]) -> SealedSecret:
+        _check_version(data)
+        return cls(nonce=_b64d(str(data["nonce"])), ciphertext=_b64d(str(data["ciphertext"])))
 
 
 @dataclass(frozen=True)
@@ -123,19 +139,21 @@ class WrappedDek:
     nonce: bytes
     ciphertext: bytes
 
-    def to_dict(self) -> dict[str, str]:
+    def to_dict(self) -> dict[str, str | int]:
         return {
+            "v": FORMAT_VERSION,
             "grantee": self.grantee,
             "nonce": _b64e(self.nonce),
             "ciphertext": _b64e(self.ciphertext),
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, str]) -> WrappedDek:
+    def from_dict(cls, data: dict[str, str | int]) -> WrappedDek:
+        _check_version(data)
         return cls(
-            grantee=data["grantee"],
-            nonce=_b64d(data["nonce"]),
-            ciphertext=_b64d(data["ciphertext"]),
+            grantee=str(data["grantee"]),
+            nonce=_b64d(str(data["nonce"])),
+            ciphertext=_b64d(str(data["ciphertext"])),
         )
 
 

--- a/autobot_shared/secrets_envelope.py
+++ b/autobot_shared/secrets_envelope.py
@@ -22,33 +22,45 @@ Design
   payload is never re-encrypted or copied as plaintext and no KEK ever crosses a
   vault boundary. Revoking a share drops one wrapped DEK; rotating a KEK
   re-wraps the DEKs and leaves payloads untouched.
+- **Authenticated binding (AAD)** — both AEAD layers bind the stable
+  identifiers of where the ciphertext lives (the secret id, and for a wrapped
+  DEK the grantee), plus the format version, as Associated Data. A
+  write-capable attacker therefore cannot move a sealed value or a wrapped DEK
+  onto a different secret, relabel a grant's grantee, or downgrade the format —
+  any such tamper fails authentication (:class:`DecryptionError`). The
+  ``grantee`` field is plaintext metadata *and* is authenticated via AAD.
 
 All AEAD is AES-256-GCM (12-byte random nonce), matching ``field_encryption.py``
-and ``encryption_service.py``. Any authentication failure raises
-:class:`DecryptionError` (wrong key or tampering).
+and ``encryption_service.py``. A DEK encrypts exactly one value once, so its
+nonce never repeats. A KEK wraps many DEKs with random 96-bit nonces; the safe
+budget is ~2**32 wraps per KEK (NIST SP 800-38D) — far beyond any real
+deployment, with KEK rotation (:func:`rewrap_dek`) as the backstop. Any
+authentication failure raises :class:`DecryptionError`.
 """
 
 from __future__ import annotations
 
 import base64
+import binascii
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 
 ROOT_KEY_ENV = "AUTOBOT_SECRETS_ROOT_KEY"
 
-# On-disk crypto format. Every persisted blob carries this so the algorithm can
-# change later without guessing: a future v2 (different AEAD/KDF) is detected by
-# the tag, not by trial decryption. Bump only when the wire format changes.
+# On-disk crypto format. Persisted in every blob AND authenticated into the AAD
+# so a future v2 (different AEAD/KDF) cannot be downgraded onto by a store-write
+# attacker. Bump only when the wire format changes.
 FORMAT_VERSION = 1
 
 _KEY_LEN = 32  # AES-256
 _NONCE_LEN = 12  # AES-GCM standard nonce
 _HKDF_INFO_PREFIX = b"autobot-secrets-vault:"
+_MAX_VAULT_ID_LEN = 512
 
 
 class DecryptionError(Exception):
-    """Raised when an AEAD open fails — wrong key, wrong grantee, or tampering."""
+    """Raised when an AEAD open fails — wrong key, wrong grantee, wrong secret, or tampering."""
 
 
 class UnsupportedFormatError(Exception):
@@ -66,7 +78,26 @@ def _b64e(raw: bytes) -> str:
 
 
 def _b64d(text: str) -> bytes:
-    return base64.urlsafe_b64decode(text + "==")
+    stripped = text.rstrip("=")
+    return base64.urlsafe_b64decode(stripped + "=" * (-len(stripped) % 4))
+
+
+def _aad(kind: bytes, *fields: bytes) -> bytes:
+    """Unambiguous (length-prefixed) Associated Data, version-bound and domain-separated.
+
+    Length-prefixing each field makes the encoding injective, so no two distinct
+    (kind, fields) tuples can ever collide into the same AAD.
+    """
+    parts = (FORMAT_VERSION.to_bytes(2, "big"), kind, *fields)
+    return b"".join(len(p).to_bytes(4, "big") + p for p in parts)
+
+
+def _value_aad(secret_id: str) -> bytes:
+    return _aad(b"secret-value", secret_id.encode("utf-8"))
+
+
+def _dek_aad(grantee: str, secret_id: str) -> bytes:
+    return _aad(b"wrapped-dek", grantee.encode("utf-8"), secret_id.encode("utf-8"))
 
 
 def _aesgcm(key: bytes):
@@ -75,20 +106,20 @@ def _aesgcm(key: bytes):
     return AESGCM(key)
 
 
-def _seal_bytes(key: bytes, plaintext: bytes) -> tuple[bytes, bytes]:
-    """AES-256-GCM encrypt; return (nonce, ciphertext-with-tag)."""
+def _seal_bytes(key: bytes, plaintext: bytes, aad: bytes) -> tuple[bytes, bytes]:
+    """AES-256-GCM encrypt with associated data; return (nonce, ciphertext-with-tag)."""
     nonce = os.urandom(_NONCE_LEN)
-    return nonce, _aesgcm(key).encrypt(nonce, plaintext, None)
+    return nonce, _aesgcm(key).encrypt(nonce, plaintext, aad)
 
 
-def _open_bytes(key: bytes, nonce: bytes, ciphertext: bytes) -> bytes:
+def _open_bytes(key: bytes, nonce: bytes, ciphertext: bytes, aad: bytes) -> bytes:
     """AES-256-GCM decrypt; raise :class:`DecryptionError` on any failure."""
     from cryptography.exceptions import InvalidTag
 
     try:
-        return _aesgcm(key).decrypt(nonce, ciphertext, None)
+        return _aesgcm(key).decrypt(nonce, ciphertext, aad)
     except InvalidTag as exc:
-        raise DecryptionError("AEAD authentication failed (wrong key or tampered data)") from exc
+        raise DecryptionError("AEAD authentication failed (wrong key/grantee/secret or tampered data)") from exc
 
 
 def load_root_key() -> bytes:
@@ -96,7 +127,10 @@ def load_root_key() -> bytes:
     raw = os.environ.get(ROOT_KEY_ENV, "")
     if not raw:
         raise RuntimeError(f"{ROOT_KEY_ENV} is not set — the unified secrets root key is required")
-    key = _b64d(raw)
+    try:
+        key = _b64d(raw)
+    except (binascii.Error, ValueError) as exc:
+        raise RuntimeError(f"{ROOT_KEY_ENV} is not valid url-safe base64") from exc
     if len(key) != _KEY_LEN:
         raise RuntimeError(f"{ROOT_KEY_ENV} must decode to 32 bytes (got {len(key)})")
     return key
@@ -107,10 +141,16 @@ def derive_vault_key(root_key: bytes, vault_id: str) -> bytes:
     from cryptography.hazmat.primitives import hashes
     from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
+    if not vault_id:
+        raise ValueError("vault_id must be a non-empty string")
+    if len(vault_id) > _MAX_VAULT_ID_LEN:
+        raise ValueError(f"vault_id exceeds {_MAX_VAULT_ID_LEN} chars")
+
     hkdf = HKDF(
         algorithm=hashes.SHA256(),
         length=_KEY_LEN,
         salt=None,
+        # Single variable-length trailing field after a constant prefix → injective.
         info=_HKDF_INFO_PREFIX + vault_id.encode("utf-8"),
     )
     return hkdf.derive(root_key)
@@ -127,7 +167,7 @@ class SealedSecret:
         return {"v": FORMAT_VERSION, "nonce": _b64e(self.nonce), "ciphertext": _b64e(self.ciphertext)}
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | int]) -> SealedSecret:
+    def from_dict(cls, data: Mapping[str, str | int]) -> SealedSecret:
         _check_version(data)
         return cls(nonce=_b64d(str(data["nonce"])), ciphertext=_b64d(str(data["ciphertext"])))
 
@@ -149,7 +189,7 @@ class WrappedDek:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, str | int]) -> WrappedDek:
+    def from_dict(cls, data: Mapping[str, str | int]) -> WrappedDek:
         _check_version(data)
         return cls(
             grantee=str(data["grantee"]),
@@ -158,32 +198,32 @@ class WrappedDek:
         )
 
 
-def seal(plaintext: bytes, dek: bytes | None = None) -> tuple[SealedSecret, bytes]:
-    """Encrypt *plaintext* under a fresh (or supplied) DEK. Returns (SealedSecret, dek)."""
+def seal(plaintext: bytes, *, secret_id: str, dek: bytes | None = None) -> tuple[SealedSecret, bytes]:
+    """Encrypt *plaintext* under a fresh (or supplied) DEK, bound to *secret_id*. Returns (SealedSecret, dek)."""
     if dek is None:
         dek = os.urandom(_KEY_LEN)
-    nonce, ciphertext = _seal_bytes(dek, plaintext)
+    nonce, ciphertext = _seal_bytes(dek, plaintext, _value_aad(secret_id))
     return SealedSecret(nonce=nonce, ciphertext=ciphertext), dek
 
 
-def wrap_dek(dek: bytes, kek: bytes, grantee: str) -> WrappedDek:
-    """Wrap *dek* under a vault *kek* for *grantee* (a vault id / principal)."""
-    nonce, ciphertext = _seal_bytes(kek, dek)
+def wrap_dek(dek: bytes, kek: bytes, grantee: str, *, secret_id: str) -> WrappedDek:
+    """Wrap *dek* under a vault *kek* for *grantee*, bound to (grantee, secret_id)."""
+    nonce, ciphertext = _seal_bytes(kek, dek, _dek_aad(grantee, secret_id))
     return WrappedDek(grantee=grantee, nonce=nonce, ciphertext=ciphertext)
 
 
-def unwrap_dek(wrapped: WrappedDek, kek: bytes) -> bytes:
-    """Recover the DEK from *wrapped* using the grantee's vault *kek*."""
-    return _open_bytes(kek, wrapped.nonce, wrapped.ciphertext)
+def unwrap_dek(wrapped: WrappedDek, kek: bytes, *, secret_id: str) -> bytes:
+    """Recover the DEK from *wrapped* using the grantee's vault *kek*; authenticates (grantee, secret_id)."""
+    return _open_bytes(kek, wrapped.nonce, wrapped.ciphertext, _dek_aad(wrapped.grantee, secret_id))
 
 
-def open_secret(sealed: SealedSecret, wrapped: WrappedDek, kek: bytes) -> bytes:
-    """Decrypt *sealed* by unwrapping its DEK from *wrapped* with vault *kek*."""
-    dek = unwrap_dek(wrapped, kek)
-    return _open_bytes(dek, sealed.nonce, sealed.ciphertext)
+def open_secret(sealed: SealedSecret, wrapped: WrappedDek, kek: bytes, *, secret_id: str) -> bytes:
+    """Decrypt *sealed* by unwrapping its DEK from *wrapped* with vault *kek*; both layers bound to *secret_id*."""
+    dek = unwrap_dek(wrapped, kek, secret_id=secret_id)
+    return _open_bytes(dek, sealed.nonce, sealed.ciphertext, _value_aad(secret_id))
 
 
-def rewrap_dek(wrapped: WrappedDek, old_kek: bytes, new_kek: bytes) -> WrappedDek:
+def rewrap_dek(wrapped: WrappedDek, old_kek: bytes, new_kek: bytes, *, secret_id: str) -> WrappedDek:
     """Re-wrap a grant from *old_kek* to *new_kek* (key rotation; payload untouched)."""
-    dek = unwrap_dek(wrapped, old_kek)
-    return wrap_dek(dek, new_kek, wrapped.grantee)
+    dek = unwrap_dek(wrapped, old_kek, secret_id=secret_id)
+    return wrap_dek(dek, new_kek, wrapped.grantee, secret_id=secret_id)

--- a/autobot_shared/secrets_envelope.py
+++ b/autobot_shared/secrets_envelope.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import base64
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 ROOT_KEY_ENV = "AUTOBOT_SECRETS_ROOT_KEY"
@@ -54,7 +55,7 @@ class UnsupportedFormatError(Exception):
     """Raised when a serialized blob carries a crypto-format version we can't read."""
 
 
-def _check_version(data: dict[str, object]) -> None:
+def _check_version(data: Mapping[str, object]) -> None:
     version = data.get("v")
     if version != FORMAT_VERSION:
         raise UnsupportedFormatError(f"unsupported secrets crypto format v={version!r} (expected {FORMAT_VERSION})")

--- a/autobot_shared/secrets_envelope.py
+++ b/autobot_shared/secrets_envelope.py
@@ -1,0 +1,170 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Envelope-crypto core for AutoBot's unified secrets infrastructure.
+
+Task 1 of umbrella #10088. Pure, database-free primitives that every higher
+layer (the SecretsService, vault store, migrations) builds on.
+
+Design
+------
+- **One root key** (``AUTOBOT_SECRETS_ROOT_KEY``) — the single bootstrap
+  secret, supplied via env (it cannot live in the store it protects).
+- **Per-vault keys (KEK)** — ``derive_vault_key(root, vault_id)`` stretches the
+  root with HKDF-SHA256 keyed to the vault id, so each vault (system, a user,
+  an LLC company, a node) has a distinct key. Generalizes the per-company HKDF
+  already used by ``llc/services/secret.py``.
+- **Envelope encryption** — each secret has its own random **data key (DEK)**
+  that encrypts the value *once* (AES-256-GCM). The DEK is then **wrapped** by a
+  vault KEK and stored beside the ciphertext. Sharing a secret with another
+  user/team/LLC-company = wrapping the *same* DEK for that grantee's KEK, so the
+  payload is never re-encrypted or copied as plaintext and no KEK ever crosses a
+  vault boundary. Revoking a share drops one wrapped DEK; rotating a KEK
+  re-wraps the DEKs and leaves payloads untouched.
+
+All AEAD is AES-256-GCM (12-byte random nonce), matching ``field_encryption.py``
+and ``encryption_service.py``. Any authentication failure raises
+:class:`DecryptionError` (wrong key or tampering).
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from dataclasses import dataclass
+
+ROOT_KEY_ENV = "AUTOBOT_SECRETS_ROOT_KEY"
+
+_KEY_LEN = 32  # AES-256
+_NONCE_LEN = 12  # AES-GCM standard nonce
+_HKDF_INFO_PREFIX = b"autobot-secrets-vault:"
+
+
+class DecryptionError(Exception):
+    """Raised when an AEAD open fails — wrong key, wrong grantee, or tampering."""
+
+
+def _b64e(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def _b64d(text: str) -> bytes:
+    return base64.urlsafe_b64decode(text + "==")
+
+
+def _aesgcm(key: bytes):
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    return AESGCM(key)
+
+
+def _seal_bytes(key: bytes, plaintext: bytes) -> tuple[bytes, bytes]:
+    """AES-256-GCM encrypt; return (nonce, ciphertext-with-tag)."""
+    nonce = os.urandom(_NONCE_LEN)
+    return nonce, _aesgcm(key).encrypt(nonce, plaintext, None)
+
+
+def _open_bytes(key: bytes, nonce: bytes, ciphertext: bytes) -> bytes:
+    """AES-256-GCM decrypt; raise :class:`DecryptionError` on any failure."""
+    from cryptography.exceptions import InvalidTag
+
+    try:
+        return _aesgcm(key).decrypt(nonce, ciphertext, None)
+    except InvalidTag as exc:
+        raise DecryptionError("AEAD authentication failed (wrong key or tampered data)") from exc
+
+
+def load_root_key() -> bytes:
+    """Load the 32-byte root key from ``AUTOBOT_SECRETS_ROOT_KEY`` (url-safe base64)."""
+    raw = os.environ.get(ROOT_KEY_ENV, "")
+    if not raw:
+        raise RuntimeError(f"{ROOT_KEY_ENV} is not set — the unified secrets root key is required")
+    key = _b64d(raw)
+    if len(key) != _KEY_LEN:
+        raise RuntimeError(f"{ROOT_KEY_ENV} must decode to 32 bytes (got {len(key)})")
+    return key
+
+
+def derive_vault_key(root_key: bytes, vault_id: str) -> bytes:
+    """Derive a vault's 32-byte KEK from the root key via HKDF-SHA256."""
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=_KEY_LEN,
+        salt=None,
+        info=_HKDF_INFO_PREFIX + vault_id.encode("utf-8"),
+    )
+    return hkdf.derive(root_key)
+
+
+@dataclass(frozen=True)
+class SealedSecret:
+    """A secret value encrypted once under its own DEK (DEK stored separately)."""
+
+    nonce: bytes
+    ciphertext: bytes
+
+    def to_dict(self) -> dict[str, str]:
+        return {"nonce": _b64e(self.nonce), "ciphertext": _b64e(self.ciphertext)}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, str]) -> SealedSecret:
+        return cls(nonce=_b64d(data["nonce"]), ciphertext=_b64d(data["ciphertext"]))
+
+
+@dataclass(frozen=True)
+class WrappedDek:
+    """A secret's DEK wrapped under one grantee's vault KEK (one per share)."""
+
+    grantee: str
+    nonce: bytes
+    ciphertext: bytes
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "grantee": self.grantee,
+            "nonce": _b64e(self.nonce),
+            "ciphertext": _b64e(self.ciphertext),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, str]) -> WrappedDek:
+        return cls(
+            grantee=data["grantee"],
+            nonce=_b64d(data["nonce"]),
+            ciphertext=_b64d(data["ciphertext"]),
+        )
+
+
+def seal(plaintext: bytes, dek: bytes | None = None) -> tuple[SealedSecret, bytes]:
+    """Encrypt *plaintext* under a fresh (or supplied) DEK. Returns (SealedSecret, dek)."""
+    if dek is None:
+        dek = os.urandom(_KEY_LEN)
+    nonce, ciphertext = _seal_bytes(dek, plaintext)
+    return SealedSecret(nonce=nonce, ciphertext=ciphertext), dek
+
+
+def wrap_dek(dek: bytes, kek: bytes, grantee: str) -> WrappedDek:
+    """Wrap *dek* under a vault *kek* for *grantee* (a vault id / principal)."""
+    nonce, ciphertext = _seal_bytes(kek, dek)
+    return WrappedDek(grantee=grantee, nonce=nonce, ciphertext=ciphertext)
+
+
+def unwrap_dek(wrapped: WrappedDek, kek: bytes) -> bytes:
+    """Recover the DEK from *wrapped* using the grantee's vault *kek*."""
+    return _open_bytes(kek, wrapped.nonce, wrapped.ciphertext)
+
+
+def open_secret(sealed: SealedSecret, wrapped: WrappedDek, kek: bytes) -> bytes:
+    """Decrypt *sealed* by unwrapping its DEK from *wrapped* with vault *kek*."""
+    dek = unwrap_dek(wrapped, kek)
+    return _open_bytes(dek, sealed.nonce, sealed.ciphertext)
+
+
+def rewrap_dek(wrapped: WrappedDek, old_kek: bytes, new_kek: bytes) -> WrappedDek:
+    """Re-wrap a grant from *old_kek* to *new_kek* (key rotation; payload untouched)."""
+    dek = unwrap_dek(wrapped, old_kek)
+    return wrap_dek(dek, new_kek, wrapped.grantee)

--- a/autobot_shared/secrets_envelope_test.py
+++ b/autobot_shared/secrets_envelope_test.py
@@ -186,3 +186,24 @@ class TestSerialization:
         assert restored == sealed
         grant = env.wrap_dek(dek, kek, "company:A")
         assert env.open_secret(restored, grant, kek) == b"persist-me"
+
+    def test_dicts_carry_format_version(self) -> None:
+        sealed, dek = env.seal(b"x")
+        assert sealed.to_dict()["v"] == env.FORMAT_VERSION
+        wrapped = env.wrap_dek(dek, bytes(32), "user:alice")
+        assert wrapped.to_dict()["v"] == env.FORMAT_VERSION
+
+    def test_unknown_version_rejected(self) -> None:
+        sealed, dek = env.seal(b"x")
+        bad = {**sealed.to_dict(), "v": 999}
+        with pytest.raises(env.UnsupportedFormatError):
+            env.SealedSecret.from_dict(bad)
+        bad_wrap = {**env.wrap_dek(dek, bytes(32), "u").to_dict(), "v": 999}
+        with pytest.raises(env.UnsupportedFormatError):
+            env.WrappedDek.from_dict(bad_wrap)
+
+    def test_missing_version_rejected(self) -> None:
+        sealed, _ = env.seal(b"x")
+        legacy = {k: v for k, v in sealed.to_dict().items() if k != "v"}
+        with pytest.raises(env.UnsupportedFormatError):
+            env.SealedSecret.from_dict(legacy)

--- a/autobot_shared/secrets_envelope_test.py
+++ b/autobot_shared/secrets_envelope_test.py
@@ -13,6 +13,7 @@ import pytest
 from autobot_shared import secrets_envelope as env
 
 _ROOT = base64.urlsafe_b64encode(bytes(range(32))).decode("ascii")
+_SID = "secret:abc"  # a representative stable secret id used for AAD binding
 
 
 @pytest.fixture()
@@ -26,6 +27,10 @@ class TestRootKey:
         monkeypatch.setenv(env.ROOT_KEY_ENV, _ROOT)
         assert env.load_root_key() == bytes(range(32))
 
+    def test_load_valid_unpadded(self, monkeypatch) -> None:
+        monkeypatch.setenv(env.ROOT_KEY_ENV, _ROOT.rstrip("="))
+        assert env.load_root_key() == bytes(range(32))
+
     def test_missing_raises(self, monkeypatch) -> None:
         monkeypatch.delenv(env.ROOT_KEY_ENV, raising=False)
         with pytest.raises(RuntimeError, match=env.ROOT_KEY_ENV):
@@ -34,6 +39,11 @@ class TestRootKey:
     def test_wrong_length_raises(self, monkeypatch) -> None:
         monkeypatch.setenv(env.ROOT_KEY_ENV, base64.urlsafe_b64encode(b"tooshort").decode())
         with pytest.raises(RuntimeError, match="32 bytes"):
+            env.load_root_key()
+
+    def test_malformed_base64_raises_runtimeerror(self, monkeypatch) -> None:
+        monkeypatch.setenv(env.ROOT_KEY_ENV, "not!valid!base64!!!")
+        with pytest.raises(RuntimeError, match="base64"):
             env.load_root_key()
 
 
@@ -50,81 +60,128 @@ class TestDeriveVaultKey:
     def test_distinct_from_root(self, root_key) -> None:
         assert env.derive_vault_key(root_key, "system") != root_key
 
+    def test_empty_vault_id_rejected(self, root_key) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            env.derive_vault_key(root_key, "")
+
+    def test_overlong_vault_id_rejected(self, root_key) -> None:
+        with pytest.raises(ValueError):
+            env.derive_vault_key(root_key, "x" * (env._MAX_VAULT_ID_LEN + 1))
+
 
 class TestSealOpenRoundtrip:
     def test_seal_then_open_with_vault_grant(self, root_key) -> None:
         kek = env.derive_vault_key(root_key, "user:alice")
-        sealed, dek = env.seal(b"super-secret-value")
-        grant = env.wrap_dek(dek, kek, grantee="user:alice")
-        assert env.open_secret(sealed, grant, kek) == b"super-secret-value"
+        sealed, dek = env.seal(b"super-secret-value", secret_id=_SID)
+        grant = env.wrap_dek(dek, kek, grantee="user:alice", secret_id=_SID)
+        assert env.open_secret(sealed, grant, kek, secret_id=_SID) == b"super-secret-value"
 
-    def test_dek_is_32_bytes(self, root_key) -> None:
-        _, dek = env.seal(b"x")
+    def test_dek_is_32_bytes(self) -> None:
+        _, dek = env.seal(b"x", secret_id=_SID)
         assert len(dek) == 32
 
     def test_each_seal_uses_a_fresh_nonce(self) -> None:
-        s1, _ = env.seal(b"same")
-        s2, _ = env.seal(b"same")
+        s1, _ = env.seal(b"same", secret_id=_SID)
+        s2, _ = env.seal(b"same", secret_id=_SID)
         assert s1.nonce != s2.nonce
 
     def test_each_seal_uses_a_fresh_dek(self) -> None:
-        _, d1 = env.seal(b"same")
-        _, d2 = env.seal(b"same")
+        _, d1 = env.seal(b"same", secret_id=_SID)
+        _, d2 = env.seal(b"same", secret_id=_SID)
         assert d1 != d2
 
     def test_empty_plaintext_roundtrips(self, root_key) -> None:
         kek = env.derive_vault_key(root_key, "user:alice")
-        sealed, dek = env.seal(b"")
-        assert env.open_secret(sealed, env.wrap_dek(dek, kek, "user:alice"), kek) == b""
+        sealed, dek = env.seal(b"", secret_id=_SID)
+        grant = env.wrap_dek(dek, kek, "user:alice", secret_id=_SID)
+        assert env.open_secret(sealed, grant, kek, secret_id=_SID) == b""
 
 
 class TestWrapUnwrap:
     def test_roundtrip(self, root_key) -> None:
         kek = env.derive_vault_key(root_key, "system")
-        _, dek = env.seal(b"x")
-        wrapped = env.wrap_dek(dek, kek, grantee="system")
-        assert env.unwrap_dek(wrapped, kek) == dek
+        _, dek = env.seal(b"x", secret_id=_SID)
+        wrapped = env.wrap_dek(dek, kek, grantee="system", secret_id=_SID)
+        assert env.unwrap_dek(wrapped, kek, secret_id=_SID) == dek
 
     def test_wrong_kek_fails(self, root_key) -> None:
         kek_a = env.derive_vault_key(root_key, "user:alice")
         kek_b = env.derive_vault_key(root_key, "user:bob")
-        _, dek = env.seal(b"x")
-        wrapped = env.wrap_dek(dek, kek_a, grantee="user:alice")
+        _, dek = env.seal(b"x", secret_id=_SID)
+        wrapped = env.wrap_dek(dek, kek_a, grantee="user:alice", secret_id=_SID)
         with pytest.raises(env.DecryptionError):
-            env.unwrap_dek(wrapped, kek_b)
+            env.unwrap_dek(wrapped, kek_b, secret_id=_SID)
 
     def test_grantee_recorded(self, root_key) -> None:
         kek = env.derive_vault_key(root_key, "company:42")
-        _, dek = env.seal(b"x")
-        assert env.wrap_dek(dek, kek, grantee="company:42").grantee == "company:42"
+        _, dek = env.seal(b"x", secret_id=_SID)
+        assert env.wrap_dek(dek, kek, grantee="company:42", secret_id=_SID).grantee == "company:42"
 
 
 class TestSharingCrossVault:
     def test_share_to_second_vault_opens_same_plaintext(self, root_key) -> None:
-        # company A owns the secret; shares with company B by wrapping the same DEK.
         kek_a = env.derive_vault_key(root_key, "company:A")
         kek_b = env.derive_vault_key(root_key, "company:B")
-        sealed, dek = env.seal(b"shared-api-key")
-        grant_a = env.wrap_dek(dek, kek_a, grantee="company:A")
-        # B receives a grant; the service unwrapped DEK via A then wrapped for B.
-        recovered_dek = env.unwrap_dek(grant_a, kek_a)
-        grant_b = env.wrap_dek(recovered_dek, kek_b, grantee="company:B")
-        assert env.open_secret(sealed, grant_b, kek_b) == b"shared-api-key"
+        sealed, dek = env.seal(b"shared-api-key", secret_id=_SID)
+        grant_a = env.wrap_dek(dek, kek_a, grantee="company:A", secret_id=_SID)
+        recovered_dek = env.unwrap_dek(grant_a, kek_a, secret_id=_SID)
+        grant_b = env.wrap_dek(recovered_dek, kek_b, grantee="company:B", secret_id=_SID)
+        assert env.open_secret(sealed, grant_b, kek_b, secret_id=_SID) == b"shared-api-key"
 
     def test_b_cannot_open_a_grant(self, root_key) -> None:
         kek_a = env.derive_vault_key(root_key, "company:A")
         kek_b = env.derive_vault_key(root_key, "company:B")
-        sealed, dek = env.seal(b"private")
-        grant_a = env.wrap_dek(dek, kek_a, grantee="company:A")
+        sealed, dek = env.seal(b"private", secret_id=_SID)
+        grant_a = env.wrap_dek(dek, kek_a, grantee="company:A", secret_id=_SID)
         with pytest.raises(env.DecryptionError):
-            env.open_secret(sealed, grant_a, kek_b)
+            env.open_secret(sealed, grant_a, kek_b, secret_id=_SID)
 
     def test_multiple_grantees_all_open(self, root_key) -> None:
         keks = {v: env.derive_vault_key(root_key, v) for v in ("user:alice", "company:A", "company:B")}
-        sealed, dek = env.seal(b"multi")
-        grants = {v: env.wrap_dek(dek, kek, grantee=v) for v, kek in keks.items()}
+        sealed, dek = env.seal(b"multi", secret_id=_SID)
+        grants = {v: env.wrap_dek(dek, kek, grantee=v, secret_id=_SID) for v, kek in keks.items()}
         for v, kek in keks.items():
-            assert env.open_secret(sealed, grants[v], kek) == b"multi"
+            assert env.open_secret(sealed, grants[v], kek, secret_id=_SID) == b"multi"
+
+
+class TestAadBinding:
+    """The H1 fix: ciphertexts are bound to their secret id and grantee."""
+
+    def test_wrapped_dek_bound_to_secret_id(self, root_key) -> None:
+        kek = env.derive_vault_key(root_key, "user:alice")
+        _, dek = env.seal(b"x", secret_id="secret:X")
+        grant = env.wrap_dek(dek, kek, "user:alice", secret_id="secret:X")
+        # The same vault, same key — but claiming a different secret id must fail.
+        with pytest.raises(env.DecryptionError):
+            env.unwrap_dek(grant, kek, secret_id="secret:Y")
+
+    def test_sealed_value_bound_to_secret_id(self, root_key) -> None:
+        kek = env.derive_vault_key(root_key, "user:alice")
+        sealed, dek = env.seal(b"value", secret_id="secret:X")
+        grant = env.wrap_dek(dek, kek, "user:alice", secret_id="secret:X")
+        # Open under the wrong secret id: the DEK-unwrap AAD mismatches first.
+        with pytest.raises(env.DecryptionError):
+            env.open_secret(sealed, grant, kek, secret_id="secret:Y")
+
+    def test_cross_secret_grant_swap_rejected(self, root_key) -> None:
+        # Alice holds grants for two secrets in her vault. Moving secret Y's
+        # wrapped DEK onto secret X (same vault/key) must not disclose Y as X.
+        kek = env.derive_vault_key(root_key, "user:alice")
+        sealed_x, dek_x = env.seal(b"value-X", secret_id="secret:X")
+        _, dek_y = env.seal(b"value-Y", secret_id="secret:Y")
+        grant_y = env.wrap_dek(dek_y, kek, "user:alice", secret_id="secret:Y")
+        # Attacker places grant_y where X's grant should be; open as X.
+        with pytest.raises(env.DecryptionError):
+            env.open_secret(sealed_x, grant_y, kek, secret_id="secret:X")
+
+    def test_grantee_relabel_rejected(self, root_key) -> None:
+        kek = env.derive_vault_key(root_key, "user:alice")
+        _, dek = env.seal(b"x", secret_id=_SID)
+        grant = env.wrap_dek(dek, kek, "user:alice", secret_id=_SID)
+        # Relabel the grantee (plaintext field) — authenticated via AAD, so it fails.
+        relabeled = env.WrappedDek(grantee="user:mallory", nonce=grant.nonce, ciphertext=grant.ciphertext)
+        with pytest.raises(env.DecryptionError):
+            env.unwrap_dek(relabeled, kek, secret_id=_SID)
 
 
 class TestRotation:
@@ -132,78 +189,77 @@ class TestRotation:
         old = env.derive_vault_key(root_key, "company:A")
         new_root = bytes((b + 1) % 256 for b in root_key)
         new = env.derive_vault_key(new_root, "company:A")
-        sealed, dek = env.seal(b"rotate-me")
-        grant = env.wrap_dek(dek, old, grantee="company:A")
-        rewrapped = env.rewrap_dek(grant, old, new)
-        assert env.open_secret(sealed, rewrapped, new) == b"rotate-me"
+        sealed, dek = env.seal(b"rotate-me", secret_id=_SID)
+        grant = env.wrap_dek(dek, old, grantee="company:A", secret_id=_SID)
+        rewrapped = env.rewrap_dek(grant, old, new, secret_id=_SID)
+        assert env.open_secret(sealed, rewrapped, new, secret_id=_SID) == b"rotate-me"
         assert rewrapped.grantee == "company:A"
 
     def test_old_kek_cannot_open_rewrapped(self, root_key) -> None:
         old = env.derive_vault_key(root_key, "company:A")
         new_root = bytes((b + 1) % 256 for b in root_key)
         new = env.derive_vault_key(new_root, "company:A")
-        sealed, dek = env.seal(b"rotate-me")
-        rewrapped = env.rewrap_dek(env.wrap_dek(dek, old, "company:A"), old, new)
+        sealed, dek = env.seal(b"rotate-me", secret_id=_SID)
+        rewrapped = env.rewrap_dek(env.wrap_dek(dek, old, "company:A", secret_id=_SID), old, new, secret_id=_SID)
         with pytest.raises(env.DecryptionError):
-            env.open_secret(sealed, rewrapped, old)
+            env.open_secret(sealed, rewrapped, old, secret_id=_SID)
 
 
 class TestTamperDetection:
     def test_tampered_value_ciphertext_raises(self, root_key) -> None:
         kek = env.derive_vault_key(root_key, "user:alice")
-        sealed, dek = env.seal(b"integrity")
-        grant = env.wrap_dek(dek, kek, "user:alice")
+        sealed, dek = env.seal(b"integrity", secret_id=_SID)
+        grant = env.wrap_dek(dek, kek, "user:alice", secret_id=_SID)
         flipped = bytearray(sealed.ciphertext)
         flipped[0] ^= 0x01
         tampered = env.SealedSecret(nonce=sealed.nonce, ciphertext=bytes(flipped))
         with pytest.raises(env.DecryptionError):
-            env.open_secret(tampered, grant, kek)
+            env.open_secret(tampered, grant, kek, secret_id=_SID)
 
     def test_tampered_wrapped_dek_raises(self, root_key) -> None:
         kek = env.derive_vault_key(root_key, "user:alice")
-        _, dek = env.seal(b"x")
-        wrapped = env.wrap_dek(dek, kek, "user:alice")
+        _, dek = env.seal(b"x", secret_id=_SID)
+        wrapped = env.wrap_dek(dek, kek, "user:alice", secret_id=_SID)
         flipped = bytearray(wrapped.ciphertext)
         flipped[0] ^= 0x01
         tampered = env.WrappedDek(grantee="user:alice", nonce=wrapped.nonce, ciphertext=bytes(flipped))
         with pytest.raises(env.DecryptionError):
-            env.unwrap_dek(tampered, kek)
+            env.unwrap_dek(tampered, kek, secret_id=_SID)
 
 
 class TestSerialization:
     def test_wrapped_dek_roundtrips_through_dict(self, root_key) -> None:
         kek = env.derive_vault_key(root_key, "company:A")
-        _, dek = env.seal(b"x")
-        wrapped = env.wrap_dek(dek, kek, "company:A")
+        _, dek = env.seal(b"x", secret_id=_SID)
+        wrapped = env.wrap_dek(dek, kek, "company:A", secret_id=_SID)
         restored = env.WrappedDek.from_dict(wrapped.to_dict())
         assert restored == wrapped
-        assert env.unwrap_dek(restored, kek) == dek
+        assert env.unwrap_dek(restored, kek, secret_id=_SID) == dek
 
     def test_sealed_secret_roundtrips_through_dict(self, root_key) -> None:
         kek = env.derive_vault_key(root_key, "company:A")
-        sealed, dek = env.seal(b"persist-me")
+        sealed, dek = env.seal(b"persist-me", secret_id=_SID)
         restored = env.SealedSecret.from_dict(sealed.to_dict())
         assert restored == sealed
-        grant = env.wrap_dek(dek, kek, "company:A")
-        assert env.open_secret(restored, grant, kek) == b"persist-me"
+        grant = env.wrap_dek(dek, kek, "company:A", secret_id=_SID)
+        assert env.open_secret(restored, grant, kek, secret_id=_SID) == b"persist-me"
 
-    def test_dicts_carry_format_version(self) -> None:
-        sealed, dek = env.seal(b"x")
+    def test_dicts_carry_format_version(self, root_key) -> None:
+        sealed, dek = env.seal(b"x", secret_id=_SID)
         assert sealed.to_dict()["v"] == env.FORMAT_VERSION
-        wrapped = env.wrap_dek(dek, bytes(32), "user:alice")
+        wrapped = env.wrap_dek(dek, env.derive_vault_key(root_key, "u"), "user:alice", secret_id=_SID)
         assert wrapped.to_dict()["v"] == env.FORMAT_VERSION
 
-    def test_unknown_version_rejected(self) -> None:
-        sealed, dek = env.seal(b"x")
-        bad = {**sealed.to_dict(), "v": 999}
+    def test_unknown_version_rejected(self, root_key) -> None:
+        sealed, dek = env.seal(b"x", secret_id=_SID)
         with pytest.raises(env.UnsupportedFormatError):
-            env.SealedSecret.from_dict(bad)
-        bad_wrap = {**env.wrap_dek(dek, bytes(32), "u").to_dict(), "v": 999}
+            env.SealedSecret.from_dict({**sealed.to_dict(), "v": 999})
+        wrapped = env.wrap_dek(dek, env.derive_vault_key(root_key, "u"), "u", secret_id=_SID)
         with pytest.raises(env.UnsupportedFormatError):
-            env.WrappedDek.from_dict(bad_wrap)
+            env.WrappedDek.from_dict({**wrapped.to_dict(), "v": 999})
 
     def test_missing_version_rejected(self) -> None:
-        sealed, _ = env.seal(b"x")
+        sealed, _ = env.seal(b"x", secret_id=_SID)
         legacy = {k: v for k, v in sealed.to_dict().items() if k != "v"}
         with pytest.raises(env.UnsupportedFormatError):
             env.SealedSecret.from_dict(legacy)

--- a/autobot_shared/secrets_envelope_test.py
+++ b/autobot_shared/secrets_envelope_test.py
@@ -1,0 +1,188 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the unified-secrets envelope-crypto core (Task 1, #10089 / umbrella #10088)."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from autobot_shared import secrets_envelope as env
+
+_ROOT = base64.urlsafe_b64encode(bytes(range(32))).decode("ascii")
+
+
+@pytest.fixture()
+def root_key(monkeypatch) -> bytes:
+    monkeypatch.setenv(env.ROOT_KEY_ENV, _ROOT)
+    return env.load_root_key()
+
+
+class TestRootKey:
+    def test_load_valid(self, monkeypatch) -> None:
+        monkeypatch.setenv(env.ROOT_KEY_ENV, _ROOT)
+        assert env.load_root_key() == bytes(range(32))
+
+    def test_missing_raises(self, monkeypatch) -> None:
+        monkeypatch.delenv(env.ROOT_KEY_ENV, raising=False)
+        with pytest.raises(RuntimeError, match=env.ROOT_KEY_ENV):
+            env.load_root_key()
+
+    def test_wrong_length_raises(self, monkeypatch) -> None:
+        monkeypatch.setenv(env.ROOT_KEY_ENV, base64.urlsafe_b64encode(b"tooshort").decode())
+        with pytest.raises(RuntimeError, match="32 bytes"):
+            env.load_root_key()
+
+
+class TestDeriveVaultKey:
+    def test_deterministic(self, root_key) -> None:
+        assert env.derive_vault_key(root_key, "company:42") == env.derive_vault_key(root_key, "company:42")
+
+    def test_distinct_per_vault(self, root_key) -> None:
+        assert env.derive_vault_key(root_key, "company:42") != env.derive_vault_key(root_key, "company:43")
+
+    def test_is_32_bytes(self, root_key) -> None:
+        assert len(env.derive_vault_key(root_key, "system")) == 32
+
+    def test_distinct_from_root(self, root_key) -> None:
+        assert env.derive_vault_key(root_key, "system") != root_key
+
+
+class TestSealOpenRoundtrip:
+    def test_seal_then_open_with_vault_grant(self, root_key) -> None:
+        kek = env.derive_vault_key(root_key, "user:alice")
+        sealed, dek = env.seal(b"super-secret-value")
+        grant = env.wrap_dek(dek, kek, grantee="user:alice")
+        assert env.open_secret(sealed, grant, kek) == b"super-secret-value"
+
+    def test_dek_is_32_bytes(self, root_key) -> None:
+        _, dek = env.seal(b"x")
+        assert len(dek) == 32
+
+    def test_each_seal_uses_a_fresh_nonce(self) -> None:
+        s1, _ = env.seal(b"same")
+        s2, _ = env.seal(b"same")
+        assert s1.nonce != s2.nonce
+
+    def test_each_seal_uses_a_fresh_dek(self) -> None:
+        _, d1 = env.seal(b"same")
+        _, d2 = env.seal(b"same")
+        assert d1 != d2
+
+    def test_empty_plaintext_roundtrips(self, root_key) -> None:
+        kek = env.derive_vault_key(root_key, "user:alice")
+        sealed, dek = env.seal(b"")
+        assert env.open_secret(sealed, env.wrap_dek(dek, kek, "user:alice"), kek) == b""
+
+
+class TestWrapUnwrap:
+    def test_roundtrip(self, root_key) -> None:
+        kek = env.derive_vault_key(root_key, "system")
+        _, dek = env.seal(b"x")
+        wrapped = env.wrap_dek(dek, kek, grantee="system")
+        assert env.unwrap_dek(wrapped, kek) == dek
+
+    def test_wrong_kek_fails(self, root_key) -> None:
+        kek_a = env.derive_vault_key(root_key, "user:alice")
+        kek_b = env.derive_vault_key(root_key, "user:bob")
+        _, dek = env.seal(b"x")
+        wrapped = env.wrap_dek(dek, kek_a, grantee="user:alice")
+        with pytest.raises(env.DecryptionError):
+            env.unwrap_dek(wrapped, kek_b)
+
+    def test_grantee_recorded(self, root_key) -> None:
+        kek = env.derive_vault_key(root_key, "company:42")
+        _, dek = env.seal(b"x")
+        assert env.wrap_dek(dek, kek, grantee="company:42").grantee == "company:42"
+
+
+class TestSharingCrossVault:
+    def test_share_to_second_vault_opens_same_plaintext(self, root_key) -> None:
+        # company A owns the secret; shares with company B by wrapping the same DEK.
+        kek_a = env.derive_vault_key(root_key, "company:A")
+        kek_b = env.derive_vault_key(root_key, "company:B")
+        sealed, dek = env.seal(b"shared-api-key")
+        grant_a = env.wrap_dek(dek, kek_a, grantee="company:A")
+        # B receives a grant; the service unwrapped DEK via A then wrapped for B.
+        recovered_dek = env.unwrap_dek(grant_a, kek_a)
+        grant_b = env.wrap_dek(recovered_dek, kek_b, grantee="company:B")
+        assert env.open_secret(sealed, grant_b, kek_b) == b"shared-api-key"
+
+    def test_b_cannot_open_a_grant(self, root_key) -> None:
+        kek_a = env.derive_vault_key(root_key, "company:A")
+        kek_b = env.derive_vault_key(root_key, "company:B")
+        sealed, dek = env.seal(b"private")
+        grant_a = env.wrap_dek(dek, kek_a, grantee="company:A")
+        with pytest.raises(env.DecryptionError):
+            env.open_secret(sealed, grant_a, kek_b)
+
+    def test_multiple_grantees_all_open(self, root_key) -> None:
+        keks = {v: env.derive_vault_key(root_key, v) for v in ("user:alice", "company:A", "company:B")}
+        sealed, dek = env.seal(b"multi")
+        grants = {v: env.wrap_dek(dek, kek, grantee=v) for v, kek in keks.items()}
+        for v, kek in keks.items():
+            assert env.open_secret(sealed, grants[v], kek) == b"multi"
+
+
+class TestRotation:
+    def test_rewrap_to_new_kek(self, root_key) -> None:
+        old = env.derive_vault_key(root_key, "company:A")
+        new_root = bytes((b + 1) % 256 for b in root_key)
+        new = env.derive_vault_key(new_root, "company:A")
+        sealed, dek = env.seal(b"rotate-me")
+        grant = env.wrap_dek(dek, old, grantee="company:A")
+        rewrapped = env.rewrap_dek(grant, old, new)
+        assert env.open_secret(sealed, rewrapped, new) == b"rotate-me"
+        assert rewrapped.grantee == "company:A"
+
+    def test_old_kek_cannot_open_rewrapped(self, root_key) -> None:
+        old = env.derive_vault_key(root_key, "company:A")
+        new_root = bytes((b + 1) % 256 for b in root_key)
+        new = env.derive_vault_key(new_root, "company:A")
+        sealed, dek = env.seal(b"rotate-me")
+        rewrapped = env.rewrap_dek(env.wrap_dek(dek, old, "company:A"), old, new)
+        with pytest.raises(env.DecryptionError):
+            env.open_secret(sealed, rewrapped, old)
+
+
+class TestTamperDetection:
+    def test_tampered_value_ciphertext_raises(self, root_key) -> None:
+        kek = env.derive_vault_key(root_key, "user:alice")
+        sealed, dek = env.seal(b"integrity")
+        grant = env.wrap_dek(dek, kek, "user:alice")
+        flipped = bytearray(sealed.ciphertext)
+        flipped[0] ^= 0x01
+        tampered = env.SealedSecret(nonce=sealed.nonce, ciphertext=bytes(flipped))
+        with pytest.raises(env.DecryptionError):
+            env.open_secret(tampered, grant, kek)
+
+    def test_tampered_wrapped_dek_raises(self, root_key) -> None:
+        kek = env.derive_vault_key(root_key, "user:alice")
+        _, dek = env.seal(b"x")
+        wrapped = env.wrap_dek(dek, kek, "user:alice")
+        flipped = bytearray(wrapped.ciphertext)
+        flipped[0] ^= 0x01
+        tampered = env.WrappedDek(grantee="user:alice", nonce=wrapped.nonce, ciphertext=bytes(flipped))
+        with pytest.raises(env.DecryptionError):
+            env.unwrap_dek(tampered, kek)
+
+
+class TestSerialization:
+    def test_wrapped_dek_roundtrips_through_dict(self, root_key) -> None:
+        kek = env.derive_vault_key(root_key, "company:A")
+        _, dek = env.seal(b"x")
+        wrapped = env.wrap_dek(dek, kek, "company:A")
+        restored = env.WrappedDek.from_dict(wrapped.to_dict())
+        assert restored == wrapped
+        assert env.unwrap_dek(restored, kek) == dek
+
+    def test_sealed_secret_roundtrips_through_dict(self, root_key) -> None:
+        kek = env.derive_vault_key(root_key, "company:A")
+        sealed, dek = env.seal(b"persist-me")
+        restored = env.SealedSecret.from_dict(sealed.to_dict())
+        assert restored == sealed
+        grant = env.wrap_dek(dek, kek, "company:A")
+        assert env.open_secret(restored, grant, kek) == b"persist-me"


### PR DESCRIPTION
## Thinking Path
Task 1 of the unified-secrets umbrella #10088 (PRD). The whole initiative collapses ~11 secret stores / 5 keys / 2 UIs into one RBAC-governed, vault-partitioned store. This PR is the foundation everything else builds on: the envelope-crypto core, with no DB and no app wiring, so it can be reviewed purely as cryptography.

## What Changed
New `autobot_shared/secrets_envelope.py`:
- `load_root_key()` — the single bootstrap key (`AUTOBOT_SECRETS_ROOT_KEY`, env by design — it can't live in the store it protects).
- `derive_vault_key(root, vault_id)` — HKDF-SHA256 per-vault KEK. Generalizes the per-company HKDF already in `llc/services/secret.py`; `vault_id` is any principal (`system`, `user:`, `team:`, `role:`, `company:`, `node:`).
- **Envelope encryption**: `seal()` encrypts a value once under a random per-secret DEK (AES-256-GCM); `wrap_dek`/`unwrap_dek` wrap that DEK per grantee KEK; `open_secret` unwraps then decrypts; `rewrap_dek` rotates a KEK without re-encrypting payloads. Sharing across users/teams/roles/LLC-companies = wrapping the same DEK for another vault — no plaintext copy, no KEK crosses a boundary; revoke = drop a wrapped DEK.
- `FORMAT_VERSION` tag on every serialized blob (`SealedSecret`/`WrappedDek` → `"v":1`); `from_dict` rejects unknown/missing versions (`UnsupportedFormatError`) so the AEAD/KDF can change later without trial decryption.

AES-256-GCM (12-byte nonce), matching `field_encryption.py`; auth failures raise `DecryptionError`.

This design is what makes role-level, cross-company, and the audit "who-can-access" graph all fall out of one primitive (see #10088).

## Verification
- [x] 27 tests green: root-key load (valid/missing/wrong-len), KEK determinism + distinctness, seal/open + wrap/unwrap roundtrips, cross-vault sharing + isolation, multi-grantee, rotation re-wrap, tamper→`DecryptionError`, nonce/DEK freshness, dict (de)serialization, format-version tag + unknown/missing-version rejection
- [x] ruff clean; black (line-length 120); no `print`
- Callers land in Task 2 (the SecretsService + vault schema); no wiring in this PR by design.

## Model Used
Claude Opus 4.8 (1M context)

Closes #10089
