### PR TITLE
dedup(#9859 Family A): extract shared scoped CSS from analytics dashboards (#10301)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
@@ -786,102 +786,16 @@ onMounted(() => {
 })
 </script>
 
+<style scoped src="@/design-system/styles/dashboard-common.css"></style>
+<style scoped src="@/design-system/styles/dashboard-review-perf.css"></style>
+<style scoped src="@/design-system/styles/dashboard-review-precommit.css"></style>
+
 <style scoped>
 .code-review-dashboard {
   padding: var(--spacing-6);
   display: flex;
   flex-direction: column;
   gap: var(--spacing-6);
-}
-
-/* Header */
-.dashboard-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: var(--spacing-4);
-}
-
-.header-content h2 {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  margin: var(--spacing-0);
-  font-size: var(--text-2xl);
-  color: var(--text-primary);
-}
-
-.header-content .icon {
-  font-size: 1.75rem;
-}
-
-.subtitle {
-  color: var(--text-secondary);
-  margin: var(--spacing-1) var(--spacing-0) var(--spacing-0) var(--spacing-0);
-  font-size: var(--text-sm);
-}
-
-.header-actions {
-  display: flex;
-  gap: var(--spacing-3);
-}
-
-/* Buttons */
-.action-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  padding: var(--spacing-2) var(--spacing-4);
-  border: none;
-  border-radius: var(--radius-md);
-  font-size: var(--text-sm);
-  font-weight: 500;
-  cursor: pointer;
-  transition: all var(--duration-200);
-}
-
-.action-btn.primary {
-  background: var(--accent-color, #3b82f6);
-  color: white;
-}
-
-.action-btn.primary:hover:not(:disabled) {
-  background: var(--accent-color-hover, #2563eb);
-}
-
-.action-btn.secondary {
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
-  border: 1px solid var(--border-color);
-}
-
-.action-btn.secondary:hover:not(:disabled) {
-  background: var(--bg-quaternary);
-}
-
-.action-btn.text {
-  background: transparent;
-  color: var(--accent-color);
-  padding: var(--spacing-1) var(--spacing-2);
-}
-
-.action-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.spinner {
-  width: 14px;
-  height: 14px;
-  border: 2px solid transparent;
-  border-top-color: currentColor;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
 }
 
 /* Path Selection */
@@ -907,24 +821,6 @@ onMounted(() => {
   color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-}
-
-.input-group input {
-  padding: var(--spacing-2-5) var(--spacing-3-5);
-  background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
-  font-size: var(--text-sm);
-}
-
-.input-group input:focus {
-  outline: none;
-  border-color: var(--accent-color);
-}
-.input-group input:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
 }
 
 .language-chips {
@@ -956,34 +852,10 @@ onMounted(() => {
   gap: var(--spacing-4);
 }
 
-.summary-card {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-3);
-  padding: var(--spacing-4);
-  background: var(--bg-secondary);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border-color);
-}
-
-.card-icon {
-  font-size: var(--text-2xl);
-}
-
-.card-content {
-  display: flex;
-  flex-direction: column;
-}
-
 .card-value {
   font-size: var(--text-2xl);
   font-weight: 700;
   color: var(--text-primary);
-}
-
-.card-label {
-  font-size: var(--text-xs);
-  color: var(--text-secondary);
 }
 
 /* Content Grid */
@@ -991,42 +863,6 @@ onMounted(() => {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--spacing-6);
-}
-
-/* Panels */
-.panel {
-  background: var(--bg-secondary);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border-color);
-  overflow: hidden;
-}
-
-.panel-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--spacing-4);
-  border-bottom: 1px solid var(--border-color);
-}
-
-.panel-header h3 {
-  margin: var(--spacing-0);
-  font-size: var(--text-base);
-  color: var(--text-primary);
-}
-
-.panel-content {
-  padding: var(--spacing-4);
-  max-height: 400px;
-  overflow-y: auto;
-}
-
-.close-btn {
-  background: none;
-  border: none;
-  font-size: var(--text-xl);
-  color: var(--text-secondary);
-  cursor: pointer;
 }
 
 /* Filter Tabs */
