### PR TITLE
feat(kb): wire in the ChromaDB / vector-store explorer (#8999)

### DIFF
--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -212,6 +212,17 @@ export const routes: RouteRecordRaw[] = [
         }
       },
       {
+        // #8999: ChromaDB / vector-store explorer — browse collections,
+        // inspect documents, run similarity search (backend: api/knowledge_chroma.py)
+        path: 'vector-store',
+        name: 'knowledge-vector-store',
+        component: () => import('@/components/knowledge/ChromaDBExplorer.vue'),
+        meta: {
+          title: 'Vector Store',
+          parent: 'knowledge'
+        }
+      },
+      {
         path: 'connectors',
         name: 'knowledge-connectors',
         component: () => import('@/components/knowledge/connectors/ConnectorManager.vue'),

--- a/autobot-frontend/src/views/KnowledgeView.vue
+++ b/autobot-frontend/src/views/KnowledgeView.vue
@@ -86,6 +86,21 @@
           <span>MCP Resources</span>
         </router-link>
 
+        <!-- #8999: ChromaDB / vector-store explorer -->
+        <router-link
+          to="/knowledge/vector-store"
+          class="category-item"
+          :class="{ active: $route.name === 'knowledge-vector-store' }"
+          aria-label="Browse the vector store"
+        >
+          <svg class="item-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75">
+            </path>
+          </svg>
+          <span>Vector Store</span>
+        </router-link>
+
         <router-link
           to="/knowledge/categories"
           class="category-item"


### PR DESCRIPTION
## Thinking Path
`ChromaDBExplorer.vue` is a complete 1,146-line vector-store explorer (lists collections, inspects documents, runs similarity search via `useApiClient`) — but it was **referenced nowhere**: no route, no nav, no importer. Its backend already exists and is registered (`api/knowledge_chroma.py`, MVA-2046, in `core_routers.py`), and all 3 endpoints it calls match exactly:
- `GET /api/knowledge/chroma/collections`
- `GET /api/knowledge/chroma/collections/{name}/documents`
- `POST /api/knowledge/chroma/collections/{name}/search`

So this was a fully-built feature users couldn't reach — an "unwired, not orphan → wire it in" gap (same class as #9984). No PRD needed: nothing new is built, only the wiring.

## What Changed
- `router/index.ts`: added child route `/knowledge/vector-store` → `ChromaDBExplorer.vue` (parent: knowledge), beside the other knowledge sub-views.
- `views/KnowledgeView.vue`: added a "Vector Store" entry to the knowledge sub-nav (database/circle-stack icon), matching the existing pattern.

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json` → **0 errors**.
- `check:i18n` → all keys found; `nav-items-coverage` → 12 passed.
- Backend endpoints confirmed present + registered (paths match the component's calls exactly).

## Model Used
Opus 4.8

Fixes #8999
