### PR TITLE
feat(transcriber/frontend): build ProjectsView + ProjectDetailView — complete GUI flow (#10289)

### DIFF
--- a/autobot-frontend/src/__tests__/transcriber/ProjectDetailView.test.ts
+++ b/autobot-frontend/src/__tests__/transcriber/ProjectDetailView.test.ts
@@ -1,0 +1,172 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import ProjectDetailView from '@/views/transcriber/ProjectDetailView.vue'
+
+// --- API mock ---------------------------------------------------------------
+const getProject = vi.fn()
+const listRecordings = vi.fn()
+const uploadRecording = vi.fn()
+const deleteRecording = vi.fn()
+
+// mockReset:true wipes factories — re-apply implementations in beforeEach.
+vi.mock('@/composables/transcriber/useTranscriberApi', () => ({
+  useTranscriberApi: () => ({ getProject, listRecordings, uploadRecording, deleteRecording }),
+}))
+
+const push = vi.fn()
+// projectId resolves to 1 via the stubbed route.
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { projectId: '1' } }),
+  useRouter: () => ({ push }),
+}))
+
+function recording(id: number, status: string, extra: Record<string, unknown> = {}) {
+  return {
+    id,
+    project_id: 1,
+    filename: `rec-${id}.mp3`,
+    duration: 65,
+    status,
+    speaker_count: 2,
+    process_seconds: null,
+    engine_used: null,
+    language_detected: 'en',
+    uploaded_at: '2026-06-18T00:00:00Z',
+    failure_stage: null,
+    failure_reason: null,
+    ...extra,
+  }
+}
+
+const RouterLinkStub = {
+  name: 'RouterLink',
+  props: ['to'],
+  template: '<a class="router-link-stub"><slot /></a>',
+}
+
+function mountView() {
+  return mount(ProjectDetailView, {
+    global: { stubs: { RouterLink: RouterLinkStub } },
+  })
+}
+
+describe('ProjectDetailView.vue', () => {
+  beforeEach(() => {
+    getProject.mockResolvedValue({
+      id: 1,
+      name: 'My Project',
+      description: 'A description',
+      created_at: '2026-06-18T00:00:00Z',
+      user_id: 'u1',
+    })
+    listRecordings.mockResolvedValue([recording(10, 'complete')])
+    uploadRecording.mockResolvedValue(recording(11, 'pending'))
+    deleteRecording.mockResolvedValue(undefined)
+    push.mockClear()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+  })
+
+  it('loads the project header and recordings on mount', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    expect(getProject).toHaveBeenCalledWith(1)
+    expect(listRecordings).toHaveBeenCalledWith(1)
+    expect(wrapper.find('.detail-title').text()).toBe('My Project')
+    expect(wrapper.findAll('.recording-card')).toHaveLength(1)
+  })
+
+  it('shows the empty state when there are no recordings', async () => {
+    listRecordings.mockResolvedValue([])
+    const wrapper = mountView()
+    await flushPromises()
+    expect(wrapper.find('.recordings-list').exists()).toBe(false)
+    expect(wrapper.text()).toContain('No recordings yet')
+  })
+
+  it('shows an error state when loading fails', async () => {
+    getProject.mockRejectedValue(new Error('boom'))
+    const wrapper = mountView()
+    await flushPromises()
+    expect(wrapper.find('.detail-error').exists()).toBe(true)
+  })
+
+  it('uploads a selected file and prepends the new recording', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    const file = new File(['data'], 'audio.wav', { type: 'audio/wav' })
+    const input = wrapper.find('.upload-input')
+    Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
+    await input.trigger('change')
+    await flushPromises()
+
+    expect(uploadRecording).toHaveBeenCalledWith(1, file)
+    expect(wrapper.findAll('.recording-card')).toHaveLength(2)
+    expect(wrapper.findAll('.recording-filename')[0].text()).toBe('rec-11.mp3')
+  })
+
+  it('surfaces an upload error', async () => {
+    uploadRecording.mockRejectedValue(new Error('nope'))
+    const wrapper = mountView()
+    await flushPromises()
+
+    const file = new File(['data'], 'audio.wav', { type: 'audio/wav' })
+    const input = wrapper.find('.upload-input')
+    Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
+    await input.trigger('change')
+    await flushPromises()
+
+    expect(wrapper.find('.detail-error').exists()).toBe(true)
+  })
+
+  it('refreshes recordings via the Refresh button', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    listRecordings.mockClear()
+    const refresh = wrapper.findAll('.btn-secondary')
+    await refresh[refresh.length - 1].trigger('click')
+    await flushPromises()
+    expect(listRecordings).toHaveBeenCalledWith(1)
+  })
+
+  it('navigates to the transcript view for a completed recording', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    await wrapper.find('.recording-clickable').trigger('click')
+    expect(push).toHaveBeenCalledWith({
+      name: 'transcriber-transcript',
+      params: { projectId: 1, recordingId: 10 },
+    })
+  })
+
+  it('shows in-progress text and no transcript link while processing', async () => {
+    listRecordings.mockResolvedValue([recording(20, 'processing')])
+    const wrapper = mountView()
+    await flushPromises()
+    expect(wrapper.find('.recording-clickable').exists()).toBe(false)
+    expect(wrapper.text()).toContain('Transcription in progress')
+  })
+
+  it('shows the failure reason for an errored recording', async () => {
+    listRecordings.mockResolvedValue([
+      recording(30, 'error', { failure_reason: 'Audio too short' }),
+    ])
+    const wrapper = mountView()
+    await flushPromises()
+    expect(wrapper.find('.recording-clickable').exists()).toBe(false)
+    expect(wrapper.text()).toContain('Audio too short')
+  })
+
+  it('deletes a recording after confirmation', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    await wrapper.find('.btn-danger').trigger('click')
+    await flushPromises()
+    expect(deleteRecording).toHaveBeenCalledWith(10)
+    expect(wrapper.findAll('.recording-card')).toHaveLength(0)
+  })
+})

