### PR TITLE
fix(auth): async redis for SSO/PKCE OAuth-state + reconcile RBAC seed to canonical Permission enum (#10284, #10221)

### DIFF
--- a/autobot-slm-backend/tests/services/test_sso_service.py
+++ b/autobot-slm-backend/tests/services/test_sso_service.py
@@ -122,6 +122,16 @@ def _mock_redis(stored: dict | None = None) -> tuple[MagicMock, dict]:
     return redis, store
 
 
+def _patch_redis(redis_or_none):
+    """Return a context manager that patches get_async_redis_client in sso_service.
+
+    sso_service calls ``await get_async_redis_client()``; patching the function
+    with an AsyncMock whose return_value is *redis_or_none* makes the await
+    resolve to the desired mock (or None to simulate Redis unavailability).
+    """
+    return patch.object(_sso_mod, "get_async_redis_client", new=AsyncMock(return_value=redis_or_none))
+
+
 # ---------------------------------------------------------------------------
 # _generate_oauth_state
 # ---------------------------------------------------------------------------
@@ -134,7 +144,7 @@ class TestGenerateOauthState:
 
         redis, store = _mock_redis()
         service = _make_service()
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+        with _patch_redis(redis):
             state, verifier = await service._generate_oauth_state(_PROVIDER_ID)
 
         assert state
@@ -150,7 +160,7 @@ class TestGenerateOauthState:
 
         redis, _ = _mock_redis()
         service = _make_service()
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+        with _patch_redis(redis):
             state, verifier = await service._generate_oauth_state(_PROVIDER_ID)
 
         expected_payload = json.dumps({"provider_id": str(_PROVIDER_ID), "code_verifier": verifier})
@@ -159,7 +169,7 @@ class TestGenerateOauthState:
     @pytest.mark.asyncio
     async def test_returns_token_even_when_redis_unavailable(self):
         service = _make_service()
-        with patch.object(_sso_mod, "get_redis_client", return_value=None):
+        with _patch_redis(None):
             state, verifier = await service._generate_oauth_state(_PROVIDER_ID)
         assert state  # token still generated; Redis write silently skipped
         assert verifier  # verifier is still returned
@@ -175,7 +185,7 @@ class TestValidateOauthState:
     async def test_round_trip_returns_provider_id(self):
         redis, store = _mock_redis()
         service = _make_service()
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+        with _patch_redis(redis):
             state, _ = await service._generate_oauth_state(_PROVIDER_ID)
             recovered_id, recovered_verifier = await service._validate_oauth_state(state)
 
@@ -187,7 +197,7 @@ class TestValidateOauthState:
         """GETDEL must make state single-use to prevent replay attacks."""
         redis, store = _mock_redis()
         service = _make_service()
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+        with _patch_redis(redis):
             state, _ = await service._generate_oauth_state(_PROVIDER_ID)
             await service._validate_oauth_state(state)  # first use succeeds
             with pytest.raises(SSOAuthenticationError, match="Invalid or expired"):
@@ -197,14 +207,14 @@ class TestValidateOauthState:
     async def test_invalid_state_raises(self):
         redis, _ = _mock_redis()
         service = _make_service()
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+        with _patch_redis(redis):
             with pytest.raises(SSOAuthenticationError, match="Invalid or expired"):
                 await service._validate_oauth_state("nonexistent-state-token")
 
     @pytest.mark.asyncio
     async def test_redis_unavailable_raises(self):
         service = _make_service()
-        with patch.object(_sso_mod, "get_redis_client", return_value=None):
+        with _patch_redis(None):
             with pytest.raises(SSOAuthenticationError, match="Redis unavailable"):
                 await service._validate_oauth_state("any-state")
 
@@ -213,7 +223,7 @@ class TestValidateOauthState:
         """Key must be consumed — no residual entry in Redis after successful validation."""
         redis, store = _mock_redis()
         service = _make_service()
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+        with _patch_redis(redis):
             state, _ = await service._generate_oauth_state(_PROVIDER_ID)
             await service._validate_oauth_state(state)
 
@@ -233,7 +243,7 @@ class TestPkceStateStorage:
 
         redis, _ = _mock_redis()
         service = _make_service()
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+        with _patch_redis(redis):
             state, verifier = await service._generate_oauth_state(_PROVIDER_ID)
 
         assert isinstance(state, str) and len(verifier) >= 43
@@ -251,7 +261,7 @@ class TestPkceStateStorage:
         verifier = "v" * 64
         store["sso:state:abc"] = json.dumps({"provider_id": str(_PROVIDER_ID), "code_verifier": verifier})
         service = _make_service()
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+        with _patch_redis(redis):
             got_pid, got_verifier = await service._validate_oauth_state("abc")
 
         assert got_pid == _PROVIDER_ID and got_verifier == verifier
@@ -262,7 +272,7 @@ class TestPkceStateStorage:
         redis, store = _mock_redis()
         store["sso:state:abc"] = str(_PROVIDER_ID)
         service = _make_service()
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+        with _patch_redis(redis):
             got_pid, got_verifier = await service._validate_oauth_state("abc")
 
         assert got_pid == _PROVIDER_ID and got_verifier is None
@@ -272,7 +282,7 @@ class TestPkceStateStorage:
         """Missing state token raises SSOAuthenticationError."""
         redis, _ = _mock_redis()
         service = _make_service()
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+        with _patch_redis(redis):
             with pytest.raises(SSOAuthenticationError):
                 await service._validate_oauth_state("nonexistent")
 
@@ -282,7 +292,7 @@ class TestPkceStateStorage:
         redis, store = _mock_redis()
         store["sso:state:abc"] = "{not-valid-json-and-not-a-uuid"
         service = _make_service()
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+        with _patch_redis(redis):
             with pytest.raises(SSOAuthenticationError):
                 await service._validate_oauth_state("abc")
 
@@ -387,7 +397,7 @@ class TestSamlRelayStateRedisRoundTrip:
             {"headers": [("Location", "https://idp.example.com/sso")]},
         )
         with (
-            patch.object(_sso_mod, "get_redis_client", return_value=redis),
+            _patch_redis(redis),
             patch.object(service, "_build_saml_client", return_value=mock_client),
         ):
             redirect_url, relay_state = await service._generate_saml_authn_request(provider)
