### PR TITLE
fix(fleet): slm-agent 404 heartbeat backoff + vnc target_path detection + optional-role health classification (#9965)

### DIFF
--- a/autobot-slm-agent/agent.py
+++ b/autobot-slm-agent/agent.py
@@ -132,6 +132,11 @@ class SLMAgent:
         self.role_detector = RoleDetector()
         self._role_definitions_loaded = False
 
+        # Registration-pending backoff state (#9965).
+        # 404 responses mean the node row doesn't exist yet — keep retrying
+        # with bounded exponential backoff instead of treating it as fatal.
+        self._reg_backoff_seconds: float = 0  # 0 = not in backoff
+
     def _init_buffer_db(self):
         """Initialize SQLite buffer database."""
         Path(self.buffer_db).parent.mkdir(parents=True, exist_ok=True)
@@ -263,6 +268,9 @@ class SLMAgent:
             },
         }
 
+    # Maximum registration-pending backoff in seconds (#9965).
+    _REG_BACKOFF_CAP: float = 300
+
     async def _send_heartbeat_request(self, payload: dict) -> bool:
         """
         Send heartbeat HTTP request to admin server.
@@ -272,7 +280,7 @@ class SLMAgent:
 
         Returns:
             True if heartbeat was accepted, False otherwise.
-        Issue #620.
+        Issue #620, #9965.
         """
         try:
             async with aiohttp.ClientSession() as session:
@@ -287,15 +295,32 @@ class SLMAgent:
                         # Issue #741: Process heartbeat response
                         response_data = await response.json()
                         self._process_heartbeat_response(response_data)
+                        if self._reg_backoff_seconds:
+                            logger.info("Heartbeat accepted — node registration confirmed")
+                            self._reg_backoff_seconds = 0
                         logger.debug("Heartbeat sent successfully")
                         return True
