### PR TITLE
perf(ci): parallelize backend pytest with pytest-xdist (#10398)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         python -m pip install -r requirements-ci.txt --prefer-binary
 
         echo "Installing testing dependencies..."
-        python -m pip install pytest pytest-asyncio pytest-cov flake8 black isort mypy bandit
+        python -m pip install pytest pytest-asyncio pytest-cov pytest-xdist==3.8.0 flake8 black isort mypy bandit
 
     - name: Create necessary directories and config files
       run: |
@@ -146,7 +146,11 @@ jobs:
         echo "Running unit tests with 70% coverage gate (#3285)..."
         # Run all unit tests excluding slow/integration/distributed/performance markers.
         # --cov-fail-under=70 enforces the minimum 70% coverage threshold.
+        # -n auto --dist loadscope parallelizes across workers (#10398); pytest-cov
+        # auto-combines per-worker coverage, and loadscope keeps same-module tests
+        # on one worker so shared-fixture/ordering behaviour matches serial.
         python -m pytest \
+          -n auto --dist loadscope \
           -m "not integration and not slow and not distributed and not performance" \
           --cov=autobot-backend \
           --cov=autobot-slm-backend \

--- a/docs/guides/requirements-local.txt
+++ b/docs/guides/requirements-local.txt
@@ -20,3 +20,4 @@ rich>=14.0.0
 # Testing
 pytest>=8.3.0
 pytest-asyncio>=0.25.0
+pytest-xdist>=3.8.0

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,7 @@ markers =
     security: Security-related tests
     real_kb: Tests that run against a real (in-memory) ChromaDB instance
     migration_gate: Alembic migration-path tests requiring a disposable Postgres (#10001/#10026)
+    xdist_group: pytest-xdist group marker — tests with the same group run on the same worker
 
 # Test discovery - colocated tests live next to source files (#734)
 testpaths =
@@ -58,6 +59,12 @@ addopts =
     --import-mode=importlib
     --ignore=autobot-slm-backend/ansible
     --ignore=autobot-npu-worker/resources
+    # pytest-xdist parallelism (-n auto --dist loadscope) is applied per
+    # full-suite invocation (the ci.yml coverage gate), NOT globally here:
+    # several CI jobs (e.g. startup-import-smoke) install bare pytest without
+    # pytest-xdist and run from this rootdir, so a global -n in addopts would
+    # error them with "unrecognized arguments: -n" and break a required gate.
+    # Proven stable with --dist loadscope (#10398).
 
 # Coverage options
 # Run with: pytest --cov=autobot-backend --cov=autobot-slm-backend --cov-report=html


### PR DESCRIPTION
## Thinking Path
The last open member of umbrella #9924 — the parallelization half split from #10365. Goal: run the heavy backend pytest suite in parallel without introducing flakiness, on the serial single runner.

## What Changed
- **`ci.yml` coverage gate**: added `-n auto --dist loadscope` to the `python -m pytest --cov ... --cov-fail-under=70` command. pytest-cov auto-combines per-worker coverage; `loadscope` keeps same-module tests on one worker so shared-fixture/ordering behaviour matches serial.
- **`pytest-xdist==3.8.0`** added to the ci.yml test-deps install + `docs/guides/requirements-local.txt`.
- **`pytest.ini`**: added the `xdist_group` marker and a comment explaining the parallelism is applied per-invocation, not globally.

## Why NOT global `pytest.ini` addopts
The original audit put `-n auto` in repo-root `addopts`. That would break the **required** `startup-import-smoke` gate (and other jobs): it installs *bare* `pytest` (no pytest-xdist) and runs from this rootdir, so `-n auto` errors with "unrecognized arguments: -n". Scoping it to the invocation that actually installs xdist avoids breaking every bare-pytest gate.

## Verification
- Stability audit (`--dist loadscope`): LLC / API / knowledge / monitoring slices give **byte-identical pass/fail counts across 2-3 repeated parallel runs** — no new flakiness vs serial. Speedups: **LLC 3m13s→49s (3.9×)**, **API 9m37s→4m40s (2.0×)**.
- Locally confirmed `-n auto --dist loadscope --cov=autobot-backend` runs clean and coverage **combines + reports** (29 passed, TOTAL line emitted) — no "unrecognized -n" error.
- Pre-existing collection errors (hardcoded `data/` paths) fail identically serial and parallel — not introduced here.

## Model Used
Claude Fable 5 (xdist audit + stability proof) + Opus 4.8 (scoping fix to protect the required bare-pytest gates, coverage-combine verification)

Closes #10398. Last member of umbrella #9924.