@@ -408,7 +418,7 @@ class TestSamlRelayStateRedisRoundTrip:
             {"headers": [("Location", "https://idp.example.com/sso")]},
         )
         with (
-            patch.object(_sso_mod, "get_redis_client", return_value=redis),
+            _patch_redis(redis),
             patch.object(service, "_build_saml_client", return_value=mock_client),
         ):
             _, relay_state = await service._generate_saml_authn_request(provider)
@@ -427,7 +437,7 @@ class TestSamlRelayStateRedisRoundTrip:
             "req-id",
             {"headers": [("Location", "https://idp.example.com/sso")]},
         )
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+        with _patch_redis(redis):
             with patch.object(service, "_build_saml_client", return_value=mock_client):
                 _, relay_state = await service._generate_saml_authn_request(provider)
             recovered_id, recovered_verifier = await service._validate_oauth_state(relay_state)
@@ -449,7 +459,7 @@ class TestSamlRelayStateRedisRoundTrip:
             "req-id",
             {"headers": [("Location", "https://idp.example.com/sso")]},
         )
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+        with _patch_redis(redis):
             with patch.object(service, "_build_saml_client", return_value=mock_client):
                 _, relay_state = await service._generate_saml_authn_request(provider)
             await service._validate_oauth_state(relay_state)
@@ -468,7 +478,7 @@ class TestSamlRelayStateRedisRoundTrip:
             {"headers": [("Location", "https://idp.example.com/sso")]},
         )
         with (
-            patch.object(_sso_mod, "get_redis_client", return_value=None),
+            _patch_redis(None),
             patch.object(service, "_build_saml_client", return_value=mock_client),
         ):
             redirect_url, relay_state = await service._generate_saml_authn_request(provider)
