### PR TITLE
feat(secrets): reconciliation sweep closes revoke-resurrection gate (#10337)

### DIFF
--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -239,6 +239,12 @@ celery_app.conf.beat_schedule = {
         "task": "tasks.cleanup_expired_snapshots",
         "schedule": crontab(hour=3, minute=0),
     },
+    # #10337: hourly reconciliation of mirrored unified credential copies against canonical
+    # SQLite — bounds the revoke-resurrection window of the connector-store cutover (#10088).
+    "reconcile-unified-credentials-hourly": {
+        "task": "tasks.reconcile_unified_credentials",
+        "schedule": crontab(minute=20),
+    },
 }
 
 # GH#4459: Register web-push task_success signal so tasks that pass user_id

--- a/autobot-backend/services/unified_credential_reconcile.py
+++ b/autobot-backend/services/unified_credential_reconcile.py
@@ -1,0 +1,122 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Reconcile mirrored unified credential copies against canonical SQLite (#10088 / #10337).
+
+Closes the revoke-resurrection + silent-desync gate of the connector-store cutover. The
+dual-write mirror (#10334) is best-effort, so a swallowed unified delete/rotate can leave the
+unified copy out of sync with the canonical SQLite store — and with read-first enabled a
+revoked credential could be resurrected, or a stale token served. This sweep walks every
+marker'd unified row and reconciles it against SQLite:
+
+- SQLite row absent **or inactive** (revoked) → delete the unified copy.
+- SQLite row active but the value drifted → re-seal the unified copy to the SQLite value.
+
+**Safety:** if the canonical SQLite store is missing or unreadable the sweep aborts without
+deleting anything — a missing canonical store must never be read as "everything revoked".
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # typing only — avoid a hard cryptography import at module load
+    from cryptography.fernet import Fernet, MultiFernet
+
+logger = logging.getLogger(__name__)
+
+_MARKER = "imported_from_sqlite"
+
+
+@dataclass
+class ReconcileReport:
+    """Counts for one reconciliation sweep (``aborted`` when SQLite was unreadable)."""
+
+    checked: int = 0
+    deleted: int = 0  # revoked/absent in SQLite → removed from unified
+    resynced: int = 0  # value drifted → re-sealed to the SQLite value
+    ok: int = 0  # already consistent
+    failed: list[str] = field(default_factory=list)
+    aborted: bool = False
+
+
+def _read_sqlite_state(sqlite_path: str, fernet) -> dict[str, dict]:
+    """Canonical {id: {"active": bool, "value": str|None}} from the SQLite store.
+
+    Raises ``FileNotFoundError`` / ``sqlite3.OperationalError`` when the store or its table is
+    absent — the caller treats that as "abort", never as "everything revoked".
+    """
+    from cryptography.fernet import InvalidToken
+
+    if not Path(sqlite_path).exists():
+        raise FileNotFoundError(sqlite_path)
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        conn.row_factory = sqlite3.Row
+        cur = conn.execute("SELECT id, is_active, encrypted_value FROM secrets")
+        state: dict[str, dict] = {}
+        for r in cur.fetchall():
+            value = None
+            if r["is_active"] and r["encrypted_value"]:
+                try:
+                    value = fernet.decrypt(r["encrypted_value"].encode("utf-8")).decode("utf-8")
+                except (InvalidToken, ValueError):
+                    value = None  # undecryptable → keep the unified copy, skip value resync
+            state[str(r["id"])] = {"active": bool(r["is_active"]), "value": value}
+        return state
+    finally:
+        conn.close()
+
+
+async def _reconcile_one(session, svc, row, src, report: ReconcileReport) -> None:
+    from autobot_shared.secrets_vault import VaultKind, VaultRef
+
+    vaults = {VaultRef(VaultKind.USER, str(row.owner_id))}
+    if src is None or not src["active"]:
+        await svc.delete(session, secret_id=row.id)  # revoked or absent in canonical store
+        report.deleted += 1
+        return
+    current = await svc.read(session, secret_id=row.id, accessible_vaults=vaults)
+    if src["value"] is not None and current.decode("utf-8") != src["value"]:
+        await svc.rotate_value(
+            session, secret_id=row.id, new_plaintext=src["value"].encode("utf-8"), actor_vaults=vaults
+        )
+        report.resynced += 1
+    else:
+        report.ok += 1
+
+
+async def reconcile_connector_credentials(
+    session, *, sqlite_path: str, fernet: "Fernet | MultiFernet", root_key: bytes
+) -> ReconcileReport:
+    """Reconcile every marker'd unified row against the canonical SQLite store. Caller commits."""
+    from sqlalchemy import select
+
+    from autobot_shared.secrets_envelope import DecryptionError, UnsupportedFormatError
+    from models.secret import Secret
+    from services.unified_secrets_service import SecretAccessError, SecretNotFoundError, UnifiedSecretsService
+
+    report = ReconcileReport()
+    try:
+        sqlite_state = _read_sqlite_state(sqlite_path, fernet)
+    except (FileNotFoundError, sqlite3.OperationalError) as exc:
+        logger.warning("Reconcile aborted — canonical SQLite store unreadable (%s): %s", sqlite_path, exc)
+        report.aborted = True
+        return report
+
+    marker = Secret.extra_data[_MARKER].astext
+    rows = (await session.execute(select(Secret).where(marker.isnot(None), Secret.is_active.is_(True)))).scalars().all()
+    svc = UnifiedSecretsService(root_key=root_key)
+    for row in rows:
+        report.checked += 1
+        src = sqlite_state.get(str(row.extra_data.get(_MARKER)))
+        try:
+            await _reconcile_one(session, svc, row, src, report)
+        except (SecretAccessError, SecretNotFoundError, DecryptionError, UnsupportedFormatError, KeyError) as exc:
+            report.failed.append(f"{row.id}: {exc}")
+    return report

--- a/autobot-backend/services/unified_credential_reconcile.py
+++ b/autobot-backend/services/unified_credential_reconcile.py
@@ -13,8 +13,14 @@ marker'd unified row and reconciles it against SQLite:
 - SQLite row absent **or inactive** (revoked) → delete the unified copy.
 - SQLite row active but the value drifted → re-seal the unified copy to the SQLite value.
 
-**Safety:** if the canonical SQLite store is missing or unreadable the sweep aborts without
-deleting anything — a missing canonical store must never be read as "everything revoked".
+**Destructive-safety.** Deletes are irreversible (hard delete), so the sweep refuses to run
+when the canonical store can't be positively confirmed authoritative *and populated*:
+- SQLite file missing or its table absent → abort (``OperationalError``/``FileNotFoundError``).
+- SQLite present but **empty**, or the sweep would delete **every** unified copy → abort. A
+  populated mirror against an empty canonical store is indistinguishable from a misconfigured
+  or wiped DB (``get_secrets_service`` auto-creates an empty ``secrets.db`` at a bad path), so
+  it must never be read as "everything revoked".
+Each row is reconciled inside its own SAVEPOINT so one poison row can't abort the sweep.
 """
 
 from __future__ import annotations
@@ -35,18 +41,19 @@ _MARKER = "imported_from_sqlite"
 
 @dataclass
 class ReconcileReport:
-    """Counts for one reconciliation sweep (``aborted`` when SQLite was unreadable)."""
+    """Counts for one reconciliation sweep (``aborted`` when SQLite was unsafe to trust)."""
 
     checked: int = 0
     deleted: int = 0  # revoked/absent in SQLite → removed from unified
     resynced: int = 0  # value drifted → re-sealed to the SQLite value
     ok: int = 0  # already consistent
+    undecryptable: int = 0  # active SQLite rows whose value couldn't decrypt → drift-blind
     failed: list[str] = field(default_factory=list)
     aborted: bool = False
 
 
-def _read_sqlite_state(sqlite_path: str, fernet) -> dict[str, dict]:
-    """Canonical {id: {"active": bool, "value": str|None}} from the SQLite store.
+def _read_sqlite_state(sqlite_path: str, fernet) -> tuple[dict[str, dict], int]:
+    """Canonical ``{id: {"active": bool, "value": str|None}}`` + undecryptable-row count.
 
     Raises ``FileNotFoundError`` / ``sqlite3.OperationalError`` when the store or its table is
     absent — the caller treats that as "abort", never as "everything revoked".
@@ -56,6 +63,7 @@ def _read_sqlite_state(sqlite_path: str, fernet) -> dict[str, dict]:
     if not Path(sqlite_path).exists():
         raise FileNotFoundError(sqlite_path)
     conn = sqlite3.connect(sqlite_path)
+    undecryptable = 0
     try:
         conn.row_factory = sqlite3.Row
         cur = conn.execute("SELECT id, is_active, encrypted_value FROM secrets")
@@ -66,16 +74,25 @@ def _read_sqlite_state(sqlite_path: str, fernet) -> dict[str, dict]:
                 try:
                     value = fernet.decrypt(r["encrypted_value"].encode("utf-8")).decode("utf-8")
                 except (InvalidToken, ValueError):
-                    value = None  # undecryptable → keep the unified copy, skip value resync
+                    undecryptable += 1  # keep the unified copy, skip value resync (drift-blind)
             state[str(r["id"])] = {"active": bool(r["is_active"]), "value": value}
-        return state
+        return state, undecryptable
     finally:
         conn.close()
+
+
+def _is_revoked(sqlite_state: dict, row) -> bool:
+    """True when *row*'s canonical SQLite counterpart is absent or inactive (revoked)."""
+    src = sqlite_state.get(str(row.extra_data.get(_MARKER)))
+    return src is None or not src["active"]
 
 
 async def _reconcile_one(session, svc, row, src, report: ReconcileReport) -> None:
     from autobot_shared.secrets_vault import VaultKind, VaultRef
 
+    # The marker is the SQLite row's global PRIMARY KEY, so (marker → one row → one owner) is
+    # 1:1; the authorizing vault is the unified row's own owner. If SQLite ever adopts per-user
+    # id namespaces this coupling must be revisited.
     vaults = {VaultRef(VaultKind.USER, str(row.owner_id))}
     if src is None or not src["active"]:
         await svc.delete(session, secret_id=row.id)  # revoked or absent in canonical store
@@ -96,6 +113,7 @@ async def reconcile_connector_credentials(
 ) -> ReconcileReport:
     """Reconcile every marker'd unified row against the canonical SQLite store. Caller commits."""
     from sqlalchemy import select
+    from sqlalchemy.exc import SQLAlchemyError
 
     from autobot_shared.secrets_envelope import DecryptionError, UnsupportedFormatError
     from models.secret import Secret
@@ -103,7 +121,7 @@ async def reconcile_connector_credentials(
 
     report = ReconcileReport()
     try:
-        sqlite_state = _read_sqlite_state(sqlite_path, fernet)
+        sqlite_state, report.undecryptable = _read_sqlite_state(sqlite_path, fernet)
     except (FileNotFoundError, sqlite3.OperationalError) as exc:
         logger.warning("Reconcile aborted — canonical SQLite store unreadable (%s): %s", sqlite_path, exc)
         report.aborted = True
@@ -111,12 +129,31 @@ async def reconcile_connector_credentials(
 
     marker = Secret.extra_data[_MARKER].astext
     rows = (await session.execute(select(Secret).where(marker.isnot(None), Secret.is_active.is_(True)))).scalars().all()
+    report.checked = len(rows)
+
+    # Destructive-safety circuit breaker: refuse to mass-delete when canonical looks empty or a
+    # total wipe — that is far more likely a misconfigured/wiped store than a real "revoke all".
+    if rows and (not sqlite_state or all(_is_revoked(sqlite_state, r) for r in rows)):
+        logger.error(
+            "Reconcile aborted — would delete all %d unified copies (canonical empty=%s)", len(rows), not sqlite_state
+        )
+        report.aborted = True
+        return report
+
     svc = UnifiedSecretsService(root_key=root_key)
     for row in rows:
-        report.checked += 1
         src = sqlite_state.get(str(row.extra_data.get(_MARKER)))
         try:
-            await _reconcile_one(session, svc, row, src, report)
-        except (SecretAccessError, SecretNotFoundError, DecryptionError, UnsupportedFormatError, KeyError) as exc:
+            async with session.begin_nested():  # one poison row can't abort the sweep
+                await _reconcile_one(session, svc, row, src, report)
+        except (
+            SecretAccessError,
+            SecretNotFoundError,
+            DecryptionError,
+            UnsupportedFormatError,
+            KeyError,
+            ValueError,
+            SQLAlchemyError,
+        ) as exc:
             report.failed.append(f"{row.id}: {exc}")
     return report

--- a/autobot-backend/tasks/credential_reconcile.py
+++ b/autobot-backend/tasks/credential_reconcile.py
@@ -1,0 +1,54 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Periodic sweep reconciling unified credential copies against canonical SQLite (#10337).
+
+Bounds the revoke-resurrection window of the connector-store cutover (#10088 Task 3c-2): a
+swallowed best-effort mirror delete/rotate (#10334) leaves the unified copy out of sync, which
+read-first would serve. This Celery task runs the reconciliation sweep on a schedule.
+"""
+
+import asyncio
+import logging
+
+from celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(name="tasks.reconcile_unified_credentials")
+def reconcile_unified_credentials() -> dict:
+    """Reconcile mirrored unified credential copies against the canonical SQLite store."""
+    return asyncio.run(_run())
+
+
+async def _run() -> dict:
+    from autobot_shared.secrets_envelope import load_root_key
+    from services.secrets_service import get_secrets_service
+    from services.unified_credential_reconcile import reconcile_connector_credentials
+    from user_management.database import get_async_session_factory
+
+    try:
+        root_key = load_root_key()
+    except RuntimeError:
+        logger.info("Credential reconcile skipped — unified secrets root key not configured")
+        return {"skipped": "no_root_key"}
+
+    svc = get_secrets_service()
+    async with get_async_session_factory()() as session:
+        report = await reconcile_connector_credentials(
+            session, sqlite_path=svc.db_path, fernet=svc.cipher, root_key=root_key
+        )
+        await session.commit()
+
+    result = {
+        "checked": report.checked,
+        "deleted": report.deleted,
+        "resynced": report.resynced,
+        "ok": report.ok,
+        "failed": len(report.failed),
+        "aborted": report.aborted,
+    }
+    logger.info("Unified credential reconcile: %s", result)
+    return result

--- a/autobot-backend/tests/migrations/test_credential_reconcile.py
+++ b/autobot-backend/tests/migrations/test_credential_reconcile.py
@@ -1,0 +1,111 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Postgres tests for the unified↔SQLite credential reconciliation sweep (#10088 / #10337).
+
+Seeds marker'd unified rows in drifted states against a canonical SQLite store and verifies
+the sweep deletes revoked/orphaned copies, re-seals drifted values, leaves consistent ones,
+and — critically — aborts (deletes nothing) when the canonical store is missing.
+"""
+
+import base64
+import sqlite3
+import uuid
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from services.unified_credential_read import read_imported_credential_in_session
+from services.unified_credential_reconcile import reconcile_connector_credentials
+from services.unified_secrets_service import UnifiedSecretsService
+from tests.migrations.conftest import requires_postgres, run_alembic
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+_ROOT = base64.urlsafe_b64decode(base64.urlsafe_b64encode(bytes(range(32))))
+_FERNET = Fernet(Fernet.generate_key())
+_OWNER = uuid.uuid4()
+
+
+def _make_db(path: str, rows: list[dict]) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE secrets (id TEXT PRIMARY KEY, is_active INTEGER DEFAULT 1, encrypted_value TEXT)")
+    for r in rows:
+        enc = _FERNET.encrypt(r["value"].encode("utf-8")).decode("utf-8") if r.get("value") is not None else None
+        conn.execute(
+            "INSERT INTO secrets (id, is_active, encrypted_value) VALUES (?,?,?)", (r["id"], r.get("active", 1), enc)
+        )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture()
+async def session(fresh_db_url):
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+    engine = create_async_engine(fresh_db_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as s:
+        yield s
+    await engine.dispose()
+
+
+async def _seed_unified(session, marker: str, value: str):
+    svc = UnifiedSecretsService(root_key=_ROOT)
+    secret = await svc.create(
+        session,
+        owner_vault=VaultRef(VaultKind.USER, str(_OWNER)),
+        name="connector:c:auth",
+        secret_type="connector_oauth_token",
+        plaintext=value.encode("utf-8"),
+        created_by=_OWNER,
+    )
+    secret.extra_data = {"imported_from_sqlite": marker}
+    await session.flush()
+    return secret
+
+
+async def _read(session, marker):
+    return await read_imported_credential_in_session(session, marker, str(_OWNER), _ROOT)
+
+
+async def test_reconcile_fixes_drift(session, tmp_path):
+    db = str(tmp_path / "secrets.db")
+    _make_db(
+        db,
+        [
+            {"id": "rev", "active": 0, "value": "x"},  # revoked in SQLite
+            {"id": "drift", "active": 1, "value": "new"},  # active, value differs from unified
+            {"id": "ok", "active": 1, "value": "same"},  # already consistent
+            # "orphan" deliberately absent from SQLite
+        ],
+    )
+    await _seed_unified(session, "rev", "x")
+    await _seed_unified(session, "drift", "old")
+    await _seed_unified(session, "ok", "same")
+    await _seed_unified(session, "orphan", "y")
+    await session.commit()
+
+    report = await reconcile_connector_credentials(session, sqlite_path=db, fernet=_FERNET, root_key=_ROOT)
+    await session.commit()
+
+    assert report.aborted is False
+    assert report.checked == 4 and report.deleted == 2 and report.resynced == 1 and report.ok == 1
+    assert await _read(session, "rev") is None  # revoked → removed
+    assert await _read(session, "orphan") is None  # absent in canonical → removed
+    assert (await _read(session, "drift"))["value"] == "new"  # resynced to canonical
+    assert (await _read(session, "ok"))["value"] == "same"  # untouched
+
+
+async def test_reconcile_aborts_when_sqlite_missing(session, tmp_path):
+    # No SQLite file → must abort and delete NOTHING (a missing canonical store is not "all revoked").
+    await _seed_unified(session, "keep", "v")
+    await session.commit()
+    report = await reconcile_connector_credentials(
+        session, sqlite_path=str(tmp_path / "nope.db"), fernet=_FERNET, root_key=_ROOT
+    )
+    await session.commit()
+    assert report.aborted is True and report.deleted == 0
+    assert (await _read(session, "keep"))["value"] == "v"

--- a/autobot-backend/tests/migrations/test_credential_reconcile.py
+++ b/autobot-backend/tests/migrations/test_credential_reconcile.py
@@ -109,3 +109,29 @@ async def test_reconcile_aborts_when_sqlite_missing(session, tmp_path):
     await session.commit()
     assert report.aborted is True and report.deleted == 0
     assert (await _read(session, "keep"))["value"] == "v"
+
+
+async def test_reconcile_aborts_on_empty_canonical_table(session, tmp_path):
+    # Present-but-EMPTY secrets table (e.g. an auto-created secrets.db at a misconfigured path):
+    # a populated mirror against an empty canonical store must abort, never mass-delete.
+    db = str(tmp_path / "secrets.db")
+    _make_db(db, [])  # table exists, zero rows
+    await _seed_unified(session, "keep", "v")
+    await session.commit()
+    report = await reconcile_connector_credentials(session, sqlite_path=db, fernet=_FERNET, root_key=_ROOT)
+    await session.commit()
+    assert report.aborted is True and report.deleted == 0
+    assert (await _read(session, "keep"))["value"] == "v"
+
+
+async def test_reconcile_aborts_on_total_wipe(session, tmp_path):
+    # Canonical has other secrets but every mirrored copy is revoked → "delete all" is suspicious → abort.
+    db = str(tmp_path / "secrets.db")
+    _make_db(db, [{"id": "rev1", "active": 0, "value": "a"}, {"id": "rev2", "active": 0, "value": "b"}])
+    await _seed_unified(session, "rev1", "a")
+    await _seed_unified(session, "rev2", "b")
+    await session.commit()
+    report = await reconcile_connector_credentials(session, sqlite_path=db, fernet=_FERNET, root_key=_ROOT)
+    await session.commit()
+    assert report.aborted is True and report.deleted == 0
+    assert (await _read(session, "rev1"))["value"] == "a"


### PR DESCRIPTION
## Thinking Path
Closes the **gate #10337** surfaced by the dual-write review (#10334): the mirror is best-effort, so a swallowed unified delete/rotate can desync the unified copy from canonical SQLite — and with read-first enabled, a revoked credential could be **resurrected** or a stale token served. The standard fix for dual-store drift is a **reconciliation sweep** that periodically re-asserts the canonical store's truth onto the mirror. This is the prerequisite for enabling `AUTOBOT_SECRETS_UNIFIED_READ` in production.

## What Changed
- **`services/unified_credential_reconcile.py`** — `reconcile_connector_credentials(session, *, sqlite_path, fernet, root_key)`: walks every marker'd (`imported_from_sqlite`) active unified row and reconciles it against the canonical SQLite store:
  - SQLite row **absent or inactive** (revoked) → delete the unified copy (closes revoke-resurrection).
  - SQLite row **active but value drifted** → re-seal the unified copy to the SQLite value (closes stale-token desync).
  - already consistent → leave it.
  - **Safety:** if the SQLite store is **missing/unreadable**, the sweep **aborts and deletes nothing** — a missing canonical store must never be read as "everything revoked".
- **`tasks/credential_reconcile.py`** — Celery task `tasks.reconcile_unified_credentials` (autodiscovered) that runs the sweep, skipping cleanly when the root key is unset.
- **`celery_app.py`** — hourly beat entry to bound the resurrection window.

## Verification
- 2 Postgres tests (migration-gate): a mixed-drift sweep deletes the revoked + orphaned copies, re-syncs the drifted value, leaves the consistent one untouched (`checked=4, deleted=2, resynced=1, ok=1`); and a missing-SQLite run **aborts with zero deletions** and preserves the unified copy.
- `flake8` 0, `black` (120) clean. Reconcile core imports cleanly in the minimal migration-gate env (heavy imports are function-local).

## Effect on the cutover
With this sweep running, the unified store self-heals against canonical SQLite hourly, so **#10088 Task 3c-2 can proceed to read-first** (and the contract phase). Resolves the H1/M1 review findings from #10334.

## Model Used
Claude Opus 4.8

Closes #10337. Part of #10088.
