### PR TITLE
feat(rag): #9018 Phase 2 — wire GraphRAGService as kag strategy + collection graph endpoint

### DIFF
--- a/autobot-backend/advanced_rag_optimizer.py
+++ b/autobot-backend/advanced_rag_optimizer.py
@@ -84,6 +84,8 @@ class RAGMetrics:
     documents_loaded: int = 0
     tokens_used: int = 0
     budget: int = 0
+    # KAG observability — graph-traversal results merged into context (#9018 Phase 2).
+    graph_results_added: int = 0
 
 
 @dataclass

--- a/autobot-backend/api/graph_rag.py
+++ b/autobot-backend/api/graph_rag.py
@@ -280,3 +280,76 @@ async def graph_rag_metrics(
     except Exception as e:
         logger.error("Metrics retrieval failed: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to retrieve metrics")
+
+
+# ====================================================================
+# Issue #9018 Phase 2: KB-explorer collection graph endpoint (read-only)
+# ====================================================================
+
+
+def _serialize_graph_nodes(entities: List[Metadata]) -> List[Metadata]:
+    """Convert graph entities to explorer node dicts. Read-only; #9018 Phase 2."""
+    return [
+        {
+            "id": e.get("id"),
+            "name": e.get("name"),
+            "type": e.get("type"),
+            "observations": e.get("observations", []),
+        }
+        for e in entities
+        if e.get("id")
+    ]
+
+
+async def _collect_collection_edges(service: GraphRAGService, node_ids: List[str]) -> List[Metadata]:
+    """Gather outgoing relations for the given node ids, deduped. #9018 Phase 2."""
+    edges: List[Metadata] = []
+    seen: set = set()
+    for entity_id in node_ids:
+        relations = await service.graph.get_relations(entity_id=entity_id, direction="outgoing")
+        for rel in relations.get("relations", []):
+            key = (rel.get("from"), rel.get("to"), rel.get("type"))
+            if key in seen:
+                continue
+            seen.add(key)
+            edges.append(rel)
+    return edges
+
+
+@router.get("/collections/{collection_id}/graph")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="collection_graph",
+    error_code_prefix="GRAPH_RAG",
+)
+async def collection_graph(
+    collection_id: str,
+    service: GraphRAGService = Depends(get_graph_rag_service),
+    current_user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """Return a collection's knowledge-graph subgraph (nodes + edges).
+
+    Issue #9018 Phase 2 — read-only KB-explorer view. Reuses AutoBotMemoryGraph
+    query methods (no graph mutation). #10234: returns a plain dict via
+    JSONResponse (no response_model=Dict .model_dump footgun).
+    Issue #744: requires an authenticated user.
+    """
+    request_id = generate_request_id()
+    logger.info("[%s] Collection graph request: collection_id=%s", request_id, collection_id)
+
+    entities = await service.graph.search_entities(query=collection_id, tags=[collection_id], limit=500)
+    nodes = _serialize_graph_nodes(entities)
+    edges = await _collect_collection_edges(service, [n["id"] for n in nodes])
+
+    return JSONResponse(
+        status_code=200,
+        content={
+            "collection_id": collection_id,
+            "nodes": nodes,
+            "edges": edges,
+            "node_count": len(nodes),
+            "edge_count": len(edges),
+            "request_id": request_id,
+        },
+        media_type="application/json; charset=utf-8",
+    )

--- a/autobot-backend/api/graph_rag_collection_test.py
+++ b/autobot-backend/api/graph_rag_collection_test.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for the KB-explorer collection graph endpoint — Issue #9018 Phase 2.
+
+Covers:
+- _serialize_graph_nodes maps entities → explorer node dicts (drops id-less).
+- _collect_collection_edges gathers + dedupes outgoing relations.
+- collection_graph returns entities + relations JSON (read-only).
+
+Calls the endpoint function directly with a mocked GraphRAGService to avoid
+spinning up the full FastAPI app (and its Redis dependency at import time).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from api.graph_rag import (  # noqa: E402
+    _collect_collection_edges,
+    _serialize_graph_nodes,
+    collection_graph,
+)
+
+
+def test_serialize_graph_nodes_maps_fields():
+    entities = [
+        {"id": "e1", "name": "Service X", "type": "service", "observations": ["runs config Y"]},
+        {"id": "e2", "name": "Incident 7", "type": "incident", "observations": []},
+    ]
+    nodes = _serialize_graph_nodes(entities)
+    assert len(nodes) == 2
+    assert nodes[0] == {
+        "id": "e1",
+        "name": "Service X",
+        "type": "service",
+        "observations": ["runs config Y"],
+    }
+
+
+def test_serialize_graph_nodes_drops_idless():
+    entities = [{"name": "no id"}, {"id": "e1", "name": "ok"}]
+    nodes = _serialize_graph_nodes(entities)
+    assert [n["id"] for n in nodes] == ["e1"]
+
+
+async def test_collect_collection_edges_dedupes():
+    service = MagicMock()
+    rel = {"from": "e1", "to": "e2", "type": "OWNS", "direction": "outgoing", "metadata": {}}
+    # Same edge returned twice (e1 then duplicate path) must dedupe to one.
+    service.graph = MagicMock()
+    service.graph.get_relations = AsyncMock(return_value={"relations": [rel]})
+    edges = await _collect_collection_edges(service, ["e1", "e1"])
+    assert len(edges) == 1
+    assert edges[0]["type"] == "OWNS"
+
+
+async def test_collection_graph_returns_nodes_and_edges():
+    entities = [
+        {"id": "e1", "name": "Service X", "type": "service", "observations": ["o"]},
+        {"id": "e2", "name": "Incident 7", "type": "incident", "observations": []},
+    ]
+    rel = {"from": "e1", "to": "e2", "type": "OWNS", "direction": "outgoing", "metadata": {}}
+
+    service = MagicMock()
+    service.graph = MagicMock()
+    service.graph.search_entities = AsyncMock(return_value=entities)
+
+    async def _rels(entity_id, direction="both"):
+        return {"relations": [rel]} if entity_id == "e1" else {"relations": []}
+
+    service.graph.get_relations = AsyncMock(side_effect=_rels)
+
+    response = await collection_graph(
+        collection_id="col-123",
+        service=service,
+        current_user={"id": "u1"},
+    )
+
+    body = json.loads(bytes(response.body).decode("utf-8"))
+    assert body["collection_id"] == "col-123"
+    assert body["node_count"] == 2
+    assert body["edge_count"] == 1
+    assert {n["name"] for n in body["nodes"]} == {"Service X", "Incident 7"}
+    assert body["edges"][0]["type"] == "OWNS"
+    # Collection-scoped query: tag filter applied.
+    service.graph.search_entities.assert_awaited_once()
+    _, kwargs = service.graph.search_entities.await_args
+    assert kwargs.get("tags") == ["col-123"]

--- a/autobot-backend/api/knowledge_rag.py
+++ b/autobot-backend/api/knowledge_rag.py
@@ -124,6 +124,8 @@ def _build_search_metrics(metrics) -> dict:
         "documents_loaded": getattr(metrics, "documents_loaded", 0),
         "tokens_used": getattr(metrics, "tokens_used", 0),
         "budget": getattr(metrics, "budget", 0),
+        # Issue #9018 Phase 2: KAG graph-traversal observability.
+        "graph_results_added": getattr(metrics, "graph_results_added", 0),
     }
 
 
