### PR TITLE
feat(lint): guard against ApiClient envelope misuse — .json()/.data on parsed results (#10025)

### DIFF
--- a/autobot-frontend/eslint-tests/README.md
+++ b/autobot-frontend/eslint-tests/README.md
@@ -2,19 +2,28 @@
 
 Manual-verification fixtures for the custom ESLint rules added by this project. These files are excluded from the normal lint scope (see `eslint.config.ts` `globalIgnores`) because they contain intentional rule violations.
 
+Each `*-deny.test.*` file carries a top-of-file `/* eslint-disable */` so that an accidental full-tree `eslint . --no-ignore` does not fail on the intentional violations. To actually exercise a rule, strip that directive on a throwaway copy and lint it (see below).
+
 ## How to run
 
 ```bash
 cd autobot-frontend
-npx eslint --no-ignore eslint-tests/
+# Copy a deny fixture WITHOUT the eslint-disable banner into the linted scope,
+# lint it, then remove it. (The banner suppresses the very rule we want to test.)
+cp eslint-tests/no-apiclient-envelope-misuse-deny.test.ts src/__probe.ts
+sed -i 's|/\* eslint-disable \*/||' src/__probe.ts
+npx eslint --no-ignore src/__probe.ts
+rm -f src/__probe.ts
 ```
 
-Expected output:
+Expected output (deny fixtures count one error per `// EXPECT-ERROR` line; allow fixtures count zero rule errors):
 
-* `no-hardcoded-vm-ip-deny.test.ts` — **6 errors** (one per `// EXPECT-ERROR` line)
+* `no-hardcoded-vm-ip-deny.test.ts` — **6 errors**
 * `no-hardcoded-vm-ip-allow.test.ts` — **0 errors**
 * `no-deprecated-design-tokens-deny.test.vue` — **8 errors** (one per `<!-- EXPECT-ERROR -->` line)
 * `no-deprecated-design-tokens-allow.test.vue` — **0 errors**
+* `no-apiclient-envelope-misuse-deny.test.ts` — **10 `no-restricted-syntax` errors** (one per `// EXPECT-ERROR` line)
+* `no-apiclient-envelope-misuse-allow.test.ts` — **0 `no-restricted-syntax` errors**
 
 ## When to add fixtures here
 
@@ -27,3 +36,4 @@ When introducing a new custom ESLint rule, add a deny + allow fixture pair so fu
 
 * `no-restricted-syntax`: hardcoded VM-IP rule — `#6784`
 * `vue/no-restricted-static-attribute` + `vue/no-restricted-syntax`: deprecated design tokens — MVA-192
+* `no-restricted-syntax`: ApiClient envelope misuse (`.json()`/`.data` on parsed results) — `#10025`

--- a/autobot-frontend/eslint-tests/no-apiclient-envelope-misuse-allow.test.ts
+++ b/autobot-frontend/eslint-tests/no-apiclient-envelope-misuse-allow.test.ts
@@ -1,0 +1,60 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// ESLint test fixture for the #10025 `no-restricted-syntax` rule guarding
+// ApiClient envelope misuse. Every line below MUST NOT trigger the rule.
+//
+// Covers the legitimate cases the rule must never false-positive on:
+//   * the correct ApiClient usage (`const data = await ApiClient.get<T>(...)`)
+//   * a real fetch/rawRequest Response `.json()` (those ARE Response objects)
+//   * `.data` on non-ApiClient objects (Pinia state, refs, chart configs,
+//     event payloads) and on the two-statement `payload.data` form
+//
+// To verify locally:
+//   cd autobot-frontend
+//   npx eslint --no-ignore eslint-tests/no-apiclient-envelope-misuse-allow.test.ts
+//   # Expected: 0 errors
+
+/* eslint-disable */
+
+declare const ApiClient: any
+declare const api: any
+declare const apiClient: any
+declare function fetch(url: string): Promise<{ json(): Promise<unknown> }>
+declare function rawRequest(url: string): Promise<{ json(): Promise<unknown> }>
+
+async function good() {
+  // Correct usage: the awaited value IS the parsed payload.
+  const data = await ApiClient.get<{ items: unknown[] }>('/x')
+  const created = await api.post<unknown>('/x', {})
+  await apiClient.delete('/x')
+
+  // Real Response objects — these genuinely have .json().
+  const fromFetch = (await fetch('/x')).json()
+  const fromRaw = (await rawRequest('/x')).json()
+
+  // .data on non-ApiClient objects is legitimate.
+  const store = { data: { value: 1 } }
+  const piniaData = store.data
+  const chartRef = { value: { data: [] } }
+  const chartData = chartRef.value.data
+  const evt = { data: 'payload' }
+  const eventData = evt.data
+
+  // Two-statement form: the awaited value is bound first, then .data read.
+  // The payload may itself legitimately have a `.data` field. Out of scope
+  // for this syntactic rule (see eslint.config.ts comment), must stay allowed.
+  const payload = await api.get<{ data: unknown }>('/x')
+  const inner = payload.data
+
+  // Named (non-verb) method on a *piClient-named object — not an HTTP verb,
+  // so the rule must not fire.
+  const visionMultimodalApiClient = { getVisionHealth: async () => ({ ok: true }) }
+  const health = (await visionMultimodalApiClient.getVisionHealth()).ok
+
+  return { data, created, fromFetch, fromRaw, piniaData, chartData, eventData, inner, health }
+}
+
+export { good }

--- a/autobot-frontend/eslint-tests/no-apiclient-envelope-misuse-deny.test.ts
+++ b/autobot-frontend/eslint-tests/no-apiclient-envelope-misuse-deny.test.ts
@@ -1,0 +1,59 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// ESLint test fixture for the #10025 `no-restricted-syntax` rule guarding
+// ApiClient envelope misuse. Every `// EXPECT-ERROR` line below SHOULD trigger
+// the rule: ApiClient returns PARSED JSON directly, so calling `.json()` on the
+// awaited result, or reading `.data` off it, is always a bug.
+//
+// Wire-in: this fixture is excluded from the production lint step (see
+// eslint.config.ts ignore list); it exists only for manual verification.
+//
+// To verify locally:
+//   cd autobot-frontend
+//   npx eslint --no-ignore eslint-tests/no-apiclient-envelope-misuse-deny.test.ts
+//   # Expected: 10 errors (one per `// EXPECT-ERROR` line)
+
+/* eslint-disable */
+
+declare const ApiClient: any
+declare const api: any
+declare const apiClient: any
+
+async function bad() {
+  // EXPECT-ERROR: .json() on ApiClient.get result
+  const a = (await ApiClient.get<unknown>('/x')).json()
+
+  // EXPECT-ERROR: .json() on api.post result (useApiClient() local named `api`)
+  const b = (await api.post('/x', {})).json()
+
+  // EXPECT-ERROR: .json() on apiClient.put result
+  const c = (await apiClient.put('/x', {})).json()
+
+  // EXPECT-ERROR: .data on ApiClient.get result (axios-envelope pattern)
+  const d = (await ApiClient.get<{ data: unknown }>('/x')).data
+
+  // EXPECT-ERROR: .data on api.post result
+  const e = (await api.post('/x', {})).data
+
+  // EXPECT-ERROR: .data on apiClient.delete result
+  const f = (await apiClient.delete('/x')).data
+
+  // EXPECT-ERROR: .data on api.patch result
+  const g = (await api.patch('/x', {})).data
+
+  // EXPECT-ERROR: .json() on api.delete result
+  const h = (await api.delete('/x')).json()
+
+  // EXPECT-ERROR: .data on ApiClient.put result
+  const i = (await ApiClient.put('/x', {})).data
+
+  // EXPECT-ERROR: .json() on apiClient.get result
+  const j = (await apiClient.get('/x')).json()
+
+  return { a, b, c, d, e, f, g, h, i, j }
+}
+
+export { bad }

--- a/autobot-frontend/eslint.config.ts
+++ b/autobot-frontend/eslint.config.ts
@@ -94,6 +94,26 @@ export default defineConfigWithVueTs(
       // and any other literal/template containing the deployment range.
       // Use SSOT (window.location.hostname / VITE_*_HOST env vars) instead.
       // See docs/developer/HARDCODING_PREVENTION.md.
+      //
+      // Issue #10025: guard against ApiClient envelope misuse. The canonical
+      // ApiClient (`ApiClient.*` / the `useApiClient()` result, conventionally
+      // named `api` or `apiClient`) returns PARSED JSON directly — it is NOT a
+      // fetch `Response` and NOT an axios envelope. Calling `.json()` on the
+      // result throws `TypeError: .json is not a function`; reading `.data`
+      // yields `undefined`. This class has caused 40+ runtime bugs (latest
+      // #10013). See docs feedback "ApiClient.X returns parsed JSON directly".
+      //
+      // We flag the INLINE awaited-then-membered forms only:
+      //   (await ApiClient.get(...)).json()   and   (await ApiClient.get(...)).data
+      // (and the same for `api.*` / `apiClient.*`). The TWO-STATEMENT form
+      //   const r = await ApiClient.get(...); r.json()
+      // cannot be caught syntactically without type information and is NOT
+      // covered here — a typed rule would be required (tracked for follow-up if
+      // it recurs). The selectors are deliberately tight (callee identifier must
+      // be `api`/`apiClient`/`ApiClient`, method must be an HTTP verb) so they
+      // never fire on a real `fetch`/`rawRequest` Response `.json()`, nor on
+      // legitimate `.data` of Pinia state, refs, chart configs, or event
+      // payloads, nor on the two-statement `payload.data` pattern.
       'no-restricted-syntax': [
         'error',
         {
@@ -103,6 +123,20 @@ export default defineConfigWithVueTs(
         {
           selector: "TemplateElement[value.cooked=/172\\.16\\.168\\.[0-9]+/]",
           message: 'Hardcoded AutoBot VM IP in template literal — use window.location.hostname or VITE_*_HOST env var (#6784).',
+        },
+        {
+          // (await ApiClient.<verb>(...)).json()  — `.json()` on a parsed result.
+          selector:
+            "CallExpression[callee.property.name='json'][callee.object.type='AwaitExpression'][callee.object.argument.type='CallExpression'][callee.object.argument.callee.type='MemberExpression'][callee.object.argument.callee.property.name=/^(get|post|put|delete|patch)$/][callee.object.argument.callee.object.name=/^([aA]pi|[aA]piClient)$/]",
+          message:
+            'ApiClient already returns parsed JSON — do not call .json() on its result (#10025). Use `const data = await ApiClient.get<T>(...)` directly.',
+        },
+        {
+          // (await ApiClient.<verb>(...)).data  — axios-envelope `.data` access.
+          selector:
+            "MemberExpression[property.name='data'][object.type='AwaitExpression'][object.argument.type='CallExpression'][object.argument.callee.type='MemberExpression'][object.argument.callee.property.name=/^(get|post|put|delete|patch)$/][object.argument.callee.object.name=/^([aA]pi|[aA]piClient)$/]",
+          message:
+            'ApiClient returns parsed JSON, not an axios envelope — do not read .data on its result (#10025). The awaited value IS the payload.',
         },
       ],
       // Issue #7085: forbid console.* in production code — use createLogger from @/utils/debugUtils instead.


### PR DESCRIPTION
Fixes #10025. Member of umbrella #9922.

## Thinking Path
`ApiClient.<verb>` returns PARSED JSON (not a `Response`, not an axios envelope). Calling `.json()` or reading `.data` on the result is the recurring bug class behind 40+ runtime errors (most recently the two fixed in #10013). With the tree now clean of that class, add a guard so it can't regress.

## What Changed
- `eslint.config.ts`: two `no-restricted-syntax` selectors flag the inline forms `(await <api>.<verb>(...)).json()` and `(await <api>.<verb>(...)).data`, where `<api>` ∈ {ApiClient, api, apiClient} and `<verb>` ∈ {get,post,put,delete,patch}. Selectors prototyped against parsed ASTs to guarantee zero false positives — never fires on real `fetch`/`rawRequest` Response `.json()`, or legit `.data` on Pinia/refs/charts/events.
- `eslint-tests/`: deny fixture (10 expected errors) + allow fixture (0) + README.

## Scope note
The two-statement form (`const r = await ApiClient.get(); r.json()`) isn't catchable syntactically without type info — documented in the config; a typed rule is deferred unless it recurs. The rule covers the exact #10013 inline class.

## Verification
- Whole `src/**` scan: 0 violations (clean tree, as required).
- Deny fixture: exactly 10 errors (5 `.json()` + 5 `.data`); allow fixture: 0. Existing VM-IP rule unaffected; config loads clean.

## Model Used
Claude Sonnet (agent) + Claude Opus 4.8 (orchestration)