@@ -490,7 +500,7 @@ class TestSamlRelayStateRedisRoundTrip:
             {"headers": [("Location", expected_url)]},
         )
         with (
-            patch.object(_sso_mod, "get_redis_client", return_value=redis),
+            _patch_redis(redis),
             patch.object(service, "_build_saml_client", return_value=mock_client),
         ):
             redirect_url, _ = await service._generate_saml_authn_request(provider)
@@ -1173,7 +1183,7 @@ class TestCompleteLoginReturnsTuple:
         fake_user.username = "oauthuser"
 
         redis, store = _mock_redis()
-        with patch.object(_sso_mod, "get_redis_client", return_value=redis):
+        with _patch_redis(redis):
             state, _verifier = await service._generate_oauth_state(_PROVIDER_ID)
 
         provider = _make_oauth_provider()
@@ -1183,7 +1193,7 @@ class TestCompleteLoginReturnsTuple:
             patch.object(service, "_exchange_oauth_code", AsyncMock(return_value={"access_token": "t"})),
             patch.object(service, "_get_oauth_userinfo", AsyncMock(return_value={"sub": "ext1", "email": "u@e.com"})),
             patch.object(service, "_find_or_provision_user", AsyncMock(return_value=fake_user)),
-            patch.object(_sso_mod, "get_redis_client", return_value=redis),
+            _patch_redis(redis),
         ):
             result = await service.complete_oauth_login("code", state, "https://app/cb")
 

--- a/autobot-slm-backend/user_management/services/sso_service.py
+++ b/autobot-slm-backend/user_management/services/sso_service.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from sqlalchemy import or_, select
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from user_management.models.role import Role
 from user_management.models.sso import SSOProvider, SSOProviderType, UserSSOLink
 from user_management.models.user import User
@@ -227,7 +227,7 @@ class SSOService(BaseService):
         """Generate OAuth2 state + PKCE verifier; store both in Redis with TTL."""
         state = secrets.token_urlsafe(32)
         code_verifier = secrets.token_urlsafe(64)
-        redis = get_redis_client()
+        redis = await get_async_redis_client()
         if redis:
             payload = json.dumps({"provider_id": str(provider_id), "code_verifier": code_verifier})
             await redis.set(f"sso:state:{state}", payload, ex=OAUTH_STATE_TTL_SECONDS)
@@ -235,7 +235,7 @@ class SSOService(BaseService):
 
     async def _validate_oauth_state(self, state: str) -> tuple[uuid.UUID, str | None]:
         """Validate state via atomic GETDEL (single-use). Returns (provider_id, code_verifier)."""
-        redis = get_redis_client()
+        redis = await get_async_redis_client()
         if not redis:
             raise SSOAuthenticationError("Redis unavailable for state validation")
         raw = await redis.getdel(f"sso:state:{state}")
@@ -444,7 +444,7 @@ class SSOService(BaseService):
         """Generate SAML AuthnRequest; relay state stored in Redis with 10-min TTL."""
         client = self._build_saml_client(provider)
         relay_state = secrets.token_urlsafe(32)
-        redis = get_redis_client()
+        redis = await get_async_redis_client()
         if redis:
             await redis.set(f"sso:state:{relay_state}", str(provider.id), ex=600)
         request_id, info = client.prepare_for_authenticate()

--- a/autobot_shared/auth/permissions.py
+++ b/autobot_shared/auth/permissions.py
@@ -120,137 +120,6 @@ class Role(str, Enum):
 # Canonical role-to-permission mappings.
 # Both autobot-backend (auth_rbac.py) and autobot-slm-backend import this dict
 # so that a permission added here is enforced by both services automatically.
