### PR TITLE
chore(deps): pip security bumps — cryptography/python-multipart/pypdf/torch (manual, replaces canceled #10310)

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -35,8 +35,8 @@ boto3>=1.43.25                       # GH#9010: AWS Bedrock provider
 chromadb>=1.5.9,<2.0.0             # upper bound guards against breaking API changes; 1.5.5+ uses regenerated protos compatible with protobuf 5.x (#4053)
 protobuf>=5.29.6,<8.0.0           # required floor for chromadb 1.5.5+ opentelemetry exporter; resolves googleapis-common-protos conflict (#4061)
 sentence-transformers>=5.4.1
-torch==2.12.0  # embeddings/transcriber/multimodal; installed CPU-only in the default image (#10251). GPU build via requirements-gpu.txt
-torchvision==0.27.0  # paired with torch 2.12.0; CPU-only by default (#10251)
+torch==2.12.1  # embeddings/transcriber/multimodal; installed CPU-only in the default image (#10251). GPU build via requirements-gpu.txt
+torchvision==0.27.1  # paired with torch 2.12.1; CPU-only by default (#10251)
 # torchaudio removed (#10251): not imported anywhere in the backend, and its 2.11.0 pin mismatched torch 2.12.0
 torchmetrics>=1.9.0  # Issue #904: Training metrics
 opencv-python-headless>=4.10.0,<4.11  # MVA-3684: <4.11 avoids numpy>=2 requirement (compatible with vllm's numpy 1.x)

--- a/autobot-npu-worker/requirements.txt
+++ b/autobot-npu-worker/requirements.txt
@@ -2,5 +2,5 @@
 
 # NPU/AI
 openvino>=2026.2.0
-torch>=2.12.0
+torch>=2.12.1
 numpy>=2.4.6,<3.0.0

--- a/autobot-slm-backend/requirements.txt
+++ b/autobot-slm-backend/requirements.txt
@@ -27,7 +27,7 @@ typing_extensions>=4.15.0  # For Python 3.8 compatibility
 # Authentication
 PyJWT[crypto]>=2.12.1
 bcrypt>=5.0.0  # Direct bcrypt API — passlib removed (#2669)
-python-multipart>=0.0.29          # SECURITY UPDATE - arbitrary file write fix
+python-multipart>=0.0.32          # SECURITY UPDATE - arbitrary file write fix
 
 # Cache (GH #6511: Redis-backed permission cache replaces in-process dict)
 redis[asyncio]>=8.0.0
@@ -60,6 +60,6 @@ pysaml2>=7.5.4  # SAML 2.0 Service Provider
 pyotp>=2.9.0  # TOTP generation and verification
 
 # Security: explicit pins to override vulnerable transitive versions
-cryptography>=47.0.0  # CVE fix — pulled in by PyJWT[crypto] and pysaml2
+cryptography>=49.0.0  # CVE fix — pulled in by PyJWT[crypto] and pysaml2
 # Note: pyopenssl version resolved by pysaml2's dependencies (constraints conflict with >=26.0.0)
-# cryptography>=47.0.0 provides primary security coverage
+# cryptography>=49.0.0 provides primary security coverage

--- a/autobot-tts-worker/requirements.txt
+++ b/autobot-tts-worker/requirements.txt
@@ -1,9 +1,9 @@
 fastapi>=0.136.3                # SECURITY UPDATE - requires starlette >=0.52.1
 uvicorn[standard]>=0.47.0
 transformers>=5.10.1
-torch>=2.12.0
+torch>=2.12.1
 soundfile>=0.14.0
 numpy>=2.4.6,<3.0.0
 huggingface_hub>=1.16.1
 aiofiles>=25.1.0
-python-multipart>=0.0.29          # SECURITY UPDATE - arbitrary file write fix
+python-multipart>=0.0.32          # SECURITY UPDATE - arbitrary file write fix

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -35,7 +35,7 @@ RUN grep -v -E "(autobot.shared|^-r |^torch==|^torchvision==)" /tmp/requirements
         > /app/requirements-filtered.txt \
     && python3 -m pip install --no-cache-dir -r /app/requirements-root.txt \
     && python3 -m pip install --no-cache-dir \
-        torch==2.12.0 torchvision==0.27.0 \
+        torch==2.12.1 torchvision==0.27.1 \
         --index-url https://download.pytorch.org/whl/cpu \
     && python3 -m pip install --no-cache-dir -r /app/requirements-filtered.txt
 

--- a/requirements-ci/document.txt
+++ b/requirements-ci/document.txt
@@ -1,6 +1,6 @@
 # Document processing and text extraction
 python-docx==1.1.2
-pypdf==6.12.0
+pypdf==6.13.3
 reportlab>=4.0.0            # MVA-2174: PDF export for transcripts
 markdown==3.8.2
 nltk==3.9.4

--- a/requirements-ci/framework.txt
+++ b/requirements-ci/framework.txt
@@ -2,7 +2,7 @@
 # fastapi pins starlette range; keep these in sync
 fastapi==0.133.0
 starlette==1.3.1
-python-multipart==0.0.27
+python-multipart==0.0.32
 uvicorn==0.47.0
 pydantic[email]==2.12.3
 websockets==15.0.1

--- a/requirements-ci/security.txt
+++ b/requirements-ci/security.txt
@@ -2,4 +2,4 @@
 pre-commit==4.2.0
 detect-secrets==1.5.0
 pycryptodome==3.23.0
-cryptography==46.0.7
+cryptography==49.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ protobuf>=5.29.6,<7.0.0
 
 # Document parsing libraries for knowledge base
 # Supports PDF, Word, Excel, PowerPoint, OpenDocument formats
-pypdf>=6.13.2             # PDF parsing - SECURITY UPDATE (improved permission checks)
+pypdf>=6.13.3             # PDF parsing - SECURITY UPDATE (improved permission checks)
 python-docx>=1.2.0        # Microsoft Word (.docx)
 openpyxl>=3.1.5           # Microsoft Excel (.xlsx)
 python-pptx>=1.0.2        # Microsoft PowerPoint (.pptx)


### PR DESCRIPTION
## Thinking Path
Applying the canceled Dependabot pip group (#10310) manually, per request. **Fixed Dependabot's mistake:** #10310 bumped `torch`→2.12.1 but left `torchvision==0.27.0`, which pins torch exactly → `ResolutionImpossible` (verified via `pip install --dry-run` on the CPU index). Bumped torchvision→0.27.1 to restore the valid pair.

## What Changed
- **cryptography → 49.0.0** (CVE) — `autobot-slm-backend/requirements.txt`, `requirements-ci/security.txt`
- **python-multipart → 0.0.32** (arbitrary-file-write fix) — `autobot-slm-backend`, `autobot-tts-worker`, `requirements-ci/framework.txt`
- **pypdf → 6.13.3** (permission-check fix) — `requirements.txt`, `requirements-ci/document.txt`
- **torch → 2.12.1 + torchvision → 0.27.1** (compatible CPU pair) — `autobot-backend/requirements.txt` (+ CPU-index install in `docker/backend/Dockerfile`), `autobot-npu-worker`, `autobot-tts-worker`
- Operators preserved (`==` CI pins / `>=` libs). Out-of-scope files (ai-stack, windows-npu-worker, GPU extra) untouched.

## Verification
- `pip install --dry-run torch==2.12.1 torchvision==0.27.1 --index-url .../whl/cpu` → resolves (`torch-2.12.1+cpu torchvision-0.27.1+cpu`); the 2.12.1 + 0.27.0 combo was proven to fail first.
- smoke-test (CI) builds the backend image → authoritative check the CPU torch pair installs.

## Model Used
claude-opus-4-8

(npm group #10311 follows as a separate PR — lockfile regen + build verify.)