### PR TITLE
feat(search): WebSearchProvider abstraction + SearXNG and Brave backends (#9022, #9023)

### DIFF
--- a/autobot-backend/agent_loop/search/__init__.py
+++ b/autobot-backend/agent_loop/search/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Pluggable web-search provider abstraction for agent research.
+
+Mirrors the ``llm_shared`` provider-registry idiom (registration,
+credential-gating, fallback chain, ``get_provider``) for web search.
+
+Issues #9022 (SearXNG self-hosted backend) and #9023 (Brave Search API).
+"""
+
+from agent_loop.search.base import SearchResult, WebSearchProvider
+from agent_loop.search.registry import (
+    SearchProviderRegistry,
+    get_search_registry,
+    search as registry_search,
+)
+
+__all__ = [
+    "SearchResult",
+    "WebSearchProvider",
+    "SearchProviderRegistry",
+    "get_search_registry",
+    "registry_search",
+]

--- a/autobot-backend/agent_loop/search/__init__.py
+++ b/autobot-backend/agent_loop/search/__init__.py
@@ -14,8 +14,8 @@ from agent_loop.search.base import SearchResult, WebSearchProvider
 from agent_loop.search.registry import (
     SearchProviderRegistry,
     get_search_registry,
-    search as registry_search,
 )
+from agent_loop.search.registry import search as registry_search
 
 __all__ = [
     "SearchResult",

--- a/autobot-backend/agent_loop/search/base.py
+++ b/autobot-backend/agent_loop/search/base.py
@@ -1,0 +1,87 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Base contract for pluggable web-search providers.
+
+A ``WebSearchProvider`` turns a search request into a normalized list of
+``SearchResult`` objects. Concrete providers (SearXNG #9022, Brave #9023)
+subclass this and implement ``search`` / ``is_available``.
+
+Mirrors ``llm_shared.base_provider.BaseProvider``: a ``provider_name`` class
+attribute, settings-dict constructor, and an async availability probe used by
+the registry for credential-gating and fallback.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+# Search result categories mapped onto backend-specific engines/endpoints.
+CATEGORY_GENERAL = "general"
+CATEGORY_NEWS = "news"
+CATEGORY_CODE = "code"
+CATEGORY_ACADEMIC = "academic"
+
+DEFAULT_RESULT_COUNT = 10
+
+
+@dataclass
+class SearchResult:
+    """One normalized web-search hit shared across all providers."""
+
+    title: str
+    url: str
+    snippet: str = ""
+    freshness: Optional[str] = None
+    source: Optional[str] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a plain dict (matches the {title,url,snippet} seam shape)."""
+        data: Dict[str, Any] = {"title": self.title, "url": self.url, "snippet": self.snippet}
+        if self.freshness:
+            data["freshness"] = self.freshness
+        if self.source:
+            data["source"] = self.source
+        return data
+
+
+class WebSearchProvider(ABC):
+    """Abstract async web-search backend.
+
+    Subclasses set ``provider_name`` and implement ``search`` + ``is_available``.
+    The settings dict carries credentials/instance URLs (never hard-coded).
+    """
+
+    provider_name: str = "base"
+
+    def __init__(self, settings: Optional[Dict[str, Any]] = None) -> None:
+        """Store provider settings (credentials, instance URL, options)."""
+        self.settings: Dict[str, Any] = settings or {}
+
+    def _get_setting(self, key: str, default: Any = None) -> Any:
+        """Safe settings access mirroring ``BaseProvider._get_setting``."""
+        return self.settings.get(key, default)
+
+    @abstractmethod
+    async def search(
+        self,
+        query: str,
+        *,
+        category: Optional[str] = None,
+        count: int = DEFAULT_RESULT_COUNT,
+    ) -> List[SearchResult]:
+        """Run a search and return normalized results.
+
+        Implementations must raise on unreachable/error so the registry can
+        fall back. Returning ``[]`` means "reachable, no results" (no fallback).
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def is_available(self) -> bool:
+        """Return True when this provider is configured and usable."""
+        raise NotImplementedError

--- a/autobot-backend/agent_loop/search/brave_provider.py
+++ b/autobot-backend/agent_loop/search/brave_provider.py
@@ -1,0 +1,108 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Brave Search API provider (#9023).
+
+Independent search index for agent research diversity. Uses the REST API with
+an ``X-Subscription-Token`` header (key from the secrets/config system). Web and
+News endpoints are supported; 429/quota errors are surfaced as ``RuntimeError``
+so the registry can fall back gracefully. Credential-gated: empty key = disabled.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from agent_loop.search.base import (
+    CATEGORY_NEWS,
+    DEFAULT_RESULT_COUNT,
+    SearchResult,
+    WebSearchProvider,
+)
+from autobot_shared.http_client import get_http_client
+
+logger = logging.getLogger(__name__)
+
+_WEB_ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
+_NEWS_ENDPOINT = "https://api.search.brave.com/res/v1/news/search"
+_REQUEST_TIMEOUT_S = 15
+
+
+class BraveSearchProvider(WebSearchProvider):
+    """Search backend backed by the Brave Search API."""
+
+    provider_name = "brave"
+
+    def __init__(self, settings: Optional[Dict[str, Any]] = None) -> None:
+        """Init from settings: ``api_key`` (required, from secrets/config)."""
+        super().__init__(settings)
+        self.api_key: str = str(self._get_setting("api_key", ""))
+
+    async def is_available(self) -> bool:
+        """Available when an API key is configured."""
+        return bool(self.api_key)
+
+    def _build_headers(self) -> Dict[str, str]:
+        """Brave auth + JSON accept headers."""
+        return {
+            "Accept": "application/json",
+            "X-Subscription-Token": self.api_key,
+        }
+
+    @staticmethod
+    def _endpoint_for(category: Optional[str]) -> str:
+        """Route news searches to the News endpoint, else Web."""
+        if category == CATEGORY_NEWS:
+            return _NEWS_ENDPOINT
+        return _WEB_ENDPOINT
+
+    async def search(
+        self,
+        query: str,
+        *,
+        category: Optional[str] = None,
+        count: int = DEFAULT_RESULT_COUNT,
+    ) -> List[SearchResult]:
+        """Query Brave; raise on quota/error so the registry can fall back."""
+        if not self.api_key:
+            raise RuntimeError("Brave Search api_key not configured")
+
+        endpoint = self._endpoint_for(category)
+        params = {"q": query, "count": str(count)}
+        timeout = aiohttp.ClientTimeout(total=_REQUEST_TIMEOUT_S)
+        client = get_http_client()
+        async with await client.get(
+            endpoint, params=params, headers=self._build_headers(), timeout=timeout
+        ) as resp:
+            if resp.status == 429:
+                raise RuntimeError("Brave Search rate-limited (HTTP 429)")
+            if resp.status != 200:
+                body = await resp.text()
+                raise RuntimeError(f"Brave Search HTTP {resp.status}: {body[:200]}")
+            data = await resp.json()
+
+        return self._normalize(data, category, count)
+
+    def _normalize(self, data: Dict[str, Any], category: Optional[str], count: int) -> List[SearchResult]:
+        """Normalize Brave web/news payloads into SearchResult objects."""
+        if category == CATEGORY_NEWS:
+            items = data.get("results", [])
+        else:
+            items = (data.get("web") or {}).get("results", [])
+        return [self._to_result(item) for item in items[:count]]
+
+    @staticmethod
+    def _to_result(item: Dict[str, Any]) -> SearchResult:
+        """Map one Brave result item to a normalized SearchResult."""
+        meta = item.get("meta_url") or {}
+        return SearchResult(
+            title=item.get("title", "") or "",
+            url=item.get("url", "") or "",
+            snippet=item.get("description", "") or "",
+            freshness=item.get("age") or item.get("page_age"),
+            source=meta.get("hostname"),
+        )

--- a/autobot-backend/agent_loop/search/brave_provider.py
+++ b/autobot-backend/agent_loop/search/brave_provider.py
@@ -75,9 +75,7 @@ class BraveSearchProvider(WebSearchProvider):
         params = {"q": query, "count": str(count)}
         timeout = aiohttp.ClientTimeout(total=_REQUEST_TIMEOUT_S)
         client = get_http_client()
-        async with await client.get(
-            endpoint, params=params, headers=self._build_headers(), timeout=timeout
-        ) as resp:
+        async with await client.get(endpoint, params=params, headers=self._build_headers(), timeout=timeout) as resp:
             if resp.status == 429:
                 raise RuntimeError("Brave Search rate-limited (HTTP 429)")
             if resp.status != 200:

--- a/autobot-backend/agent_loop/search/registry.py
+++ b/autobot-backend/agent_loop/search/registry.py
@@ -1,0 +1,154 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Web-search provider registry with selection + graceful fallback.
+
+Mirrors ``llm_shared.provider_registry``: providers self-register, the registry
+applies credential-gating (only registers configured providers) and a fallback
+chain so an unreachable/erroring provider degrades to the next one. Both #9022
+and #9023 require graceful fallback to the default provider.
+
+Auto-population reads credentials/instance URLs from ``autobot_shared.ssot_config``
+(empty/unset = provider disabled).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Dict, List, Optional
+
+from agent_loop.search.base import DEFAULT_RESULT_COUNT, SearchResult, WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+
+class SearchProviderRegistry:
+    """Registry of web-search providers with an ordered fallback chain."""
+
+    def __init__(self) -> None:
+        """Create an empty registry."""
+        self._providers: Dict[str, WebSearchProvider] = {}
+        self._fallback_chain: List[str] = []
+
+    def register(self, provider: WebSearchProvider) -> None:
+        """Register a provider and append it to the fallback chain."""
+        name = provider.provider_name
+        if name in self._providers:
+            logger.warning("Replacing existing search provider: %s", name)
+        else:
+            self._fallback_chain.append(name)
+        self._providers[name] = provider
+
+    def get_provider(self, name: str) -> Optional[WebSearchProvider]:
+        """Return a registered provider by name (or None)."""
+        return self._providers.get(name)
+
+    def list_providers(self) -> List[str]:
+        """Return registered provider names in fallback order."""
+        return list(self._fallback_chain)
+
+    def _ordered_candidates(self, preferred: Optional[str]) -> List[WebSearchProvider]:
+        """Build the try-order: preferred first, then the fallback chain."""
+        order: List[str] = []
+        if preferred and preferred in self._providers:
+            order.append(preferred)
+        for name in self._fallback_chain:
+            if name not in order:
+                order.append(name)
+        return [self._providers[name] for name in order]
+
+    async def search(
+        self,
+        query: str,
+        *,
+        provider: Optional[str] = None,
+        category: Optional[str] = None,
+        count: int = DEFAULT_RESULT_COUNT,
+    ) -> List[SearchResult]:
+        """Search via the selected provider, falling back on error.
+
+        Returns ``[]`` when no provider is configured or all candidates fail.
+        A provider that returns ``[]`` (reachable, zero hits) is accepted as-is.
+        """
+        candidates = self._ordered_candidates(provider)
+        if not candidates:
+            logger.debug("No web-search provider configured; returning no results")
+            return []
+
+        last_error: Optional[Exception] = None
+        for candidate in candidates:
+            if not await candidate.is_available():
+                continue
+            try:
+                return await candidate.search(query, category=category, count=count)
+            except Exception as exc:  # graceful fallback to the next provider
+                last_error = exc
+                logger.warning(
+                    "Search provider %s failed (%s); trying fallback",
+                    candidate.provider_name,
+                    exc,
+                )
+        if last_error:
+            logger.error("All web-search providers failed; last error: %s", last_error)
+        return []
+
+
+_registry: Optional[SearchProviderRegistry] = None
+_registry_lock = threading.Lock()
+
+
+def _populate_default_providers(registry: SearchProviderRegistry) -> None:
+    """Register credential-gated providers from ssot_config (#9022/#9023)."""
+    # Import lazily so optional config/deps never break startup-import-smoke.
+    from agent_loop.search.brave_provider import BraveSearchProvider
+    from agent_loop.search.searxng_provider import SearXNGSearchProvider
+    from autobot_shared.ssot_config import config
+
+    searxng_url = getattr(config, "searxng_instance_url", "")
+    if searxng_url:
+        registry.register(
+            SearXNGSearchProvider(
+                settings={
+                    "instance_url": searxng_url,
+                    "basic_auth_user": getattr(config, "searxng_basic_auth_user", ""),
+                    "basic_auth_pass": getattr(config, "searxng_basic_auth_pass", ""),
+                    "token": getattr(config, "searxng_token", ""),
+                }
+            )
+        )
+    else:
+        logger.debug("SEARXNG_INSTANCE_URL not set — SearXNG search provider not registered")
+
+    brave_key = getattr(config, "brave_search_api_key", "")
+    if brave_key:
+        registry.register(BraveSearchProvider(settings={"api_key": brave_key}))
+    else:
+        logger.debug("BRAVE_SEARCH_API_KEY not set — Brave search provider not registered")
+
+
+def get_search_registry() -> SearchProviderRegistry:
+    """Return the process-wide registry, populating it on first use."""
+    global _registry
+    if _registry is None:
+        with _registry_lock:
+            if _registry is None:
+                registry = SearchProviderRegistry()
+                try:
+                    _populate_default_providers(registry)
+                except Exception as exc:  # never let config issues break callers
+                    logger.warning("Search provider auto-registration failed: %s", exc)
+                _registry = registry
+    return _registry
+
+
+async def search(
+    query: str,
+    *,
+    provider: Optional[str] = None,
+    category: Optional[str] = None,
+    count: int = DEFAULT_RESULT_COUNT,
+) -> List[SearchResult]:
+    """Module-level convenience: search via the default registry."""
+    return await get_search_registry().search(query, provider=provider, category=category, count=count)

--- a/autobot-backend/agent_loop/search/searxng_provider.py
+++ b/autobot-backend/agent_loop/search/searxng_provider.py
@@ -1,0 +1,123 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""SearXNG self-hosted meta-search provider (#9022).
+
+Privacy-preserving search: queries a user-run SearXNG instance via its JSON
+API. No API key required — only the instance URL. Supports instances behind
+HTTP Basic auth or a bearer/token header, and per-search engine categories
+(general / news / code / academic). Credential-gated: empty URL = disabled.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from agent_loop.search.base import (
+    CATEGORY_ACADEMIC,
+    CATEGORY_CODE,
+    CATEGORY_GENERAL,
+    CATEGORY_NEWS,
+    DEFAULT_RESULT_COUNT,
+    SearchResult,
+    WebSearchProvider,
+)
+from autobot_shared.http_client import get_http_client
+
+logger = logging.getLogger(__name__)
+
+# Map normalized categories onto SearXNG ``categories`` query values.
+_CATEGORY_MAP = {
+    CATEGORY_GENERAL: "general",
+    CATEGORY_NEWS: "news",
+    CATEGORY_CODE: "it",
+    CATEGORY_ACADEMIC: "science",
+}
+
+_REQUEST_TIMEOUT_S = 15
+
+
+class SearXNGSearchProvider(WebSearchProvider):
+    """Search backend backed by a self-hosted SearXNG instance."""
+
+    provider_name = "searxng"
+
+    def __init__(self, settings: Optional[Dict[str, Any]] = None) -> None:
+        """Init from settings: ``instance_url`` (required), optional auth."""
+        super().__init__(settings)
+        self.instance_url: str = str(self._get_setting("instance_url", "")).rstrip("/")
+        self.basic_auth_user: str = str(self._get_setting("basic_auth_user", ""))
+        self.basic_auth_pass: str = str(self._get_setting("basic_auth_pass", ""))
+        self.token: str = str(self._get_setting("token", ""))
+
+    async def is_available(self) -> bool:
+        """Available when an instance URL is configured."""
+        return bool(self.instance_url)
+
+    def _build_headers(self) -> Dict[str, str]:
+        """Bearer-token header for instances fronted by token auth."""
+        if self.token:
+            return {"Authorization": f"Bearer {self.token}"}
+        return {}
+
+    def _build_auth(self) -> Optional[aiohttp.BasicAuth]:
+        """HTTP Basic auth when user/pass are configured."""
+        if self.basic_auth_user:
+            return aiohttp.BasicAuth(self.basic_auth_user, self.basic_auth_pass)
+        return None
+
+    def _build_params(self, query: str, category: Optional[str]) -> Dict[str, str]:
+        """Assemble the SearXNG JSON-API query parameters."""
+        params = {"q": query, "format": "json"}
+        mapped = _CATEGORY_MAP.get(category or CATEGORY_GENERAL)
+        if mapped:
+            params["categories"] = mapped
+        return params
+
+    async def search(
+        self,
+        query: str,
+        *,
+        category: Optional[str] = None,
+        count: int = DEFAULT_RESULT_COUNT,
+    ) -> List[SearchResult]:
+        """Query the SearXNG instance; raise on unreachable for fallback."""
+        if not self.instance_url:
+            raise RuntimeError("SearXNG instance_url not configured")
+
+        url = f"{self.instance_url}/search"
+        timeout = aiohttp.ClientTimeout(total=_REQUEST_TIMEOUT_S)
+        client = get_http_client()
+        async with await client.get(
+            url,
+            params=self._build_params(query, category),
+            headers=self._build_headers(),
+            auth=self._build_auth(),
+            timeout=timeout,
+        ) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                raise RuntimeError(f"SearXNG HTTP {resp.status}: {body[:200]}")
+            data = await resp.json()
+
+        return self._normalize(data, count)
+
+    @staticmethod
+    def _normalize(data: Dict[str, Any], count: int) -> List[SearchResult]:
+        """Turn the SearXNG JSON payload into normalized results."""
+        results: List[SearchResult] = []
+        for item in data.get("results", [])[:count]:
+            results.append(
+                SearchResult(
+                    title=item.get("title", "") or "",
+                    url=item.get("url", "") or "",
+                    snippet=item.get("content", "") or "",
+                    freshness=item.get("publishedDate"),
+                    source=item.get("engine"),
+                )
+            )
+        return results

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -2201,10 +2201,14 @@ class ToolHandlerMixin:
     async def _web_search_structured_entries(self, query: str, max_pages: int) -> list[dict]:
         """Return raw search result entries [{title, url, snippet}]. Issue #7404.
 
-        Delegates to the Playwright search backend (the same backend used by
-        _web_search_via_playwright) and returns up to max_pages raw dicts.
-        Returns [] when the Playwright service is unavailable.
+        Routes through the pluggable search-provider registry first (#9022
+        SearXNG / #9023 Brave, credential-gated with graceful fallback). When no
+        provider is configured (or all fail) it falls back to the Playwright
+        search backend. Returns [] when every backend is unavailable.
         """
+        provider_entries = await self._web_search_via_registry(query, max_pages)
+        if provider_entries:
+            return provider_entries
         try:
             from services.playwright_service import search_web_embedded
 
@@ -2216,20 +2220,26 @@ class ToolHandlerMixin:
             logger.debug("[Issue #7404] Playwright structured search unavailable: %s", exc)
             return []
 
+    async def _web_search_via_registry(self, query: str, max_pages: int) -> list[dict]:
+        """Search via the provider registry. Returns [] when none configured. #9022/#9023."""
+        try:
+            from agent_loop.search import registry_search
+
+            results = await registry_search(query, count=max_pages)
+            return [r.to_dict() for r in results]
+        except Exception as exc:
+            logger.debug("[#9022/#9023] Search provider registry unavailable: %s", exc)
+            return []
+
     async def _web_search_via_playwright(self, query: str, max_results: int = 5) -> str:
-        """Search via Playwright service. Returns formatted text or empty string. Issue #2306.
+        """Search via the provider registry / Playwright service. Issue #2306.
 
-        ``max_results`` (#7479): caller-requested result count, threaded into
-        ``search_web_embedded`` and the post-fetch slice. Default 5 preserves
-        the historical behavior for any callers that don't pass it.
+        ``max_results`` (#7479): caller-requested result count. Now sourced from
+        ``_web_search_structured_entries`` so a configured search provider
+        (#9022 SearXNG / #9023 Brave) is used first, with graceful fallback to
+        the Playwright backend. Returns formatted text or empty string.
         """
-        from services.playwright_service import search_web_embedded
-
-        result = await search_web_embedded(query, max_results=max_results)
-        if not result.get("success", False):
-            return ""
-
-        entries = result.get("results", [])
+        entries = await self._web_search_structured_entries(query, max_results)
         if not entries:
             return ""
 

--- a/autobot-backend/tests/search/__init__.py
+++ b/autobot-backend/tests/search/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the web-search provider abstraction (#9022, #9023)."""

--- a/autobot-backend/tests/search/conftest.py
+++ b/autobot-backend/tests/search/conftest.py
@@ -1,0 +1,115 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shared fakes + real-module wiring for web-search provider tests. (#9022/#9023).
+
+The root ``autobot-backend/conftest.py`` stubs ``agent_loop`` (and submodules)
+to break orchestration import chains. These tests need the *real*
+``agent_loop.search`` package, so — mirroring ``tests/agent_loop/conftest.py``
+(#6627) — we plant a real package entry and load the search modules directly,
+restoring the stubs afterwards so sibling directories are unaffected.
+
+All fakes here keep tests fully offline (no real network).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_BACKEND = Path(__file__).parent.parent.parent  # .../autobot-backend
+_SEARCH_DIR = _BACKEND / "agent_loop" / "search"
+
+_AGENT_LOOP_KEYS = [k for k in sys.modules if k == "agent_loop" or k.startswith("agent_loop.")]
+_SAVED: Dict[str, object] = {k: sys.modules[k] for k in _AGENT_LOOP_KEYS}
+
+
+def _load_real(full_name: str, rel: str) -> None:
+    """Load a Python file directly and register it under *full_name*."""
+    path = _BACKEND / rel
+    spec = importlib.util.spec_from_file_location(full_name, str(path))
+    if not spec or not spec.loader:
+        return
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = full_name.rpartition(".")[0] or full_name
+    sys.modules[full_name] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+
+# Drop any stubs planted by the parent conftest.
+for _k in _AGENT_LOOP_KEYS:
+    sys.modules.pop(_k, None)
+
+# Plant a real ``agent_loop`` package WITHOUT running its heavy __init__.
+_pkg = types.ModuleType("agent_loop")
+_pkg.__path__ = [str(_BACKEND / "agent_loop")]  # type: ignore[assignment]
+_pkg.__package__ = "agent_loop"
+sys.modules["agent_loop"] = _pkg
+
+# Plant the search sub-package and load its modules in dependency order.
+_search_pkg = types.ModuleType("agent_loop.search")
+_search_pkg.__path__ = [str(_SEARCH_DIR)]  # type: ignore[assignment]
+_search_pkg.__package__ = "agent_loop.search"
+sys.modules["agent_loop.search"] = _search_pkg
+_pkg.search = _search_pkg  # type: ignore[attr-defined]
+
+_load_real("agent_loop.search.base", "agent_loop/search/base.py")
+_load_real("agent_loop.search.registry", "agent_loop/search/registry.py")
+_load_real("agent_loop.search.searxng_provider", "agent_loop/search/searxng_provider.py")
+_load_real("agent_loop.search.brave_provider", "agent_loop/search/brave_provider.py")
+_load_real("agent_loop.search", "agent_loop/search/__init__.py")
+
+
+def pytest_unconfigure(config) -> None:  # noqa: ARG001
+    """Restore the original stub state so other directories are unaffected."""
+    for k in list(sys.modules):
+        if k == "agent_loop" or k.startswith("agent_loop."):
+            sys.modules.pop(k, None)
+    for k, v in _SAVED.items():
+        sys.modules[k] = v  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Offline HTTP fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeResponse:
+    """Minimal aiohttp-like response usable as an async context manager."""
+
+    def __init__(self, *, status: int = 200, json_data: Optional[Dict[str, Any]] = None, text: str = "") -> None:
+        self.status = status
+        self._json = json_data or {}
+        self._text = text
+
+    async def __aenter__(self) -> "FakeResponse":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> bool:
+        return False
+
+    async def json(self) -> Dict[str, Any]:
+        return self._json
+
+    async def text(self) -> str:
+        return self._text
+
+
+class FakeHTTPClient:
+    """Records GET calls and returns a queued FakeResponse.
+
+    ``get`` mirrors the real ``get_http_client().get`` contract: it is awaited
+    and yields an async-context-manager response.
+    """
+
+    def __init__(self, response: FakeResponse) -> None:
+        self._response = response
+        self.calls: List[Dict[str, Any]] = []
+
+    async def get(self, url: str, **kwargs: Any) -> FakeResponse:
+        self.calls.append({"url": url, **kwargs})
+        return self._response

--- a/autobot-backend/tests/search/test_brave_provider.py
+++ b/autobot-backend/tests/search/test_brave_provider.py
@@ -29,9 +29,7 @@ _WEB_SAMPLE = {
 }
 
 _NEWS_SAMPLE = {
-    "results": [
-        {"title": "News One", "url": "https://news.example/1", "description": "News snippet", "page_age": "1h"}
-    ]
+    "results": [{"title": "News One", "url": "https://news.example/1", "description": "News snippet", "page_age": "1h"}]
 }
 
 

--- a/autobot-backend/tests/search/test_brave_provider.py
+++ b/autobot-backend/tests/search/test_brave_provider.py
@@ -1,0 +1,110 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Offline unit tests for BraveSearchProvider (#9023)."""
+
+from __future__ import annotations
+
+import pytest
+
+import agent_loop.search.brave_provider as brave_mod
+from agent_loop.search.base import CATEGORY_NEWS
+from agent_loop.search.brave_provider import BraveSearchProvider
+from tests.search.conftest import FakeHTTPClient, FakeResponse
+
+_WEB_SAMPLE = {
+    "web": {
+        "results": [
+            {
+                "title": "Brave One",
+                "url": "https://example.com/a",
+                "description": "Web snippet",
+                "age": "2 days ago",
+                "meta_url": {"hostname": "example.com"},
+            },
+            {"title": "Brave Two", "url": "https://example.com/b", "description": "Second"},
+        ]
+    }
+}
+
+_NEWS_SAMPLE = {
+    "results": [
+        {"title": "News One", "url": "https://news.example/1", "description": "News snippet", "page_age": "1h"}
+    ]
+}
+
+
+def _patch_client(monkeypatch, client: FakeHTTPClient) -> None:
+    monkeypatch.setattr(brave_mod, "get_http_client", lambda: client)
+
+
+@pytest.mark.asyncio
+async def test_web_search_normalizes_and_sets_auth_header(monkeypatch):
+    client = FakeHTTPClient(FakeResponse(json_data=_WEB_SAMPLE))
+    _patch_client(monkeypatch, client)
+    provider = BraveSearchProvider(settings={"api_key": "key-abc"})
+
+    results = await provider.search("python")
+
+    assert [r.url for r in results] == ["https://example.com/a", "https://example.com/b"]
+    assert results[0].title == "Brave One"
+    assert results[0].snippet == "Web snippet"
+    assert results[0].freshness == "2 days ago"
+    assert results[0].source == "example.com"
+    call = client.calls[0]
+    assert call["headers"]["X-Subscription-Token"] == "key-abc"
+    assert call["url"].endswith("/web/search")
+
+
+@pytest.mark.asyncio
+async def test_news_category_uses_news_endpoint(monkeypatch):
+    client = FakeHTTPClient(FakeResponse(json_data=_NEWS_SAMPLE))
+    _patch_client(monkeypatch, client)
+    provider = BraveSearchProvider(settings={"api_key": "key-abc"})
+
+    results = await provider.search("headline", category=CATEGORY_NEWS)
+
+    assert client.calls[0]["url"].endswith("/news/search")
+    assert results[0].title == "News One"
+    assert results[0].freshness == "1h"
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_raises_for_fallback(monkeypatch):
+    client = FakeHTTPClient(FakeResponse(status=429, text="quota"))
+    _patch_client(monkeypatch, client)
+    provider = BraveSearchProvider(settings={"api_key": "key-abc"})
+
+    with pytest.raises(RuntimeError, match="429"):
+        await provider.search("q")
+
+
+@pytest.mark.asyncio
+async def test_other_error_raises(monkeypatch):
+    client = FakeHTTPClient(FakeResponse(status=500, text="boom"))
+    _patch_client(monkeypatch, client)
+    provider = BraveSearchProvider(settings={"api_key": "key-abc"})
+
+    with pytest.raises(RuntimeError):
+        await provider.search("q")
+
+
+@pytest.mark.asyncio
+async def test_count_param_and_limit(monkeypatch):
+    client = FakeHTTPClient(FakeResponse(json_data=_WEB_SAMPLE))
+    _patch_client(monkeypatch, client)
+    provider = BraveSearchProvider(settings={"api_key": "key-abc"})
+
+    results = await provider.search("q", count=1)
+
+    assert client.calls[0]["params"]["count"] == "1"
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_unavailable_and_raises():
+    provider = BraveSearchProvider(settings={})
+    assert await provider.is_available() is False
+    with pytest.raises(RuntimeError):
+        await provider.search("q")

--- a/autobot-backend/tests/search/test_registry.py
+++ b/autobot-backend/tests/search/test_registry.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Registry selection + graceful-fallback tests (#9022/#9023)."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import pytest
+
+from agent_loop.search.base import SearchResult, WebSearchProvider
+from agent_loop.search.registry import SearchProviderRegistry
+
+
+class _StubProvider(WebSearchProvider):
+    """Configurable stub: available flag, fixed results, or raises."""
+
+    def __init__(self, name: str, *, available: bool = True, results=None, raises: bool = False) -> None:
+        super().__init__()
+        self.provider_name = name
+        self._available = available
+        self._results = results if results is not None else []
+        self._raises = raises
+        self.search_calls = 0
+
+    async def is_available(self) -> bool:
+        return self._available
+
+    async def search(self, query: str, *, category: Optional[str] = None, count: int = 10) -> List[SearchResult]:
+        self.search_calls += 1
+        if self._raises:
+            raise RuntimeError(f"{self.provider_name} boom")
+        return list(self._results)
+
+
+def _result(url: str) -> SearchResult:
+    return SearchResult(title=url, url=url, snippet="s")
+
+
+@pytest.mark.asyncio
+async def test_empty_registry_returns_no_results():
+    registry = SearchProviderRegistry()
+    assert await registry.search("q") == []
+
+
+@pytest.mark.asyncio
+async def test_preferred_provider_selected():
+    primary = _StubProvider("brave", results=[_result("https://b/1")])
+    secondary = _StubProvider("searxng", results=[_result("https://s/1")])
+    registry = SearchProviderRegistry()
+    registry.register(primary)
+    registry.register(secondary)
+
+    results = await registry.search("q", provider="searxng")
+
+    assert results[0].url == "https://s/1"
+    assert secondary.search_calls == 1
+    assert primary.search_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_fallback_on_provider_error():
+    failing = _StubProvider("brave", raises=True)
+    backup = _StubProvider("searxng", results=[_result("https://s/1")])
+    registry = SearchProviderRegistry()
+    registry.register(failing)
+    registry.register(backup)
+
+    results = await registry.search("q")
+
+    assert results[0].url == "https://s/1"
+    assert failing.search_calls == 1
+    assert backup.search_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_unavailable_provider_skipped():
+    off = _StubProvider("brave", available=False, results=[_result("https://b/1")])
+    on = _StubProvider("searxng", results=[_result("https://s/1")])
+    registry = SearchProviderRegistry()
+    registry.register(off)
+    registry.register(on)
+
+    results = await registry.search("q")
+
+    assert results[0].url == "https://s/1"
+    assert off.search_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_all_fail_returns_empty():
+    a = _StubProvider("brave", raises=True)
+    b = _StubProvider("searxng", raises=True)
+    registry = SearchProviderRegistry()
+    registry.register(a)
+    registry.register(b)
+
+    assert await registry.search("q") == []
+
+
+def test_register_dedupes_fallback_chain():
+    registry = SearchProviderRegistry()
+    registry.register(_StubProvider("brave"))
+    registry.register(_StubProvider("brave"))
+    assert registry.list_providers() == ["brave"]

--- a/autobot-backend/tests/search/test_searxng_provider.py
+++ b/autobot-backend/tests/search/test_searxng_provider.py
@@ -1,0 +1,116 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Offline unit tests for SearXNGSearchProvider (#9022)."""
+
+from __future__ import annotations
+
+import pytest
+
+import agent_loop.search.searxng_provider as searxng_mod
+from agent_loop.search.base import CATEGORY_NEWS
+from agent_loop.search.searxng_provider import SearXNGSearchProvider
+from tests.search.conftest import FakeHTTPClient, FakeResponse
+
+_SAMPLE = {
+    "results": [
+        {
+            "title": "Result One",
+            "url": "https://example.com/1",
+            "content": "First snippet",
+            "engine": "duckduckgo",
+            "publishedDate": "2026-06-01",
+        },
+        {"title": "Result Two", "url": "https://example.com/2", "content": "Second snippet"},
+    ]
+}
+
+
+def _patch_client(monkeypatch, client: FakeHTTPClient) -> None:
+    monkeypatch.setattr(searxng_mod, "get_http_client", lambda: client)
+
+
+@pytest.mark.asyncio
+async def test_search_normalizes_results(monkeypatch):
+    client = FakeHTTPClient(FakeResponse(json_data=_SAMPLE))
+    _patch_client(monkeypatch, client)
+    provider = SearXNGSearchProvider(settings={"instance_url": "https://searx.local/"})
+
+    results = await provider.search("python")
+
+    assert [r.url for r in results] == ["https://example.com/1", "https://example.com/2"]
+    assert results[0].title == "Result One"
+    assert results[0].snippet == "First snippet"
+    assert results[0].freshness == "2026-06-01"
+    assert results[0].source == "duckduckgo"
+    # Trailing slash on instance_url is stripped (no double slash in URL).
+    assert client.calls[0]["url"] == "https://searx.local/search"
+
+
+@pytest.mark.asyncio
+async def test_category_maps_to_searxng_categories(monkeypatch):
+    client = FakeHTTPClient(FakeResponse(json_data=_SAMPLE))
+    _patch_client(monkeypatch, client)
+    provider = SearXNGSearchProvider(settings={"instance_url": "https://searx.local"})
+
+    await provider.search("breaking", category=CATEGORY_NEWS)
+
+    assert client.calls[0]["params"]["categories"] == "news"
+    assert client.calls[0]["params"]["format"] == "json"
+
+
+@pytest.mark.asyncio
+async def test_basic_auth_and_token_headers(monkeypatch):
+    client = FakeHTTPClient(FakeResponse(json_data=_SAMPLE))
+    _patch_client(monkeypatch, client)
+    provider = SearXNGSearchProvider(
+        settings={
+            "instance_url": "https://searx.local",
+            "basic_auth_user": "u",
+            "basic_auth_pass": "p",
+            "token": "tok123",
+        }
+    )
+
+    await provider.search("query")
+
+    call = client.calls[0]
+    assert call["headers"]["Authorization"] == "Bearer tok123"
+    assert call["auth"].login == "u"
+    assert call["auth"].password == "p"
+
+
+@pytest.mark.asyncio
+async def test_count_limits_results(monkeypatch):
+    client = FakeHTTPClient(FakeResponse(json_data=_SAMPLE))
+    _patch_client(monkeypatch, client)
+    provider = SearXNGSearchProvider(settings={"instance_url": "https://searx.local"})
+
+    results = await provider.search("q", count=1)
+
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_non_200_raises_for_fallback(monkeypatch):
+    client = FakeHTTPClient(FakeResponse(status=502, text="bad gateway"))
+    _patch_client(monkeypatch, client)
+    provider = SearXNGSearchProvider(settings={"instance_url": "https://searx.local"})
+
+    with pytest.raises(RuntimeError):
+        await provider.search("q")
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_is_unavailable_and_raises():
+    provider = SearXNGSearchProvider(settings={})
+    assert await provider.is_available() is False
+    with pytest.raises(RuntimeError):
+        await provider.search("q")
+
+
+@pytest.mark.asyncio
+async def test_configured_is_available():
+    provider = SearXNGSearchProvider(settings={"instance_url": "https://searx.local"})
+    assert await provider.is_available() is True

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -207,6 +207,15 @@ class LLMConfig(BaseSettings):
     openai_api_key: str = Field(default="", alias="OPENAI_API_KEY")
     anthropic_api_key: str = Field(default="", alias="ANTHROPIC_API_KEY")
 
+    # Web-search providers (#9022 SearXNG, #9023 Brave). Empty = disabled.
+    # SearXNG needs no API key — only the self-hosted instance URL. Optional
+    # HTTP Basic / token auth for instances behind a reverse proxy.
+    searxng_instance_url: str = Field(default="", alias="SEARXNG_INSTANCE_URL")
+    searxng_basic_auth_user: str = Field(default="", alias="SEARXNG_BASIC_AUTH_USER")
+    searxng_basic_auth_pass: str = Field(default="", alias="SEARXNG_BASIC_AUTH_PASS")
+    searxng_token: str = Field(default="", alias="SEARXNG_TOKEN")
+    brave_search_api_key: str = Field(default="", alias="BRAVE_SEARCH_API_KEY")
+
     # Claude escalation feature flag (#8171): disabled by default so local LLM
     # path is unchanged unless AUTOBOT_CLAUDE_ESCALATION_ENABLED=true is set.
     claude_escalation_enabled: bool = Field(default=False, alias="AUTOBOT_CLAUDE_ESCALATION_ENABLED")


### PR DESCRIPTION
## Thinking Path

#9022 (SearXNG) and #9023 (Brave) both need the same thing — a pluggable web-search provider with selection + graceful fallback — so they're batched into one PR. The issues named `web_search.py` as the extension point, but that file is only an output *extractor*; the real search-execution seam is `chat_workflow/tool_handler.py`. New providers are wired into that real path (not left as orphan classes).

## What Changed

**New abstraction** `autobot-backend/agent_loop/search/` (mirrors `llm_shared/provider_registry.py`):
- `base.py` — `WebSearchProvider` ABC (`async search(query, *, category, count) -> list[SearchResult]`, `is_available()`) + `SearchResult` dataclass.
- `registry.py` — `SearchProviderRegistry` with credential-gated auto-population + ordered **fallback chain** + `registry_search()` / `get_search_registry()` singleton.
- `searxng_provider.py` (#9022) — async GET `{url}/search?format=json&categories=…`; general/news/code/academic categories; HTTP Basic **or** token auth; no API key.
- `brave_provider.py` (#9023) — async GET `api.search.brave.com/res/v1/web/search` with `X-Subscription-Token`; web + news; 429/quota handled; key from `ssot_config` (same idiom as `openai_api_key`).

**Wiring** (`chat_workflow/tool_handler.py`): `_web_search_structured_entries` routes through the registry first (`_web_search_via_registry`), falling back to the existing Playwright backend when no provider is configured or all fail. `_web_search_via_playwright` now sources from the same path, so **both** snippet and full-fetch modes use a configured provider. Reachable from the agent `web_search` tool.

**Config** (`ssot_config`, all default `""` = disabled/credential-gated): `SEARXNG_INSTANCE_URL`, `SEARXNG_BASIC_AUTH_USER/PASS`, `SEARXNG_TOKEN`, `BRAVE_SEARCH_API_KEY`.

## Verification

- `pytest tests/search/` → **19 passed** (7 SearXNG, 6 Brave, 6 registry; all HTTP mocked). flake8 clean; py_compile OK on tool_handler + the package + ssot_config.
- Fallback proven: registry returns `[]` gracefully when unconfigured → tool_handler falls back to Playwright (unchanged default behavior). Providers raise on unreachable/error → registry advances the fallback chain.
- Startup-safe: providers/config imported lazily inside `_populate_default_providers` (try/except), and the tool_handler import is method-local — no new module-level imports.

Closes #9022 and #9023.

## Model Used

Claude Opus 4.8 (1M context)
