### PR TITLE
fix(chat): add get_session — fixes thinking-preferences 500 (#10352)

### DIFF
--- a/autobot-backend/chat_history/session.py
+++ b/autobot-backend/chat_history/session.py
@@ -311,6 +311,17 @@ class SessionMixin:
 
         return cleaned_messages
 
+    async def get_session(self, session_id: str) -> Dict[str, Any] | None:
+        """Return the full decrypted session document, or None if not found (#10352).
+
+        Unlike :meth:`load_session` (which returns only the messages list), this
+        returns the entire session dict — including the session-level ``metadata``
+        sub-dict — so callers can read settings such as ``thinking_preferences``
+        (#8993). Not a hot path, so it loads from file directly.
+        """
+        self._sanitize_session_id(session_id)
+        return await self._load_session_from_file(session_id)
+
     async def _warm_cache_safe(self, session_id: str, chat_data: Dict[str, Any]) -> None:
         """Warm up Redis cache safely. (Issue #315 - extracted)"""
         if not self.redis_client:


### PR DESCRIPTION
## Thinking Path
Final #10352 item (users-router #10358 + font-src #10360 already merged). Live `backend-error.log` showed `AttributeError: 'ChatHistoryManager' object has no attribute 'get_session'` — `get_thinking_preferences` called a method that doesn't exist, 500ing `GET /api/sessions/{id}/thinking-preferences` on every chat load.

## What Changed
Added public `SessionMixin.get_session()` returning the full decrypted session dict (incl. `metadata`), wrapping `_load_session_from_file`. Distinct from `load_session()` (messages-only). The PUT handler's `update_session_metadata` already existed.

## Verification
Root cause captured live in `backend-error.log`; `py_compile` clean. Handler's `session_data.get("metadata", {})` now operates on the real session dict.

## Model Used
Claude Opus 4.8