### PR TITLE
feat(auth): SLM verifies authority RS256 tokens via cached JWKS (Pattern B) (#10197)

### DIFF
--- a/autobot-slm-backend/config.py
+++ b/autobot-slm-backend/config.py
@@ -175,6 +175,18 @@ class Settings(BaseSettings):
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 60 * 24  # 24 hours
 
+    # Authority (autobot-backend) RS256 verification — Pattern B (#10197).
+    # The SLM fetches the public key from the authority's JWKS endpoint and
+    # verifies RS256 tokens locally; the signing private key never leaves the
+    # authority.  Override these in /etc/autobot/slm-secrets.env for
+    # non-co-located deployments.
+    authority_base_url: str = os.getenv("SLM_AUTHORITY_BASE_URL", "http://127.0.0.1:8001")
+    authority_jwks_path: str = os.getenv("SLM_AUTHORITY_JWKS_PATH", "/.well-known/jwks.json")
+    # How long to trust a cached JWKS before re-fetching (seconds).
+    jwks_cache_ttl_seconds: int = int(os.getenv("SLM_JWKS_CACHE_TTL", "3600"))
+    # HTTP connect+read timeout for JWKS endpoint calls (seconds).
+    jwks_fetch_timeout_seconds: float = float(os.getenv("SLM_JWKS_FETCH_TIMEOUT", "10"))
+
     # HMAC signing key for API key hashing (#2160).
     # Default preserves backward compatibility with existing hashed keys.
     # Override in production via SLM_HMAC_API_KEY_SECRET env var.

--- a/autobot-slm-backend/services/auth.py
+++ b/autobot-slm-backend/services/auth.py
@@ -80,9 +80,7 @@ class AuthService:
             # RS256 verification is async; sync callers get None and should
             # migrate to decode_token_async.  This is not a security hole —
             # the token is simply treated as unverified rather than accepted.
-            logger.debug(
-                "decode_token (sync) received RS256 token; use decode_token_async in async contexts"
-            )
+            logger.debug("decode_token (sync) received RS256 token; use decode_token_async in async contexts")
             return None
         return decode_jwt_or_none(token, settings.secret_key)
 

--- a/autobot-slm-backend/services/auth.py
+++ b/autobot-slm-backend/services/auth.py
@@ -6,6 +6,24 @@
 SLM Authentication Service
 
 JWT-based authentication and user management.
+
+Token verification strategy (#10197, epic #10193)
+--------------------------------------------------
+The SLM accepts tokens from two issuers during the migration window:
+
+1. **Authority RS256 tokens** — issued by autobot-backend, signed with an RSA
+   private key.  Verified here using the authority's public key fetched from its
+   JWKS endpoint (Pattern B — SLM never holds the private key).  Claims are
+   normalized to a common shape.
+
+2. **Legacy SLM HS256 tokens** — issued by this service via
+   ``create_access_token``.  Verified with ``settings.secret_key`` as before.
+
+Routing is done by reading the ``alg`` header from the unverified JWT — an
+RS256 token is NEVER verified with the HS256 secret, and vice-versa.  The
+shared ``autobot_shared.auth.jwt_core`` algorithm-confusion guard applies on
+every verification call, so ``alg=none`` and cross-algorithm attacks are
+rejected before PyJWT is invoked.
 """
 
 import logging
@@ -17,7 +35,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from autobot_shared.auth.jwt_core import decode_jwt_or_none, encode_jwt, hash_password
+from autobot_shared.auth.jwt_core import _peek_alg, decode_jwt_or_none, encode_jwt, hash_password
 from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Permission, Role
 from config import settings
 from models.schemas import TokenResponse, UserCreate, UserResponse
@@ -45,8 +63,54 @@ class AuthService:
         )
 
     def decode_token(self, token: str) -> dict | None:
-        """Decode and validate a JWT token."""
+        """Decode and validate a JWT token (synchronous HS256 path only).
+
+        Routes by ``alg`` header:
+        - HS256 → legacy SLM token; verified with ``settings.secret_key``.
+        - RS256 → authority token; cannot be verified synchronously (JWKS fetch
+          is async).  Returns ``None`` so that callers with async context use
+          ``decode_token_async`` instead.  Logs a debug note to avoid silent
+          confusion in WebSocket / other sync call sites.
+
+        Use ``decode_token_async`` in async contexts — it handles both alg
+        values and performs JWKS key lookup for RS256 tokens.
+        """
+        alg = _peek_alg(token)
+        if alg == "RS256":
+            # RS256 verification is async; sync callers get None and should
+            # migrate to decode_token_async.  This is not a security hole —
+            # the token is simply treated as unverified rather than accepted.
+            logger.debug(
+                "decode_token (sync) received RS256 token; use decode_token_async in async contexts"
+            )
+            return None
         return decode_jwt_or_none(token, settings.secret_key)
+
+    async def decode_token_async(self, token: str) -> dict | None:
+        """Decode and validate a JWT token in an async context.
+
+        Routes by ``alg`` header:
+        - RS256 → authority token; fetches/caches JWKS from the authority
+          endpoint and verifies via ``jwt_core.decode_jwt(public_key=...)``.
+          Never falls back to HS256 for an RS256 token.
+        - HS256 → legacy SLM token; verified with ``settings.secret_key``.
+        - Any other / ``none`` → rejected (algorithm-confusion guard).
+
+        Returns the normalized claims dict, or ``None`` on any failure.
+        """
+        alg = _peek_alg(token)
+
+        if alg == "RS256":
+            from services.jwks_verifier import verify_authority_token
+
+            return await verify_authority_token(token)
+
+        if alg == "HS256":
+            return decode_jwt_or_none(token, settings.secret_key)
+
+        # alg=none or unsupported — reject
+        logger.warning("decode_token_async: rejecting token with unsupported alg=%r", alg)
+        return None
 
     async def create_user(self, db: AsyncSession, user_data: UserCreate) -> UserResponse:
         """Create a new user."""
@@ -97,9 +161,14 @@ auth_service = AuthService()
 async def get_current_user(
     credentials: HTTPAuthorizationCredentials = Depends(security),
 ) -> dict:
-    """FastAPI dependency to get the current authenticated user."""
+    """FastAPI dependency to get the current authenticated user.
+
+    Accepts both authority RS256 tokens (verified via JWKS) and legacy SLM
+    HS256 tokens.  Routing is determined by the JWT ``alg`` header so
+    algorithm-confusion attacks are structurally prevented.
+    """
     token = credentials.credentials
-    payload = auth_service.decode_token(token)
+    payload = await auth_service.decode_token_async(token)
 
     if not payload:
         raise HTTPException(

--- a/autobot-slm-backend/services/jwks_verifier.py
+++ b/autobot-slm-backend/services/jwks_verifier.py
@@ -1,0 +1,225 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+JWKS verifier for the SLM backend (#10197, epic #10193).
+
+Fetches the authority (autobot-backend) JWKS public-key set and caches it
+locally.  Tokens are verified via the shared ``jwt_core.decode_jwt`` so the
+algorithm-confusion guard applies on every call.
+
+Usage::
+
+    from services.jwks_verifier import verify_authority_token
+
+    payload = await verify_authority_token(token)   # None on failure
+
+Design notes
+------------
+- The SLM NEVER holds the signing private key.  Only the public key(s) are
+  cached here (Pattern B).
+- Key lookup is by ``kid`` JWT header field.  On an unknown ``kid``, the cache
+  is refreshed once (handles key rotation) before giving up.
+- JWKS-unreachable returns ``None`` — the caller falls back to HS256 or raises
+  401.  This module never raises to the caller; all errors are logged + None.
+- The async HTTP fetch uses ``httpx.AsyncClient`` (already in requirements.txt);
+  no new dependency is introduced.
+- The cache TTL is read from ``config.settings`` (``jwks_cache_ttl_seconds``),
+  defaulting to 3600 s.  The authority base URL is ``settings.authority_base_url``.
+"""
+
+import json
+import logging
+import time
+from typing import Any, Dict, Optional
+
+import httpx
+
+from autobot_shared.auth.jwt_core import JWTDecodeError, JWTExpiredError, _peek_alg, decode_jwt
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Internal cache — module-level singleton (never use mutable default args)
+# ---------------------------------------------------------------------------
+
+_cache_entries: Dict[str, Any] = {}   # kid -> public key object (RSA)
+_cache_fetched_at: float = 0.0        # epoch seconds of last successful fetch
+
+
+def _cache_expired(ttl: int) -> bool:
+    """Return True when the cache is empty or older than *ttl* seconds."""
+    return not _cache_entries or (time.monotonic() - _cache_fetched_at) > ttl
+
+
+def _invalidate_cache() -> None:
+    """Clear the in-process key cache so the next call re-fetches."""
+    global _cache_fetched_at
+    _cache_entries.clear()
+    _cache_fetched_at = 0.0
+
+
+# ---------------------------------------------------------------------------
+# JWKS fetch + reconstruction
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_jwks(url: str, timeout: float) -> Optional[Dict[str, Any]]:
+    """GET *url* and return the parsed JWKS dict, or None on error."""
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.get(url)
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPError as exc:
+        logger.warning("JWKS fetch HTTP error from %s: %s", url, exc)
+        return None
+    except Exception as exc:
+        logger.warning("JWKS fetch failed from %s: %s", url, exc)
+        return None
+
+
+def _build_key_cache(jwks: Dict[str, Any]) -> Dict[str, Any]:
+    """Reconstruct RSA public key objects from a JWKS ``keys`` list.
+
+    Uses PyJWT's ``RSAAlgorithm.from_jwk`` to convert ``n``/``e`` JWK values
+    to a public key that ``decode_jwt(public_key=...)`` accepts.
+
+    Returns a dict keyed by ``kid`` (falls back to ``""`` for a keyless JWK).
+    """
+    from jwt.algorithms import RSAAlgorithm
+
+    result: Dict[str, Any] = {}
+    for jwk in jwks.get("keys", []):
+        if jwk.get("kty") != "RSA" or jwk.get("use", "sig") != "sig":
+            continue
+        kid = jwk.get("kid", "")
+        try:
+            pub_key = RSAAlgorithm.from_jwk(json.dumps(jwk))
+            result[kid] = pub_key
+        except Exception as exc:
+            logger.warning("Skipping invalid JWK (kid=%r): %s", kid, exc)
+    return result
+
+
+async def _refresh_cache(authority_url: str, timeout: float) -> bool:
+    """Fetch the JWKS and rebuild the in-process cache.
+
+    Returns True on success, False when the endpoint is unreachable or returns
+    an unusable payload.
+    """
+    global _cache_fetched_at
+
+    jwks = await _fetch_jwks(authority_url, timeout)
+    if jwks is None:
+        return False
+
+    new_keys = _build_key_cache(jwks)
+    if not new_keys:
+        logger.warning("JWKS response contained no usable RSA signature keys from %s", authority_url)
+        return False
+
+    _cache_entries.clear()
+    _cache_entries.update(new_keys)
+    _cache_fetched_at = time.monotonic()
+    logger.debug("JWKS cache refreshed: %d key(s) loaded", len(_cache_entries))
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def _normalize_claims(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize authority token claims to a common SLM payload shape.
+
+    Authority tokens carry ``username`` / ``user_id`` / ``role``.
+    SLM HS256 legacy tokens carry ``sub`` / ``admin`` / ``role``.
+
+    The returned dict always has:
+      - ``sub``      — username (set from ``username`` if ``sub`` absent)
+      - ``username`` — canonical username
+      - ``role``     — role string (preserved as-is)
+      - ``admin``    — bool derived from role (True when role == "admin")
+      - ``authority_token`` — True (marks the token source)
+    """
+    username = payload.get("username") or payload.get("sub", "")
+    role = payload.get("role", "user")
+    normalized = dict(payload)
+    normalized["sub"] = username
+    normalized["username"] = username
+    normalized["role"] = role
+    normalized["admin"] = role == "admin"
+    normalized["authority_token"] = True
+    return normalized
+
+
+async def verify_authority_token(token: str) -> Optional[Dict[str, Any]]:
+    """Verify an RS256 authority token via cached JWKS and return normalized claims.
+
+    On any failure (JWKS unreachable, bad signature, expired, algorithm mismatch)
+    returns ``None`` — never raises.
+
+    Key-rotation refresh
+    --------------------
+    If the token's ``kid`` is not in the cache, the cache is refreshed once.
+    If the kid is still absent after refresh the token is rejected (unknown key).
+
+    Args:
+        token: RS256 JWT string from the identity authority.
+
+    Returns:
+        Normalized claims dict, or ``None`` on verification failure.
+    """
+    from config import settings  # deferred: avoids circular import at module load
+
+    authority_url = settings.authority_base_url.rstrip("/") + settings.authority_jwks_path
+    ttl = settings.jwks_cache_ttl_seconds
+    fetch_timeout = settings.jwks_fetch_timeout_seconds
+
+    token_alg = _peek_alg(token)
+    if token_alg != "RS256":
+        # Called with a non-RS256 token — logic error in caller
+        logger.warning("verify_authority_token called with non-RS256 token (alg=%r)", token_alg)
+        return None
+
+    import jwt as _jwt
+
+    token_kid: Optional[str] = None
+    try:
+        hdr = _jwt.get_unverified_header(token)
+        token_kid = hdr.get("kid")
+    except Exception:
+        logger.warning("Cannot decode JWT header — rejecting token")
+        return None
+
+    # Ensure cache is fresh or contains the kid
+    if _cache_expired(ttl):
+        await _refresh_cache(authority_url, fetch_timeout)
+
+    # On unknown kid, attempt one refresh (key rotation)
+    if token_kid not in _cache_entries:
+        logger.info("Unknown kid=%r; refreshing JWKS from %s", token_kid, authority_url)
+        refreshed = await _refresh_cache(authority_url, fetch_timeout)
+        if not refreshed or token_kid not in _cache_entries:
+            logger.warning(
+                "Authority token rejected: kid=%r not found in JWKS (keys=%r)",
+                token_kid,
+                list(_cache_entries.keys()),
+            )
+            return None
+
+    pub_key = _cache_entries[token_kid]
+
+    try:
+        payload = decode_jwt(token, public_key=pub_key, algorithms=["RS256"])
+    except JWTExpiredError:
+        logger.warning("Authority RS256 token expired (kid=%r)", token_kid)
+        return None
+    except JWTDecodeError as exc:
+        logger.warning("Authority RS256 token invalid (kid=%r): %s", token_kid, exc)
+        return None
+
+    return _normalize_claims(payload)

--- a/autobot-slm-backend/services/jwks_verifier.py
+++ b/autobot-slm-backend/services/jwks_verifier.py
@@ -44,8 +44,8 @@ logger = logging.getLogger(__name__)
 # Internal cache — module-level singleton (never use mutable default args)
 # ---------------------------------------------------------------------------
 
-_cache_entries: Dict[str, Any] = {}   # kid -> public key object (RSA)
-_cache_fetched_at: float = 0.0        # epoch seconds of last successful fetch
+_cache_entries: Dict[str, Any] = {}  # kid -> public key object (RSA)
+_cache_fetched_at: float = 0.0  # epoch seconds of last successful fetch
 
 
 def _cache_expired(ttl: int) -> bool:

--- a/autobot-slm-backend/services/jwks_verifier.py
+++ b/autobot-slm-backend/services/jwks_verifier.py
@@ -180,7 +180,7 @@ async def verify_authority_token(token: str) -> Optional[Dict[str, Any]]:
     fetch_timeout = settings.jwks_fetch_timeout_seconds
 
     token_alg = _peek_alg(token)
-    if token_alg != "RS256":
+    if token_alg != "RS256":  # nosec B105 - JWT algorithm identifier, not a credential
         # Called with a non-RS256 token — logic error in caller
         logger.warning("verify_authority_token called with non-RS256 token (alg=%r)", token_alg)
         return None

--- a/autobot-slm-backend/services/jwks_verifier_test.py
+++ b/autobot-slm-backend/services/jwks_verifier_test.py
@@ -1,0 +1,481 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for SLM JWKS verifier (#10197).
+
+Covers:
+- Authority RS256 token verifies and yields normalized claims
+- Algorithm-confusion: RS256 token must not verify via HS256 path
+- alg=none rejected
+- Legacy SLM HS256 token still verifies (via decode_token_async)
+- Unknown kid triggers a JWKS refresh
+- JWKS-unreachable returns None (no crash)
+- Expired authority token rejected
+- Claims normalization (username / sub / admin / authority_token)
+
+The tests are isolated from the real backend: a test RSA keypair signs tokens
+and a mocked httpx response serves the JWKS payload.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+# ---------------------------------------------------------------------------
+# Ensure autobot-slm-backend and autobot_shared are importable
+# ---------------------------------------------------------------------------
+_SLM_ROOT = Path(__file__).resolve().parent.parent
+_SHARED_ROOT = _SLM_ROOT.parent / "autobot_shared"
+
+for _p in [str(_SLM_ROOT), str(_SLM_ROOT.parent)]:
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# Stub heavy SLM deps before any import triggers them
+import types as _types
+
+for _name in [
+    "sqlalchemy",
+    "sqlalchemy.ext",
+    "sqlalchemy.ext.asyncio",
+    "sqlalchemy.orm",
+    "models",
+    "models.database",
+    "models.schemas",
+    "services.database",
+    "services.deployment",
+    "services.fleet_sync_guard",
+    "services.reconciler",
+    "services.role_registry",
+    "services.service_categorizer",
+    "services.service_orchestrator",
+    "services.sync_orchestrator",
+    "user_management",
+    "user_management.models",
+    "user_management.models.user",
+    "user_management.database",
+]:
+    if _name not in sys.modules:
+        _mod = MagicMock()
+        _mod.__name__ = _name
+        _mod.__package__ = _name.split(".")[0]
+        _mod.__spec__ = None
+        sys.modules[_name] = _mod
+
+# Stub config before jwks_verifier imports it
+_config_stub = _types.ModuleType("config")
+_settings_stub = MagicMock()
+_settings_stub.authority_base_url = "http://localhost:8001"
+_settings_stub.authority_jwks_path = "/.well-known/jwks.json"
+_settings_stub.jwks_cache_ttl_seconds = 3600
+_settings_stub.jwks_fetch_timeout_seconds = 10.0
+_settings_stub.secret_key = "test-hs256-secret-for-unit-tests-only-32ch"
+_settings_stub.algorithm = "HS256"
+_config_stub.settings = _settings_stub
+sys.modules["config"] = _config_stub
+
+# ---------------------------------------------------------------------------
+# Now import the modules under test
+# ---------------------------------------------------------------------------
+from autobot_shared.auth.jwt_core import JWTDecodeError, encode_jwt  # noqa: E402
+from services import jwks_verifier  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# RSA keypair fixtures
+# ---------------------------------------------------------------------------
+
+_KID = "autobot-test-1"
+_HS256_SECRET = "test-hs256-secret-for-unit-tests-only-32ch"
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair():
+    """Generate a test RSA-2048 keypair once per module."""
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend(),
+    )
+    pem_private = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    pem_public = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+    return pem_private, pem_public
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair_b():
+    """A second RSA keypair — for wrong-key tests."""
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend(),
+    )
+    pem_private = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    pem_public = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+    return pem_private, pem_public
+
+
+# ---------------------------------------------------------------------------
+# JWKS builder — converts a PEM public key to a JWKS JSON response dict
+# ---------------------------------------------------------------------------
+
+
+def _make_jwks(pem_public: str, kid: str = _KID) -> Dict[str, Any]:
+    """Build a JWKS dict from a PEM public key, mimicking the backend response."""
+    from cryptography.hazmat.primitives import serialization as _ser
+    from jwt.algorithms import RSAAlgorithm
+
+    pub_key_obj = _ser.load_pem_public_key(pem_public.encode("utf-8"), backend=default_backend())
+    base_jwk = json.loads(RSAAlgorithm.to_jwk(pub_key_obj))
+    base_jwk.pop("key_ops", None)
+    base_jwk.update({"use": "sig", "alg": "RS256", "kid": kid})
+    return {"keys": [base_jwk]}
+
+
+def _make_authority_token(
+    pem_private: str,
+    claims: Dict[str, Any] | None = None,
+    expires_delta: timedelta | None = None,
+) -> str:
+    """Sign an RS256 authority token with the given private key."""
+    payload = claims or {"username": "alice", "user_id": "uid-1", "role": "admin"}
+    return encode_jwt(
+        payload,
+        private_key=pem_private,
+        algorithm="RS256",
+        kid=_KID,
+        expires_delta=expires_delta if expires_delta is not None else timedelta(hours=1),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper: mock the httpx fetch inside jwks_verifier
+# ---------------------------------------------------------------------------
+
+
+def _mock_httpx_fetch(jwks_dict: Dict[str, Any] | None):
+    """Return a context-manager patch that makes _fetch_jwks return jwks_dict."""
+
+    async def _fake_fetch(url: str, timeout: float):
+        return jwks_dict
+
+    return patch.object(jwks_verifier, "_fetch_jwks", side_effect=_fake_fetch)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — reset module-level cache between tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    """Clear the JWKS in-process cache before every test."""
+    jwks_verifier._invalidate_cache()
+    yield
+    jwks_verifier._invalidate_cache()
+
+
+# ---------------------------------------------------------------------------
+# Test: authority RS256 token verifies + claims normalized
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_authority_rs256_token_accepted_and_claims_normalized(rsa_keypair):
+    pem_priv, pem_pub = rsa_keypair
+    token = _make_authority_token(pem_priv, claims={"username": "alice", "user_id": "uid-1", "role": "admin"})
+    jwks = _make_jwks(pem_pub)
+
+    with _mock_httpx_fetch(jwks):
+        result = await jwks_verifier.verify_authority_token(token)
+
+    assert result is not None, "Valid authority RS256 token should verify"
+    assert result["username"] == "alice"
+    assert result["sub"] == "alice"
+    assert result["role"] == "admin"
+    assert result["admin"] is True
+    assert result["authority_token"] is True
+
+
+@pytest.mark.asyncio
+async def test_authority_rs256_user_role_maps_admin_false(rsa_keypair):
+    pem_priv, pem_pub = rsa_keypair
+    token = _make_authority_token(pem_priv, claims={"username": "bob", "role": "user"})
+    jwks = _make_jwks(pem_pub)
+
+    with _mock_httpx_fetch(jwks):
+        result = await jwks_verifier.verify_authority_token(token)
+
+    assert result is not None
+    assert result["admin"] is False
+    assert result["role"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# Test: algorithm-confusion — RS256 token MUST NOT verify via HS256
+# ---------------------------------------------------------------------------
+
+
+def test_algorithm_confusion_rs256_vs_hs256_direct():
+    """The shared jwt_core guard rejects RS256 token when secret= only supplied."""
+    from autobot_shared.auth.jwt_core import decode_jwt
+
+    # We can't call verify_authority_token with HS256 path — it routes to RS256.
+    # Directly test that decode_jwt rejects the attempt.
+    from cryptography.hazmat.backends import default_backend as _db
+    from cryptography.hazmat.primitives.asymmetric import rsa as _rsa
+
+    priv = _rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=_db())
+    pem_priv = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    ).decode("utf-8")
+
+    token = encode_jwt({"sub": "evil"}, private_key=pem_priv, algorithm="RS256")
+    with pytest.raises(JWTDecodeError):
+        decode_jwt(token, secret=_HS256_SECRET, algorithms=["HS256"])
+
+
+# ---------------------------------------------------------------------------
+# Test: alg=none rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alg_none_rejected():
+    """A manually crafted alg=none token must be rejected by verify_authority_token."""
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "none", "typ": "JWT"}).encode()).rstrip(b"=").decode()
+    payload_b = base64.urlsafe_b64encode(json.dumps({"sub": "evil"}).encode()).rstrip(b"=").decode()
+    none_token = f"{header}.{payload_b}."
+
+    result = await jwks_verifier.verify_authority_token(none_token)
+    assert result is None, "alg=none token must be rejected"
+
+
+# ---------------------------------------------------------------------------
+# Test: legacy SLM HS256 token still verifies via decode_token_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_hs256_token_still_verifies():
+    """Legacy SLM HS256 tokens accepted by decode_token_async HS256 path.
+
+    Imports AuthService directly from the source file to bypass the
+    sys.modules["services.auth"] MagicMock stub installed for other tests.
+    """
+    import importlib.util
+
+    _auth_path = str(Path(__file__).parent / "auth.py")
+    spec = importlib.util.spec_from_file_location("_auth_direct", _auth_path)
+    _auth_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(_auth_mod)  # type: ignore[union-attr]
+
+    svc = _auth_mod.AuthService()
+    token = encode_jwt({"sub": "legacy", "admin": True, "role": "admin"}, secret=_HS256_SECRET)
+    payload = await svc.decode_token_async(token)
+    assert payload is not None, "Legacy HS256 token should verify"
+    assert payload["sub"] == "legacy"
+
+
+# ---------------------------------------------------------------------------
+# Test: sync decode_token returns None for RS256 tokens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_decode_token_returns_none_for_rs256(rsa_keypair):
+    """Sync decode_token must not accept RS256 tokens — returns None."""
+    import importlib.util
+
+    pem_priv, _ = rsa_keypair
+    token = _make_authority_token(pem_priv)
+
+    _auth_path = str(Path(__file__).parent / "auth.py")
+    spec = importlib.util.spec_from_file_location("_auth_direct2", _auth_path)
+    _auth_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(_auth_mod)  # type: ignore[union-attr]
+
+    svc = _auth_mod.AuthService()
+    result = svc.decode_token(token)
+    assert result is None, "Sync decode_token must return None for RS256 tokens"
+
+
+# ---------------------------------------------------------------------------
+# Test: unknown kid triggers a refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_kid_triggers_refresh(rsa_keypair):
+    """A token with a kid absent from the cache triggers exactly one refresh."""
+    pem_priv, pem_pub = rsa_keypair
+    token = _make_authority_token(pem_priv)
+    jwks = _make_jwks(pem_pub)
+
+    fetch_calls = []
+
+    async def _counting_fetch(url: str, timeout: float):
+        fetch_calls.append(url)
+        return jwks
+
+    with patch.object(jwks_verifier, "_fetch_jwks", side_effect=_counting_fetch):
+        # Cache is empty; first call will trigger one fetch (TTL-expired path),
+        # and since kid is present after that fetch no second fetch happens.
+        result = await jwks_verifier.verify_authority_token(token)
+
+    assert result is not None
+    assert len(fetch_calls) == 1, "Should fetch exactly once when cache was empty"
+
+
+@pytest.mark.asyncio
+async def test_unknown_kid_after_stale_cache_triggers_second_refresh(rsa_keypair, rsa_keypair_b):
+    """Stale cache with wrong kid triggers a refresh; if kid still absent → None."""
+    pem_priv_a, pem_pub_a = rsa_keypair
+    _, pem_pub_b = rsa_keypair_b
+
+    # Pre-populate cache with keypair B's key (different kid)
+    wrong_jwks = _make_jwks(pem_pub_b, kid="other-kid")
+    good_jwks = _make_jwks(pem_pub_a, kid=_KID)
+
+    # Token signed with keypair A (kid=_KID) but cache only has "other-kid"
+    token = _make_authority_token(pem_priv_a)
+
+    # Seed cache with wrong key so it looks "fresh" (non-expired)
+    import time
+
+    with patch.object(jwks_verifier, "_fetch_jwks", AsyncMock(return_value=wrong_jwks)):
+        await jwks_verifier._refresh_cache("http://test", 10.0)
+
+    # Now call with _KID absent → should refresh once and find it
+    fetch_calls = []
+
+    async def _second_fetch(url: str, timeout: float):
+        fetch_calls.append(url)
+        return good_jwks
+
+    with patch.object(jwks_verifier, "_fetch_jwks", side_effect=_second_fetch):
+        # Force cache as non-expired so only unknown-kid refresh fires
+        jwks_verifier._cache_fetched_at = time.monotonic()
+        result = await jwks_verifier.verify_authority_token(token)
+
+    assert result is not None, "Should succeed after refresh revealed the correct kid"
+    assert len(fetch_calls) == 1, "Exactly one refresh for unknown kid"
+
+
+# ---------------------------------------------------------------------------
+# Test: JWKS unreachable returns None (no crash)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_jwks_unreachable_returns_none(rsa_keypair):
+    """When the JWKS endpoint is unreachable, verify_authority_token returns None."""
+    pem_priv, _ = rsa_keypair
+    token = _make_authority_token(pem_priv)
+
+    with _mock_httpx_fetch(None):  # _fetch_jwks returns None → unreachable
+        result = await jwks_verifier.verify_authority_token(token)
+
+    assert result is None, "JWKS-unreachable must return None without raising"
+
+
+# ---------------------------------------------------------------------------
+# Test: expired authority RS256 token rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_expired_authority_token_rejected(rsa_keypair):
+    pem_priv, pem_pub = rsa_keypair
+    token = _make_authority_token(pem_priv, expires_delta=timedelta(seconds=-1))
+    jwks = _make_jwks(pem_pub)
+
+    with _mock_httpx_fetch(jwks):
+        result = await jwks_verifier.verify_authority_token(token)
+
+    assert result is None, "Expired RS256 token must be rejected"
+
+
+# ---------------------------------------------------------------------------
+# Test: wrong signing key rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wrong_signing_key_rejected(rsa_keypair, rsa_keypair_b):
+    """Token signed with keypair A but JWKS carries keypair B's key → rejected."""
+    pem_priv_a, _ = rsa_keypair
+    _, pem_pub_b = rsa_keypair_b
+
+    token = _make_authority_token(pem_priv_a)
+    jwks_with_wrong_key = _make_jwks(pem_pub_b, kid=_KID)
+
+    with _mock_httpx_fetch(jwks_with_wrong_key):
+        result = await jwks_verifier.verify_authority_token(token)
+
+    assert result is None, "Token signed by different key must be rejected"
+
+
+# ---------------------------------------------------------------------------
+# Test: non-RS256 token passed to verify_authority_token returns None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hs256_token_to_verify_authority_returns_none():
+    """verify_authority_token called with an HS256 token returns None (not crash)."""
+    token = encode_jwt({"sub": "attacker"}, secret=_HS256_SECRET)
+    result = await jwks_verifier.verify_authority_token(token)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Test: _normalize_claims handles sub-only tokens (legacy authority shape)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_claims_sub_only():
+    """If authority token has sub but no username, sub is promoted to username."""
+    payload = {"sub": "carol", "role": "user"}
+    result = jwks_verifier._normalize_claims(payload)
+    assert result["username"] == "carol"
+    assert result["sub"] == "carol"
+    assert result["admin"] is False
+    assert result["authority_token"] is True
+
+
+def test_normalize_claims_username_preferred_over_sub():
+    """username claim takes precedence over sub for canonical identity."""
+    payload = {"sub": "old-sub", "username": "alice", "role": "admin"}
+    result = jwks_verifier._normalize_claims(payload)
+    assert result["username"] == "alice"
+    assert result["sub"] == "alice"
+    assert result["admin"] is True

--- a/autobot-slm-backend/services/jwks_verifier_test.py
+++ b/autobot-slm-backend/services/jwks_verifier_test.py
@@ -114,10 +114,14 @@ def rsa_keypair():
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         encryption_algorithm=serialization.NoEncryption(),
     ).decode("utf-8")
-    pem_public = private_key.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode("utf-8")
+    pem_public = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
     return pem_private, pem_public
 
 
@@ -134,10 +138,14 @@ def rsa_keypair_b():
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         encryption_algorithm=serialization.NoEncryption(),
     ).decode("utf-8")
-    pem_public = private_key.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode("utf-8")
+    pem_public = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
     return pem_private, pem_public
 
 
@@ -244,12 +252,12 @@ async def test_authority_rs256_user_role_maps_admin_false(rsa_keypair):
 
 def test_algorithm_confusion_rs256_vs_hs256_direct():
     """The shared jwt_core guard rejects RS256 token when secret= only supplied."""
-    from autobot_shared.auth.jwt_core import decode_jwt
-
     # We can't call verify_authority_token with HS256 path — it routes to RS256.
     # Directly test that decode_jwt rejects the attempt.
     from cryptography.hazmat.backends import default_backend as _db
     from cryptography.hazmat.primitives.asymmetric import rsa as _rsa
+
+    from autobot_shared.auth.jwt_core import decode_jwt
 
     priv = _rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=_db())
     pem_priv = priv.private_bytes(


### PR DESCRIPTION
## Thinking Path
Phase 2 of #10193. The SLM must accept identity-authority-issued user tokens **without holding the signing secret** (Pattern B). It fetches the authority's public key from JWKS and verifies RS256 locally; legacy HS256 SLM tokens still work during transition.

## What Changed
- **`services/jwks_verifier.py` (new):** async JWKS client + {kid→public key} cache (TTL + unknown-kid refresh for rotation). Verifies via `jwt_core.decode_jwt(token, public_key=…, algorithms=["RS256"])` so the shared algorithm-confusion guard applies. JWKS-unreachable → returns not-verified (no crash; full degraded policy is #10201). Never falls back to HS256 for an RS256 token; never holds the private key.
- **`services/auth.py`:** `decode_token_async` routes by the token's `alg` header — RS256→JWKS verifier (authority token), HS256→existing `settings.secret_key` (legacy SLM token), `alg=none`/other→rejected. Claims normalized (authority `username`/`role`/`user_id` vs SLM `sub`/`admin`/`role`).
- **`config.py`:** `SLM_AUTHORITY_BASE_URL` (default co-located `http://127.0.0.1:8001`), JWKS path, cache TTL. No signing secret on the SLM.

## Verification
- 14 new tests pass: authority RS256 token verifies via mocked JWKS + normalized claims; **alg-confusion rejected** (RS256-as-HS256, alg=none); legacy HS256 still verifies; unknown-kid triggers refresh; JWKS-unreachable → not-verified (no crash); expired rejected.
- `py_compile` clean; bandit clean (`-c .bandit`).

## Follow-ups (flagged, out of scope)
The **sync** `decode_token` (used by `api/websocket.py:61`, `api/mfa.py:103`) returns None for RS256 — those call sites need migrating to the async path before WebSocket/MFA accept authority tokens. `api/sso_auth.py` still mints HS256. Tracked for a follow-on (will note on the epic).

## Model Used
Opus 4.8 (1M) — implemented via subagent, security-reviewed (alg-routing, confusion guard, no private key on SLM).

Advances #10197 (part of #10193). #10198 adds the `service_management` RBAC gate.