### PR TITLE
feat(analytics): LLM model-comparison BenchmarkView — ratings, history, scatter, prompt sets, CSV (#9024)

### DIFF
--- a/autobot-backend/api/benchmarks.py
+++ b/autobot-backend/api/benchmarks.py
@@ -25,7 +25,7 @@ Each field value is a JSON-encoded run document.
 
 import json
 from datetime import datetime, timezone
-from typing import List, Literal, Optional
+from typing import List, Optional
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query

--- a/autobot-backend/api/benchmarks.py
+++ b/autobot-backend/api/benchmarks.py
@@ -1,0 +1,237 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+LLM benchmark runs API (Issue #9024).
+
+Persists saved multi-model comparison runs and their per-response star ratings
+so operators can compare quality/cost across providers over time.  The actual
+fan-out execution stays in POST /api/chat/compare (Issue #4414); this module
+only stores the *outcome* of a run plus the human quality signal.
+
+Endpoints (all per-user scoped, frontend contract = plain JSON, no envelope):
+  GET    /api/benchmarks/prompt-sets   -> built-in benchmark prompt sets
+  POST   /api/benchmarks/runs          -> save a run (201)
+  GET    /api/benchmarks/runs          -> list runs (filters: model, prompt_type, since)
+  GET    /api/benchmarks/runs/{id}     -> single run
+  DELETE /api/benchmarks/runs/{id}     -> 204
+
+Storage: a Redis hash in the sessions database, one field per run id:
+  `benchmark:runs:user:{user_id}`
+
+Each field value is a JSON-encoded run document.
+"""
+
+import json
+from datetime import datetime, timezone
+from typing import List, Literal, Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel, Field
+
+from auth_middleware import get_current_user
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_async_redis_client
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["benchmarks"])
+
+REDIS_DB = "sessions"
+
+
+# ---------------------------------------------------------------------------
+# Built-in benchmark prompt sets (Issue #9024)
+# ---------------------------------------------------------------------------
+
+BUILTIN_PROMPT_SETS: List[dict] = [
+    {
+        "id": "rag",
+        "name": "Retrieval & grounding",
+        "promptType": "rag",
+        "prompts": [
+            "Given the context, list only the facts that directly answer the question. "
+            "If the context is insufficient, say so explicitly.",
+            "Summarize the key claims in the provided passage and cite the sentence each claim came from.",
+        ],
+    },
+    {
+        "id": "code",
+        "name": "Code generation",
+        "promptType": "code",
+        "prompts": [
+            "Write a Python function that returns the nth Fibonacci number iteratively, with a docstring.",
+            "Given this failing test, explain the bug and provide a corrected implementation.",
+        ],
+    },
+    {
+        "id": "summarization",
+        "name": "Summarization",
+        "promptType": "summarization",
+        "prompts": [
+            "Summarize the following text in three bullet points, preserving every numeric figure.",
+            "Rewrite the passage as a one-sentence executive summary.",
+        ],
+    },
+    {
+        "id": "reasoning",
+        "name": "Reasoning",
+        "promptType": "reasoning",
+        "prompts": [
+            "A bat and a ball cost $1.10 in total. The bat costs $1.00 more than the ball. "
+            "How much does the ball cost? Show your reasoning.",
+            "If all Bloops are Razzies and all Razzies are Lazzies, are all Bloops definitely Lazzies? Explain.",
+        ],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class BenchmarkResult(BaseModel):
+    """One model's outcome within a benchmark run."""
+
+    model: str = Field(..., description="'provider/model' spec")
+    content: str = Field(default="", description="Model response text")
+    rating: int = Field(default=0, ge=0, le=5, description="User star rating 0-5 (0 = unrated)")
+    costUsd: float = Field(default=0.0, ge=0, description="Estimated cost in USD for this response")
+    latencyMs: int = Field(default=0, ge=0, description="Response latency in milliseconds")
+    error: Optional[str] = Field(default=None, description="Error message if the model failed")
+
+
+class BenchmarkRunCreate(BaseModel):
+    """Request body for saving a benchmark run."""
+
+    prompt: str = Field(..., description="The prompt that was compared")
+    promptType: str = Field(default="custom", description="rag | code | summarization | reasoning | custom")
+    promptSetId: Optional[str] = Field(default=None, description="Source prompt-set id, if any")
+    results: List[BenchmarkResult] = Field(default_factory=list)
+
+
+def _user_hash_key(user_id: str) -> str:
+    return f"benchmark:runs:user:{user_id}"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+async def _require_redis(user_id: str):
+    redis = await get_async_redis_client(database=REDIS_DB)
+    if redis is None:
+        logger.warning("benchmarks: Redis unavailable for user %s", user_id)
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
+    return redis
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/benchmarks/prompt-sets")
+async def list_prompt_sets(
+    current_user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """Return the built-in benchmark prompt sets (Issue #9024)."""
+    return JSONResponse(content=BUILTIN_PROMPT_SETS)
+
+
+@router.post("/benchmarks/runs", status_code=201)
+async def create_run(
+    payload: BenchmarkRunCreate,
+    current_user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """Persist a benchmark run for the authenticated user (Issue #9024)."""
+    user_id = current_user.get("user_id") or current_user.get("username", "")
+    redis = await _require_redis(user_id)
+
+    run = {
+        "id": str(uuid4()),
+        "prompt": payload.prompt,
+        "promptType": payload.promptType,
+        "promptSetId": payload.promptSetId,
+        "results": [r.model_dump() for r in payload.results],
+        "models": [r.model for r in payload.results],
+        "createdAt": _now_iso(),
+    }
+    await redis.hset(_user_hash_key(user_id), run["id"], json.dumps(run))
+    logger.info("Saved benchmark run %s for user %s", run["id"], user_id)
+    return JSONResponse(content=run, status_code=201)
+
+
+def _matches_filters(run: dict, model: Optional[str], prompt_type: Optional[str], since: Optional[str]) -> bool:
+    """Apply list filters to a single run document."""
+    if model and model not in run.get("models", []):
+        return False
+    if prompt_type and run.get("promptType") != prompt_type:
+        return False
+    if since and run.get("createdAt", "") < since:
+        return False
+    return True
+
+
+@router.get("/benchmarks/runs")
+async def list_runs(
+    model: Optional[str] = Query(default=None, description="Filter by 'provider/model' present in the run"),
+    prompt_type: Optional[str] = Query(default=None, description="Filter by promptType"),
+    since: Optional[str] = Query(default=None, description="ISO timestamp — only runs at/after this time"),
+    current_user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """List saved runs for the user, newest first, with optional filters (Issue #9024)."""
+    user_id = current_user.get("user_id") or current_user.get("username", "")
+    redis = await _require_redis(user_id)
+
+    raw = await redis.hgetall(_user_hash_key(user_id))
+    runs: List[dict] = []
+    for value in raw.values():
+        try:
+            run = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Skipping corrupt benchmark run for user %s", user_id)
+            continue
+        if _matches_filters(run, model, prompt_type, since):
+            runs.append(run)
+
+    runs.sort(key=lambda r: r.get("createdAt", ""), reverse=True)
+    return JSONResponse(content=runs)
+
+
+@router.get("/benchmarks/runs/{run_id}")
+async def get_run(
+    run_id: str,
+    current_user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """Return a single saved run owned by the user (Issue #9024)."""
+    user_id = current_user.get("user_id") or current_user.get("username", "")
+    redis = await _require_redis(user_id)
+
+    raw = await redis.hget(_user_hash_key(user_id), run_id)
+    if raw is None:
+        raise HTTPException(status_code=404, detail="Benchmark run not found")
+    try:
+        return JSONResponse(content=json.loads(raw))
+    except (json.JSONDecodeError, TypeError):
+        raise HTTPException(status_code=500, detail="Benchmark run data corrupted")
+
+
+@router.delete("/benchmarks/runs/{run_id}", status_code=204)
+async def delete_run(
+    run_id: str,
+    current_user: dict = Depends(get_current_user),
+) -> Response:
+    """Delete a saved run owned by the user (Issue #9024)."""
+    user_id = current_user.get("user_id") or current_user.get("username", "")
+    redis = await _require_redis(user_id)
+
+    deleted = await redis.hdel(_user_hash_key(user_id), run_id)
+    if deleted == 0:
+        raise HTTPException(status_code=404, detail="Benchmark run not found")
+    logger.info("Deleted benchmark run %s for user %s", run_id, user_id)
+    return Response(status_code=204)

--- a/autobot-backend/api/benchmarks_test.py
+++ b/autobot-backend/api/benchmarks_test.py
@@ -1,0 +1,193 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the LLM benchmark runs API (Issue #9024)."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.benchmarks import BUILTIN_PROMPT_SETS, router
+
+USER = {"user_id": "u-1", "username": "testuser", "role": "user"}
+OTHER = {"user_id": "u-2", "username": "otheruser", "role": "user"}
+USER_HASH_KEY = "benchmark:runs:user:u-1"
+OTHER_HASH_KEY = "benchmark:runs:user:u-2"
+
+
+def _make_app(current_user=None) -> FastAPI:
+    app = FastAPI()
+
+    async def _override_user():
+        return current_user or USER
+
+    from auth_middleware import get_current_user
+
+    app.dependency_overrides[get_current_user] = _override_user
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def mock_redis():
+    redis = AsyncMock()
+    with patch(
+        "api.benchmarks.get_async_redis_client",
+        new_callable=AsyncMock,
+        return_value=redis,
+    ) as p:
+        p.return_value = redis
+        yield redis
+
+
+@pytest.fixture
+def client(mock_redis):
+    return TestClient(_make_app())
+
+
+@pytest.fixture
+def other_client(mock_redis):
+    return TestClient(_make_app(current_user=OTHER))
+
+
+def _run_doc(run_id="r1", prompt_type="code", model="openai/gpt-4o", created="2025-01-02T00:00:00+00:00"):
+    return {
+        "id": run_id,
+        "prompt": "p",
+        "promptType": prompt_type,
+        "promptSetId": None,
+        "results": [{"model": model, "content": "out", "rating": 4, "costUsd": 0.01, "latencyMs": 500}],
+        "models": [model],
+        "createdAt": created,
+    }
+
+
+class TestPromptSets:
+    def test_returns_builtin_sets(self, client):
+        resp = client.get("/benchmarks/prompt-sets")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == len(BUILTIN_PROMPT_SETS)
+        ids = {s["id"] for s in data}
+        assert {"rag", "code", "summarization", "reasoning"}.issubset(ids)
+
+
+class TestCreateRun:
+    def test_creates_run(self, client, mock_redis):
+        mock_redis.hset.return_value = 1
+        resp = client.post(
+            "/benchmarks/runs",
+            json={
+                "prompt": "Write a function",
+                "promptType": "code",
+                "results": [
+                    {"model": "openai/gpt-4o", "content": "ok", "rating": 5, "costUsd": 0.02, "latencyMs": 800}
+                ],
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["prompt"] == "Write a function"
+        assert data["promptType"] == "code"
+        assert data["models"] == ["openai/gpt-4o"]
+        assert data["results"][0]["rating"] == 5
+        assert "id" in data and "createdAt" in data
+        mock_redis.hset.assert_awaited_once()
+
+    def test_persists_under_user_scoped_key(self, client, mock_redis):
+        mock_redis.hset.return_value = 1
+        client.post("/benchmarks/runs", json={"prompt": "x", "results": []})
+        args = mock_redis.hset.await_args.args
+        assert args[0] == USER_HASH_KEY
+
+    def test_rejects_out_of_range_rating(self, client):
+        resp = client.post(
+            "/benchmarks/runs",
+            json={"prompt": "x", "results": [{"model": "a/b", "rating": 9}]},
+        )
+        assert resp.status_code == 422
+
+
+class TestListRuns:
+    def test_empty(self, client, mock_redis):
+        mock_redis.hgetall.return_value = {}
+        resp = client.get("/benchmarks/runs")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_newest_first(self, client, mock_redis):
+        old = _run_doc("old", created="2025-01-01T00:00:00+00:00")
+        new = _run_doc("new", created="2025-02-01T00:00:00+00:00")
+        mock_redis.hgetall.return_value = {"old": json.dumps(old), "new": json.dumps(new)}
+        resp = client.get("/benchmarks/runs")
+        assert [r["id"] for r in resp.json()] == ["new", "old"]
+
+    def test_filter_by_model(self, client, mock_redis):
+        a = _run_doc("a", model="openai/gpt-4o")
+        b = _run_doc("b", model="anthropic/claude")
+        mock_redis.hgetall.return_value = {"a": json.dumps(a), "b": json.dumps(b)}
+        resp = client.get("/benchmarks/runs?model=anthropic/claude")
+        ids = [r["id"] for r in resp.json()]
+        assert ids == ["b"]
+
+    def test_filter_by_prompt_type(self, client, mock_redis):
+        a = _run_doc("a", prompt_type="code")
+        b = _run_doc("b", prompt_type="reasoning")
+        mock_redis.hgetall.return_value = {"a": json.dumps(a), "b": json.dumps(b)}
+        resp = client.get("/benchmarks/runs?prompt_type=reasoning")
+        assert [r["id"] for r in resp.json()] == ["b"]
+
+    def test_filter_since(self, client, mock_redis):
+        old = _run_doc("old", created="2025-01-01T00:00:00+00:00")
+        new = _run_doc("new", created="2025-03-01T00:00:00+00:00")
+        mock_redis.hgetall.return_value = {"old": json.dumps(old), "new": json.dumps(new)}
+        resp = client.get("/benchmarks/runs?since=2025-02-01T00:00:00+00:00")
+        assert [r["id"] for r in resp.json()] == ["new"]
+
+    def test_skips_corrupt(self, client, mock_redis):
+        good = _run_doc("good")
+        mock_redis.hgetall.return_value = {"good": json.dumps(good), "bad": "{not json"}
+        resp = client.get("/benchmarks/runs")
+        assert [r["id"] for r in resp.json()] == ["good"]
+
+
+class TestGetRun:
+    def test_found(self, client, mock_redis):
+        mock_redis.hget.return_value = json.dumps(_run_doc("r1"))
+        resp = client.get("/benchmarks/runs/r1")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "r1"
+
+    def test_404(self, client, mock_redis):
+        mock_redis.hget.return_value = None
+        resp = client.get("/benchmarks/runs/missing")
+        assert resp.status_code == 404
+
+
+class TestDeleteRun:
+    def test_deletes(self, client, mock_redis):
+        mock_redis.hdel.return_value = 1
+        resp = client.delete("/benchmarks/runs/r1")
+        assert resp.status_code == 204
+        mock_redis.hdel.assert_awaited_once_with(USER_HASH_KEY, "r1")
+
+    def test_404(self, client, mock_redis):
+        mock_redis.hdel.return_value = 0
+        resp = client.delete("/benchmarks/runs/missing")
+        assert resp.status_code == 404
+
+
+class TestPerUserScoping:
+    def test_other_user_reads_own_key(self, other_client, mock_redis):
+        mock_redis.hgetall.return_value = {}
+        other_client.get("/benchmarks/runs")
+        mock_redis.hgetall.assert_awaited_with(OTHER_HASH_KEY)
+
+    def test_other_user_deletes_own_key(self, other_client, mock_redis):
+        mock_redis.hdel.return_value = 1
+        other_client.delete("/benchmarks/runs/r1")
+        mock_redis.hdel.assert_awaited_once_with(OTHER_HASH_KEY, "r1")

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -24,13 +24,13 @@ from api.agent_org import router as agent_org_router  # #1405
 from api.approval_gates import router as approval_gates_router  # #1402
 from api.audit import router as audit_router
 from api.auth import router as auth_router
+from api.benchmarks import router as benchmarks_router  # Issue #9024
 from api.browser_mcp import router as browser_mcp_router
 from api.canvas import router as canvas_router  # MVA-359
 from api.chat import router as chat_router
 from api.chat_compare import router as chat_compare_router  # Issue #4414
 from api.chat_embed import router as chat_embed_router  # GH#9047
 from api.chat_presets import router as chat_presets_router  # GH#8595
-from api.benchmarks import router as benchmarks_router  # Issue #9024
 from api.collaboration import router as collaboration_router
 from api.config_revisions import router as config_revisions_router  # #1404
 from api.data_storage import router as data_storage_router

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -30,6 +30,7 @@ from api.chat import router as chat_router
 from api.chat_compare import router as chat_compare_router  # Issue #4414
 from api.chat_embed import router as chat_embed_router  # GH#9047
 from api.chat_presets import router as chat_presets_router  # GH#8595
+from api.benchmarks import router as benchmarks_router  # Issue #9024
 from api.collaboration import router as collaboration_router
 from api.config_revisions import router as config_revisions_router  # #1404
 from api.data_storage import router as data_storage_router
@@ -142,6 +143,7 @@ def _get_system_routers() -> list:
         (chat_compare_router, "", ["chat", "compare"], "chat_compare"),  # Issue #4414
         (chat_embed_router, "", ["chat", "embed"], "chat_embed"),  # GH#9047
         (chat_presets_router, "", ["chat"], "chat_presets"),  # GH#8595
+        (benchmarks_router, "", ["benchmarks"], "benchmarks"),  # Issue #9024
         (collaboration_router, "", ["collaboration"], "collaboration"),
         (
             telegram_bot_router,

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -1407,7 +1407,9 @@
         "errors": "Errors",
         "errorsAria": "Error monitoring",
         "diagnostics": "Diagnostics",
-        "diagnosticsAria": "Failure analysis and causal inference"
+        "diagnosticsAria": "Failure analysis and causal inference",
+        "benchmark": "Benchmark",
+        "benchmarkAria": "Model benchmark and comparison"
       }
     },
     "header": {
@@ -7811,5 +7813,36 @@
       "action": "Resolve",
       "resolved": "Resolved"
     }
+  },
+  "benchmark": {
+    "title": "Model Benchmark",
+    "subtitle": "Compare quality and cost across LLM providers side by side",
+    "promptSet": "Prompt set",
+    "customPrompt": "Custom prompt",
+    "prompt": "Prompt",
+    "promptPlaceholder": "Enter a prompt to run across the selected models…",
+    "models": "Models",
+    "runBenchmark": "Run benchmark",
+    "running": "Running…",
+    "saveRun": "Save run",
+    "exportCsv": "Export CSV",
+    "quality": "Quality",
+    "rateStars": "Rate {n} stars",
+    "scatterTitle": "Cost vs Quality",
+    "scatterSubtitle": "Estimated cost (USD) plotted against your star rating",
+    "scatterSeries": "Models",
+    "axisCost": "Estimated cost (USD)",
+    "axisQuality": "Quality rating",
+    "history": "Run history",
+    "filterModel": "Filter by model",
+    "allTypes": "All types",
+    "applyFilters": "Apply",
+    "noRuns": "No saved runs yet.",
+    "date": "Date",
+    "type": "Type",
+    "modelsCol": "Models",
+    "avgQuality": "Avg quality",
+    "totalCost": "Total cost",
+    "delete": "Delete"
   }
 }

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -1407,7 +1407,9 @@
         "errors": "Errors",
         "errorsAria": "Error monitoring",
         "diagnostics": "Diagnostics",
-        "diagnosticsAria": "Failure analysis and causal inference"
+        "diagnosticsAria": "Failure analysis and causal inference",
+        "benchmark": "Benchmark",
+        "benchmarkAria": "Model benchmark and comparison"
       }
     },
     "header": {
@@ -7811,5 +7813,36 @@
       "action": "Resolve",
       "resolved": "Resolved"
     }
+  },
+  "benchmark": {
+    "title": "Model Benchmark",
+    "subtitle": "Compare quality and cost across LLM providers side by side",
+    "promptSet": "Prompt set",
+    "customPrompt": "Custom prompt",
+    "prompt": "Prompt",
+    "promptPlaceholder": "Enter a prompt to run across the selected models…",
+    "models": "Models",
+    "runBenchmark": "Run benchmark",
+    "running": "Running…",
+    "saveRun": "Save run",
+    "exportCsv": "Export CSV",
+    "quality": "Quality",
+    "rateStars": "Rate {n} stars",
+    "scatterTitle": "Cost vs Quality",
+    "scatterSubtitle": "Estimated cost (USD) plotted against your star rating",
+    "scatterSeries": "Models",
+    "axisCost": "Estimated cost (USD)",
+    "axisQuality": "Quality rating",
+    "history": "Run history",
+    "filterModel": "Filter by model",
+    "allTypes": "All types",
+    "applyFilters": "Apply",
+    "noRuns": "No saved runs yet.",
+    "date": "Date",
+    "type": "Type",
+    "modelsCol": "Models",
+    "avgQuality": "Avg quality",
+    "totalCost": "Total cost",
+    "delete": "Delete"
   }
 }

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -1407,7 +1407,9 @@
         "errors": "Errors",
         "errorsAria": "Error monitoring",
         "diagnostics": "Diagnostics",
-        "diagnosticsAria": "Failure analysis and causal inference"
+        "diagnosticsAria": "Failure analysis and causal inference",
+        "benchmark": "Benchmark",
+        "benchmarkAria": "Model benchmark and comparison"
       }
     },
     "header": {
@@ -7811,5 +7813,36 @@
       "noData": "No data",
       "metricsUnavailable": "Metrics unavailable"
     }
+  },
+  "benchmark": {
+    "title": "Model Benchmark",
+    "subtitle": "Compare quality and cost across LLM providers side by side",
+    "promptSet": "Prompt set",
+    "customPrompt": "Custom prompt",
+    "prompt": "Prompt",
+    "promptPlaceholder": "Enter a prompt to run across the selected models…",
+    "models": "Models",
+    "runBenchmark": "Run benchmark",
+    "running": "Running…",
+    "saveRun": "Save run",
+    "exportCsv": "Export CSV",
+    "quality": "Quality",
+    "rateStars": "Rate {n} stars",
+    "scatterTitle": "Cost vs Quality",
+    "scatterSubtitle": "Estimated cost (USD) plotted against your star rating",
+    "scatterSeries": "Models",
+    "axisCost": "Estimated cost (USD)",
+    "axisQuality": "Quality rating",
+    "history": "Run history",
+    "filterModel": "Filter by model",
+    "allTypes": "All types",
+    "applyFilters": "Apply",
+    "noRuns": "No saved runs yet.",
+    "date": "Date",
+    "type": "Type",
+    "modelsCol": "Models",
+    "avgQuality": "Avg quality",
+    "totalCost": "Total cost",
+    "delete": "Delete"
   }
 }

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -1407,7 +1407,9 @@
         "errors": "Errors",
         "errorsAria": "Error monitoring",
         "diagnostics": "Diagnostics",
