### PR TITLE
fix(auth): include sub/user_id in single_user bypass token — fixes login redirect loop

### DIFF
--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -195,6 +195,11 @@ async def login(request: Request, login_data: LoginRequest):
             }
             jwt_token = get_auth_middleware().create_jwt_token(
                 {
+                    # Include user_id + sub so user endpoints (e.g. /users/me/preferences)
+                    # can resolve the identity; without them they 401'd and the frontend
+                    # logged out → login redirect loop in single_user bypass mode.
+                    "sub": "admin",
+                    "user_id": "admin",
                     "username": "admin",
                     "role": "admin",
                     "email": f"admin@{ssot_config.auth.domain}",


### PR DESCRIPTION
## Thinking Path
User reported 'unable to log in', then 'redirects back to login'. Login returned 200 + token, and /api/auth/me worked, but /api/users/me/preferences → 401 `User ID not found in token` → frontend 401-interceptor logged out → redirect loop.

## Root Cause
The single_user bypass token (auth.py:196) was minted with only {username, role, email} — no `sub`/`user_id`. `get_user_preferences` reads `current_user['user_id'] or ['sub']` → 401.

## What Changed
Add `sub` + `user_id` ('admin') to the bypass token claims. Real-auth path already includes user_id.

## Verification
Applied live: login → token → /api/users/me/preferences now 200 (no redirect).

## Model Used
Claude Opus 4.8