### PR TITLE
fix(secrets): clear CodeQL secret-logging taint on system-vault audit logs (#10436)

### DIFF
--- a/autobot-backend/api/unified_secrets.py
+++ b/autobot-backend/api/unified_secrets.py
@@ -295,7 +295,7 @@ async def service_read_system_secret(
     coordinator: SecretsCoordinator = Depends(get_coordinator),
 ) -> SecretValue:
     """Read a system-vault secret value via service identity."""
-    logger.info("service CRUD: read system secret", extra={"service_id": service_id, "entry_id": str(secret_id)})
+    logger.info("service CRUD: read system secret", extra={"service_id": service_id})
     try:
         value = await coordinator.service_read(session, secret_id=secret_id, vault=_SYSTEM_VAULT)
     except (SecretAccessError, SecretNotFoundError) as exc:
@@ -312,7 +312,7 @@ async def service_rotate_system_secret(
     coordinator: SecretsCoordinator = Depends(get_coordinator),
 ) -> SecretMetadata:
     """Rotate a system-vault secret value (re-seal with new DEK) via service identity."""
-    logger.info("service CRUD: rotate system secret", extra={"service_id": service_id, "entry_id": str(secret_id)})
+    logger.info("service CRUD: rotate system secret", extra={"service_id": service_id})
     try:
         secret = await coordinator.service_rotate(
             session, secret_id=secret_id, new_plaintext=body.value.encode("utf-8"), vault=_SYSTEM_VAULT
@@ -331,7 +331,7 @@ async def service_delete_system_secret(
     coordinator: SecretsCoordinator = Depends(get_coordinator),
 ) -> None:
     """Delete a system-vault secret via service identity."""
-    logger.info("service CRUD: delete system secret", extra={"service_id": service_id, "entry_id": str(secret_id)})
+    logger.info("service CRUD: delete system secret", extra={"service_id": service_id})
     try:
         await coordinator.service_delete(session, secret_id=secret_id, vault=_SYSTEM_VAULT)
         await session.commit()


### PR DESCRIPTION
## Thinking Path
PR #10478 (#10436) added `/api/v2/secrets/system/*` service routes whose read/rotate/delete audit logs include `extra={"entry_id": str(secret_id)}`. CodeQL `py/clear-text-logging-sensitive-data` taints the **value** `str(secret_id)` — the `uuid.UUID` path parameter named `secret_id` flows into the logger, and CodeQL's heuristic treats `secret_id`-named data as sensitive. The earlier in-PR remediation renamed the dict **key** (`secret_id`→`entry_id`), which does not break the value taint, so 3 high-severity alerts (938/939/940) persisted into `Dev_new_gui` when #10478 merged.

This is a CodeQL false positive (the secret's UUID identifier is not its value), but it fails CodeQL on every future PR touching this file and clutters the security dashboard, so it is worth clearing at the source.

## What Changed
- `autobot-backend/api/unified_secrets.py`: removed the `entry_id: str(secret_id)` field from the three system-route audit logs (read/rotate/delete), leaving `action + service_id`.
- This matches the canonical pattern already in the file: the `list` system route logs `service_id` only (not flagged), and the user-principal read/rotate/delete routes log nothing at all.

No behaviour change; operational visibility (which service performed which action) is preserved.

## Verification
- `python3 -m py_compile autobot-backend/api/unified_secrets.py` → OK.
- The three flagged `logger.info` lines now carry only `service_id`, identical in shape to the non-flagged `list` route.

## Model Used
Claude Opus 4.8 (1M context)