-        "diagnosticsAria": "Failure analysis and causal inference"
+        "diagnosticsAria": "Failure analysis and causal inference",
+        "benchmark": "Benchmark",
+        "benchmarkAria": "Model benchmark and comparison"
       }
     },
     "header": {
@@ -7811,5 +7813,36 @@
       "action": "Resolve",
       "resolved": "Resolved"
     }
+  },
+  "benchmark": {
+    "title": "Model Benchmark",
+    "subtitle": "Compare quality and cost across LLM providers side by side",
+    "promptSet": "Prompt set",
+    "customPrompt": "Custom prompt",
+    "prompt": "Prompt",
+    "promptPlaceholder": "Enter a prompt to run across the selected models…",
+    "models": "Models",
+    "runBenchmark": "Run benchmark",
+    "running": "Running…",
+    "saveRun": "Save run",
+    "exportCsv": "Export CSV",
+    "quality": "Quality",
+    "rateStars": "Rate {n} stars",
+    "scatterTitle": "Cost vs Quality",
+    "scatterSubtitle": "Estimated cost (USD) plotted against your star rating",
+    "scatterSeries": "Models",
+    "axisCost": "Estimated cost (USD)",
+    "axisQuality": "Quality rating",
+    "history": "Run history",
+    "filterModel": "Filter by model",
+    "allTypes": "All types",
+    "applyFilters": "Apply",
+    "noRuns": "No saved runs yet.",
+    "date": "Date",
+    "type": "Type",
+    "modelsCol": "Models",
+    "avgQuality": "Avg quality",
+    "totalCost": "Total cost",
+    "delete": "Delete"
   }
 }

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -819,7 +819,9 @@
         "errors": "Errors",
         "errorsAria": "Error monitoring",
         "diagnostics": "Diagnostics",
