### PR TITLE
feat(transcriber/frontend): build TranscriptView with waveform player + segment sync, consume #9466 audio API (#10129)

### DIFF
--- a/autobot-frontend/src/__tests__/transcriber/TranscriptView.test.ts
+++ b/autobot-frontend/src/__tests__/transcriber/TranscriptView.test.ts
@@ -1,0 +1,142 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { h } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import TranscriptView from '@/views/transcriber/TranscriptView.vue'
+
+// --- API mock ---------------------------------------------------------------
+const getRecording = vi.fn()
+const getTranscript = vi.fn()
+const getWaveform = vi.fn()
+const audioChunksUrl = vi.fn()
+
+// mockReset:true wipes factories — re-apply implementations in beforeEach.
+vi.mock('@/composables/transcriber/useTranscriberApi', () => ({
+  useTranscriberApi: () => ({
+    getRecording,
+    getTranscript,
+    getWaveform,
+    audioChunksUrl,
+    updateSegment: vi.fn(),
+    updateSpeaker: vi.fn(),
+  }),
+}))
+
+// Stub the route so recordingId resolves to 7.
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { recordingId: '7' } }),
+}))
+
+// Stub WaveformPlayer (it dynamically imports wavesurfer.js in jsdom).
+const seekTo = vi.fn()
+const WaveformPlayerStub = {
+  name: 'WaveformPlayer',
+  props: ['audioUrl', 'peaks'],
+  emits: ['seek'],
+  setup(_props: unknown, { expose }: { expose: (e: Record<string, unknown>) => void }) {
+    expose({ seekTo })
+    return () => h('div', { class: 'waveform-player-stub' })
+  },
+}
+
+const SegmentTableStub = {
+  name: 'SegmentTable',
+  props: ['segments', 'speakers', 'currentTime'],
+  emits: ['seek'],
+  template: '<div class="segment-table-stub" :data-current-time="currentTime" />',
+}
+
+function mountView() {
+  return mount(TranscriptView, {
+    global: {
+      plugins: [createPinia()],
+      stubs: {
+        WaveformPlayer: WaveformPlayerStub,
+        SegmentTable: SegmentTableStub,
+      },
+    },
+  })
+}
+
+const SEGMENTS = [
+  { id: 1, recording_id: 7, speaker_id: 1, start_time: 0, end_time: 5, text: 'Hello', original_text: 'Hello', is_edited: false, is_overlap: false },
+  { id: 2, recording_id: 7, speaker_id: 2, start_time: 5, end_time: 10, text: 'World', original_text: 'World', is_edited: false, is_overlap: false },
+]
+const SPEAKERS = [
+  { id: 1, recording_id: 7, label: 'A', display_name: 'Alice', language: null },
+  { id: 2, recording_id: 7, label: 'B', display_name: 'Bob', language: null },
+]
+
+function completeRecording() {
+  return { id: 7, project_id: 1, filename: 'a.mp3', duration: 10, status: 'complete', speaker_count: 2, process_seconds: 3, engine_used: 'whisper', language_detected: 'en', uploaded_at: '', failure_stage: null, failure_reason: null }
+}
+
+describe('TranscriptView.vue', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    // Re-apply mock implementations (mockReset wipes them).
+    audioChunksUrl.mockReturnValue('http://backend/api/transcriber/recordings/7/audio/chunks')
+    getWaveform.mockResolvedValue({ recording_id: 7, duration: 10, peaks: [0.1, 0.5, 0.9], width: 800, segments: [] })
+    getTranscript.mockResolvedValue({ recording: completeRecording(), speakers: SPEAKERS, segments: SEGMENTS })
+    getRecording.mockResolvedValue(completeRecording())
+    seekTo.mockClear()
+  })
+
+  it('renders WaveformPlayer and SegmentTable when recording is complete with segments', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(getRecording).toHaveBeenCalledWith(7)
+    expect(getTranscript).toHaveBeenCalledWith(7)
+    expect(wrapper.findComponent(WaveformPlayerStub).exists()).toBe(true)
+    const table = wrapper.findComponent(SegmentTableStub)
+    expect(table.exists()).toBe(true)
+    expect(table.props('segments')).toHaveLength(2)
+    expect(table.props('speakers')).toHaveLength(2)
+  })
+
+  it('passes the streamed audio chunks URL to WaveformPlayer', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    expect(audioChunksUrl).toHaveBeenCalledWith(7)
+    expect(wrapper.findComponent(WaveformPlayerStub).props('audioUrl')).toBe(
+      'http://backend/api/transcriber/recordings/7/audio/chunks'
+    )
+  })
+
+  it('shows in-progress state and does not fetch the transcript while processing', async () => {
+    getRecording.mockResolvedValue({ ...completeRecording(), status: 'processing' })
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(getTranscript).not.toHaveBeenCalled()
+    expect(wrapper.find('.transcript-progress').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Transcription in progress')
+    expect(wrapper.findComponent(SegmentTableStub).exists()).toBe(false)
+  })
+
+  it('updates currentTime passed to SegmentTable when the player reports progress', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findComponent(WaveformPlayerStub).vm.$emit('seek', 6)
+    await flushPromises()
+
+    expect(wrapper.findComponent(SegmentTableStub).props('currentTime')).toBe(6)
+  })
+
+  it('seeks the player when a segment requests a seek', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findComponent(SegmentTableStub).vm.$emit('seek', 5)
+    await flushPromises()
+
+    expect(seekTo).toHaveBeenCalledWith(5)
+    expect(wrapper.findComponent(SegmentTableStub).props('currentTime')).toBe(5)
+  })
+})

