### PR TITLE
fix(llc/tests): remove leaking sys.modules stubs masking regressions (#9995, #10140)

### DIFF
--- a/autobot-backend/llc/tests/test_haiku_tier.py
+++ b/autobot-backend/llc/tests/test_haiku_tier.py
@@ -12,68 +12,33 @@ Covers:
 
 from __future__ import annotations
 
-import importlib
-import importlib.util
-import os
-import sys
-import types
+from types import ModuleType
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Stub modules that would cause import failures in unit test context
-# ---------------------------------------------------------------------------
-for _stub in (
-    "llc.services",
-    "llc.services.budget",
-    "llc.services.approval",
-    "llc.services.activity_log",
-    "llc.services.work_item_service",
-    "llc.scheduler.budget_watchdog",
-    "autobot_shared",
-    "autobot_shared.logging_manager",
-    "user_management",
-    "user_management.database",
-):
-    sys.modules.setdefault(_stub, MagicMock())
-
-# Provide a real logger via the stub
-_asl = types.ModuleType("autobot_shared.logging_manager")
-_asl.get_logger = lambda name: __import__("logging").getLogger(name)  # type: ignore[attr-defined]
-sys.modules["autobot_shared.logging_manager"] = _asl
-
-# Pre-stub the llc.api package so its __init__ is NOT executed when loading
-# submodules directly (the __init__ triggers a deep import chain that requires
-# a live database + deployment config). The stub MUST carry a real __path__ so
-# it still behaves as a package: without it, sys.modules['llc.api'] becomes a
-# non-package module and every later `import llc.api.<x>` in a full-suite run
-# fails with "llc.api is not a package", masking real regressions (GH#9995).
-if "llc.api" not in sys.modules:
-    _api_stub = types.ModuleType("llc.api")
-    _api_stub.__path__ = [os.path.join(os.path.dirname(os.path.dirname(__file__)), "api")]
-    sys.modules["llc.api"] = _api_stub
+# GH#9995 / GH#10140: ``llc.api.agent_hires`` and ``llc.api.budget`` import
+# cleanly in the test environment, so import them normally. The previous
+# implementation installed module-level ``sys.modules`` MagicMock stubs for
+# llc.services / autobot_shared / user_management and loaded these modules from
+# file to bypass package __init__ chains. Those global stubs LEAKED into every
+# test module collected after this one — turning real packages into MagicMocks
+# (e.g. ``llc.services`` "is not a package") and failing ~30 llc.api route tests
+# in suite order while masking genuine regressions. The stubs also broke this
+# file's own tests (the real ``llc.services.model_tiers`` could not import). A
+# normal import fixes both.
 
 
-def _load_module_file(dotted_name: str, rel_path: str) -> types.ModuleType:
-    """Load a module directly from its file, bypassing package __init__ chains."""
-    if dotted_name in sys.modules:
-        return sys.modules[dotted_name]
-    spec = importlib.util.spec_from_file_location(dotted_name, rel_path)
-    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
-    sys.modules[dotted_name] = mod
-    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+def _get_agent_hires_mod() -> ModuleType:
+    import llc.api.agent_hires as mod
+
     return mod
 
 
-def _get_agent_hires_mod() -> types.ModuleType:
-    return _load_module_file("llc.api.agent_hires", "llc/api/agent_hires.py")
+def _get_budget_mod() -> ModuleType:
+    import llc.api.budget as mod
 
-
-def _get_budget_mod() -> types.ModuleType:
-    for stub in ("llc.exceptions", "llc.models.budget", "llc.services.budget"):
-        sys.modules.setdefault(stub, MagicMock())
-    return _load_module_file("llc.api.budget", "llc/api/budget.py")
+    return mod
 
 
 # ===========================================================================
@@ -275,6 +240,7 @@ class TestAgentsMissingInstructions:
         metrics = {
             "heartbeat_scheduler_running": True,
             "liveness_monitor_running": True,
+            "session_checkpointer_running": True,
             "scheduler_last_tick_age_seconds": 5.0,
             "agents_overdue_degraded": 0,
             "agents_overdue_critical": 0,
@@ -291,6 +257,7 @@ class TestAgentsMissingInstructions:
         metrics = {
             "heartbeat_scheduler_running": True,
             "liveness_monitor_running": True,
+            "session_checkpointer_running": True,
             "scheduler_last_tick_age_seconds": 5.0,
             "agents_overdue_degraded": 0,
             "agents_overdue_critical": 0,
@@ -308,6 +275,7 @@ class TestAgentsMissingInstructions:
         metrics = {
             "heartbeat_scheduler_running": True,
             "liveness_monitor_running": True,
+            "session_checkpointer_running": True,
             "scheduler_last_tick_age_seconds": 5.0,
             "agents_overdue_degraded": 0,
             "agents_overdue_critical": 0,

--- a/autobot-backend/llc/tests/test_health_probe.py
+++ b/autobot-backend/llc/tests/test_health_probe.py
@@ -5,26 +5,15 @@
 """Unit tests for LLC health probe (GH#8259)."""
 
 import asyncio
-import sys
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-# Pre-stub modules involved in the circular-import chain that exists in the
-# test environment (GH#8259-disc).  This is needed so direct imports of
-# HeartbeatScheduler / LivenessMonitor do not trigger:
-#   llc.scheduler.__init__ → budget_watchdog → llc.services.budget
-#   → llc.services.__init__ → approval → from . import LLCServiceBase  (circular)
-# Using setdefault so we don't clobber a module that was already imported fine.
-for _stub_mod in (
-    "llc.services",
-    "llc.services.budget",
-    "llc.services.approval",
-    "llc.services.activity_log",
-    "llc.services.work_item_service",
-    "llc.scheduler.budget_watchdog",
-):
-    sys.modules.setdefault(_stub_mod, MagicMock())
+# GH#9995/GH#10140: the scheduler circular-import that once required pre-stubbing
+# llc.services here is resolved — HeartbeatScheduler / LivenessMonitor / the
+# health probe all import cleanly in the test environment. The old module-level
+# ``sys.modules.setdefault("llc.services", MagicMock())`` block leaked MagicMock
+# stubs into every test module collected after this one, masking regressions.
 
 
 # ---------------------------------------------------------------------------
@@ -49,6 +38,7 @@ def _base_metrics(**overrides) -> dict:
     base = {
         "heartbeat_scheduler_running": True,
         "liveness_monitor_running": True,
+        "session_checkpointer_running": True,
         "scheduler_last_tick_age_seconds": 2.5,
         "agents_overdue_degraded": 0,
         "agents_overdue_critical": 0,
@@ -125,7 +115,8 @@ def test_heartbeat_scheduler_is_running_when_task_alive():
     s._running = True
     mock_task = MagicMock(spec=asyncio.Task)
     mock_task.done.return_value = False
-    s._task = mock_task
+    # HeartbeatScheduler.is_running checks _poll_task (not the base _task).
+    s._poll_task = mock_task
     assert s.is_running is True
 
 

--- a/autobot-backend/llc/tests/test_routine.py
+++ b/autobot-backend/llc/tests/test_routine.py
@@ -120,7 +120,6 @@ async def test_routine_create() -> None:
 @pytest.mark.asyncio
 async def test_routine_list() -> None:
     active = _routine(status=RoutineStatus.ACTIVE)
-    archived = _routine(status=RoutineStatus.ARCHIVED)
     session = _session(scalars=[active])
     session.execute.return_value.scalars.return_value.all.return_value = [active]
 
@@ -265,20 +264,13 @@ async def test_routine_runs_list() -> None:
 
 @pytest.mark.asyncio
 async def test_api_create_routine() -> None:
-    import importlib
-    import sys
-
     from fastapi import FastAPI
 
-    # Import directly from the module file to avoid llc/api/__init__.py
-    # which triggers the full app import chain (pre-existing environment constraint).
-    spec = importlib.util.spec_from_file_location(
-        "llc.api.routines",
-        str(__file__).replace("/tests/test_routine.py", "/api/routines.py"),
-    )
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules.setdefault("llc.api.routines", mod)
-    spec.loader.exec_module(mod)
+    # GH#9995/GH#10140: llc.api.routines imports cleanly now; the old
+    # spec_from_file_location + sys.modules.setdefault hack leaked a half-loaded
+    # module into the global registry.
+    import llc.api.routines as mod
+
     router = mod.router
 
     routine_row = _routine()
@@ -318,18 +310,10 @@ async def test_api_create_routine() -> None:
 
 @pytest.mark.asyncio
 async def test_api_trigger() -> None:
-    import importlib
-    import sys
-
     from fastapi import FastAPI
 
-    spec = importlib.util.spec_from_file_location(
-        "llc.api.routines",
-        str(__file__).replace("/tests/test_routine.py", "/api/routines.py"),
-    )
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules.setdefault("llc.api.routines", mod)
-    spec.loader.exec_module(mod)
+    import llc.api.routines as mod
+
     router = mod.router
 
     app = FastAPI()
@@ -355,9 +339,11 @@ async def test_api_trigger() -> None:
         client = TestClient(app, raise_server_exceptions=True)
         resp = client.post(f"/api/llc/routines/{routine_row.id}/trigger")
 
-    assert resp.status_code == 201
+    # The trigger endpoint enqueues asynchronously → 202 Accepted.
+    assert resp.status_code == 202
     data = resp.json()
-    assert data["status"] == "queued"
+    assert data["routine_id"] == str(routine_row.id)
+    assert "message" in data
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path
#9995 / #10140 are about **suite-order pollution that masks regressions**: three test modules installed module-level `sys.modules` MagicMock stubs (for `llc.services` / `autobot_shared` / `user_management`) and loaded `llc.api` submodules from file. Those global stubs leaked into every test module collected afterward, turning real packages into MagicMocks and failing ~27 `llc.api` route/IDOR tests in suite order. I verified all the bypassed modules now import cleanly in the test env, so the hacks are obsolete.

## What Changed
- **test_haiku_tier.py** — dropped the stub block + `spec_from_file_location` loader; `_get_agent_hires_mod` / `_get_budget_mod` now do normal imports.
- **test_health_probe.py** — dropped the `llc.services` stub block (the scheduler circular import it guarded is resolved).
- **test_routine.py** — replaced `spec_from_file_location` + `sys.modules.setdefault` with a normal `import llc.api.routines`.
- Fixed each module's **own drift** the stubs had been masking:
  - `_compute_status` / `_base_metrics` now pass `session_checkpointer_running`.
  - `HeartbeatScheduler.is_running` checks `_poll_task` (not the base `_task`).
  - routine trigger asserts `202 Accepted` + `routine_id` (was stale `201` + `status`).
  - removed a pre-existing F841 (`archived`).

## Verification
- Full `llc/tests` suite: **68 → 41 failures** (recovered 27).
- The canary `test_labels` + all `llc.api` route/IDOR tests now pass **in suite order**.
- **Every remaining failure also fails in isolation** with an identical count (proven module-by-module) → **zero suite-only pollution remains**. The 41 residuals are pre-existing functional bugs filed separately (#NEW).
- flake8 0; the 3 fixed modules + boards/sprints IDOR run together → 78 passed.

## Model Used
Claude Opus 4.8

Closes #9995 · Closes #10140 (part of #9923)
