### PR TITLE
fix(slm): remove stray '-o' in node role-sync ssh command (#10277)

### DIFF
--- a/autobot-slm-backend/services/sync_orchestrator.py
+++ b/autobot-slm-backend/services/sync_orchestrator.py
@@ -116,7 +116,6 @@ class SyncOrchestrator:
             "ssh",
             "-o",
             "StrictHostKeyChecking=accept-new",
-            "-o",
             "-p",
             str(port),
         ]

--- a/autobot-slm-backend/services/sync_orchestrator.py
+++ b/autobot-slm-backend/services/sync_orchestrator.py
@@ -337,7 +337,6 @@ class SyncOrchestrator:
             "-o",
             "StrictHostKeyChecking=accept-new",
             "-o",
-            "-o",
             "ConnectTimeout=10",
         ]
         if Path(SSH_KEY_PATH).exists():

--- a/autobot-slm-backend/tests/services/test_sync_orchestrator_ssh.py
+++ b/autobot-slm-backend/tests/services/test_sync_orchestrator_ssh.py
@@ -1,0 +1,40 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for SyncOrchestrator._build_ssh_command (Issue #10277).
+
+Regression guard: a stray ``-o`` with no ``key=value`` argument made ssh fail
+with ``command-line line 0: no argument after keyword "-o"``, breaking every
+node role-sync. These tests assert the produced argv is well-formed.
+"""
+
+from services.sync_orchestrator import SyncOrchestrator
+
+
+def _build(port: int = 2222, user: str = "autobot", host: str = "10.0.0.5") -> list:
+    # __new__ skips __init__ (which only creates a cache dir); _build_ssh_command
+    # does not touch instance state, so this is a safe, side-effect-free build.
+    orchestrator = SyncOrchestrator.__new__(SyncOrchestrator)
+    return orchestrator._build_ssh_command(port, user, host)
+
+
+def test_every_dash_o_has_keyvalue_argument():
+    cmd = _build()
+    for idx, token in enumerate(cmd):
+        if token == "-o":
+            assert idx + 1 < len(cmd), "trailing -o with no argument"
+            value = cmd[idx + 1]
+            assert "=" in value and not value.startswith("-"), f"-o not followed by key=value: {value!r}"
+
+
+def test_port_flag_passed_correctly():
+    cmd = _build(port=2222)
+    assert "-p" in cmd
+    assert cmd[cmd.index("-p") + 1] == "2222"
+
+
+def test_target_host_is_last_argument():
+    cmd = _build(user="u", host="h")
+    assert cmd[-1] == "u@h"

--- a/autobot-slm-backend/tests/services/test_sync_orchestrator_ssh.py
+++ b/autobot-slm-backend/tests/services/test_sync_orchestrator_ssh.py
@@ -3,38 +3,56 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Unit tests for SyncOrchestrator._build_ssh_command (Issue #10277).
+Unit tests for SyncOrchestrator ssh command construction (Issue #10277).
 
-Regression guard: a stray ``-o`` with no ``key=value`` argument made ssh fail
-with ``command-line line 0: no argument after keyword "-o"``, breaking every
-node role-sync. These tests assert the produced argv is well-formed.
+Regression guard: stray ``-o`` tokens with no ``key=value`` argument made ssh
+fail with ``command-line line 0: no argument after keyword "-o"``, breaking node
+role-sync (_build_ssh_command) and source-commit lookup (_get_current_git_commit).
+These tests assert every ssh argv built in the orchestrator is well-formed.
 """
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from services.sync_orchestrator import SyncOrchestrator
 
 
-def _build(port: int = 2222, user: str = "autobot", host: str = "10.0.0.5") -> list:
-    # __new__ skips __init__ (which only creates a cache dir); _build_ssh_command
-    # does not touch instance state, so this is a safe, side-effect-free build.
-    orchestrator = SyncOrchestrator.__new__(SyncOrchestrator)
-    return orchestrator._build_ssh_command(port, user, host)
-
-
-def test_every_dash_o_has_keyvalue_argument():
-    cmd = _build()
+def _assert_ssh_argv_wellformed(cmd: list) -> None:
+    """Every ``-o`` must be followed by a ``key=value`` token (never a bare flag)."""
     for idx, token in enumerate(cmd):
         if token == "-o":
-            assert idx + 1 < len(cmd), "trailing -o with no argument"
+            assert idx + 1 < len(cmd), f"trailing -o with no argument: {cmd!r}"
             value = cmd[idx + 1]
-            assert "=" in value and not value.startswith("-"), f"-o not followed by key=value: {value!r}"
+            assert "=" in value and not value.startswith("-"), f"-o not followed by key=value: {value!r} in {cmd!r}"
 
 
-def test_port_flag_passed_correctly():
-    cmd = _build(port=2222)
-    assert "-p" in cmd
-    assert cmd[cmd.index("-p") + 1] == "2222"
+def _orchestrator() -> SyncOrchestrator:
+    # __new__ skips __init__ (which only creates a cache dir); the ssh builders
+    # do not touch instance state, so this is a safe, side-effect-free build.
+    return SyncOrchestrator.__new__(SyncOrchestrator)
 
 
-def test_target_host_is_last_argument():
-    cmd = _build(user="u", host="h")
+def test_build_ssh_command_argv_is_wellformed():
+    cmd = _orchestrator()._build_ssh_command(2222, "autobot", "10.0.0.5")
+    _assert_ssh_argv_wellformed(cmd)
+
+
+def test_build_ssh_command_port_and_target():
+    cmd = _orchestrator()._build_ssh_command(2222, "u", "h")
+    assert "-p" in cmd and cmd[cmd.index("-p") + 1] == "2222"
     assert cmd[-1] == "u@h"
+
+
+@pytest.mark.asyncio
+async def test_get_current_git_commit_argv_is_wellformed():
+    """_get_current_git_commit must also build a valid ssh argv (#10277)."""
+    proc = MagicMock()
+    proc.communicate = AsyncMock(return_value=(b"a" * 40 + b"\n", b""))
+    proc.returncode = 0
+    with patch(
+        "services.sync_orchestrator.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=proc),
+    ) as mock_exec:
+        await _orchestrator()._get_current_git_commit("10.0.0.5", "autobot", "/home/autobot/code")
+    _assert_ssh_argv_wellformed(list(mock_exec.call_args[0]))


### PR DESCRIPTION
## Thinking Path
Closes #10277. Node role-sync failed with `command-line line 0: no argument after keyword "-o"`. `SyncOrchestrator._build_ssh_command()` emitted `[..., '-o', 'StrictHostKeyChecking=accept-new', '-o', '-p', <port>]` — the second `-o` had no `key=value` argument, so ssh read the following `-p` as its value and errored before connecting. Every role-sync via this helper broke.

## What Changed
- `services/sync_orchestrator.py` — drop the spurious `-o` so the port flag passes correctly.
- `tests/services/test_sync_orchestrator_ssh.py` — regression guard: every `-o` is followed by a `key=value` token, the port flag is correct, and the target host is last.

## Verification
- `py_compile` + `black --check` clean.
- Reproduced from the live SLM error; the corrected argv is well-formed ssh.

## Model Used
Claude Opus 4.8