### PR TITLE
fix(frontend): AdminUsersView 404 + de-flake useModal perf tests (#10036, #10275)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useModal.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useModal.test.ts
@@ -643,46 +643,40 @@ describe('useModal composable', () => {
   // Performance Tests
   // ========================================
 
-  describe('useModal - performance', () => {
-    it('should execute quickly for repeated open/close calls', async () => {
+  // #10275: these assert correctness at scale, NOT wall-clock time. Wall-clock
+  // assertions (toBeLessThan(<ms>)) are flaky on shared/loaded CI runners and
+  // catch no real regression — perf belongs in dedicated benchmarks, not here.
+  describe('useModal - bulk operations', () => {
+    it('stays consistent across many repeated open/close calls', async () => {
       const modal = useModal()
-      const startTime = performance.now()
 
       for (let i = 0; i < 100; i++) {
         await modal.open()
+        expect(modal.isOpen.value).toBe(true)
         await modal.close()
+        expect(modal.isOpen.value).toBe(false)
       }
 
-      const duration = performance.now() - startTime
-
-      // 100 open/close cycles should complete in less than 50ms
-      expect(duration).toBeLessThan(50)
+      expect(modal.isOpen.value).toBe(false)
     })
 
-    it('should handle creating many modals efficiently', () => {
-      const startTime = performance.now()
-
+    it('creates many independent modals, each initially closed', () => {
       const names = Array.from({ length: 50 }, (_, i) => `modal${i}`)
       const modals = useModals(names)
 
-      const duration = performance.now() - startTime
-
       expect(Object.keys(modals).length).toBe(50)
-      expect(duration).toBeLessThan(10)
+      expect(Object.values(modals).every((m) => m.isOpen.value === false)).toBe(true)
     })
 
-    it('should handle modal group operations efficiently', async () => {
+    it('opens and closes a whole modal group correctly', async () => {
       const names = Array.from({ length: 20 }, (_, i) => `modal${i}`)
-      const { _modals, closeAll, openAll } = useModalGroup(names)
-
-      const startTime = performance.now()
+      const { hasOpenModal, allClosed, closeAll, openAll } = useModalGroup(names)
 
       await openAll()
+      expect(hasOpenModal.value).toBe(true)
+
       await closeAll()
-
-      const duration = performance.now() - startTime
-
-      expect(duration).toBeLessThan(20)
+      expect(allClosed.value).toBe(true)
     })
   })
 

--- a/autobot-frontend/src/views/AdminUsersView.vue
+++ b/autobot-frontend/src/views/AdminUsersView.vue
@@ -328,7 +328,7 @@ async function loadUsers(): Promise<void> {
     if (searchQuery.value.trim()) {
       params.set('search', searchQuery.value.trim())
     }
-    const res = await fetchWithAuth(`${getBackendUrl()}/user-management/users?${params}`)
+    const res = await fetchWithAuth(`${getBackendUrl()}/api/user-management/users?${params}`)
     if (!res.ok) {
       const body = await res.json().catch(() => ({}))
       throw new Error((body as { detail?: string }).detail ?? `HTTP ${res.status}`)
@@ -423,7 +423,7 @@ function changePage(delta: number): void {
 
 async function onRoleChange(user: UserRecord, role: string): Promise<void> {
   try {
-    const res = await fetchWithAuth(`${getBackendUrl()}/user-management/users/${user.id}/role`, {
+    const res = await fetchWithAuth(`${getBackendUrl()}/api/user-management/users/${user.id}/role`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ role }),
@@ -442,7 +442,7 @@ async function onRoleChange(user: UserRecord, role: string): Promise<void> {
 async function toggleActive(user: UserRecord, activate: boolean): Promise<void> {
   const action = activate ? 'activate' : 'deactivate'
   try {
-    const res = await fetchWithAuth(`${getBackendUrl()}/user-management/users/${user.id}/${action}`, {
+    const res = await fetchWithAuth(`${getBackendUrl()}/api/user-management/users/${user.id}/${action}`, {
       method: 'POST',
     })
     if (!res.ok) {
@@ -463,7 +463,7 @@ function confirmDelete(user: UserRecord): void {
 async function deleteUser(): Promise<void> {
   if (!deleteTarget.value) return
   try {
-    const res = await fetchWithAuth(`${getBackendUrl()}/user-management/users/${deleteTarget.value.id}`, {
+    const res = await fetchWithAuth(`${getBackendUrl()}/api/user-management/users/${deleteTarget.value.id}`, {
       method: 'DELETE',
     })
     if (!res.ok) {
@@ -483,7 +483,7 @@ async function createUser(): Promise<void> {
   creating.value = true
   createError.value = null
   try {
-    const res = await fetchWithAuth(`${getBackendUrl()}/user-management/users`, {
+    const res = await fetchWithAuth(`${getBackendUrl()}/api/user-management/users`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({


### PR DESCRIPTION
Fixes #10036. Fixes #10275. Two small frontend problems batched (both discovered during the #9922 sweep).

## #10036 — AdminUsersView every call 404s (priority: high)
`AdminUsersView.vue` built 5 requests as `${getBackendUrl()}/user-management/...`. `getBackendUrl()` is host-level (no `/api`), and the backend serves only `/api/user-management/*` (router prefix `/user-management` + app-factory `/api`; nginx has no `/user-management` location), so every list/role/activate/deactivate/delete/create call fell through to the SPA catch-all → 404. Prefixed all 5 with `/api` (verified against `api.ts` + the backend router). Same bug class as #10012/BudgetPolicies.

## #10275 — flaky useModal perf tests (recurring CI blocker)
The `useModal - performance` block had three wall-clock assertions (`toBeLessThan(50|10|20)` ms) that flaked on loaded CI runners (the `<10ms` one failed at 17ms and blocked PRs this session). Wall-clock timing in unit tests catches no real regression — perf belongs in benchmarks. Rewrote them to assert **functional correctness at scale** instead: 100 open/close cycles stay consistent; 50 modals all create independently-closed; a 20-modal group opens (`hasOpenModal`) and closes (`allClosed`) correctly. Renamed the block to `useModal - bulk operations`.

## Verification
- `vitest run useModal.test.ts` → **63 passed** (0 wall-clock assertions remain).
- `vue-tsc -p tsconfig.app.json` → no new errors in changed files; oxlint clean.
- AdminUsersView: 5/5 calls now `/api/user-management/*`, 0 bare; paths confirmed present in `api.ts`.

## Model Used
Claude Opus 4.8