### PR TITLE
feat(secrets): migrate PG legacy Fernet secrets → envelope, in-place (#10286)

### DIFF
--- a/autobot-backend/services/legacy_secrets_migrator.py
+++ b/autobot-backend/services/legacy_secrets_migrator.py
@@ -1,0 +1,120 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Migrate legacy Fernet ``secrets`` rows onto the envelope store (#10088 / Task 3a).
+
+In-place conversion of the PostgreSQL ``secrets`` table: rows written the old way
+(``encrypted_value`` = Fernet ciphertext, ``sealed_value`` NULL) are decrypted
+with the legacy Fernet key and re-sealed under the envelope crypto
+(``autobot_shared.secrets_envelope``), keeping the same row id. This store has no
+live readers/writers (the envelope path is already authoritative for PG writes),
+so there is no cutover risk — it's the reusable conversion + reconciliation core
+the JSON/SQLite cutovers (separate, higher-risk slices) build on.
+
+Idempotent (the query only selects un-converted rows) and conservative:
+``encrypted_value`` is **kept** so a row can be rolled back / re-verified until a
+later cleanup slice nulls it.
+
+Legacy scope → vault mapping:
+- ``user`` / ``session`` / ``workflow`` → owner ``user:<owner_id>``
+- ``organization`` → owner ``company:<org_id>`` (falls back to the creator's user
+  vault if ``org_id`` is unset)
+- ``shared`` → owner ``user:<owner_id>`` + a grant per ``shared_with`` user
+- ``group`` → owner ``user:<owner_id>`` + a grant per ``team_ids`` team
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.secrets_envelope import derive_vault_key, seal, wrap_dek
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from models.secret import Secret
+from models.secret_grant import SecretGrant
+
+
+@dataclass
+class MigrationReport:
+    """Reconciliation counts for one migration run."""
+
+    total_legacy: int = 0
+    migrated: int = 0
+    failed: list[str] = field(default_factory=list)
+
+
+def _owner_and_extra_grantees(secret: Secret) -> tuple[VaultRef, list[VaultRef]]:
+    """Map a legacy row's scope/ownership to an owner vault + extra grantee vaults."""
+    if secret.scope == "organization" and secret.org_id is not None:
+        owner = VaultRef(VaultKind.COMPANY, str(secret.org_id))
+    else:
+        owner = VaultRef(VaultKind.USER, str(secret.owner_id))
+
+    extra: list[VaultRef] = []
+    if secret.scope == "shared":
+        extra += [VaultRef(VaultKind.USER, str(u)) for u in (secret.shared_with or [])]
+    if secret.scope == "group":
+        extra += [VaultRef(VaultKind.TEAM, str(t)) for t in (secret.team_ids or [])]
+    return owner, extra
+
+
+def _prepare_envelope(secret: Secret, plaintext: bytes, root_key: bytes) -> tuple[dict, str, list[SecretGrant]]:
+    """Seal *plaintext* and build the grant rows for *secret*. Raises (before any row mutation)
+    on a bad vault id, so a partial conversion never persists."""
+    sid = str(secret.id)
+    sealed, dek = seal(plaintext, secret_id=sid)
+    owner, extra = _owner_and_extra_grantees(secret)
+    grants: list[SecretGrant] = []
+    seen: set[str] = set()
+    for grantee in (owner, *extra):
+        key = grantee.to_str()
+        if key in seen:
+            continue
+        seen.add(key)
+        wrapped = wrap_dek(dek, derive_vault_key(root_key, key), key, secret_id=sid)
+        grants.append(
+            SecretGrant(secret_id=secret.id, grantee=key, wrapped_dek=wrapped.to_dict(), created_by=secret.owner_id)
+        )
+    return sealed.to_dict(), owner.to_str(), grants
+
+
+async def migrate_pg_legacy_secrets(session: AsyncSession, *, fernet, root_key: bytes) -> MigrationReport:
+    """Convert every legacy Fernet row in ``secrets`` to envelope form. Returns a reconciliation report.
+
+    ``fernet`` is a ``cryptography.fernet.Fernet`` (or MultiFernet) built from the legacy
+    ``AUTOBOT_SECRETS_KEY``; ``root_key`` is the envelope root key (``AUTOBOT_SECRETS_ROOT_KEY``).
+    """
+    from cryptography.fernet import InvalidToken
+
+    report = MigrationReport()
+    # Filter "not yet envelope-backed" in Python (``sealed_value is None``) to match
+    # exactly how UnifiedSecretsService detects legacy rows. A SQL ``sealed_value IS
+    # NULL`` would miss rows whose JSONB holds JSON ``null`` (not SQL NULL) — SQLAlchemy's
+    # JSONB defaults to none_as_null=False, so an explicit None persists as JSON null.
+    rows = (await session.execute(select(Secret).where(Secret.encrypted_value.isnot(None)))).scalars().all()
+    candidates = [s for s in rows if s.sealed_value is None]
+    report.total_legacy = len(candidates)
+
+    for secret in candidates:
+        try:
+            plaintext = fernet.decrypt(secret.encrypted_value.encode("utf-8"))
+        except (InvalidToken, ValueError) as exc:
+            report.failed.append(f"{secret.id}: decrypt failed ({exc})")
+            continue
+        try:
+            sealed_dict, owner_vault, grants = _prepare_envelope(secret, plaintext, root_key)
+        except ValueError as exc:  # bad vault id from corrupt scope data — row left untouched
+            report.failed.append(f"{secret.id}: convert failed ({exc})")
+            continue
+        secret.sealed_value = sealed_dict
+        secret.owner_vault = owner_vault
+        secret.version = secret.version or 1
+        for grant in grants:
+            session.add(grant)
+        report.migrated += 1
+
+    await session.flush()
+    return report

--- a/autobot-backend/services/legacy_secrets_migrator.py
+++ b/autobot-backend/services/legacy_secrets_migrator.py
@@ -12,14 +12,20 @@ live readers/writers (the envelope path is already authoritative for PG writes),
 so there is no cutover risk — it's the reusable conversion + reconciliation core
 the JSON/SQLite cutovers (separate, higher-risk slices) build on.
 
-Idempotent (the query only selects un-converted rows) and conservative:
-``encrypted_value`` is **kept** so a row can be rolled back / re-verified until a
-later cleanup slice nulls it.
+Conservative: ``encrypted_value`` is **kept** so a row can be rolled back /
+re-verified until a later cleanup slice nulls it.
+
+Transaction contract: call inside a single transaction and ``commit()`` the
+session once afterwards. Each row is converted inside its own SAVEPOINT, so a
+single bad row is reported and skipped without poisoning the batch. Idempotent
+across runs — a re-run skips rows that already carry a ``sealed_value`` (the
+seal + its grants commit together within one savepoint, so a converted row never
+re-seals or double-grants).
 
 Legacy scope → vault mapping:
-- ``user`` / ``session`` / ``workflow`` → owner ``user:<owner_id>``
+- ``user`` / ``session`` / ``workflow`` (and any unknown scope) → owner ``user:<owner_id>``
 - ``organization`` → owner ``company:<org_id>`` (falls back to the creator's user
-  vault if ``org_id`` is unset)
+  vault if ``org_id`` is unset — recorded in the report's ``warnings``)
 - ``shared`` → owner ``user:<owner_id>`` + a grant per ``shared_with`` user
 - ``group`` → owner ``user:<owner_id>`` + a grant per ``team_ids`` team
 """
@@ -27,14 +33,19 @@ Legacy scope → vault mapping:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.secrets_envelope import derive_vault_key, seal, wrap_dek
 from autobot_shared.secrets_vault import VaultKind, VaultRef
 from models.secret import Secret
 from models.secret_grant import SecretGrant
+
+if TYPE_CHECKING:  # avoid a hard import at module load; only used for typing
+    from cryptography.fernet import Fernet, MultiFernet
 
 
 @dataclass
@@ -44,48 +55,71 @@ class MigrationReport:
     total_legacy: int = 0
     migrated: int = 0
     failed: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
 
 
-def _owner_and_extra_grantees(secret: Secret) -> tuple[VaultRef, list[VaultRef]]:
-    """Map a legacy row's scope/ownership to an owner vault + extra grantee vaults."""
+def _grantee_vaults(values, kind: VaultKind, field_name: str) -> list[VaultRef]:
+    """Build grantee vaults from a legacy JSONB list field. Raises on dirty (non-list) data
+    so the row is reported rather than silently mis-granted (iterating a str/dict)."""
+    if values is None:
+        return []
+    if not isinstance(values, list):
+        raise ValueError(f"{field_name} is not a list: {type(values).__name__}")
+    return [VaultRef(kind, str(v)) for v in values]
+
+
+def _owner_and_extra_grantees(secret: Secret) -> tuple[VaultRef, list[VaultRef], str | None]:
+    """Map a legacy row's scope/ownership to an owner vault + extra grantee vaults.
+
+    Returns ``(owner, extra, warning)`` — ``warning`` is set when an organization-scoped
+    secret lacks ``org_id`` and is demoted to the creator's personal vault.
+    """
+    warning: str | None = None
     if secret.scope == "organization" and secret.org_id is not None:
         owner = VaultRef(VaultKind.COMPANY, str(secret.org_id))
     else:
         owner = VaultRef(VaultKind.USER, str(secret.owner_id))
+        if secret.scope == "organization":
+            warning = f"{secret.id}: organization scope with no org_id → demoted to owner user vault"
 
     extra: list[VaultRef] = []
     if secret.scope == "shared":
-        extra += [VaultRef(VaultKind.USER, str(u)) for u in (secret.shared_with or [])]
+        extra += _grantee_vaults(secret.shared_with, VaultKind.USER, "shared_with")
     if secret.scope == "group":
-        extra += [VaultRef(VaultKind.TEAM, str(t)) for t in (secret.team_ids or [])]
-    return owner, extra
+        extra += _grantee_vaults(secret.team_ids, VaultKind.TEAM, "team_ids")
+    return owner, extra, warning
 
 
-def _prepare_envelope(secret: Secret, plaintext: bytes, root_key: bytes) -> tuple[dict, str, list[SecretGrant]]:
+def _prepare_envelope(
+    secret: Secret, plaintext: bytes, root_key: bytes
+) -> tuple[dict, str, list[SecretGrant], str | None]:
     """Seal *plaintext* and build the grant rows for *secret*. Raises (before any row mutation)
-    on a bad vault id, so a partial conversion never persists."""
+    on dirty scope data, so a partial conversion never persists."""
     sid = str(secret.id)
     sealed, dek = seal(plaintext, secret_id=sid)
-    owner, extra = _owner_and_extra_grantees(secret)
+    owner, extra, warning = _owner_and_extra_grantees(secret)
     grants: list[SecretGrant] = []
     seen: set[str] = set()
     for grantee in (owner, *extra):
         key = grantee.to_str()
-        if key in seen:
+        if key in seen:  # e.g. owner also listed in shared_with — avoid UNIQUE(secret_id,grantee)
             continue
         seen.add(key)
         wrapped = wrap_dek(dek, derive_vault_key(root_key, key), key, secret_id=sid)
         grants.append(
             SecretGrant(secret_id=secret.id, grantee=key, wrapped_dek=wrapped.to_dict(), created_by=secret.owner_id)
         )
-    return sealed.to_dict(), owner.to_str(), grants
+    return sealed.to_dict(), owner.to_str(), grants, warning
 
 
-async def migrate_pg_legacy_secrets(session: AsyncSession, *, fernet, root_key: bytes) -> MigrationReport:
+async def migrate_pg_legacy_secrets(
+    session: AsyncSession, *, fernet: "Fernet | MultiFernet", root_key: bytes
+) -> MigrationReport:
     """Convert every legacy Fernet row in ``secrets`` to envelope form. Returns a reconciliation report.
 
     ``fernet`` is a ``cryptography.fernet.Fernet`` (or MultiFernet) built from the legacy
     ``AUTOBOT_SECRETS_KEY``; ``root_key`` is the envelope root key (``AUTOBOT_SECRETS_ROOT_KEY``).
+    See the module docstring for the transaction contract.
     """
     from cryptography.fernet import InvalidToken
 
@@ -101,20 +135,29 @@ async def migrate_pg_legacy_secrets(session: AsyncSession, *, fernet, root_key: 
     for secret in candidates:
         try:
             plaintext = fernet.decrypt(secret.encrypted_value.encode("utf-8"))
-        except (InvalidToken, ValueError) as exc:
+        except (InvalidToken, ValueError, TypeError) as exc:
             report.failed.append(f"{secret.id}: decrypt failed ({exc})")
             continue
         try:
-            sealed_dict, owner_vault, grants = _prepare_envelope(secret, plaintext, root_key)
-        except ValueError as exc:  # bad vault id from corrupt scope data — row left untouched
+            sealed_dict, owner_vault, grants, warning = _prepare_envelope(secret, plaintext, root_key)
+        except ValueError as exc:  # dirty scope data — row left untouched
             report.failed.append(f"{secret.id}: convert failed ({exc})")
             continue
-        secret.sealed_value = sealed_dict
-        secret.owner_vault = owner_vault
-        secret.version = secret.version or 1
-        for grant in grants:
-            session.add(grant)
+        try:
+            # Per-row SAVEPOINT: one bad row (e.g. a UNIQUE grant collision from a prior
+            # partial run) is reported and skipped without aborting the whole batch.
+            async with session.begin_nested():
+                secret.sealed_value = sealed_dict
+                secret.owner_vault = owner_vault
+                if secret.version is None:
+                    secret.version = 1
+                session.add_all(grants)
+                await session.flush()
+        except IntegrityError as exc:
+            report.failed.append(f"{secret.id}: persist failed ({exc})")
+            continue
+        if warning:
+            report.warnings.append(warning)
         report.migrated += 1
 
-    await session.flush()
     return report

--- a/autobot-backend/tests/migrations/test_legacy_secrets_migrator.py
+++ b/autobot-backend/tests/migrations/test_legacy_secrets_migrator.py
@@ -149,3 +149,32 @@ async def test_atomic_on_bad_grant_vault(session):
     await session.commit()
     assert report.total_legacy == 1 and report.migrated == 0 and len(report.failed) == 1
     assert row.sealed_value is None and row.owner_vault is None  # nothing persisted
+
+
+async def test_org_without_org_id_demoted_with_warning(session):
+    # An organization secret missing org_id is migrated to the creator's user vault,
+    # and the demotion is surfaced in the report for operator reconciliation.
+    row = _legacy("organization", b"o-val")  # no org_id
+    session.add(row)
+    await session.commit()
+    report = await migrate_pg_legacy_secrets(session, fernet=_FERNET, root_key=_ROOT)
+    await session.commit()
+    assert report.migrated == 1 and len(report.warnings) == 1
+    assert row.owner_vault == f"user:{_OWNER}"
+    svc = UnifiedSecretsService(root_key=_ROOT)
+    assert (
+        await svc.read(session, secret_id=row.id, accessible_vaults={VaultRef(VaultKind.USER, str(_OWNER))}) == b"o-val"
+    )
+
+
+async def test_dirty_non_list_shared_with_fails_row(session):
+    # Legacy dirty data: shared_with stored as a bare string would iterate characters and
+    # silently mis-grant — instead the row must fail and be left untouched.
+    row = _legacy("shared", b"s-val")
+    row.shared_with = "not-a-list"
+    session.add(row)
+    await session.commit()
+    report = await migrate_pg_legacy_secrets(session, fernet=_FERNET, root_key=_ROOT)
+    await session.commit()
+    assert report.migrated == 0 and len(report.failed) == 1
+    assert row.sealed_value is None

--- a/autobot-backend/tests/migrations/test_legacy_secrets_migrator.py
+++ b/autobot-backend/tests/migrations/test_legacy_secrets_migrator.py
@@ -1,0 +1,151 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the legacy Fernet → envelope migrator (#10088 / Task 3a).
+
+Postgres-backed (migration-gate job): seeds legacy Fernet ``secrets`` rows of
+each scope on an ``upgrade head`` schema, runs the migrator, and verifies each
+row is now envelope-readable via UnifiedSecretsService with the right owner vault
+and grants.
+"""
+
+import base64
+import uuid
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from models.secret import Secret
+from services.legacy_secrets_migrator import migrate_pg_legacy_secrets
+from services.unified_secrets_service import UnifiedSecretsService
+from tests.migrations.conftest import requires_postgres, run_alembic
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+_ROOT = base64.urlsafe_b64decode(base64.urlsafe_b64encode(bytes(range(32))))
+_FERNET = Fernet(Fernet.generate_key())
+_OWNER = uuid.uuid4()
+_ORG = uuid.uuid4()
+_FRIEND = uuid.uuid4()
+_TEAM = uuid.uuid4()
+
+
+def _legacy(scope: str, value: bytes, **kw) -> Secret:
+    return Secret(
+        id=uuid.uuid4(),
+        owner_id=_OWNER,
+        name=f"{scope}-secret",
+        type="password",
+        scope=scope,
+        encrypted_value=_FERNET.encrypt(value).decode("utf-8"),
+        sealed_value=None,
+        **kw,
+    )
+
+
+@pytest.fixture()
+async def session(fresh_db_url):
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+    engine = create_async_engine(fresh_db_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as s:
+        yield s
+    await engine.dispose()
+
+
+async def test_migrates_each_scope_and_envelope_readable(session):
+    rows = {
+        "user": _legacy("user", b"u-val"),
+        "organization": _legacy("organization", b"o-val", org_id=_ORG),
+        "shared": _legacy("shared", b"s-val", shared_with=[str(_FRIEND)]),
+        "group": _legacy("group", b"g-val", team_ids=[str(_TEAM)]),
+    }
+    for r in rows.values():
+        session.add(r)
+    await session.commit()
+
+    report = await migrate_pg_legacy_secrets(session, fernet=_FERNET, root_key=_ROOT)
+    await session.commit()
+    assert report.total_legacy == 4 and report.migrated == 4 and report.failed == []
+
+    svc = UnifiedSecretsService(root_key=_ROOT)
+
+    # user → readable via the owner's user vault
+    assert (
+        await svc.read(session, secret_id=rows["user"].id, accessible_vaults={VaultRef(VaultKind.USER, str(_OWNER))})
+        == b"u-val"
+    )
+    # organization → owned by the company vault
+    assert rows["organization"].owner_vault == f"company:{_ORG}"
+    assert (
+        await svc.read(
+            session, secret_id=rows["organization"].id, accessible_vaults={VaultRef(VaultKind.COMPANY, str(_ORG))}
+        )
+        == b"o-val"
+    )
+    # shared → owner reads, and the friend reads via their own user vault
+    assert (
+        await svc.read(session, secret_id=rows["shared"].id, accessible_vaults={VaultRef(VaultKind.USER, str(_FRIEND))})
+        == b"s-val"
+    )
+    assert (
+        await svc.read(session, secret_id=rows["shared"].id, accessible_vaults={VaultRef(VaultKind.USER, str(_OWNER))})
+        == b"s-val"
+    )
+    # group → owner reads, and the team vault reads
+    assert (
+        await svc.read(session, secret_id=rows["group"].id, accessible_vaults={VaultRef(VaultKind.TEAM, str(_TEAM))})
+        == b"g-val"
+    )
+
+
+async def test_keeps_legacy_blob_for_rollback(session):
+    row = _legacy("user", b"keepme")
+    session.add(row)
+    await session.commit()
+    await migrate_pg_legacy_secrets(session, fernet=_FERNET, root_key=_ROOT)
+    await session.commit()
+    assert row.sealed_value is not None
+    assert row.encrypted_value is not None  # retained for rollback
+
+
+async def test_idempotent(session):
+    session.add(_legacy("user", b"once"))
+    await session.commit()
+    first = await migrate_pg_legacy_secrets(session, fernet=_FERNET, root_key=_ROOT)
+    await session.commit()
+    second = await migrate_pg_legacy_secrets(session, fernet=_FERNET, root_key=_ROOT)
+    assert first.migrated == 1
+    assert second.total_legacy == 0 and second.migrated == 0  # already converted → skipped
+
+
+async def test_bad_ciphertext_reported_not_raised(session):
+    row = Secret(
+        id=uuid.uuid4(),
+        owner_id=_OWNER,
+        name="bad",
+        type="password",
+        scope="user",
+        encrypted_value="not-a-valid-fernet-token",
+        sealed_value=None,
+    )
+    session.add(row)
+    await session.commit()
+    report = await migrate_pg_legacy_secrets(session, fernet=_FERNET, root_key=_ROOT)
+    assert report.total_legacy == 1 and report.migrated == 0 and len(report.failed) == 1
+    assert row.sealed_value is None  # untouched on failure
+
+
+async def test_atomic_on_bad_grant_vault(session):
+    # A corrupt team id (contains ':') makes grant-building raise mid-row; the seal
+    # already succeeded, so this proves the row is left fully untouched (atomic).
+    row = _legacy("group", b"g-val", team_ids=["bad:id"])
+    session.add(row)
+    await session.commit()
+    report = await migrate_pg_legacy_secrets(session, fernet=_FERNET, root_key=_ROOT)
+    await session.commit()
+    assert report.total_legacy == 1 and report.migrated == 0 and len(report.failed) == 1
+    assert row.sealed_value is None and row.owner_vault is None  # nothing persisted


### PR DESCRIPTION
## Thinking Path
Task 3 of the secrets-unification umbrella (#10088) migrates the legacy stores onto the new envelope store. The **PG legacy Fernet rows** are the right first slice: same `secrets` table (in-place conversion), well-defined owner mapping from `owner_id`/scope, key available (`AUTOBOT_SECRETS_KEY`), and — critically — **no live readers/writers** (the envelope path is already authoritative for PG writes), so zero cutover risk. It also establishes the reusable legacy→envelope conversion + reconciliation core the JSON/SQLite cutovers (separate, higher-risk slices) will build on.

## What Changed
- **`services/legacy_secrets_migrator.py`** — `migrate_pg_legacy_secrets(session, *, fernet, root_key)`:
  - Selects rows with `encrypted_value` set and filters "not yet envelope-backed" with Python `sealed_value is None` — matching `UnifiedSecretsService`'s exact detection (a SQL `IS NULL` would miss JSONB rows holding JSON `null`, since SQLAlchemy JSONB defaults to `none_as_null=False`).
  - Decrypts the Fernet value, re-seals under the envelope keeping the row id, sets `owner_vault`/`sealed_value`/`version`, and writes per-grantee `secret_grants`.
  - **Atomic per row:** seal + all grants are built (`_prepare_envelope`) *before* any row mutation, so a bad vault id leaves the row fully untouched and reported — never half-converted.
  - **Idempotent** (re-run finds 0 candidates); **keeps `encrypted_value`** for rollback (a later cleanup slice nulls it); returns a reconciliation report (`total_legacy`/`migrated`/`failed`).
  - **Vault map:** `user`/`session`/`workflow` → `user:<owner_id>`; `organization` → `company:<org_id>` (falls back to the creator's user vault if unset); `shared` → owner + `user:` grants from `shared_with`; `group` → owner + `team:` grants from `team_ids`.

## Verification
- 5 Postgres tests (migration-gate), all green on disposable PG 16:
  - each scope migrates and is envelope-readable via `UnifiedSecretsService` with the right owner vault + grants
  - keeps the legacy blob for rollback
  - idempotent (second run: 0 candidates)
  - bad ciphertext reported, not raised; row untouched
  - bad grant vault id → atomic (row left fully untouched)
- `flake8` 0, `isort` clean, `black` (120) clean.

## Out of scope (next slices, flagged decisions)
- **JSON-store cutover** — the live GUI path; its records lack a clear owner_id → needs a product decision on owner mapping.
- **SQLite-store cutover** (connectors/workflows/agents) — has live readers to repoint.

## Model Used
Claude Opus 4.8

Part of #10088. Closes #10286.
