### PR TITLE
fix(voice): surface user-visible message when zero TTS voices available (#9999)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useVoiceOutput.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useVoiceOutput.test.ts
@@ -1,0 +1,118 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// useVoiceOutput zero-voices UX (#9999): when a deployment has no TTS voices,
+// speak()/speakStreaming() must surface a user-visible toast instead of
+// failing silently.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+
+const mockShowToast = vi.fn()
+const mockFetchVoices = vi.fn()
+const voicesRef = ref<Array<{ id: string }>>([])
+
+vi.mock('@/composables/useToast', () => ({
+  useToast: () => ({
+    showToast: mockShowToast,
+    toasts: { value: [] },
+    removeToast: vi.fn(),
+    clearAllToasts: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useVoiceProfiles', () => ({
+  useVoiceProfiles: () => ({
+    voices: voicesRef,
+    fetchVoices: mockFetchVoices,
+    effectiveVoiceId: ref(''),
+  }),
+}))
+
+vi.mock('@/composables/usePreferences', () => ({
+  usePreferences: () => ({ language: ref('en') }),
+}))
+
+vi.mock('@/utils/fetchWithAuth', () => ({
+  fetchWithAuth: vi.fn(),
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api',
+  getBackendWsUrl: () => 'ws://test',
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+import { useVoiceOutput } from '../useVoiceOutput'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
+
+// The composable suppresses repeat "no voices" toasts within a 30s cooldown
+// keyed on Date.now(). Advance a monotonic clock well past that window before
+// each test so each test reliably surfaces (or asserts the absence of) a toast.
+let _clock = 10_000_000
+
+describe('useVoiceOutput — zero-voices UX (#9999)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    voicesRef.value = []
+    mockFetchVoices.mockResolvedValue(undefined)
+    _clock += 60_000 // jump past the notify cooldown
+    vi.spyOn(Date, 'now').mockImplementation(() => _clock)
+  })
+
+  it('speak() surfaces a warning toast and does not call synthesize when no voices', async () => {
+    const { speak } = useVoiceOutput()
+
+    await speak('hello world', true)
+
+    expect(mockShowToast).toHaveBeenCalledTimes(1)
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.stringContaining('Text-to-speech is not available'),
+      'warning',
+    )
+    expect(fetchWithAuth).not.toHaveBeenCalled()
+  })
+
+  it('speak() lazily fetches voices before deciding there are none', async () => {
+    const { speak } = useVoiceOutput()
+
+    await speak('hello', true)
+
+    expect(mockFetchVoices).toHaveBeenCalled()
+  })
+
+  it('speakStreaming() surfaces a warning toast when no voices', async () => {
+    const { speakStreaming } = useVoiceOutput()
+
+    await speakStreaming('hello world')
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.stringContaining('Text-to-speech is not available'),
+      'warning',
+    )
+  })
+
+  it('speak() proceeds to synthesize when at least one voice is available', async () => {
+    voicesRef.value = [{ id: 'v1' }]
+    ;(fetchWithAuth as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+    })
+
+    const { speak } = useVoiceOutput()
+    await speak('hello', true)
+
+    expect(fetchWithAuth).toHaveBeenCalled()
+    expect(mockShowToast).not.toHaveBeenCalled()
+  })
+})

--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -14,11 +14,18 @@ import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 import { useVoiceProfiles } from '@/composables/useVoiceProfiles'
 import { usePreferences } from '@/composables/usePreferences'
