### PR TITLE
feat(transcriber/frontend): implement ProjectsView + ProjectDetailView — make the transcriber reachable in the GUI (#10289)

### DIFF
--- a/autobot-frontend/src/__tests__/transcriber/ProjectDetailView.test.ts
+++ b/autobot-frontend/src/__tests__/transcriber/ProjectDetailView.test.ts
@@ -1,0 +1,152 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { h } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import ProjectDetailView from '@/views/transcriber/ProjectDetailView.vue'
+
+// --- API mock ---------------------------------------------------------------
+const getProject = vi.fn()
+const listRecordings = vi.fn()
+const getRecording = vi.fn()
+const deleteRecording = vi.fn()
+
+vi.mock('@/composables/transcriber/useTranscriberApi', () => ({
+  useTranscriberApi: () => ({ getProject, listRecordings, getRecording, deleteRecording }),
+}))
+
+// --- router mock ------------------------------------------------------------
+const push = vi.fn()
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { projectId: '1' } }),
+  useRouter: () => ({ push }),
+}))
+
+// Stub child components — ProcessingProgress opens an EventSource (SSE),
+// UploadModal teleports; we only assert wiring here.
+const UploadModalStub = {
+  name: 'UploadModal',
+  props: ['projectId', 'open'],
+  emits: ['close', 'uploaded'],
+  setup() {
+    return () => h('div', { class: 'upload-modal-stub' })
+  },
+}
+const ProcessingProgressStub = {
+  name: 'ProcessingProgress',
+  props: ['recordingId'],
+  emits: ['complete', 'error'],
+  setup() {
+    return () => h('div', { class: 'processing-progress-stub' })
+  },
+}
+
+function recording(id: number, status: string, extra: Record<string, unknown> = {}) {
+  return {
+    id,
+    project_id: 1,
+    filename: `rec-${id}.mp3`,
+    duration: 65,
+    status,
+    speaker_count: 0,
+    process_seconds: null,
+    engine_used: null,
+    language_detected: null,
+    uploaded_at: '2026-01-02T00:00:00Z',
+    failure_stage: null,
+    failure_reason: null,
+    ...extra,
+  }
+}
+
+function mountView() {
+  return mount(ProjectDetailView, {
+    global: {
+      plugins: [createPinia()],
+      stubs: { UploadModal: UploadModalStub, ProcessingProgress: ProcessingProgressStub },
+    },
+  })
+}
+
+describe('ProjectDetailView.vue', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    getProject.mockResolvedValue({ id: 1, name: 'Interviews', description: 'Q3', created_at: '', user_id: 'u1' })
+    listRecordings.mockResolvedValue([recording(10, 'complete'), recording(11, 'processing')])
+    getRecording.mockResolvedValue(recording(11, 'complete'))
+    deleteRecording.mockResolvedValue(undefined)
+    push.mockClear()
+  })
+
+  it('loads the project and its recordings', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(getProject).toHaveBeenCalledWith(1)
+    expect(listRecordings).toHaveBeenCalledWith(1)
+    expect(wrapper.text()).toContain('Interviews')
+    expect(wrapper.findAll('.recording-card')).toHaveLength(2)
+  })
+
+  it('renders ProcessingProgress only for in-progress recordings', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    // recording 11 is "processing" → one progress bar.
+    expect(wrapper.findAllComponents(ProcessingProgressStub)).toHaveLength(1)
+  })
+
+  it('formats duration as m:ss', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    expect(wrapper.text()).toContain('1:05')
+  })
+
+  it('navigates to the transcript for a complete recording', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    // The first card (recording 10, complete) has an enabled "View transcript".
+    const viewBtn = wrapper.findAll('.recording-card')[0].find('.recording-actions .btn')
+    expect(viewBtn.attributes('disabled')).toBeUndefined()
+    await viewBtn.trigger('click')
+
+    expect(push).toHaveBeenCalledWith({
+      name: 'transcriber-transcript',
+      params: { projectId: '1', recordingId: '10' },
+    })
+  })
+
+  it('disables "View transcript" while a recording is still processing', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    const processingBtn = wrapper.findAll('.recording-card')[1].find('.recording-actions .btn')
+    expect(processingBtn.attributes('disabled')).toBeDefined()
+  })
+
+  it('prepends an uploaded recording to the list', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findComponent(UploadModalStub).vm.$emit('uploaded', recording(99, 'pending'))
+    await flushPromises()
+
+    const cards = wrapper.findAll('.recording-card')
+    expect(cards).toHaveLength(3)
+    expect(cards[0].text()).toContain('rec-99.mp3')
+  })
+
+  it('refreshes a recording when processing completes', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findComponent(ProcessingProgressStub).vm.$emit('complete')
+    await flushPromises()
+
+    expect(getRecording).toHaveBeenCalledWith(11)
+  })
+})

