### PR TITLE
feat(rag): CAG context-augmented retrieval strategy + dispatcher behind enable_cag flag (#9018 Phase 1)

### DIFF
--- a/autobot-backend/advanced_rag_optimizer.py
+++ b/autobot-backend/advanced_rag_optimizer.py
@@ -78,6 +78,12 @@ class RAGMetrics:
     final_results_count: int = 0
     gpu_acceleration_used: bool = False
     hybrid_search_enabled: bool = False
+    # Retrieval strategy that produced this result: "rag" | "cag" | "kag" (#9018).
+    strategy: str = "rag"
+    # CAG-specific observability (0 for non-CAG strategies).
+    documents_loaded: int = 0
+    tokens_used: int = 0
+    budget: int = 0
 
 
 @dataclass

--- a/autobot-backend/api/knowledge_rag.py
+++ b/autobot-backend/api/knowledge_rag.py
@@ -30,6 +30,8 @@ from knowledge.schemas.rag import (
     RagStatsResponse,
     RerankRequest,
     RerankResultsResponse,
+    RetrievalContextRequest,
+    RetrievalContextResponse,
     RunBenchmarkRequest,
     UpdateRagConfigResponse,
 )
@@ -117,6 +119,11 @@ def _build_search_metrics(metrics) -> dict:
         "documents_considered": metrics.documents_considered,
         "final_results_count": metrics.final_results_count,
         "hybrid_search_enabled": metrics.hybrid_search_enabled,
+        # Issue #9018: retrieval strategy + CAG observability (defaults for non-CAG).
+        "strategy": getattr(metrics, "strategy", "rag"),
+        "documents_loaded": getattr(metrics, "documents_loaded", 0),
+        "tokens_used": getattr(metrics, "tokens_used", 0),
+        "budget": getattr(metrics, "budget", 0),
     }
 
 
@@ -607,4 +614,53 @@ async def get_entity_history(
         "entity_id": entity_id,
         "versions": versions,
         "count": len(versions),
+    }
+
+
+# Issue #9018: CAG/KAG strategy-dispatched context retrieval endpoint.
+
+
+@router.post("/context", response_model=RetrievalContextResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="retrieval_context",
+    error_code_prefix="KNOWLEDGE_RAG",
+)
+async def retrieval_context(
+    request: RetrievalContextRequest,
+    rag_service: RAGService = Depends(get_rag_service_dependency),
+    current_user: dict = Depends(get_current_user),
+):
+    """Strategy-dispatched context retrieval (RAG / CAG).
+
+    Issue #9018 Phase 1.
+
+    **Parameters:**
+    - **query**: Generation query string.
+    - **collection_id**: Optional collection to target (future: per-collection mode lookup).
+    - **mode**: Retrieval mode — 'auto' | 'rag' | 'cag' | 'kag'.
+    - **model**: Active model name for token-budget calculation (CAG only).
+
+    **Returns:**
+    - **context**: Assembled context string for LLM injection.
+    - **strategy**: Actual strategy used ('rag' or 'cag').
+    - **metrics**: Timing and result-count metrics.
+    """
+    from services.cag_service import CAGService
+    from services.retrieval_dispatcher import get_context
+
+    cag_service = CAGService(rag_service)
+    context, metrics = await get_context(
+        query=request.query,
+        rag_service=rag_service,
+        cag_service=cag_service,
+        mode=request.mode,
+        collection=request.collection_id,
+        model=request.model,
+    )
+    strategy = getattr(metrics, "strategy", "rag")
+    return {
+        "context": context,
+        "strategy": strategy,
+        "metrics": _build_search_metrics(metrics),
     }

--- a/autobot-backend/knowledge/schemas/rag.py
+++ b/autobot-backend/knowledge/schemas/rag.py
@@ -160,3 +160,25 @@ class RunBenchmarkRequest(BaseModel):
         pattern="^(dev|test|all)$",
     )
     k: int = Field(default=5, ge=1, le=50, description="Top-k results per query.")
