### PR TITLE
fix(auth): re-land single_user user_id/sub + async redis (login redirect loop, #10438 follow-up)

### DIFF
--- a/autobot-backend/api/users.py
+++ b/autobot-backend/api/users.py
@@ -90,7 +90,7 @@ async def _get_user_preferences_from_redis(user_id: str) -> UserPreferences:
         UserPreferences object with stored or default values
     """
     try:
-        redis_client = await get_redis_client(database=RedisDatabase.MAIN)
+        redis_client = await get_redis_client(async_client=True, database=RedisDatabase.MAIN)
 
         async def _read(field: str) -> str | None:
             raw = await redis_client.get(f"user:{user_id}:preferences:{field}")
@@ -123,7 +123,7 @@ async def _store_user_preferences_to_redis(user_id: str, preferences: UserPrefer
     Raises:
         RedisError: If Redis operation fails
     """
-    redis_client = await get_redis_client(database=RedisDatabase.MAIN)
+    redis_client = await get_redis_client(async_client=True, database=RedisDatabase.MAIN)
 
     # Store each preference under its own key (no expiration - permanent preference)
     for field in ("reasoning_effort", *_APPEARANCE_FIELDS):

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -266,6 +266,11 @@ class AuthenticationMiddleware:
         Returns default admin user dict when auth is disabled.
         """
         return {
+            # user_id/sub so user endpoints (e.g. /users/me/preferences) resolve
+            # the identity in single_user mode; without them they 401'd ('User ID
+            # not found in token') → frontend logout → login redirect loop.
+            "user_id": "admin",
+            "sub": "admin",
             "username": "admin",
             "role": "admin",
             "email": f"admin@{ssot_config.auth.domain}",
@@ -1038,6 +1043,11 @@ async def authenticate_websocket(websocket) -> dict | None:
         deployment_config = get_deployment_config()
         if deployment_config.mode == DeploymentMode.SINGLE_USER:
             return {
+                # user_id/sub so user endpoints (e.g. /users/me/preferences) can
+                # resolve the identity; without them they 401'd ('User ID not found
+                # in token') and the frontend logged out → login redirect loop.
+                "user_id": "admin",
+                "sub": "admin",
                 "username": "admin",
                 "role": "admin",
                 "email": f"admin@{ssot_config.auth.domain}",


### PR DESCRIPTION
## Thinking Path
#10438's squash merge captured only the auth.py token change; the two fixes that actually resolve the login redirect loop were dropped from Dev_new_gui (verified: only auth.py landed). The live box has them (applied directly) but they must be durable.

## What Changed
- `auth_middleware.py`: `_get_auth_disabled_user` + the single_user WS path include `user_id`/`sub`='admin' (user endpoints 401'd 'User ID not found in token' → logout → redirect).
- `api/users.py`: `await get_redis_client(async_client=True, …)` in preferences get/store (sync getter was awaited → 500).

## Verification
Diff vs Dev_new_gui is exactly these changes; py_compile clean; live box verified (login → all on-load endpoints 200, no redirect).

## Model Used
Claude Opus 4.8