### PR TITLE
fix(governance): scope branch-cleanup PR search, harden git-guard vs global opts, reconcile mcp-task-manager-server license (#10114, #10434, #10117)

### DIFF
--- a/.claude/hooks/block-dangerous-commands.sh
+++ b/.claude/hooks/block-dangerous-commands.sh
@@ -90,7 +90,13 @@ fi
 # checking out main locally has no legitimate use case here.
 # ──────────────────────────────────────────────
 
-if echo "$COMMAND_TO_CHECK" | grep -qE '(^|[;&|()]+[[:space:]]*)git[[:space:]]+(checkout|switch)[[:space:]]+(main|master)([[:space:]]|$)'; then
+# Optional git GLOBAL options that may sit between `git` and the subcommand
+# (#10434). `git -c core.foo=bar checkout some-branch` must not slip past the
+# branch-switch guards. Tolerate any run of -c/-C/--git-dir global options.
+# Written as a fixed-length-free ERE so GNU grep 3.7 (bash) handles it.
+GIT_GLOBAL_OPTS='(-c[[:space:]]+[^[:space:]]+[[:space:]]+|-C[[:space:]]+[^[:space:]]+[[:space:]]+|--git-dir[=[:space:]][^[:space:]]+[[:space:]]+)*'
+
+if echo "$COMMAND_TO_CHECK" | grep -qE "(^|[;&|()]+[[:space:]]*)git[[:space:]]+${GIT_GLOBAL_OPTS}(checkout|switch)[[:space:]]+(main|master)([[:space:]]|\$)"; then
   deny "Blocked: never check out main/master locally (#4113, #6512). Main is read-only; commits flow Dev_new_gui → main via release cycle. If you need to inspect main, use git log origin/main or create a worktree: git worktree add .worktrees/inspect-main main"
 fi
 
@@ -104,18 +110,20 @@ fi
 #   - file restore: `git checkout -- <path>`, `git checkout .`
 #   - detached / toggle switches: `git switch -`, `git switch --detach`
 #   - SHA / tag / Dev_new_gui checkouts
-if echo "$COMMAND_TO_CHECK" | grep -qE '(^|[;&|()]+[[:space:]]*)git[[:space:]]+(checkout|switch)[[:space:]]'; then
+if echo "$COMMAND_TO_CHECK" | grep -qE "(^|[;&|()]+[[:space:]]*)git[[:space:]]+${GIT_GLOBAL_OPTS}(checkout|switch)[[:space:]]"; then
   CURRENT_DIR=$(pwd)
   if [[ ! "$CURRENT_DIR" =~ \.worktrees/ ]]; then
     # New-branch creation (-b/-B/-c/--create/--orphan) anywhere in the args.
+    # ${GIT_GLOBAL_OPTS} tolerates global opts before the subcommand (#10434);
+    # the new-branch flags are still only recognised AFTER checkout/switch.
     IS_NEW_BRANCH=0
-    if echo "$COMMAND_TO_CHECK" | grep -qE 'git[[:space:]]+(checkout|switch)[[:space:]]+(.*[[:space:]])?(-b|-B|-c|--create|--orphan)([[:space:]]|$)'; then
+    if echo "$COMMAND_TO_CHECK" | grep -qE "git[[:space:]]+${GIT_GLOBAL_OPTS}(checkout|switch)[[:space:]]+(.*[[:space:]])?(-b|-B|-c|--create|--orphan)([[:space:]]|\$)"; then
       IS_NEW_BRANCH=1
     fi
 
     # Explicit file restore: `git checkout -- <path>` (the `--` separator).
     IS_FILE_RESTORE=0
-    if echo "$COMMAND_TO_CHECK" | grep -qE 'git[[:space:]]+checkout[[:space:]]+--([[:space:]]|$)'; then
+    if echo "$COMMAND_TO_CHECK" | grep -qE "git[[:space:]]+${GIT_GLOBAL_OPTS}checkout[[:space:]]+--([[:space:]]|\$)"; then
       IS_FILE_RESTORE=1
     fi
 

--- a/.claude/hooks/block-dangerous-commands_test.sh
+++ b/.claude/hooks/block-dangerous-commands_test.sh
@@ -69,6 +69,14 @@ expect_block "git switch some-branch"                "git switch some-branch"
 expect_block "git checkout main"                     "git checkout main"
 expect_block "git checkout master"                   "git checkout master"
 expect_block "git checkout hotfix-something"         "git checkout hotfix-something"
+# Global options between `git` and the subcommand must not bypass the guard (#10434).
+expect_block "git -c foo=bar checkout some-branch"   "git -c core.foo=bar checkout some-branch"
+expect_block "git -c x=y checkout main"              "git -c http.sslVerify=false checkout main"
+expect_block "git -C /path switch some-branch"       "git -C /some/path switch some-branch"
+expect_block "git --git-dir=.git checkout feature"   "git --git-dir=.git checkout feature-branch"
+# Benign global-option commands (not a branch switch) must still pass.
+expect_allow "git -c x=y status (benign)"            "git -c core.pager=cat status"
+expect_allow "git -c x=y checkout -b (new branch)"   "git -c core.foo=bar checkout -b issue-9999 origin/Dev_new_gui"
 
 echo ""
 echo "--- Push protections ---"

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -180,8 +180,8 @@ jobs:
               issue_state=$(gh issue view "$issue_number" --json state --jq '.state' 2>/dev/null || echo "")
 
               if [ "$issue_state" = "CLOSED" ]; then
-                # Verify there's a merged PR for this issue
-                merged_pr=$(gh pr list --search "$issue_number" --state merged --json number -q '.[0].number' 2>/dev/null || true)
+                # Verify a merged PR actually closes this issue (#10114)
+                merged_pr=$(merged_pr_for_issue "$issue_number")
 
                 if [ -n "$merged_pr" ]; then
                   if [ "$DRY_RUN" = "true" ]; then

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -27,13 +27,19 @@ mcp-structured-thinking
 
 mcp-task-manager-server
   Path:        autobot-infrastructure/shared/mcp/tools/mcp-task-manager-server/
-  License:     UNRESOLVED — the bundled LICENSE file is GNU GPL v3, but the
-               package.json `license` field declares "ISC". These conflict.
-               Until the upstream license is confirmed, treat this component as
-               GPL-3.0 (the more restrictive of the two) for compliance
-               purposes. GPL-3.0 and Apache-2.0 have one-way compatibility, so
-               this MUST be resolved before AutoBot is redistributed with this
-               component included. See repository issue tracker.
+  License:     GPL-3.0-only (license: .../mcp-task-manager-server/LICENSE)
+               RESOLVED (#10117): the bundled LICENSE file is the full, verbatim
+               GNU GPL v3 text and is the authoritative grant for this vendored
+               component. The earlier package.json `license: "ISC"` was the
+               leftover `npm init` scaffold default ("My new MCP Server",
+               v0.1.0) and has been corrected to "GPL-3.0-only" to stop the
+               metadata contradicting the LICENSE file.
+               COMPATIBILITY: GPL-3.0 is one-way INCOMPATIBLE with the AutoBot
+               Apache-2.0 distribution (#9826) — GPL-3.0 code cannot be
+               redistributed under Apache-2.0 terms. This component MUST be
+               removed, replaced, or isolated before AutoBot is redistributed
+               with it included. The keep / remove / isolate decision is a
+               human/maintainer call (see #10117).
   Copyright:   Not stated by upstream (package "My new MCP Server", v0.1.0).
 ---------------------------------------------------------------------------
 

--- a/autobot-infrastructure/shared/mcp/tools/mcp-task-manager-server/package.json
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-task-manager-server/package.json
@@ -17,7 +17,7 @@
     "mcp",
     "model-context-protocol"
   ],
-  "license": "ISC",
+  "license": "GPL-3.0-only",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@types/better-sqlite3": "^7.6.13",

--- a/scripts/cleanup-worktrees.sh
+++ b/scripts/cleanup-worktrees.sh
@@ -196,8 +196,8 @@ if [ -n "$local_branches" ]; then
 
         issue_state=$(gh issue view "$issue_number" --json state --jq '.state' 2>/dev/null) || true
         if [ "$issue_state" = "CLOSED" ]; then
-            # Verify work is merged (check for merged PR)
-            merged_pr=$(gh pr list --search "$issue_number" --state merged --json number -q '.[0].number' 2>/dev/null) || true
+            # Verify work is merged by a PR that actually closes this issue (#10114)
+            merged_pr=$(merged_pr_for_issue "$issue_number")
             if [ -n "$merged_pr" ]; then
                 if $DRY_RUN; then
                     echo "  WOULD DELETE local: ${branch}  (#${issue_number} closed, PR #${merged_pr} merged)"
@@ -235,7 +235,7 @@ if [ -n "$remote_branches" ]; then
 
         issue_state=$(gh issue view "$issue_number" --json state --jq '.state' 2>/dev/null) || true
         if [ "$issue_state" = "CLOSED" ]; then
-            merged_pr=$(gh pr list --search "$issue_number" --state merged --json number -q '.[0].number' 2>/dev/null) || true
+            merged_pr=$(merged_pr_for_issue "$issue_number")
             if [ -n "$merged_pr" ]; then
                 if $DRY_RUN; then
                     echo "  WOULD DELETE remote: origin/${branch}  (#${issue_number} closed, PR #${merged_pr} merged)"

--- a/scripts/lib/branch-guards.sh
+++ b/scripts/lib/branch-guards.sh
@@ -65,3 +65,25 @@ branch_has_open_pr() {
     pr=$(gh pr list --head "$branch" --state open --json number -q '.[0].number' 2>/dev/null || true)
     [ -n "$pr" ]
 }
+
+# Print the number of a merged PR that ACTUALLY closes the given issue, or
+# nothing when none exists. Requires an authenticated `gh`.
+#
+# A bare `gh pr list --search "$issue_number"` over-matches (#10114): the search
+# index hits the number anywhere -- title, body, comments -- and even in a
+# superstring like `#19943` when searching for `9943`. A branch for an issue
+# whose number merely appears in some unrelated merged PR would then pass the
+# merge-confirmation gate. To avoid that, this filters the candidate PRs to
+# those whose `closingIssuesReferences` contains the EXACT issue number. On any
+# error it prints nothing so callers fall through to "no merged PR found"
+# (which keeps the branch -- the safe default).
+merged_pr_for_issue() {
+    local issue_number="$1"
+    [ -n "$issue_number" ] || return 0
+    gh pr list --search "$issue_number" --state merged \
+        --json number,closingIssuesReferences 2>/dev/null \
+        | jq -r --argjson n "$issue_number" \
+            'map(select(any(.closingIssuesReferences[]?; .number == $n)))
+             | .[0].number // empty' 2>/dev/null \
+        || true
+}


### PR DESCRIPTION
## Thinking Path
Three governance/hooks/license correctness issues from prior discovery rules.

## What Changed
- **#10114** — branch-cleanup merged-PR confirmation used an unscoped `gh pr list --search "$n"` (over-matches superstrings/body/comments). Added shared `merged_pr_for_issue()` to `scripts/lib/branch-guards.sh` (per the #10112 shared-lib pattern) that filters merged PRs by exact `closingIssuesReferences` membership; replaced all 3 call sites (`branch-cleanup.yml`, `cleanup-worktrees.sh` ×2). Verified: superstring `9943`→reject, exact `10032`→accept.
- **#10434** — `block-dangerous-commands.sh` git guard was bypassed by a global option (`git -c x=y checkout`). Added a GNU-grep-3.7-safe `GIT_GLOBAL_OPTS` ERE fragment (no fixed-length lookbehind) tolerating repeated `-c`/`-C`/`--git-dir`, wired into all four checkout/switch anchors. `git -c x=y checkout foo` now blocks; benign `git -c x=y status` still passes.
- **#10117** — `mcp-task-manager-server` shipped a verbatim GPL-3.0 LICENSE but `package.json` declared `ISC` (leftover `npm init` scaffold default). Reconciled metadata to reality: `package.json` license → `GPL-3.0-only`; `THIRD-PARTY-NOTICES` entry UNRESOLVED → RESOLVED, documenting the GPL-3.0-only determination + remaining Apache-2.0 incompatibility (#9826). No deletion — keep/remove/isolate decision left to the maintainer.

## Verification
- `bash .claude/hooks/block-dangerous-commands_test.sh` → **33 passed, 0 failed** (was 27; +6 cases: 4 block forms for the bypass, 2 benign global-opt allow forms).
- jq scoping logic verified against superstring + exact cases.
- Closes #10114, #10434, #10117.

## Model Used
Claude Opus 4.8 (general-purpose subagent).