--- a/autobot-frontend/src/__tests__/transcriber/ProjectsView.test.ts
+++ b/autobot-frontend/src/__tests__/transcriber/ProjectsView.test.ts
@@ -1,0 +1,113 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ProjectsView from '@/views/transcriber/ProjectsView.vue'
+
+// --- API mock ---------------------------------------------------------------
+const listProjects = vi.fn()
+const createProject = vi.fn()
+const deleteProject = vi.fn()
+
+// mockReset:true wipes factories — re-apply implementations in beforeEach.
+vi.mock('@/composables/transcriber/useTranscriberApi', () => ({
+  useTranscriberApi: () => ({ listProjects, createProject, deleteProject }),
+}))
+
+// --- router mock ------------------------------------------------------------
+const push = vi.fn()
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}))
+
+function project(id: number, name: string, description = '') {
+  return { id, name, description, created_at: '2026-01-02T00:00:00Z', user_id: 'u1' }
+}
+
+function mountView() {
+  return mount(ProjectsView, { global: { plugins: [createPinia()] } })
+}
+
+describe('ProjectsView.vue', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    listProjects.mockResolvedValue([project(1, 'Interviews', 'Q3'), project(2, 'Standups')])
+    createProject.mockResolvedValue(project(3, 'New one'))
+    deleteProject.mockResolvedValue(undefined)
+    push.mockClear()
+  })
+
+  it('loads and renders the project list', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(listProjects).toHaveBeenCalled()
+    const cards = wrapper.findAll('.project-card')
+    expect(cards).toHaveLength(2)
+    expect(wrapper.text()).toContain('Interviews')
+    expect(wrapper.text()).toContain('Standups')
+  })
+
+  it('shows the empty state when there are no projects', async () => {
+    listProjects.mockResolvedValue([])
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.find('.project-card').exists()).toBe(false)
+    expect(wrapper.text()).toContain('No projects yet')
+  })
+
+  it('shows an error state and can retry', async () => {
+    listProjects.mockRejectedValueOnce(new Error('boom'))
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.find('.projects-error').exists()).toBe(true)
+    listProjects.mockResolvedValue([project(1, 'Interviews')])
+    await wrapper.find('.projects-error button').trigger('click')
+    await flushPromises()
+    expect(wrapper.findAll('.project-card')).toHaveLength(1)
+  })
+
+  it('creates a project and navigates to its detail view', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('.projects-header .btn-primary').trigger('click') // open form
+    await wrapper.find('.project-form-field input').setValue('New one')
+    await wrapper.find('.project-form').trigger('submit')
+    await flushPromises()
+
+    expect(createProject).toHaveBeenCalledWith('New one', '')
+    expect(push).toHaveBeenCalledWith({
+      name: 'transcriber-project-detail',
+      params: { projectId: '3' },
+    })
+  })
+
+  it('does not submit an empty project name', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('.projects-header .btn-primary').trigger('click')
+    await wrapper.find('.project-form').trigger('submit')
+    await flushPromises()
+
+    expect(createProject).not.toHaveBeenCalled()
+    expect(wrapper.find('.project-form-error').text()).toContain('required')
+  })
+
+  it('navigates to a project when its card is clicked', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('.project-card .project-card-main').trigger('click')
+    expect(push).toHaveBeenCalledWith({
+      name: 'transcriber-project-detail',
+      params: { projectId: '1' },
+    })
+  })
+})

