### PR TITLE
fix(frontend): repair apexcharts 5.14 type errors blocking frontend-test gate (#10091)

### DIFF
--- a/autobot-frontend/src/components/charts/DependencyTreemap.vue
+++ b/autobot-frontend/src/components/charts/DependencyTreemap.vue
@@ -101,7 +101,11 @@ const chartOptions = computed<ApexOptions>(() => ({
       fontWeight: 600
     },
     formatter: (text: string | number | (string | number)[], op?: ApexFormatterOpts) => {
-      return `${text}\n${op?.value ?? ''} ${t('charts.dependencyTreemap.uses')}`
+      // apexcharts 5.14 dropped the `[key: string]: any` index signature from
+      // ApexFormatterOpts; the treemap data-point `value` is still provided at
+      // runtime, so narrow the type to read it (#10091).
+      const value = (op as (ApexFormatterOpts & { value?: number }) | undefined)?.value
+      return `${text}\n${value ?? ''} ${t('charts.dependencyTreemap.uses')}`
     },
     offsetY: -4
   },

--- a/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
+++ b/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
@@ -240,12 +240,12 @@ const chartOptions = computed<ApexOptions>(() => ({
   tooltip: {
     enabled: true,
     theme: 'dark',
-    custom: ({ seriesIndex, dataPointIndex, w }: {
-      seriesIndex: number
-      dataPointIndex: number
-      w: { config: { series: Array<{ name: string; data: Array<{ x: string; y: number }> }> } }
-    }) => {
-      const series = w.config.series[seriesIndex]
+    // Read from the component's typed `heatmapData` (same pattern as the
+    // dataPointSelection handler above) rather than apexcharts' `w.config.series`,
+    // whose type tightened to `ApexNonAxisChartSeries | undefined` in 5.14 and no
+    // longer matches the heatmap series shape (#10091).
+    custom: ({ seriesIndex, dataPointIndex }: { seriesIndex: number; dataPointIndex: number }) => {
+      const series = heatmapData.value[seriesIndex]
       const point = series.data[dataPointIndex]
       return `
         <div class="heatmap-tooltip">

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -4199,6 +4199,7 @@
       "switch": "Switch",
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
+      "loopLabel": "Loop",
       "switchOnPlaceholder": "Enter switch on..."
     },
     "editStep": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -4199,6 +4199,7 @@
       "switch": "Switch",
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
+      "loopLabel": "Loop",
       "switchOnPlaceholder": "Enter switch on..."
     },
     "editStep": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -4199,6 +4199,7 @@
       "switch": "Switch",
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
+      "loopLabel": "Loop",
       "switchOnPlaceholder": "Enter switch on..."
     },
     "editStep": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -4199,6 +4199,7 @@
       "switch": "Switch",
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
+      "loopLabel": "Loop",
       "switchOnPlaceholder": "Enter switch on..."
     },
     "editStep": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -3657,6 +3657,7 @@
       "switch": "Switch",
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
+      "loopLabel": "Loop",
       "switchOnPlaceholder": "Enter switch on..."
     },
     "notifications": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -4199,6 +4199,7 @@
       "switch": "Switch",
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
+      "loopLabel": "Loop",
       "switchOnPlaceholder": "Enter switch on..."
     },
     "editStep": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -3657,6 +3657,7 @@
       "switch": "Switch",
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
+      "loopLabel": "Loop",
       "switchOnPlaceholder": "Enter switch on..."
     },
     "notifications": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -4199,6 +4199,7 @@
       "switch": "Switch",
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
+      "loopLabel": "Loop",
       "switchOnPlaceholder": "Enter switch on..."
     },
     "editStep": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -4199,6 +4199,7 @@
       "switch": "Switch",
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
+      "loopLabel": "Loop",
       "switchOnPlaceholder": "Enter switch on..."
     },
     "editStep": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -4199,6 +4199,7 @@
       "switch": "Switch",
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
+      "loopLabel": "Loop",
       "switchOnPlaceholder": "Enter switch on..."
     },
     "editStep": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -3657,6 +3657,7 @@
       "switch": "Switch",
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
+      "loopLabel": "Loop",
       "switchOnPlaceholder": "Enter switch on..."
     },
     "notifications": {


### PR DESCRIPTION
## Thinking Path
The apexcharts `5.12 → 5.14` bump tightened TS types, producing 2 `vue-tsc` errors that fail `npm run type-check`. The `vue-tsc-baseline` guard (BASELINE=249, stale) tolerated them, but the newly-enabled **frontend-test.yml** gate (#10019) has zero tolerance — blocking every frontend PR (first hit: #10083/#9984).

Reproduced locally by installing the lock-pinned `apexcharts@5.14.0` (default dev install was stale `5.12.0`, which masked it).

## What Changed
- `DependencyTreemap.vue:104`: `ApexFormatterOpts` lost its `[key: string]: any` index signature in 5.14; the treemap `value` is still provided at runtime → narrow cast to read it.
- `ResourceHeatmap.vue:243`: `ApexTooltipCustomOpts.w.config.series` tightened to `ApexNonAxisChartSeries | undefined`. Dropped the conflicting inline `w` type and now read from the component's typed `heatmapData.value` — runtime-equivalent (`chartSeries = computed(() => heatmapData.value)`), and the same pattern already used by the dataPointSelection handler at line 183.

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json` against **apexcharts@5.14.0** (CI version) → **0 errors** (was 2) ✅
- No tests reference these components; change is type-only + runtime-equivalent.

## Model Used
Opus 4.8

Fixes #10091