### PR TITLE
feat(integrations): plugin-loader file-path fallback for core-plugins + route WhatsApp inbound media into chat (#10294, #10267)

### DIFF
--- a/autobot-backend/api/whatsapp.py
+++ b/autobot-backend/api/whatsapp.py
@@ -17,9 +17,11 @@ Telegram bot adapter (``api/telegram_bot.py``):
 
 Outbound replies reuse ``WhatsAppIntegration`` so opt-in enforcement, error
 handling, and PII masking are applied on the send path.
+
+Issue #10267 - Route inbound WhatsApp media/voice into chat pipeline.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse, PlainTextResponse
@@ -32,6 +34,7 @@ from autobot_shared.logging_manager import get_logger
 from services.gateway.gateway_manager import GatewayManager
 from services.whatsapp_service import (
     build_integration,
+    download_whatsapp_media,
     flatten_messages,
     get_whatsapp_app_secret,
     get_whatsapp_verify_token,
@@ -62,8 +65,21 @@ async def send_whatsapp_response(to: str, response_text: str) -> None:
     await integration.send_text_message({"to": to, "body": response_text})
 
 
-async def _route_to_chat_and_reply(request: Request, unified_message: Any) -> None:
-    """Route a normalized WhatsApp message to chat and send the AI reply."""
+async def _route_to_chat_and_reply(
+    request: Request,
+    unified_message: Any,
+    media_bytes: Optional[bytes] = None,
+    media_mime_type: Optional[str] = None,
+) -> None:
+    """Route a normalized WhatsApp message to chat and send the AI reply.
+
+    Args:
+        request:         FastAPI request (used to reach app.state services).
+        unified_message: Gateway-normalized message.
+        media_bytes:     Raw media bytes downloaded from the Graph API, if the
+                         inbound message carried a media attachment (GH#10267).
+        media_mime_type: MIME type of the downloaded media, or None.
+    """
     from api.chat import process_chat_message
     from services.llm_service import LLMService
     from utils.chat_utils import get_chat_history_manager
@@ -71,6 +87,15 @@ async def _route_to_chat_and_reply(request: Request, unified_message: Any) -> No
 
     session_id = _get_chat_session_id(unified_message.channel_id)
     request_id = generate_request_id()
+
+    extra_metadata: Dict[str, Any] = {}
+    if media_bytes is not None:
+        # Attach media to the chat message metadata mirroring telegram_adapter's has_file pattern
+        extra_metadata["has_file"] = True
+        extra_metadata["file_bytes"] = media_bytes
+        extra_metadata["file_type"] = unified_message.metadata.get("message_type", "media")
+        if media_mime_type:
+            extra_metadata["mime_type"] = media_mime_type
 
     chat_message = ChatMessage(
         content=unified_message.message,
@@ -81,6 +106,7 @@ async def _route_to_chat_and_reply(request: Request, unified_message: Any) -> No
             "whatsapp_user_id": unified_message.user_id,
             "whatsapp_chat_id": unified_message.channel_id,
             **unified_message.metadata,
+            **extra_metadata,
         },
     )
 
@@ -138,6 +164,11 @@ async def whatsapp_webhook(request: Request) -> JSONResponse:
 
     Security: verifies the ``X-Hub-Signature-256`` HMAC over the raw body using
     the stored app secret (Meta security requirement). Fails closed.
+
+    Text messages are routed immediately.  Media messages (image/audio/voice/
+    video/document) are downloaded from the Graph API and attached to the chat
+    message as ``has_file`` metadata before dispatch, mirroring the Telegram
+    adapter's has_file flow (GH#10267).
     """
     raw_body = await request.body()
 
@@ -160,12 +191,35 @@ async def whatsapp_webhook(request: Request) -> JSONResponse:
         return JSONResponse({"status": "ok"})
 
     for raw_message in flatten_messages(webhook_body):
+        media_bytes: Optional[bytes] = None
+        media_mime_type: Optional[str] = None
+
         if not raw_message.get("body"):
-            # Non-text (media/voice) — acknowledged but not routed to text chat
-            logger.info("Received non-text WhatsApp message type=%s", raw_message.get("message_type"))
-            continue
+            # Non-text inbound message — attempt to download and route media (GH#10267)
+            media_id: Optional[str] = raw_message.get("media_id")
+            if not media_id:
+                logger.info(
+                    "Received non-text WhatsApp message type=%s (no downloadable media_id)",
+                    raw_message.get("message_type"),
+                )
+                continue
+            media_bytes, media_mime_type = await download_whatsapp_media(media_id)
+            if media_bytes is None:
+                logger.warning(
+                    "Could not download WhatsApp media (media_id=%s, type=%s) — skipping",
+                    media_id,
+                    raw_message.get("message_type"),
+                )
+                continue
+            logger.info(
+                "Downloaded WhatsApp media (media_id=%s, type=%s, size=%d bytes)",
+                media_id,
+                raw_message.get("message_type"),
+                len(media_bytes),
+            )
+
         unified_message = await gateway_manager.normalize_message(raw_message)
-        await _route_to_chat_and_reply(request, unified_message)
+        await _route_to_chat_and_reply(request, unified_message, media_bytes, media_mime_type)
 
     return JSONResponse({"status": "ok"})
 

--- a/autobot-backend/plugin_sdk/loader.py
+++ b/autobot-backend/plugin_sdk/loader.py
@@ -13,6 +13,7 @@ Issue #9049 - Plugin capability manifest system.
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import json
 import os
 from pathlib import Path
@@ -45,6 +46,13 @@ class PluginLoader:
         self.registry = PluginRegistry()
         self.capability_checker = CapabilityChecker()
         self._logger = get_logger(__name__)
+        # Plugin name -> on-disk source directory, captured at discovery so the
+        # loader can import the module by file path. The manifest entry_point
+        # (e.g. "plugins.core_plugins.hello_plugin.main") is NOT importable: the
+        # on-disk dirs are hyphenated ("plugins/core-plugins/hello-plugin") and
+        # not on sys.path, so import_module silently failed for every core
+        # plugin (#10294).
+        self._manifest_dirs: Dict[str, Path] = {}
 
     def discover_plugins(self) -> List[PluginManifest]:
         """Discover all plugins from configured directories.
@@ -74,6 +82,7 @@ class PluginLoader:
                         data = json.load(f)
                     manifest = PluginManifest(**data)
                     manifests.append(manifest)
+                    self._manifest_dirs[manifest.name] = subdir
                     self._logger.debug(
                         "Discovered plugin: %s v%s",
                         manifest.name,
@@ -88,6 +97,69 @@ class PluginLoader:
                     )
 
         return manifests
+
+    def _import_entry_point(self, manifest: PluginManifest):
+        """Import a plugin's module, preferring file-path import (#10294).
+
+        Core plugins live in hyphenated dirs (``plugins/core-plugins/hello-plugin``)
+        that are not importable via the dotted ``entry_point``. Load the module
+        file directly from the discovered source directory; fall back to
+        ``import_module`` for plugins genuinely installed on ``sys.path``.
+
+        The module is registered in ``sys.modules`` under ``entry_point`` so that
+        intra-plugin dataclasses and relative refs resolve to the correct module name.
+        """
+        import sys
+
+        source_dir = self._manifest_dirs.get(manifest.name)
+        if source_dir is not None:
+            module_file = manifest.entry_point.rsplit(".", 1)[-1] + ".py"  # "...main" -> main.py
+            module_path = source_dir / module_file
+            if module_path.is_file():
+                spec = importlib.util.spec_from_file_location(manifest.entry_point, module_path)
+                if spec and spec.loader:
+                    module = importlib.util.module_from_spec(spec)
+                    # Register before exec so intra-plugin dataclasses/relative refs resolve.
+                    sys.modules[manifest.entry_point] = module
+                    try:
+                        spec.loader.exec_module(module)  # type: ignore[union-attr]
+                        self._logger.info(
+                            "Loaded plugin module %r from %s (file-path fallback)",
+                            manifest.entry_point,
+                            module_path,
+                        )
+                        return module
+                    except Exception as exc:
+                        sys.modules.pop(manifest.entry_point, None)
+                        self._logger.warning(
+                            "File-path fallback failed for %r at %s: %s",
+                            manifest.entry_point,
+                            module_path,
+                            exc,
+                        )
+        try:
+            return importlib.import_module(manifest.entry_point)
+        except ModuleNotFoundError as exc:
+            self._logger.error(
+                "Plugin '%s' module not importable (entry_point=%s, source_dir=%s): %s",
+                manifest.name,
+                manifest.entry_point,
+                source_dir,
+                exc,
+            )
+            return None
+
+    @staticmethod
+    def _resolve_plugin_class(module):
+        """Return the plugin class: explicit ``Plugin`` export, else a BasePlugin subclass (#10294)."""
+        plugin_class = getattr(module, "Plugin", None)
+        if isinstance(plugin_class, type) and issubclass(plugin_class, BasePlugin):
+            return plugin_class
+        for attr in vars(module).values():
+            if isinstance(attr, type) and issubclass(attr, BasePlugin) and attr is not BasePlugin:
+                if getattr(attr, "__module__", None) == module.__name__:
+                    return attr
+        return None
 
     async def load_plugin(
         self,
@@ -107,18 +179,22 @@ class PluginLoader:
             Loaded plugin instance, or None if load failed
         """
         try:
-            # Import plugin module
-            module = importlib.import_module(manifest.entry_point)
+            # Import plugin module (by file path; see _import_entry_point) (#10294)
+            module = self._import_entry_point(manifest)
+            if module is None:
+                return None
 
-            # Get Plugin class
-            if not hasattr(module, "Plugin"):
+            # Resolve the plugin class: prefer an explicit ``Plugin`` export,
+            # otherwise fall back to the module's BasePlugin subclass so a plugin
+            # that forgot the ``Plugin = MyPlugin`` alias still loads instead of
+            # silently failing to register (#10294).
+            plugin_class = self._resolve_plugin_class(module)
+            if plugin_class is None:
                 self._logger.error(
-                    "Plugin module '%s' does not export 'Plugin' class",
+                    "Plugin module '%s' exports no 'Plugin' alias or BasePlugin subclass",
                     manifest.entry_point,
                 )
                 return None
-
-            plugin_class = module.Plugin
 
             # Instantiate plugin
             plugin = plugin_class(manifest, config)

--- a/autobot-backend/services/whatsapp_service.py
+++ b/autobot-backend/services/whatsapp_service.py
@@ -14,6 +14,7 @@ Bridges the inbound WhatsApp webhook route to the reusable
   delivery (Meta security requirement).
 - Flattens Meta's nested webhook envelope into the flat shape the gateway
   ``WhatsAppAdapter`` expects, so messages can be normalized and routed to chat.
+- Downloads inbound media via the Graph API media endpoint (GH#10267).
 
 Security: access token and app secret are encrypted at rest (see
 ``autobot_shared.field_encryption``).
@@ -21,7 +22,7 @@ Security: access token and app secret are encrypted at rest (see
 
 import hashlib
 import hmac
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from autobot_shared.field_encryption import decrypt_field, encrypt_field
 from autobot_shared.logging_manager import get_logger
@@ -149,13 +150,81 @@ def verify_webhook_signature(payload: bytes, signature_header: Optional[str], ap
     return hmac.compare_digest(provided, expected)
 
 
+async def download_whatsapp_media(media_id: str) -> Tuple[Optional[bytes], Optional[str]]:
+    """Download WhatsApp media bytes via the Graph API media endpoint.
+
+    Flow (Graph API):
+      1. GET /{media-id}  -> JSON with a short-lived ``url`` field.
+      2. GET {url} with Bearer access token -> raw media bytes.
+
+    Returns:
+        Tuple of (raw_bytes, mime_type) on success; (None, None) on failure.
+        Never raises; logs and returns (None, None) on any error.
+
+    GH#10267 -- mirrors telegram_adapter's has_file/media-download flow.
+    """
+    import aiohttp
+
+    access_token = await _get(WHATSAPP_ACCESS_TOKEN_KEY)
+    if not access_token:
+        logger.warning("Cannot download WhatsApp media — access token not configured")
+        return None, None
+
+    base_url = (await _get(WHATSAPP_BASE_URL_KEY)) or "https://graph.facebook.com/v18.0"
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    try:
+        timeout = aiohttp.ClientTimeout(total=30)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            # Step 1: resolve the temporary download URL
+            async with session.get(f"{base_url}/{media_id}", headers=headers) as resp:
+                if resp.status != 200:
+                    logger.warning(
+                        "WhatsApp media metadata fetch failed (media_id=%s, status=%s)",
+                        media_id,
+                        resp.status,
+                    )
+                    return None, None
+                meta = await resp.json()
+
+            download_url = meta.get("url")
+            mime_type: Optional[str] = meta.get("mime_type")
+            if not download_url:
+                logger.warning("WhatsApp media metadata missing 'url' field (media_id=%s)", media_id)
+                return None, None
+
+            # Step 2: fetch the raw bytes
+            async with session.get(download_url, headers=headers) as resp:
+                if resp.status != 200:
+                    logger.warning(
+                        "WhatsApp media download failed (media_id=%s, status=%s)",
+                        media_id,
+                        resp.status,
+                    )
+                    return None, None
+                raw_bytes = await resp.read()
+                # Prefer Content-Type from the download response if metadata lacked it
+                if not mime_type:
+                    mime_type = resp.headers.get("Content-Type")
+                return raw_bytes, mime_type
+
+    except Exception as exc:
+        logger.error("Exception downloading WhatsApp media (media_id=%s): %s", media_id, exc)
+        return None, None
+
+
+# Media types that carry a downloadable ``id`` in the Meta webhook envelope.
+_MEDIA_MESSAGE_TYPES = frozenset({"image", "audio", "voice", "video", "document", "sticker"})
+
+
 def flatten_messages(webhook_body: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Flatten a Meta webhook envelope into adapter-ready message dicts.
 
     Meta nests messages under ``entry[].changes[].value.messages[]``. The gateway
     ``WhatsAppAdapter`` expects a flat dict with ``from``, ``chat_id``, ``body``,
-    ``id``, ``timestamp``. Only text messages carry a routable body; others are
-    flattened with an empty body and their type recorded in metadata.
+    ``id``, ``timestamp``.  Text messages carry a routable ``body``; media messages
+    (image/audio/voice/video/document/sticker) carry a ``media_id`` so the webhook
+    handler can download them and attach them to the chat pipeline (GH#10267).
     """
     flattened: List[Dict[str, Any]] = []
     for entry in webhook_body.get("entry", []):
@@ -165,15 +234,23 @@ def flatten_messages(webhook_body: Dict[str, Any]) -> List[Dict[str, Any]]:
                 sender = message.get("from", "")
                 msg_type = message.get("type", "text")
                 body = message.get("text", {}).get("body", "") if msg_type == "text" else ""
-                flattened.append(
-                    {
-                        "platform": "whatsapp",
-                        "from": sender,
-                        "chat_id": sender,
-                        "body": body,
-                        "id": message.get("id"),
-                        "timestamp": message.get("timestamp", 0),
-                        "message_type": msg_type,
-                    }
-                )
+
+                # Extract the media object id for downloadable types (GH#10267)
+                media_id: Optional[str] = None
+                if msg_type in _MEDIA_MESSAGE_TYPES:
+                    media_obj = message.get(msg_type, {})
+                    media_id = media_obj.get("id") if isinstance(media_obj, dict) else None
+
+                flat: Dict[str, Any] = {
+                    "platform": "whatsapp",
+                    "from": sender,
+                    "chat_id": sender,
+                    "body": body,
+                    "id": message.get("id"),
+                    "timestamp": message.get("timestamp", 0),
+                    "message_type": msg_type,
+                }
+                if media_id:
+                    flat["media_id"] = media_id
+                flattened.append(flat)
     return flattened

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -10,6 +10,7 @@ Dynamic plugin discovery and loading system.
 Issue #730 - Plugin SDK for extensible tool architecture.
 Issue #6970 - Validate declared hooks against HOOK_REGISTRY on load.
 Issue #6971 - Raise PluginLoadError for missing required env vars.
+Issue #10294 - File-path fallback for hyphenated core-plugin directories.
 """
 
 import importlib
@@ -43,6 +44,8 @@ class PluginLoader:
         """
         self.plugin_dirs = plugin_dirs or []
         self.registry = PluginRegistry()
+        # Maps plugin name -> directory containing its plugin.json (set during discover_plugins)
+        self._manifest_dirs: Dict[str, Path] = {}
 
     def discover_plugins(self) -> List[PluginManifest]:
         """
@@ -65,6 +68,8 @@ class PluginLoader:
                         data = json.load(f)
 
                     manifest = PluginManifest(**data)
+                    # Remember where on disk this plugin lives (needed for file-path fallback)
+                    self._manifest_dirs[manifest.name] = manifest_file.parent
                     manifests.append(manifest)
                     logger.info("Discovered plugin: %s v%s", manifest.name, manifest.version)
 
@@ -117,8 +122,9 @@ class PluginLoader:
                     missing_optional,
                 )
 
-            # Import plugin module
-            plugin_class = self._import_plugin_class(manifest.entry_point)
+            # Import plugin module — pass on-disk directory for file-path fallback (#10294)
+            plugin_dir = self._manifest_dirs.get(manifest.name)
+            plugin_class = self._import_plugin_class(manifest.entry_point, plugin_dir)
             if not plugin_class:
                 return None
 
@@ -260,32 +266,106 @@ class PluginLoader:
             for env in plugin.manifest.required_env
         }
 
-    def _import_plugin_class(self, entry_point: str) -> Type[BasePlugin] | None:
+    def _import_plugin_class(
+        self, entry_point: str, plugin_dir: Path | None = None
+    ) -> Type[BasePlugin] | None:
         """
         Import plugin class from entry point.
 
+        Tries ``importlib.import_module(entry_point)`` first.  When that raises
+        ``ModuleNotFoundError`` (e.g. core-plugins whose hyphenated directory is not
+        importable as a Python package -- GH#10294), falls back to loading the
+        ``main.py`` from the plugin's on-disk directory via
+        ``importlib.util.spec_from_file_location``, mirroring the approach used in
+        ``autobot-backend/api/_video_providers_loader.py``.
+
         Args:
-            entry_point: Python module path (e.g., 'plugins.hello.main')
+            entry_point: Python module path (e.g., 'plugins.core_plugins.image_generation_plugin.main')
+            plugin_dir:  Directory that contains plugin.json -- used for the file-path fallback.
 
         Returns:
             Plugin class or None on failure
         """
+        module = None
+
         try:
-            # Import module
             module = importlib.import_module(entry_point)
+        except ModuleNotFoundError as exc:
+            logger.debug(
+                "importlib.import_module(%r) failed (%s); attempting file-path fallback",
+                entry_point,
+                exc,
+            )
+            module = self._import_from_file(entry_point, plugin_dir)
 
-            # Look for Plugin class or class with 'Plugin' suffix
-            for attr_name in dir(module):
-                attr = getattr(module, attr_name)
-                if isinstance(attr, type) and issubclass(attr, BasePlugin) and attr is not BasePlugin:
-                    return attr
-
-            logger.error("No plugin class found in module: %s", entry_point)
+        if module is None:
+            logger.error("Failed to import plugin module: %s", entry_point)
             return None
 
-        except Exception as e:
-            logger.error("Failed to import plugin %s: %s", entry_point, e, exc_info=True)
-            return None
+        # Look for Plugin class or class with 'Plugin' suffix
+        for attr_name in dir(module):
+            attr = getattr(module, attr_name)
+            if isinstance(attr, type) and issubclass(attr, BasePlugin) and attr is not BasePlugin:
+                return attr
+
+        logger.error("No plugin class found in module: %s", entry_point)
+        return None
+
+    def _import_from_file(self, entry_point: str, plugin_dir: Path | None) -> object | None:
+        """
+        File-path fallback for plugins whose directory name is not importable
+        (e.g. ``core-plugins/image-generation-plugin`` -- hyphen prevents normal import).
+
+        Resolves ``main.py`` relative to *plugin_dir* (preferred) or by translating
+        the underscored entry-point path back to the hyphenated on-disk path inside
+        any configured plugin_dirs.  Registers the module under *entry_point* in
+        ``sys.modules`` so intra-plugin relative imports and dataclasses resolve.
+
+        GH#10294 -- mirrors ``autobot-backend/api/_video_providers_loader.py``.
+        """
+        import sys
+
+        # Candidate file paths, most-canonical first.
+        candidates: List[Path] = []
+
+        # 1. Use the stored manifest directory directly (most reliable).
+        if plugin_dir is not None:
+            candidates.append(plugin_dir / "main.py")
+
+        # 2. Derive the path from the entry_point by mapping underscores -> hyphens
+        #    for each segment, then looking inside every configured plugin_dir.
+        #    entry_point like "plugins.core_plugins.image_generation_plugin.main"
+        #    -> segments ["plugins", "core_plugins", "image_generation_plugin", "main"]
+        #    -> on-disk path: <plugin_root>/core-plugins/image-generation-plugin/main.py
+        parts = entry_point.split(".")
+        # Drop the leading "plugins" segment and the trailing "main" module name.
+        inner_parts = parts[1:-1] if len(parts) >= 3 else parts[:-1]
+        hyphenated_parts = [p.replace("_", "-") for p in inner_parts]
+        rel_path = Path(*hyphenated_parts) / "main.py" if hyphenated_parts else None
+
+        for base_dir in self.plugin_dirs:
+            if rel_path is not None:
+                candidates.append(base_dir / rel_path)
+
+        for path in candidates:
+            if not path.exists():
+                continue
+            try:
+                spec = importlib.util.spec_from_file_location(entry_point, path)
+                if spec is None or spec.loader is None:
+                    continue
+                module = importlib.util.module_from_spec(spec)
+                # Register before exec so intra-plugin dataclasses/relative refs resolve.
+                sys.modules[entry_point] = module
+                spec.loader.exec_module(module)  # type: ignore[union-attr]
+                logger.info("Loaded plugin module %r from %s (file-path fallback)", entry_point, path)
+                return module
+            except Exception as exc:
+                logger.warning("File-path fallback failed for %r at %s: %s", entry_point, path, exc)
+                sys.modules.pop(entry_point, None)
+                continue
+
+        return None
 
     def get_loaded_plugins(self) -> Dict[str, BasePlugin]:
         """Get all loaded plugins."""

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -266,9 +266,7 @@ class PluginLoader:
             for env in plugin.manifest.required_env
         }
 
-    def _import_plugin_class(
-        self, entry_point: str, plugin_dir: Path | None = None
-    ) -> Type[BasePlugin] | None:
+    def _import_plugin_class(self, entry_point: str, plugin_dir: Path | None = None) -> Type[BasePlugin] | None:
         """
         Import plugin class from entry point.
 

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from types import ModuleType
 from typing import Dict, List, Tuple, Type
 
 from .base import BasePlugin, PluginLoadError, PluginManifest, PluginRegistry, PluginStatus
@@ -309,7 +310,7 @@ class PluginLoader:
         logger.error("No plugin class found in module: %s", entry_point)
         return None
 
-    def _import_from_file(self, entry_point: str, plugin_dir: Path | None) -> object | None:
+    def _import_from_file(self, entry_point: str, plugin_dir: Path | None) -> ModuleType | None:
         """
         File-path fallback for plugins whose directory name is not importable
         (e.g. ``core-plugins/image-generation-plugin`` -- hyphen prevents normal import).

--- a/plugins/core-plugins/image-generation-plugin/main.py
+++ b/plugins/core-plugins/image-generation-plugin/main.py
@@ -63,3 +63,6 @@ class ImageGenerationPlugin(BasePlugin):
                 registry.unregister(GenerateImageTool.metadata.name)
             except Exception:
                 pass
+
+# Loader entry-point alias (#10294)
+Plugin = ImageGenerationPlugin

--- a/plugins/core-plugins/video-generation-plugin/main.py
+++ b/plugins/core-plugins/video-generation-plugin/main.py
@@ -63,3 +63,6 @@ class VideoGenerationPlugin(BasePlugin):
                 registry.unregister(GenerateVideoTool.metadata.name)
             except Exception:
                 pass
+
+# Loader entry-point alias (#10294)
+Plugin = VideoGenerationPlugin


### PR DESCRIPTION
## Thinking Path
Two integration gaps. #10294: the plugin loader imports core plugins via the underscored module path `plugins.core_plugins.<name>.main`, but they live in hyphenated dirs `plugins/core-plugins/<name>/` with no namespace-package bridge → `ModuleNotFoundError`, so loader-path tool registration silently failed. #10267: WhatsApp inbound text relays end-to-end but media/voice messages were flattened + acked, never dispatched into the chat pipeline.

## What Changed
- `autobot_shared/plugin_sdk/loader.py` + `autobot-backend/plugin_sdk/loader.py` — on `ModuleNotFoundError`, fall back to `spec_from_file_location` using the manifest's on-disk dir (maps `core_plugins`↔`core-plugins`, `<name>_plugin`↔`<name>-plugin`), registering the module in `sys.modules` under the underscored name (mirrors `_video_providers_loader.py`). Added `_resolve_plugin_class` to accept an explicit `Plugin` export or fall back to the module's `BasePlugin` subclass.
- `plugins/core-plugins/{image,video}-generation-plugin/main.py` — added the `Plugin = XPlugin` loader entry-point alias the loader expects.
- `autobot-backend/services/whatsapp_service.py` — `flatten_messages` now extracts `media_id` for image/audio/voice/video/document/sticker; new `download_whatsapp_media()` does the two-step Graph API media fetch (never raises).
- `autobot-backend/api/whatsapp.py` — non-text inbound with a `media_id` is now downloaded and dispatched with `has_file`/`file_bytes`/`mime_type` metadata, mirroring the Telegram adapter.

## Verification
- `python3 -m py_compile` on all changed files → OK.
- Confirmed `plugins.core_plugins.image_generation_plugin.main` resolves to the real on-disk file via the fallback.
- Closes #10294, #10267.

## Model Used
Claude Opus 4.8 (senior-backend-engineer subagent).
