### PR TITLE
fix(provision): stamp node_roles so optional assigned roles activate (#9965 facet 2)

### DIFF
--- a/autobot-slm-backend/services/inventory_builder.py
+++ b/autobot-slm-backend/services/inventory_builder.py
@@ -220,6 +220,14 @@ def _build_hostvars(node: Any, local_ip_check: Any) -> dict:
         "ansible_user": node.ssh_user or "autobot",
         "ansible_port": node.ssh_port or 22,
         "slm_node_id": node.node_id,
+        # #9965: stamp the node's assigned role tokens so role_active_facts can
+        # activate roles via node_roles, not group membership alone. Group-based
+        # activation silently skips roles whose inventory group isn't the one
+        # role_*_active checks (e.g. tts-worker -> npu_worker group, but
+        # role_tts_worker_active checks node_roles only; browser-service ->
+        # browser_automation group, but role_browser_active checks browser/
+        # browser_worker) — so optional assigned roles never deploy.
+        "node_roles": _union_roles(node),
     }
     if local_ip_check(node.ip_address):
         hostvars["ansible_connection"] = "local"

--- a/autobot-slm-backend/tests/services/test_inventory_builder_node_roles.py
+++ b/autobot-slm-backend/tests/services/test_inventory_builder_node_roles.py
@@ -1,0 +1,44 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit test for inventory_builder node_roles stamping (Issue #9965).
+
+Regression guard: the generated inventory must stamp each node's assigned role
+tokens as the `node_roles` hostvar, so role_active_facts.yml activates roles via
+node_roles (not group membership alone). Without it, optional roles whose
+inventory group isn't the one role_*_active checks (tts-worker, browser-service)
+never provision.
+"""
+
+from types import SimpleNamespace
+
+from services.inventory_builder import build_registry_inventory
+
+
+def _node(node_id="00-SLM-Manager", roles=None, detected=None):
+    return SimpleNamespace(
+        node_id=node_id,
+        ip_address="127.0.0.1",
+        ssh_user="autobot",
+        ssh_port=22,
+        roles=roles or [],
+        detected_roles=detected or [],
+    )
+
+
+def test_node_roles_stamped_into_hostvars():
+    node = _node(roles=["ai-stack", "tts-worker", "browser-service"])
+    inv = build_registry_inventory([node], local_ip_check=lambda ip: True)
+    hostvars = inv["all"]["hosts"]["00-SLM-Manager"]
+    assert "node_roles" in hostvars, "node_roles must be stamped for role_active_facts"
+    for role in ("ai-stack", "tts-worker", "browser-service"):
+        assert role in hostvars["node_roles"], f"{role} missing from node_roles"
+
+
+def test_node_roles_unions_detected_roles():
+    node = _node(roles=["backend"], detected=["redis"])
+    inv = build_registry_inventory([node], local_ip_check=lambda ip: False)
+    roles = inv["all"]["hosts"]["00-SLM-Manager"]["node_roles"]
+    assert "backend" in roles and "redis" in roles


### PR DESCRIPTION
## Thinking Path
Part of umbrella #9919 / closes facet 2 of #9965. On the live box a fresh fleet provision returned `failed=0` yet **tts-worker + browser-service never deployed** (inactive, no venv). Their Phase 5c/6 plays ran but the role includes were **skipped** (`when: role_*_active` = false).

Root cause: `inventory_builder` only assigns **group membership** (`_role_tokens_to_groups`) and never stamps `node_roles`. `role_active_facts.yml` then activates a role only if its inventory group is the one that fact checks. That matches for ai-stack (`ai_stack` group ✓) but **not** for tts-worker (mapped to `npu_worker`, but `role_tts_worker_active` checks `node_roles` only) or browser-service (mapped to `browser_automation`, but `role_browser_active` checks `browser`/`browser_worker`). So optional roles silently never activate.

## What Changed
- `inventory_builder._build_hostvars`: stamp `node_roles: _union_roles(node)` so every assigned role activates via its `node_roles` token regardless of group-name mismatch.
- Regression test: `node_roles` stamped + unions detected_roles.

## Verification
- Reproduced live: provision `ok=307 failed=0` but tts/browser skipped; `host_name = node.node_id` and group-only assignment confirmed.
- `py_compile` + `black --check` clean.

## Note
#9965 facet 1 (VM agent heartbeat death) is separate and not addressed here.

## Model Used
Claude Opus 4.8