### PR TITLE
docs(sso): enterprise SSO/OIDC federation build-out PRD (#8994)

### DIFF
--- a/docs/superpowers/plans/2026-06-15-sso-pkce-a1.md
+++ b/docs/superpowers/plans/2026-06-15-sso-pkce-a1.md
@@ -1,0 +1,376 @@
+# SSO PKCE (S256) Implementation Plan — Phase A1 (#10150)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add PKCE (S256) proof-key to AutoBot's existing OIDC authorization-code flow so the auth-code grant is bound to a per-login secret verifier.
+
+**Architecture:** The existing flow stores an opaque `state` token in Redis (`sso:state:{state}` → provider_id, 600s TTL) and validates it via atomic GETDEL. We extend that single Redis entry to also carry a per-login `code_verifier`; the authorize URL sends the derived `code_challenge` (S256), and the token exchange replays the `code_verifier`. No new storage keys, no new TTLs — the verifier rides the state entry that already exists, preserving the replay-safe single-use guarantee.
+
+**Tech Stack:** Python 3.12, authlib `AsyncOAuth2Client`, Redis (`autobot_shared.redis_client`), pytest + pytest-asyncio.
+
+**Scope note:** Phase A2 (RP-logout/revocation, #10151) and A3 (group→role, #10152) are separate child issues with their own plans; each requires a grounding read (logout endpoints / `user_management` roles model) before its TDD code can be written without placeholders. This plan covers A1 only.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `autobot-slm-backend/user_management/services/sso_service.py` | OAuth state + authorize + token exchange | Modify: PKCE verifier/challenge into state lifecycle |
+| `autobot-slm-backend/tests/services/test_sso_service.py` | SSO service unit tests | Modify: add PKCE tests |
+
+Current relevant code (sso_service.py):
+- `_generate_oauth_state(provider_id)` lines ~204-210 — stores `sso:state:{state}` = `str(provider_id)`, 600s.
+- `_validate_oauth_state(state)` lines ~212-220 — atomic GETDEL, returns `provider_id`.
+- `_get_oauth_authorize_url(provider, callback_url)` lines ~241-253 — `create_authorization_url(...)`.
+- `_exchange_oauth_code(provider, code, callback_url)` lines ~255-264 — `fetch_token(...)`.
+- `complete_oauth_login(...)` lines ~282-296 — validates state, then exchanges code.
+
+---
+
+### Task 1: PKCE helper — derive S256 challenge from a verifier
+
+**Files:**
+- Modify: `autobot-slm-backend/user_management/services/sso_service.py` (module-level helper near the top imports)
+- Test: `autobot-slm-backend/tests/services/test_sso_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/test_sso_service.py
+import base64
+import hashlib
+from user_management.services.sso_service import _pkce_challenge_s256
+
+
+def test_pkce_challenge_s256_matches_rfc7636():
+    verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    expected = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest()).rstrip(b"=").decode("ascii")
+    assert _pkce_challenge_s256(verifier) == expected
+
+
+def test_pkce_challenge_is_url_safe_and_unpadded():
+    challenge = _pkce_challenge_s256("a" * 64)
+    assert "=" not in challenge and "+" not in challenge and "/" not in challenge
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-slm-backend && python -m pytest tests/services/test_sso_service.py::test_pkce_challenge_s256_matches_rfc7636 -v`
+Expected: FAIL — `ImportError: cannot import name '_pkce_challenge_s256'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# sso_service.py — add near the top-level imports (after existing `import secrets`)
+import base64
+import hashlib
+
+
+def _pkce_challenge_s256(verifier: str) -> str:
+    """Derive the RFC 7636 S256 code_challenge from a code_verifier."""
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd autobot-slm-backend && python -m pytest tests/services/test_sso_service.py -k pkce_challenge -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add autobot-slm-backend/user_management/services/sso_service.py autobot-slm-backend/tests/services/test_sso_service.py
+git commit -m "feat(sso): add PKCE S256 challenge helper (#10150)"
+```
+
+---
+
+### Task 2: Store the code_verifier alongside OAuth state
+
+**Files:**
+- Modify: `autobot-slm-backend/user_management/services/sso_service.py:204-220`
+- Test: `autobot-slm-backend/tests/services/test_sso_service.py`
+
+The state entry becomes a JSON object `{"provider_id": "...", "code_verifier": "..."}`. `_generate_oauth_state` returns `(state, code_verifier)`; `_validate_oauth_state` returns `(provider_id, code_verifier)`. Backward read: a legacy plain-UUID value (no verifier) decodes to `code_verifier=None` so in-flight logins during deploy still validate.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/test_sso_service.py
+import json
+import uuid
+from unittest.mock import AsyncMock
+import pytest
+from user_management.services.sso_service import SSOService, SSOAuthenticationError
+
+
+@pytest.mark.asyncio
+async def test_generate_state_persists_verifier(monkeypatch):
+    redis = AsyncMock()
+    monkeypatch.setattr("user_management.services.sso_service.get_redis_client", lambda: redis)
+    svc = SSOService(session=AsyncMock())
+    pid = uuid.uuid4()
+    state, verifier = await svc._generate_oauth_state(pid)
+    assert isinstance(state, str) and len(verifier) >= 43
+    key, value = redis.set.call_args.args[0], redis.set.call_args.args[1]
+    assert key == f"sso:state:{state}"
+    stored = json.loads(value)
+    assert stored == {"provider_id": str(pid), "code_verifier": verifier}
+
+
+@pytest.mark.asyncio
+async def test_validate_state_returns_provider_and_verifier(monkeypatch):
+    redis = AsyncMock()
+    pid = uuid.uuid4()
+    verifier = "v" * 64
+    redis.getdel.return_value = json.dumps({"provider_id": str(pid), "code_verifier": verifier})
+    monkeypatch.setattr("user_management.services.sso_service.get_redis_client", lambda: redis)
+    svc = SSOService(session=AsyncMock())
+    got_pid, got_verifier = await svc._validate_oauth_state("abc")
+    assert got_pid == pid and got_verifier == verifier
+
+
+@pytest.mark.asyncio
+async def test_validate_state_legacy_plain_uuid(monkeypatch):
+    redis = AsyncMock()
+    pid = uuid.uuid4()
+    redis.getdel.return_value = str(pid)  # legacy in-flight value, no JSON
+    monkeypatch.setattr("user_management.services.sso_service.get_redis_client", lambda: redis)
+    svc = SSOService(session=AsyncMock())
+    got_pid, got_verifier = await svc._validate_oauth_state("abc")
+    assert got_pid == pid and got_verifier is None
+
+
+@pytest.mark.asyncio
+async def test_validate_state_rejects_missing(monkeypatch):
+    redis = AsyncMock()
+    redis.getdel.return_value = None
+    monkeypatch.setattr("user_management.services.sso_service.get_redis_client", lambda: redis)
+    svc = SSOService(session=AsyncMock())
+    with pytest.raises(SSOAuthenticationError):
+        await svc._validate_oauth_state("abc")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-slm-backend && python -m pytest tests/services/test_sso_service.py -k "state" -v`
+Expected: FAIL — `_generate_oauth_state` returns a str (not a tuple); `_validate_oauth_state` returns a UUID (not a tuple).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# sso_service.py — replace _generate_oauth_state and _validate_oauth_state
+import json
+
+OAUTH_STATE_TTL_SECONDS = 600  # module-level constant (no hard-coded literal at call site)
+
+async def _generate_oauth_state(self, provider_id: uuid.UUID) -> tuple[str, str]:
+    """Generate OAuth2 state + PKCE verifier; store both in Redis with TTL."""
+    state = secrets.token_urlsafe(32)
+    code_verifier = secrets.token_urlsafe(64)  # 43-128 chars per RFC 7636
+    redis = get_redis_client()
+    if redis:
+        payload = json.dumps({"provider_id": str(provider_id), "code_verifier": code_verifier})
+        await redis.set(f"sso:state:{state}", payload, ex=OAUTH_STATE_TTL_SECONDS)
+    return state, code_verifier
+
+async def _validate_oauth_state(self, state: str) -> tuple[uuid.UUID, str | None]:
+    """Validate state via atomic GETDEL (single-use). Returns (provider_id, code_verifier)."""
+    redis = get_redis_client()
+    if not redis:
+        raise SSOAuthenticationError("Redis unavailable for state validation")
+    raw = await redis.getdel(f"sso:state:{state}")
+    if not raw:
+        raise SSOAuthenticationError("Invalid or expired OAuth state")
+    try:
+        data = json.loads(raw)
+        return uuid.UUID(data["provider_id"]), data.get("code_verifier")
+    except (json.JSONDecodeError, TypeError, KeyError):
+        return uuid.UUID(raw), None  # legacy plain-UUID value (in-flight during deploy)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd autobot-slm-backend && python -m pytest tests/services/test_sso_service.py -k "state" -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add autobot-slm-backend/user_management/services/sso_service.py autobot-slm-backend/tests/services/test_sso_service.py
+git commit -m "feat(sso): carry PKCE verifier in OAuth state entry (#10150)"
+```
+
+---
+
+### Task 3: Send code_challenge on authorize, replay code_verifier on token exchange
+
+**Files:**
+- Modify: `autobot-slm-backend/user_management/services/sso_service.py:241-296`
+- Test: `autobot-slm-backend/tests/services/test_sso_service.py`
+
+`_get_oauth_authorize_url` now adds `code_challenge`/`code_challenge_method="S256"`. `_exchange_oauth_code` accepts a `code_verifier` argument and forwards it. `complete_oauth_login` threads the verifier from state validation into the exchange. When `code_verifier` is `None` (legacy entry) the exchange omits it.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/test_sso_service.py
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+
+def _provider():
+    p = MagicMock()
+    p.id = uuid.uuid4()
+    p.is_active = True
+    p.config = {
+        "client_id": "cid",
+        "authorize_url": "https://idp/authorize",
+        "token_url": "https://idp/token",
+        "scope": "openid email",
+    }
+    return p
+
+
+@pytest.mark.asyncio
+async def test_authorize_url_sends_s256_challenge(monkeypatch):
+    svc = SSOService(session=AsyncMock())
+    provider = _provider()
+    client = AsyncMock()
+    client.create_authorization_url.return_value = ("https://idp/authorize?x=1", "ignored")
+    monkeypatch.setattr(svc, "_build_oauth_client", AsyncMock(return_value=client))
+    monkeypatch.setattr(svc, "_generate_oauth_state", AsyncMock(return_value=("st", "ver123")))
+    url, state = await svc._get_oauth_authorize_url(provider, "https://app/cb")
+    kwargs = client.create_authorization_url.call_args.kwargs
+    assert kwargs["code_challenge_method"] == "S256"
+    from user_management.services.sso_service import _pkce_challenge_s256
+    assert kwargs["code_challenge"] == _pkce_challenge_s256("ver123")
+    assert state == "st"
+
+
+@pytest.mark.asyncio
+async def test_exchange_forwards_code_verifier(monkeypatch):
+    svc = SSOService(session=AsyncMock())
+    provider = _provider()
+    client = AsyncMock()
+    client.fetch_token.return_value = {"access_token": "t"}
+    monkeypatch.setattr(svc, "_build_oauth_client", AsyncMock(return_value=client))
+    await svc._exchange_oauth_code(provider, "code1", "https://app/cb", code_verifier="ver123")
+    assert client.fetch_token.call_args.kwargs["code_verifier"] == "ver123"
+
+
+@pytest.mark.asyncio
+async def test_exchange_omits_verifier_when_none(monkeypatch):
+    svc = SSOService(session=AsyncMock())
+    provider = _provider()
+    client = AsyncMock()
+    client.fetch_token.return_value = {"access_token": "t"}
+    monkeypatch.setattr(svc, "_build_oauth_client", AsyncMock(return_value=client))
+    await svc._exchange_oauth_code(provider, "code1", "https://app/cb", code_verifier=None)
+    assert "code_verifier" not in client.fetch_token.call_args.kwargs
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-slm-backend && python -m pytest tests/services/test_sso_service.py -k "authorize_url or exchange" -v`
+Expected: FAIL — `create_authorization_url` called without `code_challenge`; `_exchange_oauth_code` has no `code_verifier` parameter.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# sso_service.py — _get_oauth_authorize_url
+async def _get_oauth_authorize_url(self, provider: SSOProvider, callback_url: str) -> tuple[str, str]:
+    """Generate OAuth2 authorization URL with PKCE (S256)."""
+    client = await self._build_oauth_client(provider)
+    state, code_verifier = await self._generate_oauth_state(provider.id)
+    authorize_url = provider.config.get("authorize_url")
+    scope = provider.config.get("scope", "openid email profile")
+    url, _ = await client.create_authorization_url(
+        authorize_url,
+        redirect_uri=callback_url,
+        scope=scope,
+        state=state,
+        code_challenge=_pkce_challenge_s256(code_verifier),
+        code_challenge_method="S256",
+    )
+    return url, state
+
+# sso_service.py — _exchange_oauth_code
+async def _exchange_oauth_code(
+    self, provider: SSOProvider, code: str, callback_url: str, code_verifier: str | None = None
+) -> dict[str, Any]:
+    """Exchange OAuth2 authorization code for access token (PKCE verifier when present)."""
+    client = await self._build_oauth_client(provider)
+    token_url = provider.config.get("token_url")
+    kwargs: dict[str, Any] = {"code": code, "redirect_uri": callback_url}
+    if code_verifier:
+        kwargs["code_verifier"] = code_verifier
+    return await client.fetch_token(token_url, **kwargs)
+
+# sso_service.py — complete_oauth_login: thread verifier from state validation
+async def complete_oauth_login(
+    self, code: str, state: str, callback_url: str, provider_id: uuid.UUID | None = None
+) -> User:
+    """Complete OAuth2 login flow and return authenticated user."""
+    state_provider_id, code_verifier = await self._validate_oauth_state(state)
+    if provider_id is not None and provider_id != state_provider_id:
+        raise SSOAuthenticationError("State/provider mismatch")
+    provider_id = state_provider_id
+    provider = await self.get_provider(provider_id)
+    token = await self._exchange_oauth_code(provider, code, callback_url, code_verifier=code_verifier)
+    userinfo = await self._get_oauth_userinfo(provider, token)
+    external_id = userinfo.get("sub") or userinfo.get("id")
+    user_data = self._extract_oauth_user_data(userinfo, provider)
+    return await self._find_or_provision_user(provider, external_id, user_data)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd autobot-slm-backend && python -m pytest tests/services/test_sso_service.py -v`
+Expected: PASS (all sso_service tests, including pre-existing state/replay tests, green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add autobot-slm-backend/user_management/services/sso_service.py autobot-slm-backend/tests/services/test_sso_service.py
+git commit -m "feat(sso): send PKCE S256 challenge + replay verifier on token exchange (#10150)"
+```
+
+---
+
+### Task 4: Verify full suite + open PR
+
+- [ ] **Step 1: Run the SSO test modules**
+
+Run: `cd autobot-slm-backend && python -m pytest tests/services/test_sso_service.py tests/services/test_sso_security.py tests/api/test_sso_auth.py -v`
+Expected: PASS (no regressions in state/replay/security tests).
+
+- [ ] **Step 2: Lint**
+
+Run: `cd autobot-slm-backend && ruff check user_management/services/sso_service.py && black --line-length 120 --check user_management/services/sso_service.py`
+Expected: clean.
+
+- [ ] **Step 3: Open PR**
+
+```bash
+gh pr create --base Dev_new_gui --head issue-10150 \
+  --title "feat(sso): PKCE (S256) on the OIDC authorization-code flow (#10150)" \
+  --body "## Thinking Path
+...## What Changed
+PKCE verifier rides the existing Redis state entry; authorize sends S256 challenge; token exchange replays verifier. Legacy in-flight states (plain UUID) still validate.
+## Verification
+pytest tests/services/test_sso_service.py tests/services/test_sso_security.py tests/api/test_sso_auth.py — all pass.
+## Model Used
+Claude Opus 4.8"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** A1 (PKCE S256) fully covered. A2/A3/C/E are out of this plan's scope by design (separate child issues + plans).
+- **Placeholder scan:** none — every code step shows real code; the PR-body `...` in Task 4 Step 3 is a fill-at-author-time prose field, not code.
+- **Type consistency:** `_generate_oauth_state` → `tuple[str, str]` and `_validate_oauth_state` → `tuple[uuid.UUID, str | None]` are used consistently in `_get_oauth_authorize_url` and `complete_oauth_login`. `_pkce_challenge_s256` signature `(str) -> str` consistent across Tasks 1 and 3. `_exchange_oauth_code` gains `code_verifier: str | None = None` and is called with that kwarg in `complete_oauth_login`.

--- a/docs/superpowers/specs/2026-06-15-enterprise-sso-federation-design.md
+++ b/docs/superpowers/specs/2026-06-15-enterprise-sso-federation-design.md
@@ -1,0 +1,147 @@
+# Enterprise SSO/OIDC Federation — full build-out (#8994)
+
+> Spec / PRD for GitHub issue [#8994](https://github.com/mrveiss/AutoBot-AI/issues/8994),
+> member of umbrella [#9930](https://github.com/mrveiss/AutoBot-AI/issues/9930) (enterprise-auth).
+> Status: **design — awaiting sign-off.** No code until the task tree is confirmed.
+> Date: 2026-06-15.
+
+## 1. Context & problem
+
+The umbrella sized #8994 as an `L` greenfield "SSO/OIDC federation" build. Investigation shows it is
+**~90% already implemented** in `autobot-slm-backend`:
+
+- OAuth2/OIDC auth-code flow for **Okta**, **Microsoft Entra ID (Azure AD)**, **Google Workspace**
+  (endpoint templates, token exchange, userinfo) — `user_management/services/sso_service.py`.
+- LDAP/Active Directory bind+search (RFC-4515 escaped), SAML 2.0 (AuthnRequest/ACS/assertion).
+- JIT user provisioning, org scoping, per-IP/per-username rate limiting.
+- AES-256-GCM secret encryption in `system_secrets` (`autobot_shared/field_encryption.py`,
+  `user_management/services/sso_secrets.py`).
+- Callback-URL allowlist (SSRF/CRLF, MVA-3542), replay-safe Redis OAuth state (atomic GETDEL).
+- Admin CRUD (`api/sso.py`, `Permission.SECURITY_MANAGE`) + frontend `SSOSettings.vue`,
+  `SSOCallbackView.vue`, `useSsoApi.ts`.
+
+So #8994 is **not** a from-scratch build. It is: (a) close the enterprise-grade gaps the current
+implementation lacks, (b) sign off the two flagged human-decisions (provider matrix, rotation policy),
+and (c) reconcile with the unified-secrets umbrella #10088.
+
+### Gaps the current implementation lacks
+1. **group→role enforcement** — `group_mapping` JSONB is stored but never applied during JIT/login.
+2. **PKCE** — auth-code flow has no S256 proof-key.
+3. **Secret rotation** — encryption-at-rest exists, but no rotation mechanism or policy.
+4. **IdP-initiated logout / session revocation** — no RP-initiated logout or SAML SLO.
+5. (deferred) SCIM inbound provisioning, token caching, step-up auth, device flow.
+
+## 2. Decisions (locked with owner, 2026-06-15)
+
+| # | Decision | Choice |
+|---|---|---|
+| D1 | Overall scope | **Full enterprise build-out** — #8994 becomes a sub-umbrella |
+| D2 | Where SSO secrets + rotation live | **Build on unified-secrets #10088** (vault + envelope crypto); rotation = envelope `rewrap_dek`. Not a throwaway rotation layer. |
+| D3 | IdP group→role mapping authority | **Instance RBAC roles only** (`user_management` roles/`user_roles`). LLC `MembershipRole` out of scope. |
+| D4 | v1 vs v2 phasing | **Ship Phase A (standards) first; defer SCIM (Phase B) to v2.** |
+| D5 | GitHub recording | **Convert #8994 → sub-umbrella + child issues** under #9930. |
+
+## 3. Supported-provider matrix *(flagged human-decision #1 — D1 resolved)*
+
+| Tier | Providers | Protocol | Action in this umbrella |
+|---|---|---|---|
+| **Certified** (e2e-tested, documented, PKCE) | Okta · Microsoft Entra ID (Azure AD) · Google Workspace | OIDC auth-code + PKCE | add PKCE (A1) + e2e verification + docs (E) |
+| **Supported** | Generic OIDC (any compliant IdP) · SAML 2.0 · LDAP/Active Directory | OIDC / SAML / LDAP | already present; covered by hardening + docs |
+| **Social (non-enterprise)** | GitHub · Facebook · Google consumer | OAuth2 | unchanged, not part of the enterprise tier |
+
+## 4. Secret-rotation policy *(flagged human-decision #2 — D2 resolved)*
+
+- SSO client secrets are stored in the unified-secrets **System/SSO vault** (#10088): value sealed under a
+  per-secret DEK, the DEK wrapped by the vault KEK.
+- **Rotation = two independent operations:**
+  - **KEK rotation** — envelope `rewrap_dek` rewraps the DEK under a new KEK; payload is **not** re-encrypted.
+  - **Value rotation** — when the operator rotates the secret at the IdP, the new value is re-sealed
+    under a fresh DEK.
+- **Cadence**: default **90-day advisory**, **warn-on-stale — never hard-expire** (a forced expiry that
+  locks out SSO is worse than a stale secret). Admin-initiated rotation always available.
+- **Audit**: every rotation (who, which provider/secret, KEK-vs-value, when) is logged.
+
+### 4.1 Cross-backend boundary (design risk)
+The unified store and `UnifiedSecretsService` live in **autobot-backend**
+(`services/unified_secrets_service.py`, `autobot_shared/secrets_envelope.py`), while SSO lives in
+**autobot-slm-backend** (the control plane). Phase C therefore crosses a backend boundary. The SLM must
+not embed a second copy of the store; it consumes the unified store as a client (service API or the
+shared envelope primitives in `autobot_shared`). The exact integration surface is a **Phase C
+prerequisite** to settle with the #10088 owner before C1.
+
+## 5. Phased task tree (sub-umbrella under #9930)
+
+### Phase A — Standards hardening *(v1; independent of #10088; ships now)*
+- **A1 — PKCE (S256)** on the OIDC auth-code flow: generate `code_verifier`/`code_challenge`, persist the
+  verifier in Redis alongside the existing OAuth `state`, send `code_challenge` on authorize and
+  `code_verifier` on token exchange. `autobot-slm-backend/user_management/services/sso_service.py`,
+  `api/sso_auth.py`.
+- **A2 — RP-initiated logout + session/token revocation**: OIDC `end_session_endpoint` logout and SAML
+  SLO; revoke the local session/token on logout. Frontend logout wires to it.
+- **A3 — group→role enforcement**: apply `group_mapping` to **instance roles** during JIT **and**
+  re-sync on every login (add/remove roles to match current IdP groups). Reconciliation is idempotent;
+  removal of an IdP group removes the mapped role.
+
+### Phase C — Secret rotation *(v1; depends on #10088 SecretsService — landed in #10111/#10134, verify first)*
+- **C1 — migrate SSO secrets into the #10088 vault**: move existing `system_secrets` SSO entries into the
+  System/SSO vault; settle the cross-backend integration surface (§4.1) first. Backward-compatible read
+  path during rollout.
+- **C2 — rotation mechanism**: `rewrap_dek` (KEK) + value re-seal, admin UI control, warn-on-stale
+  surfacing in `SSOSettings.vue`, audit log.
+
+### Phase E — Docs *(v1)*
+- Provider matrix (§3), rotation policy (§4), admin runbook (configure each certified IdP, rotate a
+  secret, read the audit). **Absorbs #9687** (SSO secret-migration docs).
+
+### Phase D — Operational polish *(v1, optional / lower priority)*
+- **D3 — provider-health dashboard** (failed-auth visibility). D1 token caching and D2 step-up auth are
+  **deferred** (YAGNI for v1) → filed as follow-up issues, not built now.
+
+### Phase B — SCIM 2.0 provisioning *(v2 — deferred per D4)*
+- B1 SCIM inbound `/scim/v2` Users (create/update/**deactivate**), bearer-token auth.
+- B2 SCIM Groups → instance-role mapping + deprovisioning on IdP removal.
+- Filed as a v2 follow-up sub-umbrella; not part of v1.
+
+## 6. Reconciliation with existing #9930 members
+
+| #9930 member | Disposition |
+|---|---|
+| #9500 callback-URL allowlist | **Already implemented** (`_build_callback_url`, MVA-3542) → verify & close, not rebuild |
+| #9501 SSO client-secret encryption | **Already implemented** (AES-256-GCM in `system_secrets`) → superseded by Phase C migration; verify & close |
+| #9685 encrypted-creds tests | fold into Phase C verification |
+| #9611 rate-limit test mock fix | independent `S`; do any time (not gated on this umbrella) |
+| #9687 secret-migration docs | fold into Phase E |
+| #9651 telegram webhook encryption | unrelated to SSO; remains a standalone `S` in #9930 |
+
+## 7. Dependencies & ordering
+
+```
+#10088 SecretsService (LANDED #10111/#10134) ──> Phase C (C1 ─> C2)
+Phase A (A1, A2, A3)  ── independent ──> ships in parallel with C
+Phase E (docs)        ── after A + C feature-complete
+Phase D3              ── optional, after A
+Phase B (SCIM)        ── v2, separate follow-up
+```
+
+- Critical edge: **C is gated on #10088** (now satisfied — verify the service surface before C1).
+- A1/A2/A3 have **no** cross-dependency and can be three parallel PRs.
+
+## 8. Testing strategy
+
+- **A1 PKCE**: unit — verifier/challenge generation + Redis round-trip; integration — token exchange
+  rejects a missing/mismatched verifier.
+- **A2 logout**: session revoked after RP logout; token no longer authenticates.
+- **A3 group→role**: JIT assigns mapped roles; login re-sync adds/removes roles; idempotent; unmapped
+  groups grant nothing.
+- **C1/C2**: secret round-trips through the vault; `rewrap_dek` rotates KEK without changing plaintext;
+  value rotation re-seals; warn-on-stale fires past cadence; audit row written. (Absorbs #9685.)
+- Reuse existing `tests/services/test_sso_*.py`, `tests/api/test_sso_auth.py`.
+- Gates: wiring audit (frontend↔backend SSO endpoints), duplication guard, smoke-test.
+
+## 9. Out of scope (filed as follow-ups, not built here)
+- SCIM (→ v2 sub-umbrella), token caching (D1), step-up auth (D2), OAuth device flow.
+- LLC `MembershipRole` mapping from IdP groups (D3 decision — instance-only for v1).
+
+## 10. Open items to confirm during planning
+- §4.1 cross-backend integration surface with the #10088 owner (SLM-as-client vs shared primitives).
+- Whether #9500/#9501 are closed as "verified-done" or folded as verification subtasks of this umbrella.


### PR DESCRIPTION
## Thinking Path
#8994 was sized as a greenfield `L` SSO build. Investigation found ~90% of OIDC federation (Okta/Azure AD/Google Workspace), LDAP, SAML, JIT, AES-GCM secret encryption, callback allowlist, and admin/frontend already exist. This PR lands the design/PRD that reframes #8994 as gap-completion and decomposes it into a sub-umbrella.

## What Changed
- Adds `docs/superpowers/specs/2026-06-15-enterprise-sso-federation-design.md`.
- Locks 5 decisions: full build-out; SSO secrets ride on unified-secrets #10088 (envelope `rewrap_dek`); group→role maps instance RBAC roles only; Phase A ships first, SCIM deferred to v2; #8994→sub-umbrella.
- v1 child issues created: #10150–#10156; deferred #10157 (SCIM), #10158 (caching/step-up).

## Verification
Docs-only. Spec self-review passed (no placeholders, phases consistent with ordering/decisions). No code changes.

## Model Used
Claude Opus 4.8