### PR TITLE
ci(frontend): drop redundant double unit-test run (#10365)

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -112,15 +112,14 @@ jobs:
       - name: Check locale completeness
         working-directory: autobot-frontend
         run: npm run check:locales
-      - name: Run unit tests
-        working-directory: autobot-frontend
-        run: npm run test:unit
-
+      # #10365: the unit suite runs once, with coverage — `test:coverage` is
+      # `vitest run --coverage` over the same default config as `test:unit`, so a
+      # separate `test:unit` step just ran every unit test twice on the self-hosted runner.
       - name: Run integration tests
         working-directory: autobot-frontend
         run: npm run test:integration
 
-      - name: Generate coverage report
+      - name: Run unit tests with coverage
         working-directory: autobot-frontend
         run: npm run test:coverage
 


### PR DESCRIPTION
## Thinking Path
Investigating #10365 (CI speedup), the two items I'd planned were **already in place**: `Unit & Integration Tests` is already path-filtered to frontend changes (`if: needs.changes.outputs.frontend == 'true'` + a `changes` always-report job), and npm deps are already cached (`cache: 'npm'`). The genuine, safe win left was a redundancy: the frontend job ran the unit suite **twice**.

## What Changed
- **`.github/workflows/frontend-test.yml`** — removed the standalone `Run unit tests` step (`npm run test:unit` = `vitest run`). The `Run unit tests with coverage` step (`npm run test:coverage` = `vitest run --coverage`) runs the **same tests over the same default config**, so the plain run was pure duplication on the serial self-hosted runner. Integration tests (separate config) untouched; Codecov upload unchanged.

## Verification
- YAML valid (`yaml.safe_load`); `test:unit` step removed, `test:integration` + `test:coverage` retained. Injection-safe (no untrusted-input usage). The job change will be exercised by the next frontend PR (this PR is workflow-only, so the path-filtered frontend job won't re-run here).

## Remaining (out of scope)
- **pytest-xdist** for the backend suite (`ci.yml`, GitHub-hosted — not the singleton bottleneck): needs an xdist-safety audit (shared DB/Redis/global state) before `-n auto`.
- A second self-hosted runner removes the serial-queue bottleneck entirely (infra, not a code change).

## Model Used
Claude Opus 4.8

Part of #10365.
