### PR TITLE
feat(chat): in-folder search + folder archive (#8987)

### DIFF
--- a/autobot-backend/api/chat_folders.py
+++ b/autobot-backend/api/chat_folders.py
@@ -73,6 +73,7 @@ def _serialize_folder(f: Dict) -> Dict:
         "parent_id": f.get("parent_id"),
         "owner": f.get("owner", ""),
         "pinned": f.get("pinned", False),
+        "archived": f.get("archived", False),
         "created_at": f.get("created_at", ""),
         "session_ids": session_ids,
         "session_count": len(session_ids),
@@ -141,6 +142,7 @@ async def create_folder(
         "parent_id": body.parent_id,
         "owner": username,
         "pinned": False,
+        "archived": False,
         "created_at": datetime.now(timezone.utc).isoformat(),
         "session_ids": [],
     }
@@ -182,6 +184,8 @@ async def update_folder(
         folder["name"] = body.name
     if body.pinned is not None:
         folder["pinned"] = body.pinned
+    if body.archived is not None:
+        folder["archived"] = body.archived
     if "parent_id" in body.model_fields_set:
         if body.parent_id is not None:
             if body.parent_id == folder_id:

--- a/autobot-backend/api/schemas_chat.py
+++ b/autobot-backend/api/schemas_chat.py
@@ -673,6 +673,7 @@ class FolderUpdate(BaseModel):
     name: str | None = Field(None, min_length=1, max_length=100, description="New folder name")
     parent_id: str | None = Field(None, description="New parent folder ID (None = root)")
     pinned: bool | None = Field(None, description="Pin folder to top of list")
+    archived: bool | None = Field(None, description="Archive folder (hidden from main list, still searchable)")
 
 
 class FolderData(BaseModel):
@@ -683,6 +684,7 @@ class FolderData(BaseModel):
     parent_id: str | None = None
     owner: str
     pinned: bool = False
+    archived: bool = False
     created_at: str
     session_ids: List[str] = Field(default_factory=list)
     session_count: int = 0

--- a/autobot-backend/tests/api/test_chat_folders.py
+++ b/autobot-backend/tests/api/test_chat_folders.py
@@ -1,0 +1,96 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for chat conversation folder endpoints (GH#8987).
+
+Covers the two acceptance criteria added in this change:
+- Folders carry an ``archived`` flag (default False) in create + serialize.
+- PUT /chat/folders/{id} can set/clear ``archived`` and it persists in Redis.
+"""
+
+import json
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.chat_folders import _serialize_folder, router
+from auth_middleware import get_current_user
+
+_USER = {"user_id": "alice", "username": "alice", "role": "user"}
+
+
+class _FakeRedis:
+    """Minimal async Redis stand-in backed by a dict (string get/set only)."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+
+    async def get(self, key: str):
+        return self._store.get(key)
+
+    async def set(self, key: str, value: str) -> None:
+        self._store[key] = value
+
+
+def _make_client(redis: _FakeRedis) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+
+    async def _override_user():
+        return _USER
+
+    app.dependency_overrides[get_current_user] = _override_user
+
+    async def _fake_get_redis(*args, **kwargs):
+        return redis
+
+    # The route imports get_redis_client lazily inside the function body.
+    patcher = patch("autobot_shared.redis_client.get_redis_client", _fake_get_redis)
+    patcher.start()
+    client = TestClient(app)
+    client._redis_patcher = patcher  # type: ignore[attr-defined]
+    return client
+
+
+def test_serialize_folder_defaults_archived_false():
+    out = _serialize_folder({"id": "f1", "name": "Work"})
+    assert out["archived"] is False
+    assert out["pinned"] is False
+
+
+def test_serialize_folder_preserves_archived_true():
+    out = _serialize_folder({"id": "f1", "name": "Work", "archived": True})
+    assert out["archived"] is True
+
+
+def test_create_folder_is_unarchived_by_default():
+    redis = _FakeRedis()
+    client = _make_client(redis)
+    try:
+        resp = client.post("/chat/folders", json={"name": "Work"})
+        assert resp.status_code == 201
+        assert resp.json()["archived"] is False
+    finally:
+        client._redis_patcher.stop()  # type: ignore[attr-defined]
+
+
+def test_update_folder_archives_and_persists():
+    redis = _FakeRedis()
+    client = _make_client(redis)
+    try:
+        folder_id = client.post("/chat/folders", json={"name": "Old"}).json()["id"]
+
+        resp = client.put(f"/chat/folders/{folder_id}", json={"archived": True})
+        assert resp.status_code == 200
+        assert resp.json()["archived"] is True
+
+        stored = json.loads(redis._store["chat:folders:alice"])
+        assert stored[0]["archived"] is True
+
+        # Unarchive round-trips back to False.
+        resp = client.put(f"/chat/folders/{folder_id}", json={"archived": False})
+        assert resp.json()["archived"] is False
+    finally:
+        client._redis_patcher.stop()  # type: ignore[attr-defined]

--- a/autobot-frontend/src/components/chat/ChatFolderNode.vue
+++ b/autobot-frontend/src/components/chat/ChatFolderNode.vue
@@ -83,6 +83,15 @@
           <Icon name="edit" class="text-xs" />
         </button>
 
+        <!-- Archive / Unarchive -->
+        <button
+          class="p-0.5 rounded hover:bg-autobot-bg-card text-autobot-text-muted hover:text-autobot-text-secondary"
+          :title="folder.archived ? $t('chat.folders.unarchive') : $t('chat.folders.archive')"
+          @click="folderStore.toggleArchive(folder.id)"
+        >
+          <Icon :name="folder.archived ? 'box-open' : 'archive'" class="text-xs" />
+        </button>
+
         <!-- Delete -->
         <button
           class="p-0.5 rounded hover:bg-autobot-bg-card text-red-400 hover:text-red-500"

--- a/autobot-frontend/src/components/chat/ChatSidebar.vue
+++ b/autobot-frontend/src/components/chat/ChatSidebar.vue
@@ -52,10 +52,32 @@
         </div>
         <ChatFolderTree
           v-if="showFolders"
-          :sessions="store.sessions"
+          :sessions="filteredSessions"
           :current-session-id="store.currentSessionId"
           @session-click="(id) => controller.switchToSession(id)"
         />
+
+        <!-- GH#8987: Archived folders (hidden by default, chats remain searchable) -->
+        <div v-if="folderStore.archivedFolders.length > 0" class="mt-2 pt-2 border-t border-autobot-border">
+          <button
+            class="flex items-center gap-1 text-xs font-semibold text-autobot-text-muted hover:text-autobot-text-secondary transition-colors"
+            @click="showArchived = !showArchived"
+          >
+            <Icon :name="showArchived ? 'chevron-down' : 'chevron-right'" class="text-xs" />
+            {{ $t('chat.folders.archived') }}
+            <span class="font-normal">({{ folderStore.archivedFolders.length }})</span>
+          </button>
+          <FolderNode
+            v-for="folder in folderStore.archivedFolders"
+            v-show="showArchived"
+            :key="folder.id"
+            :folder="folder"
+            :depth="0"
+            :sessions="filteredSessions"
+            :current-session-id="store.currentSessionId"
+            @session-click="(id) => controller.switchToSession(id)"
+          />
+        </div>
       </section>
 
       <!-- Chat History Section - FIXED: Scrollable area with multi-select -->
@@ -85,10 +107,32 @@
           </div>
         </div>
 
+        <!-- GH#8987: Search / filter chats by title (across folders) -->
+        <div class="relative mb-2 shrink-0">
+          <Icon name="search" class="absolute start-2 top-1/2 -translate-y-1/2 text-xs text-autobot-text-muted pointer-events-none" />
+          <input
+            id="chat-search"
+            v-model="searchQuery"
+            type="search"
+            class="w-full text-xs ps-7 pe-7 py-1.5 border border-autobot-border rounded bg-autobot-bg-card focus:outline-none focus:ring-1 focus:ring-electric-500"
+            :placeholder="$t('chat.sidebar.searchChats')"
+            :aria-label="$t('chat.sidebar.searchChats')"
+          />
+          <button
+            v-if="searchQuery"
+            type="button"
+            class="absolute end-2 top-1/2 -translate-y-1/2 text-autobot-text-muted hover:text-autobot-text-primary"
+            :aria-label="$t('common.clear')"
+            @click="clearSearch"
+          >
+            <Icon name="times" class="text-xs" />
+          </button>
+        </div>
+
         <!-- FIXED: Scrollable chat history container -->
         <div class="flex-1 overflow-y-auto space-y-1.5 pe-1 mb-3" style="scrollbar-width: thin;">
           <div
-            v-for="(session, index) in store.sessions"
+            v-for="(session, index) in filteredSessions"
             :key="session.id"
             :ref="el => setSessionRef(el as HTMLElement | null, index)"
             class="p-2.5 rounded-lg transition-all duration-150 group relative"
@@ -200,6 +244,12 @@
             v-if="store.sessions.length === 0"
             icon="comments"
             :message="$t('chat.sidebar.noSessions')"
+          />
+          <!-- GH#8987: No search results -->
+          <EmptyState
+            v-else-if="filteredSessions.length === 0"
+            icon="search"
+            :message="$t('chat.sidebar.noSearchResults')"
           />
         </div>
 
@@ -371,6 +421,7 @@ import { useChatStore } from '@/stores/useChatStore'
 import { useChatController } from '@/models/controllers'
 import { useDisplaySettings, type DisplaySettings } from '@/composables/useDisplaySettings'
 import ChatFolderTree from './ChatFolderTree.vue'
+import FolderNode from './ChatFolderNode.vue'
 import { useFolderStore } from '@/stores/useFolderStore'
 import { useBatchSelection } from '@/composables/useBatchSelection'
 import type { ChatSession } from '@/stores/useChatStore'
@@ -397,7 +448,22 @@ const folderStore = useFolderStore()
 
 // GH#8987: state for folder section
 const showFolders = ref(true)
+const showArchived = ref(false)
 const folderAssignTarget = ref<string | null>(null)
+
+// GH#8987: in-folder / chat-list search. Client-side filter by title over
+// the already-loaded sessions; archived folders' chats stay searchable.
+const searchQuery = ref('')
+const filteredSessions = computed(() => {
+  const q = searchQuery.value.trim().toLowerCase()
+  if (!q) return store.sessions
+  return store.sessions.filter((s) =>
+    (s.title || getSessionPreview(s)).toLowerCase().includes(q)
+  )
+})
+const clearSearch = () => {
+  searchQuery.value = ''
+}
 
 onMounted(() => {
   folderStore.fetchFolders()
@@ -447,7 +513,7 @@ const handleSessionKeydown = (event: KeyboardEvent, session: ChatSession, index:
   switch (event.key) {
     case 'ArrowDown':
       event.preventDefault()
-      if (index < store.sessions.length - 1) {
+      if (index < filteredSessions.value.length - 1) {
         focusedIndex.value = index + 1
         nextTick(() => {
           sessionRefs.value[index + 1]?.focus()
@@ -475,9 +541,9 @@ const handleSessionKeydown = (event: KeyboardEvent, session: ChatSession, index:
 
     case 'End':
       event.preventDefault()
-      focusedIndex.value = store.sessions.length - 1
+      focusedIndex.value = filteredSessions.value.length - 1
       nextTick(() => {
-        sessionRefs.value[store.sessions.length - 1]?.focus()
+        sessionRefs.value[filteredSessions.value.length - 1]?.focus()
       })
       break
 

--- a/autobot-frontend/src/components/ui/Icon.vue
+++ b/autobot-frontend/src/components/ui/Icon.vue
@@ -324,6 +324,10 @@ export const ICONS = {
     'M9 16v-3l3-1v3m6 6H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z',
   'file-archive':
     'M12 7v1m0 3v1m0 3v1m6 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z',
+  archive:
+    'M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4',
+  'box-open':
+    'M21 8l-9-5-9 5m18 0l-9 5m9-5v8l-9 5m0-8L3 8m9 5v8M3 8v8l9 5',
 } as const
 
 export type IconName = keyof typeof ICONS

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -208,7 +208,9 @@
       "deletedWithFactsPreserved": "Deleted {count} chats (facts preserved in knowledge base)",
       "deletedSuccess": "Deleted {count} chats",
       "deleteFailed": "Failed to delete some chats",
-      "sharedSuccess": "Chat shared successfully"
+      "sharedSuccess": "Chat shared successfully",
+      "searchChats": "Search chats",
+      "noSearchResults": "No chats match your search"
     },
     "interface": {
       "loadFailed": "Failed to load chat interface",
@@ -691,7 +693,10 @@
       "unpin": "Unpin folder",
       "assignToFolder": "Move to folder",
       "removeFromFolder": "Remove from folder",
-      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root.",
+      "archive": "Archive folder",
+      "unarchive": "Unarchive folder",
+      "archived": "Archived"
     },
     "presets": {
       "modalTitle": "Slash Command Presets",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -208,7 +208,9 @@
       "deletedWithFactsPreserved": "Gelöschte {count}-Chats (Fakten bleiben in der Wissensdatenbank erhalten)",
       "deletedSuccess": "Gelöschte {count}-Chats",
       "deleteFailed": "Einige Chats konnten nicht gelöscht werden",
-      "sharedSuccess": "Chat erfolgreich geteilt"
+      "sharedSuccess": "Chat erfolgreich geteilt",
+      "searchChats": "Search chats",
+      "noSearchResults": "No chats match your search"
     },
     "interface": {
       "loadFailed": "Die Chat-Oberfläche konnte nicht geladen werden",
@@ -691,7 +693,10 @@
       "unpin": "Unpin folder",
       "assignToFolder": "Move to folder",
       "removeFromFolder": "Remove from folder",
-      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root.",
+      "archive": "Archive folder",
+      "unarchive": "Unarchive folder",
+      "archived": "Archived"
     },
     "presets": {
       "modalTitle": "Slash Command Presets",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -232,7 +232,9 @@
       "deletedWithFactsPreserved": "Deleted {count} chats (facts preserved in knowledge base)",
       "deletedSuccess": "Deleted {count} chats",
       "deleteFailed": "Failed to delete some chats",
-      "sharedSuccess": "Chat shared successfully"
+      "sharedSuccess": "Chat shared successfully",
+      "searchChats": "Search chats",
+      "noSearchResults": "No chats match your search"
     },
     "folders": {
       "folders": "Folders",
@@ -244,7 +246,10 @@
       "unpin": "Unpin folder",
       "assignToFolder": "Move to folder",
       "removeFromFolder": "Remove from folder",
-      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root.",
+      "archive": "Archive folder",
+      "unarchive": "Unarchive folder",
+      "archived": "Archived"
     },
     "interface": {
       "loadFailed": "Failed to load chat interface",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -208,7 +208,9 @@
       "deletedWithFactsPreserved": "Chats {count} eliminados (datos conservados en la base de conocimientos)",
       "deletedSuccess": "Chats {count} eliminados",
       "deleteFailed": "No se pudieron eliminar algunos chats",
-      "sharedSuccess": "Chat compartido exitosamente"
+      "sharedSuccess": "Chat compartido exitosamente",
+      "searchChats": "Search chats",
+      "noSearchResults": "No chats match your search"
     },
     "interface": {
       "loadFailed": "No se pudo cargar la interfaz de chat",
@@ -691,7 +693,10 @@
       "unpin": "Unpin folder",
       "assignToFolder": "Move to folder",
       "removeFromFolder": "Remove from folder",
-      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root.",
+      "archive": "Archive folder",
+      "unarchive": "Unarchive folder",
+      "archived": "Archived"
     },
     "presets": {
       "modalTitle": "Slash Command Presets",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -4911,7 +4911,9 @@
       "noSessions": "No chat sessions yet",
       "showSources": "Show Sources",
       "deletedWithFactsRemoved": "Deleted {count} chats and removed associated facts",
-      "deletedSuccess": "Deleted {count} chats"
+      "deletedSuccess": "Deleted {count} chats",
+      "searchChats": "Search chats",
+      "noSearchResults": "No chats match your search"
     },
     "overseer": {
       "copyCommand": "Copy command",
@@ -5440,7 +5442,10 @@
       "unpin": "Unpin folder",
       "assignToFolder": "Move to folder",
       "removeFromFolder": "Remove from folder",
-      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root.",
+      "archive": "Archive folder",
+      "unarchive": "Unarchive folder",
+      "archived": "Archived"
     },
     "presets": {
       "modalTitle": "Slash Command Presets",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -208,7 +208,9 @@
       "deletedWithFactsPreserved": "Chats {count} supprimés (faits conservés dans la base de connaissances)",
       "deletedSuccess": "Discussions {count} supprimées",
       "deleteFailed": "Échec de la suppression de certaines discussions",
-      "sharedSuccess": "Chat partagé avec succès"
+      "sharedSuccess": "Chat partagé avec succès",
+      "searchChats": "Search chats",
+      "noSearchResults": "No chats match your search"
     },
     "interface": {
       "loadFailed": "Échec du chargement de l'interface de discussion",
@@ -691,7 +693,10 @@
       "unpin": "Unpin folder",
       "assignToFolder": "Move to folder",
       "removeFromFolder": "Remove from folder",
-      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root.",
+      "archive": "Archive folder",
+      "unarchive": "Unarchive folder",
+      "archived": "Archived"
     },
     "presets": {
       "modalTitle": "Slash Command Presets",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -4911,7 +4911,9 @@
       "noSessions": "No chat sessions yet",
       "showSources": "Show Sources",
       "deletedWithFactsRemoved": "Deleted {count} chats and removed associated facts",
-      "deletedSuccess": "Deleted {count} chats"
+      "deletedSuccess": "Deleted {count} chats",
+      "searchChats": "Search chats",
+      "noSearchResults": "No chats match your search"
     },
     "overseer": {
       "copyCommand": "Copy command",
@@ -5440,7 +5442,10 @@
       "unpin": "Unpin folder",
       "assignToFolder": "Move to folder",
       "removeFromFolder": "Remove from folder",
-      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root.",
+      "archive": "Archive folder",
+      "unarchive": "Unarchive folder",
+      "archived": "Archived"
     },
     "presets": {
       "modalTitle": "Slash Command Presets",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -208,7 +208,9 @@
       "deletedWithFactsPreserved": "Izdzēstas {count} tērzēšanas sarunas (fakti saglabāti zināšanu bāzē)",
       "deletedSuccess": "Izdzēstas {count} tērzēšanas sarunas",
       "deleteFailed": "Neizdevās izdzēst dažas tērzēšanas sarunas",
-      "sharedSuccess": "Tērzēšana veiksmīgi kopīgota"
+      "sharedSuccess": "Tērzēšana veiksmīgi kopīgota",
+      "searchChats": "Search chats",
+      "noSearchResults": "No chats match your search"
     },
     "interface": {
       "loadFailed": "Neizdevās ielādēt tērzēšanas saskarni",
@@ -691,7 +693,10 @@
       "unpin": "Unpin folder",
       "assignToFolder": "Move to folder",
       "removeFromFolder": "Remove from folder",
-      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root.",
+      "archive": "Archive folder",
+      "unarchive": "Unarchive folder",
+      "archived": "Archived"
     },
     "presets": {
       "modalTitle": "Slash Command Presets",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -208,7 +208,9 @@
       "deletedWithFactsPreserved": "Usunięte czaty {count} (fakty zachowane w bazie wiedzy)",
       "deletedSuccess": "Usunięto czaty {count}",
       "deleteFailed": "Nie udało się usunąć niektórych czatów",
-      "sharedSuccess": "Czat został udostępniony"
+      "sharedSuccess": "Czat został udostępniony",
+      "searchChats": "Search chats",
+      "noSearchResults": "No chats match your search"
     },
     "interface": {
       "loadFailed": "Nie udało się załadować interfejsu czatu",
@@ -691,7 +693,10 @@
       "unpin": "Unpin folder",
       "assignToFolder": "Move to folder",
       "removeFromFolder": "Remove from folder",
-      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root.",
+      "archive": "Archive folder",
+      "unarchive": "Unarchive folder",
+      "archived": "Archived"
     },
     "presets": {
       "modalTitle": "Slash Command Presets",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -208,7 +208,9 @@
       "deletedWithFactsPreserved": "Bate-papos {count} excluídos (fatos preservados na base de conhecimento)",
       "deletedSuccess": "Bate-papos {count} excluídos",
       "deleteFailed": "Falha ao excluir alguns bate-papos",
-      "sharedSuccess": "Bate-papo compartilhado com sucesso"
+      "sharedSuccess": "Bate-papo compartilhado com sucesso",
+      "searchChats": "Search chats",
+      "noSearchResults": "No chats match your search"
     },
     "interface": {
       "loadFailed": "Falha ao carregar a interface de bate-papo",
@@ -691,7 +693,10 @@
       "unpin": "Unpin folder",
       "assignToFolder": "Move to folder",
       "removeFromFolder": "Remove from folder",
-      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root.",
+      "archive": "Archive folder",
+      "unarchive": "Unarchive folder",
+      "archived": "Archived"
     },
     "presets": {
       "modalTitle": "Slash Command Presets",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -4911,7 +4911,9 @@
       "noSessions": "No chat sessions yet",
       "showSources": "Show Sources",
       "deletedWithFactsRemoved": "Deleted {count} chats and removed associated facts",
-      "deletedSuccess": "Deleted {count} chats"
+      "deletedSuccess": "Deleted {count} chats",
+      "searchChats": "Search chats",
+      "noSearchResults": "No chats match your search"
     },
     "overseer": {
       "copyCommand": "Copy command",
@@ -5440,7 +5442,10 @@
       "unpin": "Unpin folder",
       "assignToFolder": "Move to folder",
       "removeFromFolder": "Remove from folder",
-      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root."
+      "confirmDelete": "Delete folder \"{name}\"? Subfolders will be moved to root.",
+      "archive": "Archive folder",
+      "unarchive": "Unarchive folder",
+      "archived": "Archived"
     },
     "presets": {
       "modalTitle": "Slash Command Presets",

--- a/autobot-frontend/src/stores/useFolderStore.ts
+++ b/autobot-frontend/src/stores/useFolderStore.ts
@@ -20,6 +20,7 @@ export interface ChatFolder {
   parent_id: string | null
   owner: string
   pinned: boolean
+  archived: boolean
   created_at: string
   session_ids: string[]
   session_count: number
@@ -34,6 +35,7 @@ export interface FolderUpdate {
   name?: string
   parent_id?: string | null
   pinned?: boolean
+  archived?: boolean
 }
 
 export const useFolderStore = defineStore('chatFolders', () => {
@@ -41,17 +43,24 @@ export const useFolderStore = defineStore('chatFolders', () => {
   const isLoading = ref(false)
   const error = ref<string | null>(null)
 
-  // Folders that have no parent (root level)
+  // Root-level folders shown in the main tree (archived folders excluded).
   const rootFolders = computed(() =>
-    folders.value.filter((f) => !f.parent_id).sort((a, b) => {
+    folders.value.filter((f) => !f.parent_id && !f.archived).sort((a, b) => {
       if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
       return a.name.localeCompare(b.name)
     })
   )
 
+  // Archived root-level folders, shown only in the dedicated "Archived" section.
+  const archivedFolders = computed(() =>
+    folders.value
+      .filter((f) => !f.parent_id && f.archived)
+      .sort((a, b) => a.name.localeCompare(b.name))
+  )
+
   function childrenOf(parentId: string): ChatFolder[] {
     return folders.value
-      .filter((f) => f.parent_id === parentId)
+      .filter((f) => f.parent_id === parentId && !f.archived)
       .sort((a, b) => a.name.localeCompare(b.name))
   }
 
@@ -153,9 +162,16 @@ export const useFolderStore = defineStore('chatFolders', () => {
     await updateFolder(id, { pinned: !folder.pinned })
   }
 
+  async function toggleArchive(id: string): Promise<void> {
+    const folder = folders.value.find((f) => f.id === id)
+    if (!folder) return
+    await updateFolder(id, { archived: !folder.archived })
+  }
+
   return {
     folders,
     rootFolders,
+    archivedFolders,
     isLoading,
     error,
     childrenOf,
@@ -166,5 +182,6 @@ export const useFolderStore = defineStore('chatFolders', () => {
     deleteFolder,
     assignSessionToFolder,
     togglePin,
+    toggleArchive,
   }
 })


### PR DESCRIPTION
## Thinking Path
Completes the two missing ACs of #8987 (conversation folders): folder CRUD/nesting/persistence + assign already existed; this adds **in-folder search** and **folder archive**.

## What Changed
- **Search** (`ChatSidebar.vue`): a labeled `type="search"` input (icon + clear) drives a `filteredSessions` computed (client-side title filter of the already-loaded sessions). It feeds the main list, the folder tree, AND the archived section — so chats inside folders (incl. archived) are searchable.
- **Archive** (`chat_folders.py` + `schemas_chat.py` + `useFolderStore.ts` + `ChatFolderNode.vue` + `ChatSidebar.vue`): `archived` bool on the Redis folder model; the existing `PUT /chat/folders/{id}` sets/clears it; an archive/unarchive action in the folder hover-row; archived folders are excluded from the main tree and shown in a collapsible "Archived (n)" section (hidden by default).
- i18n keys added to all 11 locales; `archive`/`box-open` icons added to the keyed `Icon` map.

## Verification
- Backend: `pytest tests/api/test_chat_folders.py` → 4 passed; black + py_compile clean.
- Frontend: `vue-tsc --noEmit` → 0 errors; `check:locales` complete; `check:i18n` clean.

## Model Used
Opus 4.8

Fixes #8987
