### PR TITLE
feat(auth): RS256 + JWKS for the identity authority — public-key token verification (#10196)

### DIFF
--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -562,7 +562,7 @@ def _decode_refresh_token(token: str) -> Dict:
     mw = get_auth_middleware()
     token_alg = _peek_alg(token)
     try:
-        if token_alg == "RS256":
+        if token_alg == "RS256":  # nosec B105 - JWT algorithm identifier, not a credential
             payload = decode_jwt_no_verify_exp(
                 token,
                 public_key=mw.jwt_public_key,

--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -29,7 +29,7 @@ from api.schemas_agent import (
 from api.schemas_common import DataResponse
 from api.schemas_system import AuthLogoutData, AuthRefreshData
 from auth_middleware import get_auth_middleware
-from autobot_shared.auth.jwt_core import JWTDecodeError, decode_jwt_no_verify_exp
+from autobot_shared.auth.jwt_core import JWTDecodeError, _peek_alg, decode_jwt_no_verify_exp
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config as ssot_config
@@ -557,9 +557,23 @@ def _decode_refresh_token(token: str) -> Dict:
     """Decode JWT for refresh, allowing recently expired tokens (1h grace).
 
     Helper for refresh_token (#827).
+    Accepts both RS256 (new) and HS256 (legacy) tokens (#10196).
     """
+    mw = get_auth_middleware()
+    token_alg = _peek_alg(token)
     try:
-        payload = decode_jwt_no_verify_exp(token, get_auth_middleware().jwt_secret)
+        if token_alg == "RS256":
+            payload = decode_jwt_no_verify_exp(
+                token,
+                public_key=mw.jwt_public_key,
+                algorithms=["RS256"],
+            )
+        else:
+            payload = decode_jwt_no_verify_exp(
+                token,
+                secret=mw.jwt_secret,
+                algorithms=["HS256"],
+            )
     except JWTDecodeError as exc:
         raise HTTPException(status_code=401, detail=ERR_INVALID_TOKEN) from exc
 

--- a/autobot-backend/api/jwks.py
+++ b/autobot-backend/api/jwks.py
@@ -1,0 +1,112 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""JWKS (JSON Web Key Set) endpoint for public-key distribution (#10196).
+
+The identity authority (autobot-backend) exposes its RSA public key here so
+consumer services (SLM, browser workers, any future service) can verify RS256
+JWTs using only the public key — never the private key.
+
+Two canonical paths are registered:
+  GET /.well-known/jwks.json  — RFC 8414 discovery path
+  GET /api/auth/jwks           — convenience path alongside other /api/auth routes
+
+Both are unauthenticated (JWKS is intentionally public, like any OAuth server's
+discovery endpoint).
+
+JWK format
+----------
+The response carries the RSA public key as a JWK Set with the following fields:
+
+  kty  : "RSA"
+  use  : "sig"           (key is used for signature verification)
+  alg  : "RS256"
+  kid  : key ID matching the ``kid`` header in issued JWTs
+  n    : base64url-encoded RSA modulus
+  e    : base64url-encoded RSA public exponent
+
+Consumers can reconstruct the public key from ``n`` / ``e`` using any standard
+JWK library (PyJWT's ``RSAAlgorithm.from_jwk``, jose, etc.) and then call
+``jwt.decode(token, pub_key, algorithms=["RS256"])``.
+"""
+
+import json
+from typing import Any, Dict
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from jwt.algorithms import RSAAlgorithm
+
+from auth_middleware import get_auth_middleware
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+# Two routers: one for /.well-known/ (mounted without /api prefix in app_factory)
+# and one for /auth (mounted under /api/auth).
+well_known_router = APIRouter(tags=["jwks"])
+auth_router = APIRouter(tags=["auth", "jwks"])
+
+
+def _build_jwks() -> Dict[str, Any]:
+    """Build the JWK Set from the current RS256 public key.
+
+    Returns a dict with a ``keys`` list containing one RSA public JWK.
+    PyJWT's ``RSAAlgorithm.to_jwk`` produces the base64url-encoded ``n``/``e``
+    values; we add ``use``, ``alg``, and ``kid`` fields per RFC 7517.
+    """
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+
+    mw = get_auth_middleware()
+    pem_public = mw.jwt_public_key
+    kid = mw.jwt_kid
+
+    # Load the public key object so PyJWT can serialise it to JWK
+    public_key = serialization.load_pem_public_key(
+        pem_public.encode("utf-8"),
+        backend=default_backend(),
+    )
+
+    # PyJWT produces {"kty","key_ops","n","e"} — we augment with RFC 7517 fields
+    base_jwk: Dict[str, Any] = json.loads(RSAAlgorithm.to_jwk(public_key))
+    base_jwk.pop("key_ops", None)  # replace with "use" (more standard)
+    base_jwk.update(
+        {
+            "use": "sig",
+            "alg": "RS256",
+            "kid": kid,
+        }
+    )
+
+    return {"keys": [base_jwk]}
+
+
+@well_known_router.get("/jwks.json", include_in_schema=True)
+async def get_jwks_well_known() -> JSONResponse:
+    """Return the JWKS at the RFC 8414 well-known discovery path.
+
+    This endpoint is **unauthenticated** — the public key is intentionally
+    readable by any client that needs to verify JWTs.
+    """
+    try:
+        jwks = _build_jwks()
+    except Exception as exc:
+        logger.error("Failed to build JWKS response: %s", exc)
+        return JSONResponse(status_code=503, content={"detail": "JWKS temporarily unavailable"})
+    return JSONResponse(
+        content=jwks,
+        media_type="application/json",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+@auth_router.get("/jwks", include_in_schema=True)
+async def get_jwks_auth() -> JSONResponse:
+    """Return the JWKS at the /api/auth/jwks convenience path.
+
+    Alias of the well-known endpoint — same response, same cache headers.
+    Unauthenticated (public key distribution, RFC 7517).
+    """
+    return await get_jwks_well_known()

--- a/autobot-backend/api/jwks_test.py
+++ b/autobot-backend/api/jwks_test.py
@@ -18,7 +18,6 @@ from jwt.algorithms import RSAAlgorithm
 
 from autobot_shared.auth.jwt_core import decode_jwt, encode_jwt
 
-
 # ---------------------------------------------------------------------------
 # Helpers: minimal AuthenticationMiddleware stub
 # ---------------------------------------------------------------------------
@@ -28,9 +27,7 @@ class _StubMiddleware:
     """Minimal stub that provides the attributes consumed by _build_jwks."""
 
     def __init__(self):
-        private_key = rsa.generate_private_key(
-            public_exponent=65537, key_size=2048, backend=default_backend()
-        )
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
         public_key = private_key.public_key()
         self.jwt_private_key = private_key.private_bytes(
             encoding=serialization.Encoding.PEM,
@@ -53,8 +50,9 @@ def stub_mw():
 def jwks_response(stub_mw, monkeypatch):
     """Build a JWKS dict using our stub middleware."""
     # Patch get_auth_middleware to return the stub
-    import api.jwks as jwks_module
     from unittest.mock import patch
+
+    import api.jwks as jwks_module
 
     with patch.object(jwks_module, "get_auth_middleware", return_value=stub_mw):
         return jwks_module._build_jwks()
@@ -66,8 +64,9 @@ def jwks_response(stub_mw, monkeypatch):
 
 
 def test_jwks_has_keys_list(stub_mw):
-    import api.jwks as jwks_module
     from unittest.mock import patch
+
+    import api.jwks as jwks_module
 
     with patch.object(jwks_module, "get_auth_middleware", return_value=stub_mw):
         jwks = jwks_module._build_jwks()
@@ -76,8 +75,9 @@ def test_jwks_has_keys_list(stub_mw):
 
 
 def test_jwks_key_fields(stub_mw):
-    import api.jwks as jwks_module
     from unittest.mock import patch
+
+    import api.jwks as jwks_module
 
     with patch.object(jwks_module, "get_auth_middleware", return_value=stub_mw):
         jwks = jwks_module._build_jwks()
@@ -95,8 +95,9 @@ def test_jwks_key_fields(stub_mw):
 
 def test_jwks_n_e_reconstruct_key_and_verify_token(stub_mw):
     """The JWK n/e values must reconstruct a key that verifies a freshly-minted token."""
-    import api.jwks as jwks_module
     from unittest.mock import patch
+
+    import api.jwks as jwks_module
 
     with patch.object(jwks_module, "get_auth_middleware", return_value=stub_mw):
         jwks = jwks_module._build_jwks()
@@ -122,9 +123,11 @@ def test_jwks_n_e_reconstruct_key_and_verify_token(stub_mw):
 
 def test_jwks_kid_matches_token_kid(stub_mw):
     """The kid in the JWK must match the kid embedded in signed tokens."""
-    import jwt as _jwt
-    import api.jwks as jwks_module
     from unittest.mock import patch
+
+    import jwt as _jwt
+
+    import api.jwks as jwks_module
 
     with patch.object(jwks_module, "get_auth_middleware", return_value=stub_mw):
         jwks = jwks_module._build_jwks()

--- a/autobot-backend/api/jwks_test.py
+++ b/autobot-backend/api/jwks_test.py
@@ -1,0 +1,141 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the JWKS endpoint at /.well-known/jwks.json (#10196).
+
+These tests exercise _build_jwks() directly (no FastAPI test client needed)
+so they run without standing up the full backend stack.
+"""
+
+import json
+
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
+
+from autobot_shared.auth.jwt_core import decode_jwt, encode_jwt
+
+
+# ---------------------------------------------------------------------------
+# Helpers: minimal AuthenticationMiddleware stub
+# ---------------------------------------------------------------------------
+
+
+class _StubMiddleware:
+    """Minimal stub that provides the attributes consumed by _build_jwks."""
+
+    def __init__(self):
+        private_key = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048, backend=default_backend()
+        )
+        public_key = private_key.public_key()
+        self.jwt_private_key = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode("utf-8")
+        self.jwt_public_key = public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode("utf-8")
+        self.jwt_kid = "autobot-test-1"
+
+
+@pytest.fixture(scope="module")
+def stub_mw():
+    return _StubMiddleware()
+
+
+@pytest.fixture(scope="module")
+def jwks_response(stub_mw, monkeypatch):
+    """Build a JWKS dict using our stub middleware."""
+    # Patch get_auth_middleware to return the stub
+    import api.jwks as jwks_module
+    from unittest.mock import patch
+
+    with patch.object(jwks_module, "get_auth_middleware", return_value=stub_mw):
+        return jwks_module._build_jwks()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_jwks_has_keys_list(stub_mw):
+    import api.jwks as jwks_module
+    from unittest.mock import patch
+
+    with patch.object(jwks_module, "get_auth_middleware", return_value=stub_mw):
+        jwks = jwks_module._build_jwks()
+    assert "keys" in jwks
+    assert len(jwks["keys"]) == 1
+
+
+def test_jwks_key_fields(stub_mw):
+    import api.jwks as jwks_module
+    from unittest.mock import patch
+
+    with patch.object(jwks_module, "get_auth_middleware", return_value=stub_mw):
+        jwks = jwks_module._build_jwks()
+
+    key = jwks["keys"][0]
+    assert key["kty"] == "RSA"
+    assert key["use"] == "sig"
+    assert key["alg"] == "RS256"
+    assert key["kid"] == "autobot-test-1"
+    assert "n" in key
+    assert "e" in key
+    # "key_ops" is replaced by "use"
+    assert "key_ops" not in key
+
+
+def test_jwks_n_e_reconstruct_key_and_verify_token(stub_mw):
+    """The JWK n/e values must reconstruct a key that verifies a freshly-minted token."""
+    import api.jwks as jwks_module
+    from unittest.mock import patch
+
+    with patch.object(jwks_module, "get_auth_middleware", return_value=stub_mw):
+        jwks = jwks_module._build_jwks()
+
+    key_dict = jwks["keys"][0]
+
+    # Reconstruct public key from JWK n/e
+    reconstructed_pub = RSAAlgorithm.from_jwk(json.dumps(key_dict))
+
+    # Mint a token with the stub's private key
+    token = encode_jwt(
+        {"sub": "test-user", "role": "admin"},
+        private_key=stub_mw.jwt_private_key,
+        algorithm="RS256",
+        kid=stub_mw.jwt_kid,
+    )
+
+    # Verify using the reconstructed public key from the JWK
+    payload = decode_jwt(token, public_key=reconstructed_pub, algorithms=["RS256"])  # type: ignore[arg-type]
+    assert payload["sub"] == "test-user"
+    assert payload["role"] == "admin"
+
+
+def test_jwks_kid_matches_token_kid(stub_mw):
+    """The kid in the JWK must match the kid embedded in signed tokens."""
+    import jwt as _jwt
+    import api.jwks as jwks_module
+    from unittest.mock import patch
+
+    with patch.object(jwks_module, "get_auth_middleware", return_value=stub_mw):
+        jwks = jwks_module._build_jwks()
+
+    key_kid = jwks["keys"][0]["kid"]
+
+    token = encode_jwt(
+        {"sub": "alice"},
+        private_key=stub_mw.jwt_private_key,
+        algorithm="RS256",
+        kid=stub_mw.jwt_kid,
+    )
+    token_kid = _jwt.get_unverified_header(token)["kid"]
+    assert key_kid == token_kid == stub_mw.jwt_kid

--- a/autobot-backend/app_factory.py
+++ b/autobot-backend/app_factory.py
@@ -107,6 +107,15 @@ def _register_routers(app: FastAPI) -> None:
     except Exception as e:
         logger.warning("⚠️ Failed to register Anthropic-compat router: %s", e)
 
+    # #10196: JWKS well-known endpoint at /.well-known/jwks.json (unauthenticated)
+    try:
+        from api.jwks import well_known_router as jwks_well_known_router
+
+        app.include_router(jwks_well_known_router, prefix="/.well-known")
+        logger.info("✅ Registered JWKS well-known router at /.well-known/jwks.json")
+    except Exception as e:
+        logger.warning("⚠️ Failed to register JWKS well-known router: %s", e)
+
     logger.info("✅ API routes configured with optional AI Stack integration")
 
 

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -16,6 +16,8 @@ from typing import Dict, Tuple
 from fastapi import HTTPException, Request, status
 
 from autobot_shared.auth.jwt_core import (
+    JWTDecodeError,
+    decode_jwt_multi,
     decode_jwt_or_none,
     encode_jwt,
     hash_password,
@@ -45,6 +47,9 @@ class AuthenticationMiddleware:
         self.session_timeout_minutes = self.security_config.get("session_timeout_minutes", 30)
         self.max_failed_attempts = self.security_config.get("max_failed_attempts", 3)
         self.lockout_duration_minutes = self.security_config.get("lockout_duration_minutes", 15)
+
+        # RS256 keypair (#10196): loaded/generated at startup
+        self.jwt_private_key, self.jwt_public_key, self.jwt_kid = self._get_rs256_keypair()
 
         # Use Redis for session storage if available, fallback to in-memory
         self.redis_client = None
@@ -110,6 +115,94 @@ class AuthenticationMiddleware:
             logger.error("Failed to store JWT secret in config: %s", e)
             # Still return the secure secret even if we can't store it
             return secure_secret
+
+    def _get_rs256_keypair(self) -> Tuple[str, str, str]:
+        """Load or auto-generate the RS256 keypair for signing user JWTs (#10196).
+
+        Priority order:
+        1. ``AUTOBOT_JWT_PRIVATE_KEY`` env var (PEM string)
+        2. Auto-generate a 2048-bit RSA keypair, persist in security config
+           (mirrors the existing HS256 generated-secret pattern)
+
+        The public key is always derived from the private key so they are
+        guaranteed to be consistent even when only the private key is supplied.
+
+        Returns:
+            Tuple of (pem_private_key, pem_public_key, kid).
+        """
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        kid = ssot_config.misc.jwt_kid or "autobot-1"
+
+        # 1. Check env var for private key
+        pem_private = ssot_config.misc.jwt_private_key
+        if pem_private:
+            try:
+                private_key = serialization.load_pem_private_key(
+                    pem_private.encode("utf-8"),
+                    password=None,
+                    backend=default_backend(),
+                )
+                public_key = private_key.public_key()
+                pem_public = public_key.public_bytes(
+                    encoding=serialization.Encoding.PEM,
+                    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+                ).decode("utf-8")
+                logger.info("RS256 private key loaded from AUTOBOT_JWT_PRIVATE_KEY")
+                return pem_private, pem_public, kid
+            except Exception as exc:
+                logger.error("Failed to load AUTOBOT_JWT_PRIVATE_KEY: %s — will auto-generate", exc)
+
+        # 2. Check security config for a previously persisted keypair
+        stored_pem = self.security_config.get("jwt_private_key_pem", "")
+        if stored_pem:
+            try:
+                private_key = serialization.load_pem_private_key(
+                    stored_pem.encode("utf-8"),
+                    password=None,
+                    backend=default_backend(),
+                )
+                public_key = private_key.public_key()
+                pem_public = public_key.public_bytes(
+                    encoding=serialization.Encoding.PEM,
+                    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+                ).decode("utf-8")
+                logger.info("RS256 keypair loaded from security config (previously auto-generated)")
+                return stored_pem, pem_public, kid
+            except Exception as exc:
+                logger.warning("Stored RS256 keypair in config is invalid: %s — regenerating", exc)
+
+        # 3. Auto-generate a fresh RSA-2048 keypair and persist it
+        logger.warning(
+            "No RS256 private key configured. Auto-generating RSA-2048 keypair. "
+            "Set AUTOBOT_JWT_PRIVATE_KEY to use a stable externally-managed key."
+        )
+        private_key = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=2048,
+            backend=default_backend(),
+        )
+        public_key = private_key.public_key()
+
+        pem_private = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode("utf-8")
+        pem_public = public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode("utf-8")
+
+        try:
+            config.set_nested("security_config.jwt_private_key_pem", pem_private)
+            logger.info("Auto-generated RS256 keypair persisted in security config")
+        except Exception as exc:
+            logger.error("Failed to persist RS256 keypair in config: %s — keypair is ephemeral", exc)
+
+        return pem_private, pem_public, kid
 
     def hash_password(self, password: str) -> str:
         """Hash password using bcrypt."""
@@ -257,7 +350,13 @@ class AuthenticationMiddleware:
         return self._build_successful_auth_response(username, user_config, ip_address)
 
     def create_jwt_token(self, user_data: Dict) -> str:
-        """Create JWT token for authenticated user."""
+        """Create an RS256-signed JWT token for authenticated user (#10196).
+
+        Signs with the RS256 private key and embeds the ``kid`` header so
+        consumers can locate the correct public key in the JWKS response.
+        Claims are unchanged: username / role / email / iat (+ user_id / org_id
+        from #684).
+        """
         payload = {
             "username": user_data["username"],
             "role": user_data["role"],
@@ -271,12 +370,32 @@ class AuthenticationMiddleware:
         if user_data.get("org_id"):
             payload["org_id"] = str(user_data["org_id"])
 
-        return encode_jwt(payload, secret=self.jwt_secret, expiry_hours=self.jwt_expiry_hours)
+        return encode_jwt(
+            payload,
+            private_key=self.jwt_private_key,
+            algorithm="RS256",
+            kid=self.jwt_kid,
+            expiry_hours=self.jwt_expiry_hours,
+        )
 
     def verify_jwt_token(self, token: str) -> Dict | None:
-        """Verify and decode JWT token."""
-        payload = decode_jwt_or_none(token, self.jwt_secret)
-        if payload is None:
+        """Verify and decode a JWT token.
+
+        Accepts both:
+        - RS256 tokens (new, signed by this authority with the private key)
+        - HS256 tokens (legacy, signed before the RS256 migration)
+
+        Algorithm-confusion is prevented by ``decode_jwt_multi``: an RS256
+        token is never verified with the HS256 secret, and vice-versa.
+        HS256 acceptance is logged as deprecated to track migration progress.
+        """
+        try:
+            payload = decode_jwt_multi(
+                token,
+                public_key=self.jwt_public_key,
+                hs256_secret=self.jwt_secret,
+            )
+        except Exception:
             return None
 
         # Check if user is locked out even when token is structurally valid

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -16,9 +16,7 @@ from typing import Dict, Tuple
 from fastapi import HTTPException, Request, status
 
 from autobot_shared.auth.jwt_core import (
-    JWTDecodeError,
     decode_jwt_multi,
-    decode_jwt_or_none,
     encode_jwt,
     hash_password,
     verify_password,

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -24,6 +24,7 @@ from api.agent_org import router as agent_org_router  # #1405
 from api.approval_gates import router as approval_gates_router  # #1402
 from api.audit import router as audit_router
 from api.auth import router as auth_router
+from api.jwks import auth_router as jwks_auth_router  # #10196
 from api.browser_mcp import router as browser_mcp_router
 from api.canvas import router as canvas_router  # MVA-359
 from api.chat import router as chat_router
@@ -134,6 +135,7 @@ def _get_system_routers() -> list:
         ),  # GH#6594
         (audit_router, "", ["audit"], "audit"),
         (auth_router, "/auth", ["auth"], "auth"),
+        (jwks_auth_router, "/auth", ["auth", "jwks"], "jwks_auth"),  # #10196 /api/auth/jwks
         (service_messages_router, "", ["service-messages"], "service_messages"),
         (chat_router, "", ["chat"], "chat"),
         (chat_compare_router, "", ["chat", "compare"], "chat_compare"),  # Issue #4414

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -24,7 +24,6 @@ from api.agent_org import router as agent_org_router  # #1405
 from api.approval_gates import router as approval_gates_router  # #1402
 from api.audit import router as audit_router
 from api.auth import router as auth_router
-from api.jwks import auth_router as jwks_auth_router  # #10196
 from api.browser_mcp import router as browser_mcp_router
 from api.canvas import router as canvas_router  # MVA-359
 from api.chat import router as chat_router
@@ -43,6 +42,7 @@ from api.frontend_config import router as frontend_config_router
 from api.git_mcp import router as git_mcp_router
 from api.http_client_mcp import router as http_client_mcp_router
 from api.intelligent_agent import router as intelligent_agent_router
+from api.jwks import auth_router as jwks_auth_router  # #10196
 from api.knowledge import router as knowledge_router
 from api.knowledge_ai_stack import router as knowledge_ai_stack_router
 from api.knowledge_audit import router as knowledge_audit_router

--- a/autobot_shared/auth/jwt_core.py
+++ b/autobot_shared/auth/jwt_core.py
@@ -220,8 +220,7 @@ def decode_jwt(
 
     if token_alg not in algorithms:
         raise JWTDecodeError(
-            f"JWT algorithm mismatch: token uses {token_alg!r} "
-            f"but allowed algorithms are {algorithms!r}"
+            f"JWT algorithm mismatch: token uses {token_alg!r} " f"but allowed algorithms are {algorithms!r}"
         )
 
     if token_alg == _ALGORITHM_RS256:
@@ -296,17 +295,20 @@ def decode_jwt_no_verify_exp(
 
     if token_alg not in algorithms:
         raise JWTDecodeError(
-            f"JWT algorithm mismatch: token uses {token_alg!r} "
-            f"but allowed algorithms are {algorithms!r}"
+            f"JWT algorithm mismatch: token uses {token_alg!r} " f"but allowed algorithms are {algorithms!r}"
         )
 
     if token_alg == _ALGORITHM_RS256:
         if not public_key:
-            raise JWTDecodeError("RS256 token presented but no public_key supplied — algorithm-confusion guard rejected")
+            raise JWTDecodeError(
+                "RS256 token presented but no public_key supplied — algorithm-confusion guard rejected"
+            )
         key: Any = public_key
     else:
         if not secret:
-            raise JWTDecodeError(f"{token_alg} token presented but no secret supplied — algorithm-confusion guard rejected")
+            raise JWTDecodeError(
+                f"{token_alg} token presented but no secret supplied — algorithm-confusion guard rejected"
+            )
         key = secret
 
     try:

--- a/autobot_shared/auth/jwt_core.py
+++ b/autobot_shared/auth/jwt_core.py
@@ -3,7 +3,7 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Shared JWT encode/decode core and bcrypt password helpers (#3840).
+Shared JWT encode/decode core and bcrypt password helpers (#3840, #10196).
 
 Both autobot-backend (auth_middleware.py) and autobot-slm-backend
 (services/auth.py) duplicated identical jwt.encode/jwt.decode and bcrypt
@@ -16,21 +16,39 @@ Design decisions:
   without this module touching environment variables or config objects.
 - ``decode_jwt`` distinguishes expiry from other decode failures via the two
   typed exceptions below, letting callers log each case appropriately.
-- The algorithm is hard-coded to HS256 because neither backend ever changed
-  it; if that changes in the future the parameter can be promoted.
+- RS256 support (#10196): the identity authority (autobot-backend) signs new
+  tokens with an RSA private key.  Consumer services verify using only the
+  public key fetched from the JWKS endpoint.  Legacy HS256 tokens (signed
+  before the upgrade) are still accepted via a graceful fallback so in-flight
+  sessions are not invalidated.
+- Algorithm-confusion prevention: the verification path reads the ``alg``
+  header from the token and matches it against an explicit allow-list.  An
+  RS256 token is NEVER verified with an HS256 secret, and vice-versa.
+  ``alg=none`` is blocked by always passing ``algorithms=[...]`` to PyJWT.
 - Password helpers are included because both backends contained byte-for-byte
   identical bcrypt wrappers.
 
-Usage (backend)::
+Usage (HS256 — unchanged default)::
 
     from autobot_shared.auth.jwt_core import encode_jwt, decode_jwt
 
     token = encode_jwt(payload, secret=jwt_secret)
     data   = decode_jwt(token,   secret=jwt_secret)  # raises on failure
 
-Usage (slm-backend)::
+Usage (RS256 — identity authority)::
 
     from autobot_shared.auth.jwt_core import encode_jwt, decode_jwt
+
+    token = encode_jwt(payload, private_key=pem_str, algorithm="RS256", kid="autobot-1")
+    data  = decode_jwt(token,   public_key=pem_str,  algorithms=["RS256"])
+
+Usage (dual-accept — consumer that accepts both during migration)::
+
+    from autobot_shared.auth.jwt_core import decode_jwt_multi
+
+    data = decode_jwt_multi(token, public_key=pem_pub, hs256_secret=legacy_secret)
+
+Usage (slm-backend — HS256 unchanged)::
 
     token = encode_jwt({"sub": username, "exp": expire}, secret=settings.secret_key)
     data   = decode_jwt(token, secret=settings.secret_key)
@@ -38,7 +56,7 @@ Usage (slm-backend)::
 
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import bcrypt
 import jwt
@@ -47,6 +65,8 @@ from jwt.exceptions import ExpiredSignatureError, InvalidTokenError
 logger = logging.getLogger(__name__)
 
 _ALGORITHM = "HS256"
+_ALGORITHM_RS256 = "RS256"
+_ALLOWED_ALGORITHMS = frozenset({"HS256", "RS256"})
 
 
 class JWTDecodeError(Exception):
@@ -57,13 +77,36 @@ class JWTExpiredError(JWTDecodeError):
     """Raised when a token is structurally valid but has expired."""
 
 
+def _peek_alg(token: str) -> str | None:
+    """Return the ``alg`` header value from *token* without verifying the signature.
+
+    Used to route verification to the correct key type before calling PyJWT.
+    Returns ``None`` if the header cannot be decoded (malformed token).
+
+    Security note: the algorithm is read from the *unverified* header.  We only
+    use it to select the verification key; PyJWT's own ``algorithms=`` guard
+    re-checks the header value against the allow-list during verification so a
+    tampered algorithm header cannot bypass signature validation.
+    """
+    try:
+        unverified = jwt.get_unverified_header(token)
+        return unverified.get("alg")
+    except Exception:
+        return None
+
+
 def encode_jwt(
     payload: Dict[str, Any],
-    secret: str,
+    secret: str | None = None,
+    private_key: str | None = None,
+    algorithm: str = _ALGORITHM,
+    kid: str | None = None,
     expires_delta: timedelta | None = None,
     expiry_hours: float | None = None,
 ) -> str:
-    """Encode *payload* as a signed HS256 JWT.
+    """Encode *payload* as a signed JWT.
+
+    Supports both HS256 (legacy / SLM) and RS256 (identity authority).
 
     Expiry precedence (first truthy value wins):
     1. ``exp`` key already present in *payload*
@@ -73,13 +116,24 @@ def encode_jwt(
 
     Args:
         payload: Claims dict.  A copy is taken; the caller's dict is not mutated.
-        secret: HMAC signing secret.
+        secret: HMAC signing secret.  Required when ``algorithm="HS256"``.
+        private_key: PEM-encoded RSA private key string.  Required when
+            ``algorithm="RS256"``.
+        algorithm: JWT algorithm — ``"HS256"`` (default) or ``"RS256"``.
+        kid: Key ID to embed in the JWT header.  Only used for RS256.
         expires_delta: Optional explicit TTL.
         expiry_hours: Optional TTL expressed as a float number of hours.
 
     Returns:
         Signed JWT string.
+
+    Raises:
+        ValueError: If neither ``secret`` nor ``private_key`` is supplied, or
+            if an unsupported ``algorithm`` is requested.
     """
+    if algorithm not in _ALLOWED_ALGORITHMS:
+        raise ValueError(f"Unsupported algorithm {algorithm!r}. Allowed: {sorted(_ALLOWED_ALGORITHMS)}")
+
     to_encode = payload.copy()
 
     if "exp" not in to_encode:
@@ -88,20 +142,52 @@ def encode_jwt(
         elif expiry_hours is not None:
             to_encode["exp"] = datetime.now(tz=timezone.utc) + timedelta(hours=expiry_hours)
 
+    if algorithm == _ALGORITHM_RS256:
+        if not private_key:
+            raise ValueError("private_key is required for RS256 encoding")
+        headers: Dict[str, Any] = {}
+        if kid:
+            headers["kid"] = kid
+        return jwt.encode(to_encode, private_key, algorithm=_ALGORITHM_RS256, headers=headers or None)
+
+    # HS256 path — unchanged behaviour for all existing callers
+    if not secret:
+        raise ValueError("secret is required for HS256 encoding")
     return jwt.encode(to_encode, secret, algorithm=_ALGORITHM)
 
 
-def decode_jwt(token: str, secret: str, audience: str | None = None) -> Dict[str, Any]:
-    """Decode and verify a signed HS256 JWT.
+def decode_jwt(
+    token: str,
+    secret: str | None = None,
+    public_key: str | None = None,
+    algorithms: List[str] | None = None,
+    audience: str | None = None,
+) -> Dict[str, Any]:
+    """Decode and verify a signed JWT.
+
+    Supports both HS256 (legacy / SLM) and RS256 (identity authority).
+
+    Algorithm-confusion prevention
+    --------------------------------
+    The ``alg`` header is read from the token before verification and compared
+    against the ``algorithms`` allow-list passed to PyJWT.  An RS256 token is
+    **never** verified with an HS256 secret: if the token's ``alg`` is RS256
+    but ``public_key`` is absent (or vice-versa), ``JWTDecodeError`` is raised
+    before PyJWT is called.  ``alg=none`` is blocked because PyJWT requires an
+    explicit non-empty algorithms list.
 
     Args:
         token: JWT string.
-        secret: HMAC signing secret.
-        audience: Expected ``aud`` claim value.  When provided, PyJWT enforces
-            that the token's ``aud`` matches; a missing or mismatched audience
-            raises ``JWTDecodeError``.  When ``None`` (default), audience
-            verification is skipped for backward compatibility with tokens that
-            do not carry an ``aud`` claim.
+        secret: HMAC signing secret.  Required for HS256 tokens when
+            ``algorithms`` does not include RS256 only.
+        public_key: PEM-encoded RSA public key string.  Required for RS256
+            tokens.
+        algorithms: Explicit allow-list passed to PyJWT.  Defaults to
+            ``["HS256"]`` when only ``secret`` is provided, and to ``["RS256"]``
+            when only ``public_key`` is provided.  The caller may pass
+            ``["HS256", "RS256"]`` to accept either, but must also supply the
+            appropriate key for the algorithm the token actually uses.
+        audience: Expected ``aud`` claim value.
 
     Returns:
         Decoded claims dict.
@@ -109,71 +195,202 @@ def decode_jwt(token: str, secret: str, audience: str | None = None) -> Dict[str
     Raises:
         JWTExpiredError: The token signature is valid but the token has expired.
         JWTDecodeError: The token is invalid for any other reason (bad signature,
-            malformed header/payload, unknown algorithm, audience mismatch, etc.).
+            malformed header/payload, unknown algorithm, audience mismatch,
+            algorithm-confusion attempt, etc.).
     """
+    # Resolve default algorithms from whichever key was supplied
+    if algorithms is None:
+        if public_key and not secret:
+            algorithms = [_ALGORITHM_RS256]
+        else:
+            algorithms = [_ALGORITHM]
+
+    # Validate that the algorithm list only contains supported values
+    unsupported = [a for a in algorithms if a not in _ALLOWED_ALGORITHMS]
+    if unsupported:
+        raise JWTDecodeError(f"Unsupported algorithms requested: {unsupported!r}")
+
+    # --- Algorithm-confusion guard -------------------------------------------
+    # Read the unverified header to select the correct verification key.
+    # PyJWT will re-validate the header against `algorithms` during decode,
+    # so this peek is only used to route to the right key.
+    token_alg = _peek_alg(token)
+    if token_alg is None:
+        raise JWTDecodeError("JWT token is invalid: cannot decode header")
+
+    if token_alg not in algorithms:
+        raise JWTDecodeError(
+            f"JWT algorithm mismatch: token uses {token_alg!r} "
+            f"but allowed algorithms are {algorithms!r}"
+        )
+
+    if token_alg == _ALGORITHM_RS256:
+        if not public_key:
+            raise JWTDecodeError(
+                "RS256 token presented but no public_key supplied for verification — "
+                "algorithm-confusion guard rejected"
+            )
+        key: Any = public_key
+    else:
+        # HS256 (or any future HMAC variant)
+        if not secret:
+            raise JWTDecodeError(
+                f"{token_alg} token presented but no secret supplied for verification — "
+                "algorithm-confusion guard rejected"
+            )
+        key = secret
+    # -------------------------------------------------------------------------
+
     try:
         if audience is not None:
-            return jwt.decode(token, secret, algorithms=[_ALGORITHM], audience=audience)
-        return jwt.decode(token, secret, algorithms=[_ALGORITHM], options={"verify_aud": False})
+            return jwt.decode(token, key, algorithms=algorithms, audience=audience)
+        return jwt.decode(token, key, algorithms=algorithms, options={"verify_aud": False})
     except ExpiredSignatureError as exc:
         raise JWTExpiredError("JWT token has expired") from exc
     except InvalidTokenError as exc:
         raise JWTDecodeError(f"JWT token is invalid: {exc}") from exc
 
 
-def decode_jwt_no_verify_exp(token: str, secret: str) -> Dict[str, Any]:
+def decode_jwt_no_verify_exp(
+    token: str,
+    secret: str | None = None,
+    public_key: str | None = None,
+    algorithms: List[str] | None = None,
+) -> Dict[str, Any]:
     """Decode a JWT without verifying expiry — for use in refresh-token flows only.
 
     Callers MUST perform their own grace-period check on the ``exp`` claim.
     This function still validates the signature and algorithm so a tampered
     token is rejected.
 
+    The algorithm-confusion guard from ``decode_jwt`` applies here too.
+
     Args:
         token: JWT string.
-        secret: HMAC signing secret.
+        secret: HMAC signing secret (HS256 tokens).
+        public_key: PEM-encoded RSA public key string (RS256 tokens).
+        algorithms: Explicit allow-list.  Defaults to ``["HS256"]`` or
+            ``["RS256"]`` based on which key is supplied.
 
     Returns:
         Decoded claims dict (expiry not enforced).
 
     Raises:
-        JWTDecodeError: The token is structurally invalid or the signature does
-            not match.
+        JWTDecodeError: The token is structurally invalid, the signature does
+            not match, or an algorithm-confusion attempt was detected.
     """
+    if algorithms is None:
+        if public_key and not secret:
+            algorithms = [_ALGORITHM_RS256]
+        else:
+            algorithms = [_ALGORITHM]
+
+    unsupported = [a for a in algorithms if a not in _ALLOWED_ALGORITHMS]
+    if unsupported:
+        raise JWTDecodeError(f"Unsupported algorithms requested: {unsupported!r}")
+
+    # Algorithm-confusion guard (same logic as decode_jwt)
+    token_alg = _peek_alg(token)
+    if token_alg is None:
+        raise JWTDecodeError("JWT token is invalid: cannot decode header")
+
+    if token_alg not in algorithms:
+        raise JWTDecodeError(
+            f"JWT algorithm mismatch: token uses {token_alg!r} "
+            f"but allowed algorithms are {algorithms!r}"
+        )
+
+    if token_alg == _ALGORITHM_RS256:
+        if not public_key:
+            raise JWTDecodeError("RS256 token presented but no public_key supplied — algorithm-confusion guard rejected")
+        key: Any = public_key
+    else:
+        if not secret:
+            raise JWTDecodeError(f"{token_alg} token presented but no secret supplied — algorithm-confusion guard rejected")
+        key = secret
+
     try:
         return jwt.decode(
             token,
-            secret,
-            algorithms=[_ALGORITHM],
+            key,
+            algorithms=algorithms,
             options={"verify_exp": False},
         )
     except InvalidTokenError as exc:
         raise JWTDecodeError(f"JWT token is invalid: {exc}") from exc
 
 
-def decode_jwt_or_none(token: str, secret: str) -> Dict[str, Any] | None:
+def decode_jwt_or_none(
+    token: str,
+    secret: str | None = None,
+    public_key: str | None = None,
+    algorithms: List[str] | None = None,
+) -> Dict[str, Any] | None:
     """Decode a JWT, returning ``None`` on any failure instead of raising.
 
-    Convenience wrapper for call sites that prefer ``None``-on-failure
-    (mirrors the original pattern in both backends).
+    Convenience wrapper for call sites that prefer ``None``-on-failure.
+    Expiry and invalid-signature failures are both logged at WARNING level.
 
-    Expiry and invalid-signature failures are both logged at WARNING level
-    so they remain visible in production logs without propagating exceptions.
+    For backward compatibility, the positional form ``decode_jwt_or_none(token, secret)``
+    continues to work (``secret`` accepts both positional and keyword).
 
     Args:
         token: JWT string.
-        secret: HMAC signing secret.
+        secret: HMAC signing secret (HS256 tokens).
+        public_key: PEM-encoded RSA public key string (RS256 tokens).
+        algorithms: Explicit allow-list.
 
     Returns:
         Decoded claims dict, or ``None`` if the token is invalid or expired.
     """
     try:
-        return decode_jwt(token, secret)
+        return decode_jwt(token, secret=secret, public_key=public_key, algorithms=algorithms)
     except JWTExpiredError:
         logger.warning("JWT token expired")
         return None
     except JWTDecodeError as exc:
         logger.warning("Invalid JWT token: %s", exc)
         return None
+
+
+def decode_jwt_multi(
+    token: str,
+    public_key: str,
+    hs256_secret: str,
+) -> Dict[str, Any]:
+    """Verify a JWT that may be RS256 (new) or HS256 (legacy), auto-routing by ``alg`` header.
+
+    This is the dual-accept helper for the identity authority's verify path
+    during the migration window.  It prevents algorithm-confusion by routing
+    each token to the correct key based on its own ``alg`` header.
+
+    Args:
+        token: JWT string.
+        public_key: PEM-encoded RSA public key (used for RS256 tokens).
+        hs256_secret: HMAC secret (used for HS256 legacy tokens).
+
+    Returns:
+        Decoded claims dict.
+
+    Raises:
+        JWTExpiredError: Token has expired.
+        JWTDecodeError: Token is invalid or algorithm-confusion was detected.
+    """
+    token_alg = _peek_alg(token)
+    if token_alg is None:
+        raise JWTDecodeError("JWT token is invalid: cannot decode header")
+
+    if token_alg == _ALGORITHM_RS256:
+        return decode_jwt(token, public_key=public_key, algorithms=[_ALGORITHM_RS256])
+
+    if token_alg == _ALGORITHM:
+        logger.warning(
+            "Accepted legacy HS256 JWT — token was issued before RS256 migration; "
+            "encourage client to re-login to receive a new RS256 token"
+        )
+        return decode_jwt(token, secret=hs256_secret, algorithms=[_ALGORITHM])
+
+    raise JWTDecodeError(f"JWT uses unsupported algorithm {token_alg!r}")
 
 
 def hash_password(password: str) -> str:

--- a/autobot_shared/auth/jwt_core_rs256_test.py
+++ b/autobot_shared/auth/jwt_core_rs256_test.py
@@ -1,0 +1,359 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""RS256 and algorithm-confusion tests for autobot_shared.auth.jwt_core (#10196)."""
+
+from datetime import timedelta
+
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from autobot_shared.auth.jwt_core import (
+    JWTDecodeError,
+    JWTExpiredError,
+    _peek_alg,
+    decode_jwt,
+    decode_jwt_multi,
+    decode_jwt_no_verify_exp,
+    decode_jwt_or_none,
+    encode_jwt,
+)
+
+_HS256_SECRET = "test-hs256-secret-for-unit-tests-only-32chars"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: RSA keypair
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair():
+    """Generate a test RSA-2048 keypair once per module."""
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend(),
+    )
+    public_key = private_key.public_key()
+    pem_private = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    pem_public = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+    return pem_private, pem_public
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair_b(rsa_keypair):
+    """A second, different RSA keypair — used to test wrong-key rejection."""
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend(),
+    )
+    public_key = private_key.public_key()
+    pem_private = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    pem_public = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+    return pem_private, pem_public
+
+
+# ---------------------------------------------------------------------------
+# encode_jwt / decode_jwt — RS256 round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_rs256_roundtrip_basic(rsa_keypair):
+    pem_priv, pem_pub = rsa_keypair
+    token = encode_jwt({"sub": "alice", "role": "admin"}, private_key=pem_priv, algorithm="RS256")
+    payload = decode_jwt(token, public_key=pem_pub, algorithms=["RS256"])
+    assert payload["sub"] == "alice"
+    assert payload["role"] == "admin"
+
+
+def test_rs256_token_carries_kid(rsa_keypair):
+    """Tokens signed with RS256 must embed the kid header."""
+    pem_priv, pem_pub = rsa_keypair
+    token = encode_jwt(
+        {"sub": "alice"},
+        private_key=pem_priv,
+        algorithm="RS256",
+        kid="autobot-1",
+    )
+    header = _peek_alg.__module__  # confirm module imported
+    import jwt as _jwt
+
+    unverified = _jwt.get_unverified_header(token)
+    assert unverified.get("kid") == "autobot-1"
+    assert unverified.get("alg") == "RS256"
+
+
+def test_rs256_expiry_from_expiry_hours(rsa_keypair):
+    pem_priv, pem_pub = rsa_keypair
+    token = encode_jwt({"sub": "alice"}, private_key=pem_priv, algorithm="RS256", expiry_hours=1)
+    payload = decode_jwt(token, public_key=pem_pub, algorithms=["RS256"])
+    assert "exp" in payload
+
+
+def test_rs256_expired_raises_jwt_expired_error(rsa_keypair):
+    pem_priv, pem_pub = rsa_keypair
+    token = encode_jwt(
+        {"sub": "alice"},
+        private_key=pem_priv,
+        algorithm="RS256",
+        expires_delta=timedelta(seconds=-1),
+    )
+    with pytest.raises(JWTExpiredError):
+        decode_jwt(token, public_key=pem_pub, algorithms=["RS256"])
+
+
+def test_rs256_wrong_public_key_raises_jwt_decode_error(rsa_keypair, rsa_keypair_b):
+    """RS256 token verified with a different public key must be rejected."""
+    pem_priv, _ = rsa_keypair
+    _, pem_pub_b = rsa_keypair_b
+    token = encode_jwt({"sub": "alice"}, private_key=pem_priv, algorithm="RS256")
+    with pytest.raises(JWTDecodeError):
+        decode_jwt(token, public_key=pem_pub_b, algorithms=["RS256"])
+
+
+# ---------------------------------------------------------------------------
+# Algorithm-confusion prevention (SECURITY-CRITICAL)
+# ---------------------------------------------------------------------------
+
+
+def test_algorithm_confusion_rs256_token_rejected_with_hs256_secret(rsa_keypair):
+    """RS256 token MUST NOT verify when passed the HS256 secret.
+
+    This is the primary algorithm-confusion attack vector.  PyJWT's
+    ``algorithms=`` guard prevents it, and our own header-routing guard
+    catches it before PyJWT is even called.
+    """
+    pem_priv, pem_pub = rsa_keypair
+    token = encode_jwt({"sub": "alice"}, private_key=pem_priv, algorithm="RS256")
+    with pytest.raises(JWTDecodeError):
+        decode_jwt(token, secret=_HS256_SECRET, algorithms=["HS256"])
+
+
+def test_algorithm_confusion_hs256_token_rejected_with_public_key(rsa_keypair):
+    """HS256 token MUST NOT verify when passed an RSA public key."""
+    _, pem_pub = rsa_keypair
+    token = encode_jwt({"sub": "alice"}, secret=_HS256_SECRET, algorithm="HS256")
+    with pytest.raises(JWTDecodeError):
+        decode_jwt(token, public_key=pem_pub, algorithms=["RS256"])
+
+
+def test_alg_none_rejected_rs256(rsa_keypair):
+    """A manually-crafted ``alg=none`` token must be rejected.
+
+    We fabricate an alg=none token by using PyJWT with options={"verify_signature":False}
+    only to get the structure, then confirm our decode_jwt rejects it.
+    """
+    import base64
+    import json
+
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "none", "typ": "JWT"}).encode()).rstrip(b"=").decode()
+    payload_b = base64.urlsafe_b64encode(json.dumps({"sub": "evil"}).encode()).rstrip(b"=").decode()
+    none_token = f"{header}.{payload_b}."
+
+    _, pem_pub = rsa_keypair
+    with pytest.raises(JWTDecodeError):
+        decode_jwt(none_token, public_key=pem_pub, algorithms=["RS256"])
+
+
+def test_algorithm_mismatch_in_algorithms_list_rejected(rsa_keypair):
+    """RS256 token presented to an HS256-only allow-list is rejected."""
+    pem_priv, _ = rsa_keypair
+    token = encode_jwt({"sub": "alice"}, private_key=pem_priv, algorithm="RS256")
+    with pytest.raises(JWTDecodeError):
+        # algorithms=["HS256"] explicitly: token's RS256 alg is not in the list
+        decode_jwt(token, secret=_HS256_SECRET, algorithms=["HS256"])
+
+
+def test_encode_jwt_rejects_unsupported_algorithm():
+    with pytest.raises(ValueError, match="Unsupported algorithm"):
+        encode_jwt({"sub": "x"}, secret="s", algorithm="ES256")
+
+
+# ---------------------------------------------------------------------------
+# decode_jwt_no_verify_exp with RS256
+# ---------------------------------------------------------------------------
+
+
+def test_decode_jwt_no_verify_exp_rs256_expired_still_decodes(rsa_keypair):
+    pem_priv, pem_pub = rsa_keypair
+    token = encode_jwt(
+        {"sub": "alice"},
+        private_key=pem_priv,
+        algorithm="RS256",
+        expires_delta=timedelta(seconds=-60),
+    )
+    payload = decode_jwt_no_verify_exp(token, public_key=pem_pub, algorithms=["RS256"])
+    assert payload["sub"] == "alice"
+
+
+def test_decode_jwt_no_verify_exp_rs256_rejects_wrong_key(rsa_keypair, rsa_keypair_b):
+    pem_priv, _ = rsa_keypair
+    _, pem_pub_b = rsa_keypair_b
+    token = encode_jwt({"sub": "alice"}, private_key=pem_priv, algorithm="RS256")
+    with pytest.raises(JWTDecodeError):
+        decode_jwt_no_verify_exp(token, public_key=pem_pub_b, algorithms=["RS256"])
+
+
+def test_decode_jwt_no_verify_exp_rs256_algo_confusion_blocked(rsa_keypair):
+    pem_priv, _ = rsa_keypair
+    token = encode_jwt({"sub": "alice"}, private_key=pem_priv, algorithm="RS256")
+    with pytest.raises(JWTDecodeError):
+        decode_jwt_no_verify_exp(token, secret=_HS256_SECRET, algorithms=["HS256"])
+
+
+# ---------------------------------------------------------------------------
+# decode_jwt_or_none with RS256
+# ---------------------------------------------------------------------------
+
+
+def test_decode_jwt_or_none_rs256_success(rsa_keypair):
+    pem_priv, pem_pub = rsa_keypair
+    token = encode_jwt({"sub": "bob"}, private_key=pem_priv, algorithm="RS256")
+    result = decode_jwt_or_none(token, public_key=pem_pub, algorithms=["RS256"])
+    assert result is not None
+    assert result["sub"] == "bob"
+
+
+def test_decode_jwt_or_none_rs256_expired_returns_none(rsa_keypair):
+    pem_priv, pem_pub = rsa_keypair
+    token = encode_jwt(
+        {"sub": "bob"},
+        private_key=pem_priv,
+        algorithm="RS256",
+        expires_delta=timedelta(seconds=-1),
+    )
+    assert decode_jwt_or_none(token, public_key=pem_pub, algorithms=["RS256"]) is None
+
+
+def test_decode_jwt_or_none_rs256_wrong_key_returns_none(rsa_keypair, rsa_keypair_b):
+    pem_priv, _ = rsa_keypair
+    _, pem_pub_b = rsa_keypair_b
+    token = encode_jwt({"sub": "bob"}, private_key=pem_priv, algorithm="RS256")
+    assert decode_jwt_or_none(token, public_key=pem_pub_b, algorithms=["RS256"]) is None
+
+
+# ---------------------------------------------------------------------------
+# decode_jwt_multi — dual-accept migration helper
+# ---------------------------------------------------------------------------
+
+
+def test_decode_jwt_multi_accepts_rs256(rsa_keypair):
+    pem_priv, pem_pub = rsa_keypair
+    token = encode_jwt({"sub": "alice"}, private_key=pem_priv, algorithm="RS256")
+    payload = decode_jwt_multi(token, public_key=pem_pub, hs256_secret=_HS256_SECRET)
+    assert payload["sub"] == "alice"
+
+
+def test_decode_jwt_multi_accepts_hs256_legacy(rsa_keypair):
+    """Legacy HS256 tokens still accepted during migration window."""
+    _, pem_pub = rsa_keypair
+    token = encode_jwt({"sub": "legacy-user"}, secret=_HS256_SECRET)
+    payload = decode_jwt_multi(token, public_key=pem_pub, hs256_secret=_HS256_SECRET)
+    assert payload["sub"] == "legacy-user"
+
+
+def test_decode_jwt_multi_rs256_rejected_with_wrong_public_key(rsa_keypair, rsa_keypair_b):
+    pem_priv, _ = rsa_keypair
+    _, pem_pub_b = rsa_keypair_b
+    token = encode_jwt({"sub": "alice"}, private_key=pem_priv, algorithm="RS256")
+    with pytest.raises(JWTDecodeError):
+        decode_jwt_multi(token, public_key=pem_pub_b, hs256_secret=_HS256_SECRET)
+
+
+def test_decode_jwt_multi_rs256_wrong_hs256_secret_is_irrelevant(rsa_keypair):
+    """RS256 token routed to public-key path; wrong HS256 secret is not used."""
+    pem_priv, pem_pub = rsa_keypair
+    token = encode_jwt({"sub": "alice"}, private_key=pem_priv, algorithm="RS256")
+    # Even with a garbage HS256 secret, RS256 verification works because the
+    # secret is never used for RS256 tokens.
+    payload = decode_jwt_multi(token, public_key=pem_pub, hs256_secret="garbage")
+    assert payload["sub"] == "alice"
+
+
+def test_decode_jwt_multi_hs256_wrong_secret_rejected(rsa_keypair):
+    _, pem_pub = rsa_keypair
+    token = encode_jwt({"sub": "alice"}, secret=_HS256_SECRET)
+    with pytest.raises(JWTDecodeError):
+        decode_jwt_multi(token, public_key=pem_pub, hs256_secret="wrong-secret-32charssssssssssssssss")
+
+
+def test_decode_jwt_multi_expired_rs256_raises_jwt_expired_error(rsa_keypair):
+    pem_priv, pem_pub = rsa_keypair
+    token = encode_jwt(
+        {"sub": "alice"},
+        private_key=pem_priv,
+        algorithm="RS256",
+        expires_delta=timedelta(seconds=-1),
+    )
+    with pytest.raises(JWTExpiredError):
+        decode_jwt_multi(token, public_key=pem_pub, hs256_secret=_HS256_SECRET)
+
+
+# ---------------------------------------------------------------------------
+# JWKS endpoint — public key round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_jwks_n_e_reconstruct_signing_key_and_verify(rsa_keypair):
+    """The n/e values in the JWK must reconstruct a key that verifies signed tokens."""
+    import json
+
+    from jwt.algorithms import RSAAlgorithm
+
+    pem_priv, pem_pub = rsa_keypair
+
+    # Simulate what the JWKS endpoint emits
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+
+    public_key_obj = serialization.load_pem_public_key(pem_pub.encode(), backend=default_backend())
+    base_jwk = json.loads(RSAAlgorithm.to_jwk(public_key_obj))
+    base_jwk.update({"use": "sig", "alg": "RS256", "kid": "autobot-1"})
+    base_jwk.pop("key_ops", None)
+
+    # Reconstruct public key from JWK
+    reconstructed_pub = RSAAlgorithm.from_jwk(json.dumps(base_jwk))
+
+    # Mint a fresh token and verify with the reconstructed key
+    token = encode_jwt({"sub": "alice"}, private_key=pem_priv, algorithm="RS256")
+    payload = decode_jwt(token, public_key=reconstructed_pub, algorithms=["RS256"])  # type: ignore[arg-type]
+    assert payload["sub"] == "alice"
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: legacy HS256 callers unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_hs256_encode_decode_still_works():
+    """The positional (secret) HS256 API is unchanged — no regression."""
+    token = encode_jwt({"sub": "alice"}, secret=_HS256_SECRET)
+    payload = decode_jwt(token, secret=_HS256_SECRET)
+    assert payload["sub"] == "alice"
+
+
+def test_hs256_decode_jwt_or_none_positional_secret_still_works():
+    """Positional call ``decode_jwt_or_none(token, secret)`` still works."""
+    token = encode_jwt({"sub": "alice"}, secret=_HS256_SECRET)
+    result = decode_jwt_or_none(token, _HS256_SECRET)
+    assert result is not None
+    assert result["sub"] == "alice"

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1306,6 +1306,31 @@ class MiscConfig(BaseSettings):
     internal_api_key: str = Field(default="", alias="AUTOBOT_INTERNAL_API_KEY")
     jaeger_endpoint: str = Field(default="", alias="AUTOBOT_JAEGER_ENDPOINT")
     jwt_secret: str = Field(default="", alias="AUTOBOT_JWT_SECRET")
+    jwt_private_key: str = Field(
+        default="",
+        alias="AUTOBOT_JWT_PRIVATE_KEY",
+        description=(
+            "PEM-encoded RSA private key for signing RS256 user JWTs (#10196). "
+            "When absent, autobot-backend auto-generates and persists a 2048-bit keypair. "
+            "Supply this to use an externally-managed key (e.g. from a secrets manager). "
+            "NEVER share with consumer services; they use the public key from JWKS."
+        ),
+    )
+    jwt_public_key: str = Field(
+        default="",
+        alias="AUTOBOT_JWT_PUBLIC_KEY",
+        description=(
+            "PEM-encoded RSA public key corresponding to AUTOBOT_JWT_PRIVATE_KEY (#10196). "
+            "Optional: derived from the private key at startup when absent. "
+            "Useful when you want to distribute the public key via env without "
+            "embedding the private key on consumer hosts."
+        ),
+    )
+    jwt_kid: str = Field(
+        default="autobot-1",
+        alias="AUTOBOT_JWT_KID",
+        description="Key ID (kid) embedded in RS256 JWT headers and published in the JWKS (#10196).",
+    )
     llm_key_rotation_grace_secs: str = Field(default="", alias="AUTOBOT_LLM_KEY_ROTATION_GRACE_SECS")
     llm_key_rotation_interval_minutes: str = Field(default="", alias="AUTOBOT_LLM_KEY_ROTATION_INTERVAL_MINUTES")
     llm_models_yaml: str = Field(default="", alias="AUTOBOT_LLM_MODELS_YAML")


### PR DESCRIPTION
## Thinking Path
Phase 1 foundation of the unified-userbase epic (#10193). For one identity across machines (Pattern B, distributed), token verification must use a **public** key so the SLM/consumers never hold the signing secret. Today JWTs are HS256 (symmetric) — verifying off-host requires spreading the secret. Move the identity authority (autobot-backend) to **RS256 + JWKS**: authority holds the private key; consumers verify with the published public key. HS256 stays supported during transition so in-flight sessions don't break.

## What Changed
- **`autobot_shared/auth/jwt_core.py`**: dual-algorithm support. `encode_jwt(..., algorithm="RS256", private_key=, kid=)` signs RS256 with a `kid` header; HS256 path unchanged (default — all existing callers keep working). Decode paths take `public_key` + an explicit `algorithms` allow-list.
- **Algorithm-confusion guard (security core):** `_ALLOWED_ALGORITHMS={HS256,RS256}` (no `none`); decode resolves a restrictive `algorithms` list, peeks the header only to *route* the key (RS256→public key, HS256→secret), rejects any token whose `alg` isn't in the allow-list, and always passes explicit `algorithms=` to PyJWT (defense-in-depth). An RS256 token cannot be verified with the HS256 secret, and vice-versa.
- **Keypair provisioning** (`ssot_config` + `auth_middleware._get_rs256_keypair`): `AUTOBOT_JWT_PRIVATE_KEY`/`_PUBLIC_KEY`/`_KID`; auto-generates + persists an RSA-2048 keypair if unset (same pattern as the current generated HS256 secret).
- **Authority signs RS256** (`create_jwt_token`) with `kid`; **`verify_jwt_token` accepts RS256 (public key) AND legacy HS256** (deprecated, logged) so existing sessions survive. Refresh routes by `alg`.
- **JWKS endpoint:** `GET /.well-known/jwks.json` + `GET /api/auth/jwks` (unauthenticated) returning the public key as a JWK Set (`kty/use/alg/kid/n/e`), `Cache-Control: public, max-age=3600`.

## Verification
- **58 tests pass**: 25 RS256/confusion (incl. RS256-with-HS256-secret rejected, HS256-with-public-key rejected, `alg=none` rejected, wrong-key rejected — for both decode + no-verify-exp paths), 4 JWKS (JWK `n`/`e` reconstruct the signing key + verify a minted token), 14 legacy HS256 (no regression), 15 cross-service parity. `py_compile` clean.
- Reviewed the decode key-routing + allow-list myself.

## Follow-ups (flagged, not in scope)
`services/run_jwt.py`, `services/device_jwt.py`, and the SLM's own session tokens remain HS256 (domain-scoped, unchanged, still working). The SLM consuming JWKS to verify authority tokens is **#10197**.

## Model Used
Opus 4.8 (1M) — implemented via subagent, security-reviewed.

Advances #10196 (part of #10193).