### PR TITLE
feat(sso): migrate SSO secrets to unified vault + rotation (#10153, #10154)

### DIFF
--- a/autobot-infrastructure/shared/scripts/export_service_keys.py
+++ b/autobot-infrastructure/shared/scripts/export_service_keys.py
@@ -36,6 +36,11 @@ SERVICES = [
         "description": "Main backend API server",
     },
     {
+        "id": "slm-backend",
+        "host": "10.0.0.1",
+        "description": "SLM control-plane backend (unified-secrets System-vault client, #10153)",
+    },
+    {
         "id": "frontend",
         "host": "10.0.0.2",
         "description": "Vue.js frontend web interface",

--- a/autobot-infrastructure/shared/scripts/generate_service_keys.py
+++ b/autobot-infrastructure/shared/scripts/generate_service_keys.py
@@ -39,6 +39,11 @@ SERVICES = [
         "description": "Main backend API server",
     },
     {
+        "id": "slm-backend",
+        "host_attr": "slm",
+        "description": "SLM control-plane backend (unified-secrets System-vault client, #10153)",
+    },
+    {
         "id": "frontend",
         "host_attr": "frontend",
         "description": "Vue.js frontend web interface",

--- a/autobot-slm-backend/api/sso.py
+++ b/autobot-slm-backend/api/sso.py
@@ -28,6 +28,9 @@ from user_management.schemas.sso import (
     SSOProviderListResponse,
     SSOProviderResponse,
     SSOProviderUpdate,
+    SSORotateKEKRequest,
+    SSORotateValueRequest,
+    SSORotationResponse,
     SSOTestResponse,
 )
 from user_management.services.base_service import TenantContext
@@ -152,6 +155,8 @@ async def get_providers_health(
     )
     rows = {row.resource_id: row for row in agg_result.all()}
 
+    from user_management.services.sso_rotation import check_staleness
+
     results: list[SSOProviderHealthResponse] = []
     for provider in providers:
         pid_str = str(provider.id)
@@ -160,6 +165,7 @@ async def get_providers_health(
         failure_count = int(row.failure_count) if row else 0
         last_success_at = row.last_success_at if row else None
         health_status = _derive_health_status(success_count, failure_count, last_success_at, window_start)
+        staleness = check_staleness(provider.id, provider.config)
         results.append(
             SSOProviderHealthResponse(
                 provider_id=provider.id,
@@ -168,6 +174,7 @@ async def get_providers_health(
                 failure_count=failure_count,
                 last_success_at=last_success_at,
                 health_status=health_status,
+                secret_staleness=staleness,
             )
         )
 
@@ -277,3 +284,86 @@ async def get_provider_template(
 ) -> dict:
     """Get pre-filled endpoint template for a known SSO provider type."""
     return SSOService.get_provider_endpoint_template(provider_type, domain)
+
+
+# ---------------------------------------------------------------------------
+# Secret rotation endpoints (#10154)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{provider_id}/rotate-kek", response_model=SSORotationResponse)
+async def rotate_secret_kek(
+    provider_id: uuid.UUID,
+    body: SSORotateKEKRequest,
+    current_user: dict = Depends(require_permission(Permission.SECURITY_MANAGE)),
+    db: AsyncSession = Depends(get_slm_db),
+) -> SSORotationResponse:
+    """Rotate the wrapping KEK for a provider secret (rewrap DEKs, plaintext unchanged).
+
+    Use this for periodic key-hygiene cycles after rotating AUTOBOT_SECRETS_ROOT_KEY.
+    """
+    from user_management.services.sso_rotation import SSORotationError, rotate_kek
+
+    logger.info("KEK rotation requested: provider=%s field=%s", provider_id, body.field)
+    actor_id = current_user.get("user_id") or current_user.get("username")
+    try:
+        result = await rotate_kek(
+            db,
+            provider_id=provider_id,
+            field=body.field,
+            new_root_key_b64=body.new_root_key,
+            actor_id=str(actor_id) if actor_id else None,
+        )
+        await db.commit()
+    except SSORotationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error("KEK rotation failed: provider=%s field=%s: %s", provider_id, body.field, type(exc).__name__)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="rotation failed") from exc
+    return SSORotationResponse(
+        provider_id=provider_id,
+        field=body.field,
+        action=result["action"],
+        vault_id=result["vault_id"],
+        rotated_at=result["rotated_at"],
+    )
+
+
+@router.post("/{provider_id}/rotate-value", response_model=SSORotationResponse)
+async def rotate_secret_value(
+    provider_id: uuid.UUID,
+    body: SSORotateValueRequest,
+    current_user: dict = Depends(require_permission(Permission.SECURITY_MANAGE)),
+    db: AsyncSession = Depends(get_slm_db),
+) -> SSORotationResponse:
+    """Re-seal a provider secret with a new plaintext value (operator-initiated rotation).
+
+    Use this when the client secret has been rotated at the IdP.
+    """
+    from user_management.services.sso_rotation import SSORotationError, rotate_value
+
+    logger.info("Value rotation requested: provider=%s field=%s", provider_id, body.field)
+    actor_id = current_user.get("user_id") or current_user.get("username")
+    try:
+        result = await rotate_value(
+            db,
+            provider_id=provider_id,
+            field=body.field,
+            new_value=body.new_value,
+            actor_id=str(actor_id) if actor_id else None,
+        )
+        await db.commit()
+    except SSORotationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error(
+            "Value rotation failed: provider=%s field=%s: %s", provider_id, body.field, type(exc).__name__
+        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="rotation failed") from exc
+    return SSORotationResponse(
+        provider_id=provider_id,
+        field=body.field,
+        action=result["action"],
+        vault_id=result["vault_id"],
+        rotated_at=result["rotated_at"],
+    )

--- a/autobot-slm-backend/api/sso.py
+++ b/autobot-slm-backend/api/sso.py
@@ -356,9 +356,7 @@ async def rotate_secret_value(
     except SSORotationError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except Exception as exc:
-        logger.error(
-            "Value rotation failed: provider=%s field=%s: %s", provider_id, body.field, type(exc).__name__
-        )
+        logger.error("Value rotation failed: provider=%s field=%s: %s", provider_id, body.field, type(exc).__name__)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="rotation failed") from exc
     return SSORotationResponse(
         provider_id=provider_id,

--- a/autobot-slm-backend/migrations/migrate_sso_to_unified_vault.py
+++ b/autobot-slm-backend/migrations/migrate_sso_to_unified_vault.py
@@ -32,7 +32,6 @@ or with an explicit DB URL:
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import os
 import sys
@@ -55,9 +54,9 @@ def _require_env() -> None:
 
 async def _run(db_url: str) -> None:
     """Async migration body."""
+    from sqlalchemy import select
     from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
     from sqlalchemy.orm import sessionmaker
-    from sqlalchemy import select
 
     engine = create_async_engine(db_url, echo=False)
     async_session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
@@ -102,9 +101,7 @@ async def _run(db_url: str) -> None:
         await session.commit()
 
     await engine.dispose()
-    logger.info(
-        "Migration complete: migrated=%d skipped=%d failed=%d", migrated, skipped, failed
-    )
+    logger.info("Migration complete: migrated=%d skipped=%d failed=%d", migrated, skipped, failed)
     if failed:
         logger.warning("%d providers failed; re-run after fixing the above errors", failed)
 
@@ -124,9 +121,11 @@ if __name__ == "__main__":
     else:
         try:
             from migrations.runner import get_db_url
+
             _db_url = get_db_url()
         except ImportError:
             from config import settings
+
             _db_url = settings.autobot_users_database_url
 
     logger.info("Starting SSO → unified-vault migration (db=%s)", _db_url.split("@")[-1])

--- a/autobot-slm-backend/migrations/migrate_sso_to_unified_vault.py
+++ b/autobot-slm-backend/migrations/migrate_sso_to_unified_vault.py
@@ -1,0 +1,133 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Migration: move SSO secrets from SystemSecret table to the unified-secrets System vault (#10153).
+
+This is a ONE-TIME, IDEMPOTENT data migration.  Safe to run multiple times.
+
+For each SSO provider:
+1. Skip fields that already have a ``{field}_vault_id`` in the config
+   (already migrated — idempotency guard).
+2. Read the current SystemSecret entry (legacy encrypted store).
+3. Decrypt and write to the unified-secrets vault via
+   ``SSOSecretsManager.migrate_to_vault``.
+4. Update the provider's config JSONB with the vault UUID.
+5. Leave the SystemSecret row in place (the fallback read path still
+   works during rollout), but log that it can be pruned later.
+
+Prerequisites:
+    - AUTOBOT_SECRETS_ROOT_KEY must be set (backend's root key).
+    - SLM_SERVICE_KEY / SLM_SERVICE_ID must be configured (service auth).
+    - SLM_AUTHORITY_BASE_URL must point to a running autobot-backend.
+    - SLM_ENCRYPTION_KEY / SLM_SECRET_KEY for legacy decryption.
+
+Run:
+    python -m migrations.migrate_sso_to_unified_vault
+
+or with an explicit DB URL:
+    python -m migrations.migrate_sso_to_unified_vault postgresql+asyncpg://...
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _require_env() -> None:
+    """Abort with a clear message when required env vars are missing."""
+    missing = []
+    if not os.getenv("SLM_SERVICE_KEY") and not os.getenv("SLM_SERVICE_ID"):
+        missing.append("SLM_SERVICE_KEY + SLM_SERVICE_ID (service auth to backend)")
+    if not any(os.getenv(v) for v in ("SLM_ENCRYPTION_KEY", "SLM_SECRET_KEY")):
+        missing.append("SLM_ENCRYPTION_KEY or SLM_SECRET_KEY (legacy decryption)")
+    if missing:
+        msg = "Migration aborted — missing configuration:\n" + "\n".join(f"  - {m}" for m in missing)
+        raise RuntimeError(msg)
+
+
+async def _run(db_url: str) -> None:
+    """Async migration body."""
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy import select
+
+    engine = create_async_engine(db_url, echo=False)
+    async_session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session_maker() as session:
+        from user_management.models.sso import SSOProvider
+        from user_management.services.sso_secrets import SSOSecretsManager
+
+        result = await session.execute(select(SSOProvider))
+        providers = list(result.scalars().all())
+        logger.info("Found %d SSO providers to process", len(providers))
+
+        migrated = 0
+        skipped = 0
+        failed = 0
+
+        for provider in providers:
+            config: dict[str, Any] = provider.config or {}
+            mgr = SSOSecretsManager(session)
+            try:
+                updated_config = await mgr.migrate_to_vault(provider.id, config)
+            except Exception as exc:
+                logger.error(
+                    "Migration failed for provider %s (%s): %s — skipping",
+                    provider.id,
+                    provider.name,
+                    type(exc).__name__,
+                )
+                failed += 1
+                continue
+
+            if updated_config == config:
+                logger.info("Provider %s (%s): already migrated — skipping", provider.id, provider.name)
+                skipped += 1
+                continue
+
+            provider.config = updated_config
+            await session.flush()
+            migrated += 1
+            logger.info("Provider %s (%s): migrated to vault", provider.id, provider.name)
+
+        await session.commit()
+
+    await engine.dispose()
+    logger.info(
+        "Migration complete: migrated=%d skipped=%d failed=%d", migrated, skipped, failed
+    )
+    if failed:
+        logger.warning("%d providers failed; re-run after fixing the above errors", failed)
+
+
+def migrate(db_url: str) -> None:
+    """Synchronous entry point (compatible with existing runner infrastructure)."""
+    _require_env()
+    asyncio.run(_run(db_url))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s %(message)s")
+    _require_env()
+
+    if len(sys.argv) > 1:
+        _db_url = sys.argv[1]
+    else:
+        try:
+            from migrations.runner import get_db_url
+            _db_url = get_db_url()
+        except ImportError:
+            from config import settings
+            _db_url = settings.autobot_users_database_url
+
+    logger.info("Starting SSO → unified-vault migration (db=%s)", _db_url.split("@")[-1])
+    migrate(_db_url)

--- a/autobot-slm-backend/tests/services/test_sso_vault_client.py
+++ b/autobot-slm-backend/tests/services/test_sso_vault_client.py
@@ -1,0 +1,366 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for SSO unified-vault client and rotation service (#10153, #10154).
+
+The conftest pre-stubs user_management.services.* so we load our modules the
+same way test_sso_service.py does: directly via importlib.util.spec_from_file_location
+so real module code executes without the MagicMock collision.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Directory of the autobot-slm-backend package root
+_BACKEND = Path(__file__).parent.parent.parent
+
+
+def _load_module(rel_path: str, mod_name: str):
+    """Load a real .py file bypassing sys.modules stubs."""
+    spec = importlib.util.spec_from_file_location(mod_name, _BACKEND / rel_path)
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    # Inject lightweight stubs for any imports the module needs at load time.
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+# Pre-stub aiohttp (not installed in test env) before loading vault client
+if "aiohttp" not in sys.modules:
+    sys.modules["aiohttp"] = MagicMock()
+    sys.modules["aiohttp.ClientTimeout"] = MagicMock()
+    sys.modules["aiohttp.ClientSession"] = MagicMock()
+
+# Pre-stub autobot_shared.http_client with the real sign_request signature
+_hs_mod = types.ModuleType("autobot_shared.http_client")
+
+
+def _sign_stub(service_id, service_key, method, path, timestamp):
+    return {
+        "X-Service-ID": service_id,
+        "X-Service-Signature": "fakesig",
+        "X-Service-Timestamp": str(timestamp),
+    }
+
+
+_hs_mod.sign_request = _sign_stub  # type: ignore[attr-defined]
+sys.modules["autobot_shared.http_client"] = _hs_mod
+if "autobot_shared" not in sys.modules:
+    sys.modules["autobot_shared"] = types.ModuleType("autobot_shared")
+
+# Pre-stub user_management.models.sso so sso_rotation lazy imports succeed
+_sso_model_stub = MagicMock()
+sys.modules.setdefault("user_management.models.sso", _sso_model_stub)
+
+# Pre-stub user_management.services.unified_vault_client (lazy-imported in rotation)
+# We set real AsyncMock placeholders; individual tests replace them via patch.object.
+_uvc_stub = types.ModuleType("user_management.services.unified_vault_client")
+_uvc_stub.vault_rewrap_kek = AsyncMock()  # type: ignore[attr-defined]
+_uvc_stub.vault_rotate = AsyncMock()  # type: ignore[attr-defined]
+_uvc_stub.vault_read = AsyncMock()  # type: ignore[attr-defined]
+_uvc_stub.vault_delete = AsyncMock()  # type: ignore[attr-defined]
+_uvc_stub.vault_list = AsyncMock()  # type: ignore[attr-defined]
+_uvc_stub.vault_create = AsyncMock()  # type: ignore[attr-defined]
+_uvc_stub.UnifiedVaultClientError = Exception  # type: ignore[attr-defined]
+_uvc_stub.UnifiedVaultSecretNotFound = Exception  # type: ignore[attr-defined]
+sys.modules["user_management.services.unified_vault_client"] = _uvc_stub
+
+# Load unified_vault_client directly (reads real module code)
+_vault_client_mod = _load_module(
+    "user_management/services/unified_vault_client.py",
+    "_vault_client_under_test",
+)
+
+# Load sso_rotation directly (needs minimal stubs)
+_sso_rotation_mod = _load_module(
+    "user_management/services/sso_rotation.py",
+    "_sso_rotation_under_test",
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_session():
+    session = AsyncMock()
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = None
+    session.execute.return_value = result_mock
+    return session
+
+
+def _mock_provider(provider_id: uuid.UUID, config: dict) -> MagicMock:
+    p = MagicMock()
+    p.id = provider_id
+    p.config = config
+    return p
+
+
+# ---------------------------------------------------------------------------
+# unified_vault_client tests
+# ---------------------------------------------------------------------------
+
+class TestUnifiedVaultClientConfig:
+    def test_check_configured_raises_when_key_missing(self, monkeypatch):
+        monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "")
+        with pytest.raises(_vault_client_mod.UnifiedVaultClientError, match="SLM_SERVICE_KEY"):
+            _vault_client_mod._check_configured()
+
+    def test_check_configured_passes_with_key(self, monkeypatch):
+        monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "aabbcc" * 10)
+        # Should not raise
+        _vault_client_mod._check_configured()
+
+    def test_is_configured_false_without_key(self, monkeypatch):
+        monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "")
+        assert _vault_client_mod.is_configured() is False
+
+    def test_is_configured_true_with_key(self, monkeypatch):
+        monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "aabbcc" * 10)
+        assert _vault_client_mod.is_configured() is True
+
+    def test_auth_headers_returns_three_keys(self, monkeypatch):
+        monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "aabbcc" * 10)
+        monkeypatch.setattr(_vault_client_mod, "_SERVICE_ID", "test-slm")
+        headers = _vault_client_mod._auth_headers("POST", "/api/v2/secrets/system")
+        assert set(headers.keys()) == {"X-Service-ID", "X-Service-Signature", "X-Service-Timestamp"}
+        assert headers["X-Service-ID"] == "test-slm"
+
+    @pytest.mark.asyncio
+    async def test_request_raises_secret_not_found_on_404(self, monkeypatch):
+        monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "aabbcc" * 10)
+
+        # Simulate a 404 response from aiohttp
+        resp_mock = AsyncMock()
+        resp_mock.status = 404
+        resp_mock.ok = False
+        resp_mock.__aenter__ = AsyncMock(return_value=resp_mock)
+        resp_mock.__aexit__ = AsyncMock(return_value=False)
+
+        session_mock = AsyncMock()
+        session_mock.request = MagicMock(return_value=resp_mock)
+        session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+        session_mock.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(
+            sys.modules["aiohttp"],
+            "ClientSession",
+            return_value=session_mock,
+        ):
+            with pytest.raises(_vault_client_mod.UnifiedVaultSecretNotFound):
+                await _vault_client_mod._request("GET", "/api/v2/secrets/system/some-id")
+
+    @pytest.mark.asyncio
+    async def test_request_raises_client_error_on_500(self, monkeypatch):
+        monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "aabbcc" * 10)
+
+        resp_mock = AsyncMock()
+        resp_mock.status = 500
+        resp_mock.ok = False
+        resp_mock.text = AsyncMock(return_value="internal error")
+        resp_mock.__aenter__ = AsyncMock(return_value=resp_mock)
+        resp_mock.__aexit__ = AsyncMock(return_value=False)
+
+        session_mock = AsyncMock()
+        session_mock.request = MagicMock(return_value=resp_mock)
+        session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+        session_mock.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(sys.modules["aiohttp"], "ClientSession", return_value=session_mock):
+            with pytest.raises(_vault_client_mod.UnifiedVaultClientError):
+                await _vault_client_mod._request("GET", "/api/v2/secrets/system/some-id")
+
+
+# ---------------------------------------------------------------------------
+# sso_rotation tests — staleness
+# ---------------------------------------------------------------------------
+
+class TestSSORotationStaleness:
+    def test_none_timestamp_is_stale(self):
+        assert _sso_rotation_mod._is_stale(None) is True
+
+    def test_recent_timestamp_not_stale(self):
+        max_age = _sso_rotation_mod.SSO_SECRET_MAX_AGE_DAYS
+        fresh = (datetime.now(timezone.utc) - timedelta(days=max_age - 1)).isoformat()
+        assert _sso_rotation_mod._is_stale(fresh) is False
+
+    def test_old_timestamp_is_stale(self):
+        max_age = _sso_rotation_mod.SSO_SECRET_MAX_AGE_DAYS
+        old = (datetime.now(timezone.utc) - timedelta(days=max_age + 1)).isoformat()
+        assert _sso_rotation_mod._is_stale(old) is True
+
+    def test_invalid_timestamp_is_stale(self):
+        assert _sso_rotation_mod._is_stale("not-a-date") is True
+
+    def test_check_staleness_returns_per_field_report(self):
+        pid = uuid.uuid4()
+        max_age = _sso_rotation_mod.SSO_SECRET_MAX_AGE_DAYS
+        old = (datetime.now(timezone.utc) - timedelta(days=max_age + 5)).isoformat()
+        config = {"client_secret_rotated_at": old}
+        report = _sso_rotation_mod.check_staleness(pid, config, fields=["client_secret"])
+        assert report["client_secret"]["stale"] is True
+        assert report["client_secret"]["max_age_days"] == max_age
+
+    def test_check_staleness_fresh_not_stale(self):
+        pid = uuid.uuid4()
+        fresh = datetime.now(timezone.utc).isoformat()
+        config = {"client_secret_rotated_at": fresh}
+        report = _sso_rotation_mod.check_staleness(pid, config, fields=["client_secret"])
+        assert report["client_secret"]["stale"] is False
+
+    def test_check_staleness_unknown_timestamp_is_stale(self):
+        pid = uuid.uuid4()
+        report = _sso_rotation_mod.check_staleness(pid, {}, fields=["client_secret"])
+        assert report["client_secret"]["stale"] is True
+
+
+# ---------------------------------------------------------------------------
+# sso_rotation — rotate_kek
+# ---------------------------------------------------------------------------
+
+def _make_session_with_provider(provider):
+    """Return an AsyncMock session whose execute().scalar_one_or_none() yields *provider*."""
+    session = _mock_session()
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = provider
+    session.execute.return_value = result_mock
+    return session
+
+
+class TestRotateKEK:
+    @pytest.mark.asyncio
+    async def test_rotate_kek_calls_vault_rewrap_and_returns_result(self):
+        pid = uuid.uuid4()
+        vault_id = uuid.uuid4()
+
+        provider = _mock_provider(pid, {"client_secret_vault_id": str(vault_id)})
+        # Stub SSOProvider query result via the model stub
+        _sso_model_stub.SSOProvider = MagicMock()
+        session = _make_session_with_provider(provider)
+
+        rewrap_ret = {"id": str(vault_id), "version": 2, "name": "test"}
+        _uvc_stub.vault_rewrap_kek = AsyncMock(return_value=rewrap_ret)
+
+        with patch.object(_sso_rotation_mod, "_update_provider_config", new=AsyncMock()), \
+             patch.object(_sso_rotation_mod, "_write_audit", new=AsyncMock()):
+            result = await _sso_rotation_mod.rotate_kek(
+                session,
+                provider_id=pid,
+                field="client_secret",
+                new_root_key_b64="dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdGtleQ==",
+                actor_id="admin",
+            )
+
+        assert result["action"] == "rotate_kek"
+        assert result["vault_id"] == str(vault_id)
+        assert "rotated_at" in result
+
+    @pytest.mark.asyncio
+    async def test_rotate_kek_raises_when_no_vault_id_in_config(self):
+        pid = uuid.uuid4()
+        provider = _mock_provider(pid, {})  # no vault_id
+        _sso_model_stub.SSOProvider = MagicMock()
+        session = _make_session_with_provider(provider)
+
+        with pytest.raises(_sso_rotation_mod.SSORotationError, match="vault_id"):
+            await _sso_rotation_mod.rotate_kek(
+                session, provider_id=pid, field="client_secret", new_root_key_b64="dGVzdA=="
+            )
+
+    @pytest.mark.asyncio
+    async def test_rotate_kek_raises_when_provider_not_found(self):
+        _sso_model_stub.SSOProvider = MagicMock()
+        session = _make_session_with_provider(None)
+
+        with pytest.raises(_sso_rotation_mod.SSORotationError, match="not found"):
+            await _sso_rotation_mod.rotate_kek(
+                session, provider_id=uuid.uuid4(), field="client_secret", new_root_key_b64="dGVzdA=="
+            )
+
+
+# ---------------------------------------------------------------------------
+# sso_rotation — rotate_value
+# ---------------------------------------------------------------------------
+
+class TestRotateValue:
+    @pytest.mark.asyncio
+    async def test_rotate_value_calls_vault_rotate_and_returns_result(self):
+        pid = uuid.uuid4()
+        vault_id = uuid.uuid4()
+
+        provider = _mock_provider(pid, {"client_secret_vault_id": str(vault_id)})
+        _sso_model_stub.SSOProvider = MagicMock()
+        session = _make_session_with_provider(provider)
+
+        rotate_ret = {"id": str(vault_id), "version": 3, "name": "test"}
+        _uvc_stub.vault_rotate = AsyncMock(return_value=rotate_ret)
+
+        with patch.object(_sso_rotation_mod, "_update_provider_config", new=AsyncMock()), \
+             patch.object(_sso_rotation_mod, "_write_audit", new=AsyncMock()):
+            result = await _sso_rotation_mod.rotate_value(
+                session,
+                provider_id=pid,
+                field="client_secret",
+                new_value="new-super-secret",
+                actor_id="admin",
+            )
+
+        assert result["action"] == "rotate_value"
+        assert result["vault_id"] == str(vault_id)
+        assert "rotated_at" in result
+
+    @pytest.mark.asyncio
+    async def test_rotate_value_raises_when_no_vault_id_in_config(self):
+        pid = uuid.uuid4()
+        provider = _mock_provider(pid, {})
+        _sso_model_stub.SSOProvider = MagicMock()
+        session = _make_session_with_provider(provider)
+
+        with pytest.raises(_sso_rotation_mod.SSORotationError, match="vault_id"):
+            await _sso_rotation_mod.rotate_value(
+                session, provider_id=pid, field="client_secret", new_value="something"
+            )
+
+    @pytest.mark.asyncio
+    async def test_rotate_value_raises_when_provider_not_found(self):
+        _sso_model_stub.SSOProvider = MagicMock()
+        session = _make_session_with_provider(None)
+
+        with pytest.raises(_sso_rotation_mod.SSORotationError, match="not found"):
+            await _sso_rotation_mod.rotate_value(
+                session, provider_id=uuid.uuid4(), field="client_secret", new_value="x"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Module-level constant env override (SSO_SECRET_MAX_AGE_DAYS)
+# ---------------------------------------------------------------------------
+
+class TestMaxAgeDaysConstant:
+    def test_default_is_90(self):
+        # Default when env var not set is 90
+        assert _sso_rotation_mod._DEFAULT_MAX_AGE_DAYS == 90
+
+    def test_resolver_returns_default_for_invalid_value(self, monkeypatch):
+        monkeypatch.setenv("SSO_SECRET_MAX_AGE_DAYS", "bad-value")
+        result = _sso_rotation_mod._resolve_max_age_days()
+        assert result == 90
+
+    def test_resolver_returns_default_for_zero(self, monkeypatch):
+        monkeypatch.setenv("SSO_SECRET_MAX_AGE_DAYS", "0")
+        result = _sso_rotation_mod._resolve_max_age_days()
+        assert result == 90
+
+    def test_resolver_returns_custom_valid_value(self, monkeypatch):
+        monkeypatch.setenv("SSO_SECRET_MAX_AGE_DAYS", "30")
+        result = _sso_rotation_mod._resolve_max_age_days()
+        assert result == 30

--- a/autobot-slm-backend/tests/services/test_sso_vault_client.py
+++ b/autobot-slm-backend/tests/services/test_sso_vault_client.py
@@ -90,6 +90,7 @@ _sso_rotation_mod = _load_module(
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _mock_session():
     session = AsyncMock()
     result_mock = MagicMock()
@@ -108,6 +109,7 @@ def _mock_provider(provider_id: uuid.UUID, config: dict) -> MagicMock:
 # ---------------------------------------------------------------------------
 # unified_vault_client tests
 # ---------------------------------------------------------------------------
+
 
 class TestUnifiedVaultClientConfig:
     def test_check_configured_raises_when_key_missing(self, monkeypatch):
@@ -184,6 +186,7 @@ class TestUnifiedVaultClientConfig:
 # sso_rotation tests — staleness
 # ---------------------------------------------------------------------------
 
+
 class TestSSORotationStaleness:
     def test_none_timestamp_is_stale(self):
         assert _sso_rotation_mod._is_stale(None) is True
@@ -227,6 +230,7 @@ class TestSSORotationStaleness:
 # sso_rotation — rotate_kek
 # ---------------------------------------------------------------------------
 
+
 def _make_session_with_provider(provider):
     """Return an AsyncMock session whose execute().scalar_one_or_none() yields *provider*."""
     session = _mock_session()
@@ -250,8 +254,10 @@ class TestRotateKEK:
         rewrap_ret = {"id": str(vault_id), "version": 2, "name": "test"}
         _uvc_stub.vault_rewrap_kek = AsyncMock(return_value=rewrap_ret)
 
-        with patch.object(_sso_rotation_mod, "_update_provider_config", new=AsyncMock()), \
-             patch.object(_sso_rotation_mod, "_write_audit", new=AsyncMock()):
+        with (
+            patch.object(_sso_rotation_mod, "_update_provider_config", new=AsyncMock()),
+            patch.object(_sso_rotation_mod, "_write_audit", new=AsyncMock()),
+        ):
             result = await _sso_rotation_mod.rotate_kek(
                 session,
                 provider_id=pid,
@@ -291,6 +297,7 @@ class TestRotateKEK:
 # sso_rotation — rotate_value
 # ---------------------------------------------------------------------------
 
+
 class TestRotateValue:
     @pytest.mark.asyncio
     async def test_rotate_value_calls_vault_rotate_and_returns_result(self):
@@ -304,8 +311,10 @@ class TestRotateValue:
         rotate_ret = {"id": str(vault_id), "version": 3, "name": "test"}
         _uvc_stub.vault_rotate = AsyncMock(return_value=rotate_ret)
 
-        with patch.object(_sso_rotation_mod, "_update_provider_config", new=AsyncMock()), \
-             patch.object(_sso_rotation_mod, "_write_audit", new=AsyncMock()):
+        with (
+            patch.object(_sso_rotation_mod, "_update_provider_config", new=AsyncMock()),
+            patch.object(_sso_rotation_mod, "_write_audit", new=AsyncMock()),
+        ):
             result = await _sso_rotation_mod.rotate_value(
                 session,
                 provider_id=pid,
@@ -326,9 +335,7 @@ class TestRotateValue:
         session = _make_session_with_provider(provider)
 
         with pytest.raises(_sso_rotation_mod.SSORotationError, match="vault_id"):
-            await _sso_rotation_mod.rotate_value(
-                session, provider_id=pid, field="client_secret", new_value="something"
-            )
+            await _sso_rotation_mod.rotate_value(session, provider_id=pid, field="client_secret", new_value="something")
 
     @pytest.mark.asyncio
     async def test_rotate_value_raises_when_provider_not_found(self):
@@ -344,6 +351,7 @@ class TestRotateValue:
 # ---------------------------------------------------------------------------
 # Module-level constant env override (SSO_SECRET_MAX_AGE_DAYS)
 # ---------------------------------------------------------------------------
+
 
 class TestMaxAgeDaysConstant:
     def test_default_is_90(self):

--- a/autobot-slm-backend/user_management/schemas/sso.py
+++ b/autobot-slm-backend/user_management/schemas/sso.py
@@ -119,9 +119,7 @@ class SSORotateKEKRequest(BaseModel):
     """Request body for KEK rotation (rewrap DEKs, plaintext unchanged)."""
 
     field: str = Field(..., description="Secret field name, e.g. 'client_secret' or 'bind_password'")
-    new_root_key: str = Field(
-        ..., description="URL-safe base64-encoded new root key (32 bytes decoded)"
-    )
+    new_root_key: str = Field(..., description="URL-safe base64-encoded new root key (32 bytes decoded)")
 
 
 class SSORotateValueRequest(BaseModel):

--- a/autobot-slm-backend/user_management/schemas/sso.py
+++ b/autobot-slm-backend/user_management/schemas/sso.py
@@ -104,6 +104,38 @@ class SSOProviderHealthResponse(BaseModel):
     failure_count: int
     last_success_at: datetime | None
     health_status: str  # healthy | warning | error | unknown
+    secret_staleness: dict[str, Any] | None = None  # from sso_rotation.check_staleness (#10154)
 
     class Config:
         from_attributes = True
+
+
+# ---------------------------------------------------------------------------
+# Rotation schemas (#10154)
+# ---------------------------------------------------------------------------
+
+
+class SSORotateKEKRequest(BaseModel):
+    """Request body for KEK rotation (rewrap DEKs, plaintext unchanged)."""
+
+    field: str = Field(..., description="Secret field name, e.g. 'client_secret' or 'bind_password'")
+    new_root_key: str = Field(
+        ..., description="URL-safe base64-encoded new root key (32 bytes decoded)"
+    )
+
+
+class SSORotateValueRequest(BaseModel):
+    """Request body for value rotation (new secret supplied by operator)."""
+
+    field: str = Field(..., description="Secret field name, e.g. 'client_secret' or 'bind_password'")
+    new_value: str = Field(..., min_length=1, description="New secret value from the IdP")
+
+
+class SSORotationResponse(BaseModel):
+    """Response from a rotation operation."""
+
+    provider_id: uuid.UUID
+    field: str
+    action: str  # rotate_kek | rotate_value
+    vault_id: str
+    rotated_at: str

--- a/autobot-slm-backend/user_management/services/sso_rotation.py
+++ b/autobot-slm-backend/user_management/services/sso_rotation.py
@@ -128,9 +128,7 @@ async def _write_audit(
         logger.warning("SSO rotation audit write failed: %s", type(exc).__name__)
 
 
-async def _update_provider_config(
-    session: AsyncSession, provider_id: uuid.UUID, updates: dict[str, Any]
-) -> None:
+async def _update_provider_config(session: AsyncSession, provider_id: uuid.UUID, updates: dict[str, Any]) -> None:
     """Merge *updates* into the provider's config JSONB and flush."""
     from user_management.models.sso import SSOProvider
 
@@ -142,9 +140,7 @@ async def _update_provider_config(
     await session.flush()
 
 
-def check_staleness(
-    provider_id: uuid.UUID, config: dict[str, Any], fields: list[str] | None = None
-) -> dict[str, Any]:
+def check_staleness(provider_id: uuid.UUID, config: dict[str, Any], fields: list[str] | None = None) -> dict[str, Any]:
     """Return a staleness report for a provider's secrets.
 
     Returns a dict mapping each field to whether it is stale, plus its
@@ -195,8 +191,7 @@ async def rotate_kek(
     vault_id_str = provider.config.get(_vault_id_key(field))
     if not vault_id_str:
         raise SSORotationError(
-            f"field {field!r} has no vault_id in config for provider {provider_id}; "
-            "run migrate_to_vault first"
+            f"field {field!r} has no vault_id in config for provider {provider_id}; " "run migrate_to_vault first"
         )
     vault_id = uuid.UUID(vault_id_str)
 
@@ -214,9 +209,7 @@ async def rotate_kek(
         actor_id=actor_id,
         details={"field": field, "vault_id": str(vault_id), "rotated_at": now_iso},
     )
-    logger.info(
-        "SSO KEK rotation complete: provider=%s field=%s vault_id=%s", provider_id, field, vault_id
-    )
+    logger.info("SSO KEK rotation complete: provider=%s field=%s vault_id=%s", provider_id, field, vault_id)
     return {"vault_id": str(vault_id), "rotated_at": now_iso, "action": "rotate_kek", **meta}
 
 
@@ -244,8 +237,7 @@ async def rotate_value(
     vault_id_str = provider.config.get(_vault_id_key(field))
     if not vault_id_str:
         raise SSORotationError(
-            f"field {field!r} has no vault_id in config for provider {provider_id}; "
-            "run migrate_to_vault first"
+            f"field {field!r} has no vault_id in config for provider {provider_id}; " "run migrate_to_vault first"
         )
     vault_id = uuid.UUID(vault_id_str)
 
@@ -263,7 +255,5 @@ async def rotate_value(
         actor_id=actor_id,
         details={"field": field, "vault_id": str(vault_id), "rotated_at": now_iso},
     )
-    logger.info(
-        "SSO value rotation complete: provider=%s field=%s vault_id=%s", provider_id, field, vault_id
-    )
+    logger.info("SSO value rotation complete: provider=%s field=%s vault_id=%s", provider_id, field, vault_id)
     return {"vault_id": str(vault_id), "rotated_at": now_iso, "action": "rotate_value", **meta}

--- a/autobot-slm-backend/user_management/services/sso_rotation.py
+++ b/autobot-slm-backend/user_management/services/sso_rotation.py
@@ -1,0 +1,269 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""SSO client-secret rotation service (#10154).
+
+Two rotation modes:
+- **KEK rotation** (``rotate_kek``): rewrap the vault DEK under a new root key;
+  the sealed plaintext is unchanged.  Use this for periodic key-hygiene cycles.
+- **Value rotation** (``rotate_value``): operator supplies a new client secret;
+  the vault re-seals with a fresh DEK.  Use this when the secret is changed at
+  the IdP.
+
+Warn-on-stale
+-------------
+Each SSO secret stores its last-rotation timestamp as ``{field}_rotated_at`` in
+the provider's config JSONB.  When the age exceeds ``SSO_SECRET_MAX_AGE_DAYS``
+(module-level constant derived from env var — never hard-coded) a warning is
+surfaced in the log AND returned in the rotation-status response so the
+``/health`` dashboard (#10156) can display it.
+
+Audit
+-----
+Every rotation writes an ``AuditLog`` row (category="sso", action="rotate_kek"
+or "rotate_value") so there is a durable rotation history per provider.
+
+Never log secret values.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level constant: max secret age before a staleness warning is emitted.
+# Never hard-coded — reads from env; falls back to 90 days.
+# Pattern mirrors autobot-backend/chat_history/cache.py.
+# ---------------------------------------------------------------------------
+_DEFAULT_MAX_AGE_DAYS = 90
+
+
+def _resolve_max_age_days() -> int:
+    raw = os.getenv("SSO_SECRET_MAX_AGE_DAYS", str(_DEFAULT_MAX_AGE_DAYS))
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "SSO_SECRET_MAX_AGE_DAYS=%r is not an integer; falling back to %d days",
+            raw,
+            _DEFAULT_MAX_AGE_DAYS,
+        )
+        return _DEFAULT_MAX_AGE_DAYS
+    if value <= 0:
+        logger.warning(
+            "SSO_SECRET_MAX_AGE_DAYS=%d must be positive; falling back to %d days",
+            value,
+            _DEFAULT_MAX_AGE_DAYS,
+        )
+        return _DEFAULT_MAX_AGE_DAYS
+    return value
+
+
+SSO_SECRET_MAX_AGE_DAYS: int = _resolve_max_age_days()
+
+
+class SSORotationError(Exception):
+    """Raised when a rotation operation fails."""
+
+
+def _rotated_at_key(field: str) -> str:
+    return f"{field}_rotated_at"
+
+
+def _vault_id_key(field: str) -> str:
+    return f"{field}_vault_id"
+
+
+def _is_stale(rotated_at_iso: str | None) -> bool:
+    """Return True when the secret has not been rotated within max-age window."""
+    if rotated_at_iso is None:
+        return True  # unknown age → treat as stale
+    try:
+        rotated_at = datetime.fromisoformat(rotated_at_iso)
+    except ValueError:
+        return True
+    if rotated_at.tzinfo is None:
+        rotated_at = rotated_at.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) - rotated_at > timedelta(days=SSO_SECRET_MAX_AGE_DAYS)
+
+
+async def _write_audit(
+    session: AsyncSession,
+    *,
+    provider_id: uuid.UUID,
+    action: str,
+    actor_id: str | None,
+    details: dict[str, Any],
+) -> None:
+    """Append an audit row for this rotation event (best-effort).
+
+    Reuses the canonical ``create_audit_log`` helper so the row matches the
+    ``audit_logs`` schema (``log_id``/``user_id``/``extra_data`` — there is no
+    ``actor_id``/``details`` column). A failure here never aborts the rotation.
+    """
+    try:
+        from api.security import create_audit_log
+
+        await create_audit_log(
+            session,
+            category="security",
+            action=action,
+            user_id=actor_id,
+            resource_type="sso_provider",
+            resource_id=str(provider_id),
+            description=f"SSO secret {action} for field {details.get('field')}",
+            extra_data=details,
+        )
+    except Exception as exc:
+        logger.warning("SSO rotation audit write failed: %s", type(exc).__name__)
+
+
+async def _update_provider_config(
+    session: AsyncSession, provider_id: uuid.UUID, updates: dict[str, Any]
+) -> None:
+    """Merge *updates* into the provider's config JSONB and flush."""
+    from user_management.models.sso import SSOProvider
+
+    row = await session.execute(select(SSOProvider).where(SSOProvider.id == provider_id))
+    provider = row.scalar_one_or_none()
+    if provider is None:
+        raise SSORotationError(f"SSO provider {provider_id} not found")
+    provider.config = {**provider.config, **updates}
+    await session.flush()
+
+
+def check_staleness(
+    provider_id: uuid.UUID, config: dict[str, Any], fields: list[str] | None = None
+) -> dict[str, Any]:
+    """Return a staleness report for a provider's secrets.
+
+    Returns a dict mapping each field to whether it is stale, plus its
+    last-rotation timestamp.  Suitable for embedding in a health response.
+    """
+    fields = fields or ["client_secret", "bind_password"]
+    report: dict[str, Any] = {}
+    for field in fields:
+        rotated_at = config.get(_rotated_at_key(field))
+        stale = _is_stale(rotated_at)
+        if stale:
+            logger.warning(
+                "SSO secret stale: provider=%s field=%s last_rotated=%s max_age_days=%d",
+                provider_id,
+                field,
+                rotated_at,
+                SSO_SECRET_MAX_AGE_DAYS,
+            )
+        report[field] = {
+            "stale": stale,
+            "last_rotated_at": rotated_at,
+            "max_age_days": SSO_SECRET_MAX_AGE_DAYS,
+        }
+    return report
+
+
+async def rotate_kek(
+    session: AsyncSession,
+    *,
+    provider_id: uuid.UUID,
+    field: str,
+    new_root_key_b64: str,
+    actor_id: str | None = None,
+) -> dict[str, Any]:
+    """Rewrap the vault DEK for one SSO secret field under a new root key.
+
+    The sealed plaintext is unchanged (key-hygiene rotation only).
+    Returns metadata from the vault response.
+    """
+    from user_management.models.sso import SSOProvider
+    from user_management.services.unified_vault_client import UnifiedVaultClientError, vault_rewrap_kek
+
+    row = await session.execute(select(SSOProvider).where(SSOProvider.id == provider_id))
+    provider = row.scalar_one_or_none()
+    if provider is None:
+        raise SSORotationError(f"SSO provider {provider_id} not found")
+
+    vault_id_str = provider.config.get(_vault_id_key(field))
+    if not vault_id_str:
+        raise SSORotationError(
+            f"field {field!r} has no vault_id in config for provider {provider_id}; "
+            "run migrate_to_vault first"
+        )
+    vault_id = uuid.UUID(vault_id_str)
+
+    try:
+        meta = await vault_rewrap_kek(vault_id, new_root_key_b64)
+    except UnifiedVaultClientError as exc:
+        raise SSORotationError(f"KEK rotation failed for provider {provider_id} field {field}: {exc}") from exc
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    await _update_provider_config(session, provider_id, {_rotated_at_key(field): now_iso})
+    await _write_audit(
+        session,
+        provider_id=provider_id,
+        action="rotate_kek",
+        actor_id=actor_id,
+        details={"field": field, "vault_id": str(vault_id), "rotated_at": now_iso},
+    )
+    logger.info(
+        "SSO KEK rotation complete: provider=%s field=%s vault_id=%s", provider_id, field, vault_id
+    )
+    return {"vault_id": str(vault_id), "rotated_at": now_iso, "action": "rotate_kek", **meta}
+
+
+async def rotate_value(
+    session: AsyncSession,
+    *,
+    provider_id: uuid.UUID,
+    field: str,
+    new_value: str,
+    actor_id: str | None = None,
+) -> dict[str, Any]:
+    """Re-seal a vault secret with a new plaintext value (operator-supplied rotation).
+
+    Updates the vault entry and timestamps the rotation in the provider config.
+    Returns metadata from the vault response.
+    """
+    from user_management.models.sso import SSOProvider
+    from user_management.services.unified_vault_client import UnifiedVaultClientError, vault_rotate
+
+    row = await session.execute(select(SSOProvider).where(SSOProvider.id == provider_id))
+    provider = row.scalar_one_or_none()
+    if provider is None:
+        raise SSORotationError(f"SSO provider {provider_id} not found")
+
+    vault_id_str = provider.config.get(_vault_id_key(field))
+    if not vault_id_str:
+        raise SSORotationError(
+            f"field {field!r} has no vault_id in config for provider {provider_id}; "
+            "run migrate_to_vault first"
+        )
+    vault_id = uuid.UUID(vault_id_str)
+
+    try:
+        meta = await vault_rotate(vault_id, new_value)
+    except UnifiedVaultClientError as exc:
+        raise SSORotationError(f"value rotation failed for provider {provider_id} field {field}: {exc}") from exc
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    await _update_provider_config(session, provider_id, {_rotated_at_key(field): now_iso})
+    await _write_audit(
+        session,
+        provider_id=provider_id,
+        action="rotate_value",
+        actor_id=actor_id,
+        details={"field": field, "vault_id": str(vault_id), "rotated_at": now_iso},
+    )
+    logger.info(
+        "SSO value rotation complete: provider=%s field=%s vault_id=%s", provider_id, field, vault_id
+    )
+    return {"vault_id": str(vault_id), "rotated_at": now_iso, "action": "rotate_value", **meta}

--- a/autobot-slm-backend/user_management/services/sso_secrets.py
+++ b/autobot-slm-backend/user_management/services/sso_secrets.py
@@ -161,9 +161,7 @@ class SSOSecretsManager:
                     logger.info("unified-vault: created SSO secret field=%s provider=%s", field, provider_id)
             except UnifiedVaultClientError as exc:
                 # Vault unavailable — keep plaintext out of config, propagate.
-                logger.error(
-                    "unified-vault: failed to store SSO secret field=%s: %s", field, type(exc).__name__
-                )
+                logger.error("unified-vault: failed to store SSO secret field=%s: %s", field, type(exc).__name__)
                 raise
 
             sanitized[_vault_id_config_key(field)] = existing_vault_id_str
@@ -245,9 +243,7 @@ class SSOSecretsManager:
             except UnifiedVaultSecretNotFound:
                 pass  # already gone — idempotent
             except UnifiedVaultClientError as exc:
-                logger.warning(
-                    "unified-vault: delete failed field=%s: %s", field, type(exc).__name__
-                )
+                logger.warning("unified-vault: delete failed field=%s: %s", field, type(exc).__name__)
 
         # Also clean up legacy SystemSecret rows if present.
         await self._delete_legacy(provider_id)
@@ -284,9 +280,7 @@ class SSOSecretsManager:
         for field in SENSITIVE_FIELDS:
             vault_id_key = _vault_id_config_key(field)
             if updated.get(vault_id_key):
-                logger.info(
-                    "migrate_to_vault: skip field=%s provider=%s (already migrated)", field, provider_id
-                )
+                logger.info("migrate_to_vault: skip field=%s provider=%s (already migrated)", field, provider_id)
                 continue
 
             # Read from legacy store.
@@ -301,7 +295,9 @@ class SSOSecretsManager:
             except Exception as exc:
                 logger.error(
                     "migrate_to_vault: decrypt failed field=%s provider=%s: %s",
-                    field, provider_id, type(exc).__name__,
+                    field,
+                    provider_id,
+                    type(exc).__name__,
                 )
                 continue
 
@@ -310,7 +306,9 @@ class SSOSecretsManager:
             except UnifiedVaultClientError as exc:
                 logger.error(
                     "migrate_to_vault: vault_create failed field=%s provider=%s: %s",
-                    field, provider_id, type(exc).__name__,
+                    field,
+                    provider_id,
+                    type(exc).__name__,
                 )
                 raise
 
@@ -319,7 +317,9 @@ class SSOSecretsManager:
             updated.pop(field, None)
             logger.info(
                 "migrate_to_vault: migrated field=%s provider=%s vault_id=%s",
-                field, provider_id, meta["id"],
+                field,
+                provider_id,
+                meta["id"],
             )
 
         return updated
@@ -331,8 +331,9 @@ class SSOSecretsManager:
     async def _resolve_vault_id(self, provider_id: uuid.UUID, field: str) -> uuid.UUID | None:
         """Look up the vault UUID from the provider's persisted config (fast path)."""
         try:
-            from user_management.models.sso import SSOProvider
             from sqlalchemy import select as sa_select
+
+            from user_management.models.sso import SSOProvider
 
             row = await self._session.execute(sa_select(SSOProvider).where(SSOProvider.id == provider_id))
             provider = row.scalar_one_or_none()
@@ -344,7 +345,9 @@ class SSOSecretsManager:
         except Exception as exc:
             logger.warning(
                 "unified-vault: vault_id lookup failed field=%s provider=%s: %s",
-                field, provider_id, type(exc).__name__,
+                field,
+                provider_id,
+                type(exc).__name__,
             )
         return None
 

--- a/autobot-slm-backend/user_management/services/sso_secrets.py
+++ b/autobot-slm-backend/user_management/services/sso_secrets.py
@@ -2,154 +2,376 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""
-SSO Secrets Management Helper
+"""SSO secrets management via the unified-secrets System vault (#10153).
 
-Manages secure storage of SSO credentials (client_secret, bind_password)
-using the SystemSecret encrypted storage backend.
+The SLM Manager is a *client* of the autobot-backend unified-secrets API.
+Secrets are stored in the **System vault** via HMAC-authenticated HTTP calls
+(``unified_vault_client``), replacing the previous SLM-local ``SystemSecret``
+table as the canonical store.
+
+Backward-compatible read path
+------------------------------
+During rollout (before migration runs) the vault may not yet hold a secret.
+``retrieve_secret`` falls back to the legacy ``SystemSecret`` table when the
+vault lookup returns ``UnifiedVaultSecretNotFound``.  Once ``migrate_to_vault``
+has been run the fallback never fires.
+
+Secret naming in the vault
+---------------------------
+Each SSO provider field maps to a vault secret whose ``name`` is the canonical
+key used by the legacy store:
+
+    ``sso:provider:{provider_id}:{field}``
+
+The vault ``secret_id`` (UUID) is stashed in the provider's sanitized config as
+``{field}_vault_id`` so that subsequent reads and rotations can address the
+secret directly without an expensive list-then-filter round-trip.
+
+Never log secret values.  Never expose them in exception messages.
 """
+
+from __future__ import annotations
 
 import logging
 import uuid
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.database import SystemSecret
-from services.encryption import decrypt_data, encrypt_data
-
 logger = logging.getLogger(__name__)
+
+# Sensitive fields extracted from provider config before persistence.
+SENSITIVE_FIELDS: list[str] = ["client_secret", "bind_password"]
+
+# Vault secret type label stored with each secret entry.
+_SECRET_TYPE = "sso-credential"
+
+
+def _vault_name(provider_id: uuid.UUID, field: str) -> str:
+    """Canonical vault secret name — mirrors the legacy SystemSecret key."""
+    return f"sso:provider:{provider_id}:{field}"
+
+
+def _vault_id_config_key(field: str) -> str:
+    """Config key where the vault secret UUID is cached."""
+    return f"{field}_vault_id"
+
+
+async def _legacy_retrieve(session: AsyncSession, provider_id: uuid.UUID, field: str) -> str | None:
+    """Read from the legacy SystemSecret table (fallback during migration window)."""
+    try:
+        from models.database import SystemSecret
+        from services.encryption import decrypt_data
+
+        key = _vault_name(provider_id, field)
+        result = await session.execute(select(SystemSecret).where(SystemSecret.key == key))
+        secret = result.scalar_one_or_none()
+        if secret is None:
+            return None
+        return decrypt_data(secret.encrypted_value)
+    except Exception as exc:
+        logger.warning("legacy SSO secret fallback failed for field %s: %s", field, type(exc).__name__)
+        return None
+
+
+async def _legacy_store(session: AsyncSession, provider_id: uuid.UUID, config: dict) -> dict:
+    """Write sensitive fields to the legacy SystemSecret table (rollout window).
+
+    Used when the unified vault is not yet configured so existing deployments
+    keep working unchanged until ``SLM_SERVICE_KEY`` is provisioned.
+    """
+    from models.database import SystemSecret
+    from services.encryption import encrypt_data
+
+    sanitized = config.copy()
+    for field in SENSITIVE_FIELDS:
+        value = config.get(field)
+        if not value:
+            continue
+        key = _vault_name(provider_id, field)
+        result = await session.execute(select(SystemSecret).where(SystemSecret.key == key))
+        existing = result.scalar_one_or_none()
+        if existing is not None:
+            existing.encrypted_value = encrypt_data(value)
+        else:
+            session.add(
+                SystemSecret(
+                    key=key,
+                    encrypted_value=encrypt_data(value),
+                    category="sso",
+                    description=f"SSO {field} for provider {provider_id}",
+                )
+            )
+        sanitized[f"{field}_ref"] = key
+        sanitized.pop(field, None)
+    return sanitized
 
 
 class SSOSecretsManager:
+    """Manage SSO provider secrets via the unified-secrets System vault.
+
+    Constructed with an ``AsyncSession`` for the legacy fallback read path only.
+    The primary store is the unified vault (HTTP); the session is never used
+    for vault writes.
     """
-    Manages SSO provider secrets using encrypted SystemSecret storage.
 
-    Secrets are stored with keys:
-    - sso:provider:{provider_id}:client_secret
-    - sso:provider:{provider_id}:bind_password
-    """
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
 
-    SENSITIVE_FIELDS = ["client_secret", "bind_password"]
-
-    def __init__(self, session: AsyncSession):
-        self.session = session
-
-    def _get_secret_key(self, provider_id: uuid.UUID, field: str) -> str:
-        """Generate SystemSecret key for an SSO provider field."""
-        return f"sso:provider:{provider_id}:{field}"
+    # ------------------------------------------------------------------
+    # Public interface (same surface as before — sso_service.py unchanged)
+    # ------------------------------------------------------------------
 
     async def store_secrets(self, provider_id: uuid.UUID, config: dict) -> dict:
+        """Extract sensitive fields from config, write to vault, return sanitized config.
+
+        Sanitized config gains ``{field}_vault_id`` (UUID str) and
+        ``{field}_ref`` (vault name) in place of the plaintext value.
+        Idempotent: updates the vault secret when ``{field}_vault_id`` is
+        already present in config (or when a vault entry with that name exists).
         """
-        Extract sensitive fields from config, store in SystemSecret, return sanitized config.
+        from user_management.services.unified_vault_client import (
+            UnifiedVaultClientError,
+            is_configured,
+            vault_create,
+            vault_rotate,
+        )
 
-        Args:
-            provider_id: SSO provider UUID
-            config: Provider configuration dictionary
+        # Rollout fallback: until the vault service key is provisioned, behave
+        # exactly as before and write to the legacy SystemSecret store.
+        if not is_configured():
+            return await _legacy_store(self._session, provider_id, config)
 
-        Returns:
-            Sanitized config with secret references instead of plaintext values
-        """
-        sanitized_config = config.copy()
-
-        for field in self.SENSITIVE_FIELDS:
+        sanitized = config.copy()
+        for field in SENSITIVE_FIELDS:
             value = config.get(field)
-            if value:
-                secret_key = self._get_secret_key(provider_id, field)
-
-                # Check if secret already exists
-                result = await self.session.execute(select(SystemSecret).where(SystemSecret.key == secret_key))
-                existing = result.scalar_one_or_none()
-
-                if existing:
-                    # Update existing secret
-                    existing.encrypted_value = encrypt_data(value)
-                    logger.info("Updated SSO secret for field: %s", field)
+            if not value:
+                continue
+            name = _vault_name(provider_id, field)
+            existing_vault_id_str = config.get(_vault_id_config_key(field))
+            try:
+                if existing_vault_id_str:
+                    existing_id = uuid.UUID(existing_vault_id_str)
+                    await vault_rotate(existing_id, value)
+                    logger.info("unified-vault: updated SSO secret field=%s provider=%s", field, provider_id)
                 else:
-                    # Create new secret
-                    secret = SystemSecret(
-                        key=secret_key,
-                        encrypted_value=encrypt_data(value),
-                        category="sso",
-                        description=f"SSO {field} for provider {provider_id}",
-                    )
-                    self.session.add(secret)
-                    logger.info("Created SSO secret for field: %s", field)
+                    meta = await vault_create(name, _SECRET_TYPE, value)
+                    existing_vault_id_str = str(meta["id"])
+                    logger.info("unified-vault: created SSO secret field=%s provider=%s", field, provider_id)
+            except UnifiedVaultClientError as exc:
+                # Vault unavailable — keep plaintext out of config, propagate.
+                logger.error(
+                    "unified-vault: failed to store SSO secret field=%s: %s", field, type(exc).__name__
+                )
+                raise
 
-                # Replace with reference in config
-                sanitized_config[f"{field}_ref"] = secret_key
-                del sanitized_config[field]
+            sanitized[_vault_id_config_key(field)] = existing_vault_id_str
+            sanitized[f"{field}_ref"] = name
+            sanitized.pop(field, None)
 
-        return sanitized_config
+        return sanitized
 
     async def retrieve_secret(self, provider_id: uuid.UUID, field: str) -> str | None:
+        """Retrieve and return the plaintext secret value.
+
+        Primary: unified vault (via vault UUID cached in provider config).
+        Fallback: legacy SystemSecret table (migration window only).
         """
-        Retrieve and decrypt a secret value for an SSO provider.
+        from user_management.services.unified_vault_client import (
+            UnifiedVaultClientError,
+            UnifiedVaultSecretNotFound,
+            is_configured,
+            vault_read,
+        )
 
-        Args:
-            provider_id: SSO provider UUID
-            field: Secret field name (e.g., "client_secret")
+        # Rollout fallback: vault not provisioned → read straight from legacy.
+        if not is_configured():
+            return await _legacy_retrieve(self._session, provider_id, field)
 
-        Returns:
-            Decrypted secret value or None if not found
-        """
-        secret_key = self._get_secret_key(provider_id, field)
+        # Try to resolve vault_id from the provider's stored config.
+        vault_id = await self._resolve_vault_id(provider_id, field)
 
-        result = await self.session.execute(select(SystemSecret).where(SystemSecret.key == secret_key))
-        secret = result.scalar_one_or_none()
+        if vault_id is not None:
+            try:
+                return await vault_read(vault_id)
+            except UnifiedVaultSecretNotFound:
+                logger.warning(
+                    "unified-vault: secret not found, falling back to legacy; field=%s provider=%s",
+                    field,
+                    provider_id,
+                )
+            except UnifiedVaultClientError as exc:
+                logger.error(
+                    "unified-vault: read failed field=%s: %s; falling back to legacy",
+                    field,
+                    type(exc).__name__,
+                )
+        else:
+            # vault_id not in config — try finding by name in vault listing.
+            vault_id = await self._find_vault_id_by_name(provider_id, field)
+            if vault_id is not None:
+                try:
+                    return await vault_read(vault_id)
+                except UnifiedVaultClientError:
+                    pass
 
-        if not secret:
-            logger.warning("SSO secret not found for field: %s", field)
-            return None
-
-        try:
-            return decrypt_data(secret.encrypted_value)
-        except Exception as e:
-            logger.error("Failed to decrypt SSO secret for field %s: %s", field, type(e).__name__)
-            raise ValueError(f"Failed to decrypt secret {field}") from e
+        # Legacy fallback (migration window only).
+        return await _legacy_retrieve(self._session, provider_id, field)
 
     async def delete_secrets(self, provider_id: uuid.UUID) -> None:
-        """
-        Delete all secrets for an SSO provider.
+        """Delete all vault secrets for an SSO provider."""
+        from user_management.services.unified_vault_client import (
+            UnifiedVaultClientError,
+            UnifiedVaultSecretNotFound,
+            is_configured,
+            vault_delete,
+        )
 
-        Args:
-            provider_id: SSO provider UUID
-        """
-        for field in self.SENSITIVE_FIELDS:
-            secret_key = self._get_secret_key(provider_id, field)
+        # Rollout fallback: vault not provisioned → only legacy rows exist.
+        if not is_configured():
+            await self._delete_legacy(provider_id)
+            return
 
-            result = await self.session.execute(select(SystemSecret).where(SystemSecret.key == secret_key))
-            secret = result.scalar_one_or_none()
+        for field in SENSITIVE_FIELDS:
+            vault_id = await self._resolve_vault_id(provider_id, field)
+            if vault_id is None:
+                vault_id = await self._find_vault_id_by_name(provider_id, field)
+            if vault_id is None:
+                continue
+            try:
+                await vault_delete(vault_id)
+                logger.info("unified-vault: deleted SSO secret field=%s provider=%s", field, provider_id)
+            except UnifiedVaultSecretNotFound:
+                pass  # already gone — idempotent
+            except UnifiedVaultClientError as exc:
+                logger.warning(
+                    "unified-vault: delete failed field=%s: %s", field, type(exc).__name__
+                )
 
-            if secret:
-                await self.session.delete(secret)
-                logger.info("Deleted SSO secret for field: %s", field)
+        # Also clean up legacy SystemSecret rows if present.
+        await self._delete_legacy(provider_id)
 
     async def has_plaintext_secrets(self, config: dict) -> bool:
-        """
-        Check if config contains plaintext secrets (not yet migrated).
-
-        Args:
-            config: Provider configuration dictionary
-
-        Returns:
-            True if plaintext secrets found
-        """
-        return any(field in config for field in self.SENSITIVE_FIELDS)
+        """Return True when config contains un-migrated plaintext secrets."""
+        return any(field in config for field in SENSITIVE_FIELDS)
 
     async def migrate_plaintext_to_secrets(self, provider_id: uuid.UUID, config: dict) -> dict:
-        """
-        Migrate plaintext secrets in config to SystemSecret storage.
-
-        Args:
-            provider_id: SSO provider UUID
-            config: Provider configuration with plaintext secrets
-
-        Returns:
-            Sanitized config with secret references
-        """
+        """Migrate plaintext secrets in config to the unified vault (idempotent)."""
         if not await self.has_plaintext_secrets(config):
             return config
-
-        logger.info("Migrating plaintext secrets to SystemSecret for provider %s", provider_id)
+        logger.info("migrating plaintext SSO secrets to unified vault for provider %s", provider_id)
         return await self.store_secrets(provider_id, config)
+
+    # ------------------------------------------------------------------
+    # One-shot vault migration helper (called from migration script)
+    # ------------------------------------------------------------------
+
+    async def migrate_to_vault(self, provider_id: uuid.UUID, config: dict[str, Any]) -> dict[str, Any]:
+        """Copy existing SystemSecret entries into the vault (idempotent).
+
+        Called by the migration script for each SSO provider.  Returns the
+        updated config (with vault IDs) so the caller can persist it.
+        """
+        from models.database import SystemSecret
+        from services.encryption import decrypt_data
+        from user_management.services.unified_vault_client import (
+            UnifiedVaultClientError,
+            vault_create,
+        )
+
+        updated = config.copy()
+        for field in SENSITIVE_FIELDS:
+            vault_id_key = _vault_id_config_key(field)
+            if updated.get(vault_id_key):
+                logger.info(
+                    "migrate_to_vault: skip field=%s provider=%s (already migrated)", field, provider_id
+                )
+                continue
+
+            # Read from legacy store.
+            key = _vault_name(provider_id, field)
+            row = await self._session.execute(select(SystemSecret).where(SystemSecret.key == key))
+            secret_row = row.scalar_one_or_none()
+            if secret_row is None:
+                continue
+
+            try:
+                plaintext = decrypt_data(secret_row.encrypted_value)
+            except Exception as exc:
+                logger.error(
+                    "migrate_to_vault: decrypt failed field=%s provider=%s: %s",
+                    field, provider_id, type(exc).__name__,
+                )
+                continue
+
+            try:
+                meta = await vault_create(key, _SECRET_TYPE, plaintext)
+            except UnifiedVaultClientError as exc:
+                logger.error(
+                    "migrate_to_vault: vault_create failed field=%s provider=%s: %s",
+                    field, provider_id, type(exc).__name__,
+                )
+                raise
+
+            updated[vault_id_key] = str(meta["id"])
+            updated[f"{field}_ref"] = key
+            updated.pop(field, None)
+            logger.info(
+                "migrate_to_vault: migrated field=%s provider=%s vault_id=%s",
+                field, provider_id, meta["id"],
+            )
+
+        return updated
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _resolve_vault_id(self, provider_id: uuid.UUID, field: str) -> uuid.UUID | None:
+        """Look up the vault UUID from the provider's persisted config (fast path)."""
+        try:
+            from user_management.models.sso import SSOProvider
+            from sqlalchemy import select as sa_select
+
+            row = await self._session.execute(sa_select(SSOProvider).where(SSOProvider.id == provider_id))
+            provider = row.scalar_one_or_none()
+            if provider is None:
+                return None
+            vault_id_str = provider.config.get(_vault_id_config_key(field))
+            if vault_id_str:
+                return uuid.UUID(vault_id_str)
+        except Exception as exc:
+            logger.warning(
+                "unified-vault: vault_id lookup failed field=%s provider=%s: %s",
+                field, provider_id, type(exc).__name__,
+            )
+        return None
+
+    async def _find_vault_id_by_name(self, provider_id: uuid.UUID, field: str) -> uuid.UUID | None:
+        """Scan vault listing to find a secret by canonical name (slow path)."""
+        from user_management.services.unified_vault_client import UnifiedVaultClientError, vault_list
+
+        target = _vault_name(provider_id, field)
+        try:
+            entries = await vault_list()
+            for entry in entries:
+                if entry.get("name") == target:
+                    return uuid.UUID(entry["id"])
+        except UnifiedVaultClientError:
+            pass
+        return None
+
+    async def _delete_legacy(self, provider_id: uuid.UUID) -> None:
+        """Remove legacy SystemSecret rows for a provider (cleanup after migration)."""
+        try:
+            from models.database import SystemSecret
+
+            for field in SENSITIVE_FIELDS:
+                key = _vault_name(provider_id, field)
+                row = await self._session.execute(select(SystemSecret).where(SystemSecret.key == key))
+                secret = row.scalar_one_or_none()
+                if secret is not None:
+                    await self._session.delete(secret)
+        except Exception as exc:
+            logger.warning("_delete_legacy failed for provider %s: %s", provider_id, type(exc).__name__)

--- a/autobot-slm-backend/user_management/services/unified_vault_client.py
+++ b/autobot-slm-backend/user_management/services/unified_vault_client.py
@@ -1,0 +1,144 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""HTTP client for the autobot-backend unified-secrets System vault (#10153).
+
+The SLM Manager is a *client* of the unified-secrets API.  It uses its
+registered service identity (``SLM_SERVICE_ID`` / ``SLM_SERVICE_KEY``) and the
+HMAC ``sign_request`` helper from ``autobot_shared.http_client`` to reach the
+System-vault endpoints at ``/api/v2/secrets/system`` on autobot-backend.
+
+Integration shape: option (a) — HTTP client with X-Service-* HMAC auth.
+The SLM and autobot-backend may run on separate machines (distributed topology),
+so sharing the DB session directly is not guaranteed; the HTTP boundary is the
+safe canonical choice.
+
+Configuration (read from env at module import):
+    SLM_SERVICE_ID      — service identifier registered in the backend's Redis
+                          key registry (default: "slm-backend").
+    SLM_SERVICE_KEY     — 256-bit hex-encoded HMAC secret (must match the key
+                          the backend stored under service:key:{service_id}).
+    SLM_AUTHORITY_BASE_URL — base URL of autobot-backend (e.g. http://127.0.0.1:8001).
+
+Never log the service key or any secret value.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+import uuid
+from typing import Any
+
+import aiohttp
+
+from autobot_shared.http_client import sign_request
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level configuration — read once from env, never hard-coded.
+# ---------------------------------------------------------------------------
+_SERVICE_ID: str = os.getenv("SLM_SERVICE_ID", "slm-backend")
+_SERVICE_KEY: str = os.getenv("SLM_SERVICE_KEY", "")
+_BACKEND_BASE_URL: str = os.getenv("SLM_AUTHORITY_BASE_URL", "http://127.0.0.1:8001").rstrip("/")
+_SYSTEM_VAULT_PATH = "/api/v2/secrets/system"
+_REQUEST_TIMEOUT_SECONDS: float = float(os.getenv("SLM_VAULT_CLIENT_TIMEOUT", "10"))
+
+
+class UnifiedVaultClientError(Exception):
+    """Raised when the vault API call fails (HTTP error, config missing, …)."""
+
+
+class UnifiedVaultSecretNotFound(UnifiedVaultClientError):
+    """404 from the vault API — secret does not exist."""
+
+
+def is_configured() -> bool:
+    """Return True when a service key is present so the client can authenticate.
+
+    Callers use this to decide whether the unified vault is the active store
+    (configured) or whether to fall back to the legacy SLM-local store during
+    the rollout window (not yet configured).
+    """
+    return bool(_SERVICE_KEY)
+
+
+def _check_configured() -> None:
+    """Raise early with a clear message when the service key is absent."""
+    if not _SERVICE_KEY:
+        raise UnifiedVaultClientError(
+            "SLM_SERVICE_KEY is not set; unified-vault client cannot authenticate. "
+            "Set SLM_SERVICE_KEY (hex-encoded 256-bit) and SLM_SERVICE_ID in slm-secrets.env."
+        )
+
+
+def _auth_headers(method: str, path: str) -> dict[str, str]:
+    """Build HMAC auth headers for a single request."""
+    return sign_request(_SERVICE_ID, _SERVICE_KEY, method, path, int(time.time()))
+
+
+async def _request(method: str, path: str, **kwargs: Any) -> Any:
+    """Issue one authenticated HTTP request; map status codes to exceptions."""
+    _check_configured()
+    url = f"{_BACKEND_BASE_URL}{path}"
+    headers = _auth_headers(method, path)
+    timeout = aiohttp.ClientTimeout(total=_REQUEST_TIMEOUT_SECONDS)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.request(method, url, headers=headers, **kwargs) as resp:
+            if resp.status == 404:
+                raise UnifiedVaultSecretNotFound(f"secret not found at {path}")
+            if resp.status == 204:
+                return None
+            if not resp.ok:
+                body = await resp.text()
+                raise UnifiedVaultClientError(
+                    f"vault API {method} {path} returned {resp.status}: {body[:200]}"
+                )
+            return await resp.json()
+
+
+async def vault_create(name: str, secret_type: str, value: str) -> dict[str, Any]:
+    """Create a secret in the system vault; returns the metadata dict."""
+    payload = {"owner_vault": "system", "name": name, "secret_type": secret_type, "value": value}
+    logger.info("unified-vault: creating system secret name=%s type=%s", name, secret_type)
+    return await _request("POST", _SYSTEM_VAULT_PATH, json=payload)
+
+
+async def vault_read(secret_id: uuid.UUID) -> str:
+    """Read and return the plaintext value of a system-vault secret."""
+    path = f"{_SYSTEM_VAULT_PATH}/{secret_id}"
+    data = await _request("GET", path)
+    return data["value"]
+
+
+async def vault_rotate(secret_id: uuid.UUID, new_value: str) -> dict[str, Any]:
+    """Re-seal a system-vault secret with a new plaintext value (rotate_value)."""
+    path = f"{_SYSTEM_VAULT_PATH}/{secret_id}"
+    logger.info("unified-vault: rotating system secret id=%s", secret_id)
+    return await _request("PUT", path, json={"value": new_value})
+
+
+async def vault_delete(secret_id: uuid.UUID) -> None:
+    """Delete a system-vault secret."""
+    path = f"{_SYSTEM_VAULT_PATH}/{secret_id}"
+    logger.info("unified-vault: deleting system secret id=%s", secret_id)
+    await _request("DELETE", path)
+
+
+async def vault_list() -> list[dict[str, Any]]:
+    """List system-vault secret metadata accessible to this service identity."""
+    return await _request("GET", _SYSTEM_VAULT_PATH)
+
+
+async def vault_rewrap_kek(secret_id: uuid.UUID, new_root_key_b64: str) -> dict[str, Any]:
+    """Rewrap DEKs under a new root key (KEK rotation, plaintext unchanged).
+
+    ``new_root_key_b64`` must be URL-safe base64 encoding of 32 bytes — the
+    same format the ``/api/v2/secrets/{id}/rewrap`` endpoint expects.
+    """
+    path = f"/api/v2/secrets/{secret_id}/rewrap"
+    logger.info("unified-vault: rewrapping KEK for secret id=%s", secret_id)
+    return await _request("POST", path, json={"new_root_key": new_root_key_b64})

--- a/autobot-slm-backend/user_management/services/unified_vault_client.py
+++ b/autobot-slm-backend/user_management/services/unified_vault_client.py
@@ -94,9 +94,7 @@ async def _request(method: str, path: str, **kwargs: Any) -> Any:
                 return None
             if not resp.ok:
                 body = await resp.text()
-                raise UnifiedVaultClientError(
-                    f"vault API {method} {path} returned {resp.status}: {body[:200]}"
-                )
+                raise UnifiedVaultClientError(f"vault API {method} {path} returned {resp.status}: {body[:200]}")
             return await resp.json()
 
 


### PR DESCRIPTION
## Thinking Path
Phase C of the enterprise-SSO sub-umbrella (#8994 / umbrella #9930). The prerequisites merged earlier (#10436 System-vault service-auth, #10437 KEK rotation, #10458 RBAC vocab). The cross-backend integration surface (§4.1) was resolved as **Option B (per-service HMAC)** per discovery #10492: the SLM authenticates to autobot-backend's `/api/v2/secrets/system/*` routes as a registered service identity (`slm-backend`) using the already-shared `autobot_shared.http_client.sign_request` helper — no new crypto, no new auth scheme. The unified vault is the crown-jewels store (#10088), so a scoped, replay-protected, revocable identity is the right posture over reusing the broad `X-Internal-API-Key`.

## What Changed
**C1 — migrate SSO secrets into the unified vault (#10153)**
- `unified_vault_client.py` (new): signed HTTP client for the System-vault routes; signs over `path` so the HMAC matches `ServiceAuthManager.validate_signature`. Never logs secrets.
- `sso_secrets.py`: vault is the canonical store (secret name `sso:provider:{id}:{field}`, vault UUID cached in provider config as `{field}_vault_id`). **Backward-compatible rollout** — when `SLM_SERVICE_KEY` is unprovisioned (`is_configured()` is False), store/retrieve/delete fall back to the legacy `SystemSecret` table, so existing deployments are unchanged until cutover.
- `migrate_sso_to_unified_vault.py` (new): one-time, idempotent data migration.
- `generate_service_keys.py` / `export_service_keys.py`: provision + export the `slm-backend` service key (was missing from the `SERVICES` lists).

**C2 — secret rotation (#10154)**
- `sso_rotation.py` (new): KEK rotation (`rewrap_dek`, plaintext unchanged) + value re-seal; warn-on-stale (90-day advisory, env-tunable `SSO_SECRET_MAX_AGE_DAYS`, never hard-expire) surfaced in the provider-health response; an audit row per rotation via the canonical `create_audit_log` helper.
- `api/sso.py`: `POST /{provider_id}/rotate-kek` and `/rotate-value`, guarded by `Permission.SECURITY_MANAGE`; health response now carries `secret_staleness`.

**Completion fixes over the initial WIP** (caught by verify-don't-trust):
- audit was constructing `AuditLog` with non-existent `actor_id`/`details` columns + a missing required `log_id` (silently swallowed) → now reuses `create_audit_log`.
- store/delete hard-failed when the vault key was unprovisioned → legacy fallback gated on `is_configured()`.
- `slm-backend` added to the key-provisioning `SERVICES` lists.
- tightened a silent `except` in `_resolve_vault_id`; dropped an unused import.

## Verification
- `python3 -m pytest tests/services/test_sso_vault_client.py` → **24 passed** (vault client config/auth/error-mapping, `is_configured` gating, rotation staleness/KEK/value, max-age env override).
- `py_compile` clean on all 9 changed files. Rebased onto latest `Dev_new_gui`, no conflicts.

## Deploy note
The `slm-backend` key is provisioned by `generate_service_keys.py` and distributed via `export_service_keys.py` (existing mechanism). Until it is provisioned + the migration is run, the SLM transparently uses the legacy store (no behaviour change).

## Model Used
Claude Opus 4.8 (1M context). Builds on prior-session WIP (same author).

Closes #10153, #10154. Resolves #10492.
