### PR TITLE
feat(secrets): envelope store schema — secrets cols + secret_grants table (#10099)

### DIFF
--- a/autobot-backend/migrations/versions/20260614_057_secrets_envelope_store.py
+++ b/autobot-backend/migrations/versions/20260614_057_secrets_envelope_store.py
@@ -1,0 +1,126 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unified envelope secrets store: secrets envelope columns + secret_grants.
+
+Revision ID: 20260614_057
+Revises: 20260612_056
+Create Date: 2026-06-14
+
+Umbrella #10088 / Task 2.1. Additive only — adds the envelope columns to
+``secrets`` and the per-grantee ``secret_grants`` child table, and relaxes the
+legacy ``encrypted_value`` to nullable (a row is envelope-backed iff
+``sealed_value IS NOT NULL``). Touches no runtime read/write path; the live
+``secrets.json`` GUI store is unaffected.
+
+Guarded with ``migrations.guards`` so it is safe on databases where these were
+already created via ``create_all`` (#10027 pattern).
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from migrations.guards import has_column, has_table
+
+revision: str = "20260614_057"
+down_revision: Union[str, None] = "20260612_056"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # --- envelope columns on secrets ---
+    if not has_column("secrets", "owner_vault"):
+        op.add_column(
+            "secrets",
+            sa.Column(
+                "owner_vault",
+                sa.String(512),
+                nullable=True,
+                comment="VaultRef.to_str() of the owning vault (envelope store). NULL for legacy rows.",
+            ),
+        )
+        op.create_index("ix_secrets_owner_vault", "secrets", ["owner_vault"])
+
+    if not has_column("secrets", "sealed_value"):
+        op.add_column(
+            "secrets",
+            sa.Column(
+                "sealed_value",
+                postgresql.JSONB,
+                nullable=True,
+                comment="SealedSecret.to_dict() — envelope-sealed value (#10088); NULL for legacy rows.",
+            ),
+        )
+
+    if not has_column("secrets", "version"):
+        op.add_column(
+            "secrets",
+            sa.Column(
+                "version",
+                sa.Integer(),
+                nullable=False,
+                server_default="1",
+                comment="Envelope DEK/rotation generation (#10088).",
+            ),
+        )
+
+    # Legacy Fernet blob is no longer required (envelope rows have none).
+    op.alter_column("secrets", "encrypted_value", existing_type=sa.Text(), nullable=True)
+
+    # --- secret_grants child table (one wrapped DEK per grantee vault) ---
+    if not has_table("secret_grants"):
+        op.create_table(
+            "secret_grants",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+            sa.Column(
+                "secret_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("secrets.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "grantee",
+                sa.String(512),
+                nullable=False,
+                comment="VaultRef.to_str() of the grantee vault; matches WrappedDek.grantee",
+            ),
+            sa.Column(
+                "wrapped_dek",
+                postgresql.JSONB,
+                nullable=False,
+                comment="WrappedDek.to_dict() — the secret's DEK wrapped under this grantee's vault KEK",
+            ),
+            sa.Column(
+                "created_by",
+                postgresql.UUID(as_uuid=True),
+                nullable=True,
+                comment="Acting principal (user_id) who created this grant",
+            ),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+            sa.UniqueConstraint("secret_id", "grantee", name="uq_secret_grants_secret_grantee"),
+        )
+        op.create_index("ix_secret_grants_secret_id", "secret_grants", ["secret_id"])
+        op.create_index("ix_secret_grants_grantee", "secret_grants", ["grantee"])
+
+
+def downgrade() -> None:
+    if has_table("secret_grants"):
+        op.drop_index("ix_secret_grants_grantee", table_name="secret_grants")
+        op.drop_index("ix_secret_grants_secret_id", table_name="secret_grants")
+        op.drop_table("secret_grants")
+
+    if has_column("secrets", "version"):
+        op.drop_column("secrets", "version")
+    if has_column("secrets", "sealed_value"):
+        op.drop_column("secrets", "sealed_value")
+    if has_column("secrets", "owner_vault"):
+        op.drop_index("ix_secrets_owner_vault", table_name="secrets")
+        op.drop_column("secrets", "owner_vault")
+
+    # Leave ``encrypted_value`` nullable: the pre-057 NOT NULL cannot be safely
+    # restored once envelope rows (with NULL here) exist.

--- a/autobot-backend/models/__init__.py
+++ b/autobot-backend/models/__init__.py
@@ -42,6 +42,7 @@ from models.ml_model import MLModel
 # Process adapter models (#1406)
 from models.process_run import AgentSession, ProcessRun, TaskDecomposition
 from models.secret import Secret
+from models.secret_grant import SecretGrant
 from models.session_collaboration import SessionCollaboration
 
 # Task delegation model (#1753)
@@ -63,6 +64,7 @@ __all__ = [
     "CompletionFeedback",
     "MLModel",
     "Secret",
+    "SecretGrant",
     "SessionCollaboration",
     # Central agent registry (#1754)
     "Agent",

--- a/autobot-backend/models/secret.py
+++ b/autobot-backend/models/secret.py
@@ -13,7 +13,7 @@ import uuid
 from datetime import datetime
 from enum import Enum
 
-from sqlalchemy import Boolean, DateTime, String, Text
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.types import Uuid
@@ -147,11 +147,35 @@ class Secret(Base):
         comment="Array of user IDs for shared secrets",
     )
 
-    # Encrypted storage (Issue #870)
-    encrypted_value: Mapped[str] = mapped_column(
+    # Encrypted storage (Issue #870). Legacy Fernet path — nullable since the
+    # unified envelope store (#10088) holds the value in ``sealed_value``
+    # instead. A row is envelope-backed iff ``sealed_value IS NOT NULL``.
+    encrypted_value: Mapped[str | None] = mapped_column(
         Text,
+        nullable=True,
+        comment="Fernet-encrypted secret value (legacy path; NULL for envelope rows)",
+    )
+
+    # Unified envelope store (umbrella #10088). The value is sealed once under a
+    # per-secret DEK; the DEK is wrapped per grantee vault in ``secret_grants``.
+    owner_vault: Mapped[str | None] = mapped_column(
+        String(512),
+        nullable=True,
+        index=True,
+        comment="VaultRef.to_str() of the owning vault (envelope store). NULL for legacy rows.",
+    )
+
+    sealed_value: Mapped[dict | None] = mapped_column(
+        JSONB,
+        nullable=True,
+        comment="SealedSecret.to_dict() — envelope-sealed value (#10088); NULL for legacy rows.",
+    )
+
+    version: Mapped[int] = mapped_column(
+        Integer,
         nullable=False,
-        comment="Fernet-encrypted secret value",
+        server_default="1",
+        comment="Envelope DEK/rotation generation (#10088).",
     )
 
     # Metadata

--- a/autobot-backend/models/secret_grant.py
+++ b/autobot-backend/models/secret_grant.py
@@ -1,0 +1,72 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Per-grantee wrapped-DEK grants for the unified envelope secrets store.
+
+Task 2.1 of umbrella #10088. A secret's value is sealed once under a per-secret
+DEK (stored on ``secrets.sealed_value``); the DEK is then **wrapped** for each
+grantee vault and each wrap is one row here. Sharing a secret = adding a row;
+revoking a share = deleting one; the owner's own access is just the row whose
+``grantee == secrets.owner_vault`` (so the read path is uniform).
+
+``grantee`` is a :func:`autobot_shared.secrets_vault.VaultRef.to_str` string and
+matches ``WrappedDek.grantee``; ``wrapped_dek`` is ``WrappedDek.to_dict()``.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import Uuid
+
+from user_management.models.base import Base
+
+
+class SecretGrant(Base):
+    """One wrapped DEK granting a vault access to a secret (1:N with ``secrets``)."""
+
+    __tablename__ = "secret_grants"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    secret_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True),
+        ForeignKey("secrets.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    grantee: Mapped[str] = mapped_column(
+        String(512),
+        nullable=False,
+        index=True,
+        comment="VaultRef.to_str() of the grantee vault; matches WrappedDek.grantee",
+    )
+
+    wrapped_dek: Mapped[dict] = mapped_column(
+        JSONB,
+        nullable=False,
+        comment="WrappedDek.to_dict() — the secret's DEK wrapped under this grantee's vault KEK",
+    )
+
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(as_uuid=True),
+        nullable=True,
+        comment="Acting principal (user_id) who created this grant",
+    )
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        # One wrapped DEK per (secret, grantee vault); re-share rewraps in place.
+        UniqueConstraint("secret_id", "grantee", name="uq_secret_grants_secret_grantee"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<SecretGrant(secret_id={self.secret_id}, grantee={self.grantee!r})>"

--- a/autobot-backend/tests/migrations/test_secrets_envelope_store.py
+++ b/autobot-backend/tests/migrations/test_secrets_envelope_store.py
@@ -1,0 +1,92 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Migration 20260614_057 builds the unified envelope secrets store (#10088 / Task 2.1)."""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from tests.migrations.conftest import requires_postgres, run_alembic
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+
+async def _scalar(url: str, sql: str):
+    engine = create_async_engine(url)
+    try:
+        async with engine.connect() as conn:
+            return (await conn.execute(text(sql))).scalar()
+    finally:
+        await engine.dispose()
+
+
+async def test_envelope_schema_present_at_head(fresh_db_url):
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+
+    for column in ("owner_vault", "sealed_value", "version"):
+        present = await _scalar(
+            fresh_db_url,
+            f"SELECT count(*) FROM information_schema.columns "
+            f"WHERE table_name='secrets' AND column_name='{column}'",
+        )
+        assert present == 1, f"secrets.{column} missing at head"
+
+    # Legacy Fernet column is relaxed to nullable so envelope rows need no blob.
+    nullable = await _scalar(
+        fresh_db_url,
+        "SELECT is_nullable FROM information_schema.columns "
+        "WHERE table_name='secrets' AND column_name='encrypted_value'",
+    )
+    assert nullable == "YES"
+
+    assert (
+        await _scalar(fresh_db_url, "SELECT count(*) FROM information_schema.tables WHERE table_name='secret_grants'")
+        == 1
+    )
+    assert (
+        await _scalar(
+            fresh_db_url, "SELECT count(*) FROM pg_constraint WHERE conname='uq_secret_grants_secret_grantee'"
+        )
+        == 1
+    )
+    assert (
+        await _scalar(fresh_db_url, "SELECT count(*) FROM pg_indexes WHERE indexname='ix_secret_grants_grantee'") == 1
+    )
+
+
+async def test_grant_unique_constraint_enforced(fresh_db_url):
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+    engine = create_async_engine(fresh_db_url)
+    try:
+        async with engine.begin() as conn:
+            sid = (
+                await conn.execute(
+                    text(
+                        "INSERT INTO secrets (id, owner_id, name, type, scope, team_ids, shared_with, tags, "
+                        "extra_data, is_active, version, owner_vault, sealed_value) "
+                        "VALUES (gen_random_uuid(), gen_random_uuid(), 's', 'api_key', 'user', '[]', '[]', '[]', "
+                        "'{}', true, 1, 'user:alice', '{}'::jsonb) RETURNING id"
+                    )
+                )
+            ).scalar()
+            await conn.execute(
+                text(
+                    "INSERT INTO secret_grants (id, secret_id, grantee, wrapped_dek) "
+                    "VALUES (gen_random_uuid(), :sid, 'user:alice', '{}'::jsonb)"
+                ),
+                {"sid": sid},
+            )
+        # Same (secret_id, grantee) again must violate the unique constraint.
+        with pytest.raises(Exception):
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        "INSERT INTO secret_grants (id, secret_id, grantee, wrapped_dek) "
+                        "VALUES (gen_random_uuid(), :sid, 'user:alice', '{}'::jsonb)"
+                    ),
+                    {"sid": sid},
+                )
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Thinking Path
Task 2.1 of unified-secrets umbrella #10088 — the schema the SecretsService (2.2), RBAC (2.3), and sharing API (2.4) build on. Grounded in the planning on #10088: build on the existing PG `secrets` table; the live GUI path is the separate `secrets.json` store, so this additive schema can't regress it.

## What Changed
- `models/secret.py`: + `owner_vault` (`String(512)`, a `VaultRef.to_str()`), + `sealed_value` (`JSONB`, `SealedSecret.to_dict()`), + `version`; `encrypted_value` relaxed to nullable — a row is envelope-backed iff `sealed_value IS NOT NULL`.
- New `models/secret_grant.py` → `secret_grants` child table: `secret_id` FK `ON DELETE CASCADE`, `grantee` (`String(512)`, matches `WrappedDek.grantee`), `wrapped_dek` (`JSONB`, `WrappedDek.to_dict()`), `created_by`, timestamps; `UNIQUE(secret_id, grantee)` + indexes on `secret_id`/`grantee`. **One wrapped DEK per grantee vault**; the owner's access is just the grant whose `grantee == owner_vault`, keeping the read path uniform. One index declaration per column (avoids the #10075 dup-index class).
- Migration `20260614_057` (← `20260612_056`) via `migrations/guards.py` (#10027), guarded so it's inert where `create_all` already built these.
- Registered `SecretGrant` in `models/__init__.py`.

## Verification
- Disposable Postgres 16: `upgrade → downgrade -1 → re-upgrade head` roundtrip clean; all columns/table/unique-constraint/index present; `encrypted_value` nullable post-migration.
- Model imports + registers on `Base.metadata` (no startup-smoke break).
- 2 migration-gate tests (`test_secrets_envelope_store.py`): schema present at head; `UNIQUE(secret_id, grantee)` enforced. ruff/black clean; backend mypy unchanged (new file clean; required mypy gate is `autobot_shared/`-only, untouched).

## Model Used
Claude Opus 4.8 (1M context)

Closes #10099
