### PR TITLE
fix(transcriber): wire transcription pipeline — repair orchestrator, register providers, Celery trigger (#10128)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -424,7 +424,7 @@ async def _init_builtin_extensions(app: FastAPI) -> None:
 
 
 async def _init_transcriber_db(app: FastAPI) -> None:
-    """Initialize the transcriber SQLite database (GH#9044).
+    """Initialize the transcriber SQLite database and speech providers (GH#9044, #10128).
 
     Non-critical: a failure logs a warning but does not block startup.
     Skipped entirely when TRANSCRIBER_ENABLED != true.
@@ -455,6 +455,16 @@ async def _init_transcriber_db(app: FastAPI) -> None:
         logger.info("Transcriber DB initialized")
     except Exception as _tc_err:
         logger.warning("Transcriber DB init failed (non-critical): %s", _tc_err)
+
+    # Register speech providers (GH#10128 F3).  Non-critical — a single bad
+    # provider must not abort startup.
+    try:
+        from voice_processing.providers.registry_init import initialize_providers
+
+        initialize_providers()
+        logger.info("Speech provider registry initialized")
+    except Exception as _prov_err:
+        logger.warning("Speech provider registry init failed (non-critical): %s", _prov_err)
 
 
 async def initialize_critical_services(app: FastAPI):

--- a/autobot-backend/tasks/transcriber_tasks.py
+++ b/autobot-backend/tasks/transcriber_tasks.py
@@ -13,9 +13,8 @@ work runs inside ``asyncio.run()``, matching the pattern of
 
 import asyncio
 
-from celery_app import celery_app
-
 from autobot_shared.logging_manager import get_logger
+from celery_app import celery_app
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/tasks/transcriber_tasks.py
+++ b/autobot-backend/tasks/transcriber_tasks.py
@@ -1,0 +1,48 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Transcriber Celery Tasks (GH#10128)
+
+Async Celery task that drives the transcription pipeline for each uploaded
+recording.  The task body is synchronous (Celery requirement); all async
+work runs inside ``asyncio.run()``, matching the pattern of
+``tasks/mobile_device_tasks.py``.
+"""
+
+import asyncio
+
+from celery_app import celery_app
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+
+@celery_app.task(
+    name="tasks.transcribe_recording",
+    acks_late=True,
+    max_retries=3,
+)
+def transcribe_recording(recording_id: int) -> dict:
+    """Enqueue-and-forget task: run the transcription pipeline for *recording_id*.
+
+    Args:
+        recording_id: Primary key of the recording row to process.
+
+    Returns:
+        Dict returned by ``TranscriberOrchestrator.process_recording``.
+    """
+    logger.info("Celery: transcribe_recording started for recording_id=%d", recording_id)
+    result = asyncio.run(_run_pipeline(recording_id))
+    logger.info("Celery: transcribe_recording done for recording_id=%d", recording_id)
+    return result
+
+
+async def _run_pipeline(recording_id: int) -> dict:
+    """Async wrapper so the orchestrator can use await internally."""
+    from transcriber.orchestrator import get_transcriber_orchestrator
+
+    orchestrator = get_transcriber_orchestrator()
+    return await orchestrator.process_recording(recording_id)

--- a/autobot-backend/transcriber/database.py
+++ b/autobot-backend/transcriber/database.py
@@ -229,6 +229,16 @@ class Database:
         if cur.rowcount == 0:
             raise KeyError(f"no recording with id={recording_id}")
 
+    async def update_recording_duration(self, recording_id: int, duration: float) -> None:
+        """Set the audio duration for a recording after ffmpeg probe."""
+        cur = await self._db().execute(
+            "UPDATE recordings SET duration=? WHERE id=?",
+            (duration, recording_id),
+        )
+        await self._db().commit()
+        if cur.rowcount == 0:
+            raise KeyError(f"no recording with id={recording_id}")
+
     async def delete_recording(self, recording_id: int) -> None:
         cur = await self._db().execute("DELETE FROM recordings WHERE id=?", (recording_id,))
         await self._db().commit()
@@ -393,15 +403,16 @@ _db_instance: Database | None = None
 async def get_transcriber_db() -> Database:
     """Get or create the singleton transcriber database instance.
 
+    Migrations are applied inside ``connect()``. Callers do not need to call
+    ``migrate()`` separately.
+
     Returns:
         Database: The shared database connection instance
     """
     global _db_instance
     if _db_instance is None:
-        # Get database path from environment, default to data/transcriber.db
         db_path = os.getenv("AUTOBOT_TRANSCRIBER_DB_PATH", "data/transcriber.db")
         _db_instance = Database(db_path)
         await _db_instance.connect()
-        await _db_instance.migrate()
-        logger.info(f"Transcriber database initialized at {db_path}")
+        logger.info("Transcriber database initialized at %s", db_path)
     return _db_instance

--- a/autobot-backend/transcriber/models.py
+++ b/autobot-backend/transcriber/models.py
@@ -3,12 +3,26 @@
 # autobot-backend/transcriber/models.py
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Pydantic request/response schemas for the transcriber module."""
+"""Pydantic request/response schemas and status enum for the transcriber module."""
 
 from datetime import datetime
+from enum import Enum
 from typing import Literal
 
 from pydantic import BaseModel, Field
+
+
+class RecordingStatus(str, Enum):
+    """Canonical recording lifecycle states.
+
+    Values match the DB default ('pending'), the RecordingOut schema Literal,
+    and the frontend type — do not change string values.
+    """
+
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETE = "complete"
+    ERROR = "error"
 
 
 class ProjectCreate(BaseModel):

--- a/autobot-backend/transcriber/orchestrator.py
+++ b/autobot-backend/transcriber/orchestrator.py
@@ -8,8 +8,8 @@
 
 """Orchestration service for the transcription pipeline."""
 
-import time
 import tempfile
+import time
 from pathlib import Path
 from typing import Dict, List, Optional
 

--- a/autobot-backend/transcriber/orchestrator.py
+++ b/autobot-backend/transcriber/orchestrator.py
@@ -4,34 +4,32 @@
 # Author: mrveiss
 #
 # Transcriber Orchestrator
-# Issue #9044, #9214
+# Issue #9044, #9214, #10128
 
-"""Orchestration service for transcription pipeline."""
+"""Orchestration service for the transcription pipeline."""
 
+import time
 import tempfile
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from autobot_shared.logging_manager import get_logger
-from media.audio.diarization_service import get_diarization_service
+from media.audio.diarization_service import SpeakerSegment, get_diarization_service, is_diarization_available
 from media.audio.ffmpeg_service import get_ffmpeg_service
-from transcriber.database import TranscriberDatabase, get_transcriber_db
+from transcriber.database import Database, get_transcriber_db
 from transcriber.models import RecordingStatus
 from voice_processing.language_detection import detect_language
-from voice_processing.providers import get_speech_provider_registry
+from voice_processing.providers import TranscriptSegment, get_speech_provider_registry
 
 logger = get_logger(__name__)
+
+_SINGLE_SPEAKER_LABEL = "SPEAKER_00"
 
 
 class TranscriberOrchestrator:
     """Orchestrates the transcription pipeline with speaker diarization."""
 
-    def __init__(self, db: Optional[TranscriberDatabase] = None):
-        """Initialize orchestrator.
-
-        Args:
-            db: Optional TranscriberDatabase instance (for testing)
-        """
+    def __init__(self, db: Optional[Database] = None):
         self.db = db
         self.ffmpeg_service = get_ffmpeg_service()
         self.diarization_service = get_diarization_service()
@@ -41,263 +39,201 @@ class TranscriberOrchestrator:
         """Process a recording through the full pipeline.
 
         Pipeline stages:
-        1. Validate file path security (Issue #9214)
-        2. Extract and normalize audio with FFmpeg
+        1. Validate + guard status
+        2. Extract and normalize audio (FFmpeg)
         3. Detect language
-        4. Generate speaker segments with Pyannote diarization
-        5. Transcribe audio with language-appropriate speech provider
-        6. Merge transcription text with speaker timestamps
-        7. Persist segments to database
-
-        Args:
-            recording_id: Recording ID to process
-
-        Returns:
-            Dictionary with processing results
-
-        Raises:
-            Exception: If processing fails at any stage
-            ValueError: If path validation fails (Issue #9214)
+        4. Speaker diarization (Pyannote, or single-speaker fallback)
+        5. Transcribe audio
+        6. Merge transcription segments with speakers by time-overlap
+        7. Persist speakers + segments to database
         """
-        # Get database if not injected
         if self.db is None:
             self.db = await get_transcriber_db()
 
-        # Get recording
         recording = await self.db.get_recording(recording_id)
         if recording is None:
             raise ValueError(f"Recording {recording_id} not found")
 
-        if recording.status != RecordingStatus.PENDING:
-            raise ValueError(f"Recording {recording_id} is not in pending status (current: {recording.status})")
+        if recording["status"] != RecordingStatus.PENDING.value:
+            raise ValueError(f"Recording {recording_id} is not pending (current: {recording['status']})")
 
-        # Security: Validate file path before processing (Issue #9214)
-        # This is a defense-in-depth measure - paths should already be validated at upload time
-        logger.debug("Validating file path for recording %d: %s", recording_id, recording.file_path)
+        _validate_file_path(recording["filepath"])
 
-        # Ensure path is absolute
-        if not Path(recording.file_path).is_absolute():
-            raise ValueError(f"Path must be absolute: {recording.file_path}")
+        await self.db.update_recording_status(recording_id, RecordingStatus.PROCESSING.value)
 
-        # Ensure path is within upload base directory
-        from transcriber.upload_security import get_upload_base_dir
-
-        upload_base = get_upload_base_dir()
+        start_ts = time.monotonic()
+        tmp_wav_path: Optional[str] = None
         try:
-            Path(recording.file_path).resolve().relative_to(upload_base)
-        except ValueError:
-            raise ValueError(f"Path traversal blocked: {recording.file_path} not in upload directory {upload_base}")
-
-        # Ensure file exists and is not a symlink
-        if not Path(recording.file_path).exists():
-            raise ValueError(f"File not found: {recording.file_path}")
-
-        if Path(recording.file_path).is_symlink():
-            raise ValueError(f"Symlinks not allowed: {recording.file_path}")
-
-        logger.info("Path validation passed for recording %d", recording_id)
-
-        # Update status to processing
-        await self.db.update_recording_status(recording_id, RecordingStatus.PROCESSING)
-
-        try:
-            # Stage 1: Extract and normalize audio
-            logger.info(
-                "Stage 1/5: Extracting and normalizing audio for recording %d",
-                recording_id,
-            )
-            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp_wav:
-                tmp_wav_path = tmp_wav.name
-
-            await self.ffmpeg_service.extract_audio(input_path=recording.file_path, output_path=tmp_wav_path)
-
-            # Get audio duration
+            tmp_wav_path = await self._extract_audio(recording_id, recording["filepath"])
             duration = await self.ffmpeg_service.get_audio_duration(tmp_wav_path)
-            logger.info("Audio duration: %.2f seconds", duration)
+            await self.db.update_recording_duration(recording_id, duration)
+            logger.info("Recording %d: audio duration=%.2fs", recording_id, duration)
 
-            # Stage 2: Detect language
-            logger.info("Stage 2/5: Detecting language")
-            language = await detect_language(audio_path=tmp_wav_path, filename_hint=recording.filename)
-            logger.info("Detected language: %s", language)
+            language = await detect_language(audio_path=tmp_wav_path, filename_hint=recording["filename"])
+            logger.info("Recording %d: detected language=%s", recording_id, language)
 
+            speaker_segments = await self._diarize(tmp_wav_path)
+            transcript_segments = await self._transcribe(tmp_wav_path, language)
+
+            speaker_ids = await self._persist_speakers(recording_id, speaker_segments, language)
+            await self._persist_segments(recording_id, transcript_segments, speaker_segments, speaker_ids)
+
+            speaker_count = len(speaker_ids)
+            process_seconds = time.monotonic() - start_ts
+            engine = self.provider_registry.get_provider(language)
+            engine_name = engine.provider_name if engine else None
             await self.db.update_recording_status(
-                recording_id, RecordingStatus.PROCESSING, duration=duration, language=language
-            )
-
-            # Stage 3: Speaker diarization
-            logger.info("Stage 3/5: Performing speaker diarization")
-            speaker_segments = await self.diarization_service.diarize(tmp_wav_path)
-            logger.info("Found %d speaker segments", len(speaker_segments))
-
-            # Stage 4: Speech recognition
-            logger.info("Stage 4/5: Transcribing audio (language: %s)", language)
-            provider = self.provider_registry.get_provider(language)
-            if provider is None:
-                raise ValueError(f"No speech provider available for language: {language}")
-
-            logger.info("Using provider: %s", provider.__class__.__name__)
-            transcription_result = await provider.transcribe(tmp_wav_path, language)
-
-            if transcription_result is None:
-                raise ValueError("Transcription failed - no result returned")
-
-            # Stage 5: Merge diarization with transcription
-            logger.info("Stage 5/5: Merging diarization with transcription")
-            merged_segments = self._merge_segments(
-                speaker_segments=speaker_segments,
-                transcription_text=transcription_result.get("text", ""),
-                confidence=transcription_result.get("confidence", 0.95),
-            )
-
-            logger.info("Merged into %d final segments", len(merged_segments))
-
-            # Persist segments to database
-            created_segments = await self.db.create_segments(segments=merged_segments, recording_id=recording_id)
-
-            # Update recording status to completed
-            await self.db.update_recording_status(recording_id, RecordingStatus.COMPLETED)
-
-            # Clean up temp file
-            Path(tmp_wav_path).unlink(missing_ok=True)
-
-            logger.info(
-                "Recording %d processed successfully: %d segments",
                 recording_id,
-                len(created_segments),
+                RecordingStatus.COMPLETE.value,
+                language_detected=language,
+                speaker_count=speaker_count,
+                process_seconds=process_seconds,
+                engine_used=engine_name,
             )
-
+            logger.info(
+                "Recording %d complete: speakers=%d segments=%d engine=%s",
+                recording_id,
+                speaker_count,
+                len(transcript_segments),
+                engine_name,
+            )
             return {
                 "recording_id": recording_id,
-                "status": RecordingStatus.COMPLETED.value,
-                "segments_count": len(created_segments),
+                "status": RecordingStatus.COMPLETE.value,
+                "segments_count": len(transcript_segments),
                 "language": language,
                 "duration": duration,
             }
 
         except Exception as exc:
-            logger.error("Processing failed for recording %d: %s", recording_id, exc)
-            await self.db.update_recording_status(recording_id, RecordingStatus.FAILED)
-
-            # Clean up temp file if it exists
-            try:
-                Path(tmp_wav_path).unlink(missing_ok=True)
-            except Exception:
-                pass
-
+            process_seconds = time.monotonic() - start_ts
+            failure_stage = type(exc).__name__
+            logger.error("Recording %d failed at %s", recording_id, failure_stage)
+            await self.db.update_recording_status(
+                recording_id,
+                RecordingStatus.ERROR.value,
+                process_seconds=process_seconds,
+                failure_stage=failure_stage,
+                failure_reason="Processing failed — see backend logs",
+            )
             raise
+        finally:
+            if tmp_wav_path:
+                Path(tmp_wav_path).unlink(missing_ok=True)
 
-    def _merge_segments(
-        self,
-        speaker_segments: List,
-        transcription_text: str,
-        confidence: float,
-    ) -> List[dict]:
-        """Merge speaker segments with transcription text.
+    # ── private helpers ───────────────────────────────────────────────────────
 
-        Algorithm:
-        1. Split transcription text by words
-        2. Distribute words proportionally across speaker segments based on duration
-        3. Assign each segment its portion of the text
+    async def _extract_audio(self, recording_id: int, filepath: str) -> str:
+        """Extract audio to a temporary WAV file; return the tmp path."""
+        logger.info("Recording %d: extracting audio from %s", recording_id, filepath)
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            tmp_path = tmp.name
+        await self.ffmpeg_service.extract_audio(input_path=filepath, output_path=tmp_path)
+        return tmp_path
 
-        Args:
-            speaker_segments: List of SpeakerSegment objects from diarization
-            transcription_text: Full transcription text
-            confidence: Overall confidence score
-
-        Returns:
-            List of merged segment dictionaries with speaker_label, start_time, end_time, text, confidence
-        """
-        if not speaker_segments:
-            logger.warning("No speaker segments - returning empty list")
+    async def _diarize(self, wav_path: str) -> List[SpeakerSegment]:
+        """Diarize audio; return single-speaker fallback if Pyannote unavailable."""
+        if not is_diarization_available():
+            logger.info("Pyannote unavailable — using single-speaker fallback")
+            return []
+        try:
+            segments = await self.diarization_service.diarize(wav_path)
+            logger.info("Diarization: %d segments", len(segments))
+            return segments
+        except Exception as exc:
+            logger.warning("Diarization failed (%s) — using single-speaker fallback", exc)
             return []
 
-        if not transcription_text.strip():
-            logger.warning("Empty transcription text - returning segments with empty text")
-            return [
-                {
-                    "speaker_label": seg.speaker,
-                    "start_time": seg.start,
-                    "end_time": seg.end,
-                    "text": "",
-                    "confidence": confidence,
-                }
-                for seg in speaker_segments
-            ]
+    async def _transcribe(self, wav_path: str, language: str) -> List[TranscriptSegment]:
+        """Transcribe audio via the registered provider for the detected language."""
+        provider = self.provider_registry.get_provider(language)
+        if provider is None:
+            raise ValueError(f"No speech provider available for language: {language}")
+        logger.info("Transcribing with %s (lang=%s)", provider.provider_name, language)
+        result = await provider.transcribe(wav_path, language)
+        if result is None:
+            raise ValueError("Transcription returned None")
+        return result
 
-        # Split text into words
-        words = transcription_text.split()
-        total_duration = sum(seg.end - seg.start for seg in speaker_segments)
-
-        if total_duration == 0:
-            logger.warning("Total duration is 0 - equal word distribution")
-            words_per_segment = len(words) // len(speaker_segments)
-            remainder = len(words) % len(speaker_segments)
+    async def _persist_speakers(
+        self,
+        recording_id: int,
+        diar_segments: List[SpeakerSegment],
+        language: str,
+    ) -> Dict[str, int]:
+        """Create speaker rows; return {label: speaker_id}."""
+        if diar_segments:
+            labels = sorted({s.speaker_label for s in diar_segments})
         else:
-            words_per_segment = None
-            remainder = 0
+            labels = [_SINGLE_SPEAKER_LABEL]
 
-        merged = []
-        word_index = 0
+        label_to_id: Dict[str, int] = {}
+        for label in labels:
+            sid = await self.db.create_speaker(recording_id, label=label, display_name=label, language=language)
+            label_to_id[label] = sid
+        return label_to_id
 
-        for i, seg in enumerate(speaker_segments):
-            # Calculate how many words for this segment based on duration proportion
-            if words_per_segment is None:
-                segment_duration = seg.end - seg.start
-                proportion = segment_duration / total_duration
-                num_words = round(proportion * len(words))
-            else:
-                num_words = words_per_segment + (1 if i < remainder else 0)
-
-            # Ensure we don't exceed available words
-            num_words = min(num_words, len(words) - word_index)
-
-            # Extract words for this segment
-            segment_words = words[word_index : word_index + num_words]
-            segment_text = " ".join(segment_words)
-
-            # Create merged segment
-            merged.append(
-                {
-                    "speaker_label": seg.speaker,
-                    "start_time": seg.start,
-                    "end_time": seg.end,
-                    "text": segment_text,
-                    "confidence": confidence,
-                }
+    async def _persist_segments(
+        self,
+        recording_id: int,
+        transcript_segments: List[TranscriptSegment],
+        diar_segments: List[SpeakerSegment],
+        speaker_ids: Dict[str, int],
+    ) -> None:
+        """Write transcript segments with speaker assignment to the database."""
+        for seg in transcript_segments:
+            label = _assign_speaker(seg, diar_segments)
+            speaker_id = speaker_ids.get(label, speaker_ids.get(_SINGLE_SPEAKER_LABEL))
+            await self.db.create_segment(
+                recording_id,
+                speaker_id=speaker_id,
+                start_time=seg.start_time,
+                end_time=seg.end_time,
+                text=seg.text,
             )
 
-            word_index += num_words
 
-        # If any words remain, append to last segment
-        if word_index < len(words):
-            remaining_words = " ".join(words[word_index:])
-            if merged:
-                merged[-1]["text"] += " " + remaining_words
-            else:
-                # Fallback: create a single segment with all text
-                merged.append(
-                    {
-                        "speaker_label": "SPEAKER_00",
-                        "start_time": 0.0,
-                        "end_time": total_duration,
-                        "text": transcription_text,
-                        "confidence": confidence,
-                    }
-                )
+def _validate_file_path(filepath: str) -> None:
+    """Raise ValueError for insecure or missing paths (Issue #9214)."""
+    from transcriber.upload_security import get_upload_base_dir
 
-        return merged
+    if not Path(filepath).is_absolute():
+        raise ValueError(f"Path must be absolute: {filepath}")
+    upload_base = get_upload_base_dir()
+    try:
+        Path(filepath).resolve().relative_to(upload_base)
+    except ValueError:
+        raise ValueError(f"Path traversal blocked: {filepath} not in {upload_base}")
+    if not Path(filepath).exists():
+        raise ValueError(f"File not found: {filepath}")
+    if Path(filepath).is_symlink():
+        raise ValueError(f"Symlinks not allowed: {filepath}")
 
 
-# Singleton instance
+def _assign_speaker(seg: TranscriptSegment, diar_segments: List[SpeakerSegment]) -> str:
+    """Return the speaker label with maximum time-overlap with the transcript segment.
+
+    Falls back to SPEAKER_00 when diarization produced no segments.
+    """
+    if not diar_segments:
+        return _SINGLE_SPEAKER_LABEL
+    best_label = _SINGLE_SPEAKER_LABEL
+    best_overlap = 0.0
+    for ds in diar_segments:
+        overlap = max(0.0, min(seg.end_time, ds.end_time) - max(seg.start_time, ds.start_time))
+        if overlap > best_overlap:
+            best_overlap = overlap
+            best_label = ds.speaker_label
+    return best_label
+
+
+# ── Singleton ──────────────────────────────────────────────────────────────────
+
 _orchestrator: Optional[TranscriberOrchestrator] = None
 
 
 def get_transcriber_orchestrator() -> TranscriberOrchestrator:
-    """Get or create transcriber orchestrator singleton.
-
-    Returns:
-        TranscriberOrchestrator instance
-    """
+    """Return (or create) the module-level orchestrator singleton."""
     global _orchestrator
     if _orchestrator is None:
         _orchestrator = TranscriberOrchestrator()

--- a/autobot-backend/transcriber/routes/recordings.py
+++ b/autobot-backend/transcriber/routes/recordings.py
@@ -72,6 +72,21 @@ async def upload_recording(
         project_id,
         file.filename,
     )
+
+    # GH#10128 F5: enqueue transcription pipeline via Celery.
+    # Guard against broker unavailability — a broken broker must not 500 the upload.
+    try:
+        from tasks.transcriber_tasks import transcribe_recording
+
+        transcribe_recording.delay(rid)
+        logger.info("Transcription task enqueued for recording_id=%s", rid)
+    except Exception as _enqueue_err:
+        logger.warning(
+            "Failed to enqueue transcription task for recording_id=%s (broker unavailable?): %s",
+            rid,
+            _enqueue_err,
+        )
+
     rec = await db.get_recording(rid)
     return RecordingOut(**rec)
 

--- a/autobot-backend/transcriber/tests/test_orchestrator.py
+++ b/autobot-backend/transcriber/tests/test_orchestrator.py
@@ -1,0 +1,253 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# autobot-backend/transcriber/tests/test_orchestrator.py
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for TranscriberOrchestrator (GH#10128).
+
+No real audio, ffmpeg, or ML runs.  All heavy dependencies are mocked.
+"""
+
+import io
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from transcriber.database import Database
+from transcriber.deps import get_db
+from transcriber.models import RecordingStatus
+from transcriber.orchestrator import TranscriberOrchestrator, _assign_speaker
+from transcriber.routes.projects import router as projects_router
+from transcriber.routes.recordings import router as recordings_router
+from voice_processing.providers import TranscriptSegment
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path):
+    """Bare transcriber database connected to a temp file."""
+    _db = Database(str(tmp_path / "test.db"))
+    await _db.connect()
+    yield _db
+    await _db.close()
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path):
+    """Full ASGI client with DB and upload dir wired in."""
+    app = FastAPI()
+    _db = Database(str(tmp_path / "test.db"))
+    upload_dir = tmp_path / "uploads"
+    upload_dir.mkdir()
+
+    async def override_db():
+        return _db
+
+    await _db.connect()
+    app.dependency_overrides[get_db] = override_db
+    app.state.transcriber_upload_dir = str(upload_dir)
+    app.include_router(projects_router, prefix="/api/transcriber")
+    app.include_router(recordings_router, prefix="/api/transcriber")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+# ── helper ────────────────────────────────────────────────────────────────────
+
+
+async def _make_recording(db: Database, tmp_path, status: str = "pending") -> int:
+    """Insert a project + recording row; write a dummy file; return recording id."""
+    pid = await db.create_project("TestProject", "", "user1")
+    filepath = str(tmp_path / "audio.wav")
+    with open(filepath, "wb") as f:
+        f.write(b"\x00" * 64)
+    rid = await db.create_recording(pid, "audio.wav", filepath, "user1")
+    if status != "pending":
+        await db.update_recording_status(rid, status)
+    return rid
+
+
+# ── unit tests: _assign_speaker ───────────────────────────────────────────────
+
+
+def test_assign_speaker_no_diar_returns_speaker_00():
+    seg = TranscriptSegment(text="hi", start_time=0.0, end_time=1.0, confidence=1.0)
+    assert _assign_speaker(seg, []) == "SPEAKER_00"
+
+
+def test_assign_speaker_picks_max_overlap():
+    from media.audio.diarization_service import SpeakerSegment
+
+    seg = TranscriptSegment(text="hello", start_time=1.0, end_time=3.0, confidence=1.0)
+    diar = [
+        SpeakerSegment("SPEAKER_00", 0.0, 1.5),  # overlap = 0.5
+        SpeakerSegment("SPEAKER_01", 1.5, 4.0),  # overlap = 1.5
+    ]
+    assert _assign_speaker(seg, diar) == "SPEAKER_01"
+
+
+# ── orchestrator happy path ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_process_recording_happy_path(db, tmp_path):
+    from media.audio.diarization_service import SpeakerSegment
+
+    rid = await _make_recording(db, tmp_path)
+
+    diar_segments = [
+        SpeakerSegment("SPEAKER_00", 0.0, 2.0),
+        SpeakerSegment("SPEAKER_01", 2.0, 4.0),
+    ]
+    transcript_segments = [
+        TranscriptSegment(text="Hello world", start_time=0.0, end_time=2.0, confidence=0.9),
+        TranscriptSegment(text="Goodbye", start_time=2.5, end_time=4.0, confidence=0.85),
+    ]
+
+    mock_ffmpeg = MagicMock()
+    mock_ffmpeg.extract_audio = AsyncMock(return_value=None)
+    mock_ffmpeg.get_audio_duration = AsyncMock(return_value=4.0)
+
+    mock_diar = MagicMock()
+    mock_diar.diarize = AsyncMock(return_value=diar_segments)
+
+    mock_provider = MagicMock()
+    mock_provider.provider_name = "mock_provider"
+    mock_provider.transcribe = AsyncMock(return_value=transcript_segments)
+
+    mock_registry = MagicMock()
+    mock_registry.get_provider = MagicMock(return_value=mock_provider)
+
+    orch = TranscriberOrchestrator(db=db)
+    orch.ffmpeg_service = mock_ffmpeg
+    orch.diarization_service = mock_diar
+    orch.provider_registry = mock_registry
+
+    with (
+        patch("transcriber.orchestrator.is_diarization_available", return_value=True),
+        patch("transcriber.orchestrator.detect_language", new=AsyncMock(return_value="en")),
+        patch("transcriber.orchestrator._validate_file_path"),
+    ):
+        result = await orch.process_recording(rid)
+
+    assert result["status"] == RecordingStatus.COMPLETE.value
+    assert result["segments_count"] == 2
+
+    # Speaker rows created
+    speakers = await db.list_speakers(rid)
+    speaker_labels = {s["label"] for s in speakers}
+    assert "SPEAKER_00" in speaker_labels
+    assert "SPEAKER_01" in speaker_labels
+
+    # Segments persisted with correct speaker assignment
+    segments = await db.list_segments(rid)
+    assert len(segments) == 2
+    sp00_id = next(s["id"] for s in speakers if s["label"] == "SPEAKER_00")
+    sp01_id = next(s["id"] for s in speakers if s["label"] == "SPEAKER_01")
+    assert segments[0]["speaker_id"] == sp00_id
+    assert segments[1]["speaker_id"] == sp01_id
+
+    # Final DB status
+    rec = await db.get_recording(rid)
+    assert rec["status"] == RecordingStatus.COMPLETE.value
+    assert rec["speaker_count"] == 2
+    assert rec["language_detected"] == "en"
+
+
+# ── single-speaker fallback ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_process_recording_single_speaker_fallback(db, tmp_path):
+    rid = await _make_recording(db, tmp_path)
+
+    transcript_segments = [
+        TranscriptSegment(text="Only speaker", start_time=0.0, end_time=3.0, confidence=0.95),
+    ]
+
+    mock_ffmpeg = MagicMock()
+    mock_ffmpeg.extract_audio = AsyncMock(return_value=None)
+    mock_ffmpeg.get_audio_duration = AsyncMock(return_value=3.0)
+
+    mock_provider = MagicMock()
+    mock_provider.provider_name = "mock_provider"
+    mock_provider.transcribe = AsyncMock(return_value=transcript_segments)
+
+    mock_registry = MagicMock()
+    mock_registry.get_provider = MagicMock(return_value=mock_provider)
+
+    orch = TranscriberOrchestrator(db=db)
+    orch.ffmpeg_service = mock_ffmpeg
+    orch.provider_registry = mock_registry
+
+    with (
+        patch("transcriber.orchestrator.is_diarization_available", return_value=False),
+        patch("transcriber.orchestrator.detect_language", new=AsyncMock(return_value="en")),
+        patch("transcriber.orchestrator._validate_file_path"),
+    ):
+        result = await orch.process_recording(rid)
+
+    assert result["status"] == RecordingStatus.COMPLETE.value
+    speakers = await db.list_speakers(rid)
+    assert len(speakers) == 1
+    assert speakers[0]["label"] == "SPEAKER_00"
+    segments = await db.list_segments(rid)
+    assert len(segments) == 1
+    assert segments[0]["text"] == "Only speaker"
+
+
+# ── failure path ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_process_recording_failure_sets_error_status(db, tmp_path):
+    rid = await _make_recording(db, tmp_path)
+
+    mock_ffmpeg = MagicMock()
+    mock_ffmpeg.extract_audio = AsyncMock(side_effect=RuntimeError("ffmpeg not found"))
+    mock_ffmpeg.get_audio_duration = AsyncMock(return_value=0.0)
+
+    orch = TranscriberOrchestrator(db=db)
+    orch.ffmpeg_service = mock_ffmpeg
+
+    with (patch("transcriber.orchestrator._validate_file_path"),):
+        with pytest.raises(RuntimeError, match="ffmpeg not found"):
+            await orch.process_recording(rid)
+
+    rec = await db.get_recording(rid)
+    assert rec["status"] == RecordingStatus.ERROR.value
+    assert rec["failure_stage"] == "RuntimeError"
+    assert rec["failure_reason"] is not None
+
+
+# ── upload route enqueues task ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_upload_enqueues_transcription_task(client):
+    r = await client.post("/api/transcriber/projects", json={"name": "P", "description": ""})
+    pid = r.json()["id"]
+    audio_bytes = b"RIFF" + b"\x00" * 100
+
+    mock_task = MagicMock()
+    mock_delay = MagicMock()
+    mock_task.delay = mock_delay
+
+    # The route uses a deferred `from tasks.transcriber_tasks import transcribe_recording`
+    # inside the request handler to avoid circular imports, so we patch the source module.
+    with patch("tasks.transcriber_tasks.transcribe_recording", mock_task):
+        r2 = await client.post(
+            f"/api/transcriber/projects/{pid}/recordings",
+            files={"file": ("test.wav", io.BytesIO(audio_bytes), "audio/wav")},
+        )
+
+    assert r2.status_code == 202
+    assert r2.json()["status"] == "pending"
+    mock_delay.assert_called_once()
+    called_rid = mock_delay.call_args[0][0]
+    assert isinstance(called_rid, int)


### PR DESCRIPTION
## Thinking Path
#10128 (CRITICAL): the transcription pipeline never ran. The orchestrator was unimportable (`TranscriberDatabase`/`RecordingStatus` didn't exist), used attribute access on a dict-returning `Database`, called non-existent methods, and nothing triggered it. This wires the self-hosted/local tier with a single-speaker fallback (cloud Tier-1 = separate #10147).

## What Changed
- **models.py**: added `RecordingStatus(str, Enum)` = pending/processing/complete/error (matches DB default + frontend type)
- **orchestrator.py**: fixed imports (`Database`, `get_transcriber_db`); dict access (`recording["filepath"]`); status mapping (COMPLETED→complete, FAILED→error); rewrote merge — assign each `TranscriptSegment` a speaker by **max time-overlap** with diarization `SpeakerSegment`s; single-speaker `SPEAKER_00` fallback when diarization unavailable/empty; create speaker rows + loop `create_segment`; failure→ERROR with `failure_stage`/generic `failure_reason` (no exc leak, #9216)
- **database.py**: added `update_recording_duration()`; fixed `get_transcriber_db()` calling a non-existent `migrate()`
- **lifespan.py**: call `initialize_providers()` at startup (was never called → providers unregistered) — isolated try/except
- **tasks/transcriber_tasks.py** (new): Celery task `transcribe_recording(recording_id)` (mobile_device_tasks.py pattern: sync body + `asyncio.run`, deferred import, acks_late, max_retries=3)
- **routes/recordings.py**: `upload_recording` enqueues `transcribe_recording.delay(rid)` after creating the pending row; broker-unavailable logs + leaves pending (no 500)

## Verification
- `python3 -c "import transcriber.orchestrator"` — **now imports** (was the core bug)
- `pytest transcriber/tests/test_orchestrator.py test_recordings_api.py` — **9 passed** (overlap assignment, single-speaker fallback, failure→ERROR, upload enqueues task)
- `py_compile` all touched files OK; `black --check` clean
- NOTE: end-to-end transcription requires the deploy to have FFmpeg + a registered speech provider (+ optional Pyannote/GPU); ML stages are mocked in tests. Cloud Tier-1 provider for weak hardware is #10147.

## Model Used
claude-opus-4-8 (orchestration) + senior-backend-engineer agent

Part of #9925. Closes #10128