### PR TITLE
dedup(#9859 Family G): extract shared chat CSS via @reference (#10306, retry)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -1219,30 +1219,15 @@ onMounted(async () => {
 })
 </script>
 
+<style scoped src="@/design-system/styles/chat-message-shared.css"></style>
+
 <style scoped>
 @reference "../../assets/tailwind.css";
+
 .message-wrapper {
   @apply rounded-lg shadow-sm border transition-all duration-200 relative;
   max-width: 85%;
   padding: var(--spacing-1-5) var(--spacing-2-5);
-}
-
-.message-wrapper:hover {
-  @apply shadow-md;
-}
-
-/* USER MESSAGES - Right side, blue theme */
-.message-wrapper.user-message {
-  @apply ml-auto mr-0;
-  background: var(--color-primary);
-  color: var(--text-inverse);
-  border-color: var(--color-primary);
-  border-radius: 18px 18px 4px 18px;
-}
-
-.message-wrapper.user-message .sender-name,
-.message-wrapper.user-message .message-time {
-  color: rgba(255, 255, 255, 0.85);
 }
 
 .message-wrapper.user-message .message-content {
@@ -1253,25 +1238,6 @@ onMounted(async () => {
 .message-wrapper.assistant-message {
   @apply bg-autobot-bg-tertiary text-autobot-text-primary border-autobot-border mr-auto ml-0;
   border-radius: 18px 18px 18px 4px;
-}
-
-.message-wrapper.assistant-message .sender-name {
-  @apply text-autobot-text-primary;
-}
-
-.message-wrapper.assistant-message .message-time {
-  @apply text-autobot-text-secondary;
-}
-
-.message-wrapper.assistant-message .message-content {
-  @apply text-autobot-text-primary;
-}
-
-/* SYSTEM MESSAGES - Centered, subtle */
-.message-wrapper.system-message {
-  @apply bg-autobot-bg-tertiary border-autobot-border mx-auto text-autobot-text-secondary;
-  max-width: 70%;
-  border-radius: var(--radius-xl);
 }
 
 /* MVA-2006: SUMMARY MESSAGES - Context compression indicator */
@@ -1579,40 +1545,12 @@ onMounted(async () => {
   color: var(--color-error);
 }
 
-.message-wrapper.sending {
-  @apply opacity-70;
-}
-
-.message-header {
-  @apply flex items-start justify-between mb-1;
-}
-
-.message-avatar {
-  @apply w-7 h-7 rounded-full flex items-center justify-center text-white text-xs font-semibold;
-}
-
-.message-avatar.user {
-  background: var(--color-primary);
-}
-
 .message-avatar.assistant {
   @apply bg-autobot-bg-secondary;
 }
 
 .message-avatar.system {
   @apply bg-autobot-bg-secondary;
-}
-
-.message-info {
-  @apply flex flex-col ml-1.5;
-}
-
-.sender-name {
-  @apply font-semibold text-xs;
-}
-
-.model-name {
-  @apply font-normal text-xs opacity-80 ml-1;
 }
 
 /* Issue #1310: Type badges for clear message identification */
@@ -1652,27 +1590,10 @@ onMounted(async () => {
   border: 1px solid rgba(20, 184, 166, 0.3);
 }
 
-.message-time {
-  @apply text-xs leading-tight;
-}
-
-.message-actions {
-  @apply flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity;
-}
-
 /* Button styling handled by BaseButton component */
 
 .message-status {
   @apply flex items-center gap-1.5 mb-1.5 text-xs;
-}
-
-.message-content {
-  @apply leading-snug text-sm;
-}
-
-.message-text {
-  @apply break-words;
-  line-height: 1.4;
 }
 
 /* User message code styling - lighter for blue background */
@@ -1682,32 +1603,16 @@ onMounted(async () => {
   color: var(--text-inverse);
 }
 
-.user-message .message-text :deep(pre) {
-  @apply p-3 rounded-lg overflow-x-auto my-1.5;
-  background: rgba(0, 0, 0, 0.2);
-  color: var(--text-inverse);
-}
-
-.user-message .message-text :deep(a) {
-  @apply hover:text-white underline;
-  color: rgba(255, 255, 255, 0.85);
-}
-
 /* Assistant message code styling - standard colors for light background */
 .assistant-message .message-text :deep(code) {
   @apply bg-autobot-bg-tertiary text-autobot-text-primary px-1.5 py-0.5 rounded text-xs font-mono;
-}
-
-.assistant-message .message-text :deep(pre) {
-  @apply p-3 rounded-lg overflow-x-auto my-1.5;
-  background: var(--code-bg);
-  color: var(--code-text);
 }
 
 .assistant-message .message-text :deep(a) {
   color: var(--text-link);
   text-decoration: underline;
 }
+
 .assistant-message .message-text :deep(a):hover {
   color: var(--text-link-hover);
 }
@@ -1718,22 +1623,9 @@ onMounted(async () => {
   border-color: rgba(255, 255, 255, 0.3);
 }
 
-.user-message .metadata-items {
-  @apply flex flex-wrap gap-1.5 text-xs;
-  color: rgba(255, 255, 255, 0.85);
-}
-
 /* Assistant message metadata - standard styling */
 .assistant-message .message-metadata {
   @apply mt-1.5 pt-1 border-t border-autobot-border;
-}
-
-.assistant-message .metadata-items {
-  @apply flex flex-wrap gap-1.5 text-xs text-autobot-text-secondary;
-}
-
-.metadata-item {
-  @apply flex items-center gap-1;
 }
 
 /* GH#8993: Thinking used badge */
@@ -1765,33 +1657,18 @@ onMounted(async () => {
   @apply text-xs text-autobot-text-muted;
 }
 
-.typing-indicator {
-  @apply flex items-center gap-1.5;
-}
-
 .typing-indicator.large {
   @apply py-3;
 }
 
-.typing-dots {
-  @apply flex gap-1;
-}
-
-.typing-dots span {
-  @apply w-1.5 h-1.5 bg-autobot-text-muted rounded-full animate-pulse;
-  animation-delay: calc(var(--index) * 0.2s);
-}
-
 .typing-dots span:nth-child(1) { --index: 0; }
+
 .typing-dots span:nth-child(2) { --index: 1; }
+
 .typing-dots span:nth-child(3) { --index: 2; }
 
 .typing-text {
   @apply text-xs text-autobot-text-muted;
-}
-
-.streaming-content {
-  @apply space-y-1.5;
 }
 
 /* Enhanced Typing Indicator */
@@ -1818,8 +1695,11 @@ onMounted(async () => {
 }
 
 .typing-dots-enhanced span:nth-child(1) { animation-delay: -0.32s; }
+
 .typing-dots-enhanced span:nth-child(2) { animation-delay: -0.16s; }
+
 .typing-dots-enhanced span:nth-child(3) { animation-delay: 0s; }
+
 .typing-dots-enhanced span:nth-child(4) { animation-delay: 0.16s; }
 
 @keyframes typingBounce {

--- a/autobot-frontend/src/components/chat/MessageItem.vue
+++ b/autobot-frontend/src/components/chat/MessageItem.vue
@@ -369,31 +369,16 @@ const formattedContent = computed(() => {
 })
 </script>
 
+<style scoped src="@/design-system/styles/chat-message-shared.css"></style>
+
 <style scoped>
 @reference "../../assets/tailwind.css";
+
 .message-wrapper {
   @apply rounded-lg shadow-sm border transition-all duration-200;
   max-width: 85%;
   padding: var(--spacing-1-5) var(--spacing-2-5);
   animation: slideInFromBottom 0.25s ease-out;
-}
-
-.message-wrapper:hover {
-  @apply shadow-md;
-}
-
-/* USER MESSAGES - Right side, blue theme */
-.message-wrapper.user-message {
-  @apply ml-auto mr-0;
-  background: var(--color-primary);
-  color: var(--text-inverse);
-  border-color: var(--color-primary);
-  border-radius: 18px 18px 4px 18px;
-}
-
-.message-wrapper.user-message .sender-name,
-.message-wrapper.user-message .message-time {
-  color: rgba(255, 255, 255, 0.85);
 }
 
 .message-wrapper.user-message .message-content {
@@ -406,45 +391,10 @@ const formattedContent = computed(() => {
   border-radius: 18px 18px 18px 4px;
 }
 
-.message-wrapper.assistant-message .sender-name {
-  @apply text-autobot-text-primary;
-}
-
-.message-wrapper.assistant-message .message-time {
-  @apply text-autobot-text-secondary;
-}
-
-.message-wrapper.assistant-message .message-content {
-  @apply text-autobot-text-primary;
-}
-
-/* SYSTEM MESSAGES - Centered, subtle */
-.message-wrapper.system-message {
-  @apply bg-autobot-bg-tertiary border-autobot-border mx-auto text-autobot-text-secondary;
-  max-width: 70%;
-  border-radius: var(--radius-xl);
-}
-
 .message-wrapper.error {
   background: var(--color-error-bg);
   border-color: var(--color-error-border);
   color: var(--color-error);
-}
-
-.message-wrapper.sending {
-  @apply opacity-70;
-}
-
-.message-header {
-  @apply flex items-start justify-between mb-1;
-}
-
-.message-avatar {
-  @apply w-7 h-7 rounded-full flex items-center justify-center text-white text-xs font-semibold;
-}
-
-.message-avatar.user {
-  background: var(--color-primary);
 }
 
 .message-avatar.assistant {
@@ -455,37 +405,8 @@ const formattedContent = computed(() => {
   @apply bg-autobot-text-muted;
 }
 
-.message-info {
-  @apply flex flex-col ml-1.5;
-}
-
-.sender-name {
-  @apply font-semibold text-xs;
-}
-
-.model-name {
-  @apply font-normal text-xs opacity-80 ml-1;
-}
-
-.message-time {
-  @apply text-xs leading-tight;
-}
-
-.message-actions {
-  @apply flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity;
-}
-
 .message-status-container {
   @apply mt-1.5 flex justify-end;
-}
-
-.message-content {
-  @apply leading-snug text-sm;
-}
-
-.message-text {
-  @apply break-words;
-  line-height: 1.4;
 }
 
 /* User message code styling */
@@ -495,32 +416,16 @@ const formattedContent = computed(() => {
   color: var(--text-inverse);
 }
 
-.user-message .message-text :deep(pre) {
-  @apply p-3 rounded-lg overflow-x-auto my-1.5;
-  background: rgba(0, 0, 0, 0.2);
-  color: var(--text-inverse);
-}
-
-.user-message .message-text :deep(a) {
-  @apply hover:text-white underline;
-  color: rgba(255, 255, 255, 0.85);
-}
-
 /* Assistant message code styling */
 .assistant-message .message-text :deep(code) {
   @apply bg-autobot-bg-tertiary text-autobot-text-primary px-1.5 py-0.5 rounded text-xs font-mono;
-}
-
-.assistant-message .message-text :deep(pre) {
-  @apply p-3 rounded-lg overflow-x-auto my-1.5;
-  background: var(--code-bg);
-  color: var(--code-text);
 }
 
 .assistant-message .message-text :deep(a) {
   @apply text-autobot-text-link hover:text-autobot-text-link underline;
   opacity: 0.9;
 }
+
 .assistant-message .message-text :deep(a):hover {
   opacity: 1;
 }
@@ -531,21 +436,8 @@ const formattedContent = computed(() => {
   border-color: rgba(255, 255, 255, 0.3);
 }
 
-.user-message .metadata-items {
-  @apply flex flex-wrap gap-1.5 text-xs;
-  color: rgba(255, 255, 255, 0.85);
-}
-
 .assistant-message .message-metadata {
   @apply mt-1.5 pt-1 border-t border-autobot-border;
-}
-
-.assistant-message .metadata-items {
-  @apply flex flex-wrap gap-1.5 text-xs text-autobot-text-secondary;
-}
-
-.metadata-item {
-  @apply flex items-center gap-1;
 }
 
 .metadata-item.thinking-badge {
@@ -553,29 +445,14 @@ const formattedContent = computed(() => {
   color: var(--color-primary);
 }
 
-.streaming-content {
-  @apply space-y-1.5;
-}
-
-.typing-indicator {
-  @apply flex items-center gap-1.5;
-}
-
-.typing-dots {
-  @apply flex gap-1;
-}
-
-.typing-dots span {
-  @apply w-1.5 h-1.5 bg-autobot-text-muted rounded-full animate-pulse;
-  animation-delay: calc(var(--index) * 0.2s);
-}
-
 .typing-dots span:nth-child(1) {
   --index: 0;
 }
+
 .typing-dots span:nth-child(2) {
   --index: 1;
 }
+
 .typing-dots span:nth-child(3) {
   --index: 2;
 }

--- a/autobot-frontend/src/design-system/styles/chat-message-shared.css
+++ b/autobot-frontend/src/design-system/styles/chat-message-shared.css
@@ -1,0 +1,142 @@
+/* Copyright 2025-2026 mrveiss
+ * SPDX-License-Identifier: Apache-2.0
+ * AutoBot - AI-Powered Automation Platform
+ * Author: mrveiss
+ *
+ * Shared scoped styles for the chat message components (#10306, part of #9859).
+ * Byte-identical scoped-CSS rule blocks extracted from ChatMessages.vue and
+ * MessageItem.vue. @reference imports the Tailwind theme so the @apply
+ * directives resolve here exactly as they did inline; selectors are disjoint
+ * from each component's remaining rules ⇒ order-independent ⇒ identical output.
+ */
+
+@reference "../../assets/tailwind.css";
+
+.message-wrapper:hover {
+  @apply shadow-md;
+}
+
+/* USER MESSAGES - Right side, blue theme */
+.message-wrapper.user-message {
+  @apply ml-auto mr-0;
+  background: var(--color-primary);
+  color: var(--text-inverse);
+  border-color: var(--color-primary);
+  border-radius: 18px 18px 4px 18px;
+}
+
+.message-wrapper.user-message .sender-name,
+.message-wrapper.user-message .message-time {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.message-wrapper.assistant-message .sender-name {
+  @apply text-autobot-text-primary;
+}
+
+.message-wrapper.assistant-message .message-time {
+  @apply text-autobot-text-secondary;
+}
+
+.message-wrapper.assistant-message .message-content {
+  @apply text-autobot-text-primary;
+}
+
+/* SYSTEM MESSAGES - Centered, subtle */
+.message-wrapper.system-message {
+  @apply bg-autobot-bg-tertiary border-autobot-border mx-auto text-autobot-text-secondary;
+  max-width: 70%;
+  border-radius: var(--radius-xl);
+}
+
+.message-wrapper.sending {
+  @apply opacity-70;
+}
+
+.message-header {
+  @apply flex items-start justify-between mb-1;
+}
+
+.message-avatar {
+  @apply w-7 h-7 rounded-full flex items-center justify-center text-white text-xs font-semibold;
+}
+
+.message-avatar.user {
+  background: var(--color-primary);
+}
+
+.message-info {
+  @apply flex flex-col ml-1.5;
+}
+
+.sender-name {
+  @apply font-semibold text-xs;
+}
+
+.model-name {
+  @apply font-normal text-xs opacity-80 ml-1;
+}
+
+.message-time {
+  @apply text-xs leading-tight;
+}
+
+.message-actions {
+  @apply flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity;
+}
+
+.message-content {
+  @apply leading-snug text-sm;
+}
+
+.message-text {
+  @apply break-words;
+  line-height: 1.4;
+}
+
+.user-message .message-text :deep(pre) {
+  @apply p-3 rounded-lg overflow-x-auto my-1.5;
+  background: rgba(0, 0, 0, 0.2);
+  color: var(--text-inverse);
+}
+
+.user-message .message-text :deep(a) {
+  @apply hover:text-white underline;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.assistant-message .message-text :deep(pre) {
+  @apply p-3 rounded-lg overflow-x-auto my-1.5;
+  background: var(--code-bg);
+  color: var(--code-text);
+}
+
+.user-message .metadata-items {
+  @apply flex flex-wrap gap-1.5 text-xs;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.assistant-message .metadata-items {
+  @apply flex flex-wrap gap-1.5 text-xs text-autobot-text-secondary;
+}
+
+.metadata-item {
+  @apply flex items-center gap-1;
+}
+
+.typing-indicator {
+  @apply flex items-center gap-1.5;
+}
+
+.typing-dots {
+  @apply flex gap-1;
+}
+
+.typing-dots span {
+  @apply w-1.5 h-1.5 bg-autobot-text-muted rounded-full animate-pulse;
+  animation-delay: calc(var(--index) * 0.2s);
+}
+
+.streaming-content {
+  @apply space-y-1.5;
+}


### PR DESCRIPTION
## Thinking Path
Completes the previously-deferred chat family (#9859 Wave 2). The first attempt extracted the 28 shared blocks bare and broke the build — 26 are Tailwind `@apply` that need theme context. This retry adds the repo's sanctioned `@reference "../../assets/tailwind.css"` to the shared sheet so `@apply` resolves there exactly as inline.

## What Changed
- Extracted 28 byte-identical shared blocks (~106 lines) from `ChatMessages.vue` + `MessageItem.vue` → `chat-message-shared.css`, with `@reference` at the top (and each component keeps `@reference` on its remaining inline `<style scoped>`).
- Net **−101 lines**.

## Why this is safe (build-error-only failure mode)
- `@apply` either expands to the same utility CSS (via the same `@reference` theme) or it errors at build — there is **no silent-wrong-render path**. So the frontend build (smoke-test) is a definitive gate.
- Selectors are disjoint per file ⇒ order-independent. Verified the effective rule-set unchanged vs `HEAD` (197/53 rules, 0 missing/changed/extra).

## Verification / merge gate
- ⛔ **Will NOT merge unless smoke-test (frontend build) passes** — that proves `@reference`+`@apply` resolves in the imported scoped sheet and the output compiles identically.

Closes #10306 · part of #9859 · part of #9921

## Model Used
claude-opus-4-8