### PR TITLE
feat(secrets): access transparency — who can access a secret (#10343)

### DIFF
--- a/autobot-backend/api/unified_secrets.py
+++ b/autobot-backend/api/unified_secrets.py
@@ -112,6 +112,29 @@ class SecretValue(BaseModel):
     value: str
 
 
+class VaultAccessOut(BaseModel):
+    vault: str
+    kind: str
+    id: str | None
+    members: list[str]
+
+
+class SecretAccessOut(BaseModel):
+    secret_id: str
+    owner_vault: str
+    grants: list[VaultAccessOut]
+    effective_users: list[str]
+
+    @classmethod
+    def of(cls, report) -> "SecretAccessOut":
+        return cls(
+            secret_id=report.secret_id,
+            owner_vault=report.owner_vault,
+            grants=[VaultAccessOut(vault=g.vault, kind=g.kind, id=g.id, members=g.members) for g in report.grants],
+            effective_users=report.effective_users,
+        )
+
+
 @router.post("", response_model=SecretMetadata, status_code=status.HTTP_201_CREATED)
 async def create_secret(
     body: CreateSecretBody,
@@ -160,6 +183,22 @@ async def read_secret(
     except (SecretAccessError, SecretNotFoundError) as exc:
         raise _mapped(exc)
     return SecretValue(value=value.decode("utf-8"))
+
+
+@router.get("/{secret_id}/access", response_model=SecretAccessOut)
+async def secret_access(
+    secret_id: uuid.UUID,
+    who: tuple[uuid.UUID, set[str]] = Depends(principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> SecretAccessOut:
+    """Who can access this secret: owner + every grantee vault, resolved to member users."""
+    user_id, perms = who
+    try:
+        report = await coordinator.describe_access(session, user_id=user_id, permissions=perms, secret_id=secret_id)
+    except (SecretAccessError, SecretNotFoundError, ValueError) as exc:
+        raise _mapped(exc)
+    return SecretAccessOut.of(report)
 
 
 @router.put("/{secret_id}", response_model=SecretMetadata)

--- a/autobot-backend/services/secrets_access_audit.py
+++ b/autobot-backend/services/secrets_access_audit.py
@@ -89,7 +89,13 @@ async def describe_secret_access(session, secret_id) -> SecretAccessReport | Non
     from models.secret import Secret
     from models.secret_grant import SecretGrant
 
-    secret = (await session.execute(select(Secret).where(Secret.id == secret_id))).scalars().first()
+    # Only envelope-backed rows (sealed_value set) are governed here — matches the coordinator's
+    # _owner_vault gate, so a direct call can't report access for a legacy/value-less row.
+    secret = (
+        (await session.execute(select(Secret).where(Secret.id == secret_id, Secret.sealed_value.isnot(None))))
+        .scalars()
+        .first()
+    )
     if secret is None:
         return None
 

--- a/autobot-backend/services/secrets_access_audit.py
+++ b/autobot-backend/services/secrets_access_audit.py
@@ -1,0 +1,110 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Access-transparency for unified secrets — "who can access this secret" (#10088 / Task 4).
+
+Answers the PRD's tree-level audit requirement: given a secret, return its owner vault plus
+every grantee vault, each resolved to the **member users** behind it (the reverse of
+``services.secrets_principal_resolver``, which goes user → vaults). Pure read path over the
+``secret_grants`` rows + the membership tables — no decryption, no mutation.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class VaultAccess:
+    """One vault that can reach a secret, resolved to the users behind it."""
+
+    vault: str  # canonical "kind:id" (or "system")
+    kind: str  # VaultKind value
+    id: str | None
+    members: list[str]  # member user ids ([the id] for a user vault; [] for system/agent/etc.)
+
+
+@dataclass
+class SecretAccessReport:
+    secret_id: str
+    owner_vault: str
+    grants: list[VaultAccess] = field(default_factory=list)
+    effective_users: list[str] = field(default_factory=list)  # union of all member users
+
+
+async def _members_of(session, ref) -> list[str]:
+    """Member user ids behind a vault. Group vaults reverse the membership tables."""
+    from sqlalchemy import select
+
+    from autobot_shared.secrets_vault import VaultKind
+
+    if ref.kind == VaultKind.USER:
+        return [ref.id]
+    if ref.kind == VaultKind.TEAM:
+        from user_management.models.team import TeamMembership
+
+        tid = _as_uuid(ref.id)
+        if tid is None:
+            return []
+        rows = await session.execute(select(TeamMembership.user_id).where(TeamMembership.team_id == tid))
+        return [str(u) for u in rows.scalars()]
+    if ref.kind == VaultKind.ROLE:
+        from user_management.models.role import Role, UserRole
+
+        rows = await session.execute(
+            select(UserRole.user_id).join(Role, Role.id == UserRole.role_id).where(Role.name == ref.id)
+        )
+        return [str(u) for u in rows.scalars()]
+    if ref.kind == VaultKind.COMPANY:
+        from llc.models.membership import LLCCompanyMembership
+
+        cid = _as_uuid(ref.id)
+        if cid is None:
+            return []
+        rows = await session.execute(select(LLCCompanyMembership.user_id).where(LLCCompanyMembership.company_id == cid))
+        return [str(u) for u in rows.scalars()]
+    return []  # system / agent / service / node — not expanded to member users here
+
+
+def _as_uuid(value) -> uuid.UUID | None:
+    try:
+        return uuid.UUID(str(value))
+    except (ValueError, TypeError):
+        return None
+
+
+async def describe_secret_access(session, secret_id) -> SecretAccessReport | None:
+    """Who can access *secret_id*: owner + every grantee vault, each resolved to its members.
+
+    Returns ``None`` when the secret does not exist.
+    """
+    from sqlalchemy import select
+
+    from autobot_shared.secrets_vault import VaultRef
+    from models.secret import Secret
+    from models.secret_grant import SecretGrant
+
+    secret = (await session.execute(select(Secret).where(Secret.id == secret_id))).scalars().first()
+    if secret is None:
+        return None
+
+    grants = (await session.execute(select(SecretGrant).where(SecretGrant.secret_id == secret_id))).scalars().all()
+    report = SecretAccessReport(secret_id=str(secret_id), owner_vault=secret.owner_vault or "")
+    effective: set[str] = set()
+    for grant in grants:
+        try:
+            ref = VaultRef.parse(grant.grantee)
+        except ValueError:
+            logger.warning("Skipping unparseable grantee %r on secret %s", grant.grantee, secret_id)
+            continue
+        members = await _members_of(session, ref)
+        report.grants.append(VaultAccess(vault=grant.grantee, kind=ref.kind.value, id=ref.id, members=members))
+        effective.update(members)
+    report.grants.sort(key=lambda v: v.vault)
+    report.effective_users = sorted(effective)
+    return report

--- a/autobot-backend/services/secrets_coordinator.py
+++ b/autobot-backend/services/secrets_coordinator.py
@@ -103,10 +103,13 @@ class SecretsCoordinator:
     async def describe_access(
         self, session: AsyncSession, *, user_id: uuid.UUID, permissions: set[str], secret_id: uuid.UUID
     ) -> SecretAccessReport:
-        """Who can access *secret_id*. Authorized to callers who may read the owner vault (or admins)."""
+        """Who can access *secret_id*. Gated on **manage** authority (``share``): you may audit who
+        has access only if you may change who has access — i.e. the owner, an admin, or a company
+        OWNER/ADMIN/LEAD — so a mere reader (company guest/member, plain grantee) cannot enumerate
+        the cross-vault roster."""
         facts = await self._facts(session, user_id, permissions)
         owner = await self._owner_vault(session, secret_id)  # raises SecretNotFoundError when absent
-        if not authorize(facts, "read", owner):
+        if not authorize(facts, "share", owner):
             raise SecretAccessError(f"not authorized to view access for secret {secret_id}")
         return await describe_secret_access(session, secret_id)
 

--- a/autobot-backend/services/secrets_coordinator.py
+++ b/autobot-backend/services/secrets_coordinator.py
@@ -39,6 +39,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from autobot_shared.secrets_vault import VaultRef
 from models.secret import Secret
 from models.secret_grant import SecretGrant
+from services.secrets_access_audit import SecretAccessReport, describe_secret_access
 from services.secrets_authz import PrincipalFacts, authorize
 from services.secrets_principal_resolver import resolve_principal_facts
 from services.unified_secrets_service import (
@@ -98,6 +99,16 @@ class SecretsCoordinator:
     async def list(self, session: AsyncSession, *, user_id: uuid.UUID, permissions: set[str]) -> list[Secret]:
         facts = await self._facts(session, user_id, permissions)
         return await self._service.list_for_vaults(session, accessible_vaults=facts.accessible_vaults())
+
+    async def describe_access(
+        self, session: AsyncSession, *, user_id: uuid.UUID, permissions: set[str], secret_id: uuid.UUID
+    ) -> SecretAccessReport:
+        """Who can access *secret_id*. Authorized to callers who may read the owner vault (or admins)."""
+        facts = await self._facts(session, user_id, permissions)
+        owner = await self._owner_vault(session, secret_id)  # raises SecretNotFoundError when absent
+        if not authorize(facts, "read", owner):
+            raise SecretAccessError(f"not authorized to view access for secret {secret_id}")
+        return await describe_secret_access(session, secret_id)
 
     async def share(
         self,

--- a/autobot-backend/tests/migrations/test_secrets_access_audit.py
+++ b/autobot-backend/tests/migrations/test_secrets_access_audit.py
@@ -129,3 +129,20 @@ async def test_coordinator_authorizes_owner_denies_stranger(session):
     # missing secret → 404-equivalent
     with pytest.raises(SecretNotFoundError):
         await coord.describe_access(session, user_id=_OWNER, permissions=set(), secret_id=uuid.uuid4())
+
+
+async def test_company_member_cannot_audit(session):
+    # H1: a company MEMBER can read/write company secrets but lacks 'share' authority, so it must
+    # NOT be able to enumerate who-has-access. Only OWNER/ADMIN/LEAD (manage authority) or admins may.
+    from services.secrets_coordinator import SecretsCoordinator
+    from services.unified_secrets_service import SecretAccessError
+
+    await _seed_memberships(session)  # _BOB is a "member" of _COMPANY
+    coord = SecretsCoordinator(service=UnifiedSecretsService(root_key=_ROOT))
+    company = VaultRef(VaultKind.COMPANY, str(_COMPANY))
+    secret = await coord.create(
+        session, user_id=_BOB, permissions=set(), owner_vault=company, name="cs", secret_type="password", plaintext=b"v"
+    )
+    await session.commit()
+    with pytest.raises(SecretAccessError):
+        await coord.describe_access(session, user_id=_BOB, permissions=set(), secret_id=secret.id)

--- a/autobot-backend/tests/migrations/test_secrets_access_audit.py
+++ b/autobot-backend/tests/migrations/test_secrets_access_audit.py
@@ -1,0 +1,131 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for secrets access-transparency — "who can access this secret" (#10088 / Task 4).
+
+Postgres-backed (migration-gate): seeds a user-, role-, and company-scoped membership graph,
+shares one secret to those vaults, and asserts the audit resolves each grantee vault to its
+member users. (The team path needs an Organization → not seeded here, same as the resolver
+test; its query is structurally identical to the role path.)
+"""
+
+import base64
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from services.secrets_access_audit import describe_secret_access
+from services.unified_secrets_service import UnifiedSecretsService
+from tests.migrations.conftest import requires_postgres, run_alembic
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+_ROOT = base64.urlsafe_b64decode(base64.urlsafe_b64encode(bytes(range(32))))
+_OWNER = uuid.uuid4()  # owner (user vault); not seeded as a User row — audit returns the id as-is
+_ALICE = uuid.uuid4()  # role member
+_BOB = uuid.uuid4()  # company member
+_COMPANY = uuid.uuid4()
+
+
+@pytest.fixture()
+async def session(fresh_db_url):
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+    engine = create_async_engine(fresh_db_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as s:
+        yield s
+    await engine.dispose()
+
+
+async def _seed_memberships(session) -> None:
+    from llc.models.membership import LLCCompanyMembership
+    from user_management.models.role import Role, UserRole
+    from user_management.models.user import User
+
+    role_id = uuid.uuid4()
+    session.add(User(id=_ALICE, email="alice@example.com", username="alice"))
+    session.add(User(id=_BOB, email="bob@example.com", username="bob"))
+    session.add(Role(id=role_id, name="engineer"))
+    await session.flush()
+    session.add(UserRole(user_id=_ALICE, role_id=role_id))
+    session.add(LLCCompanyMembership(company_id=_COMPANY, user_id=_BOB, role="member"))
+    await session.flush()
+
+
+async def test_describe_resolves_grantee_members(session):
+    await _seed_memberships(session)
+    svc = UnifiedSecretsService(root_key=_ROOT)
+    owner = VaultRef(VaultKind.USER, str(_OWNER))
+    secret = await svc.create(
+        session, owner_vault=owner, name="db-pw", secret_type="password", plaintext=b"v", created_by=_OWNER
+    )
+    await svc.share(
+        session,
+        secret_id=secret.id,
+        actor_vaults={owner},
+        grantee=VaultRef(VaultKind.ROLE, "engineer"),
+        created_by=_OWNER,
+    )
+    await svc.share(
+        session,
+        secret_id=secret.id,
+        actor_vaults={owner},
+        grantee=VaultRef(VaultKind.COMPANY, str(_COMPANY)),
+        created_by=_OWNER,
+    )
+    await session.commit()
+
+    report = await describe_secret_access(session, secret.id)
+    assert report is not None
+    assert report.owner_vault == f"user:{_OWNER}"
+    by_vault = {g.vault: g for g in report.grants}
+    assert by_vault[f"user:{_OWNER}"].members == [str(_OWNER)]  # owner grant → the owner
+    assert by_vault["role:engineer"].members == [str(_ALICE)]  # role → its member
+    assert by_vault[f"company:{_COMPANY}"].members == [str(_BOB)]  # company → its member
+    assert report.effective_users == sorted({str(_OWNER), str(_ALICE), str(_BOB)})
+
+
+async def test_describe_missing_secret_returns_none(session):
+    assert await describe_secret_access(session, uuid.uuid4()) is None
+
+
+async def test_describe_unshared_secret_lists_only_owner(session):
+    svc = UnifiedSecretsService(root_key=_ROOT)
+    owner = VaultRef(VaultKind.USER, str(_OWNER))
+    secret = await svc.create(
+        session, owner_vault=owner, name="solo", secret_type="password", plaintext=b"v", created_by=_OWNER
+    )
+    await session.commit()
+    report = await describe_secret_access(session, secret.id)
+    assert [g.vault for g in report.grants] == [f"user:{_OWNER}"]
+    assert report.effective_users == [str(_OWNER)]
+
+
+async def test_coordinator_authorizes_owner_denies_stranger(session):
+    from services.secrets_coordinator import SecretsCoordinator
+    from services.unified_secrets_service import SecretAccessError, SecretNotFoundError
+
+    coord = SecretsCoordinator(service=UnifiedSecretsService(root_key=_ROOT))
+    owner = VaultRef(VaultKind.USER, str(_OWNER))
+    secret = await coord.create(
+        session, user_id=_OWNER, permissions=set(), owner_vault=owner, name="x", secret_type="password", plaintext=b"v"
+    )
+    await session.commit()
+
+    # the owner may view who has access
+    report = await coord.describe_access(session, user_id=_OWNER, permissions=set(), secret_id=secret.id)
+    assert report.owner_vault == f"user:{_OWNER}"
+    # a stranger (non-admin, no grant on the owner vault) may not
+    with pytest.raises(SecretAccessError):
+        await coord.describe_access(session, user_id=uuid.uuid4(), permissions=set(), secret_id=secret.id)
+    # an admin may view any secret's access
+    admin_report = await coord.describe_access(
+        session, user_id=uuid.uuid4(), permissions={"admin:access"}, secret_id=secret.id
+    )
+    assert admin_report.secret_id == str(secret.id)
+    # missing secret → 404-equivalent
+    with pytest.raises(SecretNotFoundError):
+        await coord.describe_access(session, user_id=_OWNER, permissions=set(), secret_id=uuid.uuid4())


### PR DESCRIPTION
## Thinking Path
The connector-store cutover is at a safe code-pause (the contract flip needs production flag-verification first, which can't be coded ahead). The next decision-free, high-value piece is the PRD's headline audit requirement — **"organisation should be tree-level auditable: who has access to a secret"**. It's read-side (no cutover risk) and builds directly on the `secret_grants` + membership tables the unified store already holds — the exact reverse of the principal resolver (which goes user → vaults).

## What Changed
- **`services/secrets_access_audit.py`** — `describe_secret_access(session, secret_id)`: returns the owner vault + every grantee vault, each resolved to its **member users**:
  - `user:` → the user itself · `team:` → `team_memberships` · `role:` → `user_roles`→`roles` · `company:` → `llc_company_memberships` · `system`/`agent`/`service`/`node` → not user-expanded.
  - plus `effective_users` (the union of everyone who can reach it). Pure read — no decryption, no mutation.
- **`SecretsCoordinator.describe_access`** — authorizes via `authorize("read", owner_vault)`, so the owner (or anyone who may read the owner vault, or an admin) can view it; others get 403.
- **`GET /api/v2/secrets/{secret_id}/access`** — thin HTTP surface returning `SecretAccessOut`.

## Verification
- 4 Postgres tests (migration-gate): grantee→member resolution across user/role/company; unshared secret → owner only; missing secret → `None`; coordinator authz (owner allowed, stranger denied, admin allowed, missing → `SecretNotFoundError`). flake8/black clean; service/coordinator/API parse-check clean.
- Team member-resolution is implemented identically to the role path; its positive seed needs an `Organization` (ORM drift, same constraint as the resolver test) so it's covered structurally rather than seeded.

## Out of scope (follow-ups on #10088)
- The *"what service/agent depends on this secret"* dependency graph (needs a usage-reference source).
- A frontend access-transparency view.

## Model Used
Claude Opus 4.8

Part of #10088. Closes #10343.
