### PR TITLE
feat(sso): Phase A enterprise hardening — RP-logout+revocation, group→role, PKCE docs (#10151, #10152, #10155)

### DIFF
--- a/autobot-slm-backend/api/auth.py
+++ b/autobot-slm-backend/api/auth.py
@@ -11,13 +11,17 @@ Consolidated from legacy auth.py and slm_auth.py in Issue #1922.
 """
 
 import logging
+import time
 from datetime import timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
 from api.security import create_audit_log
+from autobot_shared.auth.jwt_core import _peek_alg, decode_jwt_no_verify_exp
 from autobot_shared.auth.permissions import Permission
 from autobot_shared.proxy_utils import get_client_ip
 from config import settings
@@ -30,11 +34,22 @@ from models.schemas import (
 )
 from services.auth import auth_service, get_current_user, get_slm_db, require_permission
 from services.database import get_db
+from services.token_denylist import revoke_jti
+from user_management.models.sso import UserSSOLink
 from user_management.models.user import User
 from user_management.services import TenantContext, UserService
 
+_bearer = HTTPBearer()
+
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+async def _get_raw_token(
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(_bearer)],
+) -> str:
+    """Extract the raw bearer token string (for logout jti revocation)."""
+    return credentials.credentials
 
 
 def _create_mfa_challenge(user: User) -> MfaChallengeResponse:
@@ -163,6 +178,84 @@ async def get_current_user_info(
         "is_admin": current_user.get("admin", False),
         "user_type": "slm_admin",
     }
+
+
+def _build_end_session_url(link: "UserSSOLink") -> str | None:
+    """Return the IdP end-session URL for *link*, or None if not configured."""
+    endpoint = link.provider.config.get("end_session_endpoint") if link and link.provider else None
+    if not endpoint:
+        return None
+    parts = [endpoint]
+    post_logout = link.provider.config.get("post_logout_redirect_uri")
+    if post_logout:
+        parts.append(f"post_logout_redirect_uri={post_logout}")
+    id_token = (link.sso_metadata or {}).get("id_token")
+    if id_token:
+        parts.append(f"id_token_hint={id_token}")
+    separator = "&" if "?" in endpoint else "?"
+    params = "&".join(parts[1:])
+    return f"{endpoint}{separator}{params}" if params else endpoint
+
+
+async def _get_user_sso_link(db: AsyncSession, username: str) -> "UserSSOLink | None":
+    """Return the first active SSO link for *username*, or None."""
+    result = await db.execute(
+        select(UserSSOLink).join(User, UserSSOLink.user_id == User.id).where(User.username == username).limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+@router.post("/logout")
+async def logout(
+    http_request: Request,
+    current_user: Annotated[dict, Depends(get_current_user)],
+    token: Annotated[str, Depends(_get_raw_token)],
+    slm_db: Annotated[AsyncSession, Depends(get_slm_db)],
+    audit_db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
+    """Revoke the presented token and return IdP logout URL if applicable.
+
+    - Denylists the token's ``jti`` in Redis (HS256 tokens only).
+    - Queries the user's SSO link for an ``end_session_endpoint``.
+    - Returns ``{"logout_url": "<url>"}`` (url may be null when not SSO-linked).
+    """
+    client_ip = get_client_ip(http_request, trusted_proxies=settings.trusted_proxies)
+    username = current_user.get("sub", "unknown")
+
+    # Revoke the jti if this is an HS256 token with a jti claim
+    if _peek_alg(token) == "HS256":
+        try:
+            claims = decode_jwt_no_verify_exp(token, secret=settings.secret_key)
+            jti = claims.get("jti")
+            exp = claims.get("exp")
+            if jti and exp:
+                ttl = max(1, int(exp) - int(time.time()))
+                await revoke_jti(jti, ttl_seconds=ttl)
+        except Exception:
+            logger.warning("logout: could not decode token for jti revocation (user=%s)", username)
+
+    # Audit the logout event
+    await create_audit_log(
+        audit_db,
+        category="authentication",
+        action="logout",
+        username=username,
+        ip_address=client_ip,
+        resource_type="session",
+        description=f"User '{username}' logged out",
+        request_method="POST",
+        request_path="/api/auth/logout",
+        response_status=200,
+        success=True,
+    )
+    await audit_db.commit()
+
+    logger.info("User logged out: %s", username)
+
+    # SSO RP-initiated logout
+    link = await _get_user_sso_link(slm_db, username)
+    logout_url = _build_end_session_url(link) if link else None
+    return {"logout_url": logout_url}
 
 
 @router.post("/refresh", response_model=TokenResponse)

--- a/autobot-slm-backend/api/auth.py
+++ b/autobot-slm-backend/api/auth.py
@@ -13,6 +13,7 @@ Consolidated from legacy auth.py and slm_auth.py in Issue #1922.
 import logging
 import time
 from datetime import timedelta
+from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -185,16 +186,17 @@ def _build_end_session_url(link: "UserSSOLink") -> str | None:
     endpoint = link.provider.config.get("end_session_endpoint") if link and link.provider else None
     if not endpoint:
         return None
-    parts = [endpoint]
+    params: dict[str, str] = {}
     post_logout = link.provider.config.get("post_logout_redirect_uri")
     if post_logout:
-        parts.append(f"post_logout_redirect_uri={post_logout}")
+        params["post_logout_redirect_uri"] = post_logout
     id_token = (link.sso_metadata or {}).get("id_token")
     if id_token:
-        parts.append(f"id_token_hint={id_token}")
+        params["id_token_hint"] = id_token
+    if not params:
+        return endpoint
     separator = "&" if "?" in endpoint else "?"
-    params = "&".join(parts[1:])
-    return f"{endpoint}{separator}{params}" if params else endpoint
+    return f"{endpoint}{separator}{urlencode(params)}"
 
 
 async def _get_user_sso_link(db: AsyncSession, username: str) -> "UserSSOLink | None":

--- a/autobot-slm-backend/api/websocket.py
+++ b/autobot-slm-backend/api/websocket.py
@@ -58,7 +58,7 @@ async def _authenticate_websocket_token(websocket: WebSocket) -> dict | None:
         logger.warning("WebSocket connection rejected: missing token")
         return None
 
-    payload = auth_service.decode_token(token)
+    payload = await auth_service.decode_token_async(token)
     if not payload:
         await websocket.accept()
         await websocket.close(code=4001, reason="Invalid or expired token")

--- a/autobot-slm-backend/services/auth.py
+++ b/autobot-slm-backend/services/auth.py
@@ -123,9 +123,13 @@ class AuthService:
             if claims is None:
                 return None
             jti = claims.get("jti")
-            if jti and await is_jti_revoked(jti):
-                logger.warning("decode_token_async: HS256 token with jti=%r is revoked", jti)
-                return None
+            if jti:
+                try:
+                    if await is_jti_revoked(jti):
+                        logger.warning("decode_token_async: HS256 token with jti=%r is revoked", jti)
+                        return None
+                except Exception:
+                    logger.warning("jti denylist check failed; failing open", exc_info=True)
             return claims
 
         # alg=none or unsupported — reject

--- a/autobot-slm-backend/services/auth.py
+++ b/autobot-slm-backend/services/auth.py
@@ -27,6 +27,7 @@ rejected before PyJWT is invoked.
 """
 
 import logging
+import secrets
 from datetime import timedelta
 from typing import Callable
 
@@ -39,6 +40,7 @@ from autobot_shared.auth.jwt_core import _peek_alg, decode_jwt_or_none, encode_j
 from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Permission, Role
 from config import settings
 from models.schemas import TokenResponse, UserCreate, UserResponse
+from services.token_denylist import is_jti_revoked
 from user_management.models.user import User
 
 logger = logging.getLogger(__name__)
@@ -54,10 +56,19 @@ class AuthService:
         return hash_password(password)
 
     def create_access_token(self, data: dict, expires_delta: timedelta | None = None) -> str:
-        """Create a JWT access token."""
+        """Create a JWT access token.
+
+        Every SLM-minted HS256 token receives a unique ``jti`` claim so that
+        individual tokens can be revoked via the Redis denylist without
+        invalidating other tokens issued to the same user.  Revocation is
+        enforced on the async decode path (``decode_token_async``).
+        The sync ``decode_token`` path does not check Redis — see its docstring.
+        """
+        payload = dict(data)
+        payload.setdefault("jti", secrets.token_urlsafe(16))
         default_delta = timedelta(minutes=settings.access_token_expire_minutes)
         return encode_jwt(
-            data,
+            payload,
             secret=settings.secret_key,
             expires_delta=expires_delta if expires_delta is not None else default_delta,
         )
@@ -74,6 +85,10 @@ class AuthService:
 
         Use ``decode_token_async`` in async contexts — it handles both alg
         values and performs JWKS key lookup for RS256 tokens.
+
+        **Revocation note:** ``jti`` denylist checks require Redis (async).
+        This sync path does NOT check the denylist.  Token revocation is
+        enforced on the async HTTP auth path via ``decode_token_async``.
         """
         alg = _peek_alg(token)
         if alg == "RS256":
@@ -104,7 +119,14 @@ class AuthService:
             return await verify_authority_token(token)
 
         if alg == "HS256":
-            return decode_jwt_or_none(token, settings.secret_key)
+            claims = decode_jwt_or_none(token, settings.secret_key)
+            if claims is None:
+                return None
+            jti = claims.get("jti")
+            if jti and await is_jti_revoked(jti):
+                logger.warning("decode_token_async: HS256 token with jti=%r is revoked", jti)
+                return None
+            return claims
 
         # alg=none or unsupported — reject
         logger.warning("decode_token_async: rejecting token with unsupported alg=%r", alg)

--- a/autobot-slm-backend/services/token_denylist.py
+++ b/autobot-slm-backend/services/token_denylist.py
@@ -39,7 +39,7 @@ async def revoke_jti(jti: str, ttl_seconds: int) -> None:
     so no background cleanup is needed.  Silently no-ops if Redis is
     unavailable (logs a warning).
     """
-    redis = get_redis_client()
+    redis = await get_redis_client(async_client=True)
     if redis is None:
         logger.warning("revoke_jti: Redis unavailable; jti=%r NOT revoked", jti)
         return
@@ -54,7 +54,7 @@ async def is_jti_revoked(jti: str) -> bool:
     Fail-open: returns ``False`` when Redis is unavailable.  The token's own
     TTL still provides a time-bounded guard in that case.
     """
-    redis = get_redis_client()
+    redis = await get_redis_client(async_client=True)
     if redis is None:
         logger.warning("is_jti_revoked: Redis unavailable; treating jti=%r as NOT revoked (fail-open)", jti)
         return False

--- a/autobot-slm-backend/services/token_denylist.py
+++ b/autobot-slm-backend/services/token_denylist.py
@@ -1,0 +1,62 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+JWT jti-denylist backed by Redis.
+
+Revocation is enforced on the async auth path (``decode_token_async``).
+The sync ``decode_token`` path cannot check Redis and is documented
+accordingly — it is used only in contexts where a short token TTL is the
+primary guard.
+
+Fail-open policy for ``is_jti_revoked``: if Redis is unavailable the
+function returns ``False``.  This is acceptable because:
+- SLM HS256 tokens have a short configured TTL (default 30 min).
+- A revoked token will expire naturally before long.
+- Denying all auth on Redis downtime would be worse than a brief window
+  where a revoked token could be reused.
+"""
+
+import logging
+
+from autobot_shared.redis_client import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+_DENYLIST_PREFIX = "slm:jwt:denylist:"
+
+
+def _denylist_key(jti: str) -> str:
+    """Return the Redis key for *jti*."""
+    return f"{_DENYLIST_PREFIX}{jti}"
+
+
+async def revoke_jti(jti: str, ttl_seconds: int) -> None:
+    """Add *jti* to the denylist with a Redis TTL of *ttl_seconds*.
+
+    The key auto-expires when the original token would have expired anyway,
+    so no background cleanup is needed.  Silently no-ops if Redis is
+    unavailable (logs a warning).
+    """
+    redis = get_redis_client()
+    if redis is None:
+        logger.warning("revoke_jti: Redis unavailable; jti=%r NOT revoked", jti)
+        return
+    ttl = max(1, ttl_seconds)
+    await redis.set(_denylist_key(jti), "1", ex=ttl)
+    logger.info("revoke_jti: jti=%r revoked with ttl=%d", jti, ttl)
+
+
+async def is_jti_revoked(jti: str) -> bool:
+    """Return ``True`` if *jti* is in the denylist.
+
+    Fail-open: returns ``False`` when Redis is unavailable.  The token's own
+    TTL still provides a time-bounded guard in that case.
+    """
+    redis = get_redis_client()
+    if redis is None:
+        logger.warning("is_jti_revoked: Redis unavailable; treating jti=%r as NOT revoked (fail-open)", jti)
+        return False
+    exists = await redis.exists(_denylist_key(jti))
+    return bool(exists)

--- a/autobot-slm-backend/tests/api/test_auth_logout.py
+++ b/autobot-slm-backend/tests/api/test_auth_logout.py
@@ -165,7 +165,9 @@ class TestBuildEndSessionUrl:
         )
         result = _build_end_session_url(link)
         assert result is not None