--- a/autobot-frontend/src/views/transcriber/ProjectDetailView.vue
+++ b/autobot-frontend/src/views/transcriber/ProjectDetailView.vue
@@ -1,6 +1,326 @@
 <!-- AutoBot - AI-Powered Automation Platform -->
-<!-- Copyright (c) 2025 mrveiss -->
+<!-- Copyright (c) 2025-2026 mrveiss -->
 <script setup lang="ts">
-// Implemented in Plan 4
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import UploadModal from '@/components/transcriber/UploadModal.vue'
+import ProcessingProgress from '@/components/transcriber/ProcessingProgress.vue'
+import {
+  useTranscriberApi,
+  type Project,
+  type Recording,
+} from '@/composables/transcriber/useTranscriberApi'
+import { useTranscriberStore } from '@/stores/transcriber/useTranscriberStore'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('TranscriberProjectDetailView')
+
+const route = useRoute()
+const router = useRouter()
+const api = useTranscriberApi()
+const store = useTranscriberStore()
+
+const projectId = computed(() => Number(route.params.projectId))
+
+const project = ref<Project | null>(null)
+const recordings = ref<Recording[]>([])
+const loading = ref(true)
+const error = ref<string | null>(null)
+const uploadOpen = ref(false)
+
+async function loadRecordings() {
+  const list = await api.listRecordings(projectId.value)
+  recordings.value = list
+  store.setRecordings(list)
+}
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    project.value = await api.getProject(projectId.value)
+    store.setActiveProject(project.value)
+    await loadRecordings()
+  } catch (err) {
+    logger.error('Failed to load project', err)
+    error.value = 'Failed to load this project.'
+  } finally {
+    loading.value = false
+  }
+}
+
+function onUploaded(recording: Recording) {
+  // Surface the new recording immediately; ProcessingProgress drives it to done.
+  recordings.value = [recording, ...recordings.value]
+  store.setRecordings(recordings.value)
+}
+
+// A recording finished (or failed) processing — refresh its row from the server.
+async function onProcessingSettled(recordingId: number) {
+  try {
+    const fresh = await api.getRecording(recordingId)
+    const idx = recordings.value.findIndex((r) => r.id === recordingId)
+    if (idx !== -1) recordings.value[idx] = fresh
+  } catch (err) {
+    logger.warn('Failed to refresh recording after processing', err)
+  }
+}
+
+async function deleteRecording(recording: Recording) {
+  if (!window.confirm(`Delete recording "${recording.filename}"?`)) return
+  try {
+    await api.deleteRecording(recording.id)
+    recordings.value = recordings.value.filter((r) => r.id !== recording.id)
+    store.setRecordings(recordings.value)
+  } catch (err) {
+    logger.error('Failed to delete recording', err)
+    error.value = 'Failed to delete recording.'
+  }
+}
+
+function openTranscript(recording: Recording) {
+  router.push({
+    name: 'transcriber-transcript',
+    params: { projectId: String(projectId.value), recordingId: String(recording.id) },
+  })
+}
+
+function backToProjects() {
+  router.push({ name: 'transcriber-projects' })
+}
+
+function isInProgress(r: Recording): boolean {
+  return r.status === 'pending' || r.status === 'processing'
+}
+
+function formatDuration(seconds: number | null): string {
+  if (seconds === null || Number.isNaN(seconds)) return '—'
+  const total = Math.round(seconds)
+  const mins = Math.floor(total / 60)
+  const secs = total % 60
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString()
+}
+
+// Re-load when navigating directly between sibling project routes.
+watch(projectId, (next, prev) => {
+  if (next !== prev) load()
+})
+
+onMounted(load)
 </script>
