### PR TITLE
fix(deps): ignore protobuf-7/websockets-16 majors (Dependabot treadmill, #10474)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,14 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "torch"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "protobuf"
+        # #10474: cap <7.0 — opentelemetry-proto (otel 1.42) requires protobuf<7.0.
+        # Dependabot's 7.x bump is unsatisfiable; unblock when otel supports it.
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "websockets"
+        # #10474: cap <16 — langgraph-sdk 0.4.2 requires websockets >=14,<16.
+        # The 16.x bump is unsatisfiable; unblock when langgraph-sdk supports it.
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/autobot_shared"
@@ -440,4 +448,10 @@ updates:
       - dependency-name: "sqlalchemy"
         update-types: ["version-update:semver-major"]
       - dependency-name: "starlette"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "protobuf"
+        # #10474: cap <7.0 — opentelemetry-proto (otel 1.42) requires protobuf<7.0.
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "websockets"
+        # #10474: cap <16 — langgraph-sdk 0.4.2 requires websockets >=14,<16.
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Thinking Path
#10467/#10470 (and prior #10453/#10454) fail CI and recreate every run. Real cause (not a migration): Dependabot proposes protobuf 7.x and websockets 16 — both violate intentional caps (otel-proto needs protobuf<7.0; langgraph-sdk 0.4.2 needs websockets<16). They were missing from the ignore list.

## What Changed
- .github/dependabot.yml: add protobuf + websockets semver-major ignores to the /autobot-backend and / pip ecosystems.

## Verification
YAML validates. After merge, the next grouped PR drops protobuf/websockets and carries only satisfiable bumps (numpy-minor, opencv, langchain-core/langgraph patches) → mergeable. Closes #10467/#10470 as superseded.

## Model Used
Claude Opus 4.8