### PR TITLE
chore: verify always-report gate skip-path (#10022)

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,3 +453,7 @@ It's suitable for:
 ---
 
 **Made with ❤️ by the AutoBot community**
+
+<!-- always-report gate verification (#10022): this README-only PR touches none of the
+     code-quality / startup-import-smoke / frontend filters, so those three checks must
+     skip-to-success rather than deadlock. Verification artifact; safe to revert. -->


### PR DESCRIPTION
## Purpose
Verification artifact for #10022. This PR changes **only README.md**, which is in none of the `code-quality` / `startup-import-smoke` / frontend path filters. It confirms the three refactored contexts report **success-by-skip** (not a deadlocking 'Expected — Waiting') on a PR that touches none of their paths — the case the always-report refactor (#10136) exists to handle.

Once observed, the three contexts are promoted to required, and this PR is closed (or merged — the change is a harmless comment).

Part of umbrella #9924.