-<template><div class="project-detail-view">Project Detail — coming in Plan 4</div></template>
+
+<template>
+  <div class="project-detail-view">
+    <header class="project-detail-header">
+      <div class="project-detail-heading">
+        <button type="button" class="btn btn-sm" @click="backToProjects">← Projects</button>
+        <h1 class="project-detail-title">{{ project?.name ?? 'Project' }}</h1>
+      </div>
+      <button type="button" class="btn btn-primary" :disabled="!project" @click="uploadOpen = true">
+        Upload recording
+      </button>
+    </header>
+
+    <p v-if="project?.description" class="project-detail-desc">{{ project.description }}</p>
+
+    <div v-if="loading" class="recordings-state">Loading recordings…</div>
+
+    <div v-else-if="error" class="recordings-state recordings-error">
+      <p>{{ error }}</p>
+      <button type="button" class="btn btn-sm" @click="load">Retry</button>
+    </div>
+
+    <div v-else-if="!recordings.length" class="recordings-state">
+      <p>No recordings yet.</p>
+      <p>Upload an audio or video file to start transcribing.</p>
+    </div>
+
+    <ul v-else class="recordings-list">
+      <li v-for="recording in recordings" :key="recording.id" class="recording-card">
+        <div class="recording-main">
+          <span class="recording-filename">{{ recording.filename }}</span>
+          <span class="recording-meta">
+            <span class="recording-status" :class="`recording-status-${recording.status}`">
+              {{ recording.status }}
+            </span>
+            <span>{{ formatDuration(recording.duration) }}</span>
+            <span>{{ formatDate(recording.uploaded_at) }}</span>
+          </span>
+
+          <ProcessingProgress
+            v-if="isInProgress(recording)"
+            :recording-id="recording.id"
+            class="recording-progress"
+            @complete="onProcessingSettled(recording.id)"
+            @error="onProcessingSettled(recording.id)"
+          />
+
+          <span
+            v-else-if="recording.status === 'error'"
+            class="recording-failure"
+          >
+            {{ recording.failure_reason || 'Transcription failed.' }}
+          </span>
+        </div>
+
+        <div class="recording-actions">
+          <button
+            type="button"
+            class="btn btn-sm"
+            :disabled="recording.status !== 'complete'"
+            @click="openTranscript(recording)"
+          >
+            View transcript
+          </button>
+          <button
+            type="button"
+            class="btn-icon"
+            :aria-label="`Delete recording ${recording.filename}`"
+            @click="deleteRecording(recording)"
+          >
+            ✕
+          </button>
+        </div>
+      </li>
+    </ul>
+
+    <UploadModal
+      v-if="project"
+      :project-id="projectId"
+      :open="uploadOpen"
+      @close="uploadOpen = false"
+      @uploaded="onUploaded"
+    />
+  </div>
+</template>
+
+<style scoped>
+.project-detail-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.project-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.project-detail-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.project-detail-title {
+  margin: 0;
+  font-size: var(--text-2xl, 1.5rem);
+  font-weight: var(--font-medium, 600);
+  color: var(--text-primary);
+}
+
+.project-detail-desc {
+  margin: 0;
+  color: var(--text-secondary, #6b7280);
+}
+
+.recordings-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 2rem;
+  color: var(--text-secondary, #6b7280);
+  text-align: center;
+}
+
+.recordings-error {
+  color: var(--color-danger-600, #dc2626);
+}
+
+.recordings-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.recording-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 0.5rem;
+  background: var(--bg-primary, #fff);
+}
+
+.recording-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.recording-filename {
+  font-weight: var(--font-medium, 600);
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.recording-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--text-tertiary, #9ca3af);
+}
+
+.recording-status {
+  text-transform: capitalize;
+  font-weight: var(--font-medium, 600);
+}
+
+.recording-status-complete {
+  color: var(--color-success-600, #16a34a);
+}
+
+.recording-status-processing,
+.recording-status-pending {
+  color: var(--color-warning-600, #d97706);
+}
+
+.recording-status-error {
+  color: var(--color-danger-600, #dc2626);
+}
+
+.recording-progress {
+  margin-top: 0.25rem;
+}
+
+.recording-failure {
+  font-size: var(--text-sm, 0.875rem);
+  color: var(--color-danger-600, #dc2626);
+}
+
+.recording-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+</style>

--- a/autobot-frontend/src/views/transcriber/ProjectsView.vue
+++ b/autobot-frontend/src/views/transcriber/ProjectsView.vue
@@ -1,6 +1,283 @@
 <!-- AutoBot - AI-Powered Automation Platform -->
-<!-- Copyright (c) 2025 mrveiss -->
+<!-- Copyright (c) 2025-2026 mrveiss -->
 <script setup lang="ts">
-// Implemented in Plan 4
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useTranscriberApi, type Project } from '@/composables/transcriber/useTranscriberApi'
+import { useTranscriberStore } from '@/stores/transcriber/useTranscriberStore'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('TranscriberProjectsView')
+
+const router = useRouter()
+const api = useTranscriberApi()
+const store = useTranscriberStore()
+
+const projects = ref<Project[]>([])
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+// New-project form state.
+const creating = ref(false)
+const newName = ref('')
+const newDescription = ref('')
+const saving = ref(false)
+const formError = ref<string | null>(null)
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    const list = await api.listProjects()
+    projects.value = list
+    store.setProjects(list)
+  } catch (err) {
+    logger.error('Failed to load projects', err)
+    error.value = 'Failed to load projects.'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function createProject() {
+  const name = newName.value.trim()
+  if (!name) {
+    formError.value = 'Project name is required.'
+    return
+  }
+  saving.value = true
+  formError.value = null
+  try {
+    const project = await api.createProject(name, newDescription.value.trim())
+    newName.value = ''
+    newDescription.value = ''
+    creating.value = false
+    await load()
+    openProject(project.id)
+  } catch (err) {
+    logger.error('Failed to create project', err)
+    formError.value = 'Failed to create project.'
+  } finally {
+    saving.value = false
+  }
+}
+
+async function deleteProject(project: Project) {
+  if (!window.confirm(`Delete project "${project.name}" and all its recordings?`)) return
+  try {
+    await api.deleteProject(project.id)
+    await load()
+  } catch (err) {
+    logger.error('Failed to delete project', err)
+    error.value = 'Failed to delete project.'
+  }
+}
+
+function openProject(projectId: number) {
+  router.push({ name: 'transcriber-project-detail', params: { projectId: String(projectId) } })
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleDateString()
+}
+
+onMounted(load)
 </script>
-<template><div class="projects-view">Projects — coming in Plan 4</div></template>
+
+<template>
+  <div class="projects-view">
+    <header class="projects-header">
+      <h1 class="projects-title">Transcriber projects</h1>
+      <button type="button" class="btn btn-primary" @click="creating = !creating">
+        {{ creating ? 'Cancel' : 'New project' }}
+      </button>
+    </header>
+
+    <form v-if="creating" class="project-form" @submit.prevent="createProject">
+      <label class="project-form-field">
+        <span>Name</span>
+        <input
+          v-model="newName"
+          type="text"
+          maxlength="120"
+          placeholder="e.g. Q3 customer interviews"
+        />
+      </label>
+      <label class="project-form-field">
+        <span>Description <em>(optional)</em></span>
+        <input
+          v-model="newDescription"
+          type="text"
+          maxlength="500"
+          placeholder="Short description"
+        />
+      </label>
+      <p v-if="formError" class="project-form-error">{{ formError }}</p>
+      <div class="project-form-actions">
+        <button type="submit" class="btn btn-primary" :disabled="saving">
+          {{ saving ? 'Creating…' : 'Create project' }}
+        </button>
+      </div>
+    </form>
+
+    <div v-if="loading" class="projects-state">Loading projects…</div>
+
+    <div v-else-if="error" class="projects-state projects-error">
+      <p>{{ error }}</p>
+      <button type="button" class="btn btn-sm" @click="load">Retry</button>
+    </div>
+
+    <div v-else-if="!projects.length" class="projects-state">
+      <p>No projects yet.</p>
+      <p>Create a project to upload audio or video and get a diarized transcript.</p>
+    </div>
+
+    <ul v-else class="projects-list">
+      <li v-for="project in projects" :key="project.id" class="project-card">
+        <button type="button" class="project-card-main" @click="openProject(project.id)">
+          <span class="project-card-name">{{ project.name }}</span>
+          <span v-if="project.description" class="project-card-desc">{{ project.description }}</span>
+          <span class="project-card-meta">Created {{ formatDate(project.created_at) }}</span>
+        </button>
+        <button
+          type="button"
+          class="btn-icon project-card-delete"
+          :aria-label="`Delete project ${project.name}`"
+          @click="deleteProject(project)"
+        >
+          ✕
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.projects-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.projects-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.projects-title {
+  margin: 0;
+  font-size: var(--text-2xl, 1.5rem);
+  font-weight: var(--font-medium, 600);
+  color: var(--text-primary);
+}
+
+.project-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 0.5rem;
+  background: var(--bg-secondary, #f9fafb);
+}
+
+.project-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: var(--text-sm, 0.875rem);
+  color: var(--text-secondary, #6b7280);
+}
+
+.project-form-field input {
+  padding: 0.5rem;
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 0.375rem;
+  background: var(--bg-primary, #fff);
+  color: var(--text-primary);
+}
+
+.project-form-error {
+  margin: 0;
+  color: var(--color-danger-600, #dc2626);
+  font-size: var(--text-sm, 0.875rem);
+}
+
+.project-form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.projects-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 2rem;
+  color: var(--text-secondary, #6b7280);
+  text-align: center;
+}
+
+.projects-error {
+  color: var(--color-danger-600, #dc2626);
+}
+
+.projects-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.project-card {
+  display: flex;
+  align-items: stretch;
+  gap: 0.5rem;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 0.5rem;
+  background: var(--bg-primary, #fff);
+}
+
+.project-card-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding: 0.75rem 1rem;
+  background: transparent;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+}
+
+.project-card-main:hover {
+  background: var(--bg-hover, #f3f4f6);
+}
+
+.project-card-name {
+  font-weight: var(--font-medium, 600);
+  color: var(--text-primary);
+}
+
+.project-card-desc {
+  font-size: var(--text-sm, 0.875rem);
+  color: var(--text-secondary, #6b7280);
+}
+
+.project-card-meta {
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--text-tertiary, #9ca3af);
+}
+
+.project-card-delete {
+  align-self: center;
+  margin-right: 0.5rem;
+}
+</style>


### PR DESCRIPTION
## Thinking Path
The transcriber backend pipeline (#10128), TranscriptView + waveform (#10129), and cloud ASR selection (#10147) all shipped, but the two **entry/navigation views were left as `coming in Plan 4` stubs**. So clicking **Transcriber** in the nav landed on a dead placeholder — no way to create a project, upload a recording, or reach the working `TranscriptView`. The entire built stack was unreachable from the GUI (#10289). An api-wiring audit confirmed the backend is fully mounted (`/api/transcriber/*`) and only these two views were missing.

## What Changed
- **`ProjectsView.vue`** (the `/transcriber` landing): lists projects (`listProjects`), inline create form (`createProject` → navigates into the new project), delete with confirm (`deleteProject`), click-through to a project. Loading / empty / error(+retry) states.
- **`ProjectDetailView.vue`** (`projects/:projectId`): lists recordings (`listRecordings`), **upload** via the existing `UploadModal`, live per-recording status with `ProcessingProgress` (SSE) for pending/processing rows, failure reason for errors, delete, and "View transcript" → `transcriber-transcript` (enabled only when complete). Back-link to projects; duration/date formatting; loading / empty / error states.

Both views compose existing components (`UploadModal`, `ProcessingProgress`) and the `useTranscriberStore`, and call only `useTranscriberApi` methods that already map to mounted backend routes — **no new API surface, no wiring risk**. Plain-English strings match the module's existing `TranscriptView` style (avoids locale-parity churn across 11 locales).

## Verification
- `npx vue-tsc --noEmit -p tsconfig.app.json` → **0 errors in the new views**.
- `eslint` on all 4 new files → 0.
- New tests `src/__tests__/transcriber/{ProjectsView,ProjectDetailView}.test.ts` (13 tests: load/empty/error/retry, create→navigate, card→navigate, upload-prepend, status-gated 'View transcript', processing→refresh). **Full transcriber suite: 64 passed.**
- Wiring: every call resolves to an existing mounted route (`projects` CRUD, `projects/{id}/recordings`, `recordings/{id}`); backend confirmed registered in `core_routers.py`.

## End-to-end flow now reachable
Transcriber nav → Projects (create) → Project detail (upload → live progress) → completed recording → TranscriptView (waveform + diarized segments + edit/export/ASR-tier).

## Model Used
Claude Opus 4.8 (main session)

Closes #10289. Part of transcriber umbrella #9925.