### PR TITLE
fix(slm-ui): handle 401 in code-sync + updates pollers — stop the 401 flood (#10369)

### DIFF
--- a/autobot-slm-frontend/src/composables/useCodeSync.ts
+++ b/autobot-slm-frontend/src/composables/useCodeSync.ts
@@ -15,6 +15,7 @@ import axios, { type AxiosInstance } from 'axios'
 import { useRoles, type Role, type SyncResult } from './useRoles'
 import { formatCommitHash } from '@/utils/commitHashUtils'
 import { getSlmApiBase } from '@/config/ssot-config'
+import { useAuthStore } from '@/stores/auth'
 
 // SLM Admin uses the local SLM backend API
 const API_BASE = getSlmApiBase()
@@ -213,6 +214,8 @@ export interface UpdateAllJob {
 // =============================================================================
 
 export function useCodeSync() {
+  const authStore = useAuthStore()
+
   // Create axios client
   const client: AxiosInstance = axios.create({
     baseURL: API_BASE,
@@ -229,6 +232,18 @@ export function useCodeSync() {
     }
     return config
   })
+
+  // #10369 — without a 401 handler an expired/invalid token makes the status
+  // poller spam 401s forever; log out so the UI redirects to login instead.
+  client.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      if (error.response?.status === 401) {
+        authStore.logout()
+      }
+      return Promise.reject(error)
+    }
+  )
 
   // Initialize roles composable (Issue #779)
   const rolesComposable = useRoles()

--- a/autobot-slm-frontend/src/composables/useSystemUpdates.ts
+++ b/autobot-slm-frontend/src/composables/useSystemUpdates.ts
@@ -13,6 +13,7 @@
 import { ref, computed, readonly } from 'vue'
 import axios, { type AxiosInstance } from 'axios'
 import { getSlmApiBase } from '@/config/ssot-config'
+import { useAuthStore } from '@/stores/auth'
 
 const API_BASE = getSlmApiBase()
 
@@ -84,6 +85,8 @@ export interface UpdateJob {
 // =============================================================================
 
 export function useSystemUpdates() {
+  const authStore = useAuthStore()
+
   const client: AxiosInstance = axios.create({
     baseURL: API_BASE,
     headers: { 'Content-Type': 'application/json' },
@@ -96,6 +99,18 @@ export function useSystemUpdates() {
     }
     return config
   })
+
+  // #10369 — without a 401 handler an expired/invalid token makes the badge
+  // poller spam 401s forever; log out so the UI redirects to login instead.
+  client.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      if (error.response?.status === 401) {
+        authStore.logout()
+      }
+      return Promise.reject(error)
+    }
+  )
 
   // ===========================================================================
   // Reactive State


### PR DESCRIPTION
## Thinking Path
Live SLM console flooded with hundreds of `/slm/api/code-sync/status` + `/slm/api/updates/summary` **401s**. `useCodeSync`/`useSystemUpdates` attach a Bearer token (request interceptor) but have **no response interceptor**, so an invalid/expired token (e.g. the SLM signing key rotated across redeploys) → every poll 401s → consuming views keep polling → flood. `useSecretsApi` already does it right.

## What Changed
Added the `useSecretsApi` 401 response-interceptor pattern (`authStore.logout()` on 401) to both composables + imported `useAuthStore`. Expired token now redirects to login instead of spamming.

## Verification
Confirmed live: unauth `GET /slm/api/{updates/summary,code-sync/status}` → 401; neither composable had `interceptors.response`. Both now do (grep-verified). Immediate workaround for the user: re-login (current token invalid).

## Model Used
Claude Opus 4.8