--- a/autobot-frontend/src/__tests__/transcriber/ProjectsView.test.ts
+++ b/autobot-frontend/src/__tests__/transcriber/ProjectsView.test.ts
@@ -1,0 +1,113 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import ProjectsView from '@/views/transcriber/ProjectsView.vue'
+
+// --- API mock ---------------------------------------------------------------
+const listProjects = vi.fn()
+const createProject = vi.fn()
+const deleteProject = vi.fn()
+
+// mockReset:true wipes factories — re-apply implementations in beforeEach.
+vi.mock('@/composables/transcriber/useTranscriberApi', () => ({
+  useTranscriberApi: () => ({ listProjects, createProject, deleteProject }),
+}))
+
+// Capture router.push to assert navigation.
+const push = vi.fn()
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}))
+
+function project(id: number, name = `Project ${id}`) {
+  return {
+    id,
+    name,
+    description: `Desc ${id}`,
+    created_at: '2026-06-18T00:00:00Z',
+    user_id: 'u1',
+  }
+}
+
+function mountView() {
+  return mount(ProjectsView)
+}
+
+describe('ProjectsView.vue', () => {
+  beforeEach(() => {
+    listProjects.mockResolvedValue([project(1), project(2)])
+    createProject.mockResolvedValue(project(3, 'New One'))
+    deleteProject.mockResolvedValue(undefined)
+    push.mockClear()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+  })
+
+  it('lists projects on mount', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    expect(listProjects).toHaveBeenCalled()
+    const cards = wrapper.findAll('.project-card')
+    expect(cards).toHaveLength(2)
+    expect(wrapper.text()).toContain('Project 1')
+  })
+
+  it('shows the empty state when there are no projects', async () => {
+    listProjects.mockResolvedValue([])
+    const wrapper = mountView()
+    await flushPromises()
+    expect(wrapper.find('.projects-list').exists()).toBe(false)
+    expect(wrapper.text()).toContain('No projects yet')
+  })
+
+  it('shows an error state when loading fails', async () => {
+    listProjects.mockRejectedValue(new Error('boom'))
+    const wrapper = mountView()
+    await flushPromises()
+    expect(wrapper.find('.projects-error').exists()).toBe(true)
+  })
+
+  it('creates a project and prepends it to the list', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.find('.btn-primary').trigger('click')
+    await wrapper.findAll('.create-input')[0].setValue('New One')
+    await wrapper.find('.create-form').trigger('submit')
+    await flushPromises()
+
+    expect(createProject).toHaveBeenCalledWith('New One', '')
+    expect(wrapper.findAll('.project-card')).toHaveLength(3)
+    expect(wrapper.findAll('.project-name')[0].text()).toBe('New One')
+  })
+
+  it('does not create a project with an empty name', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    await wrapper.find('.btn-primary').trigger('click')
+    await wrapper.find('.create-form').trigger('submit')
+    await flushPromises()
+    expect(createProject).not.toHaveBeenCalled()
+  })
+
+  it('deletes a project after confirmation and refreshes the list', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    await wrapper.findAll('.btn-danger')[0].trigger('click')
+    await flushPromises()
+    expect(deleteProject).toHaveBeenCalledWith(1)
+    expect(wrapper.findAll('.project-card')).toHaveLength(1)
+  })
+
+  it('navigates to the project detail view when a project is opened', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+    await wrapper.findAll('.project-open')[0].trigger('click')
+    expect(push).toHaveBeenCalledWith({
+      name: 'transcriber-project-detail',
+      params: { projectId: 1 },
+    })
+  })
+})

