### PR TITLE
fix(llc/tests): repair test-isolation + liveness mock rot (#9995, #9987, #9978)

### DIFF
--- a/autobot-backend/llc/tests/test_haiku_tier.py
+++ b/autobot-backend/llc/tests/test_haiku_tier.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import os
 import sys
 import types
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -44,9 +45,14 @@ sys.modules["autobot_shared.logging_manager"] = _asl
 
 # Pre-stub the llc.api package so its __init__ is NOT executed when loading
 # submodules directly (the __init__ triggers a deep import chain that requires
-# a live database + deployment config).
+# a live database + deployment config). The stub MUST carry a real __path__ so
+# it still behaves as a package: without it, sys.modules['llc.api'] becomes a
+# non-package module and every later `import llc.api.<x>` in a full-suite run
+# fails with "llc.api is not a package", masking real regressions (GH#9995).
 if "llc.api" not in sys.modules:
-    sys.modules["llc.api"] = types.ModuleType("llc.api")
+    _api_stub = types.ModuleType("llc.api")
+    _api_stub.__path__ = [os.path.join(os.path.dirname(os.path.dirname(__file__)), "api")]
+    sys.modules["llc.api"] = _api_stub
 
 
 def _load_module_file(dotted_name: str, rel_path: str) -> types.ModuleType:

--- a/autobot-backend/llc/tests/test_liveness_monitor.py
+++ b/autobot-backend/llc/tests/test_liveness_monitor.py
@@ -11,6 +11,36 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from llc.scheduler.liveness_monitor import LivenessMonitor, run_id_label
+from user_management.config import DeploymentMode
+
+
+@pytest.fixture(autouse=True)
+def _multi_company_mode():
+    """_check_once() early-returns in single_user mode (no PostgreSQL, #9089);
+    force a multi-tenant mode so the recovery path under test actually runs."""
+    with patch("llc.scheduler.liveness_monitor.get_deployment_config") as cfg:
+        cfg.return_value.mode = DeploymentMode.MULTI_COMPANY
+        yield
+
+
+def _mock_session(stuck_runs: list, work_item: object | None = None) -> AsyncMock:
+    """Build an async session mock whose execute() returns a *sync* result.
+
+    ``AsyncMock`` propagates async to its children, so the naive
+    ``session.execute.return_value.scalars()`` yields a coroutine, not a row
+    set. Configure execute() to return an explicit MagicMock instead so
+    ``.scalars().all()`` / ``.scalar_one_or_none()`` / ``.fetchone()`` work.
+    """
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = stuck_runs
+    result.scalar_one_or_none.return_value = work_item
+    result.fetchone.return_value = None  # _agent_deliberately_paused DB fallback
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result)
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    return session
 
 
 def _make_run(
@@ -66,18 +96,13 @@ async def test_stuck_run_marked_timed_out() -> None:
 
     with (
         patch("llc.scheduler.liveness_monitor.get_async_redis_client", new_callable=AsyncMock) as mock_redis,
-        patch("llc.scheduler.liveness_monitor.get_adapter_for_agent", new_callable=AsyncMock) as mock_adapter,
+        patch("llc.adapters.get_adapter_for_agent", new_callable=AsyncMock) as mock_adapter,
         patch("llc.scheduler.liveness_monitor.WorkItemService"),
     ):
         mock_redis.return_value = None
         mock_adapter.return_value = None
 
-        session = AsyncMock()
-        session.execute.return_value.scalars.return_value.all.return_value = [run]
-        session.execute.return_value.scalar_one_or_none.return_value = None
-        session.add = MagicMock()
-        session.commit = AsyncMock()
-        session.rollback = AsyncMock()
+        session = _mock_session([run])
 
         factory = MagicMock()
         factory.return_value.__aenter__ = AsyncMock(return_value=session)
@@ -98,6 +123,9 @@ async def test_checkout_lock_released_on_recovery() -> None:
 
     mock_redis = AsyncMock()
     mock_redis.delete = AsyncMock()
+    # exists() must be falsy or _agent_deliberately_paused() treats the agent as
+    # paused and skips the recovery flow under test.
+    mock_redis.exists = AsyncMock(return_value=0)
 
     with (
         patch(
@@ -105,15 +133,10 @@ async def test_checkout_lock_released_on_recovery() -> None:
             new_callable=AsyncMock,
             return_value=mock_redis,
         ),
-        patch("llc.scheduler.liveness_monitor.get_adapter_for_agent", new_callable=AsyncMock, return_value=None),
+        patch("llc.adapters.get_adapter_for_agent", new_callable=AsyncMock, return_value=None),
         patch("llc.scheduler.liveness_monitor.WorkItemService"),
     ):
-        session = AsyncMock()
-        session.execute.return_value.scalars.return_value.all.return_value = [run]
-        session.execute.return_value.scalar_one_or_none.return_value = None
-        session.add = MagicMock()
-        session.commit = AsyncMock()
-        session.rollback = AsyncMock()
+        session = _mock_session([run])
 
         factory = MagicMock()
         factory.return_value.__aenter__ = AsyncMock(return_value=session)
@@ -135,19 +158,14 @@ async def test_adapter_cancel_called_best_effort() -> None:
 
     with (
         patch(
-            "llc.scheduler.liveness_monitor.get_adapter_for_agent",
+            "llc.adapters.get_adapter_for_agent",
             new_callable=AsyncMock,
             return_value=mock_adapter,
         ),
         patch("llc.scheduler.liveness_monitor.get_async_redis_client", new_callable=AsyncMock, return_value=None),
         patch("llc.scheduler.liveness_monitor.WorkItemService"),
     ):
-        session = AsyncMock()
-        session.execute.return_value.scalars.return_value.all.return_value = [run]
-        session.execute.return_value.scalar_one_or_none.return_value = None
-        session.add = MagicMock()
-        session.commit = AsyncMock()
-        session.rollback = AsyncMock()
+        session = _mock_session([run])
 
         factory = MagicMock()
         factory.return_value.__aenter__ = AsyncMock(return_value=session)
@@ -169,19 +187,14 @@ async def test_adapter_cancel_exception_is_swallowed() -> None:
 
     with (
         patch(
-            "llc.scheduler.liveness_monitor.get_adapter_for_agent",
+            "llc.adapters.get_adapter_for_agent",
             new_callable=AsyncMock,
             return_value=mock_adapter,
         ),
         patch("llc.scheduler.liveness_monitor.get_async_redis_client", new_callable=AsyncMock, return_value=None),
         patch("llc.scheduler.liveness_monitor.WorkItemService"),
     ):
-        session = AsyncMock()
-        session.execute.return_value.scalars.return_value.all.return_value = [run]
-        session.execute.return_value.scalar_one_or_none.return_value = None
-        session.add = MagicMock()
-        session.commit = AsyncMock()
-        session.rollback = AsyncMock()
+        session = _mock_session([run])
 
         factory = MagicMock()
         factory.return_value.__aenter__ = AsyncMock(return_value=session)

--- a/autobot-frontend/src/views/llc/CompanyTreeNode.vue
+++ b/autobot-frontend/src/views/llc/CompanyTreeNode.vue
@@ -59,7 +59,7 @@ const budgetBarColor = (node: CompanyNode) => {
         <span class="text-xs text-gray-400 w-8 text-right">{{ budgetPercent(node) }}%</span>
       </div>
 
-      <span class="text-xs text-gray-500">{{ node.agent_count }} agents</span>
+      <span v-if="node.agent_count != null" class="text-xs text-gray-500">{{ node.agent_count }} agents</span>
       <svg class="w-4 h-4 text-gray-300 group-hover:text-indigo-400 transition-colors flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
       </svg>


### PR DESCRIPTION
## Thinking Path
Batch of three LLC test-infra/quality bugs from umbrella #9923's triage-delta. Each turned out deeper than its one-line description (layered test rot), so each fix is root-cause and verified by running the affected suites.

## What Changed

### #9995 — `sys.modules['llc.api']` clobbered to a non-package
`test_haiku_tier.py` pre-stubbed `llc.api` as a bare `ModuleType` (no `__path__`). In full-suite order that makes `sys.modules['llc.api']` a non-package, so every later `import llc.api.<x>` fails with *"llc.api is not a package"* — ~30 route tests error at setup and **real regressions get masked** (a broken test looks identical to the pollution error). Fix: give the stub a real `__path__` pointing at the `llc/api` dir, so it still skips the `__init__` deep-import chain but submodule imports resolve.
- **`llc/tests` full suite: 832→949 passed, 36→5 errors, 150→64 failed.**
- Residual failures are a deeper isolation layer (other module-level package stubs) — filed as a follow-up, scoped out per "test-infra cleanup = sprint, not single PR".

### #9987 — `test_liveness_monitor` recovery tests fully broken (4 stacked causes)
1. patched `get_adapter_for_agent` on `liveness_monitor` — but it's a lazy `from ..adapters import …` inside the function, so the patch never applied → patch `llc.adapters.get_adapter_for_agent` (the source).
2. never patched `get_deployment_config`, so `_check_once` early-returned in single_user mode → autouse fixture forces `MULTI_COMPANY`.
3. `AsyncMock` session made `.scalars()` return a coroutine → explicit `MagicMock` result via a `_mock_session` helper.
4. truthy `redis.exists()` tripped the deliberately-paused skip → `exists` returns `0`.
- **test_liveness_monitor: 3→7 passed (all green).**

### #9978 — GoalTree/SubCompanyTree
The TS2352/TS2741 type errors were already resolved by #9724 (fields made optional; vue-tsc clean). Fixed the residual **user-visible** bug: `SubCompanyTree` rendered an empty " agents" label when `agent_count` is absent → guarded with `v-if`.

## Verification
- `pytest llc/tests/test_liveness_monitor.py` → 7 passed
- `pytest llc/tests/` full suite → 949 passed / 64 failed / 5 error (was 832 / 150 / 36 on base; **+117 passing**)
- flake8 clean; vue-tsc unaffected (trivial `v-if`)

## Model Used
Claude Opus 4.8

Closes #9987 · Closes #9978 · addresses the named root cause of #9995 (residual layers tracked in a follow-up)
