### PR TITLE
fix(migrations): create llc_work_products+relations, fix env.py/enum drift (#10043, #10044, #10075, #10076)

### DIFF
--- a/autobot-backend/llc/models/enums.py
+++ b/autobot-backend/llc/models/enums.py
@@ -207,13 +207,19 @@ class BoardType(str, Enum):
 
 
 class MembershipRole(str, Enum):
-    """Role of a human user within an LLC company (GH#8223)."""
+    """Role of a human user within an LLC company (GH#8223).
+
+    Member order matches the deployed (migration-built) enum label order so a
+    create_all-built ``membershiprole`` sorts identically to a migration-built
+    one (GH#10076): migration 031 created ('owner','admin','member','guest') and
+    043 appended 'lead' at the end via ALTER TYPE ADD VALUE.
+    """
 
     OWNER = "owner"
     ADMIN = "admin"
-    LEAD = "lead"
     MEMBER = "member"
     GUEST = "guest"
+    LEAD = "lead"
 
 
 class RoutineStatus(str, Enum):

--- a/autobot-backend/llc/models/secret.py
+++ b/autobot-backend/llc/models/secret.py
@@ -28,10 +28,7 @@ class LLCSecret(Base):
     __tablename__ = "llc_secrets"
 
     id: Mapped[uuid.UUID] = mapped_column(sa.Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    # GH#10075: the company_id index is declared once via the explicit Index()
-    # in __table_args__ below. A second index=True here emits a duplicate
-    # CREATE INDEX with the same name → DuplicateTableError under create_all.
-    company_id: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    company_id: Mapped[str] = mapped_column(sa.String(255), nullable=False, index=True)
     name: Mapped[str] = mapped_column(sa.String(255), nullable=False)
     value: Mapped[bytes] = mapped_column(sa.LargeBinary, nullable=False)
     version: Mapped[int] = mapped_column(sa.Integer, nullable=False, default=1)

--- a/autobot-backend/llc/models/secret.py
+++ b/autobot-backend/llc/models/secret.py
@@ -28,7 +28,10 @@ class LLCSecret(Base):
     __tablename__ = "llc_secrets"
 
     id: Mapped[uuid.UUID] = mapped_column(sa.Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    company_id: Mapped[str] = mapped_column(sa.String(255), nullable=False, index=True)
+    # GH#10075: the company_id index is declared once via the explicit Index()
+    # in __table_args__ below. A second index=True here emits a duplicate
+    # CREATE INDEX with the same name → DuplicateTableError under create_all.
+    company_id: Mapped[str] = mapped_column(sa.String(255), nullable=False)
     name: Mapped[str] = mapped_column(sa.String(255), nullable=False)
     value: Mapped[bytes] = mapped_column(sa.LargeBinary, nullable=False)
     version: Mapped[int] = mapped_column(sa.Integer, nullable=False, default=1)

--- a/autobot-backend/migrations/alembic.ini
+++ b/autobot-backend/migrations/alembic.ini
@@ -36,8 +36,10 @@ version_locations = migrations/versions
 
 # version path separator; As mentioned above, this is the character used to split
 # version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
-# version_path_separator = :
-version_path_separator = os
+# GH#10044: Alembic 1.18 renamed version_path_separator → path_separator
+# (the old key warns DeprecationWarning on every invocation).
+# path_separator = :
+path_separator = os
 
 # the output encoding used when revision files
 # are written from script.py.mako

--- a/autobot-backend/migrations/env.py
+++ b/autobot-backend/migrations/env.py
@@ -22,6 +22,11 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Import canvas models so Alembic autogenerate sees them (MVA-359)
 import canvas.models  # noqa: F401
+
+# GH#10044: ProcessRun/TaskDecomposition/AgentSession live on the UM Base and
+# their tables are built by migration 010 — register them so autogenerate does
+# not emit spurious drop_table ops for process_runs/task_decompositions/agent_sessions.
+import models.process_run  # noqa: F401,E402
 from autobot_shared.async_compat import run_or_schedule
 
 # Import models to register with SQLAlchemy

--- a/autobot-backend/migrations/versions/20260615_059_llc_work_products_and_relations.py
+++ b/autobot-backend/migrations/versions/20260615_059_llc_work_products_and_relations.py
@@ -1,0 +1,134 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Create llc_work_products + llc_work_item_relations (GH#10043).
+
+These two wired ORM tables (``LLCWorkProduct``, ``LLCWorkItemRelation``) had no
+creating migration — they were only ever built by the ``create_all`` bootstrap.
+With the create_all faucet closed (#10001/#10026), a fresh ``alembic upgrade
+head`` would have neither table, and ``work_product_service`` /
+``work_item_relations`` / ``artifact_ingestor`` would 500 on first touch.
+
+This migration creates both tables and their enum types with **lowercase enum
+values** (matching the model's ``values_callable`` fix, #9980 — never the member
+NAMES a bare ``sa.Enum(PyEnum)`` would emit). It is guarded with the #10027
+helpers so it is a safe no-op on databases where ``create_all`` already built
+the tables (the same situation migration 002 handles for ``secrets``).
+
+Revision ID: 20260615_059
+Revises: 20260614_058
+Create Date: 2026-06-15
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+from migrations.guards import drop_pg_enum, ensure_pg_enum, has_table, pg_enum
+
+revision = "20260615_059"
+down_revision = "20260614_058"
+branch_labels = None
+depends_on = None
+
+# Enum VALUES (lowercase) — must equal the model's values_callable output (#9980).
+_workproducttype = pg_enum(
+    "workproducttype",
+    "code",
+    "document",
+    "report",
+    "plan",
+    "screenshot",
+    "pr_link",
+    "other",
+)
+_workitemrelationtype = pg_enum(
+    "workitemrelationtype",
+    "blocks",
+    "blocked_by",
+    "duplicates",
+    "relates_to",
+)
+
+
+def upgrade() -> None:
+    ensure_pg_enum(_workproducttype)
+    ensure_pg_enum(_workitemrelationtype)
+
+    if not has_table("llc_work_products"):
+        op.create_table(
+            "llc_work_products",
+            sa.Column(
+                "id",
+                UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column("company_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("work_item_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("heartbeat_run_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("type", _workproducttype, nullable=False),
+            sa.Column("title", sa.String(512), nullable=False),
+            sa.Column("content_text", sa.Text(), nullable=True),
+            sa.Column("storage_path", sa.Text(), nullable=True),
+            sa.Column("url", sa.Text(), nullable=True),
+            sa.Column("kb_indexed", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.ForeignKeyConstraint(["work_item_id"], ["llc_work_items.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["heartbeat_run_id"], ["llc_heartbeat_runs.id"], ondelete="SET NULL"),
+        )
+        op.create_index("ix_llc_work_products_company_id", "llc_work_products", ["company_id"])
+        op.create_index("ix_llc_work_products_work_item_id", "llc_work_products", ["work_item_id"])
+
+    if not has_table("llc_work_item_relations"):
+        op.create_table(
+            "llc_work_item_relations",
+            sa.Column(
+                "id",
+                UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column("company_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("source_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("target_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("relation_type", _workitemrelationtype, nullable=False),
+            sa.Column("created_by_agent_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("created_by_user_id", UUID(as_uuid=True), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.ForeignKeyConstraint(["source_id"], ["llc_work_items.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["target_id"], ["llc_work_items.id"], ondelete="CASCADE"),
+            sa.UniqueConstraint("source_id", "target_id", "relation_type", name="uq_work_item_relation"),
+            sa.CheckConstraint("source_id != target_id", name="ck_work_item_relation_no_self"),
+        )
+        op.create_index("ix_llc_work_item_relations_company_id", "llc_work_item_relations", ["company_id"])
+        op.create_index("ix_llc_work_item_relations_source_id", "llc_work_item_relations", ["source_id"])
+        op.create_index("ix_llc_work_item_relations_target_id", "llc_work_item_relations", ["target_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("llc_work_item_relations")
+    op.drop_table("llc_work_products")
+    drop_pg_enum(_workitemrelationtype)
+    drop_pg_enum(_workproducttype)


### PR DESCRIPTION
## Thinking Path
Four model/migration-drift bugs from umbrella #9920's follow-ups, all surfaced by the create_all-faucet close (#10001/#10026) making migrations the sole schema authority. Batched since they're one theme and their prerequisites (#10027 guards, #9980 values, #10001 faucet) are now all merged. Verified end-to-end on a fresh PG16 via pg_virtualenv.

## What Changed

### #10043 (HIGH) — two ORM tables had no creating migration
`llc_work_products` (LLCWorkProduct) and `llc_work_item_relations` (LLCWorkItemRelation) were only ever built by `create_all`. With the faucet closed, a fresh `alembic upgrade head` would lack both, and `work_product_service` / `work_item_relations` / `artifact_ingestor` would 500 on first touch. New migration **20260615_059** creates both tables + their `workproducttype`/`workitemrelationtype` enums with **lowercase VALUES** (matching the #9980 `values_callable` fix), guarded with the #10027 helpers (`has_table`/`ensure_pg_enum`) so it is a no-op on create_all-built DBs.

### #10044 — env.py autogenerate gap + deprecated ini key
Registered `models.process_run` in `migrations/env.py` so `alembic revision --autogenerate` stops emitting spurious `drop_table` for `process_runs`/`task_decompositions`/`agent_sessions`. Replaced deprecated `version_path_separator` with `path_separator` in `alembic.ini` (Alembic 1.18 warns on every invocation).

### #10075 — duplicate index → create_all abort
`secret.py` declared `ix_llc_secrets_company_id` twice (`index=True` on the column **and** an explicit `Index()`), so `create_all` emitted `CREATE INDEX` twice → `DuplicateTableError`. Dropped the `index=True`, kept the explicit `Index()` (matches migration 028).

### #10076 — enum label-order drift
Reordered `MembershipRole` to `OWNER, ADMIN, MEMBER, GUEST, LEAD` to match the deployed migration-built order (031 created `owner,admin,member,guest`; 043 appended `lead` last via `ALTER TYPE ADD VALUE`). Pure member reorder — no ordinal references exist.

## Verification (fresh PG16, pg_virtualenv)
- `alembic upgrade head` → both tables created; `workproducttype` = `code,document,report,plan,screenshot,pr_link,other`; `workitemrelationtype` = `blocks,blocked_by,duplicates,relates_to`; `membershiprole` = `owner,admin,member,guest,lead` (all **values**, matching order)
- **Idempotency**: re-running 059 with the tables already present is a clean no-op (guards skip) — no `DuplicateTableError`
- **#10044**: autogenerate emits no `drop_table` for the three tables; no `path_separator` deprecation warning
- **#10075**: `LLCSecret.__table__.indexes` has exactly one `ix_llc_secrets_company_id`
- Tests: 39 pass (membership/secrets/relations); flake8 clean

## Model Used
Claude Opus 4.8

Closes #10043 · Closes #10044 · Closes #10075 · Closes #10076 (part of #9920 follow-ups)
