### PR TITLE
dedup(#9859 Family C): extract shared scoped CSS from source modals (#10300)

### DIFF
--- a/autobot-frontend/src/components/analytics/AddSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/AddSourceModal.vue
@@ -417,6 +417,8 @@ onMounted(() => {
 })
 </script>
 
+<style scoped src="@/design-system/styles/source-modal-shared.css"></style>
+
 <style scoped>
 /* Issue #1133: Add Source Modal */
 
@@ -443,63 +445,8 @@ onMounted(() => {
   overflow: hidden;
 }
 
-/* Header */
-.modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--spacing-5) var(--spacing-6);
-  border-bottom: 1px solid var(--border-default);
-  flex-shrink: 0;
-}
-
-.modal-header h3 {
-  font-size: var(--text-lg);
-  font-weight: var(--font-semibold);
-  color: var(--text-primary);
-  margin: var(--spacing-0);
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2-5);
-}
-
 .modal-header h3 i {
   color: var(--color-info);
-}
-
-.close-btn {
-  width: 2rem;
-  height: 2rem;
-  border: none;
-  background: var(--bg-tertiary);
-  border-radius: var(--radius-md);
-  color: var(--text-secondary);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.close-btn:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-
-/* Body */
-.modal-body {
-  flex: 1;
-  overflow-y: auto;
-  padding: var(--spacing-6);
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-5);
-}
-
-/* Form Groups */
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-1-5);
 }
 
 .form-label {
@@ -530,6 +477,7 @@ onMounted(() => {
   border-color: var(--color-info);
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
 }
+
 .form-input:focus-visible,
 .form-select:focus-visible {
   outline: 2px solid var(--color-primary);
@@ -547,14 +495,6 @@ onMounted(() => {
 .form-error {
   font-size: var(--text-xs);
   color: var(--color-error);
-}
-
-.form-hint {
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-1);
 }
 
 /* Source Type Toggle */
@@ -590,108 +530,6 @@ onMounted(() => {
   color: var(--bg-secondary);
 }
 
-/* Access Selector */
-.access-selector {
-  display: flex;
-  gap: var(--spacing-2-5);
-}
-
-.access-option {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--spacing-1);
-  padding: var(--spacing-3) var(--spacing-2);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  cursor: pointer;
-  text-align: center;
-  transition: all var(--duration-200);
-  background: var(--bg-tertiary);
-}
-
-.access-option:hover {
-  border-color: var(--border-default);
-}
-
-.access-option--active {
-  border-color: var(--color-info);
-  background: rgba(59, 130, 246, 0.08);
-}
-
-.access-option i {
-  font-size: var(--text-lg);
-  color: var(--text-muted);
-}
-
-.access-option--active i {
-  color: var(--color-info);
-}
-
-.access-option span {
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  color: var(--text-primary);
-}
-
-.access-option small {
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: var(--spacing-0);
-  margin: var(--spacing-neg-px);
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-
-/* Submit error */
-.submit-error {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--spacing-2);
-  padding: var(--spacing-3) var(--spacing-4);
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.3);
-  border-radius: var(--radius-lg);
-  font-size: var(--text-sm);
-  color: var(--color-error);
-}
-
-/* Footer */
-.modal-footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--spacing-3);
-  padding: var(--spacing-5) var(--spacing-6);
-  border-top: 1px solid var(--border-default);
-  flex-shrink: 0;
-}
-
-.btn-cancel {
-  padding: var(--spacing-2-5) var(--spacing-5);
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  color: var(--text-secondary);
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  cursor: pointer;
-  transition: all var(--duration-200);
-}
-
-.btn-cancel:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-
 .btn-submit {
   padding: var(--spacing-2-5) var(--spacing-5);
   background: var(--color-info);
@@ -709,31 +547,5 @@ onMounted(() => {
 
 .btn-submit:hover:not(:disabled) {
   background: var(--color-info-dark);
-}
-
-.btn-submit:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-/* Transitions */
-.modal-fade-enter-active,
-.modal-fade-leave-active {
-  transition: opacity var(--duration-300);
-}
-
-.modal-fade-enter-active .modal-dialog,
-.modal-fade-leave-active .modal-dialog {
-  transition: all var(--duration-300);
-}
-
-.modal-fade-enter-from,
-.modal-fade-leave-to {
-  opacity: 0;
-}
-
-.modal-fade-enter-from .modal-dialog,
-.modal-fade-leave-to .modal-dialog {
-  transform: scale(0.95);
 }
 </style>

--- a/autobot-frontend/src/components/analytics/ShareSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/ShareSourceModal.vue
@@ -249,6 +249,8 @@ watch(() => props.source, (source) => {
 })
 </script>
 
+<style scoped src="@/design-system/styles/source-modal-shared.css"></style>
+
 <style scoped>
 /* Issue #1133: Share Source Modal */
 
@@ -275,56 +277,8 @@ watch(() => props.source, (source) => {
   overflow: hidden;
 }
 
-/* Header */
-.modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--spacing-5) var(--spacing-6);
-  border-bottom: 1px solid var(--border-default);
-  flex-shrink: 0;
-}
-
-.modal-header h3 {
-  font-size: var(--text-lg);
-  font-weight: var(--font-semibold);
-  color: var(--text-primary);
-  margin: var(--spacing-0);
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2-5);
-}
-
 .modal-header h3 i {
   color: var(--color-success);
-}
-
-.close-btn {
-  width: 2rem;
-  height: 2rem;
-  border: none;
-  background: var(--bg-tertiary);
-  border-radius: var(--radius-md);
-  color: var(--text-secondary);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.close-btn:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-
-/* Body */
-.modal-body {
-  flex: 1;
-  overflow-y: auto;
-  padding: var(--spacing-6);
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-5);
 }
 
 /* Source info bar */
@@ -354,13 +308,6 @@ watch(() => props.source, (source) => {
   font-size: var(--text-xs);
   color: var(--text-muted);
   font-family: var(--font-mono, monospace);
-}
-
-/* Form Groups */
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-1-5);
 }
 
 .form-label {
@@ -396,79 +343,10 @@ watch(() => props.source, (source) => {
   border-color: var(--color-info);
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
 }
+
 .form-textarea:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
-}
-
-.form-hint {
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-1);
-}
-
-/* Access Selector */
-.access-selector {
-  display: flex;
-  gap: var(--spacing-2-5);
-}
-
-.access-option {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--spacing-1);
-  padding: var(--spacing-3) var(--spacing-2);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  cursor: pointer;
-  text-align: center;
-  transition: all var(--duration-200);
-  background: var(--bg-tertiary);
-}
-
-.access-option:hover {
-  border-color: var(--border-default);
-}
-
-.access-option--active {
-  border-color: var(--color-info);
-  background: rgba(59, 130, 246, 0.08);
-}
-
-.access-option i {
-  font-size: var(--text-lg);
-  color: var(--text-muted);
-}
-
-.access-option--active i {
-  color: var(--color-info);
-}
-
-.access-option span {
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  color: var(--text-primary);
-}
-
-.access-option small {
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: var(--spacing-0);
-  margin: var(--spacing-neg-px);
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
 }
 
 /* Shared-with section */
