### PR TITLE
feat(secrets): flagged unified-read + SQLite fallback in ConnectorCredentialStore (#10326)

### DIFF
--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -17,6 +17,7 @@ from datetime import timedelta
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.time_utils import now_utc, parse_utc_iso
+from services.unified_credential_read import load_imported_credential
 
 logger = get_logger(__name__)
 
@@ -107,7 +108,7 @@ class ConnectorCredentialStore:
         """
         secret = None
         if _unified_read_enabled():
-            secret = await _load_credential_from_unified(secret_id, owner_id)
+            secret = await load_imported_credential(secret_id, owner_id)
         if secret is None:
             secret = await asyncio.get_running_loop().run_in_executor(
                 None,
@@ -314,87 +315,6 @@ class ConnectorCredentialStore:
         if fields is None:
             raise ValueError(f"{auth_cls.__name__} has no __sensitive_fields__ — cannot separate credentials")
         return fields
-
-
-# ---------------------------------------------------------------------------
-# Unified envelope store read path (expand phase — #10088 Task 3c-2)
-# ---------------------------------------------------------------------------
-
-
-async def _read_unified_in_session(session, secret_id: str, owner_id: str, root_key: bytes) -> dict | None:
-    """Resolve + decrypt an imported credential within *session* (the testable core).
-
-    Matches the legacy SQLite id via the ``imported_from_sqlite`` marker the 3c-1 import
-    stamped (scoped to *owner_id* for defence in depth), then decrypts through the owner's
-    user vault. Returns a SecretsService-shaped dict (``{"created_by", "value"}``), or
-    ``None`` to fall back to SQLite. Any unified-read failure — not imported, not
-    accessible, or a corrupt/partial row — returns ``None`` so the fallback can never be
-    fatal while SQLite is still authoritative.
-    """
-    import uuid
-
-    from sqlalchemy import select
-
-    from autobot_shared.secrets_envelope import DecryptionError, UnsupportedFormatError
-    from autobot_shared.secrets_vault import VaultKind, VaultRef
-    from models.secret import Secret
-    from services.unified_secrets_service import SecretAccessError, SecretNotFoundError, UnifiedSecretsService
-
-    try:
-        owner_uuid = uuid.UUID(str(owner_id))
-    except ValueError:
-        return None  # connector owner isn't a uuid → cannot match an imported row
-
-    marker = Secret.extra_data["imported_from_sqlite"].astext
-    row = (
-        (
-            await session.execute(
-                select(Secret).where(
-                    marker == str(secret_id), Secret.owner_id == owner_uuid, Secret.is_active.is_(True)
-                )
-            )
-        )
-        .scalars()
-        .first()
-    )
-    if row is None:
-        return None  # not yet imported → SQLite fallback
-    try:
-        plaintext = await UnifiedSecretsService(root_key=root_key).read(
-            session, secret_id=row.id, accessible_vaults={VaultRef(VaultKind.USER, str(owner_id))}
-        )
-    except (
-        SecretAccessError,
-        SecretNotFoundError,
-        DecryptionError,
-        UnsupportedFormatError,
-        KeyError,
-        ValueError,
-    ) as exc:
-        logger.warning(
-            "Unified read unusable for imported secret %s (owner %s): %s — falling back", secret_id, owner_id, exc
-        )
-        return None
-    return {"created_by": str(owner_id), "value": plaintext.decode("utf-8")}
-
-
-async def _load_credential_from_unified(secret_id: str, owner_id: str) -> dict | None:
-    """Acquire a session and read an imported credential from the unified store.
-
-    Returns ``None`` to fall back to SQLite when the unified store is not configured
-    (root key unset) on this deployment. See :func:`_read_unified_in_session`.
-    """
-    from autobot_shared.secrets_envelope import load_root_key
-    from user_management.database import get_async_session_factory
-
-    try:
-        root_key = load_root_key()
-    except RuntimeError:
-        return None  # unified store not configured on this deployment
-
-    factory = get_async_session_factory()
-    async with factory() as session:
-        return await _read_unified_in_session(session, secret_id, owner_id, root_key)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -321,34 +321,56 @@ class ConnectorCredentialStore:
 # ---------------------------------------------------------------------------
 
 
-async def _read_unified_in_session(session, secret_id: str, owner_id: str) -> dict | None:
+async def _read_unified_in_session(session, secret_id: str, owner_id: str, root_key: bytes) -> dict | None:
     """Resolve + decrypt an imported credential within *session* (the testable core).
 
     Matches the legacy SQLite id via the ``imported_from_sqlite`` marker the 3c-1 import
-    stamped, then decrypts through the owner's user vault. Returns a SecretsService-shaped
-    dict (``{"created_by", "value"}``), or ``None`` to fall back to SQLite (not imported,
-    or the owner cannot open it).
+    stamped (scoped to *owner_id* for defence in depth), then decrypts through the owner's
+    user vault. Returns a SecretsService-shaped dict (``{"created_by", "value"}``), or
+    ``None`` to fall back to SQLite. Any unified-read failure — not imported, not
+    accessible, or a corrupt/partial row — returns ``None`` so the fallback can never be
+    fatal while SQLite is still authoritative.
     """
+    import uuid
+
     from sqlalchemy import select
 
-    from autobot_shared.secrets_envelope import DecryptionError
+    from autobot_shared.secrets_envelope import DecryptionError, UnsupportedFormatError
     from autobot_shared.secrets_vault import VaultKind, VaultRef
     from models.secret import Secret
-    from services.unified_secrets_service import SecretAccessError, UnifiedSecretsService
+    from services.unified_secrets_service import SecretAccessError, SecretNotFoundError, UnifiedSecretsService
+
+    try:
+        owner_uuid = uuid.UUID(str(owner_id))
+    except ValueError:
+        return None  # connector owner isn't a uuid → cannot match an imported row
 
     marker = Secret.extra_data["imported_from_sqlite"].astext
     row = (
-        (await session.execute(select(Secret).where(marker == str(secret_id), Secret.is_active.is_(True))))
+        (
+            await session.execute(
+                select(Secret).where(
+                    marker == str(secret_id), Secret.owner_id == owner_uuid, Secret.is_active.is_(True)
+                )
+            )
+        )
         .scalars()
         .first()
     )
     if row is None:
         return None  # not yet imported → SQLite fallback
     try:
-        plaintext = await UnifiedSecretsService().read(
+        plaintext = await UnifiedSecretsService(root_key=root_key).read(
             session, secret_id=row.id, accessible_vaults={VaultRef(VaultKind.USER, str(owner_id))}
         )
-    except (SecretAccessError, DecryptionError) as exc:
+    except (
+        SecretAccessError,
+        SecretNotFoundError,
+        DecryptionError,
+        UnsupportedFormatError,
+        KeyError,
+        ValueError,
+    ) as exc:
         logger.warning(
             "Unified read unusable for imported secret %s (owner %s): %s — falling back", secret_id, owner_id, exc
         )
@@ -366,13 +388,13 @@ async def _load_credential_from_unified(secret_id: str, owner_id: str) -> dict |
     from user_management.database import get_async_session_factory
 
     try:
-        load_root_key()
+        root_key = load_root_key()
     except RuntimeError:
         return None  # unified store not configured on this deployment
 
     factory = get_async_session_factory()
     async with factory() as session:
-        return await _read_unified_in_session(session, secret_id, owner_id)
+        return await _read_unified_in_session(session, secret_id, owner_id, root_key)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -11,6 +11,7 @@ Bridges ConnectorConfig ↔ SecretsService so that sensitive auth fields
 
 import asyncio
 import json
+import os
 from datetime import timedelta
 
 from autobot_shared.logging_manager import get_logger
@@ -18,6 +19,17 @@ from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 
 logger = get_logger(__name__)
+
+# Feature flag (expand/contract cutover — #10088 Task 3c-2). When enabled, credential
+# READS try the unified envelope store first (matching the legacy id via the
+# ``imported_from_sqlite`` marker the 3c-1 import stamped) and fall back to the legacy
+# SQLite store. Default off → behaviour is byte-identical to before. Writes are unchanged.
+UNIFIED_READ_ENV = "AUTOBOT_SECRETS_UNIFIED_READ"
+
+
+def _unified_read_enabled() -> bool:
+    return os.environ.get(UNIFIED_READ_ENV, "false").strip().lower() in ("1", "true", "yes")
+
 
 _AUTH_TYPE_TO_SECRET_TYPE: dict = {
     "OAuthRefreshAuth": "connector_oauth_token",
@@ -89,15 +101,22 @@ class ConnectorCredentialStore:
 
         Raises PermissionError when owner_id does not match the stored secret.
         Raises LookupError when secret_id is not found or has expired.
+
+        When the unified-read flag is on, the unified envelope store is tried first
+        (by the legacy-id marker) and the SQLite store is the fallback.
         """
-        secret = await asyncio.get_running_loop().run_in_executor(
-            None,
-            lambda: self._svc.get_secret(
-                secret_id=secret_id,
-                include_value=True,
-                accessed_by=owner_id,
-            ),
-        )
+        secret = None
+        if _unified_read_enabled():
+            secret = await _load_credential_from_unified(secret_id, owner_id)
+        if secret is None:
+            secret = await asyncio.get_running_loop().run_in_executor(
+                None,
+                lambda: self._svc.get_secret(
+                    secret_id=secret_id,
+                    include_value=True,
+                    accessed_by=owner_id,
+                ),
+            )
         if secret is None:
             raise LookupError(f"Credential secret {secret_id!r} not found or expired")
 
@@ -295,6 +314,65 @@ class ConnectorCredentialStore:
         if fields is None:
             raise ValueError(f"{auth_cls.__name__} has no __sensitive_fields__ — cannot separate credentials")
         return fields
+
+
+# ---------------------------------------------------------------------------
+# Unified envelope store read path (expand phase — #10088 Task 3c-2)
+# ---------------------------------------------------------------------------
+
+
+async def _read_unified_in_session(session, secret_id: str, owner_id: str) -> dict | None:
+    """Resolve + decrypt an imported credential within *session* (the testable core).
+
+    Matches the legacy SQLite id via the ``imported_from_sqlite`` marker the 3c-1 import
+    stamped, then decrypts through the owner's user vault. Returns a SecretsService-shaped
+    dict (``{"created_by", "value"}``), or ``None`` to fall back to SQLite (not imported,
+    or the owner cannot open it).
+    """
+    from sqlalchemy import select
+
+    from autobot_shared.secrets_envelope import DecryptionError
+    from autobot_shared.secrets_vault import VaultKind, VaultRef
+    from models.secret import Secret
+    from services.unified_secrets_service import SecretAccessError, UnifiedSecretsService
+
+    marker = Secret.extra_data["imported_from_sqlite"].astext
+    row = (
+        (await session.execute(select(Secret).where(marker == str(secret_id), Secret.is_active.is_(True))))
+        .scalars()
+        .first()
+    )
+    if row is None:
+        return None  # not yet imported → SQLite fallback
+    try:
+        plaintext = await UnifiedSecretsService().read(
+            session, secret_id=row.id, accessible_vaults={VaultRef(VaultKind.USER, str(owner_id))}
+        )
+    except (SecretAccessError, DecryptionError) as exc:
+        logger.warning(
+            "Unified read unusable for imported secret %s (owner %s): %s — falling back", secret_id, owner_id, exc
+        )
+        return None
+    return {"created_by": str(owner_id), "value": plaintext.decode("utf-8")}
+
+
+async def _load_credential_from_unified(secret_id: str, owner_id: str) -> dict | None:
+    """Acquire a session and read an imported credential from the unified store.
+
+    Returns ``None`` to fall back to SQLite when the unified store is not configured
+    (root key unset) on this deployment. See :func:`_read_unified_in_session`.
+    """
+    from autobot_shared.secrets_envelope import load_root_key
+    from user_management.database import get_async_session_factory
+
+    try:
+        load_root_key()
+    except RuntimeError:
+        return None  # unified store not configured on this deployment
+
+    factory = get_async_session_factory()
+    async with factory() as session:
+        return await _read_unified_in_session(session, secret_id, owner_id)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/services/unified_credential_read.py
+++ b/autobot-backend/services/unified_credential_read.py
@@ -1,0 +1,94 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unified-store read path for imported credentials (#10088 / Task 3c-2).
+
+Resolves a credential imported from the legacy SQLite store into the unified envelope
+store via the ``imported_from_sqlite`` marker the 3c-1 import stamped, and decrypts it
+through the owner's user vault. Lives in the service layer (not the heavy
+``knowledge.connectors`` package) so it imports cleanly in the minimal migration-gate
+test environment.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def read_imported_credential_in_session(session, secret_id: str, owner_id: str, root_key: bytes) -> dict | None:
+    """Resolve + decrypt an imported credential within *session* (the testable core).
+
+    Matches the legacy SQLite id via the ``imported_from_sqlite`` marker the 3c-1 import
+    stamped (scoped to *owner_id* for defence in depth), then decrypts through the owner's
+    user vault. Returns a SecretsService-shaped dict (``{"created_by", "value"}``), or
+    ``None`` to fall back to SQLite. Any unified-read failure — not imported, not
+    accessible, or a corrupt/partial row — returns ``None`` so the fallback can never be
+    fatal while SQLite is still authoritative.
+    """
+    import uuid
+
+    from sqlalchemy import select
+
+    from autobot_shared.secrets_envelope import DecryptionError, UnsupportedFormatError
+    from autobot_shared.secrets_vault import VaultKind, VaultRef
+    from models.secret import Secret
+    from services.unified_secrets_service import SecretAccessError, SecretNotFoundError, UnifiedSecretsService
+
+    try:
+        owner_uuid = uuid.UUID(str(owner_id))
+    except ValueError:
+        return None  # owner isn't a uuid → cannot match an imported row
+
+    marker = Secret.extra_data["imported_from_sqlite"].astext
+    row = (
+        (
+            await session.execute(
+                select(Secret).where(
+                    marker == str(secret_id), Secret.owner_id == owner_uuid, Secret.is_active.is_(True)
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if row is None:
+        return None  # not yet imported → SQLite fallback
+    try:
+        plaintext = await UnifiedSecretsService(root_key=root_key).read(
+            session, secret_id=row.id, accessible_vaults={VaultRef(VaultKind.USER, str(owner_id))}
+        )
+    except (
+        SecretAccessError,
+        SecretNotFoundError,
+        DecryptionError,
+        UnsupportedFormatError,
+        KeyError,
+        ValueError,
+    ) as exc:
+        logger.warning(
+            "Unified read unusable for imported secret %s (owner %s): %s — falling back", secret_id, owner_id, exc
+        )
+        return None
+    return {"created_by": str(owner_id), "value": plaintext.decode("utf-8")}
+
+
+async def load_imported_credential(secret_id: str, owner_id: str) -> dict | None:
+    """Acquire a session and read an imported credential from the unified store.
+
+    Returns ``None`` to fall back to SQLite when the unified store is not configured
+    (root key unset) on this deployment. See :func:`read_imported_credential_in_session`.
+    """
+    from autobot_shared.secrets_envelope import load_root_key
+    from user_management.database import get_async_session_factory
+
+    try:
+        root_key = load_root_key()
+    except RuntimeError:
+        return None  # unified store not configured on this deployment
+
+    factory = get_async_session_factory()
+    async with factory() as session:
+        return await read_imported_credential_in_session(session, secret_id, owner_id, root_key)

--- a/autobot-backend/tests/migrations/test_credential_store_unified_read.py
+++ b/autobot-backend/tests/migrations/test_credential_store_unified_read.py
@@ -16,7 +16,7 @@ import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from autobot_shared.secrets_vault import VaultKind, VaultRef
-from knowledge.connectors.credential_store import _read_unified_in_session
+from services.unified_credential_read import read_imported_credential_in_session
 from services.unified_secrets_service import UnifiedSecretsService
 from tests.migrations.conftest import requires_postgres, run_alembic
 
@@ -54,21 +54,21 @@ async def _seed(session, legacy_id: str, value: bytes, owner=_OWNER):
 async def test_reads_imported_by_marker(session):
     await _seed(session, "legacy-1", b'{"token":"abc"}')
     await session.commit()
-    out = await _read_unified_in_session(session, "legacy-1", str(_OWNER), _ROOT)
+    out = await read_imported_credential_in_session(session, "legacy-1", str(_OWNER), _ROOT)
     assert out == {"created_by": str(_OWNER), "value": '{"token":"abc"}'}
 
 
 async def test_returns_none_when_not_imported(session):
     await _seed(session, "legacy-1", b'{"token":"abc"}')
     await session.commit()
-    assert await _read_unified_in_session(session, "no-such-id", str(_OWNER), _ROOT) is None
+    assert await read_imported_credential_in_session(session, "no-such-id", str(_OWNER), _ROOT) is None
 
 
 async def test_returns_none_on_owner_mismatch(session):
     await _seed(session, "legacy-1", b'{"token":"abc"}')
     await session.commit()
     # A different owner has no grant (and no marker+owner match) → fall back to SQLite.
-    assert await _read_unified_in_session(session, "legacy-1", str(uuid.uuid4()), _ROOT) is None
+    assert await read_imported_credential_in_session(session, "legacy-1", str(uuid.uuid4()), _ROOT) is None
 
 
 async def test_returns_none_on_corrupt_row(session):
@@ -78,4 +78,4 @@ async def test_returns_none_on_corrupt_row(session):
     secret.sealed_value = {"v": 999, "garbage": True}
     await session.flush()
     await session.commit()
-    assert await _read_unified_in_session(session, "legacy-1", str(_OWNER), _ROOT) is None
+    assert await read_imported_credential_in_session(session, "legacy-1", str(_OWNER), _ROOT) is None

--- a/autobot-backend/tests/migrations/test_credential_store_unified_read.py
+++ b/autobot-backend/tests/migrations/test_credential_store_unified_read.py
@@ -27,9 +27,7 @@ _OWNER = uuid.uuid4()
 
 
 @pytest.fixture()
-async def session(fresh_db_url, monkeypatch):
-    # _read_unified_in_session builds UnifiedSecretsService() which reads the root key from env.
-    monkeypatch.setenv("AUTOBOT_SECRETS_ROOT_KEY", base64.urlsafe_b64encode(_ROOT).decode("utf-8"))
+async def session(fresh_db_url):
     assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
     engine = create_async_engine(fresh_db_url)
     maker = async_sessionmaker(engine, expire_on_commit=False)
@@ -56,18 +54,28 @@ async def _seed(session, legacy_id: str, value: bytes, owner=_OWNER):
 async def test_reads_imported_by_marker(session):
     await _seed(session, "legacy-1", b'{"token":"abc"}')
     await session.commit()
-    out = await _read_unified_in_session(session, "legacy-1", str(_OWNER))
+    out = await _read_unified_in_session(session, "legacy-1", str(_OWNER), _ROOT)
     assert out == {"created_by": str(_OWNER), "value": '{"token":"abc"}'}
 
 
 async def test_returns_none_when_not_imported(session):
     await _seed(session, "legacy-1", b'{"token":"abc"}')
     await session.commit()
-    assert await _read_unified_in_session(session, "no-such-id", str(_OWNER)) is None
+    assert await _read_unified_in_session(session, "no-such-id", str(_OWNER), _ROOT) is None
 
 
 async def test_returns_none_on_owner_mismatch(session):
     await _seed(session, "legacy-1", b'{"token":"abc"}')
     await session.commit()
-    # A different owner has no grant → SecretAccessError caught → fall back to SQLite.
-    assert await _read_unified_in_session(session, "legacy-1", str(uuid.uuid4())) is None
+    # A different owner has no grant (and no marker+owner match) → fall back to SQLite.
+    assert await _read_unified_in_session(session, "legacy-1", str(uuid.uuid4()), _ROOT) is None
+
+
+async def test_returns_none_on_corrupt_row(session):
+    # A marker-matched row with a malformed sealed_value (e.g. an unsupported format version)
+    # must fall back, not escape an exception that would break a live connector load.
+    secret = await _seed(session, "legacy-1", b'{"token":"abc"}')
+    secret.sealed_value = {"v": 999, "garbage": True}
+    await session.flush()
+    await session.commit()
+    assert await _read_unified_in_session(session, "legacy-1", str(_OWNER), _ROOT) is None

--- a/autobot-backend/tests/migrations/test_credential_store_unified_read.py
+++ b/autobot-backend/tests/migrations/test_credential_store_unified_read.py
@@ -1,0 +1,73 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Postgres core test for the ConnectorCredentialStore unified read (#10088 / Task 3c-2).
+
+Seeds an imported-style envelope secret (carrying the ``imported_from_sqlite`` marker)
+and verifies the unified-read core resolves it by legacy id, decrypts via the owner's
+user vault, and falls back (returns None) when not imported or not accessible.
+"""
+
+import base64
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from knowledge.connectors.credential_store import _read_unified_in_session
+from services.unified_secrets_service import UnifiedSecretsService
+from tests.migrations.conftest import requires_postgres, run_alembic
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+_ROOT = base64.urlsafe_b64decode(base64.urlsafe_b64encode(bytes(range(32))))
+_OWNER = uuid.uuid4()
+
+
+@pytest.fixture()
+async def session(fresh_db_url, monkeypatch):
+    # _read_unified_in_session builds UnifiedSecretsService() which reads the root key from env.
+    monkeypatch.setenv("AUTOBOT_SECRETS_ROOT_KEY", base64.urlsafe_b64encode(_ROOT).decode("utf-8"))
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+    engine = create_async_engine(fresh_db_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as s:
+        yield s
+    await engine.dispose()
+
+
+async def _seed(session, legacy_id: str, value: bytes, owner=_OWNER):
+    svc = UnifiedSecretsService(root_key=_ROOT)
+    secret = await svc.create(
+        session,
+        owner_vault=VaultRef(VaultKind.USER, str(owner)),
+        name="connector:x:auth",
+        secret_type="connector_oauth_token",
+        plaintext=value,
+        created_by=owner,
+    )
+    secret.extra_data = {"imported_from_sqlite": legacy_id}
+    await session.flush()
+    return secret
+
+
+async def test_reads_imported_by_marker(session):
+    await _seed(session, "legacy-1", b'{"token":"abc"}')
+    await session.commit()
+    out = await _read_unified_in_session(session, "legacy-1", str(_OWNER))
+    assert out == {"created_by": str(_OWNER), "value": '{"token":"abc"}'}
+
+
+async def test_returns_none_when_not_imported(session):
+    await _seed(session, "legacy-1", b'{"token":"abc"}')
+    await session.commit()
+    assert await _read_unified_in_session(session, "no-such-id", str(_OWNER)) is None
+
+
+async def test_returns_none_on_owner_mismatch(session):
+    await _seed(session, "legacy-1", b'{"token":"abc"}')
+    await session.commit()
+    # A different owner has no grant → SecretAccessError caught → fall back to SQLite.
+    assert await _read_unified_in_session(session, "legacy-1", str(uuid.uuid4())) is None

--- a/autobot-backend/tests/unit/knowledge/connectors/test_credential_store_unified_read.py
+++ b/autobot-backend/tests/unit/knowledge/connectors/test_credential_store_unified_read.py
@@ -44,7 +44,7 @@ async def test_load_flag_off_uses_sqlite_only(monkeypatch):
     async def _boom(*a, **k):
         raise AssertionError("unified path must not be consulted when flag is off")
 
-    monkeypatch.setattr(cs, "_load_credential_from_unified", _boom)
+    monkeypatch.setattr(cs, "load_imported_credential", _boom)
     svc = _FakeSvc({"created_by": "u1", "value": json.dumps({"token": "sqlite"})})
     out = await ConnectorCredentialStore(svc).load("sid", {"host": "h"}, object, "u1")
     assert out == {"host": "h", "token": "sqlite"} and svc.get_calls == 1
@@ -56,7 +56,7 @@ async def test_load_flag_on_prefers_unified(monkeypatch):
     async def _unified(secret_id, owner_id):
         return {"created_by": owner_id, "value": json.dumps({"token": "unified"})}
 
-    monkeypatch.setattr(cs, "_load_credential_from_unified", _unified)
+    monkeypatch.setattr(cs, "load_imported_credential", _unified)
     svc = _FakeSvc({"created_by": "u1", "value": json.dumps({"token": "sqlite"})})
     out = await ConnectorCredentialStore(svc).load("sid", {"host": "h"}, object, "u1")
     assert out == {"host": "h", "token": "unified"} and svc.get_calls == 0  # SQLite untouched
@@ -68,7 +68,7 @@ async def test_load_flag_on_falls_back_when_not_imported(monkeypatch):
     async def _none(secret_id, owner_id):
         return None
 
-    monkeypatch.setattr(cs, "_load_credential_from_unified", _none)
+    monkeypatch.setattr(cs, "load_imported_credential", _none)
     svc = _FakeSvc({"created_by": "u1", "value": json.dumps({"token": "sqlite"})})
     out = await ConnectorCredentialStore(svc).load("sid", {"host": "h"}, object, "u1")
     assert out == {"host": "h", "token": "sqlite"} and svc.get_calls == 1

--- a/autobot-backend/tests/unit/knowledge/connectors/test_credential_store_unified_read.py
+++ b/autobot-backend/tests/unit/knowledge/connectors/test_credential_store_unified_read.py
@@ -1,0 +1,74 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Routing tests for the ConnectorCredentialStore unified-read flag (#10088 / Task 3c-2).
+
+Verifies the expand-phase feature flag: off → SQLite only (byte-identical to before);
+on → unified store first with SQLite fallback. The unified core itself is exercised
+against Postgres in tests/migrations/test_credential_store_unified_read.py.
+"""
+
+import json
+
+from knowledge.connectors import credential_store as cs
+from knowledge.connectors.credential_store import ConnectorCredentialStore
+
+
+class _FakeSvc:
+    """Stand-in for the sync SQLite SecretsService."""
+
+    def __init__(self, secret=None):
+        self._secret = secret
+        self.get_calls = 0
+
+    def get_secret(self, **kw):
+        self.get_calls += 1
+        return self._secret
+
+
+def test_flag_parsing(monkeypatch):
+    monkeypatch.delenv(cs.UNIFIED_READ_ENV, raising=False)
+    assert cs._unified_read_enabled() is False
+    for v in ("true", "1", "YES", " True "):
+        monkeypatch.setenv(cs.UNIFIED_READ_ENV, v)
+        assert cs._unified_read_enabled() is True
+    for v in ("false", "0", "", "nope"):
+        monkeypatch.setenv(cs.UNIFIED_READ_ENV, v)
+        assert cs._unified_read_enabled() is False
+
+
+async def test_load_flag_off_uses_sqlite_only(monkeypatch):
+    monkeypatch.setattr(cs, "_unified_read_enabled", lambda: False)
+
+    async def _boom(*a, **k):
+        raise AssertionError("unified path must not be consulted when flag is off")
+
+    monkeypatch.setattr(cs, "_load_credential_from_unified", _boom)
+    svc = _FakeSvc({"created_by": "u1", "value": json.dumps({"token": "sqlite"})})
+    out = await ConnectorCredentialStore(svc).load("sid", {"host": "h"}, object, "u1")
+    assert out == {"host": "h", "token": "sqlite"} and svc.get_calls == 1
+
+
+async def test_load_flag_on_prefers_unified(monkeypatch):
+    monkeypatch.setattr(cs, "_unified_read_enabled", lambda: True)
+
+    async def _unified(secret_id, owner_id):
+        return {"created_by": owner_id, "value": json.dumps({"token": "unified"})}
+
+    monkeypatch.setattr(cs, "_load_credential_from_unified", _unified)
+    svc = _FakeSvc({"created_by": "u1", "value": json.dumps({"token": "sqlite"})})
+    out = await ConnectorCredentialStore(svc).load("sid", {"host": "h"}, object, "u1")
+    assert out == {"host": "h", "token": "unified"} and svc.get_calls == 0  # SQLite untouched
+
+
+async def test_load_flag_on_falls_back_when_not_imported(monkeypatch):
+    monkeypatch.setattr(cs, "_unified_read_enabled", lambda: True)
+
+    async def _none(secret_id, owner_id):
+        return None
+
+    monkeypatch.setattr(cs, "_load_credential_from_unified", _none)
+    svc = _FakeSvc({"created_by": "u1", "value": json.dumps({"token": "sqlite"})})
+    out = await ConnectorCredentialStore(svc).load("sid", {"host": "h"}, object, "u1")
+    assert out == {"host": "h", "token": "sqlite"} and svc.get_calls == 1


### PR DESCRIPTION
## Thinking Path
Industry standard for migrating a live secrets store is **expand/contract** (parallel-change) behind a **feature flag**, keeping the old store for rollback. After 3a + 3c-1 backfilled the unified store, this is **PR 1 of the expand phase, read-side**: start reading from the new store with fallback to the old, gated by an off-by-default flag, so we verify the unified path in production without changing any write or risking a regression.

`ConnectorCredentialStore` is the right first reader — it's already async (no sync→async ripple) and is the Task-5 connector-token bridge. Scope is deliberately the **pure-read `load()` only** (not the write or read-modify-write methods), so there's no read/write divergence and the change is fully reversible.

## What Changed
- **`knowledge/connectors/credential_store.py`**
  - New flag `AUTOBOT_SECRETS_UNIFIED_READ` (**default off**) via `_unified_read_enabled()`.
  - `load()` now tries the unified store first when the flag is on, then falls back to the existing SQLite executor path. Flag off → byte-identical to before.
  - `_read_unified_in_session()` (testable core): resolves the legacy SQLite id via the `imported_from_sqlite` marker the 3c-1 import stamped, decrypts through the owner's user vault, and returns a SecretsService-shaped dict — or `None` to fall back when **not imported** or the owner **can't open it** (`SecretAccessError`/`DecryptionError` caught + logged).
  - `_load_credential_from_unified()` wraps it with session acquisition and returns `None` when the **root key is unset** (unified store not configured on this deployment) → SQLite fallback.

## Verification
- **4 unit routing tests** (no DB): flag parsing; flag off → SQLite only (unified never consulted); flag on → unified preferred (SQLite untouched); flag on + not-imported → SQLite fallback.
- **3 Postgres core tests** (migration-gate): marker resolve + decrypt round-trip; unknown id → `None`; owner mismatch → `None`.
- `flake8` 0, `black` (120) clean. Module imports cleanly (lazy imports inside the helper).

## Rollout (follow-ups on #10088)
- **PR 2** — expand, write-side: dual-write under the same flag.
- **PR 3** — contract: make unified canonical; **3d** retires SQLite.
- Sync readers (WorkflowSecretService, AgentSecretsIntegration) need a separate sync→async decision.

## Model Used
Claude Opus 4.8

Part of #10088. Closes #10326.