-        "diagnosticsAria": "Failure analysis and causal inference"
+        "diagnosticsAria": "Failure analysis and causal inference",
+        "benchmark": "Benchmark",
+        "benchmarkAria": "Model benchmark and comparison"
       }
     },
     "header": {
@@ -7811,5 +7813,36 @@
       "action": "Resolve",
       "resolved": "Resolved"
     }
+  },
+  "benchmark": {
+    "title": "Model Benchmark",
+    "subtitle": "Compare quality and cost across LLM providers side by side",
+    "promptSet": "Prompt set",
+    "customPrompt": "Custom prompt",
+    "prompt": "Prompt",
+    "promptPlaceholder": "Enter a prompt to run across the selected models…",
+    "models": "Models",
+    "runBenchmark": "Run benchmark",
+    "running": "Running…",
+    "saveRun": "Save run",
+    "exportCsv": "Export CSV",
+    "quality": "Quality",
+    "rateStars": "Rate {n} stars",
+    "scatterTitle": "Cost vs Quality",
+    "scatterSubtitle": "Estimated cost (USD) plotted against your star rating",
+    "scatterSeries": "Models",
+    "axisCost": "Estimated cost (USD)",
+    "axisQuality": "Quality rating",
+    "history": "Run history",
+    "filterModel": "Filter by model",
+    "allTypes": "All types",
+    "applyFilters": "Apply",
+    "noRuns": "No saved runs yet.",
+    "date": "Date",
+    "type": "Type",
+    "modelsCol": "Models",
+    "avgQuality": "Avg quality",
+    "totalCost": "Total cost",
+    "delete": "Delete"
   }
 }

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -1407,7 +1407,9 @@
         "errors": "Errors",
         "errorsAria": "Error monitoring",
         "diagnostics": "Diagnostics",
