### PR TITLE
feat(secrets): seed secrets:* RBAC permissions for team/role vaults (#10223)

### DIFF
--- a/autobot-backend/services/secrets_authz_perms_test.py
+++ b/autobot-backend/services/secrets_authz_perms_test.py
@@ -1,0 +1,47 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The registered secrets:* RBAC permissions match the authz policy (#10088).
+
+Guards the contract between the permission registry
+(``autobot_shared.auth.permissions``) and the policy that consumes the names
+(``services.secrets_authz``): the team/role vault permissions the policy checks
+must all exist in ``SYSTEM_PERMISSIONS`` and be assigned to the right roles.
+"""
+
+from __future__ import annotations
+
+from autobot_shared.auth.permissions import SYSTEM_PERMISSIONS, SYSTEM_ROLES
+from autobot_shared.secrets_vault import VaultKind
+from services.secrets_authz import secrets_permission
+
+_REGISTERED = {row[0] for row in SYSTEM_PERMISSIONS}
+# Only team and role vaults consult RBAC permissions in the policy.
+_RBAC_VAULTS = (VaultKind.TEAM, VaultKind.ROLE)
+_ACTIONS = ("read", "write", "share", "revoke")
+_EXPECTED = {secrets_permission(k, a) for k in _RBAC_VAULTS for a in _ACTIONS}
+
+
+def test_all_policy_permissions_are_registered():
+    missing = _EXPECTED - _REGISTERED
+    assert not missing, f"secrets:* permissions checked by the policy but not registered: {missing}"
+
+
+def test_admin_role_has_full_secrets_control():
+    admin = set(SYSTEM_ROLES["admin"]["permissions"])
+    assert _EXPECTED <= admin, f"admin missing secrets perms: {_EXPECTED - admin}"
+
+
+def test_user_role_has_readwrite_not_share_revoke():
+    user = set(SYSTEM_ROLES["user"]["permissions"])
+    for kind in _RBAC_VAULTS:
+        assert secrets_permission(kind, "read") in user
+        assert secrets_permission(kind, "write") in user
+        assert secrets_permission(kind, "share") not in user
+        assert secrets_permission(kind, "revoke") not in user
+
+
+def test_readonly_role_has_no_secrets_write():
+    readonly = set(SYSTEM_ROLES["readonly"]["permissions"])
+    assert not any(p.startswith("secrets:") and p.endswith((":write", ":share", ":revoke")) for p in readonly)

--- a/autobot_shared/auth/permissions.py
+++ b/autobot_shared/auth/permissions.py
@@ -152,6 +152,17 @@ SYSTEM_PERMISSIONS: List[tuple] = [
     # Audit (Issue #683: Role-Based Access Control)
     ("audit:read", "audit", "read", "View audit logs"),
     ("audit:write", "audit", "write", "Manage audit logs (cleanup)"),
+    # Unified secrets — team/role vault access (#10088). The system/user/company/
+    # node vaults are gated by admin / ownership / LLC-membership, so only the
+    # team and role vaults consult these RBAC permissions (services/secrets_authz).
+    ("secrets:team:read", "secrets", "team:read", "Read team-vault secrets"),
+    ("secrets:team:write", "secrets", "team:write", "Write team-vault secrets"),
+    ("secrets:team:share", "secrets", "team:share", "Share team-vault secrets"),
+    ("secrets:team:revoke", "secrets", "team:revoke", "Revoke team-vault secret grants"),
+    ("secrets:role:read", "secrets", "role:read", "Read role-vault secrets"),
+    ("secrets:role:write", "secrets", "role:write", "Write role-vault secrets"),
+    ("secrets:role:share", "secrets", "role:share", "Share role-vault secrets"),
+    ("secrets:role:revoke", "secrets", "role:revoke", "Revoke role-vault secret grants"),
 ]
 
 # Default system roles with their permissions for database seeding.
@@ -184,6 +195,15 @@ SYSTEM_ROLES: Dict[str, Dict] = {
             "admin:organization",
             "audit:read",
             "audit:write",
+            # Unified secrets (#10088): full team/role vault control.
+            "secrets:team:read",
+            "secrets:team:write",
+            "secrets:team:share",
+            "secrets:team:revoke",
+            "secrets:role:read",
+            "secrets:role:write",
+            "secrets:role:share",
+            "secrets:role:revoke",
         ],
     },
     "user": {
@@ -200,6 +220,12 @@ SYSTEM_ROLES: Dict[str, Dict] = {
             "files:upload",
             "files:download",
             "settings:read",
+            # Unified secrets (#10088): members read/write their team/role vault
+            # secrets; sharing/revoking grants stays admin-only.
+            "secrets:team:read",
+            "secrets:team:write",
+            "secrets:role:read",
+            "secrets:role:write",
         ],
     },
     "readonly": {


### PR DESCRIPTION
## Thinking Path
The final piece of the secrets RBAC layer (umbrella #10088). The authz policy (#10135) checks `secrets:<kind>:<action>` for **team** and **role** vaults; those permissions didn't exist in the registry yet, so team/role grants couldn't be authorized. (System/user/company/node vaults already work via admin/ownership/LLC-membership.)

## What Changed
`autobot_shared/auth/permissions.py`:
- Register 8 perms in `SYSTEM_PERMISSIONS`: `secrets:{team,role}:{read,write,share,revoke}`.
- Assign in `SYSTEM_ROLES`: **admin** → all 8; **user** → `team/role:read,write` (members manage their team/role secrets; share/revoke grants stay admin-only); **readonly** → none.

## Verification
- `services/secrets_authz_perms_test.py` (4 tests): every name the policy checks (`secrets_permission(kind, action)`) is registered; admin has full control; user has read/write but not share/revoke; readonly has no secrets writes. Guards policy↔registry drift.
- ruff/black clean; mypy clean on `autobot_shared`.

## Model Used
Claude Opus 4.8 (1M context)

Closes #10223