+import { useToast } from '@/composables/useToast'
 import { getBackendWsUrl, getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useVoiceOutput')
 
 const STORAGE_KEY = 'autobot-voice-output-enabled'
+
+// #9999: user-visible message when a deployment has no TTS voices installed
+// (e.g. no tts-worker provisioned in small topologies). Without this, TTS
+// no-ops silently and the operator gets no feedback.
+const NO_VOICES_MESSAGE =
+  'Text-to-speech is not available on this deployment — no speech voices are installed.'
 
 // Module-level singletons so state is shared across component instances
 const voiceOutputEnabled = ref<boolean>(
@@ -47,6 +54,11 @@ let _ttsWsConnecting: Promise<WebSocket> | null = null
 let _ttsWsIdleTimer: ReturnType<typeof setTimeout> | null = null
 const _TTS_WS_IDLE_TIMEOUT = 30_000
 
+// #9999: suppress repeat "no voices" toasts within a short window so a burst of
+// speak() calls (e.g. per-sentence streaming) surfaces the message only once.
+let _noVoicesNotifiedAt = 0
+const _NO_VOICES_NOTIFY_COOLDOWN = 30_000
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type VoiceMessage = Record<string, any>
 type VoiceMessageHandler = (msg: VoiceMessage) => void
@@ -56,6 +68,42 @@ const wsConnected = ref<boolean>(false)
 // AbortController for the current in-flight speak() HTTP request.
 // Module-level so a new speak() call can abort the previous one.
 let _speakController: AbortController | null = null
+
+/**
+ * #9999: Surface the "no voices available" message once per cooldown window.
+ * Uses the app's standard toast mechanism so the operator gets feedback
+ * instead of TTS silently no-op'ing.
+ */
+function _notifyNoVoices(): void {
+  const now = Date.now()
+  if (now - _noVoicesNotifiedAt < _NO_VOICES_NOTIFY_COOLDOWN) return
+  _noVoicesNotifiedAt = now
+  logger.warn('TTS attempted with zero available voices')
+  useToast().showToast(NO_VOICES_MESSAGE, 'warning')
+}
+
+/**
+ * #9999: Return true when at least one TTS voice is available, otherwise
+ * surface a user-visible message and return false. Lazily fetches the voice
+ * list once if it has not been loaded yet (it is normally only populated by
+ * the settings panel), so an empty list reflects a genuine zero-voices
+ * deployment rather than an unfetched cache.
+ */
+async function _hasVoicesAvailable(): Promise<boolean> {
+  const { voices, fetchVoices } = useVoiceProfiles()
+  if (voices.value.length === 0) {
+    try {
+      await fetchVoices()
+    } catch (e) {
+      logger.warn('fetchVoices failed during TTS voice check:', e)
+    }
+  }
+  if (voices.value.length === 0) {
+    _notifyNoVoices()
+    return false
+  }
+  return true
+}
 
 function _getOrCreateContext(): AudioContext {
   if (!_audioContext) {
@@ -270,6 +318,10 @@ export function useVoiceOutput() {
     if ((!force && !voiceOutputEnabled.value) || !text.trim()) return
     if (isSpeaking.value) _stopCurrentAudio()
 
+    // #9999: surface a clear message instead of failing silently when the
+    // deployment has no TTS voices installed.
+    if (!(await _hasVoicesAvailable())) return
+
     _speakController?.abort()
     _speakController = new AbortController()
     const signal = _speakController.signal
@@ -293,6 +345,10 @@ export function useVoiceOutput() {
       })
       if (!response.ok) {
         logger.warn('TTS synthesize failed:', response.status)
+        // #9999: 404/503 here means no TTS service/voices on this deployment.
+        if (response.status === 404 || response.status === 503) {
+          _notifyNoVoices()
+        }
         return
       }
       const blob = await response.blob()
@@ -319,6 +375,9 @@ export function useVoiceOutput() {
 
   async function speakStreaming(text: string): Promise<void> {
     if (!text.trim()) return
+    // #9999: surface a clear message instead of failing silently when the
+    // deployment has no TTS voices installed.
+    if (!(await _hasVoicesAvailable())) return
     try {
       const ws = await _connectTtsWs()
       const { effectiveVoiceId } = useVoiceProfiles()


### PR DESCRIPTION
## Thinking Path
When a deployment has zero TTS voices (no tts-worker → `GET /api/voice/voices` returns `[]`), `useVoiceOutput.ts`'s `speak()` (HTTP) and `speakStreaming()` (WS) entry points silently no-op'd or only `logger.warn`'d — the user got no feedback (#9999). (The deploy-side cause is the separate #9965.)

## What Changed
- `composables/useVoiceOutput.ts`: added `_hasVoicesAvailable()` (lazily fetches the voice list) + `_notifyNoVoices()` which surfaces a warning toast via the app's standard `useToast` ("Text-to-speech is not available on this deployment — no speech voices are installed."). Both TTS entry points guard on it; the synthesize 404/503 path also surfaces the message. A 30s cooldown prevents toast spam during per-sentence streaming. Behavior preserved — nothing throws, callers still return early.

## Verification
- `vue-tsc --noEmit` → 0 new errors.
- New `useVoiceOutput.test.ts` → 4/4 pass; existing `useRealtimeVoice.test.ts` 11/11 still green.

## Model Used
Opus 4.8

Fixes #9999
