### PR TITLE
dedup(#9859 Family E): extract shared scoped CSS from orphan managers (#10302)

### DIFF
--- a/autobot-frontend/src/components/knowledge/MemoryOrphanManager.vue
+++ b/autobot-frontend/src/components/knowledge/MemoryOrphanManager.vue
@@ -224,6 +224,8 @@ const cleanupOrphans = async () => {
 }
 </script>
 
+<style scoped src="@/design-system/styles/orphan-manager-shared.css"></style>
+
 <style scoped>
 /**
  * Issue #704: CSS Design System - Using design tokens
@@ -259,43 +261,11 @@ const cleanupOrphans = async () => {
   font-size: var(--text-sm);
 }
 
-.orphan-content {
-  padding: var(--spacing-5);
-}
-
-.orphan-summary {
-  margin-bottom: var(--spacing-6);
-}
-
-.summary-stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: var(--spacing-4);
-  margin-bottom: var(--spacing-6);
-}
-
-.stat-item {
-  text-align: center;
-  padding: var(--spacing-4);
-  background: var(--bg-secondary);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border-default);
-}
-
-.stat-item.highlight {
-  background: var(--color-warning-bg);
-  border-color: var(--color-warning);
-}
-
 .stat-value {
   display: block;
   font-size: var(--text-2xl);
   font-weight: var(--font-bold);
   color: var(--text-primary);
-}
-
-.stat-item.highlight .stat-value {
-  color: var(--color-warning-dark);
 }
 
 .stat-label {
@@ -319,27 +289,6 @@ const cleanupOrphans = async () => {
   margin: 0 0 var(--spacing-3) 0;
 }
 
-.orphan-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-3);
-  max-height: 300px;
-  overflow-y: auto;
-}
-
-.orphan-item {
-  background: var(--bg-card);
-  border: 1px solid var(--color-warning-light);
-  border-radius: var(--radius-md);
-  padding: var(--spacing-3);
-}
-
-.orphan-meta {
-  display: flex;
-  gap: var(--spacing-2);
-  margin-bottom: var(--spacing-2);
-}
-
 .orphan-name {
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);
@@ -360,23 +309,12 @@ const cleanupOrphans = async () => {
   white-space: nowrap;
 }
 
-.orphan-session {
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-}
-
 .orphan-more {
   font-size: var(--text-sm);
   color: var(--text-secondary);
   font-style: italic;
   margin: var(--spacing-3) 0 0 0;
   text-align: center;
-}
-
-.orphan-actions {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: var(--spacing-6);
 }
 
 .action-card {
@@ -391,43 +329,14 @@ const cleanupOrphans = async () => {
   background: var(--bg-card);
 }
 
-.action-card:hover {
-  border-color: var(--color-primary);
-  box-shadow: var(--shadow-md);
-}
-
 .action-card.warning {
   border-color: var(--color-warning-light);
   background: var(--color-warning-bg);
 }
 
-.action-card.warning:hover {
-  border-color: var(--color-warning);
-}
-
-.action-content {
-  flex: 1;
-}
-
-.action-icon {
-  width: 3rem;
-  height: 3rem;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: var(--text-xl);
-  margin-bottom: var(--spacing-4);
-}
-
 .action-icon.scan {
   background: var(--color-info-bg);
   color: var(--color-info);
-}
-
-.action-icon.cleanup {
-  background: var(--color-warning-bg);
-  color: var(--color-warning);
 }
 
 .action-card h5 {
@@ -443,39 +352,6 @@ const cleanupOrphans = async () => {
   line-height: var(--leading-normal);
 }
 
-.action-meta {
-  color: var(--text-muted);
-  font-size: var(--text-xs);
-  display: block;
-  margin-bottom: var(--spacing-4);
-}
-
-.action-btn {
-  width: 100%;
-}
-
-/* Status Messages */
-.status-message {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-3);
-  padding: var(--spacing-4);
-  border-radius: var(--radius-lg);
-  margin-top: var(--spacing-6);
-}
-
-.status-message.success {
-  background: var(--color-success-bg);
-  border: 1px solid var(--color-success);
-  color: var(--color-success-dark);
-}
-
-.status-message.error {
-  background: var(--color-error-bg);
-  border: 1px solid var(--color-error);
-  color: var(--color-error-dark);
-}
-
 .status-message.warning {
   background: var(--color-warning-bg);
   border: 1px solid var(--color-warning);
@@ -488,10 +364,6 @@ const cleanupOrphans = async () => {
   color: var(--color-info-dark);
 }
 
-.status-message span {
-  flex: 1;
-}
-
 .dismiss-btn {
   background: none;
   border: none;
@@ -500,20 +372,5 @@ const cleanupOrphans = async () => {
   color: inherit;
   opacity: 0.7;
   transition: opacity var(--duration-200);
-}
-
-.dismiss-btn:hover {
-  opacity: 1;
-}
-
-/* Responsive */
-@media (max-width: 768px) {
-  .orphan-actions {
-    grid-template-columns: 1fr;
-  }
-
-  .summary-stats {
-    grid-template-columns: repeat(2, 1fr);
-  }
 }
 </style>

--- a/autobot-frontend/src/components/knowledge/SessionOrphanManager.vue
+++ b/autobot-frontend/src/components/knowledge/SessionOrphanManager.vue
@@ -206,6 +206,8 @@ const cleanupSessionOrphans = async () => {
 }
 </script>
 
+<style scoped src="@/design-system/styles/orphan-manager-shared.css"></style>
+
 <style scoped>
 /* Issue #704: Migrated to CSS design tokens */
 .session-orphan-manager {
@@ -237,43 +239,11 @@ const cleanupSessionOrphans = async () => {
   font-size: var(--text-sm);
 }
 
-.orphan-content {
-  padding: var(--spacing-5);
-}
-
-.orphan-summary {
-  margin-bottom: var(--spacing-6);
-}
-
-.summary-stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: var(--spacing-4);
-  margin-bottom: var(--spacing-6);
-}
-
-.stat-item {
-  text-align: center;
-  padding: var(--spacing-4);
-  background: var(--bg-secondary);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border-default);
-}
-
-.stat-item.highlight {
-  background: var(--color-warning-bg);
-  border-color: var(--color-warning);
-}
-
 .stat-value {
   display: block;
   font-size: var(--text-2xl);
   font-weight: 700;
   color: var(--text-primary);
-}
-
-.stat-item.highlight .stat-value {
-  color: var(--color-warning-dark);
 }
 
 .stat-label {
@@ -295,27 +265,6 @@ const cleanupSessionOrphans = async () => {
   font-weight: 600;
   color: var(--color-warning-darker);
   margin: var(--spacing-0) var(--spacing-0) var(--spacing-3) var(--spacing-0);
-}
-
-.orphan-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-3);
-  max-height: 300px;
-  overflow-y: auto;
-}
-
-.orphan-item {
-  background: var(--bg-card);
-  border: 1px solid var(--color-warning-light);
-  border-radius: var(--radius-md);
-  padding: var(--spacing-3);
-}
-
-.orphan-meta {
-  display: flex;
-  gap: var(--spacing-2);
-  margin-bottom: var(--spacing-2);
 }
 
 .orphan-category {
@@ -344,23 +293,12 @@ const cleanupSessionOrphans = async () => {
   white-space: nowrap;
 }
 
-.orphan-session {
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-}
-
 .orphan-more {
   font-size: var(--text-sm);
   color: var(--text-tertiary);
   font-style: italic;
   margin: var(--spacing-3) var(--spacing-0) var(--spacing-0) var(--spacing-0);
   text-align: center;
-}
-
-.orphan-actions {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: var(--spacing-6);
 }
 
 .action-card {
@@ -374,43 +312,14 @@ const cleanupSessionOrphans = async () => {
   transition: all var(--duration-200);
 }
 
-.action-card:hover {
-  border-color: var(--color-primary);
-  box-shadow: var(--shadow-md);
-}
-
 .action-card.warning {
   border-color: var(--color-warning-light);
   background: var(--color-warning-bg-light);
 }
 
-.action-card.warning:hover {
-  border-color: var(--color-warning);
-}
-
-.action-content {
-  flex: 1;
-}
-
-.action-icon {
-  width: 3rem;
-  height: 3rem;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: var(--text-xl);
-  margin-bottom: var(--spacing-4);
-}
-
 .action-icon.scan {
   background: var(--color-primary-bg);
   color: var(--color-primary);
-}
-
-.action-icon.cleanup {
-  background: var(--color-warning-bg);
-  color: var(--color-warning);
 }
 
 .action-card h5 {
@@ -426,39 +335,6 @@ const cleanupSessionOrphans = async () => {
   line-height: 1.5;
 }
 
-.action-meta {
-  color: var(--text-muted);
-  font-size: var(--text-xs);
-  display: block;
-  margin-bottom: var(--spacing-4);
-}
-
-.action-btn {
-  width: 100%;
-}
-
-/* Status Messages */
-.status-message {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-3);
-  padding: var(--spacing-4);
-  border-radius: var(--radius-lg);
-  margin-top: var(--spacing-6);
-}
-
-.status-message.success {
-  background: var(--color-success-bg);
-  border: 1px solid var(--color-success);
-  color: var(--color-success-dark);
-}
-
-.status-message.error {
-  background: var(--color-error-bg);
-  border: 1px solid var(--color-error);
-  color: var(--color-error-dark);
-}
-
 .status-message.warning {
   background: var(--color-warning-bg-light);
   border: 1px solid var(--color-warning);
@@ -471,10 +347,6 @@ const cleanupSessionOrphans = async () => {
   color: var(--color-info-dark);
 }
 
-.status-message span {
-  flex: 1;
-}
-
 .dismiss-btn {
   background: none;
   border: none;
@@ -482,20 +354,5 @@ const cleanupSessionOrphans = async () => {
   padding: var(--spacing-1);
   color: inherit;
   opacity: 0.7;
-}
-
-.dismiss-btn:hover {
-  opacity: 1;
-}
-
-/* Responsive */
-@media (max-width: 768px) {
-  .orphan-actions {
-    grid-template-columns: 1fr;
-  }
-
-  .summary-stats {
-    grid-template-columns: repeat(2, 1fr);
-  }
 }
 </style>

--- a/autobot-frontend/src/design-system/styles/orphan-manager-shared.css
+++ b/autobot-frontend/src/design-system/styles/orphan-manager-shared.css
@@ -1,0 +1,156 @@
+/* Copyright 2025-2026 mrveiss
+ * SPDX-License-Identifier: Apache-2.0
+ * AutoBot - AI-Powered Automation Platform
+ * Author: mrveiss
+ *
+ * Shared scoped styles for the knowledge orphan managers (#10302, part of #9859).
+ * Byte-identical rule blocks extracted from MemoryOrphanManager.vue and
+ * SessionOrphanManager.vue; selectors here are disjoint from each component's
+ * remaining scoped rules, so `<style scoped src>` inclusion is order-independent
+ * and identical to inlining.
+ */
+
+.orphan-content {
+  padding: var(--spacing-5);
+}
+
+.orphan-summary {
+  margin-bottom: var(--spacing-6);
+}
+
+.summary-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
+}
+
+.stat-item {
+  text-align: center;
+  padding: var(--spacing-4);
+  background: var(--bg-secondary);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-default);
+}
+
+.stat-item.highlight {
+  background: var(--color-warning-bg);
+  border-color: var(--color-warning);
+}
+
+.stat-item.highlight .stat-value {
+  color: var(--color-warning-dark);
+}
+
+.orphan-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.orphan-item {
+  background: var(--bg-card);
+  border: 1px solid var(--color-warning-light);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-3);
+}
+
+.orphan-meta {
+  display: flex;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
+}
+
+.orphan-session {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.orphan-actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--spacing-6);
+}
+
+.action-card:hover {
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-md);
+}
+
+.action-card.warning:hover {
+  border-color: var(--color-warning);
+}
+
+.action-content {
+  flex: 1;
+}
+
+.action-icon {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-xl);
+  margin-bottom: var(--spacing-4);
+}
+
+.action-icon.cleanup {
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+}
+
+.action-meta {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  display: block;
+  margin-bottom: var(--spacing-4);
+}
+
+.action-btn {
+  width: 100%;
+}
+
+/* Status Messages */
+.status-message {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
+  border-radius: var(--radius-lg);
+  margin-top: var(--spacing-6);
+}
+
+.status-message.success {
+  background: var(--color-success-bg);
+  border: 1px solid var(--color-success);
+  color: var(--color-success-dark);
+}
+
+.status-message.error {
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error);
+  color: var(--color-error-dark);
+}
+
+.status-message span {
+  flex: 1;
+}
+
+.dismiss-btn:hover {
+  opacity: 1;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .orphan-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .summary-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}


