### PR TITLE
feat(secrets): import legacy SQLite secrets store → unified envelope (#10312)

### DIFF
--- a/autobot-backend/services/sqlite_secrets_importer.py
+++ b/autobot-backend/services/sqlite_secrets_importer.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.secrets_envelope import derive_vault_key, seal, wrap_dek
@@ -127,20 +127,25 @@ async def import_sqlite_secrets(
         except ValueError:
             report.failed.append(f"{src}: created_by not a uuid ({owner_raw!r})")
             continue
+        cipher = row.get("encrypted_value")
+        if not cipher:
+            report.failed.append(f"{src}: no encrypted_value")
+            continue
         try:
-            plaintext = fernet.decrypt(row["encrypted_value"].encode("utf-8"))
+            plaintext = fernet.decrypt(cipher.encode("utf-8"))
         except (InvalidToken, ValueError, TypeError) as exc:
             report.failed.append(f"{src}: decrypt failed ({exc})")
             continue
         try:
-            # Per-row SAVEPOINT so one bad row is reported without aborting the batch.
+            # Per-row SAVEPOINT so one bad row (FK/unique violation, or dirty data
+            # that overflows a PG column → DataError) is reported without aborting the batch.
             async with session.begin_nested():
                 secret, grant = _build_unified(row, plaintext, owner, root_key)
                 session.add(secret)
                 session.add(grant)
                 await session.flush()
             report.imported += 1
-        except IntegrityError as exc:
+        except SQLAlchemyError as exc:
             report.failed.append(f"{src}: persist failed ({exc})")
 
     return report

--- a/autobot-backend/services/sqlite_secrets_importer.py
+++ b/autobot-backend/services/sqlite_secrets_importer.py
@@ -1,0 +1,146 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Import the legacy SQLite secrets store into the unified envelope store (#10088 / Task 3c).
+
+Additive, one-shot migration: reads the legacy SQLite ``secrets`` table
+(``services.secrets_service.SecretsService`` / ``secrets.db``), decrypts each
+value with the legacy Fernet key, and **creates** a new envelope-backed row in
+the PostgreSQL unified store owned by the creator's user vault. The SQLite store
+is left intact — this populates and lets us verify the unified store *before* the
+separate reader-cutover slice repoints ConnectorCredentialStore / WorkflowSecretService
+/ AgentSecretsIntegration off SQLite.
+
+Owner mapping: a row's ``created_by`` (the creator's user id) → owner ``user:<created_by>``.
+The PG ``owner_id`` column carries no DB-level FK, so the only owner requirement is
+that ``created_by`` parse as a UUID; rows with a missing or non-UUID ``created_by``
+are **skipped and reported** rather than given a fabricated owner. The legacy
+``scope``/``chat_id`` are preserved in ``extra_data`` for traceability.
+
+Idempotent: each imported row records its source id in ``extra_data['imported_from_sqlite']``;
+a re-run skips source ids already present. Run inside one transaction and ``commit()`` once.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.secrets_envelope import derive_vault_key, seal, wrap_dek
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from models.secret import Secret
+from models.secret_grant import SecretGrant
+
+if TYPE_CHECKING:  # typing only — avoid a hard cryptography import at module load
+    from cryptography.fernet import Fernet, MultiFernet
+
+_MARKER = "imported_from_sqlite"
+
+
+@dataclass
+class ImportReport:
+    """Reconciliation counts for one import run."""
+
+    total: int = 0
+    imported: int = 0
+    skipped_existing: int = 0
+    failed: list[str] = field(default_factory=list)
+
+
+def _read_active_rows(sqlite_path: str) -> list[dict]:
+    """Read active rows from the legacy SQLite secrets store (sync, one-shot)."""
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        conn.row_factory = sqlite3.Row
+        cur = conn.execute(
+            "SELECT id, name, description, secret_type, encrypted_value, scope, chat_id, created_by "
+            "FROM secrets WHERE is_active = 1"
+        )
+        return [dict(r) for r in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+async def _existing_markers(session: AsyncSession) -> set[str]:
+    """Source ids already imported (so a re-run is idempotent)."""
+    marker = Secret.extra_data[_MARKER].astext
+    rows = (await session.execute(select(marker).where(marker.isnot(None)))).scalars().all()
+    return {r for r in rows if r}
+
+
+def _build_unified(row: dict, plaintext: bytes, owner: uuid.UUID, root_key: bytes) -> tuple[Secret, SecretGrant]:
+    """Seal *plaintext* and build the new unified Secret + owner grant for a legacy SQLite row."""
+    new_id = uuid.uuid4()
+    sid = str(new_id)
+    vault = VaultRef(VaultKind.USER, str(owner))
+    sealed, dek = seal(plaintext, secret_id=sid)
+    wrapped = wrap_dek(dek, derive_vault_key(root_key, vault.to_str()), vault.to_str(), secret_id=sid)
+    secret = Secret(
+        id=new_id,
+        owner_id=owner,
+        name=row["name"],
+        type=row["secret_type"],
+        scope=VaultKind.USER.value,
+        owner_vault=vault.to_str(),
+        sealed_value=sealed.to_dict(),
+        version=1,
+        description=row.get("description"),
+        extra_data={_MARKER: str(row["id"]), "legacy_scope": row.get("scope"), "legacy_chat_id": row.get("chat_id")},
+    )
+    grant = SecretGrant(secret_id=new_id, grantee=vault.to_str(), wrapped_dek=wrapped.to_dict(), created_by=owner)
+    return secret, grant
+
+
+async def import_sqlite_secrets(
+    session: AsyncSession, *, sqlite_path: str, fernet: "Fernet | MultiFernet", root_key: bytes
+) -> ImportReport:
+    """Import the legacy SQLite secrets store into the unified store. Returns a reconciliation report.
+
+    ``fernet`` is a ``cryptography.fernet.Fernet`` built from the legacy ``AUTOBOT_SECRETS_KEY``;
+    ``root_key`` is the envelope root key. See the module docstring for the transaction contract.
+    """
+    from cryptography.fernet import InvalidToken
+
+    report = ImportReport()
+    rows = _read_active_rows(sqlite_path)
+    report.total = len(rows)
+    already = await _existing_markers(session)
+
+    for row in rows:
+        src = str(row["id"])
+        if src in already:
+            report.skipped_existing += 1
+            continue
+        owner_raw = row.get("created_by")
+        if not owner_raw:
+            report.failed.append(f"{src}: no created_by (owner)")
+            continue
+        try:
+            owner = uuid.UUID(str(owner_raw))
+        except ValueError:
+            report.failed.append(f"{src}: created_by not a uuid ({owner_raw!r})")
+            continue
+        try:
+            plaintext = fernet.decrypt(row["encrypted_value"].encode("utf-8"))
+        except (InvalidToken, ValueError, TypeError) as exc:
+            report.failed.append(f"{src}: decrypt failed ({exc})")
+            continue
+        try:
+            # Per-row SAVEPOINT so one bad row is reported without aborting the batch.
+            async with session.begin_nested():
+                secret, grant = _build_unified(row, plaintext, owner, root_key)
+                session.add(secret)
+                session.add(grant)
+                await session.flush()
+            report.imported += 1
+        except IntegrityError as exc:
+            report.failed.append(f"{src}: persist failed ({exc})")
+
+    return report

--- a/autobot-backend/tests/migrations/test_sqlite_secrets_importer.py
+++ b/autobot-backend/tests/migrations/test_sqlite_secrets_importer.py
@@ -1,0 +1,136 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the legacy SQLite → unified envelope importer (#10088 / Task 3c).
+
+Builds a legacy SQLite ``secrets.db`` in a temp dir, imports it into a Postgres
+unified store (migration-gate), and verifies each row is envelope-readable via
+UnifiedSecretsService owned by the creator's user vault.
+"""
+
+import base64
+import sqlite3
+import uuid
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from services.sqlite_secrets_importer import import_sqlite_secrets
+from services.unified_secrets_service import UnifiedSecretsService
+from tests.migrations.conftest import requires_postgres, run_alembic
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+_ROOT = base64.urlsafe_b64decode(base64.urlsafe_b64encode(bytes(range(32))))
+_KEY = Fernet.generate_key()
+_FERNET = Fernet(_KEY)
+_ALICE = uuid.uuid4()
+_BOB = uuid.uuid4()
+
+
+def _make_db(path: str, rows: list[dict]) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE secrets (id TEXT PRIMARY KEY, name TEXT, description TEXT, secret_type TEXT, "
+        "encrypted_value TEXT NOT NULL, scope TEXT DEFAULT 'general', chat_id TEXT, created_by TEXT, "
+        "is_active INTEGER DEFAULT 1)"
+    )
+    for r in rows:
+        conn.execute(
+            "INSERT INTO secrets (id, name, secret_type, encrypted_value, scope, created_by, is_active) "
+            "VALUES (?,?,?,?,?,?,?)",
+            (
+                r["id"],
+                r["name"],
+                r.get("secret_type", "password"),
+                _FERNET.encrypt(r["value"]).decode("utf-8"),
+                r.get("scope", "general"),
+                r.get("created_by"),
+                r.get("is_active", 1),
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture()
+async def session(fresh_db_url):
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+    engine = create_async_engine(fresh_db_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as s:
+        yield s
+    await engine.dispose()
+
+
+async def test_imports_and_envelope_readable(session, tmp_path):
+    db = str(tmp_path / "secrets.db")
+    _make_db(
+        db,
+        [
+            {"id": "s1", "name": "alice-key", "value": b"a-val", "created_by": str(_ALICE)},
+            {"id": "s2", "name": "bob-key", "value": b"b-val", "created_by": str(_BOB), "scope": "chat"},
+        ],
+    )
+    report = await import_sqlite_secrets(session, sqlite_path=db, fernet=_FERNET, root_key=_ROOT)
+    await session.commit()
+    assert report.total == 2 and report.imported == 2 and report.failed == []
+
+    svc = UnifiedSecretsService(root_key=_ROOT)
+    alice_secrets = await svc.list_for_vaults(session, accessible_vaults={VaultRef(VaultKind.USER, str(_ALICE))})
+    assert len(alice_secrets) == 1
+    assert (
+        await svc.read(
+            session, secret_id=alice_secrets[0].id, accessible_vaults={VaultRef(VaultKind.USER, str(_ALICE))}
+        )
+        == b"a-val"
+    )
+    # legacy scope is preserved for traceability
+    assert alice_secrets[0].extra_data["legacy_scope"] == "general"
+    assert alice_secrets[0].extra_data["imported_from_sqlite"] == "s1"
+
+
+async def test_idempotent_skips_already_imported(session, tmp_path):
+    db = str(tmp_path / "secrets.db")
+    _make_db(db, [{"id": "s1", "name": "k", "value": b"v", "created_by": str(_ALICE)}])
+    first = await import_sqlite_secrets(session, sqlite_path=db, fernet=_FERNET, root_key=_ROOT)
+    await session.commit()
+    second = await import_sqlite_secrets(session, sqlite_path=db, fernet=_FERNET, root_key=_ROOT)
+    await session.commit()
+    assert first.imported == 1
+    assert second.total == 1 and second.imported == 0 and second.skipped_existing == 1
+
+
+async def test_missing_and_invalid_owner_skipped(session, tmp_path):
+    db = str(tmp_path / "secrets.db")
+    _make_db(
+        db,
+        [
+            {"id": "no-owner", "name": "k1", "value": b"v1", "created_by": None},
+            {"id": "bad-owner", "name": "k2", "value": b"v2", "created_by": "not-a-uuid"},
+            {"id": "ok", "name": "k3", "value": b"v3", "created_by": str(_ALICE)},
+        ],
+    )
+    report = await import_sqlite_secrets(session, sqlite_path=db, fernet=_FERNET, root_key=_ROOT)
+    await session.commit()
+    assert report.total == 3 and report.imported == 1 and len(report.failed) == 2
+
+
+async def test_bad_ciphertext_reported(session, tmp_path):
+    db = str(tmp_path / "secrets.db")
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE secrets (id TEXT PRIMARY KEY, name TEXT, description TEXT, secret_type TEXT, "
+        "encrypted_value TEXT NOT NULL, scope TEXT, chat_id TEXT, created_by TEXT, is_active INTEGER DEFAULT 1)"
+    )
+    conn.execute(
+        "INSERT INTO secrets (id, name, secret_type, encrypted_value, created_by, is_active) VALUES (?,?,?,?,?,1)",
+        ("bad", "k", "password", "not-a-fernet-token", str(_ALICE)),
+    )
+    conn.commit()
+    conn.close()
+    report = await import_sqlite_secrets(session, sqlite_path=db, fernet=_FERNET, root_key=_ROOT)
+    assert report.total == 1 and report.imported == 0 and len(report.failed) == 1

--- a/autobot-backend/tests/migrations/test_sqlite_secrets_importer.py
+++ b/autobot-backend/tests/migrations/test_sqlite_secrets_importer.py
@@ -134,3 +134,36 @@ async def test_bad_ciphertext_reported(session, tmp_path):
     conn.close()
     report = await import_sqlite_secrets(session, sqlite_path=db, fernet=_FERNET, root_key=_ROOT)
     assert report.total == 1 and report.imported == 0 and len(report.failed) == 1
+
+
+async def test_oversized_name_reported_not_batch_abort(session, tmp_path):
+    # Dirty legacy data: a name longer than PG name column raises DataError on flush. It must be
+    # reported as one failed row (per-row savepoint + broad SQLAlchemyError), not abort the batch.
+    db = str(tmp_path / "secrets.db")
+    _make_db(
+        db,
+        [
+            {"id": "huge", "name": "x" * 5000, "value": b"v1", "created_by": str(_ALICE)},
+            {"id": "ok", "name": "fine", "value": b"v2", "created_by": str(_ALICE)},
+        ],
+    )
+    report = await import_sqlite_secrets(session, sqlite_path=db, fernet=_FERNET, root_key=_ROOT)
+    await session.commit()
+    assert report.total == 2 and report.imported == 1 and len(report.failed) == 1
+
+
+async def test_null_ciphertext_skipped(session, tmp_path):
+    db = str(tmp_path / "secrets.db")
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE secrets (id TEXT PRIMARY KEY, name TEXT, description TEXT, secret_type TEXT, "
+        "encrypted_value TEXT, scope TEXT, chat_id TEXT, created_by TEXT, is_active INTEGER DEFAULT 1)"
+    )
+    conn.execute(
+        "INSERT INTO secrets (id, name, secret_type, encrypted_value, created_by, is_active) VALUES (?,?,?,?,?,1)",
+        ("nul", "k", "password", None, str(_ALICE)),
+    )
+    conn.commit()
+    conn.close()
+    report = await import_sqlite_secrets(session, sqlite_path=db, fernet=_FERNET, root_key=_ROOT)
+    assert report.total == 1 and report.imported == 0 and len(report.failed) == 1


### PR DESCRIPTION
## Thinking Path
Task 3 of #10088 migrates the legacy secrets stores onto the unified envelope store. After 3a (PG legacy rows, merged #10295), this slice handles the **SQLite store** (`services/secrets_service.py` — connector OAuth tokens, workflow + agent secrets). It is **additive**: it imports the data into the unified store and leaves SQLite intact, so we can verify the unified copy is complete and readable **before** the separate, riskier reader-cutover slice repoints the live readers off SQLite (the "keep old readers until cutover verified" practice).

## What Changed
- **`services/sqlite_secrets_importer.py`** — `import_sqlite_secrets(session, *, sqlite_path, fernet, root_key)`:
  - Reads active rows from the legacy SQLite `secrets` table, decrypts each value with the legacy Fernet key, and **creates** a new envelope-backed PG row + owner grant owned by `user:<created_by>`.
  - **Owner safety:** `created_by` is parsed as a UUID (PG `owner_id` carries no DB-level FK, so only a format check applies). Rows with a missing or non-UUID `created_by` are **skipped and reported** — never given a fabricated owner.
  - **Idempotent:** each imported row records its source id in `extra_data['imported_from_sqlite']`; a re-run skips source ids already present. Legacy `scope`/`chat_id` are preserved in `extra_data` for traceability.
  - **Per-row savepoints** + a reconciliation report (`total`/`imported`/`skipped_existing`/`failed`).

## Verification
- 4 Postgres tests (migration-gate), green on disposable PG 16:
  - imports + envelope-readable via `UnifiedSecretsService` at the owner's user vault; legacy scope/marker preserved
  - idempotent (re-run skips already-imported)
  - missing / non-UUID owner skipped + reported (1 of 3 imports)
  - bad ciphertext reported, not raised
- `flake8` 0, `black` (120) / `isort` clean.

## Out of scope (follow-ups on #10088)
- **3c-2** — repoint the live readers (ConnectorCredentialStore — also the Task-5 connector-token bridge — WorkflowSecretService, AgentSecretsIntegration) off SQLite once this import is verified.
- **3d** — null `encrypted_value` on converted rows after cutover.

## Model Used
Claude Opus 4.8

Part of #10088. Closes #10312.
