### PR TITLE
fix(constants): add PathConstants.TEMP_DIR + SecurityConstants.ALLOWED_WEB_PORTS (#10384)

### DIFF
--- a/autobot_shared/ssot_constants.py
+++ b/autobot_shared/ssot_constants.py
@@ -382,6 +382,8 @@ class PathConstants:
     STATIC_DIR: Path = PROJECT_ROOT / "autobot-backend" / "static"
     FRONTEND_DIR: Path = PROJECT_ROOT / "autobot-frontend"
     TESTS_DIR: Path = PROJECT_ROOT / "autobot-backend"
+    # Temp/generated-files dir cleaned by tasks.cleanup_generated_files (#10385-adjacent)
+    TEMP_DIR: Path = DATA_DIR / "temp"
 
 
 PATH = PathConstants()
@@ -430,6 +432,9 @@ class SecurityConstants:
         "224.0.0.0/4",
         "240.0.0.0/4",
     ]
+
+    # Web ports permitted for outbound/domain network validation (#10384).
+    ALLOWED_WEB_PORTS: List[int] = [80, 443, 8080, 8443]
 
     USER_AGENT_POOL: List[str] = [
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",  # noqa: E501


### PR DESCRIPTION
## Thinking Path
Two AttributeErrors in the live logs (goal: solve log errors at source):
- `cleanup_generated_files` → `'PathConstants' object has no attribute 'TEMP_DIR'`
- `/api/security/domain-security/stats` 500 → `'SecurityConstants' object has no attribute 'ALLOWED_WEB_PORTS'` (#10384)

## What Changed
`autobot_shared/ssot_constants.py`: added `PathConstants.TEMP_DIR = DATA_DIR/temp` (consumed by knowledge_tasks.py:681) and `SecurityConstants.ALLOWED_WEB_PORTS = [80,443,8080,8443]` (consumed by domain_security.py:136).

## Verification
`py_compile` clean; both attrs resolve. Closes #10384.

## Model Used
Claude Opus 4.8