### PR TITLE
feat(slm): retention & data-hygiene TTL policies — config + nightly purge + audit + keep-forever (#8995)

### DIFF
--- a/autobot-backend/api/admin_retention_policies.py
+++ b/autobot-backend/api/admin_retention_policies.py
@@ -3,18 +3,20 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Admin API: Data Retention Policy CRUD Endpoints (MVA-3145, GH#8995)
+Admin API: Data Retention Policy CRUD + Settings/Stats Endpoints (MVA-3145, GH#8995)
 
 Endpoints:
-    GET    /api/admin/retention-policies       - List all policies
-    POST   /api/admin/retention-policies       - Create/update policy
-    GET    /api/admin/retention-policies/{type} - Get policy by type
-    DELETE /api/admin/retention-policies/{type} - Delete policy by type
+    GET    /api/admin/retention-policies             - List all policies
+    POST   /api/admin/retention-policies             - Create/update policy
+    GET    /api/admin/retention-policies/{type}      - Get policy by type
+    DELETE /api/admin/retention-policies/{type}      - Delete policy by type
+    GET    /api/admin/retention-settings             - Active config + per-type storage counts
 
-Access: admin role required (RBAC enforced).
+Access: admin role required (RBAC enforced via _require_admin dependency).
 """
 
 import uuid
+from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy import select
@@ -22,6 +24,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.user_management.dependencies import get_db_session
 from auth_middleware import get_auth_middleware
+from autobot_shared.error_boundaries import with_error_handling
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config as ssot_config
 from user_management.models.retention_policy import RetentionPolicy
 from user_management.schemas.retention_policy import (
     PolicyType,
@@ -30,6 +35,8 @@ from user_management.schemas.retention_policy import (
     RetentionPolicyResponse,
 )
 from utils.catalog_http_exceptions import raise_auth_error
+
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/admin")
 
@@ -190,3 +197,116 @@ async def delete_retention_policy(
 
     await session.delete(policy)
     await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/retention-settings — active config + per-type storage counts
+# ---------------------------------------------------------------------------
+
+
+async def _count_redis_keys(pattern: str) -> int:
+    """Return count of Redis keys matching pattern (best-effort, 0 on error)."""
+    try:
+        from autobot_shared.redis_client import get_async_redis_client
+
+        redis = await get_async_redis_client(database="main")
+        if redis is None:
+            return 0
+        count = 0
+        cursor: int = 0
+        while True:
+            cursor, keys = await redis.scan(cursor, match=pattern, count=500)
+            count += len(keys)
+            if cursor == 0:
+                break
+        return count
+    except Exception as exc:
+        logger.debug("_count_redis_keys(%s) failed: %s", pattern, exc)
+        return 0
+
+
+async def _count_audit_entries() -> int:
+    """Return total entries across all audit: sorted sets."""
+    try:
+        from autobot_shared.redis_client import get_async_redis_client
+
+        redis = await get_async_redis_client(database="main")
+        if redis is None:
+            return 0
+        total = 0
+        cursor: int = 0
+        while True:
+            cursor, keys = await redis.scan(cursor, match="audit:*", count=500)
+            for key in keys:
+                key_type = await redis.type(key)
+                if key_type == "zset":
+                    total += await redis.zcard(key)
+            if cursor == 0:
+                break
+        return total
+    except Exception as exc:
+        logger.debug("_count_audit_entries failed: %s", exc)
+        return 0
+
+
+async def _count_kb_facts() -> int:
+    """Return count of bare fact:<id> Redis hashes."""
+    try:
+        from autobot_shared.redis_client import get_async_redis_client
+
+        redis = await get_async_redis_client(database="main")
+        if redis is None:
+            return 0
+        count = 0
+        cursor: int = 0
+        while True:
+            cursor, keys = await redis.scan(cursor, match="fact:*", count=500)
+            for key in keys:
+                key_str = key.decode() if isinstance(key, bytes) else key
+                if len(key_str.split(":")) == 2:
+                    count += 1
+            if cursor == 0:
+                break
+        return count
+    except Exception as exc:
+        logger.debug("_count_kb_facts failed: %s", exc)
+        return 0
+
+
+@with_error_handling
+@router.get("/retention-settings", response_model=Dict[str, Any])
+async def get_retention_settings(
+    request: Request,
+    _admin: dict = Depends(_require_admin),
+) -> Dict[str, Any]:
+    """Return active retention configuration and per-type storage counts (GH#8995).
+
+    Config values come from ssot_config (env-var-driven).
+    Counts are approximate (best-effort Redis scan); 0 = unavailable.
+    """
+    import asyncio
+
+    chat_count, audit_count, kb_count = await asyncio.gather(
+        _count_redis_keys("chat:session:*"),
+        _count_audit_entries(),
+        _count_kb_facts(),
+    )
+
+    return {
+        "config": {
+            "chat_retention_days": ssot_config.chat_retention_days,
+            "file_retention_days": ssot_config.file_retention_days,
+            "audit_retention_days": ssot_config.audit_retention_days,
+            "kb_retention_days": ssot_config.kb_retention_days,
+        },
+        "storage_counts": {
+            "chat_sessions": chat_count,
+            "audit_log_entries": audit_count,
+            "kb_entries": kb_count,
+        },
+        "notes": {
+            "zero_means_disabled": "retention_days=0 means retention is OFF (safe default).",
+            "keep_forever": "Chat sessions with keep_forever=true are exempt from chat purge.",
+            "file_count": "File attachment count not shown (filesystem scan is expensive).",
+        },
+    }

--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -250,30 +250,22 @@ celery_app.conf.beat_schedule = {
     # Schedules are configurable via AUTOBOT_*_RETENTION_SCHEDULE env vars (5-field cron).
     "data-retention-chats-nightly": {
         "task": "tasks.cleanup_expired_chats",
-        "schedule": _crontab_from_string(
-            getattr(ssot_config.misc, "chat_retention_schedule", None) or "0 1 * * *"
-        ),
+        "schedule": _crontab_from_string(getattr(ssot_config.misc, "chat_retention_schedule", None) or "0 1 * * *"),
         "kwargs": {"dry_run": False},
     },
     "data-retention-files-nightly": {
         "task": "tasks.cleanup_expired_files",
-        "schedule": _crontab_from_string(
-            getattr(ssot_config.misc, "file_retention_schedule", None) or "15 1 * * *"
-        ),
+        "schedule": _crontab_from_string(getattr(ssot_config.misc, "file_retention_schedule", None) or "15 1 * * *"),
         "kwargs": {"dry_run": False},
     },
     "data-retention-audit-nightly": {
         "task": "tasks.cleanup_expired_audit_logs",
-        "schedule": _crontab_from_string(
-            getattr(ssot_config.misc, "audit_retention_schedule", None) or "30 1 * * *"
-        ),
+        "schedule": _crontab_from_string(getattr(ssot_config.misc, "audit_retention_schedule", None) or "30 1 * * *"),
         "kwargs": {"dry_run": False},
     },
     "data-retention-kb-nightly": {
         "task": "tasks.cleanup_expired_kb_entries",
-        "schedule": _crontab_from_string(
-            getattr(ssot_config.misc, "kb_retention_schedule", None) or "45 1 * * *"
-        ),
+        "schedule": _crontab_from_string(getattr(ssot_config.misc, "kb_retention_schedule", None) or "45 1 * * *"),
         "kwargs": {"dry_run": False},
     },
 }

--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -245,7 +245,44 @@ celery_app.conf.beat_schedule = {
         "task": "tasks.reconcile_unified_credentials",
         "schedule": crontab(minute=20),
     },
+    # GH#8995: data-hygiene retention tasks (nightly, staggered to avoid Redis contention)
+    # All tasks are no-ops when their respective retention_days == 0 (safe default).
+    # Schedules are configurable via AUTOBOT_*_RETENTION_SCHEDULE env vars (5-field cron).
+    "data-retention-chats-nightly": {
+        "task": "tasks.cleanup_expired_chats",
+        "schedule": _crontab_from_string(
+            getattr(ssot_config.misc, "chat_retention_schedule", None) or "0 1 * * *"
+        ),
+        "kwargs": {"dry_run": False},
+    },
+    "data-retention-files-nightly": {
+        "task": "tasks.cleanup_expired_files",
+        "schedule": _crontab_from_string(
+            getattr(ssot_config.misc, "file_retention_schedule", None) or "15 1 * * *"
+        ),
+        "kwargs": {"dry_run": False},
+    },
+    "data-retention-audit-nightly": {
+        "task": "tasks.cleanup_expired_audit_logs",
+        "schedule": _crontab_from_string(
+            getattr(ssot_config.misc, "audit_retention_schedule", None) or "30 1 * * *"
+        ),
+        "kwargs": {"dry_run": False},
+    },
+    "data-retention-kb-nightly": {
+        "task": "tasks.cleanup_expired_kb_entries",
+        "schedule": _crontab_from_string(
+            getattr(ssot_config.misc, "kb_retention_schedule", None) or "45 1 * * *"
+        ),
+        "kwargs": {"dry_run": False},
+    },
 }
+
+# GH#8995: import retention tasks so Celery registers them at worker startup
+import tasks.chat_retention  # noqa: F401
+import tasks.file_retention  # noqa: F401
+import tasks.audit_log_retention  # noqa: F401
+import tasks.knowledge_retention  # noqa: F401
 
 # GH#4459: Register web-push task_success signal so tasks that pass user_id
 # in their kwargs trigger a browser push notification on completion.

--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -270,10 +270,11 @@ celery_app.conf.beat_schedule = {
     },
 }
 
+import tasks.audit_log_retention  # noqa: F401
+
 # GH#8995: import retention tasks so Celery registers them at worker startup
 import tasks.chat_retention  # noqa: F401
 import tasks.file_retention  # noqa: F401
-import tasks.audit_log_retention  # noqa: F401
 import tasks.knowledge_retention  # noqa: F401
 
 # GH#4459: Register web-push task_success signal so tasks that pass user_id

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -663,6 +663,13 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["voice", "realtime", "webrtc"],
         "realtime_session",
     ),
+    # GH#8995: data-hygiene retention policy CRUD + settings/stats
+    (
+        "api.admin_retention_policies",
+        "",
+        ["admin", "retention", "data-hygiene"],
+        "admin_retention_policies",
+    ),
     # GH#8605: Per-user voice bundle assignment (admin + user endpoints)
     (
         "api.voice_bundle_admin",

--- a/autobot-backend/tasks/__init__.py
+++ b/autobot-backend/tasks/__init__.py
@@ -20,6 +20,10 @@ from .analytics_tasks import (
     run_pattern_analysis,
     run_security_analysis,
 )
+from .audit_log_retention import cleanup_expired_audit_logs
+from .chat_retention import cleanup_expired_chats
+from .file_retention import cleanup_expired_files
+from .knowledge_retention import cleanup_expired_kb_entries
 from .knowledge_tasks import (
     cleanup_generated_files,
     cleanup_orphan_documents,
@@ -66,4 +70,9 @@ __all__ = [
     "extract_facts_task",
     "update_graph_task",
     "compact_snapshot_task",
+    # GH#8995: data-hygiene retention tasks
+    "cleanup_expired_chats",
+    "cleanup_expired_files",
+    "cleanup_expired_audit_logs",
+    "cleanup_expired_kb_entries",
 ]

--- a/autobot-backend/tasks/audit_log_retention.py
+++ b/autobot-backend/tasks/audit_log_retention.py
@@ -3,133 +3,109 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Celery beat task: audit log retention cleanup (GH#8995, MVA-3044).
+Celery beat task: audit log retention cleanup (GH#8995).
 
-Removes audit log entries older than the configured TTL to prevent
-unbounded storage growth in long-running deployments.
+Prunes entries from Redis audit sorted-sets that are older than the
+configured TTL.
+
+Safe defaults: period=0 → task is a no-op.  Nothing is deleted unless
+AUTOBOT_AUDIT_RETENTION_DAYS is set to a positive integer.
 """
 
-import os
 from datetime import datetime, timedelta, timezone
-from typing import Dict
+from typing import Any, Dict
 
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.ssot_config import config as ssot_config
 from celery_app import celery_app
+from services.audit.unified_audit import AuditCategory, AuditEvent, emit as audit_emit
 
 logger = get_logger(__name__)
 
-_DEFAULT_AUDIT_RETENTION_DAYS = 365  # 1 year default for audit logs
+# Module-level constant — reads env at import time (cache.py pattern)
+_AUDIT_RETENTION_DAYS = ssot_config.audit_retention_days
+
+_AUDIT_PATTERN = "audit:*"
+
+
+def _emit_purge_audit(deleted_logs: int, retention_days: int, extra: Dict[str, Any]) -> None:
+    """Emit a single audit event summarising the purge run."""
+    audit_emit(
+        AuditEvent(
+            category=AuditCategory.SECURITY,
+            action="audit_log_retention_purge",
+            actor_id="system:retention_worker",
+            resource_type="audit_log",
+            metadata={"deleted_logs": deleted_logs, "retention_days": retention_days, **extra},
+        )
+    )
 
 
 async def _async_cleanup_expired_audit_logs(retention_days: int, dry_run: bool = False) -> Dict[str, int]:
-    """Remove audit log entries older than retention_days (async helper for Celery task).
+    """Remove audit log entries older than retention_days from Redis zsets.
 
-    Args:
-        retention_days: Number of days to retain audit logs
-        dry_run: If True, log what would be deleted without actually deleting
-
-    Returns:
-        Dict with "deleted_logs" and "errors" counts
+    Idempotent: keys already expired/deleted are silently skipped.
     """
+    if retention_days <= 0:
+        logger.info("Audit log retention disabled (retention_days=%d), skipping.", retention_days)
+        return {"deleted_logs": 0, "errors": 0}
+
     redis_client = get_redis_client()
     if not redis_client:
-        logger.warning("Redis client not available, skipping audit log retention cleanup")
+        logger.warning("Redis client unavailable — skipping audit log retention cleanup.")
         return {"deleted_logs": 0, "errors": 0}
 
     cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
-    cutoff_timestamp = cutoff.timestamp()
-
+    cutoff_ts = cutoff.timestamp()
     deleted_logs = 0
     errors = 0
 
-    try:
-        # Cleanup audit log sorted sets/keys
-        # Pattern: audit:* (assumes audit logs use timestamp-based sorted sets)
-        audit_pattern = "audit:*"
-        cursor = 0
-        while True:
-            cursor, keys = redis_client.scan(cursor, match=audit_pattern, count=100)
-            for key in keys:
-                try:
-                    # Check if it's a sorted set (audit logs typically use zsets with timestamps)
-                    key_type = redis_client.type(key)
-                    if key_type == "zset":
-                        # Remove entries with scores (timestamps) older than cutoff
-                        if dry_run:
-                            old_count = redis_client.zcount(key, "-inf", cutoff_timestamp)
-                            if old_count > 0:
-                                logger.info(
-                                    "[DRY RUN] Would remove %d old entries from %s (older than %s)",
-                                    old_count,
-                                    key,
-                                    cutoff.isoformat(),
-                                )
-                                deleted_logs += old_count
-                        else:
-                            removed = redis_client.zremrangebyscore(key, "-inf", cutoff_timestamp)
-                            if removed > 0:
-                                deleted_logs += removed
-                                logger.info(
-                                    "Removed %d old entries from %s (older than %s)",
-                                    removed,
-                                    key,
-                                    cutoff.isoformat(),
-                                )
-                    elif key_type == "string":
-                        # For string keys, check idle time
-                        idle_time = redis_client.object("IDLETIME", key)
-                        if idle_time is None:
-                            continue
+    cursor: int = 0
+    while True:
+        cursor, keys = redis_client.scan(cursor, match=_AUDIT_PATTERN, count=200)
+        for key in keys:
+            try:
+                key_type = redis_client.type(key)
+                if key_type != "zset":
+                    continue
+                if dry_run:
+                    count = redis_client.zcount(key, "-inf", cutoff_ts)
+                    if count:
+                        logger.info("[DRY RUN] Would remove %d entries from %s", count, key)
+                        deleted_logs += count
+                else:
+                    removed = redis_client.zremrangebyscore(key, "-inf", cutoff_ts)
+                    if removed:
+                        deleted_logs += removed
+                        logger.debug("Removed %d old entries from %s", removed, key)
+            except Exception as exc:
+                errors += 1
+                logger.error("Error processing audit key %s: %s", key, exc)
+        if cursor == 0:
+            break
 
-                        idle_days = idle_time / 86400
-                        if idle_days > retention_days:
-                            if dry_run:
-                                logger.info("[DRY RUN] Would delete audit key: %s (idle: %.1f days)", key, idle_days)
-                                deleted_logs += 1
-                            else:
-                                redis_client.delete(key)
-                                deleted_logs += 1
-                                logger.debug("Deleted audit key: %s (idle: %.1f days)", key, idle_days)
-
-                except Exception as exc:
-                    errors += 1
-                    logger.error("Failed to process audit key %s: %s", key, exc)
-
-            if cursor == 0:
-                break
-
-    except Exception as exc:
-        errors += 1
-        logger.error("Audit log retention cleanup failed: %s", exc)
+    if deleted_logs and not dry_run:
+        _emit_purge_audit(deleted_logs, retention_days, {"cutoff_ts": cutoff_ts})
 
     logger.info(
-        "Audit log retention cleanup: deleted_logs=%d, errors=%d, retention_days=%d, dry_run=%s",
+        "Audit log retention: deleted_logs=%d errors=%d retention_days=%d dry_run=%s",
         deleted_logs,
         errors,
         retention_days,
         dry_run,
     )
-    return {
-        "deleted_logs": deleted_logs,
-        "errors": errors,
-    }
+    return {"deleted_logs": deleted_logs, "errors": errors}
 
 
 @celery_app.task(bind=True, name="tasks.cleanup_expired_audit_logs")
 def cleanup_expired_audit_logs(self, retention_days: int = None, dry_run: bool = False) -> Dict[str, int]:
-    """Remove audit log entries older than retention_days (GH#8995, MVA-3044).
+    """Remove audit log entries older than retention_days (GH#8995).
 
-    Args:
-        retention_days: Number of days to retain audit logs. Defaults to
-                        AUTOBOT_AUDIT_RETENTION_DAYS env var or 365 days.
-        dry_run: If True, log what would be deleted without actually deleting.
-
-    Returns:
-        Dict with "deleted_logs" and "errors" counts.
+    retention_days defaults to AUTOBOT_AUDIT_RETENTION_DAYS (0 = disabled).
+    dry_run=True logs what would be deleted without making changes.
     """
     if retention_days is None:
-        retention_days = int(os.getenv("AUTOBOT_AUDIT_RETENTION_DAYS", _DEFAULT_AUDIT_RETENTION_DAYS))
-
+        retention_days = _AUDIT_RETENTION_DAYS
     return run_or_schedule(_async_cleanup_expired_audit_logs(retention_days, dry_run))

--- a/autobot-backend/tasks/audit_log_retention.py
+++ b/autobot-backend/tasks/audit_log_retention.py
@@ -20,7 +20,8 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.ssot_config import config as ssot_config
 from celery_app import celery_app
-from services.audit.unified_audit import AuditCategory, AuditEvent, emit as audit_emit
+from services.audit.unified_audit import AuditCategory, AuditEvent
+from services.audit.unified_audit import emit as audit_emit
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/tasks/chat_retention.py
+++ b/autobot-backend/tasks/chat_retention.py
@@ -3,136 +3,169 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Celery beat task: chat history retention cleanup (GH#8995, MVA-3044).
+Celery beat task: chat history retention cleanup (GH#8995).
 
-Removes chat sessions and conversations older than the configured TTL to prevent
-unbounded storage growth in long-running deployments.
+Removes chat sessions older than the configured TTL.  Sessions with
+``keep_forever=true`` in their stored JSON are always exempt.
+
+Safe defaults: period=0 → task is a no-op.  Nothing is deleted unless
+AUTOBOT_CHAT_RETENTION_DAYS is set to a positive integer.
 """
 
-import os
+import json
 from datetime import datetime, timedelta, timezone
-from typing import Dict
+from typing import Any, Dict
 
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.ssot_config import config as ssot_config
 from celery_app import celery_app
+from services.audit.unified_audit import AuditCategory, AuditEvent, emit as audit_emit
 
 logger = get_logger(__name__)
 
-_DEFAULT_CHAT_RETENTION_DAYS = 90
+# Module-level constant — reads env at import time (cache.py pattern)
+_CHAT_RETENTION_DAYS = ssot_config.chat_retention_days
+
+# Redis sorted-set that maps session_id → last-update timestamp
+_RECENT_KEY = "chat:recent"
+# Prefix for individual session JSON blobs
+_SESSION_PREFIX = "chat:session:"
+_CONVERSATION_PREFIX = "chat:conversation:"
+
+
+def _is_keep_forever(raw: bytes) -> bool:
+    """Return True if the stored session JSON has keep_forever set."""
+    try:
+        data = json.loads(raw)
+        return bool(data.get("keep_forever") or data.get("keepForever"))
+    except Exception:
+        return False
+
+
+def _parse_created_at(raw: bytes) -> datetime | None:
+    """Extract createdAt timestamp from stored session JSON.
+
+    Returns a timezone-aware datetime or None when unavailable/unparseable.
+    """
+    try:
+        data = json.loads(raw)
+        raw_ts = data.get("createdAt") or data.get("createdTime")
+        if not raw_ts:
+            return None
+        if isinstance(raw_ts, (int, float)):
+            return datetime.fromtimestamp(float(raw_ts), tz=timezone.utc)
+        dt = datetime.fromisoformat(str(raw_ts))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except Exception:
+        return None
+
+
+def _emit_deletion_audit(resource_id: str, resource_type: str, extra: Dict[str, Any]) -> None:
+    """Fire-and-forget audit event for a retention deletion."""
+    audit_emit(
+        AuditEvent(
+            category=AuditCategory.SECURITY,
+            action="retention_purge",
+            actor_id="system:retention_worker",
+            resource_type=resource_type,
+            resource_id=resource_id,
+            metadata=extra,
+        )
+    )
 
 
 async def _async_cleanup_expired_chats(retention_days: int, dry_run: bool = False) -> Dict[str, int]:
-    """Remove chat sessions older than retention_days (async helper for Celery task).
+    """Remove chat sessions/conversations older than retention_days.
 
-    Args:
-        retention_days: Number of days to retain chat sessions
-        dry_run: If True, log what would be deleted without actually deleting
-
-    Returns:
-        Dict with "deleted_sessions", "deleted_conversations", and "errors" counts
+    Idempotent: re-running against already-deleted keys is safe.
+    Returns counts for deleted_sessions, deleted_conversations, skipped, errors.
     """
+    if retention_days <= 0:
+        logger.info("Chat retention disabled (retention_days=%d), skipping.", retention_days)
+        return {"deleted_sessions": 0, "deleted_conversations": 0, "skipped": 0, "errors": 0}
+
     redis_client = get_redis_client()
     if not redis_client:
-        logger.warning("Redis client not available, skipping chat retention cleanup")
-        return {"deleted_sessions": 0, "deleted_conversations": 0, "errors": 0}
+        logger.warning("Redis client unavailable — skipping chat retention cleanup.")
+        return {"deleted_sessions": 0, "deleted_conversations": 0, "skipped": 0, "errors": 0}
 
     cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
-    cutoff_timestamp = cutoff.timestamp()
-
     deleted_sessions = 0
     deleted_conversations = 0
+    skipped = 0
     errors = 0
 
+    # Prune chat:recent sorted set entries older than cutoff
+    cutoff_ts = cutoff.timestamp()
     try:
-        # Cleanup chat:recent sorted set - remove entries older than retention window
-        # ZREMRANGEBYSCORE chat:recent -inf <cutoff_timestamp>
-        recent_key = "chat:recent"
         if dry_run:
-            old_count = redis_client.zcount(recent_key, "-inf", cutoff_timestamp)
-            logger.info(
-                "[DRY RUN] Would remove %d old entries from %s (older than %s)",
-                old_count,
-                recent_key,
-                cutoff.isoformat(),
-            )
+            count = redis_client.zcount(_RECENT_KEY, "-inf", cutoff_ts)
+            logger.info("[DRY RUN] Would prune %d entries from %s older than %s", count, _RECENT_KEY, cutoff)
         else:
-            removed = redis_client.zremrangebyscore(recent_key, "-inf", cutoff_timestamp)
+            removed = redis_client.zremrangebyscore(_RECENT_KEY, "-inf", cutoff_ts)
             deleted_sessions += removed
-            logger.info(
-                "Removed %d old entries from %s (older than %s)",
-                removed,
-                recent_key,
-                cutoff.isoformat(),
-            )
-
-        # Cleanup individual chat:session:* keys
-        # Scan for keys and check their creation time via OBJECT IDLETIME
-        session_pattern = "chat:session:*"
-        cursor = 0
-        while True:
-            cursor, keys = redis_client.scan(cursor, match=session_pattern, count=100)
-            for key in keys:
-                try:
-                    # OBJECT IDLETIME returns seconds since last access
-                    idle_time = redis_client.object("IDLETIME", key)
-                    if idle_time is None:
-                        continue
-
-                    # Convert idle time to age and compare with retention window
-                    idle_days = idle_time / 86400
-                    if idle_days > retention_days:
-                        if dry_run:
-                            logger.info("[DRY RUN] Would delete session key: %s (idle: %.1f days)", key, idle_days)
-                        else:
-                            redis_client.delete(key)
-                            deleted_sessions += 1
-                            if deleted_sessions % 100 == 0:
-                                logger.info("Deleted %d session keys so far...", deleted_sessions)
-                except Exception as exc:
-                    errors += 1
-                    logger.error("Failed to process session key %s: %s", key, exc)
-
-            if cursor == 0:
-                break
-
-        # Cleanup chat:conversation:* keys
-        conversation_pattern = "chat:conversation:*"
-        cursor = 0
-        while True:
-            cursor, keys = redis_client.scan(cursor, match=conversation_pattern, count=100)
-            for key in keys:
-                try:
-                    idle_time = redis_client.object("IDLETIME", key)
-                    if idle_time is None:
-                        continue
-
-                    idle_days = idle_time / 86400
-                    if idle_days > retention_days:
-                        if dry_run:
-                            logger.info("[DRY RUN] Would delete conversation key: %s (idle: %.1f days)", key, idle_days)
-                        else:
-                            redis_client.delete(key)
-                            deleted_conversations += 1
-                            if deleted_conversations % 100 == 0:
-                                logger.info("Deleted %d conversation keys so far...", deleted_conversations)
-                except Exception as exc:
-                    errors += 1
-                    logger.error("Failed to process conversation key %s: %s", key, exc)
-
-            if cursor == 0:
-                break
-
+            if removed:
+                logger.info("Pruned %d entries from %s (older than %s)", removed, _RECENT_KEY, cutoff)
     except Exception as exc:
         errors += 1
-        logger.error("Chat retention cleanup failed: %s", exc)
+        logger.error("Failed to prune %s: %s", _RECENT_KEY, exc)
+
+    # Scan and delete individual session keys
+    for prefix, counter_attr in ((_SESSION_PREFIX, "sessions"), (_CONVERSATION_PREFIX, "conversations")):
+        cursor: int = 0
+        while True:
+            cursor, keys = redis_client.scan(cursor, match=f"{prefix}*", count=200)
+            for key in keys:
+                try:
+                    raw = redis_client.get(key)
+                    if raw is None:
+                        continue  # Already gone — idempotent
+
+                    if _is_keep_forever(raw):
+                        skipped += 1
+                        continue
+
+                    created_at = _parse_created_at(raw)
+                    if created_at is None or created_at >= cutoff:
+                        continue
+
+                    age_days = (datetime.now(timezone.utc) - created_at).days
+                    key_str = key.decode() if isinstance(key, bytes) else key
+
+                    if dry_run:
+                        logger.info("[DRY RUN] Would delete %s (age=%dd)", key_str, age_days)
+                        if counter_attr == "sessions":
+                            deleted_sessions += 1
+                        else:
+                            deleted_conversations += 1
+                    else:
+                        redis_client.delete(key)
+                        _emit_deletion_audit(
+                            resource_id=key_str,
+                            resource_type=f"chat:{counter_attr[:-1]}",
+                            extra={"age_days": age_days, "retention_days": retention_days},
+                        )
+                        if counter_attr == "sessions":
+                            deleted_sessions += 1
+                        else:
+                            deleted_conversations += 1
+                        logger.debug("Deleted %s (age=%dd)", key_str, age_days)
+                except Exception as exc:
+                    errors += 1
+                    logger.error("Error processing key %s: %s", key, exc)
+            if cursor == 0:
+                break
 
     logger.info(
-        "Chat retention cleanup: deleted_sessions=%d, deleted_conversations=%d, errors=%d, retention_days=%d, "
-        "dry_run=%s",
+        "Chat retention: deleted_sessions=%d deleted_conversations=%d skipped=%d errors=%d "
+        "retention_days=%d dry_run=%s",
         deleted_sessions,
         deleted_conversations,
+        skipped,
         errors,
         retention_days,
         dry_run,
@@ -140,23 +173,18 @@ async def _async_cleanup_expired_chats(retention_days: int, dry_run: bool = Fals
     return {
         "deleted_sessions": deleted_sessions,
         "deleted_conversations": deleted_conversations,
+        "skipped": skipped,
         "errors": errors,
     }
 
 
 @celery_app.task(bind=True, name="tasks.cleanup_expired_chats")
 def cleanup_expired_chats(self, retention_days: int = None, dry_run: bool = False) -> Dict[str, int]:
-    """Remove chat sessions and conversations older than retention_days (GH#8995, MVA-3044).
+    """Remove chat sessions older than retention_days (GH#8995).
 
-    Args:
-        retention_days: Number of days to retain chats. Defaults to
-                        AUTOBOT_CHAT_RETENTION_DAYS env var or 90 days.
-        dry_run: If True, log what would be deleted without actually deleting.
-
-    Returns:
-        Dict with "deleted_sessions", "deleted_conversations", and "errors" counts.
+    retention_days defaults to AUTOBOT_CHAT_RETENTION_DAYS (0 = disabled).
+    dry_run=True logs what would be deleted without making changes.
     """
     if retention_days is None:
-        retention_days = int(os.getenv("AUTOBOT_CHAT_RETENTION_DAYS", _DEFAULT_CHAT_RETENTION_DAYS))
-
+        retention_days = _CHAT_RETENTION_DAYS
     return run_or_schedule(_async_cleanup_expired_chats(retention_days, dry_run))

--- a/autobot-backend/tasks/chat_retention.py
+++ b/autobot-backend/tasks/chat_retention.py
@@ -21,7 +21,8 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.ssot_config import config as ssot_config
 from celery_app import celery_app
-from services.audit.unified_audit import AuditCategory, AuditEvent, emit as audit_emit
+from services.audit.unified_audit import AuditCategory, AuditEvent
+from services.audit.unified_audit import emit as audit_emit
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/tasks/file_retention.py
+++ b/autobot-backend/tasks/file_retention.py
@@ -18,7 +18,8 @@ from typing import Any, Dict
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config as ssot_config
 from celery_app import celery_app
-from services.audit.unified_audit import AuditCategory, AuditEvent, emit as audit_emit
+from services.audit.unified_audit import AuditCategory, AuditEvent
+from services.audit.unified_audit import emit as audit_emit
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/tasks/file_retention.py
+++ b/autobot-backend/tasks/file_retention.py
@@ -3,39 +3,57 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Celery beat task: file attachment retention cleanup (GH#8995, MVA-3044).
+Celery beat task: file attachment retention cleanup (GH#8995).
 
-Removes uploaded file attachments older than the configured TTL to prevent
-unbounded storage growth in long-running deployments.
+Removes uploaded file attachments older than the configured TTL.
+
+Safe defaults: period=0 → task is a no-op.  Nothing is deleted unless
+AUTOBOT_FILE_RETENTION_DAYS is set to a positive integer.
 """
 
-import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config as ssot_config
 from celery_app import celery_app
+from services.audit.unified_audit import AuditCategory, AuditEvent, emit as audit_emit
 
 logger = get_logger(__name__)
 
-_DEFAULT_FILE_RETENTION_DAYS = 90
+# Module-level constant — reads env at import time (cache.py pattern)
+_FILE_RETENTION_DAYS = ssot_config.file_retention_days
+_STORAGE_BASE = Path(ssot_config.misc.chats_directory or "data") / "uploads"
+
+
+def _emit_deletion_audit(file_path: str, extra: Dict[str, Any]) -> None:
+    """Fire-and-forget audit event for a file retention deletion."""
+    audit_emit(
+        AuditEvent(
+            category=AuditCategory.SECURITY,
+            action="retention_purge",
+            actor_id="system:retention_worker",
+            resource_type="file_attachment",
+            resource_id=file_path,
+            metadata=extra,
+        )
+    )
 
 
 def _cleanup_expired_files(retention_days: int, dry_run: bool = False) -> Dict[str, int]:
     """Remove uploaded files older than retention_days.
 
-    Args:
-        retention_days: Number of days to retain files
-        dry_run: If True, log what would be deleted without actually deleting
-
-    Returns:
-        Dict with "deleted_files", "deleted_bytes", and "errors" counts
+    Idempotent: files already deleted are silently skipped.
+    Returns counts for deleted_files, deleted_bytes, errors.
     """
-    # Get storage directories from conversation_file_manager pattern
-    storage_base = Path(os.getenv("AUTOBOT_FILE_STORAGE_DIR", "data/uploads"))
+    if retention_days <= 0:
+        logger.info("File retention disabled (retention_days=%d), skipping.", retention_days)
+        return {"deleted_files": 0, "deleted_bytes": 0, "errors": 0}
+
+    storage_base = _STORAGE_BASE
     if not storage_base.exists():
-        logger.info("File storage directory %s does not exist, skipping cleanup", storage_base)
+        logger.info("File storage dir %s does not exist — nothing to purge.", storage_base)
         return {"deleted_files": 0, "deleted_bytes": 0, "errors": 0}
 
     cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
@@ -43,87 +61,64 @@ def _cleanup_expired_files(retention_days: int, dry_run: bool = False) -> Dict[s
     deleted_bytes = 0
     errors = 0
 
-    try:
-        # Walk through all files in storage directory
-        for file_path in storage_base.rglob("*"):
-            if not file_path.is_file():
+    for file_path in storage_base.rglob("*"):
+        if not file_path.is_file():
+            continue
+        try:
+            stat = file_path.stat()
+            mtime = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
+            if mtime >= cutoff:
                 continue
 
-            try:
-                # Get file modification time
-                mtime = datetime.fromtimestamp(file_path.stat().st_mtime, tz=timezone.utc)
-                file_size = file_path.stat().st_size
+            size = stat.st_size
+            age_days = (datetime.now(timezone.utc) - mtime).days
 
-                if mtime < cutoff:
-                    if dry_run:
-                        logger.info(
-                            "[DRY RUN] Would delete file: %s (age: %d days, size: %d bytes)",
-                            file_path,
-                            (datetime.now(timezone.utc) - mtime).days,
-                            file_size,
-                        )
-                        deleted_files += 1
-                        deleted_bytes += file_size
-                    else:
-                        file_path.unlink()
-                        deleted_files += 1
-                        deleted_bytes += file_size
-                        logger.debug(
-                            "Deleted file: %s (age: %d days, size: %d bytes)",
-                            file_path,
-                            (datetime.now(timezone.utc) - mtime).days,
-                            file_size,
-                        )
+            if dry_run:
+                logger.info("[DRY RUN] Would delete %s (age=%dd, size=%d)", file_path, age_days, size)
+                deleted_files += 1
+                deleted_bytes += size
+            else:
+                file_path.unlink()
+                _emit_deletion_audit(
+                    str(file_path),
+                    {"age_days": age_days, "size_bytes": size, "retention_days": retention_days},
+                )
+                deleted_files += 1
+                deleted_bytes += size
+                logger.debug("Deleted %s (age=%dd, size=%d)", file_path, age_days, size)
+        except FileNotFoundError:
+            pass  # Already deleted — idempotent
+        except Exception as exc:
+            errors += 1
+            logger.error("Error processing %s: %s", file_path, exc)
 
-                        if deleted_files % 100 == 0:
-                            logger.info("Deleted %d files so far...", deleted_files)
-
-            except Exception as exc:
-                errors += 1
-                logger.error("Failed to process file %s: %s", file_path, exc)
-
-        # Cleanup empty directories
-        if not dry_run:
-            for dir_path in sorted(storage_base.rglob("*"), key=lambda p: len(p.parts), reverse=True):
-                if dir_path.is_dir() and not any(dir_path.iterdir()):
-                    try:
-                        dir_path.rmdir()
-                        logger.debug("Removed empty directory: %s", dir_path)
-                    except Exception as exc:
-                        logger.debug("Could not remove directory %s: %s", dir_path, exc)
-
-    except Exception as exc:
-        errors += 1
-        logger.error("File retention cleanup failed: %s", exc)
+    # Remove empty directories (best-effort)
+    if not dry_run:
+        for dir_path in sorted(storage_base.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+            if dir_path.is_dir() and not any(dir_path.iterdir()):
+                try:
+                    dir_path.rmdir()
+                except Exception:
+                    pass
 
     logger.info(
-        "File retention cleanup: deleted_files=%d, deleted_bytes=%d, errors=%d, retention_days=%d, dry_run=%s",
+        "File retention: deleted_files=%d deleted_bytes=%d errors=%d retention_days=%d dry_run=%s",
         deleted_files,
         deleted_bytes,
         errors,
         retention_days,
         dry_run,
     )
-    return {
-        "deleted_files": deleted_files,
-        "deleted_bytes": deleted_bytes,
-        "errors": errors,
-    }
+    return {"deleted_files": deleted_files, "deleted_bytes": deleted_bytes, "errors": errors}
 
 
 @celery_app.task(bind=True, name="tasks.cleanup_expired_files")
 def cleanup_expired_files(self, retention_days: int = None, dry_run: bool = False) -> Dict[str, int]:
-    """Remove uploaded file attachments older than retention_days (GH#8995, MVA-3044).
+    """Remove uploaded file attachments older than retention_days (GH#8995).
 
-    Args:
-        retention_days: Number of days to retain files. Defaults to
-                        AUTOBOT_FILE_RETENTION_DAYS env var or 90 days.
-        dry_run: If True, log what would be deleted without actually deleting.
-
-    Returns:
-        Dict with "deleted_files", "deleted_bytes", and "errors" counts.
+    retention_days defaults to AUTOBOT_FILE_RETENTION_DAYS (0 = disabled).
+    dry_run=True logs what would be deleted without making changes.
     """
     if retention_days is None:
-        retention_days = int(os.getenv("AUTOBOT_FILE_RETENTION_DAYS", _DEFAULT_FILE_RETENTION_DAYS))
-
+        retention_days = _FILE_RETENTION_DAYS
     return _cleanup_expired_files(retention_days, dry_run)

--- a/autobot-backend/tasks/knowledge_retention.py
+++ b/autobot-backend/tasks/knowledge_retention.py
@@ -20,7 +20,8 @@ from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config as ssot_config
 from celery_app import celery_app
-from services.audit.unified_audit import AuditCategory, AuditEvent, emit as audit_emit
+from services.audit.unified_audit import AuditCategory, AuditEvent
+from services.audit.unified_audit import emit as audit_emit
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/tasks/knowledge_retention.py
+++ b/autobot-backend/tasks/knowledge_retention.py
@@ -1,0 +1,156 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Celery beat task: knowledge-base entry retention cleanup (GH#8995).
+
+Removes KB facts (Redis ``fact:*`` hashes) older than the configured TTL.
+Delegates actual deletion to KnowledgeBase.delete_fact so all vector/BM25
+index side-effects are applied correctly.
+
+Safe defaults: period=0 → task is a no-op.  Nothing is deleted unless
+AUTOBOT_KB_RETENTION_DAYS is set to a positive integer.
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from autobot_shared.async_compat import run_or_schedule
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config as ssot_config
+from celery_app import celery_app
+from services.audit.unified_audit import AuditCategory, AuditEvent, emit as audit_emit
+
+logger = get_logger(__name__)
+
+# Module-level constant — reads env at import time (cache.py pattern)
+_KB_RETENTION_DAYS = ssot_config.kb_retention_days
+
+_FACT_PATTERN = "fact:*"
+
+
+def _emit_deletion_audit(fact_id: str, extra: Dict[str, Any]) -> None:
+    """Fire-and-forget audit event for a KB retention deletion."""
+    audit_emit(
+        AuditEvent(
+            category=AuditCategory.KNOWLEDGE,
+            action="retention_purge",
+            actor_id="system:retention_worker",
+            resource_type="kb_entry",
+            resource_id=fact_id,
+            metadata=extra,
+        )
+    )
+
+
+async def _async_cleanup_expired_kb_entries(retention_days: int, dry_run: bool = False) -> Dict[str, int]:
+    """Remove KB facts older than retention_days.
+
+    Uses KnowledgeBase.delete_fact so vector index side-effects are applied.
+    Idempotent: facts already deleted are silently skipped.
+    """
+    if retention_days <= 0:
+        logger.info("KB retention disabled (retention_days=%d), skipping.", retention_days)
+        return {"deleted_entries": 0, "skipped": 0, "errors": 0}
+
+    from autobot_shared.redis_client import get_redis_client
+    from knowledge import get_knowledge_base
+
+    redis_client = get_redis_client()
+    if not redis_client:
+        logger.warning("Redis client unavailable — skipping KB retention cleanup.")
+        return {"deleted_entries": 0, "skipped": 0, "errors": 0}
+
+    # Compute cutoff as ISO timestamp string for comparison
+    from datetime import timedelta
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+
+    deleted_entries = 0
+    skipped = 0
+    errors = 0
+
+    # Collect candidate fact IDs first (avoid mutating while scanning)
+    candidates = []
+    cursor: int = 0
+    while True:
+        cursor, keys = redis_client.scan(cursor, match=_FACT_PATTERN, count=200)
+        for key in keys:
+            key_str = key.decode("utf-8") if isinstance(key, bytes) else key
+            # Only process bare fact:<id> hashes, not index/mapping keys
+            parts = key_str.split(":")
+            if len(parts) != 2:
+                continue
+            fact_id = parts[1]
+            try:
+                raw_ts = redis_client.hget(key, "timestamp")
+                if not raw_ts:
+                    skipped += 1
+                    continue
+                ts_str = raw_ts.decode("utf-8") if isinstance(raw_ts, bytes) else raw_ts
+                fact_ts = datetime.fromisoformat(ts_str)
+                if fact_ts.tzinfo is None:
+                    fact_ts = fact_ts.replace(tzinfo=timezone.utc)
+                if fact_ts >= cutoff:
+                    continue
+                age_days = (datetime.now(timezone.utc) - fact_ts).days
+                candidates.append((fact_id, age_days))
+            except Exception as exc:
+                skipped += 1
+                logger.debug("Skipping %s — cannot parse timestamp: %s", key_str, exc)
+        if cursor == 0:
+            break
+
+    if not candidates:
+        logger.info("KB retention: no entries older than %d days found.", retention_days)
+        return {"deleted_entries": 0, "skipped": skipped, "errors": 0}
+
+    kb = await get_knowledge_base()
+
+    for fact_id, age_days in candidates:
+        try:
+            if dry_run:
+                logger.info("[DRY RUN] Would delete KB fact %s (age=%dd)", fact_id, age_days)
+                deleted_entries += 1
+            else:
+                result = await kb.delete_fact(fact_id, _skip_bm25_refresh=True)
+                if result.get("status") == "success":
+                    _emit_deletion_audit(fact_id, {"age_days": age_days, "retention_days": retention_days})
+                    deleted_entries += 1
+                    logger.debug("Deleted KB fact %s (age=%dd)", fact_id, age_days)
+                else:
+                    # Already deleted or not found — idempotent
+                    skipped += 1
+        except Exception as exc:
+            errors += 1
+            logger.error("Error deleting KB fact %s: %s", fact_id, exc)
+
+    # Trigger BM25 refresh once after bulk delete
+    if deleted_entries and not dry_run:
+        try:
+            kb._schedule_bm25_refresh()
+        except Exception:
+            pass
+
+    logger.info(
+        "KB retention: deleted_entries=%d skipped=%d errors=%d retention_days=%d dry_run=%s",
+        deleted_entries,
+        skipped,
+        errors,
+        retention_days,
+        dry_run,
+    )
+    return {"deleted_entries": deleted_entries, "skipped": skipped, "errors": errors}
+
+
+@celery_app.task(bind=True, name="tasks.cleanup_expired_kb_entries")
+def cleanup_expired_kb_entries(self, retention_days: int = None, dry_run: bool = False) -> Dict[str, int]:
+    """Remove knowledge-base entries older than retention_days (GH#8995).
+
+    retention_days defaults to AUTOBOT_KB_RETENTION_DAYS (0 = disabled).
+    dry_run=True logs what would be deleted without making changes.
+    """
+    if retention_days is None:
+        retention_days = _KB_RETENTION_DAYS
+    return run_or_schedule(_async_cleanup_expired_kb_entries(retention_days, dry_run))

--- a/autobot-backend/tests/unit/test_data_retention.py
+++ b/autobot-backend/tests/unit/test_data_retention.py
@@ -1,0 +1,491 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for GH#8995 data-hygiene retention tasks.
+
+Covers:
+- Purge deletes only items older than the retention period
+- No-op when period is 0 (disabled)
+- keep_forever flag exempts chat sessions from purge
+- Idempotent re-run (already-deleted keys are silently skipped)
+- audit_emit called once per actual deletion
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ts(days_ago: float) -> str:
+    """Return an ISO timestamp string `days_ago` days in the past."""
+    dt = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return dt.isoformat()
+
+
+def _session_json(days_ago: float, keep_forever: bool = False) -> bytes:
+    """Return a serialised session blob for a session created `days_ago` days ago."""
+    data = {
+        "id": f"chat-session-{days_ago}",
+        "createdAt": _ts(days_ago),
+        "keep_forever": keep_forever,
+    }
+    return json.dumps(data).encode()
+
+
+# ---------------------------------------------------------------------------
+# _is_keep_forever / _parse_created_at helpers
+# ---------------------------------------------------------------------------
+
+
+class TestParseHelpers:
+    def test_is_keep_forever_true(self):
+        from tasks.chat_retention import _is_keep_forever
+
+        raw = json.dumps({"keep_forever": True}).encode()
+        assert _is_keep_forever(raw) is True
+
+    def test_is_keep_forever_false(self):
+        from tasks.chat_retention import _is_keep_forever
+
+        raw = json.dumps({"keep_forever": False}).encode()
+        assert _is_keep_forever(raw) is False
+
+    def test_is_keep_forever_missing_key(self):
+        from tasks.chat_retention import _is_keep_forever
+
+        raw = json.dumps({"id": "abc"}).encode()
+        assert _is_keep_forever(raw) is False
+
+    def test_is_keep_forever_camelcase(self):
+        from tasks.chat_retention import _is_keep_forever
+
+        raw = json.dumps({"keepForever": True}).encode()
+        assert _is_keep_forever(raw) is True
+
+    def test_parse_created_at_iso(self):
+        from tasks.chat_retention import _parse_created_at
+
+        ts = _ts(10)
+        raw = json.dumps({"createdAt": ts}).encode()
+        result = _parse_created_at(raw)
+        assert result is not None
+        assert result.tzinfo is not None
+        assert abs((datetime.now(timezone.utc) - result).days - 10) <= 1
+
+    def test_parse_created_at_missing(self):
+        from tasks.chat_retention import _parse_created_at
+
+        raw = json.dumps({"id": "abc"}).encode()
+        assert _parse_created_at(raw) is None
+
+    def test_parse_created_at_malformed(self):
+        from tasks.chat_retention import _parse_created_at
+
+        raw = json.dumps({"createdAt": "not-a-date"}).encode()
+        assert _parse_created_at(raw) is None
+
+
+# ---------------------------------------------------------------------------
+# chat retention — _async_cleanup_expired_chats
+# ---------------------------------------------------------------------------
+
+
+class TestChatRetention:
+    @pytest.mark.asyncio
+    async def test_no_op_when_disabled(self):
+        """retention_days=0 → immediate return, Redis not touched."""
+        from tasks.chat_retention import _async_cleanup_expired_chats
+
+        with patch("tasks.chat_retention.get_redis_client") as mock_redis:
+            result = await _async_cleanup_expired_chats(retention_days=0)
+
+        mock_redis.assert_not_called()
+        assert result["deleted_sessions"] == 0
+        assert result["deleted_conversations"] == 0
+
+    @pytest.mark.asyncio
+    async def test_deletes_old_session(self):
+        """Sessions older than retention_days are deleted with audit emit."""
+        from tasks.chat_retention import _async_cleanup_expired_chats
+
+        old_key = b"chat:session:old"
+        old_blob = _session_json(days_ago=91)
+
+        redis = MagicMock()
+        redis.zremrangebyscore.return_value = 0
+        # scan: first call returns the old session key, second ends iteration
+        redis.scan.side_effect = [
+            (1, [old_key]),  # first scan page
+            (0, []),  # end of iteration
+            (0, []),  # conversation scan — empty
+        ]
+        redis.get.return_value = old_blob
+        redis.delete.return_value = 1
+
+        with (
+            patch("tasks.chat_retention.get_redis_client", return_value=redis),
+            patch("tasks.chat_retention.audit_emit") as mock_emit,
+        ):
+            result = await _async_cleanup_expired_chats(retention_days=90)
+
+        redis.delete.assert_called_once_with(old_key)
+        assert result["deleted_sessions"] == 1
+        assert result["errors"] == 0
+        mock_emit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_keeps_recent_session(self):
+        """Sessions newer than retention_days are NOT deleted."""
+        from tasks.chat_retention import _async_cleanup_expired_chats
+
+        new_key = b"chat:session:new"
+        new_blob = _session_json(days_ago=10)
+
+        redis = MagicMock()
+        redis.zremrangebyscore.return_value = 0
+        redis.scan.side_effect = [
+            (1, [new_key]),
+            (0, []),
+            (0, []),
+        ]
+        redis.get.return_value = new_blob
+
+        with (
+            patch("tasks.chat_retention.get_redis_client", return_value=redis),
+            patch("tasks.chat_retention.audit_emit") as mock_emit,
+        ):
+            result = await _async_cleanup_expired_chats(retention_days=90)
+
+        redis.delete.assert_not_called()
+        assert result["deleted_sessions"] == 0
+        mock_emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_keep_forever_exemption(self):
+        """Sessions with keep_forever=True are skipped even if old."""
+        from tasks.chat_retention import _async_cleanup_expired_chats
+
+        key = b"chat:session:keep"
+        blob = _session_json(days_ago=200, keep_forever=True)
+
+        redis = MagicMock()
+        redis.zremrangebyscore.return_value = 0
+        redis.scan.side_effect = [
+            (1, [key]),
+            (0, []),
+            (0, []),
+        ]
+        redis.get.return_value = blob
+
+        with (
+            patch("tasks.chat_retention.get_redis_client", return_value=redis),
+            patch("tasks.chat_retention.audit_emit") as mock_emit,
+        ):
+            result = await _async_cleanup_expired_chats(retention_days=90)
+
+        redis.delete.assert_not_called()
+        assert result["skipped"] == 1
+        mock_emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_already_deleted(self):
+        """If redis.get returns None (key already gone) → silently skip."""
+        from tasks.chat_retention import _async_cleanup_expired_chats
+
+        key = b"chat:session:gone"
+
+        redis = MagicMock()
+        redis.zremrangebyscore.return_value = 0
+        redis.scan.side_effect = [
+            (1, [key]),
+            (0, []),
+            (0, []),
+        ]
+        redis.get.return_value = None  # already deleted
+
+        with (
+            patch("tasks.chat_retention.get_redis_client", return_value=redis),
+            patch("tasks.chat_retention.audit_emit") as mock_emit,
+        ):
+            result = await _async_cleanup_expired_chats(retention_days=90)
+
+        redis.delete.assert_not_called()
+        mock_emit.assert_not_called()
+        assert result["errors"] == 0
+
+    @pytest.mark.asyncio
+    async def test_dry_run_does_not_delete(self):
+        """dry_run=True logs intent but never calls redis.delete."""
+        from tasks.chat_retention import _async_cleanup_expired_chats
+
+        old_key = b"chat:session:old"
+        old_blob = _session_json(days_ago=91)
+
+        redis = MagicMock()
+        redis.zremrangebyscore.return_value = 0
+        redis.zcount.return_value = 0
+        redis.scan.side_effect = [
+            (1, [old_key]),
+            (0, []),
+            (0, []),
+        ]
+        redis.get.return_value = old_blob
+
+        with (
+            patch("tasks.chat_retention.get_redis_client", return_value=redis),
+            patch("tasks.chat_retention.audit_emit") as mock_emit,
+        ):
+            result = await _async_cleanup_expired_chats(retention_days=90, dry_run=True)
+
+        redis.delete.assert_not_called()
+        mock_emit.assert_not_called()
+        assert result["deleted_sessions"] == 1  # counted but not deleted
+
+    @pytest.mark.asyncio
+    async def test_audit_emit_called_per_deletion(self):
+        """One audit_emit call per deleted session."""
+        from tasks.chat_retention import _async_cleanup_expired_chats
+
+        keys = [b"chat:session:a", b"chat:session:b"]
+        blobs = [_session_json(days_ago=100), _session_json(days_ago=110)]
+
+        redis = MagicMock()
+        redis.zremrangebyscore.return_value = 0
+        redis.scan.side_effect = [
+            (1, [keys[0]]),
+            (1, [keys[1]]),
+            (0, []),
+            (0, []),  # conversation scans
+        ]
+        redis.get.side_effect = blobs
+        redis.delete.return_value = 1
+
+        with (
+            patch("tasks.chat_retention.get_redis_client", return_value=redis),
+            patch("tasks.chat_retention.audit_emit") as mock_emit,
+        ):
+            result = await _async_cleanup_expired_chats(retention_days=90)
+
+        assert mock_emit.call_count == 2
+        assert result["deleted_sessions"] == 2
+
+
+# ---------------------------------------------------------------------------
+# file retention — _cleanup_expired_files
+# ---------------------------------------------------------------------------
+
+
+class TestFileRetention:
+    def test_no_op_when_disabled(self, tmp_path):
+        """retention_days=0 → immediate return, no files deleted."""
+        from tasks.file_retention import _cleanup_expired_files
+
+        (tmp_path / "old.txt").write_text("x")
+        with patch("tasks.file_retention._STORAGE_BASE", tmp_path):
+            result = _cleanup_expired_files(retention_days=0)
+
+        assert result["deleted_files"] == 0
+
+    def test_deletes_old_file(self, tmp_path):
+        """Files older than retention_days are deleted with audit emit."""
+        from tasks.file_retention import _cleanup_expired_files
+
+        old_file = tmp_path / "old.txt"
+        old_file.write_text("x")
+        # backdate mtime
+        import os
+        import time
+
+        old_ts = time.time() - (91 * 86400)
+        os.utime(old_file, (old_ts, old_ts))
+
+        with (
+            patch("tasks.file_retention._STORAGE_BASE", tmp_path),
+            patch("tasks.file_retention.audit_emit") as mock_emit,
+        ):
+            result = _cleanup_expired_files(retention_days=90)
+
+        assert result["deleted_files"] == 1
+        assert not old_file.exists()
+        mock_emit.assert_called_once()
+
+    def test_keeps_recent_file(self, tmp_path):
+        """Files newer than retention_days are NOT deleted."""
+        from tasks.file_retention import _cleanup_expired_files
+
+        new_file = tmp_path / "new.txt"
+        new_file.write_text("x")
+
+        with (
+            patch("tasks.file_retention._STORAGE_BASE", tmp_path),
+            patch("tasks.file_retention.audit_emit") as mock_emit,
+        ):
+            result = _cleanup_expired_files(retention_days=90)
+
+        assert result["deleted_files"] == 0
+        assert new_file.exists()
+        mock_emit.assert_not_called()
+
+    def test_idempotent_already_deleted(self, tmp_path):
+        """FileNotFoundError during unlink is silently ignored."""
+        from tasks.file_retention import _cleanup_expired_files
+
+        # Create a file then patch unlink to raise FileNotFoundError
+        old_file = tmp_path / "gone.txt"
+        old_file.write_text("x")
+        import os
+        import time
+
+        old_ts = time.time() - (91 * 86400)
+        os.utime(old_file, (old_ts, old_ts))
+
+        original_unlink = old_file.__class__.unlink
+
+        def raise_not_found(self, missing_ok=False):
+            raise FileNotFoundError("already gone")
+
+        with (
+            patch("tasks.file_retention._STORAGE_BASE", tmp_path),
+            patch.object(old_file.__class__, "unlink", raise_not_found),
+            patch("tasks.file_retention.audit_emit") as mock_emit,
+        ):
+            result = _cleanup_expired_files(retention_days=90)
+
+        assert result["errors"] == 0  # FileNotFoundError is not an error
+        mock_emit.assert_not_called()
+
+    def test_dry_run_does_not_delete(self, tmp_path):
+        """dry_run=True counts but does not delete files."""
+        from tasks.file_retention import _cleanup_expired_files
+
+        old_file = tmp_path / "old.txt"
+        old_file.write_text("x")
+        import os
+        import time
+
+        old_ts = time.time() - (91 * 86400)
+        os.utime(old_file, (old_ts, old_ts))
+
+        with (
+            patch("tasks.file_retention._STORAGE_BASE", tmp_path),
+            patch("tasks.file_retention.audit_emit") as mock_emit,
+        ):
+            result = _cleanup_expired_files(retention_days=90, dry_run=True)
+
+        assert result["deleted_files"] == 1
+        assert old_file.exists()  # not actually deleted
+        mock_emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# audit log retention — _async_cleanup_expired_audit_logs
+# ---------------------------------------------------------------------------
+
+
+class TestAuditLogRetention:
+    @pytest.mark.asyncio
+    async def test_no_op_when_disabled(self):
+        """retention_days=0 → immediate return, Redis not touched."""
+        from tasks.audit_log_retention import _async_cleanup_expired_audit_logs
+
+        with patch("tasks.audit_log_retention.get_redis_client") as mock_redis:
+            result = await _async_cleanup_expired_audit_logs(retention_days=0)
+
+        mock_redis.assert_not_called()
+        assert result["deleted_logs"] == 0
+
+    @pytest.mark.asyncio
+    async def test_removes_old_entries_from_zset(self):
+        """Old entries in audit: zsets are removed."""
+        from tasks.audit_log_retention import _async_cleanup_expired_audit_logs
+
+        redis = MagicMock()
+        redis.scan.side_effect = [
+            (1, [b"audit:unified"]),
+            (0, []),
+        ]
+        redis.type.return_value = "zset"
+        redis.zremrangebyscore.return_value = 5  # 5 entries removed
+
+        with (
+            patch("tasks.audit_log_retention.get_redis_client", return_value=redis),
+            patch("tasks.audit_log_retention.audit_emit") as mock_emit,
+        ):
+            result = await _async_cleanup_expired_audit_logs(retention_days=90)
+
+        assert result["deleted_logs"] == 5
+        redis.zremrangebyscore.assert_called_once()
+        mock_emit.assert_called_once()  # summary audit event
+
+    @pytest.mark.asyncio
+    async def test_idempotent_empty_zset(self):
+        """zremrangebyscore returning 0 → no audit emit, no errors."""
+        from tasks.audit_log_retention import _async_cleanup_expired_audit_logs
+
+        redis = MagicMock()
+        redis.scan.side_effect = [(1, [b"audit:unified"]), (0, [])]
+        redis.type.return_value = "zset"
+        redis.zremrangebyscore.return_value = 0
+
+        with (
+            patch("tasks.audit_log_retention.get_redis_client", return_value=redis),
+            patch("tasks.audit_log_retention.audit_emit") as mock_emit,
+        ):
+            result = await _async_cleanup_expired_audit_logs(retention_days=90)
+
+        assert result["deleted_logs"] == 0
+        mock_emit.assert_not_called()  # no deletions → no event
+
+    @pytest.mark.asyncio
+    async def test_skips_non_zset_keys(self):
+        """String keys under audit:* are skipped (not deleted)."""
+        from tasks.audit_log_retention import _async_cleanup_expired_audit_logs
+
+        redis = MagicMock()
+        redis.scan.side_effect = [(1, [b"audit:config"]), (0, [])]
+        redis.type.return_value = "string"
+
+        with patch("tasks.audit_log_retention.get_redis_client", return_value=redis):
+            result = await _async_cleanup_expired_audit_logs(retention_days=90)
+
+        redis.zremrangebyscore.assert_not_called()
+        assert result["deleted_logs"] == 0
+
+
+# ---------------------------------------------------------------------------
+# ssot_config defaults
+# ---------------------------------------------------------------------------
+
+
+class TestSsotConfigDefaults:
+    def test_chat_retention_days_default_zero(self):
+        """chat_retention_days defaults to 0 (disabled)."""
+        from autobot_shared.ssot_config import config
+
+        assert config.chat_retention_days == 0
+
+    def test_file_retention_days_default_zero(self):
+        """file_retention_days defaults to 0 (disabled)."""
+        from autobot_shared.ssot_config import config
+
+        assert config.file_retention_days == 0
+
+    def test_audit_retention_days_default_zero(self):
+        """audit_retention_days defaults to 0 (disabled)."""
+        from autobot_shared.ssot_config import config
+
+        assert config.audit_retention_days == 0
+
+    def test_kb_retention_days_default_zero(self):
+        """kb_retention_days defaults to 0 (disabled)."""
+        from autobot_shared.ssot_config import config
+
+        assert config.kb_retention_days == 0

--- a/autobot-backend/tests/unit/test_data_retention.py
+++ b/autobot-backend/tests/unit/test_data_retention.py
@@ -15,7 +15,7 @@ Covers:
 
 import json
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -347,7 +347,7 @@ class TestFileRetention:
         old_ts = time.time() - (91 * 86400)
         os.utime(old_file, (old_ts, old_ts))
 
-        original_unlink = old_file.__class__.unlink
+        old_file.__class__.unlink
 
         def raise_not_found(self, missing_ok=False):
             raise FileNotFoundError("already gone")

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1708,14 +1708,41 @@ class AutoBotConfig(BaseSettings):
     debug: bool = Field(default=False, alias="AUTOBOT_DEBUG")
     log_level: str = Field(default="INFO", alias="AUTOBOT_LOG_LEVEL")
 
+    # GH#8995: Data-hygiene TTL settings (retention OFF by default — 0 means disabled)
+    # Safe defaults: nothing is deleted unless an admin explicitly sets a period.
+    chat_retention_days: int = Field(
+        default=0,
+        alias="AUTOBOT_CHAT_RETENTION_DAYS",
+        description=(
+            "Days to retain chat sessions/conversations (0 = retention disabled). "
+            "Chats flagged keep_forever=true are always exempt. "
+            "Applied nightly by tasks.cleanup_expired_chats."
+        ),
+    )
+    file_retention_days: int = Field(
+        default=0,
+        alias="AUTOBOT_FILE_RETENTION_DAYS",
+        description=(
+            "Days to retain uploaded file attachments (0 = retention disabled). "
+            "Applied nightly by tasks.cleanup_expired_files."
+        ),
+    )
+    kb_retention_days: int = Field(
+        default=0,
+        alias="AUTOBOT_KB_RETENTION_DAYS",
+        description=(
+            "Days to retain knowledge-base entries (0 = retention disabled). "
+            "Applied nightly by tasks.cleanup_expired_kb_entries."
+        ),
+    )
+
     # Audit logging — issue #3277
     audit_retention_days: int = Field(
-        default=90,
+        default=0,
         alias="AUTOBOT_AUDIT_RETENTION_DAYS",
         description=(
-            "Number of days to retain security audit logs in Redis. "
-            "Default 90 days satisfies most compliance requirements. "
-            "Range: 7–365."
+            "Days to retain audit logs in Redis (0 = retention disabled). "
+            "Applied nightly by tasks.cleanup_expired_audit_logs."
         ),
     )
 


### PR DESCRIPTION
## Thinking Path
#8995 — operator-level retention/data-hygiene TTL policies. SLM/infra feature: config + nightly Celery Beat purge + audit logging + per-conversation keep-forever + admin settings/stats endpoint. **Safe by default**: every retention period defaults to 0 (= disabled), so no data is ever deleted unless an admin explicitly configures a period.

## What Changed
- `autobot_shared/ssot_config.py`: `chat_retention_days`, `file_retention_days`, `audit_retention_days`, `kb_retention_days` — env-driven, **all default 0 (disabled)**.
- `tasks/{chat,file,audit_log,knowledge}_retention.py`: idempotent purge per data type; **no-op when period is 0/unset**; each deletion emits a SECURITY/KNOWLEDGE audit event.
- `celery_app.py`: nightly Beat schedule (01:00–01:45 UTC, staggered).
- Per-conversation **keep-forever** flag (`keep_forever`) exempts a chat from purge.
- `api/admin_retention_policies.py`: `GET /api/admin/retention-settings` (`Depends(_require_admin)`) → current periods + storage stats; router registered.

## Verification
- `pytest tests/unit/test_data_retention.py` → **27 passed** (no-op-when-disabled, deletes-only-older, keep-forever-exempt, idempotent re-run, dry-run-no-delete, audit-emit-per-deletion, defaults=0).
- `celery_app` imports; black + py_compile clean.

## Notes
- **`audit_retention_days` default changed 90 → 0** deliberately: this PR newly *schedules* the audit purge, so a 90 default would suddenly start deleting old audit logs on existing deployments. 0 = opt-in. Set `AUTOBOT_AUDIT_RETENTION_DAYS=90` to restore.
- Admin **UI panel deferred** — it's a thin consumer of the new `GET /api/admin/retention-settings` endpoint (would add 11-locale i18n churn); backend + API complete. Recommend a follow-up for the SLM settings view.

## Model Used
Opus 4.8

Fixes #8995
