### PR TITLE
fix(deploy): batched SLM/deployment-health follow-ups (#10285 #10248 #10264 #10274)

### DIFF
--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -11,7 +11,7 @@ and distributed system optimization.
 import asyncio
 import json
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List
 
 import aiohttp
@@ -19,6 +19,7 @@ from fastapi import (
     APIRouter,
     BackgroundTasks,
     Depends,
+    HTTPException,
     Query,
     WebSocket,
     WebSocketDisconnect,
@@ -180,6 +181,26 @@ async def _query_prometheus_range(
         logger.error("Error parsing Prometheus range response: %s", e)
         return []
 
+
+# #10264: PromQL per resource-heatmap metric, grouped by node-exporter `instance`
+# so each returned series maps to one machine (job 'node', :9100). cpu/disk/network
+# are rates over 5m; values are percent except network (bytes/s, rendered relative).
+_HEATMAP_PROMQL: Dict[str, str] = {
+    "cpu": '100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)',
+    "memory": "(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100",
+    "disk": 'avg by (instance) ((1 - (node_filesystem_avail_bytes{fstype!="tmpfs"} '
+    '/ node_filesystem_size_bytes{fstype!="tmpfs"})) * 100)',
+    "network": "sum by (instance) (rate(node_network_receive_bytes_total[5m]) "
+    "+ rate(node_network_transmit_bytes_total[5m]))",
+}
+
+# Maps the heatmap time-range selector to (window, Prometheus step).
+_HEATMAP_RANGE: Dict[str, tuple] = {
+    "1h": (timedelta(hours=1), "1m"),
+    "6h": (timedelta(hours=6), "5m"),
+    "24h": (timedelta(hours=24), "15m"),
+    "7d": (timedelta(days=7), "1h"),
+}
 
 # Issue #474: AlertManager API timeout and cache
 _ALERTMANAGER_TIMEOUT = 5.0  # seconds
@@ -513,6 +534,50 @@ async def get_services_health():
     summary = _compute_overall_status(svc_list)
     summary["services"] = svc_list
     return summary
+
+
+@router.get("/metrics/history")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_resource_metrics_history",
+    error_code_prefix="MONITORING",
+)
+async def get_resource_metrics_history(
+    metric: str = Query("cpu", description="cpu | memory | disk | network"),
+    range: str = Query("1h", description="1h | 6h | 24h | 7d"),
+    machine: str = Query("", description="Optional substring filter on the node instance label"),
+):
+    """Per-machine resource-utilization history for the dashboard heatmap (#10264).
+
+    Queries Prometheus node-exporter range data and groups the series by the
+    ``instance`` label so each machine becomes one heatmap row. Shapes the result
+    as ``{machines: [{name, metrics: [{time, value}]}]}`` — the contract
+    ``useResourceMetrics.processData`` expects.
+    """
+    promql = _HEATMAP_PROMQL.get(metric)
+    if promql is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid metric '{metric}'. Must be one of: {sorted(_HEATMAP_PROMQL)}",
+        )
+    delta, step = _HEATMAP_RANGE.get(range, (timedelta(hours=1), "1m"))
+    end = datetime.now(timezone.utc)
+    start = end - delta
+
+    points = await _query_prometheus_range(promql, start, end, step)
+
+    machines: Dict[str, List[Dict[str, Any]]] = {}
+    for point in points:
+        instance = point.get("labels", {}).get("instance", "unknown")
+        if machine and machine not in instance:
+            continue
+        machines.setdefault(instance, []).append({"time": point["timestamp"], "value": round(point["value"], 2)})
+
+    return {
+        "metric": metric,
+        "range": range,
+        "machines": [{"name": name, "metrics": series} for name, series in sorted(machines.items())],
+    }
 
 
 @router.get("/status", response_model=MonitoringStatus)

--- a/autobot-frontend/src/composables/useSystemStatus.ts
+++ b/autobot-frontend/src/composables/useSystemStatus.ts
@@ -100,6 +100,10 @@ const SERVICE_DISPLAY_NAMES: Record<string, string> = {
   frontend: 'Frontend',
   npu_worker: 'NPU Worker',
   browser: 'Browser Service',
+  // #10285: /service-monitor/services reports this under key `chromadb` while
+  // /service-monitor/vms/status reports the same health as 'AI Stack (ChromaDB)'.
+  // Map both to one display name so deduplicateServices() collapses the pair.
+  chromadb: 'AI Stack (ChromaDB)',
 }
 
 const DEFAULT_SERVICES: SystemService[] = [

--- a/autobot-infrastructure/shared/config/hyperv-deployment.yaml
+++ b/autobot-infrastructure/shared/config/hyperv-deployment.yaml
@@ -1,4 +1,7 @@
-# AutoBot Hyper-V Deployment Configuration
+# AutoBot Deployment Configuration (target hosts/VMs, hypervisor-agnostic)
+# Legacy separated multi-VM topology layout; retained for reference. AutoBot
+# now deploys co-located via the SLM onto one or more hosts (co-located or
+# distributed). Requirements are a supported OS + hardware.
 network:
   subnet: "192.168.65.0/24"
   gateway: "192.168.65.1"

--- a/autobot-infrastructure/shared/scripts/validate-native-deployment.py
+++ b/autobot-infrastructure/shared/scripts/validate-native-deployment.py
@@ -5,8 +5,8 @@
 """
 AutoBot Native VM Deployment Validation Script
 
-Tests connectivity and health of all services across 6 machines:
-- 5 Hyper-V VMs (10.0.0.2-25)
+Tests connectivity and health of all services across the deployment hosts:
+- One or more target hosts/VMs (hypervisor-agnostic; e.g. 10.0.0.2-25)
 - 1 WSL machine (10.0.0.1) running backend + terminal + noVNC
 All services run natively (no Docker containers).
 """

--- a/autobot-slm-backend/ansible/deploy.sh
+++ b/autobot-slm-backend/ansible/deploy.sh
@@ -2,8 +2,9 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
 #
-# AutoBot Hyper-V Deployment Script
-# Comprehensive deployment orchestration for migrating AutoBot from Docker to 5 VMs
+# AutoBot Deployment Script (hypervisor-agnostic)
+# Comprehensive deployment orchestration for migrating AutoBot from Docker to
+# one or more target hosts/VMs (co-located or distributed)
 #
 
 set -euo pipefail
@@ -464,7 +465,7 @@ setup_passwordless_sudo() {
 # Usage information
 show_usage() {
     cat << EOF
-AutoBot Hyper-V Deployment Script
+AutoBot Deployment Script
 
 USAGE:
   $0 [OPTIONS]
@@ -552,7 +553,7 @@ main() {
     # Record start time
     START_TIME=$(date +%s)
 
-    log "INFO" "🤖 AutoBot Hyper-V Deployment Script Starting..."
+    log "INFO" "🤖 AutoBot Deployment Script Starting..."
     log "INFO" "Timestamp: $(date)"
     log "INFO" "Log file: $LOG_FILE"
 

--- a/autobot-slm-backend/ansible/inventory/production.yml
+++ b/autobot-slm-backend/ansible/inventory/production.yml
@@ -1,8 +1,8 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
 ---
-# AutoBot Production Inventory - Hyper-V VMs
-# Update the ansible_host IPs with your actual VM addresses
+# AutoBot Production Inventory - target hosts/VMs (hypervisor-agnostic)
+# Update the ansible_host IPs with your actual host/VM addresses
 
 all:
   vars:

--- a/autobot-slm-backend/ansible/playbooks/data-migration.yml
+++ b/autobot-slm-backend/ansible/playbooks/data-migration.yml
@@ -2,9 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 # Data Migration Playbook
-# Migrates data from Docker containers to Hyper-V VMs
+# Migrates data from Docker containers to target hosts/VMs.
+#
+# DEPRECATION NOTICE: This playbook encodes the obsolete separated multi-VM
+# topology (one role per VM). AutoBot now deploys co-located, orchestrated by
+# the SLM, onto one or more hosts (co-located or distributed). Requirements are
+# a supported OS + hardware; the deployment is hypervisor-agnostic. Retained for
+# reference and legacy migrations — do not delete.
 
-- name: "AutoBot Data Migration - Docker to Hyper-V"
+- name: "AutoBot Data Migration - Docker to VM"
   hosts: localhost
   gather_facts: false
   vars:
@@ -18,7 +24,7 @@
         msg:
           - "📦 AutoBot Data Migration Starting"
           - "Source: Docker Containers"
-          - "Target: 5 Hyper-V VMs"
+          - "Target: one or more hosts (co-located or distributed)"
           - "Migration ID: {{ migration_timestamp }}"
           - "Backup Directory: {{ migration_backup_dir }}"
 
@@ -435,7 +441,7 @@
           Date: {{ ansible_facts['date_time'].iso8601 }}
 
           Source: Docker Containers
-          Target: 5 Hyper-V VMs
+          Target: one or more hosts (co-located or distributed)
 
           Migrated Components:
           - Redis Database: {{ 'Yes' if hostvars[groups['database'][0]]['redis_dbsize'] is defined else 'No' }}
@@ -459,7 +465,7 @@
           - "🎉 AutoBot Data Migration Completed!"
           - "=================================="
           - ""
-          - "✅ Migration successful from Docker containers to 5 Hyper-V VMs"
+          - "✅ Migration successful from Docker containers to target hosts/VMs"
           - "📁 Backup preserved at: {{ migration_backup_dir }}"
           - "📝 Summary available at: {{ migration_backup_dir }}/migration-summary.txt"
           - ""

--- a/autobot-slm-backend/ansible/playbooks/deploy-full.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-full.yml
@@ -17,9 +17,15 @@
   tags: ['pre-deployment', 'validation']
 
 # AutoBot Full Deployment Playbook
-# Orchestrates complete migration from Docker to Hyper-V VMs
+# Orchestrates complete migration from Docker containers to target hosts/VMs.
+#
+# DEPRECATION NOTICE: This playbook encodes the obsolete separated multi-VM
+# topology (one role per VM). AutoBot now deploys co-located, orchestrated by
+# the SLM, onto one or more hosts (co-located or distributed). Requirements are
+# a supported OS + hardware; the deployment is hypervisor-agnostic. Retained for
+# reference and legacy migrations — do not delete.
 
-- name: "AutoBot Full Deployment - Docker to Hyper-V Migration"
+- name: "AutoBot Full Deployment - Docker to VM Migration"
   hosts: localhost
   gather_facts: false
   vars:
@@ -30,10 +36,10 @@
     - name: Display deployment information
       debug:
         msg:
-          - "🤖 AutoBot Hyper-V Deployment Starting"
+          - "🤖 AutoBot Deployment Starting"
           - "Deployment ID: {{ deployment_id }}"
           - "Timestamp: {{ ansible_facts['date_time'].iso8601 }}"
-          - "Target Infrastructure: 5 Hyper-V VMs"
+          - "Target Infrastructure: one or more hosts (co-located or distributed)"
           - "Migration: Docker Containers → Virtual Machines"
 
     - name: Create deployment log directory
@@ -48,7 +54,7 @@
         content: |
           Deployment ID: {{ deployment_id }}
           Start Time: {{ ansible_facts['date_time'].iso8601 }}
-          Infrastructure: 5 Hyper-V VMs
+          Infrastructure: one or more hosts (co-located or distributed)
           Migration: Docker → VM
         dest: "/var/log/autobot/deployment/{{ deployment_id }}.log"
         mode: '0644'
@@ -253,7 +259,7 @@
     - name: Display deployment summary
       debug:
         msg:
-          - "🎉 AutoBot Hyper-V Deployment Completed Successfully!"
+          - "🎉 AutoBot Deployment Completed Successfully!"
           - "======================================================"
           - ""
           - "⏱️  Deployment Duration: {{ deployment_duration }} seconds ({{ (deployment_duration | int / 60) | round(1) }} minutes)"
@@ -277,7 +283,7 @@
           - "   AI/ML:        ssh autobot@{{ _aiml_ip }}"
           - "   Browser:      ssh autobot@{{ _browser_ip }}"
           - ""
-          - "✅ Migration Status: Docker Containers → Hyper-V VMs Complete"
+          - "✅ Migration Status: Docker Containers → VMs Complete"
           - "📊 Performance: Dedicated resources, native VM performance"
           - "🔒 Security: Internal network isolation, firewall protection"
           - "📈 Scalability: Independent VM scaling and resource allocation"
@@ -307,7 +313,7 @@
           - Browser: http://{{ _browser_ip }}:{{ _browser_port }}
           - VNC: vnc://{{ _browser_ip }}:{{ _vnc_port }}
 
-          Migration: Docker Containers → 5 Hyper-V VMs
+          Migration: Docker Containers → VMs
           Infrastructure: Production-ready with monitoring and backups
         dest: "/var/log/autobot/deployment/{{ deployment_id }}-complete.log"
         mode: '0644'

--- a/autobot-slm-backend/ansible/playbooks/deploy-hybrid-docker.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-hybrid-docker.yml
@@ -2,8 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 # Hybrid Deployment: Docker Containers on VMs
-# Deploys AutoBot services as Docker containers on Hyper-V VMs
-# Backend remains on host machine
+# Deploys AutoBot services as Docker containers on target hosts/VMs.
+# Backend remains on host machine.
+#
+# DEPRECATION NOTICE: This playbook encodes the obsolete separated multi-VM
+# topology. AutoBot now deploys co-located, orchestrated by the SLM, onto one
+# or more hosts (co-located or distributed). Requirements are a supported OS +
+# hardware; the deployment is hypervisor-agnostic. Retained for reference and
+# legacy migrations — do not delete.
 
 - name: Deploy Docker Containers to VMs
   hosts: all

--- a/autobot-slm-backend/ansible/utils/backup.sh
+++ b/autobot-slm-backend/ansible/utils/backup.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # AutoBot Backup Utility
-# Comprehensive backup solution for the Hyper-V deployment
+# Comprehensive backup solution for the AutoBot deployment (hypervisor-agnostic)
 #
 
 set -euo pipefail

--- a/autobot-slm-backend/ansible/utils/health-check.sh
+++ b/autobot-slm-backend/ansible/utils/health-check.sh
@@ -2,8 +2,8 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
 #
-# AutoBot Hyper-V Deployment Health Check Utility
-# Validates all services across the 5-VM deployment
+# AutoBot Deployment Health Check Utility
+# Validates all services across the deployment (one or more hosts/VMs)
 #
 
 set -euo pipefail

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -447,7 +447,8 @@ async def resolve_drift(
     (#9982) so that the synced code is immediately live:
       - Python backend components: pip install -r requirements.txt + service restart
       - Frontend components: npm ci + npm run build + nginx restart
-      - Library components (autobot_shared): no-op (no service to restart)
+      - Library components (autobot_shared): restart every dependent service so
+        the new shared code is loaded (#10248)
 
     Body:
         component: Sub-directory under /opt/autobot/. Must be in ALLOWED_COMPONENTS.
@@ -743,6 +744,18 @@ _COMPONENT_SERVICES: Dict[str, List[str]] = {
     "autobot-slm-backend": ["autobot-slm-backend"],
     "autobot-frontend": ["nginx"],
     "autobot-slm-frontend": ["nginx"],
+    # #10248: autobot_shared is imported by every Python service, so syncing it
+    # must restart them all (else they keep running the old shared code and may
+    # ImportError on a newly-referenced symbol). Restarts tolerate absent units
+    # (distributed nodes won't have every service) — failures are logged, not fatal.
+    "autobot_shared": [
+        "autobot-slm-backend",
+        "autobot-backend",
+        "autobot-ai-stack",
+        "autobot-celery",
+        "autobot-celery-beat",
+        "autobot-npu-worker",
+    ],
 }
 
 
@@ -899,8 +912,11 @@ async def _run_post_sync_steps(
     elif component in _COMPONENT_FRONTEND_DIRS:
         await _build_npm_frontend_for_component(component, steps)
         await _restart_component_services(component, steps)
+    elif component in _COMPONENT_SERVICES:
+        # Library component (autobot_shared): no build step, but every service
+        # that imports it must restart so the new shared code is loaded (#10248).
+        await _restart_component_services(component, steps)
     else:
-        # autobot_shared and any future library-only components — no services
         steps.append(f"post-sync: no service or build step for {component}")
 
     return deps_changed, steps

--- a/autobot-slm-backend/services/drift_checker.py
+++ b/autobot-slm-backend/services/drift_checker.py
@@ -67,6 +67,12 @@ ALLOWED_COMPONENTS = frozenset(
         "autobot-slm-frontend",
         "autobot-backend",
         "autobot-frontend",
+        # #10248: the shared library is its own syncable component. Without this,
+        # component code could be advanced past the autobot_shared it imports
+        # (e.g. a new symbol) with no way to sync the lib and no drift signal,
+        # crash-looping every backend that imports it. Resolving it restarts all
+        # dependent services (see _COMPONENT_SERVICES in api/code_sync.py).
+        "autobot_shared",
     }
 )
 

--- a/autobot-slm-backend/tests/api/test_drift_resolve.py
+++ b/autobot-slm-backend/tests/api/test_drift_resolve.py
@@ -318,3 +318,17 @@ def test_shared_lib_post_steps_noop():
 def _run_async_return(value):
     """Backward-compat alias for _async_return."""
     return _async_return(value)
+
+
+def test_autobot_shared_is_syncable_and_restarts_dependents():
+    """#10248: autobot_shared is a first-class syncable component whose resolve
+    restarts every dependent service (so component code can't outrun the lib)."""
+    from api.code_sync import _COMPONENT_SERVICES
+    from services.drift_checker import ALLOWED_COMPONENTS
+
+    assert "autobot_shared" in ALLOWED_COMPONENTS
+    deps = _COMPONENT_SERVICES.get("autobot_shared", [])
+    # Must restart the core Python services that import autobot_shared.
+    assert "autobot-backend" in deps
+    assert "autobot-slm-backend" in deps
+    assert len(deps) >= 2

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -271,7 +271,7 @@ Frontend build tool and development server. Only runs on VM1.
 Virtual Network Computing - desktop streaming protocol. AutoBot exposes VNC at port 6080.
 
 ### VM (Virtual Machine)
-Isolated computing environments running on Hyper-V. AutoBot uses 6 VMs.
+Isolated computing environments. AutoBot is hypervisor-agnostic and can deploy onto one or more hosts or VMs (co-located or distributed); it requires only a supported OS and hardware.
 
 ### Vue
 Frontend JavaScript framework (Vue 3) used for the AutoBot web interface.

--- a/docs/architecture/Kubernetes_Migration_Strategy.md
+++ b/docs/architecture/Kubernetes_Migration_Strategy.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-Migrating AutoBot from current Hyper-V + WSL architecture to Kubernetes would provide enhanced scalability, resilience, and native centralized logging capabilities. Our current modular architecture is well-positioned for this transition.
+Migrating AutoBot from the current host/VM-based architecture to Kubernetes would provide enhanced scalability, resilience, and native centralized logging capabilities. Our current modular architecture is well-positioned for this transition.
 
 ## Current Architecture Benefits for K8s Migration
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -80,7 +80,7 @@ Key architectural decisions are documented in ADRs. See [docs/adr/](../adr/READM
 - **Intel NPU** - Hardware acceleration
 
 ### Infrastructure
-- **Hyper-V** - VM hypervisor
+- **Hypervisor-agnostic** - runs on any supported hypervisor or bare metal (VirtualBox, VMware, Hyper-V, KVM, WSL2); requires only a supported OS + hardware
 - **Docker** - Containerization (optional)
 - **Playwright** - Browser automation
 - **noVNC** - Desktop streaming

--- a/docs/guides/HYPER_V_MIGRATION_PLAN.md
+++ b/docs/guides/HYPER_V_MIGRATION_PLAN.md
@@ -1,9 +1,14 @@
-# 🔄 AutoBot Hyper-V Migration Plan
+# 🔄 AutoBot VM Migration Plan (legacy)
+
+> **Deprecation notice:** This plan documents the obsolete separated multi-VM
+> topology. AutoBot now deploys co-located, orchestrated by the SLM, onto one or
+> more hosts (co-located or distributed) and is hypervisor-agnostic — it requires
+> only a supported OS + hardware. Retained for historical reference.
 
 **GitHub Issue:** [#257](https://github.com/mrveiss/AutoBot-AI/issues/257)
 **Migration Date:** Post P0 Critical Tasks Completion
-**Current Architecture:** 8 Docker Containers → 5 Hyper-V VMs
-**Target Infrastructure:** Hyper-V with SSH-enabled VMs
+**Current Architecture:** 8 Docker Containers → 5 target VMs
+**Target Infrastructure:** SSH-enabled hosts/VMs (hypervisor-agnostic)
 
 ---
 


### PR DESCRIPTION
## Thinking Path
Batched follow-ups from the local-install health work (umbrella #9919), grouped into one PR (one CI run) per request, with one commit per issue for review clarity.

## What Changed (per commit)
- **#10285** `fix(slm-ui)` — ChromaDB appeared twice in the Services panel ('AI Stack (ChromaDB)' from `/vms/status` + 'chromadb' from `/services`). Map the `chromadb` key to the same display name so `deduplicateServices()` collapses the pair. (`useSystemStatus.ts`)
- **#10248** `fix(code-sync)` — `autobot_shared` was unsyncable via Code Sync (not in `ALLOWED_COMPONENTS`) and invisible to drift, yet every service imports it → component code could outrun the shared lib and crash-loop. Add it as a first-class component + map it to all dependent services so resolving it restarts them; post-sync dispatch now restarts library-component dependents instead of no-op. (`drift_checker.py`, `code_sync.py` + test)
- **#10264** `feat(monitoring)` — ResourceHeatmap fetched `/api/monitoring/metrics/history` (404 → sample-data fallback). Add the endpoint backed by Prometheus node-exporter range queries, grouped by `instance` (one machine per row); cpu/memory/disk/network over 1h/6h/24h/7d in the `{machines:[{name,metrics:[{time,value}]}]}` shape the FE expects. (`monitoring.py`)
- **#10274** `cleanup(deploy)` — genericize baked-in 'Hyper-V'/'5-VM' framing to hypervisor-agnostic (OS + hardware only) across legacy playbooks/scripts/docs; the 3 dead multi-VM migration playbooks get a DEPRECATION NOTICE and are KEPT (no deletions). No functional change (no hypervisor gate exists).

## Verification
- `py_compile` + `black --check` clean on all changed Python; no conflict markers; no file deletions.
- #10248: path resolution already maps `autobot_shared` (code_source ↔ /opt/autobot); the `autobot_shared/` drift exclusion only applies to other components' reports. Guard test added.
- #10264: data source confirmed — node-exporter is scraped (`prometheus.yml` job 'node' :9100); `_query_prometheus_range` already returns per-`instance` labelled series.
- #10285/#10274 verified against the live UI errors.

## Model Used
Claude Opus 4.8