### PR TITLE
feat(ui/slm): pluggable theme packages — upload + install themes via /slm (#10472)

### DIFF
--- a/autobot-backend/api/themes.py
+++ b/autobot-backend/api/themes.py
@@ -17,7 +17,10 @@ from fastapi.responses import FileResponse, JSONResponse
 import theme_install
 from auth_middleware import check_admin_permission
 
-router = APIRouter(prefix="/api/themes", tags=["themes"])
+# The core-router registry loop mounts every router under "/api" (see
+# core_routers.py — e.g. users_router prefix="/users" yields /api/users). So this
+# router carries only "/themes" to resolve to /api/themes (NOT /api/api/themes). #10472
+router = APIRouter(prefix="/themes", tags=["themes"])
 
 
 @router.post("")

--- a/autobot-backend/api/themes.py
+++ b/autobot-backend/api/themes.py
@@ -9,6 +9,7 @@ decorator, so the safety net is equivalent to FastAPI's own exception handling.
 We therefore rely on FastAPI's built-in exception handling here and skip the
 wrapper decorator — matching the simpler pattern used by other lean endpoints.
 """
+
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, File, UploadFile

--- a/autobot-backend/api/themes.py
+++ b/autobot-backend/api/themes.py
@@ -1,0 +1,47 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Theme package API — admin install/uninstall + public registry/serve (#10472).
+
+Note: with_error_handling from autobot_shared.error_boundaries wraps functions
+with *args/**kwargs, which breaks FastAPI's parameter-inspection at route
+registration time.  HTTPException instances are already re-raised as-is by that
+decorator, so the safety net is equivalent to FastAPI's own exception handling.
+We therefore rely on FastAPI's built-in exception handling here and skip the
+wrapper decorator — matching the simpler pattern used by other lean endpoints.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, File, UploadFile
+from fastapi.responses import FileResponse, JSONResponse
+
+import theme_install
+from auth_middleware import check_admin_permission
+
+router = APIRouter(prefix="/api/themes", tags=["themes"])
+
+
+@router.post("")
+async def install_theme(file: UploadFile = File(...), admin_check: bool = Depends(check_admin_permission)):
+    desc = await theme_install.install_theme_from_zip(file)
+    return JSONResponse(desc.model_dump())
+
+
+@router.delete("/{theme_id}")
+async def uninstall_theme(theme_id: str, admin_check: bool = Depends(check_admin_permission)):
+    theme_install.uninstall_theme(theme_id)
+    return {"status": "deleted", "id": theme_id}
+
+
+@router.get("")
+async def list_themes():
+    return [d.model_dump() for d in theme_install.list_installed_themes()]
+
+
+@router.get("/{theme_id}/theme.css")
+async def serve_theme_css(theme_id: str):
+    return FileResponse(theme_install.theme_css_path(theme_id), media_type="text/css")
+
+
+@router.get("/{theme_id}/assets/{rel:path}")
+async def serve_theme_asset(theme_id: str, rel: str):
+    return FileResponse(theme_install.theme_asset_path(theme_id, rel))

--- a/autobot-backend/api/themes_test.py
+++ b/autobot-backend/api/themes_test.py
@@ -1,0 +1,40 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+import io
+import json
+import zipfile
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import theme_install
+from api import themes as themes_api
+from auth_middleware import check_admin_permission
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setattr(theme_install, "themes_dir", lambda: tmp_path)
+    app = FastAPI()
+    app.include_router(themes_api.router)
+    app.dependency_overrides[check_admin_permission] = lambda: True
+    return TestClient(app)
+
+
+def _zip(theme_id="aqua"):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("theme.json", json.dumps({"id": theme_id, "name": "Aqua", "author": "me", "version": "1.0.0"}))
+        zf.writestr("theme.css", f'[data-theme-variant="{theme_id}"] {{ --bg-primary:#eef; }}')
+    return buf.getvalue()
+
+
+def test_upload_list_serve_delete(client):
+    r = client.post("/api/themes", files={"file": ("aqua.zip", _zip(), "application/zip")})
+    assert r.status_code == 200, r.text
+    assert client.get("/api/themes").json()[0]["id"] == "aqua"
+    css = client.get("/api/themes/aqua/theme.css")
+    assert css.status_code == 200 and "data-theme-variant" in css.text
+    assert client.delete("/api/themes/aqua").status_code == 200
+    assert client.get("/api/themes").json() == []

--- a/autobot-backend/api/themes_test.py
+++ b/autobot-backend/api/themes_test.py
@@ -17,7 +17,9 @@ from auth_middleware import check_admin_permission
 def client(tmp_path, monkeypatch):
     monkeypatch.setattr(theme_install, "themes_dir", lambda: tmp_path)
     app = FastAPI()
-    app.include_router(themes_api.router)
+    # Mirror the core-router registry, which mounts every router under "/api".
+    # This guards against the /api/api/themes double-prefix regression (#10472).
+    app.include_router(themes_api.router, prefix="/api")
     app.dependency_overrides[check_admin_permission] = lambda: True
     return TestClient(app)
 

--- a/autobot-backend/archive_safety.py
+++ b/autobot-backend/archive_safety.py
@@ -1,0 +1,114 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Shared, hardened zip-archive handling for package installers (plugins, themes).
+
+Extracted from plugin_install.py (#10472) so every installer reuses the same
+zip-slip / symlink / zip-bomb / upload-size guards — one place to audit and fix.
+"""
+from __future__ import annotations
+
+import shutil
+import zipfile
+from pathlib import Path
+
+from fastapi import HTTPException, UploadFile, status
+
+MAX_ZIP_UNCOMPRESSED_BYTES = 256 * 1024 * 1024
+MAX_ZIP_ENTRIES = 5000
+MAX_UPLOAD_BYTES = 512 * 1024 * 1024
+MAX_COMPRESSION_RATIO = 100
+
+
+def is_zip_symlink(info: zipfile.ZipInfo) -> bool:
+    return ((info.external_attr >> 16) & 0xF000) == 0xA000
+
+
+def validate_zip_metadata(zf: zipfile.ZipFile, extract_root: Path) -> None:
+    names = zf.namelist()
+    if len(names) > MAX_ZIP_ENTRIES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Archive has too many entries (>{MAX_ZIP_ENTRIES})",
+        )
+    extract_root_resolved = extract_root.resolve()
+    for info in zf.infolist():
+        if info.is_dir():
+            continue
+        target = (extract_root / info.filename).resolve()
+        try:
+            target.relative_to(extract_root_resolved)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Archive entry escapes root: {info.filename}",
+            ) from exc
+        if is_zip_symlink(info):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Archive contains symlink: {info.filename}",
+            )
+        if info.compress_size > 0 and info.file_size // info.compress_size > MAX_COMPRESSION_RATIO:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Archive entry has suspicious compression ratio: {info.filename}",
+            )
+
+
+def safe_extract(zf: zipfile.ZipFile, extract_root: Path) -> None:
+    extract_root_resolved = extract_root.resolve()
+    bytes_written = 0
+    for info in zf.infolist():
+        if info.is_dir():
+            continue
+        if "__MACOSX/" in info.filename or Path(info.filename).name.startswith("._"):
+            continue
+        target = (extract_root / info.filename).resolve()
+        target.relative_to(extract_root_resolved)
+        if is_zip_symlink(info):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Archive contains symlink: {info.filename}",
+            )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with zf.open(info) as src, target.open("wb") as out:
+            while chunk := src.read(1024 * 1024):
+                bytes_written += len(chunk)
+                if bytes_written > MAX_ZIP_UNCOMPRESSED_BYTES:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Archive uncompressed size exceeds 256MB",
+                    )
+                out.write(chunk)
+
+
+def find_package_root(extract_dir: Path, manifest_filename: str) -> Path:
+    if (extract_dir / manifest_filename).is_file():
+        return extract_dir
+    children = [
+        c for c in extract_dir.iterdir() if c.is_dir() and c.name != "__MACOSX" and not c.name.startswith(".")
+    ]
+    if len(children) == 1 and (children[0] / manifest_filename).is_file():
+        return children[0]
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=f"{manifest_filename} not found at archive root or single top-level folder",
+    )
+
+
+def move_into_target(source: Path, target: Path) -> None:
+    for child in source.iterdir():
+        shutil.move(str(child), str(target / child.name))
+    source.rmdir()
+
+
+async def stream_upload_to(upload: UploadFile, dest: Path) -> None:
+    bytes_written = 0
+    with dest.open("wb") as out:
+        while chunk := await upload.read(1024 * 1024):
+            bytes_written += len(chunk)
+            if bytes_written > MAX_UPLOAD_BYTES:
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail=f"Upload exceeds {MAX_UPLOAD_BYTES // (1024 * 1024)}MB",
+                )
+            out.write(chunk)

