### PR TITLE
docs(migrations): fix 018 docstring column names (#10371)

### DIFF
--- a/autobot-backend/migrations/versions/20260422_018_skills_process_run_timestamptz.py
+++ b/autobot-backend/migrations/versions/20260422_018_skills_process_run_timestamptz.py
@@ -4,8 +4,8 @@
 # Author: mrveiss
 """Convert naive DateTime columns to TIMESTAMPTZ in skills and process_run tables.
 
-skills_packages.created_at, skill_repos.last_synced, skill_approvals.requested_at,
-skill_approvals.reviewed_at, skill_approvals.promoted_at, process_runs.started_at,
+skill_packages.created_at, skill_packages.promoted_at, skill_repos.last_synced,
+skill_approvals.requested_at, skill_approvals.reviewed_at, process_runs.started_at,
 process_runs.completed_at, agent_sessions.expires_at.
 
 Revision ID: 20260422_018


### PR DESCRIPTION
## Thinking Path
Resolving the open discovery issues filed this session. #10363 (SLM CSP) and #10253 (dependabot uv/pip overlap) were already resolved on latest `Dev_new_gui` and have been closed. #10371 (migration 018 docstring typo) was the one genuine remaining fix.

## What Changed
- **`migrations/versions/20260422_018_skills_process_run_timestamptz.py`** — docstring listed `skills_packages.created_at` (extra `s`) and `skill_approvals.promoted_at`, but the migration's own `_COLUMNS` and `skills/models.py` have `skill_packages.created_at` and `skill_packages.promoted_at`. Corrected the docstring to match.

## Verification
- Docstring-only change — **no DDL**, so the probe-ladder/baseline gates (which extract `create_table`/`add_column` artifacts) are unaffected. `ast.parse` + `flake8` clean.

## Model Used
Claude Opus 4.8

Closes #10371.
