### PR TITLE
fix(frontend): repoint 404 health-checks — add /api/mcp/health route + SLM batch-jobs health (#10429)

### DIFF
--- a/autobot-backend/api/mcp_registry.py
+++ b/autobot-backend/api/mcp_registry.py
@@ -58,6 +58,7 @@ from .schemas_code import (
     MCPRegistryBridgesResponse,
     MCPRegistryCacheInvalidateResponse,
     MCPRegistryCacheStatsResponse,
+    MCPRegistryHealthResponse,
     MCPRegistryInfoResponse,
     MCPRegistryStatsResponse,
     MCPRegistryToolDetailResponse,
@@ -583,6 +584,47 @@ async def _fetch_bridges_info() -> Metadata:
 # ============================================================================
 # API Endpoints
 # ============================================================================
+
+
+@router.get("/health", response_model=MCPRegistryHealthResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_mcp_registry_health",
+    error_code_prefix="MCP_REGISTRY",
+)
+async def get_mcp_registry_health() -> Metadata:
+    """Aggregate health check for the MCP registry (#10429).
+
+    The frontend MCP manager and SLM admin monitoring poll
+    GET /api/mcp/health (advertised by the registry info route) expecting an
+    aggregate of per-bridge health. It previously 404'd because only
+    /tools, /bridges, /stats and / existed. Reuses the cached bridge probe.
+    """
+    bridges_response = await get_mcp_bridges()
+    bridges = bridges_response.get("bridges", [])
+    total_bridges = bridges_response.get("total_bridges", len(bridges))
+    healthy_bridges = bridges_response.get(
+        "healthy_bridges",
+        sum(1 for b in bridges if b.get("status") == "healthy"),
+    )
+
+    if total_bridges == 0:
+        overall = "unknown"
+    elif healthy_bridges == total_bridges:
+        overall = "healthy"
+    elif healthy_bridges == 0:
+        overall = "unavailable"
+    else:
+        overall = "degraded"
+
+    return {
+        "status": overall,
+        "total_bridges": total_bridges,
+        "healthy_bridges": healthy_bridges,
+        "checks": bridges,
+        "cache_stats": mcp_cache.get_stats(),
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+    }
 
 
 @router.get("/tools", response_model=MCPRegistryToolsResponse)

--- a/autobot-slm-frontend/src/composables/useAutobotApi.ts
+++ b/autobot-slm-frontend/src/composables/useAutobotApi.ts
@@ -852,7 +852,9 @@ export function useAutobotApi() {
   }
 
   async function getBatchJobHealth(): Promise<Record<string, unknown>> {
-    const response = await client.get('/batch-jobs/health')
+    // #10429: backend exposes /batch-jobs/status (returns status: "healthy"),
+    // never /batch-jobs/health (404). Repointed to the real route.
+    const response = await client.get('/batch-jobs/status')
     return response.data
   }
 


### PR DESCRIPTION
## Thinking Path
Frontend health-check polls returned 404 (#10429). Audited each path against the real backend routers. `/api/vision/health` and the main-app `/api/batch-jobs` probe were already correct in base; the two remaining gaps were the SLM frontend's `getBatchJobHealth` (hit non-existent `/batch-jobs/health`) and `getMCPHealth` (hit `/api/mcp/health`, which the registry router *advertised* but never wired).

## What Changed
- `autobot-backend/api/mcp_registry.py` — added the missing `GET /health` route (the `mcp_registry` info route already advertised it and a `MCPRegistryHealthResponse` schema already existed; the route was intended but never registered). Reuses the cached `get_mcp_bridges()` probe to compute an aggregate (`healthy`/`degraded`/`unavailable`/`unknown`).
- `autobot-slm-frontend/src/composables/useAutobotApi.ts` — repointed `getBatchJobHealth` to the real `/batch-jobs/status` route (shape-compatible with the existing `HealthData` consumer).

## Verification
- `python3 -m py_compile autobot-backend/api/mcp_registry.py` → OK.
- Confirmed targets exist: `/api/vision/health`, `/api/vision/status`, `/api/batch-jobs/status`, new `/api/mcp/health`.
- Closes #10429.

## Model Used
Claude Opus 4.8 (frontend-engineer subagent).
