### PR TITLE
feat(ui): default the user GUI to the warm Ember theme (#10461)

### DIFF
--- a/autobot-frontend/.env.example
+++ b/autobot-frontend/.env.example
@@ -22,3 +22,9 @@ VITE_ENABLE_RUM=true
 # VITE_BACKEND_PORT=8001
 # VITE_API_BASE_URL=http://localhost:8001
 # VITE_WS_BASE_URL=ws://localhost:8001/ws
+
+# Theme (Issue #10461 / #9274)
+# Default theme variant for a fresh user (no saved choice). The user GUI ships the
+# warm "ember" palette by default. Set to "default" to keep the cool-neutral base
+# look — e.g. for a build shared with the /slm control plane.
+# VITE_DEFAULT_THEME_VARIANT=ember

--- a/autobot-frontend/src/composables/__tests__/useThemeVariant.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useThemeVariant.test.ts
@@ -1,0 +1,89 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * useThemeVariant.test.ts — default-variant resolution + persistence (Issue #10461)
+ *
+ * The user GUI defaults to the warm "ember" palette, overridable at build time via
+ * VITE_DEFAULT_THEME_VARIANT. A saved user choice always wins. The composable is a
+ * module-level singleton, so each test resets modules and imports a fresh instance.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+const KEY = 'autobot-theme-variant'
+
+async function freshComposable() {
+  vi.resetModules()
+  const mod = await import('../useThemeVariant')
+  return mod.useThemeVariant()
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  document.documentElement.removeAttribute('data-theme-variant')
+  vi.unstubAllEnvs()
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('useThemeVariant — default resolution', () => {
+  it('defaults to ember when nothing is stored and no env override', async () => {
+    const { themeVariant } = await freshComposable()
+    expect(themeVariant.value).toBe('ember')
+  })
+
+  it('honours VITE_DEFAULT_THEME_VARIANT=default override', async () => {
+    vi.stubEnv('VITE_DEFAULT_THEME_VARIANT', 'default')
+    const { themeVariant } = await freshComposable()
+    expect(themeVariant.value).toBe('default')
+  })
+
+  it('falls back to ember when the env override is an unknown value', async () => {
+    vi.stubEnv('VITE_DEFAULT_THEME_VARIANT', 'not-a-real-theme')
+    const { themeVariant } = await freshComposable()
+    expect(themeVariant.value).toBe('ember')
+  })
+
+  it('a saved choice wins over the default', async () => {
+    localStorage.setItem(KEY, 'default')
+    const { themeVariant } = await freshComposable()
+    expect(themeVariant.value).toBe('default')
+  })
+
+  it('ignores an unknown saved value and uses the default (ember)', async () => {
+    localStorage.setItem(KEY, 'garbage')
+    const { themeVariant } = await freshComposable()
+    expect(themeVariant.value).toBe('ember')
+  })
+
+  it('exposes both known variants', async () => {
+    const { availableVariants } = await freshComposable()
+    expect(availableVariants).toEqual(['default', 'ember'])
+  })
+})
+
+describe('useThemeVariant — DOM application + persistence', () => {
+  it('applies data-theme-variant=ember to <html> by default (no-flash parity)', async () => {
+    await freshComposable()
+    expect(document.documentElement.getAttribute('data-theme-variant')).toBe('ember')
+  })
+
+  it('removes the attribute when switching to default, and persists the choice', async () => {
+    const { setThemeVariant } = await freshComposable()
+    setThemeVariant('default')
+    await nextTick()
+    expect(document.documentElement.getAttribute('data-theme-variant')).toBeNull()
+    expect(localStorage.getItem(KEY)).toBe('default')
+  })
+
+  it('sets the attribute and persists when switching back to ember', async () => {
+    localStorage.setItem(KEY, 'default')
+    const { setThemeVariant } = await freshComposable()
+    setThemeVariant('ember')
+    await nextTick()
+    expect(document.documentElement.getAttribute('data-theme-variant')).toBe('ember')
+    expect(localStorage.getItem(KEY)).toBe('ember')
+  })
+})

--- a/autobot-frontend/src/composables/useThemeVariant.ts
+++ b/autobot-frontend/src/composables/useThemeVariant.ts
@@ -25,8 +25,27 @@ export type ThemeVariant = 'default' | 'ember'
 /** Storage key for persisting variant preference */
 const THEME_VARIANT_STORAGE_KEY = 'autobot-theme-variant'
 
+/** All known variants — single source of truth for validation. */
+const VALID_VARIANTS: readonly ThemeVariant[] = ['default', 'ember']
+
+/**
+ * Default variant when the user has no saved preference.
+ *
+ * The user GUI ships the warm "ember" palette by default (Issue #10461 / #9274).
+ * Build-time overridable via `VITE_DEFAULT_THEME_VARIANT` so a deployment that
+ * shares this build with the /slm control plane can pin `default` and keep the
+ * current look. An unset or unrecognised value falls back to `ember`.
+ */
+function resolveDefaultVariant(): ThemeVariant {
+  const fromEnv = import.meta.env?.VITE_DEFAULT_THEME_VARIANT as string | undefined
+  if (fromEnv && (VALID_VARIANTS as readonly string[]).includes(fromEnv)) {
+    return fromEnv as ThemeVariant
+  }
+  return 'ember'
+}
+
 /** Default variant when no preference is set */
-const DEFAULT_VARIANT: ThemeVariant = 'default'
+const DEFAULT_VARIANT: ThemeVariant = resolveDefaultVariant()
 
 /** Global reactive state (singleton pattern) */
 const currentVariant = ref<ThemeVariant>(DEFAULT_VARIANT)
@@ -62,8 +81,7 @@ function saveThemeVariant(variant: ThemeVariant): void {
 function loadThemeVariant(): ThemeVariant {
   try {
     const stored = localStorage.getItem(THEME_VARIANT_STORAGE_KEY) as ThemeVariant | null
-    const validVariants: ThemeVariant[] = ['default', 'ember']
-    if (stored && validVariants.includes(stored)) {
+    if (stored && VALID_VARIANTS.includes(stored)) {
       return stored
     }
   } catch {
@@ -128,7 +146,7 @@ export function useThemeVariant() {
   /**
    * Available theme variant options
    */
-  const availableVariants: ThemeVariant[] = ['default', 'ember']
+  const availableVariants: ThemeVariant[] = [...VALID_VARIANTS]
 
   /**
    * Theme variant labels for UI display

--- a/autobot-frontend/src/theme-variant-init.ts
+++ b/autobot-frontend/src/theme-variant-init.ts
@@ -19,12 +19,30 @@
  */
 
 const THEME_VARIANT_STORAGE_KEY = 'autobot-theme-variant'
+const VALID_VARIANTS = ['default', 'ember']
+
+/**
+ * Default variant for the user GUI (Issue #10461 / #9274): the warm "ember" palette.
+ * Build-time overridable via `VITE_DEFAULT_THEME_VARIANT` (Vite inlines this) so a
+ * deployment sharing this build with the /slm control plane can pin `default`.
+ * Mirrors resolveDefaultVariant() in composables/useThemeVariant.ts.
+ */
+function defaultVariant(): string {
+  const fromEnv = import.meta.env?.VITE_DEFAULT_THEME_VARIANT as string | undefined
+  return fromEnv && VALID_VARIANTS.includes(fromEnv) ? fromEnv : 'ember'
+}
 
 try {
-  const variant = localStorage.getItem(THEME_VARIANT_STORAGE_KEY)
-  if (variant && variant !== 'default') {
+  const stored = localStorage.getItem(THEME_VARIANT_STORAGE_KEY)
+  const variant = stored && VALID_VARIANTS.includes(stored) ? stored : defaultVariant()
+  // 'default' = base theme = no attribute; any other known variant sets it (no-flash).
+  if (variant !== 'default') {
     document.documentElement.setAttribute('data-theme-variant', variant)
   }
 } catch {
-  // localStorage may be unavailable (private mode / sandboxed) — fall back to default.
+  // localStorage unavailable (private mode / sandboxed): still apply the env/ember default.
+  const fallback = defaultVariant()
+  if (fallback !== 'default') {
+    document.documentElement.setAttribute('data-theme-variant', fallback)
+  }
 }

--- a/docs/superpowers/specs/2026-06-22-amber-ember-default-theme-design.md
+++ b/docs/superpowers/specs/2026-06-22-amber-ember-default-theme-design.md
@@ -1,0 +1,87 @@
+# Amber/Ember default theme for the user GUI — design (#10461)
+
+**Date:** 2026-06-22
+**Issue:** #10461 (follow-up to #8988 theme system, #9929 umbrella; design source #9274 "Ember")
+**Status:** Phase 1 design — approved decisions captured below
+
+## Goal
+
+Make the warm amber **Ember** palette the **default theme for the AutoBot user GUI**, while the
+`/slm` (Service Lifecycle Manager) control plane keeps its current look. Users can switch themes
+from user settings.
+
+## Decisions (from brainstorming)
+
+- **Design source = Ember (#9274) as-is.** Reuse the already-built `ember` variant
+  (marigold `#C4651A`, apricot-linen `#F5EEDE` light surfaces, mulberry-plum `#1E1418` dark,
+  gold `#ECA22A`). No new palette work. Its light mode is the warm cream/amber "pastel" look.
+- **Phased.** This spec is **Phase 1** (Ember default + user switching). The pluggable
+  "upload theme folder/zip via /slm, install, runtime-deliver" subsystem is **Phase 2** with its
+  own spec → plan → PR.
+- **`/slm` is a separate frontend deployment.** This `autobot-frontend` app contains only one
+  embedded `/slm/tools/novnc` tool and a single Vite entry; the SLM control plane is served
+  separately (`VITE_SLM_HOST`). So defaulting this app to Ember = defaulting the **user GUI**;
+  the SLM GUI is unaffected automatically.
+
+## Approach (chosen: A)
+
+Flip the default variant in the **existing** `data-theme-variant` system, made env-overridable.
+Ember is already a registered variant with CSS, persistence, and a working switcher — so this is a
+small, reversible change, not a new subsystem.
+
+Rejected: (B) route/area-scoped default — unnecessary, `/slm` is already separate (YAGNI);
+(C) hardcode `data-theme-variant="ember"` in `index.html` — breaks the default-vs-chosen logic and
+no-flash init.
+
+## Architecture (reused, unchanged subsystems)
+
+- `src/assets/css/themes/ember.css` — palette tokens, gated on `[data-theme-variant="ember"]`.
+- `src/composables/useThemeVariant.ts` — reactive variant state, localStorage persistence, applies
+  `data-theme-variant` to `<html>`.
+- `src/theme-variant-init.ts` — pre-mount no-flash bootstrap (module script in `index.html`).
+- `src/components/theme/EmberThemeToggle.vue` — generic switcher (iterates `availableVariants`),
+  already mounted in `src/components/ui/PreferencesPanel.vue`.
+
+## Changes
+
+1. **`useThemeVariant.ts`** — `DEFAULT_VARIANT = (import.meta.env.VITE_DEFAULT_THEME_VARIANT as ThemeVariant) || 'ember'`.
+   `loadThemeVariant()` already returns `DEFAULT_VARIANT` when nothing is stored; ensure an unknown
+   stored value or invalid env value falls back to `'ember'`.
+2. **`theme-variant-init.ts`** — when no stored variant, apply the env default (`'ember'`) to
+   `<html data-theme-variant>` before mount, so first paint is Ember with no flash. Vite inlines
+   `import.meta.env.VITE_DEFAULT_THEME_VARIANT` at build.
+3. **User settings** — the switcher (`EmberThemeToggle`, iterates `availableVariants`) is already
+   reachable: `SettingsView` → `PreferencesPanel` renders it under a "Theme Variant" fieldset,
+   alongside the separate light/dark "Theme" control. Kept the existing "Theme Variant" label
+   (a rename to "Theme" would collide with the light/dark control). The switcher is generic, so
+   Phase 2 themes appear automatically once registered in `availableVariants`.
+4. **`/slm` safety valve** — env override documented: an SLM/operator-console build can set
+   `VITE_DEFAULT_THEME_VARIANT=default` to pin the current look even if it ever shares this build.
+
+## Data flow
+
+init script (pre-mount) reads `localStorage` → else env-default (`ember`) → sets
+`data-theme-variant` → `useThemeVariant` on mount reconciles, `watch` persists user choice and
+re-applies the attribute → `EmberThemeToggle` calls `setThemeVariant`.
+
+## Migration / behavior
+
+- Users with **no** saved choice now see Ember (intended new default).
+- Users who explicitly chose "Default" have it in `localStorage` → unaffected.
+
+## Error handling
+
+`localStorage` unavailable → fall back to `ember`; unknown stored value → `ember`; invalid env
+value → `ember`.
+
+## Testing
+
+Unit tests for `useThemeVariant`: empty store → `ember`; env override respected; stored choice
+wins; unknown stored value → `ember`. Init-script no-flash behavior. Existing `EmberThemeToggle`
+still switches and persists. `vue-tsc` clean.
+
+## Out of scope (Phase 2 — separate spec)
+
+Theme package format (folder/zip manifest + CSS + fonts/icons); `/slm` upload + install flow;
+storage of installed themes; runtime dynamic-CSS delivery to the running frontend; validation and
+sandboxing/sanitization of uploaded CSS (security-sensitive).


### PR DESCRIPTION
## Thinking Path
Goal: make the warm **amber/Ember** palette the **default theme for the user GUI**, with the `/slm` control plane left on its current look and users able to switch themes in settings. Brainstormed → design source confirmed = the existing **Ember** theme (#9274, full color-coded palette + already implemented as the `ember` `data-theme-variant`). Scope **phased**: this is **Phase 1** (default + switching); pluggable theme packages uploaded/installed via `/slm` is Phase 2 (separate spec). Confirmed `/slm` is a **separate frontend deployment** (this app has only an embedded `/slm/tools/novnc` tool), so defaulting this app = defaulting the user GUI only.

## What Changed
- `composables/useThemeVariant.ts`: `DEFAULT_VARIANT` now resolves to `VITE_DEFAULT_THEME_VARIANT` (build-time override) else **`ember`**; single `VALID_VARIANTS` source for validation; unknown stored/env value → `ember`.
- `theme-variant-init.ts`: no-flash bootstrap now applies the `ember` (or env) default before mount when no choice is saved; a saved choice still wins.
- `.env.example`: documents `VITE_DEFAULT_THEME_VARIANT` (set `default` to keep the cool-neutral base — e.g. an `/slm`-shared build).
- The switcher already lives in user settings (`SettingsView` → `PreferencesPanel` → `EmberThemeToggle`); it's generic so Phase 2 themes appear automatically.
- `docs/superpowers/specs/2026-06-22-amber-ember-default-theme-design.md`: the design.

Reuses the existing Ember CSS/variant system — no new subsystem, fully reversible.

## Verification
- `vitest src/composables/__tests__/useThemeVariant.test.ts` → **9 passed** (default=ember; env override; unknown→ember; saved choice wins; DOM attr applied/removed; persistence).
- `vue-tsc --noEmit` → **0 errors**. `eslint` on changed files → clean.
- Migration: users with no saved choice now see Ember (intended); anyone who explicitly picked "Default" keeps it (localStorage).

## Model Used
Opus 4.8

Fixes #10461