-        "diagnosticsAria": "Failure analysis and causal inference"
+        "diagnosticsAria": "Failure analysis and causal inference",
+        "benchmark": "Benchmark",
+        "benchmarkAria": "Model benchmark and comparison"
       }
     },
     "header": {
@@ -7811,5 +7813,36 @@
       "action": "Resolve",
       "resolved": "Resolved"
     }
+  },
+  "benchmark": {
+    "title": "Model Benchmark",
+    "subtitle": "Compare quality and cost across LLM providers side by side",
+    "promptSet": "Prompt set",
+    "customPrompt": "Custom prompt",
+    "prompt": "Prompt",
+    "promptPlaceholder": "Enter a prompt to run across the selected models…",
+    "models": "Models",
+    "runBenchmark": "Run benchmark",
+    "running": "Running…",
+    "saveRun": "Save run",
+    "exportCsv": "Export CSV",
+    "quality": "Quality",
+    "rateStars": "Rate {n} stars",
+    "scatterTitle": "Cost vs Quality",
+    "scatterSubtitle": "Estimated cost (USD) plotted against your star rating",
+    "scatterSeries": "Models",
+    "axisCost": "Estimated cost (USD)",
+    "axisQuality": "Quality rating",
+    "history": "Run history",
+    "filterModel": "Filter by model",
+    "allTypes": "All types",
+    "applyFilters": "Apply",
+    "noRuns": "No saved runs yet.",
+    "date": "Date",
+    "type": "Type",
+    "modelsCol": "Models",
+    "avgQuality": "Avg quality",
+    "totalCost": "Total cost",
+    "delete": "Delete"
   }
 }

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -819,7 +819,9 @@
         "errors": "Errors",
         "errorsAria": "Error monitoring",
         "diagnostics": "Diagnostics",
-        "diagnosticsAria": "Failure analysis and causal inference"
+        "diagnosticsAria": "Failure analysis and causal inference",
+        "benchmark": "Benchmark",
+        "benchmarkAria": "Model benchmark and comparison"
       }
     },
     "header": {
@@ -7811,5 +7813,36 @@
       "action": "Resolve",
       "resolved": "Resolved"
     }
+  },
+  "benchmark": {
+    "title": "Model Benchmark",
+    "subtitle": "Compare quality and cost across LLM providers side by side",
+    "promptSet": "Prompt set",
+    "customPrompt": "Custom prompt",
+    "prompt": "Prompt",
+    "promptPlaceholder": "Enter a prompt to run across the selected models…",
+    "models": "Models",
+    "runBenchmark": "Run benchmark",
+    "running": "Running…",
+    "saveRun": "Save run",
+    "exportCsv": "Export CSV",
+    "quality": "Quality",
+    "rateStars": "Rate {n} stars",
+    "scatterTitle": "Cost vs Quality",
+    "scatterSubtitle": "Estimated cost (USD) plotted against your star rating",
+    "scatterSeries": "Models",
+    "axisCost": "Estimated cost (USD)",
+    "axisQuality": "Quality rating",
+    "history": "Run history",
+    "filterModel": "Filter by model",
+    "allTypes": "All types",
+    "applyFilters": "Apply",
+    "noRuns": "No saved runs yet.",
+    "date": "Date",
+    "type": "Type",
+    "modelsCol": "Models",
+    "avgQuality": "Avg quality",
+    "totalCost": "Total cost",
+    "delete": "Delete"
   }
 }

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -1407,7 +1407,9 @@
         "errors": "Errors",
         "errorsAria": "Error monitoring",
         "diagnostics": "Diagnostics",
-        "diagnosticsAria": "Failure analysis and causal inference"
+        "diagnosticsAria": "Failure analysis and causal inference",
+        "benchmark": "Benchmark",
+        "benchmarkAria": "Model benchmark and comparison"
       }
     },
     "header": {
@@ -7811,5 +7813,36 @@
       "action": "Resolve",
       "resolved": "Resolved"
     }
