### PR TITLE
fix: U7 #9926 leftover discoveries — hook over-block + git-cliff dropped commits (#10126, #10118)

### DIFF
--- a/.claude/hooks/block-dangerous-commands.sh
+++ b/.claude/hooks/block-dangerous-commands.sh
@@ -94,42 +94,56 @@ if echo "$COMMAND_TO_CHECK" | grep -qE '(^|[;&|()]+[[:space:]]*)git[[:space:]]+(
   deny "Blocked: never check out main/master locally (#4113, #6512). Main is read-only; commits flow Dev_new_gui → main via release cycle. If you need to inspect main, use git log origin/main or create a worktree: git worktree add .worktrees/inspect-main main"
 fi
 
-# Block ALL branch checkouts and branch creation from the main working tree (#6512)
-# Subagents running in parallel would trample the shared HEAD for every other session.
-# Any branch work must happen inside an isolated worktree.
-# BUG FIX: previously -b/-B/-c flags bypassed the pattern because [^-] required a
-# non-dash first char after checkout/switch. Now both cases are caught explicitly.
+# Block bare branch *switches* from the main working tree (#6512, #10126)
+# Subagents running in parallel would trample the shared HEAD for every other
+# session if they switched onto an existing shared branch. Only that form is
+# dangerous — the worktree mandate targets branch-switching on the MAIN tree.
+# The following git forms are SAFE and explicitly allowed even on the main tree:
+#   - new-branch creation (-b/-B/-c/--create/--orphan): forks a fresh branch,
+#     does not move HEAD onto a shared one
+#   - file restore: `git checkout -- <path>`, `git checkout .`
+#   - detached / toggle switches: `git switch -`, `git switch --detach`
+#   - SHA / tag / Dev_new_gui checkouts
 if echo "$COMMAND_TO_CHECK" | grep -qE '(^|[;&|()]+[[:space:]]*)git[[:space:]]+(checkout|switch)[[:space:]]'; then
   CURRENT_DIR=$(pwd)
   if [[ ! "$CURRENT_DIR" =~ \.worktrees/ ]]; then
-    # Detect -b/-B/-c/--create/--orphan flags — new-branch creation always denied on main tree
-    # because it still moves HEAD away from Dev_new_gui.
-    HAS_NEW_BRANCH_FLAG=0
-    if echo "$COMMAND_TO_CHECK" | grep -qE 'git[[:space:]]+(checkout|switch)[[:space:]]+(-b|-B|-c|--create|--orphan)([[:space:]]|$)' || \
-       echo "$COMMAND_TO_CHECK" | grep -qE 'git[[:space:]]+(checkout|switch)[[:space:]]+.*[[:space:]](-b|-B|-c|--create|--orphan)([[:space:]]|$)'; then
-      HAS_NEW_BRANCH_FLAG=1
+    # New-branch creation (-b/-B/-c/--create/--orphan) anywhere in the args.
+    IS_NEW_BRANCH=0
+    if echo "$COMMAND_TO_CHECK" | grep -qE 'git[[:space:]]+(checkout|switch)[[:space:]]+(.*[[:space:]])?(-b|-B|-c|--create|--orphan)([[:space:]]|$)'; then
+      IS_NEW_BRANCH=1
     fi
 
-    BRANCH_ARG=$(echo "$COMMAND_TO_CHECK" | awk '{
-      found=0
-      for(i=1;i<=NF;i++) {
-        if ($i=="checkout" || $i=="switch") { found=i; break }
-      }
-      if (found) {
-        for(j=found+1;j<=NF;j++) {
-          if (substr($j,1,1)!="-") { print $j; break }
-        }
-      }
-    }')
+    # Explicit file restore: `git checkout -- <path>` (the `--` separator).
+    IS_FILE_RESTORE=0
+    if echo "$COMMAND_TO_CHECK" | grep -qE 'git[[:space:]]+checkout[[:space:]]+--([[:space:]]|$)'; then
+      IS_FILE_RESTORE=1
+    fi
 
