### PR TITLE
fix(restart): defensive LLM key-rotation interval + MemoryGraph aclose (#10415)

### DIFF
--- a/autobot-backend/autobot_memory_graph/core.py
+++ b/autobot-backend/autobot_memory_graph/core.py
@@ -12,6 +12,7 @@ Part of Issue #716 - Refactored from monolithic autobot_memory_graph.py
 """
 
 import asyncio
+import inspect
 from typing import Any, Dict, List, Set
 
 from autobot_shared.logging_manager import get_logger
@@ -172,7 +173,14 @@ class AutoBotMemoryGraphCore:
         """Close Redis connection and cleanup resources."""
         if self.redis_client:
             try:
-                await self.redis_client.close()
+                # redis-py's async client deprecated close() (which now returns
+                # None) in favour of aclose(); awaiting the None return raised
+                # "object NoneType can't be used in 'await' expression" on every
+                # shutdown. Prefer aclose() and only await an awaitable result.
+                closer = getattr(self.redis_client, "aclose", None) or self.redis_client.close
+                result = closer()
+                if inspect.isawaitable(result):
+                    await result
                 logger.info("AutoBotMemoryGraph closed successfully")
             except Exception as e:
                 logger.error(f"Error closing AutoBotMemoryGraph: {e}")

--- a/autobot-backend/services/llm_key_rotation_scheduler.py
+++ b/autobot-backend/services/llm_key_rotation_scheduler.py
@@ -19,7 +19,30 @@ from services.llm_api_key_service import get_llm_api_key_service
 
 logger = get_logger(__name__)
 
-_ROTATION_INTERVAL_MINUTES = int(config.llm_key_rotation_interval_minutes)
+_DEFAULT_ROTATION_INTERVAL_MINUTES = 60
+
+
+def _resolve_rotation_interval_minutes() -> int:
+    """Resolve the rotation interval, defaulting when unset/invalid.
+
+    AUTOBOT_LLM_KEY_ROTATION_INTERVAL_MINUTES defaults to "" in ssot_config, so
+    int("") raised ValueError at import time and silently disabled the scheduler
+    on every startup. Default to hourly (#6590) instead of crashing the import.
+    """
+    raw = (config.llm_key_rotation_interval_minutes or "").strip()
+    try:
+        minutes = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid AUTOBOT_LLM_KEY_ROTATION_INTERVAL_MINUTES=%r; defaulting to %dm",
+            raw,
+            _DEFAULT_ROTATION_INTERVAL_MINUTES,
+        )
+        return _DEFAULT_ROTATION_INTERVAL_MINUTES
+    return minutes if minutes > 0 else _DEFAULT_ROTATION_INTERVAL_MINUTES
+
+
+_ROTATION_INTERVAL_MINUTES = _resolve_rotation_interval_minutes()
 
 
 class LLMKeyRotationScheduler:

--- a/autobot-backend/services/llm_key_rotation_scheduler_test.py
+++ b/autobot-backend/services/llm_key_rotation_scheduler_test.py
@@ -12,6 +12,7 @@ conftest stubs the whole ``services`` package (heavy import chain), so we load
 the module fresh from its file with apscheduler stubbed to exercise the real
 resolver logic.
 """
+
 from __future__ import annotations
 
 import importlib.util

--- a/autobot-backend/services/llm_key_rotation_scheduler_test.py
+++ b/autobot-backend/services/llm_key_rotation_scheduler_test.py
@@ -1,0 +1,57 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the LLM key-rotation interval resolver (#10415).
+
+The interval env var defaults to "" in ssot_config, so the old
+``int(config.llm_key_rotation_interval_minutes)`` at module import raised
+ValueError on every startup and silently disabled the scheduler.
+
+conftest stubs the whole ``services`` package (heavy import chain), so we load
+the module fresh from its file with apscheduler stubbed to exercise the real
+resolver logic.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_MODULE_PATH = Path(__file__).with_name("llm_key_rotation_scheduler.py")
+
+
+def _load_real_module():
+    # Stub apscheduler (not installed in the test env) so the import succeeds.
+    aps = types.ModuleType("apscheduler.schedulers.asyncio")
+    aps.AsyncIOScheduler = MagicMock
+    sys.modules.setdefault("apscheduler", types.ModuleType("apscheduler"))
+    sys.modules.setdefault("apscheduler.schedulers", types.ModuleType("apscheduler.schedulers"))
+    sys.modules["apscheduler.schedulers.asyncio"] = aps
+    spec = importlib.util.spec_from_file_location("_lkr_real_under_test", _MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("", 60),
+        ("   ", 60),
+        ("abc", 60),
+        ("0", 60),
+        ("-5", 60),
+        ("30", 30),
+        ("120", 120),
+        (None, 60),
+    ],
+)
+def test_resolve_rotation_interval_minutes(monkeypatch, raw, expected):
+    mod = _load_real_module()
+    monkeypatch.setattr(mod.config, "llm_key_rotation_interval_minutes", raw, raising=False)
+    assert mod._resolve_rotation_interval_minutes() == expected


### PR DESCRIPTION
## Thinking Path
Scanning the live `/var/log/autobot/backend-error.log` (20MB) for the "log errors solved in codebase / services restart without warning" goal surfaced two genuine bugs that fire on **every** backend restart cycle. (The two larger floods — NPU 1519×, SLM-WS-403 1100× — are already fixed by #10391, pending deploy.)

## What Changed
- **`services/llm_key_rotation_scheduler.py`** — `int(config.llm_key_rotation_interval_minutes)` ran at **module import**; the ssot_config field defaults to `""`, so `int("")` raised `ValueError` on every startup → the scheduler was silently disabled and key rotation never ran. Now resolved defensively (`_resolve_rotation_interval_minutes`): empty / whitespace / non-numeric / `<= 0` → hourly default (60m); valid values pass through.
- **`autobot_memory_graph/core.py`** — `await self.redis_client.close()` raised `object NoneType can't be used in 'await' expression` on every shutdown (redis-py's async client deprecated `close()`, which now returns `None`, in favour of `aclose()`). Now prefers `aclose()` and only awaits an awaitable result.
- **`services/llm_key_rotation_scheduler_test.py`** — 8-case resolver test (loads the real module from file with apscheduler stubbed, since conftest stubs the whole `services` package).

## Verification
- `python -m pytest services/llm_key_rotation_scheduler_test.py` → **8 passed**.
- `ast.parse` + `flake8 --max-line-length=120` clean on both modules.

## Model Used
Claude Opus 4.8

Closes #10415.
