### PR TITLE
feat(secrets): UnifiedSecretsService — envelope CRUD + sharing (#10111)

### DIFF
--- a/.github/workflows/migration-gate.yml
+++ b/.github/workflows/migration-gate.yml
@@ -79,6 +79,7 @@ jobs:
             "alembic>=1.13" "sqlalchemy[asyncio]>=2.0" asyncpg aiosqlite \
             pydantic pydantic-settings \
             bcrypt pyjwt redis httpx aiofiles python-dotenv pyyaml \
+            cryptography \
             pytest pytest-asyncio
 
       - name: Run migration matrix

--- a/autobot-backend/services/unified_secrets_service.py
+++ b/autobot-backend/services/unified_secrets_service.py
@@ -1,0 +1,210 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unified envelope SecretsService — CRUD + sharing orchestration (#10088 / Task 2.2).
+
+Orchestrates the envelope crypto (``autobot_shared.secrets_envelope``) over the
+``secrets`` + ``secret_grants`` schema (Task 2.1) using the canonical vault
+namespace (``autobot_shared.secrets_vault``):
+
+- **create**  seal the value once under a fresh DEK; wrap the DEK for the owner
+  vault → one ``secrets`` row + one owner ``secret_grants`` row.
+- **read**    find a grant whose grantee is one of the caller's accessible
+  vaults; unwrap that DEK and open the value.
+- **share**   recover the DEK via a vault the actor already holds, wrap it for
+  the new grantee → an extra grant (no re-encrypt, no plaintext copy).
+- **revoke**  drop one grant. **rotate** re-seal with a new DEK and re-wrap
+  every grant. **delete** removes the secret (grants cascade).
+
+This service is **policy-free**: callers pass the already-resolved set of vaults
+they may use (``accessible_vaults`` / ``actor_vaults``). The RBAC layer that
+computes those sets from user/agent identity + membership is Task 2.3 / 9.2.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.secrets_envelope import (
+    SealedSecret,
+    WrappedDek,
+    derive_vault_key,
+    load_root_key,
+    open_secret,
+    seal,
+    unwrap_dek,
+    wrap_dek,
+)
+from autobot_shared.secrets_vault import VaultRef
+from models.secret import Secret
+from models.secret_grant import SecretGrant
+
+
+class SecretNotFoundError(Exception):
+    """The secret does not exist (or is not envelope-backed)."""
+
+
+class SecretAccessError(PermissionError):
+    """The caller holds no grant for any of their accessible vaults."""
+
+
+def _vault_strs(vaults: Iterable[VaultRef]) -> set[str]:
+    return {v.to_str() for v in vaults}
+
+
+class UnifiedSecretsService:
+    """Envelope CRUD + sharing over ``secrets`` / ``secret_grants``."""
+
+    def __init__(self, root_key: bytes | None = None) -> None:
+        self._root = root_key if root_key is not None else load_root_key()
+
+    def _kek(self, vault_str: str) -> bytes:
+        return derive_vault_key(self._root, vault_str)
+
+    async def create(
+        self,
+        session: AsyncSession,
+        *,
+        owner_vault: VaultRef,
+        name: str,
+        secret_type: str,
+        plaintext: bytes,
+        created_by: uuid.UUID,
+    ) -> Secret:
+        """Seal *plaintext* for *owner_vault* and persist the secret + owner grant."""
+        secret_id = uuid.uuid4()
+        sid = str(secret_id)
+        sealed, dek = seal(plaintext, secret_id=sid)
+        wrapped = wrap_dek(dek, self._kek(owner_vault.to_str()), owner_vault.to_str(), secret_id=sid)
+        secret = Secret(
+            id=secret_id,
+            owner_id=created_by,
+            name=name,
+            type=secret_type,
+            scope=owner_vault.kind.value,
+            owner_vault=owner_vault.to_str(),
+            sealed_value=sealed.to_dict(),
+            version=1,
+        )
+        session.add(secret)
+        session.add(
+            SecretGrant(
+                secret_id=secret_id,
+                grantee=owner_vault.to_str(),
+                wrapped_dek=wrapped.to_dict(),
+                created_by=created_by,
+            )
+        )
+        await session.flush()
+        return secret
+
+    async def _load(self, session: AsyncSession, secret_id: uuid.UUID) -> Secret:
+        secret = await session.get(Secret, secret_id)
+        if secret is None or secret.sealed_value is None:
+            raise SecretNotFoundError(f"envelope secret {secret_id} not found")
+        return secret
+
+    async def _grants(self, session: AsyncSession, secret_id: uuid.UUID) -> list[SecretGrant]:
+        rows = await session.execute(select(SecretGrant).where(SecretGrant.secret_id == secret_id))
+        return list(rows.scalars())
+
+    def _recover_dek(self, secret: Secret, grant: SecretGrant) -> bytes:
+        return unwrap_dek(WrappedDek.from_dict(grant.wrapped_dek), self._kek(grant.grantee), secret_id=str(secret.id))
+
+    async def read(
+        self, session: AsyncSession, *, secret_id: uuid.UUID, accessible_vaults: Iterable[VaultRef]
+    ) -> bytes:
+        """Decrypt the value via any grant whose grantee is in *accessible_vaults*."""
+        secret = await self._load(session, secret_id)
+        allowed = _vault_strs(accessible_vaults)
+        for grant in await self._grants(session, secret_id):
+            if grant.grantee in allowed:
+                sealed = SealedSecret.from_dict(secret.sealed_value)
+                return open_secret(
+                    sealed, WrappedDek.from_dict(grant.wrapped_dek), self._kek(grant.grantee), secret_id=str(secret_id)
+                )
+        raise SecretAccessError(f"no accessible grant for secret {secret_id}")
+
+    async def _dek_via(self, session: AsyncSession, secret: Secret, actor_vaults: Iterable[VaultRef]) -> bytes:
+        allowed = _vault_strs(actor_vaults)
+        for grant in await self._grants(session, secret.id):
+            if grant.grantee in allowed:
+                return self._recover_dek(secret, grant)
+        raise SecretAccessError(f"actor cannot open secret {secret.id} to act on it")
+
+    async def share(
+        self,
+        session: AsyncSession,
+        *,
+        secret_id: uuid.UUID,
+        actor_vaults: Iterable[VaultRef],
+        grantee: VaultRef,
+        created_by: uuid.UUID,
+    ) -> SecretGrant:
+        """Grant *grantee* access by wrapping the same DEK for its vault (idempotent rewrap)."""
+        secret = await self._load(session, secret_id)
+        dek = await self._dek_via(session, secret, actor_vaults)
+        wrapped = wrap_dek(dek, self._kek(grantee.to_str()), grantee.to_str(), secret_id=str(secret_id))
+        existing = next((g for g in await self._grants(session, secret_id) if g.grantee == grantee.to_str()), None)
+        if existing is not None:
+            existing.wrapped_dek = wrapped.to_dict()
+            grant = existing
+        else:
+            grant = SecretGrant(
+                secret_id=secret_id, grantee=grantee.to_str(), wrapped_dek=wrapped.to_dict(), created_by=created_by
+            )
+            session.add(grant)
+        await session.flush()
+        return grant
+
+    async def revoke(self, session: AsyncSession, *, secret_id: uuid.UUID, grantee: VaultRef) -> None:
+        """Drop a grant. The owner grant cannot be revoked (delete the secret instead)."""
+        secret = await self._load(session, secret_id)
+        if secret.owner_vault == grantee.to_str():
+            raise ValueError("cannot revoke the owner grant; delete the secret instead")
+        await session.execute(
+            delete(SecretGrant).where(SecretGrant.secret_id == secret_id, SecretGrant.grantee == grantee.to_str())
+        )
+
+    async def rotate_value(
+        self,
+        session: AsyncSession,
+        *,
+        secret_id: uuid.UUID,
+        new_plaintext: bytes,
+        actor_vaults: Iterable[VaultRef],
+    ) -> Secret:
+        """Re-seal with a fresh DEK and re-wrap for every existing grantee; bump version."""
+        secret = await self._load(session, secret_id)
+        await self._dek_via(session, secret, actor_vaults)  # authorize: actor must currently hold access
+        new_sealed, new_dek = seal(new_plaintext, secret_id=str(secret_id))
+        secret.sealed_value = new_sealed.to_dict()
+        secret.version = (secret.version or 1) + 1
+        for grant in await self._grants(session, secret_id):
+            grant.wrapped_dek = wrap_dek(
+                new_dek, self._kek(grant.grantee), grant.grantee, secret_id=str(secret_id)
+            ).to_dict()
+        await session.flush()
+        return secret
+
+    async def delete(self, session: AsyncSession, *, secret_id: uuid.UUID) -> None:
+        """Delete the secret; its grants cascade."""
+        await session.execute(delete(Secret).where(Secret.id == secret_id))
+
+    async def list_for_vaults(self, session: AsyncSession, *, accessible_vaults: Iterable[VaultRef]) -> list[Secret]:
+        """Every envelope secret reachable by one of *accessible_vaults* (metadata; no decryption)."""
+        allowed = list(_vault_strs(accessible_vaults))
+        if not allowed:
+            return []
+        rows = await session.execute(
+            select(Secret)
+            .join(SecretGrant, SecretGrant.secret_id == Secret.id)
+            .where(SecretGrant.grantee.in_(allowed), Secret.sealed_value.isnot(None))
+            .distinct()
+        )
+        return list(rows.scalars())

--- a/autobot-backend/tests/migrations/test_unified_secrets_service.py
+++ b/autobot-backend/tests/migrations/test_unified_secrets_service.py
@@ -1,0 +1,147 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""End-to-end tests for UnifiedSecretsService (#10088 / Task 2.2).
+
+Co-located under tests/migrations because that is AutoBot's Postgres-backed CI
+job (migration-gate): the service stores JSONB + Uuid columns, so it needs a
+real Postgres, not SQLite. Builds just the ``secrets`` + ``secret_grants``
+tables (no FKs out of them) and exercises create/read/share/revoke/rotate.
+"""
+
+import base64
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from models.secret import Secret
+from models.secret_grant import SecretGrant
+from services.unified_secrets_service import (
+    SecretAccessError,
+    SecretNotFoundError,
+    UnifiedSecretsService,
+)
+from tests.migrations.conftest import requires_postgres
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+_ROOT = base64.urlsafe_b64decode(base64.urlsafe_b64encode(bytes(range(32))))
+_USER = VaultRef(VaultKind.USER, "alice")
+_COMPANY = VaultRef(VaultKind.COMPANY, "acme")
+_OTHER = VaultRef(VaultKind.COMPANY, "rival")
+
+
+@pytest.fixture()
+async def session(fresh_db_url):
+    engine = create_async_engine(fresh_db_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda c: Secret.__table__.create(c))
+        await conn.run_sync(lambda c: SecretGrant.__table__.create(c))
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as s:
+        yield s
+    await engine.dispose()
+
+
+@pytest.fixture()
+def svc():
+    return UnifiedSecretsService(root_key=_ROOT)
+
+
+async def _new(svc, session, **kw):
+    defaults = dict(owner_vault=_USER, name="api", secret_type="api_key", plaintext=b"s3cr3t", created_by=uuid.uuid4())
+    defaults.update(kw)
+    secret = await svc.create(session, **defaults)
+    await session.commit()
+    return secret
+
+
+async def test_create_then_read_by_owner(svc, session):
+    secret = await _new(svc, session)
+    assert await svc.read(session, secret_id=secret.id, accessible_vaults={_USER}) == b"s3cr3t"
+    assert secret.sealed_value is not None and secret.encrypted_value is None
+    assert secret.owner_vault == "user:alice" and secret.version == 1
+
+
+async def test_read_without_access_denied(svc, session):
+    secret = await _new(svc, session)
+    with pytest.raises(SecretAccessError):
+        await svc.read(session, secret_id=secret.id, accessible_vaults={_OTHER})
+
+
+async def test_share_then_read_by_grantee(svc, session):
+    secret = await _new(svc, session)
+    await svc.share(session, secret_id=secret.id, actor_vaults={_USER}, grantee=_COMPANY, created_by=uuid.uuid4())
+    await session.commit()
+    assert await svc.read(session, secret_id=secret.id, accessible_vaults={_COMPANY}) == b"s3cr3t"
+    # owner still reads too (multi-grantee)
+    assert await svc.read(session, secret_id=secret.id, accessible_vaults={_USER}) == b"s3cr3t"
+
+
+async def test_share_is_idempotent_rewrap(svc, session):
+    secret = await _new(svc, session)
+    await svc.share(session, secret_id=secret.id, actor_vaults={_USER}, grantee=_COMPANY, created_by=uuid.uuid4())
+    await svc.share(session, secret_id=secret.id, actor_vaults={_USER}, grantee=_COMPANY, created_by=uuid.uuid4())
+    await session.commit()
+    grants = await svc._grants(session, secret.id)
+    assert sum(1 for g in grants if g.grantee == "company:acme") == 1  # no duplicate row
+
+
+async def test_revoke_removes_access(svc, session):
+    secret = await _new(svc, session)
+    await svc.share(session, secret_id=secret.id, actor_vaults={_USER}, grantee=_COMPANY, created_by=uuid.uuid4())
+    await session.commit()
+    await svc.revoke(session, secret_id=secret.id, grantee=_COMPANY)
+    await session.commit()
+    with pytest.raises(SecretAccessError):
+        await svc.read(session, secret_id=secret.id, accessible_vaults={_COMPANY})
+    assert await svc.read(session, secret_id=secret.id, accessible_vaults={_USER}) == b"s3cr3t"
+
+
+async def test_cannot_revoke_owner_grant(svc, session):
+    secret = await _new(svc, session)
+    with pytest.raises(ValueError, match="owner grant"):
+        await svc.revoke(session, secret_id=secret.id, grantee=_USER)
+
+
+async def test_rotate_value_rewraps_all_grantees(svc, session):
+    secret = await _new(svc, session)
+    await svc.share(session, secret_id=secret.id, actor_vaults={_USER}, grantee=_COMPANY, created_by=uuid.uuid4())
+    await session.commit()
+    await svc.rotate_value(session, secret_id=secret.id, new_plaintext=b"rotated", actor_vaults={_USER})
+    await session.commit()
+    assert secret.version == 2
+    # both grantees read the NEW value
+    assert await svc.read(session, secret_id=secret.id, accessible_vaults={_USER}) == b"rotated"
+    assert await svc.read(session, secret_id=secret.id, accessible_vaults={_COMPANY}) == b"rotated"
+
+
+async def test_rotate_requires_access(svc, session):
+    secret = await _new(svc, session)
+    with pytest.raises(SecretAccessError):
+        await svc.rotate_value(session, secret_id=secret.id, new_plaintext=b"x", actor_vaults={_OTHER})
+
+
+async def test_list_for_vaults(svc, session):
+    s1 = await _new(svc, session, name="one")
+    await _new(svc, session, name="two", owner_vault=_COMPANY)
+    got = await svc.list_for_vaults(session, accessible_vaults={_USER})
+    assert [s.id for s in got] == [s1.id]
+    assert await svc.list_for_vaults(session, accessible_vaults={_OTHER}) == []
+
+
+async def test_delete_cascades_grants(svc, session):
+    secret = await _new(svc, session)
+    await svc.delete(session, secret_id=secret.id)
+    await session.commit()
+    with pytest.raises(SecretNotFoundError):
+        await svc.read(session, secret_id=secret.id, accessible_vaults={_USER})
+    assert await svc._grants(session, secret.id) == []
+
+
+async def test_read_missing_secret(svc, session):
+    with pytest.raises(SecretNotFoundError):
+        await svc.read(session, secret_id=uuid.uuid4(), accessible_vaults={_USER})


### PR DESCRIPTION
## Thinking Path
Task 2.2 of unified-secrets umbrella #10088. The service layer over the Task 2.1 schema (#10100), using the envelope crypto (#10090) and vault namespace (#10096). Policy-free by design so the RBAC layer (#10113 / Task 2.3) composes on top.

## What Changed
New `services/unified_secrets_service.py` — `UnifiedSecretsService`:
- **create** → `seal` value once under a fresh DEK, `wrap_dek` for the owner vault → `secrets` row + owner `secret_grants` row.
- **read** → find a grant whose `grantee` is in the caller's `accessible_vaults`, unwrap that DEK, `open_secret`.
- **share** → recover the DEK via a vault the actor holds, wrap the *same* DEK for the new grantee (no re-encrypt, no plaintext copy; idempotent rewrap on the unique constraint).
- **revoke** → drop a grant (owner grant protected — delete the secret instead). **rotate_value** → re-seal new DEK + re-wrap every grantee + bump version. **delete** (cascade), **list_for_vaults** (metadata, no decrypt).
- Policy-free: callers pass already-resolved `accessible_vaults`/`actor_vaults`; RBAC resolution is #10113 / Task 9.2.

## Verification
- **11 tests on disposable Postgres 16** (`tests/migrations/test_unified_secrets_service.py`, runs in the migration-gate CI job): create/read, access-denial, share + multi-grantee, idempotent rewrap, revoke, owner-grant protection, rotate + rotate-authz, list, cascade-delete, missing-secret. ruff/black clean; new module mypy-clean (required mypy gate is `autobot_shared/`-only).

## Model Used
Claude Opus 4.8 (1M context)

Closes #10111