+
+
+# Issue #9018: CAG/KAG retrieval strategy dispatcher schemas.
+
+
+class RetrievalContextRequest(BaseModel):
+    """Request body for POST /context — strategy-dispatched context retrieval."""
+
+    query: str = Field(..., min_length=1, max_length=2000, description="Generation query")
+    collection_id: str | None = Field(default=None, description="Target collection identifier")
+    mode: str = Field(default="auto", pattern="^(auto|rag|cag|kag)$", description="Retrieval mode")
+    model: str | None = Field(default=None, description="Active model name for budget calculation")
+
+
+class RetrievalContextResponse(BaseModel):
+    """Response from POST /context."""
+
+    model_config = ConfigDict(extra="allow")
+
+    context: str
+    strategy: str
+    metrics: Dict[str, Any] = Field(default_factory=dict)

--- a/autobot-backend/services/cag_service.py
+++ b/autobot-backend/services/cag_service.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+CAG Service — Context-Augmented Generation.
+
+Loads full source documents (ranked by RAGService.advanced_search) into the
+context window when the combined token count fits the model's adaptive budget.
+Falls back to RAGService.get_optimized_context when documents don't fit or
+when no source paths can be resolved.
+
+Issue #9018 Phase 1.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, List, Tuple
+
+from autobot_shared.logging_manager import get_llm_logger
+
+if TYPE_CHECKING:
+    from advanced_rag_optimizer import RAGMetrics
+    from services.rag_service import RAGService
+
+logger = get_llm_logger("cag_service")
+
+# Reserve this many tokens for the model's output when computing the CAG budget.
+# Overridden by RAGConfig.cag_output_headroom_tokens at runtime.
+_DEFAULT_OUTPUT_HEADROOM = 2048
+
+# Maximum number of full documents to load in a single CAG pass.
+# Overridden by RAGConfig.cag_max_documents at runtime.
+_DEFAULT_MAX_DOCUMENTS = 10
+
+
+@dataclass
+class _CandidateDoc:
+    """Internal representation of a ranked candidate document."""
+
+    source_path: str
+    chunks: List[str] = field(default_factory=list)
+    rank: int = 0
+
+
+def _unique_source_paths(results: list) -> List[_CandidateDoc]:
+    """Map ranked SearchResult list → deduplicated CandidateDoc list (rank-ordered)."""
+    seen: dict[str, _CandidateDoc] = {}
+    for result in results:
+        sp = result.source_path or ""
+        if not sp or sp in ("unknown", "topic_cache", "semantic_cache"):
+            continue
+        if sp not in seen:
+            seen[sp] = _CandidateDoc(source_path=sp, rank=len(seen))
+        seen[sp].chunks.append(result.content)
+    return list(seen.values())
+
+
+async def _read_source_file(source_path: str) -> str | None:
+    """Read a source file asynchronously. Returns None when unreadable."""
+    import asyncio
+    from pathlib import Path
+
+    path = Path(source_path)
+    try:
+        if not await asyncio.to_thread(path.exists):
+            return None
+        return await asyncio.to_thread(path.read_text, encoding="utf-8")
+    except Exception as exc:
+        logger.debug("CAG: cannot read %s — %s", source_path, exc)
+        return None
+
+
+def _assemble_context(docs: List[tuple[str, str]]) -> str:
+    """Format (source_path, content) pairs into a CAG context block."""
+    parts: List[str] = []
+    for source_path, content in docs:
+        header = f"=== Source: {source_path} ==="
+        parts.append(f"{header}\n{content.strip()}")
+    return "\n\n".join(parts)
+
+
+class CAGService:
+    """Context-Augmented Generation: loads full documents within the token budget.
+
+    Depends on RAGService for candidate ranking; never re-implements search.
+    """
+
+    def __init__(self, rag_service: "RAGService") -> None:
+        self._rag = rag_service
+
+    def _budget(self, model: str | None, config: Any) -> int:
+        """Return effective token budget for CAG assembly."""
+        from context_window_manager import ContextWindowManager
+
+        cwm = ContextWindowManager()
+        adaptive = cwm.get_adaptive_context_length(model)
+        headroom = getattr(config, "cag_output_headroom_tokens", _DEFAULT_OUTPUT_HEADROOM)
+        budget = adaptive - headroom
+        if adaptive <= 4096:
+            logger.warning(
+                "CAG: model %r resolved to default 4 096-token window — " "budget source may be the fallback value",
+                model,
+            )
+        return max(budget, 0)
+
+    async def get_full_context(
+        self,
+        query: str,
+        collection: str | None = None,
+        model: str | None = None,
+    ) -> "Tuple[str, RAGMetrics]":
+        """Return (context, metrics) with strategy='cag' or fall back to RAG.
+
+        Steps:
+        1. Rank candidates via RAGService.advanced_search.
+        2. Map chunks → unique source documents by source_path.
+        3. Read full files; keep top-N that fit within the token budget.
+        4. If any docs fit, assemble CAG context and emit metrics.
+        5. Otherwise fall back to RAGService.get_optimized_context.
+        """
+        from context_window_manager import ContextWindowManager
+
+        config = self._rag.config
+        t_start = time.monotonic()
+
+        results, search_metrics = await self._rag.advanced_search(query=query)
+        candidates = _unique_source_paths(results)
+
+        if not candidates:
+            logger.debug("CAG: no source paths in results — falling back to RAG")
+            return await self._fallback(query, search_metrics)
+
+        budget = self._budget(model, config)
+        cwm = ContextWindowManager()
+        max_docs = getattr(config, "cag_max_documents", _DEFAULT_MAX_DOCUMENTS)
+
+        loaded: List[tuple[str, str]] = []
+        tokens_used = 0
+
+        for doc in candidates[:max_docs]:
+            content = await _read_source_file(doc.source_path)
+            if content is None:
+                logger.debug("CAG: %s unreadable — skipping", doc.source_path)
+                continue
+            doc_tokens = cwm.estimate_tokens(content)
+            if tokens_used + doc_tokens > budget:
+                logger.debug(
+                    "CAG: %s (%d tok) would exceed budget %d — stopping",
+                    doc.source_path,
+                    doc_tokens,
+                    budget,
+                )
+                break
+            loaded.append((doc.source_path, content))
+            tokens_used += doc_tokens
+
+        if not loaded:
+            logger.info("CAG: no documents fit within budget %d — falling back to RAG", budget)
+            return await self._fallback(query, search_metrics)
+
+        context = _assemble_context(loaded)
+        elapsed = time.monotonic() - t_start
+
+        from advanced_rag_optimizer import RAGMetrics
+
+        metrics = RAGMetrics(
+            query_processing_time=search_metrics.query_processing_time,
+            retrieval_time=elapsed,
+            reranking_time=search_metrics.reranking_time,
+            total_time=elapsed,
+            documents_considered=len(candidates),
+            final_results_count=len(loaded),
+            hybrid_search_enabled=search_metrics.hybrid_search_enabled,
+        )
+        # Strategy + CAG observability — declared fields on RAGMetrics (#9018).
+        metrics.strategy = "cag"
+        metrics.documents_loaded = len(loaded)
+        metrics.tokens_used = tokens_used
+        metrics.budget = budget
+
+        logger.info(
+            "CAG assembled %d document(s) (%d tokens, budget %d) for query %r",
+            len(loaded),
+            tokens_used,
+            budget,
+            query,
+        )
+        return context, metrics
+
+    async def _fallback(self, query: str, prior_metrics: "RAGMetrics") -> "Tuple[str, RAGMetrics]":
+        """Delegate to RAGService.get_optimized_context and tag metrics."""
+        context, metrics = await self._rag.get_optimized_context(query=query)
+        metrics.strategy = "rag"
+        logger.debug("CAG fell back to RAG for query %r", query)
+        return context, metrics

