### PR TITLE
feat(llc): aggregate card enrichment for Portfolio/Program/Project browsers + velocity sparkline (#10232)

### DIFF
--- a/autobot-backend/llc/api/sprints.py
+++ b/autobot-backend/llc/api/sprints.py
@@ -32,11 +32,11 @@ Routes:
 
 import uuid
 from datetime import date, datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.user_management.dependencies import get_current_user, require_org_context
@@ -45,7 +45,7 @@ from llc.deps import get_session
 from user_management.services import TenantContext
 
 from ..kb.collections import KbCollectionManager
-from ..models.enums import SprintStatus, WorkItemRelationType
+from ..models.enums import SprintStatus, WorkItemRelationType, WorkItemStatus
 from ..models.sprint import LLCPortfolio, LLCProgram, LLCProject, LLCSprint
 from ..models.work_item import LLCWorkItem, LLCWorkItemRelation
 from ..services.approval import ApprovalNotFoundError, ApprovalService, ApprovalStateError
@@ -84,6 +84,8 @@ class PortfolioResponse(BaseModel):
     status: str
     created_at: datetime
     updated_at: datetime
+    # Card enrichment (#10232) — populated by list endpoints; 0 on detail reads.
+    program_count: int = 0
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -111,6 +113,8 @@ class ProgramResponse(BaseModel):
     status: str
     created_at: datetime
     updated_at: datetime
+    # Card enrichment (#10232) — populated by list endpoints; 0 on detail reads.
+    project_count: int = 0
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -153,6 +157,9 @@ class ProjectResponse(BaseModel):
     auto_rollover: Optional[bool]
     created_at: datetime
     updated_at: datetime
+    # Card enrichment (#10232) — populated by list endpoints; defaults on detail reads.
+    open_work_item_count: int = 0
+    active_sprint_name: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -210,18 +217,89 @@ class SprintCloseRequest(BaseModel):
 # ------------------------------------------------------------------ Portfolio routes
 
 
+# ---------------------------------------------------------------------------
+# Card-enrichment aggregation helpers (#10232)
+#
+# Each returns a {parent_id: value} map computed with a single grouped query so
+# list endpoints stay O(1) queries — never N+1 per card.
+# ---------------------------------------------------------------------------
+_OPEN_WORK_ITEM_STATUSES = [s.value for s in WorkItemStatus if s not in (WorkItemStatus.DONE, WorkItemStatus.CANCELLED)]
+
+
+async def _count_map(session: AsyncSession, id_col, count_col, ids: List[uuid.UUID]) -> Dict[uuid.UUID, int]:
+    if not ids:
+        return {}
+    rows = (await session.execute(select(id_col, func.count(count_col)).where(id_col.in_(ids)).group_by(id_col))).all()
+    return {key: cnt for key, cnt in rows}
+
+
+async def _open_work_item_counts(session: AsyncSession, project_ids: List[uuid.UUID]) -> Dict[uuid.UUID, int]:
+    if not project_ids:
+        return {}
+    rows = (
+        await session.execute(
+            select(LLCWorkItem.project_id, func.count(LLCWorkItem.id))
+            .where(LLCWorkItem.project_id.in_(project_ids), LLCWorkItem.status.in_(_OPEN_WORK_ITEM_STATUSES))
+            .group_by(LLCWorkItem.project_id)
+        )
+    ).all()
+    return {pid: cnt for pid, cnt in rows}
+
+
+async def _active_sprint_names(session: AsyncSession, project_ids: List[uuid.UUID]) -> Dict[uuid.UUID, str]:
+    if not project_ids:
+        return {}
+    rows = (
+        await session.execute(
+            select(LLCSprint.project_id, LLCSprint.name).where(
+                LLCSprint.project_id.in_(project_ids), LLCSprint.status == SprintStatus.ACTIVE.value
+            )
+        )
+    ).all()
+    names: Dict[uuid.UUID, str] = {}
+    for pid, name in rows:  # first active sprint per project (typically one)
+        names.setdefault(pid, name)
+    return names
+
+
+def _enrich(model_cls, orm_obj, **extra):
+    """Build a response model from an ORM row, then graft the aggregate fields."""
+    resp = model_cls.model_validate(orm_obj)
+    for key, value in extra.items():
+        setattr(resp, key, value)
+    return resp
+
+
+async def _enrich_projects(session: AsyncSession, projects: List[LLCProject]) -> List[ProjectResponse]:
+    """Attach open-work-item counts + the active sprint name to project cards."""
+    pids = [p.id for p in projects]
+    open_counts = await _open_work_item_counts(session, pids)
+    active = await _active_sprint_names(session, pids)
+    return [
+        _enrich(
+            ProjectResponse,
+            p,
+            open_work_item_count=open_counts.get(p.id, 0),
+            active_sprint_name=active.get(p.id),
+        )
+        for p in projects
+    ]
+
+
 @router.get("/companies/{company_id}/portfolios", response_model=List[PortfolioResponse])
 async def list_portfolios(
     company_id: uuid.UUID,
     session: AsyncSession = Depends(get_session),
     _current_user: dict = Depends(get_current_user),
     ctx: TenantContext = Depends(require_org_context),
-) -> List[LLCPortfolio]:
+) -> List[PortfolioResponse]:
     # IDOR guard (#10148): reject callers accessing another company's portfolios.
     if str(company_id) != str(ctx.org_id):
         raise HTTPException(status_code=404, detail="Company not found")
     result = await session.execute(select(LLCPortfolio).where(LLCPortfolio.company_id == company_id))
