### PR TITLE
feat(secrets): service-auth System-vault access + KEK rotation (rewrap_dek) on UnifiedSecretsService + API (#10436, #10437)

### DIFF
--- a/.github/workflows/migration-gate.yml
+++ b/.github/workflows/migration-gate.yml
@@ -73,13 +73,16 @@ jobs:
         # Deliberately minimal — exactly what migrations/env.py and the
         # baseline entrypoint import. Keeping this lean keeps the gate fast
         # and proves migrations don't silently grow heavyweight deps.
+        # structlog is required because test_unified_secrets_api.py mounts the
+        # full FastAPI router which transitively imports security.service_auth
+        # (structlog-based structured logging for HMAC service-auth).
         run: |
           python -m pip install --upgrade pip
           python -m pip install \
             "alembic>=1.13" "sqlalchemy[asyncio]>=2.0" asyncpg aiosqlite \
             pydantic pydantic-settings \
             bcrypt pyjwt redis httpx aiofiles python-dotenv pyyaml \
-            cryptography fastapi \
+            cryptography fastapi structlog \
             pytest pytest-asyncio
 
       - name: Run migration matrix

--- a/autobot-backend/api/unified_secrets.py
+++ b/autobot-backend/api/unified_secrets.py
@@ -295,7 +295,7 @@ async def service_read_system_secret(
     coordinator: SecretsCoordinator = Depends(get_coordinator),
 ) -> SecretValue:
     """Read a system-vault secret value via service identity."""
-    logger.info("service CRUD: read system secret", extra={"service_id": service_id, "secret_id": str(secret_id)})
+    logger.info("service CRUD: read system secret", extra={"service_id": service_id, "entry_id": str(secret_id)})
     try:
         value = await coordinator.service_read(session, secret_id=secret_id, vault=_SYSTEM_VAULT)
     except (SecretAccessError, SecretNotFoundError) as exc:
@@ -312,7 +312,7 @@ async def service_rotate_system_secret(
     coordinator: SecretsCoordinator = Depends(get_coordinator),
 ) -> SecretMetadata:
     """Rotate a system-vault secret value (re-seal with new DEK) via service identity."""
-    logger.info("service CRUD: rotate system secret", extra={"service_id": service_id, "secret_id": str(secret_id)})
+    logger.info("service CRUD: rotate system secret", extra={"service_id": service_id, "entry_id": str(secret_id)})
     try:
         secret = await coordinator.service_rotate(
             session, secret_id=secret_id, new_plaintext=body.value.encode("utf-8"), vault=_SYSTEM_VAULT
@@ -331,7 +331,7 @@ async def service_delete_system_secret(
     coordinator: SecretsCoordinator = Depends(get_coordinator),
 ) -> None:
     """Delete a system-vault secret via service identity."""
-    logger.info("service CRUD: delete system secret", extra={"service_id": service_id, "secret_id": str(secret_id)})
+    logger.info("service CRUD: delete system secret", extra={"service_id": service_id, "entry_id": str(secret_id)})
     try:
         await coordinator.service_delete(session, secret_id=secret_id, vault=_SYSTEM_VAULT)
         await session.commit()

--- a/autobot-backend/api/unified_secrets.py
+++ b/autobot-backend/api/unified_secrets.py
@@ -21,6 +21,7 @@ Coordinator exceptions map to HTTP: ``SecretNotFoundError``→404,
 
 from __future__ import annotations
 
+import logging
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -28,11 +29,17 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth_middleware import get_auth_middleware
-from autobot_shared.secrets_vault import VaultRef
+from autobot_shared.secrets_vault import VaultKind, VaultRef
 from llc.deps import get_session
 from models.secret import Secret
+from security.service_auth import validate_service_auth
 from services.secrets_coordinator import SecretsCoordinator
 from services.unified_secrets_service import SecretAccessError, SecretNotFoundError
+
+logger = logging.getLogger(__name__)
+
+#: The singleton system vault reference — the only vault a service principal may touch.
+_SYSTEM_VAULT = VaultRef(VaultKind.SYSTEM)
 
 router = APIRouter()
 
@@ -60,6 +67,39 @@ async def principal(request: Request) -> tuple[uuid.UUID, set[str]]:
 
     permissions = await rbac_middleware.get_user_permissions(user_id)
     return user_id, set(permissions)
+
+
+async def service_principal(request: Request) -> str:
+    """Validate HMAC service auth (X-Service-* headers) and return the service_id.
+
+    A service identity is scoped STRICTLY to the system vault — any attempt to
+    access a user/company/team/role vault via this path is rejected (403) at the
+    endpoint level, not here, so the audit log always sees the attempt.
+    """
+    try:
+        info = await validate_service_auth(request)
+    except HTTPException:
+        raise
+    service_id: str = info["service_id"]
+    logger.info(
+        "service principal authenticated for secrets API",
+        extra={"service_id": service_id, "path": request.url.path, "method": request.method},
+    )
+    return service_id
+
+
+def _require_system_vault(vault: VaultRef, service_id: str) -> None:
+    """Enforce that a service principal only touches the system vault; 403 otherwise."""
+    if vault.kind is not VaultKind.SYSTEM:
+        logger.warning(
+            "service principal rejected: attempted non-system vault access",
+            extra={"service_id": service_id, "vault": vault.to_str()},
+        )
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            f"service identity '{service_id}' is restricted to the system vault; "
+            f"attempted vault: {vault.to_str()!r}",
+        )
 
 
 def _vault(value: str) -> VaultRef:
@@ -92,6 +132,12 @@ class ShareBody(BaseModel):
 
 class RotateBody(BaseModel):
     value: str
+
+
+class RewrapBody(BaseModel):
+    """New root key (url-safe base64, 32 bytes decoded) to derive fresh KEKs for rewrapping."""
+
+    new_root_key: str
 
 
 class SecretMetadata(BaseModel):
@@ -193,6 +239,109 @@ async def list_secrets(
     user_id, perms = who
     secrets = await coordinator.list(session, user_id=user_id, permissions=perms)
     return [SecretMetadata.of(s) for s in secrets]
+
+
+# ---------------------------------------------------------------------------
+# Service-auth System vault access (#10436) — registered BEFORE /{secret_id}
+# so that literal "/system" and "/system/{id}" paths take priority over the
+# parameterised UUID routes. Service principals carry valid X-Service-* HMAC
+# headers and may ONLY access secrets whose owner_vault is "system".
+# ---------------------------------------------------------------------------
+
+
+@router.post("/system", response_model=SecretMetadata, status_code=status.HTTP_201_CREATED)
+async def service_create_system_secret(
+    body: CreateSecretBody,
+    service_id: str = Depends(service_principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> SecretMetadata:
+    """Create a secret in the system vault via service identity (HMAC-authenticated)."""
+    vault = _vault(body.owner_vault)
+    _require_system_vault(vault, service_id)
+    logger.info("service CRUD: create system secret", extra={"service_id": service_id, "name": body.name})
+    try:
+        secret = await coordinator.service_create(
+            session,
+            owner_vault=vault,
+            name=body.name,
+            secret_type=body.secret_type,
+            plaintext=body.value.encode("utf-8"),
+            service_id=service_id,
+        )
+        await session.commit()
+    except (SecretAccessError, SecretNotFoundError, ValueError) as exc:
+        raise _mapped(exc)
+    return SecretMetadata.of(secret)
+
+
+@router.get("/system", response_model=list[SecretMetadata])
+async def service_list_system_secrets(
+    service_id: str = Depends(service_principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> list[SecretMetadata]:
+    """List system-vault secrets accessible to a service identity."""
+    logger.info("service CRUD: list system secrets", extra={"service_id": service_id})
+    secrets = await coordinator.service_list(session, vault=_SYSTEM_VAULT)
+    return [SecretMetadata.of(s) for s in secrets]
+
+
+@router.get("/system/{secret_id}", response_model=SecretValue)
+async def service_read_system_secret(
+    secret_id: uuid.UUID,
+    service_id: str = Depends(service_principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> SecretValue:
+    """Read a system-vault secret value via service identity."""
+    logger.info("service CRUD: read system secret", extra={"service_id": service_id, "secret_id": str(secret_id)})
+    try:
+        value = await coordinator.service_read(session, secret_id=secret_id, vault=_SYSTEM_VAULT)
+    except (SecretAccessError, SecretNotFoundError) as exc:
+        raise _mapped(exc)
+    return SecretValue(value=value.decode("utf-8"))
+
+
+@router.put("/system/{secret_id}", response_model=SecretMetadata)
+async def service_rotate_system_secret(
+    secret_id: uuid.UUID,
+    body: RotateBody,
+    service_id: str = Depends(service_principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> SecretMetadata:
+    """Rotate a system-vault secret value (re-seal with new DEK) via service identity."""
+    logger.info("service CRUD: rotate system secret", extra={"service_id": service_id, "secret_id": str(secret_id)})
+    try:
+        secret = await coordinator.service_rotate(
+            session, secret_id=secret_id, new_plaintext=body.value.encode("utf-8"), vault=_SYSTEM_VAULT
+        )
+        await session.commit()
+    except (SecretAccessError, SecretNotFoundError) as exc:
+        raise _mapped(exc)
+    return SecretMetadata.of(secret)
+
+
+@router.delete("/system/{secret_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def service_delete_system_secret(
+    secret_id: uuid.UUID,
+    service_id: str = Depends(service_principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> None:
+    """Delete a system-vault secret via service identity."""
+    logger.info("service CRUD: delete system secret", extra={"service_id": service_id, "secret_id": str(secret_id)})
+    try:
+        await coordinator.service_delete(session, secret_id=secret_id, vault=_SYSTEM_VAULT)
+        await session.commit()
+    except (SecretAccessError, SecretNotFoundError) as exc:
+        raise _mapped(exc)
+
+
+# ---------------------------------------------------------------------------
+# User-principal parameterised routes — registered AFTER literal /system paths
+# ---------------------------------------------------------------------------
 
 
 @router.get("/{secret_id}", response_model=SecretValue)
@@ -311,3 +460,45 @@ async def revoke_share(
         await session.commit()
     except (SecretAccessError, SecretNotFoundError, ValueError) as exc:
         raise _mapped(exc)
+
+
+# ---------------------------------------------------------------------------
+# KEK rotation endpoint (#10437) — rewrap DEKs under a new root key without
+# changing the sealed payload. Requires user auth (admin rights gate this
+# operation through the coordinator). Route registered after /system/* but
+# before /{secret_id} so the literal paths take priority; /rewrap sub-path
+# is unambiguous since it cannot be a valid UUID.
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{secret_id}/rewrap", response_model=SecretMetadata)
+async def rewrap_secret_kek(
+    secret_id: uuid.UUID,
+    body: RewrapBody,
+    who: tuple[uuid.UUID, set[str]] = Depends(principal),
+    session: AsyncSession = Depends(get_session),
+    coordinator: SecretsCoordinator = Depends(get_coordinator),
+) -> SecretMetadata:
+    """Rotate the wrapping KEK for *secret_id* by rewrapping all grants under the new root key.
+
+    The sealed value is untouched — only the wrapped DEKs change. Use this after
+    rotating ``AUTOBOT_SECRETS_ROOT_KEY`` to migrate grants to the new KEK.
+    """
+    import base64
+    import binascii
+
+    try:
+        new_root = base64.urlsafe_b64decode(body.new_root_key + "==")
+    except (binascii.Error, ValueError) as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "new_root_key must be url-safe base64") from exc
+    if len(new_root) != 32:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "new_root_key must decode to exactly 32 bytes")
+    user_id, perms = who
+    try:
+        secret = await coordinator.rotate_kek(
+            session, user_id=user_id, permissions=perms, secret_id=secret_id, new_root_key=new_root
+        )
+        await session.commit()
+    except (SecretAccessError, SecretNotFoundError) as exc:
+        raise _mapped(exc)
+    return SecretMetadata.of(secret)

--- a/autobot-backend/services/secrets_coordinator.py
+++ b/autobot-backend/services/secrets_coordinator.py
@@ -31,12 +31,13 @@ in the owning vault, never by B's.
 
 from __future__ import annotations
 
+import logging
 import uuid
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from autobot_shared.secrets_vault import VaultRef
+from autobot_shared.secrets_vault import VaultKind, VaultRef
 from models.secret import Secret
 from models.secret_dependency import SecretDependency
 from models.secret_grant import SecretGrant
@@ -49,6 +50,11 @@ from services.unified_secrets_service import (
     SecretNotFoundError,
     UnifiedSecretsService,
 )
+
+logger = logging.getLogger(__name__)
+
+#: Sentinel UUID used as ``created_by`` for service-principal operations (no real user).
+_SERVICE_OWNER_ID = uuid.UUID("00000000-0000-0000-0000-000000000000")
 
 
 class SecretsCoordinator:
@@ -179,6 +185,26 @@ class SecretsCoordinator:
             session, secret_id=secret_id, new_plaintext=new_plaintext, actor_vaults=facts.accessible_vaults()
         )
 
+    async def rotate_kek(
+        self,
+        session: AsyncSession,
+        *,
+        user_id: uuid.UUID,
+        permissions: set[str],
+        secret_id: uuid.UUID,
+        new_root_key: bytes,
+    ) -> Secret:
+        facts = await self._facts(session, user_id, permissions)
+        owner_vault = await self._owner_vault(session, secret_id)
+        if not authorize(facts, "write", owner_vault):
+            raise SecretAccessError(f"not authorized to rotate KEK for secrets in {owner_vault.to_str()}")
+        return await self._service.rotate_kek(
+            session,
+            secret_id=secret_id,
+            new_root_key=new_root_key,
+            actor_vaults=facts.accessible_vaults(),
+        )
+
     async def delete(
         self, session: AsyncSession, *, user_id: uuid.UUID, permissions: set[str], secret_id: uuid.UUID
     ) -> None:
@@ -186,4 +212,68 @@ class SecretsCoordinator:
         owner_vault = await self._owner_vault(session, secret_id)
         if not authorize(facts, "write", owner_vault):
             raise SecretAccessError(f"not authorized to delete secrets in {owner_vault.to_str()}")
+        await self._service.delete(session, secret_id=secret_id)
+
+    # ------------------------------------------------------------------
+    # Service-principal operations (#10436): bypass user RBAC; scope is
+    # STRICTLY the system vault — callers must already have enforced this
+    # (see _require_system_vault in the API layer).  These methods exist
+    # so the coordinator boundary is still the single enforcement point
+    # for crypto orchestration, while the API layer handles auth.
+    # ------------------------------------------------------------------
+
+    def _assert_system_vault(self, vault: VaultRef) -> None:
+        """Double-check that only the system vault is used; raises SecretAccessError otherwise."""
+        if vault.kind is not VaultKind.SYSTEM:
+            raise SecretAccessError(f"service operations are restricted to the system vault; got {vault.to_str()!r}")
+
+    async def service_create(
+        self,
+        session: AsyncSession,
+        *,
+        owner_vault: VaultRef,
+        name: str,
+        secret_type: str,
+        plaintext: bytes,
+        service_id: str,
+    ) -> Secret:
+        """Create a system-vault secret on behalf of a service identity."""
+        self._assert_system_vault(owner_vault)
+        logger.info("service_create system secret", extra={"service_id": service_id, "name": name})
+        return await self._service.create(
+            session,
+            owner_vault=owner_vault,
+            name=name,
+            secret_type=secret_type,
+            plaintext=plaintext,
+            created_by=_SERVICE_OWNER_ID,
+        )
+
+    async def service_read(self, session: AsyncSession, *, secret_id: uuid.UUID, vault: VaultRef) -> bytes:
+        """Read a system-vault secret value on behalf of a service identity."""
+        self._assert_system_vault(vault)
+        return await self._service.read(session, secret_id=secret_id, accessible_vaults={vault})
+
+    async def service_list(self, session: AsyncSession, *, vault: VaultRef) -> list[Secret]:
+        """List system-vault secrets accessible to a service identity."""
+        self._assert_system_vault(vault)
+        return await self._service.list_for_vaults(session, accessible_vaults={vault})
+
+    async def service_rotate(
+        self, session: AsyncSession, *, secret_id: uuid.UUID, new_plaintext: bytes, vault: VaultRef
+    ) -> Secret:
+        """Rotate (re-seal) a system-vault secret value on behalf of a service identity."""
+        self._assert_system_vault(vault)
+        return await self._service.rotate_value(
+            session, secret_id=secret_id, new_plaintext=new_plaintext, actor_vaults={vault}
+        )
+
+    async def service_delete(self, session: AsyncSession, *, secret_id: uuid.UUID, vault: VaultRef) -> None:
+        """Delete a system-vault secret on behalf of a service identity."""
+        self._assert_system_vault(vault)
+        owner_vault = await self._owner_vault(session, secret_id)
+        if owner_vault.kind is not VaultKind.SYSTEM:
+            raise SecretAccessError(
+                f"service may only delete system-vault secrets; found owner {owner_vault.to_str()!r}"
+            )
         await self._service.delete(session, secret_id=secret_id)

--- a/autobot-backend/services/unified_secrets_service.py
+++ b/autobot-backend/services/unified_secrets_service.py
@@ -36,6 +36,7 @@ from autobot_shared.secrets_envelope import (
     derive_vault_key,
     load_root_key,
     open_secret,
+    rewrap_dek,
     seal,
     unwrap_dek,
     wrap_dek,
@@ -189,6 +190,31 @@ class UnifiedSecretsService:
             grant.wrapped_dek = wrap_dek(
                 new_dek, self._kek(grant.grantee), grant.grantee, secret_id=str(secret_id)
             ).to_dict()
+        await session.flush()
+        return secret
+
+    async def rotate_kek(
+        self,
+        session: AsyncSession,
+        *,
+        secret_id: uuid.UUID,
+        new_root_key: bytes,
+        actor_vaults: Iterable[VaultRef],
+    ) -> Secret:
+        """Rewrap every grant from the current KEK to a KEK derived from *new_root_key*.
+
+        The sealed value (payload) is untouched; only the wrapped DEKs change.  Use this
+        when the root key is rotated: pass the new root key and every grant is migrated so
+        the secret is readable with the new key. ``actor_vaults`` must contain at least one
+        current grantee vault — the actor proves access before rewrapping is allowed.
+        """
+        secret = await self._load(session, secret_id)
+        await self._dek_via(session, secret, actor_vaults)  # authorize: actor holds access
+        for grant in await self._grants(session, secret_id):
+            old_kek = self._kek(grant.grantee)
+            new_kek = derive_vault_key(new_root_key, grant.grantee)
+            old_wrapped = WrappedDek.from_dict(grant.wrapped_dek)
+            grant.wrapped_dek = rewrap_dek(old_wrapped, old_kek, new_kek, secret_id=str(secret_id)).to_dict()
         await session.flush()
         return secret
 

--- a/autobot-backend/tests/migrations/test_unified_secrets_api.py
+++ b/autobot-backend/tests/migrations/test_unified_secrets_api.py
@@ -139,3 +139,120 @@ async def test_invalid_vault_ref_400(client):
         headers=_as(_ADMIN),
     )
     assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# KEK rotation — /api/v2/secrets/{id}/rewrap (#10437)
+# ---------------------------------------------------------------------------
+
+_ROOT2_B64 = base64.urlsafe_b64encode(bytes(reversed(bytes(range(32))))).decode("ascii")
+
+
+async def test_rewrap_same_plaintext(client):
+    """After /rewrap the admin can still decrypt (new root key); version unchanged."""
+    sid = (await _create(client)).json()["id"]
+    r = await client.post(f"{_P}/{sid}/rewrap", json={"new_root_key": _ROOT2_B64}, headers=_as(_ADMIN))
+    assert r.status_code == 200, r.text
+    # version must NOT change (payload untouched — only wrapped DEK changed)
+    assert r.json()["version"] == 1
+
+
+async def test_rewrap_bad_key_400(client):
+    """Invalid base64 new_root_key returns 400."""
+    sid = (await _create(client)).json()["id"]
+    r = await client.post(f"{_P}/{sid}/rewrap", json={"new_root_key": "not-base64!!!"}, headers=_as(_ADMIN))
+    assert r.status_code == 400
+
+
+async def test_rewrap_missing_secret_404(client):
+    r = await client.post(f"{_P}/{uuid.uuid4()}/rewrap", json={"new_root_key": _ROOT2_B64}, headers=_as(_ADMIN))
+    assert r.status_code == 404
+
+
+async def test_rewrap_unauthorized_403(client):
+    sid = (await _create(client)).json()["id"]
+    r = await client.post(f"{_P}/{sid}/rewrap", json={"new_root_key": _ROOT2_B64}, headers=_as(_OUTSIDER))
+    assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Service-auth system vault access (#10436)
+# Override service_principal to inject a fake service identity; verify system
+# vault CRUD succeeds and non-system vault is rejected 403.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def service_client(fresh_db_url):
+    """App with service_principal overridden to inject service_id='test-slm'."""
+    from api.unified_secrets import service_principal as _sp
+
+    assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
+    engine = create_async_engine(fresh_db_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    app = FastAPI()
+    app.include_router(unified_secrets.router, prefix=_P)
+
+    async def _session_override():
+        async with maker() as sess:
+            yield sess
+
+    async def _service_principal_override():
+        return "test-slm"
+
+    app.dependency_overrides[unified_secrets.get_session] = _session_override
+    app.dependency_overrides[unified_secrets.get_coordinator] = lambda: SecretsCoordinator(
+        UnifiedSecretsService(root_key=_ROOT)
+    )
+    app.dependency_overrides[unified_secrets.service_principal] = _service_principal_override
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t", follow_redirects=True) as c:
+        yield c
+    await engine.dispose()
+
+
+async def _svc_create(client, vault="system", value="fleet-secret"):
+    return await client.post(
+        f"{_P}/system",
+        json={"owner_vault": vault, "name": "fleet-sso", "secret_type": "token", "value": value},
+    )
+
+
+async def test_service_create_and_read_system_vault(service_client):
+    r = await _svc_create(service_client)
+    assert r.status_code == 201, r.text
+    sid = r.json()["id"]
+    assert r.json()["owner_vault"] == "system"
+    rr = await service_client.get(f"{_P}/system/{sid}")
+    assert rr.status_code == 200 and rr.json()["value"] == "fleet-secret"
+
+
+async def test_service_list_system_vault(service_client):
+    await _svc_create(service_client, value="s1")
+    await _svc_create(service_client, value="s2")
+    lst = await service_client.get(f"{_P}/system")
+    assert lst.status_code == 200
+    assert len(lst.json()) >= 2
+
+
+async def test_service_rotate_system_vault(service_client):
+    sid = (await _svc_create(service_client)).json()["id"]
+    r = await service_client.put(f"{_P}/system/{sid}", json={"value": "rotated"})
+    assert r.status_code == 200 and r.json()["version"] == 2
+    rr = await service_client.get(f"{_P}/system/{sid}")
+    assert rr.json()["value"] == "rotated"
+
+
+async def test_service_delete_system_vault(service_client):
+    sid = (await _svc_create(service_client)).json()["id"]
+    dr = await service_client.delete(f"{_P}/system/{sid}")
+    assert dr.status_code == 204
+    assert (await service_client.get(f"{_P}/system/{sid}")).status_code == 404
+
+
+async def test_service_rejected_on_non_system_vault(service_client):
+    """Service principal 403 on any non-system vault."""
+    r = await _svc_create(service_client, vault=f"user:{_ADMIN}")
+    assert r.status_code == 403

--- a/autobot-backend/tests/migrations/test_unified_secrets_api.py
+++ b/autobot-backend/tests/migrations/test_unified_secrets_api.py
@@ -185,7 +185,6 @@ async def test_rewrap_unauthorized_403(client):
 @pytest.fixture()
 async def service_client(fresh_db_url):
     """App with service_principal overridden to inject service_id='test-slm'."""
-    from api.unified_secrets import service_principal as _sp
 
     assert run_alembic(["upgrade", "head"], fresh_db_url).returncode == 0
     engine = create_async_engine(fresh_db_url)

--- a/autobot-backend/tests/migrations/test_unified_secrets_service.py
+++ b/autobot-backend/tests/migrations/test_unified_secrets_service.py
@@ -145,3 +145,52 @@ async def test_delete_cascades_grants(svc, session):
 async def test_read_missing_secret(svc, session):
     with pytest.raises(SecretNotFoundError):
         await svc.read(session, secret_id=uuid.uuid4(), accessible_vaults={_USER})
+
+
+# ---------------------------------------------------------------------------
+# rotate_kek (#10437) — rewrap DEKs under new root key, payload unchanged
+# ---------------------------------------------------------------------------
+
+_ROOT2 = bytes(reversed(bytes(range(32))))  # a distinct second root key for KEK rotation tests
+
+
+async def test_rotate_kek_same_plaintext_decrypts(svc, session):
+    """After KEK rotation the sealed value decrypts identically under the new root key."""
+    secret = await _new(svc, session, plaintext=b"kek_test")
+    await svc.rotate_kek(session, secret_id=secret.id, new_root_key=_ROOT2, actor_vaults={_USER})
+    await session.commit()
+    # Decrypt with new root key
+    svc2 = UnifiedSecretsService(root_key=_ROOT2)
+    plaintext = await svc2.read(session, secret_id=secret.id, accessible_vaults={_USER})
+    assert plaintext == b"kek_test"
+
+
+async def test_rotate_kek_old_key_no_longer_decrypts(svc, session):
+    """After KEK rotation, the OLD root key's KEK can no longer unwrap the DEK."""
+    from autobot_shared.secrets_envelope import DecryptionError
+
+    secret = await _new(svc, session, plaintext=b"will_rotate")
+    await svc.rotate_kek(session, secret_id=secret.id, new_root_key=_ROOT2, actor_vaults={_USER})
+    await session.commit()
+    # Old svc (root=_ROOT) must now fail to decrypt
+    with pytest.raises(DecryptionError):
+        await svc.read(session, secret_id=secret.id, accessible_vaults={_USER})
+
+
+async def test_rotate_kek_rewraps_all_grantees(svc, session):
+    """All grantees can decrypt after KEK rotation via the new root key."""
+    secret = await _new(svc, session, plaintext=b"shared")
+    await svc.share(session, secret_id=secret.id, actor_vaults={_USER}, grantee=_COMPANY, created_by=uuid.uuid4())
+    await session.commit()
+    await svc.rotate_kek(session, secret_id=secret.id, new_root_key=_ROOT2, actor_vaults={_USER})
+    await session.commit()
+    svc2 = UnifiedSecretsService(root_key=_ROOT2)
+    assert await svc2.read(session, secret_id=secret.id, accessible_vaults={_USER}) == b"shared"
+    assert await svc2.read(session, secret_id=secret.id, accessible_vaults={_COMPANY}) == b"shared"
+
+
+async def test_rotate_kek_requires_access(svc, session):
+    """rotate_kek raises SecretAccessError when actor holds no grant."""
+    secret = await _new(svc, session, plaintext=b"private")
+    with pytest.raises(SecretAccessError):
+        await svc.rotate_kek(session, secret_id=secret.id, new_root_key=_ROOT2, actor_vaults={_OTHER})


### PR DESCRIPTION
## Thinking Path
Two unified-secrets platform prerequisites (surfaced while scoping SSO secret migration onto #10088). Both unblock #10153/#10154.

## What Changed
**#10436 — service/system access path to the System vault:**
- `api/unified_secrets.py` — added `service_principal` dependency (validates via `validate_service_auth`, the `X-Service-*` channel used by `voice_proxy.py`) + `_require_system_vault` guard; 5 service-auth endpoints (`POST/GET/GET{id}/PUT/DELETE /system`) registered before the parameterized routes.
- `services/secrets_coordinator.py` — `service_*` methods scoped strictly to the System vault.
- **Double-fence scoping**: API layer 403s any non-system vault before touching the coordinator; coordinator independently re-asserts system-vault kind (defence in depth). User auth path unchanged. Service access audit-logged.

**#10437 — KEK rotation (rewrap_dek):**
- `services/unified_secrets_service.py` — `rotate_kek(...)` rewraps every grant's DEK via the existing `rewrap_dek` primitive (`autobot_shared/secrets_envelope.py:226`), rotating the wrapping KEK without touching the sealed plaintext.
- `services/secrets_coordinator.py` — `rotate_kek` with authorization.
- `api/unified_secrets.py` — `POST /{secret_id}/rewrap` endpoint (base64 32-byte new root key).

## Verification
- `py_compile` + line-length clean on all 5 files.
- Tests: 15 passed (non-postgres); new service/rewrap/KEK tests tagged `migration_gate`+`requires_postgres` (run in CI's migration-gate). Covers: service CRUD on system vault, 403 on user vault, same-plaintext-decrypts-after-KEK-rotation, old-key-fails, unauthorized-403.
- Closes #10436, #10437. Unblocks #10153/#10154.

## Model Used
Claude Opus 4.8 (senior-backend-engineer subagent).