--- a/autobot-backend/services/cag_service_test.py
+++ b/autobot-backend/services/cag_service_test.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for CAGService — Issue #9018 Phase 1.
+
+Covers:
+- CAG assembles full docs under token budget.
+- CAG falls back to RAG when docs exceed budget.
+- CAG falls back to RAG when no source paths are resolved.
+- CAG falls back to RAG when all source files are unreadable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("advanced_rag_optimizer")
+
+from advanced_rag_optimizer import RAGMetrics, SearchResult
+from services.cag_service import CAGService, _assemble_context, _unique_source_paths
+from services.rag_config import RAGConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_result(source_path: str, content: str = "chunk", rank: int = 1) -> SearchResult:
+    return SearchResult(
+        content=content,
+        metadata={"source": source_path},
+        semantic_score=0.9,
+        keyword_score=0.8,
+        hybrid_score=0.85,
+        relevance_rank=rank,
+        source_path=source_path,
+    )
+
+
+def _make_rag_service(results: List[SearchResult] | None = None, config: RAGConfig | None = None) -> MagicMock:
+    svc = MagicMock()
+    svc.config = config or RAGConfig(enable_cag=True, cag_max_documents=10, cag_output_headroom_tokens=512)
+    metrics = RAGMetrics(total_time=0.05, final_results_count=len(results or []))
+    svc.advanced_search = AsyncMock(return_value=(results or [], metrics))
+    context_metrics = RAGMetrics(total_time=0.1, final_results_count=1)
+    context_metrics.strategy = "rag"  # type: ignore[attr-defined]
+    svc.get_optimized_context = AsyncMock(return_value=("fallback-context", context_metrics))
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for internal helpers
+# ---------------------------------------------------------------------------
+
+
+def test_unique_source_paths_deduplication():
+    """Multiple chunks from the same source_path collapse into one CandidateDoc."""
+    results = [
+        _make_result("docs/a.md", "chunk1"),
+        _make_result("docs/a.md", "chunk2"),
+        _make_result("docs/b.md", "chunk3"),
+    ]
+    docs = _unique_source_paths(results)
+    assert len(docs) == 2
+    assert docs[0].source_path == "docs/a.md"
+    assert len(docs[0].chunks) == 2
+
+
+def test_unique_source_paths_filters_synthetic():
+    """source_path values like 'unknown', 'topic_cache', 'semantic_cache' are skipped."""
+    results = [
+        _make_result("unknown"),
+        _make_result("topic_cache"),
+        _make_result("semantic_cache"),
+        _make_result("docs/real.md"),
+    ]
+    docs = _unique_source_paths(results)
+    assert len(docs) == 1
+    assert docs[0].source_path == "docs/real.md"
+
+
+def test_assemble_context_format():
+    """_assemble_context produces source headers and deduped sections."""
+    pairs = [("docs/a.md", "content-a"), ("docs/b.md", "content-b")]
+    ctx = _assemble_context(pairs)
+    assert "=== Source: docs/a.md ===" in ctx
+    assert "content-a" in ctx
+    assert "=== Source: docs/b.md ===" in ctx
+    assert "content-b" in ctx
+
+
+# ---------------------------------------------------------------------------
+# CAGService async tests
+# ---------------------------------------------------------------------------
+
+
+async def test_cag_assembles_docs_under_budget(tmp_path: Path):
+    """When docs fit in budget, CAGService returns 'cag' strategy with full content."""
+    doc_file = tmp_path / "doc.md"
+    doc_file.write_text("This is the full document content.", encoding="utf-8")
+
+    rag = _make_rag_service(results=[_make_result(str(doc_file))])
+    cag = CAGService(rag)
+
+    with patch("context_window_manager.ContextWindowManager.get_adaptive_context_length", return_value=8192):
+        context, metrics = await cag.get_full_context(query="test query", model="llama3")
+
+    assert "full document content" in context
+    assert getattr(metrics, "strategy", None) == "cag"
+    assert getattr(metrics, "documents_loaded", 0) == 1
+
+
+async def test_cag_falls_back_when_budget_zero(tmp_path: Path):
+    """When budget is 0 (headroom >= adaptive), CAG falls back to RAG."""
+    doc_file = tmp_path / "doc.md"
+    doc_file.write_text("content" * 100, encoding="utf-8")
+
+    # headroom equals the adaptive length → budget = 0
+    config = RAGConfig(enable_cag=True, cag_output_headroom_tokens=8192, cag_max_documents=10)
+    rag = _make_rag_service(results=[_make_result(str(doc_file))], config=config)
+    cag = CAGService(rag)
+
+    with patch("context_window_manager.ContextWindowManager.get_adaptive_context_length", return_value=8192):
+        context, metrics = await cag.get_full_context(query="test query")
+
+    assert context == "fallback-context"
+    assert getattr(metrics, "strategy", None) == "rag"
+
+
+async def test_cag_falls_back_when_no_source_paths():
+    """When all results have synthetic source paths, CAG falls back to RAG."""
+    results = [_make_result("unknown"), _make_result("topic_cache")]
+    rag = _make_rag_service(results=results)
+    cag = CAGService(rag)
+
+    with patch("context_window_manager.ContextWindowManager.get_adaptive_context_length", return_value=8192):
+        context, metrics = await cag.get_full_context(query="test query")
+
+    assert context == "fallback-context"
+    assert getattr(metrics, "strategy", None) == "rag"
+
+
+async def test_cag_falls_back_when_no_results():
+    """When advanced_search returns empty, CAG falls back to RAG."""
+    rag = _make_rag_service(results=[])
+    cag = CAGService(rag)
+
+    with patch("context_window_manager.ContextWindowManager.get_adaptive_context_length", return_value=8192):
+        context, metrics = await cag.get_full_context(query="test query")
+
+    assert context == "fallback-context"
+    assert getattr(metrics, "strategy", None) == "rag"
+
+
+async def test_cag_falls_back_when_file_unreadable():
+    """When the source file doesn't exist on disk, CAG falls back to RAG."""
+    rag = _make_rag_service(results=[_make_result("/nonexistent/path/doc.md")])
+    cag = CAGService(rag)
+
+    with patch("context_window_manager.ContextWindowManager.get_adaptive_context_length", return_value=8192):
+        context, metrics = await cag.get_full_context(query="test query")
+
+    assert context == "fallback-context"
+    assert getattr(metrics, "strategy", None) == "rag"
+
+
+async def test_cag_respects_max_documents(tmp_path: Path):
+    """cag_max_documents caps the number of docs loaded."""
+    files = []
+    for i in range(5):
+        f = tmp_path / f"doc{i}.md"
+        f.write_text(f"content of document {i}", encoding="utf-8")
+        files.append(f)
+
+    config = RAGConfig(enable_cag=True, cag_max_documents=2, cag_output_headroom_tokens=256)
+    results = [_make_result(str(f), rank=i) for i, f in enumerate(files)]
+    rag = _make_rag_service(results=results, config=config)
+    cag = CAGService(rag)
+
+    with patch("context_window_manager.ContextWindowManager.get_adaptive_context_length", return_value=131072):
+        context, metrics = await cag.get_full_context(query="test")
+
+    assert getattr(metrics, "documents_loaded", 0) <= 2