-        assert "post_logout_redirect_uri=https://app.example.com/loggedout" in result
+        # urlencode percent-encodes the value; check the key is present and value is encoded
+        assert "post_logout_redirect_uri=" in result
+        assert "app.example.com" in result
 
     def test_appends_id_token_hint_when_present(self):
         link = _mock_sso_link(
@@ -184,6 +186,18 @@ class TestBuildEndSessionUrl:
         result = _build_end_session_url(link)
         assert result is not None
         assert "&post_logout_redirect_uri=" in result
+
+    def test_post_logout_uri_with_special_chars_is_percent_encoded(self):
+        """A post_logout_redirect_uri containing '&' and '=' must be percent-encoded."""
+        link = _mock_sso_link(
+            end_session="https://idp.example.com/logout",
+            post_logout="https://app.example.com/done?foo=bar&baz=qux",
+        )
+        result = _build_end_session_url(link)
+        assert result is not None
+        # Raw '&' and '=' from the redirect URI must NOT appear unencoded in params
+        assert "post_logout_redirect_uri=https%3A" in result
+        assert "foo%3D" in result or "%26" in result
 
 
 # ---------------------------------------------------------------------------
@@ -232,10 +246,12 @@ class TestRevokeTtlFromToken:
 
         redis_mock = AsyncMock()
         redis_mock.set = AsyncMock(return_value=True)
+        get_client = AsyncMock(return_value=redis_mock)
 
-        with patch.object(_dl_mod, "get_redis_client", return_value=redis_mock):
+        with patch.object(_dl_mod, "get_redis_client", get_client):
             await _dl_mod.revoke_jti(jti, ttl_seconds=expected_ttl)
 
+        get_client.assert_called_once_with(async_client=True)
         redis_mock.set.assert_awaited_once()
         _, kwargs = redis_mock.set.call_args
         assert kwargs["ex"] >= 1

--- a/autobot-slm-backend/tests/api/test_auth_logout.py
+++ b/autobot-slm-backend/tests/api/test_auth_logout.py
@@ -1,0 +1,241 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+TDD tests for POST /api/auth/logout.
+
+Tests the logout business logic helpers directly (FastAPI decorator machinery
+is a MagicMock in this test environment — see conftest; we test the pure
+Python helpers and the integration points that are callable).
+
+Covers:
+- _build_end_session_url: returns URL from provider config
+- _build_end_session_url: returns None when no end_session_endpoint
+- _build_end_session_url: appends post_logout_redirect_uri and id_token_hint
+- revoke_jti called with sane TTL when token is valid HS256
+- SSO link lookup returns None for unlinked users
+"""
+
+import importlib.util
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+_BACKEND = Path(__file__).parent.parent.parent
+_ROOT = _BACKEND.parent
+sys.path.insert(0, str(_BACKEND))
+sys.path.insert(0, str(_ROOT))
+
+# ---------------------------------------------------------------------------
+# Module stubs — config first so auth.py loads with the right secret key
+# ---------------------------------------------------------------------------
+_SECRET_KEY = "test-logout-secret-key-32characters"
+_EXPIRE_MINUTES = 30
+
+_cfg_mod = MagicMock()
+_cfg_mod.settings = MagicMock()
+_cfg_mod.settings.secret_key = _SECRET_KEY
+_cfg_mod.settings.access_token_expire_minutes = _EXPIRE_MINUTES
+_cfg_mod.settings.trusted_proxies = []
+sys.modules["config"] = _cfg_mod
+
+for _mod_name in [
+    "models.schemas",
+    "user_management",
+    "user_management.models",
+    "user_management.models.user",
+    "user_management.models.sso",
+    "user_management.services",
+    "user_management.database",
+    "services.jwks_verifier",
+    "services.database",
+    "autobot_shared.proxy_utils",
+    "fastapi",
+    "fastapi.security",
+    "sqlalchemy",
+    "sqlalchemy.ext",
+    "sqlalchemy.ext.asyncio",
+    "sqlalchemy.orm",
+    "models",
+    "models.database",
+    "api.security",
+]:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+
+# Ensure real jwt_core is reachable (decode_jwt_no_verify_exp used in logout impl)
+from autobot_shared.auth.jwt_core import decode_jwt_or_none  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Load real token_denylist
+# ---------------------------------------------------------------------------
+_DENYLIST_PY = _BACKEND / "services" / "token_denylist.py"
+_dl_spec = importlib.util.spec_from_file_location("services.token_denylist", _DENYLIST_PY)
+_dl_mod = importlib.util.module_from_spec(_dl_spec)  # type: ignore[arg-type]
+_dl_spec.loader.exec_module(_dl_mod)  # type: ignore[union-attr]
+sys.modules["services.token_denylist"] = _dl_mod  # type: ignore[assignment]
+
+# ---------------------------------------------------------------------------
+# Load real auth service (auth.py)
+# ---------------------------------------------------------------------------
+_AUTH_PY = _BACKEND / "services" / "auth.py"
+_auth_spec = importlib.util.spec_from_file_location("services.auth", _AUTH_PY)
+_auth_mod = importlib.util.module_from_spec(_auth_spec)  # type: ignore[arg-type]
+_auth_spec.loader.exec_module(_auth_mod)  # type: ignore[union-attr]
+sys.modules["services.auth"] = _auth_mod  # type: ignore[assignment]
+
+# ---------------------------------------------------------------------------
+# Load api/auth.py — router.post is a MagicMock so 'logout' is overwritten.
+# We extract the helpers before decoration by loading the raw source
+# via exec into a fresh namespace.
+# ---------------------------------------------------------------------------
+_AUTH_ROUTER_PY = _BACKEND / "api" / "auth.py"
+_router_ns: dict = {
+    "__name__": "api.auth_under_test",
+    "__file__": str(_AUTH_ROUTER_PY),
+}
+# Inject the real helpers this module needs before exec
+_router_ns.update(
+    {
+        "revoke_jti": _dl_mod.revoke_jti,
+        "is_jti_revoked": _dl_mod.is_jti_revoked,
+    }
+)
+
+# Execute the source so helper functions are defined in _router_ns
+_router_src = _AUTH_ROUTER_PY.read_text(encoding="utf-8")
+exec(compile(_router_src, str(_AUTH_ROUTER_PY), "exec"), _router_ns)  # nosec B102
+
+_build_end_session_url = _router_ns["_build_end_session_url"]
+_get_user_sso_link = _router_ns["_get_user_sso_link"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mint_token(username: str = "testuser") -> str:
+    svc = _auth_mod.AuthService()
+    return svc.create_access_token(data={"sub": username, "admin": False, "role": "user"})
+
+
+def _mock_sso_link(end_session: str | None = None, post_logout: str | None = None, id_token: str | None = None):
+    provider = MagicMock()
+    provider.config = {}
+    if end_session:
+        provider.config["end_session_endpoint"] = end_session
+    if post_logout:
+        provider.config["post_logout_redirect_uri"] = post_logout
+    link = MagicMock()
+    link.provider = provider
+    link.sso_metadata = {"id_token": id_token} if id_token else {}
+    return link
+
+
+# ---------------------------------------------------------------------------
+# _build_end_session_url tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEndSessionUrl:
+    def test_returns_url_when_configured(self):
+        link = _mock_sso_link(end_session="https://idp.example.com/logout")
+        result = _build_end_session_url(link)
+        assert result == "https://idp.example.com/logout"
+
+    def test_returns_none_when_no_endpoint(self):
+        link = _mock_sso_link()
+        assert _build_end_session_url(link) is None
+
+    def test_returns_none_when_link_is_none(self):
+        assert _build_end_session_url(None) is None
+
+    def test_appends_post_logout_redirect_uri(self):
+        link = _mock_sso_link(
+            end_session="https://idp.example.com/logout",
+            post_logout="https://app.example.com/loggedout",
+        )
+        result = _build_end_session_url(link)
+        assert result is not None
+        assert "post_logout_redirect_uri=https://app.example.com/loggedout" in result
+
+    def test_appends_id_token_hint_when_present(self):
+        link = _mock_sso_link(
+            end_session="https://idp.example.com/logout",
+            id_token="eyJhbGciOiJSUzI1NiJ9.test",
+        )
+        result = _build_end_session_url(link)
+        assert result is not None
+        assert "id_token_hint=eyJhbGciOiJSUzI1NiJ9.test" in result
+
+    def test_separator_is_ampersand_when_question_already_present(self):
+        link = _mock_sso_link(
+            end_session="https://idp.example.com/logout?client_id=abc",
+            post_logout="https://app.example.com/done",
+        )
+        result = _build_end_session_url(link)
+        assert result is not None
+        assert "&post_logout_redirect_uri=" in result
+
+
+# ---------------------------------------------------------------------------
+# _get_user_sso_link test (async DB mock)
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserSsoLink:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_link(self):
+        mock_db = MagicMock()
+        mock_row = MagicMock()
+        mock_row.scalar_one_or_none = MagicMock(return_value=None)
+        mock_db.execute = AsyncMock(return_value=mock_row)
+
+        result = await _get_user_sso_link(mock_db, "nolink_user")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_link_when_found(self):
+        fake_link = MagicMock()
+        mock_db = MagicMock()
+        mock_row = MagicMock()
+        mock_row.scalar_one_or_none = MagicMock(return_value=fake_link)
+        mock_db.execute = AsyncMock(return_value=mock_row)
+
+        result = await _get_user_sso_link(mock_db, "linked_user")
+        assert result is fake_link
+
+
+# ---------------------------------------------------------------------------
+# revoke_jti integration: TTL derived from token exp
+# ---------------------------------------------------------------------------
+
+
+class TestRevokeTtlFromToken:
+    @pytest.mark.asyncio
+    async def test_revoke_called_with_positive_ttl(self):
+        """revoke_jti must be called with ttl_seconds >= 1 for a fresh token."""
+        token = _mint_token("alice")
+        claims = decode_jwt_or_none(token, secret=_SECRET_KEY)
+        assert claims is not None
+        jti = claims["jti"]
+        exp = int(claims["exp"])
+        expected_ttl = max(1, exp - int(time.time()))
+
+        redis_mock = AsyncMock()
+        redis_mock.set = AsyncMock(return_value=True)
+
+        with patch.object(_dl_mod, "get_redis_client", return_value=redis_mock):
+            await _dl_mod.revoke_jti(jti, ttl_seconds=expected_ttl)
+
+        redis_mock.set.assert_awaited_once()
+        _, kwargs = redis_mock.set.call_args
+        assert kwargs["ex"] >= 1

--- a/autobot-slm-backend/tests/services/test_sso_logout.py
+++ b/autobot-slm-backend/tests/services/test_sso_logout.py
@@ -1,0 +1,213 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+TDD tests for Task 3: provider end_session_endpoint templates + SAML SLO config.
+
+Covers:
+- get_provider_endpoint_template includes end_session_endpoint for Okta
+- get_provider_endpoint_template includes end_session_endpoint for Microsoft Entra
+- get_provider_endpoint_template has no end_session_endpoint for Google
+  (Google uses /o/oauth2/revoke which is token-revocation, not RP-initiated OIDC logout)
+- _get_saml_config includes single_logout_service in the SP endpoints
+- initiate_saml_logout generates a redirect URL and stores relay state in Redis
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+_BACKEND = Path(__file__).parent.parent.parent
+_ROOT = _BACKEND.parent
+sys.path.insert(0, str(_BACKEND))
+sys.path.insert(0, str(_ROOT))
+
+# ---------------------------------------------------------------------------
+# Stubs — mirror the pattern from test_sso_service.py, with a real
+# SSOProviderType enum so dict lookups resolve correctly.
+# ---------------------------------------------------------------------------
+import enum  # noqa: E402
+
+_MODELS_SSO = "user_management.models.sso"
+
+
+class _SSOProviderType(str, enum.Enum):
+    """Minimal replica matching the real SSOProviderType string values."""
+
+    OKTA = "okta"
+    MICROSOFT_ENTRA = "microsoft_entra"
+    GOOGLE_WORKSPACE = "google_workspace"
+    GITHUB = "github"
+    SAML = "saml"
+
+
+_sso_models_stub = MagicMock()
+_sso_models_stub.SSOProviderType = _SSOProviderType
+sys.modules[_MODELS_SSO] = _sso_models_stub
+
+_SSO_SECRETS = "user_management.services.sso_secrets"
+if _SSO_SECRETS not in sys.modules:
+    sys.modules[_SSO_SECRETS] = MagicMock()
+
+_base_mod = types.ModuleType("user_management.services.base_service")
+
+
+class _BaseService:
+    def __init__(self, session):
+        self.session = session
+
+
+_base_mod.BaseService = _BaseService  # type: ignore[attr-defined]
+sys.modules["user_management.services.base_service"] = _base_mod
+
+# ---------------------------------------------------------------------------
+# Load sso_service.py directly (same technique as test_sso_service.py)
+# ---------------------------------------------------------------------------
+_SSO_PY = _BACKEND / "user_management" / "services" / "sso_service.py"
+_spec = importlib.util.spec_from_file_location("_sso_service_under_test", _SSO_PY)
+_sso_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_sso_mod)  # type: ignore[union-attr]
+
+SSOService = _sso_mod.SSOService
+SSOServiceError = _sso_mod.SSOServiceError
+
+# Provider type constants (access via the MagicMock stub module)
+_provider_types = sys.modules[_MODELS_SSO].SSOProviderType
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_template(provider_value: str, domain: str = "dev.okta.com") -> dict:
+    return SSOService.get_provider_endpoint_template(provider_value, domain=domain)
+
+
+# ---------------------------------------------------------------------------
+# Task 3a: end_session_endpoint in OIDC templates
+# ---------------------------------------------------------------------------
+
+
+class TestOktaEndSessionEndpoint:
+    def test_okta_template_has_end_session_endpoint(self):
+        template = _get_template("okta", domain="example.okta.com")
+        assert "end_session_endpoint" in template
+
+    def test_okta_end_session_uses_domain(self):
+        template = _get_template("okta", domain="example.okta.com")
+        assert "example.okta.com" in template["end_session_endpoint"]
+        assert "/oauth2/v1/logout" in template["end_session_endpoint"]
+
+
+class TestMicrosoftEntraEndSessionEndpoint:
+    def test_entra_template_has_end_session_endpoint(self):
+        template = _get_template("microsoft_entra", domain="common")
+        assert "end_session_endpoint" in template
+
+    def test_entra_end_session_uses_common_tenant(self):
+        template = _get_template("microsoft_entra", domain="common")
+        url = template["end_session_endpoint"]
+        assert "login.microsoftonline.com" in url
+        assert "common" in url
+        assert "oauth2/v2.0/logout" in url
+
+    def test_entra_end_session_uses_custom_tenant(self):
+        template = _get_template("microsoft_entra", domain="mytenant")
+        url = template["end_session_endpoint"]
+        assert "mytenant" in url
+
+
+class TestGoogleWorkspaceEndSessionEndpoint:
+    def test_google_end_session_endpoint_is_null(self):
+        """Google does not support RP-initiated OIDC end_session; must be None or absent."""
+        template = _get_template("google_workspace")
+        # Acceptable: key absent OR value is None
+        endpoint = template.get("end_session_endpoint")
+        assert endpoint is None
+
+
+# ---------------------------------------------------------------------------
+# Task 3b: SAML SLO in _get_saml_config
+# ---------------------------------------------------------------------------
+
+
+class TestSamlSloConfig:
+    def _make_provider(self, **config_overrides) -> MagicMock:
+        provider = MagicMock()
+        base_cfg = {
+            "sp_entity_id": "https://slm.example.com/saml/metadata",
+            "acs_url": "https://slm.example.com/api/auth/sso/saml/acs",
+            "slo_url": "https://slm.example.com/api/auth/sso/saml/slo",
+            "idp_metadata_url": "https://idp.example.com/metadata.xml",
+        }
+        base_cfg.update(config_overrides)
+        provider.config = base_cfg
+        return provider
+
+    def test_saml_config_includes_single_logout_service(self):
+        service = SSOService(session=MagicMock())
+        provider = self._make_provider()
+        config = service._get_saml_config(provider)
+        sp_section = config["service"]["sp"]
+        assert "single_logout_service" in sp_section["endpoints"]
+
+    def test_saml_slo_endpoint_uses_provider_slo_url(self):
+        service = SSOService(session=MagicMock())
+        provider = self._make_provider(slo_url="https://slm.example.com/api/auth/sso/saml/slo")
+        config = service._get_saml_config(provider)
+        slo_entries = config["service"]["sp"]["endpoints"]["single_logout_service"]
+        slo_urls = [entry[0] for entry in slo_entries]
+        assert any("saml/slo" in url for url in slo_urls)
+
+
+# ---------------------------------------------------------------------------
+# Task 3c: initiate_saml_logout method exists and returns (url, relay_state)
+# ---------------------------------------------------------------------------
+
+
+class TestInitiateSamlLogout:
+    def test_method_exists_on_sso_service(self):
+        assert hasattr(SSOService, "initiate_saml_logout")
+
+    @pytest.mark.asyncio
+    async def test_returns_tuple_of_url_and_relay_state(self):
+        """initiate_saml_logout must return a (redirect_url, relay_state) tuple."""
+        service = SSOService(session=MagicMock())
+        provider = MagicMock()
+        provider.id = "test-provider-id"
+        provider.config = {
+            "sp_entity_id": "https://slm.example.com/saml",
+            "acs_url": "https://slm.example.com/api/auth/sso/saml/acs",
+            "slo_url": "https://slm.example.com/api/auth/sso/saml/slo",
+            "idp_metadata_url": "https://idp.example.com/metadata.xml",
+        }
+
+        # Mock the Saml2Client so we don't need a real IdP
+        mock_client = MagicMock()
+        mock_client.global_logout.return_value = (
+            "test-logout-request-id",
+            {"headers": [("Location", "https://idp.example.com/slo")]},
+        )
+
+        redis_mock = AsyncMock()
+        redis_mock.set = AsyncMock(return_value=True)
+
+        with patch.object(_sso_mod, "get_redis_client", return_value=redis_mock):
+            with patch.object(service, "_build_saml_client", return_value=mock_client):
+                result = await service.initiate_saml_logout(provider)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        redirect_url, relay_state = result
+        assert isinstance(redirect_url, str)
+        assert isinstance(relay_state, str)
+        assert len(relay_state) > 0

--- a/autobot-slm-backend/tests/services/test_sso_logout.py
+++ b/autobot-slm-backend/tests/services/test_sso_logout.py
@@ -3,24 +3,22 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-TDD tests for Task 3: provider end_session_endpoint templates + SAML SLO config.
+Tests for provider end_session_endpoint templates (OIDC RP-initiated logout).
 
 Covers:
 - get_provider_endpoint_template includes end_session_endpoint for Okta
 - get_provider_endpoint_template includes end_session_endpoint for Microsoft Entra
 - get_provider_endpoint_template has no end_session_endpoint for Google
   (Google uses /o/oauth2/revoke which is token-revocation, not RP-initiated OIDC logout)
-- _get_saml_config includes single_logout_service in the SP endpoints
-- initiate_saml_logout generates a redirect URL and stores relay state in Redis
+
+SAML SLO is not yet implemented — tracked in #10281.
 """
 
 import importlib.util
 import sys
 import types
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
+from unittest.mock import MagicMock
 
 # ---------------------------------------------------------------------------
 # Path setup
@@ -77,10 +75,6 @@ _sso_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
 _spec.loader.exec_module(_sso_mod)  # type: ignore[union-attr]
 
 SSOService = _sso_mod.SSOService
-SSOServiceError = _sso_mod.SSOServiceError
-
-# Provider type constants (access via the MagicMock stub module)
-_provider_types = sys.modules[_MODELS_SSO].SSOProviderType
 
 
 # ---------------------------------------------------------------------------
@@ -93,7 +87,7 @@ def _get_template(provider_value: str, domain: str = "dev.okta.com") -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Task 3a: end_session_endpoint in OIDC templates
+# end_session_endpoint in OIDC templates
 # ---------------------------------------------------------------------------
 
 
@@ -133,81 +127,3 @@ class TestGoogleWorkspaceEndSessionEndpoint:
         # Acceptable: key absent OR value is None
         endpoint = template.get("end_session_endpoint")
         assert endpoint is None
-
-
-# ---------------------------------------------------------------------------
-# Task 3b: SAML SLO in _get_saml_config
-# ---------------------------------------------------------------------------
-
-
-class TestSamlSloConfig:
-    def _make_provider(self, **config_overrides) -> MagicMock:
-        provider = MagicMock()
-        base_cfg = {
-            "sp_entity_id": "https://slm.example.com/saml/metadata",
-            "acs_url": "https://slm.example.com/api/auth/sso/saml/acs",
-            "slo_url": "https://slm.example.com/api/auth/sso/saml/slo",
-            "idp_metadata_url": "https://idp.example.com/metadata.xml",
-        }
-        base_cfg.update(config_overrides)
-        provider.config = base_cfg
-        return provider
-
-    def test_saml_config_includes_single_logout_service(self):
-        service = SSOService(session=MagicMock())
-        provider = self._make_provider()
-        config = service._get_saml_config(provider)
-        sp_section = config["service"]["sp"]
-        assert "single_logout_service" in sp_section["endpoints"]
-
-    def test_saml_slo_endpoint_uses_provider_slo_url(self):
-        service = SSOService(session=MagicMock())
-        provider = self._make_provider(slo_url="https://slm.example.com/api/auth/sso/saml/slo")
-        config = service._get_saml_config(provider)
-        slo_entries = config["service"]["sp"]["endpoints"]["single_logout_service"]
-        slo_urls = [entry[0] for entry in slo_entries]
-        assert any("saml/slo" in url for url in slo_urls)
-
-
-# ---------------------------------------------------------------------------
-# Task 3c: initiate_saml_logout method exists and returns (url, relay_state)
-# ---------------------------------------------------------------------------
-
-
-class TestInitiateSamlLogout:
-    def test_method_exists_on_sso_service(self):
-        assert hasattr(SSOService, "initiate_saml_logout")
-
-    @pytest.mark.asyncio
-    async def test_returns_tuple_of_url_and_relay_state(self):
-        """initiate_saml_logout must return a (redirect_url, relay_state) tuple."""
-        service = SSOService(session=MagicMock())
-        provider = MagicMock()
-        provider.id = "test-provider-id"
-        provider.config = {
-            "sp_entity_id": "https://slm.example.com/saml",
-            "acs_url": "https://slm.example.com/api/auth/sso/saml/acs",
-            "slo_url": "https://slm.example.com/api/auth/sso/saml/slo",
-            "idp_metadata_url": "https://idp.example.com/metadata.xml",
-        }
-
-        # Mock the Saml2Client so we don't need a real IdP
-        mock_client = MagicMock()
-        mock_client.global_logout.return_value = (
-            "test-logout-request-id",
-            {"headers": [("Location", "https://idp.example.com/slo")]},
-        )
-
-        redis_mock = AsyncMock()
-        redis_mock.set = AsyncMock(return_value=True)
-
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis_mock):
-            with patch.object(service, "_build_saml_client", return_value=mock_client):
-                result = await service.initiate_saml_logout(provider)
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        redirect_url, relay_state = result
-        assert isinstance(redirect_url, str)
-        assert isinstance(relay_state, str)
-        assert len(relay_state) > 0

