### PR TITLE
feat(media): AI video generation — Runway provider + async API + generate_video tool (#9016)

### DIFF
--- a/autobot-backend/api/_video_providers_loader.py
+++ b/autobot-backend/api/_video_providers_loader.py
@@ -1,0 +1,82 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Video providers loader — GH#9016.
+
+The video-generation-plugin lives under ``plugins/core-plugins/`` whose directory
+name (hyphenated) is not importable as a Python package. This helper resolves the
+plugin's ``providers`` module by file path and registers it in ``sys.modules`` so
+the API layer can use the provider abstraction without the plugin loader.
+
+``load_video_providers()`` returns the module (with get_provider/provider_names/
+ProviderError) or ``None`` when the plugin tree or aiohttp is unavailable, keeping
+startup-import-smoke safe.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from pathlib import Path
+from types import ModuleType
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_MODULE_NAME = "autobot_video_providers"
+_REL_PATH = Path("core-plugins") / "video-generation-plugin" / "tools" / "providers.py"
+
+_cached: Optional[ModuleType] = None
+_loaded = False
+
+
+def _candidate_paths() -> list[Path]:
+    """Return candidate providers.py locations, most-canonical first."""
+    candidates: list[Path] = []
+    try:
+        from autobot_shared.ssot_config import config as _cfg
+
+        plugins_root = getattr(getattr(_cfg, "path", None), "plugins_path", None)
+        if plugins_root:
+            candidates.append(Path(plugins_root) / _REL_PATH)
+    except Exception:  # pragma: no cover - config optional during smoke
+        pass
+    # Repo-relative fallback: api/ -> autobot-backend/ -> repo root -> plugins/
+    repo_root = Path(__file__).resolve().parents[2]
+    candidates.append(repo_root / "plugins" / _REL_PATH)
+    candidates.append(Path("plugins") / _REL_PATH)
+    return candidates
+
+
+def load_video_providers() -> Optional[ModuleType]:
+    """Load and cache the video providers module, or None if unavailable."""
+    global _cached, _loaded
+    if _loaded:
+        return _cached
+    _loaded = True
+
+    import sys
+
+    for path in _candidate_paths():
+        try:
+            if not path.exists():
+                continue
+            spec = importlib.util.spec_from_file_location(_MODULE_NAME, path)
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            # Register before exec so dataclasses can resolve the module.
+            sys.modules[_MODULE_NAME] = module
+            spec.loader.exec_module(module)
+            _cached = module
+            logger.info("Video providers loaded from %s", path)
+            return _cached
+        except Exception as exc:  # pragma: no cover - import guard
+            logger.warning("Failed loading video providers from %s: %s", path, exc)
+            sys.modules.pop(_MODULE_NAME, None)
+            continue
+
+    logger.warning("Video providers module not found in any candidate path")
+    return None

--- a/autobot-backend/api/video_generation.py
+++ b/autobot-backend/api/video_generation.py
@@ -56,6 +56,7 @@ else:  # pragma: no cover - import guard
     def provider_names():  # type: ignore[no-redef]
         return ["runway", "sora", "kling"]
 
+
 router = APIRouter(tags=["video-generation", "media"])
 
 # Job records are short-lived; TTL is env-tunable (no hard-coded magic number).
@@ -198,9 +199,7 @@ async def generate_video(request: VideoGenerationRequest, current_user=Depends(g
 
 
 @router.get("/status/{job_id}", response_model=VideoStatusResponse)
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR, operation="video_job_status", error_code_prefix="VIDEO_GEN"
-)
+@with_error_handling(category=ErrorCategory.SERVER_ERROR, operation="video_job_status", error_code_prefix="VIDEO_GEN")
 async def get_status(job_id: str, current_user=Depends(get_current_user)):
     """Poll a submitted job for progress and the final video URL."""
     record = await _load_job(job_id)
@@ -213,8 +212,12 @@ async def get_status(job_id: str, current_user=Depends(get_current_user)):
     except ProviderError as exc:
         logger.warning("video poll failed (job=%s): %s", job_id, exc)
         return VideoStatusResponse(
-            success=False, job_id=job_id, status="failed", provider=record.get("provider", ""),
-            prompt=record.get("prompt", ""), error=str(exc),
+            success=False,
+            job_id=job_id,
+            status="failed",
+            provider=record.get("provider", ""),
+            prompt=record.get("prompt", ""),
+            error=str(exc),
         )
 
     return VideoStatusResponse(

--- a/autobot-backend/api/video_generation.py
+++ b/autobot-backend/api/video_generation.py
@@ -1,0 +1,229 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Video Generation API — GH#9016.
+
+REST surface for the video-generation-plugin. Video generation is async, so
+unlike image generation this exposes a submit + poll lifecycle:
+
+    POST /api/video-generation/generate       — submit a job, returns job_id
+    GET  /api/video-generation/status/{id}     — poll progress + final URL
+    GET  /api/video-generation/providers       — list configured providers
+
+Mirrors api/image_generation.py (provider listing, secrets-gated keys, router
+shape). The job record is persisted in Redis so polling works across workers.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from api._video_providers_loader import load_video_providers
+from auth_middleware import get_current_user
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.redis_client import redis_get, redis_set
+
+logger = logging.getLogger(__name__)
+
+# Providers live in the video-generation-plugin tree. The plugin loader's
+# package path (plugins.core_plugins.*) is not importable directly, so we
+# resolve the module by file path. The loader is guarded so startup-import-smoke
+# never breaks if the plugin tree or its deps are absent.
+_providers = load_video_providers()
+_PROVIDERS_AVAILABLE = _providers is not None
+
+if _PROVIDERS_AVAILABLE:
+    ProviderError = _providers.ProviderError  # type: ignore[attr-defined]
+    get_provider = _providers.get_provider  # type: ignore[attr-defined]
+    provider_names = _providers.provider_names  # type: ignore[attr-defined]
+else:  # pragma: no cover - import guard
+
+    class ProviderError(Exception):  # type: ignore[no-redef]
+        pass
+
+    def get_provider(name: str):  # type: ignore[no-redef]
+        raise ProviderError("video providers unavailable")
+
+    def provider_names():  # type: ignore[no-redef]
+        return ["runway", "sora", "kling"]
+
+router = APIRouter(tags=["video-generation", "media"])
+
+# Job records are short-lived; TTL is env-tunable (no hard-coded magic number).
+_JOB_TTL_S = int(os.environ.get("VIDEO_GEN_JOB_TTL_S", "3600"))
+_JOB_KEY_PREFIX = "video_gen:job:"
+
+_PROVIDER_ENV = {"runway": "RUNWAY_API_KEY", "sora": "SORA_API_KEY", "kling": "KLING_API_KEY"}
+
+
+# ------------------------------------------------------------------
+# Request / Response models
+# ------------------------------------------------------------------
+
+
+class VideoGenerationRequest(BaseModel):
+    prompt: str = Field(..., min_length=1, max_length=4000)
+    provider: str = Field("runway", pattern="^(runway|sora|kling)$")
+    duration: int = Field(5, ge=1, le=20)
+    resolution: Optional[str] = Field(None)
+    aspect_ratio: Optional[str] = Field(None, pattern="^(16:9|9:16|1:1)$")
+
+
+class VideoJobResponse(BaseModel):
+    success: bool
+    job_id: str = ""
+    provider: str = ""
+    status: str = "pending"
+    error: Optional[str] = None
+
+
+class VideoStatusResponse(BaseModel):
+    success: bool
+    job_id: str = ""
+    status: str = "pending"
+    progress: float = 0.0
+    video_url: Optional[str] = None
+    provider: str = ""
+    prompt: str = ""
+    error: Optional[str] = None
+
+
+class ProviderStatus(BaseModel):
+    name: str
+    available: bool
+    reason: Optional[str] = None
+
+
+class ProvidersResponse(BaseModel):
+    providers: list[ProviderStatus]
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _job_key(job_id: str) -> str:
+    return f"{_JOB_KEY_PREFIX}{job_id}"
+
+
+async def _load_job(job_id: str) -> Optional[dict]:
+    raw = await redis_get(_job_key(job_id))
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+async def _store_job(job_id: str, record: dict) -> None:
+    await redis_set(_job_key(job_id), json.dumps(record), expire=_JOB_TTL_S)
+
+
+# ------------------------------------------------------------------
+# Endpoints
+# ------------------------------------------------------------------
+
+
+@router.get("/providers", response_model=ProvidersResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR, operation="list_video_providers", error_code_prefix="VIDEO_GEN"
+)
+async def list_providers(current_user=Depends(get_current_user)):
+    """Return which video providers have API keys configured."""
+    providers = []
+    for name in provider_names():
+        env_var = _PROVIDER_ENV.get(name, "")
+        configured = bool(os.environ.get(env_var))
+        providers.append(
+            ProviderStatus(
+                name=name,
+                available=configured,
+                reason=None if configured else f"{env_var} not set",
+            )
+        )
+    return ProvidersResponse(providers=providers)
+
+
+@router.post("/generate", response_model=VideoJobResponse)
+@with_error_handling(category=ErrorCategory.SERVER_ERROR, operation="generate_video", error_code_prefix="VIDEO_GEN")
+async def generate_video(request: VideoGenerationRequest, current_user=Depends(get_current_user)):
+    """Submit an async video-generation job; returns a job id to poll."""
+    if not _PROVIDERS_AVAILABLE:
+        return VideoJobResponse(success=False, error="video-generation-plugin not installed")
+
+    try:
+        provider = get_provider(request.provider)
+    except ProviderError as exc:
+        return VideoJobResponse(success=False, error=str(exc))
+
+    if not provider.available:
+        env_var = _PROVIDER_ENV.get(request.provider, "API key")
+        return VideoJobResponse(
+            success=False,
+            provider=request.provider,
+            error=f"{env_var} not configured — {request.provider} provider disabled",
+        )
+
+    try:
+        job_id = await provider.submit(
+            request.prompt,
+            duration=request.duration,
+            resolution=request.resolution or "1280x720",
+            aspect_ratio=request.aspect_ratio or "16:9",
+        )
+    except ProviderError as exc:
+        logger.warning("video submit failed (provider=%s): %s", request.provider, exc)
+        return VideoJobResponse(success=False, provider=request.provider, error=str(exc))
+
+    record = {
+        "provider": request.provider,
+        "provider_job_id": job_id,
+        "prompt": request.prompt,
+        "duration": request.duration,
+    }
+    local_id = uuid.uuid4().hex
+    await _store_job(local_id, record)
+    return VideoJobResponse(success=True, job_id=local_id, provider=request.provider, status="pending")
+
+
+@router.get("/status/{job_id}", response_model=VideoStatusResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR, operation="video_job_status", error_code_prefix="VIDEO_GEN"
+)
+async def get_status(job_id: str, current_user=Depends(get_current_user)):
+    """Poll a submitted job for progress and the final video URL."""
+    record = await _load_job(job_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="Video job not found or expired")
+
+    try:
+        provider = get_provider(record["provider"])
+        status = await provider.poll(record["provider_job_id"])
+    except ProviderError as exc:
+        logger.warning("video poll failed (job=%s): %s", job_id, exc)
+        return VideoStatusResponse(
+            success=False, job_id=job_id, status="failed", provider=record.get("provider", ""),
+            prompt=record.get("prompt", ""), error=str(exc),
+        )
+
+    return VideoStatusResponse(
+        success=status.status != "failed",
+        job_id=job_id,
+        status=status.status,
+        progress=status.progress,
+        video_url=status.video_url,
+        provider=status.provider or record.get("provider", ""),
+        prompt=record.get("prompt", ""),
+        error=status.error,
+    )

--- a/autobot-backend/api/video_generation_test.py
+++ b/autobot-backend/api/video_generation_test.py
@@ -1,0 +1,138 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the video generation API — GH#9016. All I/O is mocked."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api import video_generation as vg
+
+USER = {"username": "testuser", "role": "user", "org_id": "org123"}
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+
+    async def _override_user():
+        return USER
+
+    from auth_middleware import get_current_user
+
+    app.dependency_overrides[get_current_user] = _override_user
+    app.include_router(vg.router)
+    return app
+
+
+@pytest.fixture
+def store():
+    """In-memory Redis stand-in keyed by job key."""
+    data = {}
+
+    async def _set(key, value, expire=None, database="main"):
+        data[key] = value
+        return True
+
+    async def _get(key, database="main"):
+        return data.get(key)
+
+    with (
+        patch.object(vg, "redis_set", new=AsyncMock(side_effect=_set)),
+        patch.object(vg, "redis_get", new=AsyncMock(side_effect=_get)),
+    ):
+        yield data
+
+
+@pytest.fixture
+def client(store):
+    return TestClient(_make_app())
+
+
+def _fake_provider(available=True, name="runway"):
+    p = MagicMock()
+    p.name = name
+    p.available = available
+    p.submit = AsyncMock(return_value="provider-job-1")
+    return p
+
+
+def test_list_providers(client):
+    with patch.dict("os.environ", {"RUNWAY_API_KEY": "x", "SORA_API_KEY": "", "KLING_API_KEY": ""}, clear=False):
+        resp = client.get("/providers")
+    assert resp.status_code == 200
+    names = {p["name"]: p["available"] for p in resp.json()["providers"]}
+    assert names["runway"] is True
+    assert names["sora"] is False
+
+
+def test_generate_submits_and_returns_job_id(client, store):
+    provider = _fake_provider()
+    with patch.object(vg, "get_provider", return_value=provider), patch.object(vg, "_PROVIDERS_AVAILABLE", True):
+        resp = client.post("/generate", json={"prompt": "a cat", "duration": 5, "provider": "runway"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    job_id = body["job_id"]
+    assert job_id
+    # Record persisted with provider job id.
+    stored = json.loads(next(iter(store.values())))
+    assert stored["provider_job_id"] == "provider-job-1"
+    assert stored["prompt"] == "a cat"
+
+
+def test_generate_provider_disabled(client):
+    provider = _fake_provider(available=False)
+    with patch.object(vg, "get_provider", return_value=provider), patch.object(vg, "_PROVIDERS_AVAILABLE", True):
+        resp = client.post("/generate", json={"prompt": "a cat", "provider": "runway"})
+    assert resp.status_code == 200
+    assert resp.json()["success"] is False
+    assert "RUNWAY_API_KEY" in resp.json()["error"]
+
+
+def test_status_unknown_job_404(client):
+    resp = client.get("/status/does-not-exist")
+    assert resp.status_code == 404
+
+
+def test_status_running_then_succeeded(client, store):
+    provider = _fake_provider()
+    # Submit first to create a job record.
+    with patch.object(vg, "get_provider", return_value=provider), patch.object(vg, "_PROVIDERS_AVAILABLE", True):
+        job_id = client.post("/generate", json={"prompt": "a cat", "provider": "runway"}).json()["job_id"]
+
+    running = vg.VideoStatusResponse  # noqa: F841 - sanity reference
+    poll_provider = MagicMock()
+    poll_provider.poll = AsyncMock(
+        return_value=MagicMock(
+            status="succeeded", progress=1.0, video_url="https://v/c.mp4", provider="runway", error=None
+        )
+    )
+    with patch.object(vg, "get_provider", return_value=poll_provider):
+        resp = client.get(f"/status/{job_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "succeeded"
+    assert body["video_url"] == "https://v/c.mp4"
+    assert body["progress"] == 1.0
+
+
+def test_full_lifecycle_submit_then_poll_progress(client, store):
+    provider = _fake_provider()
+    with patch.object(vg, "get_provider", return_value=provider), patch.object(vg, "_PROVIDERS_AVAILABLE", True):
+        job_id = client.post("/generate", json={"prompt": "clip", "provider": "runway"}).json()["job_id"]
+
+    poll_provider = MagicMock()
+    poll_provider.poll = AsyncMock(
+        return_value=MagicMock(status="running", progress=0.5, video_url=None, provider="runway", error=None)
+    )
+    with patch.object(vg, "get_provider", return_value=poll_provider):
+        resp = client.get(f"/status/{job_id}")
+    body = resp.json()
+    assert body["status"] == "running"
+    assert body["progress"] == 0.5
+    assert body["video_url"] is None

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -221,6 +221,13 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["image-generation", "media"],
         "image_generation",
     ),
+    # GH#9016: Video generation — Runway ML (baseline), Sora, Kling (async submit/poll)
+    (
+        "api.video_generation",
+        "/video-generation",
+        ["video-generation", "media"],
+        "video_generation",
+    ),
     (
         "api.web_research_settings",
         "/web-research-settings",

--- a/autobot-frontend/src/components/artifact-cells/VideoCell.test.ts
+++ b/autobot-frontend/src/components/artifact-cells/VideoCell.test.ts
@@ -1,0 +1,68 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// GH#9016 — VideoCell rendering tests
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import VideoCell from './VideoCell.vue'
+import { createI18n } from 'vue-i18n'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      videoCell: {
+        copyUrl: 'Copy url',
+        download: 'Download',
+        failed: 'Video generation failed',
+        generating: 'Generating video…',
+        placeholder: 'Video',
+      },
+    },
+  },
+})
+
+const mountCell = (richPayload: Record<string, unknown> | null) =>
+  mount(VideoCell, {
+    props: { richPayload },
+    global: { stubs: { Icon: true }, plugins: [i18n] },
+  })
+
+describe('VideoCell.vue', () => {
+  it('shows placeholder when richPayload is null', () => {
+    const wrapper = mountCell(null)
+    expect(wrapper.find('.video-placeholder').exists()).toBe(true)
+    expect(wrapper.find('.video-content').exists()).toBe(false)
+  })
+
+  it('renders an inline video element when a video_url is present', () => {
+    const wrapper = mountCell({
+      video_url: 'https://v/clip.mp4',
+      provider: 'runway',
+      prompt: 'a sunrise',
+      status: 'succeeded',
+    })
+    const video = wrapper.find('video.generated-video')
+    expect(video.exists()).toBe(true)
+    expect(video.attributes('src')).toBe('https://v/clip.mp4')
+    expect(wrapper.find('.video-progress').exists()).toBe(false)
+  })
+
+  it('shows a progress indicator while generating', () => {
+    const wrapper = mountCell({ provider: 'runway', status: 'running', progress: 0.4 })
+    expect(wrapper.find('.video-progress').exists()).toBe(true)
+    expect(wrapper.find('.progress-bar').attributes('style')).toContain('40%')
+    expect(wrapper.find('video').exists()).toBe(false)
+  })
+
+  it('shows an error state when status is failed', () => {
+    const wrapper = mountCell({ provider: 'runway', status: 'failed', error: 'moderation' })
+    expect(wrapper.find('.video-error').exists()).toBe(true)
+    expect(wrapper.text()).toContain('moderation')
+  })
+
+  it('maps the provider label', () => {
+    const wrapper = mountCell({ video_url: 'https://v/c.mp4', provider: 'kling', status: 'succeeded' })
+    expect(wrapper.find('.provider-badge').text()).toBe('Kling AI')
+  })
+})

--- a/autobot-frontend/src/components/artifact-cells/VideoCell.vue
+++ b/autobot-frontend/src/components/artifact-cells/VideoCell.vue
@@ -1,0 +1,319 @@
+<!--
+  AutoBot - AI-Powered Automation Platform
+  Copyright (c) 2025 mrveiss
+  Author: mrveiss
+
+  VideoCell.vue - AI-generated video display component
+  Renders a generated video clip inline (Runway ML, Sora, or Kling) with a
+  progress indicator while generation is in flight, plus download / copy-URL.
+  GH#9016
+-->
+<template>
+  <div class="video-cell">
+    <!-- Empty state -->
+    <div v-if="!richPayload" class="video-placeholder">
+      <div class="placeholder-content">
+        <Icon name="video" />
+        <span>{{ $t('videoCell.placeholder', 'Video') }}</span>
+      </div>
+    </div>
+
+    <!-- Content -->
+    <div v-else class="video-content">
+      <!-- Provider badge -->
+      <div v-if="provider" class="video-meta">
+        <span class="provider-badge">{{ providerLabel }}</span>
+        <span v-if="durationLabel" class="size-badge">{{ durationLabel }}</span>
+      </div>
+
+      <!-- In-progress indicator -->
+      <div v-if="isGenerating" class="video-progress" role="status" aria-live="polite">
+        <div class="spinner" aria-hidden="true"></div>
+        <div class="progress-track">
+          <div class="progress-bar" :style="{ width: `${progressPct}%` }"></div>
+        </div>
+        <span class="progress-label">
+          {{ $t('videoCell.generating', 'Generating video…') }} {{ progressPct }}%
+        </span>
+      </div>
+
+      <!-- Failed state -->
+      <div v-else-if="hasError" class="video-error">
+        <Icon name="exclamation-circle" />
+        <span>{{ errorText || $t('videoCell.failed', 'Video generation failed') }}</span>
+      </div>
+
+      <!-- Playable video -->
+      <div v-else-if="videoUrl" class="video-wrapper">
+        <video
+          :src="videoUrl"
+          class="generated-video"
+          controls
+          playsinline
+          preload="metadata"
+          @error="onVideoError"
+        ></video>
+      </div>
+
+      <!-- Prompt caption -->
+      <p v-if="promptText" class="video-prompt">
+        <Icon name="pencil" />
+        <span>{{ promptText }}</span>
+      </p>
+
+      <!-- Actions -->
+      <div v-if="videoUrl" class="video-actions">
+        <a
+          class="action-btn"
+          :href="videoUrl"
+          :download="downloadName"
+          rel="noopener noreferrer"
+          :title="$t('videoCell.download', 'Download video')"
+        >
+          <Icon name="download" />
+        </a>
+        <button
+          class="action-btn"
+          @click.stop="copyVideoUrl(videoUrl)"
+          :title="$t('videoCell.copyUrl', 'Copy URL')"
+        >
+          <Icon :name="copied ? 'check' : 'copy'" />
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Icon from '@/components/ui/Icon.vue'
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+interface VideoCellProps {
+  richPayload?: Record<string, unknown> | null
+}
+
+const props = withDefaults(defineProps<VideoCellProps>(), {
+  richPayload: null,
+})
+
+const videoUrl = computed<string | null>(() => (props.richPayload?.video_url as string) ?? null)
+const provider = computed<string>(() => (props.richPayload?.provider as string) ?? '')
+const promptText = computed<string>(() => (props.richPayload?.prompt as string) ?? '')
+const statusValue = computed<string>(() => (props.richPayload?.status as string) ?? '')
+const errorText = computed<string>(() => (props.richPayload?.error as string) ?? '')
+
+const duration = computed<number | null>(() => {
+  const d = props.richPayload?.duration
+  return typeof d === 'number' ? d : null
+})
+const durationLabel = computed<string>(() => (duration.value ? `${duration.value}s` : ''))
+
+const progressPct = computed<number>(() => {
+  const raw = Number(props.richPayload?.progress ?? 0)
+  const pct = raw > 1 ? raw : raw * 100
+  return Math.max(0, Math.min(100, Math.round(pct)))
+})
+
+const localError = ref(false)
+const hasError = computed<boolean>(() => statusValue.value === 'failed' || !!errorText.value || localError.value)
+const isGenerating = computed<boolean>(
+  () => !videoUrl.value && !hasError.value && ['pending', 'running'].includes(statusValue.value),
+)
+
+const providerLabel = computed<string>(() => {
+  const map: Record<string, string> = { runway: 'Runway ML', sora: 'Sora', kling: 'Kling AI' }
+  return map[provider.value] ?? provider.value
+})
+
+const downloadName = computed<string>(() => `generated-video.${guessExt(videoUrl.value)}`)
+
+function guessExt(url: string | null): string {
+  if (!url) return 'mp4'
+  const m = url.split('?')[0].match(/\.(mp4|webm|mov)$/i)
+  return m ? m[1].toLowerCase() : 'mp4'
+}
+
+const onVideoError = () => {
+  localError.value = true
+}
+
+const copied = ref(false)
+const copyVideoUrl = async (url: string) => {
+  try {
+    await navigator.clipboard.writeText(url)
+    copied.value = true
+    setTimeout(() => {
+      copied.value = false
+    }, 2000)
+  } catch {
+    // silent fail
+  }
+}
+</script>
+
+<style scoped>
+.video-cell {
+  width: 100%;
+}
+
+.video-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  border: 1px dashed var(--color-border, #e5e7eb);
+  border-radius: 0.5rem;
+  color: var(--color-text-muted, #6b7280);
+}
+
+.placeholder-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.video-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.video-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.provider-badge,
+.size-badge {
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  background: var(--color-surface-2, #f3f4f6);
+  color: var(--color-text-muted, #6b7280);
+  font-weight: 500;
+}
+
+.video-wrapper {
+  width: 100%;
+  max-width: 640px;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: #000;
+}
+
+.generated-video {
+  width: 100%;
+  display: block;
+  border-radius: 0.5rem;
+}
+
+.video-progress {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.5rem;
+  max-width: 640px;
+}
+
+.spinner {
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 3px solid var(--color-surface-2, #f3f4f6);
+  border-top-color: var(--color-primary, #3b82f6);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.progress-track {
+  width: 100%;
+  height: 0.375rem;
+  background: var(--color-surface-2, #f3f4f6);
+  border-radius: 9999px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  background: var(--color-primary, #3b82f6);
+  transition: width 0.3s ease;
+}
+
+.progress-label {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted, #6b7280);
+}
+
+.video-error {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  background: var(--color-surface-2, #f3f4f6);
+  color: var(--color-danger, #dc2626);
+  font-size: 0.875rem;
+  max-width: 640px;
+}
+
+.video-prompt {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted, #6b7280);
+  font-style: italic;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.video-actions {
+  display: flex;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+}
+
+.action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.75rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.375rem;
+  background: var(--color-surface, #fff);
+  color: var(--color-text, #374151);
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+
+.action-btn:hover {
+  background: var(--color-surface-2, #f3f4f6);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none;
+  }
+  .generated-video,
+  .action-btn,
+  .progress-bar {
+    transition: none;
+  }
+}
+</style>

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -152,6 +152,12 @@
           :rich-payload="(message.metadata.image_payload as Record<string, unknown>)"
         />
 
+        <!-- GH#9016: AI-generated video message -->
+        <VideoCell
+          v-else-if="(message.type === 'video' || message.metadata?.display_type === 'video') && message.metadata?.video_payload"
+          :rich-payload="(message.metadata.video_payload as Record<string, unknown>)"
+        />
+
         <!-- MVA-2006: Context summary message -->
         <div
           v-else-if="message.type === 'summary' || message.metadata?.is_summary"
@@ -570,6 +576,7 @@ import OverseerPlanMessage from '@/components/chat/OverseerPlanMessage.vue'
 import OverseerStepMessage from '@/components/chat/OverseerStepMessage.vue'
 import CitationsDisplay from '@/components/chat/CitationsDisplay.vue'
 import ImageCell from '@/components/artifact-cells/ImageCell.vue'
+import VideoCell from '@/components/artifact-cells/VideoCell.vue'
 import { formatFileSize, formatTime } from '@/utils/formatHelpers'
 import { createLogger } from '@/utils/debugUtils'
 import { useCommandApproval } from '@/composables/useCommandApproval'

--- a/autobot-frontend/src/composables/useVideoGeneration.ts
+++ b/autobot-frontend/src/composables/useVideoGeneration.ts
@@ -1,0 +1,140 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+// GH#9016 — async video generation composable (submit + poll)
+import apiClient from '@/utils/ApiClient'
+import { ref } from 'vue'
+
+export interface GenerateVideoParams {
+  prompt: string
+  provider?: 'runway' | 'sora' | 'kling'
+  duration?: number
+  resolution?: string
+  aspect_ratio?: '16:9' | '9:16' | '1:1'
+}
+
+export interface VideoJobResponse {
+  success: boolean
+  job_id: string
+  provider: string
+  status: string
+  error?: string | null
+}
+
+export interface VideoStatusResponse {
+  success: boolean
+  job_id: string
+  status: string
+  progress: number
+  video_url?: string | null
+  provider: string
+  prompt: string
+  error?: string | null
+}
+
+export interface VideoProviderStatus {
+  name: string
+  available: boolean
+  reason?: string | null
+}
+
+// Poll cadence is env-tunable on the backend; the UI default is conservative.
+const DEFAULT_POLL_MS = Number(import.meta.env.VITE_VIDEO_POLL_MS ?? 4000)
+const DEFAULT_MAX_POLLS = Number(import.meta.env.VITE_VIDEO_MAX_POLLS ?? 150)
+
+export function useVideoGeneration() {
+  const generating = ref(false)
+  const progress = ref(0)
+  const status = ref<string>('idle')
+  const videoUrl = ref<string | null>(null)
+  const error = ref<string | null>(null)
+  const providers = ref<VideoProviderStatus[]>([])
+
+  async function submit(params: GenerateVideoParams): Promise<VideoJobResponse | null> {
+    try {
+      const result = await apiClient.post<VideoJobResponse>('/video-generation/generate', params)
+      if (!result.success) {
+        error.value = result.error ?? 'Video generation failed'
+      }
+      return result
+    } catch (err: unknown) {
+      error.value = err instanceof Error ? err.message : String(err)
+      return null
+    }
+  }
+
+  async function pollStatus(jobId: string): Promise<VideoStatusResponse | null> {
+    try {
+      return await apiClient.get<VideoStatusResponse>(`/video-generation/status/${jobId}`)
+    } catch (err: unknown) {
+      error.value = err instanceof Error ? err.message : String(err)
+      return null
+    }
+  }
+
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+  /** Submit a job and poll until it succeeds, fails, or the ceiling is hit. */
+  async function generateVideo(params: GenerateVideoParams): Promise<string | null> {
+    generating.value = true
+    error.value = null
+    progress.value = 0
+    videoUrl.value = null
+    status.value = 'pending'
+
+    try {
+      const job = await submit(params)
+      if (!job || !job.success) {
+        status.value = 'failed'
+        return null
+      }
+      for (let i = 0; i < DEFAULT_MAX_POLLS; i++) {
+        const s = await pollStatus(job.job_id)
+        if (!s) {
+          status.value = 'failed'
+          return null
+        }
+        status.value = s.status
+        progress.value = s.progress ?? 0
+        if (s.status === 'succeeded' && s.video_url) {
+          videoUrl.value = s.video_url
+          progress.value = 1
+          return s.video_url
+        }
+        if (s.status === 'failed') {
+          error.value = s.error ?? 'Video generation failed'
+          return null
+        }
+        await sleep(DEFAULT_POLL_MS)
+      }
+      error.value = 'Video generation timed out'
+      status.value = 'failed'
+      return null
+    } finally {
+      generating.value = false
+    }
+  }
+
+  async function fetchProviders(): Promise<void> {
+    try {
+      const data = await apiClient.get<{ providers: VideoProviderStatus[] }>('/video-generation/providers')
+      providers.value = data.providers ?? []
+    } catch {
+      providers.value = []
+    }
+  }
+
+  return {
+    generating,
+    progress,
+    status,
+    videoUrl,
+    error,
+    providers,
+    submit,
+    pollStatus,
+    generateVideo,
+    fetchProviders,
+  }
+}

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -7737,6 +7737,13 @@
     "placeholder": "Placeholder",
     "viewFull": "View full"
   },
+  "videoCell": {
+    "copyUrl": "نسخ الرابط",
+    "download": "تنزيل",
+    "failed": "فشل إنشاء الفيديو",
+    "generating": "جارٍ إنشاء الفيديو…",
+    "placeholder": "فيديو"
+  },
   "plugins": {
     "capabilities": {
       "approvalDescription": "Approval description",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -7737,6 +7737,13 @@
     "placeholder": "Placeholder",
     "viewFull": "View full"
   },
+  "videoCell": {
+    "copyUrl": "URL kopieren",
+    "download": "Herunterladen",
+    "failed": "Videoerstellung fehlgeschlagen",
+    "generating": "Video wird erstellt…",
+    "placeholder": "Video"
+  },
   "plugins": {
     "capabilities": {
       "approvalDescription": "Approval description",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -7737,6 +7737,13 @@
     "placeholder": "Placeholder",
     "viewFull": "View full"
   },
+  "videoCell": {
+    "copyUrl": "Copy url",
+    "download": "Download",
+    "failed": "Video generation failed",
+    "generating": "Generating video…",
+    "placeholder": "Video"
+  },
   "plugins": {
     "capabilities": {
       "approvalDescription": "Approval description",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -7737,6 +7737,13 @@
     "placeholder": "Placeholder",
     "viewFull": "View full"
   },
+  "videoCell": {
+    "copyUrl": "Copiar URL",
+    "download": "Descargar",
+    "failed": "Error al generar el vídeo",
+    "generating": "Generando vídeo…",
+    "placeholder": "Vídeo"
+  },
   "plugins": {
     "capabilities": {
       "approvalDescription": "Approval description",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -7737,6 +7737,13 @@
     "placeholder": "Placeholder",
     "viewFull": "View full"
   },
+  "videoCell": {
+    "copyUrl": "کپی نشانی",
+    "download": "دانلود",
+    "failed": "تولید ویدیو ناموفق بود",
+    "generating": "در حال تولید ویدیو…",
+    "placeholder": "ویدیو"
+  },
   "plugins": {
     "capabilities": {
       "approvalDescription": "Approval description",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -7737,6 +7737,13 @@
     "placeholder": "Placeholder",
     "viewFull": "View full"
   },
+  "videoCell": {
+    "copyUrl": "Copier l'URL",
+    "download": "Télécharger",
+    "failed": "Échec de la génération de la vidéo",
+    "generating": "Génération de la vidéo…",
+    "placeholder": "Vidéo"
+  },
   "plugins": {
     "capabilities": {
       "approvalDescription": "Approval description",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -7737,6 +7737,13 @@
     "placeholder": "Placeholder",
     "viewFull": "View full"
   },
+  "videoCell": {
+    "copyUrl": "העתק כתובת",
+    "download": "הורדה",
+    "failed": "יצירת הווידאו נכשלה",
+    "generating": "יוצר וידאו…",
+    "placeholder": "וידאו"
+  },
   "plugins": {
     "capabilities": {
       "approvalDescription": "Approval description",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -7737,6 +7737,13 @@
     "placeholder": "Placeholder",
     "viewFull": "View full"
   },
+  "videoCell": {
+    "copyUrl": "Kopēt URL",
+    "download": "Lejupielādēt",
+    "failed": "Video ģenerēšana neizdevās",
+    "generating": "Ģenerē video…",
+    "placeholder": "Video"
+  },
   "plugins": {
     "capabilities": {
       "approvalDescription": "Approval description",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -7737,6 +7737,13 @@
     "placeholder": "Placeholder",
     "viewFull": "View full"
   },
+  "videoCell": {
+    "copyUrl": "Kopiuj URL",
+    "download": "Pobierz",
+    "failed": "Generowanie wideo nie powiodło się",
+    "generating": "Generowanie wideo…",
+    "placeholder": "Wideo"
+  },
   "plugins": {
     "capabilities": {
       "approvalDescription": "Approval description",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -7737,6 +7737,13 @@
     "placeholder": "Placeholder",
     "viewFull": "View full"
   },
+  "videoCell": {
+    "copyUrl": "Copiar URL",
+    "download": "Baixar",
+    "failed": "Falha ao gerar o vídeo",
+    "generating": "Gerando vídeo…",
+    "placeholder": "Vídeo"
+  },
   "plugins": {
     "capabilities": {
       "approvalDescription": "Approval description",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -7737,6 +7737,13 @@
     "placeholder": "Placeholder",
     "viewFull": "View full"
   },
+  "videoCell": {
+    "copyUrl": "یو آر ایل کاپی کریں",
+    "download": "ڈاؤن لوڈ",
+    "failed": "ویڈیو بنانے میں ناکامی",
+    "generating": "ویڈیو بنائی جا رہی ہے…",
+    "placeholder": "ویڈیو"
+  },
   "plugins": {
     "capabilities": {
       "approvalDescription": "Approval description",

--- a/plugins/core-plugins/video-generation-plugin/__init__.py
+++ b/plugins/core-plugins/video-generation-plugin/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss

--- a/plugins/core-plugins/video-generation-plugin/main.py
+++ b/plugins/core-plugins/video-generation-plugin/main.py
@@ -1,0 +1,65 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Video Generation Plugin — GH#9016.
+
+Registers the generate_video tool with the ToolSDKRegistry so LLC agent tasks
+and direct chat requests can generate short video clips via Runway ML (baseline),
+OpenAI Sora, and Kling AI (the latter two credential-gated).
+
+Plugin lifecycle:
+    initialize() → registers GenerateVideoTool
+    shutdown()   → unregisters tool
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Dict, Optional
+
+from plugin_sdk.base import BasePlugin, PluginManifest
+from tool_sdk.registry import get_tool_registry
+
+from .tools import GenerateVideoTool
+
+logger = logging.getLogger(__name__)
+
+
+class VideoGenerationPlugin(BasePlugin):
+    """Plugin that adds video generation as an agent-callable tool."""
+
+    def __init__(self, manifest: PluginManifest, config: Optional[Dict] = None) -> None:
+        super().__init__(manifest, config)
+        self._registered: bool = False
+
+    async def initialize(self) -> None:
+        self._logger.info("VideoGenerationPlugin: initializing")
+
+        runway_key = os.environ.get("RUNWAY_API_KEY", "")
+        sora_key = os.environ.get("SORA_API_KEY", "")
+        kling_key = os.environ.get("KLING_API_KEY", "")
+
+        if not any([runway_key, sora_key, kling_key]):
+            self._logger.warning(
+                "VideoGenerationPlugin: no API keys configured — "
+                "tool registered but all providers will fail at call time. "
+                "Set RUNWAY_API_KEY (baseline), SORA_API_KEY, or KLING_API_KEY."
+            )
+
+        registry = get_tool_registry()
+        if "generate_video" not in {m.name for m in registry.list_tools()}:
+            registry.register(GenerateVideoTool)
+        self._registered = True
+        self._logger.info("VideoGenerationPlugin: registered generate_video tool")
+
+    async def shutdown(self) -> None:
+        self._logger.info("VideoGenerationPlugin: shutting down")
+        if self._registered:
+            try:
+                registry = get_tool_registry()
+                registry.unregister(GenerateVideoTool.metadata.name)
+            except Exception:
+                pass

--- a/plugins/core-plugins/video-generation-plugin/plugin.json
+++ b/plugins/core-plugins/video-generation-plugin/plugin.json
@@ -1,0 +1,79 @@
+{
+  "name": "video-generation-plugin",
+  "version": "1.0.0",
+  "display_name": "Video Generation Plugin",
+  "description": "Adds AI video generation to chat and agent workflows via Runway ML (baseline), with OpenAI Sora and Kling AI registered behind credential gates. Registers the generate_video tool callable from LLC agent tasks. Generation is async (submit then poll).",
+  "author": "mrveiss",
+  "entry_point": "plugins.core_plugins.video_generation_plugin.main",
+  "capabilities": ["llm:call", "network:outbound", "system:env"],
+  "trust_tier": "official",
+  "dependencies": [],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "default_provider": {
+        "type": "string",
+        "enum": ["runway", "sora", "kling"],
+        "default": "runway",
+        "description": "Default provider used when none is specified in the tool call"
+      },
+      "default_duration": {
+        "type": "integer",
+        "default": 5,
+        "minimum": 1,
+        "maximum": 20,
+        "description": "Default clip duration in seconds"
+      },
+      "default_resolution": {
+        "type": "string",
+        "default": "1280x720",
+        "description": "Default output resolution (provider-specific values apply)"
+      },
+      "default_aspect_ratio": {
+        "type": "string",
+        "enum": ["16:9", "9:16", "1:1"],
+        "default": "16:9",
+        "description": "Default aspect ratio"
+      }
+    }
+  },
+  "hooks": [],
+  "required_env": [
+    {
+      "name": "RUNWAY_API_KEY",
+      "secret": true,
+      "required": false,
+      "description": "Runway ML API key for video generation (Gen-3/Gen-4 via the developer API)",
+      "docs_url": "https://docs.dev.runwayml.com",
+      "obtain_steps": [
+        "Go to https://dev.runwayml.com",
+        "Create a developer account and generate an API key",
+        "Set RUNWAY_API_KEY to the generated key"
+      ]
+    },
+    {
+      "name": "SORA_API_KEY",
+      "secret": true,
+      "required": false,
+      "description": "OpenAI Sora API key for video generation (credential-gated; enabled when the key is set)",
+      "docs_url": "https://platform.openai.com/api-keys",
+      "obtain_steps": [
+        "Go to https://platform.openai.com/api-keys",
+        "Create an API key with Sora video access",
+        "Set SORA_API_KEY to the generated key"
+      ]
+    },
+    {
+      "name": "KLING_API_KEY",
+      "secret": true,
+      "required": false,
+      "description": "Kling AI API key for video generation (credential-gated; enabled when the key is set)",
+      "docs_url": "https://klingai.com",
+      "obtain_steps": [
+        "Go to https://klingai.com and obtain API access",
+        "Generate an API key",
+        "Set KLING_API_KEY to the generated key"
+      ]
+    }
+  ]
+}

--- a/plugins/core-plugins/video-generation-plugin/tools/__init__.py
+++ b/plugins/core-plugins/video-generation-plugin/tools/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+from .generate_video import GenerateVideoTool
+
+__all__ = ["GenerateVideoTool"]

--- a/plugins/core-plugins/video-generation-plugin/tools/generate_video.py
+++ b/plugins/core-plugins/video-generation-plugin/tools/generate_video.py
@@ -1,0 +1,131 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+generate_video tool — GH#9016.
+
+LLC-callable tool that generates a short video clip from a text prompt via
+Runway ML (baseline), OpenAI Sora, or Kling AI. Generation is async: the tool
+submits the job, polls the provider until completion, and returns the video URL.
+
+Returns ToolResult.data = {video_url, provider, prompt, duration, job_id}.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Dict
+
+from tool_sdk.base import BaseTool, ToolMetadata, ToolPermission, ToolResult
+
+from .providers import ProviderError, get_provider
+
+logger = logging.getLogger(__name__)
+
+# Poll cadence / ceiling are env-tunable (no hard-coded magic numbers).
+_POLL_INTERVAL_S = float(os.environ.get("VIDEO_GEN_POLL_INTERVAL_S", "5"))
+_POLL_MAX_ATTEMPTS = int(os.environ.get("VIDEO_GEN_POLL_MAX_ATTEMPTS", "120"))
+
+
+class GenerateVideoTool(BaseTool):
+    """Generate a short video clip using Runway ML, Sora, or Kling AI."""
+
+    metadata = ToolMetadata(
+        name="generate_video",
+        description=(
+            "Generate a short video clip from a text prompt. Generation is "
+            "asynchronous; the tool waits for the provider and returns the "
+            "playable video URL. Use provider='runway' (default, most stable), "
+            "'sora', or 'kling'. duration is in seconds."
+        ),
+        version="1.0.0",
+        permission=ToolPermission.AUTHENTICATED,
+        tags=["media", "video", "generation", "ai"],
+    )
+
+    input_schema: Dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Text description of the video to generate",
+                "minLength": 1,
+                "maxLength": 4000,
+            },
+            "duration": {
+                "type": "integer",
+                "description": "Clip duration in seconds (1-20, provider limits apply).",
+                "minimum": 1,
+                "maximum": 20,
+            },
+            "provider": {
+                "type": "string",
+                "enum": ["runway", "sora", "kling"],
+                "description": "Video generation provider. Defaults to 'runway'.",
+            },
+            "resolution": {
+                "type": "string",
+                "description": "Output resolution, e.g. '1280x720'.",
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": ["16:9", "9:16", "1:1"],
+                "description": "Aspect ratio. Defaults to '16:9'.",
+            },
+        },
+        "required": ["prompt"],
+        "additionalProperties": False,
+    }
+
+    async def execute(self, validated_input: Dict[str, Any]) -> ToolResult:
+        prompt: str = validated_input["prompt"]
+        provider_name: str = validated_input.get("provider", "runway")
+        duration: int = int(validated_input.get("duration", 5))
+        resolution: str = validated_input.get("resolution", "1280x720")
+        aspect_ratio: str = validated_input.get("aspect_ratio", "16:9")
+
+        try:
+            provider = get_provider(provider_name)
+        except ProviderError as exc:
+            return ToolResult(success=False, error=str(exc))
+
+        if not provider.available:
+            return ToolResult(
+                success=False,
+                error=f"{provider.env_var} not configured — {provider_name} provider disabled",
+            )
+
+        try:
+            job_id = await provider.submit(
+                prompt, duration=duration, resolution=resolution, aspect_ratio=aspect_ratio
+            )
+            return await self._await_completion(provider, job_id, prompt, duration)
+        except ProviderError as exc:
+            logger.warning("generate_video provider error (provider=%s): %s", provider_name, exc)
+            return ToolResult(success=False, error=str(exc))
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("generate_video failed (provider=%s): %s", provider_name, exc, exc_info=True)
+            return ToolResult(success=False, error=str(exc))
+
+    async def _await_completion(self, provider, job_id: str, prompt: str, duration: int) -> ToolResult:
+        """Poll the provider until the job finishes or the ceiling is reached."""
+        for _ in range(_POLL_MAX_ATTEMPTS):
+            status = await provider.poll(job_id)
+            if status.status == "succeeded" and status.video_url:
+                return ToolResult(
+                    success=True,
+                    data={
+                        "video_url": status.video_url,
+                        "provider": provider.name,
+                        "prompt": prompt,
+                        "duration": duration,
+                        "job_id": job_id,
+                    },
+                )
+            if status.status == "failed":
+                return ToolResult(success=False, error=status.error or "video generation failed")
+            await asyncio.sleep(_POLL_INTERVAL_S)
+        return ToolResult(success=False, error="video generation timed out waiting for provider")

--- a/plugins/core-plugins/video-generation-plugin/tools/generate_video_test.py
+++ b/plugins/core-plugins/video-generation-plugin/tools/generate_video_test.py
@@ -1,0 +1,117 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the generate_video tool — GH#9016. Providers are mocked."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+
+
+def _load(mod_name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(mod_name, _HERE / filename)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# Load providers first so generate_video's relative import resolves.
+providers = _load("vg_providers_tool_test", "providers.py")
+
+
+@pytest.fixture
+def tool(monkeypatch):
+    """Build the GenerateVideoTool with tool_sdk stubbed (no backend deps)."""
+    base = MagicMock()
+    base.ToolMetadata = lambda **k: MagicMock(**k)
+    base.ToolPermission = MagicMock(AUTHENTICATED="authenticated")
+
+    class _Result:
+        def __init__(self, success, data=None, error=None, duration_ms=0.0):
+            self.success = success
+            self.data = data
+            self.error = error
+            self.duration_ms = duration_ms
+
+    base.ToolResult = _Result
+
+    class _BaseTool:
+        def __init_subclass__(cls, **k):
+            super().__init_subclass__(**k)
+
+    base.BaseTool = _BaseTool
+
+    monkeypatch.setitem(sys.modules, "tool_sdk", MagicMock())
+    monkeypatch.setitem(sys.modules, "tool_sdk.base", base)
+
+    # Build a real package module so `from .providers import ...` resolves.
+    import types
+
+    pkg = types.ModuleType("vg_tool_pkg")
+    pkg.__path__ = [str(_HERE)]  # mark as a package
+    monkeypatch.setitem(sys.modules, "vg_tool_pkg", pkg)
+    monkeypatch.setitem(sys.modules, "vg_tool_pkg.providers", providers)
+
+    spec = importlib.util.spec_from_file_location("vg_tool_pkg.generate_video", _HERE / "generate_video.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["vg_tool_pkg.generate_video"] = mod
+    spec.loader.exec_module(mod)
+    return mod.GenerateVideoTool(), mod
+
+
+@pytest.mark.asyncio
+async def test_generate_video_returns_url(tool, monkeypatch):
+    instance, mod = tool
+
+    fake_provider = MagicMock()
+    fake_provider.name = "runway"
+    fake_provider.env_var = "RUNWAY_API_KEY"
+    fake_provider.available = True
+    fake_provider.submit = AsyncMock(return_value="job-1")
+    succeeded = providers.JobStatus("job-1", "succeeded", 1.0, video_url="https://v/c.mp4", provider="runway")
+    fake_provider.poll = AsyncMock(return_value=succeeded)
+    monkeypatch.setattr(mod, "get_provider", lambda name: fake_provider)
+
+    result = await instance.execute({"prompt": "a sunrise", "duration": 5})
+    assert result.success is True
+    assert result.data["video_url"] == "https://v/c.mp4"
+    assert result.data["provider"] == "runway"
+    assert result.data["job_id"] == "job-1"
+
+
+@pytest.mark.asyncio
+async def test_generate_video_provider_disabled(tool, monkeypatch):
+    instance, mod = tool
+    disabled = MagicMock()
+    disabled.available = False
+    disabled.env_var = "RUNWAY_API_KEY"
+    monkeypatch.setattr(mod, "get_provider", lambda name: disabled)
+
+    result = await instance.execute({"prompt": "x", "provider": "runway"})
+    assert result.success is False
+    assert "RUNWAY_API_KEY" in result.error
+
+
+@pytest.mark.asyncio
+async def test_generate_video_failure(tool, monkeypatch):
+    instance, mod = tool
+    fake = MagicMock()
+    fake.name = "runway"
+    fake.available = True
+    fake.submit = AsyncMock(return_value="job-2")
+    failed = providers.JobStatus("job-2", "failed", 0.0, error="moderation", provider="runway")
+    fake.poll = AsyncMock(return_value=failed)
+    monkeypatch.setattr(mod, "get_provider", lambda name: fake)
+
+    result = await instance.execute({"prompt": "x"})
+    assert result.success is False
+    assert "moderation" in result.error

--- a/plugins/core-plugins/video-generation-plugin/tools/providers.py
+++ b/plugins/core-plugins/video-generation-plugin/tools/providers.py
@@ -1,0 +1,325 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Video-generation provider abstraction — GH#9016.
+
+Defines the async provider contract used by both the generate_video tool and
+the /video-generation API:
+
+    submit(prompt, ...) -> job_id          (queue a generation task)
+    poll(job_id)        -> JobStatus       (check progress / fetch URL)
+
+Each provider is credential-gated: an unset/empty API key means the provider is
+disabled (``available`` is False) and submit/poll raise ProviderError.
+
+Providers shipped:
+    * RunwayProvider — Runway ML developer API (Gen-3/Gen-4). Baseline, working.
+    * SoraProvider   — OpenAI Sora. Registered; credential-gated (SORA_API_KEY).
+    * KlingProvider  — Kling AI. Registered; credential-gated (KLING_API_KEY).
+
+All HTTP is async (aiohttp). No blocking calls on the event loop.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Runway developer API base + version header (stable public API surface).
+RUNWAY_API_BASE = "https://api.dev.runwayml.com/v1"
+RUNWAY_API_VERSION = "2024-11-06"
+
+
+class ProviderError(Exception):
+    """Raised when a provider call fails (auth, quota, network, or API error)."""
+
+
+@dataclass
+class JobStatus:
+    """Normalized status of a video-generation job, provider-agnostic."""
+
+    job_id: str
+    status: str  # one of: pending | running | succeeded | failed
+    progress: float = 0.0  # 0.0 .. 1.0
+    video_url: Optional[str] = None
+    error: Optional[str] = None
+    provider: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "job_id": self.job_id,
+            "status": self.status,
+            "progress": round(self.progress, 3),
+            "video_url": self.video_url,
+            "error": self.error,
+            "provider": self.provider,
+            "metadata": self.metadata,
+        }
+
+
+class BaseVideoProvider:
+    """Async contract every video-generation provider implements."""
+
+    name: str = "base"
+    env_var: str = ""
+
+    def __init__(self, api_key: Optional[str] = None) -> None:
+        self._api_key = api_key if api_key is not None else os.environ.get(self.env_var, "")
+
+    @property
+    def available(self) -> bool:
+        """True when an API key is configured (empty key == disabled)."""
+        return bool(self._api_key)
+
+    def _require_key(self) -> str:
+        if not self._api_key:
+            raise ProviderError(f"{self.env_var} not configured")
+        return self._api_key
+
+    async def submit(
+        self,
+        prompt: str,
+        *,
+        duration: int = 5,
+        resolution: str = "1280x720",
+        aspect_ratio: str = "16:9",
+    ) -> str:
+        """Queue a generation task; return a provider job id."""
+        raise NotImplementedError
+
+    async def poll(self, job_id: str) -> JobStatus:
+        """Return the current normalized status for *job_id*."""
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Runway ML — baseline working provider
+# ---------------------------------------------------------------------------
+
+
+class RunwayProvider(BaseVideoProvider):
+    """Runway ML developer API (text-to-video, Gen-3/Gen-4)."""
+
+    name = "runway"
+    env_var = "RUNWAY_API_KEY"
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._require_key()}",
+            "X-Runway-Version": RUNWAY_API_VERSION,
+            "Content-Type": "application/json",
+        }
+
+    @staticmethod
+    def _ratio_to_runway(aspect_ratio: str) -> str:
+        """Map a friendly aspect ratio to a Runway ratio string."""
+        mapping = {"16:9": "1280:720", "9:16": "720:1280", "1:1": "960:960"}
+        return mapping.get(aspect_ratio, "1280:720")
+
+    async def submit(
+        self,
+        prompt: str,
+        *,
+        duration: int = 5,
+        resolution: str = "1280x720",
+        aspect_ratio: str = "16:9",
+    ) -> str:
+        import aiohttp
+
+        payload: Dict[str, Any] = {
+            "promptText": prompt,
+            "model": "gen3a_turbo",
+            "duration": max(1, min(int(duration), 10)),
+            "ratio": self._ratio_to_runway(aspect_ratio),
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{RUNWAY_API_BASE}/text_to_video",
+                json=payload,
+                headers=self._headers(),
+            ) as resp:
+                body = await resp.json()
+                if resp.status == 429:
+                    raise ProviderError("Runway quota/rate limit exceeded (HTTP 429)")
+                if resp.status not in (200, 201):
+                    raise ProviderError(f"Runway submit failed (HTTP {resp.status}): {body}")
+        job_id = body.get("id")
+        if not job_id:
+            raise ProviderError(f"Runway: no task id in response: {body}")
+        return str(job_id)
+
+    async def poll(self, job_id: str) -> JobStatus:
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{RUNWAY_API_BASE}/tasks/{job_id}",
+                headers=self._headers(),
+            ) as resp:
+                body = await resp.json()
+                if resp.status != 200:
+                    raise ProviderError(f"Runway poll failed (HTTP {resp.status}): {body}")
+        return self._normalize(job_id, body)
+
+    def _normalize(self, job_id: str, body: Dict[str, Any]) -> JobStatus:
+        """Translate a Runway task payload into a JobStatus."""
+        raw = str(body.get("status", "")).upper()
+        if raw == "SUCCEEDED":
+            outputs = body.get("output") or []
+            url = outputs[0] if outputs else None
+            return JobStatus(job_id, "succeeded", 1.0, video_url=url, provider=self.name)
+        if raw == "FAILED":
+            reason = body.get("failure") or body.get("failureCode") or "generation failed"
+            return JobStatus(job_id, "failed", 0.0, error=str(reason), provider=self.name)
+        if raw in ("RUNNING", "THROTTLED"):
+            progress = float(body.get("progress") or 0.0)
+            return JobStatus(job_id, "running", progress, provider=self.name)
+        # PENDING / queued / unknown
+        return JobStatus(job_id, "pending", 0.0, provider=self.name)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Sora — credential-gated (API surface not yet broadly stable)
+# ---------------------------------------------------------------------------
+
+
+class SoraProvider(BaseVideoProvider):
+    """OpenAI Sora video generation (enabled only when SORA_API_KEY is set)."""
+
+    name = "sora"
+    env_var = "SORA_API_KEY"
+    SORA_API_BASE = "https://api.openai.com/v1/videos"
+
+    def _headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {self._require_key()}", "Content-Type": "application/json"}
+
+    async def submit(
+        self,
+        prompt: str,
+        *,
+        duration: int = 5,
+        resolution: str = "1280x720",
+        aspect_ratio: str = "16:9",
+    ) -> str:
+        import aiohttp
+
+        payload = {"model": "sora-2", "prompt": prompt, "seconds": str(max(1, int(duration)))}
+        async with aiohttp.ClientSession() as session:
+            async with session.post(self.SORA_API_BASE, json=payload, headers=self._headers()) as resp:
+                body = await resp.json()
+                if resp.status == 429:
+                    raise ProviderError("Sora quota/rate limit exceeded (HTTP 429)")
+                if resp.status not in (200, 201):
+                    raise ProviderError(f"Sora submit failed (HTTP {resp.status}): {body}")
+        job_id = body.get("id")
+        if not job_id:
+            raise ProviderError(f"Sora: no job id in response: {body}")
+        return str(job_id)
+
+    async def poll(self, job_id: str) -> JobStatus:
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"{self.SORA_API_BASE}/{job_id}", headers=self._headers()) as resp:
+                body = await resp.json()
+                if resp.status != 200:
+                    raise ProviderError(f"Sora poll failed (HTTP {resp.status}): {body}")
+        status = str(body.get("status", "")).lower()
+        if status == "completed":
+            url = body.get("url") or (body.get("output") or {}).get("url")
+            return JobStatus(job_id, "succeeded", 1.0, video_url=url, provider=self.name)
+        if status == "failed":
+            return JobStatus(job_id, "failed", 0.0, error=str(body.get("error", "failed")), provider=self.name)
+        progress = float(body.get("progress") or 0.0)
+        progress = progress / 100.0 if progress > 1.0 else progress
+        return JobStatus(job_id, "running" if progress > 0 else "pending", progress, provider=self.name)
+
+
+# ---------------------------------------------------------------------------
+# Kling AI — credential-gated
+# ---------------------------------------------------------------------------
+
+
+class KlingProvider(BaseVideoProvider):
+    """Kling AI video generation (enabled only when KLING_API_KEY is set)."""
+
+    name = "kling"
+    env_var = "KLING_API_KEY"
+    KLING_API_BASE = "https://api.klingai.com/v1/videos/text2video"
+
+    def _headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {self._require_key()}", "Content-Type": "application/json"}
+
+    async def submit(
+        self,
+        prompt: str,
+        *,
+        duration: int = 5,
+        resolution: str = "1280x720",
+        aspect_ratio: str = "16:9",
+    ) -> str:
+        import aiohttp
+
+        payload = {"prompt": prompt, "duration": str(max(1, int(duration))), "aspect_ratio": aspect_ratio}
+        async with aiohttp.ClientSession() as session:
+            async with session.post(self.KLING_API_BASE, json=payload, headers=self._headers()) as resp:
+                body = await resp.json()
+                if resp.status == 429:
+                    raise ProviderError("Kling quota/rate limit exceeded (HTTP 429)")
+                if resp.status not in (200, 201):
+                    raise ProviderError(f"Kling submit failed (HTTP {resp.status}): {body}")
+        job_id = (body.get("data") or {}).get("task_id") or body.get("task_id")
+        if not job_id:
+            raise ProviderError(f"Kling: no task id in response: {body}")
+        return str(job_id)
+
+    async def poll(self, job_id: str) -> JobStatus:
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"{self.KLING_API_BASE}/{job_id}", headers=self._headers()) as resp:
+                body = await resp.json()
+                if resp.status != 200:
+                    raise ProviderError(f"Kling poll failed (HTTP {resp.status}): {body}")
+        data = body.get("data") or body
+        status = str(data.get("task_status", "")).lower()
+        if status == "succeed":
+            videos = ((data.get("task_result") or {}).get("videos")) or []
+            url = videos[0].get("url") if videos else None
+            return JobStatus(job_id, "succeeded", 1.0, video_url=url, provider=self.name)
+        if status == "failed":
+            msg = data.get("task_status_msg") or "failed"
+            return JobStatus(job_id, "failed", 0.0, error=str(msg), provider=self.name)
+        return JobStatus(job_id, "running" if status == "processing" else "pending", 0.0, provider=self.name)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+_PROVIDERS: Dict[str, type[BaseVideoProvider]] = {
+    "runway": RunwayProvider,
+    "sora": SoraProvider,
+    "kling": KlingProvider,
+}
+
+
+def get_provider(name: str) -> BaseVideoProvider:
+    """Return a provider instance for *name* (raises ProviderError if unknown)."""
+    cls = _PROVIDERS.get(name)
+    if cls is None:
+        raise ProviderError(f"Unknown video provider: {name}")
+    return cls()
+
+
+def provider_names() -> list[str]:
+    """Return the registered provider names in a stable order."""
+    return list(_PROVIDERS.keys())

--- a/plugins/core-plugins/video-generation-plugin/tools/providers_test.py
+++ b/plugins/core-plugins/video-generation-plugin/tools/providers_test.py
@@ -1,0 +1,196 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for video-generation providers — GH#9016. All HTTP is mocked."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Load the providers module by file path (hyphenated plugin dir is not importable).
+_PROVIDERS_PATH = Path(__file__).resolve().parent / "providers.py"
+_spec = importlib.util.spec_from_file_location("vg_providers_under_test", _PROVIDERS_PATH)
+providers = importlib.util.module_from_spec(_spec)
+sys.modules["vg_providers_under_test"] = providers
+_spec.loader.exec_module(providers)
+
+
+class _FakeResponse:
+    """Mimics an aiohttp response usable as an async context manager."""
+
+    def __init__(self, status: int, payload: dict):
+        self.status = status
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return str(self._payload)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    """Mimics aiohttp.ClientSession; returns queued responses for post/get."""
+
+    def __init__(self, post=None, get=None):
+        self._post = post
+        self._get = get
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def post(self, *a, **k):
+        return self._post
+
+    def get(self, *a, **k):
+        return self._get
+
+
+def _patch_aiohttp(post=None, get=None):
+    fake_aiohttp = MagicMock()
+    fake_aiohttp.ClientSession = lambda *a, **k: _FakeSession(post=post, get=get)
+    return patch.dict(sys.modules, {"aiohttp": fake_aiohttp})
+
+
+# ---------------------------------------------------------------------------
+# Availability / credential gating
+# ---------------------------------------------------------------------------
+
+
+def test_provider_disabled_without_key():
+    with patch.dict("os.environ", {"RUNWAY_API_KEY": ""}, clear=False):
+        p = providers.RunwayProvider()
+        assert p.available is False
+
+
+def test_provider_enabled_with_key():
+    p = providers.RunwayProvider(api_key="secret")
+    assert p.available is True
+
+
+def test_unknown_provider_raises():
+    with pytest.raises(providers.ProviderError):
+        providers.get_provider("nope")
+
+
+def test_provider_names_stable():
+    assert providers.provider_names() == ["runway", "sora", "kling"]
+
+
+# ---------------------------------------------------------------------------
+# Runway submit + poll + normalize
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runway_submit_returns_job_id():
+    post = _FakeResponse(200, {"id": "task-123"})
+    p = providers.RunwayProvider(api_key="k")
+    with _patch_aiohttp(post=post):
+        job_id = await p.submit("a cat", duration=5)
+    assert job_id == "task-123"
+
+
+@pytest.mark.asyncio
+async def test_runway_submit_quota_error():
+    post = _FakeResponse(429, {"error": "rate limited"})
+    p = providers.RunwayProvider(api_key="k")
+    with _patch_aiohttp(post=post):
+        with pytest.raises(providers.ProviderError) as exc:
+            await p.submit("a cat")
+    assert "quota" in str(exc.value).lower() or "429" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_runway_submit_missing_id():
+    post = _FakeResponse(200, {})
+    p = providers.RunwayProvider(api_key="k")
+    with _patch_aiohttp(post=post):
+        with pytest.raises(providers.ProviderError):
+            await p.submit("a cat")
+
+
+@pytest.mark.asyncio
+async def test_runway_poll_succeeded():
+    get = _FakeResponse(200, {"status": "SUCCEEDED", "output": ["https://v/clip.mp4"]})
+    p = providers.RunwayProvider(api_key="k")
+    with _patch_aiohttp(get=get):
+        status = await p.poll("task-123")
+    assert status.status == "succeeded"
+    assert status.video_url == "https://v/clip.mp4"
+    assert status.progress == 1.0
+
+
+@pytest.mark.asyncio
+async def test_runway_poll_running_progress():
+    get = _FakeResponse(200, {"status": "RUNNING", "progress": 0.42})
+    p = providers.RunwayProvider(api_key="k")
+    with _patch_aiohttp(get=get):
+        status = await p.poll("task-123")
+    assert status.status == "running"
+    assert status.progress == pytest.approx(0.42)
+
+
+@pytest.mark.asyncio
+async def test_runway_poll_failed():
+    get = _FakeResponse(200, {"status": "FAILED", "failure": "moderation"})
+    p = providers.RunwayProvider(api_key="k")
+    with _patch_aiohttp(get=get):
+        status = await p.poll("task-123")
+    assert status.status == "failed"
+    assert "moderation" in (status.error or "")
+
+
+@pytest.mark.asyncio
+async def test_runway_poll_http_error_raises():
+    get = _FakeResponse(500, {"error": "boom"})
+    p = providers.RunwayProvider(api_key="k")
+    with _patch_aiohttp(get=get):
+        with pytest.raises(providers.ProviderError):
+            await p.poll("task-123")
+
+
+# ---------------------------------------------------------------------------
+# Credential-gated providers still implement the contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sora_submit_and_poll():
+    post = _FakeResponse(200, {"id": "sora-1"})
+    p = providers.SoraProvider(api_key="k")
+    with _patch_aiohttp(post=post):
+        assert await p.submit("clip") == "sora-1"
+    get = _FakeResponse(200, {"status": "completed", "url": "https://s/o.mp4"})
+    with _patch_aiohttp(get=get):
+        st = await p.poll("sora-1")
+    assert st.status == "succeeded" and st.video_url == "https://s/o.mp4"
+
+
+@pytest.mark.asyncio
+async def test_kling_submit_and_poll():
+    post = _FakeResponse(200, {"data": {"task_id": "kling-1"}})
+    p = providers.KlingProvider(api_key="k")
+    with _patch_aiohttp(post=post):
+        assert await p.submit("clip") == "kling-1"
+    get = _FakeResponse(
+        200, {"data": {"task_status": "succeed", "task_result": {"videos": [{"url": "https://k/o.mp4"}]}}}
+    )
+    with _patch_aiohttp(get=get):
+        st = await p.poll("kling-1")
+    assert st.status == "succeeded" and st.video_url == "https://k/o.mp4"


### PR DESCRIPTION
## Thinking Path

Last member of #9928. AutoBot had no video output. Mirrors the existing **image generation** plugin pattern end-to-end (the issue's stated approach), adding the async submit→poll lifecycle that video requires.

## What Changed

**Backend** — `plugins/core-plugins/video-generation-plugin/` (plugin.json + main.py register/unregister, mirroring image-gen):
- `tools/providers.py` — `RunwayProvider` (working baseline: text_to_video submit → poll `tasks/{id}` → normalized URL); `SoraProvider` + `KlingProvider` registered, contract-complete, **credential-gated** (empty key ⇒ `available=False`).
- `tools/generate_video.py` — `GenerateVideoTool(BaseTool)` → `generate_video(prompt, duration) -> url`, registered via the same `tool_sdk` registry mechanism as `generate_image`.
- `api/video_generation.py` — async REST router: `/generate` (returns job id), `/status/{job_id}` (progress + final URL), `/providers`; Redis-persisted jobs, env-tunable TTL/poll. Registered in `feature_routers.py` (same tuple shape/place as image_generation).
- Secrets/config: `RUNWAY_API_KEY` (baseline), `SORA_API_KEY`, `KLING_API_KEY` (`required_env`, secret, empty=disabled); settings: default_provider/duration/resolution/aspect_ratio.

**Frontend** — `useVideoGeneration.ts` (submit+poll), `VideoCell.vue` (inline `<video>` + progress bar/spinner + error/download), wired in `ChatMessages.vue` (`type==='video'`); i18n across all 11 locales.

## Verification

- Backend: **22 passed** (providers 13, generate_video 3, endpoint 6; all HTTP mocked). Frontend: `VideoCell.test.ts` 5 passed; `vue-tsc` 0 errors; `check-locale-completeness.py` complete. py_compile + startup-import safe (lazy guarded provider/aiohttp imports).
- Wiring: provider → `video_generation.py` router → `feature_routers.py:226`; tool → `tool_sdk` registry via plugin `main.py` (same path as `generate_image`).

## Discovery

Filed **#10294**: the plugin-loader entry-point path (`plugins.core_plugins.*`) isn't importable (hyphenated `core-plugins` dir) — a **pre-existing** bug that silently breaks loader-based tool registration for **both** image-gen and video-gen. The video REST API works around it via a file-path providers loader; the shared loader fix is tracked in #10294.

## Model Used

Claude Opus 4.8 (1M context)
