### PR TITLE
fix(llc): validate adapter_type at hire time + decompose #9008/#9033 remaining ACs

### DIFF
--- a/autobot-backend/llc/adapters/__init__.py
+++ b/autobot-backend/llc/adapters/__init__.py
@@ -21,7 +21,13 @@ Public surface:
 from typing import Optional
 
 from .autobot_agent_adapter import AutoBotAgentAdapter
-from .base import AdapterRunStatus, LLCAdapter, get_adapter, register_adapter
+from .base import (
+    AdapterRunStatus,
+    LLCAdapter,
+    get_adapter,
+    register_adapter,
+    registered_adapter_types,
+)
 from .claude_code_adapter import ClaudeCodeAdapter
 from .claude_code_subscription_adapter import ClaudeCodeSubscriptionAdapter
 from .codex_subscription_adapter import CodexSubscriptionAdapter
@@ -40,6 +46,7 @@ __all__ = [
     "get_adapter",
     "get_adapter_for_agent",
     "register_adapter",
+    "registered_adapter_types",
 ]
 
 # Register adapters under their canonical type keys.

--- a/autobot-backend/llc/adapters/base.py
+++ b/autobot-backend/llc/adapters/base.py
@@ -69,3 +69,13 @@ def get_adapter(adapter_type: str) -> LLCAdapter:
     if adapter_type not in _registry:
         raise KeyError(f"No LLC adapter registered for type {adapter_type!r}. " f"Known types: {sorted(_registry)}")
     return _registry[adapter_type]
+
+
+def registered_adapter_types() -> list[str]:
+    """Sorted list of adapter_type keys currently in the registry.
+
+    Used to validate an agent's ``adapter_type`` at hire time (GH#9008/#9033)
+    so an unknown type cannot create an agent that is then perpetually SKIPPED
+    by the heartbeat scheduler (no adapter registered → skip).
+    """
+    return sorted(_registry)

--- a/autobot-backend/llc/api/agent_hires.py
+++ b/autobot-backend/llc/api/agent_hires.py
@@ -22,6 +22,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.logging_manager import get_logger
+from llc.adapters import registered_adapter_types
 from llc.services.budget import BudgetService
 from llc.services.model_tiers import get_model_tier_service
 from user_management.database import get_async_session
@@ -351,6 +352,16 @@ async def hire_agent(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"Unsupported model {resolved_model!r}. Supported values: {sorted(_VALID_MODELS)}",
+        )
+
+    # GH#9008/#9033: reject an unregistered adapter_type at hire time. Without
+    # this, an unknown type silently creates an agent whose every heartbeat is
+    # skipped (no adapter registered), looking degraded forever.
+    resolved_adapter = body.adapter_type or "claude_code"
+    if resolved_adapter not in registered_adapter_types():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(f"Unknown adapter_type {resolved_adapter!r}. " f"Registered types: {registered_adapter_types()}"),
         )
 
     is_haiku = resolved_model == HAIKU_MODEL

--- a/autobot-backend/llc/tests/test_budget_provision.py
+++ b/autobot-backend/llc/tests/test_budget_provision.py
@@ -429,3 +429,68 @@ async def test_provision_budget_race_returns_existing(session_factory) -> None: 
 
     assert created is False
     assert row.agent_id == agent_id
+
+
+# ---------------------------------------------------------------------------
+# adapter_type validation at hire time (GH#9008/#9033)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hire_rejects_unknown_adapter_type(client) -> None:  # noqa: ANN001
+    """An unregistered adapter_type is rejected with 422 (not silently created
+    into a perpetually-skipped agent)."""
+    company_id = str(uuid.uuid4())
+    resp = await client.post(
+        f"/api/llc/companies/{company_id}/agent-hires",
+        json={"agent_name": "BadAdapter", "adapter_type": "totally-bogus"},
+    )
+    assert resp.status_code == 422
+    assert "adapter_type" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_hire_accepts_registered_adapter_type(client) -> None:  # noqa: ANN001
+    """A registered adapter_type (e.g. copilot_local) passes validation."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    company_id = str(uuid.uuid4())
+    mock_provision = AsyncMock(
+        return_value=(
+            MagicMock(
+                agent_id="stub",
+                company_id=company_id,
+                budget_mode="dollars",
+                budget_spent=Decimal("0"),
+                budget_limit=Decimal("10.00"),
+                token_limit=None,
+                tokens_spent=0,
+                alert_threshold=0.8,
+            ),
+            True,
+        )
+    )
+    with (
+        patch("llc.api.agent_hires.BudgetService.provision_budget", mock_provision),
+        patch("sqlalchemy.ext.asyncio.AsyncSession.execute", AsyncMock(return_value=MagicMock())),
+    ):
+        resp = await client.post(
+            f"/api/llc/companies/{company_id}/agent-hires",
+            json={"agent_name": "GoodAdapter", "adapter_type": "copilot_local"},
+        )
+    assert resp.status_code == 201, resp.text
+
+
+def test_registered_adapter_types_includes_all_five() -> None:
+    """The five canonical adapter types are registered (GH#9008/#9033)."""
+    from llc.adapters import registered_adapter_types
+
+    types = registered_adapter_types()
+    for expected in (
+        "claude_code",
+        "claude_code_subscription",
+        "copilot_local",
+        "copilot_subscription",
+        "codex_subscription",
+    ):
+        assert expected in types, types


### PR DESCRIPTION
## Thinking Path
"Take next batch under #9923" → the remaining members are three L features. Audited #9008 (copilot_local) and #9033 (subscription adapters): all 5 adapter types are implemented and **registered**, but the features are not done — substantial ACs remain (frontend selector, OAuth wiring, token→budget, quota auto-pause). Rather than half-build two L features, this PR ships the one **real bug** the audit found and decomposes the rest into scoped discovery issues.

## What Changed
- **`adapter_type` validation at hire (the bug)**: `POST /companies/{id}/agent-hires` accepted any `adapter_type` string. An unknown/typo'd value silently created an agent whose every heartbeat is skipped ("no adapter registered") — looking degraded forever, and (since #9951) recorded as a perpetual `SKIPPED`. Now rejected with **422**, mirroring the existing model validation.
- `registered_adapter_types()` helper added to the adapter registry (`base.py`), exported from `llc.adapters`.

## Remaining #9008/#9033 ACs → discovery issues (NOT closed here)
- **#10219** — frontend agent-hire form + adapter-type selector + `GET /api/llc/adapters` introspection (AC1 for both)
- **#10220** — parse CLI token usage → `BudgetService.ingest_cost_event` (#9008 AC5, #9033 AC4)
- **#10217** — subscription OAuth token wiring via secrets (#9033 AC2)
- **#10218** — quota exhaustion → agent auto-pause + board notification (#9033 AC5, the explicit TODOs)

## Verification
- `pytest llc/tests/test_budget_provision.py` → 14 passed (3 new: unknown adapter → 422, `copilot_local` → 201, all five types registered)
- flake8 clean

## Model Used
Claude Opus 4.8

Addresses part of #9008 and #9033 (umbrella #9923); remaining ACs tracked in #10217/#10218/#10219/#10220.
