### PR TITLE
feat(secrets): PrincipalFacts DB resolver from membership tables (#10190)

### DIFF
--- a/autobot-backend/llc/models/secret.py
+++ b/autobot-backend/llc/models/secret.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import Optional
 
 import sqlalchemy as sa
-from sqlalchemy import Index, UniqueConstraint
+from sqlalchemy import UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from user_management.models.base import Base
@@ -44,10 +44,10 @@ class LLCSecret(Base):
     )
     revoked_at: Mapped[Optional[datetime]] = mapped_column(sa.DateTime(timezone=True), nullable=True, default=None)
 
-    __table_args__ = (
-        UniqueConstraint("company_id", "name", name="uq_llc_secrets_company_name"),
-        Index("ix_llc_secrets_company_id", "company_id"),
-    )
+    # company_id already declares index=True above (auto-creates
+    # ix_llc_secrets_company_id); a second explicit Index of the same name made
+    # create_all emit it twice → DuplicateTableError (#10075).
+    __table_args__ = (UniqueConstraint("company_id", "name", name="uq_llc_secrets_company_name"),)
 
     @property
     def is_revoked(self) -> bool:

--- a/autobot-backend/services/secrets_principal_resolver.py
+++ b/autobot-backend/services/secrets_principal_resolver.py
@@ -1,0 +1,74 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Build :class:`PrincipalFacts` from the membership tables (#10088 / Task 2.3 part 2).
+
+The DB half of the secrets RBAC layer: turns an authenticated ``user_id`` plus
+their RBAC permission set into the :class:`PrincipalFacts` that
+``services.secrets_authz`` (part 1, pure) reasons over. Kept thin — three
+membership queries plus a permission filter — so the policy stays where the
+unit tests are.
+
+``permissions`` is passed in (the router fetches it once via
+``RBACMiddleware.get_user_permissions``) rather than fetched here, so the
+resolver has no Redis/middleware dependency and is straightforward to test.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from llc.models.enums import MembershipRole
+from llc.models.membership import LLCCompanyMembership
+from services.secrets_authz import PrincipalFacts
+from user_management.models.role import Role, UserRole
+from user_management.models.team import TeamMembership
+
+#: Permission name that marks an instance administrator (grants system vault + any user vault).
+ADMIN_PERMISSION = "admin:access"
+_SECRETS_PREFIX = "secrets:"
+
+
+def _company_role(value: str) -> MembershipRole | None:
+    try:
+        return MembershipRole(value)
+    except ValueError:
+        return None
+
+
+async def resolve_principal_facts(session: AsyncSession, user_id: uuid.UUID, permissions: set[str]) -> PrincipalFacts:
+    """Assemble the principal's vault-access facts from RBAC + membership tables."""
+    is_admin = ADMIN_PERMISSION in permissions
+    granted = frozenset(p for p in permissions if p.startswith(_SECRETS_PREFIX))
+
+    team_rows = await session.execute(select(TeamMembership.team_id).where(TeamMembership.user_id == user_id))
+    team_ids = frozenset(str(t) for t in team_rows.scalars())
+
+    role_rows = await session.execute(
+        select(Role.name).join(UserRole, UserRole.role_id == Role.id).where(UserRole.user_id == user_id)
+    )
+    role_names = frozenset(role_rows.scalars())
+
+    company_rows = await session.execute(
+        select(LLCCompanyMembership.company_id, LLCCompanyMembership.role).where(
+            LLCCompanyMembership.user_id == user_id
+        )
+    )
+    company_roles: dict[str, MembershipRole] = {}
+    for company_id, role_value in company_rows.all():
+        role = _company_role(role_value)
+        if role is not None:
+            company_roles[str(company_id)] = role
+
+    return PrincipalFacts(
+        user_id=str(user_id),
+        is_admin=is_admin,
+        team_ids=team_ids,
+        role_names=role_names,
+        company_roles=company_roles,
+        granted_permissions=granted,
+    )

--- a/autobot-backend/tests/migrations/test_secrets_principal_resolver.py
+++ b/autobot-backend/tests/migrations/test_secrets_principal_resolver.py
@@ -1,0 +1,94 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the PrincipalFacts DB resolver (#10088 / Task 2.3 part 2).
+
+Postgres-backed (co-located under tests/migrations for the migration-gate CI
+job): builds the full schema via ``alembic upgrade head`` so the membership
+FKs resolve, seeds one user with a team / role / company membership, and
+asserts the resolver reads them into PrincipalFacts.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from llc.models.enums import MembershipRole
+from services.secrets_principal_resolver import resolve_principal_facts
+from tests.migrations.conftest import requires_postgres, run_alembic
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+_USER = uuid.uuid4()
+_COMPANY = uuid.uuid4()
+
+
+@pytest.fixture()
+async def session(fresh_db_url):
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+    engine = create_async_engine(fresh_db_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as s:
+        await _seed(s)
+        yield s
+    await engine.dispose()
+
+
+async def _seed(session) -> None:
+    """One user holding a role and an LLC company membership.
+
+    The team path (organizations → teams → team_memberships) is not seeded here:
+    the ``organizations`` ORM model has columns no migration adds (#10189), so an
+    ORM Organization insert fails on a migration-built DB. The team query is
+    structurally identical to the role query (both join through a membership
+    table) and is covered by the empty-result assertion; the positive team path
+    rides 2.4's end-to-end test once #10189 is fixed.
+    """
+    from llc.models.membership import LLCCompanyMembership
+    from user_management.models.role import Role, UserRole
+    from user_management.models.user import User
+
+    role_id = uuid.uuid4()
+    session.add(User(id=_USER, email="alice@example.com", username="alice"))
+    session.add(Role(id=role_id, name="engineer"))
+    await session.flush()
+    session.add(UserRole(user_id=_USER, role_id=role_id))
+    session.add(LLCCompanyMembership(company_id=_COMPANY, user_id=_USER, role="admin"))
+    await session.commit()
+    session.expunge_all()
+
+
+async def test_resolves_role_and_company_memberships(session):
+    facts = await resolve_principal_facts(session, _USER, {"secrets:system:read", "other:x"})
+    assert facts.user_id == str(_USER)
+    assert facts.role_names == frozenset({"engineer"})
+    assert facts.company_roles == {str(_COMPANY): MembershipRole.ADMIN}
+    assert facts.team_ids == frozenset()  # no team seeded; query returns empty cleanly
+    # only secrets:* permissions are retained as granted
+    assert facts.granted_permissions == frozenset({"secrets:system:read"})
+    assert facts.is_admin is False
+
+
+async def test_admin_permission_sets_is_admin(session):
+    facts = await resolve_principal_facts(session, _USER, {"admin:access"})
+    assert facts.is_admin is True
+
+
+async def test_unknown_user_has_empty_memberships(session):
+    facts = await resolve_principal_facts(session, uuid.uuid4(), {"secrets:user:read"})
+    assert facts.team_ids == frozenset()
+    assert facts.role_names == frozenset()
+    assert facts.company_roles == {}
+    assert facts.granted_permissions == frozenset({"secrets:user:read"})
+
+
+async def test_accessible_vaults_compose_from_resolved_facts(session):
+    from autobot_shared.secrets_vault import VaultKind, VaultRef
+
+    facts = await resolve_principal_facts(session, _USER, set())
+    vaults = facts.accessible_vaults()
+    assert VaultRef(VaultKind.USER, str(_USER)) in vaults
+    assert VaultRef(VaultKind.COMPANY, str(_COMPANY)) in vaults
+    assert VaultRef(VaultKind.ROLE, "engineer") in vaults


### PR DESCRIPTION
## Thinking Path
Task 2.3 part-2 of unified-secrets umbrella #10088 — the DB half of the RBAC layer. The pure authz policy (#10135) reasons over `PrincipalFacts`; this resolver builds those facts from the membership tables so the (upcoming) `/api/v2/secrets` router can call `authorize`/`accessible_vaults`.

## What Changed
New `services/secrets_principal_resolver.py`:
- `resolve_principal_facts(session, user_id, permissions) -> PrincipalFacts`: `is_admin` = `admin:access` ∈ perms; `granted_permissions` = the `secrets:*` subset; `team_ids` ← `team_memberships`; `role_names` ← `user_roles ⋈ roles.name`; `company_roles` ← `llc_company_memberships` (`company_id`→`MembershipRole`, guarded against enum drift à la #9980).
- `permissions` is **passed in** (the router fetches it once via `RBACMiddleware.get_user_permissions`) so the resolver has no Redis/middleware coupling and is straightforward to test.

## Verification
- **4 tests on disposable Postgres 16** (`tests/migrations/test_secrets_principal_resolver.py`, migration-gate job): role+company resolution, `admin:access`→`is_admin`, unknown-user→empty, and `accessible_vaults()` composing user/company/role vaults from resolved facts. ruff/black/mypy clean.
- Discovery **#10189** filed: the test surfaced that `organizations` has ORM-only columns no migration adds — it blocked the team-path seeding (covered here via the empty-result query; positive team path rides 2.4's e2e once #10189 lands).

## Model Used
Claude Opus 4.8 (1M context)

Closes #10190
