### PR TITLE
fix(frontend): stop calling .json() on ApiClient parsed results (#10013)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatSidebar.vue
+++ b/autobot-frontend/src/components/chat/ChatSidebar.vue
@@ -678,8 +678,8 @@ const reloadSystem = async () => {
 
   try {
     // Call real system reload API
-    const response = await ApiClient.post<any>(`${getApiBase()}/system/reload_config`)
-    const data = await (response as any).json()
+    // ApiClient.post returns parsed JSON directly — no .json() (#10013)
+    const data = await ApiClient.post<any>(`${getApiBase()}/system/reload_config`)
 
     if (data && data.success) {
       systemStatus.value = t('status.ready')

--- a/autobot-frontend/src/composables/useDocumentChanges.ts
+++ b/autobot-frontend/src/composables/useDocumentChanges.ts
@@ -183,14 +183,17 @@ export function useDocumentChanges() {
 
     try {
       // Issue #552: Fixed path - backend uses /api/knowledge-maintenance/*
-      const response = await ApiClient.post<any>(`${getApiBase()}/knowledge-maintenance/scan_host_changes`, {
-        machine_id: machineId.value,
-        force,
-        scan_type: 'manpages',
-        auto_vectorize: autoVectorize
-      })
-
-      const result: ChangeDetectionResult = await response.json()
+      // ApiClient.post returns parsed JSON directly — do NOT call .json() on it
+      // (#10013: the old `await response.json()` threw "json is not a function").
+      const result = await ApiClient.post<ChangeDetectionResult>(
+        `${getApiBase()}/knowledge-maintenance/scan_host_changes`,
+        {
+          machine_id: machineId.value,
+          force,
+          scan_type: 'manpages',
+          auto_vectorize: autoVectorize
+        }
+      )
 
       if (result.status === 'success') {
         // Update summary


### PR DESCRIPTION
Fixes #10013 (part 1 — the ApiClient envelope `.json()` misuse). Member of umbrella #9922.

## Thinking Path
`ApiClient.get/post` already return **parsed JSON**, not a `Response`. Calling `.json()` on the result throws `TypeError: ...json is not a function` (the documented envelope-misuse class). #10013 reported it via `useDocumentChanges`; a repo-wide sweep found one more live instance of the identical bug.

## What Changed
- `composables/useDocumentChanges.ts`: `scan_host_changes` — typed the call `ApiClient.post<ChangeDetectionResult>(...)` and dropped `await response.json()`.
- `components/chat/ChatSidebar.vue`: `reload_config` — dropped `await (response as any).json()`, consume the parsed result directly.
- Sweep confirms these are the only two instances of the class in `src/`.

## Scope note
The issue's 2nd bullet (RUM `component_error — e.split is not a function`) is split to **#10208** — it's a minified-bundle error with no static culprit and needs source-map localization, not a guess.

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json`: no new errors in the changed files.
- Repo sweep for `ApiClient.<verb>(...)` followed by `.json()`: 0 remaining.

## Model Used
Claude Opus 4.8