### PR TITLE
feat(voice): multi-provider realtime voice architecture — provider registry + swappable providers (#9025)

### DIFF
--- a/autobot-backend/api/realtime_session.py
+++ b/autobot-backend/api/realtime_session.py
@@ -3,33 +3,38 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Backend SDP proxy for OpenAI Realtime WebRTC (GH#7342).
+Backend SDP proxy for realtime voice (GH#7342, multi-provider via #9025).
 Cost + duration telemetry wired in (GH#7421).
 
-Accepts a WebRTC SDP offer from the browser, forwards it as multipart to
-OpenAI's Realtime API with the OPENAI_API_KEY injected server-side, and
-returns the SDP answer.  The key never reaches the browser.
+Accepts a WebRTC SDP offer (or websocket handshake blob) from the browser and
+dispatches it to the *selected* realtime voice provider via the provider
+registry (#9025). The default provider is OpenAI Realtime, so behaviour is
+unchanged unless AUTOBOT_VOICE_REALTIME_PROVIDER (or a per-conversation
+override) selects another provider. Upstream credentials never reach the
+browser.
 """
 
 from __future__ import annotations
 
-import os
 import uuid
-from typing import Any
+from typing import Any, Optional
 
-import aiohttp
 from fastapi import APIRouter, Form, HTTPException
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import get_config
+from voice_processing.realtime.base import RealtimeProviderError
+from voice_processing.realtime.registry import (
+    get_active_realtime_provider,
+    get_active_provider_id,
+    list_realtime_providers,
+    set_active_provider,
+)
 
 logger = get_logger(__name__)
 router = APIRouter()
-
-_OPENAI_REALTIME_URL = "https://api.openai.com/v1/realtime/sessions"
-_OPENAI_BETA_HEADER = "realtime=v1"
 
 
 # ── Telemetry endpoint models (Issue #7421) ───────────────────────────────────
@@ -70,11 +75,26 @@ class SessionSummary(BaseModel):
     disconnect_reason: str
 
 
-def _get_api_key() -> str:
-    """Return the OpenAI API key from SSOT config with env-var fallback."""
-    cfg = get_config()
-    key = cfg.llm.openai_api_key or os.environ.get("OPENAI_API_KEY", "")
-    return key
+# ── Provider selection models (Issue #9025) ───────────────────────────────────
+
+
+class RealtimeProviderInfo(BaseModel):
+    id: str
+    name: str
+    configured: bool
+    transport: str
+    supports_tools: bool
+    supports_audio_output: bool
+    supports_cost_tracking: bool
+
+
+class RealtimeProvidersResponse(BaseModel):
+    selected: str
+    providers: list[RealtimeProviderInfo]
+
+
+class SetRealtimeProviderRequest(BaseModel):
+    provider: Optional[str] = None
 
 
 def _get_model() -> str:
@@ -83,105 +103,77 @@ def _get_model() -> str:
 
 
 @router.post("/session")
-async def create_realtime_session(  # noqa: PLR0912
+async def create_realtime_session(
     sdp: str = Form(..., media_type="text/plain"),
     session: str = Form(..., media_type="application/json"),
 ) -> Response:
     """
-    SDP offer proxy for OpenAI Realtime WebRTC.
+    SDP offer proxy for realtime voice, dispatched to the selected provider.
 
     Accepts multipart form fields:
       - sdp (text/plain): WebRTC SDP offer from the browser
       - session (application/json): session configuration JSON
 
-    Returns the SDP answer from OpenAI with Content-Type: application/sdp.
-    Maps upstream 401 → 502 and 5xx → 502; missing key → 503.
+    Returns the provider's negotiation answer. For WebRTC providers this is the
+    SDP answer with Content-Type: application/sdp. Provider errors map to 503
+    (not configured) or 502 (upstream failure).
     """
-    # Issue #7421: generate a session_id for telemetry tracking
     session_id = str(uuid.uuid4())
-
-    api_key = _get_api_key()
-    if not api_key:
-        logger.error("OPENAI_API_KEY not configured — cannot proxy SDP offer")
-        raise HTTPException(
-            status_code=503,
-            detail={"success": False, "message": "Voice service not available: API key not configured"},
-        )
-
-    model = _get_model()
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "OpenAI-Beta": _OPENAI_BETA_HEADER,
-    }
-
-    form = aiohttp.FormData()
-    form.add_field("model", model)
-    form.add_field("sdp", sdp, content_type="text/plain")
-    form.add_field("session", session, content_type="application/json")
+    provider = get_active_realtime_provider()
 
     try:
-        timeout = aiohttp.ClientTimeout(connect=30, total=60)
-        async with aiohttp.ClientSession(timeout=timeout) as http:
-            async with http.post(_OPENAI_REALTIME_URL, data=form, headers=headers) as upstream:
-                body = await upstream.read()
-
-                if upstream.status == 401:
-                    logger.warning("OpenAI Realtime API returned 401 Unauthorized")
-                    raise HTTPException(
-                        status_code=502,
-                        detail={"success": False, "message": "Upstream authentication failed"},
-                    )
-
-                if upstream.status >= 500:
-                    logger.error(
-                        "OpenAI Realtime API returned %s: %s",
-                        upstream.status,
-                        body[:256],
-                    )
-                    raise HTTPException(
-                        status_code=502,
-                        detail={"success": False, "message": f"Upstream error: {upstream.status}"},
-                    )
-
-                if upstream.status != 201 and upstream.status != 200:
-                    logger.warning(
-                        "OpenAI Realtime API returned unexpected status %s",
-                        upstream.status,
-                    )
-                    raise HTTPException(
-                        status_code=502,
-                        detail={"success": False, "message": f"Unexpected upstream status: {upstream.status}"},
-                    )
-
-                # Issue #7421: start telemetry for this session
-                try:
-                    from services.voice_realtime_telemetry import get_voice_realtime_telemetry
-
-                    await get_voice_realtime_telemetry().session_start(session_id=session_id, model=_get_model())
-                except Exception as exc:  # telemetry must never break the session
-                    logger.warning("voice_realtime telemetry start failed: %s", exc)
-
-                # Return SDP answer with session_id header so frontend can close telemetry
-                return Response(
-                    content=body,
-                    media_type="application/sdp",
-                    headers={"X-Realtime-Session-Id": session_id},
-                )
-
-    except HTTPException:
-        raise
-    except aiohttp.ClientError as exc:
-        logger.error("Network error proxying SDP offer: %s", exc)
+        negotiation = await provider.negotiate(
+            offer=sdp,
+            session_config=session,
+            session_id=session_id,
+        )
+    except RealtimeProviderError as exc:
+        logger.warning("Realtime provider %r negotiation failed: %s", provider.provider_id, exc)
         raise HTTPException(
-            status_code=502,
-            detail={"success": False, "message": "Network error contacting voice service"},
+            status_code=exc.status,
+            detail={"success": False, "message": str(exc)},
         )
     except Exception as exc:
-        logger.error("Unexpected error in SDP proxy: %s", exc)
+        logger.error("Unexpected error negotiating realtime session: %s", exc)
         raise HTTPException(
             status_code=500,
             detail={"success": False, "message": "Internal error in voice service"},
         )
+
+    # Issue #7421: start telemetry for this session (must never break the session)
+    try:
+        from services.voice_realtime_telemetry import get_voice_realtime_telemetry
+
+        await get_voice_realtime_telemetry().session_start(session_id=session_id, model=_get_model())
+    except Exception as exc:
+        logger.warning("voice_realtime telemetry start failed: %s", exc)
+
+    headers = {"X-Realtime-Session-Id": session_id, "X-Realtime-Provider": provider.provider_id}
+    headers.update(negotiation.headers)
+    return Response(content=negotiation.answer, media_type=negotiation.media_type, headers=headers)
+
+
+# ── Provider selection endpoints (Issue #9025) ────────────────────────────────
+
+
+@router.get("/providers", response_model=RealtimeProvidersResponse)
+async def list_providers() -> dict:
+    """List realtime voice providers + the active selection (never returns keys)."""
+    return {"selected": get_active_provider_id(), "providers": list_realtime_providers()}
+
+
+@router.patch("/providers", response_model=RealtimeProvidersResponse)
+async def set_provider(body: SetRealtimeProviderRequest) -> dict:
+    """Set the active realtime provider (in-process; doc'd restart limitation).
+
+    Pass {"provider": null} to clear the override and fall back to the
+    AUTOBOT_VOICE_REALTIME_PROVIDER config / default.
+    """
+    try:
+        set_active_provider(body.provider)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    return {"selected": get_active_provider_id(), "providers": list_realtime_providers()}
 
 
 # ── Telemetry endpoints (Issue #7421) ─────────────────────────────────────────

--- a/autobot-backend/api/realtime_session.py
+++ b/autobot-backend/api/realtime_session.py
@@ -27,8 +27,8 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import get_config
 from voice_processing.realtime.base import RealtimeProviderError
 from voice_processing.realtime.registry import (
-    get_active_realtime_provider,
     get_active_provider_id,
+    get_active_realtime_provider,
     list_realtime_providers,
     set_active_provider,
 )

--- a/autobot-backend/api/realtime_session_test.py
+++ b/autobot-backend/api/realtime_session_test.py
@@ -88,7 +88,9 @@ class TestHappyPath:
         session_cm = _mock_session(upstream_cm)
 
         with (
-            patch("api.realtime_session._get_api_key", return_value="sk-test-key"),
+            patch(
+                "voice_processing.realtime.openai_provider.OpenAIRealtimeProvider._api_key", return_value="sk-test-key"
+            ),
             patch("aiohttp.ClientSession", return_value=session_cm),
         ):
             resp = client.post(
@@ -103,7 +105,9 @@ class TestHappyPath:
         session_cm = _mock_session(upstream_cm)
 
         with (
-            patch("api.realtime_session._get_api_key", return_value="sk-test-key"),
+            patch(
+                "voice_processing.realtime.openai_provider.OpenAIRealtimeProvider._api_key", return_value="sk-test-key"
+            ),
             patch("aiohttp.ClientSession", return_value=session_cm),
         ):
             resp = client.post(
@@ -118,7 +122,9 @@ class TestHappyPath:
         session_cm = _mock_session(upstream_cm)
 
         with (
-            patch("api.realtime_session._get_api_key", return_value="sk-test-key"),
+            patch(
+                "voice_processing.realtime.openai_provider.OpenAIRealtimeProvider._api_key", return_value="sk-test-key"
+            ),
             patch("aiohttp.ClientSession", return_value=session_cm),
         ):
             resp = client.post(
@@ -133,7 +139,9 @@ class TestHappyPath:
         session_cm = _mock_session(upstream_cm)
 
         with (
-            patch("api.realtime_session._get_api_key", return_value="sk-test-key"),
+            patch(
+                "voice_processing.realtime.openai_provider.OpenAIRealtimeProvider._api_key", return_value="sk-test-key"
+            ),
             patch("aiohttp.ClientSession", return_value=session_cm),
         ):
             resp = client.post(
@@ -153,7 +161,7 @@ class TestMissingApiKey:
     """GH#7342 — no OPENAI_API_KEY configured must return 503."""
 
     def test_missing_key_returns_503(self, client: TestClient):
-        with patch("api.realtime_session._get_api_key", return_value=""):
+        with patch("voice_processing.realtime.openai_provider.OpenAIRealtimeProvider._api_key", return_value=""):
             resp = client.post(
                 "/api/voice/realtime/session",
                 data={"sdp": _SDP_OFFER, "session": _SESSION_JSON},
@@ -162,7 +170,7 @@ class TestMissingApiKey:
         assert resp.status_code == 503
 
     def test_missing_key_error_body(self, client: TestClient):
-        with patch("api.realtime_session._get_api_key", return_value=""):
+        with patch("voice_processing.realtime.openai_provider.OpenAIRealtimeProvider._api_key", return_value=""):
             resp = client.post(
                 "/api/voice/realtime/session",
                 data={"sdp": _SDP_OFFER, "session": _SESSION_JSON},
@@ -185,7 +193,9 @@ class TestUpstream401:
         session_cm = _mock_session(upstream_cm)
 
         with (
-            patch("api.realtime_session._get_api_key", return_value="sk-bad-key"),
+            patch(
+                "voice_processing.realtime.openai_provider.OpenAIRealtimeProvider._api_key", return_value="sk-bad-key"
+            ),
             patch("aiohttp.ClientSession", return_value=session_cm),
         ):
             resp = client.post(
@@ -200,7 +210,9 @@ class TestUpstream401:
         session_cm = _mock_session(upstream_cm)
 
         with (
-            patch("api.realtime_session._get_api_key", return_value="sk-bad-key"),
+            patch(
+                "voice_processing.realtime.openai_provider.OpenAIRealtimeProvider._api_key", return_value="sk-bad-key"
+            ),
             patch("aiohttp.ClientSession", return_value=session_cm),
         ):
             resp = client.post(
@@ -226,7 +238,9 @@ class TestUpstream5xx:
         session_cm = _mock_session(upstream_cm)
 
         with (
-            patch("api.realtime_session._get_api_key", return_value="sk-test-key"),
+            patch(
+                "voice_processing.realtime.openai_provider.OpenAIRealtimeProvider._api_key", return_value="sk-test-key"
+            ),
             patch("aiohttp.ClientSession", return_value=session_cm),
         ):
             resp = client.post(
@@ -241,7 +255,9 @@ class TestUpstream5xx:
         session_cm = _mock_session(upstream_cm)
 
         with (
-            patch("api.realtime_session._get_api_key", return_value="sk-test-key"),
+            patch(
+                "voice_processing.realtime.openai_provider.OpenAIRealtimeProvider._api_key", return_value="sk-test-key"
+            ),
             patch("aiohttp.ClientSession", return_value=session_cm),
         ):
             resp = client.post(
@@ -251,3 +267,56 @@ class TestUpstream5xx:
 
         body = resp.json()
         assert body.get("detail", {}).get("success") is False
+
+
+# ---------------------------------------------------------------------------
+# Multi-provider dispatch + providers endpoints (Issue #9025)
+# ---------------------------------------------------------------------------
+
+
+class TestProviderDispatch:
+    """#9025 — /session dispatches through the selected provider; default unchanged."""
+
+    def test_session_header_advertises_provider(self, client: TestClient):
+        upstream_cm = _mock_upstream(200, _SDP_ANSWER)
+        session_cm = _mock_session(upstream_cm)
+        with (
+            patch(
+                "voice_processing.realtime.openai_provider.OpenAIRealtimeProvider._api_key",
+                return_value="sk-test-key",
+            ),
+            patch("aiohttp.ClientSession", return_value=session_cm),
+        ):
+            resp = client.post(
+                "/api/voice/realtime/session",
+                data={"sdp": _SDP_OFFER, "session": _SESSION_JSON},
+            )
+        assert resp.status_code == 200
+        assert resp.headers.get("x-realtime-provider") == "openai"
+
+
+class TestProvidersEndpoint:
+    """#9025 — GET/PATCH /providers list + select (never leaks credentials)."""
+
+    def test_list_providers_default_openai(self, client: TestClient):
+        resp = client.get("/api/voice/realtime/providers")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["selected"] == "openai"
+        ids = {p["id"] for p in body["providers"]}
+        assert {"openai", "gemini", "elevenlabs", "ultravox"} <= ids
+        # no credential leakage
+        assert "api_key" not in resp.text and "key" not in {k for p in body["providers"] for k in p}
+
+    def test_patch_selects_then_clears(self, client: TestClient):
+        resp = client.patch("/api/voice/realtime/providers", json={"provider": "gemini"})
+        assert resp.status_code == 200
+        assert resp.json()["selected"] == "gemini"
+        # clear back to default
+        resp = client.patch("/api/voice/realtime/providers", json={"provider": None})
+        assert resp.status_code == 200
+        assert resp.json()["selected"] == "openai"
+
+    def test_patch_unknown_provider_422(self, client: TestClient):
+        resp = client.patch("/api/voice/realtime/providers", json={"provider": "bogus"})
+        assert resp.status_code == 422

--- a/autobot-backend/voice_processing/realtime/__init__.py
+++ b/autobot-backend/voice_processing/realtime/__init__.py
@@ -1,0 +1,38 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Multi-provider realtime voice architecture (Issue #9025).
+
+Defines a provider-agnostic realtime voice layer so the backend can swap the
+realtime STT/TTS provider (OpenAI Realtime, Gemini Live, ElevenLabs
+Conversational, Ultravox) without re-engineering the SDP-proxy endpoint or the
+MCP tool bridge.
+
+Mirrors the established ASR provider pattern in ``voice_processing.providers``
+(protocol + registry + config-driven selection, credential-gated).
+
+Public surface:
+    RealtimeVoiceProvider   — abstract base every realtime provider implements
+    RealtimeCapabilities    — declares transport + feature support per provider
+    RealtimeNegotiation     — provider-neutral SDP/offer negotiation result
+    RealtimeTransport       — supported negotiation transports
+    RealtimeProviderError   — raised when a provider cannot service a request
+"""
+
+from voice_processing.realtime.base import (
+    RealtimeCapabilities,
+    RealtimeNegotiation,
+    RealtimeProviderError,
+    RealtimeTransport,
+    RealtimeVoiceProvider,
+)
+
+__all__ = [
+    "RealtimeVoiceProvider",
+    "RealtimeCapabilities",
+    "RealtimeNegotiation",
+    "RealtimeTransport",
+    "RealtimeProviderError",
+]

--- a/autobot-backend/voice_processing/realtime/base.py
+++ b/autobot-backend/voice_processing/realtime/base.py
@@ -1,0 +1,148 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+RealtimeVoiceProvider abstract base + supporting types (Issue #9025).
+
+Every realtime voice backend (OpenAI Realtime, Gemini Live, ElevenLabs
+Conversational, Ultravox) implements ``RealtimeVoiceProvider``. The SDP-proxy
+endpoint and the MCP tool bridge talk only to this interface, so providers are
+drop-in.
+
+Design mirrors ``voice_processing.providers.SpeechProvider``: an abstract base
+with a ``provider_name`` / ``is_configured`` contract, credential-gated so a
+provider is only offered when its API key is present.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class RealtimeTransport(str, Enum):
+    """Negotiation transport a realtime provider speaks.
+
+    WEBRTC   — browser sends an SDP offer, provider returns an SDP answer
+               (OpenAI Realtime today).
+    WEBSOCKET — browser opens a websocket; provider returns connection params
+               (Gemini Live / ElevenLabs Conversational pattern).
+    """
+
+    WEBRTC = "webrtc"
+    WEBSOCKET = "websocket"
+
+
+class RealtimeProviderError(Exception):
+    """Raised when a provider cannot service a negotiation request.
+
+    Carries an HTTP-ish ``status`` so the endpoint can map it consistently:
+    503 = provider not configured/available, 502 = upstream error.
+    """
+
+    def __init__(self, message: str, status: int = 502) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+@dataclass
+class RealtimeCapabilities:
+    """Static declaration of what a realtime provider supports.
+
+    Surfaced to the frontend so it can adapt the UI (e.g. choose WebRTC vs
+    websocket transport, hide tool-calling toggles when unsupported).
+    """
+
+    transport: RealtimeTransport
+    #: provider can register MCP/function tools mid-session
+    supports_tools: bool = True
+    #: provider streams model audio back (TTS) over the same channel
+    supports_audio_output: bool = True
+    #: provider emits per-turn token/audio usage for cost tracking
+    supports_cost_tracking: bool = False
+
+
+@dataclass
+class RealtimeNegotiation:
+    """Provider-neutral result of negotiating a realtime session.
+
+    For WebRTC providers ``answer`` holds the SDP answer body and
+    ``media_type`` is ``application/sdp``. For websocket providers ``answer``
+    holds a JSON connection descriptor (URL + ephemeral token) and
+    ``media_type`` is ``application/json``.
+    """
+
+    answer: bytes
+    media_type: str = "application/sdp"
+    #: extra response headers (provider may surface ephemeral session ids etc.)
+    headers: dict[str, str] = field(default_factory=dict)
+
+
+class RealtimeVoiceProvider(ABC):
+    """Abstract base for a swappable realtime voice provider.
+
+    Concrete providers wrap a single upstream realtime API. The negotiate()
+    method is transport-agnostic: it consumes the browser's offer and returns
+    a :class:`RealtimeNegotiation` the endpoint relays back verbatim.
+
+    Tool registration is handled by the existing ``RealtimeMCPBridge`` which is
+    already provider-neutral, so providers do not re-implement tool routing —
+    they only declare ``supports_tools`` in their capabilities.
+    """
+
+    #: stable lowercase id used for config selection (e.g. "openai", "gemini")
+    provider_id: str = ""
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        """Human-readable provider name for logging/UI."""
+
+    @property
+    @abstractmethod
+    def is_configured(self) -> bool:
+        """True when this provider has the credentials it needs to run."""
+
+    @property
+    @abstractmethod
+    def capabilities(self) -> RealtimeCapabilities:
+        """Return this provider's static capability declaration."""
+
+    @abstractmethod
+    async def negotiate(
+        self,
+        *,
+        offer: str,
+        session_config: str,
+        session_id: str,
+    ) -> RealtimeNegotiation:
+        """Negotiate a realtime session and return a provider-neutral answer.
+
+        Args:
+            offer: the browser's WebRTC SDP offer (or websocket handshake blob)
+            session_config: provider session configuration JSON from the client
+            session_id: AutoBot-generated id for telemetry correlation
+
+        Returns:
+            RealtimeNegotiation with the answer body the endpoint relays.
+
+        Raises:
+            RealtimeProviderError: when the provider is unconfigured (status
+                503) or the upstream negotiation fails (status 502).
+        """
+
+    def describe(self) -> dict[str, Any]:
+        """Return JSON-safe metadata (never credentials) for the providers API."""
+        caps = self.capabilities
+        return {
+            "id": self.provider_id,
+            "name": self.provider_name,
+            "configured": self.is_configured,
+            "transport": caps.transport.value,
+            "supports_tools": caps.supports_tools,
+            "supports_audio_output": caps.supports_audio_output,
+            "supports_cost_tracking": caps.supports_cost_tracking,
+        }

--- a/autobot-backend/voice_processing/realtime/openai_provider.py
+++ b/autobot-backend/voice_processing/realtime/openai_provider.py
@@ -1,0 +1,123 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+OpenAI Realtime provider (Issue #9025) — first concrete RealtimeVoiceProvider.
+
+Wraps the existing SDP-proxy upstream call (originally inline in
+``api.realtime_session``, GH#7342) behind the provider abstraction. Behaviour is
+byte-identical to the previous inline implementation: it forwards the browser's
+SDP offer as multipart to OpenAI's Realtime API with the server-side
+OPENAI_API_KEY injected and returns the SDP answer. The key never reaches the
+browser.
+"""
+
+from __future__ import annotations
+
+import os
+
+import aiohttp
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import get_config
+from voice_processing.realtime.base import (
+    RealtimeCapabilities,
+    RealtimeNegotiation,
+    RealtimeProviderError,
+    RealtimeTransport,
+    RealtimeVoiceProvider,
+)
+
+logger = get_logger(__name__)
+
+_OPENAI_REALTIME_URL = "https://api.openai.com/v1/realtime/sessions"
+_OPENAI_BETA_HEADER = "realtime=v1"
+_DEFAULT_MODEL = "gpt-realtime-2"
+
+
+class OpenAIRealtimeProvider(RealtimeVoiceProvider):
+    """OpenAI Realtime WebRTC provider (default realtime voice provider)."""
+
+    provider_id = "openai"
+
+    @property
+    def provider_name(self) -> str:
+        return "OpenAI Realtime"
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self._api_key())
+
+    @property
+    def capabilities(self) -> RealtimeCapabilities:
+        return RealtimeCapabilities(
+            transport=RealtimeTransport.WEBRTC,
+            supports_tools=True,
+            supports_audio_output=True,
+            supports_cost_tracking=True,
+        )
+
+    @staticmethod
+    def _api_key() -> str:
+        """Return the OpenAI API key from SSOT config with env-var fallback."""
+        cfg = get_config()
+        return cfg.llm.openai_api_key or os.environ.get("OPENAI_API_KEY", "")
+
+    @staticmethod
+    def _model() -> str:
+        cfg = get_config()
+        return cfg.misc.voice_realtime_model or _DEFAULT_MODEL
+
+    async def negotiate(
+        self,
+        *,
+        offer: str,
+        session_config: str,
+        session_id: str,
+    ) -> RealtimeNegotiation:
+        """Proxy the SDP offer to OpenAI Realtime and return the SDP answer."""
+        api_key = self._api_key()
+        if not api_key:
+            logger.error("OPENAI_API_KEY not configured — cannot proxy SDP offer")
+            raise RealtimeProviderError("Voice service not available: API key not configured", status=503)
+
+        form = aiohttp.FormData()
+        form.add_field("model", self._model())
+        form.add_field("sdp", offer, content_type="text/plain")
+        form.add_field("session", session_config, content_type="application/json")
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "OpenAI-Beta": _OPENAI_BETA_HEADER,
+        }
+
+        body = await self._post(form, headers)
+        return RealtimeNegotiation(answer=body, media_type="application/sdp")
+
+    async def _post(self, form: aiohttp.FormData, headers: dict[str, str]) -> bytes:
+        """POST the offer upstream and map upstream failures to provider errors."""
+        timeout = aiohttp.ClientTimeout(connect=30, total=60)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as http:
+                async with http.post(_OPENAI_REALTIME_URL, data=form, headers=headers) as upstream:
+                    body = await upstream.read()
+                    self._raise_for_status(upstream.status, body)
+                    return body
+        except RealtimeProviderError:
+            raise
+        except aiohttp.ClientError as exc:
+            logger.error("Network error proxying SDP offer: %s", exc)
+            raise RealtimeProviderError("Network error contacting voice service", status=502)
+
+    @staticmethod
+    def _raise_for_status(status: int, body: bytes) -> None:
+        """Map upstream HTTP status to a RealtimeProviderError (502 on failure)."""
+        if status == 401:
+            logger.warning("OpenAI Realtime API returned 401 Unauthorized")
+            raise RealtimeProviderError("Upstream authentication failed", status=502)
+        if status >= 500:
+            logger.error("OpenAI Realtime API returned %s: %s", status, body[:256])
+            raise RealtimeProviderError(f"Upstream error: {status}", status=502)
+        if status not in (200, 201):
+            logger.warning("OpenAI Realtime API returned unexpected status %s", status)
+            raise RealtimeProviderError(f"Unexpected upstream status: {status}", status=502)

--- a/autobot-backend/voice_processing/realtime/registry.py
+++ b/autobot-backend/voice_processing/realtime/registry.py
@@ -1,0 +1,117 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Realtime voice provider registry + config-driven selection (Issue #9025).
+
+Mirrors ``voice_processing.providers.selection`` for the ASR tier:
+
+- A provider map keyed by stable id.
+- The active provider id comes from an in-process override (set per request)
+  falling back to ``AUTOBOT_VOICE_REALTIME_PROVIDER`` (ssot_config), defaulting
+  to "openai" — so the default realtime behaviour is unchanged (back-compat).
+- ``get_active_realtime_provider`` resolves the selected provider; if the
+  selection is unknown or the selected provider is unconfigured it falls back
+  to the default OpenAI provider (which itself reports unconfigured cleanly when
+  no key is present), so a bad config never crashes the endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import get_config
+from voice_processing.realtime.base import RealtimeVoiceProvider
+from voice_processing.realtime.openai_provider import OpenAIRealtimeProvider
+from voice_processing.realtime.seam import (
+    ElevenLabsConversationalProvider,
+    GeminiLiveProvider,
+    UltravoxProvider,
+)
+
+logger = get_logger(__name__)
+
+_DEFAULT_PROVIDER_ID = "openai"
+
+# Ordered so the default (openai) is first in any listing.
+_PROVIDER_MAP: dict[str, type[RealtimeVoiceProvider]] = {
+    "openai": OpenAIRealtimeProvider,
+    "gemini": GeminiLiveProvider,
+    "elevenlabs": ElevenLabsConversationalProvider,
+    "ultravox": UltravoxProvider,
+}
+
+# In-process per-conversation override (lost on restart; env is source of truth).
+_active_override: Optional[str] = None
+
+
+def _config_selected() -> str:
+    """Return the configured realtime provider id, lower-cased."""
+    cfg = get_config()
+    raw = (getattr(cfg.misc, "voice_realtime_provider", "") or "").strip().lower()
+    return raw or _DEFAULT_PROVIDER_ID
+
+
+def get_active_provider_id() -> str:
+    """Return the active provider id (override > config > default)."""
+    return (_active_override or _config_selected() or _DEFAULT_PROVIDER_ID).lower()
+
+
+def set_active_provider(provider_id: Optional[str]) -> None:
+    """Set the in-process active realtime provider override.
+
+    Pass ``None`` to clear the override and fall back to config/default.
+    Process-local — configure AUTOBOT_VOICE_REALTIME_PROVIDER for persistence.
+    """
+    global _active_override
+    if provider_id is not None:
+        normalized = provider_id.strip().lower()
+        if normalized not in _PROVIDER_MAP:
+            raise ValueError(f"Unknown realtime provider: {provider_id!r}. Valid: {list(_PROVIDER_MAP)}")
+        _active_override = normalized
+    else:
+        _active_override = None
+    logger.info("Active realtime voice provider set to: %s", _active_override or "(config default)")
+
+
+def get_provider_by_id(provider_id: str) -> Optional[RealtimeVoiceProvider]:
+    """Instantiate a provider by id, or None when the id is unknown."""
+    cls = _PROVIDER_MAP.get(provider_id.lower())
+    return cls() if cls else None
+
+
+def get_active_realtime_provider() -> RealtimeVoiceProvider:
+    """Resolve the active, configured realtime provider.
+
+    Resolution order:
+      1. The selected provider (override > config) when it is configured.
+      2. Otherwise the default OpenAI provider.
+
+    Always returns a provider instance (never None); the endpoint maps an
+    unconfigured provider to a 503 via RealtimeProviderError at negotiate time.
+    """
+    selected_id = get_active_provider_id()
+    provider = get_provider_by_id(selected_id)
+
+    if provider is None:
+        logger.warning(
+            "Realtime provider %r is unknown — falling back to default %r", selected_id, _DEFAULT_PROVIDER_ID
+        )
+        return OpenAIRealtimeProvider()
+
+    if not provider.is_configured and selected_id != _DEFAULT_PROVIDER_ID:
+        logger.warning(
+            "Selected realtime provider %r is not configured — falling back to default %r",
+            selected_id,
+            _DEFAULT_PROVIDER_ID,
+        )
+        return OpenAIRealtimeProvider()
+
+    return provider
+
+
+def list_realtime_providers() -> list[dict]:
+    """Return JSON-safe metadata for every realtime provider (never credentials)."""
+    return [cls().describe() for cls in _PROVIDER_MAP.values()]

--- a/autobot-backend/voice_processing/realtime/registry_test.py
+++ b/autobot-backend/voice_processing/realtime/registry_test.py
@@ -1,0 +1,159 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for the multi-provider realtime voice registry + selection (#9025).
+
+Scenarios:
+  - registry resolves the default provider (openai) with no config
+  - config / override selects a provider
+  - unknown override raises; unknown config falls back to default
+  - a selected-but-unconfigured non-default provider falls back to default
+  - the OpenAI provider's negotiate() proxies the SDP offer (provider I/O mocked)
+  - an unconfigured provider's negotiate() raises 503
+  - seam providers report configured state honestly and refuse cleanly (503)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from voice_processing.realtime import registry
+from voice_processing.realtime.base import RealtimeProviderError, RealtimeTransport
+from voice_processing.realtime.openai_provider import OpenAIRealtimeProvider
+from voice_processing.realtime.seam import GeminiLiveProvider
+
+
+@pytest.fixture(autouse=True)
+def _clear_override():
+    """Each test starts with no in-process override."""
+    registry.set_active_provider(None)
+    yield
+    registry.set_active_provider(None)
+
+
+# ── selection / registry resolution ───────────────────────────────────────────
+
+
+def test_default_provider_is_openai():
+    assert registry.get_active_provider_id() == "openai"
+    provider = registry.get_active_realtime_provider()
+    assert isinstance(provider, OpenAIRealtimeProvider)
+    assert provider.provider_id == "openai"
+
+
+def test_override_selects_provider():
+    registry.set_active_provider("gemini")
+    assert registry.get_active_provider_id() == "gemini"
+
+
+def test_unknown_override_raises():
+    with pytest.raises(ValueError):
+        registry.set_active_provider("does-not-exist")
+
+
+def test_unknown_config_falls_back_to_default():
+    cfg = MagicMock()
+    cfg.misc.voice_realtime_provider = "nonsense"
+    with patch.object(registry, "get_config", return_value=cfg):
+        provider = registry.get_active_realtime_provider()
+    assert isinstance(provider, OpenAIRealtimeProvider)
+
+
+def test_selected_unconfigured_non_default_falls_back_to_default():
+    # gemini selected but no GEMINI_API_KEY → fall back to openai
+    registry.set_active_provider("gemini")
+    with patch.object(GeminiLiveProvider, "is_configured", new=False):
+        provider = registry.get_active_realtime_provider()
+    assert isinstance(provider, OpenAIRealtimeProvider)
+
+
+def test_list_realtime_providers_metadata_no_secrets():
+    providers = registry.list_realtime_providers()
+    ids = {p["id"] for p in providers}
+    assert {"openai", "gemini", "elevenlabs", "ultravox"} <= ids
+    for p in providers:
+        assert set(p) == {
+            "id",
+            "name",
+            "configured",
+            "transport",
+            "supports_tools",
+            "supports_audio_output",
+            "supports_cost_tracking",
+        }
+
+
+# ── OpenAI provider dispatch (provider I/O mocked) ─────────────────────────────
+
+
+def _mock_aiohttp_session(status: int, body: bytes):
+    resp = MagicMock()
+    resp.status = status
+    resp.read = AsyncMock(return_value=body)
+    post_cm = MagicMock()
+    post_cm.__aenter__ = AsyncMock(return_value=resp)
+    post_cm.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.post = MagicMock(return_value=post_cm)
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=session)
+    session_cm.__aexit__ = AsyncMock(return_value=False)
+    return session_cm
+
+
+@pytest.mark.asyncio
+async def test_openai_negotiate_proxies_offer():
+    provider = OpenAIRealtimeProvider()
+    answer = b"v=0\r\nsdp-answer\r\n"
+    with (
+        patch.object(OpenAIRealtimeProvider, "_api_key", return_value="sk-test"),
+        patch("aiohttp.ClientSession", return_value=_mock_aiohttp_session(200, answer)),
+    ):
+        result = await provider.negotiate(offer="v=0", session_config="{}", session_id="sid")
+    assert result.answer == answer
+    assert result.media_type == "application/sdp"
+    assert provider.capabilities.transport is RealtimeTransport.WEBRTC
+
+
+@pytest.mark.asyncio
+async def test_openai_negotiate_unconfigured_raises_503():
+    provider = OpenAIRealtimeProvider()
+    with patch.object(OpenAIRealtimeProvider, "_api_key", return_value=""):
+        with pytest.raises(RealtimeProviderError) as exc:
+            await provider.negotiate(offer="v=0", session_config="{}", session_id="sid")
+    assert exc.value.status == 503
+
+
+@pytest.mark.asyncio
+async def test_openai_negotiate_upstream_500_maps_502():
+    provider = OpenAIRealtimeProvider()
+    with (
+        patch.object(OpenAIRealtimeProvider, "_api_key", return_value="sk-test"),
+        patch("aiohttp.ClientSession", return_value=_mock_aiohttp_session(500, b"boom")),
+    ):
+        with pytest.raises(RealtimeProviderError) as exc:
+            await provider.negotiate(offer="v=0", session_config="{}", session_id="sid")
+    assert exc.value.status == 502
+
+
+# ── seam providers refuse cleanly ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_seam_provider_refuses_with_503():
+    provider = GeminiLiveProvider()
+    with pytest.raises(RealtimeProviderError) as exc:
+        await provider.negotiate(offer="x", session_config="{}", session_id="sid")
+    assert exc.value.status == 503
+
+
+def test_seam_provider_configured_reflects_env():
+    provider = GeminiLiveProvider()
+    with patch.dict("os.environ", {"GEMINI_API_KEY": "k"}, clear=False):
+        assert provider.is_configured is True
+    with patch.dict("os.environ", {}, clear=True):
+        assert GeminiLiveProvider().is_configured is False

--- a/autobot-backend/voice_processing/realtime/seam.py
+++ b/autobot-backend/voice_processing/realtime/seam.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Follow-up realtime provider seams (Issue #9025).
+
+These declare the extension points for additional realtime voice providers
+named in the AC (Gemini Live, ElevenLabs Conversational, Ultravox). They are
+NOT fake implementations: each reports ``is_configured`` honestly from its
+credential env var and raises ``RealtimeProviderError`` (503) from negotiate()
+until the concrete upstream handshake is wired in a follow-up.
+
+This keeps the registry/selection/UI surface complete (providers appear with
+their capabilities + configured state) without shipping broken impls. Wiring a
+provider = replace its ``negotiate()`` body with the real handshake; the rest
+of the architecture is unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+
+from autobot_shared.logging_manager import get_logger
+from voice_processing.realtime.base import (
+    RealtimeCapabilities,
+    RealtimeNegotiation,
+    RealtimeProviderError,
+    RealtimeTransport,
+    RealtimeVoiceProvider,
+)
+
+logger = get_logger(__name__)
+
+
+class _SeamProvider(RealtimeVoiceProvider):
+    """Base for not-yet-wired realtime providers.
+
+    Subclasses set provider_id, a display name, a credential env var and a
+    transport. negotiate() refuses cleanly until the upstream is implemented.
+    """
+
+    _display_name: str = ""
+    _credential_env: str = ""
+    _transport: RealtimeTransport = RealtimeTransport.WEBSOCKET
+    _supports_cost_tracking: bool = False
+
+    @property
+    def provider_name(self) -> str:
+        return self._display_name
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self._credential_env and os.environ.get(self._credential_env))
+
+    @property
+    def capabilities(self) -> RealtimeCapabilities:
+        return RealtimeCapabilities(
+            transport=self._transport,
+            supports_tools=True,
+            supports_audio_output=True,
+            supports_cost_tracking=self._supports_cost_tracking,
+        )
+
+    async def negotiate(
+        self,
+        *,
+        offer: str,
+        session_config: str,
+        session_id: str,
+    ) -> RealtimeNegotiation:
+        logger.warning(
+            "Realtime provider %r selected but its upstream handshake is not yet implemented (#9025 follow-up)",
+            self.provider_id,
+        )
+        raise RealtimeProviderError(
+            f"Realtime provider '{self.provider_id}' is not yet available — wire its upstream handshake (#9025).",
+            status=503,
+        )
+
+
+class GeminiLiveProvider(_SeamProvider):
+    """Gemini Live realtime provider seam (AC stretch goal)."""
+
+    provider_id = "gemini"
+    _display_name = "Gemini Live"
+    _credential_env = "GEMINI_API_KEY"
+    _transport = RealtimeTransport.WEBSOCKET
+    _supports_cost_tracking = True
+
+
+class ElevenLabsConversationalProvider(_SeamProvider):
+    """ElevenLabs Conversational AI realtime provider seam."""
+
+    provider_id = "elevenlabs"
+    _display_name = "ElevenLabs Conversational"
+    _credential_env = "ELEVENLABS_API_KEY"
+    _transport = RealtimeTransport.WEBSOCKET
+
+
+class UltravoxProvider(_SeamProvider):
+    """Ultravox realtime provider seam."""
+
+    provider_id = "ultravox"
+    _display_name = "Ultravox"
+    _credential_env = "ULTRAVOX_API_KEY"
+    _transport = RealtimeTransport.WEBSOCKET

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1387,6 +1387,14 @@ class MiscConfig(BaseSettings):
     voice_toolset_bundle: str = Field(default="voice_safe", alias="AUTOBOT_VOICE_TOOLSETS")
     voice_disabled_tools: str = Field(default="", alias="AUTOBOT_VOICE_DISABLED_TOOLS")
     voice_realtime_model: str = Field(default="gpt-realtime-2", alias="AUTOBOT_VOICE_REALTIME_MODEL")
+    voice_realtime_provider: str = Field(
+        default="openai",
+        alias="AUTOBOT_VOICE_REALTIME_PROVIDER",
+        description=(
+            "Active realtime voice provider (#9025): openai | gemini | elevenlabs | ultravox. "
+            "Default openai keeps current behaviour; unconfigured/unknown selections fall back to openai."
+        ),
+    )
     voice_realtime_max_seconds: int = Field(
         default=1800,
         alias="AUTOBOT_VOICE_REALTIME_MAX_SECONDS",


### PR DESCRIPTION
## Thinking Path
#9025 — multi-provider realtime voice architecture (swap voice providers). Reused the existing transcriber ASR provider/registry pattern + the existing realtime SDP-proxy endpoint; added a provider abstraction so the realtime voice provider is swappable. **Inert: default = openai = prior behavior unchanged.**

## What Changed
- `voice_processing/realtime/`: `RealtimeVoiceProvider` protocol + neutral types (`RealtimeNegotiation`/`RealtimeCapabilities`/`RealtimeTransport`), `registry.py` (config/override-driven selection, safe default fallback), `openai_provider.py` (the existing SDP proxy, now behind the abstraction), `seam.py` (Gemini Live / ElevenLabs / Ultravox — credential-gated seams that 503 until their handshake is wired).
- `api/realtime_session.py`: `/voice/realtime/session` dispatches through the registry (+ `X-Realtime-Provider` header, 503/502 mapping preserved); new `GET/PATCH /voice/realtime/providers` (list + select). `services/realtime_mcp_bridge.py` (tool-calls) left provider-neutral → consistent tool interface across providers.
- `ssot_config`: `AUTOBOT_VOICE_REALTIME_PROVIDER` (default `openai`).

## Verification
- `pytest` (registry + realtime_session) → **28 passed** (default resolves openai, override selects, unknown→default, unconfigured-non-default→default fallback, no credential leak, dispatch proxies offer, 503/502 mapping); black + py_compile clean; import-smoke OK.
- Inert confirmed: default openai → byte-identical prior SDP-proxy behavior.

## Notes / follow-ups
- Concrete Gemini Live / ElevenLabs / Ultravox `negotiate()` handshakes are documented seams (need provider SDKs/creds) — drop-in once available; registry/config/API already complete.
- Frontend provider-selection UI is a thin follow-up consumer of `GET/PATCH /voice/realtime/providers`.

## Model Used
Opus 4.8

Fixes #9025