-    if [[ "$HAS_NEW_BRANCH_FLAG" -eq 1 ]]; then
-      deny "Blocked: creating a branch on the main working tree moves HEAD away from Dev_new_gui and tramples parallel sessions (#6512). Use a worktree instead: git worktree add .worktrees/<name> -b <branch> Dev_new_gui && cd .worktrees/<name>"
-    elif [[ "$BRANCH_ARG" != "Dev_new_gui" ]] && \
+    if [[ "$IS_NEW_BRANCH" -eq 0 && "$IS_FILE_RESTORE" -eq 0 ]]; then
+      # First non-dash positional after checkout/switch (the branch/ref/path arg).
+      BRANCH_ARG=$(echo "$COMMAND_TO_CHECK" | awk '{
+        found=0
+        for(i=1;i<=NF;i++) {
+          if ($i=="checkout" || $i=="switch") { found=i; break }
+        }
+        if (found) {
+          for(j=found+1;j<=NF;j++) {
+            if (substr($j,1,1)!="-") { print $j; break }
+          }
+        }
+      }')
+
+      # Block only when a concrete branch-name arg is present and is not one of
+      # the safe targets (base branch, file restore, detached HEAD, SHA, tag, path).
+      if [[ -n "$BRANCH_ARG" ]] && \
+         [[ "$BRANCH_ARG" != "Dev_new_gui" ]] && \
          [[ "$BRANCH_ARG" != "." ]] && \
+         [[ "$BRANCH_ARG" != "HEAD" ]] && \
          ! [[ "$BRANCH_ARG" =~ ^[0-9a-f]{7,40}$ ]] && \
          ! [[ "$BRANCH_ARG" =~ ^v[0-9]+\.[0-9]+ ]] && \
          ! [[ "$BRANCH_ARG" =~ ^/ ]]; then
-      deny "Blocked: switching branches on the main working tree tramples HEAD for parallel sessions (#6512). Use a worktree instead: git worktree add .worktrees/<name> <branch> && cd .worktrees/<name>. Then do your work and remove with: git worktree remove .worktrees/<name>"
+        deny "Blocked: switching branches on the main working tree tramples HEAD for parallel sessions (#6512). Use a worktree instead: git worktree add .worktrees/<name> <branch> && cd .worktrees/<name>. Then do your work and remove with: git worktree remove .worktrees/<name>"
+      fi
     fi
   fi
 fi

--- a/.claude/hooks/block-dangerous-commands_test.sh
+++ b/.claude/hooks/block-dangerous-commands_test.sh
@@ -9,10 +9,17 @@ HOOK="$(cd "$(dirname "$0")" && pwd)/block-dangerous-commands.sh"
 PASS=0
 FAIL=0
 
+# The branch-switch protections only apply on the MAIN working tree (the hook
+# skips them under .worktrees/). To keep the suite deterministic regardless of
+# where it is launched from (#10126), run every case from a temp dir that is
+# guaranteed not to be under .worktrees/ — i.e. always assert main-tree semantics.
+TEST_CWD=$(mktemp -d)
+trap 'rm -rf "$TEST_CWD"' EXIT
+
 hook_exit() {
   local input
   input=$(echo '{}' | /usr/bin/jq --arg c "$1" '.tool_input.command=$c')
-  bash "$HOOK" <<<"$input" >/dev/null 2>/dev/null
+  (cd "$TEST_CWD" && bash "$HOOK" <<<"$input") >/dev/null 2>/dev/null
   echo $?
 }
 

