### PR TITLE
feat(secrets): /api/v2/secrets FastAPI router over SecretsCoordinator (#10240)

### DIFF
--- a/.github/workflows/migration-gate.yml
+++ b/.github/workflows/migration-gate.yml
@@ -79,7 +79,7 @@ jobs:
             "alembic>=1.13" "sqlalchemy[asyncio]>=2.0" asyncpg aiosqlite \
             pydantic pydantic-settings \
             bcrypt pyjwt redis httpx aiofiles python-dotenv pyyaml \
-            cryptography \
+            cryptography fastapi \
             pytest pytest-asyncio
 
       - name: Run migration matrix

--- a/autobot-backend/api/unified_secrets.py
+++ b/autobot-backend/api/unified_secrets.py
@@ -1,0 +1,233 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""HTTP surface for the unified envelope secrets store (#10088 / Task 2.4 part 2).
+
+A thin FastAPI shell over :class:`SecretsCoordinator` (which does the real
+resolve→authorize→service work). Mounted at ``/api/v2/secrets`` on a new prefix,
+so the legacy ``/secrets`` (file-store) router is untouched until Task 3 migrates
+it. Three injectable dependencies keep handlers trivial and the router
+unit-testable in isolation:
+
+- ``principal`` — the caller's ``(user_id, permissions)`` from the auth
+  middleware + RBAC; 401 when unauthenticated.
+- ``get_session`` — the Postgres ``AsyncSession`` (gated by ``postgres_required``).
+- ``get_coordinator`` — the ``SecretsCoordinator``; 503 when the root key is unset.
+
+Coordinator exceptions map to HTTP: ``SecretNotFoundError``→404,
+``SecretAccessError``→403, ``ValueError`` (bad vault ref / owner-grant revoke)→400.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth_middleware import get_auth_middleware
+from autobot_shared.secrets_vault import VaultRef
+from llc.deps import get_session
+from models.secret import Secret
+from services.secrets_coordinator import SecretsCoordinator
+from services.unified_secrets_service import SecretAccessError, SecretNotFoundError
+
+router = APIRouter()
+
+_coordinator: SecretsCoordinator | None = None
+
+
+def get_coordinator() -> SecretsCoordinator:
+    """The shared coordinator; 503 if ``AUTOBOT_SECRETS_ROOT_KEY`` is not configured."""
+    global _coordinator
+    if _coordinator is None:
+        try:
+            _coordinator = SecretsCoordinator()
+        except RuntimeError as exc:
+            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "unified secrets store not configured") from exc
+    return _coordinator
+
+
+async def principal(request: Request) -> tuple[uuid.UUID, set[str]]:
+    """Resolve the caller to ``(user_id, permission_names)``; 401 when unauthenticated."""
+    user = get_auth_middleware().get_user_from_request(request)
+    if not user or not user.get("user_id"):
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "authentication required")
+    user_id = uuid.UUID(str(user["user_id"]))
+    from user_management.middleware.rbac_middleware import rbac_middleware
+
+    permissions = await rbac_middleware.get_user_permissions(user_id)
+    return user_id, set(permissions)
+
+
+def _vault(value: str) -> VaultRef:
+    try:
+        return VaultRef.parse(value)
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, f"invalid vault reference: {value!r}") from exc
+
+
+def _mapped(exc: Exception) -> HTTPException:
+    if isinstance(exc, SecretNotFoundError):
+        return HTTPException(status.HTTP_404_NOT_FOUND, str(exc))
+    if isinstance(exc, SecretAccessError):
+        return HTTPException(status.HTTP_403_FORBIDDEN, str(exc))
+    if isinstance(exc, ValueError):
+        return HTTPException(status.HTTP_400_BAD_REQUEST, str(exc))
+    raise exc
+
+
+class CreateSecretBody(BaseModel):
+    owner_vault: str
+    name: str
+    secret_type: str
+    value: str
+
+
+class ShareBody(BaseModel):
+    grantee: str
+
+
+class RotateBody(BaseModel):
+    value: str
+
+
+class SecretMetadata(BaseModel):
+    id: uuid.UUID
+    name: str
+    type: str
+    owner_vault: str | None
+    version: int
+
+    @classmethod
+    def of(cls, secret: Secret) -> "SecretMetadata":
+        return cls(
+            id=secret.id, name=secret.name, type=secret.type, owner_vault=secret.owner_vault, version=secret.version
+        )
+
+
+class SecretValue(BaseModel):
+    value: str
+
+
+@router.post("", response_model=SecretMetadata, status_code=status.HTTP_201_CREATED)
+async def create_secret(
+    body: CreateSecretBody,
+    who: tuple[uuid.UUID, set[str]] = Depends(principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> SecretMetadata:
+    user_id, perms = who
+    try:
+        secret = await coordinator.create(
+            session,
+            user_id=user_id,
+            permissions=perms,
+            owner_vault=_vault(body.owner_vault),
+            name=body.name,
+            secret_type=body.secret_type,
+            plaintext=body.value.encode("utf-8"),
+        )
+        await session.commit()
+    except (SecretAccessError, SecretNotFoundError, ValueError) as exc:
+        raise _mapped(exc)
+    return SecretMetadata.of(secret)
+
+
+@router.get("", response_model=list[SecretMetadata])
+async def list_secrets(
+    who: tuple[uuid.UUID, set[str]] = Depends(principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> list[SecretMetadata]:
+    user_id, perms = who
+    secrets = await coordinator.list(session, user_id=user_id, permissions=perms)
+    return [SecretMetadata.of(s) for s in secrets]
+
+
+@router.get("/{secret_id}", response_model=SecretValue)
+async def read_secret(
+    secret_id: uuid.UUID,
+    who: tuple[uuid.UUID, set[str]] = Depends(principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> SecretValue:
+    user_id, perms = who
+    try:
+        value = await coordinator.read(session, user_id=user_id, permissions=perms, secret_id=secret_id)
+    except (SecretAccessError, SecretNotFoundError) as exc:
+        raise _mapped(exc)
+    return SecretValue(value=value.decode("utf-8"))
+
+
+@router.put("/{secret_id}", response_model=SecretMetadata)
+async def rotate_secret(
+    secret_id: uuid.UUID,
+    body: RotateBody,
+    who: tuple[uuid.UUID, set[str]] = Depends(principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> SecretMetadata:
+    user_id, perms = who
+    try:
+        secret = await coordinator.rotate(
+            session, user_id=user_id, permissions=perms, secret_id=secret_id, new_plaintext=body.value.encode("utf-8")
+        )
+        await session.commit()
+    except (SecretAccessError, SecretNotFoundError) as exc:
+        raise _mapped(exc)
+    return SecretMetadata.of(secret)
+
+
+@router.delete("/{secret_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_secret(
+    secret_id: uuid.UUID,
+    who: tuple[uuid.UUID, set[str]] = Depends(principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> None:
+    user_id, perms = who
+    try:
+        await coordinator.delete(session, user_id=user_id, permissions=perms, secret_id=secret_id)
+        await session.commit()
+    except (SecretAccessError, SecretNotFoundError) as exc:
+        raise _mapped(exc)
+
+
+@router.post("/{secret_id}/share", status_code=status.HTTP_201_CREATED)
+async def share_secret(
+    secret_id: uuid.UUID,
+    body: ShareBody,
+    who: tuple[uuid.UUID, set[str]] = Depends(principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> dict[str, str]:
+    user_id, perms = who
+    try:
+        await coordinator.share(
+            session, user_id=user_id, permissions=perms, secret_id=secret_id, grantee=_vault(body.grantee)
+        )
+        await session.commit()
+    except (SecretAccessError, SecretNotFoundError) as exc:
+        raise _mapped(exc)
+    return {"status": "shared", "grantee": body.grantee}
+
+
+@router.delete("/{secret_id}/share/{grantee}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_share(
+    secret_id: uuid.UUID,
+    grantee: str,
+    who: tuple[uuid.UUID, set[str]] = Depends(principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> None:
+    user_id, perms = who
+    try:
+        await coordinator.revoke(
+            session, user_id=user_id, permissions=perms, secret_id=secret_id, grantee=_vault(grantee)
+        )
+        await session.commit()
+    except (SecretAccessError, SecretNotFoundError, ValueError) as exc:
+        raise _mapped(exc)

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -171,6 +171,8 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         "log_forwarding",
     ),
     ("api.secrets", "/secrets", ["secrets"], "secrets"),
+    # Unified envelope secrets store (#10088) — new prefix; legacy /secrets untouched.
+    ("api.unified_secrets", "/v2/secrets", ["secrets", "v2"], "unified_secrets"),
     # Issue #2153: workflow-scoped encrypted credential storage
     (
         "api.workflow_secrets",

--- a/autobot-backend/tests/migrations/test_unified_secrets_api.py
+++ b/autobot-backend/tests/migrations/test_unified_secrets_api.py
@@ -1,0 +1,141 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""HTTP tests for the /api/v2/secrets router (#10088 / Task 2.4 part 2).
+
+Mounts just the router in a throwaway FastAPI app (no whole-app startup) with
+the three dependencies overridden — principal (via test headers), session, and
+coordinator — and drives it with httpx + ASGITransport against the migration-gate
+Postgres. Covers the create/read/share/revoke/rotate/delete flow + HTTP error
+mapping (403/404/400).
+"""
+
+import base64
+import uuid
+
+import pytest
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api import unified_secrets
+from services.secrets_coordinator import SecretsCoordinator
+from services.unified_secrets_service import UnifiedSecretsService
+from tests.migrations.conftest import requires_postgres, run_alembic
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+_ROOT = base64.urlsafe_b64decode(base64.urlsafe_b64encode(bytes(range(32))))
+_ADMIN = uuid.uuid4()
+_OUTSIDER = uuid.uuid4()
+_GRANTEE = uuid.uuid4()
+_COMPANY = uuid.uuid4()
+_COMPANY_VAULT = f"company:{_COMPANY}"
+_P = "/api/v2/secrets"
+
+
+async def _principal_override(request: Request):
+    uid = uuid.UUID(request.headers["x-test-user"])
+    perms = {p for p in request.headers.get("x-test-perms", "").split(",") if p}
+    return uid, perms
+
+
+@pytest.fixture()
+async def client(fresh_db_url):
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+    engine = create_async_engine(fresh_db_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as s:
+        from llc.models.membership import LLCCompanyMembership
+        from user_management.models.user import User
+
+        for uid, name in ((_ADMIN, "admin"), (_OUTSIDER, "outsider"), (_GRANTEE, "grantee")):
+            s.add(User(id=uid, email=f"{name}@example.com", username=name))
+        s.add(LLCCompanyMembership(company_id=_COMPANY, user_id=_ADMIN, role="admin"))
+        await s.commit()
+
+    app = FastAPI()
+    app.include_router(unified_secrets.router, prefix=_P)
+
+    async def _session_override():
+        async with maker() as sess:
+            yield sess
+
+    app.dependency_overrides[unified_secrets.get_session] = _session_override
+    app.dependency_overrides[unified_secrets.get_coordinator] = lambda: SecretsCoordinator(
+        UnifiedSecretsService(root_key=_ROOT)
+    )
+    app.dependency_overrides[unified_secrets.principal] = _principal_override
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t", follow_redirects=True) as c:
+        yield c
+    await engine.dispose()
+
+
+def _as(user_id, perms=""):
+    return {"x-test-user": str(user_id), "x-test-perms": perms}
+
+
+async def _create(client, user=_ADMIN, vault=_COMPANY_VAULT, value="hunter2"):
+    return await client.post(
+        _P, json={"owner_vault": vault, "name": "db", "secret_type": "password", "value": value}, headers=_as(user)
+    )
+
+
+async def test_create_and_read(client):
+    r = await _create(client)
+    assert r.status_code == 201, r.text
+    sid = r.json()["id"]
+    assert r.json()["owner_vault"] == _COMPANY_VAULT and r.json()["version"] == 1
+    rr = await client.get(f"{_P}/{sid}", headers=_as(_ADMIN))
+    assert rr.status_code == 200 and rr.json()["value"] == "hunter2"
+
+
+async def test_outsider_create_forbidden(client):
+    assert (await _create(client, user=_OUTSIDER)).status_code == 403
+
+
+async def test_outsider_read_forbidden(client):
+    sid = (await _create(client)).json()["id"]
+    assert (await client.get(f"{_P}/{sid}", headers=_as(_OUTSIDER))).status_code == 403
+
+
+async def test_share_then_grantee_reads_then_revoke(client):
+    sid = (await _create(client)).json()["id"]
+    sh = await client.post(f"{_P}/{sid}/share", json={"grantee": f"user:{_GRANTEE}"}, headers=_as(_ADMIN))
+    assert sh.status_code == 201, sh.text
+    assert (await client.get(f"{_P}/{sid}", headers=_as(_GRANTEE))).json()["value"] == "hunter2"
+    rv = await client.delete(f"{_P}/{sid}/share/user:{_GRANTEE}", headers=_as(_ADMIN))
+    assert rv.status_code == 204
+    assert (await client.get(f"{_P}/{sid}", headers=_as(_GRANTEE))).status_code == 403
+
+
+async def test_rotate_and_list(client):
+    sid = (await _create(client)).json()["id"]
+    pr = await client.put(f"{_P}/{sid}", json={"value": "rotated"}, headers=_as(_ADMIN))
+    assert pr.status_code == 200 and pr.json()["version"] == 2
+    assert (await client.get(f"{_P}/{sid}", headers=_as(_ADMIN))).json()["value"] == "rotated"
+    lst = await client.get(_P, headers=_as(_ADMIN))
+    assert [s["id"] for s in lst.json()] == [sid]
+    assert (await client.get(_P, headers=_as(_OUTSIDER))).json() == []
+
+
+async def test_delete_then_404(client):
+    sid = (await _create(client)).json()["id"]
+    assert (await client.delete(f"{_P}/{sid}", headers=_as(_ADMIN))).status_code == 204
+    assert (await client.get(f"{_P}/{sid}", headers=_as(_ADMIN))).status_code == 404
+
+
+async def test_read_missing_404(client):
+    assert (await client.get(f"{_P}/{uuid.uuid4()}", headers=_as(_ADMIN))).status_code == 404
+
+
+async def test_invalid_vault_ref_400(client):
+    r = await client.post(
+        _P,
+        json={"owner_vault": "bad:has:colons", "name": "x", "secret_type": "password", "value": "x"},
+        headers=_as(_ADMIN),
+    )
+    assert r.status_code == 400


### PR DESCRIPTION
## Thinking Path
The finale of umbrella #10088's Task 2 — the `/api/v2/secrets` HTTP surface over the merged `SecretsCoordinator` (#10214). Kept a thin shell; all logic is in the coordinator (already tested). New prefix so the legacy `/secrets` file-store path is untouched until Task 3.

## What Changed
- New `api/unified_secrets.py` — `router` with create/list/read/rotate/delete/share/revoke. Three injectable deps: `principal` (auth `get_user_from_request` + RBAC `get_user_permissions`), `get_session` (Postgres), `get_coordinator` (503 if `AUTOBOT_SECRETS_ROOT_KEY` unset). Coordinator exceptions → 404/403/400.
- Registered in `initialization/router_registry/feature_routers.py` at `/v2/secrets`.
- `fastapi` added to the `migration-gate` job deps (for the standalone-router test).

## Verification
- **8 HTTP tests on disposable Postgres 16** (`tests/migrations/test_unified_secrets_api.py`): router mounted in a throwaway FastAPI app + httpx/ASGITransport + dep overrides (no whole-app startup). create/read (201/200), outsider 403, share→grantee reads→revoke→403, rotate+list, delete→404, missing→404, invalid-vault→400.
- ruff/black/mypy clean; `api.unified_secrets` imports cleanly (startup-import-smoke).

## Model Used
Claude Opus 4.8 (1M context)

Closes #10240
