### PR TITLE
fix(api): with_error_handling() parens — bare use 422'd users/preferences + verbatim_memory

### DIFF
--- a/autobot-backend/api/users.py
+++ b/autobot-backend/api/users.py
@@ -140,7 +140,7 @@ async def _store_user_preferences_to_redis(user_id: str, preferences: UserPrefer
 
 
 @router.get("/me/preferences", response_model=DataResponse[UserPreferencesData])
-@with_error_handling
+@with_error_handling()
 async def get_user_preferences(
     request: Request,
     current_user: Dict = Depends(get_current_user),
@@ -171,7 +171,7 @@ async def get_user_preferences(
 
 
 @router.patch("/me/preferences", response_model=DataResponse[UserPreferencesData])
-@with_error_handling
+@with_error_handling()
 async def update_user_preferences(
     preferences: UserPreferences,
     request: Request,

--- a/autobot-backend/api/verbatim_memory.py
+++ b/autobot-backend/api/verbatim_memory.py
@@ -39,7 +39,7 @@ def _require_user(request: Request) -> Dict[str, Any]:
 
 
 @router.get("/verbatim-memory/search")
-@with_error_handling
+@with_error_handling()
 async def verbatim_search(
     request: Request,
     q: str = Query(..., description="Search query"),
@@ -79,7 +79,7 @@ async def verbatim_search(
 
 
 @router.delete("/verbatim-memory/session/{session_id}")
-@with_error_handling
+@with_error_handling()
 async def delete_session_verbatim(
     session_id: str,
     request: Request,


### PR DESCRIPTION
## Thinking Path
Live: `GET /api/users/me/preferences` → **422 'field required: query.func'**. `with_error_handling` (from `autobot_shared.error_boundaries`) is a decorator **factory**; applied **bare** (`@with_error_handling`) the handler is passed as the `category` arg and the factory's inner `def decorator(func)` becomes the route → FastAPI sees a required `func` query param → 422. Exposed for users by the #10358 router registration; `verbatim_memory.py` had the same latent bug.

## What Changed
Added the missing `()` to all 4 bare sites: `users.py` (GET+PATCH /me/preferences), `verbatim_memory.py` (2). All params default, so `@with_error_handling()` is correct.

## Verification
`py_compile` clean. Will apply live + confirm `/api/users/me/preferences` returns 200/401 (not 422).

## Model Used
Claude Opus 4.8