### PR TITLE
fix(llc): SKIPPED heartbeat status + drain adapter stderr to sidecar (#9951, #9992)

### DIFF
--- a/autobot-backend/llc/adapters/claude_code_adapter.py
+++ b/autobot-backend/llc/adapters/claude_code_adapter.py
@@ -84,6 +84,11 @@ def _state_path(output_dir: str, run_id: str) -> str:
     return os.path.join(output_dir, f"llc_state_{safe_run}.json")
 
 
+def _stderr_path(output_file: str) -> str:
+    """Sidecar stderr capture next to the stdout .jsonl (GH#9992)."""
+    return f"{output_file}.stderr.log"
+
+
 def _resolve_claude_cli() -> str:
     path = shutil.which("claude")
     if path is None:
@@ -152,13 +157,19 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
         # GH#9623/GH#9789: forward the run-scoped LLC bearer token + API base.
         inject_agent_credentials(env, context)
 
+        # GH#9992: redirect stderr to a sidecar file instead of an unread PIPE.
+        # The run is detached (we return run_id immediately), so an unread PIPE
+        # makes CLI errors invisible AND risks a >64KB-buffer deadlock that hangs
+        # the child. A file fd drains to disk and is scanned in _status().
+        stderr_file = _stderr_path(output_file)
         out_fh = open(output_file, "w", encoding="utf-8")
+        err_fh = open(stderr_file, "w", encoding="utf-8")
         try:
             try:
                 proc = await asyncio.create_subprocess_exec(
                     *cmd,
                     stdout=out_fh,
-                    stderr=asyncio.subprocess.PIPE,
+                    stderr=err_fh,
                     env=env,
                     cwd=workspace_dir or None,
                 )
@@ -173,11 +184,12 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
                 proc = await asyncio.create_subprocess_exec(
                     *cmd,
                     stdout=out_fh,
-                    stderr=asyncio.subprocess.PIPE,
+                    stderr=err_fh,
                     env=env,
                 )
         finally:
             out_fh.close()
+            err_fh.close()
 
         run_id = f"{proc.pid}/{session_id}"
         logger.info(
@@ -193,6 +205,7 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
             "session_id": session_id,
             "agent_id": agent_id,
             "output_file": output_file,
+            "stderr_file": stderr_file,  # GH#9992
             "started_at": time.time(),
             "timeout_seconds": timeout_sec,
         }
@@ -251,15 +264,28 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
             return base
 
         # Either no result event (mid-stream kill) or an error/non-success result:
-        # scan the tail for rate-limit markers.
-        if is_rate_limit_output(tail):
+        # scan the stdout tail AND the stderr sidecar for rate-limit markers —
+        # some CLI rate-limit errors only reach stderr, never the stream-json
+        # stdout file (GH#9992).
+        stderr_file: Optional[str] = state.get("stderr_file") if state else None
+        stderr_tail = read_output_tail(stderr_file) if stderr_file else ""
+        if is_rate_limit_output(tail) or is_rate_limit_output(stderr_tail):
             logger.warning(
-                "ClaudeCodeAdapter: rate-limit markers in output for run %s — signalling RATE_LIMITED",
+                "ClaudeCodeAdapter: rate-limit markers in output/stderr for run %s — signalling RATE_LIMITED",
                 run_id,
             )
             return AdapterRunStatus(
                 status=LLCRunStatus.RATE_LIMITED,
                 error="provider rate-limited (detected in CLI output)",
+            )
+
+        # Surface non-rate-limit stderr so a failed/killed run is diagnosable
+        # instead of silent (the PIPE was previously never drained).
+        if stderr_tail.strip():
+            logger.warning(
+                "ClaudeCodeAdapter: run %s stderr tail: %s",
+                run_id,
+                stderr_tail.strip()[-1000:],
             )
 
         return base

--- a/autobot-backend/llc/adapters/copilot_local_adapter.py
+++ b/autobot-backend/llc/adapters/copilot_local_adapter.py
@@ -107,13 +107,17 @@ class CopilotLocalAdapter(SubprocessLifecycleAdapter):
         # GH#9623/GH#9789: forward the run-scoped LLC bearer token + API base.
         inject_agent_credentials(env, context)
 
+        # GH#9992: capture stderr to a sidecar file instead of discarding it to
+        # DEVNULL, so CLI errors on a failed/killed run are diagnosable.
+        stderr_file = f"{output_file}.stderr.log"
         out_fh = open(output_file, "w", encoding="utf-8")
+        err_fh = open(stderr_file, "w", encoding="utf-8")
         try:
             try:
                 proc = await asyncio.create_subprocess_exec(
                     *cmd,
                     stdout=out_fh,
-                    stderr=asyncio.subprocess.DEVNULL,
+                    stderr=err_fh,
                     env=env,
                     cwd=workspace_dir or None,
                 )
@@ -129,11 +133,12 @@ class CopilotLocalAdapter(SubprocessLifecycleAdapter):
                 proc = await asyncio.create_subprocess_exec(
                     *cmd,
                     stdout=out_fh,
-                    stderr=asyncio.subprocess.DEVNULL,
+                    stderr=err_fh,
                     env=env,
                 )
         finally:
             out_fh.close()
+            err_fh.close()
 
         run_id = f"{proc.pid}/{session_id}"
         logger.info(
@@ -146,6 +151,7 @@ class CopilotLocalAdapter(SubprocessLifecycleAdapter):
 
         state = {
             "pid": proc.pid,
+            "stderr_file": stderr_file,  # GH#9992
             "session_id": session_id,
             "agent_id": agent_id,
             "output_file": output_file,

--- a/autobot-backend/llc/adapters/tests/test_claude_code_adapter.py
+++ b/autobot-backend/llc/adapters/tests/test_claude_code_adapter.py
@@ -11,6 +11,7 @@ env injection, allowed-tools flag, Redis session resume, FD management, and
 workspace-dir retry logic.
 """
 
+import asyncio
 import json
 import os
 import tempfile
@@ -186,6 +187,39 @@ class TestInvoke:
             assert state["pid"] == 77
             assert "session_id" in state
 
+    async def test_invoke_redirects_stderr_to_sidecar(self) -> None:
+        """GH#9992: stderr must go to a sidecar file, never an unread PIPE
+        (which hides CLI errors and risks a >64KB-buffer deadlock)."""
+        adapter = ClaudeCodeAdapter()
+        fake_proc = _make_fake_proc(55)
+        captured: dict = {}
+
+        async def _fake_exec(*args, **kwargs):
+            captured.update(kwargs)
+            return fake_proc
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg = _agent_cfg(output_dir=td)
+            with (
+                patch("llc.adapters.claude_code_adapter.shutil.which", return_value="/usr/bin/claude"),
+                patch(
+                    "llc.adapters.claude_code_adapter.get_async_redis_client",
+                    new_callable=AsyncMock,
+                    return_value=None,
+                ),
+                patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+            ):
+                run_id = await adapter.invoke(cfg, {"task_id": "tX"})
+
+            # stderr is a writable file fd, not the unread PIPE.
+            assert captured["stderr"] is not asyncio.subprocess.PIPE
+            assert hasattr(captured["stderr"], "write")
+            # The sidecar path is recorded in state and exists on disk.
+            with open(_state_path(td, run_id)) as fh:
+                state = json.load(fh)
+            assert state["stderr_file"].endswith(".stderr.log")
+            assert os.path.exists(state["stderr_file"])
+
     async def test_invoke_resumes_when_session_exists(self) -> None:
         adapter = ClaudeCodeAdapter()
         fake_proc = _make_fake_proc(55)
@@ -315,7 +349,8 @@ class TestInvoke:
                 with pytest.raises(OSError):
                     await adapter.invoke(cfg, {})
 
-        fake_fh.close.assert_called_once()
+        # GH#9992: both the stdout and the stderr-sidecar handles are closed.
+        assert fake_fh.close.call_count == 2
 
     async def test_fd_closed_on_success(self) -> None:
         """out_fh must be closed even on the happy path."""
@@ -335,7 +370,8 @@ class TestInvoke:
             ):
                 await adapter.invoke(cfg, {})
 
-        fake_fh.close.assert_called_once()
+        # GH#9992: both the stdout and the stderr-sidecar handles are closed.
+        assert fake_fh.close.call_count == 2
 
     async def test_workspace_dir_missing_retries_without_cwd(self) -> None:
         """If workspace_dir is deleted, adapter retries without cwd and clears it from context."""
@@ -371,7 +407,8 @@ class TestInvoke:
         assert call_count == 2
         assert "workspace_dir" not in context
         assert run_id.startswith("77/")
-        fake_fh.close.assert_called_once()
+        # GH#9992: both the stdout and the stderr-sidecar handles are closed.
+        assert fake_fh.close.call_count == 2
         assert "AUTOBOT_WORKSPACE_DIR" in captured_envs[0]
         assert "AUTOBOT_WORKSPACE_DIR" not in captured_envs[1]
         retry_ctx = json.loads(captured_envs[1]["LLC_INVOKE_CONTEXT"])

--- a/autobot-backend/llc/adapters/tests/test_copilot_local_adapter.py
+++ b/autobot-backend/llc/adapters/tests/test_copilot_local_adapter.py
@@ -243,7 +243,8 @@ class TestInvoke:
                 with pytest.raises(OSError):
                     await adapter.invoke(cfg, {})
 
-        fake_fh.close.assert_called_once()
+        # GH#9992: both the stdout and the stderr-sidecar handles are closed.
+        assert fake_fh.close.call_count == 2
 
     async def test_fd_closed_on_success(self) -> None:
         adapter = CopilotLocalAdapter()
@@ -259,7 +260,8 @@ class TestInvoke:
             ):
                 await adapter.invoke(cfg, {})
 
-        fake_fh.close.assert_called_once()
+        # GH#9992: both the stdout and the stderr-sidecar handles are closed.
+        assert fake_fh.close.call_count == 2
 
     async def test_workspace_dir_missing_retries_without_cwd(self) -> None:
         adapter = CopilotLocalAdapter()
@@ -291,7 +293,8 @@ class TestInvoke:
         assert run_id.startswith("77/")
         assert captured_kwargs[0].get("cwd") == "/deleted/worktree"
         assert captured_kwargs[1].get("cwd") is None
-        fake_fh.close.assert_called_once()
+        # GH#9992: both the stdout and the stderr-sidecar handles are closed.
+        assert fake_fh.close.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/llc/exceptions.py
+++ b/autobot-backend/llc/exceptions.py
@@ -47,6 +47,22 @@ class AdapterRunFailed(Exception):
         super().__init__(f"{adapter_type or 'adapter'} run {run_id} ended in state {status_val!r}")
 
 
+class HeartbeatDispatchSkipped(Exception):
+    """Raised when a heartbeat is not actually dispatched to any adapter (GH#9951).
+
+    Covers the degraded-but-not-failed paths — no adapter registered for the
+    agent's type, the required CLI binary is absent from PATH, or no agent_class
+    is configured. The scheduler records the run as ``skipped`` (not COMPLETED)
+    and does NOT advance ``last_heartbeat_at``, so a non-dispatched agent shows
+    as degraded in monitoring instead of phantom-healthy.
+    """
+
+    def __init__(self, agent_id: str, reason: str) -> None:
+        self.agent_id = agent_id
+        self.reason = reason
+        super().__init__(f"agent {agent_id}: heartbeat dispatch skipped — {reason}")
+
+
 class ProviderRateLimited(Exception):
     """Raised by an adapter when the LLM provider rejects a request due to rate or quota limits.
 

--- a/autobot-backend/llc/models/enums.py
+++ b/autobot-backend/llc/models/enums.py
@@ -152,6 +152,9 @@ class LLCRunStatus(str, Enum):
     TIMEOUT = "timeout"
     CANCELLED = "cancelled"
     RATE_LIMITED = "rate_limited"
+    # GH#9951: heartbeat was not dispatched to any adapter (no adapter / CLI
+    # absent / no agent_class) — degraded, distinct from COMPLETED or FAILED.
+    SKIPPED = "skipped"
 
     def is_terminal(self) -> bool:
         """True once the run has reached a final state (not queued/running).

--- a/autobot-backend/llc/scheduler/heartbeat_scheduler.py
+++ b/autobot-backend/llc/scheduler/heartbeat_scheduler.py
@@ -49,7 +49,7 @@ from user_management.database import get_async_session_factory
 from ..adapters import AutoBotAgentAdapter, get_adapter
 from ..adapters.subprocess_base import is_subprocess_adapter
 from ..config import AGENT_API_BASE_URL
-from ..exceptions import AdapterRunFailed, ProviderRateLimited
+from ..exceptions import AdapterRunFailed, HeartbeatDispatchSkipped, ProviderRateLimited
 from ..models.enums import HeartbeatInvocationSource, LLCRunStatus
 from ..models.heartbeat_run import LLCHeartbeatRun
 from ..services.api_key import ApiKeyService
@@ -491,6 +491,11 @@ class HeartbeatScheduler:
             external_run_id = await _dispatch_adapter(agent, context)
         except ProviderRateLimited as exc:
             rate_limited_exc = exc
+        except HeartbeatDispatchSkipped as exc:
+            # GH#9951: not dispatched → record SKIPPED, do NOT bump last_heartbeat_at.
+            logger.info("Heartbeat skipped for run %s: %s", run_id, exc.reason)
+            final_status = LLCRunStatus.SKIPPED.value
+            error_msg = exc.reason
         except Exception as exc:
             logger.exception("Adapter error for run %s", run_id)
             error_msg = str(exc)
@@ -522,12 +527,14 @@ class HeartbeatScheduler:
 
         # GH#9034: fire-and-forget replay recording — must never affect run status.
         # Pass external_run_id so the recording locates the exact output file (H1).
-        _record_task = asyncio.create_task(
-            _record_run_for_replay(agent, run_id, context, final_status, external_run_id=external_run_id),
-            name=f"replay-record-{run_id}",
-        )
-        self._tasks.add(_record_task)
-        _record_task.add_done_callback(self._tasks.discard)
+        # GH#9951: a SKIPPED run never dispatched, so there is nothing to record.
+        if final_status != LLCRunStatus.SKIPPED.value:
+            _record_task = asyncio.create_task(
+                _record_run_for_replay(agent, run_id, context, final_status, external_run_id=external_run_id),
+                name=f"replay-record-{run_id}",
+            )
+            self._tasks.add(_record_task)
+            _record_task.add_done_callback(self._tasks.discard)
 
     async def _handle_rate_limited(
         self,
@@ -746,23 +753,20 @@ async def _dispatch_adapter(agent: Dict[str, Any], context: Dict[str, Any]) -> O
     try:
         adapter = get_adapter(adapter_type)
     except KeyError:
-        logger.warning(
-            "agent %s: no LLC adapter registered for type %r — skipping dispatch",
-            agent["agent_id"],
-            adapter_type,
-        )
-        return None
+        # GH#9951: signal a skip (not a phantom COMPLETED) so the run is
+        # recorded as SKIPPED and last_heartbeat_at is not advanced.
+        raise HeartbeatDispatchSkipped(
+            agent["agent_id"], f"no LLC adapter registered for type {adapter_type!r}"
+        ) from None
 
     # GH#9793: skip dispatch when the required CLI binary is absent from PATH.
-    # Converts every-heartbeat FAILED runs into a clean degraded state.
+    # Converts every-heartbeat FAILED runs into a clean degraded state (GH#9951).
     if is_subprocess_adapter(adapter) and not adapter.is_cli_available():  # type: ignore[union-attr]
-        logger.info(
-            "agent %s: adapter %r requires CLI %r which is not on PATH — skipping dispatch",
+        raise HeartbeatDispatchSkipped(
             agent["agent_id"],
-            adapter_type,
-            adapter._required_cli,  # type: ignore[union-attr]
+            f"adapter {adapter_type!r} requires CLI "
+            f"{adapter._required_cli!r} which is not on PATH",  # type: ignore[union-attr]
         )
-        return None
 
     return await _dispatch_registry_adapter(adapter, agent, context)
 
@@ -771,12 +775,11 @@ async def _dispatch_autobot_agent(agent: Dict[str, Any], context: Dict[str, Any]
     """Dispatch an in-process AutoBot agent via :class:`AutoBotAgentAdapter`."""
     adapter_config = agent.get("adapter_config") or {}
     if not adapter_config.get("agent_class"):
-        # No agent_class configured — log and return (graceful degradation).
-        logger.warning(
-            "agent %s has no adapter_config.agent_class — skipping dispatch (configure agent_class to enable)",
+        # No agent_class configured — degraded skip, not a phantom success (GH#9951).
+        raise HeartbeatDispatchSkipped(
             agent["agent_id"],
+            "no adapter_config.agent_class configured",
         )
-        return
 
     # GH#8502: use run_blocking() so ProviderRateLimited propagates to _run_adapter
     # and triggers exponential-backoff recovery.  _run_adapter is already a

--- a/autobot-backend/llc/tests/test_heartbeat_scheduler.py
+++ b/autobot-backend/llc/tests/test_heartbeat_scheduler.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from llc.adapters.base import AdapterRunStatus
-from llc.exceptions import AdapterRunFailed
+from llc.exceptions import AdapterRunFailed, HeartbeatDispatchSkipped
 from llc.models.enums import LLCRunStatus
 from llc.models.heartbeat_run import LLCHeartbeatRun
 from llc.scheduler.heartbeat_scheduler import (
@@ -325,10 +325,13 @@ class TestDispatchAdapterRouting:
         mock_reg.assert_awaited_once()
 
     async def test_unknown_adapter_type_skipped(self):
+        # GH#9951: an unregistered adapter type is a degraded SKIP, signalled by
+        # HeartbeatDispatchSkipped (not a silent return → phantom COMPLETED).
         agent = _make_agent(adapter_type="does-not-exist")
         with (
             patch(f"{_HBS}.get_adapter", side_effect=KeyError("nope")),
             patch(f"{_HBS}._dispatch_registry_adapter", new=AsyncMock()) as mock_reg,
+            pytest.raises(HeartbeatDispatchSkipped),
         ):
             await _dispatch_adapter(agent, {})
         mock_reg.assert_not_awaited()
@@ -484,8 +487,11 @@ class TestRegistryAdapterTerminalStatus:
 class TestDispatchAutobotAgent:
     async def test_skips_when_no_agent_class(self):
         agent = _make_agent(adapter_type="autobot_agent", adapter_config={})
-        # No agent_class → graceful skip, no adapter instantiated.
-        with patch(f"{_HBS}.AutoBotAgentAdapter") as mock_cls:
+        # No agent_class → degraded SKIP (GH#9951), no adapter instantiated.
+        with (
+            patch(f"{_HBS}.AutoBotAgentAdapter") as mock_cls,
+            pytest.raises(HeartbeatDispatchSkipped),
+        ):
             await _dispatch_autobot_agent(agent, {})
         mock_cls.assert_not_called()
 
@@ -509,7 +515,8 @@ class TestCliAvailabilityGate:
 
     async def test_skips_dispatch_when_cli_absent(self):
         """When is_cli_available() returns False, _dispatch_registry_adapter is
-        never called and the function returns cleanly (no raise, no run recorded).
+        never called and HeartbeatDispatchSkipped is raised so the run is
+        recorded as SKIPPED rather than phantom-COMPLETED (GH#9793, GH#9951).
         """
         agent = _make_agent(adapter_type="claude_code")
         fake_adapter = MagicMock()
@@ -520,6 +527,7 @@ class TestCliAvailabilityGate:
             patch(f"{_HBS}.get_adapter", return_value=fake_adapter),
             patch(f"{_HBS}.is_subprocess_adapter", return_value=True),
             patch(f"{_HBS}._dispatch_registry_adapter", new=AsyncMock()) as mock_reg,
+            pytest.raises(HeartbeatDispatchSkipped),
         ):
             await _dispatch_adapter(agent, {})
 
@@ -566,8 +574,58 @@ class TestCliAvailabilityGate:
             patch(f"{_HBS}.get_adapter", return_value=fake_adapter),
             patch(f"{_HBS}.is_subprocess_adapter", return_value=True),
             patch(f"{_HBS}._dispatch_registry_adapter", new=AsyncMock()) as mock_reg,
+            pytest.raises(HeartbeatDispatchSkipped),
         ):
             await _dispatch_adapter(agent, {})
+
+        mock_reg.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+class TestRunAdapterSkipped:
+    """GH#9951: a skipped dispatch records SKIPPED and never bumps last_heartbeat_at."""
+
+    async def test_skip_records_skipped_and_no_heartbeat_bump(self):
+        scheduler = HeartbeatScheduler()
+        agent = _make_agent(adapter_type="claude_code")
+        run_id = uuid.uuid4()
+
+        sql_text: list = []
+        params: list = []
+
+        class _Session:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def execute(self, stmt, *args, **kwargs):
+                sql_text.append(str(stmt))
+                try:
+                    params.append(dict(stmt.compile().params))
+                except Exception:
+                    params.append({})
+                result = MagicMock()
+                result.scalar_one_or_none.return_value = 0
+                return result
+
+            async def commit(self):
+                return None
+
+        with (
+            patch(f"{_HBS}.get_async_session_factory", return_value=lambda: _Session()),
+            patch(
+                f"{_HBS}._dispatch_adapter",
+                new=AsyncMock(side_effect=HeartbeatDispatchSkipped("agent-1", "CLI absent")),
+            ),
+        ):
+            await scheduler._run_adapter(agent, run_id, {})
+
+        # No phantom health: the last_heartbeat_at bump is never issued.
+        assert not any("agent_org_nodes" in s for s in sql_text)
+        # The run's final status is written as SKIPPED.
+        assert any(p.get("status") == LLCRunStatus.SKIPPED.value for p in params)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path
Two LLC runtime/adapter bugs from umbrella #9923's triage-delta — both make a degraded run look healthy. Batched since they're the same theme (heartbeat/adapter observability) and touch adjacent code.

## What Changed

### #9951 — phantom-healthy heartbeats
The three non-dispatch paths in `_dispatch_adapter` — no adapter registered for the type, required CLI absent from PATH (#9793), no `agent_class` configured — all `return None`, which is indistinguishable from a real in-process `autobot_agent` dispatch. So `_run_adapter` marked the run **COMPLETED** and bumped `agent_org_nodes.last_heartbeat_at` → a CLI-less / adapter-less agent showed **healthy** in monitoring.
- New `LLCRunStatus.SKIPPED` (terminal; status column is `String(32)` so **no migration** — same as RATE_LIMITED) + `HeartbeatDispatchSkipped` exception raised from all three skip paths.
- `_run_adapter` catches it → records SKIPPED, does **not** bump `last_heartbeat_at`, skips replay recording (nothing ran).

### #9992 — undrained adapter stderr
`claude_code_adapter._invoke` spawned the CLI with `stderr=PIPE` but the run is detached and nothing ever read the pipe: (1) CLI errors — including rate-limit errors that never reach the stream-json stdout — were invisible; (2) >64KB of stderr fills the pipe buffer and **deadlocks the child** (hung run, no diagnosis).
- Redirect stderr to a `<output>.stderr.log` sidecar (drains to disk, no buffer block), record it in `state`, scan its tail in `_status()` for rate-limit markers, and log non-rate-limit stderr on failure.
- Applied the same sidecar treatment to `copilot_local_adapter` (was `DEVNULL` — no deadlock but errors invisible), per the issue's "check copilot" note.

## Verification
- `pytest llc/tests/test_heartbeat_scheduler.py llc/adapters/tests/ llc/tests/test_registry_adapter_rate_limit.py` → **all pass** (81 + 137)
- 4 dispatch-skip tests now assert `HeartbeatDispatchSkipped`; new `_run_adapter` test proves SKIPPED recorded + no `last_heartbeat_at` bump; new stderr test asserts stderr is a file fd (not PIPE), recorded in state, sidecar exists.
- flake8 clean; no `print()`; `LLCRunStatus.SKIPPED.is_terminal() == True`.

## Model Used
Claude Opus 4.8

Closes #9951 · Closes #9992 (part of #9923)