--- a/autobot-frontend/src/components/transcriber/WaveformPlayer.vue
+++ b/autobot-frontend/src/components/transcriber/WaveformPlayer.vue
@@ -4,14 +4,20 @@
 import { ref, onMounted, watch } from 'vue'
 import { useWaveform } from '@/composables/transcriber/useWaveform'
 
-const props = defineProps<{ audioUrl: string }>()
+const props = defineProps<{ audioUrl: string; peaks?: number[] }>()
 const emit = defineEmits<{ (e: 'seek', seconds: number): void }>()
 
 const container = ref<HTMLElement | null>(null)
-const { currentTime, duration, isPlaying, init, togglePlay } = useWaveform(container)
+const { currentTime, duration, isPlaying, init, seekTo, togglePlay } = useWaveform(container)
 
-onMounted(() => init(props.audioUrl))
-watch(() => props.audioUrl, (url) => init(url))
+onMounted(() => init(props.audioUrl, props.peaks))
+watch(() => props.audioUrl, (url) => init(url, props.peaks))
+
+// Emit progress so the parent view can sync the active segment in SegmentTable.
+watch(currentTime, (t) => emit('seek', t))
+
+// Exposed so the parent view can seek the player when a segment is clicked.
+defineExpose({ seekTo })
 
 function fmt(s: number) {
   const m = Math.floor(s / 60), sec = Math.floor(s % 60)

--- a/autobot-frontend/src/composables/transcriber/useTranscriberApi.ts
+++ b/autobot-frontend/src/composables/transcriber/useTranscriberApi.ts
@@ -3,6 +3,7 @@
 // AutoBot - AI-Powered Automation Platform
 // Author: mrveiss
 import { useApiClient } from '@/plugins/api'
+import { getBackendUrl } from '@/config/ssot-config'
 
 export interface Project {
   id: number
@@ -55,6 +56,20 @@ export interface TranscriptResponse {
   segments: Segment[]
 }
 
+export interface WaveformSegmentMarker {
+  start_time: number
+  end_time: number
+  speaker_id: number | null
+}
+
+export interface WaveformResponse {
+  recording_id: number
+  duration: number
+  peaks: number[]
+  width: number
+  segments: WaveformSegmentMarker[]
+}
+
 export interface KbPushStatus {
   pushed: boolean
   pushed_at: string | null
@@ -97,6 +112,13 @@ export function useTranscriberApi() {
     createNote: (segmentId: number, content: string) =>
       api.post(`${base}/segments/${segmentId}/notes`, { content }),
     deleteNote: (noteId: number) => api.delete(`${base}/notes/${noteId}`),
+
+    // Audio playback (#9466)
+    // Absolute URL streamed directly by the <audio>/wavesurfer element via HTTP Range.
+    audioChunksUrl: (recordingId: number) =>
+      `${getBackendUrl()}${base}/recordings/${recordingId}/audio/chunks`,
+    getWaveform: (recordingId: number) =>
+      api.get<WaveformResponse>(`${base}/recordings/${recordingId}/audio/waveform`),
 
     // Export
     exportRecording: (recordingId: number, format: 'docx' | 'pdf' | 'srt' | 'vtt', options = {}) =>

--- a/autobot-frontend/src/composables/transcriber/useWaveform.ts
+++ b/autobot-frontend/src/composables/transcriber/useWaveform.ts
@@ -11,7 +11,7 @@ export function useWaveform(container: Ref<HTMLElement | null>) {
   const isPlaying = ref(false)
   let ws: import('wavesurfer.js').default | null = null
 
-  async function init(audioUrl: string) {
+  async function init(audioUrl: string, peaks?: number[]) {
     const WaveSurfer = (await import('wavesurfer.js')).default
     if (!container.value) return
     ws?.destroy()
@@ -21,6 +21,8 @@ export function useWaveform(container: Ref<HTMLElement | null>) {
       progressColor: 'var(--color-primary-600, #2563eb)',
       height: 64,
       normalize: true,
+      // Precomputed peaks (#9466 /audio/waveform) skip client-side decoding.
+      ...(peaks && peaks.length ? { peaks: [peaks] } : {}),
     })
     ws.on('timeupdate', (t: number) => { currentTime.value = t })
     ws.on('ready', () => { duration.value = ws!.getDuration() })

--- a/autobot-frontend/src/views/transcriber/TranscriptView.vue
+++ b/autobot-frontend/src/views/transcriber/TranscriptView.vue
@@ -1,6 +1,159 @@
 <!-- AutoBot - AI-Powered Automation Platform -->
 <!-- Copyright (c) 2025 mrveiss -->
 <script setup lang="ts">
-// Implemented in Plan 4
+import { ref, computed, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import WaveformPlayer from '@/components/transcriber/WaveformPlayer.vue'
+import SegmentTable from '@/components/transcriber/SegmentTable.vue'
+import {
+  useTranscriberApi,
+  type Recording,
+  type Segment,
+  type Speaker,
+} from '@/composables/transcriber/useTranscriberApi'
+import { useTranscriberStore } from '@/stores/transcriber/useTranscriberStore'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('TranscriptView')
+
+const route = useRoute()
+const api = useTranscriberApi()
+const store = useTranscriberStore()
+
+const recordingId = computed(() => Number(route.params.recordingId))
+
+const recording = ref<Recording | null>(null)
+const segments = ref<Segment[]>([])
+const speakers = ref<Speaker[]>([])
+const waveformPeaks = ref<number[]>([])
+const currentTime = ref(0)
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+const player = ref<InstanceType<typeof WaveformPlayer> | null>(null)
+
+const status = computed(() => recording.value?.status ?? null)
+const isInProgress = computed(
+  () => status.value === 'pending' || status.value === 'processing'
+)
+const isFailed = computed(() => status.value === 'error')
+const isComplete = computed(() => status.value === 'complete')
+const audioUrl = computed(() => api.audioChunksUrl(recordingId.value))
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    recording.value = await api.getRecording(recordingId.value)
+    // Segments only exist once transcription has completed.
+    if (recording.value.status === 'complete') {
+      const transcript = await api.getTranscript(recordingId.value)
+      store.setTranscript(transcript)
+      segments.value = transcript.segments
+      speakers.value = transcript.speakers
+      try {
+        const waveform = await api.getWaveform(recordingId.value)
+        waveformPeaks.value = waveform.peaks ?? []
+      } catch (waveErr) {
+        // Waveform peaks are an optimisation; playback still works without them.
+        logger.warn('Failed to load waveform peaks', waveErr)
+      }
+    }
+  } catch (err) {
+    logger.error('Failed to load transcript', err)
+    error.value = 'Failed to load this recording.'
+  } finally {
+    loading.value = false
+  }
+}
+
+// WaveformPlayer reports playback progress; drives active-segment highlighting.
+function onPlaybackProgress(seconds: number) {
+  currentTime.value = seconds
+}
+
+// SegmentTable requests a seek when a row's timestamp is clicked.
+function onSegmentSeek(seconds: number) {
+  currentTime.value = seconds
+  player.value?.seekTo(seconds)
+}
+
+onMounted(load)
 </script>
-<template><div class="transcript-view">Transcript — coming in Plan 4</div></template>
+
+<template>
+  <div class="transcript-view">
+    <div v-if="loading" class="transcript-state">Loading transcript…</div>
+
+    <div v-else-if="error" class="transcript-state transcript-error">{{ error }}</div>
+
+    <div v-else-if="isInProgress" class="transcript-state transcript-progress">
+      <span class="transcript-spinner" aria-hidden="true" />
+      <p>Transcription in progress… this view will populate once processing completes.</p>
+    </div>
+
+    <div v-else-if="isFailed" class="transcript-state transcript-error">
+      <p>Transcription failed{{ recording?.failure_reason ? `: ${recording.failure_reason}` : '.' }}</p>
+    </div>
+
+    <template v-else-if="isComplete">
+      <WaveformPlayer
+        ref="player"
+        class="transcript-player"
+        :audio-url="audioUrl"
+        :peaks="waveformPeaks"
+        @seek="onPlaybackProgress"
+      />
+      <SegmentTable
+        v-if="segments.length"
+        :segments="segments"
+        :speakers="speakers"
+        :current-time="currentTime"
+        @seek="onSegmentSeek"
+      />
+      <div v-else class="transcript-state">No transcript segments were produced for this recording.</div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.transcript-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.transcript-player {
+  margin-bottom: 0.5rem;
+}
+
+.transcript-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem;
+  color: var(--color-text-secondary, #6b7280);
+  text-align: center;
+}
+
+.transcript-error {
+  color: var(--color-danger-600, #dc2626);
+}
+
+.transcript-spinner {
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 2px solid var(--color-primary-300, #93c5fd);
+  border-top-color: var(--color-primary-600, #2563eb);
+  border-radius: 50%;
+  animation: transcript-spin 0.8s linear infinite;
+}
+
+@keyframes transcript-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>


### PR DESCRIPTION
## Thinking Path
#10129 (HIGH): the #9466 audio/waveform endpoints had no consumer and `TranscriptView.vue` was a 6-line stub. This builds the real per-recording transcript view and wires `WaveformPlayer` (previously mounted by no view) to the #9466 endpoints.

## What Changed
- **useTranscriberApi.ts**: `audioChunksUrl(id)` (absolute streaming URL via `getBackendUrl()`) + `getWaveform(id)` (parsed JSON, no envelope) + `WaveformResponse`/`WaveformSegmentMarker` types
- **useWaveform.ts**: `init(audioUrl, peaks?)` accepts precomputed peaks (skips client decode)
- **WaveformPlayer.vue**: optional `peaks` prop; `defineExpose({ seekTo })`; emits `seek` on playback progress
- **TranscriptView.vue**: full implementation — reads route param, loads recording + transcript + waveform; loading / in-progress (pending|processing) / error / empty / complete states
- Seek↔segment sync: player→table (emit `seek` → `currentTime` → SegmentTable `isActive` highlight); table→player (segment click → `player.seekTo`)

## Verification
- `vitest run src/__tests__/transcriber/` — **41 passed** (5 new TranscriptView cases + existing)
- vue-tsc: 0 new errors referencing changed files (#9724 baseline)
- NOTE: live playback is gated by #10128 (no completed recordings exist until the pipeline runs) — handled gracefully via the in-progress state.

## Model Used
claude-opus-4-8 (orchestration) + frontend-engineer agent

Part of #9925. Closes #10129