### PR TITLE
refactor(frontend): consolidate to single feature-flag convention — remove unused __FEATURE_* defines (#10086)

### DIFF
--- a/autobot-frontend/src/shims-vue.d.ts
+++ b/autobot-frontend/src/shims-vue.d.ts
@@ -17,8 +17,3 @@ declare module 'vue' {
 }
 
 export {};
-
-// Compile-time feature flag defines injected by Vite (#3009)
-declare const __FEATURE_VOICE__: boolean
-declare const __FEATURE_VNC__: boolean
-declare const __FEATURE_BROWSER__: boolean

--- a/autobot-frontend/vite.config.js
+++ b/autobot-frontend/vite.config.js
@@ -52,9 +52,9 @@ export default defineConfig(({ mode }) => {
 
   return {
     define: {
-      __FEATURE_VOICE__: JSON.stringify(env.VITE_FEATURE_VOICE !== 'false'),
-      __FEATURE_VNC__: JSON.stringify(env.VITE_FEATURE_VNC !== 'false'),
-      __FEATURE_BROWSER__: JSON.stringify(env.VITE_FEATURE_BROWSER !== 'false'),
+      // #10086: removed unused __FEATURE_VOICE__/VNC/BROWSER build-time defines
+      // (zero consumers). Feature gating is standardized on the single runtime
+      // convention: navItems `VITE_FEATURE_<NAME>` + `featureDefaultVisible`.
       'import.meta.env.VITE_APP_VERSION': JSON.stringify(pkg.version),
     },
     plugins: [vue(), vueDevTools(), vadAssetsPlugin()],


### PR DESCRIPTION
## Thinking Path
#10086 — two coexisting feature-flag conventions: vite.config build-time `__FEATURE_VOICE__/VNC/BROWSER` defines (opt-out) vs navItems runtime `VITE_FEATURE_*` (opt-in). The build-time defines had **zero consumers** (verified `grep`).

## What Changed
- Removed the 3 unused `__FEATURE_*` `define`s from `vite.config.js` and their declarations from `shims-vue.d.ts`. Feature gating now uses the single runtime convention: navItems `VITE_FEATURE_<NAME>` + `featureDefaultVisible` (#9984).

## Verification
- vue-tsc `--noEmit` → 0 errors. No remaining references to `__FEATURE_*`.

## Model Used
Opus 4.8

Fixes #10086