### PR TITLE
fix(frontend): repair 2 strict vue-tsc errors under apexcharts 5.14 (#9924)

### DIFF
--- a/autobot-frontend/src/components/charts/DependencyTreemap.vue
+++ b/autobot-frontend/src/components/charts/DependencyTreemap.vue
@@ -101,7 +101,10 @@ const chartOptions = computed<ApexOptions>(() => ({
       fontWeight: 600
     },
     formatter: (text: string | number | (string | number)[], op?: ApexFormatterOpts) => {
-      return `${text}\n${op?.value ?? ''} ${t('charts.dependencyTreemap.uses')}`
+      // apexcharts 5.14 dropped `.value` from ApexFormatterOpts; read the cell
+      // value from the chart globals (typed `any`) instead.
+      const value = op ? op.w?.globals?.series?.[op.seriesIndex]?.[op.dataPointIndex] : undefined
+      return `${text}\n${value ?? ''} ${t('charts.dependencyTreemap.uses')}`
     },
     offsetY: -4
   },

--- a/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
+++ b/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
@@ -90,7 +90,7 @@ import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import VueApexCharts from 'vue3-apexcharts'
-import type { ApexOptions, ApexChartEventOpts } from 'apexcharts'
+import type { ApexOptions, ApexChartEventOpts, ApexTooltipCustomOpts } from 'apexcharts'
 import { useResourceMetrics } from '@/composables/visualizations/useResourceMetrics'
 import { usePollingJob } from '@/composables/usePollingJob'
 import { getCssVar } from '@/composables/useCssVars'
@@ -240,12 +240,11 @@ const chartOptions = computed<ApexOptions>(() => ({
   tooltip: {
     enabled: true,
     theme: 'dark',
-    custom: ({ seriesIndex, dataPointIndex, w }: {
-      seriesIndex: number
-      dataPointIndex: number
-      w: { config: { series: Array<{ name: string; data: Array<{ x: string; y: number }> }> } }
-    }) => {
-      const series = w.config.series[seriesIndex]
+    custom: ({ seriesIndex, dataPointIndex, w }: ApexTooltipCustomOpts) => {
+      // w.config.series is the loosely-typed ApexOptions union; cast to the
+      // heatmap row shape this chart actually builds (apexcharts 5.14 typing).
+      const heatmapSeries = w.config.series as Array<{ name: string; data: Array<{ x: string; y: number }> }>
+      const series = heatmapSeries[seriesIndex]
       const point = series.data[dataPointIndex]
       return `
         <div class="heatmap-tooltip">


### PR DESCRIPTION
## Thinking Path
The new frontend-test PR gate (#10019) went live and immediately flagged 2 strict `vue-tsc` errors on Dev_new_gui — in `DependencyTreemap.vue` and `ResourceHeatmap.vue`. Root cause: the dev box had `apexcharts@5.12.0` installed, but the lockfile pins `5.14.0`; the stricter 5.14 types surface errors invisible to local vue-tsc (which is why #9724's local 'vue-tsc → 0' didn't catch them). CI's `npm ci` installs 5.14, so it sees them. The gate did exactly its job.

## What Changed
- `DependencyTreemap.vue`: `ApexFormatterOpts` dropped `.value` in 5.14 → read the cell value from `op.w.globals.series[seriesIndex][dataPointIndex]` (globals is typed `any`). Display unchanged.
- `ResourceHeatmap.vue`: tooltip `custom` must accept `ApexTooltipCustomOpts` (imported), not a hand-written inline type incompatible with `ApexOptions`; cast `w.config.series` to the heatmap row shape this chart builds.

## Verification
Installed `apexcharts@5.14.0` (the lockfile/CI version) into an isolated worktree and ran `npx vue-tsc --noEmit -p tsconfig.app.json` → **0 errors** (was 2). eslint on both files → 0. Restores the genuinely-green strict-vue-tsc baseline that #9724 targeted; now enforced pre-merge by #10019.

## Model Used
Claude Opus 4.8 (main session)

Part of umbrella #9924 (follow-up surfaced by the #10019 gate).