### PR TITLE
consolidation: promote AIStackClient.connection_status to ConnectionStatus enum (#10008)

### DIFF
--- a/.session/HANDOFF-issue-10008.md
+++ b/.session/HANDOFF-issue-10008.md
@@ -1,0 +1,28 @@
+# Handoff: issue-10008
+status: complete
+pr: DEFERRED — open PR queue at 6 (project limit 5); branch ready + mergeable
+base_at_push: origin/Dev_new_gui (rebased clean; three-dot diff = 6 files only)
+gates: tests=PASS (ai_stack_client_gate_test 4/4) flake8=0 byte-compile=PASS
+needs_rebase_before_merge: no (rebased onto latest at push; re-check if base moves)
+remaining:
+  - Open the PR once open-PR count < 5:
+    gh pr create --base Dev_new_gui --head issue-10008 \
+      --title "consolidation: promote AIStackClient.connection_status to ConnectionStatus enum (#10008)"
+  - PR body headings required: Thinking Path · What Changed · Verification · Model Used
+blocked_on: PR-queue limit only (no technical blocker)
+worktree: .worktrees/issue-10008  (safe to remove after merge)
+
+## What landed on the branch
+- autobot_shared/status_enums.py — new `ConnectionStatus(str, Enum)` {UNKNOWN, CONNECTED, ERROR, DISABLED} + __all__
+- autobot-backend/constants/status_enums.py — re-export shim updated (canonical import path)
+- autobot-backend/services/ai_stack_client.py — connection_status typed + all 6 assignments/compares use enum
+- autobot-backend/initialization/endpoints.py — _ai_stack_status reads via enum (str-subclass back-compat kept)
+- autobot-backend/initialization/ai_stack_init.py — 3 sibling status writes routed through ConnectionStatus.value
+- autobot-backend/services/ai_stack_client_gate_test.py — asserts enum identity + str back-compat
+
+## Scope notes
+- `(str, Enum)` chosen over `enum.StrEnum`: local/CI Python is 3.10 (StrEnum is 3.11+);
+  matches the existing `AgentLifecycleStatus(str, Enum)` precedent in the same file;
+  preserves all `== "connected"` comparisons and JSON serialization.
+- Deliberately NOT touched (distinct vocabularies — avoid wrong abstraction):
+  `ai_stack_agents` ready/partial, and health_check()'s "status" payload (healthy/unhealthy/disabled).

--- a/autobot-backend/constants/status_enums.py
+++ b/autobot-backend/constants/status_enums.py
@@ -17,6 +17,7 @@ New code should import directly from ``autobot_shared.status_enums``.
 from autobot_shared.status_enums import (
     AgentLifecycleStatus,
     AgentStatus,
+    ConnectionStatus,
     HealthStatus,
     LLMProvider,
     OperationOutcome,
@@ -29,6 +30,7 @@ from autobot_shared.status_enums import (
 __all__ = [
     "AgentLifecycleStatus",
     "AgentStatus",
+    "ConnectionStatus",
     "HealthStatus",
     "LLMProvider",
     "OperationOutcome",

--- a/autobot-backend/initialization/ai_stack_init.py
+++ b/autobot-backend/initialization/ai_stack_init.py
@@ -12,6 +12,7 @@ for the AutoBot backend.
 from fastapi import FastAPI
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import ConnectionStatus
 from services.ai_stack_client import get_ai_stack_client
 
 logger = get_logger(__name__, "backend")
@@ -51,10 +52,10 @@ async def initialize_ai_stack(app: FastAPI, update_status_fn, append_error_fn) -
         app.state.ai_stack_client = ai_client
 
         if health_status["status"] == "disabled":
-            await update_status_fn("ai_stack", "disabled")
+            await update_status_fn("ai_stack", ConnectionStatus.DISABLED.value)
             log_initialization_step("AI Stack", "AI Stack disabled — skipping (single_user/compose)", 100, True)
         elif health_status["status"] == "healthy":
-            await update_status_fn("ai_stack", "connected")
+            await update_status_fn("ai_stack", ConnectionStatus.CONNECTED.value)
             log_initialization_step("AI Stack", "AI Stack connection established", 50, True)
 
             # Test agent availability
@@ -80,13 +81,13 @@ async def initialize_ai_stack(app: FastAPI, update_status_fn, append_error_fn) -
                 "AI Stack API unreachable at %s — agent routing disabled",
                 ai_client.base_url,
             )
-            await update_status_fn("ai_stack", "error")
+            await update_status_fn("ai_stack", ConnectionStatus.ERROR.value)
             await append_error_fn("AI Stack health check failed")
             ai_client.start_retry_loop()
             log_initialization_step("AI Stack", "AI Stack unreachable — retry enabled", 100, False)
 
     except Exception as e:
         logger.warning("AI Stack API unreachable — agent routing disabled: %s", e)
-        await update_status_fn("ai_stack", "error")
+        await update_status_fn("ai_stack", ConnectionStatus.ERROR.value)
         await append_error_fn(f"AI Stack init: {str(e)}")
         log_initialization_step("AI Stack", f"Initialization failed: {str(e)}", 100, False)

--- a/autobot-backend/initialization/endpoints.py
+++ b/autobot-backend/initialization/endpoints.py
@@ -16,6 +16,7 @@ from fastapi import FastAPI, Request
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import ConnectionStatus
 from circuit_breaker import get_circuit_breaker_manager
 
 logger = get_logger(__name__)
@@ -40,12 +41,12 @@ def _ai_stack_status(state: Any) -> str:
     client = getattr(state, "ai_stack_client", None)
     if not client:
         return "unavailable"
-    status = getattr(client, "connection_status", "unknown")
-    if status == "connected":
-        return "connected"
-    if status == "error":
-        return "error"
-    return "unknown"
+    status = getattr(client, "connection_status", ConnectionStatus.UNKNOWN)
+    if status == ConnectionStatus.CONNECTED:
+        return ConnectionStatus.CONNECTED.value
+    if status == ConnectionStatus.ERROR:
+        return ConnectionStatus.ERROR.value
+    return ConnectionStatus.UNKNOWN.value
 
 
 def _build_services_status(state: Any) -> Dict[str, str]:

--- a/autobot-backend/services/ai_stack_client.py
+++ b/autobot-backend/services/ai_stack_client.py
@@ -21,6 +21,7 @@ import aiohttp
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
+from autobot_shared.status_enums import ConnectionStatus
 from autobot_shared.time_utils import utc_timestamp
 from constants.network_constants import NetworkConstants
 from type_defs.common import Metadata
@@ -138,8 +139,8 @@ class AIStackClient:
         to a "disabled" status with no network attempts — stopping the per-boot
         warning flood (#9782).
         """
-        # Connection status: "unknown" -> "connected" | "error" | "disabled"
-        self.connection_status: str = "unknown"
+        # Connection status: UNKNOWN -> CONNECTED | ERROR | DISABLED (#10008)
+        self.connection_status: ConnectionStatus = ConnectionStatus.UNKNOWN
         self._retry_task: asyncio.Task | None = None
         self.enabled: bool = config.ai_stack_enabled if enabled is None else enabled
 
@@ -203,7 +204,7 @@ class AIStackClient:
         """Initialize HTTP session and verify AI Stack reachability."""
         if not self.enabled:
             logger.info("AI Stack disabled (AUTOBOT_AI_STACK_ENABLED=false) — skipping connection")
-            self.connection_status = "disabled"
+            self.connection_status = ConnectionStatus.DISABLED
             return
         logger.info("AI Stack client connecting to %s", self.base_url)
         check = await self.health_check()
@@ -349,7 +350,7 @@ class AIStackClient:
         """Check AI Stack health — uses Ollama as backing service when configured (#6228)."""
         if not self.enabled:
             # Gated off (#9782): no network attempt, no warning flood.
-            self.connection_status = "disabled"
+            self.connection_status = ConnectionStatus.DISABLED
             return {
                 "status": "disabled",
                 "backend": "none",
@@ -365,9 +366,9 @@ class AIStackClient:
                         if resp.status == 200:
                             data = await resp.json()
                             models = [m["name"] for m in data.get("models", [])]
-                            if self.connection_status != "connected":
+                            if self.connection_status != ConnectionStatus.CONNECTED:
                                 logger.info("Ollama backing connected at %s", self._ollama_url)
-                            self.connection_status = "connected"
+                            self.connection_status = ConnectionStatus.CONNECTED
                             return {
                                 "status": "healthy",
                                 "models": models,
@@ -383,9 +384,9 @@ class AIStackClient:
             # AI Stack exposes /health (#6649) — /api/v2 is the ChromaDB heartbeat
             # path and was wrongly applied here, producing a 404 every poll.
             response = await self._make_request("GET", "/health")
-            if self.connection_status != "connected":
+            if self.connection_status != ConnectionStatus.CONNECTED:
                 logger.info("AI Stack connection restored at %s", self.base_url)
-            self.connection_status = "connected"
+            self.connection_status = ConnectionStatus.CONNECTED
             return {
                 "status": "healthy",
                 "ai_stack_response": response,
@@ -393,8 +394,8 @@ class AIStackClient:
             }
         except AIStackError as e:
             prev = self.connection_status
-            self.connection_status = "error"
-            if prev != "error":
+            self.connection_status = ConnectionStatus.ERROR
+            if prev != ConnectionStatus.ERROR:
                 logger.warning(
                     "AI Stack unreachable at %s: %s — starting retry loop",
                     self.base_url,

--- a/autobot-backend/services/ai_stack_client_gate_test.py
+++ b/autobot-backend/services/ai_stack_client_gate_test.py
@@ -11,6 +11,7 @@ single_user deployments that ship no AI Stack VM).
 
 import pytest
 
+from autobot_shared.status_enums import ConnectionStatus
 from services.ai_stack_client import AIStackClient
 
 
@@ -26,14 +27,15 @@ async def test_health_check_disabled_returns_disabled_without_network(monkeypatc
 
     result = await client.health_check()
     assert result["status"] == "disabled"
-    assert client.connection_status == "disabled"
+    assert client.connection_status is ConnectionStatus.DISABLED
+    assert client.connection_status == "disabled"  # str-subclass back-compat
 
 
 @pytest.mark.asyncio
 async def test_connect_disabled_is_quiet_noop():
     client = AIStackClient(enabled=False)
     await client.connect()  # must not raise / must not hit the network
-    assert client.connection_status == "disabled"
+    assert client.connection_status is ConnectionStatus.DISABLED
 
 
 def test_start_retry_loop_noop_when_disabled():

--- a/autobot_shared/status_enums.py
+++ b/autobot_shared/status_enums.py
@@ -268,6 +268,23 @@ class AgentLifecycleStatus(str, Enum):
     ARCHIVED = "archived"
 
 
+class ConnectionStatus(str, Enum):
+    """
+    Client-side reachability state of an external service connection (#10008).
+
+    Canonical states for AIStackClient.connection_status and sibling client
+    status fields. str-subclass so existing ``== "connected"`` comparisons and
+    JSON serialization keep working while the states become type-checked and
+    greppable. Replaces the bare literals "unknown"/"connected"/"error"/
+    "disabled" that drifted when #9782 added the 4th value.
+    """
+
+    UNKNOWN = "unknown"
+    CONNECTED = "connected"
+    ERROR = "error"
+    DISABLED = "disabled"
+
+
 # Task priority — canonical alias for Priority covering agent/task scheduling.
 # Replaces local TaskPriority classes in services/agents/subagent_task.py,
 # utils/task_queue.py, and orchestrator.py (#7504).
@@ -286,4 +303,5 @@ __all__ = [
     "HealthStatus",
     "AgentStatus",
     "AgentLifecycleStatus",
+    "ConnectionStatus",
 ]


### PR DESCRIPTION
## Thinking Path
Umbrella #9921 triage-delta item. `AIStackClient.connection_status` was a stringly-typed field cycling through `"unknown"`/`"connected"`/`"error"`/`"disabled"` — #9782 added the 4th literal with no single source of truth, which is exactly how these drift. A small canonical enum makes the states type-checked and greppable. Followed canonical-coding: the shared status-enum home already exists (`autobot_shared/status_enums.py`), so I extended it rather than inventing a local enum.

## What Changed
- **New `ConnectionStatus(str, Enum)`** {UNKNOWN, CONNECTED, ERROR, DISABLED} in `autobot_shared/status_enums.py` (+ `__all__`), re-exported through the `constants/status_enums.py` shim.
- `AIStackClient.connection_status` typed to the enum; all 6 assignment/comparison sites converted.
- **Sibling drift closed** (the "+siblings" the issue calls out): the reader `endpoints._ai_stack_status` and the writer `ai_stack_init.initialize_ai_stack` used the same bare literals — both now source the vocabulary from `ConnectionStatus`.
- Gate test asserts enum identity **and** str back-compat.

**`(str, Enum)` not `enum.StrEnum`:** local/CI Python is 3.10 (StrEnum is 3.11+); matches the existing `AgentLifecycleStatus(str, Enum)` precedent in the same module; keeps every `== "connected"` comparison and JSON output byte-identical.

**Deliberately untouched** (distinct vocabularies — avoiding a wrong abstraction): `ai_stack_agents` ready/partial and `health_check()`'s `status` payload (healthy/unhealthy/disabled).

## Verification
- `pytest services/ai_stack_client_gate_test.py` → **4/4 pass**
- `flake8 --max-line-length=120` on all changed files → **0**
- byte-compile of all changed modules → clean
- `_ai_stack_status` mapping verified directly: CONNECTED→"connected", ERROR→"error", UNKNOWN/DISABLED→"unknown" (prior behavior preserved), raw-string input still works.

Closes #10008.

## Model Used
claude-opus-4-8