### PR TITLE
feat(secrets): canonical vault/principal namespace — VaultRef + kinds (#10094)

### DIFF
--- a/autobot_shared/secrets_vault.py
+++ b/autobot_shared/secrets_vault.py
@@ -1,0 +1,98 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Canonical vault & principal namespace for AutoBot's unified secrets infrastructure.
+
+Task 9.1 of umbrella #10088. The single source of truth for the ``vault_id``
+strings that ``secrets_envelope.derive_vault_key()`` consumes and that a wrapped
+DEK stores as its ``grantee`` — so the crypto layer, the RBAC checks, and the
+audit access-graph all agree on one namespace instead of passing ad-hoc strings.
+
+A :class:`VaultRef` is a key/access boundary; a :class:`PrincipalKind` is the
+kind of actor that resolves to a set of vaults (the resolution itself —
+credential → principal → vaults via role/team/company membership — is DB-backed
+and lands with Task 2/9.2).
+
+Canonical string form: ``system`` for the singleton system vault, else
+``<kind>:<id>`` (e.g. ``user:alice``, ``company:acme-42``, ``role:admin``). The
+``id`` may not contain the ``:`` separator or whitespace, which keeps the
+encoding unambiguous and round-trippable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+_SEP = ":"
+# Matches the String(255) limit on company_id / agent_id in the LLC models.
+_MAX_ID_LEN = 255
+
+
+class VaultKind(str, Enum):
+    """A key/access boundary within the one secrets store."""
+
+    SYSTEM = "system"  # admin-only system secrets (provider keys, internal tokens)
+    USER = "user"  # a person's personal vault
+    AGENT = "agent"  # an agent's own vault
+    SERVICE = "service"  # a service principal's vault
+    TEAM = "team"  # a team / department group vault
+    ROLE = "role"  # a role group vault
+    COMPANY = "company"  # an LLC company vault
+    NODE = "node"  # a fleet node's credential vault
+
+
+class PrincipalKind(str, Enum):
+    """The kind of actor that authenticates and resolves to a set of vaults."""
+
+    USER = "user"
+    AGENT = "agent"
+    SERVICE = "service"
+    WORKFLOW = "workflow"
+
+
+# Vault kinds that are singletons (no id): exactly the system vault.
+_SINGLETON_KINDS = frozenset({VaultKind.SYSTEM})
+
+
+@dataclass(frozen=True)
+class VaultRef:
+    """A reference to one vault: a kind plus an id (id omitted for ``system``).
+
+    Frozen + hashable so it can be a dict key or set member (e.g. the set of
+    vaults a principal may use, or a grant's grantee).
+    """
+
+    kind: VaultKind
+    id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind in _SINGLETON_KINDS:
+            if self.id is not None:
+                raise ValueError(f"{self.kind.value} vault takes no id")
+            return
+        if not self.id:
+            raise ValueError(f"{self.kind.value} vault requires an id")
+        if _SEP in self.id:
+            raise ValueError(f"vault id may not contain the {_SEP!r} separator: {self.id!r}")
+        if any(c.isspace() for c in self.id):
+            raise ValueError(f"vault id may not contain whitespace: {self.id!r}")
+        if len(self.id) > _MAX_ID_LEN:
+            raise ValueError(f"vault id exceeds {_MAX_ID_LEN} chars")
+
+    def to_str(self) -> str:
+        """Canonical ``vault_id`` string for crypto/storage."""
+        if self.id is None:
+            return self.kind.value
+        return f"{self.kind.value}{_SEP}{self.id}"
+
+    def __str__(self) -> str:
+        return self.to_str()
+
+    @classmethod
+    def parse(cls, value: str) -> VaultRef:
+        """Parse a canonical ``vault_id`` string back into a :class:`VaultRef`."""
+        kind_str, sep, id_str = value.partition(_SEP)
+        kind = VaultKind(kind_str)  # raises ValueError on an unknown kind
+        return cls(kind, id_str if sep else None)

--- a/autobot_shared/secrets_vault_test.py
+++ b/autobot_shared/secrets_vault_test.py
@@ -1,0 +1,142 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the canonical vault/principal namespace (Task 9.1, #10094 / umbrella #10088)."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from autobot_shared import secrets_vault as sv
+from autobot_shared.secrets_vault import PrincipalKind, VaultKind, VaultRef
+
+
+class TestVaultKind:
+    def test_expected_kinds(self) -> None:
+        assert {k.value for k in VaultKind} == {
+            "system",
+            "user",
+            "agent",
+            "service",
+            "team",
+            "role",
+            "company",
+            "node",
+        }
+
+
+class TestPrincipalKind:
+    def test_expected_kinds(self) -> None:
+        assert {k.value for k in PrincipalKind} == {"user", "agent", "service", "workflow"}
+
+
+class TestVaultRefFormat:
+    @pytest.mark.parametrize(
+        "ref,expected",
+        [
+            (VaultRef(VaultKind.SYSTEM), "system"),
+            (VaultRef(VaultKind.USER, "alice"), "user:alice"),
+            (VaultRef(VaultKind.COMPANY, "acme-42"), "company:acme-42"),
+            (VaultRef(VaultKind.AGENT, "agent_007"), "agent:agent_007"),
+            (VaultRef(VaultKind.NODE, "node.1"), "node:node.1"),
+            (VaultRef(VaultKind.ROLE, "admin"), "role:admin"),
+        ],
+    )
+    def test_to_str(self, ref: VaultRef, expected: str) -> None:
+        assert ref.to_str() == expected
+        assert str(ref) == expected
+
+    @pytest.mark.parametrize(
+        "ref",
+        [
+            VaultRef(VaultKind.SYSTEM),
+            VaultRef(VaultKind.USER, "550e8400-e29b-41d4-a716-446655440000"),
+            VaultRef(VaultKind.COMPANY, "acme-42"),
+            VaultRef(VaultKind.TEAM, "platform"),
+            VaultRef(VaultKind.NODE, "node_00.SLM"),
+        ],
+    )
+    def test_parse_roundtrip(self, ref: VaultRef) -> None:
+        assert VaultRef.parse(ref.to_str()) == ref
+
+
+class TestVaultRefValidation:
+    def test_system_takes_no_id(self) -> None:
+        with pytest.raises(ValueError, match="no id"):
+            VaultRef(VaultKind.SYSTEM, "x")
+
+    def test_non_system_requires_id(self) -> None:
+        with pytest.raises(ValueError, match="requires an id"):
+            VaultRef(VaultKind.USER)
+        with pytest.raises(ValueError, match="requires an id"):
+            VaultRef(VaultKind.COMPANY, "")
+
+    def test_id_rejects_separator(self) -> None:
+        # An id containing ':' would make the canonical string ambiguous.
+        with pytest.raises(ValueError, match="separator"):
+            VaultRef(VaultKind.USER, "a:b")
+
+    def test_id_rejects_whitespace(self) -> None:
+        with pytest.raises(ValueError, match="whitespace"):
+            VaultRef(VaultKind.USER, "a b")
+        with pytest.raises(ValueError):
+            VaultRef(VaultKind.USER, "a\tb")
+
+    def test_id_rejects_overlong(self) -> None:
+        with pytest.raises(ValueError, match="255"):
+            VaultRef(VaultKind.USER, "x" * 256)
+
+    def test_id_allows_255(self) -> None:
+        assert VaultRef(VaultKind.USER, "x" * 255).id == "x" * 255
+
+
+class TestVaultRefParse:
+    def test_unknown_kind_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            VaultRef.parse("bogus:1")
+
+    def test_unknown_singleton_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            VaultRef.parse("bogus")
+
+    def test_empty_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match="requires an id"):
+            VaultRef.parse("user:")
+
+    def test_system_with_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match="no id"):
+            VaultRef.parse("system:x")
+
+
+class TestHashableUsableAsGrantee:
+    def test_frozen_hashable(self) -> None:
+        s = {VaultRef(VaultKind.COMPANY, "A"), VaultRef(VaultKind.COMPANY, "A"), VaultRef(VaultKind.USER, "alice")}
+        assert len(s) == 2
+
+    def test_distinct_refs_differ(self) -> None:
+        assert VaultRef(VaultKind.COMPANY, "A") != VaultRef(VaultKind.COMPANY, "B")
+        assert VaultRef(VaultKind.COMPANY, "A") != VaultRef(VaultKind.TEAM, "A")
+
+
+class TestInteropWithEnvelopeCrypto:
+    """The whole point of the namespace: to_str() is what derive_vault_key consumes."""
+
+    def test_to_str_drives_distinct_keys(self, monkeypatch) -> None:
+        from autobot_shared import secrets_envelope as env
+
+        monkeypatch.setenv(env.ROOT_KEY_ENV, base64.urlsafe_b64encode(bytes(range(32))).decode())
+        root = env.load_root_key()
+        k_a = env.derive_vault_key(root, VaultRef(VaultKind.COMPANY, "A").to_str())
+        k_b = env.derive_vault_key(root, VaultRef(VaultKind.COMPANY, "B").to_str())
+        k_sys = env.derive_vault_key(root, VaultRef(VaultKind.SYSTEM).to_str())
+        assert len({k_a, k_b, k_sys}) == 3
+        assert len(k_a) == 32
+
+
+class TestModuleConstants:
+    def test_max_id_len_matches_db_string_limit(self) -> None:
+        # company_id / agent_id are String(255) in the LLC models.
+        assert sv._MAX_ID_LEN == 255


