### PR TITLE
feat(deploy): fail-closed remote-Postgres pre-migration backup + GPU vLLM requirements-gpu install (#10045, #10288)

### DIFF
--- a/autobot-backend/tests/migrations/test_ansible_migration_contract.py
+++ b/autobot-backend/tests/migrations/test_ansible_migration_contract.py
@@ -17,6 +17,16 @@ carried on. These tests pin the strict contract for BOTH playbooks:
 5. update-all-nodes' migrate play stops the deploy on failure
    (``any_errors_fatal``).
 
+#10045 hardens the backup into a FAIL-CLOSED step. The original #10026 backup
+only handled local Postgres (``pg_dumpall``) and warned-and-skipped when
+Postgres was remote (colocated on the SLM server) — the one fleet state that
+most needs the backup was the one that silently skipped it. The contract now
+also asserts:
+
+6. a remote ``pg_dump`` path exists (network dump from a derived libpq URL);
+7. NO skip-path exists — no warn-and-skip branch, and the backup never carries
+   ``failed_when: false``.
+
 Pure YAML inspection — no Ansible runtime needed.
 """
 
@@ -25,8 +35,11 @@ from pathlib import Path
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-SETUP_PLAYBOOK = REPO_ROOT / "autobot-slm-backend" / "ansible" / "setup-user-backend.yml"
-UPDATE_PLAYBOOK = REPO_ROOT / "autobot-slm-backend" / "ansible" / "playbooks" / "update-all-nodes.yml"
+ANSIBLE_ROOT = REPO_ROOT / "autobot-slm-backend" / "ansible"
+SETUP_PLAYBOOK = ANSIBLE_ROOT / "setup-user-backend.yml"
+UPDATE_PLAYBOOK = ANSIBLE_ROOT / "playbooks" / "update-all-nodes.yml"
+# Reusable fail-closed backup task file included by both playbooks (#10045).
+BACKUP_TASKS = ANSIBLE_ROOT / "_shared" / "tasks" / "pre_migration_backup.yml"
 
 
 def _flatten_tasks(items):
@@ -42,15 +55,40 @@ def _flatten_tasks(items):
             yield item
 
 
-def _playbook_tasks(path: Path):
-    """Yield (play, task) for every task in the playbook, document order."""
+def _include_target(task, base_dir: Path):
+    """Resolve an ``include_tasks``/``import_tasks`` target to an absolute path."""
+    for key in ("ansible.builtin.include_tasks", "include_tasks", "ansible.builtin.import_tasks", "import_tasks"):
+        ref = task.get(key)
+        if isinstance(ref, str):
+            return (base_dir / ref).resolve()
+        if isinstance(ref, dict) and isinstance(ref.get("file"), str):
+            return (base_dir / ref["file"]).resolve()
+    return None
+
+
+def _expanded_tasks(path: Path):
+    """Yield (play, task) for every task, descending into included task files.
+
+    Included files have no play context of their own, so the including play is
+    propagated to the included tasks. (#10045: the pre-migration backup now
+    lives in a shared include.)
+    """
     plays = yaml.safe_load(path.read_text(encoding="utf-8"))
     for play in plays if isinstance(plays, list) else [plays]:
-        for section in ("pre_tasks", "roles", "tasks", "post_tasks"):
-            if section == "roles":
-                continue
+        for section in ("pre_tasks", "tasks", "post_tasks"):
             for task in _flatten_tasks(play.get(section)):
-                yield play, task
+                target = _include_target(task, path.parent)
+                if target is not None and target.exists():
+                    included = yaml.safe_load(target.read_text(encoding="utf-8"))
+                    for sub in _flatten_tasks(included):
+                        yield play, sub
+                else:
+                    yield play, task
+
+
+# Backwards-compatible alias used by the existing tests.
+def _playbook_tasks(path: Path):
+    yield from _expanded_tasks(path)
 
 
 def _task_text(task) -> str:
@@ -100,7 +138,7 @@ def _has_backup_before_upgrade(path: Path) -> bool:
     saw_backup = False
     for _, task in _playbook_tasks(path):
         text = _task_text(task)
-        if "pg_dump" in text:
+        if "pg_dump" in text:  # matches both pg_dumpall (local) and pg_dump (remote)
             saw_backup = True
         if "upgrade head" in text:
             return saw_backup
@@ -136,3 +174,63 @@ def test_update_playbook_migrate_play_is_fatal():
             )
             return
     raise AssertionError("update-all-nodes.yml: no upgrade head task found")
+
+
+# --- #10045: fail-closed backup contract --------------------------------------
+
+
+def test_shared_backup_task_file_exists():
+    assert BACKUP_TASKS.exists(), f"missing shared pre-migration backup task file: {BACKUP_TASKS}"
+
+
+def test_backup_covers_remote_postgres():
+    """A remote pg_dump (network dump from a derived URL) path must exist (#10045)."""
+    text = BACKUP_TASKS.read_text(encoding="utf-8")
+    assert "pg_dumpall" in text, "pre_migration_backup.yml: missing the local pg_dumpall fast path"
+    assert "pg_dump " in text or "pg_dump\n" in text or "pg_dump --" in text, (
+        "pre_migration_backup.yml: missing the remote 'pg_dump' (network dump) "
+        "path for colocated/remote Postgres (#10045)"
+    )
+    # The remote path must derive a libpq URL by stripping the +asyncpg driver.
+    assert "+asyncpg" in text or "postgres(ql)?)\\+" in text or "+[a-z" in text, (
+        "pre_migration_backup.yml: remote path must strip the SQLAlchemy "
+        "'+asyncpg' driver suffix to build a libpq URL (#10045)"
+    )
+
+
+def test_backup_is_fail_closed_no_skip_path():
+    """The backup must FAIL when it cannot run — no warn-and-skip branch (#10045)."""
+    backup = yaml.safe_load(BACKUP_TASKS.read_text(encoding="utf-8"))
+    text_all = BACKUP_TASKS.read_text(encoding="utf-8").lower()
+
+    # No warn-and-skip language anywhere in the backup tasks.
+    assert "backup skipped" not in text_all, (
+        "pre_migration_backup.yml: a 'backup skipped' warn-and-proceed branch "
+        "still exists — the migration must fail-closed instead (#10045)"
+    )
+
+    # No backup task may swallow failures.
+    for task in _flatten_tasks(backup):
+        ttext = _task_text(task)
+        if "pg_dump" in ttext:
+            assert task.get("failed_when") is not False, (
+                f"pre_migration_backup.yml: backup task swallows failures with "
+                f"failed_when: false (#10045): {task.get('name')}"
+            )
+
+    # The remote shell explicitly exits non-zero when no source can be derived.
+    src = BACKUP_TASKS.read_text(encoding="utf-8")
+    assert "exit 1" in src, (
+        "pre_migration_backup.yml: remote path must 'exit 1' (abort) when no "
+        "database URL / Postgres vars are available (#10045)"
+    )
+
+
+def test_playbooks_have_no_warn_and_skip_backup():
+    """Neither playbook may keep the old warn-and-skip backup branch (#10045)."""
+    for pb in (SETUP_PLAYBOOK, UPDATE_PLAYBOOK):
+        text = pb.read_text(encoding="utf-8").lower()
+        assert "backup skipped" not in text, (
+            f"{pb.name}: still contains the warn-and-skip backup branch — "
+            "remove it; the backup must fail-closed (#10045)"
+        )

--- a/autobot-slm-backend/ansible/_shared/tasks/pre_migration_backup.yml
+++ b/autobot-slm-backend/ansible/_shared/tasks/pre_migration_backup.yml
@@ -1,0 +1,77 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+---
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+#
+# Reusable fail-closed pre-migration PostgreSQL backup (#10045)
+#
+# Runs immediately before the schema-mutating Alembic upgrade in both
+# setup-user-backend.yml and playbooks/update-all-nodes.yml. Two paths:
+#
+#   1. Local Postgres (data dir at /var/lib/postgresql): fast path — a full
+#      cluster dump via `su - postgres -c "pg_dumpall --clean --if-exists"`.
+#   2. Remote Postgres (colocated on the SLM server via
+#      AUTOBOT_USERS_DATABASE_URL / AUTOBOT_DATABASE_URL): derive a libpq URL
+#      from the backend .env — strip the `+asyncpg` SQLAlchemy driver suffix,
+#      or build one from AUTOBOT_POSTGRES_* — and `pg_dump --format=custom`
+#      over the network. Requires postgresql-client on the backend node
+#      (added to the backend role package list, #10045).
+#
+# FAIL-CLOSED (#10045): there is NO warn-and-skip branch. When neither path
+# can produce a backup the task errors and aborts the deploy — the one fleet
+# state that most needs the backup (remote shared DB) used to be the one that
+# silently skipped it (the original #10026 gap).
+#
+# Caller must set:
+#   pre_migration_env_file  — absolute path to the backend .env to read the
+#                             database URL / Postgres connection vars from.
+
+- name: "Pre-migration backup | Check for local PostgreSQL data directory (#10026, #10045)"
+  ansible.builtin.stat:
+    path: /var/lib/postgresql
+  register: pre_migration_pg_dir
+
+- name: "Pre-migration backup | Ensure backup directory exists (#10045)"
+  ansible.builtin.file:
+    path: /opt/autobot/backups/pre-migration
+    state: directory
+    mode: "0750"
+
+# Local fast path — full cluster dump from the on-node Postgres.
+- name: "Pre-migration backup | Local pg_dumpall (#10026, #10045)"
+  ansible.builtin.shell: |
+    set -o pipefail
+    su - postgres -c "pg_dumpall --clean --if-exists" \
+      | gzip > /opt/autobot/backups/pre-migration/backend-$(date +%s).sql.gz
+  args:
+    executable: /bin/bash
+  when: pre_migration_pg_dir.stat.exists
+
+# Remote path — Postgres lives on another node (colocated on the SLM server).
+# Derive a libpq URL from the backend .env and pg_dump over the network.
+# FAIL-CLOSED: no failed_when override — a missing URL or unreachable DB aborts.
+- name: "Pre-migration backup | Remote pg_dump over network (#10045)"
+  ansible.builtin.shell: |
+    set -euo pipefail
+    set -a
+    [ -f "{{ pre_migration_env_file }}" ] && . "{{ pre_migration_env_file }}"
+    set +a
+    # Prefer the users DB URL, then the generic backend URL.
+    RAW_URL="${AUTOBOT_USERS_DATABASE_URL:-${AUTOBOT_DATABASE_URL:-}}"
+    if [ -n "${RAW_URL}" ]; then
+      # Strip the SQLAlchemy "+asyncpg"/"+psycopg" driver suffix so libpq
+      # accepts the URL: postgresql+asyncpg://... -> postgresql://...
+      DUMP_URL="$(printf '%s' "${RAW_URL}" | sed -E 's#^(postgres(ql)?)\+[a-z0-9_]+://#\1://#')"
+    elif [ -n "${AUTOBOT_POSTGRES_HOST:-}" ]; then
+      # Build a libpq URL from discrete AUTOBOT_POSTGRES_* vars.
+      DUMP_URL="postgresql://${AUTOBOT_POSTGRES_USER:-autobot_app}:${AUTOBOT_POSTGRES_PASSWORD:-}@${AUTOBOT_POSTGRES_HOST}:${AUTOBOT_POSTGRES_PORT:-5432}/${AUTOBOT_POSTGRES_DB:-autobot_users}"
+    else
+      echo "FATAL: no local PostgreSQL and no AUTOBOT_USERS_DATABASE_URL / AUTOBOT_DATABASE_URL / AUTOBOT_POSTGRES_* in {{ pre_migration_env_file }} — cannot back up before migrating (#10045)" >&2
+      exit 1
+    fi
+    pg_dump --dbname="${DUMP_URL}" --format=custom \
+      --file="/opt/autobot/backups/pre-migration/backend-$(date +%s).dump"
+  args:
+    executable: /bin/bash
+  when: not pre_migration_pg_dir.stat.exists

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -611,30 +611,13 @@
         - backend_user_mode_probe.stdout | default('') | trim not in ['', 'single_user']
       tags: [backend, migrate]
       block:
-        - name: "[PLAY 2] Backend | Check for local PostgreSQL data directory (#10026)"
-          ansible.builtin.stat:
-            path: /var/lib/postgresql
-          register: backend_pg_dir
+        # Fail-closed pre-migration backup (#10045): local pg_dumpall OR
+        # remote pg_dump derived from .env URL; aborts if neither is possible.
+        - name: "[PLAY 2] Backend | Back up PostgreSQL before migrations (local or remote) (#10026, #10045)"
+          ansible.builtin.include_tasks: ../_shared/tasks/pre_migration_backup.yml
           become: true
-
-        - name: "[PLAY 2] Backend | Back up PostgreSQL before migrations (#10026)"
-          ansible.builtin.shell: |
-            set -o pipefail
-            install -d -m 0750 /opt/autobot/backups/pre-migration
-            su - postgres -c "pg_dumpall --clean --if-exists" \
-              | gzip > /opt/autobot/backups/pre-migration/backend-$(date +%s).sql.gz
-          args:
-            executable: /bin/bash
-          become: true
-          when: backend_pg_dir.stat.exists
-
-        - name: "[PLAY 2] Backend | Warn when no local PostgreSQL to back up (#10026)"
-          ansible.builtin.debug:
-            msg: >-
-              WARNING: no local PostgreSQL data directory — pre-migration
-              backup skipped. Back up the remote database before relying on
-              this deploy.
-          when: not backend_pg_dir.stat.exists
+          vars:
+            pre_migration_env_file: /opt/autobot/autobot-backend/.env
 
         - name: "[PLAY 2] Backend | Run database baseline adoption (#10001)"
           ansible.builtin.shell: |

--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -95,3 +95,13 @@ backend_health_check_delay: 5          # Seconds between retries
 
 # Audit log file path (#8936: ensures AUTOBOT_AUDIT_LOG_FILE is always set in prod)
 backend_audit_log_file: /opt/autobot/logs/audit.log
+
+# GPU / vLLM inference (#10288)
+# vllm moved to opt-in requirements-gpu.txt (#10251/#10287) to keep the default
+# CPU image lean (it drags the CUDA toolkit + CUDA-built torch — several GB).
+# Install requirements-gpu.txt ONLY when both an NVIDIA GPU is present AND vLLM
+# is enabled for this deployment.
+#   backend_vllm_enabled: deployment opts into in-process vLLM (llm.vllm.enabled).
+#   backend_has_gpu: "auto" runs nvidia-smi at deploy time; "true"/"false" override.
+backend_vllm_enabled: false
+backend_has_gpu: "auto"

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -250,6 +250,9 @@
       - libtesseract-dev
       # Matplotlib GUI backend
       - python3-tk
+      # PostgreSQL client — pg_dump for the fail-closed pre-migration backup
+      # of a REMOTE (colocated SLM) Postgres before Alembic upgrades (#10045)
+      - postgresql-client
     state: present
   tags: ['backend', 'packages']
 
@@ -586,6 +589,41 @@
     PIP_USE_DEPRECATED: "legacy-resolver"  # Issue #858: Handle complex OpenTelemetry+ChromaDB dependency graph
   timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
   register: pip_install_result
+
+# GPU / vLLM extras (#10288): vllm was moved to an opt-in requirements-gpu.txt
+# (#10251/#10287) to keep the default CPU image lean. Install it ONLY on a
+# GPU-enabled backend that opts into vLLM, so CPU deploys stay slim.
+- name: "Backend | Detect NVIDIA GPU for vLLM extras (#10288)"
+  ansible.builtin.command:
+    cmd: nvidia-smi --query-gpu=name --format=csv,noheader
+  register: backend_nvidia_smi_result
+  changed_when: false
+  # nvidia-smi exits rc != 0 when no GPU is present; the result only gates the
+  # optional GPU-reqs install below, so a non-zero rc is expected on CPU nodes.
+  failed_when: false
+  when:
+    - backend_vllm_enabled | bool
+    - backend_has_gpu == "auto"
+
+- name: "Backend | Resolve GPU availability for vLLM extras (#10288)"
+  ansible.builtin.set_fact:
+    backend_gpu_available: "{{ (backend_nvidia_smi_result.rc | default(1)) == 0 and (backend_nvidia_smi_result.stdout | default('') | trim | length > 0) if backend_has_gpu == 'auto' else (backend_has_gpu | bool) }}"
+  when: backend_vllm_enabled | bool
+
+# Install GPU/vLLM requirements only when vLLM is enabled AND a GPU is present.
+# Uses the repo-root requirements-gpu.txt from code_source (sibling of the
+# autobot-backend subtree; not part of the backend code rsync).
+- name: "Backend | Install GPU/vLLM requirements (requirements-gpu.txt) (#10288)"
+  ansible.builtin.pip:
+    requirements: "{{ code_source_dir | default('/opt/autobot/code_source') }}/requirements-gpu.txt"
+    virtualenv: "{{ backend_code_dir }}/venv"
+  become_user: "{{ backend_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 1800  # CUDA-built torch + vllm wheels are large
+  when:
+    - backend_vllm_enabled | bool
+    - backend_gpu_available | default(false) | bool
 
 - name: Deploy aioredis compatibility shim for Python 3.12
   ansible.builtin.template:

--- a/autobot-slm-backend/ansible/setup-user-backend.yml
+++ b/autobot-slm-backend/ansible/setup-user-backend.yml
@@ -93,28 +93,13 @@
       when: backend_user_mode_probe.stdout | default('') | trim not in ['', 'single_user']
       tags: [migrations]
       block:
-        - name: Check for local PostgreSQL data directory (#10026)
-          ansible.builtin.stat:
-            path: /var/lib/postgresql
-          register: backend_pg_dir
+        # Fail-closed pre-migration backup (#10045): local pg_dumpall OR
+        # remote pg_dump derived from .env URL; aborts if neither is possible.
+        - name: Back up PostgreSQL before migrations (local or remote) (#10026, #10045)
+          ansible.builtin.include_tasks: _shared/tasks/pre_migration_backup.yml
+          vars:
+            pre_migration_env_file: "{{ backend_code_dir }}/.env"
 
-        - name: Back up PostgreSQL before migrations (#10026)
-          ansible.builtin.shell: |
-            set -o pipefail
-            install -d -m 0750 /opt/autobot/backups/pre-migration
-            su - postgres -c "pg_dumpall --clean --if-exists" \
-              | gzip > /opt/autobot/backups/pre-migration/backend-$(date +%s).sql.gz
-          args:
-            executable: /bin/bash
-          when: backend_pg_dir.stat.exists
-
-        - name: Warn when no local PostgreSQL to back up (#10026)
-          ansible.builtin.debug:
-            msg: >-
-              WARNING: no local PostgreSQL data directory — pre-migration
-              backup skipped. Back up the remote database before relying on
-              this deploy.
-          when: not backend_pg_dir.stat.exists
 
         - name: Run database baseline adoption (#10001)
           ansible.builtin.shell: |


### PR DESCRIPTION
## Thinking Path
Two deploy-durability gaps. #10045: the pre-migration backup used local-only `pg_dumpall`, so a REMOTE Postgres (colocated on SLM) got warn-and-skip — no backup before a schema-mutating migration. #10288: `vllm` moved to opt-in `requirements-gpu.txt` (#10287) but nothing installs it on GPU deploys that enable vLLM.

## What Changed
**#10045 — fail-closed remote-Postgres pre-migration backup:**
- New shared include `autobot-slm-backend/ansible/_shared/tasks/pre_migration_backup.yml`: local `pg_dumpall` fast path; else reads backend `.env`, prefers `AUTOBOT_USERS_DATABASE_URL`/`AUTOBOT_DATABASE_URL`, strips the `+asyncpg` driver suffix, and runs `pg_dump --format=custom` over the network. If neither path can produce a backup → **`exit 1` (fail-closed)**, no warn-and-skip.
- Wired into `setup-user-backend.yml` + `update-all-nodes.yml` (DRY); added `postgresql-client` to the backend role packages.
- `test_ansible_migration_contract.py`: +4 tests asserting no skip-path exists.

**#10288 — GPU vLLM install:**
- backend role: nvidia-smi GPU detect (gated on `backend_vllm_enabled`), conditional `pip install -r requirements-gpu.txt`. Defaults `backend_vllm_enabled: false` → CPU deploys never pull GPU reqs (preserves #10287's lean image).

## Verification
- Contract test: 9 passed (was 5). YAML safe_load OK on all changed files; `py_compile` clean.
- Closes #10045, #10288.

## Model Used
Claude Opus 4.8 (devops-engineer subagent).
