### PR TITLE
fix(telegram): caption-less media crash — placeholder content (#10483)

### DIFF
--- a/autobot-backend/api/telegram_bot.py
+++ b/autobot-backend/api/telegram_bot.py
@@ -186,9 +186,18 @@ async def _route_to_chat_and_reply(request: Request, unified_message: Any) -> No
     session_id = _get_chat_session_id(unified_message.channel_id)
     request_id = generate_request_id()
 
+    # ChatMessage.content requires >=1 char. Caption-less media (photo/voice/
+    # document/video/audio with no text) normalizes to an empty message, which
+    # would raise ValidationError and drop the update. Synthesize a placeholder
+    # naming the attachment so the turn is valid and the model knows media was
+    # sent (GH#10483, mirrors the WhatsApp fix GH#10481).
+    content = unified_message.message
+    if not content and unified_message.metadata.get("has_file"):
+        content = f"[{unified_message.metadata.get('file_type', 'media')} attachment]"
+
     # Build ChatMessage from normalized Telegram message
     chat_message = ChatMessage(
-        content=unified_message.message,
+        content=content,
         role="user",
         session_id=session_id,
         metadata={

--- a/autobot-backend/api/telegram_bot_test.py
+++ b/autobot-backend/api/telegram_bot_test.py
@@ -14,6 +14,8 @@ These verify the inbound path is actually reachable and dispatched:
 - command handling produces the expected replies.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from initialization.router_registry.integration_routers import INTEGRATION_ROUTER_CONFIGS
@@ -129,3 +131,50 @@ class TestCommandHandling:
 
         reply = await _handle_command("nope", [], chat_id="4242", message_id=1)
         assert reply is None
+
+
+class TestCaptionlessMediaRouting:
+    """Caption-less media must not crash ChatMessage construction (GH#10483)."""
+
+    @pytest.mark.asyncio
+    async def test_captionless_attachment_gets_placeholder_content(self, monkeypatch):
+        from api import telegram_bot as tg
+        from services.gateway.gateway_manager import GatewayManager
+
+        captured: dict = {}
+
+        async def fake_process(message, **kwargs):
+            captured["message"] = message
+            return SimpleNamespace(content="ack")
+
+        async def fake_send(*args, **kwargs):
+            captured["sent"] = True
+
+        # Lazily-imported deps are patched at their source modules.
+        monkeypatch.setattr("api.chat.process_chat_message", fake_process)
+        monkeypatch.setattr(tg, "send_telegram_response", fake_send)
+        monkeypatch.setattr("utils.chat_utils.get_chat_history_manager", lambda req: object())
+        monkeypatch.setattr("utils.lazy_singleton.lazy_init_singleton", lambda state, name, cls: object())
+
+        # A document with no caption normalizes to an empty message + has_file.
+        unified = await GatewayManager().normalize_message(
+            {
+                "platform": "telegram",
+                "message": {
+                    "message_id": 21,
+                    "date": 1700000003,
+                    "chat": {"id": 4242, "type": "private"},
+                    "from": {"id": 99},
+                    "document": {"file_id": "doc-9", "file_name": "x.pdf", "mime_type": "application/pdf"},
+                },
+            }
+        )
+        assert unified.message == ""
+        assert unified.metadata.get("has_file") is True
+
+        request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+        # Without the fix this raises pydantic ValidationError (content min_length=1).
+        await tg._route_to_chat_and_reply(request, unified)
+
+        assert captured["message"].content == "[document attachment]"
+        assert captured.get("sent") is True


### PR DESCRIPTION
## Thinking Path
Found while fixing the equivalent WhatsApp bug (#10481) during umbrella #9928 verification. The Telegram channel (#9006) has the same caption-less-media crash.

## What Changed
`autobot-backend/api/telegram_bot.py` `_route_to_chat_and_reply`: caption-less media (photo/voice/document/video/audio with no text) normalizes to `message=""`, but `ChatMessage.content` is `Field(..., min_length=1)` → `pydantic ValidationError` → uncaught in the webhook handler → the update is dropped and no reply is sent. Now synthesizes a `"[<file_type> attachment]"` placeholder when content is empty and `has_file` is set (the Telegram adapter already records `has_file`/`file_type` in metadata).

`autobot-backend/api/telegram_bot_test.py`: adds a regression test driving the real `GatewayManager.normalize_message` path with a caption-less document — fails with `ValidationError` without the fix.

## Verification
```
python3 -m pytest api/telegram_bot_test.py -q
10 passed
```

## Model Used
Opus 4.8 (1M context)

Closes #10483

🤖 Generated with [Claude Code](https://claude.com/claude-code)
