### PR TITLE
fix(nginx/csp): allow data: fonts in strict security-headers snippet

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-security-headers-strict.conf.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-security-headers-strict.conf.j2
@@ -9,4 +9,4 @@ add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header X-XSS-Protection "1; mode=block" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' wss://$host; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' wss://$host; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;


### PR DESCRIPTION
## Thinking Path
Live user-app font error (`font-src 'self'` blocks base64 woff2). The CSP is served by the **slm_manager strict snippet** (`autobot-security-headers-strict.conf.j2`, included by autobot-slm `location /`) — #10360 only fixed the frontend-role template, missing this one.

## What Changed
`font-src 'self'` → `font-src 'self' data:` in the strict snippet template.

## Verification
Applied the same change to the live snippet + reloaded nginx; fresh `curl` of `/` and `/transcriber` now returns `font-src 'self' data:`.

## Model Used
Claude Opus 4.8