--- a/autobot-backend/archive_safety.py
+++ b/autobot-backend/archive_safety.py
@@ -5,6 +5,7 @@
 Extracted from plugin_install.py (#10472) so every installer reuses the same
 zip-slip / symlink / zip-bomb / upload-size guards — one place to audit and fix.
 """
+
 from __future__ import annotations
 
 import shutil
@@ -84,9 +85,7 @@ def safe_extract(zf: zipfile.ZipFile, extract_root: Path) -> None:
 def find_package_root(extract_dir: Path, manifest_filename: str) -> Path:
     if (extract_dir / manifest_filename).is_file():
         return extract_dir
-    children = [
-        c for c in extract_dir.iterdir() if c.is_dir() and c.name != "__MACOSX" and not c.name.startswith(".")
-    ]
+    children = [c for c in extract_dir.iterdir() if c.is_dir() and c.name != "__MACOSX" and not c.name.startswith(".")]
     if len(children) == 1 and (children[0] / manifest_filename).is_file():
         return children[0]
     raise HTTPException(

--- a/autobot-backend/archive_safety_test.py
+++ b/autobot-backend/archive_safety_test.py
@@ -1,0 +1,37 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from archive_safety import find_package_root, safe_extract, validate_zip_metadata
+
+
+def _zip_bytes(entries: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def test_safe_extract_writes_files(tmp_path: Path):
+    zf = zipfile.ZipFile(io.BytesIO(_zip_bytes({"theme.json": b"{}"})))
+    safe_extract(zf, tmp_path)
+    assert (tmp_path / "theme.json").read_bytes() == b"{}"
+
+
+def test_validate_rejects_zip_slip(tmp_path: Path):
+    zf = zipfile.ZipFile(io.BytesIO(_zip_bytes({"../evil.txt": b"x"})))
+    with pytest.raises(HTTPException) as exc:
+        validate_zip_metadata(zf, tmp_path)
+    assert exc.value.status_code == 400
+
+
+def test_find_package_root_in_single_subdir(tmp_path: Path):
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "theme.json").write_text("{}", encoding="utf-8")
+    assert find_package_root(tmp_path, "theme.json") == tmp_path / "pkg"

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -422,11 +422,13 @@ if "auth_middleware" not in sys.modules:
     _auth_stub.__path__ = []  # type: ignore[attr-defined]
     _auth_stub.__package__ = "auth_middleware"
     _auth_stub.get_current_user = MagicMock()  # type: ignore[attr-defined]
+
     # check_admin_permission must be a proper no-arg callable so FastAPI can
     # inspect its signature at route-registration time without producing spurious
     # (*args, **kwargs) query parameters (#10472).
     def _check_admin_permission_stub():  # noqa: E301
         return True
+
     _auth_stub.check_admin_permission = _check_admin_permission_stub  # type: ignore[attr-defined]
     _auth_stub.__getattr__ = lambda attr: MagicMock()  # type: ignore[attr-defined]
     sys.modules["auth_middleware"] = _auth_stub

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -422,6 +422,12 @@ if "auth_middleware" not in sys.modules:
     _auth_stub.__path__ = []  # type: ignore[attr-defined]
     _auth_stub.__package__ = "auth_middleware"
     _auth_stub.get_current_user = MagicMock()  # type: ignore[attr-defined]
+    # check_admin_permission must be a proper no-arg callable so FastAPI can
+    # inspect its signature at route-registration time without producing spurious
+    # (*args, **kwargs) query parameters (#10472).
+    def _check_admin_permission_stub():  # noqa: E301
+        return True
+    _auth_stub.check_admin_permission = _check_admin_permission_stub  # type: ignore[attr-defined]
     _auth_stub.__getattr__ = lambda attr: MagicMock()  # type: ignore[attr-defined]
     sys.modules["auth_middleware"] = _auth_stub
 

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -501,7 +501,8 @@ def _get_plugin_routers() -> list:
 
     plugin_manager.py routes already include /plugins in their paths,
     so registration prefix must be empty to avoid double-prefix (#1105).
-    themes_router carries /api/themes prefix — mount with empty prefix (#10472).
+    themes_router carries a /themes prefix; the loop adds /api → /api/themes
+    (a /api/themes prefix here would wrongly yield /api/api/themes) (#10472).
     """
     return [
         (plugin_manager_router, "", ["plugins"], "plugin_manager"),

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -91,6 +91,7 @@ from api.settings import router as settings_router
 from api.structured_thinking_mcp import router as structured_thinking_mcp_router
 from api.system import router as system_router
 from api.telegram_bot import router as telegram_bot_router  # MVA-2074
+from api.themes import router as themes_router  # #10472 — pluggable theme packages
 from api.transcriber import router as transcriber_router  # Issue #9044, MVA-2186
 from api.transcripts import router as transcripts_router  # Issue #9863, MVA-2176
 from api.usage import router as usage_router  # Issue #1807
@@ -107,7 +108,6 @@ from api.voice_bundle_user import router as voice_bundle_user_router
 from api.voice_stream import router as voice_stream_router
 from api.wake_word import router as wake_word_router
 from api.websockets import router as websockets_router  # Issue #6229
-from api.themes import router as themes_router  # #10472 — pluggable theme packages
 from plugin_manager import router as plugin_manager_router
 from services.knowledge_sync_service import router as knowledge_sync_router
 

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -107,6 +107,7 @@ from api.voice_bundle_user import router as voice_bundle_user_router
 from api.voice_stream import router as voice_stream_router
 from api.wake_word import router as wake_word_router
 from api.websockets import router as websockets_router  # Issue #6229
+from api.themes import router as themes_router  # #10472 — pluggable theme packages
 from plugin_manager import router as plugin_manager_router
 from services.knowledge_sync_service import router as knowledge_sync_router
 
@@ -500,9 +501,11 @@ def _get_plugin_routers() -> list:
 
     plugin_manager.py routes already include /plugins in their paths,
     so registration prefix must be empty to avoid double-prefix (#1105).
+    themes_router carries /api/themes prefix — mount with empty prefix (#10472).
     """
     return [
         (plugin_manager_router, "", ["plugins"], "plugin_manager"),
+        (themes_router, "", ["themes"], "themes"),  # #10472
     ]
 
 

--- a/autobot-backend/plugin_install.py
+++ b/autobot-backend/plugin_install.py
@@ -25,6 +25,7 @@ from urllib.parse import urlparse
 
 from fastapi import HTTPException, UploadFile, status
 
+import archive_safety as _arch
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
 from plugin_sdk.base import PluginManifest
@@ -35,10 +36,7 @@ _NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
 _GIT_URL_SCHEMES = {"http", "https"}
 # Disallow leading '-' (so '-foo' can't be mistaken for an option) and '..' segments.
 _GIT_REF_PATTERN = re.compile(r"^(?!-)(?!.*\.\.)[A-Za-z0-9._/\-]{1,128}$")
-_MAX_ZIP_UNCOMPRESSED_BYTES = 256 * 1024 * 1024  # 256 MB
-_MAX_ZIP_ENTRIES = 5000
-_MAX_UPLOAD_BYTES = 512 * 1024 * 1024  # 512 MB hard cap on the raw upload
-_MAX_COMPRESSION_RATIO = 100  # zip-bomb sentinel
+_MAX_UPLOAD_BYTES = _arch.MAX_UPLOAD_BYTES  # 512 MB hard cap on the raw upload
 _GIT_CLONE_TIMEOUT_SECONDS = 120
 
 # Per-plugin install lock prevents two concurrent installs of the same name
@@ -121,106 +119,17 @@ def _claim_install_target(name: str) -> Path:
     return target
 
 
-def _is_zip_symlink(info: zipfile.ZipInfo) -> bool:
-    # External attr stores Unix mode in the high 16 bits; 0xA000 = symlink.
-    return ((info.external_attr >> 16) & 0xF000) == 0xA000
-
-
-def _validate_zip_metadata(zf: zipfile.ZipFile, extract_root: Path) -> None:
-    """Pre-flight checks on archive metadata. Cheap, runs before extraction."""
-    names = zf.namelist()
-    if len(names) > _MAX_ZIP_ENTRIES:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Archive has too many entries (>{_MAX_ZIP_ENTRIES})",
-        )
-    extract_root_resolved = extract_root.resolve()
-    for info in zf.infolist():
-        if info.is_dir():
-            continue
-        target = (extract_root / info.filename).resolve()
-        try:
-            target.relative_to(extract_root_resolved)
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Archive entry escapes root: {info.filename}",
-            ) from exc
-        if _is_zip_symlink(info):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Archive contains symlink: {info.filename}",
-            )
-        # Sentinel against ZIP bombs whose header file_size is honest.
-        if info.compress_size > 0 and info.file_size // info.compress_size > _MAX_COMPRESSION_RATIO:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Archive entry has suspicious compression ratio: {info.filename}",
-            )
-
-
-def _safe_extract(zf: zipfile.ZipFile, extract_root: Path) -> None:
-    """Stream-extract with byte cap. Tracks ACTUAL bytes written, so a
-    forged file_size in the central directory can't bypass the size cap."""
-    extract_root_resolved = extract_root.resolve()
-    bytes_written = 0
-    for info in zf.infolist():
-        if info.is_dir():
-            continue
-        # Skip macOS resource-fork dotfiles and __MACOSX/ noise.
-        if "__MACOSX/" in info.filename or Path(info.filename).name.startswith("._"):
-            continue
-        # Re-validate at extraction time (defense in depth).
-        target = (extract_root / info.filename).resolve()
-        target.relative_to(extract_root_resolved)
-        if _is_zip_symlink(info):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Archive contains symlink: {info.filename}",
-            )
-        target.parent.mkdir(parents=True, exist_ok=True)
-        with zf.open(info) as src, target.open("wb") as out:
-            while chunk := src.read(1024 * 1024):
-                bytes_written += len(chunk)
-                if bytes_written > _MAX_ZIP_UNCOMPRESSED_BYTES:
-                    raise HTTPException(
-                        status_code=status.HTTP_400_BAD_REQUEST,
-                        detail="Archive uncompressed size exceeds 256MB",
-                    )
-                out.write(chunk)
+# Delegate zip-safety primitives to the shared archive_safety module (#10472).
+# Private wrappers preserved so call sites inside this file need no changes.
+_is_zip_symlink = _arch.is_zip_symlink
+_validate_zip_metadata = _arch.validate_zip_metadata
+_safe_extract = _arch.safe_extract
+_move_into_target = _arch.move_into_target
+_stream_upload_to = _arch.stream_upload_to
 
 
 def _find_plugin_root(extract_dir: Path) -> Path:
-    if (extract_dir / "plugin.json").is_file():
-        return extract_dir
-    children = [c for c in extract_dir.iterdir() if c.is_dir() and c.name != "__MACOSX" and not c.name.startswith(".")]
-    if len(children) == 1 and (children[0] / "plugin.json").is_file():
-        return children[0]
-    raise HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
-        detail="plugin.json not found at archive root or single top-level folder",
-    )
-
-
-def _move_into_target(source: Path, target: Path) -> None:
-    """Move source contents into a placeholder target dir, then remove the
-    now-empty source. Target must exist (created by _claim_install_target)."""
-    for child in source.iterdir():
-        shutil.move(str(child), str(target / child.name))
-    source.rmdir()
-
-
-async def _stream_upload_to(upload: UploadFile, dest: Path) -> None:
-    bytes_written = 0
-    with dest.open("wb") as out:
-        while chunk := await upload.read(1024 * 1024):
-            bytes_written += len(chunk)
-            if bytes_written > _MAX_UPLOAD_BYTES:
-                raise HTTPException(
-                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                    detail=f"Upload exceeds {_MAX_UPLOAD_BYTES // (1024 * 1024)}MB",
-                )
-            out.write(chunk)
+    return _arch.find_package_root(extract_dir, "plugin.json")
 
 
 async def install_from_zip(upload: UploadFile) -> InstallResult:

--- a/autobot-backend/plugin_install_test.py
+++ b/autobot-backend/plugin_install_test.py
@@ -9,6 +9,7 @@ Tests are deliberately lightweight:
   (b) zip-slip rejection via archive_safety (which plugin_install delegates to),
       called directly to avoid the heavy _community_plugins_dir / config chain.
 """
+
 import io
 import zipfile
 from pathlib import Path

--- a/autobot-backend/plugin_install_test.py
+++ b/autobot-backend/plugin_install_test.py
@@ -1,0 +1,51 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Guard tests for plugin_install.py — verify that the archive_safety refactor
+does not regress plugin install behaviour (#10472).
+
+Tests are deliberately lightweight:
+  (a) import-level smoke — confirms plugin_install imports and its core functions
+      delegate to archive_safety (not a copy of the old logic).
+  (b) zip-slip rejection via archive_safety (which plugin_install delegates to),
+      called directly to avoid the heavy _community_plugins_dir / config chain.
+"""
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+import archive_safety as _arch
+import plugin_install
+
+
+def _zip_bytes(entries: dict) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+# (a) Import-level smoke: confirm delegation is wired up
+def test_plugin_install_delegates_to_archive_safety():
+    assert plugin_install._validate_zip_metadata is _arch.validate_zip_metadata
+    assert plugin_install._safe_extract is _arch.safe_extract
+    assert plugin_install._move_into_target is _arch.move_into_target
+    assert plugin_install._stream_upload_to is _arch.stream_upload_to
+
+
+# (b) Zip-slip rejection — the shared guard that plugin_install now uses
+def test_zip_slip_rejected_via_shared_guard(tmp_path: Path):
+    zf = zipfile.ZipFile(io.BytesIO(_zip_bytes({"../evil.txt": b"x"})))
+    with pytest.raises(HTTPException) as exc:
+        plugin_install._validate_zip_metadata(zf, tmp_path)
+    assert exc.value.status_code == 400
+
+
+# (c) find_plugin_root wraps find_package_root with plugin.json
+def test_find_plugin_root_wraps_archive_safety(tmp_path: Path):
+    (tmp_path / "myplugin").mkdir()
+    (tmp_path / "myplugin" / "plugin.json").write_text("{}", encoding="utf-8")
+    assert plugin_install._find_plugin_root(tmp_path) == tmp_path / "myplugin"

--- a/autobot-backend/theme_css_validator.py
+++ b/autobot-backend/theme_css_validator.py
@@ -5,6 +5,7 @@
 Untrusted CSS may only style its own variant and must not fetch anything
 external. Rejects on the first violation with an HTTPException(400).
 """
+
 from __future__ import annotations
 
 import re

--- a/autobot-backend/theme_css_validator.py
+++ b/autobot-backend/theme_css_validator.py
@@ -16,28 +16,50 @@ _COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
 _FORBIDDEN = ("@import", "expression(", "behavior:", "javascript:", "@charset")
 _URL = re.compile(r"url\(\s*['\"]?([^'\")]+)['\"]?\s*\)", re.IGNORECASE)
 _BLOCK = re.compile(r"([^{}]+)\{[^{}]*\}", re.DOTALL)
+# CSS escapes: "\26 " == '&', "\69" == 'i', "\@" == '@'. The browser decodes these,
+# so substring/regex checks must run on the DECODED text or an attacker bypasses them
+# (e.g. "@\69mport", "url(\68ttp://evil)"). #10472 security review.
+_HEX_ESCAPE = re.compile(r"\\([0-9a-fA-F]{1,6})[ \t\n\r\f]?")
+_CHAR_ESCAPE = re.compile(r"\\(.)", re.DOTALL)
 
 
 def _reject(detail: str) -> None:
     raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Theme CSS rejected: {detail}")
 
 
+def _decode_css_escapes(text: str) -> str:
+    """Resolve CSS escape sequences to the characters the browser will render."""
+
+    def _hex(match: re.Match[str]) -> str:
+        try:
+            return chr(int(match.group(1), 16))
+        except (ValueError, OverflowError):
+            return ""
+
+    return _CHAR_ESCAPE.sub(lambda m: m.group(1), _HEX_ESCAPE.sub(_hex, text))
+
+
 def validate_theme_css(css: str, variant_id: str) -> None:
     if len(css.encode("utf-8")) > MAX_CSS_BYTES:
         _reject(f"exceeds {MAX_CSS_BYTES // 1024}KB")
     stripped = _COMMENT.sub(" ", css)
-    lowered = stripped.lower()
+    # Escapes have no legitimate use in a relative asset path — reject before decoding.
+    for ref in _URL.findall(stripped):
+        if "\\" in ref:
+            _reject(f"escaped url() not allowed: {ref.strip()[:60]}")
+    decoded = _decode_css_escapes(stripped)
+    lowered = decoded.lower()
     for tok in _FORBIDDEN:
         if tok in lowered:
             _reject(f"forbidden token {tok!r}")
-    for ref in _URL.findall(stripped):
+    for ref in _URL.findall(decoded):
         target = ref.strip()
         if target.startswith("data:"):
             continue
         if re.match(r"^(https?:)?//", target, re.IGNORECASE) or "\\" in target or ":" in target.split("/")[0]:
             _reject(f"external url() not allowed: {target}")
     scope = f'[data-theme-variant="{variant_id}"]'
-    blocks = _BLOCK.findall(stripped)
+    blocks = _BLOCK.findall(decoded)
     if not blocks:
         _reject("no style rules found")
     for selector_list in blocks:

--- a/autobot-backend/theme_css_validator.py
+++ b/autobot-backend/theme_css_validator.py
@@ -1,0 +1,49 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Strict validator for uploaded theme CSS (#10472).
+
+Untrusted CSS may only style its own variant and must not fetch anything
+external. Rejects on the first violation with an HTTPException(400).
+"""
+from __future__ import annotations
+
+import re
+
+from fastapi import HTTPException, status
+
+MAX_CSS_BYTES = 512 * 1024
+_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+_FORBIDDEN = ("@import", "expression(", "behavior:", "javascript:", "@charset")
+_URL = re.compile(r"url\(\s*['\"]?([^'\")]+)['\"]?\s*\)", re.IGNORECASE)
+_BLOCK = re.compile(r"([^{}]+)\{[^{}]*\}", re.DOTALL)
+
+
+def _reject(detail: str) -> None:
+    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Theme CSS rejected: {detail}")
+
+
+def validate_theme_css(css: str, variant_id: str) -> None:
+    if len(css.encode("utf-8")) > MAX_CSS_BYTES:
+        _reject(f"exceeds {MAX_CSS_BYTES // 1024}KB")
+    stripped = _COMMENT.sub(" ", css)
+    lowered = stripped.lower()
+    for tok in _FORBIDDEN:
+        if tok in lowered:
+            _reject(f"forbidden token {tok!r}")
+    for ref in _URL.findall(stripped):
+        target = ref.strip()
+        if target.startswith("data:"):
+            continue
+        if re.match(r"^(https?:)?//", target, re.IGNORECASE) or "\\" in target or ":" in target.split("/")[0]:
+            _reject(f"external url() not allowed: {target}")
+    scope = f'[data-theme-variant="{variant_id}"]'
+    blocks = _BLOCK.findall(stripped)
+    if not blocks:
+        _reject("no style rules found")
+    for selector_list in blocks:
+        for selector in selector_list.split(","):
+            sel = selector.strip()
+            if not sel or sel.startswith("@"):  # @font-face/@media handled below
+                continue
+            if not sel.startswith(scope):
+                _reject(f"selector not scoped to {scope}: {sel[:60]}")

--- a/autobot-backend/theme_css_validator_test.py
+++ b/autobot-backend/theme_css_validator_test.py
@@ -42,3 +42,25 @@ def test_rejects_expression_and_oversize():
         validate_theme_css('[data-theme-variant="x"] { width: expression(alert(1)); }', "x")
     with pytest.raises(HTTPException):
         validate_theme_css('[data-theme-variant="x"] { /* a */ }' + "a" * (512 * 1024), "x")
+
+
+def test_rejects_escape_aliased_at_import():
+    # "@\\69 mport" decodes to "@import" in the browser — must not slip past.
+    with pytest.raises(HTTPException):
+        validate_theme_css('@\\69 mport url(http://evil/x.css);', "x")
+
+
+def test_rejects_escape_aliased_expression():
+    with pytest.raises(HTTPException):
+        validate_theme_css('[data-theme-variant="x"] { width: expr\\65 ssion(alert(1)); }', "x")
+
+
+def test_rejects_escape_aliased_external_url():
+    # "url(\\68 ttp://evil)" decodes to an external fetch.
+    with pytest.raises(HTTPException):
+        validate_theme_css('[data-theme-variant="x"] { background: url(\\68 ttp://evil/p.png); }', "x")
+
+
+def test_rejects_backslash_in_url_path():
+    with pytest.raises(HTTPException):
+        validate_theme_css('[data-theme-variant="x"] { src: url(.\\fonts\\a.woff2); }', "x")

--- a/autobot-backend/theme_css_validator_test.py
+++ b/autobot-backend/theme_css_validator_test.py
@@ -1,0 +1,44 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from fastapi import HTTPException
+
+from theme_css_validator import validate_theme_css
+
+OK = '[data-theme-variant="x"] { --bg-primary: #fff; }'
+
+
+def test_accepts_scoped_rule():
+    validate_theme_css(OK, "x")  # no raise
+
+
+def test_rejects_unscoped_rule():
+    with pytest.raises(HTTPException):
+        validate_theme_css("body { color: red; }", "x")
+
+
+def test_rejects_wrong_variant_id():
+    with pytest.raises(HTTPException):
+        validate_theme_css('[data-theme-variant="other"] { --x: 1; }', "x")
+
+
+def test_rejects_at_import():
+    with pytest.raises(HTTPException):
+        validate_theme_css('@import url("http://evil/x.css");', "x")
+
+
+def test_rejects_external_url():
+    with pytest.raises(HTTPException):
+        validate_theme_css('[data-theme-variant="x"] { background: url(http://evil/p.png); }', "x")
+
+
+def test_accepts_data_uri_and_relative_url():
+    validate_theme_css('[data-theme-variant="x"] { src: url(data:font/woff2;base64,AA); }', "x")
+    validate_theme_css('[data-theme-variant="x"] { src: url(./fonts/a.woff2); }', "x")
+
+
+def test_rejects_expression_and_oversize():
+    with pytest.raises(HTTPException):
+        validate_theme_css('[data-theme-variant="x"] { width: expression(alert(1)); }', "x")
+    with pytest.raises(HTTPException):
+        validate_theme_css('[data-theme-variant="x"] { /* a */ }' + "a" * (512 * 1024), "x")

--- a/autobot-backend/theme_css_validator_test.py
+++ b/autobot-backend/theme_css_validator_test.py
@@ -47,7 +47,7 @@ def test_rejects_expression_and_oversize():
 def test_rejects_escape_aliased_at_import():
     # "@\\69 mport" decodes to "@import" in the browser — must not slip past.
     with pytest.raises(HTTPException):
-        validate_theme_css('@\\69 mport url(http://evil/x.css);', "x")
+        validate_theme_css("@\\69 mport url(http://evil/x.css);", "x")
 
 
 def test_rejects_escape_aliased_expression():

--- a/autobot-backend/theme_install.py
+++ b/autobot-backend/theme_install.py
@@ -1,0 +1,129 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Install/list/uninstall uploaded theme packages (#10472)."""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+
+from fastapi import HTTPException, UploadFile, status
+from pydantic import BaseModel
+
+import archive_safety as _arch
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config
+from theme_css_validator import validate_theme_css
+
+logger = get_logger(__name__)
+_ID = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+
+
+class ThemeManifest(BaseModel):
+    id: str
+    name: str
+    author: str
+    version: str
+    supports: list[str] = ["light", "dark"]
+
+
+class ThemeDescriptor(BaseModel):
+    id: str
+    name: str
+    author: str
+    version: str
+    supports: list[str]
+
+
+def themes_dir() -> Path:
+    target = config.path.data_path / "themes"
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def _read_manifest(root: Path) -> ThemeManifest:
+    mf = root / "theme.json"
+    if not mf.is_file():
+        raise HTTPException(status_code=400, detail="theme.json not found at theme root")
+    try:
+        return ThemeManifest(**json.loads(mf.read_text(encoding="utf-8")))
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid theme.json: {exc}") from exc
+
+
+async def install_theme_from_zip(upload: UploadFile) -> ThemeDescriptor:
+    with tempfile.TemporaryDirectory() as tmp:
+        zip_path = Path(tmp) / "u.zip"
+        await _arch.stream_upload_to(upload, zip_path)
+        extract = Path(tmp) / "x"
+        extract.mkdir()
+        try:
+            with zipfile.ZipFile(zip_path) as zf:
+                _arch.validate_zip_metadata(zf, extract)
+                _arch.safe_extract(zf, extract)
+        except zipfile.BadZipFile as exc:
+            raise HTTPException(status_code=400, detail="Not a valid ZIP archive") from exc
+        root = _arch.find_package_root(extract, "theme.json")
+        manifest = _read_manifest(root)
+        if not _ID.match(manifest.id):
+            raise HTTPException(status_code=400, detail="Invalid theme id (lowercase alphanumeric/-/_, ≤63)")
+        css_file = root / "theme.css"
+        if not css_file.is_file():
+            raise HTTPException(status_code=400, detail="theme.css not found")
+        validate_theme_css(css_file.read_text(encoding="utf-8"), manifest.id)
+        target = themes_dir() / manifest.id
+        try:
+            target.mkdir(parents=False, exist_ok=False)
+        except FileExistsError as exc:
+            raise HTTPException(status_code=409, detail=f"Theme '{manifest.id}' already installed") from exc
+        _arch.move_into_target(root, target)
+        logger.info("Installed theme '%s' v%s", manifest.id, manifest.version)
+        return ThemeDescriptor(**manifest.model_dump())
+
+
+def list_installed_themes() -> list[ThemeDescriptor]:
+    out: list[ThemeDescriptor] = []
+    base = themes_dir()
+    for d in sorted(base.iterdir()):
+        mf = d / "theme.json"
+        if d.is_dir() and mf.is_file():
+            try:
+                out.append(ThemeDescriptor(**ThemeManifest(**json.loads(mf.read_text(encoding="utf-8"))).model_dump()))
+            except Exception:
+                logger.warning("Skipping malformed theme dir: %s", d.name)
+    return out
+
+
+def _theme_dir(theme_id: str) -> Path:
+    if not _ID.match(theme_id):
+        raise HTTPException(status_code=400, detail="Invalid theme id")
+    d = themes_dir() / theme_id
+    if not d.is_dir():
+        raise HTTPException(status_code=404, detail=f"Theme '{theme_id}' not found")
+    return d
+
+
+def uninstall_theme(theme_id: str) -> None:
+    shutil.rmtree(_theme_dir(theme_id))
+
+
+def theme_css_path(theme_id: str) -> Path:
+    p = _theme_dir(theme_id) / "theme.css"
+    if not p.is_file():
+        raise HTTPException(status_code=404, detail="theme.css missing")
+    return p
+
+
+def theme_asset_path(theme_id: str, rel: str) -> Path:
+    base = _theme_dir(theme_id).resolve()
+    target = (base / rel).resolve()
+    try:
+        target.relative_to(base)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid asset path") from exc
+    if not target.is_file():
+        raise HTTPException(status_code=404, detail="Asset not found")
+    return target

--- a/autobot-backend/theme_install.py
+++ b/autobot-backend/theme_install.py
@@ -1,6 +1,7 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
 """Install/list/uninstall uploaded theme packages (#10472)."""
+
 from __future__ import annotations
 
 import json
@@ -10,7 +11,7 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-from fastapi import HTTPException, UploadFile, status
+from fastapi import HTTPException, UploadFile
 from pydantic import BaseModel
 
 import archive_safety as _arch

--- a/autobot-backend/theme_install_test.py
+++ b/autobot-backend/theme_install_test.py
@@ -1,0 +1,49 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+import io
+import json
+import zipfile
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+import theme_install
+
+
+def _theme_zip(theme_id="aqua", css=None) -> UploadFile:
+    css = css or f'[data-theme-variant="{theme_id}"] {{ --bg-primary: #eef; }}'
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("theme.json", json.dumps({"id": theme_id, "name": "Aqua", "author": "me", "version": "1.0.0"}))
+        zf.writestr("theme.css", css)
+    buf.seek(0)
+    return UploadFile(filename=f"{theme_id}.zip", file=buf)
+
+
+@pytest.fixture(autouse=True)
+def _tmp_themes(tmp_path, monkeypatch):
+    monkeypatch.setattr(theme_install, "themes_dir", lambda: tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_install_then_list_then_uninstall():
+    desc = await theme_install.install_theme_from_zip(_theme_zip("aqua"))
+    assert desc.id == "aqua"
+    assert [t.id for t in theme_install.list_installed_themes()] == ["aqua"]
+    assert theme_install.theme_css_path("aqua").is_file()
+    theme_install.uninstall_theme("aqua")
+    assert theme_install.list_installed_themes() == []
+
+
+@pytest.mark.asyncio
+async def test_install_rejects_unscoped_css():
+    with pytest.raises(HTTPException):
+        await theme_install.install_theme_from_zip(_theme_zip("bad", css="body { color: red }"))
+
+
+@pytest.mark.asyncio
+async def test_duplicate_install_conflicts():
+    await theme_install.install_theme_from_zip(_theme_zip("dup"))
+    with pytest.raises(HTTPException) as exc:
+        await theme_install.install_theme_from_zip(_theme_zip("dup"))
+    assert exc.value.status_code == 409

--- a/autobot-frontend/src/composables/__tests__/useThemeRegistry.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useThemeRegistry.test.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-vi.mock('@/utils/ApiClient', () => ({ apiClient: { get: vi.fn() } }))
-import { apiClient } from '@/utils/ApiClient'
+vi.mock('@/utils/ApiClient', () => ({ default: { get: vi.fn() } }))
+import apiClient from '@/utils/ApiClient'
 import { fetchInstalledThemes } from '../useThemeRegistry'
 
 describe('fetchInstalledThemes', () => {

--- a/autobot-frontend/src/composables/__tests__/useThemeRegistry.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useThemeRegistry.test.ts
@@ -1,0 +1,24 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/utils/ApiClient', () => ({ apiClient: { get: vi.fn() } }))
+import { apiClient } from '@/utils/ApiClient'
+import { fetchInstalledThemes } from '../useThemeRegistry'
+
+describe('fetchInstalledThemes', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns installed themes from the registry', async () => {
+    ;(apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 'aqua', name: 'Aqua', author: 'me', version: '1.0.0', supports: ['light'] },
+    ])
+    const themes = await fetchInstalledThemes()
+    expect(themes.map((t) => t.id)).toEqual(['aqua'])
+  })
+
+  it('returns [] when the registry call fails (graceful)', async () => {
+    ;(apiClient.get as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network'))
+    expect(await fetchInstalledThemes()).toEqual([])
+  })
+})

--- a/autobot-frontend/src/composables/__tests__/useThemeVariant.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useThemeVariant.test.ts
@@ -10,6 +10,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { nextTick } from 'vue'
 
+// Installed-theme registry is exercised by useThemeVariantRuntime.test.ts; here we
+// stub it so the fire-and-forget loadInstalledThemes() in initVariant() is inert and
+// the built-in availableVariants stay deterministic.
+vi.mock('../useThemeRegistry', () => ({
+  fetchInstalledThemes: vi.fn().mockResolvedValue([]),
+}))
+
 const KEY = 'autobot-theme-variant'
 
 async function freshComposable() {
@@ -60,7 +67,7 @@ describe('useThemeVariant — default resolution', () => {
 
   it('exposes both known variants', async () => {
     const { availableVariants } = await freshComposable()
-    expect(availableVariants).toEqual(['default', 'ember'])
+    expect(availableVariants.value).toEqual(['default', 'ember'])
   })
 })
 
@@ -72,7 +79,7 @@ describe('useThemeVariant — DOM application + persistence', () => {
 
   it('removes the attribute when switching to default, and persists the choice', async () => {
     const { setThemeVariant } = await freshComposable()
-    setThemeVariant('default')
+    await setThemeVariant('default')
     await nextTick()
     expect(document.documentElement.getAttribute('data-theme-variant')).toBeNull()
     expect(localStorage.getItem(KEY)).toBe('default')
@@ -81,7 +88,7 @@ describe('useThemeVariant — DOM application + persistence', () => {
   it('sets the attribute and persists when switching back to ember', async () => {
     localStorage.setItem(KEY, 'default')
     const { setThemeVariant } = await freshComposable()
-    setThemeVariant('ember')
+    await setThemeVariant('ember')
     await nextTick()
     expect(document.documentElement.getAttribute('data-theme-variant')).toBe('ember')
     expect(localStorage.getItem(KEY)).toBe('ember')

--- a/autobot-frontend/src/composables/__tests__/useThemeVariantRuntime.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useThemeVariantRuntime.test.ts
@@ -1,0 +1,66 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * useThemeVariantRuntime.test.ts — runtime installed-theme delivery (#10472)
+ *
+ * Installed themes are merged into availableVariants after loadInstalledThemes,
+ * and applied by fetching their CSS and adopting a constructed stylesheet
+ * (CSP-safe: no inline <style>, no cross-origin <link>).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const AQUA = { id: 'aqua', name: 'Aqua', author: 'me', version: '1.0.0', supports: ['light'] }
+const fetchInstalledThemesMock = vi.fn()
+vi.mock('../useThemeRegistry', () => ({ fetchInstalledThemes: fetchInstalledThemesMock }))
+
+class FakeCSSStyleSheet {
+  cssText = ''
+  async replace(text: string): Promise<void> {
+    this.cssText = text
+  }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  document.documentElement.removeAttribute('data-theme-variant')
+  ;(document as unknown as { adoptedStyleSheets: unknown[] }).adoptedStyleSheets = []
+  ;(globalThis as unknown as { CSSStyleSheet: unknown }).CSSStyleSheet = FakeCSSStyleSheet
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('[data-theme-variant="aqua"]{--bg-primary:#eef}'),
+    }),
+  )
+  fetchInstalledThemesMock.mockResolvedValue([AQUA])
+  vi.resetModules()
+})
+
+describe('useThemeVariant runtime themes', () => {
+  it('merges installed theme ids into availableVariants after loadInstalledThemes', async () => {
+    const { useThemeVariant } = await import('../useThemeVariant')
+    const { availableVariants, loadInstalledThemes } = useThemeVariant()
+    await loadInstalledThemes()
+    expect(availableVariants.value).toContain('aqua')
+  })
+
+  it('exposes the installed theme descriptors', async () => {
+    const { useThemeVariant } = await import('../useThemeVariant')
+    const { installedThemes, loadInstalledThemes } = useThemeVariant()
+    await loadInstalledThemes()
+    expect(installedThemes.value.map((t) => t.id)).toEqual(['aqua'])
+  })
+
+  it('adopts a constructed stylesheet when applying an installed variant', async () => {
+    const { useThemeVariant } = await import('../useThemeVariant')
+    const { setThemeVariant, loadInstalledThemes } = useThemeVariant()
+    await loadInstalledThemes()
+    await setThemeVariant('aqua')
+    expect(document.documentElement.getAttribute('data-theme-variant')).toBe('aqua')
+    expect((document as unknown as { adoptedStyleSheets: unknown[] }).adoptedStyleSheets.length).toBe(1)
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/themes/aqua/theme.css'),
+      expect.objectContaining({ credentials: 'include' }),
+    )
+  })
+})

--- a/autobot-frontend/src/composables/useThemeRegistry.ts
+++ b/autobot-frontend/src/composables/useThemeRegistry.ts
@@ -7,7 +7,7 @@
  * user frontend can offer them as selectable variants at runtime. Degrades
  * gracefully to built-in variants only when the registry is unavailable.
  */
-import { apiClient } from '@/utils/ApiClient'
+import apiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 
 const log = createLogger('ThemeRegistry')

--- a/autobot-frontend/src/composables/useThemeRegistry.ts
+++ b/autobot-frontend/src/composables/useThemeRegistry.ts
@@ -1,0 +1,32 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * useThemeRegistry.ts — installed theme registry (#10472)
+ *
+ * Fetches the list of admin-installed theme packages from the backend so the
+ * user frontend can offer them as selectable variants at runtime. Degrades
+ * gracefully to built-in variants only when the registry is unavailable.
+ */
+import { apiClient } from '@/utils/ApiClient'
+import { createLogger } from '@/utils/debugUtils'
+
+const log = createLogger('ThemeRegistry')
+
+export interface InstalledTheme {
+  id: string
+  name: string
+  author: string
+  version: string
+  supports: string[]
+}
+
+/** Fetch installed theme descriptors. Returns [] on any error (graceful degrade). */
+export async function fetchInstalledThemes(): Promise<InstalledTheme[]> {
+  try {
+    const themes = await apiClient.get<InstalledTheme[]>('/api/themes')
+    return Array.isArray(themes) ? themes : []
+  } catch (err) {
+    log.warn('Failed to fetch installed themes; using built-ins only', err)
+    return []
+  }
+}

--- a/autobot-frontend/src/composables/useThemeVariant.ts
+++ b/autobot-frontend/src/composables/useThemeVariant.ts
@@ -6,27 +6,38 @@
  *
  * useThemeVariant.ts - Theme Variant Management Composable
  * Issue #9274 / MVA-3096: Ember Theme Integration
+ * Issue #10472: Runtime installed-theme delivery
  *
- * Provides reactive theme variant switching for Ember theme:
- * - Default/Ember variant modes
+ * Provides reactive theme variant switching:
+ * - Built-in Default/Ember variant modes (build-time)
+ * - Admin-installed theme packages, delivered at runtime via fetch +
+ *   adoptedStyleSheets (CSP-safe: no inline <style>, no cross-origin <link>)
  * - LocalStorage persistence
  * - Works alongside existing useTheme composable
  *
  * Usage:
  *   const { themeVariant, setThemeVariant, variantLabels } = useThemeVariant()
- *   setThemeVariant('ember')  // or 'default'
+ *   setThemeVariant('ember')  // or 'default', or an installed theme id
  */
 
-import { ref, readonly, watch, onMounted, getCurrentInstance } from 'vue'
+import { ref, readonly, computed, watch, onMounted, getCurrentInstance } from 'vue'
+import { getBackendUrl } from '@/config/ssot-config'
+import { createLogger } from '@/utils/debugUtils'
+import { fetchInstalledThemes, type InstalledTheme } from './useThemeRegistry'
 
-/** Available theme variant options */
-export type ThemeVariant = 'default' | 'ember'
+const log = createLogger('ThemeVariant')
+
+/** Built-in theme variant options */
+export type BuiltinThemeVariant = 'default' | 'ember'
+
+/** A theme variant id — a built-in or an installed theme's id. */
+export type ThemeVariant = string
 
 /** Storage key for persisting variant preference */
 const THEME_VARIANT_STORAGE_KEY = 'autobot-theme-variant'
 
-/** All known variants — single source of truth for validation. */
-const VALID_VARIANTS: readonly ThemeVariant[] = ['default', 'ember']
+/** All built-in variants — single source of truth for validation. */
+const VALID_VARIANTS: readonly BuiltinThemeVariant[] = ['default', 'ember']
 
 /**
  * Default variant when the user has no saved preference.
@@ -36,32 +47,81 @@ const VALID_VARIANTS: readonly ThemeVariant[] = ['default', 'ember']
  * shares this build with the /slm control plane can pin `default` and keep the
  * current look. An unset or unrecognised value falls back to `ember`.
  */
-function resolveDefaultVariant(): ThemeVariant {
+function resolveDefaultVariant(): BuiltinThemeVariant {
   const fromEnv = import.meta.env?.VITE_DEFAULT_THEME_VARIANT as string | undefined
   if (fromEnv && (VALID_VARIANTS as readonly string[]).includes(fromEnv)) {
-    return fromEnv as ThemeVariant
+    return fromEnv as BuiltinThemeVariant
   }
   return 'ember'
 }
 
 /** Default variant when no preference is set */
-const DEFAULT_VARIANT: ThemeVariant = resolveDefaultVariant()
+const DEFAULT_VARIANT: BuiltinThemeVariant = resolveDefaultVariant()
 
 /** Global reactive state (singleton pattern) */
 const currentVariant = ref<ThemeVariant>(DEFAULT_VARIANT)
 
+/** Installed theme descriptors fetched from the backend registry (#10472) */
+const installedThemes = ref<InstalledTheme[]>([])
+
+/** Installed theme ids, merged into availableVariants at runtime (#10472) */
+const runtimeVariantIds = ref<string[]>([])
+
+/** Constructed stylesheets already adopted, keyed by theme id (idempotent). */
+const adopted = new Set<string>()
+
 /** Track if initialized */
 let isInitialized = false
 
+function isBuiltin(variant: ThemeVariant): boolean {
+  return (VALID_VARIANTS as readonly string[]).includes(variant)
+}
+
 /**
- * Applies the theme variant to the document root element
+ * Fetch an installed theme's CSS and adopt it as a constructed stylesheet.
+ *
+ * CSP-safe: the CSS text is fetched same-credentials from the backend and
+ * adopted via `document.adoptedStyleSheets` — never injected as an inline
+ * `<style>` or a cross-origin `<link>`. `apiClient.get` always parses JSON, so
+ * a raw `fetch` is used here to retrieve the CSS as text.
  */
-function applyThemeVariant(variant: ThemeVariant): void {
+async function ensureThemeStylesheet(id: string): Promise<void> {
+  if (adopted.has(id)) return
+  const response = await fetch(`${getBackendUrl()}/api/themes/${id}/theme.css`, {
+    credentials: 'include',
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to fetch theme CSS for '${id}': HTTP ${response.status}`)
+  }
+  const css = await response.text()
+  const sheet = new CSSStyleSheet()
+  await sheet.replace(css)
+  document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet]
+  adopted.add(id)
+}
+
+/**
+ * Applies the theme variant to the document root element.
+ *
+ * Built-in variants apply synchronously (no-flash parity preserved). Installed
+ * variants first fetch + adopt their stylesheet; on failure the previous
+ * variant is restored and the error surfaced to the caller.
+ */
+async function applyThemeVariant(variant: ThemeVariant, previous: ThemeVariant): Promise<void> {
   if (variant === 'default') {
     document.documentElement.removeAttribute('data-theme-variant')
-  } else {
-    document.documentElement.setAttribute('data-theme-variant', variant)
+    return
   }
+  if (!isBuiltin(variant)) {
+    try {
+      await ensureThemeStylesheet(variant)
+    } catch (err) {
+      log.error(`Failed to apply installed theme '${variant}'; reverting`, err)
+      currentVariant.value = previous
+      throw err
+    }
+  }
+  document.documentElement.setAttribute('data-theme-variant', variant)
 }
 
 /**
@@ -76,18 +136,35 @@ function saveThemeVariant(variant: ThemeVariant): void {
 }
 
 /**
- * Loads theme variant preference from localStorage
+ * Loads theme variant preference from localStorage. Accepts built-in variants
+ * and any currently-known installed theme id.
  */
 function loadThemeVariant(): ThemeVariant {
   try {
-    const stored = localStorage.getItem(THEME_VARIANT_STORAGE_KEY) as ThemeVariant | null
-    if (stored && VALID_VARIANTS.includes(stored)) {
+    const stored = localStorage.getItem(THEME_VARIANT_STORAGE_KEY)
+    if (stored && (isBuiltin(stored) || runtimeVariantIds.value.includes(stored))) {
       return stored
     }
   } catch {
     // localStorage may be unavailable
   }
   return DEFAULT_VARIANT
+}
+
+/**
+ * Fetch installed themes and merge their ids into the available variants.
+ * Safe to call repeatedly; degrades to built-ins only on failure.
+ */
+async function loadInstalledThemes(): Promise<void> {
+  try {
+    const themes = await fetchInstalledThemes()
+    installedThemes.value = Array.isArray(themes) ? themes : []
+    runtimeVariantIds.value = installedThemes.value.map((t) => t.id)
+  } catch (err) {
+    log.warn('Failed to load installed themes; using built-ins only', err)
+    installedThemes.value = []
+    runtimeVariantIds.value = []
+  }
 }
 
 /**
@@ -124,45 +201,63 @@ export function useThemeVariant() {
 
     const savedVariant = loadThemeVariant()
     currentVariant.value = savedVariant
-    applyThemeVariant(savedVariant)
+    void applyThemeVariant(savedVariant, savedVariant)
 
     // Watch for changes and persist
     watch(currentVariant, (variant) => {
-      applyThemeVariant(variant)
       saveThemeVariant(variant)
     })
 
     isInitialized = true
+
+    // Fire-and-forget: installed themes appear once the registry loads.
+    void loadInstalledThemes()
   }
 
   /**
-   * Set the theme variant
-   * @param variant - Theme variant to apply ('default' or 'ember')
+   * Set the theme variant.
+   * @param variant - Theme variant to apply ('default', 'ember', or an installed id)
+   * @returns a Promise that resolves once the variant (incl. any installed
+   *   stylesheet) has been applied. Rejects — and reverts — on apply failure.
    */
-  function setThemeVariant(variant: ThemeVariant): void {
+  async function setThemeVariant(variant: ThemeVariant): Promise<void> {
+    const previous = currentVariant.value
     currentVariant.value = variant
+    await applyThemeVariant(variant, previous)
   }
 
   /**
-   * Available theme variant options
+   * Available theme variant options — built-ins plus installed theme ids.
    */
-  const availableVariants: ThemeVariant[] = [...VALID_VARIANTS]
+  const availableVariants = computed<ThemeVariant[]>(() => [...VALID_VARIANTS, ...runtimeVariantIds.value])
 
   /**
-   * Theme variant labels for UI display
+   * Theme variant labels for UI display (built-ins + installed theme names).
    */
-  const variantLabels: Record<ThemeVariant, string> = {
-    default: 'Default',
-    ember: 'Ember',
-  }
+  const variantLabels = computed<Record<string, string>>(() => {
+    const labels: Record<string, string> = {
+      default: 'Default',
+      ember: 'Ember',
+    }
+    for (const theme of installedThemes.value) {
+      labels[theme.id] = theme.name
+    }
+    return labels
+  })
 
   /**
-   * Theme variant descriptions
+   * Theme variant descriptions (built-ins + installed author/version).
    */
-  const variantDescriptions: Record<ThemeVariant, string> = {
-    default: 'Standard AutoBot theme with cool neutrals',
-    ember: 'Warm palette with marigold accents and apricot-plum tones',
-  }
+  const variantDescriptions = computed<Record<string, string>>(() => {
+    const descriptions: Record<string, string> = {
+      default: 'Standard AutoBot theme with cool neutrals',
+      ember: 'Warm palette with marigold accents and apricot-plum tones',
+    }
+    for (const theme of installedThemes.value) {
+      descriptions[theme.id] = `v${theme.version} — ${theme.author}`
+    }
+    return descriptions
+  })
 
   // Initialize on mount if in browser context
   if (getCurrentInstance()) {
@@ -180,11 +275,17 @@ export function useThemeVariant() {
     /** Current theme variant setting (reactive) */
     themeVariant: readonly(currentVariant),
 
-    /** Set the theme variant */
+    /** Set the theme variant (async — awaits installed-theme stylesheet adopt) */
     setThemeVariant,
 
-    /** Available theme variant options */
+    /** Available theme variant options (built-ins + installed, reactive) */
     availableVariants,
+
+    /** Installed theme descriptors from the backend registry */
+    installedThemes: readonly(installedThemes),
+
+    /** Fetch + merge installed themes into availableVariants */
+    loadInstalledThemes,
 
     /** Theme variant display labels */
     variantLabels,
@@ -205,7 +306,7 @@ export function initializeThemeVariant(): void {
   if (typeof document === 'undefined') return
 
   const savedVariant = loadThemeVariant()
-  applyThemeVariant(savedVariant)
+  void applyThemeVariant(savedVariant, savedVariant)
   currentVariant.value = savedVariant
   isInitialized = true
 }

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -916,6 +916,19 @@ export const routes: RouteRecordRaw[] = [
       hideFooter: true,
     },
   },
+  // Issue #10472: Admin theme-package management under the /slm route group.
+  // Upload/list/uninstall theme zips; install is admin-gated server-side.
+  {
+    path: '/slm/themes',
+    name: 'slm-themes',
+    component: () => import('@/views/slm/ThemeManagerView.vue'),
+    meta: {
+      title: 'Theme Manager',
+      requiresAuth: true,
+      // Admin-only operator view, reached via /slm — not in the primary nav rail.
+      hideInNav: true,
+    },
+  },
   // Issue #3502: Custom Dashboard renamed to /home (see home route above)
 
   // Issue #729: Infrastructure routes redirected to slm-admin

--- a/autobot-frontend/src/views/slm/ThemeManagerView.vue
+++ b/autobot-frontend/src/views/slm/ThemeManagerView.vue
@@ -1,0 +1,89 @@
+<!-- Copyright 2025-2026 mrveiss -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+  ThemeManagerView.vue - Admin theme package management (#10472)
+
+  Upload a theme package (.zip) to install it, list installed themes, and
+  uninstall. Thin client of the backend theme API (admin-gated server-side).
+  Reachable under the /slm route group.
+-->
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import apiClient from '@/utils/ApiClient'
+import { fetchInstalledThemes, type InstalledTheme } from '@/composables/useThemeRegistry'
+import { createLogger } from '@/utils/debugUtils'
+
+const log = createLogger('ThemeManager')
+const themes = ref<InstalledTheme[]>([])
+const busy = ref(false)
+const error = ref('')
+
+async function refresh(): Promise<void> {
+  themes.value = await fetchInstalledThemes()
+}
+
+async function onUpload(e: Event): Promise<void> {
+  const file = (e.target as HTMLInputElement).files?.[0]
+  if (!file) return
+  busy.value = true
+  error.value = ''
+  try {
+    const form = new FormData()
+    form.append('file', file)
+    await apiClient.post('/api/themes', form)
+    await refresh()
+  } catch (err) {
+    error.value = (err as Error).message
+    log.error('Theme upload failed', err)
+  } finally {
+    busy.value = false
+  }
+}
+
+async function remove(id: string): Promise<void> {
+  busy.value = true
+  error.value = ''
+  try {
+    await apiClient.delete(`/api/themes/${id}`)
+    await refresh()
+  } catch (err) {
+    error.value = (err as Error).message
+    log.error('Theme uninstall failed', err)
+  } finally {
+    busy.value = false
+  }
+}
+
+onMounted(refresh)
+</script>
+
+<template>
+  <section class="theme-manager">
+    <h1 class="text-2xl font-semibold mb-2">Themes</h1>
+    <p class="text-autobot-text-secondary mb-4">
+      Upload a theme package (.zip) to make it available to all users.
+    </p>
+    <input type="file" accept=".zip" :disabled="busy" @change="onUpload" />
+    <p v-if="error" class="error text-red-500 mt-2">{{ error }}</p>
+    <ul class="mt-4 space-y-2">
+      <li v-for="t in themes" :key="t.id" class="flex items-center gap-3">
+        <strong>{{ t.name }}</strong>
+        <small class="text-autobot-text-secondary">v{{ t.version }} — {{ t.author }}</small>
+        <button
+          type="button"
+          class="px-3 py-1 rounded-md bg-autobot-bg-tertiary hover:bg-autobot-bg-hover"
+          :disabled="busy"
+          @click="remove(t.id)"
+        >
+          Uninstall
+        </button>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<style scoped>
+.theme-manager {
+  padding: 1.5rem;
+}
+</style>

--- a/autobot-frontend/src/views/slm/__tests__/ThemeManagerView.test.ts
+++ b/autobot-frontend/src/views/slm/__tests__/ThemeManagerView.test.ts
@@ -1,0 +1,20 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+const AQUA = { id: 'aqua', name: 'Aqua', author: 'me', version: '1.0.0', supports: ['light'] }
+const { fetchInstalledThemesMock } = vi.hoisted(() => ({ fetchInstalledThemesMock: vi.fn() }))
+
+vi.mock('@/composables/useThemeRegistry', () => ({ fetchInstalledThemes: fetchInstalledThemesMock }))
+vi.mock('@/utils/ApiClient', () => ({ default: { post: vi.fn(), delete: vi.fn() } }))
+import ThemeManagerView from '../ThemeManagerView.vue'
+
+describe('ThemeManagerView', () => {
+  it('lists installed themes on mount', async () => {
+    fetchInstalledThemesMock.mockResolvedValue([AQUA])
+    const wrapper = mount(ThemeManagerView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Aqua')
+  })
+})

--- a/docs/superpowers/plans/2026-06-23-pluggable-themes-slm.md
+++ b/docs/superpowers/plans/2026-06-23-pluggable-themes-slm.md
@@ -1,0 +1,1040 @@
+# Pluggable Theme Packages via /slm — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let admins install themes by uploading a zip via /slm; deliver them to the running user frontend at runtime and make them user-selectable — no rebuild.
+
+**Architecture:** Themes are a backend-owned package type modeled on `plugin_install.py`. Shared zip-safety primitives are extracted to `archive_safety.py` (used by both plugins and themes). A strict CSS validator enforces `[data-theme-variant="<id>"]` scoping and blocks external fetches. The backend stores/serves themes; the frontend fetches a registry, extends `availableVariants`, and applies a selected theme via `fetch` + `adoptedStyleSheets` (CSP-safe).
+
+**Tech Stack:** Python/FastAPI (autobot-backend), pytest; Vue 3 + TypeScript (autobot-frontend), vitest, vue-tsc.
+
+## Global Constraints
+
+- Worktree: `.worktrees/issue-10472`, branch `issue-10472`. Base/PR target: `Dev_new_gui`.
+- Python line length 120; functions ≤30 lines; `encoding="utf-8"` explicit; logging via `get_logger(__name__)` (no `print`).
+- Frontend: no `console.*` (use `createLogger`); strict CSP (`style-src 'self'`, no `unsafe-inline`) — runtime CSS must use `adoptedStyleSheets`, never inline `<style>` or cross-origin `<link>`.
+- Admin gate = `from auth_middleware import check_admin_permission` (`Depends(check_admin_permission)`), as used by `plugin_manager.py`.
+- Route error wrapper = `from error_handler import with_error_handling` (decorator BELOW `@router.*`).
+- Copyright header `# Copyright 2025-2026 mrveiss` + `# SPDX-License-Identifier: Apache-2.0` on new Python files; `// Copyright …` on new TS/Vue files.
+- Commit format: `<type>(scope): <desc> (#10472)`.
+
+---
+
+### Task 1: Extract shared archive-safety primitives
+
+Generalize the plugin zip-hardening into a reusable module so themes reuse the exact same security code (DRY — one place to fix zip-slip/symlink/bomb guards).
+
+**Files:**
+- Create: `autobot-backend/archive_safety.py`
+- Modify: `autobot-backend/plugin_install.py` (re-point to the shared module)
+- Test: `autobot-backend/archive_safety_test.py`
+
+**Interfaces:**
+- Produces:
+  - `MAX_ZIP_UNCOMPRESSED_BYTES`, `MAX_ZIP_ENTRIES`, `MAX_UPLOAD_BYTES`, `MAX_COMPRESSION_RATIO` (ints)
+  - `is_zip_symlink(info: zipfile.ZipInfo) -> bool`
+  - `validate_zip_metadata(zf: zipfile.ZipFile, extract_root: Path) -> None`
+  - `safe_extract(zf: zipfile.ZipFile, extract_root: Path) -> None`
+  - `find_package_root(extract_dir: Path, manifest_filename: str) -> Path`
+  - `move_into_target(source: Path, target: Path) -> None`
+  - `async stream_upload_to(upload: UploadFile, dest: Path) -> None`
+  - all raise `fastapi.HTTPException` on violation.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# autobot-backend/archive_safety_test.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from archive_safety import find_package_root, safe_extract, validate_zip_metadata
+
+
+def _zip_bytes(entries: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def test_safe_extract_writes_files(tmp_path: Path):
+    zf = zipfile.ZipFile(io.BytesIO(_zip_bytes({"theme.json": b"{}"})))
+    safe_extract(zf, tmp_path)
+    assert (tmp_path / "theme.json").read_bytes() == b"{}"
+
+
+def test_validate_rejects_zip_slip(tmp_path: Path):
+    zf = zipfile.ZipFile(io.BytesIO(_zip_bytes({"../evil.txt": b"x"})))
+    with pytest.raises(HTTPException) as exc:
+        validate_zip_metadata(zf, tmp_path)
+    assert exc.value.status_code == 400
+
+
+def test_find_package_root_in_single_subdir(tmp_path: Path):
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "theme.json").write_text("{}", encoding="utf-8")
+    assert find_package_root(tmp_path, "theme.json") == tmp_path / "pkg"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-backend && python -m pytest archive_safety_test.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'archive_safety'`.
+
+- [ ] **Step 3: Create `archive_safety.py`**
+
+Move the bodies of `_is_zip_symlink`, `_validate_zip_metadata`, `_safe_extract`, `_move_into_target`, `_stream_upload_to`, and a generalized `find_package_root` (the old `_find_plugin_root` but taking `manifest_filename`) from `plugin_install.py` into `archive_safety.py` as public functions. Copy the constants `_MAX_*` as public `MAX_*`. Keep the logic byte-for-byte; only rename (drop leading `_`) and parameterize the manifest filename.
+
+```python
+# autobot-backend/archive_safety.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Shared, hardened zip-archive handling for package installers (plugins, themes).
+
+Extracted from plugin_install.py (#10472) so every installer reuses the same
+zip-slip / symlink / zip-bomb / upload-size guards — one place to audit and fix.
+"""
+from __future__ import annotations
+
+import shutil
+import zipfile
+from pathlib import Path
+
+from fastapi import HTTPException, UploadFile, status
+
+MAX_ZIP_UNCOMPRESSED_BYTES = 256 * 1024 * 1024
+MAX_ZIP_ENTRIES = 5000
+MAX_UPLOAD_BYTES = 512 * 1024 * 1024
+MAX_COMPRESSION_RATIO = 100
+
+
+def is_zip_symlink(info: zipfile.ZipInfo) -> bool:
+    return ((info.external_attr >> 16) & 0xF000) == 0xA000
+
+
+def validate_zip_metadata(zf: zipfile.ZipFile, extract_root: Path) -> None:
+    names = zf.namelist()
+    if len(names) > MAX_ZIP_ENTRIES:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Archive has too many entries (>{MAX_ZIP_ENTRIES})")
+    extract_root_resolved = extract_root.resolve()
+    for info in zf.infolist():
+        if info.is_dir():
+            continue
+        target = (extract_root / info.filename).resolve()
+        try:
+            target.relative_to(extract_root_resolved)
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Archive entry escapes root: {info.filename}") from exc
+        if is_zip_symlink(info):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Archive contains symlink: {info.filename}")
+        if info.compress_size > 0 and info.file_size // info.compress_size > MAX_COMPRESSION_RATIO:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Archive entry has suspicious compression ratio: {info.filename}")
+
+
+def safe_extract(zf: zipfile.ZipFile, extract_root: Path) -> None:
+    extract_root_resolved = extract_root.resolve()
+    bytes_written = 0
+    for info in zf.infolist():
+        if info.is_dir():
+            continue
+        if "__MACOSX/" in info.filename or Path(info.filename).name.startswith("._"):
+            continue
+        target = (extract_root / info.filename).resolve()
+        target.relative_to(extract_root_resolved)
+        if is_zip_symlink(info):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Archive contains symlink: {info.filename}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with zf.open(info) as src, target.open("wb") as out:
+            while chunk := src.read(1024 * 1024):
+                bytes_written += len(chunk)
+                if bytes_written > MAX_ZIP_UNCOMPRESSED_BYTES:
+                    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Archive uncompressed size exceeds 256MB")
+                out.write(chunk)
+
+
+def find_package_root(extract_dir: Path, manifest_filename: str) -> Path:
+    if (extract_dir / manifest_filename).is_file():
+        return extract_dir
+    children = [c for c in extract_dir.iterdir() if c.is_dir() and c.name != "__MACOSX" and not c.name.startswith(".")]
+    if len(children) == 1 and (children[0] / manifest_filename).is_file():
+        return children[0]
+    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"{manifest_filename} not found at archive root or single top-level folder")
+
+
+def move_into_target(source: Path, target: Path) -> None:
+    for child in source.iterdir():
+        shutil.move(str(child), str(target / child.name))
+    source.rmdir()
+
+
+async def stream_upload_to(upload: UploadFile, dest: Path) -> None:
+    bytes_written = 0
+    with dest.open("wb") as out:
+        while chunk := await upload.read(1024 * 1024):
+            bytes_written += len(chunk)
+            if bytes_written > MAX_UPLOAD_BYTES:
+                raise HTTPException(status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail=f"Upload exceeds {MAX_UPLOAD_BYTES // (1024 * 1024)}MB")
+            out.write(chunk)
+```
+
+- [ ] **Step 4: Re-point `plugin_install.py` to the shared module**
+
+In `plugin_install.py`, delete the moved private functions + `_MAX_*` constants, and add `import archive_safety as _arch`. Replace internal calls: `_validate_zip_metadata(...)`→`_arch.validate_zip_metadata(...)`, `_safe_extract`→`_arch.safe_extract`, `_find_plugin_root(d)`→`_arch.find_package_root(d, "plugin.json")`, `_move_into_target`→`_arch.move_into_target`, `_stream_upload_to`→`_arch.stream_upload_to`. Keep `_MAX_UPLOAD_BYTES` references pointing at `_arch.MAX_UPLOAD_BYTES`.
+
+- [ ] **Step 5: Run tests (new + plugin regression)**
+
+Run: `cd autobot-backend && python -m pytest archive_safety_test.py plugin_install_test.py -q` (if `plugin_install_test.py` is absent, run `python -m pytest -k plugin_install -q`).
+Expected: PASS — new archive-safety tests pass AND existing plugin install tests still pass (behavior preserved).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add autobot-backend/archive_safety.py autobot-backend/archive_safety_test.py autobot-backend/plugin_install.py
+git commit -m "refactor(backend): extract shared archive-safety zip hardening from plugin_install (#10472)"
+```
+
+---
+
+### Task 2: Strict theme CSS validator
+
+The security keystone: a pure function that accepts theme CSS only if every rule is scoped to the theme's variant and contains no external fetches.
+
+**Files:**
+- Create: `autobot-backend/theme_css_validator.py`
+- Test: `autobot-backend/theme_css_validator_test.py`
+
+**Interfaces:**
+- Produces: `validate_theme_css(css: str, variant_id: str) -> None` — raises `HTTPException(400, detail=...)` on the first violation; returns `None` if valid.
+- Consumes: nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# autobot-backend/theme_css_validator_test.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from fastapi import HTTPException
+
+from theme_css_validator import validate_theme_css
+
+OK = '[data-theme-variant="x"] { --bg-primary: #fff; }'
+
+
+def test_accepts_scoped_rule():
+    validate_theme_css(OK, "x")  # no raise
+
+
+def test_rejects_unscoped_rule():
+    with pytest.raises(HTTPException):
+        validate_theme_css("body { color: red; }", "x")
+
+
+def test_rejects_wrong_variant_id():
+    with pytest.raises(HTTPException):
+        validate_theme_css('[data-theme-variant="other"] { --x: 1; }', "x")
+
+
+def test_rejects_at_import():
+    with pytest.raises(HTTPException):
+        validate_theme_css('@import url("http://evil/x.css");', "x")
+
+
+def test_rejects_external_url():
+    with pytest.raises(HTTPException):
+        validate_theme_css('[data-theme-variant="x"] { background: url(http://evil/p.png); }', "x")
+
+
+def test_accepts_data_uri_and_relative_url():
+    validate_theme_css('[data-theme-variant="x"] { src: url(data:font/woff2;base64,AA); }', "x")
+    validate_theme_css('[data-theme-variant="x"] { src: url(./fonts/a.woff2); }', "x")
+
+
+def test_rejects_expression_and_oversize():
+    with pytest.raises(HTTPException):
+        validate_theme_css('[data-theme-variant="x"] { width: expression(alert(1)); }', "x")
+    with pytest.raises(HTTPException):
+        validate_theme_css("[data-theme-variant=\"x\"] { /* a */ }" + "a" * (512 * 1024), "x")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-backend && python -m pytest theme_css_validator_test.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'theme_css_validator'`.
+
+- [ ] **Step 3: Write the validator**
+
+Approach: strip comments; enforce size cap; reject forbidden tokens anywhere (`@import`, `expression(`, `behavior:`, `javascript:`); reject any `url(...)` whose target is not `data:` or a relative path (no `http:`/`https:`/`//`/`\\`); then split into top-level rule blocks and require each block's selector list to start every selector with `[data-theme-variant="<variant_id>"]`.
+
+```python
+# autobot-backend/theme_css_validator.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Strict validator for uploaded theme CSS (#10472).
+
+Untrusted CSS may only style its own variant and must not fetch anything
+external. Rejects on the first violation with an HTTPException(400).
+"""
+from __future__ import annotations
+
+import re
+
+from fastapi import HTTPException, status
+
+MAX_CSS_BYTES = 512 * 1024
+_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+_FORBIDDEN = ("@import", "expression(", "behavior:", "javascript:", "@charset")
+_URL = re.compile(r"url\(\s*['\"]?([^'\")]+)['\"]?\s*\)", re.IGNORECASE)
+_BLOCK = re.compile(r"([^{}]+)\{[^{}]*\}", re.DOTALL)
+
+
+def _reject(detail: str) -> None:
+    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Theme CSS rejected: {detail}")
+
+
+def validate_theme_css(css: str, variant_id: str) -> None:
+    if len(css.encode("utf-8")) > MAX_CSS_BYTES:
+        _reject(f"exceeds {MAX_CSS_BYTES // 1024}KB")
+    stripped = _COMMENT.sub(" ", css)
+    lowered = stripped.lower()
+    for tok in _FORBIDDEN:
+        if tok in lowered:
+            _reject(f"forbidden token {tok!r}")
+    for ref in _URL.findall(stripped):
+        target = ref.strip()
+        if target.startswith("data:"):
+            continue
+        if re.match(r"^(https?:)?//", target, re.IGNORECASE) or "\\" in target or ":" in target.split("/")[0]:
+            _reject(f"external url() not allowed: {target}")
+    scope = f'[data-theme-variant="{variant_id}"]'
+    blocks = _BLOCK.findall(stripped)
+    if not blocks:
+        _reject("no style rules found")
+    for selector_list in blocks:
+        for selector in selector_list.split(","):
+            sel = selector.strip()
+            if not sel or sel.startswith("@"):  # @font-face/@media handled below
+                continue
+            if not sel.startswith(scope):
+                _reject(f"selector not scoped to {scope}: {sel[:60]}")
+```
+
+Note: `@font-face`/`@media` wrappers — for MVP, reject at-rules other than the allowed set by treating any selector beginning with `@` as needing review; keep it simple: the test suite above does not require `@media`, and `@import`/`@charset` are already forbidden. If a later theme needs `@font-face`, that is a follow-up (documented in spec "out of scope"). Keep this MVP behavior: at-rule selectors are skipped only if they are `@font-face` with `src: url(data:|relative)` — already covered by the url() check.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd autobot-backend && python -m pytest theme_css_validator_test.py -q`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add autobot-backend/theme_css_validator.py autobot-backend/theme_css_validator_test.py
+git commit -m "feat(backend): strict theme CSS validator — scope + sanitise uploads (#10472)"
+```
+
+---
+
+### Task 3: Theme install service
+
+Install/list/uninstall theme packages on disk using the shared archive-safety guards and the CSS validator.
+
+**Files:**
+- Create: `autobot-backend/theme_install.py`
+- Test: `autobot-backend/theme_install_test.py`
+
+**Interfaces:**
+- Consumes: `archive_safety` (Task 1), `validate_theme_css` (Task 2).
+- Produces:
+  - `class ThemeManifest(BaseModel)`: `id: str`, `name: str`, `author: str`, `version: str`, `supports: list[str] = ["light","dark"]`.
+  - `class ThemeDescriptor(BaseModel)`: same fields (registry shape).
+  - `themes_dir() -> Path` → `config.path.data_path / "themes"` (created).
+  - `async install_theme_from_zip(upload: UploadFile) -> ThemeDescriptor`
+  - `list_installed_themes() -> list[ThemeDescriptor]`
+  - `uninstall_theme(theme_id: str) -> None` (404 if absent)
+  - `theme_css_path(theme_id: str) -> Path` (404 if absent), `theme_asset_path(theme_id, rel: str) -> Path` (path-traversal guarded; 404 if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# autobot-backend/theme_install_test.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+import io
+import json
+import zipfile
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+import theme_install
+
+
+def _theme_zip(theme_id="aqua", css=None) -> UploadFile:
+    css = css or f'[data-theme-variant="{theme_id}"] {{ --bg-primary: #eef; }}'
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("theme.json", json.dumps({"id": theme_id, "name": "Aqua", "author": "me", "version": "1.0.0"}))
+        zf.writestr("theme.css", css)
+    buf.seek(0)
+    return UploadFile(filename=f"{theme_id}.zip", file=buf)
+
+
+@pytest.fixture(autouse=True)
+def _tmp_themes(tmp_path, monkeypatch):
+    monkeypatch.setattr(theme_install, "themes_dir", lambda: tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_install_then_list_then_uninstall():
+    desc = await theme_install.install_theme_from_zip(_theme_zip("aqua"))
+    assert desc.id == "aqua"
+    assert [t.id for t in theme_install.list_installed_themes()] == ["aqua"]
+    assert theme_install.theme_css_path("aqua").is_file()
+    theme_install.uninstall_theme("aqua")
+    assert theme_install.list_installed_themes() == []
+
+
+@pytest.mark.asyncio
+async def test_install_rejects_unscoped_css():
+    with pytest.raises(HTTPException):
+        await theme_install.install_theme_from_zip(_theme_zip("bad", css="body { color: red }"))
+
+
+@pytest.mark.asyncio
+async def test_duplicate_install_conflicts():
+    await theme_install.install_theme_from_zip(_theme_zip("dup"))
+    with pytest.raises(HTTPException) as exc:
+        await theme_install.install_theme_from_zip(_theme_zip("dup"))
+    assert exc.value.status_code == 409
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-backend && python -m pytest theme_install_test.py -q`
+Expected: FAIL — `AttributeError`/`ImportError` (module/functions absent).
+
+- [ ] **Step 3: Write `theme_install.py`**
+
+```python
+# autobot-backend/theme_install.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Install/list/uninstall uploaded theme packages (#10472)."""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+
+from fastapi import HTTPException, UploadFile, status
+from pydantic import BaseModel
+
+import archive_safety as _arch
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config
+from theme_css_validator import validate_theme_css
+
+logger = get_logger(__name__)
+_ID = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+
+
+class ThemeManifest(BaseModel):
+    id: str
+    name: str
+    author: str
+    version: str
+    supports: list[str] = ["light", "dark"]
+
+
+class ThemeDescriptor(BaseModel):
+    id: str
+    name: str
+    author: str
+    version: str
+    supports: list[str]
+
+
+def themes_dir() -> Path:
+    target = config.path.data_path / "themes"
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def _read_manifest(root: Path) -> ThemeManifest:
+    mf = root / "theme.json"
+    if not mf.is_file():
+        raise HTTPException(status_code=400, detail="theme.json not found at theme root")
+    try:
+        return ThemeManifest(**json.loads(mf.read_text(encoding="utf-8")))
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid theme.json: {exc}") from exc
+
+
+async def install_theme_from_zip(upload: UploadFile) -> ThemeDescriptor:
+    with tempfile.TemporaryDirectory() as tmp:
+        zip_path = Path(tmp) / "u.zip"
+        await _arch.stream_upload_to(upload, zip_path)
+        extract = Path(tmp) / "x"
+        extract.mkdir()
+        try:
+            with zipfile.ZipFile(zip_path) as zf:
+                _arch.validate_zip_metadata(zf, extract)
+                _arch.safe_extract(zf, extract)
+        except zipfile.BadZipFile as exc:
+            raise HTTPException(status_code=400, detail="Not a valid ZIP archive") from exc
+        root = _arch.find_package_root(extract, "theme.json")
+        manifest = _read_manifest(root)
+        if not _ID.match(manifest.id):
+            raise HTTPException(status_code=400, detail="Invalid theme id (lowercase alphanumeric/-/_, ≤63)")
+        css_file = root / "theme.css"
+        if not css_file.is_file():
+            raise HTTPException(status_code=400, detail="theme.css not found")
+        validate_theme_css(css_file.read_text(encoding="utf-8"), manifest.id)
+        target = themes_dir() / manifest.id
+        try:
+            target.mkdir(parents=False, exist_ok=False)
+        except FileExistsError as exc:
+            raise HTTPException(status_code=409, detail=f"Theme '{manifest.id}' already installed") from exc
+        _arch.move_into_target(root, target)
+        logger.info("Installed theme '%s' v%s", manifest.id, manifest.version)
+        return ThemeDescriptor(**manifest.model_dump())
+
+
+def list_installed_themes() -> list[ThemeDescriptor]:
+    out: list[ThemeDescriptor] = []
+    base = themes_dir()
+    for d in sorted(base.iterdir()):
+        mf = d / "theme.json"
+        if d.is_dir() and mf.is_file():
+            try:
+                out.append(ThemeDescriptor(**ThemeManifest(**json.loads(mf.read_text(encoding="utf-8"))).model_dump()))
+            except Exception:
+                logger.warning("Skipping malformed theme dir: %s", d.name)
+    return out
+
+
+def _theme_dir(theme_id: str) -> Path:
+    if not _ID.match(theme_id):
+        raise HTTPException(status_code=400, detail="Invalid theme id")
+    d = themes_dir() / theme_id
+    if not d.is_dir():
+        raise HTTPException(status_code=404, detail=f"Theme '{theme_id}' not found")
+    return d
+
+
+def uninstall_theme(theme_id: str) -> None:
+    shutil.rmtree(_theme_dir(theme_id))
+
+
+def theme_css_path(theme_id: str) -> Path:
+    p = _theme_dir(theme_id) / "theme.css"
+    if not p.is_file():
+        raise HTTPException(status_code=404, detail="theme.css missing")
+    return p
+
+
+def theme_asset_path(theme_id: str, rel: str) -> Path:
+    base = _theme_dir(theme_id).resolve()
+    target = (base / rel).resolve()
+    try:
+        target.relative_to(base)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid asset path") from exc
+    if not target.is_file():
+        raise HTTPException(status_code=404, detail="Asset not found")
+    return target
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd autobot-backend && python -m pytest theme_install_test.py -q`
+Expected: PASS (3 tests). (If `pytest-asyncio` mode requires it, the repo already uses async tests — mirror `plugin_install_test.py`'s markers.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add autobot-backend/theme_install.py autobot-backend/theme_install_test.py
+git commit -m "feat(backend): theme package install/list/uninstall service (#10472)"
+```
+
+---
+
+### Task 4: Theme API router
+
+Expose admin install/uninstall + public registry/CSS/asset serving, and register the router.
+
+**Files:**
+- Create: `autobot-backend/api/themes.py`
+- Modify: `autobot-backend/initialization/router_registry/core_routers.py` (register router)
+- Test: `autobot-backend/api/themes_test.py`
+
+**Interfaces:**
+- Consumes: `theme_install` (Task 3), `check_admin_permission`, `with_error_handling`.
+- Produces routes: `POST /api/themes`, `DELETE /api/themes/{theme_id}`, `GET /api/themes`, `GET /api/themes/{theme_id}/theme.css`, `GET /api/themes/{theme_id}/assets/{rel:path}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# autobot-backend/api/themes_test.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+import io
+import json
+import zipfile
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import theme_install
+from api import themes as themes_api
+from auth_middleware import check_admin_permission
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setattr(theme_install, "themes_dir", lambda: tmp_path)
+    app = FastAPI()
+    app.include_router(themes_api.router)
+    app.dependency_overrides[check_admin_permission] = lambda: True
+    return TestClient(app)
+
+
+def _zip(theme_id="aqua"):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("theme.json", json.dumps({"id": theme_id, "name": "Aqua", "author": "me", "version": "1.0.0"}))
+        zf.writestr("theme.css", f'[data-theme-variant="{theme_id}"] {{ --bg-primary:#eef; }}')
+    return buf.getvalue()
+
+
+def test_upload_list_serve_delete(client):
+    r = client.post("/api/themes", files={"file": ("aqua.zip", _zip(), "application/zip")})
+    assert r.status_code == 200, r.text
+    assert client.get("/api/themes").json()[0]["id"] == "aqua"
+    css = client.get("/api/themes/aqua/theme.css")
+    assert css.status_code == 200 and "data-theme-variant" in css.text
+    assert client.delete("/api/themes/aqua").status_code == 200
+    assert client.get("/api/themes").json() == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-backend && python -m pytest api/themes_test.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'api.themes'`.
+
+- [ ] **Step 3: Write `api/themes.py`**
+
+```python
+# autobot-backend/api/themes.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Theme package API — admin install/uninstall + public registry/serve (#10472)."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, File, UploadFile
+from fastapi.responses import FileResponse, JSONResponse
+
+import theme_install
+from auth_middleware import check_admin_permission
+from error_handler import with_error_handling
+
+router = APIRouter(prefix="/api/themes", tags=["themes"])
+
+
+@router.post("")
+@with_error_handling(error_code_prefix="THEME_INSTALL")
+async def install_theme(file: UploadFile = File(...), admin_check: bool = Depends(check_admin_permission)):
+    desc = await theme_install.install_theme_from_zip(file)
+    return JSONResponse(desc.model_dump())
+
+
+@router.delete("/{theme_id}")
+@with_error_handling(error_code_prefix="THEME_UNINSTALL")
+async def uninstall_theme(theme_id: str, admin_check: bool = Depends(check_admin_permission)):
+    theme_install.uninstall_theme(theme_id)
+    return {"status": "deleted", "id": theme_id}
+
+
+@router.get("")
+@with_error_handling(error_code_prefix="THEME_LIST")
+async def list_themes():
+    return [d.model_dump() for d in theme_install.list_installed_themes()]
+
+
+@router.get("/{theme_id}/theme.css")
+@with_error_handling(error_code_prefix="THEME_CSS")
+async def serve_theme_css(theme_id: str):
+    return FileResponse(theme_install.theme_css_path(theme_id), media_type="text/css")
+
+
+@router.get("/{theme_id}/assets/{rel:path}")
+@with_error_handling(error_code_prefix="THEME_ASSET")
+async def serve_theme_asset(theme_id: str, rel: str):
+    return FileResponse(theme_install.theme_asset_path(theme_id, rel))
+```
+
+- [ ] **Step 4: Register the router**
+
+In `autobot-backend/initialization/router_registry/core_routers.py`: near the existing `from plugin_manager import router as plugin_manager_router` (line ~109) add `from api.themes import router as themes_router`. In the registration tuple list (near line ~503 where `(plugin_manager_router, "", ["plugins"], "plugin_manager")` is) add `(themes_router, "", ["themes"], "themes")` (the router already carries its `/api/themes` prefix, so mount prefix is `""`).
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd autobot-backend && python -m pytest api/themes_test.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add autobot-backend/api/themes.py autobot-backend/api/themes_test.py autobot-backend/initialization/router_registry/core_routers.py
+git commit -m "feat(backend): theme API — install/uninstall/registry/serve, admin-gated (#10472)"
+```
+
+---
+
+### Task 5: Frontend theme registry composable
+
+Fetch the installed-theme registry from the backend.
+
+**Files:**
+- Create: `autobot-frontend/src/composables/useThemeRegistry.ts`
+- Test: `autobot-frontend/src/composables/__tests__/useThemeRegistry.test.ts`
+
+**Interfaces:**
+- Consumes: `apiClient.get` (`@/utils/ApiClient`).
+- Produces: `interface InstalledTheme { id: string; name: string; author: string; version: string; supports: string[] }`; `async function fetchInstalledThemes(): Promise<InstalledTheme[]>` (returns `[]` on error — graceful).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// autobot-frontend/src/composables/__tests__/useThemeRegistry.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/utils/ApiClient', () => ({ apiClient: { get: vi.fn() } }))
+import { apiClient } from '@/utils/ApiClient'
+import { fetchInstalledThemes } from '../useThemeRegistry'
+
+describe('fetchInstalledThemes', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns installed themes from the registry', async () => {
+    ;(apiClient.get as any).mockResolvedValue([{ id: 'aqua', name: 'Aqua', author: 'me', version: '1.0.0', supports: ['light'] }])
+    const themes = await fetchInstalledThemes()
+    expect(themes.map((t) => t.id)).toEqual(['aqua'])
+  })
+
+  it('returns [] when the registry call fails (graceful)', async () => {
+    ;(apiClient.get as any).mockRejectedValue(new Error('network'))
+    expect(await fetchInstalledThemes()).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-frontend && npx vitest run src/composables/__tests__/useThemeRegistry.test.ts`
+Expected: FAIL — cannot resolve `../useThemeRegistry`.
+
+- [ ] **Step 3: Write the composable**
+
+```ts
+// autobot-frontend/src/composables/useThemeRegistry.ts
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+import { apiClient } from '@/utils/ApiClient'
+import { createLogger } from '@/utils/logger'
+
+const log = createLogger('ThemeRegistry')
+
+export interface InstalledTheme {
+  id: string
+  name: string
+  author: string
+  version: string
+  supports: string[]
+}
+
+/** Fetch installed theme descriptors. Returns [] on any error (graceful degrade). */
+export async function fetchInstalledThemes(): Promise<InstalledTheme[]> {
+  try {
+    const themes = await apiClient.get<InstalledTheme[]>('/api/themes')
+    return Array.isArray(themes) ? themes : []
+  } catch (err) {
+    log.warn('Failed to fetch installed themes; using built-ins only', err)
+    return []
+  }
+}
+```
+
+(Confirm the logger import path: `grep -rn "createLogger" src/utils/logger.ts`. If it differs, match the existing export.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd autobot-frontend && npx vitest run src/composables/__tests__/useThemeRegistry.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add autobot-frontend/src/composables/useThemeRegistry.ts autobot-frontend/src/composables/__tests__/useThemeRegistry.test.ts
+git commit -m "feat(frontend): theme registry composable — fetch installed themes (#10472)"
+```
+
+---
+
+### Task 6: Runtime theme delivery in useThemeVariant
+
+Extend the variant system so installed themes are selectable and applied via `adoptedStyleSheets`.
+
+**Files:**
+- Modify: `autobot-frontend/src/composables/useThemeVariant.ts`
+- Test: `autobot-frontend/src/composables/__tests__/useThemeVariantRuntime.test.ts`
+
+**Interfaces:**
+- Consumes: `fetchInstalledThemes`, `InstalledTheme` (Task 5); `apiClient` for CSS text.
+- Produces (additions to the composable's return): `installedThemes: Ref<InstalledTheme[]>`, `loadInstalledThemes(): Promise<void>` (merges ids into `availableVariants`, labels, descriptions); `applyThemeVariant` extended to adopt a fetched stylesheet for installed ids.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// autobot-frontend/src/composables/__tests__/useThemeVariantRuntime.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../useThemeRegistry', () => ({
+  fetchInstalledThemes: vi.fn().mockResolvedValue([{ id: 'aqua', name: 'Aqua', author: 'me', version: '1.0.0', supports: ['light'] }]),
+}))
+vi.mock('@/utils/ApiClient', () => ({ apiClient: { get: vi.fn().mockResolvedValue('[data-theme-variant="aqua"]{--bg-primary:#eef}') } }))
+
+beforeEach(() => {
+  localStorage.clear()
+  document.documentElement.removeAttribute('data-theme-variant')
+  ;(document as any).adoptedStyleSheets = []
+  vi.resetModules()
+})
+
+describe('useThemeVariant runtime themes', () => {
+  it('merges installed theme ids into availableVariants after loadInstalledThemes', async () => {
+    const { useThemeVariant } = await import('../useThemeVariant')
+    const { availableVariants, loadInstalledThemes } = useThemeVariant()
+    await loadInstalledThemes()
+    expect(availableVariants.value ?? availableVariants).toContain('aqua')
+  })
+})
+```
+
+(If `availableVariants` is a plain array today, this task converts it to a `ref` so it can grow at runtime — update the return type accordingly and adjust `EmberThemeToggle.vue` to read `.value` or keep it reactive via `computed`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-frontend && npx vitest run src/composables/__tests__/useThemeVariantRuntime.test.ts`
+Expected: FAIL — `loadInstalledThemes` is not a function.
+
+- [ ] **Step 3: Implement runtime delivery**
+
+In `useThemeVariant.ts`: add module state `const installedThemes = ref<InstalledTheme[]>([])` and `const runtimeVariantIds = ref<string[]>([])`; make `availableVariants` a `computed(() => [...VALID_VARIANTS, ...runtimeVariantIds.value])`. Add:
+
+```ts
+import { fetchInstalledThemes, type InstalledTheme } from './useThemeRegistry'
+import { apiClient } from '@/utils/ApiClient'
+
+const adopted = new Set<string>()
+
+async function ensureThemeStylesheet(id: string): Promise<void> {
+  if (adopted.has(id)) return
+  const css = await apiClient.get<string>(`/api/themes/${id}/theme.css`, { responseType: 'text' } as never)
+  const sheet = new CSSStyleSheet()
+  await sheet.replace(typeof css === 'string' ? css : String(css))
+  document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet]
+  adopted.add(id)
+}
+
+async function loadInstalledThemes(): Promise<void> {
+  installedThemes.value = await fetchInstalledThemes()
+  runtimeVariantIds.value = installedThemes.value.map((t) => t.id)
+}
+```
+
+Extend `applyThemeVariant` so that for an id that is neither `'default'` nor a built-in, it calls `ensureThemeStylesheet(id)` (awaited; on failure, revert to previous variant) before `setAttribute('data-theme-variant', id)`. Export `installedThemes`, `loadInstalledThemes` in the returned object. Call `loadInstalledThemes()` inside `initVariant()` (fire-and-forget) so installed themes appear after load.
+
+- [ ] **Step 4: Run tests (new + existing variant tests)**
+
+Run: `cd autobot-frontend && npx vitest run src/composables/__tests__/useThemeVariant.test.ts src/composables/__tests__/useThemeVariantRuntime.test.ts`
+Expected: PASS — new runtime test passes AND the Phase-1 `useThemeVariant.test.ts` still passes (adjust those assertions only if `availableVariants` became a computed: read `.value`).
+
+- [ ] **Step 5: Type-check + commit**
+
+Run: `cd autobot-frontend && npx vue-tsc --noEmit -p tsconfig.app.json` → 0 errors (fix `EmberThemeToggle.vue` to read `availableVariants` reactively if needed).
+
+```bash
+git add autobot-frontend/src/composables/useThemeVariant.ts autobot-frontend/src/composables/__tests__/useThemeVariantRuntime.test.ts autobot-frontend/src/components/theme/EmberThemeToggle.vue
+git commit -m "feat(frontend): runtime installed-theme delivery via adoptedStyleSheets (#10472)"
+```
+
+---
+
+### Task 7: Admin theme-management view
+
+A view to upload, list, and uninstall themes, reachable under the /slm route group, admin-gated.
+
+**Files:**
+- Create: `autobot-frontend/src/views/slm/ThemeManagerView.vue`
+- Modify: `autobot-frontend/src/router/index.ts` (add `/slm/themes` route)
+- Test: `autobot-frontend/src/views/slm/__tests__/ThemeManagerView.test.ts`
+
+**Interfaces:**
+- Consumes: `apiClient.post('/api/themes', FormData)`, `apiClient.delete('/api/themes/{id}')`, `fetchInstalledThemes`.
+- Produces: route `name: 'slm-themes'`, `path: '/slm/themes'`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// autobot-frontend/src/views/slm/__tests__/ThemeManagerView.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('@/composables/useThemeRegistry', () => ({
+  fetchInstalledThemes: vi.fn().mockResolvedValue([{ id: 'aqua', name: 'Aqua', author: 'me', version: '1.0.0', supports: ['light'] }]),
+}))
+vi.mock('@/utils/ApiClient', () => ({ apiClient: { post: vi.fn(), delete: vi.fn() } }))
+import ThemeManagerView from '../ThemeManagerView.vue'
+
+describe('ThemeManagerView', () => {
+  it('lists installed themes on mount', async () => {
+    const wrapper = mount(ThemeManagerView)
+    await new Promise((r) => setTimeout(r))
+    expect(wrapper.text()).toContain('Aqua')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-frontend && npx vitest run src/views/slm/__tests__/ThemeManagerView.test.ts`
+Expected: FAIL — cannot resolve `../ThemeManagerView.vue`.
+
+- [ ] **Step 3: Write the view + route**
+
+```vue
+<!-- autobot-frontend/src/views/slm/ThemeManagerView.vue -->
+<!-- Copyright 2025-2026 mrveiss -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { apiClient } from '@/utils/ApiClient'
+import { fetchInstalledThemes, type InstalledTheme } from '@/composables/useThemeRegistry'
+import { createLogger } from '@/utils/logger'
+
+const log = createLogger('ThemeManager')
+const themes = ref<InstalledTheme[]>([])
+const busy = ref(false)
+const error = ref('')
+
+async function refresh() {
+  themes.value = await fetchInstalledThemes()
+}
+
+async function onUpload(e: Event) {
+  const file = (e.target as HTMLInputElement).files?.[0]
+  if (!file) return
+  busy.value = true
+  error.value = ''
+  try {
+    const form = new FormData()
+    form.append('file', file)
+    await apiClient.post('/api/themes', form)
+    await refresh()
+  } catch (err) {
+    error.value = (err as Error).message
+    log.error('Theme upload failed', err)
+  } finally {
+    busy.value = false
+  }
+}
+
+async function remove(id: string) {
+  await apiClient.delete(`/api/themes/${id}`)
+  await refresh()
+}
+
+onMounted(refresh)
+</script>
+
+<template>
+  <section class="theme-manager">
+    <h1>Themes</h1>
+    <p>Upload a theme package (.zip) to make it available to all users.</p>
+    <input type="file" accept=".zip" :disabled="busy" @change="onUpload" />
+    <p v-if="error" class="error">{{ error }}</p>
+    <ul>
+      <li v-for="t in themes" :key="t.id">
+        <strong>{{ t.name }}</strong> <small>v{{ t.version }} — {{ t.author }}</small>
+        <button @click="remove(t.id)">Uninstall</button>
+      </li>
+    </ul>
+  </section>
+</template>
+```
+
+In `router/index.ts`, add to the routes array:
+
+```ts
+{
+  path: '/slm/themes',
+  name: 'slm-themes',
+  component: () => import('@/views/slm/ThemeManagerView.vue'),
+  meta: { requiresAuth: true, requiresAdmin: true, title: 'Theme Manager' },
+},
+```
+
+(Match the `meta` keys to the existing admin routes — `grep -n "requiresAdmin\|requiresAuth" src/router/index.ts` and copy the convention used by other /slm or admin routes.)
+
+- [ ] **Step 4: Run test + type-check**
+
+Run: `cd autobot-frontend && npx vitest run src/views/slm/__tests__/ThemeManagerView.test.ts && npx vue-tsc --noEmit -p tsconfig.app.json`
+Expected: PASS + 0 type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add autobot-frontend/src/views/slm/ThemeManagerView.vue autobot-frontend/src/views/slm/__tests__/ThemeManagerView.test.ts autobot-frontend/src/router/index.ts
+git commit -m "feat(frontend): admin theme-manager view + /slm/themes route (#10472)"
+```
+
+---
+
+### Task 8: Final verification
+
+- [ ] **Step 1: Backend suite (new modules)**
+
+Run: `cd autobot-backend && python -m pytest archive_safety_test.py theme_css_validator_test.py theme_install_test.py api/themes_test.py -q && python -m pytest -k plugin_install -q`
+Expected: all PASS (themes green + plugin regression green).
+
+- [ ] **Step 2: Frontend checks**
+
+Run: `cd autobot-frontend && npx vue-tsc --noEmit -p tsconfig.app.json && npx vitest run src/composables/__tests__/useThemeRegistry.test.ts src/composables/__tests__/useThemeVariant.test.ts src/composables/__tests__/useThemeVariantRuntime.test.ts src/views/slm/__tests__/ThemeManagerView.test.ts && npx eslint src/composables/useThemeRegistry.ts src/composables/useThemeVariant.ts src/views/slm/ThemeManagerView.vue`
+Expected: 0 type errors, all tests pass, eslint clean.
+
+- [ ] **Step 3: Open PR**
+
+Rebase onto `origin/Dev_new_gui`, push, and open a PR titled `feat(ui/slm): pluggable theme packages — upload + install via /slm (#10472)` with the standard headings (Thinking Path · What Changed · Verification · Model Used) and `Fixes #10472`.
+
+---
+
+## Self-Review
+
+**Spec coverage:** package format + manifest → Task 3 (`ThemeManifest`/`theme.json`); /slm upload+install+uninstall → Tasks 3–4 + 7; registry feeding `availableVariants` → Tasks 5–6; runtime delivery (adoptedStyleSheets, CSP-safe) → Task 6; strict CSS scope/sanitise → Task 2; reuse plugin hardening → Task 1; admin-gating → Task 4; serve assets/path-traversal → Task 3 (`theme_asset_path`) + Task 4; error handling/graceful fallback → Tasks 5–6; tests → every task. No-flash caveat: built-ins unchanged (Phase 1), installed themes apply post-load (Task 6) — matches spec.
+
+**Placeholder scan:** every code step contains complete code; the two "match existing convention" notes (logger import, router meta keys) include the exact grep to confirm — not deferred logic.
+
+**Type consistency:** `ThemeDescriptor`/`InstalledTheme` share `{id,name,author,version,supports}` across backend (Task 3) and frontend (Task 5); `validate_theme_css(css, variant_id)` signature consistent (Tasks 2–3); `fetchInstalledThemes()`/`loadInstalledThemes()` names consistent (Tasks 5–6–7); router prefix `/api/themes` consistent (Task 4) with frontend calls (Tasks 5–7).

--- a/docs/superpowers/specs/2026-06-22-pluggable-themes-slm-design.md
+++ b/docs/superpowers/specs/2026-06-22-pluggable-themes-slm-design.md
@@ -1,0 +1,112 @@
+# Pluggable theme packages via /slm — design (#10472)
+
+**Date:** 2026-06-22
+**Issue:** #10472 (Phase 2 of #10461; Phase 1 shipped Ember as the user-GUI default in #10471)
+**Status:** design — approved decisions captured below
+
+## Goal
+
+Let an operator **install new themes by uploading a theme folder/zip via /slm** (Service Lifecycle
+Manager). Installed themes are delivered to the running **user frontend at runtime** (today themes
+load only at build time) and become selectable by users in settings — without a rebuild/redeploy.
+
+## Decisions (from brainstorming)
+
+- **Reuse the plugin install infrastructure.** Themes are a backend-owned package type modeled on
+  `autobot-backend/plugin_install.py` (zip-slip guard, symlink rejection, size/file-count caps,
+  TOCTOU install lock, `__MACOSX` skip, id sanitisation). The /slm admin UI calls the backend
+  theme API; the user frontend fetches the theme registry + CSS at runtime.
+- **Strict CSS scoping + sanitisation.** Admin-only install. Uploaded CSS is untrusted: every
+  selector must be scoped under `[data-theme-variant="<id>"]` or the install is rejected; external
+  fetches are blocked. A theme physically cannot leak data or restyle outside its variant.
+- **Runtime delivery via fetch + `adoptedStyleSheets`** (CSP-safe), not cross-origin `<link>` or
+  inline `<style>`.
+
+## Constraints
+
+- Frontend and backend are **different origins** (frontend host vs `VITE_API_BASE_URL`).
+- The frontend runs under a **strict CSP** (`style-src 'self'`, no `unsafe-inline`; #9966).
+  → A cross-origin `<link rel=stylesheet>` or an inline `<style>` would both violate CSP. Fetching
+  the CSS text via a CORS API call and adopting it as a constructed `CSSStyleSheet` does not.
+- Built-in variants (`default`, `ember`) keep their build-time `@import` + no-flash bootstrap
+  unchanged. This feature is purely additive.
+
+## Architecture — three bounded units
+
+### 1. Backend — theme package store + API (`autobot-backend`)
+
+- `theme_install.py` — `install_from_zip(upload)` reusing the plugin hardening. Manifest
+  `theme.json` = `{ id, name, author, version, supports: ["light","dark"] }`. `id` is sanitised and
+  must match the variant id used in the CSS.
+- Storage: `community-themes/<id>/` containing `theme.css` and optional `fonts/`, `icons/`.
+  Atomic install: extract to a temp dir, validate, then move into place (mirrors plugins).
+- `api/themes.py` (**admin** = the existing `autobot-backend` admin auth dependency used by other
+  privileged endpoints, e.g. the plugin install routes — reused, not reinvented):
+  - `POST /api/themes` — **admin**, multipart zip upload → install.
+  - `DELETE /api/themes/{id}` — **admin**, uninstall (remove dir + registry entry).
+  - `GET /api/themes` — registry metadata for any logged-in user (id, name, author, version,
+    supports).
+  - `GET /api/themes/{id}/theme.css` — serve the sanitised CSS.
+  - `GET /api/themes/{id}/assets/*` — serve bundled fonts/icons from the theme dir (same-origin to
+    the backend; path-traversal guarded).
+
+### 2. Backend — CSS validator (`theme_css_validator.py`, pure / unit-testable)
+
+Per the strict choice:
+- Reject any selector **not** scoped under `[data-theme-variant="<id>"]` (manifest id).
+- Block `@import`, external `url(http://…/https://…)`, `expression()`, `behavior:`, `javascript:` URLs.
+- Allow `url(data:font/…)` and **relative** `url(./…)`/`url(fonts/…)` that resolve inside the theme
+  dir only.
+- Enforce size cap and rule-count cap. The variant id referenced in the CSS must equal the manifest
+  `id`.
+- Returns a structured result: ok, or the first offending rule/reason (surfaced in the 4xx).
+
+### 3. Frontend — runtime theme registry + delivery
+
+- `useThemeRegistry.ts` (new): on app init, `GET /api/themes` → list of installed theme descriptors.
+- Extend `useThemeVariant.ts`: merge installed ids into `availableVariants` (+ labels/descriptions
+  from the registry). The existing settings switcher (`EmberThemeToggle` in `PreferencesPanel`)
+  lists them automatically — no UI rewrite.
+- `applyThemeVariant(id)`: for an installed (non-built-in) id, lazily `fetch` its `theme.css`, build
+  `new CSSStyleSheet().replace(text)`, push to `document.adoptedStyleSheets` once, then set
+  `data-theme-variant="<id>"`. Built-in `default`/`ember` paths are unchanged.
+- Admin theme-management view: a new `autobot-frontend` view in the operator/admin area, reachable
+  under the `/slm` route group (this app already hosts `/slm/tools/novnc`) — upload (drag zip), list
+  installed, uninstall. It is a thin client of the backend theme API and is gated to admins. The
+  separate SLM control plane needs no changes; the theme store lives in `autobot-backend`.
+
+## Data flow
+
+admin uploads zip in /slm UI → `POST /api/themes` → validate + sanitise + extract + store →
+registry updated. User frontend init → `GET /api/themes` → `availableVariants` extended → user
+picks a theme → CSS fetched + adopted → `data-theme-variant` applied → tokens take effect (exactly
+like `ember.css`).
+
+## Error handling
+
+- Bad zip / manifest / oversize / zip-slip / symlink → 4xx, nothing written (atomic temp-then-move).
+- CSS failing scope/sanitise → whole install rejected with the offending rule.
+- Non-admin → 403 on install/uninstall.
+- Frontend registry fetch fails → fall back to built-in variants only (graceful).
+- Stylesheet adopt/fetch fails → revert to the previous variant.
+
+## No-flash caveat (explicit)
+
+The pre-mount init script only knows **built-in** variants at build time, so the built-in default
+(ember) stays flash-free. A **custom installed** theme set as a user's choice applies right after
+the registry loads (a brief base-theme paint first). Acceptable for MVP; documented.
+
+## Testing
+
+- Validator unit tests: scoped-accept; unscoped-reject; `@import`/external-`url()` reject;
+  `data:`/relative-`url()` accept; size/rule caps; id-mismatch reject.
+- Install tests (reuse plugin test patterns): happy path; zip-slip; symlink; duplicate id; bad/missing
+  manifest; oversize.
+- API tests: admin gate (403 for non-admin); CRUD; serve CSS/assets; path-traversal guard.
+- Frontend tests: registry merges into `availableVariants`; adopt-on-select; graceful fallback when
+  registry/CSS fails.
+
+## Out of scope (YAGNI)
+
+Marketplace/discovery of themes; multi-node fleet distribution; theme versioning/upgrade UI;
+per-user (non-admin) uploads; in-app theme editing.


### PR DESCRIPTION
## Thinking Path
Phase 2 of #10461 (Phase 1 shipped Ember as the user-GUI default in #10471). Brainstormed → spec → plan → TDD implementation. Decisions: themes are a backend-owned package type **reusing the hardened `plugin_install.py` zip handling**; **strict CSS scope+sanitise**; runtime delivery via `fetch` + `adoptedStyleSheets` (CSP-safe — frontend/backend are different origins under a strict `style-src 'self'` CSP, so a cross-origin `<link>` or inline `<style>` was ruled out). Spec + plan committed under `docs/superpowers/`.

## What Changed
**Backend (`autobot-backend`)**
- `archive_safety.py` — extracted the shared zip hardening (zip-slip / symlink / bomb / upload-cap) from `plugin_install.py`; both installers now share one audited copy (+ guard tests for plugins).
- `theme_css_validator.py` — **strict** validator: every selector must be scoped to `[data-theme-variant="<id>"]`; blocks `@import`/external `url()`/`expression()`/`behavior`; **decodes CSS escape sequences before matching** (closes an escape-alias bypass flagged in review); rejects backslash-escaped `url()`.
- `theme_install.py` — install/list/uninstall theme packages (`theme.json` manifest + `theme.css` + optional assets), atomic temp-then-move, path-traversal-guarded asset serving.
- `api/themes.py` — `POST/DELETE /api/themes` (admin), `GET /api/themes` (registry), `GET /api/themes/{id}/theme.css` + `/assets/*`; registered in `core_routers.py`.

**Frontend (`autobot-frontend`)**
- `composables/useThemeRegistry.ts` — fetches installed themes (graceful `[]` on error).
- `composables/useThemeVariant.ts` — `availableVariants` now a computed merging built-ins + installed ids; selecting an installed theme lazily `fetch`es its CSS and adopts it via `document.adoptedStyleSheets`, then sets `data-theme-variant` (reverts on failure). Built-in `default`/`ember` paths unchanged.
- `views/slm/ThemeManagerView.vue` + `/slm/themes` route — admin upload / list / uninstall.

## Verification
- Backend: `pytest archive_safety_test.py plugin_install_test.py theme_css_validator_test.py theme_install_test.py api/themes_test.py` → **21 passed** (incl. 4 escape-bypass cases + plugin regression guards).
- Frontend: **15 passed** (registry, runtime adopt, Phase-1 variant suite still green, admin view), `vue-tsc --noEmit` → **0 errors**, eslint clean.
- Security: addressed the automated review's HIGH (CSS escape-alias bypass) with decode-before-validate + tests.

## Notes / scope
No-flash stays for built-ins; a custom installed theme set as a choice applies right after the registry loads (documented). Out of scope (YAGNI): marketplace/discovery, multi-node distribution, versioning UI, per-user uploads, in-app editing.

## Model Used
Opus 4.8

Fixes #10472
