### PR TITLE
fix(api): await list_operations + correct domain-security stats attrs (500 cascade)

### DIFF
--- a/autobot-backend/api/long_running_operations.py
+++ b/autobot-backend/api/long_running_operations.py
@@ -414,7 +414,7 @@ async def list_operations(
         status_filter = OperationStatus(status) if status else None
         type_filter = OperationType(operation_type) if operation_type else None
 
-        operations = manager.operation_manager.list_operations(status_filter, type_filter)
+        operations = await manager.operation_manager.list_operations(status_filter, type_filter)
         operations = operations[:limit]
 
         # Convert to response format

--- a/autobot-backend/api/security.py
+++ b/autobot-backend/api/security.py
@@ -310,6 +310,7 @@ async def get_domain_security_stats(request: Request):
         # Get threat intel status
         threat_status = await threat_service.get_service_status()
 
+        _dsec_cfg = domain_manager.config.config.get("domain_security", {})
         stats = {
             "whitelist_count": len(domain_manager.whitelist_patterns),
             "blacklist_count": len(domain_manager.blacklist_patterns),
@@ -321,9 +322,11 @@ async def get_domain_security_stats(request: Request):
                 "cache_size": threat_status.get("cache", {}).get("size", 0),
             },
             "settings": {
-                "require_https": domain_manager._require_https,
-                "max_redirects": domain_manager._max_redirects,
-                "check_dns": domain_manager._check_dns,
+                # Read from the domain_security config with safe defaults — these
+                # are not manager attributes (#10384-cascade).
+                "require_https": _dsec_cfg.get("require_https", False),
+                "max_redirects": _dsec_cfg.get("max_redirects", 0),
+                "check_dns": _dsec_cfg.get("check_dns", False),
             },
         }
 

--- a/autobot-backend/api/security.py
+++ b/autobot-backend/api/security.py
@@ -311,9 +311,9 @@ async def get_domain_security_stats(request: Request):
         threat_status = await threat_service.get_service_status()
 
         stats = {
-            "whitelist_count": len(domain_manager._whitelist),
-            "blacklist_count": len(domain_manager._blacklist),
-            "suspicious_tlds_count": len(domain_manager._suspicious_tlds),
+            "whitelist_count": len(domain_manager.whitelist_patterns),
+            "blacklist_count": len(domain_manager.blacklist_patterns),
+            "suspicious_tlds_count": len(domain_manager.SUSPICIOUS_TLDS),
             "threat_intelligence": {
                 "enabled": threat_service.is_any_service_configured,
                 "virustotal_configured": threat_status.get("virustotal", {}).get("configured", False),

--- a/autobot-backend/security/domain_security.py
+++ b/autobot-backend/security/domain_security.py
@@ -158,6 +158,9 @@ class DomainSecurityConfig:
 class DomainSecurityManager:
     """Manages domain security validation and threat intelligence"""
 
+    # TLDs treated as higher-risk in reputation scoring + reported in stats (#10384-cascade)
+    SUSPICIOUS_TLDS = [".tk", ".ml", ".ga", ".cf"]
+
     def __init__(self, config: DomainSecurityConfig | None = None):
         """Initialize domain security manager with config and compiled patterns."""
         self.config = config or DomainSecurityConfig()
@@ -644,8 +647,7 @@ class DomainSecurityManager:
                 break
 
         # TLD reputation
-        suspicious_tlds = [".tk", ".ml", ".ga", ".cf"]
-        for tld in suspicious_tlds:
+        for tld in self.SUSPICIOUS_TLDS:
             if domain.endswith(tld):
                 score -= 0.4
                 break


### PR DESCRIPTION
## Thinking Path
Re-syncing the live box after #10390/#10394 exposed the next-level 500s (goal: log errors solved):
- `/api/long-running` → `coroutine 'list_operations' was never awaited`
- `/api/security/domain-security/stats` → `'DomainSecurityManager' object has no attribute '_whitelist'`

## What Changed
- `long_running_operations.py`: `await` the async `list_operations`.
- `api/security.py`: `_whitelist`/`_blacklist`/`_suspicious_tlds` → real attrs `whitelist_patterns`/`blacklist_patterns`/`SUSPICIOUS_TLDS`.
- `domain_security.py`: extract `SUSPICIOUS_TLDS` class constant (reused by reputation scoring + stats).

## Verification
`py_compile` clean. Will apply live + confirm both endpoints return 200.

## Model Used
Claude Opus 4.8