### PR TITLE
fix(secrets): deny vault access to deactivated/soft-deleted principals (#10346)

### DIFF
--- a/autobot-backend/services/secrets_access_audit.py
+++ b/autobot-backend/services/secrets_access_audit.py
@@ -111,6 +111,27 @@ async def describe_secret_access(session, secret_id) -> SecretAccessReport | Non
         members = await _members_of(session, ref)
         report.grants.append(VaultAccess(vault=grant.grantee, kind=ref.kind.value, id=ref.id, members=members))
         effective.update(members)
+
+    # Drop known-inactive/soft-deleted users — they no longer reach the vault (#10346), so the
+    # audit must not claim they have access. Unknown ids (non-user principals) are kept.
+    inactive = await _inactive_users(session, effective)
+    if inactive:
+        for grant_access in report.grants:
+            grant_access.members = [m for m in grant_access.members if m not in inactive]
+        effective -= inactive
     report.grants.sort(key=lambda v: v.vault)
     report.effective_users = sorted(effective)
     return report
+
+
+async def _inactive_users(session, ids: set[str]) -> set[str]:
+    """Subset of *ids* that are known, deactivated/soft-deleted users (``is_active = False``)."""
+    from sqlalchemy import select
+
+    from user_management.models.user import User
+
+    uuids = [u for u in (_as_uuid(i) for i in ids) if u is not None]
+    if not uuids:
+        return set()
+    rows = await session.execute(select(User.id).where(User.id.in_(uuids), User.is_active.is_(False)))
+    return {str(u) for u in rows.scalars()}

--- a/autobot-backend/services/secrets_authz.py
+++ b/autobot-backend/services/secrets_authz.py
@@ -57,9 +57,12 @@ class PrincipalFacts:
     role_names: frozenset[str] = frozenset()
     company_roles: Mapping[str, MembershipRole] = field(default_factory=dict)
     granted_permissions: frozenset[str] = frozenset()
+    active: bool = True  # False for a deactivated/soft-deleted principal → reaches no vault
 
     def accessible_vaults(self) -> set[VaultRef]:
         """Every vault this principal can reach (feeds ``read`` / ``list_for_vaults``)."""
+        if not self.active:
+            return set()
         vaults: set[VaultRef] = {VaultRef(VaultKind.USER, self.user_id)}
         if self.is_admin:
             vaults.add(VaultRef(VaultKind.SYSTEM))
@@ -74,6 +77,8 @@ class PrincipalFacts:
 
 def authorize(facts: PrincipalFacts, action: str, vault: VaultRef) -> bool:
     """True if *facts* permits *action* on *vault*."""
+    if not facts.active:  # deactivated/soft-deleted principal → denied everywhere
+        return False
     kind = vault.kind
     if kind == VaultKind.SYSTEM:
         return facts.is_admin

--- a/autobot-backend/services/secrets_authz_test.py
+++ b/autobot-backend/services/secrets_authz_test.py
@@ -112,3 +112,17 @@ class TestAuthorizeNode:
     def test_admin_only(self) -> None:
         assert authorize(_facts(is_admin=True), "read", VaultRef(VaultKind.NODE, "node1"))
         assert not authorize(_facts(), "read", VaultRef(VaultKind.NODE, "node1"))
+
+
+class TestInactivePrincipal:
+    def test_inactive_reaches_no_vault(self) -> None:
+        # active=False (deactivated/soft-deleted) → empty accessible vaults, denied everywhere (#10346)
+        facts = _facts(is_admin=True, team_ids=frozenset({"t1"}), active=False)
+        assert facts.accessible_vaults() == set()
+        assert not authorize(facts, "read", VaultRef(VaultKind.USER, "alice"))
+        assert not authorize(facts, "read", VaultRef(VaultKind.SYSTEM))
+        assert not authorize(facts, "read", VaultRef(VaultKind.TEAM, "t1"))
+
+    def test_active_default_unchanged(self) -> None:
+        assert _facts().active is True
+        assert VaultRef(VaultKind.USER, "alice") in _facts().accessible_vaults()

--- a/autobot-backend/services/secrets_principal_resolver.py
+++ b/autobot-backend/services/secrets_principal_resolver.py
@@ -27,6 +27,7 @@ from llc.models.membership import LLCCompanyMembership
 from services.secrets_authz import PrincipalFacts
 from user_management.models.role import Role, UserRole
 from user_management.models.team import TeamMembership
+from user_management.models.user import User
 
 #: Permission name that marks an instance administrator (grants system vault + any user vault).
 ADMIN_PERMISSION = "admin:access"
@@ -41,7 +42,16 @@ def _company_role(value: str) -> MembershipRole | None:
 
 
 async def resolve_principal_facts(session: AsyncSession, user_id: uuid.UUID, permissions: set[str]) -> PrincipalFacts:
-    """Assemble the principal's vault-access facts from RBAC + membership tables."""
+    """Assemble the principal's vault-access facts from RBAC + membership tables.
+
+    A caller that **exists but is deactivated/soft-deleted** resolves to inactive facts that
+    reach no vault — residual access from a still-valid session is denied (#10346). An absent
+    ``user_id`` (a non-User principal) keeps its existing permission-only behaviour.
+    """
+    is_active = (await session.execute(select(User.is_active).where(User.id == user_id))).scalar_one_or_none()
+    if is_active is False:
+        return PrincipalFacts(user_id=str(user_id), active=False)
+
     is_admin = ADMIN_PERMISSION in permissions
     granted = frozenset(p for p in permissions if p.startswith(_SECRETS_PREFIX))
 

--- a/autobot-backend/tests/migrations/test_secrets_access_audit.py
+++ b/autobot-backend/tests/migrations/test_secrets_access_audit.py
@@ -92,6 +92,36 @@ async def test_describe_missing_secret_returns_none(session):
     assert await describe_secret_access(session, uuid.uuid4()) is None
 
 
+async def test_audit_excludes_inactive_members(session):
+    # A deactivated user in a granted role must not be listed as having access (#10346); unknown
+    # ids (the owner here, not seeded as a User row) are kept.
+    from user_management.models.role import Role, UserRole
+    from user_management.models.user import User
+
+    dead = uuid.uuid4()
+    role_id = uuid.uuid4()
+    session.add(User(id=dead, email="dead@example.com", username="dead", is_active=False))
+    session.add(Role(id=role_id, name="ops"))
+    await session.flush()
+    session.add(UserRole(user_id=dead, role_id=role_id))
+
+    svc = UnifiedSecretsService(root_key=_ROOT)
+    owner = VaultRef(VaultKind.USER, str(_OWNER))
+    secret = await svc.create(
+        session, owner_vault=owner, name="x", secret_type="password", plaintext=b"v", created_by=_OWNER
+    )
+    await svc.share(
+        session, secret_id=secret.id, actor_vaults={owner}, grantee=VaultRef(VaultKind.ROLE, "ops"), created_by=_OWNER
+    )
+    await session.commit()
+
+    report = await describe_secret_access(session, secret.id)
+    by_vault = {g.vault: g for g in report.grants}
+    assert by_vault["role:ops"].members == []  # inactive role member excluded
+    assert str(dead) not in report.effective_users
+    assert str(_OWNER) in report.effective_users  # owner (unknown id) kept
+
+
 async def test_describe_unshared_secret_lists_only_owner(session):
     svc = UnifiedSecretsService(root_key=_ROOT)
     owner = VaultRef(VaultKind.USER, str(_OWNER))

--- a/autobot-backend/tests/migrations/test_secrets_principal_resolver.py
+++ b/autobot-backend/tests/migrations/test_secrets_principal_resolver.py
@@ -77,11 +77,31 @@ async def test_admin_permission_sets_is_admin(session):
 
 
 async def test_unknown_user_has_empty_memberships(session):
+    # An absent user_id (a non-User principal) keeps permission-only behaviour, stays active.
     facts = await resolve_principal_facts(session, uuid.uuid4(), {"secrets:user:read"})
+    assert facts.active is True
     assert facts.team_ids == frozenset()
     assert facts.role_names == frozenset()
     assert facts.company_roles == {}
     assert facts.granted_permissions == frozenset({"secrets:user:read"})
+
+
+async def test_deactivated_user_reaches_no_vault(session):
+    # A soft-deleted/deactivated user (exists, is_active=False) gets inactive facts → no access,
+    # even holding admin permission (residual access from a still-valid session is denied). #10346
+    from autobot_shared.secrets_vault import VaultKind, VaultRef
+    from services.secrets_authz import authorize
+    from user_management.models.user import User
+
+    dead = uuid.uuid4()
+    session.add(User(id=dead, email="dead@example.com", username="dead", is_active=False))
+    await session.commit()
+
+    facts = await resolve_principal_facts(session, dead, {"admin:access"})
+    assert facts.active is False
+    assert facts.accessible_vaults() == set()  # not even their own user vault
+    assert authorize(facts, "read", VaultRef(VaultKind.USER, str(dead))) is False
+    assert authorize(facts, "read", VaultRef(VaultKind.SYSTEM)) is False
 
 
 async def test_accessible_vaults_compose_from_resolved_facts(session):


### PR DESCRIPTION
## Thinking Path
Discovered during the Task 4 access-audit review (#10344): the principal resolver reads team/role/company memberships with **no soft-delete filter**, so a deactivated or soft-deleted user (`User.is_active=False`, which `User.soft_delete()` sets) holding a still-valid session keeps secret access — and the new access audit faithfully listed them as members. This closes that residual-access gap (a real, if low-probability, RBAC hole) at the resolver, with the audit kept consistent.

## What Changed
- **`services/secrets_authz.py`** — `PrincipalFacts` gains an `active: bool = True` flag. When `False`, `accessible_vaults()` returns the empty set and `authorize()` denies every action (the principal reaches no vault — not even its own user vault or, for an admin, the system vault).
- **`services/secrets_principal_resolver.py`** — short-circuits to `active=False` facts when the caller **exists but is `is_active=False`**. An **absent** `user_id` (a non-User principal: service token, etc.) keeps its prior permission-only behaviour, so this is a precise fix, not a blanket change.
- **`services/secrets_access_audit.py`** — `describe_secret_access` drops **known-inactive** users from grantee member lists + `effective_users` (unknown ids, e.g. a non-User owner, are kept).

## Verification
- **+2 authz unit tests** (`secrets_authz_test.py`): inactive facts → empty vaults + denied everywhere (even admin+team); active default unchanged. 23 pass.
- **+1 resolver PG test**: a deactivated user reaches no vault even holding `admin:access`.
- **+1 audit PG test**: an inactive role member is excluded; the (unknown-id) owner is kept.
- Existing resolver/audit tests updated (unknown user stays `active=True`). 11 PG tests pass; flake8/black clean.

## Model Used
Claude Opus 4.8

Closes #10346.