--- a/autobot-slm-backend/tests/services/test_sso_logout.py
+++ b/autobot-slm-backend/tests/services/test_sso_logout.py
@@ -55,6 +55,14 @@ _SSO_SECRETS = "user_management.services.sso_secrets"
 if _SSO_SECRETS not in sys.modules:
     sys.modules[_SSO_SECRETS] = MagicMock()
 
+# sso_service.py imports Role from user_management.models.role; stub it.
+if "user_management.models.role" not in sys.modules:
+    sys.modules["user_management.models.role"] = MagicMock()
+
+# sso_service.py lazy-imports UserService; pre-populate stub.
+if "user_management.services.user_service" not in sys.modules:
+    sys.modules["user_management.services.user_service"] = MagicMock()
+
 _base_mod = types.ModuleType("user_management.services.base_service")
 
 

--- a/autobot-slm-backend/tests/services/test_sso_security.py
+++ b/autobot-slm-backend/tests/services/test_sso_security.py
@@ -33,6 +33,14 @@ _SSO_SECRETS = "user_management.services.sso_secrets"
 if _SSO_SECRETS not in sys.modules:
     sys.modules[_SSO_SECRETS] = MagicMock()
 
+# sso_service.py imports Role from user_management.models.role; stub it.
+if "user_management.models.role" not in sys.modules:
+    sys.modules["user_management.models.role"] = MagicMock()
+
+# sso_service.py lazy-imports UserService; pre-populate stub.
+if "user_management.services.user_service" not in sys.modules:
+    sys.modules["user_management.services.user_service"] = MagicMock()
+
 _base_mod = types.ModuleType("user_management.services.base_service")
 
 

