### PR TITLE
fix(api): agents/status + dev-speedup routes + audit host (#10502)

### DIFF
--- a/autobot-backend/api/agent_org.py
+++ b/autobot-backend/api/agent_org.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.schemas_agent import (
     AgentDelegateRequest,
+    AgentStatusListResponse,
     AgentSummary,
     ChainOfCommandResponse,
     DelegationResponse,
@@ -57,6 +58,31 @@ async def get_org_tree(
     """
     svc = AgentOrgService(session)
     return await svc.get_org_tree()
+
+
+@router.get(
+    "/status",
+    response_model=AgentStatusListResponse,
+    tags=["agent-org"],
+)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_agents_status",
+    error_code_prefix="AGENT_ORG",
+)
+async def get_agents_status(
+    session: AsyncSession = Depends(get_db_session),
+) -> AgentStatusListResponse:
+    """Return all registered agents with runtime status (#10502).
+
+    Backs the Home dashboard "Agent Activity Monitor". Previously the
+    frontend ``GET /api/agents/status`` 404'd because no route existed at
+    the ``/agents`` prefix, so the monitor fell back to sample data and
+    showed only a subset of agents.
+    """
+    svc = AgentOrgService(session)
+    agents = await svc.get_agent_statuses()
+    return AgentStatusListResponse(agents=agents, total=len(agents))
 
 
 @router.get(

--- a/autobot-backend/api/dev_speedup_templates.py
+++ b/autobot-backend/api/dev_speedup_templates.py
@@ -1,0 +1,109 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Developer Speedup — code templates catalog.
+
+Curated, reusable code templates surfaced by ``GET /api/dev-speedup/templates``
+and rendered in the Developer Speedup view (#902). Each entry matches the
+frontend ``CodeTemplate`` shape:
+``id, name, description, language, template, variables, category``.
+
+``{{variable}}`` placeholders are filled in by the client; ``variables`` lists
+the placeholder names so the UI can render input fields.
+"""
+
+from typing import Any, Dict, List
+
+CODE_TEMPLATES: List[Dict[str, Any]] = [
+    {
+        "id": "py-fastapi-router",
+        "name": "FastAPI Router",
+        "description": "A FastAPI APIRouter with a single GET endpoint.",
+        "language": "python",
+        "category": "backend",
+        "variables": ["resource", "Resource"],
+        "template": (
+            "from fastapi import APIRouter\n\n"
+            "router = APIRouter()\n\n\n"
+            '@router.get("/{{resource}}")\n'
+            "async def list_{{resource}}():\n"
+            '    """List {{Resource}} items."""\n'
+            '    return {"items": []}\n'
+        ),
+    },
+    {
+        "id": "py-pytest-case",
+        "name": "Pytest Test Case",
+        "description": "An async pytest test with arrange/act/assert structure.",
+        "language": "python",
+        "category": "testing",
+        "variables": ["unit", "behavior"],
+        "template": (
+            "import pytest\n\n\n"
+            "@pytest.mark.asyncio\n"
+            "async def test_{{unit}}_{{behavior}}():\n"
+            "    # Arrange\n"
+            "    subject = None\n"
+            "    # Act\n"
+            "    result = subject\n"
+            "    # Assert\n"
+            "    assert result is not None\n"
+        ),
+    },
+    {
+        "id": "py-pydantic-model",
+        "name": "Pydantic Model",
+        "description": "A Pydantic v2 response model with typed fields.",
+        "language": "python",
+        "category": "backend",
+        "variables": ["Model", "field"],
+        "template": (
+            "from pydantic import BaseModel\n\n\n"
+            "class {{Model}}(BaseModel):\n"
+            '    """{{Model}} payload."""\n\n'
+            "    {{field}}: str\n"
+        ),
+    },
+    {
+        "id": "vue-composable",
+        "name": "Vue Composable",
+        "description": "A Vue 3 composable returning reactive state and a fetcher.",
+        "language": "typescript",
+        "category": "frontend",
+        "variables": ["name", "Resource"],
+        "template": (
+            "import { ref } from 'vue'\n"
+            "import ApiClient from '@/utils/ApiClient'\n"
+            "import { getApiBase } from '@/config/ssot-config'\n\n"
+            "export function use{{Resource}}() {\n"
+            "  const items = ref<unknown[]>([])\n\n"
+            "  async function fetch{{Resource}}(): Promise<void> {\n"
+            "    const data = await ApiClient.get<{ items: unknown[] }>("
+            "`${getApiBase()}/{{name}}`)\n"
+            "    items.value = data.items || []\n"
+            "  }\n\n"
+            "  return { items, fetch{{Resource}} }\n"
+            "}\n"
+        ),
+    },
+    {
+        "id": "vue-sfc",
+        "name": "Vue Single-File Component",
+        "description": "A minimal Vue 3 SFC with <script setup> and typed props.",
+        "language": "vue",
+        "category": "frontend",
+        "variables": ["title"],
+        "template": (
+            "<template>\n"
+            '  <section class="panel">\n'
+            "    <h2>{{ title }}</h2>\n"
+            "  </section>\n"
+            "</template>\n\n"
+            '<script setup lang="ts">\n'
+            "defineProps<{ title: string }>()\n"
+            "</script>\n"
+        ),
+    },
+]

--- a/autobot-backend/api/development_speedup.py
+++ b/autobot-backend/api/development_speedup.py
@@ -8,6 +8,8 @@ Development Speedup API
 Advanced code analysis endpoints for development acceleration using NPU and Redis.
 """
 
+import asyncio
+import json
 from typing import Any, Awaitable, Callable, Dict
 
 from fastapi import APIRouter, HTTPException, Query
@@ -18,26 +20,35 @@ from agents.development_speedup_agent import (
     find_duplicates,
     get_development_speedup_agent,
 )
+from api.dev_speedup_templates import CODE_TEMPLATES
 from api.schemas_code import (
     DevelopmentSpeedupAnalysisRequest,
     DevSpeedupAnalysisResultResponse,
     DevSpeedupDeadCodeResultResponse,
     DevSpeedupDuplicatesResultResponse,
     DevSpeedupExamplesResultResponse,
+    DevSpeedupHistoryResponse,
     DevSpeedupImportsResultResponse,
     DevSpeedupPatternsResultResponse,
     DevSpeedupQualityResultResponse,
     DevSpeedupRecommendationsResultResponse,
     DevSpeedupRefactoringResultResponse,
     DevSpeedupStatusResultResponse,
+    DevSpeedupTemplatesResponse,
 )
 from api.schemas_common import DataResponse
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
 
 router = APIRouter()
 logger = get_logger(__name__)
+
+# Redis list of recent developer-speedup actions, newest first (#10502).
+# Bounded so the history view stays cheap to read.
+DEV_SPEEDUP_HISTORY_KEY = "autobot:dev-speedup:history"
+DEV_SPEEDUP_HISTORY_LIMIT = 50
 
 # Issue #380: Module-level frozenset for valid severity levels
 _VALID_SEVERITIES = frozenset({"low", "medium", "high", "critical"})
@@ -609,3 +620,49 @@ async def get_analysis_examples():
             ],
         },
     )
+
+
+@router.get("/templates", response_model=DevSpeedupTemplatesResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_dev_speedup_templates",
+    error_code_prefix="DEVELOPMENT_SPEEDUP",
+)
+async def get_templates(category: str | None = Query(None, description="Filter by template category")):
+    """Return reusable code templates for the Developer Speedup view (#902, #10502).
+
+    Optional ``category`` filters the catalog (e.g. ``backend``, ``frontend``,
+    ``testing``).
+    """
+    templates = CODE_TEMPLATES
+    if category:
+        templates = [t for t in templates if t.get("category") == category]
+    return JSONResponse(status_code=200, content={"templates": templates})
+
+
+@router.get("/history", response_model=DevSpeedupHistoryResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_dev_speedup_history",
+    error_code_prefix="DEVELOPMENT_SPEEDUP",
+)
+async def get_history():
+    """Return recent developer-speedup actions, newest first (#902, #10502).
+
+    Reads the bounded Redis history list. A fresh system with no recorded
+    actions returns an empty list.
+    """
+    redis_client = get_redis_client(async_client=False)
+    raw = await asyncio.to_thread(
+        redis_client.lrange,
+        DEV_SPEEDUP_HISTORY_KEY,
+        0,
+        DEV_SPEEDUP_HISTORY_LIMIT - 1,
+    )
+    actions = []
+    for entry in raw or []:
+        try:
+            actions.append(json.loads(entry))
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Skipping malformed dev-speedup history entry")
+    return JSONResponse(status_code=200, content={"actions": actions})

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -1108,6 +1108,32 @@ class ChainOfCommandResponse(BaseModel):
     chain: List[AgentSummary]
 
 
+class AgentStatusItem(BaseModel):
+    """Runtime status for one registered agent (#10502).
+
+    Shape consumed by the Home dashboard "Agent Activity Monitor"
+    (frontend ``useAgentActivityData`` ``Agent`` interface).
+    """
+
+    id: str
+    name: str
+    type: str = "worker"
+    status: str = "idle"
+    currentTask: str | None = None
+    tasksCompleted: int = 0
+    uptime: int = 0
+    successRate: int = 0
+    recentTasks: List[Dict[str, Any]] = Field(default_factory=list)
+    activityTimeline: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class AgentStatusListResponse(BaseModel):
+    """All registered agents with runtime status (#10502)."""
+
+    agents: List[AgentStatusItem] = Field(default_factory=list)
+    total: int = 0
+
+
 class UpdateOrgRequest(BaseModel):
     """Request body for PATCH /agents/{agent_id}/org (#1405)."""
 

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -2135,6 +2135,40 @@ class DevSpeedupExamplesResultResponse(BaseModel):
     performance_tips: List[str]
 
 
+class DevSpeedupCodeTemplate(BaseModel):
+    """A reusable code template (#10502, #902)."""
+
+    id: str
+    name: str
+    description: str
+    language: str
+    template: str
+    variables: List[str] = Field(default_factory=list)
+    category: str
+
+
+class DevSpeedupTemplatesResponse(BaseModel):
+    """Response for GET /templates (#10502)."""
+
+    templates: List[DevSpeedupCodeTemplate] = Field(default_factory=list)
+
+
+class DevSpeedupAction(BaseModel):
+    """A recorded developer-speedup action for history (#10502)."""
+
+    id: str
+    action: str
+    timestamp: str
+    input: str = ""
+    output: str = ""
+
+
+class DevSpeedupHistoryResponse(BaseModel):
+    """Response for GET /history (#10502)."""
+
+    actions: List[DevSpeedupAction] = Field(default_factory=list)
+
+
 # ---------------------------------------------------------------------------
 # code_search.py route response schemas (GH #6509 Batch A)
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -260,8 +260,12 @@ async def get_frontend_config(admin_check: bool = Depends(check_admin_permission
     }
 
 
-@router.get("/health", response_model=SystemHealthResponse)
-@router.get("/system/health", response_model=SystemHealthResponse)  # Frontend compatibility alias
+# #10502: include HEAD so the frontend ServiceDiscovery liveness probe
+# (HEAD /api/system/health) resolves instead of 405 → false "backend offline".
+@router.api_route("/health", methods=["GET", "HEAD"], response_model=SystemHealthResponse)
+@router.api_route(
+    "/system/health", methods=["GET", "HEAD"], response_model=SystemHealthResponse
+)  # Frontend compatibility alias
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_system_health",

--- a/autobot-backend/services/agent_org_service.py
+++ b/autobot-backend/services/agent_org_service.py
@@ -49,6 +49,16 @@ _ROLE_DEFAULTS: Dict[str, Dict[str, Any]] = {
 }
 
 
+# Map org roles onto the frontend activity-monitor agent "type" vocabulary
+# (orchestrator | worker | monitor | analyzer | executor). (#10502)
+_ROLE_TO_ACTIVITY_TYPE: Dict[str, str] = {
+    OrgRole.MANAGER.value: "orchestrator",
+    OrgRole.COORDINATOR.value: "orchestrator",
+    OrgRole.SPECIALIST.value: "analyzer",
+    OrgRole.WORKER.value: "worker",
+}
+
+
 class AgentOrgService:
     """Service for agent organizational hierarchy operations (#1405)."""
 
@@ -93,6 +103,38 @@ class AgentOrgService:
         """
         nodes = await self.get_all_nodes()
         return self._build_tree(nodes, parent_id=None)
+
+    @staticmethod
+    def _status_for_node(node: AgentOrgNode) -> str:
+        """Derive a runtime status string for the activity monitor (#10502)."""
+        if node.pre_pause_status is not None:
+            return "paused"
+        return "idle"
+
+    async def get_agent_statuses(self) -> List[Dict[str, Any]]:
+        """Return all registered agents with runtime status (#10502).
+
+        Backs ``GET /api/agents/status`` for the Home dashboard "Agent
+        Activity Monitor", which previously 404'd and showed only a subset
+        of agents. Sourced from the org registry so every registered agent
+        is returned.
+        """
+        nodes = await self.get_all_nodes()
+        return [
+            {
+                "id": node.agent_id,
+                "name": node.name,
+                "type": _ROLE_TO_ACTIVITY_TYPE.get(node.org_role, "worker"),
+                "status": self._status_for_node(node),
+                "currentTask": None,
+                "tasksCompleted": 0,
+                "uptime": 0,
+                "successRate": 0,
+                "recentTasks": [],
+                "activityTimeline": [],
+            }
+            for node in nodes
+        ]
 
     async def get_chain_of_command(self, agent_id: str) -> List[Dict[str, Any]]:
         """

--- a/autobot-backend/services/config_service.py
+++ b/autobot-backend/services/config_service.py
@@ -106,9 +106,17 @@ class ConfigService:
         default_api_endpoint = _ssot.backend_url if _ssot else f"{HTTP_PROTOCOL}://{BACKEND_HOST_IP}:{BACKEND_PORT}"
         default_port = _ssot.port.backend if _ssot else BACKEND_PORT
 
+        # #10502: report the reachable backend host, not the bind-all sentinel.
+        # "0.0.0.0" is the listen address; the audit/security dashboard needs
+        # the address clients actually connect to. Default to the SSOT host and
+        # rewrite an explicitly-configured bind-all value to the reachable host.
+        configured_host = get("backend.server_host", BACKEND_HOST_IP)
+        if configured_host == NetworkConstants.BIND_ALL_INTERFACES:
+            configured_host = BACKEND_HOST_IP
+
         return {
             "api_endpoint": get("backend.api_endpoint", default_api_endpoint),
-            "server_host": get("backend.server_host", NetworkConstants.BIND_ALL_INTERFACES),
+            "server_host": configured_host,
             "server_port": get("backend.server_port", default_port),
             "chat_data_dir": get("backend.chat_data_dir", "data/chats"),
             "chat_history_file": get("backend.chat_history_file", "data/chat_history.json"),


### PR DESCRIPTION
## Thinking Path

Umbrella #10502 reported four GUI-facing backend defects. I diagnosed each against the live backend (`https://127.0.0.1/api`, `-k`) and the codebase before fixing:

| Issue | Live probe (before) | Root cause |
|---|---|---|
| #3 `GET /api/agents/status` | **404** | No route at the `/agents` prefix. `agent.py`'s `/agents/status` is mounted at `/agent` → resolves to `/api/agent/agents/status`; `agent_org.py` (mounted at `/agents`) had no `/status`. Frontend `useAgentActivityData` canonically calls `/api/agents/status`. |
| #4 `GET /api/dev-speedup/templates` + `/history` | **404** | Router IS registered at `/dev-speedup`, but `development_speedup.py` never implemented the `/templates`/`/history` routes the `useDevSpeedup` composable autofetches on mount (it only had analyze/duplicates/patterns/…). |
| #1 HEAD health probe | `HEAD /api/health` = **200** (already OK); `HEAD /api/system/health` = **405** | Frontend `ServiceDiscovery` runs a second liveness probe — `HEAD /api/system/health` — against a GET-only route → 405 → `response.ok===false` → backend marked offline. |
| #11 audit shows `0.0.0.0` | n/a | `config_service._build_backend_config` reports `server_host` = `NetworkConstants.BIND_ALL_INTERFACES` (`0.0.0.0`), the bind address, not the reachable host. |

## What Changed

**#3 — `/api/agents/status`**
- `api/agent_org.py`: new `GET /status` (resolves to `/api/agents/status`), same `get_db_session`-only dependency as the existing `/org` route.
- `services/agent_org_service.py`: `get_agent_statuses()` returns **all** registered agents from the org registry (fixes 3/5), with role→activity-type mapping and `paused`/`idle` status derivation.
- `api/schemas_agent.py`: `AgentStatusItem` / `AgentStatusListResponse` matching the frontend `Agent` shape (`id, name, type, status, tasksCompleted, …`).

**#4 — `/api/dev-speedup/templates` + `/history`**
- `api/development_speedup.py`: `GET /templates` (optional `category` filter) and `GET /history` (bounded Redis list `autobot:dev-speedup:history`, newest-first; empty list on a fresh system).
- `api/dev_speedup_templates.py` (new): curated reusable `CODE_TEMPLATES` catalog in the frontend `CodeTemplate` shape.
- `api/schemas_code.py`: `DevSpeedupTemplatesResponse` / `DevSpeedupHistoryResponse` + item models.

**#1 — HEAD health**
- `api/system.py`: `/health` and `/system/health` now use `@router.api_route(methods=["GET","HEAD"])`. The handler already returns HTTP 200 (status lives in the body), so HEAD returns 200. `/api/health` was already correct in base — no change there.

**#11 — audit host**
- `services/config_service.py`: `server_host` defaults to the SSOT reachable host (`BACKEND_HOST_IP` = `_ssot.vm.main`) and rewrites an explicitly-configured `0.0.0.0` to the reachable host.

## Verification

- `python3 -m py_compile` clean on all 8 files; `black --line-length 120` + `isort` clean.
- Router import + route-table inspection (repo root + `autobot-backend` on path):
  - `agent_org` → `/status` `['GET']` → **`/api/agents/status`**
  - `development_speedup` → `/templates`, `/history` `['GET']` → **`/api/dev-speedup/{templates,history}`**
  - `system` → `/health` & `/system/health` both `['GET','HEAD']`
- Live (pre-fix) confirmation of each defect: `HEAD /api/system/health`=405, `GET /api/agents/status`=404, `GET /api/dev-speedup/templates`=404; `HEAD /api/health`=200 (already fixed). Routes deploy later — verified by registration + route resolution, not live post-deploy.
- Backend routers carry no `/api` in their own prefix (the app factory prepends it) — confirmed for every new route.

## Model Used

Claude Opus 4.8 (1M context)