--- a/autobot-frontend/src/views/transcriber/ProjectDetailView.vue
+++ b/autobot-frontend/src/views/transcriber/ProjectDetailView.vue
@@ -1,6 +1,367 @@
 <!-- AutoBot - AI-Powered Automation Platform -->
 <!-- Copyright (c) 2025 mrveiss -->
 <script setup lang="ts">
-// Implemented in Plan 4
+import { ref, computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  useTranscriberApi,
+  type Project,
+  type Recording,
+  type RecordingStatus,
+} from '@/composables/transcriber/useTranscriberApi'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('ProjectDetailView')
+
+const route = useRoute()
+const router = useRouter()
+const api = useTranscriberApi()
+
+const ACCEPTED_TYPES = '.wav,.mp3,.mp4,.m4a,.ogg,.flac,.webm'
+
+const projectId = computed(() => Number(route.params.projectId))
+
+const project = ref<Project | null>(null)
+const recordings = ref<Recording[]>([])
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+const fileInput = ref<HTMLInputElement | null>(null)
+const uploading = ref(false)
+const uploadError = ref<string | null>(null)
+
+const STATUS_LABELS: Record<RecordingStatus, string> = {
+  pending: 'Pending',
+  processing: 'Processing',
+  complete: 'Complete',
+  error: 'Failed',
+}
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    project.value = await api.getProject(projectId.value)
+    recordings.value = await api.listRecordings(projectId.value)
+  } catch (err) {
+    logger.error('Failed to load project', err)
+    error.value = 'Failed to load this project.'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function refreshRecordings() {
+  try {
+    recordings.value = await api.listRecordings(projectId.value)
+  } catch (err) {
+    logger.error('Failed to refresh recordings', err)
+    error.value = 'Failed to refresh recordings.'
+  }
+}
+
+function pickFile() {
+  fileInput.value?.click()
+}
+
+async function onFileSelected(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+  uploading.value = true
+  uploadError.value = null
+  try {
+    const recording = await api.uploadRecording(projectId.value, file)
+    recordings.value = [recording, ...recordings.value]
+  } catch (err) {
+    logger.error('Failed to upload recording', err)
+    uploadError.value = 'Failed to upload recording.'
+  } finally {
+    uploading.value = false
+    // Reset so re-selecting the same file fires the change event again.
+    input.value = ''
+  }
+}
+
+function isComplete(recording: Recording): boolean {
+  return recording.status === 'complete'
+}
+
+function isInProgress(recording: Recording): boolean {
+  return recording.status === 'pending' || recording.status === 'processing'
+}
+
+function openRecording(recording: Recording) {
+  if (!isComplete(recording)) return
+  router.push({
+    name: 'transcriber-transcript',
+    params: { projectId: projectId.value, recordingId: recording.id },
+  })
+}
+
+async function removeRecording(recording: Recording) {
+  if (!window.confirm(`Delete recording "${recording.filename}"? This cannot be undone.`)) return
+  try {
+    await api.deleteRecording(recording.id)
+    recordings.value = recordings.value.filter((r) => r.id !== recording.id)
+  } catch (err) {
+    logger.error('Failed to delete recording', err)
+    error.value = 'Failed to delete recording.'
+  }
+}
+
+function formatDuration(seconds: number | null): string {
+  if (seconds === null || Number.isNaN(seconds)) return '—'
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.round(seconds % 60)
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}
+
+onMounted(load)
 </script>
-<template><div class="project-detail-view">Project Detail — coming in Plan 4</div></template>
+
+<template>
+  <div class="project-detail-view">
+    <router-link class="back-link" :to="{ name: 'transcriber-projects' }">
+      ← Back to projects
+    </router-link>
+
+    <div v-if="loading" class="detail-state">Loading project…</div>
+
+    <div v-else-if="error" class="detail-state detail-error">{{ error }}</div>
+
+    <template v-else>
+      <header class="detail-header">
+        <h1 class="detail-title">{{ project?.name }}</h1>
+        <p v-if="project?.description" class="detail-description">{{ project.description }}</p>
+      </header>
+
+      <section class="upload-section">
+        <input
+          ref="fileInput"
+          class="upload-input"
+          type="file"
+          :accept="ACCEPTED_TYPES"
+          @change="onFileSelected"
+        />
+        <button class="btn-primary" type="button" :disabled="uploading" @click="pickFile">
+          {{ uploading ? 'Uploading…' : 'Upload recording' }}
+        </button>
+        <button class="btn-secondary" type="button" @click="refreshRecordings">Refresh</button>
+        <p v-if="uploadError" class="detail-error">{{ uploadError }}</p>
+      </section>
+
+      <div v-if="!recordings.length" class="detail-state">
+        No recordings yet — upload an audio file to begin transcription.
+      </div>
+
+      <ul v-else class="recordings-list">
+        <li v-for="recording in recordings" :key="recording.id" class="recording-card">
+          <component
+            :is="isComplete(recording) ? 'button' : 'div'"
+            class="recording-main"
+            :class="{ 'recording-clickable': isComplete(recording) }"
+            :type="isComplete(recording) ? 'button' : undefined"
+            @click="openRecording(recording)"
+          >
+            <span class="recording-filename">{{ recording.filename }}</span>
+            <span class="recording-meta">
+              <span class="status-badge" :class="`status-${recording.status}`">
+                {{ STATUS_LABELS[recording.status] }}
+              </span>
+              <span>{{ formatDuration(recording.duration) }}</span>
+              <span v-if="recording.speaker_count">{{ recording.speaker_count }} speakers</span>
+              <span v-if="recording.language_detected">{{ recording.language_detected }}</span>
+            </span>
+            <span v-if="isInProgress(recording)" class="recording-note">
+              Transcription in progress…
+            </span>
+            <span v-else-if="recording.status === 'error'" class="recording-note detail-error">
+              {{ recording.failure_reason || 'Transcription failed.' }}
+            </span>
+          </component>
+          <button
+            class="btn-danger"
+            type="button"
+            :aria-label="`Delete ${recording.filename}`"
+            @click="removeRecording(recording)"
+          >
+            Delete
+          </button>
+        </li>
+      </ul>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.project-detail-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.back-link {
+  font-size: 0.875rem;
+  color: var(--color-primary-600, #2563eb);
+  text-decoration: none;
+}
+
+.detail-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.detail-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-text, #111827);
+}
+
+.detail-description {
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.upload-section {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.upload-input {
+  display: none;
+}
+
+.recordings-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.recording-card {
+  display: flex;
+  align-items: stretch;
+  gap: 0.5rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.5rem;
+  background: var(--color-bg, #fff);
+}
+
+.recording-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+}
+
+.recording-clickable {
+  cursor: pointer;
+}
+
+.recording-clickable:hover {
+  background: var(--color-surface, #f3f4f6);
+}
+
+.recording-filename {
+  font-weight: 600;
+  color: var(--color-text, #111827);
+}
+
+.recording-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.recording-note {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.status-badge {
+  padding: 0.0625rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: var(--color-surface, #f3f4f6);
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.status-complete {
+  background: var(--color-success-100, #dcfce7);
+  color: var(--color-success-700, #15803d);
+}
+
+.status-processing,
+.status-pending {
+  background: var(--color-primary-100, #dbeafe);
+  color: var(--color-primary-700, #1d4ed8);
+}
+
+.status-error {
+  background: var(--color-danger-100, #fee2e2);
+  color: var(--color-danger-700, #b91c1c);
+}
+
+.detail-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem;
+  color: var(--color-text-secondary, #6b7280);
+  text-align: center;
+}
+
+.detail-error {
+  color: var(--color-danger-600, #dc2626);
+}
+
+.btn-primary,
+.btn-secondary,
+.btn-danger {
+  padding: 0.5rem 0.875rem;
+  border-radius: 0.375rem;
+  border: 1px solid transparent;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: var(--color-primary-600, #2563eb);
+  color: #fff;
+}
+
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background: transparent;
+  border-color: var(--color-border, #d1d5db);
+  color: var(--color-text, #111827);
+}
+
+.btn-danger {
+  margin: 0.75rem;
+  align-self: center;
+  background: transparent;
+  border-color: var(--color-danger-600, #dc2626);
+  color: var(--color-danger-600, #dc2626);
+}
+</style>

--- a/autobot-frontend/src/views/transcriber/ProjectsView.vue
+++ b/autobot-frontend/src/views/transcriber/ProjectsView.vue
@@ -1,6 +1,302 @@
 <!-- AutoBot - AI-Powered Automation Platform -->
 <!-- Copyright (c) 2025 mrveiss -->
 <script setup lang="ts">
-// Implemented in Plan 4
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useTranscriberApi, type Project } from '@/composables/transcriber/useTranscriberApi'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('ProjectsView')
+
+const router = useRouter()
+const api = useTranscriberApi()
+
+const projects = ref<Project[]>([])
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+// Create-project form state.
+const showCreate = ref(false)
+const newName = ref('')
+const newDescription = ref('')
+const creating = ref(false)
+const createError = ref<string | null>(null)
+
+const canCreate = computed(() => newName.value.trim().length > 0 && !creating.value)
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    projects.value = await api.listProjects()
+  } catch (err) {
+    logger.error('Failed to load projects', err)
+    error.value = 'Failed to load projects.'
+  } finally {
+    loading.value = false
+  }
+}
+
+function openCreate() {
+  showCreate.value = true
+  createError.value = null
+}
+
+function cancelCreate() {
+  showCreate.value = false
+  newName.value = ''
+  newDescription.value = ''
+  createError.value = null
+}
+
+async function submitCreate() {
+  if (!canCreate.value) return
+  creating.value = true
+  createError.value = null
+  try {
+    const project = await api.createProject(newName.value.trim(), newDescription.value.trim())
+    projects.value = [project, ...projects.value]
+    cancelCreate()
+  } catch (err) {
+    logger.error('Failed to create project', err)
+    createError.value = 'Failed to create project.'
+  } finally {
+    creating.value = false
+  }
+}
+
+async function removeProject(project: Project) {
+  if (!window.confirm(`Delete project "${project.name}"? This cannot be undone.`)) return
+  try {
+    await api.deleteProject(project.id)
+    projects.value = projects.value.filter((p) => p.id !== project.id)
+  } catch (err) {
+    logger.error('Failed to delete project', err)
+    error.value = 'Failed to delete project.'
+  }
+}
+
+function openProject(project: Project) {
+  router.push({ name: 'transcriber-project-detail', params: { projectId: project.id } })
+}
+
+function formatDate(value: string): string {
+  if (!value) return ''
+  const d = new Date(value)
+  return Number.isNaN(d.getTime()) ? value : d.toLocaleDateString()
+}
+
+onMounted(load)
 </script>
-<template><div class="projects-view">Projects — coming in Plan 4</div></template>
+
+<template>
+  <div class="projects-view">
+    <header class="projects-header">
+      <h1 class="projects-title">Transcription Projects</h1>
+      <button v-if="!showCreate" class="btn-primary" type="button" @click="openCreate">
+        New project
+      </button>
+    </header>
+
+    <form v-if="showCreate" class="create-form" @submit.prevent="submitCreate">
+      <div class="create-fields">
+        <input
+          v-model="newName"
+          class="create-input"
+          type="text"
+          placeholder="Project name"
+          aria-label="Project name"
+        />
+        <input
+          v-model="newDescription"
+          class="create-input"
+          type="text"
+          placeholder="Description (optional)"
+          aria-label="Project description"
+        />
+      </div>
+      <div class="create-actions">
+        <button class="btn-primary" type="submit" :disabled="!canCreate">
+          {{ creating ? 'Creating…' : 'Create' }}
+        </button>
+        <button class="btn-secondary" type="button" @click="cancelCreate">Cancel</button>
+      </div>
+      <p v-if="createError" class="projects-error">{{ createError }}</p>
+    </form>
+
+    <div v-if="loading" class="projects-state">Loading projects…</div>
+
+    <div v-else-if="error" class="projects-state projects-error">{{ error }}</div>
+
+    <div v-else-if="!projects.length" class="projects-state">
+      No projects yet — create one to start transcribing.
+    </div>
+
+    <ul v-else class="projects-list">
+      <li v-for="project in projects" :key="project.id" class="project-card">
+        <button class="project-open" type="button" @click="openProject(project)">
+          <span class="project-name">{{ project.name }}</span>
+          <span v-if="project.description" class="project-description">{{ project.description }}</span>
+          <span class="project-meta">Created {{ formatDate(project.created_at) }}</span>
+        </button>
+        <button
+          class="btn-danger"
+          type="button"
+          :aria-label="`Delete ${project.name}`"
+          @click="removeProject(project)"
+        >
+          Delete
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.projects-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.projects-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.projects-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-text, #111827);
+}
+
+.create-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.5rem;
+  background: var(--color-surface, #f9fafb);
+}
+
+.create-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.create-input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 0.375rem;
+  background: var(--color-bg, #fff);
+  color: var(--color-text, #111827);
+}
+
+.create-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.projects-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.project-card {
+  display: flex;
+  align-items: stretch;
+  gap: 0.5rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.5rem;
+  background: var(--color-bg, #fff);
+}
+
+.project-open {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+}
+
+.project-open:hover {
+  background: var(--color-surface, #f3f4f6);
+}
+
+.project-name {
+  font-weight: 600;
+  color: var(--color-text, #111827);
+}
+
+.project-description {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.project-meta {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary, #9ca3af);
+}
+
+.projects-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem;
+  color: var(--color-text-secondary, #6b7280);
+  text-align: center;
+}
+
+.projects-error {
+  color: var(--color-danger-600, #dc2626);
+}
+
+.btn-primary,
+.btn-secondary,
+.btn-danger {
+  padding: 0.5rem 0.875rem;
+  border-radius: 0.375rem;
+  border: 1px solid transparent;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: var(--color-primary-600, #2563eb);
+  color: #fff;
+}
+
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background: transparent;
+  border-color: var(--color-border, #d1d5db);
+  color: var(--color-text, #111827);
+}
+
+.btn-danger {
+  margin: 0.75rem;
+  align-self: center;
+  background: transparent;
+  border-color: var(--color-danger-600, #dc2626);
+  color: var(--color-danger-600, #dc2626);
+}
+</style>


### PR DESCRIPTION
## Thinking Path
The transcriber backend pipeline (#10128), TranscriptView+waveform (#10129), and cloud ASR (#10147) were done, but `ProjectsView` and `ProjectDetailView` were 6-line 'coming in Plan 4' stubs — so clicking **Transcriber** in the nav dead-ended and the whole stack was unreachable via the GUI. This builds the missing entry/navigation layer.

## What Changed
- **ProjectsView.vue** (was a stub): lists projects (`listProjects`), inline create (name required, `createProject`), delete-with-confirm, navigates to project detail; loading/empty/error states.
- **ProjectDetailView.vue** (was a stub): project header (`getProject`); audio upload (`uploadRecording`, accept `.wav/.mp3/.mp4/.m4a/.ogg/.flac/.webm`); recordings list with status-driven UX — `complete`→links to `transcriber-transcript`, `pending`/`processing`→'in progress' + manual Refresh, `error`→`failure_reason`; delete-with-confirm; back link.
- Reuses existing `useTranscriberApi` methods + routes; no backend changes.

## Verification
- `vitest run src/__tests__/transcriber/` — **68 passed** (17 new: ProjectsView 7 + ProjectDetailView 10, incl status-driven rendering + error paths).
- `vue-tsc --noEmit -p tsconfig.app.json` — 0 new errors referencing the files; `eslint` clean.
- **End-to-end GUI flow now wired:** Transcriber nav → /transcriber (ProjectsView) → project → ProjectDetailView upload → (pipeline) → complete → TranscriptView.

## Model Used
claude-opus-4-8 + frontend-engineer agent (verified by main session)

Part of #9925. Closes #10289