-    return list(result.scalars().all())
+    portfolios = list(result.scalars().all())
+    counts = await _count_map(session, LLCProgram.portfolio_id, LLCProgram.id, [p.id for p in portfolios])
+    return [_enrich(PortfolioResponse, p, program_count=counts.get(p.id, 0)) for p in portfolios]
 
 
 @router.post("/companies/{company_id}/portfolios", response_model=PortfolioResponse, status_code=201)
@@ -302,13 +380,15 @@ async def list_programs(
     session: AsyncSession = Depends(get_session),
     _current_user: dict = Depends(get_current_user),
     ctx: TenantContext = Depends(require_org_context),
-) -> List[LLCProgram]:
+) -> List[ProgramResponse]:
     # IDOR guard (#10148): verify the portfolio belongs to the caller's org before listing.
     pf_row = (await session.execute(select(LLCPortfolio).where(LLCPortfolio.id == portfolio_id))).scalar_one_or_none()
     if pf_row is None or str(pf_row.company_id) != str(ctx.org_id):
         raise HTTPException(status_code=404, detail="Portfolio not found")
     result = await session.execute(select(LLCProgram).where(LLCProgram.portfolio_id == portfolio_id))
-    return list(result.scalars().all())
+    programs = list(result.scalars().all())
+    counts = await _count_map(session, LLCProject.program_id, LLCProject.id, [p.id for p in programs])
+    return [_enrich(ProgramResponse, p, project_count=counts.get(p.id, 0)) for p in programs]
 
 
 @router.post("/portfolios/{portfolio_id}/programs", response_model=ProgramResponse, status_code=201)
@@ -396,13 +476,13 @@ async def list_projects(
     session: AsyncSession = Depends(get_session),
     _current_user: dict = Depends(get_current_user),
     ctx: TenantContext = Depends(require_org_context),
-) -> List[LLCProject]:
+) -> List[ProjectResponse]:
     # IDOR guard (#10148): verify the program belongs to the caller's org before listing.
     prog = (await session.execute(select(LLCProgram).where(LLCProgram.id == program_id))).scalar_one_or_none()
     if prog is None or str(prog.company_id) != str(ctx.org_id):
         raise HTTPException(status_code=404, detail="Program not found")
     result = await session.execute(select(LLCProject).where(LLCProject.program_id == program_id))