--- a/.session/HANDOFF-issue-10126-u7disc.md
+++ b/.session/HANDOFF-issue-10126-u7disc.md
@@ -1,0 +1,15 @@
+# Handoff: issue-10126-u7disc
+status: complete
+pr: #10433
+base_at_push: beb3a9f7f0d791efc6e8a451981bc83e751aa238
+gates: hook-test=27/27 git-cliff=catch-all-renders code-review=APPROVE(no HIGH/MED)
+needs_rebase_before_merge: no
+remaining: (none for this PR)
+notes:
+  - Scope was 4 U7 #9926 discovery issues; #10119 + #10059 were fixed by other
+    sessions mid-work (closed via #10402 / #10393). Dropped those 2 commits;
+    PR carries only #10126 + #10118.
+  - Filed discovery #10434 (pre-existing `git -c ... checkout` hook bypass, low).
+  - #10117 (GPL-3.0 vs ISC vendored dep) intentionally NOT touched — owner-gated
+    licensing under relicense epic #9826.
+worktree: .worktrees/issue-10126-u7disc  (safe to remove after #10433 merges)

--- a/cliff.toml
+++ b/cliff.toml
@@ -35,7 +35,10 @@ trim = true
 
 [git]
 conventional_commits = true
-filter_unconventional = true
+# Keep non-conventional commits (~752 historically) instead of silently
+# dropping them — they fall through to the catch-all parser below and surface
+# under "Other / Uncategorized" in the changelog (#10118).
+filter_unconventional = false
 split_commits = false
 commit_preprocessors = [
     { pattern = '\\(#(\\d+)\\)', replace = "" },
@@ -51,6 +54,11 @@ commit_parsers = [
     { message = "^style", group = "Styling" },
     { message = "^test", group = "Testing" },
     { message = "^revert", group = "Reverted" },
+    # Drop merge-bubble noise (Dev_new_gui → main promotions) — not real changes.
+    { message = "^Merge ", skip = true },
+    # Catch-all: any commit that didn't match a conventional type above is
+    # bucketed here rather than dropped, so no change is invisible (#10118).
+    { message = ".*", group = "Other / Uncategorized" },
 ]
 protect_breaking_commits = false
 filter_commits = false

--- a/docs/developer/RELEASE_WORKFLOW.md
+++ b/docs/developer/RELEASE_WORKFLOW.md
@@ -51,7 +51,7 @@ the whole time.
 Secondary findings from the audit:
 
 - None of the existing tags (`v0.1.0`–`v0.3.0`) were created by the workflow — all were manual. The pipeline has never cut a release end-to-end.
-- ~750 commits are skipped by git-cliff as non-conventional (`WARN ... skipped due to parse error`) — they simply don't appear in generated output.
+- ~750 commits were skipped by git-cliff as non-conventional (`WARN ... skipped due to parse error`) and never appeared in generated output. **Resolved (#10118):** `cliff.toml` now sets `filter_unconventional = false` and adds a catch-all `commit_parser` so non-conventional commits surface under an **"Other / Uncategorized"** section; merge-bubble commits are skipped to keep that section clean. Note this only restores *changelog visibility* — non-conventional commits still cannot drive a semver bump (that needs commit-message enforcement, tracked separately).
 
 Fix: derive the bumped version from the action's `content` output (the output
 *file* contains the version string), validate its shape, and guard against


### PR DESCRIPTION
## Thinking Path

All 9 working members of umbrella **#9926** are already closed; it stays open only for the owner/lawyer-gated relicense epic #9826. The genuinely actionable leftovers were the discovery issues filed during #9926. Of the four originally scoped, **#10119 and #10059 were fixed by other sessions mid-work** (closed via #10402 and #10393 respectively) — so this PR carries only the two that remained open: **#10126** and **#10118**.

## What Changed

### #10126 — `block-dangerous-commands.sh` over-blocked legitimate git
The hook blocked safe forms on the main tree (`git checkout -b`, `git checkout -- <file>`, `git switch -`, `git switch --detach HEAD`). Loosened the branch-guard so it blocks **only bare branch-name switches** (`git checkout <branch>` / `git switch <branch>`), while allowing new-branch creation, file restore, SHA/tag/`Dev_new_gui` checkouts, and detached/toggle switches. `main`/`master` stay blocked by the separate earlier guard.

Also made the **test CWD-deterministic** (runs each case from a `mktemp` dir so it always asserts main-tree semantics) — it previously regressed to 23/27 when run from inside `.worktrees/` because the hook skips the guard there.

### #10118 — git-cliff silently dropped ~752 non-conventional commits
`cliff.toml` had `filter_unconventional = true` with no catch-all parser, so non-conventional commits never reached the changelog or the `--bumped-version` logic. Set `filter_unconventional = false`, added a trailing catch-all parser (**"Other / Uncategorized"**), and skip `^Merge ` bubbles to keep that section clean. This restores changelog *visibility* only — semver-bump capability for non-conventional commits still needs commit-message enforcement (noted in `RELEASE_WORKFLOW.md`, tracked separately).

## Verification

- `bash .claude/hooks/block-dangerous-commands_test.sh` → **27 passed, 0 failed** (confirmed from both the main tree and inside a worktree).
- Beyond-suite checks: `git checkout feature-branch`, `git checkout issue-1234`, `git switch some-branch` still exit 2 (blocked); the 5 safe forms exit 0.
- git-cliff v2.10.1 run against the new `cliff.toml`: **"Other / Uncategorized"** section now renders (+177 net commit lines captured vs. the old config); 0 merge-bubble commits leak into output.
- `code-reviewer` agent: **APPROVE**, no HIGH/MEDIUM findings.

Closes #10126
Closes #10118

## Model Used

Opus 4.8 (1M context)