### PR TITLE
ci(gate): always-report refactor of code-quality / startup-import-smoke / frontend-test (#10022)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -20,9 +20,15 @@ on:
       - 'autobot-infrastructure/ansible/roles/slm_agent/files/**'
       - 'docs/developer/**'
       - '.github/workflows/code-quality.yml'
+  # NOTE: no pull_request.paths filter — this workflow ALWAYS runs on PRs so its
+  # required-check context ("code-quality") always reports a conclusion. A
+  # path-filtered required check that never triggers leaves the PR deadlocked on
+  # "Expected — Waiting for status". The real work is gated on the `changes` job
+  # below and self-skips (reporting success) when no backend paths are touched.
+  # Branch-protection promotion to required is the separate owner-confirmed
+  # follow-up (#10022).
   pull_request:
     branches: [ main, Dev_new_gui, develop ]
-    paths: *cq_paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,7 +39,35 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - '**/*.py'
+              - '**/requirements*.txt'
+              - 'requirements-ci/**'
+              - 'pyproject.toml'
+              - '.flake8'
+              - '.bandit'
+              - '.pre-commit-config.yaml'
+              - 'pipeline-scripts/**'
+              - 'tools/lint/**'
+              - 'autobot-infrastructure/shared/scripts/hooks/**'
+              - 'autobot-infrastructure/ansible/roles/slm_agent/files/**'
+              - 'docs/developer/**'
+              - '.github/workflows/code-quality.yml'
+
   code-quality:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest  # Temporary: self-hosted runner offline (MVA-2605)
 
     steps:

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -13,10 +13,15 @@ on:
     # 'Dev_*' covers the Dev_new_gui integration branch — every frontend PR
     # merges here, so the suite must run pre-merge, not only post-merge on the
     # push trigger (#10019). main/develop kept for promotion PRs.
+    #
+    # NOTE: no pull_request.paths filter — this workflow ALWAYS runs on PRs so
+    # its required-check context ("Unit & Integration Tests") always reports a
+    # conclusion. A path-filtered required check that never triggers leaves the
+    # PR deadlocked on "Expected — Waiting for status". The real work is gated on
+    # the `changes` job below and self-skips (reporting success) when no frontend
+    # paths are touched. Branch-protection promotion to required is the separate
+    # owner-confirmed follow-up (#10022).
     branches: [main, develop, 'Dev_*']
-    paths:
-      - 'autobot-frontend/**'
-      - '.github/workflows/frontend-test.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,9 +35,28 @@ permissions:
   contents: read
 
 jobs:
+  # Job 0: Detect changed paths — always runs so the required contexts report
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'autobot-frontend/**'
+              - '!autobot-frontend/node_modules/**'
+              - '.github/workflows/frontend-test.yml'
+
   # Job 1: Unit and Integration Tests
   unit-tests:
     name: Unit & Integration Tests
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: [self-hosted, Linux, X64]
 
     steps:
@@ -122,6 +146,8 @@ jobs:
   # Job 2: Security Scanning
   security-scan:
     name: Security Scan
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: [self-hosted, Linux, X64]
 
     steps:
@@ -167,7 +193,9 @@ jobs:
   build-test:
     name: Build Test
     runs-on: [self-hosted, Linux, X64]
-    needs: unit-tests
+    # `changes` added so the dependency graph is consistent; build-test already
+    # self-skips when unit-tests skips (path-untouched PRs).
+    needs: [changes, unit-tests]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/startup-import-smoke.yml
+++ b/.github/workflows/startup-import-smoke.yml
@@ -20,9 +20,15 @@ on:
       - '**/requirements*.txt'
       - 'requirements-ci/**'
       - '.github/workflows/startup-import-smoke.yml'
+  # NOTE: no pull_request.paths filter — this workflow ALWAYS runs on PRs so its
+  # required-check context ("startup-import-smoke") always reports a conclusion.
+  # A path-filtered required check that never triggers leaves the PR deadlocked
+  # on "Expected — Waiting for status". The real work is gated on the `changes`
+  # job below and self-skips (reporting success) when no backend paths are
+  # touched. Branch-protection promotion to required is the separate
+  # owner-confirmed follow-up (#10022).
   pull_request:
     branches: [main, Dev_new_gui, develop]
-    paths: *smoke_paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,7 +38,28 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'autobot-backend/**/*.py'
+              - 'autobot_shared/**/*.py'
+              - 'autobot-slm-backend/**/*.py'
+              - '**/requirements*.txt'
+              - 'requirements-ci/**'
+              - '.github/workflows/startup-import-smoke.yml'
+
   startup-import-smoke:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -72,4 +99,3 @@ jobs:
             echo "autobot-backend/tests/test_startup_imports.py with issue ref."
             exit 1
           }
-


### PR DESCRIPTION
## Thinking Path
#10022 wants `code-quality`, `startup-import-smoke`, and `Unit & Integration Tests` promoted to **required** status checks. The blocker is structural, not a settings toggle: all three are path-filtered, and GitHub deadlocks a PR when a required check's workflow never triggers (the context sits "Expected — Waiting for status" forever). This PR does the **always-report refactor** that makes promotion safe. It does NOT touch branch protection — that flip is the separate, owner-confirmed follow-up.

## What Changed (pattern matches the existing `ci.yml`)
For each of the 3 workflows:
- Removed the workflow-level `pull_request.paths` filter so the workflow **always runs on PRs** (a *workflow* skipped by a path filter never reports → deadlock).
- Added a lightweight `changes` job (`dorny/paths-filter`, same pinned SHA as ci.yml) that detects the relevant paths.
- Gated the real job with `needs: changes` + `if: needs.changes.outputs.<filter> == 'true'`. A *job* skipped via `if` reports **success** (GitHub's documented behavior), so the required context always reports — real work on match, success-by-skip otherwise.
- `push.paths` anchors (`&cq_paths`/`&smoke_paths`) kept on the push trigger; only the `pull_request` aliases removed.
- frontend-test: `unit-tests` + `security-scan` gated on `frontend`; `build-test` needs `[changes, unit-tests]`. The #10019 `'Dev_*'` branch entry preserved.

**Context names byte-identical** (so promotion targets the same contexts): `code-quality`, `startup-import-smoke`, `Unit & Integration Tests`.

## Verification
- All three YAMLs parse (`yaml.safe_load`); each has the `changes` job and the gated real job; context names confirmed unchanged; anchors intact.
- Behavior reference: GitHub treats a **workflow** skipped by path-filter as Pending (deadlock) but a **job** skipped by `if` as success — this refactor converts the former into the latter.

## Follow-up (separate, owner-confirmed — NOT in this PR)
After this merges and the three contexts are observed reporting a conclusion (success-by-skip) on a couple of real PRs — including one that touches none of the paths — add them to `required_status_checks` alongside `smoke-test`. Single-runner load to be watched per the issue.

## Model Used
Claude Fable 5 (devops-engineer agent — refactor) + Opus 4.8 (main session: pattern verification against ci.yml, YAML/context audit, review)

Part of umbrella #9924. Implements the workflow half of #10022.