### PR TITLE
fix(llc): sprints.py create-tenant from validated parent + ConfigDict migration (#10261, #10262)

### DIFF
--- a/autobot-backend/llc/api/sprints.py
+++ b/autobot-backend/llc/api/sprints.py
@@ -35,7 +35,7 @@ from datetime import date, datetime
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -85,8 +85,7 @@ class PortfolioResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ProgramCreate(BaseModel):
@@ -113,8 +112,7 @@ class ProgramResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ProjectCreate(BaseModel):
@@ -156,8 +154,7 @@ class ProjectResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class SprintCreate(BaseModel):
@@ -202,8 +199,7 @@ class SprintResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class SprintCloseRequest(BaseModel):
@@ -328,7 +324,8 @@ async def create_program(
     if pf_row is None or str(pf_row.company_id) != str(ctx.org_id):
         raise HTTPException(status_code=404, detail="Portfolio not found")
     program = LLCProgram(
-        company_id=body.company_id,
+        # #10261: derive tenant from the validated parent, never trust body.company_id.
+        company_id=pf_row.company_id,
         portfolio_id=portfolio_id,
         name=body.name,
         description=body.description,
@@ -439,7 +436,8 @@ async def create_project(
     if prog is None or str(prog.company_id) != str(ctx.org_id):
         raise HTTPException(status_code=404, detail="Program not found")
     project = LLCProject(
-        company_id=body.company_id,
+        # #10261: derive tenant from the validated parent, never trust body.company_id.
+        company_id=prog.company_id,
         program_id=program_id,
         goal_id=body.goal_id,
         name=body.name,
@@ -543,7 +541,8 @@ async def create_sprint(
     if proj is None or str(proj.company_id) != str(ctx.org_id):
         raise HTTPException(status_code=404, detail="Project not found")
     sprint = LLCSprint(
-        company_id=body.company_id,
+        # #10261: derive tenant from the validated parent, never trust body.company_id.
+        company_id=proj.company_id,
         project_id=project_id,
         name=body.name,
         goal_description=body.goal_description,

--- a/autobot-backend/llc/tests/test_sprints_idor.py
+++ b/autobot-backend/llc/tests/test_sprints_idor.py
@@ -223,6 +223,10 @@ def _make_app(
             obj.committed_points = 0
         if not getattr(obj, "actual_points", None):
             obj.actual_points = 0
+        if getattr(obj, "capacity_points", None) is None:
+            obj.capacity_points = 0
+        if getattr(obj, "velocity_actual", None) is None:
+            obj.velocity_actual = 0
         if not getattr(obj, "pending_close_approval_id", None):
             obj.pending_close_approval_id = None
 
@@ -239,6 +243,11 @@ def _make_app(
     patch(
         "llc.services.work_product_service.WorkProductService.list_indexed_by_project",
         new=AsyncMock(return_value=[]),
+    ).start()
+    # create_project / create_sprint provision a per-entity KB collection (ChromaDB).
+    patch(
+        "llc.kb.collections.KbCollectionManager.ensure_collection",
+        new=AsyncMock(return_value=None),
     ).start()
 
     return TestClient(app, raise_server_exceptions=True)
@@ -334,3 +343,47 @@ class TestSprintsIdorTimeline:
         client = _make_app(caller_org_id=org, project_exists=False)
         resp = client.get(f"/projects/{uuid.uuid4()}/timeline")
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Tests: create endpoints ignore body.company_id (#10261 — defence-in-depth)
+# A caller may only create under a parent it owns; the child's company_id must
+# come from that validated parent, never from a caller-supplied body field.
+# ---------------------------------------------------------------------------
+
+
+class TestSprintsCreateIgnoresBodyCompanyId:
+    """#10261: body.company_id must not override the validated parent's tenant."""
+
+    def test_create_program_uses_parent_company_not_body(self):
+        caller = str(uuid.uuid4())
+        attacker = str(uuid.uuid4())
+        client = _make_app(caller_org_id=caller)  # parent portfolio owned by caller
+        resp = client.post(
+            f"/portfolios/{uuid.uuid4()}/programs",
+            json={"company_id": attacker, "name": "Injected"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["company_id"] == caller  # not attacker
+
+    def test_create_project_uses_parent_company_not_body(self):
+        caller = str(uuid.uuid4())
+        attacker = str(uuid.uuid4())
+        client = _make_app(caller_org_id=caller)  # parent program owned by caller
+        resp = client.post(
+            f"/programs/{uuid.uuid4()}/projects",
+            json={"company_id": attacker, "name": "Injected"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["company_id"] == caller
+
+    def test_create_sprint_uses_parent_company_not_body(self):
+        caller = str(uuid.uuid4())
+        attacker = str(uuid.uuid4())
+        client = _make_app(caller_org_id=caller)  # parent project owned by caller
+        resp = client.post(
+            f"/projects/{uuid.uuid4()}/sprints",
+            json={"company_id": attacker, "name": "Injected"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["company_id"] == caller


### PR DESCRIPTION
## Thinking Path
Two follow-ups from #10148 (sprints.py IDOR), both in `llc/api/sprints.py` so batched into one PR.

## What Changed
### #10261 — defence-in-depth: ignore body `company_id` on create
`create_program`/`create_project`/`create_sprint` validated that the **parent** belongs to `ctx.org_id`, then set `company_id=body.company_id` — a mismatched body could attribute the child to a different company than the caller's org. Now the child's `company_id` is derived from the already-validated parent entity (`pf_row`/`prog`/`proj.company_id`); the body field is ignored for tenant assignment.
- Adds 3 regression tests (`TestSprintsCreateIgnoresBodyCompanyId`) asserting a mismatched body `company_id` is overridden by the caller's org. Harness gains mocks for the per-entity KB-collection provisioning and sprint response fields.

### #10262 — Pydantic `class Config` → `ConfigDict`
Migrate the 4 response models (`Portfolio/Program/Project/SprintResponse`) from the deprecated `class Config: from_attributes = True` to `model_config = ConfigDict(from_attributes=True)`, clearing the per-collection deprecation warnings from sprints.py.

## Verification
- `pytest llc/tests/test_sprints_idor.py` → **12 passed** (9 existing IDOR + 3 new). flake8 = 0. py_compile clean.
- Confirmed no `class Config` / `body.company_id` remain in sprints.py; sprints.py no longer emits Pydantic deprecation warnings.

Closes #10261 · Closes #10262 · part of #9921

## Model Used
claude-opus-4-8