### PR TITLE
fix(plugins): file-path import fallback for hyphenated core-plugins dirs (#10294)

### DIFF
--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -12,6 +12,7 @@ Issue #6970 - Validate declared hooks against HOOK_REGISTRY on load.
 Issue #6971 - Raise PluginLoadError for missing required env vars.
 """
 
+import sys
 import importlib
 import importlib.util
 import json
@@ -43,6 +44,11 @@ class PluginLoader:
         """
         self.plugin_dirs = plugin_dirs or []
         self.registry = PluginRegistry()
+        # Plugin name -> on-disk directory, captured at discovery. Core plugins
+        # live in hyphenated dirs (plugins/core-plugins/hello-plugin) whose dotted
+        # entry_point (plugins.core_plugins.hello_plugin.main) is not importable;
+        # the dir lets the loader import the module file by path instead (#10294).
+        self._manifest_dirs: Dict[str, Path] = {}
 
     def discover_plugins(self) -> List[PluginManifest]:
         """
@@ -66,6 +72,7 @@ class PluginLoader:
 
                     manifest = PluginManifest(**data)
                     manifests.append(manifest)
+                    self._manifest_dirs[manifest.name] = manifest_file.parent
                     logger.info("Discovered plugin: %s v%s", manifest.name, manifest.version)
 
                 except Exception as e:
@@ -118,7 +125,7 @@ class PluginLoader:
                 )
 
             # Import plugin module
-            plugin_class = self._import_plugin_class(manifest.entry_point)
+            plugin_class = self._import_plugin_class(manifest.entry_point, self._manifest_dirs.get(manifest.name))
             if not plugin_class:
                 return None
 
@@ -260,19 +267,31 @@ class PluginLoader:
             for env in plugin.manifest.required_env
         }
 
-    def _import_plugin_class(self, entry_point: str) -> Type[BasePlugin] | None:
+    def _import_plugin_class(self, entry_point: str, plugin_dir: Path | None = None) -> Type[BasePlugin] | None:
         """
         Import plugin class from entry point.
 
+        Tries ``importlib.import_module(entry_point)`` first. When that fails
+        (core plugins whose hyphenated directory is not importable as a dotted
+        module — #10294), falls back to loading the module file from the plugin's
+        on-disk directory via ``importlib.util.spec_from_file_location``.
+
         Args:
-            entry_point: Python module path (e.g., 'plugins.hello.main')
+            entry_point: Python module path (e.g., 'plugins.core_plugins.hello_plugin.main')
+            plugin_dir:  Directory containing plugin.json — used for the file-path fallback.
 
         Returns:
             Plugin class or None on failure
         """
         try:
-            # Import module
-            module = importlib.import_module(entry_point)
+            module = None
+            try:
+                module = importlib.import_module(entry_point)
+            except ModuleNotFoundError as exc:
+                module = self._import_from_file(entry_point, plugin_dir)
+                if module is None:
+                    logger.error("Failed to import plugin module %s: %s", entry_point, exc)
+                    return None
 
             # Look for Plugin class or class with 'Plugin' suffix
             for attr_name in dir(module):
@@ -286,6 +305,30 @@ class PluginLoader:
         except Exception as e:
             logger.error("Failed to import plugin %s: %s", entry_point, e, exc_info=True)
             return None
+
+    def _import_from_file(self, entry_point: str, plugin_dir: Path | None):
+        """Load a plugin module by file path from its on-disk directory (#10294)."""
+        if plugin_dir is None:
+            return None
+        module_file = entry_point.rsplit(".", 1)[-1] + ".py"  # "...main" -> main.py
+        module_path = Path(plugin_dir) / module_file
+        if not module_path.is_file():
+            logger.error("Plugin module file not found for %s at %s", entry_point, module_path)
+            return None
+        spec = importlib.util.spec_from_file_location(entry_point, module_path)
+        if spec is None or spec.loader is None:
+            return None
+        module = importlib.util.module_from_spec(spec)
+        # Register before exec so intra-plugin dataclasses / relative refs resolve.
+        sys.modules[entry_point] = module
+        try:
+            spec.loader.exec_module(module)
+        except Exception as exc:
+            sys.modules.pop(entry_point, None)
+            logger.error("File-path import failed for %s at %s: %s", entry_point, module_path, exc)
+            return None
+        logger.info("Loaded plugin module %s from %s (file-path fallback)", entry_point, module_path)
+        return module
 
     def get_loaded_plugins(self) -> Dict[str, BasePlugin]:
         """Get all loaded plugins."""

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -12,12 +12,12 @@ Issue #6970 - Validate declared hooks against HOOK_REGISTRY on load.
 Issue #6971 - Raise PluginLoadError for missing required env vars.
 """
 
-import sys
 import importlib
 import importlib.util
 import json
 import logging
 import os
+import sys
 from pathlib import Path
 from typing import Dict, List, Tuple, Type
 

--- a/autobot_shared/plugin_sdk/loader_filepath_test.py
+++ b/autobot_shared/plugin_sdk/loader_filepath_test.py
@@ -1,0 +1,71 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""File-path import fallback for core plugins — Issue #10294.
+
+Core plugins live in hyphenated dirs (plugins/core-plugins/hello-plugin) whose
+dotted entry_point (plugins.core_plugins.hello_plugin.main) is not importable.
+The loader must fall back to importing main.py by file path.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autobot_shared.plugin_sdk.loader import PluginLoader
+
+_PLUGIN_MAIN = '''
+from autobot_shared.plugin_sdk.base import BasePlugin
+
+
+class SamplePlugin(BasePlugin):
+    async def initialize(self) -> None:
+        return None
+
+    async def shutdown(self) -> None:
+        return None
+
+
+# No "Plugin" alias on purpose — loader finds the BasePlugin subclass.
+'''
+
+
+def _write_plugin(root: Path, dir_name: str, entry_point: str) -> Path:
+    pdir = root / dir_name
+    pdir.mkdir(parents=True)
+    (pdir / "main.py").write_text(_PLUGIN_MAIN, encoding="utf-8")
+    manifest = {
+        "name": dir_name,
+        "version": "1.0.0",
+        "display_name": "Sample",
+        "description": "sample",
+        "author": "test",
+        "entry_point": entry_point,
+    }
+    (pdir / "plugin.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return pdir
+
+
+@pytest.mark.asyncio
+async def test_hyphenated_plugin_loads_via_file_path(tmp_path: Path) -> None:
+    """A hyphenated dir whose dotted entry_point is not importable still loads."""
+    root = tmp_path / "core-plugins"
+    _write_plugin(root, "hello-plugin", "plugins.core_plugins.hello_plugin.main")
+
+    loader = PluginLoader([root])
+    manifests = loader.discover_plugins()
+    assert len(manifests) == 1
+    assert loader._manifest_dirs["hello-plugin"].name == "hello-plugin"
+
+    plugin = await loader.load_plugin(manifests[0])
+    assert plugin is not None
+    assert type(plugin).__name__ == "SamplePlugin"
+
+
+def test_import_from_file_missing_dir_returns_none(tmp_path: Path) -> None:
+    loader = PluginLoader([])
+    assert loader._import_from_file("plugins.core_plugins.x.main", None) is None
+    assert loader._import_from_file("plugins.core_plugins.x.main", tmp_path) is None

--- a/autobot_shared/plugin_sdk/loader_filepath_test.py
+++ b/autobot_shared/plugin_sdk/loader_filepath_test.py
@@ -8,6 +8,7 @@ Core plugins live in hyphenated dirs (plugins/core-plugins/hello-plugin) whose
 dotted entry_point (plugins.core_plugins.hello_plugin.main) is not importable.
 The loader must fall back to importing main.py by file path.
 """
+
 from __future__ import annotations
 
 import json
@@ -17,7 +18,7 @@ import pytest
 
 from autobot_shared.plugin_sdk.loader import PluginLoader
 
-_PLUGIN_MAIN = '''
+_PLUGIN_MAIN = """
 from autobot_shared.plugin_sdk.base import BasePlugin
 
 
@@ -30,7 +31,7 @@ class SamplePlugin(BasePlugin):
 
 
 # No "Plugin" alias on purpose — loader finds the BasePlugin subclass.
-'''
+"""
 
 
 def _write_plugin(root: Path, dir_name: str, entry_point: str) -> Path:


### PR DESCRIPTION
## Thinking Path
Validating "plugins load" on the box after the deploy-half fix (#10447), the core plugins still wouldn't import: they live in hyphenated dirs (`plugins/core-plugins/hello-plugin/`) whose dotted entry_point (`plugins.core_plugins.hello_plugin.main`) raises `ModuleNotFoundError`. Dev_new_gui's loader only did `import_module` + a BasePlugin-subclass scan — the import always failed first, so every core plugin (image/video generation, kb-event, mcp-wrapper, …) silently failed to register.

## What Changed
`autobot_shared/plugin_sdk/loader.py` (the canonical loader the backend imports):
- capture each plugin's on-disk dir at discovery (`_manifest_dirs`)
- on `ModuleNotFoundError`, fall back to loading the module file by path (`_import_from_file` → `spec_from_file_location`), registered in `sys.modules` so intra-plugin refs resolve
- the existing BasePlugin-subclass scan then resolves the class even without a `Plugin = X` alias

## Verification
- `ast.parse` + `flake8 --max-line-length=120` clean.
- Added `loader_filepath_test.py`: loads a hyphenated-dir plugin via the fallback + negative cases (runs in CI; the import chain needs Redis/config stubs not present in this shell, same as the existing `plugin_sdk_test.py`).
- Deploy-half (#10447, merged) verified on the running box (dir-not-found flood → 0).

## Model Used
Claude Opus 4.8

Closes #10294. (Import logic also present in #10442, bundled with #10267 WhatsApp work — decoupled here so #10294 lands independently.)
