### PR TITLE
fix(db): command_timeout so pre_ping fails fast on dropped connections (#10491)

### DIFF
--- a/autobot-backend/user_management/database.py
+++ b/autobot-backend/user_management/database.py
@@ -82,6 +82,9 @@ def get_async_engine() -> AsyncEngine:
         pool_recycle=pool["pool_recycle"],
         pool_timeout=pool["pool_timeout"],
         pool_pre_ping=True,
+        # #10491: command_timeout bounds pre_ping so a WSL-dropped idle
+        # connection fails fast instead of hanging ~30s on the dead socket.
+        connect_args={"timeout": 10, "command_timeout": 10},
         echo=False,
         future=True,
     )

--- a/autobot-slm-backend/services/database.py
+++ b/autobot-slm-backend/services/database.py
@@ -45,7 +45,10 @@ class DatabaseService:
             max_overflow=settings.db_pool_max_overflow,
             pool_recycle=settings.db_pool_recycle,
             pool_pre_ping=True,  # Verify connections before use
-            connect_args={"timeout": 10},  # Prevent indefinite hang on DB unavailable (#7689)
+            # #10491: command_timeout bounds the pre_ping SELECT 1 so a silently
+            # dropped (WSL idle) connection fails fast instead of hanging ~30s on
+            # the dead socket. timeout=10 only covers new connects, not queries.
+            connect_args={"timeout": 10, "command_timeout": 10},
         )
 
         self.session_factory = async_sessionmaker(

--- a/autobot-slm-backend/user_management/database.py
+++ b/autobot-slm-backend/user_management/database.py
@@ -87,7 +87,9 @@ def get_slm_engine() -> AsyncEngine:
                     pool_recycle=pool["pool_recycle"],
                     pool_timeout=pool["pool_timeout"],
                     pool_pre_ping=True,
-                    connect_args={"timeout": 10},
+                    # #10491: command_timeout bounds pre_ping so a WSL-dropped
+                    # idle connection fails fast instead of hanging ~30s.
+                    connect_args={"timeout": 10, "command_timeout": 10},
                 )
                 logger.info("Created SLM database engine")
     return _slm_engine
@@ -112,7 +114,9 @@ def get_autobot_engine() -> AsyncEngine:
                     pool_recycle=pool["pool_recycle"],
                     pool_timeout=pool["pool_timeout"],
                     pool_pre_ping=True,
-                    connect_args={"timeout": 10},
+                    # #10491: command_timeout bounds pre_ping so a WSL-dropped
+                    # idle connection fails fast instead of hanging ~30s.
+                    connect_args={"timeout": 10, "command_timeout": 10},
                 )
                 logger.info("Created AutoBot database engine")
     return _autobot_engine


### PR DESCRIPTION
## Thinking Path
Intermittent ~30s 'slow login' on both frontends. Root cause: WSL2 silently drops idle TCP connections; SQLAlchemy's `pool_pre_ping` SELECT 1 blocks ~30s on the dead socket because `connect_args={timeout:10}` only bounds new connects, not queries. Proof: GET /slm/api/nodes timed 32s, 32s, 0.026s (each request flushes one dead conn).

## What Changed
Add asyncpg `command_timeout=10` to `connect_args` on every request-pool engine: `autobot-slm-backend/services/database.py`, `autobot-slm-backend/user_management/database.py` (×2), `autobot-backend/user_management/database.py`. Pre-ping now fails fast → SQLAlchemy discards + reconnects.

## Verification
`pg_sleep(20)` through the engine now raises TimeoutError at **10.1s** (was 20s) — proves the ping can't hang. py_compile clean. Deployed live + endpoints fast, no regression.

## Model Used
Claude Opus 4.8