@@ -495,46 +373,6 @@ watch(() => props.source, (source) => {
   border-radius: var(--radius-full);
 }
 
-/* Submit error */
-.submit-error {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--spacing-2);
-  padding: var(--spacing-3) var(--spacing-4);
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.3);
-  border-radius: var(--radius-lg);
-  font-size: var(--text-sm);
-  color: var(--color-error);
-}
-
-/* Footer */
-.modal-footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--spacing-3);
-  padding: var(--spacing-5) var(--spacing-6);
-  border-top: 1px solid var(--border-default);
-  flex-shrink: 0;
-}
-
-.btn-cancel {
-  padding: var(--spacing-2-5) var(--spacing-5);
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  color: var(--text-secondary);
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  cursor: pointer;
-  transition: all var(--duration-200);
-}
-
-.btn-cancel:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-
 .btn-submit {
   padding: var(--spacing-2-5) var(--spacing-5);
   background: var(--color-success);
@@ -552,31 +390,5 @@ watch(() => props.source, (source) => {
 
 .btn-submit:hover:not(:disabled) {
   opacity: 0.85;
-}
-
-.btn-submit:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-/* Transitions */
-.modal-fade-enter-active,
-.modal-fade-leave-active {
-  transition: opacity var(--duration-300);
-}
-
-.modal-fade-enter-active .modal-dialog,
-.modal-fade-leave-active .modal-dialog {
-  transition: all var(--duration-300);
-}
-
-.modal-fade-enter-from,
-.modal-fade-leave-to {
-  opacity: 0;
-}
-
-.modal-fade-enter-from .modal-dialog,
-.modal-fade-leave-to .modal-dialog {
-  transform: scale(0.95);
 }
 </style>

--- a/autobot-frontend/src/design-system/styles/source-modal-shared.css
+++ b/autobot-frontend/src/design-system/styles/source-modal-shared.css
@@ -1,0 +1,202 @@
+/* Copyright 2025-2026 mrveiss
+ * SPDX-License-Identifier: Apache-2.0
+ * AutoBot - AI-Powered Automation Platform
+ * Author: mrveiss
+ *
+ * Shared scoped styles for the analytics source modals (#10300, part of #9859).
+ * Byte-identical rule blocks extracted from AddSourceModal.vue and
+ * ShareSourceModal.vue. Selectors here are disjoint from each component's
+ * remaining scoped rules, so inclusion via `<style scoped src>` is
+ * order-independent and produces output identical to inlining.
+ */
+
+/* Header */
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-5) var(--spacing-6);
+  border-bottom: 1px solid var(--border-default);
+  flex-shrink: 0;
+}
+
+.modal-header h3 {
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+  margin: var(--spacing-0);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2-5);
+}
+
+.close-btn {
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.close-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+/* Body */
+.modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--spacing-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-5);
+}
+
+/* Form Groups */
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1-5);
+}
+
+.form-hint {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+}
+
+/* Access Selector */
+.access-selector {
+  display: flex;
+  gap: var(--spacing-2-5);
+}
+
+.access-option {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-3) var(--spacing-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  text-align: center;
+  transition: all var(--duration-200);
+  background: var(--bg-tertiary);
+}
+
+.access-option:hover {
+  border-color: var(--border-default);
+}
+
+.access-option--active {
+  border-color: var(--color-info);
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.access-option i {
+  font-size: var(--text-lg);
+  color: var(--text-muted);
+}
+
+.access-option--active i {
+  color: var(--color-info);
+}
+
+.access-option span {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--text-primary);
+}
+
+.access-option small {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: var(--spacing-0);
+  margin: var(--spacing-neg-px);
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+/* Submit error */
+.submit-error {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3) var(--spacing-4);
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: var(--radius-lg);
+  font-size: var(--text-sm);
+  color: var(--color-error);
+}
+
+/* Footer */
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-3);
+  padding: var(--spacing-5) var(--spacing-6);
+  border-top: 1px solid var(--border-default);
+  flex-shrink: 0;
+}
+
+.btn-cancel {
+  padding: var(--spacing-2-5) var(--spacing-5);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition: all var(--duration-200);
+}
+
+.btn-cancel:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.btn-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Transitions */
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity var(--duration-300);
+}
+
+.modal-fade-enter-active .modal-dialog,
+.modal-fade-leave-active .modal-dialog {
+  transition: all var(--duration-300);
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
+.modal-fade-enter-from .modal-dialog,
+.modal-fade-leave-to .modal-dialog {
+  transform: scale(0.95);
+}


### PR DESCRIPTION
## Thinking Path
First execution of the #9859 dedup campaign (Wave 1 — both components are story-covered, so the visual-regression harness gates this). AddSourceModal.vue and ShareSourceModal.vue duplicate ~245 lines of `<style scoped>`.

## What Changed
- Extracted the **25 byte-identical scoped-CSS rule blocks** (~166 lines) into `src/design-system/styles/source-modal-shared.css`, included in each modal via `<style scoped src="@/design-system/styles/source-modal-shared.css">`. Vue re-applies each component's own scope id to the imported sheet ⇒ byte-identical to inlining.
- Net **−174 duplicated lines**.

## Why this is provably identical (not just plausible)
- All **42** scoped selectors are distinct within each file (no intra-file duplicate selectors → no same-selector cascade-order dependence).
- The extracted 25 are byte-identical in both files AND **disjoint** from the 17 that stay inline (12 component-unique + **5 same-selector-but-different-body** kept per-component: `.modal-dialog`, `.modal-header h3 i`, `.form-label`, `.btn-submit`, `.btn-submit:hover:not(:disabled)`).
- Disjoint selectors ⇒ order-independent ⇒ identical computed styles regardless of `<style>` block order.
- Verified programmatically that the effective rule-set (shared ∪ inline) per component is unchanged vs `HEAD`: **0 missing / 0 changed / 0 extra**.

## Verification / merge gate
- ✅ Static CSS equivalence proven (above).
- ⛔ **Merge gate: the Storybook visual-regression check must show ZERO screenshot diff** for AddSourceModal + ShareSourceModal stories (and the frontend build must pass, validating `<style scoped src>` resolution). No local browser here, so CI is the visual net — will NOT merge on any diff.

Closes #10300 · part of #9859 · part of #9921

## Model Used
claude-opus-4-8