### PR TITLE
feat(secrets): secret-dependency graph — what depends on a secret (#10374)

### DIFF
--- a/autobot-backend/migrations/versions/20260621_061_secret_dependencies.py
+++ b/autobot-backend/migrations/versions/20260621_061_secret_dependencies.py
@@ -1,0 +1,57 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Create secret_dependencies — what depends on a secret (#10088 Task 8.2).
+
+The dependency half of the auditable secrets graph: a service / agent / workflow that
+consumes a secret at run time, one row per (secret, dependent). Guarded with
+``migrations.guards`` so it is safe on databases where the table already exists.
+
+Revision ID: 20260621_061
+Revises: 20260616_060
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from migrations.guards import has_table
+
+revision: str = "20260621_061"
+down_revision: Union[str, None] = "20260616_060"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    if has_table("secret_dependencies"):
+        return
+    op.create_table(
+        "secret_dependencies",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("secret_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("dependent_kind", sa.String(length=32), nullable=False),
+        sa.Column("dependent_id", sa.String(length=255), nullable=False),
+        sa.Column("company_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["secret_id"], ["secrets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "secret_id", "dependent_kind", "dependent_id", name="uq_secret_dependencies_secret_dependent"
+        ),
+    )
+    op.create_index("ix_secret_dependencies_secret_id", "secret_dependencies", ["secret_id"])
+    op.create_index("ix_secret_dependencies_company_id", "secret_dependencies", ["company_id"])
+
+
+def downgrade() -> None:
+    if not has_table("secret_dependencies"):
+        return
+    op.drop_index("ix_secret_dependencies_company_id", table_name="secret_dependencies")
+    op.drop_index("ix_secret_dependencies_secret_id", table_name="secret_dependencies")
+    op.drop_table("secret_dependencies")

--- a/autobot-backend/models/__init__.py
+++ b/autobot-backend/models/__init__.py
@@ -42,6 +42,7 @@ from models.ml_model import MLModel
 # Process adapter models (#1406)
 from models.process_run import AgentSession, ProcessRun, TaskDecomposition
 from models.secret import Secret
+from models.secret_dependency import SecretDependency
 from models.secret_grant import SecretGrant
 from models.session_collaboration import SessionCollaboration
 
@@ -64,6 +65,7 @@ __all__ = [
     "CompletionFeedback",
     "MLModel",
     "Secret",
+    "SecretDependency",
     "SecretGrant",
     "SessionCollaboration",
     # Central agent registry (#1754)

--- a/autobot-backend/models/secret_dependency.py
+++ b/autobot-backend/models/secret_dependency.py
@@ -1,0 +1,76 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""What depends on a secret — the dependency half of the auditable secrets graph.
+
+Task 8.2 of umbrella #10088. ``secret_grants`` answers *who can access* a secret;
+this answers *what depends on* it: a service / agent / workflow that consumes the
+secret at run time. One row per (secret, dependent), so a secret's blast radius —
+the rotation/revocation impact list — is a single indexed lookup.
+
+``dependent_kind`` is one of :data:`DEPENDENT_KINDS`; ``dependent_id`` is the
+consumer's identifier in that namespace (agent type, workflow id, service name).
+``company_id`` is the optional org coordinate that lets the org-tree rollup
+(Task 8.4) aggregate dependents per node.
+"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import Uuid
+
+from user_management.models.base import Base
+
+#: Consumer namespaces a dependency may belong to (validated by the service layer).
+DEPENDENT_KINDS = ("service", "agent", "workflow")
+
+
+class SecretDependency(Base):
+    """One consumer (service/agent/workflow) that depends on a secret (N:1 with ``secrets``)."""
+
+    __tablename__ = "secret_dependencies"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    secret_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True),
+        ForeignKey("secrets.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    dependent_kind: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="One of DEPENDENT_KINDS: service / agent / workflow",
+    )
+
+    dependent_id: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        comment="The consumer's identifier in its namespace (agent type, workflow id, service name)",
+    )
+
+    company_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(as_uuid=True),
+        nullable=True,
+        index=True,
+        comment="Optional org coordinate (LLC company) for org-tree dependency rollup",
+    )
+
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(as_uuid=True),
+        nullable=True,
+        comment="Acting principal (user_id) that registered this dependency",
+    )
+
+    # created_at / updated_at are provided by Base.
+
+    __table_args__ = (
+        UniqueConstraint("secret_id", "dependent_kind", "dependent_id", name="uq_secret_dependencies_secret_dependent"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<SecretDependency(secret_id={self.secret_id}, {self.dependent_kind}:{self.dependent_id})>"

--- a/autobot-backend/services/secret_dependency_service.py
+++ b/autobot-backend/services/secret_dependency_service.py
@@ -1,0 +1,92 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Register + query what depends on a secret (#10088 Task 8.2 / 8.4 what-depends-on).
+
+The dependency counterpart to ``secrets_access_audit`` (who-has-access). Records that a
+service / agent / workflow consumes a secret, so a secret's blast radius — the
+rotation/revocation impact list — is one indexed lookup. Pure metadata; no decryption.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.secret_dependency import DEPENDENT_KINDS, SecretDependency
+
+
+class SecretDependencyService:
+    """CRUD + queries over ``secret_dependencies``. Caller owns the transaction."""
+
+    async def register(
+        self,
+        session: AsyncSession,
+        *,
+        secret_id: uuid.UUID,
+        dependent_kind: str,
+        dependent_id: str,
+        company_id: uuid.UUID | None = None,
+        created_by: uuid.UUID | None = None,
+    ) -> SecretDependency:
+        """Idempotently record that ``dependent_kind:dependent_id`` depends on *secret_id*."""
+        if dependent_kind not in DEPENDENT_KINDS:
+            raise ValueError(f"unknown dependent_kind {dependent_kind!r}; expected one of {DEPENDENT_KINDS}")
+        existing = (
+            await session.execute(
+                select(SecretDependency).where(
+                    SecretDependency.secret_id == secret_id,
+                    SecretDependency.dependent_kind == dependent_kind,
+                    SecretDependency.dependent_id == dependent_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            return existing
+        dep = SecretDependency(
+            secret_id=secret_id,
+            dependent_kind=dependent_kind,
+            dependent_id=dependent_id,
+            company_id=company_id,
+            created_by=created_by,
+        )
+        session.add(dep)
+        await session.flush()
+        return dep
+
+    async def what_depends_on(self, session: AsyncSession, *, secret_id: uuid.UUID) -> list[SecretDependency]:
+        """Every consumer of *secret_id* — the rotation/revocation impact list."""
+        rows = await session.execute(
+            select(SecretDependency)
+            .where(SecretDependency.secret_id == secret_id)
+            .order_by(SecretDependency.dependent_kind, SecretDependency.dependent_id)
+        )
+        return list(rows.scalars())
+
+    async def secrets_for_dependent(
+        self, session: AsyncSession, *, dependent_kind: str, dependent_id: str
+    ) -> list[uuid.UUID]:
+        """The secret ids a given consumer depends on."""
+        rows = await session.execute(
+            select(SecretDependency.secret_id).where(
+                SecretDependency.dependent_kind == dependent_kind,
+                SecretDependency.dependent_id == dependent_id,
+            )
+        )
+        return list(rows.scalars())
+
+    async def unregister(
+        self, session: AsyncSession, *, secret_id: uuid.UUID, dependent_kind: str, dependent_id: str
+    ) -> int:
+        """Drop one dependency row. Returns the number removed (0 or 1)."""
+        result = await session.execute(
+            delete(SecretDependency).where(
+                SecretDependency.secret_id == secret_id,
+                SecretDependency.dependent_kind == dependent_kind,
+                SecretDependency.dependent_id == dependent_id,
+            )
+        )
+        return result.rowcount or 0

--- a/autobot-backend/tests/migrations/test_secret_dependencies.py
+++ b/autobot-backend/tests/migrations/test_secret_dependencies.py
@@ -1,0 +1,95 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the secret-dependency graph (#10088 Task 8.2 / 8.4).
+
+Postgres-backed (migration-gate): the 061 migration creates ``secret_dependencies`` on an
+``upgrade head`` schema, and SecretDependencyService register/query/idempotency, the
+what-depends-on impact list, and FK CASCADE on secret deletion are exercised against it.
+"""
+
+import base64
+import uuid
+
+import pytest
+from sqlalchemy import delete, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from autobot_shared.secrets_vault import VaultKind, VaultRef
+from models.secret import Secret
+from services.secret_dependency_service import SecretDependencyService
+from services.unified_secrets_service import UnifiedSecretsService
+from tests.migrations.conftest import requires_postgres, run_alembic
+
+pytestmark = [pytest.mark.migration_gate, requires_postgres]
+
+_ROOT = base64.urlsafe_b64decode(base64.urlsafe_b64encode(bytes(range(32))))
+_OWNER = uuid.uuid4()
+
+
+@pytest.fixture()
+async def session(fresh_db_url):
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+    engine = create_async_engine(fresh_db_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as s:
+        yield s
+    await engine.dispose()
+
+
+async def _make_secret(session) -> uuid.UUID:
+    svc = UnifiedSecretsService(root_key=_ROOT)
+    secret = await svc.create(
+        session,
+        owner_vault=VaultRef(VaultKind.USER, str(_OWNER)),
+        name="db-pw",
+        secret_type="password",
+        plaintext=b"v",
+        created_by=_OWNER,
+    )
+    return secret.id
+
+
+async def test_migration_creates_table(session):
+    reg = (await session.execute(text("SELECT to_regclass('public.secret_dependencies')"))).scalar()
+    assert reg is not None
+
+
+async def test_register_query_idempotent_and_unregister(session):
+    sid = await _make_secret(session)
+    svc = SecretDependencyService()
+
+    a = await svc.register(session, secret_id=sid, dependent_kind="agent", dependent_id="researcher")
+    await svc.register(session, secret_id=sid, dependent_kind="workflow", dependent_id="wf-1")
+    again = await svc.register(session, secret_id=sid, dependent_kind="agent", dependent_id="researcher")
+    assert again.id == a.id  # idempotent — same row, no duplicate
+
+    deps = await svc.what_depends_on(session, secret_id=sid)
+    assert {(d.dependent_kind, d.dependent_id) for d in deps} == {("agent", "researcher"), ("workflow", "wf-1")}
+
+    assert await svc.secrets_for_dependent(session, dependent_kind="agent", dependent_id="researcher") == [sid]
+
+    removed = await svc.unregister(session, secret_id=sid, dependent_kind="agent", dependent_id="researcher")
+    assert removed == 1
+    assert [(d.dependent_kind, d.dependent_id) for d in await svc.what_depends_on(session, secret_id=sid)] == [
+        ("workflow", "wf-1")
+    ]
+
+
+async def test_register_rejects_unknown_kind(session):
+    sid = await _make_secret(session)
+    with pytest.raises(ValueError):
+        await SecretDependencyService().register(session, secret_id=sid, dependent_kind="bogus", dependent_id="x")
+
+
+async def test_secret_deletion_cascades_dependencies(session):
+    sid = await _make_secret(session)
+    svc = SecretDependencyService()
+    await svc.register(session, secret_id=sid, dependent_kind="service", dependent_id="connector:gitlab")
+    await session.commit()
+
+    await session.execute(delete(Secret).where(Secret.id == sid))
+    await session.commit()
+
+    assert await svc.what_depends_on(session, secret_id=sid) == []  # FK ondelete CASCADE


### PR DESCRIPTION
## Thinking Path
Continuing umbrella #10088. The who-has-access audit (Task 8.1) shipped in #10344; its counterpart — **what depends on a secret** (Task 8.2 + the 8.4 what-depends-on query) — is the next decision-free, high-value slice, and directly serves the PRD's "what service/agent depends on this secret" requirement. It's the foundation a secret's **rotation/revocation impact list** is built on.

## What Changed
- **`models/secret_dependency.py`** + **migration `20260621_061`** — new `secret_dependencies` table: one row per `(secret, dependent_kind:dependent_id)`, `dependent_kind ∈ {service, agent, workflow}`, optional `company_id` org coordinate (for the Task-8.4 org-tree rollup), FK `secrets.id` **ON DELETE CASCADE**, `UNIQUE(secret_id, dependent_kind, dependent_id)`. `created_at`/`updated_at` come from `Base`. Registered in `models/__init__.py` (+ `__all__`) so it joins `target_metadata` for env.py/autogenerate.
- **`services/secret_dependency_service.py`** — `register` (idempotent, validates kind), `what_depends_on` (the impact list), `secrets_for_dependent`, `unregister`.

## Verification
- 4 Postgres tests (migration-gate): migration creates the table; register/query/idempotency/unregister; unknown kind rejected (`ValueError`); **secret deletion cascades** its dependency rows (FK integrity).
- Migration is gate-compatible — `test_baseline_states`, `test_downgrade_roundtrip`, `test_probe_ladder_selfcheck` all pass with revision 061 (literal `create_table`, guarded, single head `061`).
- `flake8` 0, `black` (120) clean. (The model's `updated_at` is `Base`-provided — my own test caught the initial migration omission, since baseline's autogenerate-diff is model-vs-model and wouldn't.)

## Out of scope (later Task 8 slices)
- **8.3** seed scanners (`AGENT_SECRET_MAPPINGS`, workflow `${secrets.NAME}` refs, connector configs) to populate the graph.
- **8.4** org-tree subtree rollup + hygiene (orphaned/over-privileged/stale) + a query endpoint; **8.5** UI explorer.

## Model Used
Claude Opus 4.8

Part of #10088. Closes #10374.