### PR DESCRIPTION
## Thinking Path
Wave 1 of the #9859 dedup campaign (both components story-covered). Follows the exact pattern proven in #10300/#10315.

## What Changed
- Extracted the **24 byte-identical scoped-CSS rule blocks** (~121 lines) shared by `MemoryOrphanManager.vue` and `SessionOrphanManager.vue` into `src/design-system/styles/orphan-manager-shared.css`, included via `<style scoped src>`. Net **−169 dup lines**.

## Why provably identical
- All **44** scoped selectors are distinct per file (no intra-file dup → no same-selector cascade order dependence).
- The 24 extracted are byte-identical in both AND disjoint from the 20 kept inline (4 component-unique + 16 same-selector-different-body). Disjoint ⇒ order-independent ⇒ identical computed styles.
- Verified the effective rule-set (shared ∪ inline) is unchanged per component: **0 missing / 0 changed / 0 extra**.

## Verification / merge gate
- ✅ Static CSS equivalence proven.
- Visual-regression: confirm MemoryOrphanManager + SessionOrphanManager stories are NOT in the failure list (the suite currently has 16 pre-existing unrelated stale-baseline failures — #10320 — so the check is red for reasons unrelated to this PR; the PR's own stories must render identical).

Closes #10302 · part of #9859 · part of #9921

## Model Used
claude-opus-4-8