### PR TITLE
fix(telegram): remove duplicate router registration + add webhook tests (#9006)

### DIFF
--- a/autobot-backend/api/telegram_bot_test.py
+++ b/autobot-backend/api/telegram_bot_test.py
@@ -1,0 +1,131 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Wiring tests for the Telegram bot channel route (Issue #9006).
+
+These verify the inbound path is actually reachable and dispatched:
+- the router is registered exactly once (core registry; NOT duplicated in the
+  integration registry, which would double-mount the routes),
+- the webhook/config routes are exposed,
+- the gateway TelegramAdapter normalizes a raw Telegram Update into a
+  UnifiedMessage (text, command, and file attachments),
+- command handling produces the expected replies.
+"""
+
+import pytest
+
+from initialization.router_registry.integration_routers import INTEGRATION_ROUTER_CONFIGS
+
+
+class TestRouterRegistration:
+    """The Telegram webhook router must be registered exactly once to be reachable."""
+
+    def test_telegram_router_in_core_registry(self):
+        from initialization.router_registry.core_routers import load_core_routers
+
+        names = [name for (_router, _prefix, _tags, name) in load_core_routers()]
+        assert "telegram_bot" in names
+
+    def test_telegram_not_duplicated_in_integration_registry(self):
+        # Telegram is mounted via core_routers; a second entry here would
+        # double-mount /telegram/* routes and OpenAPI operations (GH#9006).
+        module_paths = [cfg[0] for cfg in INTEGRATION_ROUTER_CONFIGS]
+        assert "api.telegram_bot" not in module_paths
+
+    def test_telegram_router_exposes_routes(self):
+        from api import telegram_bot
+
+        assert hasattr(telegram_bot, "router")
+        paths = {route.path for route in telegram_bot.router.routes}
+        assert "/telegram/webhook" in paths
+        assert "/telegram/config" in paths
+
+
+class TestGatewayNormalization:
+    """A raw Telegram Update normalizes through the gateway TelegramAdapter."""
+
+    def _gateway(self):
+        from services.gateway.gateway_manager import GatewayManager
+
+        return GatewayManager()
+
+    @pytest.mark.asyncio
+    async def test_text_message_normalizes(self):
+        raw = {
+            "platform": "telegram",
+            "message": {
+                "message_id": 11,
+                "date": 1700000000,
+                "chat": {"id": 4242, "type": "private"},
+                "from": {"id": 99},
+                "text": "hi bot",
+            },
+        }
+        unified = await self._gateway().normalize_message(raw)
+        assert unified.platform == "telegram"
+        assert unified.user_id == "99"
+        assert unified.channel_id == "4242"
+        assert unified.message == "hi bot"
+        assert unified.metadata.get("is_command") is not True
+
+    @pytest.mark.asyncio
+    async def test_command_message_normalizes(self):
+        raw = {
+            "platform": "telegram",
+            "message": {
+                "message_id": 12,
+                "date": 1700000001,
+                "chat": {"id": 4242, "type": "private"},
+                "from": {"id": 99},
+                "text": "/status now",
+            },
+        }
+        unified = await self._gateway().normalize_message(raw)
+        assert unified.metadata.get("is_command") is True
+        assert unified.metadata.get("command") == "status"
+        assert unified.metadata.get("command_args") == ["now"]
+
+    @pytest.mark.asyncio
+    async def test_document_attachment_normalizes(self):
+        raw = {
+            "platform": "telegram",
+            "message": {
+                "message_id": 13,
+                "date": 1700000002,
+                "chat": {"id": 4242, "type": "private"},
+                "from": {"id": 99},
+                "document": {"file_id": "doc-1", "file_name": "x.pdf", "mime_type": "application/pdf"},
+            },
+        }
+        unified = await self._gateway().normalize_message(raw)
+        assert unified.metadata.get("has_file") is True
+        assert unified.metadata.get("file_id") == "doc-1"
+        assert unified.metadata.get("file_type") == "document"
+
+
+class TestCommandHandling:
+    """Basic command handling (/help, /status) returns user-facing replies (GH#9006 AC)."""
+
+    @pytest.mark.asyncio
+    async def test_status_command(self):
+        from api.telegram_bot import _handle_command
+
+        reply = await _handle_command("status", [], chat_id="4242", message_id=1)
+        assert reply is not None and "online" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_help_command_lists_commands(self):
+        from api.telegram_bot import _handle_command
+
+        reply = await _handle_command("help", [], chat_id="4242", message_id=1)
+        assert reply is not None
+        assert "/status" in reply and "/help" in reply
+
+    @pytest.mark.asyncio
+    async def test_unknown_command_returns_none(self):
+        from api.telegram_bot import _handle_command
+
+        reply = await _handle_command("nope", [], chat_id="4242", message_id=1)
+        assert reply is None

--- a/autobot-backend/initialization/router_registry/integration_routers.py
+++ b/autobot-backend/initialization/router_registry/integration_routers.py
@@ -79,13 +79,9 @@ INTEGRATION_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["integrations-github"],
         "integration_github",
     ),
-    # Telegram bot integration (MVA-2928 / GH#9006)
-    (
-        "api.telegram_bot",
-        "",  # No prefix - endpoints are /telegram/webhook and /telegram/config
-        ["telegram-bot"],
-        "telegram_bot",
-    ),
+    # Telegram bot integration is registered in core_routers (MVA-2074); do NOT
+    # add it here too — duplicate include_router double-mounts /telegram/* routes
+    # and OpenAPI operations (GH#9006).
     # WhatsApp Business API channel (GH#9007)
     (
         "api.whatsapp",


### PR DESCRIPTION
## Thinking Path

Verified the Telegram channel adapter end-to-end (it was WhatsApp #9007's reference pattern, so genuinely wired — not the transcriber orphan anti-pattern). Found one real defect.

## What Changed

- **Bug fix**: the Telegram router was **double-registered** — in both `core_routers.py` (canonical, MVA-2074) and `integration_routers.py` (GH#9006) — double-mounting `/telegram/webhook`, `/telegram/config` and their OpenAPI operations. Removed the redundant `integration_routers` entry (kept the canonical `core_routers` one), matching the single-registration WhatsApp pattern.
- **Test**: added `api/telegram_bot_test.py` (9 tests) — the inbound webhook path had no coverage.

## Verification

- `pytest api/telegram_bot_test.py` → **9 passed**; existing webhook-auth + gateway tests pass.
- Wiring proof (all ACs MET): inbound `api/telegram_bot.py POST /telegram/webhook` → secret verify → `gateway_manager.normalize_message` (TelegramAdapter registered `gateway_manager.py:72`) → `process_chat_message` → outbound `send_telegram_response` → `TelegramBotService.send_message/photo/document`; token encrypted in Redis; LLC notifications via `notification_service.py:501`; `/help` `/status` command handling tested.

## Model Used

Claude Opus 4.8 (1M context)
