### PR TITLE
feat(secrets): SecretsCoordinator — resolve→authorize→service orchestration (#10213)

### DIFF
--- a/autobot-backend/services/secrets_coordinator.py
+++ b/autobot-backend/services/secrets_coordinator.py
@@ -1,0 +1,162 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Authorization + envelope orchestration for the unified secrets API (#10088 / Task 2.4).
+
+The seam between HTTP and the store: each operation resolves the caller's
+:class:`PrincipalFacts` (Task 2.3 part 2), applies the RBAC policy
+(``secrets_authz``, Task 2.3 part 1), then calls the envelope
+``UnifiedSecretsService`` (Task 2.2). Kept free of FastAPI so it is testable
+against Postgres without loading the whole app (the only Postgres CI job runs a
+minimal dep set); the ``/api/v2/secrets`` router is a thin shell over this.
+
+Authorization model
+-------------------
+- **create** — ``authorize("write", owner_vault)``: you may create a secret in a
+  vault you can write to.
+- **read** / **list** — gated by ``accessible_vaults``: the service only opens a
+  secret you hold a grant for, in a vault you can reach. No accessible grant ⇒
+  :class:`SecretAccessError`.
+- **share** — ``authorize("share", owner_vault)`` (manage grants on the owning
+  vault) *and* you must already be able to open the secret (the service unwraps
+  the DEK via your ``actor_vaults``).
+- **revoke** — ``authorize("revoke", owner_vault)``.
+- **rotate** / **delete** — ``authorize("write", owner_vault)``.
+
+Every mutation authorizes against the secret's **owner vault** (the authority
+that owns it), not the grantee — sharing with company B is gated by your rights
+in the owning vault, never by B's.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.secrets_vault import VaultRef
+from models.secret import Secret
+from models.secret_grant import SecretGrant
+from services.secrets_authz import PrincipalFacts, authorize
+from services.secrets_principal_resolver import resolve_principal_facts
+from services.unified_secrets_service import (
+    SecretAccessError,
+    SecretNotFoundError,
+    UnifiedSecretsService,
+)
+
+
+class SecretsCoordinator:
+    """Resolve facts → authorize → call the envelope service."""
+
+    def __init__(self, service: UnifiedSecretsService | None = None) -> None:
+        self._service = service if service is not None else UnifiedSecretsService()
+
+    async def _facts(self, session: AsyncSession, user_id: uuid.UUID, permissions: set[str]) -> PrincipalFacts:
+        return await resolve_principal_facts(session, user_id, permissions)
+
+    async def _owner_vault(self, session: AsyncSession, secret_id: uuid.UUID) -> VaultRef:
+        row = await session.execute(
+            select(Secret.owner_vault).where(Secret.id == secret_id, Secret.sealed_value.isnot(None))
+        )
+        owner = row.scalar_one_or_none()
+        if owner is None:
+            raise SecretNotFoundError(f"envelope secret {secret_id} not found")
+        return VaultRef.parse(owner)
+
+    async def create(
+        self,
+        session: AsyncSession,
+        *,
+        user_id: uuid.UUID,
+        permissions: set[str],
+        owner_vault: VaultRef,
+        name: str,
+        secret_type: str,
+        plaintext: bytes,
+    ) -> Secret:
+        facts = await self._facts(session, user_id, permissions)
+        if not authorize(facts, "write", owner_vault):
+            raise SecretAccessError(f"not authorized to write to {owner_vault.to_str()}")
+        return await self._service.create(
+            session,
+            owner_vault=owner_vault,
+            name=name,
+            secret_type=secret_type,
+            plaintext=plaintext,
+            created_by=user_id,
+        )
+
+    async def read(
+        self, session: AsyncSession, *, user_id: uuid.UUID, permissions: set[str], secret_id: uuid.UUID
+    ) -> bytes:
+        facts = await self._facts(session, user_id, permissions)
+        return await self._service.read(session, secret_id=secret_id, accessible_vaults=facts.accessible_vaults())
+
+    async def list(self, session: AsyncSession, *, user_id: uuid.UUID, permissions: set[str]) -> list[Secret]:
+        facts = await self._facts(session, user_id, permissions)
+        return await self._service.list_for_vaults(session, accessible_vaults=facts.accessible_vaults())
+
+    async def share(
+        self,
+        session: AsyncSession,
+        *,
+        user_id: uuid.UUID,
+        permissions: set[str],
+        secret_id: uuid.UUID,
+        grantee: VaultRef,
+    ) -> SecretGrant:
+        facts = await self._facts(session, user_id, permissions)
+        owner_vault = await self._owner_vault(session, secret_id)
+        if not authorize(facts, "share", owner_vault):
+            raise SecretAccessError(f"not authorized to share secrets in {owner_vault.to_str()}")
+        return await self._service.share(
+            session,
+            secret_id=secret_id,
+            actor_vaults=facts.accessible_vaults(),
+            grantee=grantee,
+            created_by=user_id,
+        )
+
+    async def revoke(
+        self,
+        session: AsyncSession,
+        *,
+        user_id: uuid.UUID,
+        permissions: set[str],
+        secret_id: uuid.UUID,
+        grantee: VaultRef,
+    ) -> None:
+        facts = await self._facts(session, user_id, permissions)
+        owner_vault = await self._owner_vault(session, secret_id)
+        if not authorize(facts, "revoke", owner_vault):
+            raise SecretAccessError(f"not authorized to revoke grants in {owner_vault.to_str()}")
+        await self._service.revoke(session, secret_id=secret_id, grantee=grantee)
+
+    async def rotate(
+        self,
+        session: AsyncSession,
+        *,
+        user_id: uuid.UUID,
+        permissions: set[str],
+        secret_id: uuid.UUID,
+        new_plaintext: bytes,
+    ) -> Secret:
+        facts = await self._facts(session, user_id, permissions)
+        owner_vault = await self._owner_vault(session, secret_id)
+        if not authorize(facts, "write", owner_vault):
+            raise SecretAccessError(f"not authorized to rotate secrets in {owner_vault.to_str()}")
+        return await self._service.rotate_value(
+            session, secret_id=secret_id, new_plaintext=new_plaintext, actor_vaults=facts.accessible_vaults()
+        )
+
+    async def delete(
+        self, session: AsyncSession, *, user_id: uuid.UUID, permissions: set[str], secret_id: uuid.UUID
+    ) -> None:
+        facts = await self._facts(session, user_id, permissions)
+        owner_vault = await self._owner_vault(session, secret_id)
+        if not authorize(facts, "write", owner_vault):
+            raise SecretAccessError(f"not authorized to delete secrets in {owner_vault.to_str()}")
+        await self._service.delete(session, secret_id=secret_id)

--- a/autobot-backend/tests/migrations/test_secrets_coordinator.py
+++ b/autobot-backend/tests/migrations/test_secrets_coordinator.py
@@ -1,0 +1,158 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""End-to-end tests for SecretsCoordinator (#10088 / Task 2.4).
+
+Postgres-backed (migration-gate CI job): builds the full schema via
+``alembic upgrade head`` (so ``secrets``/``secret_grants``/``llc_company_memberships``
+all exist), seeds a company-admin user, and exercises the resolve→authorize→
+service path for create/read/share/revoke/rotate/delete plus denial cases.
+"""
+
+import base64
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from services.secrets_coordinator import SecretsCoordinator
+from services.unified_secrets_service import SecretAccessError, SecretNotFoundError, UnifiedSecretsService
+from tests.migrations.conftest import requires_postgres, run_alembic
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+_ROOT = base64.urlsafe_b64decode(base64.urlsafe_b64encode(bytes(range(32))))
+_ADMIN = uuid.uuid4()  # company admin
+_OUTSIDER = uuid.uuid4()  # no memberships
+_GRANTEE_USER = uuid.uuid4()
+_COMPANY = uuid.uuid4()
+_COMPANY_VAULT = VaultRef(VaultKind.COMPANY, str(_COMPANY))
+_NO_PERMS: set[str] = set()
+
+
+@pytest.fixture()
+async def session(fresh_db_url):
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+    engine = create_async_engine(fresh_db_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as s:
+        from llc.models.membership import LLCCompanyMembership
+        from user_management.models.user import User
+
+        for uid, uname in ((_ADMIN, "admin"), (_OUTSIDER, "outsider"), (_GRANTEE_USER, "grantee")):
+            s.add(User(id=uid, email=f"{uname}@example.com", username=uname))
+        s.add(LLCCompanyMembership(company_id=_COMPANY, user_id=_ADMIN, role="admin"))
+        await s.commit()
+        yield s
+    await engine.dispose()
+
+
+@pytest.fixture()
+def coord():
+    return SecretsCoordinator(UnifiedSecretsService(root_key=_ROOT))
+
+
+async def _make(coord, session) -> uuid.UUID:
+    secret = await coord.create(
+        session,
+        user_id=_ADMIN,
+        permissions=_NO_PERMS,
+        owner_vault=_COMPANY_VAULT,
+        name="db",
+        secret_type="password",
+        plaintext=b"hunter2",
+    )
+    await session.commit()
+    return secret.id
+
+
+async def test_company_admin_create_and_read(coord, session):
+    sid = await _make(coord, session)
+    assert await coord.read(session, user_id=_ADMIN, permissions=_NO_PERMS, secret_id=sid) == b"hunter2"
+
+
+async def test_outsider_cannot_create(coord, session):
+    with pytest.raises(SecretAccessError):
+        await coord.create(
+            session,
+            user_id=_OUTSIDER,
+            permissions=_NO_PERMS,
+            owner_vault=_COMPANY_VAULT,
+            name="x",
+            secret_type="password",
+            plaintext=b"x",
+        )
+
+
+async def test_outsider_cannot_read(coord, session):
+    sid = await _make(coord, session)
+    with pytest.raises(SecretAccessError):
+        await coord.read(session, user_id=_OUTSIDER, permissions=_NO_PERMS, secret_id=sid)
+
+
+async def test_share_to_user_then_grantee_reads(coord, session):
+    sid = await _make(coord, session)
+    await coord.share(
+        session,
+        user_id=_ADMIN,
+        permissions=_NO_PERMS,
+        secret_id=sid,
+        grantee=VaultRef(VaultKind.USER, str(_GRANTEE_USER)),
+    )
+    await session.commit()
+    # the grantee opens it via their own user vault, with no company membership
+    assert await coord.read(session, user_id=_GRANTEE_USER, permissions=_NO_PERMS, secret_id=sid) == b"hunter2"
+
+
+async def test_outsider_cannot_share(coord, session):
+    sid = await _make(coord, session)
+    with pytest.raises(SecretAccessError):
+        await coord.share(
+            session,
+            user_id=_OUTSIDER,
+            permissions=_NO_PERMS,
+            secret_id=sid,
+            grantee=VaultRef(VaultKind.USER, str(_OUTSIDER)),
+        )
+
+
+async def test_revoke_then_grantee_denied(coord, session):
+    sid = await _make(coord, session)
+    grantee = VaultRef(VaultKind.USER, str(_GRANTEE_USER))
+    await coord.share(session, user_id=_ADMIN, permissions=_NO_PERMS, secret_id=sid, grantee=grantee)
+    await session.commit()
+    await coord.revoke(session, user_id=_ADMIN, permissions=_NO_PERMS, secret_id=sid, grantee=grantee)
+    await session.commit()
+    with pytest.raises(SecretAccessError):
+        await coord.read(session, user_id=_GRANTEE_USER, permissions=_NO_PERMS, secret_id=sid)
+
+
+async def test_rotate_and_list(coord, session):
+    sid = await _make(coord, session)
+    await coord.rotate(session, user_id=_ADMIN, permissions=_NO_PERMS, secret_id=sid, new_plaintext=b"rotated")
+    await session.commit()
+    assert await coord.read(session, user_id=_ADMIN, permissions=_NO_PERMS, secret_id=sid) == b"rotated"
+    listed = await coord.list(session, user_id=_ADMIN, permissions=_NO_PERMS)
+    assert [s.id for s in listed] == [sid]
+    assert await coord.list(session, user_id=_OUTSIDER, permissions=_NO_PERMS) == []
+
+
+async def test_delete_then_not_found(coord, session):
+    sid = await _make(coord, session)
+    await coord.delete(session, user_id=_ADMIN, permissions=_NO_PERMS, secret_id=sid)
+    await session.commit()
+    with pytest.raises(SecretNotFoundError):
+        await coord.read(session, user_id=_ADMIN, permissions=_NO_PERMS, secret_id=sid)
+
+
+async def test_mutation_on_missing_secret_raises_not_found(coord, session):
+    with pytest.raises(SecretNotFoundError):
+        await coord.share(
+            session,
+            user_id=_ADMIN,
+            permissions=_NO_PERMS,
+            secret_id=uuid.uuid4(),
+            grantee=VaultRef(VaultKind.USER, str(_GRANTEE_USER)),
+        )


### PR DESCRIPTION
## Thinking Path
Task 2.4 (part 1) of unified-secrets umbrella #10088 — the authorization + orchestration seam between HTTP and the merged store. Kept FastAPI-free so the real integration (resolve→authorize→service) is testable on the migration-gate Postgres job, which can't load the whole app; the `/api/v2/secrets` router (part 2) is a thin shell over it.

## What Changed
New `services/secrets_coordinator.py` — `SecretsCoordinator`: per op resolves `PrincipalFacts` (#10192) → `authorize` (#10135) → `UnifiedSecretsService` (#10134).
- **Authz model:** create→`write` on owner_vault; read/list→gated by `accessible_vaults`; share→`share` on owner_vault; revoke→`revoke`; rotate/delete→`write`. Mutations always authorize against the secret's **owner vault**, never the grantee — sharing with company B is gated by your rights in the owning vault.

## Verification
- **9 tests on disposable Postgres 16** (`tests/migrations/test_secrets_coordinator.py`): company-admin create/read/share/rotate/revoke/delete; outsider denied (create/read/share); grantee reads via shared user vault; revoke removes access; missing secret → `SecretNotFoundError`. ruff/black/mypy clean.

## Model Used
Claude Opus 4.8 (1M context)

Closes #10213