--- a/autobot-slm-backend/tests/services/test_sso_service.py
+++ b/autobot-slm-backend/tests/services/test_sso_service.py
@@ -815,3 +815,143 @@ class TestSyncIdpGroupsToRoles:
 
         user_svc.assign_role.assert_not_awaited()
         user_svc.revoke_role.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Task 3: _find_or_provision_user wires group sync on every login (#10152)
+# ---------------------------------------------------------------------------
+
+
+def _make_full_provider(group_mapping: dict, org_id: uuid.UUID) -> MagicMock:
+    p = MagicMock()
+    p.id = uuid.uuid4()
+    p.group_mapping = group_mapping
+    p.org_id = org_id
+    p.allow_user_creation = True
+    return p
+
+
+class TestFindOrProvisionUserGroupSync:
+    """_find_or_provision_user calls _sync_idp_groups_to_roles in both branches."""
+
+    def _make_session_returning_user(self, user: MagicMock, link: MagicMock | None) -> MagicMock:
+        """Session that returns the given link from the SSO-link query and user from the user query."""
+        call_n = {"n": 0}
+
+        async def _execute(stmt):
+            result = MagicMock()
+            if call_n["n"] == 0:
+                # First call: _find_existing_sso_link
+                result.scalar_one_or_none.return_value = link
+            else:
+                # Second call (existing-link path): fetch user by id
+                result.scalar_one.return_value = user
+                result.scalar_one_or_none.return_value = user
+            call_n["n"] += 1
+            return result
+
+        session = MagicMock()
+        session.execute = AsyncMock(side_effect=_execute)
+        session.flush = AsyncMock()
+        session.add = MagicMock()
+        session.info = {}
+        return session
+
+    def _make_session_new_user(self, user: MagicMock) -> MagicMock:
+        """Session for the new-user path: no existing link, no existing email user."""
+        call_n = {"n": 0}
+
+        async def _execute(stmt):
+            result = MagicMock()
+            if call_n["n"] == 0:
+                result.scalar_one_or_none.return_value = None  # no existing SSO link
+            elif call_n["n"] == 1:
+                result.scalar_one_or_none.return_value = None  # no user by email
+            else:
+                result.scalar_one_or_none.return_value = user
+            call_n["n"] += 1
+            return result
+
+        session = MagicMock()
+        session.execute = AsyncMock(side_effect=_execute)
+        session.flush = AsyncMock()
+        session.add = MagicMock()
+        session.info = {}
+        return session
+
+    @pytest.mark.asyncio
+    async def test_returning_user_login_resyncs_roles(self):
+        """On every login of a returning user, group→role sync is invoked."""
+        org_id = uuid.uuid4()
+        user = _make_user()
+        link = MagicMock()
+        link.user_id = user.id
+        link.record_login = MagicMock()
+
+        provider = _make_full_provider({"eng": "engineer"}, org_id)
+        session = self._make_session_returning_user(user, link)
+        service = SSOService(session=session)
+
+        synced_args: list = []
+
+        async def _fake_sync(u, p, groups):
+            synced_args.append((u, p, groups))
+
+        service._sync_idp_groups_to_roles = _fake_sync  # type: ignore[assignment]
+
+        result = await service._find_or_provision_user(provider, "ext-id", {"email": "a@b.com", "groups": ["eng"]})
+
+        assert result is user
+        assert len(synced_args) == 1
+        _, _, groups = synced_args[0]
+        assert groups == ["eng"]
+
+    @pytest.mark.asyncio
+    async def test_new_user_jit_assigns_roles(self):
+        """On JIT provisioning of a new user, group→role sync runs after link creation."""
+        org_id = uuid.uuid4()
+        user = _make_user()
+        provider = _make_full_provider({"eng": "engineer"}, org_id)
+        session = self._make_session_new_user(user)
+        service = SSOService(session=session)
+
+        synced_args: list = []
+
+        async def _fake_sync(u, p, groups):
+            synced_args.append((u, p, groups))
+
+        service._sync_idp_groups_to_roles = _fake_sync  # type: ignore[assignment]
+        service._create_sso_user = AsyncMock(return_value=user)  # type: ignore[assignment]
+        service._create_sso_link = AsyncMock()  # type: ignore[assignment]
+
+        await service._find_or_provision_user(provider, "new-ext-id", {"email": "new@b.com", "groups": ["eng"]})
+
+        assert len(synced_args) == 1
+        _, _, groups = synced_args[0]
+        assert groups == ["eng"]
+
+    @pytest.mark.asyncio
+    async def test_returning_user_groups_none_does_not_strip_roles(self):
+        """When groups claim is absent (None), no role changes happen for returning user."""
+        org_id = uuid.uuid4()
+        user = _make_user()
+        link = MagicMock()
+        link.user_id = user.id
+        link.record_login = MagicMock()
+
+        provider = _make_full_provider({"eng": "engineer"}, org_id)
+        session = self._make_session_returning_user(user, link)
+        service = SSOService(session=session)
+
+        synced_args: list = []
+
+        async def _fake_sync(u, p, groups):
+            synced_args.append((u, p, groups))
+
+        service._sync_idp_groups_to_roles = _fake_sync  # type: ignore[assignment]
+
+        await service._find_or_provision_user(provider, "ext-id", {"email": "a@b.com"})  # no groups key
+
+        assert len(synced_args) == 1
+        _, _, groups = synced_args[0]
+        assert groups is None

--- a/autobot-slm-backend/tests/services/test_sso_service.py
+++ b/autobot-slm-backend/tests/services/test_sso_service.py
@@ -485,3 +485,118 @@ class TestSamlRelayStateRedisRoundTrip:
             redirect_url, _ = await service._generate_saml_authn_request(provider)
 
         assert redirect_url == expected_url
+
+
+# ---------------------------------------------------------------------------
+# Task 1: group claim extraction from each IdP type (#10152)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractOauthUserDataGroups:
+    """_extract_oauth_user_data captures the 'groups' claim or leaves it None."""
+
+    def _make_provider(self) -> MagicMock:
+        p = MagicMock()
+        p.config = {}
+        return p
+
+    def test_groups_present_returns_list(self):
+        service = _make_service()
+        userinfo = {"email": "a@b.com", "groups": ["eng", "devops"]}
+        data = service._extract_oauth_user_data(userinfo, self._make_provider())
+        assert data["groups"] == ["eng", "devops"]
+
+    def test_groups_absent_returns_none(self):
+        service = _make_service()
+        userinfo = {"email": "a@b.com"}
+        data = service._extract_oauth_user_data(userinfo, self._make_provider())
+        assert data["groups"] is None
+
+    def test_groups_single_string_normalized_to_list(self):
+        service = _make_service()
+        userinfo = {"email": "a@b.com", "groups": "eng"}
+        data = service._extract_oauth_user_data(userinfo, self._make_provider())
+        assert data["groups"] == ["eng"]
+
+    def test_groups_empty_list_preserved(self):
+        service = _make_service()
+        userinfo = {"email": "a@b.com", "groups": []}
+        data = service._extract_oauth_user_data(userinfo, self._make_provider())
+        assert data["groups"] == []
+
+
+class TestExtractLdapUserDataGroups:
+    """_extract_ldap_user_data captures the memberOf (or custom) attribute."""
+
+    def _make_provider(self, attr_map: dict | None = None) -> MagicMock:
+        p = MagicMock()
+        p.config = {"attribute_mapping": attr_map or {}}
+        return p
+
+    def test_memberof_present_returns_list(self):
+        service = _make_service()
+        entry = {"memberOf": ["cn=eng,dc=example,dc=com", "cn=devops,dc=example,dc=com"]}
+        data = service._extract_ldap_user_data(entry, self._make_provider())
+        assert data["groups"] == ["cn=eng,dc=example,dc=com", "cn=devops,dc=example,dc=com"]
+
+    def test_memberof_absent_returns_none(self):
+        service = _make_service()
+        entry = {"mail": ["a@b.com"]}
+        data = service._extract_ldap_user_data(entry, self._make_provider())
+        assert data["groups"] is None
+
+    def test_custom_groups_attr_via_attr_map(self):
+        service = _make_service()
+        provider = self._make_provider({"groups": "isMemberOf"})
+        entry = {"isMemberOf": ["grp1"]}
+        data = service._extract_ldap_user_data(entry, provider)
+        assert data["groups"] == ["grp1"]
+
+
+class TestExtractSamlUserDataGroups:
+    """_extract_saml_user_data captures the 'groups' SAML attribute."""
+
+    def _make_provider(self, attr_map: dict | None = None) -> MagicMock:
+        p = MagicMock()
+        p.config = {"attribute_mapping": attr_map or {}}
+        return p
+
+    def _make_authn_response(self, ava: dict) -> MagicMock:
+        r = MagicMock()
+        r.ava = ava
+        return r
+
+    def test_groups_present_returns_list(self):
+        service = _make_service()
+        response = self._make_authn_response({"email": ["a@b.com"], "groups": ["admin", "users"]})
+        data = service._extract_saml_user_data(response, self._make_provider())
+        assert data["groups"] == ["admin", "users"]
+
+    def test_groups_absent_returns_none(self):
+        service = _make_service()
+        response = self._make_authn_response({"email": ["a@b.com"]})
+        data = service._extract_saml_user_data(response, self._make_provider())
+        assert data["groups"] is None
+
+    def test_custom_groups_attr_via_attr_map(self):
+        service = _make_service()
+        provider = self._make_provider({"groups": "memberOf"})
+        response = self._make_authn_response({"memberOf": ["cn=grp,dc=example,dc=com"]})
+        data = service._extract_saml_user_data(response, provider)
+        assert data["groups"] == ["cn=grp,dc=example,dc=com"]
+
+
+class TestNormalizeGroups:
+    """_normalize_groups helper covers edge cases."""
+
+    def test_none_returns_none(self):
+        assert SSOService._normalize_groups(None) is None
+
+    def test_list_of_strings_returned_as_is(self):
+        assert SSOService._normalize_groups(["a", "b"]) == ["a", "b"]
+
+    def test_single_string_wrapped(self):
+        assert SSOService._normalize_groups("eng") == ["eng"]
+
+    def test_empty_list_returns_empty_list(self):
+        assert SSOService._normalize_groups([]) == []

--- a/autobot-slm-backend/tests/services/test_sso_service.py
+++ b/autobot-slm-backend/tests/services/test_sso_service.py
@@ -32,11 +32,22 @@ _MODELS_SSO = "user_management.models.sso"
 if _MODELS_SSO not in sys.modules:
     sys.modules[_MODELS_SSO] = MagicMock()
 
+# sso_service.py imports Role from user_management.models.role; stub it.
+_MODELS_ROLE = "user_management.models.role"
+if _MODELS_ROLE not in sys.modules:
+    sys.modules[_MODELS_ROLE] = MagicMock()
+
 # sso_service.py imports SSOSecretsManager from sso_secrets; stub it so the
 # module loads without the real SQLAlchemy/encryption stack.
 _SSO_SECRETS = "user_management.services.sso_secrets"
 if _SSO_SECRETS not in sys.modules:
     sys.modules[_SSO_SECRETS] = MagicMock()
+
+# sso_service.py lazy-imports UserService from user_management.services.user_service;
+# pre-populate so tests can control it via patch.
+_USER_SVC_MOD = "user_management.services.user_service"
+if _USER_SVC_MOD not in sys.modules:
+    sys.modules[_USER_SVC_MOD] = MagicMock()
 
 # Provide a minimal real BaseService so `class SSOService(BaseService)` compiles
 # and SSOService(session=...) is constructable.
@@ -600,3 +611,207 @@ class TestNormalizeGroups:
 
     def test_empty_list_returns_empty_list(self):
         assert SSOService._normalize_groups([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Task 2: _sync_idp_groups_to_roles (#10152)
+# ---------------------------------------------------------------------------
+
+
+def _make_role(name: str, org_id: uuid.UUID | None = None) -> MagicMock:
+    """Return a lightweight Role-like mock."""
+    r = MagicMock()
+    r.id = uuid.uuid4()
+    r.name = name
+    r.org_id = org_id
+    return r
+
+
+def _make_user(uid: uuid.UUID | None = None) -> MagicMock:
+    u = MagicMock()
+    u.id = uid or uuid.uuid4()
+    return u
+
+
+def _make_sso_provider(group_mapping: dict, org_id: uuid.UUID | None = None) -> MagicMock:
+    p = MagicMock()
+    p.group_mapping = group_mapping
+    p.org_id = org_id or uuid.uuid4()
+    return p
+
+
+def _make_async_session(roles_by_name: dict) -> MagicMock:
+    """Return a mock AsyncSession whose execute() resolves Role lookups by name."""
+
+    async def _execute(stmt):
+        # Extract the name filter value from the WHERE clause args.
+        # We rely on the fact that the compiled string contains the role name.
+        # Simpler: capture via side_effect with a closure over roles_by_name.
+        result = MagicMock()
+        # We'll override this per-call in the test when needed.
+        result.scalar_one_or_none.return_value = None
+        return result
+
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=_execute)
+    session.info = {}
+    return session
+
+
+class TestSyncIdpGroupsToRoles:
+    """_sync_idp_groups_to_roles reconciles group membership to RBAC roles."""
+
+    def _make_session_with_role_lookup(self, roles_by_name: dict) -> MagicMock:
+        """Session whose execute returns the role matching the name in the WHERE clause."""
+        call_count = {"n": 0}
+        name_sequence = list(roles_by_name.keys())
+
+        async def _execute(stmt):
+            result = MagicMock()
+            # Resolve by cycling through requested names in insertion order.
+            # Each call corresponds to one name being resolved.
+            idx = call_count["n"]
+            call_count["n"] += 1
+            if idx < len(name_sequence):
+                result.scalar_one_or_none.return_value = roles_by_name[name_sequence[idx]]
+            else:
+                result.scalar_one_or_none.return_value = None
+            return result
+
+        session = MagicMock()
+        session.execute = AsyncMock(side_effect=_execute)
+        session.info = {}
+        return session
+
+    def _make_user_service(self, current_roles: list) -> MagicMock:
+        """Return a UserService mock with controllable get_user_roles / assign / revoke."""
+        svc = MagicMock()
+        svc.get_user_roles = AsyncMock(return_value=current_roles)
+        svc.assign_role = AsyncMock(return_value=True)
+        svc.revoke_role = AsyncMock(return_value=True)
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_empty_group_mapping_returns_immediately(self):
+        """No DB access when group_mapping is empty."""
+        service = _make_service()
+        provider = _make_sso_provider({})
+        user = _make_user()
+        service.session = MagicMock()
+        service.session.execute = AsyncMock()
+
+        await service._sync_idp_groups_to_roles(user, provider, ["eng"])
+
+        service.session.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_groups_none_returns_immediately_no_changes(self):
+        """When groups is None the IdP omitted the claim — roles must not be touched."""
+        service = _make_service()
+        provider = _make_sso_provider({"eng": "engineer"})
+        user = _make_user()
+        service.session = MagicMock()
+        service.session.execute = AsyncMock()
+
+        await service._sync_idp_groups_to_roles(user, provider, None)
+
+        service.session.execute.assert_not_called()
+
+    def _patch_user_service(self, user_svc: MagicMock):
+        """Context manager that makes UserService(session) return user_svc."""
+        # The lazy import in _sync_idp_groups_to_roles does:
+        #   from user_management.services.user_service import UserService
+        # which reads sys.modules[_USER_SVC_MOD].UserService.
+        # We patch that attribute so UserService(...) returns our prepared mock.
+        cls_mock = MagicMock(return_value=user_svc)
+        return patch.object(sys.modules[_USER_SVC_MOD], "UserService", cls_mock)
+
+    @pytest.mark.asyncio
+    async def test_jit_assigns_mapped_role(self):
+        """User in mapped IdP group gets the corresponding role assigned."""
+        org_id = uuid.uuid4()
+        eng_role = _make_role("engineer", org_id)
+        provider = _make_sso_provider({"eng": "engineer"}, org_id)
+        user = _make_user()
+        session = self._make_session_with_role_lookup({"engineer": eng_role})
+        user_svc = self._make_user_service(current_roles=[])
+
+        service = SSOService(session=session)
+        with self._patch_user_service(user_svc):
+            await service._sync_idp_groups_to_roles(user, provider, ["eng"])
+
+        user_svc.assign_role.assert_awaited_once_with(user.id, eng_role.id)
+        user_svc.revoke_role.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unmapped_group_grants_nothing(self):
+        """A group not in group_mapping does not result in any role assignment."""
+        org_id = uuid.uuid4()
+        eng_role = _make_role("engineer", org_id)
+        provider = _make_sso_provider({"eng": "engineer"}, org_id)
+        user = _make_user()
+        session = self._make_session_with_role_lookup({"engineer": eng_role})
+        user_svc = self._make_user_service(current_roles=[])
+
+        service = SSOService(session=session)
+        with self._patch_user_service(user_svc):
+            await service._sync_idp_groups_to_roles(user, provider, ["random_unknown_group"])
+
+        user_svc.assign_role.assert_not_awaited()
+        user_svc.revoke_role.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_manual_role_outside_mapping_preserved(self):
+        """A manually granted role whose name is NOT in group_mapping.values() is never revoked."""
+        org_id = uuid.uuid4()
+        eng_role = _make_role("engineer", org_id)
+        admin_role = _make_role("admin", org_id)  # manually granted, NOT in mapping
+        provider = _make_sso_provider({"eng": "engineer"}, org_id)
+        user = _make_user()
+        # User currently has both engineer AND admin; only "engineer" is managed
+        session = self._make_session_with_role_lookup({"engineer": eng_role})
+        # engineer already assigned, admin is manual
+        user_svc = self._make_user_service(current_roles=[eng_role, admin_role])
+
+        service = SSOService(session=session)
+        with self._patch_user_service(user_svc):
+            # Still in "eng" group → engineer stays; admin is NOT in managed set → untouched
+            await service._sync_idp_groups_to_roles(user, provider, ["eng"])
+
+        user_svc.assign_role.assert_not_awaited()  # already has engineer
+        user_svc.revoke_role.assert_not_awaited()  # admin not managed
+
+    @pytest.mark.asyncio
+    async def test_removing_from_idp_group_revokes_managed_role(self):
+        """User removed from IdP group loses only that managed role."""
+        org_id = uuid.uuid4()
+        eng_role = _make_role("engineer", org_id)
+        provider = _make_sso_provider({"eng": "engineer"}, org_id)
+        user = _make_user()
+        session = self._make_session_with_role_lookup({"engineer": eng_role})
+        # User currently has engineer but is no longer in "eng" group
+        user_svc = self._make_user_service(current_roles=[eng_role])
+
+        service = SSOService(session=session)
+        with self._patch_user_service(user_svc):
+            await service._sync_idp_groups_to_roles(user, provider, [])  # empty groups list
+
+        user_svc.revoke_role.assert_awaited_once_with(user.id, eng_role.id)
+        user_svc.assign_role.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_already_assigned(self):
+        """assign_role is NOT called when user already has the managed role."""
+        org_id = uuid.uuid4()
+        eng_role = _make_role("engineer", org_id)
+        provider = _make_sso_provider({"eng": "engineer"}, org_id)
+        user = _make_user()
+        session = self._make_session_with_role_lookup({"engineer": eng_role})
+        user_svc = self._make_user_service(current_roles=[eng_role])
+
+        service = SSOService(session=session)
+        with self._patch_user_service(user_svc):
+            await service._sync_idp_groups_to_roles(user, provider, ["eng"])
+
+        user_svc.assign_role.assert_not_awaited()
+        user_svc.revoke_role.assert_not_awaited()

--- a/autobot-slm-backend/tests/services/test_sso_service.py
+++ b/autobot-slm-backend/tests/services/test_sso_service.py
@@ -644,12 +644,9 @@ def _make_async_session(roles_by_name: dict) -> MagicMock:
     """Return a mock AsyncSession whose execute() resolves Role lookups by name."""
 
     async def _execute(stmt):
-        # Extract the name filter value from the WHERE clause args.
-        # We rely on the fact that the compiled string contains the role name.
-        # Simpler: capture via side_effect with a closure over roles_by_name.
         result = MagicMock()
-        # We'll override this per-call in the test when needed.
         result.scalar_one_or_none.return_value = None
+        result.scalars.return_value.all.return_value = []
         return result
 
     session = MagicMock()
@@ -662,20 +659,16 @@ class TestSyncIdpGroupsToRoles:
     """_sync_idp_groups_to_roles reconciles group membership to RBAC roles."""
 
     def _make_session_with_role_lookup(self, roles_by_name: dict) -> MagicMock:
-        """Session whose execute returns the role matching the name in the WHERE clause."""
-        call_count = {"n": 0}
-        name_sequence = list(roles_by_name.keys())
+        """Session whose single execute() returns all matching Role rows via scalars().all().
+
+        _resolve_managed_roles now issues ONE query for all managed names and
+        calls result.scalars().all() — so we return the full list in one shot.
+        """
+        role_list = list(roles_by_name.values())
 
         async def _execute(stmt):
             result = MagicMock()
-            # Resolve by cycling through requested names in insertion order.
-            # Each call corresponds to one name being resolved.
-            idx = call_count["n"]
-            call_count["n"] += 1
-            if idx < len(name_sequence):
-                result.scalar_one_or_none.return_value = roles_by_name[name_sequence[idx]]
-            else:
-                result.scalar_one_or_none.return_value = None
+            result.scalars.return_value.all.return_value = role_list
             return result
 
         session = MagicMock()
@@ -815,6 +808,205 @@ class TestSyncIdpGroupsToRoles:
 
         user_svc.assign_role.assert_not_awaited()
         user_svc.revoke_role.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# I1: system roles (org_id=None) resolve via group_mapping (#10152)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSystemRoles:
+    """_resolve_managed_roles must find org_id=None system roles.
+
+    The test session mock returns only what each test puts in its role_list,
+    so we can verify the OLD code (== provider.org_id) would NOT have found
+    a system role — by checking that the result is non-empty only when the
+    implementation uses the or_(org_id==X, org_id.is_(None)) clause.
+    """
+
+    def _patch_user_service(self, user_svc: MagicMock):
+        cls_mock = MagicMock(return_value=user_svc)
+        return patch.object(sys.modules[_USER_SVC_MOD], "UserService", cls_mock)
+
+    def _make_user_service(self, current_roles: list) -> MagicMock:
+        svc = MagicMock()
+        svc.get_user_roles = AsyncMock(return_value=current_roles)
+        svc.assign_role = AsyncMock(return_value=True)
+        svc.revoke_role = AsyncMock(return_value=True)
+        return svc
+
+    def _make_session_returning_roles(self, role_list: list) -> MagicMock:
+        """Session that returns *role_list* from a single scalars().all() call."""
+
+        async def _execute(stmt):
+            result = MagicMock()
+            result.scalars.return_value.all.return_value = role_list
+            return result
+
+        session = MagicMock()
+        session.execute = AsyncMock(side_effect=_execute)
+        session.info = {}
+        return session
+
+    @pytest.mark.asyncio
+    async def test_system_role_resolves_and_is_assigned(self):
+        """A system role (org_id=None) referenced by group_mapping is assigned.
+
+        This test is a regression lock for fix I1.  It would FAIL against the
+        old ``Role.org_id == provider.org_id`` query because that clause
+        silently drops rows where org_id IS NULL.
+        """
+        org_id = uuid.uuid4()
+        # System role: org_id is None
+        system_role = _make_role("admin", org_id=None)
+        provider = _make_sso_provider({"admins": "admin"}, org_id)
+        user = _make_user()
+
+        session = self._make_session_returning_roles([system_role])
+        user_svc = self._make_user_service(current_roles=[])
+
+        service = SSOService(session=session)
+        with self._patch_user_service(user_svc):
+            await service._sync_idp_groups_to_roles(user, provider, ["admins"])
+
+        user_svc.assign_role.assert_awaited_once_with(user.id, system_role.id)
+
+    @pytest.mark.asyncio
+    async def test_org_specific_role_preferred_over_system_role(self):
+        """When both an org-scoped and a system role share the same name, the org-scoped one wins."""
+        org_id = uuid.uuid4()
+        system_role = _make_role("engineer", org_id=None)
+        org_role = _make_role("engineer", org_id=org_id)
+        provider = _make_sso_provider({"eng": "engineer"}, org_id)
+        user = _make_user()
+
+        # Both rows are returned from the single batched query.
+        session = self._make_session_returning_roles([system_role, org_role])
+        user_svc = self._make_user_service(current_roles=[])
+
+        service = SSOService(session=session)
+        with self._patch_user_service(user_svc):
+            await service._sync_idp_groups_to_roles(user, provider, ["eng"])
+
+        # Must assign the org-specific role, not the system one.
+        user_svc.assign_role.assert_awaited_once_with(user.id, org_role.id)
+
+    @pytest.mark.asyncio
+    async def test_system_role_preferred_when_only_system_role_exists(self):
+        """When only the system role exists (no org override), it resolves and is used."""
+        org_id = uuid.uuid4()
+        system_role = _make_role("viewer", org_id=None)
+        provider = _make_sso_provider({"viewers": "viewer"}, org_id)
+        user = _make_user()
+
+        session = self._make_session_returning_roles([system_role])
+        user_svc = self._make_user_service(current_roles=[system_role])
+
+        service = SSOService(session=session)
+        with self._patch_user_service(user_svc):
+            # user already has the role — idempotent, no assign/revoke
+            await service._sync_idp_groups_to_roles(user, provider, ["viewers"])
+
+        user_svc.assign_role.assert_not_awaited()
+        user_svc.revoke_role.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# I2: sync failure must not block login (#10152)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncFailureDoesNotBlockLogin:
+    """A reconciliation error inside _sync_idp_groups_to_roles must not propagate.
+
+    _find_or_provision_user wraps the call in try/except so authentication
+    always succeeds even when role-sync throws.  The test covers both the
+    returning-user path and the JIT-provisioning path.
+    """
+
+    def _make_session_returning_user(self, user: MagicMock, link: MagicMock) -> MagicMock:
+        call_n = {"n": 0}
+
+        async def _execute(stmt):
+            result = MagicMock()
+            if call_n["n"] == 0:
+                result.scalar_one_or_none.return_value = link
+            else:
+                result.scalar_one.return_value = user
+                result.scalar_one_or_none.return_value = user
+            call_n["n"] += 1
+            return result
+
+        session = MagicMock()
+        session.execute = AsyncMock(side_effect=_execute)
+        session.flush = AsyncMock()
+        session.add = MagicMock()
+        session.info = {}
+        return session
+
+    def _make_session_new_user(self, user: MagicMock) -> MagicMock:
+        call_n = {"n": 0}
+
+        async def _execute(stmt):
+            result = MagicMock()
+            if call_n["n"] == 0:
+                result.scalar_one_or_none.return_value = None  # no existing SSO link
+            elif call_n["n"] == 1:
+                result.scalar_one_or_none.return_value = None  # no user by email
+            else:
+                result.scalar_one_or_none.return_value = user
+            call_n["n"] += 1
+            return result
+
+        session = MagicMock()
+        session.execute = AsyncMock(side_effect=_execute)
+        session.flush = AsyncMock()
+        session.add = MagicMock()
+        session.info = {}
+        return session
+
+    @pytest.mark.asyncio
+    async def test_returning_user_sync_error_does_not_raise(self):
+        """A sync failure on the returning-user path still returns the user."""
+        org_id = uuid.uuid4()
+        user = _make_user()
+        link = MagicMock()
+        link.user_id = user.id
+        link.record_login = MagicMock()
+
+        provider = _make_full_provider({"eng": "engineer"}, org_id)
+        session = self._make_session_returning_user(user, link)
+        service = SSOService(session=session)
+
+        async def _boom(u, p, groups):
+            raise RuntimeError("RBAC cache exploded")
+
+        service._sync_idp_groups_to_roles = _boom  # type: ignore[assignment]
+
+        result = await service._find_or_provision_user(provider, "ext-id", {"email": "a@b.com", "groups": ["eng"]})
+
+        assert result is user  # login still succeeded
+
+    @pytest.mark.asyncio
+    async def test_jit_user_sync_error_does_not_raise(self):
+        """A sync failure on the JIT path still returns the newly provisioned user."""
+        org_id = uuid.uuid4()
+        user = _make_user()
+
+        provider = _make_full_provider({"eng": "engineer"}, org_id)
+        session = self._make_session_new_user(user)
+        service = SSOService(session=session)
+
+        async def _boom(u, p, groups):
+            raise RuntimeError("role lookup failed")
+
+        service._sync_idp_groups_to_roles = _boom  # type: ignore[assignment]
+        service._create_sso_user = AsyncMock(return_value=user)  # type: ignore[assignment]
+        service._create_sso_link = AsyncMock()  # type: ignore[assignment]
+
+        result = await service._find_or_provision_user(provider, "new-ext", {"email": "x@b.com", "groups": ["eng"]})
+
+        assert result is user
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/tests/services/test_token_denylist.py
+++ b/autobot-slm-backend/tests/services/test_token_denylist.py
@@ -1,0 +1,251 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+TDD tests for services/token_denylist.py + jti integration in auth.
+
+Covers:
+- jti present in minted tokens
+- revoke_jti stores key in Redis with correct TTL (clamped to >= 1)
+- is_jti_revoked returns True after revoke
+- Redis-unavailable path: is_jti_revoked returns False (no crash)
+- decode_token_async rejects revoked HS256 jti
+- decode_token_async accepts non-revoked HS256 token
+- Redis unavailable: valid token still decodes (fail-open)
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+_BACKEND = Path(__file__).parent.parent.parent
+_ROOT = _BACKEND.parent
+sys.path.insert(0, str(_BACKEND))
+sys.path.insert(0, str(_ROOT))
+
+# ---------------------------------------------------------------------------
+# Pre-populate sys.modules stubs BEFORE loading the real service modules via
+# spec_from_file_location so their top-level imports resolve cleanly.
+# ---------------------------------------------------------------------------
+_SECRET_KEY = "test-secret-key-for-jti-tests-32chars"
+_EXPIRE_MINUTES = 30
+
+# config.settings stub — ensure a real MagicMock is in place with the test key
+_cfg_mod = MagicMock()
+_cfg_mod.settings = MagicMock()
+_cfg_mod.settings.secret_key = _SECRET_KEY
+_cfg_mod.settings.access_token_expire_minutes = _EXPIRE_MINUTES
+sys.modules["config"] = _cfg_mod
+
+_settings = _cfg_mod.settings
+
+for _mod_name in [
+    "models.schemas",
+    "user_management",
+    "user_management.models",
+    "user_management.models.user",
+    "user_management.services",
+    "services.jwks_verifier",
+    "fastapi",
+    "fastapi.security",
+]:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+
+# autobot_shared.auth — real modules (on path)
+from autobot_shared.auth.jwt_core import decode_jwt_or_none  # noqa: E402
+
+# sqlalchemy stubs (auth.py imports select + AsyncSession)
+for _sa in ["sqlalchemy", "sqlalchemy.ext", "sqlalchemy.ext.asyncio", "sqlalchemy.orm"]:
+    if _sa not in sys.modules:
+        sys.modules[_sa] = MagicMock()
+
+# ---------------------------------------------------------------------------
+# Load services/token_denylist.py directly via spec
+# ---------------------------------------------------------------------------
+_DENYLIST_PY = _BACKEND / "services" / "token_denylist.py"
+_dl_spec = importlib.util.spec_from_file_location("_token_denylist_under_test", _DENYLIST_PY)
+_dl_mod = importlib.util.module_from_spec(_dl_spec)  # type: ignore[arg-type]
+_dl_spec.loader.exec_module(_dl_mod)  # type: ignore[union-attr]
+
+revoke_jti = _dl_mod.revoke_jti
+is_jti_revoked = _dl_mod.is_jti_revoked
+_denylist_key = _dl_mod._denylist_key
+
+# Register the real token_denylist module under both canonical names so that
+# `from services.token_denylist import ...` inside auth.py resolves correctly
+# when auth.py is exec'd below (the root conftest stubs 'services' as a
+# MagicMock package; we overwrite the sub-module slot here).
+sys.modules["services.token_denylist"] = _dl_mod  # type: ignore[assignment]
+setattr(sys.modules["services"], "token_denylist", _dl_mod)
+
+# ---------------------------------------------------------------------------
+# Load services/auth.py directly via spec so jti enforcement is real code
+# ---------------------------------------------------------------------------
+_AUTH_PY = _BACKEND / "services" / "auth.py"
+_auth_spec = importlib.util.spec_from_file_location("_auth_under_test", _AUTH_PY)
+_auth_mod = importlib.util.module_from_spec(_auth_spec)  # type: ignore[arg-type]
+_auth_spec.loader.exec_module(_auth_mod)  # type: ignore[union-attr]
+
+AuthService = _auth_mod.AuthService
+
+
+# ---------------------------------------------------------------------------
+# Helper: async Redis mock
+# ---------------------------------------------------------------------------
+
+
+def _make_redis_mock(exists_return: int = 0) -> AsyncMock:
+    mock = AsyncMock()
+    mock.set = AsyncMock(return_value=True)
+    mock.exists = AsyncMock(return_value=exists_return)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# token_denylist: key format
+# ---------------------------------------------------------------------------
+
+
+class TestDenylistKey:
+    def test_key_format(self):
+        assert _denylist_key("abc123") == "slm:jwt:denylist:abc123"
+
+
+# ---------------------------------------------------------------------------
+# token_denylist: revoke_jti
+# ---------------------------------------------------------------------------
+
+
+class TestRevokeJti:
+    @pytest.mark.asyncio
+    async def test_stores_key_with_ttl(self):
+        redis_mock = _make_redis_mock()
+        with patch.object(_dl_mod, "get_redis_client", return_value=redis_mock):
+            await revoke_jti("jti-001", ttl_seconds=600)
+
+        redis_mock.set.assert_awaited_once_with("slm:jwt:denylist:jti-001", "1", ex=600)
+
+    @pytest.mark.asyncio
+    async def test_ttl_clamped_to_minimum_1(self):
+        redis_mock = _make_redis_mock()
+        with patch.object(_dl_mod, "get_redis_client", return_value=redis_mock):
+            await revoke_jti("jti-002", ttl_seconds=-5)
+
+        _, kwargs = redis_mock.set.call_args
+        assert kwargs["ex"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_noop_when_redis_unavailable(self):
+        """revoke_jti must not raise when get_redis_client returns None."""
+        with patch.object(_dl_mod, "get_redis_client", return_value=None):
+            await revoke_jti("jti-003", ttl_seconds=60)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# token_denylist: is_jti_revoked
+# ---------------------------------------------------------------------------
+
+
+class TestIsJtiRevoked:
+    @pytest.mark.asyncio
+    async def test_returns_true_when_key_exists(self):
+        redis_mock = _make_redis_mock(exists_return=1)
+        with patch.object(_dl_mod, "get_redis_client", return_value=redis_mock):
+            result = await is_jti_revoked("jti-exists")
+
+        assert result is True
+        redis_mock.exists.assert_awaited_once_with("slm:jwt:denylist:jti-exists")
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_key_absent(self):
+        redis_mock = _make_redis_mock(exists_return=0)
+        with patch.object(_dl_mod, "get_redis_client", return_value=redis_mock):
+            result = await is_jti_revoked("jti-absent")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_redis_unavailable(self):
+        """Fail-open: no crash, returns False."""
+        with patch.object(_dl_mod, "get_redis_client", return_value=None):
+            result = await is_jti_revoked("jti-no-redis")
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# jti in minted tokens
+# ---------------------------------------------------------------------------
+
+
+class TestJtiInMintedToken:
+    def test_create_access_token_includes_jti(self):
+        """Every SLM HS256 token must carry a 'jti' claim."""
+        service = AuthService()
+        token = service.create_access_token(data={"sub": "alice", "admin": False, "role": "user"})
+        claims = decode_jwt_or_none(token, secret=_SECRET_KEY)
+        assert claims is not None
+        assert "jti" in claims
+        assert isinstance(claims["jti"], str)
+        assert len(claims["jti"]) > 0
+
+    def test_each_token_gets_unique_jti(self):
+        service = AuthService()
+        payload = {"sub": "alice", "admin": False, "role": "user"}
+        t1 = service.create_access_token(data=payload)
+        t2 = service.create_access_token(data=payload)
+        c1 = decode_jwt_or_none(t1, secret=_SECRET_KEY)
+        c2 = decode_jwt_or_none(t2, secret=_SECRET_KEY)
+        assert c1 is not None and c2 is not None
+        assert c1["jti"] != c2["jti"]
+
+
+# ---------------------------------------------------------------------------
+# decode_token_async jti revocation enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeTokenAsyncRevocation:
+    @pytest.mark.asyncio
+    async def test_revoked_jti_returns_none(self):
+        """decode_token_async must return None when jti is denylisted."""
+        service = AuthService()
+        token = service.create_access_token(data={"sub": "bob", "admin": False, "role": "user"})
+
+        # Patch is_jti_revoked directly on the loaded auth module namespace
+        with patch.object(_auth_mod, "is_jti_revoked", new=AsyncMock(return_value=True)):
+            result = await service.decode_token_async(token)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_non_revoked_jti_decodes_correctly(self):
+        """decode_token_async must succeed for a valid, non-revoked token."""
+        service = AuthService()
+        token = service.create_access_token(data={"sub": "carol", "admin": True, "role": "admin"})
+
+        with patch.object(_auth_mod, "is_jti_revoked", new=AsyncMock(return_value=False)):
+            result = await service.decode_token_async(token)
+
+        assert result is not None
+        assert result["sub"] == "carol"
+
+    @pytest.mark.asyncio
+    async def test_redis_unavailable_does_not_block_valid_token(self):
+        """Fail-open: Redis down must not block a valid HS256 token."""
+        service = AuthService()
+        token = service.create_access_token(data={"sub": "dave", "admin": False, "role": "user"})
+
+        with patch.object(_auth_mod, "is_jti_revoked", new=AsyncMock(return_value=False)):
+            result = await service.decode_token_async(token)
+
+        assert result is not None
+        assert result["sub"] == "dave"

--- a/autobot-slm-backend/tests/services/test_token_denylist.py
+++ b/autobot-slm-backend/tests/services/test_token_denylist.py
@@ -128,25 +128,32 @@ class TestRevokeJti:
     @pytest.mark.asyncio
     async def test_stores_key_with_ttl(self):
         redis_mock = _make_redis_mock()
-        with patch.object(_dl_mod, "get_redis_client", return_value=redis_mock):
+        get_client = AsyncMock(return_value=redis_mock)
+        with patch.object(_dl_mod, "get_redis_client", get_client):
             await revoke_jti("jti-001", ttl_seconds=600)
 
+        get_client.assert_called_once_with(async_client=True)
         redis_mock.set.assert_awaited_once_with("slm:jwt:denylist:jti-001", "1", ex=600)
 
     @pytest.mark.asyncio
     async def test_ttl_clamped_to_minimum_1(self):
         redis_mock = _make_redis_mock()
-        with patch.object(_dl_mod, "get_redis_client", return_value=redis_mock):
+        get_client = AsyncMock(return_value=redis_mock)
+        with patch.object(_dl_mod, "get_redis_client", get_client):
             await revoke_jti("jti-002", ttl_seconds=-5)
 
+        get_client.assert_called_once_with(async_client=True)
         _, kwargs = redis_mock.set.call_args
         assert kwargs["ex"] >= 1
 
     @pytest.mark.asyncio
     async def test_noop_when_redis_unavailable(self):
         """revoke_jti must not raise when get_redis_client returns None."""
-        with patch.object(_dl_mod, "get_redis_client", return_value=None):
+        get_client = AsyncMock(return_value=None)
+        with patch.object(_dl_mod, "get_redis_client", get_client):
             await revoke_jti("jti-003", ttl_seconds=60)  # must not raise
+
+        get_client.assert_called_once_with(async_client=True)
 
 
 # ---------------------------------------------------------------------------
@@ -158,26 +165,32 @@ class TestIsJtiRevoked:
     @pytest.mark.asyncio
     async def test_returns_true_when_key_exists(self):
         redis_mock = _make_redis_mock(exists_return=1)
-        with patch.object(_dl_mod, "get_redis_client", return_value=redis_mock):
+        get_client = AsyncMock(return_value=redis_mock)
+        with patch.object(_dl_mod, "get_redis_client", get_client):
             result = await is_jti_revoked("jti-exists")
 
+        get_client.assert_called_once_with(async_client=True)
         assert result is True
         redis_mock.exists.assert_awaited_once_with("slm:jwt:denylist:jti-exists")
 
     @pytest.mark.asyncio
     async def test_returns_false_when_key_absent(self):
         redis_mock = _make_redis_mock(exists_return=0)
-        with patch.object(_dl_mod, "get_redis_client", return_value=redis_mock):
+        get_client = AsyncMock(return_value=redis_mock)
+        with patch.object(_dl_mod, "get_redis_client", get_client):
             result = await is_jti_revoked("jti-absent")
 
+        get_client.assert_called_once_with(async_client=True)
         assert result is False
 
     @pytest.mark.asyncio
     async def test_returns_false_when_redis_unavailable(self):
         """Fail-open: no crash, returns False."""
-        with patch.object(_dl_mod, "get_redis_client", return_value=None):
+        get_client = AsyncMock(return_value=None)
+        with patch.object(_dl_mod, "get_redis_client", get_client):
             result = await is_jti_revoked("jti-no-redis")
 
+        get_client.assert_called_once_with(async_client=True)
         assert result is False
 
 
@@ -249,3 +262,15 @@ class TestDecodeTokenAsyncRevocation:
 
         assert result is not None
         assert result["sub"] == "dave"
+
+    @pytest.mark.asyncio
+    async def test_denylist_exception_treated_as_fail_open(self):
+        """When is_jti_revoked raises, decode_token_async returns claims (fail-open)."""
+        service = AuthService()
+        token = service.create_access_token(data={"sub": "eve", "admin": False, "role": "user"})
+
+        with patch.object(_auth_mod, "is_jti_revoked", new=AsyncMock(side_effect=RuntimeError("redis down"))):
+            result = await service.decode_token_async(token)
+
+        assert result is not None
+        assert result["sub"] == "eve"

--- a/autobot-slm-backend/tests/test_websocket_auth_smoke.py
+++ b/autobot-slm-backend/tests/test_websocket_auth_smoke.py
@@ -15,13 +15,15 @@ Happy path:
 Negative paths:
   - No bearer → close code 4001
   - Invalid / expired bearer → close code 4001
+  - Revoked bearer → close code 4001 (denylist enforced via decode_token_async)
 """
 
 from __future__ import annotations
 
 import sys
+from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -36,75 +38,109 @@ _VALID_PAYLOAD = {"sub": "smoke", "username": "smoketest"}
 _SMOKE_BEARER = "smoke"
 
 
-def _make_client(*, decode_fn) -> TestClient:
-    """Create a TestClient with SLM websocket router + controlled auth."""
-    with patch("api.websocket.auth_service.decode_token", side_effect=decode_fn):
-        from api.websocket import router as ws_router
+def _build_app() -> FastAPI:
+    """Build a fresh FastAPI app with the WebSocket router included."""
+    from api.websocket import router as ws_router
 
-        app = FastAPI()
-        app.include_router(ws_router)
-        return TestClient(app, raise_server_exceptions=False)
+    app = FastAPI()
+    app.include_router(ws_router)
+    return app
+
+
+@contextmanager
+def _patched_client(decode_async_fn):
+    """Context manager that yields a TestClient with decode_token_async patched.
+
+    The patch stays active for the entire lifetime of the context so that
+    WS connections made inside the block use the controlled auth function.
+    ``decode_token_async`` is an async method, so we replace it with an
+    ``AsyncMock`` whose ``side_effect`` drives the test-controlled return value.
+    """
+    app = _build_app()
+    mock = AsyncMock(side_effect=decode_async_fn)
+    with patch("api.websocket.auth_service.decode_token_async", mock):
+        yield TestClient(app, raise_server_exceptions=False)
 
 
 class TestWsEventsHappyPath:
     """Valid bearer → accepted connection with connected frame."""
 
     def test_connection_established_frame(self):
-        decode = lambda t: _VALID_PAYLOAD if t == _SMOKE_BEARER else None
-        client = _make_client(decode_fn=decode)
+        async def decode(t):
+            return _VALID_PAYLOAD if t == _SMOKE_BEARER else None
 
-        with client.websocket_connect(f"/ws/events?token={_SMOKE_BEARER}") as ws:
-            frame = ws.receive_json()
-            assert frame["type"] == "connected"
+        with _patched_client(decode) as client:
+            with client.websocket_connect(f"/ws/events?token={_SMOKE_BEARER}") as ws:
+                frame = ws.receive_json()
+                assert frame["type"] == "connected"
 
     def test_ping_receives_pong(self):
-        decode = lambda t: _VALID_PAYLOAD if t == _SMOKE_BEARER else None
-        client = _make_client(decode_fn=decode)
+        async def decode(t):
+            return _VALID_PAYLOAD if t == _SMOKE_BEARER else None
 
-        with client.websocket_connect(f"/ws/events?token={_SMOKE_BEARER}") as ws:
-            ws.receive_json()  # connected
-            ws.send_text("ping")
-            pong = ws.receive_text()
-            assert pong == "pong"
+        with _patched_client(decode) as client:
+            with client.websocket_connect(f"/ws/events?token={_SMOKE_BEARER}") as ws:
+                ws.receive_json()  # connected
+                ws.send_text("ping")
+                pong = ws.receive_text()
+                assert pong == "pong"
 
     def test_clean_close_code_1000(self):
-        decode = lambda t: _VALID_PAYLOAD if t == _SMOKE_BEARER else None
-        client = _make_client(decode_fn=decode)
+        async def decode(t):
+            return _VALID_PAYLOAD if t == _SMOKE_BEARER else None
 
-        with client.websocket_connect(f"/ws/events?token={_SMOKE_BEARER}") as ws:
-            ws.receive_json()  # connected
-            ws.close(1000)
+        with _patched_client(decode) as client:
+            with client.websocket_connect(f"/ws/events?token={_SMOKE_BEARER}") as ws:
+                ws.receive_json()  # connected
+                ws.close(1000)
 
 
 class TestWsEventsNegativePaths:
     """Missing or invalid bearer → close before accept (code 4001)."""
 
     def test_no_bearer_rejected(self):
-        decode = lambda t: None
-        client = _make_client(decode_fn=decode)
+        async def decode(t):
+            return None
 
-        with pytest.raises(WebSocketDisconnect) as exc_info:
-            with client.websocket_connect("/ws/events") as ws:
-                ws.receive_json()
+        with _patched_client(decode) as client:
+            with pytest.raises(WebSocketDisconnect) as exc_info:
+                with client.websocket_connect("/ws/events") as ws:
+                    ws.receive_json()
 
         assert exc_info.value.code == 4001
 
     def test_invalid_bearer_rejected(self):
-        decode = lambda t: None
-        client = _make_client(decode_fn=decode)
+        async def decode(t):
+            return None
 
-        with pytest.raises(WebSocketDisconnect) as exc_info:
-            with client.websocket_connect("/ws/events?token=bad") as ws:
-                ws.receive_json()
+        with _patched_client(decode) as client:
+            with pytest.raises(WebSocketDisconnect) as exc_info:
+                with client.websocket_connect("/ws/events?token=bad") as ws:
+                    ws.receive_json()
 
         assert exc_info.value.code == 4001
 
     def test_expired_bearer_rejected(self):
-        decode = lambda t: None
-        client = _make_client(decode_fn=decode)
+        async def decode(t):
+            return None
 
-        with pytest.raises(WebSocketDisconnect) as exc_info:
-            with client.websocket_connect("/ws/events?token=exp") as ws:
-                ws.receive_json()
+        with _patched_client(decode) as client:
+            with pytest.raises(WebSocketDisconnect) as exc_info:
+                with client.websocket_connect("/ws/events?token=exp") as ws:
+                    ws.receive_json()
+
+        assert exc_info.value.code == 4001
+
+    def test_revoked_bearer_rejected(self):
+        """decode_token_async returning None (revoked jti) must close with 4001."""
+
+        async def decode(t):
+            # Simulates denylist: decode_token_async returns None for a revoked token
+            return None
+
+        with _patched_client(decode) as client:
+            with pytest.raises(WebSocketDisconnect) as exc_info:
+                with client.websocket_connect("/ws/events?token=revoked-jti-token") as ws:
+                    ws.receive_json()
 
         assert exc_info.value.code == 4001

--- a/autobot-slm-backend/tests/test_websocket_auth_smoke.py
+++ b/autobot-slm-backend/tests/test_websocket_auth_smoke.py
@@ -2,145 +2,72 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""
-SLM WebSocket authenticated-handshake smoke tests (#6699).
+"""Focused unit tests for WebSocket auth (revocation-aware).
 
-Exercises the JWT auth gate on /ws/events (SLM backend) using starlette's
-TestClient — no real server or network needed.
+These test ``_authenticate_websocket_token`` directly with a fake WebSocket and
+a patched ``decode_token_async`` — no FastAPI app, TestClient, or router import.
+That keeps them isolation-safe (the previous TestClient-based smoke shared
+app/router module state and was order-dependent in the full suite).
 
-Happy path:
-  - Valid bearer → connection accepted, connected frame received
-  - Ping → pong round-trip
-
-Negative paths:
-  - No bearer → close code 4001
-  - Invalid / expired bearer → close code 4001
-  - Revoked bearer → close code 4001 (denylist enforced via decode_token_async)
+Key behavior under test (issue #10151 / M1): WS auth must use the **async**
+``decode_token_async`` so the JWT denylist is enforced — a revoked token
+(``decode_token_async`` returns ``None``) is rejected with close code 4001.
 """
 
 from __future__ import annotations
 
-import sys
-from contextlib import contextmanager
-from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from fastapi import FastAPI
-from starlette.testclient import TestClient
-from starlette.websockets import WebSocketDisconnect
 
-_SLM = Path(__file__).resolve().parent.parent
-if str(_SLM) not in sys.path:
-    sys.path.insert(0, str(_SLM))
-
-_VALID_PAYLOAD = {"sub": "smoke", "username": "smoketest"}
-_SMOKE_BEARER = "smoke"
+from api.websocket import _authenticate_websocket_token
 
 
-def _build_app() -> FastAPI:
-    """Build a fresh FastAPI app with the WebSocket router included."""
-    from api.websocket import router as ws_router
-
-    app = FastAPI()
-    app.include_router(ws_router)
-    return app
+def _fake_ws() -> AsyncMock:
+    ws = AsyncMock()
+    ws.accept = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
 
 
-@contextmanager
-def _patched_client(decode_async_fn):
-    """Context manager that yields a TestClient with decode_token_async patched.
-
-    The patch stays active for the entire lifetime of the context so that
-    WS connections made inside the block use the controlled auth function.
-    ``decode_token_async`` is an async method, so we replace it with an
-    ``AsyncMock`` whose ``side_effect`` drives the test-controlled return value.
-    """
-    app = _build_app()
-    mock = AsyncMock(side_effect=decode_async_fn)
-    with patch("api.websocket.auth_service.decode_token_async", mock):
-        yield TestClient(app, raise_server_exceptions=False)
+@pytest.mark.asyncio
+async def test_missing_token_rejected_4001():
+    ws = _fake_ws()
+    with patch("api.websocket._extract_ws_token", return_value=None):
+        result = await _authenticate_websocket_token(ws)
+    assert result is None
+    ws.close.assert_awaited_once()
+    assert ws.close.call_args.kwargs.get("code") == 4001
 
 
-class TestWsEventsHappyPath:
-    """Valid bearer → accepted connection with connected frame."""
-
-    def test_connection_established_frame(self):
-        async def decode(t):
-            return _VALID_PAYLOAD if t == _SMOKE_BEARER else None
-
-        with _patched_client(decode) as client:
-            with client.websocket_connect(f"/ws/events?token={_SMOKE_BEARER}") as ws:
-                frame = ws.receive_json()
-                assert frame["type"] == "connected"
-
-    def test_ping_receives_pong(self):
-        async def decode(t):
-            return _VALID_PAYLOAD if t == _SMOKE_BEARER else None
-
-        with _patched_client(decode) as client:
-            with client.websocket_connect(f"/ws/events?token={_SMOKE_BEARER}") as ws:
-                ws.receive_json()  # connected
-                ws.send_text("ping")
-                pong = ws.receive_text()
-                assert pong == "pong"
-
-    def test_clean_close_code_1000(self):
-        async def decode(t):
-            return _VALID_PAYLOAD if t == _SMOKE_BEARER else None
-
-        with _patched_client(decode) as client:
-            with client.websocket_connect(f"/ws/events?token={_SMOKE_BEARER}") as ws:
-                ws.receive_json()  # connected
-                ws.close(1000)
+@pytest.mark.asyncio
+async def test_valid_token_returns_payload_and_uses_async_decode():
+    ws = _fake_ws()
+    payload = {"sub": "alice", "jti": "abc"}
+    async_decode = AsyncMock(return_value=payload)
+    with (
+        patch("api.websocket._extract_ws_token", return_value="good-token"),
+        patch("api.websocket.auth_service.decode_token_async", async_decode),
+        # the sync path must NOT be used (it skips the denylist)
+        patch("api.websocket.auth_service.decode_token", side_effect=AssertionError("sync decode used")),
+    ):
+        result = await _authenticate_websocket_token(ws)
+    assert result == payload
+    async_decode.assert_awaited_once_with("good-token")
+    ws.close.assert_not_called()
 
 
-class TestWsEventsNegativePaths:
-    """Missing or invalid bearer → close before accept (code 4001)."""
-
-    def test_no_bearer_rejected(self):
-        async def decode(t):
-            return None
-
-        with _patched_client(decode) as client:
-            with pytest.raises(WebSocketDisconnect) as exc_info:
-                with client.websocket_connect("/ws/events") as ws:
-                    ws.receive_json()
-
-        assert exc_info.value.code == 4001
-
-    def test_invalid_bearer_rejected(self):
-        async def decode(t):
-            return None
-
-        with _patched_client(decode) as client:
-            with pytest.raises(WebSocketDisconnect) as exc_info:
-                with client.websocket_connect("/ws/events?token=bad") as ws:
-                    ws.receive_json()
-
-        assert exc_info.value.code == 4001
-
-    def test_expired_bearer_rejected(self):
-        async def decode(t):
-            return None
-
-        with _patched_client(decode) as client:
-            with pytest.raises(WebSocketDisconnect) as exc_info:
-                with client.websocket_connect("/ws/events?token=exp") as ws:
-                    ws.receive_json()
-
-        assert exc_info.value.code == 4001
-
-    def test_revoked_bearer_rejected(self):
-        """decode_token_async returning None (revoked jti) must close with 4001."""
-
-        async def decode(t):
-            # Simulates denylist: decode_token_async returns None for a revoked token
-            return None
-
-        with _patched_client(decode) as client:
-            with pytest.raises(WebSocketDisconnect) as exc_info:
-                with client.websocket_connect("/ws/events?token=revoked-jti-token") as ws:
-                    ws.receive_json()
-
-        assert exc_info.value.code == 4001
+@pytest.mark.asyncio
+async def test_revoked_or_invalid_token_rejected_4001():
+    """decode_token_async returning None (revoked jti / invalid) → close 4001."""
+    ws = _fake_ws()
+    async_decode = AsyncMock(return_value=None)
+    with (
+        patch("api.websocket._extract_ws_token", return_value="revoked-jti-token"),
+        patch("api.websocket.auth_service.decode_token_async", async_decode),
+    ):
+        result = await _authenticate_websocket_token(ws)
+    assert result is None
+    async_decode.assert_awaited_once_with("revoked-jti-token")
+    ws.close.assert_awaited_once()
+    assert ws.close.call_args.kwargs.get("code") == 4001

--- a/autobot-slm-backend/user_management/services/sso_service.py
+++ b/autobot-slm-backend/user_management/services/sso_service.py
@@ -17,7 +17,7 @@ import secrets
 import uuid
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 
 from autobot_shared.redis_client import get_redis_client
 from user_management.models.role import Role
@@ -529,16 +529,34 @@ class SSOService(BaseService):
         return link
 
     async def _resolve_managed_roles(self, provider: SSOProvider, managed_names: set[str]) -> dict[str, Role]:
-        """Return {role_name: Role} for names that exist in provider.org_id scope."""
-        name_to_role: dict[str, Role] = {}
+        """Return {role_name: Role} for names resolvable in provider.org_id scope or as system roles.
+
+        A single query fetches all candidates (org-scoped + system).  When both exist for the
+        same name the org-specific row is preferred over the system role (org_id IS NULL).
+        Names with no matching row are warned and omitted from the result.
+        """
+        if not managed_names:
+            return {}
+        result = await self.session.execute(
+            select(Role).where(
+                Role.name.in_(managed_names),
+                or_(Role.org_id == provider.org_id, Role.org_id.is_(None)),
+            )
+        )
+        rows = list(result.scalars().all())
+
+        # prefer org-specific row over a system role of the same name
+        by_name: dict[str, Role] = {}
+        for r in rows:
+            existing = by_name.get(r.name)
+            if existing is None or (existing.org_id is None and r.org_id is not None):
+                by_name[r.name] = r
+
         for name in managed_names:
-            result = await self.session.execute(select(Role).where(Role.name == name, Role.org_id == provider.org_id))
-            role = result.scalar_one_or_none()
-            if role is None:
+            if name not in by_name:
                 logger.warning("group_mapping references unknown role %r (org_id=%s)", name, provider.org_id)
-            else:
-                name_to_role[name] = role
-        return name_to_role
+
+        return by_name
 
     async def _sync_idp_groups_to_roles(self, user: User, provider: SSOProvider, groups: list[str] | None) -> None:
         """Reconcile IdP group membership to managed instance RBAC roles.
@@ -581,7 +599,14 @@ class SSOService(BaseService):
             await self.session.flush()
             result = await self.session.execute(select(User).where(User.id == link.user_id))
             user = result.scalar_one()
-            await self._sync_idp_groups_to_roles(user, provider, user_data.get("groups"))
+            try:
+                await self._sync_idp_groups_to_roles(user, provider, user_data.get("groups"))
+            except Exception:
+                logger.warning(
+                    "IdP group->role sync failed for user %s; proceeding with login",
+                    user.id,
+                    exc_info=True,
+                )
             return user
         if not provider.allow_user_creation:
             raise SSOAuthenticationError("User not found and auto-provisioning is disabled")
@@ -592,5 +617,12 @@ class SSOService(BaseService):
         if not user:
             user = await self._create_sso_user(provider, user_data)
         await self._create_sso_link(user, provider, external_id, user_data)
-        await self._sync_idp_groups_to_roles(user, provider, user_data.get("groups"))
+        try:
+            await self._sync_idp_groups_to_roles(user, provider, user_data.get("groups"))
+        except Exception:
+            logger.warning(
+                "IdP group->role sync failed for user %s; proceeding with login",
+                user.id,
+                exc_info=True,
+            )
         return user

--- a/autobot-slm-backend/user_management/services/sso_service.py
+++ b/autobot-slm-backend/user_management/services/sso_service.py
@@ -528,15 +528,11 @@ class SSOService(BaseService):
         logger.info("Created SSO link for user %s with provider %s", user.id, provider.id)
         return link
 
-    async def _resolve_managed_roles(
-        self, provider: SSOProvider, managed_names: set[str]
-    ) -> dict[str, Role]:
+    async def _resolve_managed_roles(self, provider: SSOProvider, managed_names: set[str]) -> dict[str, Role]:
         """Return {role_name: Role} for names that exist in provider.org_id scope."""
         name_to_role: dict[str, Role] = {}
         for name in managed_names:
-            result = await self.session.execute(
-                select(Role).where(Role.name == name, Role.org_id == provider.org_id)
-            )
+            result = await self.session.execute(select(Role).where(Role.name == name, Role.org_id == provider.org_id))
             role = result.scalar_one_or_none()
             if role is None:
                 logger.warning("group_mapping references unknown role %r (org_id=%s)", name, provider.org_id)
@@ -544,9 +540,7 @@ class SSOService(BaseService):
                 name_to_role[name] = role
         return name_to_role
 
-    async def _sync_idp_groups_to_roles(
-        self, user: User, provider: SSOProvider, groups: list[str] | None
-    ) -> None:
+    async def _sync_idp_groups_to_roles(self, user: User, provider: SSOProvider, groups: list[str] | None) -> None:
         """Reconcile IdP group membership to managed instance RBAC roles.
 
         Only roles listed in provider.group_mapping.values() are ever touched;
@@ -564,9 +558,7 @@ class SSOService(BaseService):
 
         user_svc = UserService(self.session)
         managed_names: set[str] = set(provider.group_mapping.values())
-        desired_names: set[str] = {
-            provider.group_mapping[g] for g in groups if g in provider.group_mapping
-        }
+        desired_names: set[str] = {provider.group_mapping[g] for g in groups if g in provider.group_mapping}
         name_to_role = await self._resolve_managed_roles(provider, managed_names)
         current_roles = await user_svc.get_user_roles(user.id)
         current_managed = {r.name for r in current_roles if r.name in managed_names}
@@ -578,13 +570,19 @@ class SSOService(BaseService):
                 await user_svc.revoke_role(user.id, role.id)
 
     async def _find_or_provision_user(self, provider: SSOProvider, external_id: str, user_data: dict[str, Any]) -> User:
-        """Find existing user or provision new one via JIT."""
+        """Find existing user or provision new one via JIT.
+
+        Group→role reconciliation runs in both paths so roles re-sync on every
+        login, not only at first JIT provisioning.
+        """
         link = await self._find_existing_sso_link(provider.id, external_id)
         if link:
             link.record_login()
             await self.session.flush()
             result = await self.session.execute(select(User).where(User.id == link.user_id))
-            return result.scalar_one()
+            user = result.scalar_one()
+            await self._sync_idp_groups_to_roles(user, provider, user_data.get("groups"))
+            return user
         if not provider.allow_user_creation:
             raise SSOAuthenticationError("User not found and auto-provisioning is disabled")
         email = user_data.get("email")
@@ -594,4 +592,5 @@ class SSOService(BaseService):
         if not user:
             user = await self._create_sso_user(provider, user_data)
         await self._create_sso_link(user, provider, external_id, user_data)
+        await self._sync_idp_groups_to_roles(user, provider, user_data.get("groups"))
         return user

--- a/autobot-slm-backend/user_management/services/sso_service.py
+++ b/autobot-slm-backend/user_management/services/sso_service.py
@@ -20,6 +20,7 @@ from typing import Any
 from sqlalchemy import select
 
 from autobot_shared.redis_client import get_redis_client
+from user_management.models.role import Role
 from user_management.models.sso import SSOProvider, SSOProviderType, UserSSOLink
 from user_management.models.user import User
 from user_management.schemas.sso import SSOProviderCreate, SSOProviderUpdate
@@ -526,6 +527,55 @@ class SSOService(BaseService):
         await self.session.flush()
         logger.info("Created SSO link for user %s with provider %s", user.id, provider.id)
         return link
+
+    async def _resolve_managed_roles(
+        self, provider: SSOProvider, managed_names: set[str]
+    ) -> dict[str, Role]:
+        """Return {role_name: Role} for names that exist in provider.org_id scope."""
+        name_to_role: dict[str, Role] = {}
+        for name in managed_names:
+            result = await self.session.execute(
+                select(Role).where(Role.name == name, Role.org_id == provider.org_id)
+            )
+            role = result.scalar_one_or_none()
+            if role is None:
+                logger.warning("group_mapping references unknown role %r (org_id=%s)", name, provider.org_id)
+            else:
+                name_to_role[name] = role
+        return name_to_role
+
+    async def _sync_idp_groups_to_roles(
+        self, user: User, provider: SSOProvider, groups: list[str] | None
+    ) -> None:
+        """Reconcile IdP group membership to managed instance RBAC roles.
+
+        Only roles listed in provider.group_mapping.values() are ever touched;
+        all other roles (including manual grants) are left completely unchanged.
+        If groups is None the IdP did not assert the claim — skip silently to
+        avoid stripping roles when the scope/claim is temporarily missing.
+        """
+        if not provider.group_mapping:
+            return
+        if groups is None:
+            logger.debug("IdP did not assert groups for user %s — skipping role sync", user.id)
+            return
+
+        from user_management.services.user_service import UserService  # noqa: PLC0415
+
+        user_svc = UserService(self.session)
+        managed_names: set[str] = set(provider.group_mapping.values())
+        desired_names: set[str] = {
+            provider.group_mapping[g] for g in groups if g in provider.group_mapping
+        }
+        name_to_role = await self._resolve_managed_roles(provider, managed_names)
+        current_roles = await user_svc.get_user_roles(user.id)
+        current_managed = {r.name for r in current_roles if r.name in managed_names}
+
+        for name, role in name_to_role.items():
+            if name in desired_names and name not in current_managed:
+                await user_svc.assign_role(user.id, role.id)
+            elif name not in desired_names and name in current_managed:
+                await user_svc.revoke_role(user.id, role.id)
 
     async def _find_or_provision_user(self, provider: SSOProvider, external_id: str, user_data: dict[str, Any]) -> User:
         """Find existing user or provision new one via JIT."""

--- a/autobot-slm-backend/user_management/services/sso_service.py
+++ b/autobot-slm-backend/user_management/services/sso_service.py
@@ -78,24 +78,34 @@ class SSOService(BaseService):
                 "token_url": f"https://{domain}/oauth2/v1/token",
                 "userinfo_url": f"https://{domain}/oauth2/v1/userinfo",
                 "scope": "openid email profile groups",
+                # OIDC RP-initiated logout (RFC 9207 / Okta docs)
+                "end_session_endpoint": f"https://{domain}/oauth2/v1/logout",
             },
             SSOProviderType.MICROSOFT_ENTRA.value: {
                 "authorize_url": f"https://login.microsoftonline.com/{domain}/oauth2/v2.0/authorize",
                 "token_url": f"https://login.microsoftonline.com/{domain}/oauth2/v2.0/token",
                 "userinfo_url": "https://graph.microsoft.com/oidc/userinfo",
                 "scope": "openid email profile",
+                # OIDC RP-initiated logout (Microsoft Identity Platform docs)
+                "end_session_endpoint": f"https://login.microsoftonline.com/{domain}/oauth2/v2.0/logout",
             },
             SSOProviderType.GOOGLE_WORKSPACE.value: {
                 "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
                 "token_url": "https://oauth2.googleapis.com/token",  # nosec B105 - OAuth2 public token endpoint URL,
                 "userinfo_url": "https://openidconnect.googleapis.com/v1/userinfo",
                 "scope": "openid email profile",
+                # Google does NOT support RP-initiated OIDC end_session (no end_session_endpoint
+                # in their OIDC discovery doc).  The /o/oauth2/revoke endpoint revokes tokens
+                # server-side but is not an OIDC logout redirect.  Callers should handle None.
+                "end_session_endpoint": None,
             },
             SSOProviderType.GITHUB.value: {
                 "authorize_url": "https://github.com/login/oauth/authorize",
                 "token_url": "https://github.com/login/oauth/access_token",  # nosec B105 - OAuth2 public token endpoint
                 "userinfo_url": "https://api.github.com/user",
                 "scope": "user:email read:user",
+                # GitHub OAuth2 (not OIDC) — no standard end_session_endpoint
+                "end_session_endpoint": None,
             },
         }
         return templates.get(provider_type, {})
@@ -385,21 +395,28 @@ class SSOService(BaseService):
         return await self._find_or_provision_user(provider, username, user_data)
 
     def _get_saml_config(self, provider: SSOProvider) -> dict[str, Any]:
-        """Build pysaml2 config from provider settings."""
+        """Build pysaml2 config from provider settings.
+
+        Includes Single Logout Service (SLO) endpoint when ``slo_url`` is
+        present in the provider config.  The SLO callback route is
+        ``/api/auth/sso/saml/slo`` (registered in api/sso_auth.py).
+        """
+        _http_post = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+        _http_redirect = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+        slo_url = provider.config.get("slo_url")
+        endpoints: dict[str, Any] = {
+            "assertion_consumer_service": [
+                (provider.config.get("acs_url"), _http_post),
+            ],
+        }
+        if slo_url:
+            endpoints["single_logout_service"] = [
+                (slo_url, _http_redirect),
+                (slo_url, _http_post),
+            ]
         return {
             "entityid": provider.config.get("sp_entity_id"),
-            "service": {
-                "sp": {
-                    "endpoints": {
-                        "assertion_consumer_service": [
-                            (
-                                provider.config.get("acs_url"),
-                                "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                            ),
-                        ],
-                    },
-                },
-            },
+            "service": {"sp": {"endpoints": endpoints}},
             "metadata": {"remote": [{"url": provider.config.get("idp_metadata_url")}]},
         }
 
@@ -420,6 +437,31 @@ class SSOService(BaseService):
         if redis:
             await redis.set(f"sso:state:{relay_state}", str(provider.id), ex=600)
         request_id, info = client.prepare_for_authenticate()
+        redirect_url = dict(info["headers"])["Location"]
+        return redirect_url, relay_state
+
+    async def initiate_saml_logout(self, provider: SSOProvider) -> tuple[str, str]:
+        """Initiate SAML SP-initiated Single Logout (SLO).
+
+        Generates a SAML LogoutRequest via pysaml2's ``global_logout`` method,
+        stores the relay state in Redis (same TTL pattern as authn requests),
+        and returns ``(redirect_url, relay_state)``.
+
+        Limitation: pysaml2 ``global_logout`` requires a live session subject
+        (NameID).  Without a real NameID this method uses a placeholder subject
+        — callers should pass the NameID from the user's SSO metadata when
+        available.  The SLO callback route ``/api/auth/sso/saml/slo`` must be
+        registered separately in ``api/sso_auth.py``.
+
+        Raises:
+            SSOServiceError: If pysaml2 is not installed.
+        """
+        client = self._build_saml_client(provider)
+        relay_state = secrets.token_urlsafe(32)
+        redis = get_redis_client()
+        if redis:
+            await redis.set(f"sso:slo_state:{relay_state}", str(provider.id), ex=600)
+        _request_id, info = client.global_logout(subject_id=None)
         redirect_url = dict(info["headers"])["Location"]
         return redirect_url, relay_state
 

--- a/autobot-slm-backend/user_management/services/sso_service.py
+++ b/autobot-slm-backend/user_management/services/sso_service.py
@@ -328,6 +328,20 @@ class SSOService(BaseService):
         user_data = self._extract_oauth_user_data(userinfo, provider)
         return await self._find_or_provision_user(provider, external_id, user_data)
 
+    @staticmethod
+    def _normalize_groups(raw: Any) -> list[str] | None:
+        """Normalize an IdP groups claim to list[str] or None (absent).
+
+        Returns None when the claim is absent so callers can distinguish
+        "IdP did not assert groups" from "IdP asserted an empty group list".
+        """
+        if raw is None:
+            return None
+        if isinstance(raw, list):
+            return [str(g) for g in raw]
+        # Some IdPs return a single string when the user belongs to one group.
+        return [str(raw)]
+
     def _extract_oauth_user_data(self, userinfo: dict[str, Any], provider: SSOProvider) -> dict[str, Any]:
         """Extract user data from OAuth2 userinfo."""
         email = userinfo.get("email")
@@ -338,6 +352,7 @@ class SSOService(BaseService):
             "display_name": name,
             "username": username,
             "avatar_url": userinfo.get("picture"),
+            "groups": self._normalize_groups(userinfo.get("groups")),
         }
 
     def _build_ldap_connection(self, provider: SSOProvider, username: str, password: str) -> Any:
@@ -373,10 +388,13 @@ class SSOService(BaseService):
         attr_map = provider.config.get("attribute_mapping", {})
         email = entry.get(attr_map.get("email", "mail"), [None])[0]
         display_name = entry.get(attr_map.get("display_name", "displayName"), [None])[0]
+        groups_attr = attr_map.get("groups", "memberOf")
+        raw_groups = entry.get(groups_attr)
         return {
             "email": email,
             "display_name": display_name,
             "username": entry.get(attr_map.get("username", "uid"), [None])[0],
+            "groups": self._normalize_groups(raw_groups),
         }
 
     async def authenticate_ldap(self, provider_id: uuid.UUID, username: str, password: str) -> User:
@@ -438,7 +456,13 @@ class SSOService(BaseService):
         email = attrs.get(attr_map.get("email", "email"), [None])[0]
         display_name = attrs.get(attr_map.get("display_name", "displayName"), [None])[0]
         username = attrs.get(attr_map.get("username", "uid"), [None])[0]
-        return {"email": email, "display_name": display_name, "username": username}
+        raw_groups = attrs.get(attr_map.get("groups", "groups"))
+        return {
+            "email": email,
+            "display_name": display_name,
+            "username": username,
+            "groups": self._normalize_groups(raw_groups),
+        }
 
     async def complete_saml_login(self, provider_id: uuid.UUID, saml_response: str) -> User:
         """Complete SAML login flow."""

--- a/autobot-slm-backend/user_management/services/sso_service.py
+++ b/autobot-slm-backend/user_management/services/sso_service.py
@@ -397,23 +397,14 @@ class SSOService(BaseService):
     def _get_saml_config(self, provider: SSOProvider) -> dict[str, Any]:
         """Build pysaml2 config from provider settings.
 
-        Includes Single Logout Service (SLO) endpoint when ``slo_url`` is
-        present in the provider config.  The SLO callback route is
-        ``/api/auth/sso/saml/slo`` (registered in api/sso_auth.py).
+        SAML SLO is not yet implemented — tracked in #10281.
         """
         _http_post = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-        _http_redirect = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
-        slo_url = provider.config.get("slo_url")
         endpoints: dict[str, Any] = {
             "assertion_consumer_service": [
                 (provider.config.get("acs_url"), _http_post),
             ],
         }
-        if slo_url:
-            endpoints["single_logout_service"] = [
-                (slo_url, _http_redirect),
-                (slo_url, _http_post),
-            ]
         return {
             "entityid": provider.config.get("sp_entity_id"),
             "service": {"sp": {"endpoints": endpoints}},
@@ -437,31 +428,6 @@ class SSOService(BaseService):
         if redis:
             await redis.set(f"sso:state:{relay_state}", str(provider.id), ex=600)
         request_id, info = client.prepare_for_authenticate()
-        redirect_url = dict(info["headers"])["Location"]
-        return redirect_url, relay_state
-
-    async def initiate_saml_logout(self, provider: SSOProvider) -> tuple[str, str]:
-        """Initiate SAML SP-initiated Single Logout (SLO).
-
-        Generates a SAML LogoutRequest via pysaml2's ``global_logout`` method,
-        stores the relay state in Redis (same TTL pattern as authn requests),
-        and returns ``(redirect_url, relay_state)``.
-
-        Limitation: pysaml2 ``global_logout`` requires a live session subject
-        (NameID).  Without a real NameID this method uses a placeholder subject
-        — callers should pass the NameID from the user's SSO metadata when
-        available.  The SLO callback route ``/api/auth/sso/saml/slo`` must be
-        registered separately in ``api/sso_auth.py``.
-
-        Raises:
-            SSOServiceError: If pysaml2 is not installed.
-        """
-        client = self._build_saml_client(provider)
-        relay_state = secrets.token_urlsafe(32)
-        redis = get_redis_client()
-        if redis:
-            await redis.set(f"sso:slo_state:{relay_state}", str(provider.id), ex=600)
-        _request_id, info = client.global_logout(subject_id=None)
         redirect_url = dict(info["headers"])["Location"]
         return redirect_url, relay_state
 

--- a/autobot-slm-frontend/src/stores/auth.ts
+++ b/autobot-slm-frontend/src/stores/auth.ts
@@ -13,6 +13,9 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('AuthStore')
 
 interface User {
   username: string
@@ -31,6 +34,10 @@ interface MFALoginResponse {
   access_token?: string
   token_type?: string
   expires_in?: number
+}
+
+interface LogoutResponse {
+  logout_url?: string | null
 }
 
 const TOKEN_KEY = 'slm_access_token'
@@ -186,14 +193,49 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  function logout(): void {
+  /**
+   * Revoke the current token server-side, then clear local session.
+   *
+   * The backend revokes the JWT jti and (for SSO sessions) returns an IdP
+   * end_session URL. Logout must never get stuck: if the revoke call fails the
+   * local session is still cleared and the user is redirected.
+   */
+  async function logout(): Promise<void> {
+    const currentToken = token.value
+    let logoutUrl: string | null = null
+
+    if (currentToken) {
+      try {
+        const response = await fetch(`${getApiUrl()}/api/auth/logout`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${currentToken}`,
+          },
+        })
+        if (response.ok) {
+          const data: LogoutResponse = await response.json()
+          logoutUrl = data.logout_url ?? null
+        } else {
+          logger.warn('Backend logout returned non-OK status', response.status)
+        }
+      } catch (e) {
+        logger.warn('Backend logout call failed; clearing session locally', e)
+      }
+    }
+
     token.value = null
     user.value = null
     sessionStorage.removeItem(TOKEN_KEY)
     sessionStorage.removeItem(USER_KEY)
     localStorage.removeItem(TOKEN_KEY)
     localStorage.removeItem(USER_KEY)
-    router.push('/login')
+
+    if (logoutUrl) {
+      // RP-initiated logout: end the IdP session too
+      window.location.assign(logoutUrl)
+    } else {
+      router.push('/login')
+    }
   }
 
   function getAuthHeaders(): Record<string, string> {

--- a/docs/security/ENTERPRISE_SSO_ADMIN_RUNBOOK.md
+++ b/docs/security/ENTERPRISE_SSO_ADMIN_RUNBOOK.md
@@ -1,0 +1,129 @@
+# Enterprise SSO / OIDC — Administrator Runbook
+
+> Operator guide for AutoBot's enterprise identity federation (SLM control plane).
+> Covers the supported-provider matrix, per-IdP configuration, group→role mapping,
+> logout/revocation behavior, and secret storage/migration/rotation.
+> Sub-umbrella [#8994](https://github.com/mrveiss/AutoBot-AI/issues/8994); design spec:
+> `docs/superpowers/specs/2026-06-15-enterprise-sso-federation-design.md`.
+
+## 1. Supported-provider matrix
+
+| Tier | Providers | Protocol | Notes |
+|---|---|---|---|
+| **Certified** (tested end-to-end, documented, PKCE) | Okta · Microsoft Entra ID (Azure AD) · Google Workspace | OIDC authorization-code + **PKCE (S256)** | Recommended for production. |
+| **Supported** | Generic OIDC (any spec-compliant IdP) · SAML 2.0 · LDAP / Active Directory | OIDC / SAML / LDAP | Functional; SAML **Single Logout** is tracked separately ([#10281](https://github.com/mrveiss/AutoBot-AI/issues/10281)). |
+| **Social (non-enterprise)** | GitHub · Facebook · Google consumer | OAuth2 | Not part of the enterprise tier; unchanged. |
+
+All OIDC logins use **PKCE (S256)** — the authorization-code flow is bound to a
+per-login verifier, mitigating code-interception.
+
+## 2. Configuring a provider
+
+Providers are managed by an admin (permission `SECURITY_MANAGE`) via the SSO
+admin UI (`Settings → Admin → SSO`) or the API under `/sso-providers`. Use
+`GET /sso-providers/provider-templates/{provider_type}?domain=<your-domain>` to
+pre-fill the standard endpoints.
+
+### 2.1 Okta (OIDC)
+- **client_id / client_secret**: from your Okta app integration (Web / OIDC).
+- Endpoints (auto-filled from template): `authorize_url`, `token_url`,
+  `userinfo_url`, `end_session_endpoint` (`{domain}/oauth2/v1/logout`).
+- **scope**: `openid email profile groups`.
+- Redirect/callback URI to register in Okta: `<SLM_EXTERNAL_URL>/api/auth/sso/callback`.
+
+### 2.2 Microsoft Entra ID (Azure AD) (OIDC)
+- **client_id / client_secret**: from the App Registration.
+- Endpoints use `login.microsoftonline.com/<tenant>/...`;
+  `end_session_endpoint` = `.../oauth2/v2.0/logout`.
+- Grant the **GroupMember.Read.All** (or emit `groups` claim) so group→role
+  mapping receives group IDs/names.
+
+### 2.3 Google Workspace (OIDC)
+- **client_id / client_secret**: from a Google Cloud OAuth client.
+- Google does **not** implement an OIDC RP `end_session_endpoint`; logout revokes
+  the local AutoBot session only (the Google session is not terminated). This is
+  expected and noted in the provider template.
+
+### 2.4 Generic OIDC / SAML / LDAP
+- **Generic OIDC**: supply all endpoint URLs (including an optional
+  `end_session_endpoint`) in the provider config.
+- **SAML 2.0**: set `sp_entity_id`, `acs_url`, `idp_metadata_url`. SLO is not yet
+  wired ([#10281](https://github.com/mrveiss/AutoBot-AI/issues/10281)).
+- **LDAP/AD**: `server_uri`, `bind_dn`, `base_dn`, `user_dn_template`,
+  `attribute_mapping`. Group source via `attribute_mapping.groups` (default `memberOf`).
+
+## 3. Group → role mapping
+
+Map IdP groups to **AutoBot instance roles** with the provider's `group_mapping`
+(JSONB), shape `{ "<idp_group>": "<autobot_role_name>" }`:
+
+```json
+{ "engineering": "developer", "sso-admins": "admin", "finance": "viewer" }
+```
+
+Behavior (enforced on **every** login, not just first JIT):
+- On login, the user's current IdP groups are reconciled against the mapping.
+- Only roles that appear as **values** in `group_mapping` are managed — roles you
+  assign manually (outside the mapping) are **never** stripped.
+- Adding a user to a mapped IdP group grants the role; removing them revokes it.
+- If the IdP does **not** assert a groups claim for a login, no role changes are
+  made (avoids accidental mass-revocation when the claim is temporarily absent).
+- Role names resolve against org-scoped roles first, falling back to system roles
+  (`org_id IS NULL`). Names with no matching role are skipped and logged.
+- LLC `MembershipRole` is **out of scope** — group mapping grants instance roles only.
+
+Pre-requisite: request the `groups` scope (OIDC) or configure
+`attribute_mapping.groups` (SAML/LDAP) so groups reach AutoBot.
+
+## 4. Logout & session revocation
+
+- **Endpoint**: `POST /api/auth/logout` (authenticated).
+- AutoBot SLM issues **stateless HS256 JWTs**. On logout the token's `jti` is
+  added to a Redis **denylist** (`slm:jwt:denylist:{jti}`) with a TTL equal to the
+  token's remaining lifetime, so the token is rejected server-side on subsequent
+  requests (enforced on the async HTTP auth path and WebSocket auth).
+- For OIDC providers with an `end_session_endpoint`, the logout response returns a
+  `logout_url`; the frontend redirects there for **RP-initiated** IdP logout.
+- Logout is resilient: if the revoke call fails, the local session is still cleared.
+- **Limitation**: RS256 **authority tokens** minted by autobot-backend cannot be
+  revoked by the SLM denylist — cross-service revocation is tracked under
+  [#10278](https://github.com/mrveiss/AutoBot-AI/issues/10278) (coordinate with
+  auth-unification epic #10193). Keep access-token lifetimes short.
+
+## 5. Secret storage, migration & rotation
+
+### 5.1 Storage (current)
+OAuth client secrets and LDAP bind passwords are **encrypted at rest** with
+AES-256-GCM and stored in the `system_secrets` table (key scheme
+`sso:provider:{id}:{field}`); the provider `config` holds only `{field}_ref`
+references — never plaintext. Field encryption uses `AUTOBOT_FIELD_ENCRYPTION_KEY`.
+
+### 5.2 Migrating legacy plaintext secrets (#9687)
+If you are upgrading from a build that stored secrets in plaintext config:
+1. Ensure `AUTOBOT_FIELD_ENCRYPTION_KEY` is set (the migration fails fast otherwise).
+2. Run `autobot-slm-backend/migrations/migrate_sso_secrets_to_system_secret.py`.
+   It encrypts each `client_secret`/`bind_password`, writes it to `system_secrets`,
+   replaces the config value with a `{field}_ref`, and rolls back on any error.
+3. Verify providers still authenticate (`GET /sso-providers/{id}/test` for LDAP).
+
+### 5.3 Rotation policy
+- **To rotate a client secret today**: rotate it at the IdP, then update the
+  provider via the admin UI / `PATCH /sso-providers/{id}` — the new value is
+  re-encrypted into `system_secrets`. No downtime; existing sessions are unaffected.
+- **Cadence**: a **90-day advisory** rotation is recommended. AutoBot **warns on
+  stale** secrets but does **not** hard-expire them (a forced expiry that locks out
+  SSO is worse than a stale secret).
+- **Planned**: unified-vault-backed rotation (envelope `rewrap_dek` + value re-seal)
+  lands with [#10153](https://github.com/mrveiss/AutoBot-AI/issues/10153) /
+  [#10154](https://github.com/mrveiss/AutoBot-AI/issues/10154), building on the
+  unified-secrets store ([#10088](https://github.com/mrveiss/AutoBot-AI/issues/10088)).
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| Login loops / "invalid state" | Redis unavailable (OAuth state is Redis-backed) | Check Redis; state TTL is 10 min. |
+| Roles not applied | `groups` scope/claim missing, or mapped role name not found | Confirm the IdP emits groups; check role names exist (org or system). |
+| User keeps access after logout | RS256 authority token (not SLM-issued) | Expected until #10278; shorten token TTL. |
+| Google session persists after logout | Google has no OIDC end_session endpoint | Expected; only the AutoBot session is revoked. |
+| Secret decryption errors | `AUTOBOT_FIELD_ENCRYPTION_KEY` changed/missing | Restore the key; re-enter secrets if lost. |


### PR DESCRIPTION
## Thinking Path
Phase A of the enterprise-SSO sub-umbrella #8994 (umbrella #9930), batched into one PR per request. Builds on the already-merged PKCE (#10254). Three cohesive SSO-area deliverables.

## What Changed
**#10151 — RP-initiated logout + JWT revocation**
- `jti` added to SLM-issued HS256 tokens; Redis denylist (`slm:jwt:denylist:{jti}`, TTL = remaining token life) enforced on the async decode path **and** WebSocket auth.
- `POST /api/auth/logout`: revokes the token's jti, audits LOGOUT, returns the IdP `end_session_endpoint` URL for OIDC providers.
- OIDC `end_session_endpoint` templates for Okta/Entra (Google has none — documented).
- Frontend logout calls the backend then clears storage; redirects to the IdP for RP-initiated logout; resilient to backend failure.
- Fail-open denylist (Redis down never locks out valid users); URL-encoded logout params.
- SAML SLO deferred to #10281 (the stub couldn't work — removed rather than ship broken). Cross-service RS256 authority-token revocation tracked in #10278 (coordinate with #10193).

**#10152 — IdP group→instance-role enforcement**
- IdP group claims captured (OIDC/SAML/LDAP); `group_mapping` applied on JIT **and** every login.
- Reconciles **only** roles in `set(group_mapping.values())` — manually-granted roles are never stripped; absent groups claim → no changes; resolves org-scoped then system roles; best-effort (a sync error never blocks login).

**#10155 — Admin runbook** (`docs/security/ENTERPRISE_SSO_ADMIN_RUNBOOK.md`): provider matrix, per-IdP config, group→role, logout/revocation, secret storage + migration (absorbs #9687) + rotation policy.

## Verification
Full SSO/auth suite **113 passed** (service, token_denylist, logout, auth-logout, WS auth, sso_security, sso_auth). ruff + black clean. Rebased onto latest Dev_new_gui. Each component spec+quality reviewed by subagents; review findings (async Redis client, fail-open, WS revocation, URL-encode, system-role resolution, login-blocking) all fixed. WS integration smoke replaced with isolation-safe unit tests to remove suite-order pollution.

## Model Used
Claude Opus 4.8 (subagent-driven: implementers + spec + quality reviewers)

Closes #10151
Closes #10152
Closes #10155
Closes #9687