### PR TITLE
test(voice-rbac): repair voice-bundle admin tests so audit-emit assertions run (#8977)

### DIFF
--- a/autobot-backend/tests/api/test_voice_bundle_user.py
+++ b/autobot-backend/tests/api/test_voice_bundle_user.py
@@ -18,13 +18,13 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.voice_bundle_helpers import _require_admin
 from api.voice_bundle_user import (
     _check_self_or_admin,
     _get_user_id,
     _is_admin,
     router,
 )
-from api.voice_bundle_helpers import _require_admin
 from auth_middleware import get_current_user
 from utils.catalog_http_exceptions import raise_auth_error
 

--- a/autobot-backend/tests/api/test_voice_bundle_user.py
+++ b/autobot-backend/tests/api/test_voice_bundle_user.py
@@ -24,7 +24,9 @@ from api.voice_bundle_user import (
     _is_admin,
     router,
 )
+from api.voice_bundle_helpers import _require_admin
 from auth_middleware import get_current_user
+from utils.catalog_http_exceptions import raise_auth_error
 
 # Test users
 _USER_ALICE = {"user_id": "alice", "username": "alice", "role": "user"}
@@ -33,14 +35,26 @@ _ADMIN = {"user_id": "admin-user", "username": "admin", "role": "admin"}
 
 
 def _make_client(user: dict) -> TestClient:
-    """Create a TestClient with dependency_overrides for get_current_user."""
+    """Create a TestClient with dependency_overrides for get_current_user.
+
+    Admin-gated routes depend on ``_require_admin`` (a Request-based middleware
+    check, GH#9450) rather than ``get_current_user``, so override it too —
+    role-gated against the injected user so admin routes 200 for admins and
+    403 for non-admins (GH#8977).
+    """
     app = FastAPI()
     app.include_router(router, prefix="/api/voice")
 
     async def _override():
         return user
 
+    def _override_require_admin() -> dict:
+        if user.get("role") != "admin":
+            raise_auth_error("AUTH_0003", "Admin permission required")
+        return user
+
     app.dependency_overrides[get_current_user] = _override
+    app.dependency_overrides[_require_admin] = _override_require_admin
     return TestClient(app)
 
 
@@ -111,7 +125,7 @@ class TestCheckSelfOrAdmin:
 class TestCountToolsForBundle:
     @pytest.mark.asyncio
     async def test_count_tools_returns_integer(self):
-        from api.voice_bundle_user import _count_tools_for_bundle, _tool_count_cache
+        from api.voice_bundle_helpers import _count_tools_for_bundle, _tool_count_cache
 
         _tool_count_cache.clear()
 
@@ -130,7 +144,7 @@ class TestCountToolsForBundle:
 
     @pytest.mark.asyncio
     async def test_count_tools_result_cached(self):
-        from api.voice_bundle_user import _count_tools_for_bundle, _tool_count_cache
+        from api.voice_bundle_helpers import _count_tools_for_bundle, _tool_count_cache
 
         _tool_count_cache.clear()
         call_count = 0


### PR DESCRIPTION
## Thinking Path
#8977 lists 3 findings from the PR #8974 review. Findings 1 (audit `emit()` outside try) and 2 (hardcoded `VALID_BUNDLES` drift) were already addressed on `Dev_new_gui`: `voice_bundle_user.py` now emits a failure-outcome audit inside the `except` and a success audit after commit, and imports the canonical `VALID_BUNDLES` exported from `redis_mcp/rbac.py` (no local copy). Finding 3 (the 3 admin-write tests lacked `assert_called_once`) had the assertions added — **but the tests were silently red**, so the assertions never ran.

Two pre-existing breakages (from the #9450 `_require_admin()` Depends consolidation) hid this:
1. The 3 admin-write tests + `test_invalid_bundle_name` returned **403** — `_make_client` only overrode `get_current_user`, but the endpoint now depends on `_require_admin` (a Request-based middleware check).
2. The 2 `_count_tools_for_bundle` tests raised **ImportError** — that helper + `_tool_count_cache` moved to `voice_bundle_helpers`, but the tests still imported them from `voice_bundle_user`.

## What Changed (test harness only)
- `tests/api/test_voice_bundle_user.py`: `_make_client` now also overrides `_require_admin`, role-gated against the injected user (admin → returns user; non-admin → `AUTH_0003` 403) — matching the established pattern in `test_retention_policies_api.py`. Fixed the two moved-helper imports to `api.voice_bundle_helpers`.
- Net effect: the file goes from **6 failed / 24 passed → 30 passed**, so Finding 3's `mock_emit.assert_called_once()` audit assertions now actually execute and guard the SECURITY-category audit emits.

## Verification
- `pytest tests/api/test_voice_bundle_user.py` → **30 passed**.
- `black --check --line-length 120` clean; `py_compile` OK.

## Model Used
Opus 4.8

Fixes #8977
