### PR TITLE
fix(deploy): sync plugins/ into backend tree so core plugins are discovered (#10294)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -311,6 +311,21 @@
   notify: restart backend
   tags: ['backend', 'deploy']
 
+# Issue #10294: plugins ship at the repo root (code_source/plugins/), a SIBLING of
+# autobot-backend/, so the autobot-backend code sync never copied them. The backend
+# resolves plugins at {{ backend_code_dir }}/plugins (AUTOBOT_BASE_DIR/plugins), which
+# did not exist → discover_plugins() found nothing and every core plugin (image/video
+# generation, kb-event, etc.) silently failed to register. Sync them into place.
+- name: Sync plugins directory from code_source (#10294)
+  ansible.posix.synchronize:
+    src: "{{ code_source_dir | default('/opt/autobot/code_source') }}/plugins/"
+    dest: "{{ backend_code_dir }}/plugins/"
+    rsync_opts:
+      - "--exclude=__pycache__"
+      - "--exclude=*.pyc"
+  notify: restart backend
+  tags: ['backend', 'deploy']
+
 # Issue #10020: The old rsync task created a real directory copy of autobot_shared
 # inside backend_install_dir (/opt/autobot/autobot-backend/autobot_shared/).
 # Because PYTHONPATH lists backend_install_dir first, that embedded copy shadowed


### PR DESCRIPTION
## Thinking Path
While validating "log errors solved" on the running box, `backend-error.log` was flooded with `Plugin directory does not exist: /opt/autobot/autobot-backend/plugins/core-plugins` and zero plugins registered. #10294's *import* layer (hyphenated `core-plugins` dirs not importable via the dotted entry_point) is already handled in `autobot_shared/plugin_sdk/loader.py` (file-path fallback + BasePlugin-subclass scan, via #10442/#14ad94f95). But plugins still never loaded for a **second** reason: they are never deployed to where the backend looks.

## Root Cause
Plugins ship at the repo root `plugins/` — a **sibling** of `autobot-backend/`. The backend deploy only rsyncs `code_source/autobot-backend/` → `backend_code_dir`, so `plugins/` is never copied. The backend resolves plugins at `AUTOBOT_BASE_DIR/plugins` (`= backend_code_dir/plugins`), which doesn't exist → `discover_plugins()` finds nothing → every core plugin (image/video generation, kb-event, etc.) silently fails to register, flooding the log.

## What Changed
`autobot-slm-backend/ansible/roles/backend/tasks/main.yml`: add a task that rsyncs `code_source/plugins/` → `backend_code_dir/plugins/`, mirroring the existing config-directory sync.

## Verification
On the running box: manually synced plugins into place (what the task does) and restarted the backend → the `Plugin directory does not exist` warning flood dropped to **0** with no plugin load errors. (Health endpoint stayed 200.)

## Model Used
Claude Opus 4.8

Refs #10294 (deploy half; import half handled in #10442).
