### PR TITLE
deps(backend): relax websockets to >=15,<16 to unblock langchain >=1.3.10 (#10386)

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -5,7 +5,7 @@ apscheduler>=3.11.2             # Issue #6590: hourly LLM key rotation job
 croniter>=6.2.2                 # GH#9027: required by LLC RoutineScheduler and routines API
 fastapi>=0.138.0                # SECURITY UPDATE - requires starlette >=0.52.1
 uvicorn>=0.49.0
-websockets>=16.0           # Issue #3098: required for WebSocket protocol support (desktop_streaming_manager, slm_client)
+websockets>=15.0,<16       # Issue #3098: desktop_streaming_manager + slm_client; relaxed from >=16.0 (#10386): both files use only legacy-compat API (WebSocketServerProtocol type annotation, ConnectionClosed/WebSocketException, connect(subprotocols=)) present in 15.x. CI already pins 15.0.1. websockets<16 satisfies langgraph-sdk 0.4.2 (>=14,<16), unblocking langchain >=1.3.10.
 python-dotenv>=1.2.2
 aiofiles>=25.1.0
 pydantic>=2.13.4
@@ -65,11 +65,11 @@ llama-index-llms-ollama>=0.10.1,<1.0.0       # Ollama LLM integration
 llama-index-embeddings-ollama>=0.9.0,<1.0.0  # Ollama embeddings
 llama-index-vector-stores-chroma>=0.5.5,<1.0.0  # ChromaDB vector store
 # LangChain 1.x ecosystem — migrated from 0.3.x to fix SSRF CVE (#1572)
-langchain>=1.3.1,<2.0.0                # Issue #1572 + #10386: langchain ecosystem held — 1.3.10/core 1.4.8/langgraph 1.2.6 pull langgraph-sdk 0.4.2 (websockets<16) which conflicts with required websockets>=16.0
-langchain-core>=1.3.3,<2.0.0         # Issue #1572: SSRF CVE fix requires >=1.2.11 (held with ecosystem, #10386)
-langchain-community>=0.4.1,<0.5.0     # Issue #1572: Compatible with langchain 1.x (held, #10386)
+langchain>=1.3.10,<2.0.0               # Issue #1572 + #10386: bumped from 1.3.1 — unblocked by websockets relaxation to >=15,<16; 1.3.10 requires langgraph>=1.2.5 + langchain-core>=1.4.7
+langchain-core>=1.4.7,<2.0.0          # Issue #1572 + #10386: bumped from 1.3.3 — langchain 1.3.10 requires >=1.4.7
+langchain-community>=0.4.2,<0.5.0     # Issue #1572 + #10386: bumped from 0.4.1 — aligned with ai-stack canonical (#2808)
 langchain-ollama>=1.1.0,<2.0.0        # Issue #1572: ChatOllama for QA chain
-langgraph>=1.2.0,<2.0.0               # Issue #1043: StateGraph (held <1.2.6 — 1.2.6 forces langgraph-sdk 0.4.2 websockets<16 vs websockets>=16.0, #10386)
+langgraph>=1.2.5,<2.0.0               # Issue #1043 + #10386: bumped from 1.2.0 — langchain 1.3.10 requires >=1.2.5; langgraph 1.2.6 pulls langgraph-sdk 0.4.2 (websockets>=14,<16) now satisfied by websockets>=15,<16
 langgraph-checkpoint-redis>=0.4.1,<1.0.0  # Issue #1043: Redis checkpointer for thread persistence
 markdownify>=1.2.2  # HTML to Markdown conversion
 mcp>=1.28.0            # MCP protocol for skill subprocesses (Issue #731)

--- a/autobot-slm-backend/requirements.txt
+++ b/autobot-slm-backend/requirements.txt
@@ -34,7 +34,7 @@ redis[asyncio]>=8.0.0
 
 # Async utilities
 aiofiles>=25.1.0
-websockets>=16.0
+websockets>=15.0,<16       # Issue #3098: relaxed from >=16.0 (#10386): slm_client uses only API present in 15.x; <16 satisfies langgraph-sdk 0.4.2 on backend side
 
 # Ansible integration
 ansible-runner>=2.4.3


### PR DESCRIPTION
## Thinking Path
Backend capped langchain at 1.3.2 because `langchain≥1.3.5 → langgraph-sdk≥0.4.2 → websockets<16`, conflicting with the `websockets>=16.0` pin (#3098, for desktop_streaming_manager + slm_client). I verified whether websockets 16 is truly required by auditing the actual API usage.

## What Changed (`autobot-backend/requirements.txt`, `autobot-slm-backend/requirements.txt`)
- `websockets>=16.0` → `websockets>=15.0,<16`. Both consumers use only API present in 15.x: `WebSocketServerProtocol` (type annotation only), `ConnectionClosed`/`WebSocketException`, `connect(subprotocols=...)`, `exc.rcvd.code`. CI already pins `websockets==15.0.1`, so the suite already validates 15.x.
- `langchain>=1.3.1` → `>=1.3.10`; `langchain-core>=1.3.3` → `>=1.4.7`; `langchain-community>=0.4.1` → `>=0.4.2`; `langgraph>=1.2.0` → `>=1.2.5`. The `<16` upper bound satisfies langgraph-sdk 0.4.2 (`websockets>=14,<16`), so the whole chain resolves.

## Verification
- Constraint chain traced end-to-end: `langchain 1.3.10 → langgraph≥1.2.5 → langgraph-sdk 0.4.2 → websockets≥14,<16` ✓ satisfied by `websockets>=15.0,<16`.
- websockets 15.0.1 wheel inspected to confirm all three usage patterns present. Backend smoke-test (CI) is the runtime gate.
- Keeps the PVE-2026-88512 SQL-injection fix (≥1.3.1) and the #1572 SSRF fix.
- Closes #10386.

## Model Used
Claude Opus 4.8 (senior-backend-engineer subagent).
