### PR TITLE
fix(deploy/frontend): relative same-origin API base, never emit 0.0.0.0 — fixes CSP-blocked GUI (#10348)

### DIFF
--- a/autobot-slm-backend/ansible/roles/frontend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/frontend/defaults/main.yml
@@ -28,7 +28,14 @@ nginx_http_port: 80
 # Backend runs on HTTPS port 8443 with SSL certificates
 # backend_host and backend_port are set dynamically by
 # _build_infra_vars() in setup_wizard.py at provisioning time
-frontend_backend_url: "{{ backend_protocol | default('https') }}://{{ backend_host | default(ansible_facts['default_ipv4'].address | default(ansible_host)) }}:{{ backend_port | default(8443) }}"
+#
+# #10348: default to EMPTY = relative same-origin /api. nginx serves the SPA and
+# proxies /api to the backend, so the browser must call the SAME origin it loaded
+# from — an absolute base (esp. one built from backend_host, which is the 0.0.0.0
+# BIND address) is a different origin that CSP `connect-src 'self'` blocks, making
+# the whole GUI unusable. Only set an absolute URL when the frontend is genuinely
+# served from a different origin than the backend (and add it to CSP connect-src).
+frontend_backend_url: ""
 
 # Issue #1098: Backend upstream health tracking
 backend_max_fails: 3

--- a/autobot-slm-backend/ansible/roles/frontend/templates/frontend.env.j2
+++ b/autobot-slm-backend/ansible/roles/frontend/templates/frontend.env.j2
@@ -4,10 +4,14 @@
 # Frontend Environment Configuration
 
 # Backend service configuration (ssot-config.ts expects these variables)
-VITE_BACKEND_HOST={{ backend_host | default(ansible_facts['default_ipv4'].address | default(ansible_host)) }}
+# #10348: never emit 0.0.0.0 (the backend BIND address) — it is not a valid
+# browser connect target. Fall back to the node's real IP; if that is unset too,
+# the frontend uses window.location.hostname at runtime.
+VITE_BACKEND_HOST={{ backend_host if (backend_host | default('')) not in ['', '0.0.0.0'] else (ansible_facts['default_ipv4'].address | default(ansible_host) | default('')) }}
 VITE_BACKEND_PORT={{ backend_port | default(8443) }}
 
-# Alternative API base URL (legacy compatibility)
+# API base URL — empty by default = relative same-origin /api via nginx
+# (frontend_backend_url in defaults/main.yml, #10348).
 VITE_API_BASE_URL={{ frontend_backend_url }}
 
 # Feature flags — UX visibility toggles for nav items in src/config/navItems.ts


### PR DESCRIPTION
## Thinking Path
Closes the keystone of #10348. The user-app GUI was fully unusable: `VITE_API_BASE_URL` baked to `https://0.0.0.0:8443` (backend BIND addr) → every `/api` call cross-origin → CSP `connect-src 'self'` blocked all of them.

## What Changed
- `frontend/defaults/main.yml`: `frontend_backend_url` defaults to **empty** = relative same-origin `/api` (nginx proxies it). Absolute only for split-host deploys.
- `frontend.env.j2`: `VITE_BACKEND_HOST` guards against `0.0.0.0` (node IP fallback, else runtime `window.location.hostname`).

## Verification (live)
Rebuilt the deployed frontend with the corrected `.env.production`: **zero** `0.0.0.0:8443` in dist, base resolves from `location.host`, and same-origin `/api/system/health` + `/api/frontend-config` → **200** via nginx :443. GUI loads after a hard-refresh.

## Remaining (tracked in #10348, follow-ups)
- `/api/frontend-config` still emits the bind host (no longer used for the API base).
- ApiClient double-prepends an absolute base for a few orchestrator/workflow callers.

## Model Used
Claude Opus 4.8