### PR TITLE
security(transcriber): strict ownership in can_access — fix DEFAULT_USER IDOR (#9968)

### DIFF
--- a/autobot-backend/api/transcripts.py
+++ b/autobot-backend/api/transcripts.py
@@ -35,7 +35,7 @@ from knowledge import get_knowledge_base
 from llm_shared import LLMRequest, get_provider_registry
 from transcriber.ai.context import build_context
 from transcriber.ai.prompts import get_system_prompt
-from transcriber.deps import DEFAULT_USER, can_access
+from transcriber.deps import can_access
 from transcriber.export.segments import build_segment_list
 
 logger = get_logger(__name__)
@@ -46,8 +46,16 @@ _WS_CLOSE_CODES = {404: 4004, 400: 1008}
 
 
 def _resolve_user_id(user: dict) -> str:
-    """Map an auth payload to the transcriber user-id convention."""
-    return str(user.get("user_id") or user.get("username") or DEFAULT_USER)
+    """Map an auth payload to the transcriber user-id string.
+
+    Raises 403 if the principal carries no identity fields.  A
+    malformed-but-authenticated principal must NOT silently inherit
+    DEFAULT_USER — that was the IDOR (#9968) at the resolver level.
+    """
+    uid = user.get("user_id") or user.get("username")
+    if not uid:
+        raise HTTPException(status_code=403, detail="Authenticated principal has no identity")
+    return str(uid)
 
 
 async def _load_recording(state: State, transcript_id: str, caller_id: str) -> dict:

--- a/autobot-backend/transcriber/deps.py
+++ b/autobot-backend/transcriber/deps.py
@@ -19,12 +19,23 @@ async def get_db(request: Request) -> Database:
 
 
 def can_access(row: dict, caller_id: str) -> bool:
-    """Single ownership policy for transcriber rows (recordings/projects).
+    """Strict ownership policy for transcriber rows (recordings/projects).
 
-    Rows stamped with DEFAULT_USER (created before real auth wiring) are
-    accessible to any authenticated caller; otherwise the owner must match.
+    Only the row owner may access the row.  The caller_id must equal the
+    stored user_id exactly:
+
+    - owner == caller_id  → allow (includes single_user: "default" == "default")
+    - different real users → deny
+    - DEFAULT_USER row + real caller  → DENY  (this was the IDOR — #9968)
+    - unowned / falsy user_id row    → deny (create_recording always stamps user_id)
+
+    Cross-user access to legacy DEFAULT_USER rows is intentionally NOT
+    supported.  If a future multi-user migration needs to reassign those rows
+    to real owners, that is tracked separately — do not re-introduce the
+    shared-DEFAULT_USER bypass here.
+
     All transcriber-data access checks must go through this helper so the
     policy cannot fork between routes (#9863 review).
     """
-    owner = row.get("user_id") or DEFAULT_USER
-    return owner in (DEFAULT_USER, caller_id)
+    owner = row.get("user_id")
+    return bool(owner) and owner == caller_id

--- a/autobot-backend/transcriber/tests/test_multiuser_authz.py
+++ b/autobot-backend/transcriber/tests/test_multiuser_authz.py
@@ -16,9 +16,10 @@ from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from httpx import ASGITransport, AsyncClient
 
+from api.transcripts import _resolve_user_id
 from transcriber.database import Database
 from transcriber.deps import DEFAULT_USER, can_access, get_db
 from transcriber.routes.projects import router as projects_router
@@ -76,12 +77,50 @@ async def _upload_recording(client, user: str, pid: int) -> int:
 
 
 def test_can_access_policy_unit():
-    """can_access: owner yes, other user no, legacy DEFAULT_USER rows shared."""
+    """can_access: strict ownership — owner yes, everyone else no.
+
+    Cases required by #9968:
+    (a) owner == caller → allow
+    (b) different real users → deny
+    (c) DEFAULT_USER row + DEFAULT_USER caller (single_user mode) → allow
+    (d) DEFAULT_USER row + real user → DENY  (was the IDOR)
+    (e) unowned / empty user_id → deny
+    """
+    # (a) owner == caller → allow
     assert can_access({"user_id": "alice"}, "alice") is True
+    # (b) different real users → deny
     assert can_access({"user_id": "alice"}, "bob") is False
-    assert can_access({"user_id": DEFAULT_USER}, "bob") is True
-    # Rows from before auth wiring (no user_id stamp) stay readable.
-    assert can_access({}, "bob") is True
+    # (c) single_user: DEFAULT_USER caller accesses DEFAULT_USER row → allow
+    assert can_access({"user_id": DEFAULT_USER}, DEFAULT_USER) is True
+    # (d) IDOR fix: real user must NOT access DEFAULT_USER-owned row
+    assert can_access({"user_id": DEFAULT_USER}, "bob") is False
+    # (e) unowned (no user_id key) → deny
+    assert can_access({}, "bob") is False
+    # (e) explicit empty string user_id → deny
+    assert can_access({"user_id": ""}, "bob") is False
+
+
+def test_resolve_user_id_returns_real_identity():
+    """_resolve_user_id: returns user_id or username when present."""
+    assert _resolve_user_id({"user_id": "alice"}) == "alice"
+    assert _resolve_user_id({"username": "bob"}) == "bob"
+    # user_id takes precedence over username
+    assert _resolve_user_id({"user_id": "alice", "username": "other"}) == "alice"
+
+
+def test_resolve_user_id_raises_when_no_identity():
+    """_resolve_user_id: raises 403 — never silently returns DEFAULT_USER (#9968)."""
+    with pytest.raises(HTTPException) as exc_info:
+        _resolve_user_id({})
+    assert exc_info.value.status_code == 403
+
+    with pytest.raises(HTTPException) as exc_info:
+        _resolve_user_id({"user_id": None, "username": None})
+    assert exc_info.value.status_code == 403
+
+    with pytest.raises(HTTPException) as exc_info:
+        _resolve_user_id({"user_id": "", "username": ""})
+    assert exc_info.value.status_code == 403
 
 
 @pytest.mark.asyncio
@@ -139,11 +178,21 @@ async def test_second_user_cannot_access_recordings(client):
 
 
 @pytest.mark.asyncio
-async def test_legacy_default_rows_stay_accessible(client):
-    """Pre-auth rows (stamped DEFAULT_USER) remain readable by any caller."""
+async def test_legacy_default_rows_not_accessible_to_other_users(client):
+    """DEFAULT_USER rows are NOT shared across real users (#9968 IDOR fix).
+
+    Pre-auth rows (stamped DEFAULT_USER) are accessible only by the
+    DEFAULT_USER caller (single_user mode).  Real authenticated users are
+    denied — the old "any caller can read default rows" behaviour was the
+    IDOR.  Cross-user reassignment of legacy rows is tracked separately.
+    """
     r = await client.post(
         "/api/transcriber/projects", json={"name": "legacy", "description": ""}
     )  # no user header -> DEFAULT_USER
     pid = r.json()["id"]
+    # Real user bob is DENIED access to a DEFAULT_USER-owned row
     r = await client.get(f"/api/transcriber/projects/{pid}", headers={USER_HEADER: "bob"})
+    assert r.status_code == 404, "IDOR (#9968): real user should not access DEFAULT_USER rows"
+    # DEFAULT_USER caller (single_user) can still access its own rows
+    r = await client.get(f"/api/transcriber/projects/{pid}", headers={USER_HEADER: DEFAULT_USER})
     assert r.status_code == 200


### PR DESCRIPTION
## Thinking Path
#9968 (HIGH IDOR): `can_access` did `owner = row.get("user_id") or DEFAULT_USER; return owner in (DEFAULT_USER, caller_id)` — so every authenticated user could read/mutate all `DEFAULT_USER`-owned (legacy) rows = cross-tenant IDOR in multi-user mode. Compounded by `_resolve_user_id` silently defaulting to `DEFAULT_USER`.

## What Changed
- `transcriber/deps.py` `can_access` → strict equality: `owner = row.get("user_id"); return bool(owner) and owner == caller_id`. Correct for both modes: single_user caller IS `default` (legacy rows still accessible to it); multi-user real users denied access to `default` rows. Docstring rewritten to the strict-ownership policy.
- `api/transcripts.py` `_resolve_user_id` → raises `HTTPException(403)` when no identity present (was silently returning `DEFAULT_USER`); removed now-unused import.
- Tests flipped to secure behavior + new cases (owner match allow; cross-user deny; default+default allow; default+real-user DENY; unowned deny; `_resolve_user_id` raises without identity).

## Verification
- `pytest transcriber/tests/test_multiuser_authz.py` — 8 passed; black clean.
- Cross-user legacy-row access intentionally NOT supported (that was the vuln); any future multi-user legacy-row migration is out of scope (tracked under the RBAC epic).

## Model Used
claude-opus-4-8 + senior-backend-engineer agent

Part of #9925. Closes #9968