### PR TITLE
feat(frontend): entity-anchor click handler for chat messages (#9479)

### DIFF
--- a/autobot-frontend/src/components/chat/MessageItem.vue
+++ b/autobot-frontend/src/components/chat/MessageItem.vue
@@ -80,7 +80,8 @@
     <div class="message-content" :class="contentClass">
       <!-- Streaming content with typing indicator -->
       <div v-if="isStreaming" class="streaming-content">
-        <div class="message-text" v-html="formattedContent"></div>
+        <!-- Issue #9479: intercept entity-anchor clicks for in-app navigation -->
+        <div class="message-text" v-html="formattedContent" @click="handleContentClick"></div>
         <div v-if="isTyping && isLast" class="typing-indicator">
           <div class="typing-dots">
             <span></span>
@@ -91,7 +92,8 @@
       </div>
 
       <!-- Regular message content -->
-      <div v-else class="message-text" v-html="formattedContent"></div>
+      <!-- Issue #9479: intercept entity-anchor clicks for in-app navigation -->
+      <div v-else class="message-text" v-html="formattedContent" @click="handleContentClick"></div>
 
       <!-- Message Metadata -->
       <div v-if="showMetadata" class="message-metadata">
@@ -179,6 +181,7 @@ import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
 import type { ChatMessage } from '@/stores/useChatStore'
 import { formatTime } from '@/utils/formatHelpers'
 
@@ -190,6 +193,10 @@ import CitationsDisplay from './CitationsDisplay.vue'
 import MessageAttachments from './MessageAttachments.vue'
 import { sanitizeChatHtml } from '@/utils/sanitize'
 import { useAIDocument } from '@/composables/useAIDocument'
+import {
+  createEntityAnchorClickHandler,
+  renderMarkdownLinks,
+} from '@/composables/chat/useEntityAnchors'
 
 interface Props {
   message: ChatMessage
@@ -225,6 +232,10 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const emit = defineEmits<Emits>()
+
+// Issue #9479: route entity anchors (`[Name](#kind-id)`) to the right view
+const router = useRouter()
+const handleContentClick = createEntityAnchorClickHandler(router)
 
 // Issue #3245: Save-as-document integration
 const { saveMessageAsDocument } = useAIDocument()
@@ -336,6 +347,11 @@ const formattedContent = computed(() => {
     return `<pre class="code-block${lang ? ` language-${lang}` : ''}"><code>${code.trim()}</code></pre>`
   })
 
+  // Issue #9479: render `[text](href)` markdown links — including entity
+  // anchors (`#kind-id`) — into <a> before inline formatting so they become
+  // clickable. Output is sanitized by sanitizeChatHtml below.
+  content = renderMarkdownLinks(content)
+
   // Basic markdown formatting
   content = content
     .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
@@ -343,9 +359,9 @@ const formattedContent = computed(() => {
     .replace(/`(.*?)`/g, '<code>$1</code>')
     .replace(/\n/g, '<br>')
 
-  // Links
+  // Bare URLs — skip URLs already inside an anchor href (rendered above)
   content = content.replace(
-    /(https?:\/\/[^\s]+)/g,
+    /(?<!href=")(https?:\/\/[^\s<]+)/g,
     '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>'
   )
 

--- a/autobot-frontend/src/composables/chat/__tests__/useEntityAnchors.test.ts
+++ b/autobot-frontend/src/composables/chat/__tests__/useEntityAnchors.test.ts
@@ -1,0 +1,142 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// Tests for useEntityAnchors (#9479 — entity anchor click handler, #9297 follow-up)
+
+import { describe, it, expect, vi } from 'vitest'
+import {
+  parseEntityAnchor,
+  resolveEntityRoute,
+  renderMarkdownLinks,
+  createEntityAnchorClickHandler,
+  type EntityKind,
+} from '../useEntityAnchors'
+
+describe('parseEntityAnchor', () => {
+  it.each<[string, EntityKind, string]>([
+    ['#session-abc123', 'session', 'abc123'],
+    ['#document-42', 'document', '42'],
+    ['#task-7', 'task', '7'],
+    ['#workflow-build', 'workflow', 'build'],
+    ['#knowledge-node-9', 'knowledge', 'node-9'],
+  ])('parses %s into kind/id', (href, kind, id) => {
+    expect(parseEntityAnchor(href)).toEqual({ kind, id })
+  })
+
+  it('returns null for non-entity hash anchors (headings)', () => {
+    expect(parseEntityAnchor('#section-heading')).toBeNull() // "section" is not a kind
+    expect(parseEntityAnchor('#heading')).toBeNull()
+    expect(parseEntityAnchor('#unknown-1')).toBeNull()
+  })
+
+  it('returns null for external links and empty/missing hrefs', () => {
+    expect(parseEntityAnchor('https://example.com')).toBeNull()
+    expect(parseEntityAnchor('#')).toBeNull()
+    expect(parseEntityAnchor('#document-')).toBeNull()
+    expect(parseEntityAnchor('')).toBeNull()
+    expect(parseEntityAnchor(null)).toBeNull()
+    expect(parseEntityAnchor(undefined)).toBeNull()
+  })
+})
+
+describe('resolveEntityRoute', () => {
+  it('routes sessions and documents to their detail routes by param', () => {
+    expect(resolveEntityRoute({ kind: 'session', id: 's1' })).toEqual({
+      name: 'chat-session',
+      params: { sessionId: 's1' },
+    })
+    expect(resolveEntityRoute({ kind: 'document', id: 'd1' })).toEqual({
+      name: 'document-detail',
+      params: { docId: 'd1' },
+    })
+  })
+
+  it('routes tasks/workflows to automation and knowledge to the entity explorer via query', () => {
+    expect(resolveEntityRoute({ kind: 'workflow', id: 'w1' })).toEqual({
+      name: 'automation',
+      query: { workflow: 'w1' },
+    })
+    expect(resolveEntityRoute({ kind: 'task', id: 't1' })).toEqual({
+      name: 'automation',
+      query: { task: 't1' },
+    })
+    expect(resolveEntityRoute({ kind: 'knowledge', id: 'k1' })).toEqual({
+      name: 'knowledge-graph-entities',
+      query: { entity: 'k1' },
+    })
+  })
+})
+
+describe('renderMarkdownLinks', () => {
+  it('renders entity anchors as same-tab links', () => {
+    expect(renderMarkdownLinks('see [Report](#document-42)')).toBe(
+      'see <a href="#document-42">Report</a>',
+    )
+  })
+
+  it('renders http(s) links as new-tab external links', () => {
+    expect(renderMarkdownLinks('[site](https://example.com)')).toBe(
+      '<a href="https://example.com" target="_blank" rel="noopener noreferrer">site</a>',
+    )
+  })
+
+  it('drops unsafe schemes, keeping only the link text', () => {
+    expect(renderMarkdownLinks('[x](javascript:doEvil)')).toBe('x')
+  })
+
+  it('escapes HTML in the link label', () => {
+    expect(renderMarkdownLinks('[<b>hi</b>](#task-1)')).toBe(
+      '<a href="#task-1">&lt;b&gt;hi&lt;/b&gt;</a>',
+    )
+  })
+})
+
+describe('createEntityAnchorClickHandler', () => {
+  function clickEvent(anchor: { href: string } | null): MouseEvent {
+    const anchorEl = anchor
+      ? ({ getAttribute: () => anchor.href } as unknown as HTMLAnchorElement)
+      : null
+    const target = {
+      closest: (sel: string) => (sel === 'a' ? anchorEl : null),
+    } as unknown as HTMLElement
+    return {
+      target,
+      preventDefault: vi.fn(),
+    } as unknown as MouseEvent
+  }
+
+  it('navigates and prevents default for entity anchors', () => {
+    const push = vi.fn().mockResolvedValue(undefined)
+    const handler = createEntityAnchorClickHandler({ push })
+    const ev = clickEvent({ href: '#document-42' })
+
+    handler(ev)
+
+    expect(ev.preventDefault).toHaveBeenCalled()
+    expect(push).toHaveBeenCalledWith({ name: 'document-detail', params: { docId: '42' } })
+  })
+
+  it('does not interfere with external links', () => {
+    const push = vi.fn()
+    const handler = createEntityAnchorClickHandler({ push })
+    const ev = clickEvent({ href: 'https://example.com' })
+
+    handler(ev)
+
+    expect(ev.preventDefault).not.toHaveBeenCalled()
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the click is not on an anchor', () => {
+    const push = vi.fn()
+    const handler = createEntityAnchorClickHandler({ push })
+    const ev = clickEvent(null)
+
+    handler(ev)
+
+    expect(ev.preventDefault).not.toHaveBeenCalled()
+    expect(push).not.toHaveBeenCalled()
+  })
+})

--- a/autobot-frontend/src/composables/chat/useEntityAnchors.ts
+++ b/autobot-frontend/src/composables/chat/useEntityAnchors.ts
@@ -1,0 +1,147 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Entity anchor navigation (Issue #9479, follow-up to #9297).
+ *
+ * The chat system prompt emits `[Name](#kind-id)` markdown anchors for
+ * navigable entities (sessions, documents, tasks, workflows, knowledge items).
+ * This composable resolves a hash anchor href to a Vue Router location so the
+ * chat message renderer can intercept clicks and route to the right view —
+ * with zero backend changes.
+ *
+ * Anchor format: `#<kind>-<id>` where kind is one of the keys below.
+ */
+
+import type { RouteLocationRaw } from 'vue-router'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useEntityAnchors')
+
+/** Recognised entity kinds and their anchor prefixes. */
+export type EntityKind = 'session' | 'document' | 'task' | 'workflow' | 'knowledge'
+
+const ENTITY_KINDS: readonly EntityKind[] = [
+  'session',
+  'document',
+  'task',
+  'workflow',
+  'knowledge',
+] as const
+
+/** A parsed entity anchor. */
+export interface ParsedEntityAnchor {
+  kind: EntityKind
+  id: string
+}
+
+/**
+ * Parse a hash anchor href (e.g. `#document-42`) into its kind and id.
+ *
+ * Returns `null` for hrefs that are not recognised entity anchors so that
+ * regular external links and plain heading anchors are left untouched.
+ */
+export function parseEntityAnchor(href: string | null | undefined): ParsedEntityAnchor | null {
+  if (!href || !href.startsWith('#')) return null
+
+  const body = href.slice(1)
+  const dash = body.indexOf('-')
+  if (dash <= 0) return null
+
+  const kind = body.slice(0, dash)
+  const id = body.slice(dash + 1)
+  if (!id) return null
+
+  if (!(ENTITY_KINDS as readonly string[]).includes(kind)) return null
+
+  return { kind: kind as EntityKind, id }
+}
+
+/**
+ * Resolve a parsed entity anchor to a Vue Router location.
+ *
+ * Kinds with a dedicated detail route navigate by named route + params;
+ * the rest target the most useful existing destination and pass the id as a
+ * query param so that view can focus/highlight the referenced entity.
+ */
+export function resolveEntityRoute(anchor: ParsedEntityAnchor): RouteLocationRaw {
+  switch (anchor.kind) {
+    case 'session':
+      return { name: 'chat-session', params: { sessionId: anchor.id } }
+    case 'document':
+      return { name: 'document-detail', params: { docId: anchor.id } }
+    case 'workflow':
+      return { name: 'automation', query: { workflow: anchor.id } }
+    case 'task':
+      return { name: 'automation', query: { task: anchor.id } }
+    case 'knowledge':
+      return { name: 'knowledge-graph-entities', query: { entity: anchor.id } }
+  }
+}
+
+/** Escape the HTML-significant characters in plain text. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+/**
+ * Convert `[text](href)` markdown links to anchor tags.
+ *
+ * Entity-anchor hash hrefs (`#kind-id`) become same-tab links so the click
+ * handler can intercept them; http(s) hrefs become new-tab external links.
+ * Any other scheme is dropped (rendered as the link text only) to avoid
+ * `javascript:` and similar injection — DOMPurify is the second line of
+ * defence, this is the first.
+ */
+export function renderMarkdownLinks(content: string): string {
+  return content.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (_match, text: string, href: string) => {
+    const label = escapeHtml(text)
+    if (parseEntityAnchor(href)) {
+      return `<a href="${escapeHtml(href)}">${label}</a>`
+    }
+    if (/^https?:\/\//i.test(href)) {
+      return `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${label}</a>`
+    }
+    return label
+  })
+}
+
+export interface EntityAnchorNavigator {
+  push: (to: RouteLocationRaw) => unknown
+}
+
+/**
+ * Build a click handler that intercepts entity-anchor clicks within a
+ * v-html message body and routes them via the supplied navigator.
+ *
+ * The handler is a no-op for non-anchor targets and for non-entity hrefs,
+ * leaving external links and heading anchors to their default behaviour.
+ *
+ * @param navigator - object exposing a router-like `push` (e.g. `useRouter()`)
+ * @returns a DOM event handler suitable for `@click` on the message container
+ */
+export function createEntityAnchorClickHandler(navigator: EntityAnchorNavigator) {
+  return (event: MouseEvent): void => {
+    const target = event.target as HTMLElement | null
+    const anchorEl = target?.closest('a')
+    if (!anchorEl) return
+
+    const parsed = parseEntityAnchor(anchorEl.getAttribute('href'))
+    if (!parsed) return
+
+    // It's an entity anchor — take over from the default hash behaviour.
+    event.preventDefault()
+
+    const to = resolveEntityRoute(parsed)
+    logger.debug(`Navigating to ${parsed.kind} ${parsed.id}`)
+    Promise.resolve(navigator.push(to)).catch((err: unknown) => {
+      logger.error(`Failed to navigate to ${parsed.kind} ${parsed.id}`, err)
+    })
+  }
+}


### PR DESCRIPTION
## Thinking Path
Chat messages emit entity references as `[Name](#kind-id)` markdown (per #9297), but `MessageItem.vue` only linkified bare http(s) URLs — so entity anchors weren't even rendered as links, and clicking did nothing (#9479).

## What Changed
- New `composables/chat/useEntityAnchors.ts` (pure, unit-tested): parses `#kind-id` hash anchors, resolves each to an existing router destination, renders `[text](href)` markdown into `<a>`, and provides a delegated click handler.
- `MessageItem.vue`: renders markdown links (entity anchors + http(s)) before inline formatting and intercepts clicks via the handler → in-app navigation. Routing:
  - `#session-<id>` → `/chat/:sessionId`; `#document-<id>` → `/documents/:docId` (exact detail routes)
  - `#workflow-/task-<id>` → Workflow Builder (`?workflow=`/`?task=`); `#knowledge-<id>` → Entity Explorer (`?entity=`)
- External http(s) links still open in a new tab; plain heading anchors untouched.

## Security
`escapeHtml` on label + href; anchors only for validated `#kind-id` or `http(s)` hrefs (other schemes drop to plain text); `sanitizeChatHtml` (DOMPurify) is the backstop. The pre-existing ``/`` ANSI-strip escapes are preserved as text escapes (not raw control bytes).

## Verification
- `vue-tsc --noEmit` → 0 new errors.
- New `useEntityAnchors.test.ts` → 16/16 (parse, route resolution, markdown rendering incl. HTML-escape + unsafe-scheme drop, DOM click handler).

## Model Used
Opus 4.8

Fixes #9479