-# Default system permissions for database seeding.
-# Tuple layout: (name, resource, action, description)
-SYSTEM_PERMISSIONS: List[tuple] = [
-    # User management
-    ("users:read", "users", "read", "View users"),
-    ("users:create", "users", "create", "Create users"),
-    ("users:update", "users", "update", "Update users"),
-    ("users:delete", "users", "delete", "Delete users"),
-    # Team management
-    ("teams:read", "teams", "read", "View teams"),
-    ("teams:create", "teams", "create", "Create teams"),
-    ("teams:manage", "teams", "manage", "Manage team members"),
-    ("teams:delete", "teams", "delete", "Delete teams"),
-    # Knowledge base
-    ("knowledge:read", "knowledge", "read", "View knowledge base"),
-    ("knowledge:write", "knowledge", "write", "Add/edit knowledge"),
-    ("knowledge:delete", "knowledge", "delete", "Delete knowledge entries"),
-    # Chat
-    ("chat:use", "chat", "use", "Use chat functionality"),
-    ("chat:history", "chat", "history", "View chat history"),
-    # Files
-    ("files:view", "files", "view", "View files"),
-    ("files:upload", "files", "upload", "Upload files"),
-    ("files:download", "files", "download", "Download files"),
-    ("files:delete", "files", "delete", "Delete files"),
-    # Settings
-    ("settings:read", "settings", "read", "View settings"),
-    ("settings:write", "settings", "write", "Modify settings"),
-    # Admin
-    ("admin:access", "admin", "access", "Access admin panel"),
-    ("admin:users", "admin", "users", "Manage all users"),
-    ("admin:organization", "admin", "organization", "Manage organization"),
-    # Audit (Issue #683: Role-Based Access Control)
-    ("audit:read", "audit", "read", "View audit logs"),
-    ("audit:write", "audit", "write", "Manage audit logs (cleanup)"),
-    # Unified secrets — team/role vault access (#10088). The system/user/company/
-    # node vaults are gated by admin / ownership / LLC-membership, so only the
-    # team and role vaults consult these RBAC permissions (services/secrets_authz).
-    ("secrets:team:read", "secrets", "team:read", "Read team-vault secrets"),
-    ("secrets:team:write", "secrets", "team:write", "Write team-vault secrets"),
-    ("secrets:team:share", "secrets", "team:share", "Share team-vault secrets"),
-    ("secrets:team:revoke", "secrets", "team:revoke", "Revoke team-vault secret grants"),
-    ("secrets:role:read", "secrets", "role:read", "Read role-vault secrets"),
-    ("secrets:role:write", "secrets", "role:write", "Write role-vault secrets"),
-    ("secrets:role:share", "secrets", "role:share", "Share role-vault secrets"),
-    ("secrets:role:revoke", "secrets", "role:revoke", "Revoke role-vault secret grants"),
-    # Service management (#10198) — gates the SLM/service-management surface.
-    ("service.management", "service", "management", "Manage services / SLM administrative surface"),
-]
-
-# Default system roles with their permissions for database seeding.
-SYSTEM_ROLES: Dict[str, Dict] = {
-    "admin": {
-        "description": "Full administrative access",
-        "priority": 100,
-        "permissions": [
-            "users:read",
-            "users:create",
-            "users:update",
-            "users:delete",
-            "teams:read",
-            "teams:create",
-            "teams:manage",
-            "teams:delete",
-            "knowledge:read",
-            "knowledge:write",
-            "knowledge:delete",
-            "chat:use",
-            "chat:history",
-            "files:view",
-            "files:upload",
-            "files:download",
-            "files:delete",
-            "settings:read",
-            "settings:write",
-            "admin:access",
-            "admin:users",
-            "admin:organization",
-            "audit:read",
-            "audit:write",
-            # Unified secrets (#10088): full team/role vault control.
-            "secrets:team:read",
-            "secrets:team:write",
-            "secrets:team:share",
-            "secrets:team:revoke",
-            "secrets:role:read",
-            "secrets:role:write",
-            "secrets:role:share",
-            "secrets:role:revoke",
-            "service.management",
-        ],
-    },
-    "user": {
-        "description": "Standard user access",
-        "priority": 50,
-        "permissions": [
-            "users:read",
-            "teams:read",
-            "knowledge:read",
-            "knowledge:write",
-            "chat:use",
-            "chat:history",
-            "files:view",
-            "files:upload",
-            "files:download",
-            "settings:read",
-            # Unified secrets (#10088): members read/write their team/role vault
-            # secrets; sharing/revoking grants stays admin-only.
-            "secrets:team:read",
-            "secrets:team:write",
-            "secrets:role:read",
-            "secrets:role:write",
-        ],
-    },
-    "readonly": {
-        "description": "Read-only access",
-        "priority": 10,
-        "permissions": [
-            "users:read",
-            "teams:read",
-            "knowledge:read",
-            "chat:history",
-            "files:view",
-            "files:download",
-            "settings:read",
-        ],
-    },
-    # Issue #744: Guest role REMOVED - security vulnerability
-    # Unauthenticated requests must be rejected, not assigned guest permissions
-}
-
 ROLE_PERMISSIONS: Dict[Role, List[Permission]] = {
     Role.ADMIN: [
         Permission.API_READ,
@@ -372,3 +241,104 @@ ROLE_PERMISSIONS: Dict[Role, List[Permission]] = {
         Permission.FILES_VIEW,
     ],
 }
+
+
+# ---------------------------------------------------------------------------
+# DB seeding helpers — generated from canonical sources above so a single edit
+# to Permission / ROLE_PERMISSIONS propagates automatically to both.
+# ---------------------------------------------------------------------------
+
+# Legacy colon-style secrets vault permissions required by secrets_authz policy
+# (#10088).  Not represented in the Permission enum (colon composite names) but
+# must appear in SYSTEM_PERMISSIONS and relevant SYSTEM_ROLES entries.
+_SECRETS_VAULT_LEGACY: List[tuple] = [
+    ("secrets:team:read", "secrets", "team:read", "Read team-vault secrets"),
+    ("secrets:team:write", "secrets", "team:write", "Write team-vault secrets"),
+    ("secrets:team:share", "secrets", "team:share", "Share team-vault secrets"),
+    ("secrets:team:revoke", "secrets", "team:revoke", "Revoke team-vault secret grants"),
+    ("secrets:role:read", "secrets", "role:read", "Read role-vault secrets"),
+    ("secrets:role:write", "secrets", "role:write", "Write role-vault secrets"),
+    ("secrets:role:share", "secrets", "role:share", "Share role-vault secrets"),
+    ("secrets:role:revoke", "secrets", "role:revoke", "Revoke role-vault secret grants"),
+]
+
+_SECRETS_ADMIN_PERMS: List[str] = [row[0] for row in _SECRETS_VAULT_LEGACY]
+_SECRETS_USER_PERMS: List[str] = [
+    "secrets:team:read",
+    "secrets:team:write",
+    "secrets:role:read",
+    "secrets:role:write",
+]
+
+
+def _perm_description(perm: Permission) -> str:
+    """Generate a human-readable description from a dot-style permission value."""
+    parts = perm.value.split(".")
+    resource = ".".join(parts[:-1]) if len(parts) > 1 else perm.value
+    action = parts[-1] if len(parts) > 1 else perm.value
+    return f"{action.capitalize()} {resource}"
+
+
+def _build_system_permissions() -> List[tuple]:
+    """Generate SYSTEM_PERMISSIONS from the canonical Permission enum.
+
+    Each entry: (name, resource, action, description).
+    The 'name' field equals the Permission enum value (dot-style), making it
+    the primary key used by DB seeding and parity tests.  Legacy colon-style
+    secrets:* entries are appended because the secrets_authz policy uses names
+    not representable in the dot-style enum (#10088).
+    """
+    rows: List[tuple] = []
+    for perm in Permission:
+        parts = perm.value.split(".")
+        resource = ".".join(parts[:-1]) if len(parts) > 1 else perm.value
+        action = parts[-1] if len(parts) > 1 else perm.value
+        rows.append((perm.value, resource, action, _perm_description(perm)))
+    rows.extend(_SECRETS_VAULT_LEGACY)
+    return rows
+
+
+_ROLE_META: Dict[Role, Dict] = {
+    Role.ADMIN: {"description": "Full administrative access", "priority": 100},
+    Role.OPERATOR: {"description": "Operator access for day-to-day service management", "priority": 80},
+    Role.ANALYST: {"description": "Analytics and read-heavy access", "priority": 60},
+    Role.EDITOR: {"description": "Content and knowledge editing access", "priority": 55},
+    Role.USER: {"description": "Standard user access", "priority": 50},
+    Role.READONLY: {"description": "Read-only access", "priority": 10},
+}
+
+
+def _build_system_roles() -> Dict[str, Dict]:
+    """Generate SYSTEM_ROLES from ROLE_PERMISSIONS.
+
+    Each role entry carries every dot-style permission from ROLE_PERMISSIONS plus
+    the legacy colon-style secrets:* permissions required by secrets_authz (#10088).
+    Priority and description come from _ROLE_META.
+    """
+    result: Dict[str, Dict] = {}
+    for role, perms in ROLE_PERMISSIONS.items():
+        dot_perms = [p.value if isinstance(p, Permission) else p for p in perms]
+        if role is Role.ADMIN:
+            extra = _SECRETS_ADMIN_PERMS
+        elif role is Role.USER:
+            extra = _SECRETS_USER_PERMS
+        else:
+            extra = []
+        meta = _ROLE_META.get(role, {"description": role.value, "priority": 0})
+        result[role.value] = {
+            "description": meta["description"],
+            "priority": meta["priority"],
+            "permissions": dot_perms + extra,
+        }
+    return result
+
+
+# Default system permissions for database seeding — generated from the canonical
+# Permission enum so it is always in sync.  Tuple layout: (name, resource, action, description).
+SYSTEM_PERMISSIONS: List[tuple] = _build_system_permissions()
+
+# Default system roles with their permissions for database seeding — generated
+# from ROLE_PERMISSIONS so a single edit propagates here automatically.
+# Issue #744: Guest role REMOVED — security vulnerability; unauthenticated
+# requests must be rejected, not assigned guest permissions.
+SYSTEM_ROLES: Dict[str, Dict] = _build_system_roles()


### PR DESCRIPTION
## Thinking Path
Two auth-correctness defects. #10284: SSO/PKCE/SAML OAuth-state used the sync `get_redis_client()` then `await`ed its non-awaitable methods → `TypeError` against real Redis (tests false-green via AsyncMock). #10221: `autobot_shared/auth/permissions.py` carried two divergent RBAC vocabularies — the hand-maintained colon-style `SYSTEM_PERMISSIONS`/`SYSTEM_ROLES` DB seed vs the canonical dot-style `Permission` enum / `ROLE_PERMISSIONS` — making the parity tests red.

## What Changed
- `autobot-slm-backend/user_management/services/sso_service.py` — `_generate_oauth_state`, `_validate_oauth_state`, `_generate_saml_authn_request` now `await get_async_redis_client()` (true async client) instead of the sync client.
- `autobot-slm-backend/tests/services/test_sso_service.py` — added `_patch_redis` helper; all 21 patch sites now patch the async client, exercising the correct code path.
- `autobot_shared/auth/permissions.py` — `SYSTEM_PERMISSIONS`/`SYSTEM_ROLES` are now **generated from** the canonical `Permission` enum / `ROLE_PERMISSIONS` (single source of truth), including the `operator` role and the ~25 previously-unseeded dot permissions. Legacy `secrets:*` composite entries preserved for the secrets-authz tests.

## Verification
- `python -m py_compile` both files → OK.
- `test_slm_permission_parity.py` → **8 passed** (3 previously-red now green).
- `tests/services/test_sso_service.py` → **55 passed**.
- Closes #10284, #10221.

## Follow-up
DB data-migration needed for already-seeded databases (colon→dot permission/role rows) — will file a follow-up issue. Runtime RBAC (`ROLE_PERMISSIONS`) was never broken; fresh installs seed correctly now.

## Model Used
Claude Opus 4.8 (senior-backend-engineer subagent).
