### PR TITLE
feat(code-sync): generate ansible inventory from DB node registry — node_id hosts + local self-node (#10110)

### DIFF
--- a/autobot-slm-backend/services/inventory_builder.py
+++ b/autobot-slm-backend/services/inventory_builder.py
@@ -146,7 +146,7 @@ _ALL_VARS: dict[str, str] = {
     "ansible_python_interpreter": "/usr/bin/python3",
     "slm_host": (
         "{{ lookup('env', 'SLM_HOST') | default(lookup('pipe',"
-        " 'grep -oP \"SLM_HOST=\\\\K.*\" /etc/autobot/slm-secrets.env"
+        ' \'grep -oP "SLM_HOST=\\\\K.*" /etc/autobot/slm-secrets.env'
         " 2>/dev/null || echo 127.0.0.1'), true) }}"
     ),
     "network_subnet": (

--- a/autobot-slm-backend/services/inventory_builder.py
+++ b/autobot-slm-backend/services/inventory_builder.py
@@ -1,0 +1,398 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Dynamic Ansible inventory builder from DB node registry.
+
+Fixes #10109: static slm-nodes.yml uses display names as host names which do
+not match the node_id passed as --limit, so plays target zero hosts.  The
+generated inventory uses node_id as the host name so --limit <node_id> always
+resolves.
+
+Fixes #10095: co-located self-node deploy SSHes to its own IP (refused).
+Any node whose ip_address is a local/loopback address receives
+``ansible_connection: local`` so Ansible never opens an SSH connection.
+
+The generated inventory reproduces every global all.vars from slm-nodes.yml
+and emits ALL group aliases so every ``hosts:`` / ``groups[...]`` reference
+in every playbook under autobot-slm-backend/ansible/ resolves correctly.
+
+GROUP CONTRACT
+--------------
+Exhaustive union of group names referenced by hosts:/groups[] across all
+playbooks (run:
+  grep -rhoE "hosts: [a-zA-Z0-9_:!.]+|groups\\[['\\"]+[a-z_]+['\\"]+\\]" \\
+      autobot-slm-backend/ansible/playbooks/ autobot-slm-backend/ansible/*.yml
+):
+
+  slm_server, slm, slm_nodes        — SLM-manager node
+  backend, main                      — backend/API node
+  frontend                           — frontend node
+  npu, npu_worker, npu_workers       — NPU inference worker
+  ai_stack, aiml, ai                 — AI / LLM / ChromaDB stack
+  database, redis                    — database / Redis node
+  browser, browser_worker            — browser automation node
+  infrastructure                     — all non-SLM nodes
+  autobot, autobot_cluster           — all nodes
+  monitoring_vm                      — optional; nodes with 'monitoring' role
+  llm_nodes                          — LLM CPU/GPU inference nodes
+  production_vms                     — alias for infrastructure
+
+Groups parameterised at runtime (``target``, ``autobot-backend``,
+``autobot-host``, ``{{ node_id }}``) need NOT be in the static inventory —
+they are resolved via --limit or passed as extra-vars.
+"""
+
+import logging
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# ROLE → GROUP MAPPING
+# ---------------------------------------------------------------------------
+# DB role tokens (Node.roles / Node.detected_roles union) and the ansible
+# group names they map to.  Matching rules:
+#   1. Exact key match (e.g. "redis" → redis + database)
+#   2. Prefix key match for keys ending with "-" (e.g. "slm-" catches
+#      "slm-backend", "slm-frontend", "slm-agent", etc.)
+#   3. All matching entries accumulate (no early exit).
+#
+# Real role tokens seen in production:
+#   slm-backend, slm-frontend, slm-database, slm-monitoring, slm-agent
+#   autobot-llm-cpu, autobot-llm-gpu
+#   autobot_shared
+#   browser-service
+#   tts-worker, npu-worker
+#   ai-stack, chromadb
+#   redis, frontend, backend, celery, docker, scheduler, postgres
+#   monitoring
+
+_ROLE_TO_GROUPS: dict[str, frozenset] = {
+    # SLM manager / slm-agent / any slm-* role
+    "slm-": frozenset({"slm", "slm_server", "slm_nodes"}),
+    "slm_agent": frozenset({"slm", "slm_server", "slm_nodes"}),
+    # Backend / API server
+    "backend": frozenset({"backend", "main"}),
+    "celery": frozenset({"backend", "main"}),
+    "scheduler": frozenset({"backend", "main"}),
+    "autobot_shared": frozenset({"backend", "main"}),
+    # Frontend
+    "frontend": frozenset({"frontend"}),
+    # NPU inference
+    "npu-worker": frozenset({"npu", "npu_worker", "npu_workers"}),
+    "npu_worker": frozenset({"npu", "npu_worker", "npu_workers"}),
+    # AI / LLM / ChromaDB
+    "ai-stack": frozenset({"ai_stack", "aiml", "ai", "llm_nodes"}),
+    "chromadb": frozenset({"ai_stack", "aiml", "ai"}),
+    "autobot-llm-": frozenset({"ai_stack", "aiml", "ai", "llm_nodes"}),
+    "tts-worker": frozenset({"ai_stack", "aiml", "ai"}),
+    # Database / Redis / Postgres
+    "redis": frozenset({"redis", "database"}),
+    "postgres": frozenset({"database"}),
+    "slm-database": frozenset({"redis", "database"}),
+    # Browser automation
+    "browser-service": frozenset({"browser", "browser_worker"}),
+    # Monitoring (optional; maps to monitoring_vm)
+    "monitoring": frozenset({"monitoring_vm"}),
+    "slm-monitoring": frozenset({"monitoring_vm"}),
+}
+
+# Groups that every non-SLM node belongs to
+_UNIVERSAL_NON_SLM: frozenset = frozenset({"infrastructure", "autobot", "autobot_cluster", "production_vms"})
+
+# Groups that every node (including SLM) belongs to
+_UNIVERSAL_ALL: frozenset = frozenset({"autobot", "autobot_cluster"})
+
+# Full required-group contract — see module docstring for provenance
+REQUIRED_GROUPS: frozenset = frozenset(
+    {
+        "slm",
+        "slm_server",
+        "slm_nodes",
+        "backend",
+        "main",
+        "frontend",
+        "npu",
+        "npu_worker",
+        "npu_workers",
+        "ai_stack",
+        "aiml",
+        "ai",
+        "database",
+        "redis",
+        "browser",
+        "browser_worker",
+        "infrastructure",
+        "autobot",
+        "autobot_cluster",
+        "monitoring_vm",
+        "llm_nodes",
+        "production_vms",
+    }
+)
+
+# Global all.vars — reproduced verbatim from slm-nodes.yml
+_ALL_VARS: dict[str, str] = {
+    "ansible_user": "autobot",
+    "ansible_ssh_private_key_file": "/etc/autobot/ssh/autobot_key",
+    "ansible_python_interpreter": "/usr/bin/python3",
+    "slm_host": (
+        "{{ lookup('env', 'SLM_HOST') | default(lookup('pipe',"
+        " 'grep -oP \"SLM_HOST=\\\\K.*\" /etc/autobot/slm-secrets.env"
+        " 2>/dev/null || echo 127.0.0.1'), true) }}"
+    ),
+    "network_subnet": (
+        "{{ lookup('env', 'NETWORK_SUBNET') or"
+        " lookup('pipe', 'grep -oP \"NETWORK_SUBNET=\\\\K.*\""
+        " /etc/autobot/slm-secrets.env 2>/dev/null') or '0.0.0.0/0' }}"
+    ),
+    "network_gateway": (
+        "{{ lookup('env', 'NETWORK_GATEWAY') or"
+        " lookup('pipe', 'grep -oP \"NETWORK_GATEWAY=\\\\K.*\""
+        " /etc/autobot/slm-secrets.env 2>/dev/null') or '0.0.0.0' }}"
+    ),
+}
+
+
+def _role_tokens_to_groups(role_tokens: list[str]) -> set[str]:
+    """Map a list of DB role token strings to the union of ansible group names.
+
+    Matching is exact-string first; if no exact key matches, checks each
+    mapping key as a prefix of the token (for keys ending with ``-``).
+    All matching entries accumulate.
+
+    Args:
+        role_tokens: List of role/detected_role strings from the DB.
+
+    Returns:
+        Set of ansible group name strings.
+    """
+    groups: set[str] = set()
+    for token in role_tokens:
+        token = token.strip().lower()
+        if not token:
+            continue
+        # Exact key match
+        if token in _ROLE_TO_GROUPS:
+            groups |= _ROLE_TO_GROUPS[token]
+            continue
+        # Prefix key match (handles "slm-" catching "slm-backend")
+        for key, key_groups in _ROLE_TO_GROUPS.items():
+            if key.endswith("-") and token.startswith(key):
+                groups |= key_groups
+            elif not key.endswith("-") and token == key:
+                groups |= key_groups
+    return groups
+
+
+def _union_roles(node: Any) -> list[str]:
+    """Return union of node.roles and node.detected_roles as a deduped list."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for r in list(node.roles or []) + list(node.detected_roles or []):
+        if r not in seen:
+            seen.add(r)
+            result.append(r)
+    return result
+
+
+def _build_hostvars(node: Any, local_ip_check: Any) -> dict:
+    """Return the host-variable dict for one Node record.
+
+    Args:
+        node: SQLAlchemy Node ORM instance (or duck-type compatible).
+        local_ip_check: callable(ip: str) -> bool.  When True the host gets
+            ``ansible_connection: local`` to avoid SSH to self (#10095).
+
+    Returns:
+        Dict of Ansible host variables for this node.
+    """
+    hostvars: dict[str, Any] = {
+        "ansible_host": node.ip_address,
+        "ansible_user": node.ssh_user or "autobot",
+        "ansible_port": node.ssh_port or 22,
+        "slm_node_id": node.node_id,
+    }
+    if local_ip_check(node.ip_address):
+        hostvars["ansible_connection"] = "local"
+    return hostvars
+
+
+def build_registry_inventory(nodes: list[Any], local_ip_check: Any) -> dict:
+    """Build a full Ansible YAML inventory dict from the DB node list.
+
+    The returned dict is shaped as::
+
+        all:
+          vars: {...}
+          hosts:
+            <node_id>: {ansible_host, ansible_user, ansible_port, slm_node_id, ...}
+          children:
+            <group>:
+              hosts:
+                <node_id>: {}
+
+    so that ``yaml.dump(inv)`` produces a valid Ansible inventory.
+
+    Every required group key is always present (possibly with no hosts) so
+    that plays referencing groups that have no assigned nodes produce a
+    "skipped all hosts" message rather than "Could not match host pattern".
+
+    Args:
+        nodes: List of Node ORM instances (or duck-type compatible objects).
+        local_ip_check: callable(ip: str) -> bool.  Pass
+            ``autobot_shared.network_utils.is_local_ip`` in production; pass
+            a lambda in tests.
+
+    Returns:
+        Dict suitable for ``yaml.dump`` to produce an Ansible inventory file.
+    """
+    # Pre-populate every required group so validate_inventory never complains
+    # about a missing key even when no node carries that role.
+    groups: dict[str, dict] = {g: {"hosts": {}} for g in REQUIRED_GROUPS}
+
+    host_section: dict[str, dict] = {}
+
+    for node in nodes:
+        host_name: str = node.node_id  # host name IS the node_id (#10109)
+        hostvars = _build_hostvars(node, local_ip_check)
+        host_section[host_name] = hostvars
+
+        role_tokens = _union_roles(node)
+        node_groups = _role_tokens_to_groups(role_tokens)
+
+        # Every node joins autobot + autobot_cluster (centralized logging, etc.)
+        node_groups |= _UNIVERSAL_ALL
+
+        # Non-SLM nodes also join infrastructure + production_vms
+        is_slm = bool(node_groups & {"slm", "slm_server", "slm_nodes"})
+        if not is_slm:
+            node_groups |= _UNIVERSAL_NON_SLM
+
+        for g in node_groups:
+            if g not in groups:
+                groups[g] = {"hosts": {}}
+            groups[g]["hosts"][host_name] = {}
+
+    return {
+        "all": {
+            "vars": dict(_ALL_VARS),
+            "hosts": host_section,
+            "children": groups,
+        }
+    }
+
+
+def validate_inventory(inv: dict, required_groups: frozenset = REQUIRED_GROUPS) -> None:
+    """Raise ValueError if any required group key is absent from the inventory.
+
+    Empty groups (key present, hosts dict empty) are allowed — Ansible
+    handles them gracefully.  Missing keys cause "Could not match supplied
+    host pattern" errors that are hard to diagnose at runtime.
+
+    Args:
+        inv: Inventory dict as returned by build_registry_inventory.
+        required_groups: Set of group names that MUST be present as keys.
+
+    Raises:
+        ValueError: with a sorted list of every missing group name.
+    """
+    children = inv.get("all", {}).get("children", {})
+    missing = sorted(required_groups - set(children.keys()))
+    if missing:
+        raise ValueError(
+            f"Generated inventory is missing required groups: {missing}. "
+            "Check ROLE_TO_GROUPS mapping in inventory_builder.py."
+        )
+
+
+def _write_inventory_file(inv: dict, path: Path) -> None:
+    """Dump *inv* to *path* as YAML (UTF-8, mode 0600).
+
+    Args:
+        inv: Inventory dict from build_registry_inventory.
+        path: Destination path; parent directory must exist.
+    """
+    path.write_text(
+        yaml.dump(inv, default_flow_style=False, allow_unicode=True, sort_keys=True),
+        encoding="utf-8",
+    )
+    path.chmod(0o600)
+    logger.debug("Wrote dynamic inventory to %s", path)
+
+
+def write_temp_inventory(inv: dict, uid_tmp_dir: str | None = None) -> Path:
+    """Write *inv* to a unique temp file and return its Path.
+
+    The file is created inside *uid_tmp_dir* (defaults to the uid-scoped
+    ANSIBLE_LOCAL_TMP used by PlaybookExecutor) so it cannot collide across
+    users.  The caller is responsible for deleting it after the playbook run.
+
+    Args:
+        inv: Inventory dict from build_registry_inventory.
+        uid_tmp_dir: Directory for the temp file.  If None, uses
+            ``/tmp/ansible_local_tmp_<uid>`` (nosec B108 — uid-scoped).
+
+    Returns:
+        Path to the written inventory file.
+    """
+    if uid_tmp_dir is None:
+        uid_tmp_dir = f"/tmp/ansible_local_tmp_{os.getuid()}"  # nosec B108
+    tmp_dir = Path(uid_tmp_dir)
+    tmp_dir.mkdir(mode=0o700, exist_ok=True)
+
+    fd, tmp_path_str = tempfile.mkstemp(
+        prefix="autobot_inv_",
+        suffix=".yml",
+        dir=str(tmp_dir),
+    )
+    os.close(fd)
+    tmp_path = Path(tmp_path_str)
+    _write_inventory_file(inv, tmp_path)
+    return tmp_path
+
+
+def scan_playbook_dir_for_groups(playbook_dir: Path) -> frozenset:
+    """Parse ``hosts:`` and ``groups[...]`` references from playbook YAML files.
+
+    Used as a cross-check against the hardcoded REQUIRED_GROUPS constant.
+    Returns the union set of all static group names referenced; skips Jinja2
+    expressions and built-in names (all, localhost, target).
+
+    Args:
+        playbook_dir: Directory to search recursively for *.yml files.
+
+    Returns:
+        frozenset of group name strings found in the playbooks.
+    """
+    _STATIC = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*$")
+    _IGNORE = {"all", "localhost", "target"}
+
+    found: set[str] = set()
+    hosts_re = re.compile(r"^\s*-?\s*hosts:\s*([^\s#]+)")
+    groups_re = re.compile(r"""groups\[['"]([a-zA-Z0-9_]+)['"]\]""")
+
+    for yml_file in Path(playbook_dir).rglob("*.yml"):
+        try:
+            text = yml_file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            m = hosts_re.match(line)
+            if m:
+                val = m.group(1).strip()
+                if _STATIC.match(val) and val not in _IGNORE:
+                    found.add(val)
+            for g in groups_re.findall(line):
+                if g not in _IGNORE:
+                    found.add(g)
+
+    return frozenset(found)

--- a/autobot-slm-backend/services/inventory_builder_test.py
+++ b/autobot-slm-backend/services/inventory_builder_test.py
@@ -1,0 +1,417 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for services.inventory_builder (Issue #10110).
+
+Isolated: imports only inventory_builder + stdlib dataclasses.
+No SQLAlchemy, no DB, no subprocess — safe to run with bare pytest.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pytest
+
+from services.inventory_builder import (
+    REQUIRED_GROUPS,
+    build_registry_inventory,
+    validate_inventory,
+    _role_tokens_to_groups,
+)
+
+
+# ---------------------------------------------------------------------------
+# Node stub — duck-types the Node ORM; no SQLAlchemy required in tests
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _Node:
+    node_id: str
+    ip_address: str
+    roles: list = field(default_factory=list)
+    detected_roles: list = field(default_factory=list)
+    ssh_user: Optional[str] = None
+    ssh_port: Optional[int] = None
+    ansible_name: Optional[str] = None
+    hostname: str = "host"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _local(ip: str) -> bool:
+    """Stub: only loopback is local."""
+    return ip in {"127.0.0.1", "::1", "localhost"}
+
+
+def _build(nodes, local_ip_check=_local):
+    return build_registry_inventory(nodes, local_ip_check)
+
+
+# ---------------------------------------------------------------------------
+# host name == node_id  (#10109)
+# ---------------------------------------------------------------------------
+
+def test_host_name_equals_node_id():
+    """Host name in inventory MUST equal node.node_id so --limit <node_id> works."""
+    node = _Node(node_id="01-Backend", ip_address="10.0.0.2", roles=["backend"])
+    inv = _build([node])
+    hosts = inv["all"]["hosts"]
+    assert "01-Backend" in hosts, "host name must be node_id"
+    assert hosts["01-Backend"]["slm_node_id"] == "01-Backend"
+
+
+def test_host_name_is_node_id_not_ansible_name():
+    """ansible_name field must NOT become the inventory host name."""
+    node = _Node(node_id="mynode-42", ip_address="10.0.0.5", roles=["backend"],
+                 ansible_name="some-alias")
+    inv = _build([node])
+    hosts = inv["all"]["hosts"]
+    assert "mynode-42" in hosts
+    assert "some-alias" not in hosts
+
+
+# ---------------------------------------------------------------------------
+# self-node (local IP) → ansible_connection: local  (#10095)
+# ---------------------------------------------------------------------------
+
+def test_local_ip_gets_local_connection():
+    """Self-node (loopback IP) must receive ansible_connection: local."""
+    node = _Node(node_id="00-SLM-Manager", ip_address="127.0.0.1", roles=["slm-backend"])
+    inv = _build([node], local_ip_check=_local)
+    hostvars = inv["all"]["hosts"]["00-SLM-Manager"]
+    assert hostvars.get("ansible_connection") == "local"
+
+
+def test_remote_ip_no_local_connection():
+    """Remote node must NOT have ansible_connection: local."""
+    node = _Node(node_id="01-Backend", ip_address="192.168.1.10", roles=["backend"])
+    inv = _build([node], local_ip_check=_local)
+    hostvars = inv["all"]["hosts"]["01-Backend"]
+    assert "ansible_connection" not in hostvars
+
+
+def test_custom_local_check_injectable():
+    """local_ip_check is injectable; any IP the caller declares local is treated as local."""
+    node = _Node(node_id="01-Backend", ip_address="10.0.0.1", roles=["backend"])
+    inv = _build([node], local_ip_check=lambda ip: ip == "10.0.0.1")
+    assert inv["all"]["hosts"]["01-Backend"].get("ansible_connection") == "local"
+
+
+# ---------------------------------------------------------------------------
+# hostvars completeness
+# ---------------------------------------------------------------------------
+
+def test_hostvars_defaults():
+    """ssh_user and ssh_port default to 'autobot' and 22 when None."""
+    node = _Node(node_id="02-Frontend", ip_address="10.0.0.3", roles=["frontend"],
+                 ssh_user=None, ssh_port=None)
+    inv = _build([node])
+    h = inv["all"]["hosts"]["02-Frontend"]
+    assert h["ansible_user"] == "autobot"
+    assert h["ansible_port"] == 22
+    assert h["ansible_host"] == "10.0.0.3"
+
+
+def test_hostvars_explicit_values():
+    """Node-specific ssh_user and ssh_port are used when set."""
+    node = _Node(node_id="05-LLM-CPU", ip_address="10.0.0.9", roles=["autobot-llm-cpu"],
+                 ssh_user="ubuntu", ssh_port=2222)
+    inv = _build([node])
+    h = inv["all"]["hosts"]["05-LLM-CPU"]
+    assert h["ansible_user"] == "ubuntu"
+    assert h["ansible_port"] == 2222
+
+
+# ---------------------------------------------------------------------------
+# role → group mapping
+# ---------------------------------------------------------------------------
+
+def test_slm_node_groups():
+    """slm-backend role → slm, slm_server, slm_nodes; NOT in infrastructure."""
+    node = _Node(node_id="00-SLM-Manager", ip_address="127.0.0.1", roles=["slm-backend"])
+    inv = _build([node])
+    children = inv["all"]["children"]
+    host = "00-SLM-Manager"
+    assert host in children["slm"]["hosts"]
+    assert host in children["slm_server"]["hosts"]
+    assert host in children["slm_nodes"]["hosts"]
+    # SLM node does NOT join infrastructure
+    assert host not in children.get("infrastructure", {}).get("hosts", {})
+
+
+def test_backend_node_groups():
+    """backend role → backend, main, infrastructure, autobot, autobot_cluster."""
+    node = _Node(node_id="01-Backend", ip_address="10.0.0.2", roles=["backend"])
+    inv = _build([node])
+    children = inv["all"]["children"]
+    host = "01-Backend"
+    assert host in children["backend"]["hosts"]
+    assert host in children["main"]["hosts"]
+    assert host in children["infrastructure"]["hosts"]
+    assert host in children["autobot"]["hosts"]
+    assert host in children["autobot_cluster"]["hosts"]
+
+
+def test_npu_node_groups():
+    """npu-worker role → npu, npu_worker, npu_workers."""
+    node = _Node(node_id="npu-worker", ip_address="10.0.0.6", roles=["npu-worker"])
+    inv = _build([node])
+    children = inv["all"]["children"]
+    host = "npu-worker"
+    assert host in children["npu"]["hosts"]
+    assert host in children["npu_worker"]["hosts"]
+    assert host in children["npu_workers"]["hosts"]
+
+
+def test_ai_stack_node_groups():
+    """ai-stack role → ai_stack, aiml, ai, llm_nodes."""
+    node = _Node(node_id="03-AI-Stack", ip_address="10.0.0.7", roles=["ai-stack"])
+    inv = _build([node])
+    children = inv["all"]["children"]
+    host = "03-AI-Stack"
+    assert host in children["ai_stack"]["hosts"]
+    assert host in children["aiml"]["hosts"]
+    assert host in children["ai"]["hosts"]
+    assert host in children["llm_nodes"]["hosts"]
+
+
+def test_llm_cpu_prefix_role_groups():
+    """autobot-llm-cpu prefix role → ai_stack, aiml, ai, llm_nodes."""
+    node = _Node(node_id="05-LLM-CPU", ip_address="10.0.0.8", roles=["autobot-llm-cpu"])
+    inv = _build([node])
+    children = inv["all"]["children"]
+    host = "05-LLM-CPU"
+    assert host in children["ai_stack"]["hosts"]
+    assert host in children["llm_nodes"]["hosts"]
+
+
+def test_database_node_groups():
+    """redis role → database and redis groups."""
+    node = _Node(node_id="04-Databases", ip_address="10.0.0.5", roles=["redis"])
+    inv = _build([node])
+    children = inv["all"]["children"]
+    host = "04-Databases"
+    assert host in children["database"]["hosts"]
+    assert host in children["redis"]["hosts"]
+
+
+def test_browser_node_groups():
+    """browser-service role → browser and browser_worker groups."""
+    node = _Node(node_id="browser-automation", ip_address="10.0.0.11", roles=["browser-service"])
+    inv = _build([node])
+    children = inv["all"]["children"]
+    host = "browser-automation"
+    assert host in children["browser"]["hosts"]
+    assert host in children["browser_worker"]["hosts"]
+
+
+def test_monitoring_node_groups():
+    """monitoring role → monitoring_vm group."""
+    node = _Node(node_id="mon-01", ip_address="10.0.0.20", roles=["monitoring"])
+    inv = _build([node])
+    children = inv["all"]["children"]
+    assert "mon-01" in children["monitoring_vm"]["hosts"]
+
+
+def test_frontend_node_in_infrastructure():
+    """frontend role → frontend group AND infrastructure (not SLM)."""
+    node = _Node(node_id="02-Frontend", ip_address="10.0.0.3", roles=["frontend"])
+    inv = _build([node])
+    children = inv["all"]["children"]
+    assert "02-Frontend" in children["frontend"]["hosts"]
+    assert "02-Frontend" in children["infrastructure"]["hosts"]
+
+
+def test_detected_roles_merged_with_roles():
+    """detected_roles are unioned with roles for group mapping."""
+    node = _Node(
+        node_id="01-Backend",
+        ip_address="10.0.0.2",
+        roles=["backend"],
+        detected_roles=["redis"],
+    )
+    inv = _build([node])
+    children = inv["all"]["children"]
+    host = "01-Backend"
+    assert host in children["backend"]["hosts"]
+    assert host in children["redis"]["hosts"]
+    assert host in children["database"]["hosts"]
+
+
+def test_production_vms_alias_present():
+    """Non-SLM nodes join production_vms (alias for infrastructure, deploy-time-sync.yml)."""
+    node = _Node(node_id="01-Backend", ip_address="10.0.0.2", roles=["backend"])
+    inv = _build([node])
+    assert "01-Backend" in inv["all"]["children"]["production_vms"]["hosts"]
+
+
+# ---------------------------------------------------------------------------
+# global all.vars reproduced
+# ---------------------------------------------------------------------------
+
+def test_all_vars_present():
+    """Generated inventory must include every global var from slm-nodes.yml."""
+    inv = _build([])
+    vars_ = inv["all"]["vars"]
+    assert vars_["ansible_user"] == "autobot"
+    assert vars_["ansible_ssh_private_key_file"] == "/etc/autobot/ssh/autobot_key"
+    assert vars_["ansible_python_interpreter"] == "/usr/bin/python3"
+    assert "slm_host" in vars_
+    assert "network_subnet" in vars_
+    assert "network_gateway" in vars_
+
+
+# ---------------------------------------------------------------------------
+# validate_inventory
+# ---------------------------------------------------------------------------
+
+def test_validate_passes_when_all_required_groups_present():
+    """validate_inventory does not raise when all required groups are present."""
+    slm = _Node(node_id="00-SLM-Manager", ip_address="127.0.0.1", roles=["slm-backend"])
+    be = _Node(node_id="01-Backend", ip_address="10.0.0.2", roles=["backend"])
+    fe = _Node(node_id="02-Frontend", ip_address="10.0.0.3", roles=["frontend"])
+    npu = _Node(node_id="npu-worker", ip_address="10.0.0.6", roles=["npu-worker"])
+    ai = _Node(node_id="03-AI-Stack", ip_address="10.0.0.7", roles=["ai-stack"])
+    db = _Node(node_id="04-Databases", ip_address="10.0.0.5", roles=["redis"])
+    br = _Node(node_id="browser-auto", ip_address="10.0.0.11", roles=["browser-service"])
+    mon = _Node(node_id="mon-01", ip_address="10.0.0.20", roles=["monitoring"])
+    inv = _build([slm, be, fe, npu, ai, db, br, mon])
+    validate_inventory(inv)  # must not raise
+
+
+def test_validate_raises_on_missing_group():
+    """validate_inventory raises ValueError naming every missing group."""
+    node = _Node(node_id="00-SLM-Manager", ip_address="127.0.0.1", roles=["slm-backend"])
+    inv = _build([node])
+    del inv["all"]["children"]["frontend"]
+    with pytest.raises(ValueError, match="frontend"):
+        validate_inventory(inv)
+
+
+def test_validate_empty_group_is_ok():
+    """A group key with no hosts is allowed (present but empty)."""
+    node = _Node(node_id="00-SLM-Manager", ip_address="127.0.0.1", roles=["slm-backend"])
+    inv = _build([node])
+    assert "frontend" in inv["all"]["children"]
+    assert inv["all"]["children"]["frontend"]["hosts"] == {}
+    validate_inventory(inv)  # must not raise
+
+
+def test_validate_custom_required_set():
+    """validate_inventory accepts a caller-supplied required_groups frozenset."""
+    inv = _build([])
+    # Only require 'autobot' — passes even with no nodes
+    validate_inventory(inv, required_groups=frozenset({"autobot"}))
+    # Require a nonexistent group to prove it raises
+    with pytest.raises(ValueError, match="nonexistent_group"):
+        validate_inventory(inv, required_groups=frozenset({"nonexistent_group"}))
+
+
+# ---------------------------------------------------------------------------
+# 2-node fixture: SLM self-node + remote backend (sample inventory dump)
+# ---------------------------------------------------------------------------
+
+def test_two_node_fixture_structure():
+    """2-node fixture: SLM self-node gets local conn; backend gets SSH; all groups valid."""
+    slm_node = _Node(
+        node_id="00-SLM-Manager",
+        ip_address="127.0.0.1",
+        roles=["slm-backend", "slm-agent"],
+    )
+    backend_node = _Node(
+        node_id="01-Backend",
+        ip_address="192.168.1.10",
+        roles=["backend", "celery", "scheduler"],
+        ssh_user="autobot",
+        ssh_port=22,
+    )
+    inv = _build([slm_node, backend_node], local_ip_check=_local)
+
+    # SLM: local connection (#10095)
+    assert inv["all"]["hosts"]["00-SLM-Manager"]["ansible_connection"] == "local"
+    # Backend: no local connection
+    assert "ansible_connection" not in inv["all"]["hosts"]["01-Backend"]
+
+    # All required groups present
+    validate_inventory(inv)
+
+    children = inv["all"]["children"]
+    # SLM in slm groups, NOT in infrastructure
+    slm_h = "00-SLM-Manager"
+    assert slm_h in children["slm"]["hosts"]
+    assert slm_h in children["slm_server"]["hosts"]
+    assert slm_h not in children["infrastructure"]["hosts"]
+
+    # Backend in backend/main/infrastructure/autobot (#10109 — --limit 01-Backend works)
+    be_h = "01-Backend"
+    assert be_h in children["backend"]["hosts"]
+    assert be_h in children["main"]["hosts"]
+    assert be_h in children["infrastructure"]["hosts"]
+    assert be_h in children["autobot"]["hosts"]
+
+
+# ---------------------------------------------------------------------------
+# _role_tokens_to_groups unit tests
+# ---------------------------------------------------------------------------
+
+def test_role_tokens_prefix_match():
+    """'slm-backend' matches 'slm-' prefix key."""
+    g = _role_tokens_to_groups(["slm-backend"])
+    assert "slm" in g
+    assert "slm_server" in g
+    assert "slm_nodes" in g
+
+
+def test_role_tokens_exact_match():
+    """'redis' matches 'redis' exact key."""
+    g = _role_tokens_to_groups(["redis"])
+    assert "redis" in g
+    assert "database" in g
+
+
+def test_role_tokens_unknown_produces_empty():
+    """Unknown role tokens produce no groups."""
+    g = _role_tokens_to_groups(["docker", "unknown-service"])
+    assert len(g) == 0
+
+
+def test_role_tokens_multiple_accumulate():
+    """Multiple tokens accumulate their groups."""
+    g = _role_tokens_to_groups(["backend", "redis"])
+    assert "backend" in g
+    assert "main" in g
+    assert "redis" in g
+    assert "database" in g
+
+
+def test_role_tokens_autobot_llm_prefix():
+    """'autobot-llm-gpu' matches 'autobot-llm-' prefix key."""
+    g = _role_tokens_to_groups(["autobot-llm-gpu"])
+    assert "ai_stack" in g
+    assert "llm_nodes" in g
+
+
+# ---------------------------------------------------------------------------
+# REQUIRED_GROUPS covers known playbook group references
+# ---------------------------------------------------------------------------
+
+def test_required_groups_covers_known_playbook_references():
+    """Spot-check known groups from playbook grep against REQUIRED_GROUPS."""
+    known = {
+        "slm_server", "slm", "slm_nodes",
+        "backend", "main", "frontend",
+        "npu", "npu_workers",
+        "ai_stack", "aiml", "ai",
+        "database", "redis",
+        "browser", "browser_worker",
+        "infrastructure",
+        "autobot", "autobot_cluster",
+        "monitoring_vm",
+        "llm_nodes",
+        "production_vms",
+    }
+    missing = known - REQUIRED_GROUPS
+    assert not missing, f"REQUIRED_GROUPS is missing known group refs: {missing}"

--- a/autobot-slm-backend/services/inventory_builder_test.py
+++ b/autobot-slm-backend/services/inventory_builder_test.py
@@ -15,15 +15,15 @@ import pytest
 
 from services.inventory_builder import (
     REQUIRED_GROUPS,
+    _role_tokens_to_groups,
     build_registry_inventory,
     validate_inventory,
-    _role_tokens_to_groups,
 )
-
 
 # ---------------------------------------------------------------------------
 # Node stub — duck-types the Node ORM; no SQLAlchemy required in tests
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class _Node:
@@ -41,6 +41,7 @@ class _Node:
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _local(ip: str) -> bool:
     """Stub: only loopback is local."""
     return ip in {"127.0.0.1", "::1", "localhost"}
@@ -54,6 +55,7 @@ def _build(nodes, local_ip_check=_local):
 # host name == node_id  (#10109)
 # ---------------------------------------------------------------------------
 
+
 def test_host_name_equals_node_id():
     """Host name in inventory MUST equal node.node_id so --limit <node_id> works."""
     node = _Node(node_id="01-Backend", ip_address="10.0.0.2", roles=["backend"])
@@ -65,8 +67,7 @@ def test_host_name_equals_node_id():
 
 def test_host_name_is_node_id_not_ansible_name():
     """ansible_name field must NOT become the inventory host name."""
-    node = _Node(node_id="mynode-42", ip_address="10.0.0.5", roles=["backend"],
-                 ansible_name="some-alias")
+    node = _Node(node_id="mynode-42", ip_address="10.0.0.5", roles=["backend"], ansible_name="some-alias")
     inv = _build([node])
     hosts = inv["all"]["hosts"]
     assert "mynode-42" in hosts
@@ -76,6 +77,7 @@ def test_host_name_is_node_id_not_ansible_name():
 # ---------------------------------------------------------------------------
 # self-node (local IP) → ansible_connection: local  (#10095)
 # ---------------------------------------------------------------------------
+
 
 def test_local_ip_gets_local_connection():
     """Self-node (loopback IP) must receive ansible_connection: local."""
@@ -104,10 +106,10 @@ def test_custom_local_check_injectable():
 # hostvars completeness
 # ---------------------------------------------------------------------------
 
+
 def test_hostvars_defaults():
     """ssh_user and ssh_port default to 'autobot' and 22 when None."""
-    node = _Node(node_id="02-Frontend", ip_address="10.0.0.3", roles=["frontend"],
-                 ssh_user=None, ssh_port=None)
+    node = _Node(node_id="02-Frontend", ip_address="10.0.0.3", roles=["frontend"], ssh_user=None, ssh_port=None)
     inv = _build([node])
     h = inv["all"]["hosts"]["02-Frontend"]
     assert h["ansible_user"] == "autobot"
@@ -117,8 +119,9 @@ def test_hostvars_defaults():
 
 def test_hostvars_explicit_values():
     """Node-specific ssh_user and ssh_port are used when set."""
-    node = _Node(node_id="05-LLM-CPU", ip_address="10.0.0.9", roles=["autobot-llm-cpu"],
-                 ssh_user="ubuntu", ssh_port=2222)
+    node = _Node(
+        node_id="05-LLM-CPU", ip_address="10.0.0.9", roles=["autobot-llm-cpu"], ssh_user="ubuntu", ssh_port=2222
+    )
     inv = _build([node])
     h = inv["all"]["hosts"]["05-LLM-CPU"]
     assert h["ansible_user"] == "ubuntu"
@@ -128,6 +131,7 @@ def test_hostvars_explicit_values():
 # ---------------------------------------------------------------------------
 # role → group mapping
 # ---------------------------------------------------------------------------
+
 
 def test_slm_node_groups():
     """slm-backend role → slm, slm_server, slm_nodes; NOT in infrastructure."""
@@ -252,6 +256,7 @@ def test_production_vms_alias_present():
 # global all.vars reproduced
 # ---------------------------------------------------------------------------
 
+
 def test_all_vars_present():
     """Generated inventory must include every global var from slm-nodes.yml."""
     inv = _build([])
@@ -267,6 +272,7 @@ def test_all_vars_present():
 # ---------------------------------------------------------------------------
 # validate_inventory
 # ---------------------------------------------------------------------------
+
 
 def test_validate_passes_when_all_required_groups_present():
     """validate_inventory does not raise when all required groups are present."""
@@ -314,6 +320,7 @@ def test_validate_custom_required_set():
 # 2-node fixture: SLM self-node + remote backend (sample inventory dump)
 # ---------------------------------------------------------------------------
 
+
 def test_two_node_fixture_structure():
     """2-node fixture: SLM self-node gets local conn; backend gets SSH; all groups valid."""
     slm_node = _Node(
@@ -357,6 +364,7 @@ def test_two_node_fixture_structure():
 # _role_tokens_to_groups unit tests
 # ---------------------------------------------------------------------------
 
+
 def test_role_tokens_prefix_match():
     """'slm-backend' matches 'slm-' prefix key."""
     g = _role_tokens_to_groups(["slm-backend"])
@@ -398,17 +406,28 @@ def test_role_tokens_autobot_llm_prefix():
 # REQUIRED_GROUPS covers known playbook group references
 # ---------------------------------------------------------------------------
 
+
 def test_required_groups_covers_known_playbook_references():
     """Spot-check known groups from playbook grep against REQUIRED_GROUPS."""
     known = {
-        "slm_server", "slm", "slm_nodes",
-        "backend", "main", "frontend",
-        "npu", "npu_workers",
-        "ai_stack", "aiml", "ai",
-        "database", "redis",
-        "browser", "browser_worker",
+        "slm_server",
+        "slm",
+        "slm_nodes",
+        "backend",
+        "main",
+        "frontend",
+        "npu",
+        "npu_workers",
+        "ai_stack",
+        "aiml",
+        "ai",
+        "database",
+        "redis",
+        "browser",
+        "browser_worker",
         "infrastructure",
-        "autobot", "autobot_cluster",
+        "autobot",
+        "autobot_cluster",
         "monitoring_vm",
         "llm_nodes",
         "production_vms",

--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -455,10 +455,9 @@ class PlaybookExecutor:
         Raises:
             ValueError: when validate_inventory detects missing required groups.
         """
+        from autobot_shared.network_utils import is_local_ip
         from models.database import Node
         from services.database import db_service
-
-        from autobot_shared.network_utils import is_local_ip
 
         async with db_service.session() as db:
             from sqlalchemy import select
@@ -527,8 +526,7 @@ class PlaybookExecutor:
                 effective_inventory = dynamic_inv_path
             except Exception as exc:
                 logger.warning(
-                    "execute_playbook: dynamic inventory failed (%s); "
-                    "falling back to static slm-nodes.yml",
+                    "execute_playbook: dynamic inventory failed (%s); " "falling back to static slm-nodes.yml",
                     exc,
                 )
                 effective_inventory = self.inventory_path

--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -18,6 +18,11 @@ from pathlib import Path
 from typing import Callable, Dict, List
 
 from services.ansible_secrets import fetch_deploy_secrets
+from services.inventory_builder import (
+    build_registry_inventory,
+    validate_inventory,
+    write_temp_inventory,
+)
 from services.provision_progress import TaskProgressTracker
 
 logger = logging.getLogger(__name__)
@@ -436,6 +441,41 @@ class PlaybookExecutor:
         await process.wait()
         return {"output": "\n".join(output_lines), "returncode": process.returncode}
 
+    async def _build_dynamic_inventory(self) -> Path:
+        """Generate an Ansible inventory from the DB node registry (#10109, #10095).
+
+        Queries all Node records, builds a YAML inventory where each host name
+        equals node_id (so --limit <node_id> always resolves), and writes it to
+        a uid-scoped temp file.  Nodes whose IP is local/loopback receive
+        ``ansible_connection: local`` so the SLM never SSH-loops to itself.
+
+        Returns:
+            Path to the written temp inventory file.
+
+        Raises:
+            ValueError: when validate_inventory detects missing required groups.
+        """
+        from models.database import Node
+        from services.database import db_service
+
+        from autobot_shared.network_utils import is_local_ip
+
+        async with db_service.session() as db:
+            from sqlalchemy import select
+
+            result = await db.execute(select(Node))
+            nodes = list(result.scalars().all())
+
+        inv = build_registry_inventory(nodes, is_local_ip)
+        validate_inventory(inv)
+        tmp_path = write_temp_inventory(inv, uid_tmp_dir=ANSIBLE_LOCAL_TMP)
+        logger.info(
+            "_build_dynamic_inventory: wrote inventory for %d node(s) to %s",
+            len(nodes),
+            tmp_path,
+        )
+        return tmp_path
+
     async def execute_playbook(
         self,
         playbook_name: str,
@@ -448,6 +488,12 @@ class PlaybookExecutor:
     ) -> Dict[str, any]:
         """
         Execute an Ansible playbook with optional progress updates (Issue #880).
+
+        When ``inventory_path`` is None (the normal path for all non-wizard
+        calls), a dynamic inventory is generated from the DB node registry
+        (#10109, #10095).  When ``inventory_path`` is provided explicitly
+        (wizard provisioning, Issue #1294), the caller's inventory is used
+        unchanged.
 
         Args:
             playbook_name: Name of playbook file (e.g., "update-all-nodes.yml")
@@ -464,12 +510,30 @@ class PlaybookExecutor:
         await self._update_code_source()
 
         playbook_path = self.ansible_dir / playbook_name
-        effective_inventory = inventory_path or self.inventory_path
-
         if not playbook_path.exists():
             raise FileNotFoundError(f"Playbook not found: {playbook_path}")
-        if not effective_inventory.exists():
-            raise FileNotFoundError(f"Inventory not found: {effective_inventory}")
+
+        # Determine which inventory to use.
+        # Explicit caller-supplied path (wizard) → use as-is.
+        # No path provided → generate from DB node registry (#10109, #10095).
+        dynamic_inv_path: Path | None = None
+        if inventory_path is not None:
+            effective_inventory = inventory_path
+            if not effective_inventory.exists():
+                raise FileNotFoundError(f"Inventory not found: {effective_inventory}")
+        else:
+            try:
+                dynamic_inv_path = await self._build_dynamic_inventory()
+                effective_inventory = dynamic_inv_path
+            except Exception as exc:
+                logger.warning(
+                    "execute_playbook: dynamic inventory failed (%s); "
+                    "falling back to static slm-nodes.yml",
+                    exc,
+                )
+                effective_inventory = self.inventory_path
+                if not effective_inventory.exists():
+                    raise FileNotFoundError(f"Inventory not found: {effective_inventory}") from exc
 
         # Merge stored SLM secrets into extra_vars so standalone re-deploys
         # receive the same secrets as the full wizard provisioning flow (#3519).
@@ -510,6 +574,13 @@ class PlaybookExecutor:
                 "output": f"Error: {str(e)}",
                 "returncode": -1,
             }
+        finally:
+            # Clean up the per-run temp inventory file
+            if dynamic_inv_path is not None:
+                try:
+                    dynamic_inv_path.unlink(missing_ok=True)
+                except OSError as exc:
+                    logger.debug("Could not remove temp inventory %s: %s", dynamic_inv_path, exc)
 
 
 # Singleton instance


### PR DESCRIPTION
## Thinking Path
On co-located + multi-node installs the web-UI "Update all" / node-sync fails: the orchestrator passes the DB `node_id` as ansible `--limit`, but the static `slm-nodes.yml` has no host by that name (#10109 → "no hosts to target"), and the self-node deploy SSHes to its own IP which is refused (#10095). Root cause: a static, legacy multi-VM inventory template disconnected from the live DB node registry. Approved approach: **hard cutover** to a DB-registry-driven inventory.

## What Changed
- **`services/inventory_builder.py` (new)** — `build_registry_inventory(nodes, settings)`:
  - inventory host name **== `node_id`** → `--limit <node_id>` always resolves (#10109)
  - `ansible_connection: local` when the node IP `is_local_ip()` (self/loopback) → no SSH-to-self (#10095)
  - role→group mapping emits **all alias groups** the playbooks reference (slm/slm_server/slm_nodes, backend/main, npu/npu_worker/npu_workers, ai_stack/aiml/ai/llm_nodes, redis/database, browser/browser_worker, infrastructure/production_vms, autobot/autobot_cluster) — no playbook normalization needed
  - reproduces the static inventory's global `all.vars`
  - `validate_inventory()` raises (fail-loud) if any required group key is missing — a hard cutover can't silently produce an inventory that targets zero hosts
- **`services/playbook_executor.py`** — builds + validates + writes a per-run temp inventory from the DB and uses it as `-i` (replaces static `slm-nodes.yml`). Wizard path (explicit `inventory_path`) unchanged. Safety net: on generation/validation/DB failure, logs a warning and falls back to the static file.

## Verification
- 30 new `inventory_builder` tests + 8 executor `ansible_utils` tests pass; `py_compile` clean.
- No regression (the pre-existing `test_code_sync_topology` collection error fails identically on base — unrelated missing-deps env issue).
- ⚠️ **CI does not run an ansible deploy** — full end-to-end proof requires a real deploy/reinstall.

## Model Used
Opus 4.8 (1M) — implemented via subagent, reviewed (host-name↔`--limit` alignment, role→group completeness, fallback safety, no app-wiring touched).

Fixes #10109, #10095; advances #10110 (PR-2 will parameterize remaining hardcoded NN-Name literals, #9956 tail). Part of #9919.