-                    else:
-                        logger.warning(
-                            "Heartbeat rejected: %s %s",
-                            response.status,
-                            await response.text(),
+                    if response.status == 404:
+                        # Node row not yet created — registration still in progress.
+                        # Back off and retry; do NOT buffer or treat as fatal (#9965).
+                        new_backoff = min(
+                            max(self._reg_backoff_seconds * 2, 5),
+                            self._REG_BACKOFF_CAP,
+                        )
+                        self._reg_backoff_seconds = new_backoff
+                        logger.debug(
+                            "Heartbeat 404: node %s not yet registered — "
+                            "retrying in %.0fs (registration pending, #9965)",
+                            self.node_id,
+                            new_backoff,
                         )
                         return False
+                    logger.warning(
+                        "Heartbeat rejected: %s %s",
+                        response.status,
+                        await response.text(),
+                    )
+                    return False
         except aiohttp.ClientError as e:
             logger.warning("Failed to send heartbeat: %s", e)
             self.buffer_event("heartbeat", payload)
@@ -380,15 +405,25 @@ class SLMAgent:
             # Send systemd watchdog notification (prevents timeout restart)
             sd_notify("WATCHDOG=1")
 
-            # Send heartbeat
-            success = await self.send_heartbeat()
+            try:
+                # Send heartbeat
+                success = await self.send_heartbeat()
 
-            # If connected, try to sync buffered events
-            if success:
-                await self.sync_buffered_events()
+                # If connected, try to sync buffered events
+                if success:
+                    await self.sync_buffered_events()
+            except Exception as exc:
+                # Catch-all: an unhandled error in any heartbeat step must
+                # NOT kill the loop (#9965).  Log and continue.
+                logger.exception("Unhandled error in heartbeat loop: %s", exc)
 
-            # Wait for next heartbeat
-            await asyncio.sleep(self.heartbeat_interval)
+            # When in registration-pending backoff, sleep the longer of
+            # the normal interval or the computed backoff delay (#9965).
+            sleep_secs = max(
+                float(self.heartbeat_interval),
+                self._reg_backoff_seconds,
+            )
+            await asyncio.sleep(sleep_secs)
 
         # Notify systemd we're stopping
         sd_notify("STOPPING=1")

--- a/autobot-slm-agent/role_detector.py
+++ b/autobot-slm-agent/role_detector.py
@@ -46,13 +46,18 @@ class RoleStatus:
 
     @property
     def status(self) -> str:
-        """Determine overall status."""
-        if self.path_exists and self.service_running:
-            return "active"
-        elif self.path_exists:
-            return "inactive"
-        else:
+        """Determine overall status.
+
+        - active: path exists and service running (or no service required)
+        - inactive: path exists but service is down
+        - not_installed: path absent
+        """
+        if not self.path_exists:
             return "not_installed"
+        # No service name means it's a library/passive role — path = active
+        if not self.service_name:
+            return "active"
+        return "active" if self.service_running else "inactive"
 
 
 class RoleDetector:
@@ -74,12 +79,16 @@ class RoleDetector:
         """Load role definitions from SLM server response."""
         self.roles = {}
         for defn in definitions:
-            if not defn.get("target_path"):
-                continue  # Skip roles without target path (e.g., code-source)
+            # Skip roles that have neither a target path nor a systemd service —
+            # there is nothing to detect on the node (#9965; was: skip if no
+            # target_path, which caused service-only roles like vnc to be silently
+            # omitted even when tigervncserver was running).
+            if not defn.get("target_path") and not defn.get("systemd_service"):
+                continue
 
             self.roles[defn["name"]] = RoleDefinition(
                 name=defn["name"],
-                target_path=defn["target_path"],
+                target_path=defn.get("target_path", ""),
                 systemd_service=defn.get("systemd_service"),
                 health_check_port=defn.get("health_check_port"),
             )
@@ -100,10 +109,13 @@ class RoleDetector:
         """Detect a single role."""
         status = RoleStatus()
 
-        # Check path
-        target_path = Path(role.target_path)
-        status.path_exists = target_path.exists()
-        status.path = str(target_path) if status.path_exists else None
+        # Check path (service-only roles have no target_path — always pass, #9965)
+        if role.target_path:
+            target_path = Path(role.target_path)
+            status.path_exists = target_path.exists()
+            status.path = str(target_path) if status.path_exists else None
+        else:
+            status.path_exists = True  # no path requirement
 
         # Check service
         if role.systemd_service:
@@ -115,9 +127,9 @@ class RoleDetector:
             if role.health_check_port in listening_ports:
                 status.ports.append(role.health_check_port)
 
-        # Read version if path exists
-        if status.path_exists:
-            status.version = self._read_version(target_path)
+        # Read version if path exists and path was specified
+        if status.path_exists and role.target_path:
+            status.version = self._read_version(Path(role.target_path))
 
         return status
 

--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
@@ -136,6 +136,11 @@ class SLMAgent:
         # connection pool + SSL context allocation (#9086)
         self._session: aiohttp.ClientSession | None = None
 
+        # Registration-pending backoff state (#9965).
+        # 404 responses mean the node row doesn't exist yet — keep retrying
+        # with bounded exponential backoff instead of treating it as fatal.
+        self._reg_backoff_seconds: float = 0  # 0 = not in backoff
+
     def _init_buffer_db(self):
         """Initialize SQLite buffer database."""
         Path(self.buffer_db).parent.mkdir(parents=True, exist_ok=True)
@@ -267,6 +272,9 @@ class SLMAgent:
             },
         }
 
+    # Maximum registration-pending backoff in seconds (#9965).
+    _REG_BACKOFF_CAP: float = 300
+
     async def _send_heartbeat_request(self, payload: dict) -> bool:
         """
         Send heartbeat HTTP request to admin server.
@@ -276,7 +284,7 @@ class SLMAgent:
 
         Returns:
             True if heartbeat was accepted, False otherwise.
-        Issue #620.
+        Issue #620, #9965.
         """
         assert self._session is not None
         try:
@@ -291,15 +299,32 @@ class SLMAgent:
                     # Issue #741: Process heartbeat response
                     response_data = await response.json()
                     self._process_heartbeat_response(response_data)
+                    if self._reg_backoff_seconds:
+                        logger.info("Heartbeat accepted — node registration confirmed")
+                        self._reg_backoff_seconds = 0
                     logger.debug("Heartbeat sent successfully")
                     return True
-                else:
-                    logger.warning(
-                        "Heartbeat rejected: %s %s",
-                        response.status,
-                        await response.text(),
+                if response.status == 404:
+                    # Node row not yet created — registration still in progress.
+                    # Back off and retry; do NOT buffer or treat as fatal (#9965).
+                    new_backoff = min(
+                        max(self._reg_backoff_seconds * 2, 5),
+                        self._REG_BACKOFF_CAP,
+                    )
+                    self._reg_backoff_seconds = new_backoff
+                    logger.debug(
+                        "Heartbeat 404: node %s not yet registered — "
+                        "retrying in %.0fs (registration pending, #9965)",
+                        self.node_id,
+                        new_backoff,
                     )
                     return False
+                logger.warning(
+                    "Heartbeat rejected: %s %s",
+                    response.status,
+                    await response.text(),
+                )
+                return False
         except aiohttp.ClientError as e:
             logger.warning("Failed to send heartbeat: %s", e)
             self.buffer_event("heartbeat", payload)
@@ -418,15 +443,25 @@ class SLMAgent:
                 # Send systemd watchdog notification (prevents timeout restart)
                 sd_notify("WATCHDOG=1")
 
-                # Send heartbeat
-                success = await self.send_heartbeat()
+                try:
+                    # Send heartbeat
+                    success = await self.send_heartbeat()
 
-                # If connected, try to sync buffered events
-                if success:
-                    await self.sync_buffered_events()
+                    # If connected, try to sync buffered events
+                    if success:
+                        await self.sync_buffered_events()
+                except Exception as exc:
+                    # Catch-all: an unhandled error in any heartbeat step must
+                    # NOT kill the loop (#9965).  Log and continue.
+                    logger.exception("Unhandled error in heartbeat loop: %s", exc)
 
-                # Wait for next heartbeat
-                await asyncio.sleep(self.heartbeat_interval)
+                # When in registration-pending backoff, sleep the longer of
+                # the normal interval or the computed backoff delay (#9965).
+                sleep_secs = max(
+                    float(self.heartbeat_interval),
+                    self._reg_backoff_seconds,
+                )
+                await asyncio.sleep(sleep_secs)
 
             self._session = None
 

--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -1146,7 +1146,21 @@ async def validate_fleet(
         # Only check roles that are actually assigned to nodes (#2747)
         # Roles not yet assigned via wizard are not "missing"
         assigned_roles = (await session.execute(select(NodeRole.role_name).distinct())).scalars().all()
-        missing_roles = []
+
+        # Look up which of the assigned roles are required (#9965).
+        # Optional roles (required=False) that are assigned but not yet active
+        # should not degrade the fleet health score — report them separately.
+        from models.database import Role as RoleModel
+
+        role_required_map: dict[str, bool] = {}
+        for role_name in assigned_roles:
+            role_row = await session.execute(select(RoleModel).where(RoleModel.name == role_name))
+            role_obj = role_row.scalar_one_or_none()
+            # Default required=True when the DB row is missing (fail-safe)
+            role_required_map[role_name] = (role_obj.required if role_obj is not None else True)
+
+        missing_required_roles: list[str] = []
+        inactive_optional_roles: list[str] = []
         for role_name in assigned_roles:
             active = await session.execute(
                 select(func.count(NodeRole.id)).where(
@@ -1155,10 +1169,13 @@ async def validate_fleet(
                 )
             )
             if (active.scalar() or 0) == 0:
-                missing_roles.append(role_name)
+                if role_required_map.get(role_name, True):
+                    missing_required_roles.append(role_name)
+                else:
+                    inactive_optional_roles.append(role_name)
 
     health = "healthy"
-    if missing_roles:
+    if missing_required_roles:
         health = "degraded"
     elif online_nodes < total_nodes:
         health = "degraded"
@@ -1167,6 +1184,8 @@ async def validate_fleet(
         "health": health,
         "total_nodes": total_nodes,
         "online_nodes": online_nodes,
-        "missing_required_roles": missing_roles,
+        "missing_required_roles": missing_required_roles,
+        # Informational: optional roles assigned but not yet active — not health-degrading
+        "inactive_optional_roles": inactive_optional_roles,
         "ready": total_nodes > 0,
     }

--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -1157,7 +1157,7 @@ async def validate_fleet(
             role_row = await session.execute(select(RoleModel).where(RoleModel.name == role_name))
             role_obj = role_row.scalar_one_or_none()
             # Default required=True when the DB row is missing (fail-safe)
-            role_required_map[role_name] = (role_obj.required if role_obj is not None else True)
+            role_required_map[role_name] = role_obj.required if role_obj is not None else True
 
         missing_required_roles: list[str] = []
         inactive_optional_roles: list[str] = []

--- a/autobot-slm-backend/services/role_registry.py
+++ b/autobot-slm-backend/services/role_registry.py
@@ -310,7 +310,11 @@ _OPTIONAL_ROLES = [
         "display_name": "VNC Server",
         "sync_type": None,
         "source_paths": [],
-        "target_path": "",
+        # /usr/bin/Xtigervnc is the TigerVNC binary installed by tigervnc-standalone-server.
+        # Providing a non-empty target_path lets role_detector.py skip its early-exit
+        # guard (which checks only target_path) and activate path-existence + systemd
+        # checks — mirrors the postgres fix in #9853 (#9965).
+        "target_path": "/usr/bin/Xtigervnc",
         "systemd_service": "tigervncserver",
         "auto_restart": False,
         "required": False,

--- a/autobot-slm-backend/slm/agent/agent.py
+++ b/autobot-slm-backend/slm/agent/agent.py
@@ -136,6 +136,12 @@ class SLMAgent:
         # connection pool + SSL context allocation (#9086)
         self._session: aiohttp.ClientSession | None = None
 
+        # Registration-pending backoff state (#9965).
+        # 404 responses mean the node row doesn't exist yet — keep retrying
+        # with bounded exponential backoff instead of treating it as fatal.
+        self._reg_backoff_seconds: float = 0  # 0 = not in backoff
+        _REG_BACKOFF_CAP = 300  # never wait longer than 5 min
+
     def _init_buffer_db(self):
         """Initialize SQLite buffer database."""
         Path(self.buffer_db).parent.mkdir(parents=True, exist_ok=True)
@@ -267,6 +273,9 @@ class SLMAgent:
             },
         }
 
+    # Maximum registration-pending backoff in seconds (#9965).
+    _REG_BACKOFF_CAP: float = 300
+
     async def _send_heartbeat_request(self, payload: dict) -> bool:
         """
         Send heartbeat HTTP request to admin server.
@@ -276,7 +285,7 @@ class SLMAgent:
 
         Returns:
             True if heartbeat was accepted, False otherwise.
-        Issue #620.
+        Issue #620, #9965.
         """
         assert self._session is not None
         try:
@@ -291,15 +300,32 @@ class SLMAgent:
                     # Issue #741: Process heartbeat response
                     response_data = await response.json()
                     self._process_heartbeat_response(response_data)
+                    if self._reg_backoff_seconds:
+                        logger.info("Heartbeat accepted — node registration confirmed")
+                        self._reg_backoff_seconds = 0
                     logger.debug("Heartbeat sent successfully")
                     return True
-                else:
-                    logger.warning(
-                        "Heartbeat rejected: %s %s",
-                        response.status,
-                        await response.text(),
+                if response.status == 404:
+                    # Node row not yet created — registration still in progress.
+                    # Back off and retry; do NOT buffer or treat as fatal (#9965).
+                    new_backoff = min(
+                        max(self._reg_backoff_seconds * 2, 5),
+                        self._REG_BACKOFF_CAP,
+                    )
+                    self._reg_backoff_seconds = new_backoff
+                    logger.debug(
+                        "Heartbeat 404: node %s not yet registered — "
+                        "retrying in %.0fs (registration pending, #9965)",
+                        self.node_id,
+                        new_backoff,
                     )
                     return False
+                logger.warning(
+                    "Heartbeat rejected: %s %s",
+                    response.status,
+                    await response.text(),
+                )
+                return False
         except aiohttp.ClientError as e:
             logger.warning("Failed to send heartbeat: %s", e)
             self.buffer_event("heartbeat", payload)
@@ -418,15 +444,25 @@ class SLMAgent:
                 # Send systemd watchdog notification (prevents timeout restart)
                 sd_notify("WATCHDOG=1")
 
-                # Send heartbeat
-                success = await self.send_heartbeat()
+                try:
+                    # Send heartbeat
+                    success = await self.send_heartbeat()
 
-                # If connected, try to sync buffered events
-                if success:
-                    await self.sync_buffered_events()
+                    # If connected, try to sync buffered events
+                    if success:
+                        await self.sync_buffered_events()
+                except Exception as exc:
+                    # Catch-all: an unhandled error in any heartbeat step must
+                    # NOT kill the loop (#9965).  Log and continue.
+                    logger.exception("Unhandled error in heartbeat loop: %s", exc)
 
-                # Wait for next heartbeat
-                await asyncio.sleep(self.heartbeat_interval)
+                # When in registration-pending backoff, sleep the longer of
+                # the normal interval or the computed backoff delay (#9965).
+                sleep_secs = max(
+                    float(self.heartbeat_interval),
+                    self._reg_backoff_seconds,
+                )
+                await asyncio.sleep(sleep_secs)
 
             self._session = None
 

--- a/autobot-slm-backend/tests/services/test_role_registry.py
+++ b/autobot-slm-backend/tests/services/test_role_registry.py
@@ -214,8 +214,11 @@ def test_vnc_role_has_non_empty_target_path():
 
 def test_vnc_in_get_role_definitions():
     """get_role_definitions must include vnc so agents receive its detection spec."""
-    defs_by_name = {r["name"]: r for r in _rr.get_role_definitions.__wrapped__()  # sync call
-                    } if hasattr(_rr.get_role_definitions, "__wrapped__") else None
+    defs_by_name = (
+        {r["name"]: r for r in _rr.get_role_definitions.__wrapped__()}  # sync call
+        if hasattr(_rr.get_role_definitions, "__wrapped__")
+        else None
+    )
     # Fallback: inspect DEFAULT_ROLES directly (get_role_definitions is async)
     detectable = {r["name"] for r in DEFAULT_ROLES if r.get("target_path") or r.get("systemd_service")}
     assert "vnc" in detectable, "vnc must be in the detectable role set (has target_path or systemd_service)"
@@ -224,8 +227,16 @@ def test_vnc_in_get_role_definitions():
 def test_optional_roles_are_not_required():
     """docker, browser-service, tts-worker and vnc must all be optional (required=False)
     so they cannot cause health=degraded on their own (#9965)."""
-    optional_names = {"docker", "browser-service", "tts-worker", "vnc", "npu-worker",
-                      "autobot-llm-cpu", "autobot-llm-gpu", "slm-monitoring"}
+    optional_names = {
+        "docker",
+        "browser-service",
+        "tts-worker",
+        "vnc",
+        "npu-worker",
+        "autobot-llm-cpu",
+        "autobot-llm-gpu",
+        "slm-monitoring",
+    }
     for name in optional_names:
         role = _role(name)
         assert role["required"] is False, f"{name} should be optional (required=False)"

--- a/autobot-slm-backend/tests/services/test_role_registry.py
+++ b/autobot-slm-backend/tests/services/test_role_registry.py
@@ -196,3 +196,36 @@ def test_serviceable_roles_include_postgres_and_scheduler():
     defs = {r["name"] for r in DEFAULT_ROLES if r.get("target_path") or r.get("systemd_service")}
     assert "postgres" in defs
     assert "scheduler" in defs
+
+
+# ---------------------------------------------------------------------------
+# VNC role (#9965)
+# ---------------------------------------------------------------------------
+
+
+def test_vnc_role_has_non_empty_target_path():
+    """vnc must have a non-empty target_path so role_detector.py does not skip
+    it due to the old guard that only checked target_path (#9965)."""
+    role = _role("vnc")
+    assert role["target_path"], "vnc target_path must be non-empty so role_detector detects it"
+    assert role["systemd_service"] == "tigervncserver"
+    assert role["required"] is False
+
+
+def test_vnc_in_get_role_definitions():
+    """get_role_definitions must include vnc so agents receive its detection spec."""
+    defs_by_name = {r["name"]: r for r in _rr.get_role_definitions.__wrapped__()  # sync call
+                    } if hasattr(_rr.get_role_definitions, "__wrapped__") else None
+    # Fallback: inspect DEFAULT_ROLES directly (get_role_definitions is async)
+    detectable = {r["name"] for r in DEFAULT_ROLES if r.get("target_path") or r.get("systemd_service")}
+    assert "vnc" in detectable, "vnc must be in the detectable role set (has target_path or systemd_service)"
+
+
+def test_optional_roles_are_not_required():
+    """docker, browser-service, tts-worker and vnc must all be optional (required=False)
+    so they cannot cause health=degraded on their own (#9965)."""
+    optional_names = {"docker", "browser-service", "tts-worker", "vnc", "npu-worker",
+                      "autobot-llm-cpu", "autobot-llm-gpu", "slm-monitoring"}
+    for name in optional_names:
+        role = _role(name)
+        assert role["required"] is False, f"{name} should be optional (required=False)"


### PR DESCRIPTION
## Thinking Path
Fresh 2-node install showed degraded fleet health from two independent facets: (1) the VM slm-agent died after early-404 heartbeats (posted before its node row existed), and (2) the wizard flagged optional roles (vnc/docker/browser-service/tts-worker) as "missing" even though vnc was actually running — its registry entry had no `target_path` so `role_detector.py` skipped it.

## What Changed
**Facet 1 — agent resilience** (`slm/agent/agent.py` + Ansible payload copy + `autobot-slm-agent/agent.py`):
- `_send_heartbeat_request` now treats 404 as "registration pending" with bounded exponential backoff (5s→…→300s cap) instead of fatal; clears backoff + logs INFO on first 200.
- `run()` loop body wrapped in `try/except Exception` (log + continue) so a transient error can't kill the daemon; sleep honours the backoff.

**Facet 2 — role detection + health classification**:
- `services/role_registry.py` — gave `vnc` a real `target_path` (`/usr/bin/Xtigervnc`) so detection activates it (mirrors the #9853 postgres fix).
- `autobot-slm-agent/role_detector.py` — `load_definitions` guard now also keeps roles with a `systemd_service` (not just `target_path`), aligning with the canonical agent copy.
- `api/setup_wizard.py validate_fleet` — only `required=True` roles count toward `health=degraded`; `required=False` inactive roles report in a new informational `inactive_optional_roles` field. Fail-safe defaults to required when the DB row is absent.

## Verification
- `tests/services/test_role_registry.py` → **14/14** (3 new: vnc target_path, vnc in defs, optional-not-required).
- `slm/agent/` tests → 26/28 (2 pre-existing failures unrelated: notification_service path conflict).
- `py_compile` clean on all 8 changed files.
- Closes #9965.

## Caveat
Facet-1 exact crash path couldn't be confirmed without VM logs; the two most-likely causes (unhandled loop exception, no 404 handling) are addressed. If systemd `WatchdogSec` was the killer, unit-file tuning would be a separate follow-up.

## Model Used
Claude Opus 4.8 (senior-backend-engineer subagent).