### PR DESCRIPTION
## Thinking Path
Task 9.1 of the unified-secrets umbrella #10088. Task 1 (#10090, merged) left `vault_id` as "any string". Before Task 2 wires RBAC and Task 8 builds the audit graph, the namespace those strings live in needs to be one validated, round-trippable thing — otherwise crypto, RBAC, and the access graph drift on how a vault is named.

## What Changed
New `autobot_shared/secrets_vault.py` (pure, no DB):
- `VaultKind` — the key/access boundaries: `system/user/agent/service/team/role/company/node`.
- `VaultRef(kind, id)` — frozen/hashable; canonical string `system` (singleton) or `<kind>:<id>` (e.g. `user:alice`, `company:acme-42`). `parse`/`to_str` round-trip; rejects an id containing the `:` separator, whitespace, empty id for non-system, `>255` chars (matches `String(255)` on `company_id`/`agent_id`), and unknown kinds. `VaultRef.to_str()` is exactly what `derive_vault_key()` consumes and what `WrappedDek.grantee` stores.
- `PrincipalKind` — `user/agent/service/workflow` actor taxonomy.

Resolution (credential → `Principal` → the set of `VaultRef`s it may use, via role/team/company membership) is DB-backed and lands with Task 2 / 9.2 — deliberately out of this pure PR.

## Verification
- [x] 27 tests: kind sets, format/parse round-trip, validation (system-takes-no-id, non-system-requires-id, separator/whitespace/overlong/unknown-kind), hashable-as-grantee, and an interop test that `VaultRef.to_str()` drives distinct `derive_vault_key()` KEKs.
- [x] mypy / ruff / black (120) clean; no `print`.

## Model Used
Claude Opus 4.8 (1M context)

Closes #10094
