### PR TITLE
fix(slm): auto-generate shared internal API key + derive backend URL (#10263)

### DIFF
--- a/autobot-slm-backend/api/personality_proxy.py
+++ b/autobot-slm-backend/api/personality_proxy.py
@@ -23,13 +23,17 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import Response
 
+from config import settings
 from services.auth import get_current_user
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/personality", tags=["personality-proxy"])
 
-AUTOBOT_BACKEND_URL = os.getenv("AUTOBOT_BACKEND_URL", "")  # noqa: ssot-fallback
+# Main backend base URL. Reuse the identity-authority base (#10197) so the proxy
+# works co-located (loopback:8001) and distributed with no extra config (#10263);
+# an explicit AUTOBOT_BACKEND_URL still overrides if set.
+AUTOBOT_BACKEND_URL = os.getenv("AUTOBOT_BACKEND_URL", "") or settings.authority_base_url  # noqa: ssot-fallback
 AUTOBOT_INTERNAL_API_KEY = os.getenv("AUTOBOT_INTERNAL_API_KEY", "")
 
 _MUTATION_METHODS = {"POST", "PUT", "DELETE", "PATCH"}

--- a/autobot-slm-backend/api/voice_proxy.py
+++ b/autobot-slm-backend/api/voice_proxy.py
@@ -21,13 +21,17 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import Response
 
+from config import settings
 from services.auth import get_current_user
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/voice", tags=["voice-proxy"])
 
-AUTOBOT_BACKEND_URL = os.getenv("AUTOBOT_BACKEND_URL", "")  # noqa: ssot-fallback
+# Main backend base URL. Reuse the identity-authority base (#10197) so the proxy
+# works co-located (loopback:8001) and distributed with no extra config (#10263);
+# an explicit AUTOBOT_BACKEND_URL still overrides if set.
+AUTOBOT_BACKEND_URL = os.getenv("AUTOBOT_BACKEND_URL", "") or settings.authority_base_url  # noqa: ssot-fallback
 AUTOBOT_INTERNAL_API_KEY = os.getenv("AUTOBOT_INTERNAL_API_KEY", "")
 
 _TIMEOUT = 15.0

--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -200,13 +200,20 @@ async def lifespan(app: FastAPI):
 
     try:
         await _ensure_admin_user()
-        await _ensure_internal_api_key()
         await _seed_default_roles()
         await _seed_default_agents()
         await _ensure_local_node()
     except Exception as e:
         logger.error("Data seeding failed: %s", e, exc_info=True)
         raise
+
+    # Internal API key seeding is an enhancement (enables personality/voice
+    # proxies) — a failure here must never abort SLM startup; the proxies just
+    # degrade to 503 until the key exists, as they did before (#10263).
+    try:
+        await _ensure_internal_api_key()
+    except Exception:
+        logger.exception("Internal API key seeding failed (non-fatal) (#10263)")
 
     # Compose fleet-node surfacing is best-effort cosmetic — a seeding failure here
     # must never abort SLM startup (it previously rode the re-raising block above).
@@ -436,6 +443,7 @@ async def _ensure_internal_api_key() -> None:
     import secrets as _secrets
 
     from sqlalchemy import select
+    from sqlalchemy.exc import IntegrityError
 
     from models.database import SystemSecret
     from services.encryption import encrypt_data
@@ -446,7 +454,13 @@ async def _ensure_internal_api_key() -> None:
         if result.scalar_one_or_none() is not None:
             return
         db.add(SystemSecret(key=key_name, encrypted_value=encrypt_data(_secrets.token_hex(32))))
-        await db.commit()
+        try:
+            await db.commit()
+        except IntegrityError:
+            # Concurrent startup seeded it first (unique key) — keep theirs.
+            await db.rollback()
+            logger.info("Internal API key already created concurrently — keeping existing (#10263)")
+            return
         logger.info("Generated shared internal API key — personality/voice proxies enabled (#10263)")
 
 

--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -200,6 +200,7 @@ async def lifespan(app: FastAPI):
 
     try:
         await _ensure_admin_user()
+        await _ensure_internal_api_key()
         await _seed_default_roles()
         await _seed_default_agents()
         await _ensure_local_node()
@@ -417,6 +418,36 @@ async def _ensure_admin_user():
             logger.warning("Created default admin user (username: admin)")
         except DuplicateUserError:
             logger.info("Admin user already exists (race condition avoided)")
+
+
+async def _ensure_internal_api_key() -> None:
+    """Ensure the shared internal API key exists (#10263).
+
+    The SLM personality/voice proxies authenticate to the main backend with an
+    X-Internal-API-Key header; the value must match on both sides. It is
+    distributed to deploys via fetch_deploy_secrets() -> the
+    autobot_internal_api_key extra_var -> slm-secrets.env + backend.env.
+
+    Historically the value was only present if an admin manually created the
+    secret in the SLM UI, so a fresh deployment left it empty and every
+    personality/voice request 503'd. Generate a strong key once and store it;
+    idempotent thereafter (never overwrites an existing value).
+    """
+    import secrets as _secrets
+
+    from sqlalchemy import select
+
+    from models.database import SystemSecret
+    from services.encryption import encrypt_data
+
+    key_name = "autobot_internal_api_key"  # nosec B105 - secret-store key name, not a credential
+    async with db_service.session() as db:
+        result = await db.execute(select(SystemSecret).where(SystemSecret.key == key_name))
+        if result.scalar_one_or_none() is not None:
+            return
+        db.add(SystemSecret(key=key_name, encrypted_value=encrypt_data(_secrets.token_hex(32))))
+        await db.commit()
+        logger.info("Generated shared internal API key — personality/voice proxies enabled (#10263)")
 
 
 async def _seed_default_roles():


### PR DESCRIPTION
## Thinking Path
Closes #10263. On a fresh SLM-driven deployment the personality/voice proxies always 503'd ("… service not configured (missing internal API key)"). Two unprovisioned values:
1. `autobot_internal_api_key` — the distribution path already exists (`fetch_deploy_secrets()` → `autobot_internal_api_key` extra_var → `slm-secrets.env` + `backend.env`), but **nothing generated the value**; it was only present if an admin manually created it in the SLM secrets UI.
2. `AUTOBOT_BACKEND_URL` — the proxies defaulted it to `""`, so the forward target had no host.

Per the architecture (install.sh = SLM only; the SLM deploys components at the user's chosen scale), the fix lives in the SLM layer so **every** deployment — co-located or distributed — works with no manual step.

## What Changed
- `main.py` — new `_ensure_internal_api_key()` seeds a strong `autobot_internal_api_key` (`secrets.token_hex(32)`) into the SLM `SystemSecret` store **once** at startup, idempotent, never overwriting an admin-set value. Wired into the existing seeding block. From there the established `fetch_deploy_secrets()` path distributes it to both `slm-secrets.env` and `backend.env`.
- `api/personality_proxy.py`, `api/voice_proxy.py` — `AUTOBOT_BACKEND_URL` now falls back to `settings.authority_base_url` (the #10197 identity-authority base, default loopback:8001, configurable for distributed) when the env is unset; an explicit env var still overrides.

## Verification
- `py_compile` + `black --check` clean on all three files.
- Live box (manually applying the same key+URL) confirmed the fix: `GET /slm/api/personality/profiles` → 200 with real profiles (was 503).
- No test asserted the old empty default.

## Model Used
Claude Opus 4.8