### PR TITLE
fix(health): detailed-health probes — propagate request + surface error reasons (#10460)

### DIFF
--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -558,7 +558,10 @@ async def get_detailed_health(request: Request, admin_check: bool = Depends(chec
     Issue #744: Requires admin authentication.
     """
     try:
-        basic_health = await get_system_health()
+        # Issue #10460: propagate the request so registry probes can reach
+        # app.state (memory/knowledge/graph_rag/chat_knowledge). Without it
+        # every app-state probe falsely reports "request not provided".
+        basic_health = await get_system_health(request)
         detailed_components = {}
 
         # Check components

--- a/autobot-backend/api/system_health.py
+++ b/autobot-backend/api/system_health.py
@@ -127,11 +127,14 @@ async def _run_probe(name: str, fn: ProbeFn, request: Request | None) -> Compone
             latency_ms=round((time.perf_counter() - started) * 1000, 2),
         )
     except Exception as exc:
-        logger.warning("Health probe %r raised %s", name, type(exc).__name__)
+        logger.warning("Health probe %r raised %s: %s", name, type(exc).__name__, exc)
+        # Issue #10460: surface the message, not just the type, so a "down"
+        # status is actionable (this endpoint is admin-only — no info leak).
+        reason = str(exc).strip() or "no detail"
         return ComponentHealth(
             name=name,
             status="down",
-            detail=f"probe error: {type(exc).__name__}",
+            detail=f"probe error: {type(exc).__name__}: {reason[:160]}",
             latency_ms=round((time.perf_counter() - started) * 1000, 2),
         )
     if result.latency_ms is None:
@@ -232,10 +235,13 @@ def probe_singleton(
                 data=data_callback(instance) if data_callback else None,
             )
         except Exception as exc:
+            # Issue #10460: include the message so the cause is visible
+            # (e.g. which import/arg failed), not just the exception type.
+            reason = str(exc).strip() or "no detail"
             return ComponentHealth(
                 name=probe_name,
                 status="down",
-                detail=f"probe error: {type(exc).__name__}",
+                detail=f"probe error: {type(exc).__name__}: {reason[:160]}",
                 data=data_callback(None) if data_callback else None,
             )
 
@@ -332,10 +338,13 @@ def probe_app_state(
                 data=data_callback(value) if data_callback else None,
             )
         except Exception as exc:
+            # Issue #10460: include the message so the cause is visible
+            # (e.g. which import/arg failed), not just the exception type.
+            reason = str(exc).strip() or "no detail"
             return ComponentHealth(
                 name=probe_name,
                 status="down",
-                detail=f"probe error: {type(exc).__name__}",
+                detail=f"probe error: {type(exc).__name__}: {reason[:160]}",
                 data=data_callback(None) if data_callback else None,
             )
 


### PR DESCRIPTION
## Thinking Path
`/api/system/health/detailed` reported 14 components down/degraded; most were false. Root: get_detailed_health called get_system_health() with no request, so request=None reached every probe and app-state probes (knowledge/graph_rag/memory/chat_knowledge) reported 'not provided' though services were live. Probe 'down' details showed only the exception type, hiding the cause.

## What Changed
- api/system.py: get_system_health(request) — propagate request to the probe registry.
- api/system_health.py: probe 'down' details include the exception message (truncated; admin-only endpoint).

## Verification
Live after deploy: knowledge, graph_rag, enhanced_search flipped to ok. Remaining failures now show real reasons, exposing genuine bugs (follow-ups): llm_optimization (ModelClassifier missing classifications), project_state (empty path), enterprise_features (manager None). py_compile clean.

## Model Used
Claude Opus 4.8