@@ -1061,26 +897,6 @@ onMounted(() => {
   font-size: 0.625rem;
 }
 
-/* Issues List */
-.issues-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-3);
-}
-
-.issue-card {
-  padding: var(--spacing-3-5);
-  background: var(--bg-tertiary);
-  border-radius: var(--radius-md);
-  border-left: 3px solid;
-  cursor: pointer;
-  transition: all var(--duration-200);
-}
-
-.issue-card:hover {
-  background: var(--bg-quaternary);
-}
-
 /* Issue #704: Migrated severity colors to CSS design tokens */
 .issue-card.critical {
   border-left-color: var(--color-error);
@@ -1096,17 +912,6 @@ onMounted(() => {
 
 .issue-card.low {
   border-left-color: var(--color-success);
-}
-
-.issue-header {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  margin-bottom: var(--spacing-2);
-}
-
-.severity-badge {
-  font-size: var(--text-sm);
 }
 
 .severity-badge.large {
@@ -1178,52 +983,10 @@ onMounted(() => {
   gap: var(--spacing-3);
 }
 
-.detail-title h4 {
-  margin: var(--spacing-0);
-  font-size: var(--text-base);
-  color: var(--text-primary);
-}
-
 .location-info {
   font-family: monospace;
   font-size: var(--text-sm);
   color: var(--text-primary);
-}
-
-.line-info {
-  color: var(--text-secondary);
-  margin-left: var(--spacing-2);
-}
-
-.description {
-  margin: var(--spacing-0);
-  color: var(--text-secondary);
-  line-height: 1.5;
-}
-
-.suggestion-box {
-  display: flex;
-  gap: var(--spacing-3);
-  padding: var(--spacing-3-5);
-  background: rgba(16, 185, 129, 0.1);
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(16, 185, 129, 0.3);
-}
-
-.suggestion-icon {
-  font-size: var(--text-xl);
-}
-
-.suggestion-box p {
-  margin: var(--spacing-0);
-  color: var(--text-primary);
-  line-height: 1.4;
-}
-
-.code-snippet {
-  background: var(--bg-tertiary);
-  border-radius: var(--radius-md);
-  overflow: hidden;
 }
 
 .code-snippet pre {
@@ -1329,10 +1092,6 @@ onMounted(() => {
   transition: all var(--duration-200);
 }
 
-.history-item:hover {
-  background: var(--bg-quaternary);
-}
-
 .history-info {
   display: flex;
   flex-direction: column;
@@ -1348,11 +1107,6 @@ onMounted(() => {
 .history-date {
   font-size: var(--text-xs);
   color: var(--text-secondary);
-}
-
-.history-stats {
-  display: flex;
-  gap: var(--spacing-2);
 }
 
 .stat {
@@ -1377,84 +1131,9 @@ onMounted(() => {
   color: var(--text-secondary);
 }
 
-/* Empty State */
-.empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: var(--spacing-12) var(--spacing-4);
-  color: var(--text-secondary);
-}
-
-.empty-state.small {
-  padding: var(--spacing-6) var(--spacing-4);
-}
-
-.empty-icon {
-  font-size: 2.5rem;
-  margin-bottom: var(--spacing-3);
-}
-
-.empty-state p {
-  margin: var(--spacing-0);
-  font-size: var(--text-sm);
-}
-
-/* Modal */
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-modal-backdrop);
-}
-
-.modal {
-  background: var(--bg-secondary);
-  border-radius: var(--radius-xl);
-  width: 90%;
-  max-width: 600px;
-  max-height: 80vh;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--spacing-4) var(--spacing-5);
-  border-bottom: 1px solid var(--border-color);
-}
-
 .modal-header h3 {
   margin: var(--spacing-0);
   color: var(--text-primary);
-}
-
-.modal-content {
-  padding: var(--spacing-5);
-  overflow-y: auto;
-}
-
-.pattern-category {
-  margin-bottom: var(--spacing-6);
-}
-
-.pattern-category h4 {
-  margin: var(--spacing-0) var(--spacing-0) var(--spacing-3) var(--spacing-0);
-  font-size: var(--text-sm);
-  color: var(--text-primary);
-}
-
-.pattern-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-2);
 }
 
 .pattern-item {
@@ -1465,10 +1144,6 @@ onMounted(() => {
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
   opacity: 0.6;
-}
-
-.pattern-item.enabled {
-  opacity: 1;
 }
 
 .pattern-toggle input {

--- a/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
@@ -597,6 +597,9 @@ onMounted(() => {
 })
 </script>
 
+<style scoped src="@/design-system/styles/dashboard-common.css"></style>
+<style scoped src="@/design-system/styles/dashboard-review-perf.css"></style>
+
 <style scoped>
 /* Issue #704: Migrated to CSS design tokens */
 .performance-dashboard {
@@ -604,82 +607,6 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-6);
-}
-
-/* Header */
-.dashboard-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: var(--spacing-4);
-}
-
-.header-content h2 {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  margin: var(--spacing-0);
-  font-size: var(--text-2xl);
-  color: var(--text-primary);
-}
-
-.subtitle {
-  color: var(--text-secondary);
-  margin: var(--spacing-1) var(--spacing-0) var(--spacing-0) var(--spacing-0);
-  font-size: var(--text-sm);
-}
-
-.header-actions {
-  display: flex;
-  gap: var(--spacing-3);
-}
-
-/* Buttons */
-.action-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  padding: var(--spacing-2) var(--spacing-4);
-  border: none;
-  border-radius: var(--radius-md);
-  font-size: var(--text-sm);
-  font-weight: 500;
-  cursor: pointer;
-  transition: all var(--duration-200);
-}
-
-.action-btn.primary {
-  background: var(--accent-color, #3b82f6);
-  color: white;
-}
-
-.action-btn.primary:hover:not(:disabled) {
-  background: var(--accent-color-hover, #2563eb);
-}
-
-.action-btn.secondary {
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
-  border: 1px solid var(--border-color);
-}
-
-.action-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.spinner {
-  width: 14px;
-  height: 14px;
-  border: 2px solid transparent;
-  border-top-color: currentColor;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
 }
 
 /* Path Selection */
@@ -702,24 +629,6 @@ onMounted(() => {
   font-weight: 600;
   color: var(--text-secondary);
   text-transform: uppercase;
-}
-
-.input-group input {
-  padding: var(--spacing-2-5) var(--spacing-3-5);
-  background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
-  font-size: var(--text-sm);
-}
-
-.input-group input:focus {
-  outline: none;
-  border-color: var(--accent-color);
-}
-.input-group input:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
 }
 
 .quick-paths {
@@ -819,42 +728,6 @@ onMounted(() => {
   gap: var(--spacing-6);
 }
 
-/* Panels */
-.panel {
-  background: var(--bg-secondary);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border-color);
-  overflow: hidden;
-}
-
-.panel-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--spacing-4);
-  border-bottom: 1px solid var(--border-color);
-}
-
-.panel-header h3 {
-  margin: var(--spacing-0);
-  font-size: var(--text-base);
-  color: var(--text-primary);
-}
-
-.panel-content {
-  padding: var(--spacing-4);
-  max-height: 400px;
-  overflow-y: auto;
-}
-
-.close-btn {
-  background: none;
-  border: none;
-  font-size: var(--text-xl);
-  color: var(--text-secondary);
-  cursor: pointer;
-}
-
 /* Category Tabs */
 .category-tabs {
   display: flex;
@@ -886,37 +759,13 @@ onMounted(() => {
   border-radius: var(--radius-default);
 }
 
-/* Issues List */
-.issues-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-3);
-}
-
-.issue-card {
-  padding: var(--spacing-3-5);
-  background: var(--bg-tertiary);
-  border-radius: var(--radius-md);
-  border-left: 3px solid;
-  cursor: pointer;
-  transition: all var(--duration-200);
-}
-
-.issue-card:hover {
-  background: var(--bg-quaternary);
-}
-
 .issue-card.critical { border-left-color: var(--color-error); }
-.issue-card.high { border-left-color: var(--color-warning); }
-.issue-card.medium { border-left-color: var(--color-warning-light); }
-.issue-card.low { border-left-color: var(--color-success); }
 
-.issue-header {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  margin-bottom: var(--spacing-2);
-}
+.issue-card.high { border-left-color: var(--color-warning); }
+
+.issue-card.medium { border-left-color: var(--color-warning-light); }
+
+.issue-card.low { border-left-color: var(--color-success); }
 
 .impact-badge {
   font-size: var(--text-sm);
@@ -985,12 +834,6 @@ onMounted(() => {
   margin-bottom: var(--spacing-5);
 }
 
-.detail-title h4 {
-  margin: var(--spacing-0);
-  font-size: var(--text-base);
-  color: var(--text-primary);
-}
-
 .detail-section {
   margin-bottom: var(--spacing-4);
 }
@@ -1007,23 +850,6 @@ onMounted(() => {
 .location-info {
   font-family: monospace;
   font-size: var(--text-sm);
-}
-
-.line-info {
-  color: var(--text-secondary);
-  margin-left: var(--spacing-2);
-}
-
-.description {
-  margin: var(--spacing-0);
-  color: var(--text-secondary);
-  line-height: 1.5;
-}
-
-.code-snippet {
-  background: var(--bg-tertiary);
-  border-radius: var(--radius-md);
-  overflow: hidden;
 }
 
 .code-snippet pre {
@@ -1050,25 +876,6 @@ onMounted(() => {
 .impact-text {
   font-weight: 600;
   color: var(--text-primary);
-}
-
-.suggestion-box {
-  display: flex;
-  gap: var(--spacing-3);
-  padding: var(--spacing-3-5);
-  background: rgba(16, 185, 129, 0.1);
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(16, 185, 129, 0.3);
-}
-
-.suggestion-icon {
-  font-size: var(--text-xl);
-}
-
-.suggestion-box p {
-  margin: var(--spacing-0);
-  color: var(--text-primary);
-  line-height: 1.4;
 }
 
 /* Hotspots Panel */
@@ -1177,8 +984,11 @@ onMounted(() => {
 }
 
 .bar-fill.critical { background: var(--color-error); }
+
 .bar-fill.high { background: var(--color-warning); }
+
 .bar-fill.medium { background: var(--color-warning-light); }
+
 .bar-fill.low { background: var(--color-success); }
 
 .bar-value {
@@ -1188,74 +998,8 @@ onMounted(() => {
   color: var(--text-primary);
 }
 
-/* Empty State */
-.empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: var(--spacing-12) var(--spacing-4);
-  color: var(--text-secondary);
-}
-
 .empty-state.small {
   padding: var(--spacing-6);
-}
-
-.empty-icon {
-  font-size: 2.5rem;
-  margin-bottom: var(--spacing-3);
-}
-
-/* Modal */
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-modal-backdrop);
-}
-
-.modal {
-  background: var(--bg-secondary);
-  border-radius: var(--radius-xl);
-  width: 90%;
-  max-width: 600px;
-  max-height: 80vh;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--spacing-4) var(--spacing-5);
-  border-bottom: 1px solid var(--border-color);
-}
-
-.modal-content {
-  padding: var(--spacing-5);
-  overflow-y: auto;
-}
-
-.pattern-category {
-  margin-bottom: var(--spacing-6);
-}
-
-.pattern-category h4 {
-  margin: var(--spacing-0) var(--spacing-0) var(--spacing-3) var(--spacing-0);
-  font-size: var(--text-sm);
-  color: var(--text-primary);
-}
-
-.pattern-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-2);
 }
 
 .pattern-item {
@@ -1266,10 +1010,6 @@ onMounted(() => {
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
   opacity: 0.6;
-}
-
-.pattern-item.enabled {
-  opacity: 1;
 }
 
 .pattern-toggle input {

--- a/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
@@ -609,6 +609,9 @@ onMounted(() => {
 })
 </script>
 
+<style scoped src="@/design-system/styles/dashboard-common.css"></style>
+<style scoped src="@/design-system/styles/dashboard-review-precommit.css"></style>
+
 <style scoped>
 /* Issue #704: Migrated to CSS design tokens */
 .precommit-dashboard {
@@ -618,72 +621,6 @@ onMounted(() => {
   gap: var(--spacing-6);
 }
 
-/* Header */
-.dashboard-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: var(--spacing-4);
-}
-
-.header-content h2 {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  margin: var(--spacing-0);
-  font-size: var(--text-2xl);
-  color: var(--text-primary);
-}
-
-.header-content .icon {
-  font-size: 1.75rem;
-}
-
-.subtitle {
-  color: var(--text-secondary);
-  margin: var(--spacing-1) var(--spacing-0) var(--spacing-0) var(--spacing-0);
-  font-size: var(--text-sm);
-}
-
-.header-actions {
-  display: flex;
-  gap: var(--spacing-3);
-}
-
-/* Buttons */
-.action-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  padding: var(--spacing-2) var(--spacing-4);
-  border: none;
-  border-radius: var(--radius-md);
-  font-size: var(--text-sm);
-  font-weight: 500;
-  cursor: pointer;
-  transition: all var(--duration-200);
-}
-
-.action-btn.primary {
-  background: var(--accent-color, #3b82f6);
-  color: white;
-}
-
-.action-btn.primary:hover:not(:disabled) {
-  background: var(--accent-color-hover, #2563eb);
-}
-
-.action-btn.secondary {
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
-  border: 1px solid var(--border-color);
-}
-
-.action-btn.secondary:hover:not(:disabled) {
-  background: var(--bg-quaternary);
-}
-
 .action-btn.danger {
   background: var(--color-error);
   color: var(--text-on-primary);
@@ -691,30 +628,6 @@ onMounted(() => {
 
 .action-btn.danger:hover:not(:disabled) {
   background: var(--color-error-hover);
-}
-
-.action-btn.text {
-  background: transparent;
-  color: var(--accent-color);
-  padding: var(--spacing-1) var(--spacing-2);
-}
-
-.action-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.spinner {
-  width: 14px;
-  height: 14px;
-  border: 2px solid transparent;
-  border-top-color: currentColor;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
 }
 
 /* Status Banner */
@@ -763,16 +676,6 @@ onMounted(() => {
   gap: var(--spacing-4);
 }
 
-.summary-card {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-3);
-  padding: var(--spacing-4);
-  background: var(--bg-secondary);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border-color);
-}
-
 .summary-card.success {
   border-color: var(--color-success-border);
 }
@@ -785,24 +688,10 @@ onMounted(() => {
   border-color: var(--color-warning-border);
 }
 
-.card-icon {
-  font-size: var(--text-2xl);
-}
-
-.card-content {
-  display: flex;
-  flex-direction: column;
-}
-
 .card-value {
   font-size: var(--text-xl);
   font-weight: 700;
   color: var(--text-primary);
-}
-
-.card-label {
-  font-size: var(--text-xs);
-  color: var(--text-secondary);
 }
 
 /* Content Grid */
@@ -810,34 +699,6 @@ onMounted(() => {
   display: grid;
   grid-template-columns: 1.5fr 1fr;
   gap: var(--spacing-6);
-}
-
-/* Panels */
-.panel {
-  background: var(--bg-secondary);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border-color);
-  overflow: hidden;
-}
-
-.panel-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--spacing-4);
-  border-bottom: 1px solid var(--border-color);
-}
-
-.panel-header h3 {
-  margin: var(--spacing-0);
-  font-size: var(--text-base);
-  color: var(--text-primary);
-}
-
-.panel-content {
-  padding: var(--spacing-4);
-  max-height: 400px;
-  overflow-y: auto;
 }
 
 /* Severity Filters */
@@ -892,10 +753,6 @@ onMounted(() => {
   align-items: center;
   gap: var(--spacing-2);
   margin-bottom: var(--spacing-2);
-}
-
-.severity-badge {
-  font-size: var(--text-sm);
 }
 
 .check-code {
@@ -1105,10 +962,6 @@ onMounted(() => {
   transition: all var(--duration-200);
 }
 
-.history-item:hover {
-  background: var(--bg-quaternary);
-}
-
 .history-item.failed {
   border-left: 3px solid var(--color-error);
 }
@@ -1135,11 +988,6 @@ onMounted(() => {
 .history-files {
   font-size: var(--text-xs);
   color: var(--text-secondary);
-}
-
-.history-stats {
-  display: flex;
-  gap: var(--spacing-2);
 }
 
 .stat {
@@ -1233,30 +1081,6 @@ onMounted(() => {
   font-size: var(--text-xs);
   font-weight: 600;
   color: var(--text-primary);
-}
-
-/* Empty State */
-.empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: var(--spacing-12) var(--spacing-4);
-  color: var(--text-secondary);
-}
-
-.empty-state.small {
-  padding: var(--spacing-6) var(--spacing-4);
-}
-
-.empty-icon {
-  font-size: 2.5rem;
-  margin-bottom: var(--spacing-3);
-}
-
-.empty-state p {
-  margin: var(--spacing-0);
-  font-size: var(--text-sm);
 }
 
 /* Responsive */

--- a/autobot-frontend/src/design-system/styles/dashboard-common.css
+++ b/autobot-frontend/src/design-system/styles/dashboard-common.css
@@ -1,0 +1,129 @@
+/* Copyright 2025-2026 mrveiss
+ * SPDX-License-Identifier: Apache-2.0
+ * AutoBot - AI-Powered Automation Platform
+ * Author: mrveiss
+ *
+ * Shared analytics-dashboard styles (all dashboards) (#10301, part of #9859).
+ * Byte-identical scoped-CSS rule blocks; selectors are disjoint from each
+ * including component's remaining rules ⇒ <style scoped src> is order-
+ * independent and identical to inlining.
+ */
+
+/* Header */
+.dashboard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--spacing-4);
+}
+
+.header-content h2 {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin: var(--spacing-0);
+  font-size: var(--text-2xl);
+  color: var(--text-primary);
+}
+
+.subtitle {
+  color: var(--text-secondary);
+  margin: var(--spacing-1) var(--spacing-0) var(--spacing-0) var(--spacing-0);
+  font-size: var(--text-sm);
+}
+
+.header-actions {
+  display: flex;
+  gap: var(--spacing-3);
+}
+
+/* Buttons */
+.action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-4);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--duration-200);
+}
+
+.action-btn.primary {
+  background: var(--accent-color, #3b82f6);
+  color: white;
+}
+
+.action-btn.primary:hover:not(:disabled) {
+  background: var(--accent-color-hover, #2563eb);
+}
+
+.action-btn.secondary {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+}
+
+.action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid transparent;
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Panels */
+.panel {
+  background: var(--bg-secondary);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+  overflow: hidden;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-4);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.panel-header h3 {
+  margin: var(--spacing-0);
+  font-size: var(--text-base);
+  color: var(--text-primary);
+}
+
+.panel-content {
+  padding: var(--spacing-4);
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+/* Empty State */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-12) var(--spacing-4);
+  color: var(--text-secondary);
+}
+
+.empty-icon {
+  font-size: 2.5rem;
+  margin-bottom: var(--spacing-3);
+}

--- a/autobot-frontend/src/design-system/styles/dashboard-review-perf.css
+++ b/autobot-frontend/src/design-system/styles/dashboard-review-perf.css
@@ -1,0 +1,161 @@
+/* Copyright 2025-2026 mrveiss
+ * SPDX-License-Identifier: Apache-2.0
+ * AutoBot - AI-Powered Automation Platform
+ * Author: mrveiss
+ *
+ * Shared styles for the code-review + performance dashboards (#10301, part of #9859).
+ * Byte-identical scoped-CSS rule blocks; selectors are disjoint from each
+ * including component's remaining rules ⇒ <style scoped src> is order-
+ * independent and identical to inlining.
+ */
+
+.input-group input {
+  padding: var(--spacing-2-5) var(--spacing-3-5);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+
+.input-group input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+}
+
+.input-group input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: var(--text-xl);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+/* Issues List */
+.issues-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.issue-card {
+  padding: var(--spacing-3-5);
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-md);
+  border-left: 3px solid;
+  cursor: pointer;
+  transition: all var(--duration-200);
+}
+
+.issue-card:hover {
+  background: var(--bg-quaternary);
+}
+
+.issue-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
+}
+
+.detail-title h4 {
+  margin: var(--spacing-0);
+  font-size: var(--text-base);
+  color: var(--text-primary);
+}
+
+.line-info {
+  color: var(--text-secondary);
+  margin-left: var(--spacing-2);
+}
+
+.description {
+  margin: var(--spacing-0);
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.suggestion-box {
+  display: flex;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3-5);
+  background: rgba(16, 185, 129, 0.1);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+}
+
+.suggestion-icon {
+  font-size: var(--text-xl);
+}
+
+.suggestion-box p {
+  margin: var(--spacing-0);
+  color: var(--text-primary);
+  line-height: 1.4;
+}
+
+.code-snippet {
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-modal-backdrop);
+}
+
+.modal {
+  background: var(--bg-secondary);
+  border-radius: var(--radius-xl);
+  width: 90%;
+  max-width: 600px;
+  max-height: 80vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-4) var(--spacing-5);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.modal-content {
+  padding: var(--spacing-5);
+  overflow-y: auto;
+}
+
+.pattern-category {
+  margin-bottom: var(--spacing-6);
+}
+
+.pattern-category h4 {
+  margin: var(--spacing-0) var(--spacing-0) var(--spacing-3) var(--spacing-0);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.pattern-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.pattern-item.enabled {
+  opacity: 1;
+}

--- a/autobot-frontend/src/design-system/styles/dashboard-review-precommit.css
+++ b/autobot-frontend/src/design-system/styles/dashboard-review-precommit.css
@@ -1,0 +1,70 @@
+/* Copyright 2025-2026 mrveiss
+ * SPDX-License-Identifier: Apache-2.0
+ * AutoBot - AI-Powered Automation Platform
+ * Author: mrveiss
+ *
+ * Shared styles for the code-review + precommit dashboards (#10301, part of #9859).
+ * Byte-identical scoped-CSS rule blocks; selectors are disjoint from each
+ * including component's remaining rules ⇒ <style scoped src> is order-
+ * independent and identical to inlining.
+ */
+
+.header-content .icon {
+  font-size: 1.75rem;
+}
+
+.action-btn.secondary:hover:not(:disabled) {
+  background: var(--bg-quaternary);
+}
+
+.action-btn.text {
+  background: transparent;
+  color: var(--accent-color);
+  padding: var(--spacing-1) var(--spacing-2);
+}
+
+.summary-card {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
+  background: var(--bg-secondary);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+}
+
+.card-icon {
+  font-size: var(--text-2xl);
+}
+
+.card-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.card-label {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+
+.severity-badge {
+  font-size: var(--text-sm);
+}
+
+.history-item:hover {
+  background: var(--bg-quaternary);
+}
+
+.history-stats {
+  display: flex;
+  gap: var(--spacing-2);
+}
+
+.empty-state.small {
+  padding: var(--spacing-6) var(--spacing-4);
+}
+
+.empty-state p {
+  margin: var(--spacing-0);
+  font-size: var(--text-sm);
+}


### PR DESCRIPTION
## Thinking Path
Wave 1, last item — a **3-way** clone (CodeReviewDashboard ↔ PerformanceAnalysisDashboard ↔ PrecommitHookDashboard; all three have Storybook stories). Same provably-identical disjoint-extraction approach as #10300/#10302, generalized to 3 components.

## What Changed
The shared scoped CSS splits into 3 **mutually disjoint** sets → 3 sheets, each included only by the components that share it:
- 17 blocks identical across **all 3** → `dashboard-common.css`
- 23 identical **CodeReview↔Performance** → `dashboard-review-perf.css`
- 12 identical **CodeReview↔Precommit** → `dashboard-review-precommit.css`

Net **−401 lines**.

## Why provably identical
- All selectors are distinct within each file (no intra-file dup → no same-selector cascade order dependence).
- The three extracted sets are mutually disjoint by selector and disjoint from each component's remaining inline rules ⇒ `<style scoped src>` inclusion is order-independent ⇒ identical computed styles.
- Verified each component's effective rule-set (shared sheets ∪ inline) is unchanged vs `HEAD`: **0 missing / 0 changed / 0 extra** (114 / 116 / 109 rules).

## Verification / merge gate
- ✅ Static CSS equivalence proven (all 3 components).
- Visual-regression: confirm the 3 dashboard stories aren't newly in the failure list (suite has 16 pre-existing unrelated stale-baseline failures — #10320 — and an intermittent 30s readiness flake — #10316; required gates are the hard gate).

Closes #10301 · part of #9859 · part of #9921

## Model Used
claude-opus-4-8