+  },
+  "benchmark": {
+    "title": "Model Benchmark",
+    "subtitle": "Compare quality and cost across LLM providers side by side",
+    "promptSet": "Prompt set",
+    "customPrompt": "Custom prompt",
+    "prompt": "Prompt",
+    "promptPlaceholder": "Enter a prompt to run across the selected models…",
+    "models": "Models",
+    "runBenchmark": "Run benchmark",
+    "running": "Running…",
+    "saveRun": "Save run",
+    "exportCsv": "Export CSV",
+    "quality": "Quality",
+    "rateStars": "Rate {n} stars",
+    "scatterTitle": "Cost vs Quality",
+    "scatterSubtitle": "Estimated cost (USD) plotted against your star rating",
+    "scatterSeries": "Models",
+    "axisCost": "Estimated cost (USD)",
+    "axisQuality": "Quality rating",
+    "history": "Run history",
+    "filterModel": "Filter by model",
+    "allTypes": "All types",
+    "applyFilters": "Apply",
+    "noRuns": "No saved runs yet.",
+    "date": "Date",
+    "type": "Type",
+    "modelsCol": "Models",
+    "avgQuality": "Avg quality",
+    "totalCost": "Total cost",
+    "delete": "Delete"
   }
 }

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -1407,7 +1407,9 @@
         "errors": "Errors",
         "errorsAria": "Error monitoring",
         "diagnostics": "Diagnostics",
-        "diagnosticsAria": "Failure analysis and causal inference"
+        "diagnosticsAria": "Failure analysis and causal inference",
+        "benchmark": "Benchmark",
+        "benchmarkAria": "Model benchmark and comparison"
       }
     },
     "header": {
@@ -7811,5 +7813,36 @@
       "action": "Resolve",
       "resolved": "Resolved"
     }
+  },
+  "benchmark": {
+    "title": "Model Benchmark",
+    "subtitle": "Compare quality and cost across LLM providers side by side",
+    "promptSet": "Prompt set",
+    "customPrompt": "Custom prompt",
+    "prompt": "Prompt",
+    "promptPlaceholder": "Enter a prompt to run across the selected models…",
+    "models": "Models",
+    "runBenchmark": "Run benchmark",
+    "running": "Running…",
+    "saveRun": "Save run",
+    "exportCsv": "Export CSV",
+    "quality": "Quality",
+    "rateStars": "Rate {n} stars",
+    "scatterTitle": "Cost vs Quality",
+    "scatterSubtitle": "Estimated cost (USD) plotted against your star rating",
+    "scatterSeries": "Models",
+    "axisCost": "Estimated cost (USD)",
+    "axisQuality": "Quality rating",
+    "history": "Run history",
+    "filterModel": "Filter by model",
+    "allTypes": "All types",
+    "applyFilters": "Apply",
+    "noRuns": "No saved runs yet.",
+    "date": "Date",
+    "type": "Type",
+    "modelsCol": "Models",
+    "avgQuality": "Avg quality",
+    "totalCost": "Total cost",
+    "delete": "Delete"
   }
 }

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -1407,7 +1407,9 @@
         "errors": "Errors",
         "errorsAria": "Error monitoring",
         "diagnostics": "Diagnostics",
-        "diagnosticsAria": "Failure analysis and causal inference"
+        "diagnosticsAria": "Failure analysis and causal inference",
+        "benchmark": "Benchmark",
+        "benchmarkAria": "Model benchmark and comparison"
       }
     },
     "header": {
@@ -7811,5 +7813,36 @@
       "action": "Resolve",
       "resolved": "Resolved"
     }
+  },
+  "benchmark": {
+    "title": "Model Benchmark",
+    "subtitle": "Compare quality and cost across LLM providers side by side",
+    "promptSet": "Prompt set",
+    "customPrompt": "Custom prompt",
+    "prompt": "Prompt",
+    "promptPlaceholder": "Enter a prompt to run across the selected models…",
+    "models": "Models",
+    "runBenchmark": "Run benchmark",
+    "running": "Running…",
+    "saveRun": "Save run",
+    "exportCsv": "Export CSV",
+    "quality": "Quality",
+    "rateStars": "Rate {n} stars",
+    "scatterTitle": "Cost vs Quality",
+    "scatterSubtitle": "Estimated cost (USD) plotted against your star rating",
+    "scatterSeries": "Models",
+    "axisCost": "Estimated cost (USD)",
+    "axisQuality": "Quality rating",
+    "history": "Run history",
+    "filterModel": "Filter by model",
+    "allTypes": "All types",
+    "applyFilters": "Apply",
+    "noRuns": "No saved runs yet.",
+    "date": "Date",
+    "type": "Type",
+    "modelsCol": "Models",
+    "avgQuality": "Avg quality",
+    "totalCost": "Total cost",
+    "delete": "Delete"
   }
 }

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -819,7 +819,9 @@
         "errors": "Errors",
         "errorsAria": "Error monitoring",
         "diagnostics": "Diagnostics",
-        "diagnosticsAria": "Failure analysis and causal inference"
+        "diagnosticsAria": "Failure analysis and causal inference",
+        "benchmark": "Benchmark",
+        "benchmarkAria": "Model benchmark and comparison"
       }
     },
     "header": {
@@ -7811,5 +7813,36 @@
       "action": "Resolve",
       "resolved": "Resolved"
     }
+  },
+  "benchmark": {
+    "title": "Model Benchmark",
+    "subtitle": "Compare quality and cost across LLM providers side by side",
+    "promptSet": "Prompt set",
+    "customPrompt": "Custom prompt",
+    "prompt": "Prompt",
+    "promptPlaceholder": "Enter a prompt to run across the selected models…",
+    "models": "Models",
+    "runBenchmark": "Run benchmark",
+    "running": "Running…",
+    "saveRun": "Save run",
+    "exportCsv": "Export CSV",
+    "quality": "Quality",
+    "rateStars": "Rate {n} stars",
+    "scatterTitle": "Cost vs Quality",
+    "scatterSubtitle": "Estimated cost (USD) plotted against your star rating",
+    "scatterSeries": "Models",
+    "axisCost": "Estimated cost (USD)",
+    "axisQuality": "Quality rating",
+    "history": "Run history",
+    "filterModel": "Filter by model",
+    "allTypes": "All types",
+    "applyFilters": "Apply",
+    "noRuns": "No saved runs yet.",
+    "date": "Date",
+    "type": "Type",
+    "modelsCol": "Models",
+    "avgQuality": "Avg quality",
+    "totalCost": "Total cost",
+    "delete": "Delete"
   }
 }

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -557,6 +557,16 @@ export const routes: RouteRecordRaw[] = [
           parent: 'analytics'
         }
       },