@@ -628,12 +630,13 @@ async def get_entity_history(
 )
 async def retrieval_context(
     request: RetrievalContextRequest,
+    http_request: Request,
     rag_service: RAGService = Depends(get_rag_service_dependency),
     current_user: dict = Depends(get_current_user),
 ):
-    """Strategy-dispatched context retrieval (RAG / CAG).
+    """Strategy-dispatched context retrieval (RAG / CAG / KAG).
 
-    Issue #9018 Phase 1.
+    Issue #9018 Phase 1 (CAG) + Phase 2 (KAG).
 
     **Parameters:**
     - **query**: Generation query string.
@@ -643,17 +646,20 @@ async def retrieval_context(
 
     **Returns:**
     - **context**: Assembled context string for LLM injection.
-    - **strategy**: Actual strategy used ('rag' or 'cag').
+    - **strategy**: Actual strategy used ('rag', 'cag' or 'kag').
     - **metrics**: Timing and result-count metrics.
     """
     from services.cag_service import CAGService
     from services.retrieval_dispatcher import get_context
 
     cag_service = CAGService(rag_service)
+    # GraphRAGService is initialized in the app lifespan; absent → kag falls back to rag.
+    graph_rag_service = getattr(http_request.app.state, "graph_rag_service", None)
     context, metrics = await get_context(
         query=request.query,
         rag_service=rag_service,
         cag_service=cag_service,
+        graph_rag_service=graph_rag_service,
         mode=request.mode,
         collection=request.collection_id,
         model=request.model,

--- a/autobot-backend/knowledge/pipeline/config.py
+++ b/autobot-backend/knowledge/pipeline/config.py
@@ -113,6 +113,34 @@ AUDIO_KNOWLEDGE_PIPELINE = {
 }
 
 
+# Issue #9018 Phase 2: KAG (Knowledge-Augmented Generation) ingestion profile.
+# Reuses the default ECL entity/relationship cognifiers and adds the
+# mesh_seeder + redis_graph loaders so entities/relations are persisted into
+# AutoBotMemoryGraph for graph-traversal retrieval. NOT always-on: selected via
+# get_kag_pipeline_config() when a collection is flagged KAG (enable_kag).
+KAG_KNOWLEDGE_PIPELINE = {
+    "name": "kag_knowledge_enrichment",
+    "batch_size": 10,
+    "extract": [
+        {"task": "classify_document", "params": {}},
+        {"task": "chunk_text", "params": {"max_tokens": 512, "overlap": 50}},
+        {"task": "extract_metadata", "params": {}},
+    ],
+    "cognify": [
+        {"task": "extract_entities", "params": {}},
+        {"task": "extract_relationships", "params": {}},
+        {"task": "summarize", "params": {"levels": ["sentence", "paragraph"]}},
+        {"task": "add_context", "params": {}},
+    ],
+    "load": [
+        {"task": "chromadb", "params": {}},
+        # Graph persistence for KAG: build entity/relationship edges into the graph.
+        {"task": "mesh_seeder", "params": {}},
+        {"task": "redis_graph", "params": {}},
+    ],
+}
+
+
 def get_default_config() -> Dict[str, Any]:
     """
     Get the default knowledge enrichment pipeline configuration.
@@ -130,3 +158,32 @@ def get_audio_pipeline_config() -> Dict[str, Any]:
         Audio pipeline configuration dict (deep copy)
     """
     return copy.deepcopy(AUDIO_KNOWLEDGE_PIPELINE)
+
+
+def get_kag_pipeline_config() -> Dict[str, Any]:
+    """Return the KAG ingestion pipeline configuration (Issue #9018 Phase 2).
+
+    Configurable profile (not always-on): callers select this for collections
+    flagged KAG so ECL entity/relationship extraction + mesh_seeder seed the
+    knowledge graph. Reuses existing cognifiers/loaders — no reimplementation.
+
+    Returns:
+        KAG pipeline configuration dict (deep copy)
+    """
+    return copy.deepcopy(KAG_KNOWLEDGE_PIPELINE)
+
+
+def select_pipeline_config(kag_enabled: bool = False) -> Dict[str, Any]:
+    """Return the ingestion pipeline config for a collection.
+
+    Issue #9018 Phase 2: a configurable profile flag, not forced on. When
+    kag_enabled is True the KAG profile (graph-seeding) is used; otherwise the
+    standard default profile is returned unchanged (inert default).
+
+    Args:
+        kag_enabled: Whether the target collection is flagged for KAG.
+
+    Returns:
+        Pipeline configuration dict (deep copy).
+    """
+    return get_kag_pipeline_config() if kag_enabled else get_default_config()

--- a/autobot-backend/knowledge/pipeline/config_test.py
+++ b/autobot-backend/knowledge/pipeline/config_test.py
@@ -129,10 +129,12 @@ class TestGetDefaultConfig:
 # Issue #9018 Phase 2 — KAG ingestion pipeline profile
 # ---------------------------------------------------------------------------
 
-from knowledge.pipeline.config import (  # noqa: E402
+from knowledge.pipeline.config import (
     KAG_KNOWLEDGE_PIPELINE,
     get_kag_pipeline_config,
-    load_pipeline_config as _load_pipeline_config,
+)
+from knowledge.pipeline.config import load_pipeline_config as _load_pipeline_config  # noqa: E402
+from knowledge.pipeline.config import (
     select_pipeline_config,
 )
 

--- a/autobot-backend/knowledge/pipeline/config_test.py
+++ b/autobot-backend/knowledge/pipeline/config_test.py
@@ -123,3 +123,50 @@ class TestGetDefaultConfig:
         assert "classify_document" in task_names
         assert "chunk_text" in task_names
         assert "extract_metadata" in task_names
+
+
+# ---------------------------------------------------------------------------
+# Issue #9018 Phase 2 — KAG ingestion pipeline profile
+# ---------------------------------------------------------------------------
+
+from knowledge.pipeline.config import (  # noqa: E402
+    KAG_KNOWLEDGE_PIPELINE,
+    get_kag_pipeline_config,
+    load_pipeline_config as _load_pipeline_config,
+    select_pipeline_config,
+)
+
+
+class TestKAGPipelineProfile:
+    """Tests for the configurable KAG ingestion profile (#9018 Phase 2)."""
+
+    def test_kag_config_validates(self):
+        """KAG profile passes pipeline config validation."""
+        assert _load_pipeline_config(get_kag_pipeline_config())["name"] == "kag_knowledge_enrichment"
+
+    def test_kag_seeds_graph_loaders(self):
+        """KAG profile adds mesh_seeder + redis_graph loaders alongside chromadb."""
+        loaders = {t["task"] for t in get_kag_pipeline_config()["load"]}
+        assert {"chromadb", "mesh_seeder", "redis_graph"} <= loaders
+
+    def test_kag_reuses_entity_relationship_cognifiers(self):
+        """KAG profile reuses existing ECL entity/relationship cognifiers."""
+        cognify = {t["task"] for t in get_kag_pipeline_config()["cognify"]}
+        assert {"extract_entities", "extract_relationships"} <= cognify
+
+    def test_get_kag_config_returns_copy(self):
+        """Each call returns an independent deep copy."""
+        a = get_kag_pipeline_config()
+        a["load"].clear()
+        assert KAG_KNOWLEDGE_PIPELINE["load"], "module-level template must not mutate"
+
+    def test_select_default_when_kag_disabled(self):
+        """Inert default: kag_enabled=False → standard pipeline, no graph loaders."""
+        cfg = select_pipeline_config(kag_enabled=False)
+        loaders = {t["task"] for t in cfg["load"]}
+        assert cfg["name"] == "knowledge_enrichment"
+        assert "mesh_seeder" not in loaders
+
+    def test_select_kag_when_enabled(self):
+        """kag_enabled=True → KAG profile selected."""
+        assert select_pipeline_config(kag_enabled=True)["name"] == "kag_knowledge_enrichment"

--- a/autobot-backend/services/retrieval_dispatcher.py
+++ b/autobot-backend/services/retrieval_dispatcher.py
@@ -4,23 +4,28 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Retrieval Strategy Dispatcher — Phase 1 (Issue #9018).
+Retrieval Strategy Dispatcher — Issue #9018.
 
-Composes RAGService and CAGService under a single entry-point.
-KAG and unknown modes fall back to RAG in Phase 1.
-Auto-selection: defaults to RAG unless enable_cag=True AND the collection
-explicitly requests cag (future Phase 3 adds heuristic auto-selection).
+Composes RAGService, CAGService and GraphRAGService under a single entry-point.
+- Phase 1: rag | cag (+ auto → cag when collection requests it).
+- Phase 2: kag → GraphRAGService.graph_aware_search, adapted to the shared
+  (context: str, RAGMetrics) contract. Inert (falls back to rag) when
+  enable_kag=False.
+
+Auto-selection currently honours collection_mode for cag/kag; richer
+heuristic auto-selection is Phase 3.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, List, Tuple
 
 from autobot_shared.logging_manager import get_llm_logger
 
 if TYPE_CHECKING:
-    from advanced_rag_optimizer import RAGMetrics
+    from advanced_rag_optimizer import RAGMetrics, SearchResult
     from services.cag_service import CAGService
+    from services.graph_rag_service import GraphRAGService
     from services.rag_config import RAGConfig
     from services.rag_service import RAGService
 
@@ -31,16 +36,19 @@ _MODES = frozenset({"rag", "cag", "kag", "auto"})
 
 
 def select_strategy(mode: str, config: "RAGConfig", collection_mode: str | None = None) -> str:
-    """Return the concrete strategy to use ('rag' or 'cag').
+    """Return the concrete strategy to use ('rag', 'cag' or 'kag').
 
-    Decision table (Phase 1):
+    Decision table:
     - mode == 'rag'  → 'rag'
-    - mode == 'kag'  → 'rag'  (Phase 2)
+    - mode == 'kag'  → 'kag' only when enable_kag=True, else 'rag' (inert)
     - mode == 'cag'  → 'cag' only when enable_cag=True, else 'rag'
-    - mode == 'auto' → 'cag' when enable_cag=True AND collection_mode=='cag', else 'rag'
+    - mode == 'auto' → 'cag' when enable_cag and collection_mode=='cag';
+                       'kag' when enable_kag and collection_mode=='kag';
+                       else 'rag'
     - unknown        → 'rag'
     """
     enable_cag = getattr(config, "enable_cag", False)
+    enable_kag = getattr(config, "enable_kag", False)
 
     if mode not in _MODES:
         logger.warning("Unknown retrieval mode %r — defaulting to rag", mode)
@@ -50,8 +58,10 @@ def select_strategy(mode: str, config: "RAGConfig", collection_mode: str | None 
         return "rag"
 
     if mode == "kag":
-        logger.debug("KAG not yet implemented (Phase 2) — using rag")
-        return "rag"
+        if not enable_kag:
+            logger.debug("KAG requested but enable_kag=False — using rag")
+            return "rag"
+        return "kag"
 
     if mode == "cag":
         if not enable_cag:
@@ -62,13 +72,51 @@ def select_strategy(mode: str, config: "RAGConfig", collection_mode: str | None 
     # mode == 'auto'
     if enable_cag and collection_mode == "cag":
         return "cag"
+    if enable_kag and collection_mode == "kag":
+        return "kag"
     return "rag"
+
+
+def _build_kag_context(results: List["SearchResult"]) -> str:
+    """Assemble a context string from graph-aware SearchResult list.
+
+    Mirrors RAG context assembly: ordered, provenance-headed blocks.
+    """
+    blocks = []
+    for r in results:
+        source = r.source_path or "unknown"
+        blocks.append(f"[source: {source}]\n{r.content}")
+    return "\n\n".join(blocks)
+
+
+async def _run_kag(
+    query: str,
+    graph_rag_service: "GraphRAGService",
+    model: str | None,
+) -> "Tuple[str, RAGMetrics]":
+    """Run the KAG strategy and adapt to the (context, RAGMetrics) contract.
+
+    Returns the graph-augmented context plus a RAGMetrics carrying
+    strategy='kag' and graph_results_added from GraphRAGMetrics.
+    """
+    results, graph_metrics = await graph_rag_service.graph_aware_search(query=query)
+    context = _build_kag_context(results)
+    graph_metrics.strategy = "kag"  # type: ignore[attr-defined]
+    # graph_results_added already populated by GraphRAGMetrics; mirror defensively.
+    graph_metrics.graph_results_added = getattr(graph_metrics, "graph_results_added", 0)
+    logger.info(
+        "KAG: %d results, graph_results_added=%d",
+        len(results),
+        graph_metrics.graph_results_added,
+    )
+    return context, graph_metrics
 
 
 async def get_context(
     query: str,
     rag_service: "RAGService",
     cag_service: "CAGService",
+    graph_rag_service: "GraphRAGService | None" = None,
     mode: str = "auto",
     collection: str | None = None,
     model: str | None = None,
@@ -80,6 +128,8 @@ async def get_context(
         query: Search / generation query.
         rag_service: Initialized RAGService instance.
         cag_service: CAGService wrapping rag_service.
+        graph_rag_service: Optional GraphRAGService for the kag strategy.
+            When None, a kag request falls back to rag.
         mode: Caller-requested mode ('auto'|'rag'|'cag'|'kag').
         collection: Optional collection identifier (for logging).
         model: Active model name (used by CAGService for budget calc).
@@ -102,7 +152,13 @@ async def get_context(
     if strategy == "cag":
         return await cag_service.get_full_context(query=query, collection=collection, model=model)
 
-    # RAG path (default, kag fallback, unknown mode fallback)
+    if strategy == "kag":
+        if graph_rag_service is None:
+            logger.warning("KAG selected but no GraphRAGService provided — using rag")
+        else:
+            return await _run_kag(query=query, graph_rag_service=graph_rag_service, model=model)
+
+    # RAG path (default, kag/cag-disabled fallback, unknown mode fallback)
     context, metrics = await rag_service.get_optimized_context(query=query)
     metrics.strategy = "rag"
     return context, metrics

--- a/autobot-backend/services/retrieval_dispatcher_test.py
+++ b/autobot-backend/services/retrieval_dispatcher_test.py
@@ -143,3 +143,117 @@ async def test_get_context_auto_collection_cag():
     ctx, metrics = await get_context(query="q", rag_service=rag, cag_service=cag, mode="auto", collection_mode="cag")
     assert ctx == "cag-context"
     rag.get_optimized_context.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 (KAG) — Issue #9018
+# ---------------------------------------------------------------------------
+
+from advanced_rag_optimizer import SearchResult  # noqa: E402
+
+
+def test_select_kag_enabled_returns_kag():
+    """enable_kag=True + mode='kag' → 'kag'."""
+    assert select_strategy("kag", _cfg(enable_kag=True)) == "kag"
+
+
+def test_select_kag_disabled_returns_rag():
+    """enable_kag=False + mode='kag' → 'rag' (inert)."""
+    assert select_strategy("kag", _cfg(enable_kag=False)) == "rag"
+
+
+def test_select_auto_kag_enabled_collection_kag():
+    """auto + enable_kag=True + collection_mode='kag' → 'kag'."""
+    assert select_strategy("auto", _cfg(enable_kag=True), collection_mode="kag") == "kag"
+
+
+def test_select_auto_kag_disabled_collection_kag():
+    """auto + enable_kag=False + collection_mode='kag' → 'rag'."""
+    assert select_strategy("auto", _cfg(enable_kag=False), collection_mode="kag") == "rag"
+
+
+def _make_kag_services(enable_kag: bool = True, graph_results_added: int = 2):
+    """Build rag/cag/graph_rag mocks for KAG dispatch tests."""
+    from services.graph_rag_service import GraphRAGMetrics
+
+    config = RAGConfig(enable_kag=enable_kag)
+    rag = MagicMock()
+    rag.config = config
+    rag.get_optimized_context = AsyncMock(return_value=("rag-context", RAGMetrics(total_time=0.1)))
+
+    cag = MagicMock()
+
+    results = [
+        SearchResult(
+            content="entity observation A",
+            metadata={"source": "graph_expansion"},
+            semantic_score=0.0,
+            keyword_score=0.0,
+            hybrid_score=0.9,
+            relevance_rank=1,
+            source_path="graph:EntityA",
+            chunk_index=0,
+        ),
+        SearchResult(
+            content="entity observation B",
+            metadata={"source": "graph_expansion"},
+            semantic_score=0.0,
+            keyword_score=0.0,
+            hybrid_score=0.8,
+            relevance_rank=2,
+            source_path="graph:EntityB",
+            chunk_index=0,
+        ),
+    ]
+    gmetrics = GraphRAGMetrics()
+    gmetrics.graph_results_added = graph_results_added
+    graph_rag = MagicMock()
+    graph_rag.graph_aware_search = AsyncMock(return_value=(results, gmetrics))
+    return rag, cag, graph_rag
+
+
+async def test_get_context_kag_routes_to_graph_aware_search():
+    """KAG enabled → graph_aware_search invoked; (str, RAGMetrics) with strategy=kag."""
+    rag, cag, graph_rag = _make_kag_services(enable_kag=True, graph_results_added=2)
+    ctx, metrics = await get_context(
+        query="relational q",
+        rag_service=rag,
+        cag_service=cag,
+        graph_rag_service=graph_rag,
+        mode="kag",
+    )
+    graph_rag.graph_aware_search.assert_awaited_once()
+    assert isinstance(ctx, str)
+    assert "entity observation A" in ctx and "graph:EntityA" in ctx
+    assert getattr(metrics, "strategy", None) == "kag"
+    assert metrics.graph_results_added == 2
+    rag.get_optimized_context.assert_not_called()
+
+
+async def test_get_context_kag_disabled_falls_back_to_rag():
+    """enable_kag=False → kag inert, routes to RAG, graph never called."""
+    rag, cag, graph_rag = _make_kag_services(enable_kag=False)
+    ctx, metrics = await get_context(
+        query="q",
+        rag_service=rag,
+        cag_service=cag,
+        graph_rag_service=graph_rag,
+        mode="kag",
+    )
+    assert ctx == "rag-context"
+    assert getattr(metrics, "strategy", None) == "rag"
+    graph_rag.graph_aware_search.assert_not_called()
+
+
+async def test_get_context_kag_no_service_falls_back_to_rag():
+    """KAG enabled but no GraphRAGService supplied → safe RAG fallback."""
+    rag, cag, _ = _make_kag_services(enable_kag=True)
+    ctx, metrics = await get_context(
+        query="q",
+        rag_service=rag,
+        cag_service=cag,
+        graph_rag_service=None,
+        mode="kag",
+    )
+    assert ctx == "rag-context"
+    assert getattr(metrics, "strategy", None) == "rag"


### PR DESCRIPTION
## Thinking Path
#9018 Phase 2 (KAG). Phase 1 (CAG + dispatcher) merged earlier; the dispatcher's `kag` mode was a stub→rag. This wires the existing `GraphRAGService` in as the real `kag` strategy. **Inert when `enable_kag=False`** (default).

## What Changed
- `services/retrieval_dispatcher.py`: `kag` now routes to `GraphRAGService.graph_aware_search()` (composed alongside RAG/CAG); adapts its `(List[SearchResult], GraphRAGMetrics)` to the `(context, RAGMetrics)` contract (`strategy="kag"`, `graph_results_added`). `enable_kag=False` or no graph service → safe rag fallback.
- `advanced_rag_optimizer.py`: additive `RAGMetrics.graph_results_added`. `api/knowledge_rag.py`: surfaced in metrics; `/context` now serves kag end-to-end.
- `knowledge/pipeline/config.py`: `KAG_KNOWLEDGE_PIPELINE` profile (reuses existing ECL entity/relationship cognifiers + `mesh_seeder`/`redis_graph` loaders) via `select_pipeline_config(kag_enabled)` — configurable, not always-on.
- `api/graph_rag.py`: `GET /collections/{id}/graph` (read-only entities+relations for the KB explorer).

## Verification
- `pytest` (dispatcher + pipeline config + collection-graph + cag regression) → **61 passed**; black + flake8 clean; import-smoke OK.
- Inert confirmed: `enable_kag=False` → kag falls back to rag, graph never invoked.

## Notes
- Collection→graph scoping uses a `collection_id` tag; entities aren't stamped with that tag until KAG ingestion runs (PRD Phase-3 namespacing) — endpoint is correct + inert today.
- Pre-existing (NOT this PR): 2 failing mocks in `graph_rag_service_test.py` on base — recommend a follow-up.

## Model Used
Opus 4.8

Fixes #9018