--- a/autobot-backend/services/rag_config.py
+++ b/autobot-backend/services/rag_config.py
@@ -113,6 +113,14 @@ class RAGConfig:
     autonomous_loop_dry_run: bool = True  # dry-run until explicitly disabled
     autonomous_loop_promotion_threshold: float = 0.05  # 5 % improvement required
 
+    # Issue #9018: CAG/KAG retrieval strategy flags (Phase 1)
+    # Shipped disabled by default; enable after benchmarking (Phase 4).
+    enable_cag: bool = False
+    enable_kag: bool = False
+    cag_max_documents: int = 10
+    cag_output_headroom_tokens: int = 2048
+    default_retrieval_mode: Literal["auto", "rag", "cag", "kag"] = "auto"
+
     def __post_init__(self) -> None:
         """Validate configuration values and propagate mmr_lambda to rerank_weights.
 
@@ -262,6 +270,12 @@ class RAGConfig:
             "autonomous_loop_cron": self.autonomous_loop_cron,
             "autonomous_loop_dry_run": self.autonomous_loop_dry_run,
             "autonomous_loop_promotion_threshold": self.autonomous_loop_promotion_threshold,
+            # Issue #9018: CAG/KAG retrieval strategy flags
+            "enable_cag": self.enable_cag,
+            "enable_kag": self.enable_kag,
+            "cag_max_documents": self.cag_max_documents,
+            "cag_output_headroom_tokens": self.cag_output_headroom_tokens,
+            "default_retrieval_mode": self.default_retrieval_mode,
         }
 
 

--- a/autobot-backend/services/retrieval_dispatcher.py
+++ b/autobot-backend/services/retrieval_dispatcher.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Retrieval Strategy Dispatcher — Phase 1 (Issue #9018).
+
+Composes RAGService and CAGService under a single entry-point.
+KAG and unknown modes fall back to RAG in Phase 1.
+Auto-selection: defaults to RAG unless enable_cag=True AND the collection
+explicitly requests cag (future Phase 3 adds heuristic auto-selection).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Tuple
+
+from autobot_shared.logging_manager import get_llm_logger
+
+if TYPE_CHECKING:
+    from advanced_rag_optimizer import RAGMetrics
+    from services.cag_service import CAGService
+    from services.rag_config import RAGConfig
+    from services.rag_service import RAGService
+
+logger = get_llm_logger("retrieval_dispatcher")
+
+# Supported mode literals.
+_MODES = frozenset({"rag", "cag", "kag", "auto"})
+
+
+def select_strategy(mode: str, config: "RAGConfig", collection_mode: str | None = None) -> str:
+    """Return the concrete strategy to use ('rag' or 'cag').
+
+    Decision table (Phase 1):
+    - mode == 'rag'  → 'rag'
+    - mode == 'kag'  → 'rag'  (Phase 2)
+    - mode == 'cag'  → 'cag' only when enable_cag=True, else 'rag'
+    - mode == 'auto' → 'cag' when enable_cag=True AND collection_mode=='cag', else 'rag'
+    - unknown        → 'rag'
+    """
+    enable_cag = getattr(config, "enable_cag", False)
+
+    if mode not in _MODES:
+        logger.warning("Unknown retrieval mode %r — defaulting to rag", mode)
+        return "rag"
+
+    if mode == "rag":
+        return "rag"
+
+    if mode == "kag":
+        logger.debug("KAG not yet implemented (Phase 2) — using rag")
+        return "rag"
+
+    if mode == "cag":
+        if not enable_cag:
+            logger.debug("CAG requested but enable_cag=False — using rag")
+            return "rag"
+        return "cag"
+
+    # mode == 'auto'
+    if enable_cag and collection_mode == "cag":
+        return "cag"
+    return "rag"
+
+
+async def get_context(
+    query: str,
+    rag_service: "RAGService",
+    cag_service: "CAGService",
+    mode: str = "auto",
+    collection: str | None = None,
+    model: str | None = None,
+    collection_mode: str | None = None,
+) -> "Tuple[str, RAGMetrics]":
+    """Route the query to the selected strategy and return (context, metrics).
+
+    Args:
+        query: Search / generation query.
+        rag_service: Initialized RAGService instance.
+        cag_service: CAGService wrapping rag_service.
+        mode: Caller-requested mode ('auto'|'rag'|'cag'|'kag').
+        collection: Optional collection identifier (for logging).
+        model: Active model name (used by CAGService for budget calc).
+        collection_mode: Per-collection setting from DB/metadata.
+
+    Returns:
+        (context, metrics) with metrics.strategy reflecting the strategy used.
+    """
+    config = rag_service.config
+    strategy = select_strategy(mode, config, collection_mode)
+
+    logger.info(
+        "Dispatcher: mode=%r strategy=%r collection=%r model=%r",
+        mode,
+        strategy,
+        collection,
+        model,
+    )
+
+    if strategy == "cag":
+        return await cag_service.get_full_context(query=query, collection=collection, model=model)
+
+    # RAG path (default, kag fallback, unknown mode fallback)
+    context, metrics = await rag_service.get_optimized_context(query=query)
+    metrics.strategy = "rag"
+    return context, metrics

--- a/autobot-backend/services/retrieval_dispatcher_test.py
+++ b/autobot-backend/services/retrieval_dispatcher_test.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for retrieval_dispatcher — Issue #9018 Phase 1.
+
+Covers:
+- select_strategy routes correctly for each mode.
+- enable_cag=False never dispatches to CAG.
+- get_context delegates to the right service.
+- KAG and unknown modes fall back to RAG (Phase 1 policy).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("advanced_rag_optimizer")
+
+from advanced_rag_optimizer import RAGMetrics
+from services.rag_config import RAGConfig
+from services.retrieval_dispatcher import get_context, select_strategy
+
+# ---------------------------------------------------------------------------
+# select_strategy unit tests
+# ---------------------------------------------------------------------------
+
+
+def _cfg(**kwargs) -> RAGConfig:
+    defaults = dict(enable_cag=False)
+    defaults.update(kwargs)
+    return RAGConfig(**defaults)
+
+
+def test_select_rag_returns_rag():
+    assert select_strategy("rag", _cfg()) == "rag"
+
+
+def test_select_kag_falls_back_to_rag():
+    """Phase 1: KAG always falls back to RAG."""
+    assert select_strategy("kag", _cfg(enable_cag=True)) == "rag"
+
+
+def test_select_cag_disabled_returns_rag():
+    """When enable_cag=False, requesting cag still returns rag."""
+    assert select_strategy("cag", _cfg(enable_cag=False)) == "rag"
+
+
+def test_select_cag_enabled_returns_cag():
+    assert select_strategy("cag", _cfg(enable_cag=True)) == "cag"
+
+
+def test_select_auto_cag_disabled_returns_rag():
+    """auto + enable_cag=False → rag regardless of collection_mode."""
+    assert select_strategy("auto", _cfg(enable_cag=False), collection_mode="cag") == "rag"
+
+
+def test_select_auto_cag_enabled_collection_rag():
+    """auto + enable_cag=True + collection_mode='rag' → rag."""
+    assert select_strategy("auto", _cfg(enable_cag=True), collection_mode="rag") == "rag"
+
+
+def test_select_auto_cag_enabled_collection_cag():
+    """auto + enable_cag=True + collection_mode='cag' → cag."""
+    assert select_strategy("auto", _cfg(enable_cag=True), collection_mode="cag") == "cag"
+
+
+def test_select_auto_no_collection_mode():
+    """auto + enable_cag=True + no collection_mode → rag (conservative default)."""
+    assert select_strategy("auto", _cfg(enable_cag=True), collection_mode=None) == "rag"
+
+
+def test_select_unknown_mode_returns_rag():
+    assert select_strategy("unknown_mode", _cfg(enable_cag=True)) == "rag"
+
+
+# ---------------------------------------------------------------------------
+# get_context async integration tests
+# ---------------------------------------------------------------------------
+
+
+def _make_services(enable_cag: bool = True):
+    config = RAGConfig(enable_cag=enable_cag, cag_output_headroom_tokens=512)
+    rag = MagicMock()
+    rag.config = config
+    rag_metrics = RAGMetrics(total_time=0.1)
+    rag.get_optimized_context = AsyncMock(return_value=("rag-context", rag_metrics))
+
+    cag = MagicMock()
+    cag_metrics = RAGMetrics(total_time=0.2)
+    cag_metrics.strategy = "cag"  # type: ignore[attr-defined]
+    cag.get_full_context = AsyncMock(return_value=("cag-context", cag_metrics))
+
+    return rag, cag
+
+
+async def test_get_context_rag_mode():
+    rag, cag = _make_services()
+    ctx, metrics = await get_context(query="q", rag_service=rag, cag_service=cag, mode="rag")
+    assert ctx == "rag-context"
+    assert getattr(metrics, "strategy", None) == "rag"
+    cag.get_full_context.assert_not_called()
+
+
+async def test_get_context_cag_mode_enabled():
+    rag, cag = _make_services(enable_cag=True)
+    ctx, metrics = await get_context(query="q", rag_service=rag, cag_service=cag, mode="cag")
+    assert ctx == "cag-context"
+    assert getattr(metrics, "strategy", None) == "cag"
+    rag.get_optimized_context.assert_not_called()
+
+
+async def test_get_context_cag_mode_disabled():
+    """When enable_cag=False, even mode='cag' must route to RAG."""
+    rag, cag = _make_services(enable_cag=False)
+    ctx, metrics = await get_context(query="q", rag_service=rag, cag_service=cag, mode="cag")
+    assert ctx == "rag-context"
+    cag.get_full_context.assert_not_called()
+
+
+async def test_get_context_kag_falls_back_to_rag():
+    rag, cag = _make_services(enable_cag=True)
+    ctx, metrics = await get_context(query="q", rag_service=rag, cag_service=cag, mode="kag")
+    assert ctx == "rag-context"
+    cag.get_full_context.assert_not_called()
+
+
+async def test_get_context_auto_defaults_to_rag():
+    """auto mode without collection_mode='cag' defaults to rag."""
+    rag, cag = _make_services(enable_cag=True)
+    ctx, metrics = await get_context(query="q", rag_service=rag, cag_service=cag, mode="auto", collection_mode=None)
+    assert ctx == "rag-context"
+    cag.get_full_context.assert_not_called()
+
+
+async def test_get_context_auto_collection_cag():
+    """auto + collection_mode='cag' + enable_cag=True → CAG."""
+    rag, cag = _make_services(enable_cag=True)
+    ctx, metrics = await get_context(query="q", rag_service=rag, cag_service=cag, mode="auto", collection_mode="cag")
+    assert ctx == "cag-context"
+    rag.get_optimized_context.assert_not_called()

--- a/autobot-backend/services/retrieval_dispatcher_test.py
+++ b/autobot-backend/services/retrieval_dispatcher_test.py
@@ -15,7 +15,7 @@ Covers:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 


### PR DESCRIPTION
## Thinking Path
Per the PRD attached to #9018, Phase 1 adds **CAG (context-augmented generation)** — load full source documents into the context window when they fit the model's adaptive token budget — as a new retrieval strategy behind a dispatcher, **shipped disabled** (`enable_cag=false`). Reuses the existing RAG stack (no search reimplementation) and falls back to RAG whenever full docs don't fit. KAG (Phase 2) is a stub that routes to RAG.

## What Changed
- **`services/cag_service.py`** (new): `CAGService.get_full_context(query, collection?, model?)` -> `(context, RAGMetrics)`. Ranks via `RAGService.advanced_search`, maps chunks -> unique source files by `source_path` (filters synthetic `topic_cache`/`semantic_cache`/`unknown`), reads full files via `asyncio.to_thread`, packs up to `cag_max_documents` within `ContextWindowManager.get_adaptive_context_length(model) - cag_output_headroom_tokens`. Falls back to `RAGService.get_optimized_context` when no candidates / nothing fits / files unreadable.
- **`services/retrieval_dispatcher.py`** (new): `select_strategy()` + `get_context()` composing RAGService + CAGService; respects disable flags; `kag`/unknown -> RAG.
- **`services/rag_config.py`**: 5 flags (`enable_cag=false`, `enable_kag=false`, `cag_max_documents=10`, `cag_output_headroom_tokens=2048`, `default_retrieval_mode="auto"`) from `knowledge.rag`, added to `to_dict`.
- **`api/knowledge_rag.py`**: `POST /context` (-> `/api/knowledge_base/rag/context`) returning `{context, strategy, metrics}`; dispatcher lazy-imported (import-smoke safe). `_build_search_metrics` now surfaces strategy + CAG observability.
- **`advanced_rag_optimizer.py`**: added `strategy`/`documents_loaded`/`tokens_used`/`budget` to `RAGMetrics` (all defaulted) so they are real declared fields -- removed the dynamic-attribute `# type: ignore` workaround from the first cut.
- **`knowledge/schemas/rag.py`**: `RetrievalContextRequest`/`Response`.

## Verification
- `pytest services/cag_service_test.py services/retrieval_dispatcher_test.py` -> **24 passed** (full-doc packing, all 3 fallback paths, `cag_max_documents` cap, synthetic-path filtering, dispatcher routing incl. `enable_cag=false` never dispatches CAG, auto/kag/unknown -> RAG).
- `py_compile` + `black --check --line-length 120` clean. `Literal` already imported; dispatcher lazy-imported so the router still import-smokes.

## Model Used
Opus 4.8

Fixes #9018 (Phase 1 -- CAG; Phases 2-4 KAG/auto/benchmarks tracked in the PRD)