+      // Issue #9024: LLM model-comparison / benchmark dashboard
+      {
+        path: 'benchmark',
+        name: 'analytics-benchmark',
+        component: () => import('@/views/BenchmarkView.vue'),
+        meta: {
+          title: 'Model Benchmark',
+          parent: 'analytics'
+        }
+      },
       {
         path: 'log-patterns',
         name: 'analytics-log-patterns',

--- a/autobot-frontend/src/utils/__tests__/benchmark.test.ts
+++ b/autobot-frontend/src/utils/__tests__/benchmark.test.ts
@@ -1,0 +1,79 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/** Unit tests for benchmark helpers (Issue #9024). */
+
+import { describe, it, expect } from 'vitest'
+import {
+  estimateCostUsd,
+  toCsv,
+  avgQuality,
+  totalCost,
+  type BenchmarkResultRow,
+  type BenchmarkRun,
+} from '@/utils/benchmark'
+
+function row(over: Partial<BenchmarkResultRow> = {}): BenchmarkResultRow {
+  return { model: 'openai/gpt-4o', content: 'hi', rating: 4, costUsd: 0.01, latencyMs: 0, ...over }
+}
+
+function run(over: Partial<BenchmarkRun> = {}): BenchmarkRun {
+  return {
+    id: 'r',
+    prompt: 'p',
+    promptType: 'code',
+    promptSetId: null,
+    results: [row()],
+    models: ['openai/gpt-4o'],
+    createdAt: '2025-01-01T00:00:00+00:00',
+    ...over,
+  }
+}
+
+describe('estimateCostUsd', () => {
+  it('charges for paid providers', () => {
+    const cost = estimateCostUsd('openai/gpt-4o', 'a'.repeat(4000), 'b'.repeat(4000))
+    expect(cost).toBeGreaterThan(0)
+  })
+
+  it('is free for local providers', () => {
+    expect(estimateCostUsd('ollama/llama3', 'x'.repeat(8000), 'y'.repeat(8000))).toBe(0)
+  })
+
+  it('falls back to a default price for unknown providers', () => {
+    expect(estimateCostUsd('mystery/model', 'x'.repeat(4000), '')).toBeGreaterThan(0)
+  })
+})
+
+describe('avgQuality', () => {
+  it('averages only rated results', () => {
+    const r = run({ results: [row({ rating: 2 }), row({ rating: 4 }), row({ rating: 0 })] })
+    expect(avgQuality(r)).toBe(3)
+  })
+
+  it('returns 0 when nothing is rated', () => {
+    expect(avgQuality(run({ results: [row({ rating: 0 })] }))).toBe(0)
+  })
+})
+
+describe('totalCost', () => {
+  it('sums result costs', () => {
+    expect(totalCost(run({ results: [row({ costUsd: 0.02 }), row({ costUsd: 0.03 })] }))).toBeCloseTo(0.05)
+  })
+})
+
+describe('toCsv', () => {
+  it('emits a header and one row per result', () => {
+    const csv = toCsv([row({ model: 'openai/gpt-4o' })], 'my prompt', 'code')
+    const lines = csv.split('\n')
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toContain('model')
+    expect(lines[1]).toContain('openai/gpt-4o')
+  })
+
+  it('escapes embedded quotes', () => {
+    const csv = toCsv([row({ content: 'he said "hi"' })], 'p', 'code')
+    expect(csv).toContain('"he said ""hi"""')
+  })
+})

--- a/autobot-frontend/src/utils/benchmark.ts
+++ b/autobot-frontend/src/utils/benchmark.ts
@@ -1,0 +1,89 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * Benchmark helpers (Issue #9024).
+ *
+ * Pure functions shared by BenchmarkView.vue: rough cost estimation, CSV
+ * serialization, and per-run aggregations. Kept out of the component so they
+ * stay small and unit-testable.
+ */
+
+export interface BenchmarkResultRow {
+  model: string
+  content: string
+  rating: number
+  costUsd: number
+  latencyMs: number
+  error?: string
+}
+
+export interface BenchmarkRun {
+  id: string
+  prompt: string
+  promptType: string
+  promptSetId: string | null
+  results: BenchmarkResultRow[]
+  models: string[]
+  createdAt: string
+}
+
+export interface PromptSet {
+  id: string
+  name: string
+  promptType: string
+  prompts: string[]
+}
+
+/**
+ * Rough per-1k-token USD price by provider (input+output blended). Estimates
+ * only — surfaced so the cost/quality scatter is meaningful; local providers
+ * are effectively free.
+ */
+const PRICE_PER_1K: Record<string, number> = {
+  openai: 0.005,
+  anthropic: 0.006,
+  google: 0.004,
+  ollama: 0,
+  vllm: 0,
+}
+
+/** Estimate cost from char counts (~4 chars/token) and a provider price table. */
+export function estimateCostUsd(model: string, prompt: string, output: string): number {
+  const provider = model.includes('/') ? model.split('/')[0].toLowerCase() : model.toLowerCase()
+  const pricePer1k = PRICE_PER_1K[provider] ?? 0.003
+  const tokens = (prompt.length + output.length) / 4
+  return (tokens / 1000) * pricePer1k
+}
+
+/** Average non-zero star rating across a run's results (0 when none rated). */
+export function avgQuality(run: BenchmarkRun): number {
+  const rated = run.results.filter((r) => r.rating > 0)
+  if (!rated.length) return 0
+  return rated.reduce((sum, r) => sum + r.rating, 0) / rated.length
+}
+
+/** Sum of estimated cost across a run's results. */
+export function totalCost(run: BenchmarkRun): number {
+  return run.results.reduce((sum, r) => sum + (r.costUsd || 0), 0)
+}
+
+function csvCell(value: string | number): string {
+  const s = String(value).replace(/"/g, '""')
+  return `"${s}"`
+}
+
+/** Serialize the current result rows to CSV text. */
+export function toCsv(rows: BenchmarkResultRow[], prompt: string, promptType: string): string {
+  const header = ['prompt', 'prompt_type', 'model', 'rating', 'cost_usd', 'error', 'content']
+  const lines = [header.map(csvCell).join(',')]
+  for (const r of rows) {
+    lines.push(
+      [prompt, promptType, r.model, r.rating, r.costUsd.toFixed(6), r.error ?? '', r.content]
+        .map(csvCell)
+        .join(','),
+    )
+  }
+  return lines.join('\n')
+}

--- a/autobot-frontend/src/views/AnalyticsView.vue
+++ b/autobot-frontend/src/views/AnalyticsView.vue
@@ -105,6 +105,18 @@
             <Icon name="exclamation-triangle" class="tab-icon" aria-hidden="true" />
             <span>{{ $t('analytics.views.tabs.errors') }}</span>
           </router-link>
+          <!-- Issue #9024: LLM model-comparison / benchmark dashboard -->
+          <router-link
+            to="/analytics/benchmark"
+            class="nav-tab"
+            :class="{ 'nav-tab-active': isBenchmarkActive }"
+            role="tab"
+            :aria-selected="isBenchmarkActive"
+            :aria-label="$t('analytics.views.tabs.benchmarkAria')"
+          >
+            <Icon name="chart-bar" class="tab-icon" aria-hidden="true" />
+            <span>{{ $t('analytics.views.tabs.benchmark') }}</span>
+          </router-link>
           <!-- Issue #9892: Failure Analysis / causal-inference engine -->
           <router-link
             to="/analytics/diagnostics"
@@ -173,6 +185,11 @@ const isErrorsActive = computed(() => {
 // Issue #9892: Diagnostics / failure analysis tab
 const isDiagnosticsActive = computed(() => {
   return route.path === '/analytics/diagnostics' || route.path.startsWith('/analytics/diagnostics/')
+})
+
+// Issue #9024: Model benchmark / comparison tab
+const isBenchmarkActive = computed(() => {
+  return route.path === '/analytics/benchmark' || route.path.startsWith('/analytics/benchmark/')
 })
 </script>
 

--- a/autobot-frontend/src/views/BenchmarkView.vue
+++ b/autobot-frontend/src/views/BenchmarkView.vue
@@ -1,0 +1,553 @@
+<!--
+  AutoBot - AI-Powered Automation Platform
+  Copyright (c) 2025-2026 mrveiss
+  Author: mrveiss
+
+  BenchmarkView.vue (Issue #9024) — LLM model-comparison dashboard.
+
+  Runs a prompt (or a built-in prompt set) across several selected models via
+  the existing useMultiModelCompare fan-out (POST /api/chat/compare, #4414),
+  lets the operator rate each response 1-5, persists the run backend-side
+  (/api/benchmarks/runs), lists historical runs with filters, plots cost vs
+  quality, and exports results to CSV.
+-->
+<template>
+  <div class="benchmark-view">
+    <header class="benchmark-header">
+      <h1 class="benchmark-title">{{ $t('benchmark.title') }}</h1>
+      <p class="benchmark-subtitle">{{ $t('benchmark.subtitle') }}</p>
+    </header>
+
+    <!-- ── Run configuration ───────────────────────────────────────────── -->
+    <section class="benchmark-panel">
+      <div class="field">
+        <label class="field-label">{{ $t('benchmark.promptSet') }}</label>
+        <select v-model="selectedPromptSetId" class="field-input" @change="onPromptSetChange">
+          <option value="">{{ $t('benchmark.customPrompt') }}</option>
+          <option v-for="set in promptSets" :key="set.id" :value="set.id">{{ set.name }}</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label class="field-label">{{ $t('benchmark.prompt') }}</label>
+        <textarea
+          v-model="promptText"
+          class="field-input field-textarea"
+          rows="3"
+          :placeholder="$t('benchmark.promptPlaceholder')"
+        />
+      </div>
+
+      <div class="field">
+        <label class="field-label">{{ $t('benchmark.models') }}</label>
+        <div class="model-picker">
+          <label v-for="model in availableModels" :key="model" class="model-chip">
+            <input type="checkbox" :value="model" v-model="selectedModels" />
+            <span>{{ model }}</span>
+          </label>
+        </div>
+      </div>
+
+      <div class="actions">
+        <button
+          class="btn btn-primary"
+          :disabled="isComparing || !promptText.trim() || selectedModels.length === 0"
+          @click="onRun"
+        >
+          {{ isComparing ? $t('benchmark.running') : $t('benchmark.runBenchmark') }}
+        </button>
+        <button class="btn" :disabled="!hasResults || isComparing" @click="onSaveRun">
+          {{ $t('benchmark.saveRun') }}
+        </button>
+        <button class="btn" :disabled="!hasResults" @click="exportCsv">
+          {{ $t('benchmark.exportCsv') }}
+        </button>
+      </div>
+    </section>
+
+    <!-- ── Side-by-side results ────────────────────────────────────────── -->
+    <section v-if="resultRows.length" class="benchmark-results">
+      <div v-for="row in resultRows" :key="row.model" class="result-card">
+        <div class="result-card-head">
+          <span class="result-model">{{ row.model }}</span>
+          <span class="result-cost">{{ formatCost(row.costUsd) }}</span>
+        </div>
+        <pre v-if="!row.error" class="result-content">{{ row.content || '…' }}</pre>
+        <p v-else class="result-error">{{ row.error }}</p>
+        <div class="result-rating">
+          <span class="rating-label">{{ $t('benchmark.quality') }}</span>
+          <button
+            v-for="star in 5"
+            :key="star"
+            type="button"
+            class="star"
+            :class="{ 'star-filled': star <= row.rating }"
+            :aria-label="$t('benchmark.rateStars', { n: star })"
+            @click="setRating(row.model, star)"
+          >
+            ★
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Cost / quality scatter ──────────────────────────────────────── -->
+    <section v-if="scatterSeries.length" class="benchmark-chart">
+      <BaseChart
+        type="scatter"
+        :series="scatterSeries"
+        :options="scatterOptions"
+        :title="$t('benchmark.scatterTitle')"
+        :subtitle="$t('benchmark.scatterSubtitle')"
+      />
+    </section>
+
+    <!-- ── Historical runs ─────────────────────────────────────────────── -->
+    <section class="benchmark-history">
+      <div class="history-head">
+        <h2 class="history-title">{{ $t('benchmark.history') }}</h2>
+        <div class="history-filters">
+          <input
+            v-model="filterModel"
+            class="field-input field-input-sm"
+            :placeholder="$t('benchmark.filterModel')"
+            @keyup.enter="loadHistory"
+          />
+          <select v-model="filterPromptType" class="field-input field-input-sm" @change="loadHistory">
+            <option value="">{{ $t('benchmark.allTypes') }}</option>
+            <option v-for="t in promptTypes" :key="t" :value="t">{{ t }}</option>
+          </select>
+          <input
+            v-model="filterSince"
+            type="date"
+            class="field-input field-input-sm"
+            @change="loadHistory"
+          />
+          <button class="btn btn-sm" @click="loadHistory">{{ $t('benchmark.applyFilters') }}</button>
+        </div>
+      </div>
+
+      <p v-if="!history.length" class="history-empty">{{ $t('benchmark.noRuns') }}</p>
+      <table v-else class="history-table">
+        <thead>
+          <tr>
+            <th>{{ $t('benchmark.date') }}</th>
+            <th>{{ $t('benchmark.type') }}</th>
+            <th>{{ $t('benchmark.modelsCol') }}</th>
+            <th>{{ $t('benchmark.avgQuality') }}</th>
+            <th>{{ $t('benchmark.totalCost') }}</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="run in history" :key="run.id">
+            <td>{{ formatDate(run.createdAt) }}</td>
+            <td>{{ run.promptType }}</td>
+            <td>{{ run.models.join(', ') }}</td>
+            <td>{{ avgQuality(run).toFixed(1) }}</td>
+            <td>{{ formatCost(totalCost(run)) }}</td>
+            <td>
+              <button class="btn btn-sm btn-danger" @click="deleteRun(run.id)">
+                {{ $t('benchmark.delete') }}
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { ApexOptions } from 'apexcharts'
+import ApiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
+import { createLogger } from '@/utils/debugUtils'
+import { useMultiModelCompare } from '@/composables/useMultiModelCompare'
+import { useAvailableModels } from '@/composables/useAvailableModels'
+import BaseChart from '@/components/charts/BaseChart.vue'
+import {
+  type BenchmarkResultRow,
+  type BenchmarkRun,
+  type PromptSet,
+  estimateCostUsd,
+  toCsv,
+  avgQuality,
+  totalCost,
+} from '@/utils/benchmark'
+
+const { t } = useI18n()
+const logger = createLogger('BenchmarkView')
+
+const DEFAULT_MODELS = ['ollama/llama3', 'ollama/mistral', 'openai/gpt-4o-mini']
+
+const { responses, selectedModels, isComparing, compare } = useMultiModelCompare()
+const { availableModelNames, fetchModels } = useAvailableModels()
+
+const promptText = ref('')
+const selectedPromptSetId = ref('')
+const promptSets = ref<PromptSet[]>([])
+const ratings = ref<Record<string, number>>({})
+const runStartedAt = ref<number>(0)
+
+const history = ref<BenchmarkRun[]>([])
+const filterModel = ref('')
+const filterPromptType = ref('')
+const filterSince = ref('')
+
+const promptTypes = ['rag', 'code', 'summarization', 'reasoning', 'custom']
+
+if (selectedModels.value.length === 0) selectedModels.value = [...DEFAULT_MODELS]
+
+const availableModels = computed<string[]>(() => {
+  const union = new Set<string>([...DEFAULT_MODELS, ...availableModelNames.value, ...selectedModels.value])
+  return Array.from(union)
+})
+
+const currentPromptType = computed(
+  () => promptSets.value.find((s) => s.id === selectedPromptSetId.value)?.promptType ?? 'custom',
+)
+
+// Map streaming responses → flat result rows enriched with rating + est. cost.
+const resultRows = computed<BenchmarkResultRow[]>(() => {
+  const rows: BenchmarkResultRow[] = []
+  for (const [model, resp] of responses.value.entries()) {
+    rows.push({
+      model,
+      content: resp.content,
+      error: resp.error,
+      rating: ratings.value[model] ?? 0,
+      costUsd: estimateCostUsd(model, promptText.value, resp.content),
+      latencyMs: 0,
+    })
+  }
+  return rows
+})
+
+const hasResults = computed(() => resultRows.value.some((r) => r.content || r.error))
+
+const scatterSeries = computed(() => {
+  const points = resultRows.value
+    .filter((r) => r.rating > 0)
+    .map((r) => ({ x: Number(r.costUsd.toFixed(4)), y: r.rating, model: r.model }))
+  return points.length ? [{ name: t('benchmark.scatterSeries'), data: points }] : []
+})
+
+const scatterOptions = computed<ApexOptions>(() => ({
+  xaxis: { title: { text: t('benchmark.axisCost') }, tickAmount: 5 },
+  yaxis: { title: { text: t('benchmark.axisQuality') }, min: 0, max: 5, tickAmount: 5 },
+  tooltip: {
+    // Apex's custom-tooltip context is loosely typed; cast to read our point shape.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    custom: (ctx: { seriesIndex: number; dataPointIndex: number; w: any }) => {
+      const data = ctx.w.config.series[ctx.seriesIndex].data as Array<{ model: string; x: number; y: number }>
+      const p = data[ctx.dataPointIndex]
+      return `<div style="padding:6px">${p.model}<br/>$${p.x} · ★${p.y}</div>`
+    },
+  },
+  markers: { size: 7 },
+}))
+
+function onPromptSetChange(): void {
+  const set = promptSets.value.find((s) => s.id === selectedPromptSetId.value)
+  if (set?.prompts?.length) promptText.value = set.prompts[0]
+}
+
+function setRating(model: string, value: number): void {
+  ratings.value = { ...ratings.value, [model]: value }
+}
+
+async function onRun(): Promise<void> {
+  if (!promptText.value.trim() || selectedModels.value.length === 0 || isComparing.value) return
+  ratings.value = {}
+  runStartedAt.value = Date.now()
+  await compare(promptText.value, [...selectedModels.value])
+}
+
+async function onSaveRun(): Promise<void> {
+  if (!hasResults.value) return
+  try {
+    await ApiClient.post(`${getApiBase()}/benchmarks/runs`, {
+      prompt: promptText.value,
+      promptType: currentPromptType.value,
+      promptSetId: selectedPromptSetId.value || null,
+      results: resultRows.value.map((r) => ({
+        model: r.model,
+        content: r.content,
+        rating: r.rating,
+        costUsd: r.costUsd,
+        latencyMs: r.latencyMs,
+        error: r.error ?? null,
+      })),
+    })
+    await loadHistory()
+  } catch (err) {
+    logger.error('saveRun failed:', err)
+  }
+}
+
+function exportCsv(): void {
+  const csv = toCsv(resultRows.value, promptText.value, currentPromptType.value)
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `benchmark-${Date.now()}.csv`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+async function loadHistory(): Promise<void> {
+  const params = new URLSearchParams()
+  if (filterModel.value.trim()) params.set('model', filterModel.value.trim())
+  if (filterPromptType.value) params.set('prompt_type', filterPromptType.value)
+  if (filterSince.value) params.set('since', `${filterSince.value}T00:00:00+00:00`)
+  const qs = params.toString()
+  try {
+    history.value = await ApiClient.get<BenchmarkRun[]>(
+      `${getApiBase()}/benchmarks/runs${qs ? `?${qs}` : ''}`,
+    )
+  } catch (err) {
+    logger.error('loadHistory failed:', err)
+    history.value = []
+  }
+}
+
+async function deleteRun(id: string): Promise<void> {
+  try {
+    await ApiClient.delete(`${getApiBase()}/benchmarks/runs/${id}`)
+    await loadHistory()
+  } catch (err) {
+    logger.error('deleteRun failed:', err)
+  }
+}
+
+async function loadPromptSets(): Promise<void> {
+  try {
+    promptSets.value = await ApiClient.get<PromptSet[]>(`${getApiBase()}/benchmarks/prompt-sets`)
+  } catch (err) {
+    logger.error('loadPromptSets failed:', err)
+  }
+}
+
+function formatCost(v: number): string {
+  return `$${v.toFixed(4)}`
+}
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString()
+}
+
+onMounted(() => {
+  fetchModels().catch(() => {})
+  loadPromptSets()
+  loadHistory()
+})
+</script>
+
+<style scoped>
+.benchmark-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6);
+  padding: var(--spacing-6);
+  overflow-y: auto;
+}
+
+.benchmark-title {
+  font-size: var(--text-xl);
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+  margin: 0;
+}
+.benchmark-subtitle {
+  color: var(--text-secondary);
+  margin: var(--spacing-1) 0 0;
+}
+
+.benchmark-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-5);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+.field-label {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--text-secondary);
+}
+.field-input {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  padding: var(--spacing-2) var(--spacing-3);
+  font: inherit;
+}
+.field-input-sm {
+  padding: var(--spacing-1) var(--spacing-2);
+  font-size: var(--text-sm);
+}
+.field-textarea {
+  resize: vertical;
+}
+
+.model-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+}
+.model-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-full, 999px);
+  padding: var(--spacing-1) var(--spacing-3);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+}
+.btn {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  padding: var(--spacing-2) var(--spacing-4);
+  cursor: pointer;
+  font: inherit;
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btn-primary {
+  background: var(--color-primary);
+  color: var(--text-on-primary, #fff);
+  border-color: var(--color-primary);
+}
+.btn-sm {
+  padding: var(--spacing-1) var(--spacing-3);
+  font-size: var(--text-sm);
+}
+.btn-danger {
+  color: var(--color-error, #ef4444);
+}
+
+.benchmark-results {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--spacing-4);
+}
+.result-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+.result-card-head {
+  display: flex;
+  justify-content: space-between;
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+}
+.result-cost {
+  color: var(--text-secondary);
+}
+.result-content {
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 240px;
+  overflow-y: auto;
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+.result-error {
+  color: var(--color-error, #ef4444);
+  margin: 0;
+}
+.result-rating {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+.rating-label {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+.star {
+  background: none;
+  border: none;
+  color: var(--text-tertiary, #64748b);
+  font-size: 1.25rem;
+  cursor: pointer;
+  line-height: 1;
+}
+.star-filled {
+  color: var(--chart-yellow, #f59e0b);
+}
+
+.benchmark-history {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-5);
+}
+.history-head {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-4);
+}
+.history-title {
+  font-size: var(--text-lg);
+  color: var(--text-primary);
+  margin: 0;
+}
+.history-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+}
+.history-empty {
+  color: var(--text-secondary);
+}
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+.history-table th,
+.history-table td {
+  text-align: left;
+  padding: var(--spacing-2) var(--spacing-3);
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-primary);
+}
+.history-table th {
+  color: var(--text-secondary);
+  font-weight: var(--font-semibold);
+}
+</style>


### PR DESCRIPTION
## Thinking Path
#9024 — LLM model-comparison dashboard / BenchmarkView. The #4414 compare foundation existed (`MultiModelChat` + `POST /api/chat/compare`) but 0/6 of this issue's ACs. Built the dedicated benchmark experience on top, reusing the compare execution.

## What Changed
- **Backend** `api/benchmarks.py`: per-user `benchmark_runs` persistence (Redis) + endpoints — `GET /prompt-sets`, `POST /runs`, `GET /runs` (model/type/since filters), `GET /runs/{id}`, `DELETE /runs/{id}`; all `Depends(get_current_user)`, per-user scoped.
- **Frontend** `views/BenchmarkView.vue` (route `/analytics/benchmark` + Analytics tab): runs a prompt/prompt-set across selected models (reusing `useMultiModelCompare`), side-by-side results, **1–5 star quality rating**, **historical run list w/ filters**, **cost/quality scatter** (apexcharts `BaseChart`), **built-in prompt sets**, **CSV export** (`utils/benchmark.ts`).

## AC coverage (6/6)
dedicated view ✓ · star rating ✓ · run history+filters ✓ · cost/quality scatter ✓ · prompt sets ✓ · CSV export ✓ (+ persistence).

## Verification
- Backend `pytest api/benchmarks_test.py` → **16 passed** (CRUD, filters, per-user scoping, validation); black + py_compile clean.
- Frontend **vue-tsc 0**, `check:locales` complete, `check:i18n` clean, vitest **20 passed** (8 benchmark utils + 12 nav-coverage), eslint clean.

## Notes
- Cost is an honest client-side estimate (compare SSE carries no usage); a real cost signal would need the compare endpoint to emit per-model usage (noted for follow-up).

## Model Used
Opus 4.8

Fixes #9024