-    return list(result.scalars().all())
+    return await _enrich_projects(session, list(result.scalars().all()))
 
 
 @router.get("/companies/{company_id}/projects", response_model=List[ProjectResponse])
@@ -411,7 +491,7 @@ async def list_company_projects(
     session: AsyncSession = Depends(get_session),
     _current_user: dict = Depends(get_current_user),
     ctx: TenantContext = Depends(require_org_context),
-) -> List[LLCProject]:
+) -> List[ProjectResponse]:
     """Flat list of all projects in a company (GH#9020 — drives the timeline
     project picker; also reused by the project browser)."""
     # IDOR guard (#10148): reject callers accessing another company's projects.
@@ -420,7 +500,7 @@ async def list_company_projects(
     result = await session.execute(
         select(LLCProject).where(LLCProject.company_id == company_id).order_by(LLCProject.name)
     )
-    return list(result.scalars().all())
+    return await _enrich_projects(session, list(result.scalars().all()))
 
 
 @router.post("/programs/{program_id}/projects", response_model=ProjectResponse, status_code=201)

--- a/autobot-backend/llc/tests/test_sprints_enrichment.py
+++ b/autobot-backend/llc/tests/test_sprints_enrichment.py
@@ -1,0 +1,167 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Card-enrichment aggregation tests for the browser list endpoints (GH#10232).
+
+Asserts that list_portfolios / list_programs / list_company_projects attach the
+aggregate counts (program_count, project_count, open_work_item_count,
+active_sprint_name) to each card via a single grouped query (no N+1).
+"""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_USER_ID = uuid.UUID("66666666-6666-6666-6666-666666666666")
+_NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _portfolio(company_id):
+    m = MagicMock()
+    m.id = uuid.uuid4()
+    m.company_id = company_id
+    m.name = "PF"
+    m.description = None
+    m.status = "active"
+    m.created_at = _NOW
+    m.updated_at = _NOW
+    # Real ORM rows lack the enrichment fields (Pydantic uses the default); a
+    # MagicMock auto-vivifies every attr, so pin them to valid defaults.
+    m.program_count = 0
+    return m
+
+
+def _program(company_id):
+    m = _portfolio(company_id)
+    m.portfolio_id = uuid.uuid4()
+    m.project_count = 0
+    return m
+
+
+def _project(company_id):
+    m = _program(company_id)
+    m.program_id = uuid.uuid4()
+    m.goal_id = None
+    m.lead_agent_id = None
+    m.lead_user_id = None
+    m.target_date = None
+    m.auto_rollover = None
+    m.open_work_item_count = 0
+    m.active_sprint_name = None
+    return m
+
+
+def _client(org, entities, *agg_rows):
+    """Mount the sprints router with a call-sequenced session.execute:
+    call 0 → the entity query (scalars().all()); calls 1.. → the grouped
+    aggregate queries (.all() → list of tuples), one per *agg_rows*.
+    """
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.sprints import router  # noqa: PLC0415
+    from llc.deps import get_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(router)
+
+    calls = {"n": 0}
+
+    async def _execute(stmt, *a, **kw):
+        result = MagicMock()
+        idx = calls["n"]
+        calls["n"] += 1
+        if idx == 0:
+            result.scalars.return_value.all.return_value = entities
+        else:
+            result.all.return_value = list(agg_rows[idx - 1])
+        return result
+
+    session = AsyncMock()
+    session.execute = _execute
+
+    async def _fake_session():
+        yield session
+
+    app.dependency_overrides[get_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_USER_ID)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=uuid.UUID(org), user_id=_USER_ID, is_platform_admin=False
+    )
+    return TestClient(app)
+
+
+def test_list_portfolios_attaches_program_count():
+    org = str(uuid.uuid4())
+    p1, p2 = _portfolio(org), _portfolio(org)
+    client = _client(org, [p1, p2], [(p1.id, 3)])  # p2 absent → 0
+    resp = client.get(f"/companies/{org}/portfolios")
+    assert resp.status_code == 200
+    by_id = {c["id"]: c for c in resp.json()}
+    assert by_id[str(p1.id)]["program_count"] == 3
+    assert by_id[str(p2.id)]["program_count"] == 0
+
+
+def test_list_programs_attaches_project_count():
+    org = str(uuid.uuid4())
+    pf_id = uuid.uuid4()
+    g1 = _program(org)
+    # portfolio ownership check is call 0 (scalar_one_or_none); entity list is call 1.
+    # Re-wire: the endpoint runs the IDOR portfolio fetch first, so sequence differs.
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.sprints import router  # noqa: PLC0415
+    from llc.deps import get_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(router)
+    pf = _portfolio(org)
+
+    calls = {"n": 0}
+
+    async def _execute(stmt, *a, **kw):
+        result = MagicMock()
+        idx = calls["n"]
+        calls["n"] += 1
+        if idx == 0:  # IDOR portfolio fetch
+            result.scalar_one_or_none.return_value = pf
+        elif idx == 1:  # program list
+            result.scalars.return_value.all.return_value = [g1]
+        else:  # project_count aggregate
+            result.all.return_value = [(g1.id, 7)]
+        return result
+
+    session = AsyncMock()
+    session.execute = _execute
+
+    async def _fake_session():
+        yield session
+
+    app.dependency_overrides[get_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_USER_ID)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=uuid.UUID(org), user_id=_USER_ID, is_platform_admin=False
+    )
+    client = TestClient(app)
+    resp = client.get(f"/portfolios/{pf_id}/programs")
+    assert resp.status_code == 200
+    assert resp.json()[0]["project_count"] == 7
+
+
+def test_list_company_projects_attaches_open_count_and_active_sprint():
+    org = str(uuid.uuid4())
+    pr1, pr2 = _project(org), _project(org)
+    client = _client(
+        org,
+        [pr1, pr2],
+        [(pr1.id, 5)],  # open work items: pr1=5, pr2=0
+        [(pr1.id, "Sprint 7")],  # active sprint: pr1 only
+    )
+    resp = client.get(f"/companies/{org}/projects")
+    assert resp.status_code == 200
+    by_id = {c["id"]: c for c in resp.json()}
+    assert by_id[str(pr1.id)]["open_work_item_count"] == 5
+    assert by_id[str(pr1.id)]["active_sprint_name"] == "Sprint 7"
+    assert by_id[str(pr2.id)]["open_work_item_count"] == 0
+    assert by_id[str(pr2.id)]["active_sprint_name"] is None

--- a/autobot-frontend/src/components/llc/Sparkline.vue
+++ b/autobot-frontend/src/components/llc/Sparkline.vue
@@ -1,0 +1,67 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2025-2026 mrveiss -->
+<!-- Author: mrveiss -->
+<!--
+  Sparkline (GH#10232) — a tiny inline SVG trend line for card metrics
+  (e.g. project velocity history). Renders nothing when fewer than two points
+  are available, so cards stay clean for new/empty projects.
+-->
+<template>
+  <svg
+    v-if="points.length >= 2"
+    class="sparkline"
+    :width="width"
+    :height="height"
+    :viewBox="`0 0 ${width} ${height}`"
+    role="img"
+    :aria-label="ariaLabel"
+    preserveAspectRatio="none"
+  >
+    <polyline :points="polyline" fill="none" :stroke="stroke" stroke-width="1.5" stroke-linejoin="round" />
+  </svg>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    points: number[]
+    width?: number
+    height?: number
+    stroke?: string
+    ariaLabel?: string
+  }>(),
+  {
+    width: 96,
+    height: 24,
+    stroke: 'var(--color-accent, #c4651a)',
+    ariaLabel: 'trend',
+  },
+)
+
+// Map the values into SVG coordinates, normalising the y-axis to the observed
+// min/max so a flat series renders as a centred horizontal line (no divide-by-zero).
+const polyline = computed<string>(() => {
+  const vals = props.points
+  const min = Math.min(...vals)
+  const max = Math.max(...vals)
+  const span = max - min || 1
+  const stepX = props.width / (vals.length - 1)
+  const pad = 2
+  const usableH = props.height - pad * 2
+  return vals
+    .map((v, i) => {
+      const x = i * stepX
+      const y = pad + usableH - ((v - min) / span) * usableH
+      return `${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(' ')
+})
+</script>
+
+<style scoped>
+.sparkline {
+  display: block;
+}
+</style>

--- a/autobot-frontend/src/components/llc/__tests__/Sparkline.test.ts
+++ b/autobot-frontend/src/components/llc/__tests__/Sparkline.test.ts
@@ -1,0 +1,27 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// GH#10232: Sparkline renders an SVG polyline for >=2 points, nothing otherwise.
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import Sparkline from '../Sparkline.vue'
+
+describe('Sparkline (GH#10232)', () => {
+  it('renders nothing for fewer than two points', () => {
+    expect(mount(Sparkline, { props: { points: [] } }).find('svg').exists()).toBe(false)
+    expect(mount(Sparkline, { props: { points: [5] } }).find('svg').exists()).toBe(false)
+  })
+
+  it('renders a polyline with one coordinate per point', () => {
+    const wrapper = mount(Sparkline, { props: { points: [1, 3, 2, 4] } })
+    const poly = wrapper.find('polyline')
+    expect(poly.exists()).toBe(true)
+    expect(poly.attributes('points')!.trim().split(/\s+/)).toHaveLength(4)
+  })
+
+  it('keeps a flat series finite (no divide-by-zero)', () => {
+    const poly = mount(Sparkline, { props: { points: [2, 2, 2] } }).find('polyline')
+    expect(poly.attributes('points')).not.toMatch(/NaN|Infinity/)
+  })
+})

--- a/autobot-frontend/src/views/llc/PortfolioBrowserView.vue
+++ b/autobot-frontend/src/views/llc/PortfolioBrowserView.vue
@@ -31,7 +31,10 @@
           <span class="status-badge" :class="`status-${p.status}`">{{ p.status }}</span>
         </div>
         <p v-if="p.description" class="card-desc">{{ p.description }}</p>
-        <p class="card-meta">Created {{ formatDate(p.created_at) }}</p>
+        <p class="card-meta">
+          {{ p.program_count }} {{ p.program_count === 1 ? 'program' : 'programs' }}
+          · Created {{ formatDate(p.created_at) }}
+        </p>
       </button>
     </div>
   </div>
@@ -52,6 +55,7 @@ interface PortfolioResponse {
   status: string
   created_at: string
   updated_at: string
+  program_count: number
 }
 
 const logger = createLogger('PortfolioBrowserView')

--- a/autobot-frontend/src/views/llc/ProgramBrowserView.vue
+++ b/autobot-frontend/src/views/llc/ProgramBrowserView.vue
@@ -31,6 +31,7 @@
           <span class="status-badge" :class="`status-${p.status}`">{{ p.status }}</span>
         </div>
         <p v-if="p.description" class="card-desc">{{ p.description }}</p>
+        <p class="card-meta">{{ p.project_count }} {{ p.project_count === 1 ? 'project' : 'projects' }}</p>
       </button>
     </div>
   </div>
@@ -52,6 +53,7 @@ interface ProgramResponse {
   status: string
   created_at: string
   updated_at: string
+  project_count: number
 }
 
 const logger = createLogger('ProgramBrowserView')
@@ -172,6 +174,12 @@ onMounted(loadPrograms)
   line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+
+.card-meta {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary, #9ca3af);
+  margin: 0;
 }
 
 .status-badge {

--- a/autobot-frontend/src/views/llc/ProjectBrowserView.vue
+++ b/autobot-frontend/src/views/llc/ProjectBrowserView.vue
@@ -25,6 +25,14 @@
           <span class="status-badge" :class="`status-${p.status}`">{{ p.status }}</span>
         </div>
         <p v-if="p.description" class="card-desc">{{ p.description }}</p>
+        <div class="card-stats">
+          <span class="stat">{{ p.open_work_item_count }} open</span>
+          <span class="stat">{{ p.active_sprint_name || 'No active sprint' }}</span>
+        </div>
+        <div v-if="velocityFor(p.id).length >= 2" class="card-velocity">
+          <span class="velocity-label">Velocity</span>
+          <Sparkline :points="velocityFor(p.id)" :aria-label="`Velocity for ${p.name}`" />
+        </div>
         <p class="card-meta">Target {{ formatDate(p.target_date) }}</p>
         <div class="card-actions">
           <RouterLink class="action-link" :to="`/llc/companies/${companyId}/backlog`">
@@ -45,6 +53,7 @@ import { useRoute } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import LlcBreadcrumb, { type BreadcrumbItem } from '@/components/llc/LlcBreadcrumb.vue'
+import Sparkline from '@/components/llc/Sparkline.vue'
 
 interface ProjectResponse {
   id: string
@@ -60,6 +69,12 @@ interface ProjectResponse {
   auto_rollover: boolean
   created_at: string
   updated_at: string
+  open_work_item_count: number
+  active_sprint_name: string | null
+}
+
+interface VelocityHistory {
+  sprints: { velocity: number }[]
 }
 
 const logger = createLogger('ProjectBrowserView')
@@ -70,6 +85,12 @@ const companyId = computed(() => route.params.companyId as string)
 const programId = computed(() => route.params.programId as string)
 const projects = ref<ProjectResponse[]>([])
 const loading = ref(false)
+// project id → chronological velocity series (oldest→newest) for the sparkline.
+const velocities = ref<Record<string, number[]>>({})
+
+function velocityFor(projectId: string): number[] {
+  return velocities.value[projectId] ?? []
+}
 
 const breadcrumb = computed<BreadcrumbItem[]>(() => [
   {
@@ -93,12 +114,29 @@ async function loadProjects(): Promise<void> {
     projects.value = await api.get<ProjectResponse[]>(
       `/api/llc/programs/${programId.value}/projects`,
     )
+    void loadVelocities()
   } catch (err) {
     logger.error('Failed to load projects', err)
     projects.value = []
   } finally {
     loading.value = false
   }
+}
+
+// Fetch each project's velocity history in parallel (reuses the #9861 endpoint).
+// A single failure must not blank the others, so each fetch is isolated.
+async function loadVelocities(): Promise<void> {
+  await Promise.all(
+    projects.value.map(async p => {
+      try {
+        const res = await api.get<VelocityHistory>(`/api/llc/projects/${p.id}/velocity`)
+        // Endpoint returns most-recent-first; reverse for a left-to-right trend.
+        velocities.value[p.id] = (res.sprints ?? []).map(s => s.velocity).reverse()
+      } catch (err) {
+        logger.error(`Failed to load velocity for project ${p.id}`, err)
+      }
+    }),
+  )
 }
 
 onMounted(loadProjects)
@@ -178,6 +216,34 @@ onMounted(loadProjects)
   font-size: 0.75rem;
   color: var(--color-text-secondary, #9ca3af);
   margin: 0;
+}
+
+.card-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.stat {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-text-secondary, #6b7280);
+  background: var(--bg-hover, #f3f4f6);
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+}
+
+.card-velocity {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.velocity-label {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--color-text-secondary, #9ca3af);
 }
 
 .status-badge {

--- a/autobot-frontend/src/views/llc/__tests__/ProjectBrowserView.enrichment.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/ProjectBrowserView.enrichment.test.ts
@@ -1,0 +1,75 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// GH#10232: ProjectBrowserView renders the enriched card fields (open-item
+// count, active sprint) and a velocity sparkline fed by the velocity endpoint.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+const get = vi.fn()
+
+vi.mock('@/plugins/api', () => ({ useApiClient: () => ({ get }) }))
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { companyId: 'c1', programId: 'pr1' } }),
+  RouterLink: { template: '<a><slot /></a>' },
+}))
+
+import ProjectBrowserView from '../ProjectBrowserView.vue'
+
+const PROJECT = {
+  id: 'p1',
+  company_id: 'c1',
+  program_id: 'pr1',
+  goal_id: null,
+  name: 'Apollo',
+  description: null,
+  status: 'active',
+  lead_agent_id: null,
+  lead_user_id: null,
+  target_date: null,
+  auto_rollover: false,
+  created_at: '2026-01-01',
+  updated_at: '2026-01-01',
+  open_work_item_count: 7,
+  active_sprint_name: 'Sprint 3',
+}
+
+describe('ProjectBrowserView enrichment (GH#10232)', () => {
+  beforeEach(() => get.mockReset())
+
+  it('shows open-item count, active sprint, and a velocity sparkline', async () => {
+    get.mockImplementation((url?: string) => {
+      if (url?.endsWith('/projects')) return Promise.resolve([PROJECT])
+      if (url?.includes('/velocity')) {
+        return Promise.resolve({ sprints: [{ velocity: 8 }, { velocity: 5 }, { velocity: 11 }] })
+      }
+      return Promise.resolve([])
+    })
+
+    const wrapper = mount(ProjectBrowserView, { global: { stubs: { LlcBreadcrumb: true } } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('7 open')
+    expect(wrapper.text()).toContain('Sprint 3')
+    expect(wrapper.find('.card-velocity svg').exists()).toBe(true)
+  })
+
+  it('falls back to "No active sprint" and hides the sparkline when velocity is sparse', async () => {
+    get.mockImplementation((url?: string) => {
+      if (url?.endsWith('/projects')) {
+        return Promise.resolve([{ ...PROJECT, active_sprint_name: null, open_work_item_count: 0 }])
+      }
+      if (url?.includes('/velocity')) return Promise.resolve({ sprints: [{ velocity: 8 }] })
+      return Promise.resolve([])
+    })
+
+    const wrapper = mount(ProjectBrowserView, { global: { stubs: { LlcBreadcrumb: true } } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No active sprint')
+    expect(wrapper.find('.card-velocity').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Thinking Path
Last user-facing gap on umbrella #9923. #9628's browser cards showed only the raw list fields; this adds the richer card content the issue asked for. The counts need aggregation the list endpoints didn't provide, and the project sparkline reuses the existing `/projects/{id}/velocity` endpoint.

## What Changed

### Backend — aggregate counts on the list endpoints (`llc/api/sprints.py`)
Each list endpoint now attaches counts via a **single grouped query** (never N+1 per card):
- `PortfolioResponse.program_count`
- `ProgramResponse.project_count`
- `ProjectResponse.open_work_item_count` (status not in done/cancelled) + `active_sprint_name` (the project's ACTIVE sprint)

Detail reads keep the defaults (0/None). IDOR guards unchanged.

### Frontend — enriched cards + sparkline
- Portfolio card: "{n} programs"; Program card: "{n} projects".
- Project card: "{n} open" + active sprint name (or "No active sprint") + a **velocity sparkline** fed by `/projects/{id}/velocity` (fetched per-project in parallel; isolated failures don't blank other cards).
- New reusable `Sparkline.vue` (inline SVG polyline; renders nothing for <2 points; flat-series safe — no divide-by-zero).

## Verification
- Backend: `pytest test_sprints_enrichment.py test_sprints_idor.py` → **15 passed**; flake8 0.
- Frontend: `vitest Sparkline.test.ts ProjectBrowserView.enrichment.test.ts` → **5 passed**; `vue-tsc` clean; `eslint` 0/0.

## Model Used
Claude Opus 4.8

Closes #10232 (part of #9923)
