### PR TITLE
feat(secrets): dependency query endpoint — GET /v2/secrets/{id}/dependencies (#10381)

### DIFF
--- a/autobot-backend/api/unified_secrets.py
+++ b/autobot-backend/api/unified_secrets.py
@@ -135,6 +135,31 @@ class SecretAccessOut(BaseModel):
         )
 
 
+class DependentOut(BaseModel):
+    dependent_kind: str
+    dependent_id: str
+    company_id: str | None
+
+
+class SecretDependenciesOut(BaseModel):
+    secret_id: str
+    dependents: list[DependentOut]
+
+    @classmethod
+    def of(cls, secret_id: uuid.UUID, deps) -> "SecretDependenciesOut":
+        return cls(
+            secret_id=str(secret_id),
+            dependents=[
+                DependentOut(
+                    dependent_kind=d.dependent_kind,
+                    dependent_id=d.dependent_id,
+                    company_id=str(d.company_id) if d.company_id else None,
+                )
+                for d in deps
+            ],
+        )
+
+
 @router.post("", response_model=SecretMetadata, status_code=status.HTTP_201_CREATED)
 async def create_secret(
     body: CreateSecretBody,
@@ -199,6 +224,22 @@ async def secret_access(
     except (SecretAccessError, SecretNotFoundError, ValueError) as exc:
         raise _mapped(exc)
     return SecretAccessOut.of(report)
+
+
+@router.get("/{secret_id}/dependencies", response_model=SecretDependenciesOut)
+async def secret_dependencies(
+    secret_id: uuid.UUID,
+    who: tuple[uuid.UUID, set[str]] = Depends(principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> SecretDependenciesOut:
+    """What depends on this secret: every service/agent/workflow consumer (rotation-impact list)."""
+    user_id, perms = who
+    try:
+        deps = await coordinator.describe_dependencies(session, user_id=user_id, permissions=perms, secret_id=secret_id)
+    except (SecretAccessError, SecretNotFoundError, ValueError) as exc:
+        raise _mapped(exc)
+    return SecretDependenciesOut.of(secret_id, deps)
 
 
 @router.put("/{secret_id}", response_model=SecretMetadata)

--- a/autobot-backend/services/secrets_coordinator.py
+++ b/autobot-backend/services/secrets_coordinator.py
@@ -38,7 +38,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.secrets_vault import VaultRef
 from models.secret import Secret
+from models.secret_dependency import SecretDependency
 from models.secret_grant import SecretGrant
+from services.secret_dependency_service import SecretDependencyService
 from services.secrets_access_audit import SecretAccessReport, describe_secret_access
 from services.secrets_authz import PrincipalFacts, authorize
 from services.secrets_principal_resolver import resolve_principal_facts
@@ -112,6 +114,17 @@ class SecretsCoordinator:
         if not authorize(facts, "share", owner):
             raise SecretAccessError(f"not authorized to view access for secret {secret_id}")
         return await describe_secret_access(session, secret_id)
+
+    async def describe_dependencies(
+        self, session: AsyncSession, *, user_id: uuid.UUID, permissions: set[str], secret_id: uuid.UUID
+    ) -> list[SecretDependency]:
+        """What depends on *secret_id* — the rotation/revocation impact list. Same manage-authority
+        gate as :meth:`describe_access` (owner / admin / company OWNER-ADMIN-LEAD)."""
+        facts = await self._facts(session, user_id, permissions)
+        owner = await self._owner_vault(session, secret_id)  # raises SecretNotFoundError when absent
+        if not authorize(facts, "share", owner):
+            raise SecretAccessError(f"not authorized to view dependencies for secret {secret_id}")
+        return await SecretDependencyService().what_depends_on(session, secret_id=secret_id)
 
     async def share(
         self,

--- a/autobot-backend/tests/migrations/test_secret_dependencies.py
+++ b/autobot-backend/tests/migrations/test_secret_dependencies.py
@@ -93,3 +93,34 @@ async def test_secret_deletion_cascades_dependencies(session):
     await session.commit()
 
     assert await svc.what_depends_on(session, secret_id=sid) == []  # FK ondelete CASCADE
+
+
+async def test_coordinator_describe_dependencies_authz(session):
+    # The /dependencies endpoint routes through coordinator.describe_dependencies, gated on manage
+    # (share) authority — owner/admin may view the impact list; a stranger may not.
+    from services.secrets_coordinator import SecretsCoordinator
+    from services.unified_secrets_service import SecretAccessError, SecretNotFoundError
+
+    coord = SecretsCoordinator(service=UnifiedSecretsService(root_key=_ROOT))
+    owner = VaultRef(VaultKind.USER, str(_OWNER))
+    secret = await coord.create(
+        session, user_id=_OWNER, permissions=set(), owner_vault=owner, name="x", secret_type="password", plaintext=b"v"
+    )
+    await SecretDependencyService().register(
+        session, secret_id=secret.id, dependent_kind="workflow", dependent_id="wf-7"
+    )
+    await session.commit()
+
+    deps = await coord.describe_dependencies(session, user_id=_OWNER, permissions=set(), secret_id=secret.id)
+    assert [(d.dependent_kind, d.dependent_id) for d in deps] == [("workflow", "wf-7")]
+
+    with pytest.raises(SecretAccessError):
+        await coord.describe_dependencies(session, user_id=uuid.uuid4(), permissions=set(), secret_id=secret.id)
+
+    admin_deps = await coord.describe_dependencies(
+        session, user_id=uuid.uuid4(), permissions={"admin:access"}, secret_id=secret.id
+    )
+    assert len(admin_deps) == 1
+
+    with pytest.raises(SecretNotFoundError):
+        await coord.describe_dependencies(session, user_id=_OWNER, permissions=set(), secret_id=uuid.uuid4())


### PR DESCRIPTION
## Thinking Path
Continuing #10088 Task 8. The dependency-graph foundation (model + service) merged in #10375/#10376; the natural next slice is exposing **what depends on a secret** over HTTP — the exact counterpart to the who-has-access endpoint (`GET /{id}/access`, #10344). (I deferred the 8.3 seed scanners: they need secrets resolvable to *unified* ids, which depends on the still-decision-gated JSON/SQLite store cutovers, so they'd run against a half-migrated state — this endpoint is the cleaner decision-free slice and completes the audit query surface.)

## What Changed
- **`SecretsCoordinator.describe_dependencies`** — returns the rotation/revocation impact list (`SecretDependencyService.what_depends_on`), gated on the **same manage authority** as `describe_access`: `authorize("share", owner_vault)` → owner, admin, or company OWNER/ADMIN/LEAD. A mere reader can't enumerate the impact list.
- **`GET /api/v2/secrets/{secret_id}/dependencies`** → `SecretDependenciesOut` (`{secret_id, dependents: [{dependent_kind, dependent_id, company_id}]}`); errors mapped 404/403/400 like the sibling endpoints.

## Verification
- +1 Postgres test (migration-gate) on `coordinator.describe_dependencies`: owner allowed (returns the registered dependents), stranger denied (`SecretAccessError`), admin allowed, missing secret → `SecretNotFoundError`. The 4 existing dependency tests still pass.
- `flake8` 0, `black` (120) clean; coordinator + API parse-check clean. (Endpoint is thin glue over the tested coordinator method — `api-wiring` CI validates the route registration, consistent with the `/access` endpoint.)

## Out of scope (later Task 8)
- **8.3** seed scanners (gated on store cutovers); **8.4** org-tree rollup + hygiene queries; **8.5** UI explorer.

## Model Used
Claude Opus 4.8

Part of #10088. Closes #10381.
