### PR TITLE
refactor(ansible): shared migration-sequence include + registry-driven inventory seeding (#10046, #10110)

### DIFF
--- a/autobot-backend/tests/migrations/test_ansible_migration_contract.py
+++ b/autobot-backend/tests/migrations/test_ansible_migration_contract.py
@@ -212,9 +212,9 @@ def test_shared_migration_sequence_is_ordered():
     assert backup_idx is not None, "migrate_backend_db.yml: no pg_dump backup step"
     assert baseline_idx is not None, "migrate_backend_db.yml: no baseline-adoption step"
     assert upgrade_idx is not None, "migrate_backend_db.yml: no alembic upgrade step"
-    assert backup_idx < baseline_idx < upgrade_idx, (
-        "migrate_backend_db.yml: must run backup -> baseline -> upgrade head in order"
-    )
+    assert (
+        backup_idx < baseline_idx < upgrade_idx
+    ), "migrate_backend_db.yml: must run backup -> baseline -> upgrade head in order"
 
 
 # --- #10045: fail-closed backup contract --------------------------------------

--- a/autobot-backend/tests/migrations/test_ansible_migration_contract.py
+++ b/autobot-backend/tests/migrations/test_ansible_migration_contract.py
@@ -27,6 +27,12 @@ also asserts:
 7. NO skip-path exists — no warn-and-skip branch, and the backup never carries
    ``failed_when: false``.
 
+#10046 consolidates the whole strict sequence (backup -> baseline -> upgrade)
+into a single shared include (``_shared/tasks/migrate_backend_db.yml``) that
+both playbooks call. The backup itself is now reached two include levels deep
+(playbook -> migrate_backend_db.yml -> pre_migration_backup.yml), so the
+include resolver below recurses through nested includes.
+
 Pure YAML inspection — no Ansible runtime needed.
 """
 
@@ -38,7 +44,9 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 ANSIBLE_ROOT = REPO_ROOT / "autobot-slm-backend" / "ansible"
 SETUP_PLAYBOOK = ANSIBLE_ROOT / "setup-user-backend.yml"
 UPDATE_PLAYBOOK = ANSIBLE_ROOT / "playbooks" / "update-all-nodes.yml"
-# Reusable fail-closed backup task file included by both playbooks (#10045).
+# Shared strict migration sequence included by both playbooks (#10046).
+MIGRATE_TASKS = ANSIBLE_ROOT / "_shared" / "tasks" / "migrate_backend_db.yml"
+# Reusable fail-closed backup task file included by the sequence (#10045).
 BACKUP_TASKS = ANSIBLE_ROOT / "_shared" / "tasks" / "pre_migration_backup.yml"
 
 
@@ -66,24 +74,35 @@ def _include_target(task, base_dir: Path):
     return None
 
 
+def _expand_with_includes(items, base_dir: Path):
+    """Yield tasks descending into blocks AND included task files (recursively).
+
+    Included paths resolve relative to the including FILE's directory, so each
+    nested include carries its own base_dir down. (#10046: the backup now lives
+    two include levels below the playbook.)
+    """
+    for task in _flatten_tasks(items):
+        target = _include_target(task, base_dir)
+        if target is not None and target.exists():
+            included = yaml.safe_load(target.read_text(encoding="utf-8"))
+            yield from _expand_with_includes(included, target.parent)
+        else:
+            yield task
+
+
 def _expanded_tasks(path: Path):
     """Yield (play, task) for every task, descending into included task files.
 
     Included files have no play context of their own, so the including play is
-    propagated to the included tasks. (#10045: the pre-migration backup now
-    lives in a shared include.)
+    propagated to the included tasks. (#10045/#10046: the strict migration
+    sequence — including the pre-migration backup — now lives in shared
+    includes.)
     """
     plays = yaml.safe_load(path.read_text(encoding="utf-8"))
     for play in plays if isinstance(plays, list) else [plays]:
         for section in ("pre_tasks", "tasks", "post_tasks"):
-            for task in _flatten_tasks(play.get(section)):
-                target = _include_target(task, path.parent)
-                if target is not None and target.exists():
-                    included = yaml.safe_load(target.read_text(encoding="utf-8"))
-                    for sub in _flatten_tasks(included):
-                        yield play, sub
-                else:
-                    yield play, task
+            for task in _expand_with_includes(play.get(section), path.parent):
+                yield play, task
 
 
 # Backwards-compatible alias used by the existing tests.
@@ -174,6 +193,28 @@ def test_update_playbook_migrate_play_is_fatal():
             )
             return
     raise AssertionError("update-all-nodes.yml: no upgrade head task found")
+
+
+# --- #10046: shared migration sequence ----------------------------------------
+
+
+def test_shared_migration_task_file_exists():
+    assert MIGRATE_TASKS.exists(), f"missing shared migration sequence task file: {MIGRATE_TASKS}"
+
+
+def test_shared_migration_sequence_is_ordered():
+    """The shared include keeps backup -> baseline -> upgrade ordering (#10046)."""
+    tasks = list(_expand_with_includes(yaml.safe_load(MIGRATE_TASKS.read_text(encoding="utf-8")), MIGRATE_TASKS.parent))
+    texts = [_task_text(t) for t in tasks]
+    backup_idx = next((i for i, x in enumerate(texts) if "pg_dump" in x), None)
+    baseline_idx = next((i for i, x in enumerate(texts) if "migrations.baseline" in x), None)
+    upgrade_idx = next((i for i, x in enumerate(texts) if "upgrade head" in x), None)
+    assert backup_idx is not None, "migrate_backend_db.yml: no pg_dump backup step"
+    assert baseline_idx is not None, "migrate_backend_db.yml: no baseline-adoption step"
+    assert upgrade_idx is not None, "migrate_backend_db.yml: no alembic upgrade step"
+    assert backup_idx < baseline_idx < upgrade_idx, (
+        "migrate_backend_db.yml: must run backup -> baseline -> upgrade head in order"
+    )
 
 
 # --- #10045: fail-closed backup contract --------------------------------------

--- a/autobot-slm-backend/ansible/_shared/tasks/migrate_backend_db.yml
+++ b/autobot-slm-backend/ansible/_shared/tasks/migrate_backend_db.yml
@@ -1,0 +1,66 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+---
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+#
+# Reusable strict backend migration sequence (#10046).
+#
+# The strict Alembic upgrade steps (#10001/#10026) previously existed twice,
+# near-identically, in setup-user-backend.yml (post_tasks) and
+# playbooks/update-all-nodes.yml (Play 2). The only differences were
+# parameterization (code dir / run-as user) and task-name prefixes, so the two
+# copies would drift the first time one was touched (#10045 was the first such
+# change). This consolidates the sequence into one include; future migration
+# changes happen here once.
+#
+# The sequence is: fail-closed pre-migration backup (delegated to the shared
+# pre_migration_backup.yml, #10045) -> baseline adoption -> strict
+# `alembic -c migrations/alembic.ini upgrade head`. Any failure aborts the
+# deploy. The caller gates this whole include on a Postgres-backed user mode.
+#
+# Caller must set:
+#   migration_code_dir  — absolute path to the backend checkout (chdir/PYTHONPATH).
+#   migration_user      — the user that owns the checkout / runs alembic.
+# Caller may set:
+#   migration_name_prefix — task-name prefix for log readability (default "").
+#   migration_become      — whether to `become` for the run-as user (default true).
+
+- name: "{{ migration_name_prefix }}Back up PostgreSQL before migrations (local or remote) (#10026, #10045)"
+  ansible.builtin.include_tasks: pre_migration_backup.yml
+  vars:
+    pre_migration_env_file: "{{ migration_code_dir }}/.env"
+
+- name: "{{ migration_name_prefix }}Run database baseline adoption (#10001)"
+  ansible.builtin.shell: |
+    set -a
+    [ -f .env ] && . ./.env
+    set +a
+    exec venv/bin/python -m migrations.baseline
+  args:
+    chdir: "{{ migration_code_dir }}"
+    executable: /bin/bash
+  become: "{{ migration_become | default(true) }}"
+  become_user: "{{ migration_user }}"
+  environment:
+    PYTHONPATH: "{{ migration_code_dir }}"
+  register: baseline_result
+
+- name: "{{ migration_name_prefix }}Run Alembic migrations (#10001)"
+  ansible.builtin.shell: |
+    set -a
+    [ -f .env ] && . ./.env
+    set +a
+    exec venv/bin/python -m alembic -c migrations/alembic.ini upgrade head
+  args:
+    chdir: "{{ migration_code_dir }}"
+    executable: /bin/bash
+  become: "{{ migration_become | default(true) }}"
+  become_user: "{{ migration_user }}"
+  environment:
+    PYTHONPATH: "{{ migration_code_dir }}"
+  register: migration_result
+
+- name: "{{ migration_name_prefix }}Display migration result (#10001)"
+  ansible.builtin.debug:
+    msg: "Migrations applied: {{ migration_result.stdout_lines | default([]) | last | default('up to date') }}"

--- a/autobot-slm-backend/ansible/inventory/slm-nodes.yml
+++ b/autobot-slm-backend/ansible/inventory/slm-nodes.yml
@@ -3,8 +3,18 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 #
-# SLM Managed Nodes Inventory
-# Nodes registered in SLM admin dashboard
+# SLM Managed Nodes Inventory — LEGACY STATIC FALLBACK ONLY (#10110)
+#
+# This NN-Name template is NO LONGER the source of node identity. The
+# authoritative inventory is generated at runtime from the DB node registry
+# (services/inventory_builder.py, wired in playbook_executor._build_dynamic_inventory):
+# host name == node_id, ansible_host == registered ip_address, groups from
+# assigned roles. Real machines self-register with uuid4()[:8] node_ids.
+#
+# This file is used ONLY as the emergency fallback when the registry query
+# fails, and as the seed source for genuine multi-host fleets
+# (seed-fleet-nodes.yml skips co-located collapses). Do not add new nodes
+# here — register them via the SLM dashboard / API instead.
 ---
 all:
   vars:

--- a/autobot-slm-backend/ansible/playbooks/seed-fleet-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/seed-fleet-nodes.yml
@@ -5,9 +5,18 @@
 #
 # Seed Fleet Nodes into SLM Database
 #
-# Registers all inventory nodes via the SLM REST API so that
-# heartbeats from agents are accepted and the fleet dashboard
-# shows all machines.
+# Registers the SLM manager and any DISTINCT-IP fleet machines via the SLM
+# REST API so heartbeats are accepted and the fleet dashboard shows all hosts.
+#
+# #10110: the legacy NN-Name inventory template (`00-SLM-Manager`,
+# `01-Backend`, ...) is NO LONGER the source of node identity. On a co-located
+# install every NN-Name host collapses to the SLM manager's own address, so
+# seeding them all would mint phantom duplicate records pointing at one machine.
+# The DB node registry is the single source of truth: the SLM manager is seeded
+# here (the one well-known identity), and every other co-located component is
+# owned by runtime self-registration (`_ensure_local_node` + agent enroll),
+# which mints real `uuid4()[:8]` node_ids. On a genuine multi-host fleet each
+# template host has a distinct real IP and is still seeded normally.
 #
 # Prerequisites:
 #   - SLM backend must be running on the SLM Manager node
@@ -46,6 +55,15 @@
       - autobot-slm-agent
       - autobot-slm-database
       - autobot-monitoring
+
+    # #10110: the SLM manager's own inventory address. Any other NN-Name host
+    # that resolves to this same address is a co-located collapse, not a real
+    # distinct machine, and is left to runtime self-registration.
+    slm_manager_ip: "{{ hostvars[slm_manager_inventory_host]['ansible_host'] | default('127.0.0.1') }}"
+    _loopback_ips:
+      - "127.0.0.1"
+      - "localhost"
+      - "::1"
 
 
   tasks:
@@ -90,6 +108,15 @@
         # 201 = created, 400 = already exists (idempotent)
         status_code: [201, 400]
         validate_certs: false
+      # #10110: seed the SLM manager always; skip any other NN-Name host that
+      # collapses to a loopback or to the SLM manager's own address — that is a
+      # co-located component owned by runtime self-registration, not a distinct
+      # machine. Genuine multi-host fleet members have a distinct real IP and
+      # are still seeded.
+      when: >-
+        item in (groups.get('slm_server', []) | default([]))
+        or (hostvars[item].ansible_host not in _loopback_ips
+            and hostvars[item].ansible_host != slm_manager_ip)
       loop: "{{ groups['slm_nodes'] }}"
       loop_control:
         label: "{{ item }} ({{ hostvars[item].ansible_host }})"
@@ -99,7 +126,9 @@
       ansible.builtin.debug:
         msg: >-
           {{ item.item }} ({{ hostvars[item.item].ansible_host }}):
-          {{ 'REGISTERED' if item.status == 201 else 'ALREADY EXISTS' }}
+          {{ 'SKIPPED (co-located — runtime-registered)'
+             if (item.skipped | default(false))
+             else ('REGISTERED' if item.status == 201 else 'ALREADY EXISTS') }}
       loop: "{{ register_results.results }}"
       loop_control:
         label: "{{ item.item }}"

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -611,43 +611,17 @@
         - backend_user_mode_probe.stdout | default('') | trim not in ['', 'single_user']
       tags: [backend, migrate]
       block:
-        # Fail-closed pre-migration backup (#10045): local pg_dumpall OR
-        # remote pg_dump derived from .env URL; aborts if neither is possible.
-        - name: "[PLAY 2] Backend | Back up PostgreSQL before migrations (local or remote) (#10026, #10045)"
-          ansible.builtin.include_tasks: ../_shared/tasks/pre_migration_backup.yml
-          become: true
+        # Strict migration sequence consolidated into one shared include
+        # (#10046): fail-closed backup -> baseline adoption -> strict
+        # `alembic upgrade head`. Single source for both this playbook and
+        # setup-user-backend.yml.
+        - name: "[PLAY 2] Backend | Run strict backend migration sequence (#10001, #10026, #10046)"
+          ansible.builtin.include_tasks: ../_shared/tasks/migrate_backend_db.yml
           vars:
-            pre_migration_env_file: /opt/autobot/autobot-backend/.env
-
-        - name: "[PLAY 2] Backend | Run database baseline adoption (#10001)"
-          ansible.builtin.shell: |
-            set -a
-            [ -f .env ] && . ./.env
-            set +a
-            exec venv/bin/python -m migrations.baseline
-          args:
-            chdir: /opt/autobot/autobot-backend
-            executable: /bin/bash
-          become: true
-          become_user: autobot
-          environment:
-            PYTHONPATH: /opt/autobot/autobot-backend
-          register: baseline_result
-
-        - name: "[PLAY 2] Backend | Run Alembic migrations (#10001)"
-          ansible.builtin.shell: |
-            set -a
-            [ -f .env ] && . ./.env
-            set +a
-            exec venv/bin/python -m alembic -c migrations/alembic.ini upgrade head
-          args:
-            chdir: /opt/autobot/autobot-backend
-            executable: /bin/bash
-          become: true
-          become_user: autobot
-          environment:
-            PYTHONPATH: /opt/autobot/autobot-backend
-          register: backend_migration_result
+            migration_code_dir: /opt/autobot/autobot-backend
+            migration_user: autobot
+            migration_become: true
+            migration_name_prefix: "[PLAY 2] Backend | "
 
     - name: "[PLAY 2] Backend | Restart service"
       systemd:

--- a/autobot-slm-backend/ansible/setup-user-backend.yml
+++ b/autobot-slm-backend/ansible/setup-user-backend.yml
@@ -93,45 +93,16 @@
       when: backend_user_mode_probe.stdout | default('') | trim not in ['', 'single_user']
       tags: [migrations]
       block:
-        # Fail-closed pre-migration backup (#10045): local pg_dumpall OR
-        # remote pg_dump derived from .env URL; aborts if neither is possible.
-        - name: Back up PostgreSQL before migrations (local or remote) (#10026, #10045)
-          ansible.builtin.include_tasks: _shared/tasks/pre_migration_backup.yml
+        # Strict migration sequence consolidated into one shared include
+        # (#10046): fail-closed backup -> baseline adoption -> strict
+        # `alembic upgrade head`. Changes happen in one place for both
+        # setup-user-backend.yml and playbooks/update-all-nodes.yml.
+        - name: Run strict backend migration sequence (#10001, #10026, #10046)
+          ansible.builtin.include_tasks: _shared/tasks/migrate_backend_db.yml
           vars:
-            pre_migration_env_file: "{{ backend_code_dir }}/.env"
-
-
-        - name: Run database baseline adoption (#10001)
-          ansible.builtin.shell: |
-            set -a
-            [ -f .env ] && . ./.env
-            set +a
-            exec venv/bin/python -m migrations.baseline
-          args:
-            chdir: "{{ backend_code_dir }}"
-            executable: /bin/bash
-          become_user: "{{ backend_user }}"
-          environment:
-            PYTHONPATH: "{{ backend_code_dir }}"
-          register: baseline_result
-
-        - name: Run Alembic migrations (#10001)
-          ansible.builtin.shell: |
-            set -a
-            [ -f .env ] && . ./.env
-            set +a
-            exec venv/bin/python -m alembic -c migrations/alembic.ini upgrade head
-          args:
-            chdir: "{{ backend_code_dir }}"
-            executable: /bin/bash
-          become_user: "{{ backend_user }}"
-          environment:
-            PYTHONPATH: "{{ backend_code_dir }}"
-          register: migration_result
-
-        - name: Display migration result (#10001)
-          ansible.builtin.debug:
-            msg: "Migrations applied: {{ migration_result.stdout_lines | default([]) | last | default('up to date') }}"
+            migration_code_dir: "{{ backend_code_dir }}"
+            migration_user: "{{ backend_user }}"
+            migration_become: false
 
     - name: Verify backend service
       systemd:

--- a/autobot-slm-backend/config.py
+++ b/autobot-slm-backend/config.py
@@ -164,10 +164,13 @@ class Settings(BaseSettings):
     port: int = 8000
     debug: bool = False
 
-    # SLM self-identity (#9956)
-    # The SLM manager's own DB node_id. Deployments may rename the node, so this
-    # is read from the environment instead of being hardcoded. The default
-    # matches the inventory default (slm_server host in slm-nodes.yml).
+    # SLM self-identity (#9956, #10110)
+    # The SLM manager's own DB node_id — the one well-known, stable identity
+    # in the registry-driven model (#10110: the DB node registry is the source
+    # of truth; every other node self-registers with a uuid4()[:8] node_id).
+    # Deployments may rename the manager, so this is read from the environment
+    # instead of being hardcoded; the default matches the legacy slm_server
+    # fallback host in slm-nodes.yml.
     slm_node_id: str = os.getenv("SLM_NODE_ID", "00-SLM-Manager")
 
     # Authentication


### PR DESCRIPTION
## Thinking Path
Continuation of batch #10440 — resolving remaining open issues. Details below.

## What Changed
**#10046** — extracted the duplicated backend migration SEQUENCE (fail-closed backup → `migrations.baseline` → `alembic upgrade head`) into a shared `_shared/tasks/migrate_backend_db.yml` include (parameterized by code dir/user/become/prefix), replacing the ~40-line blocks in `setup-user-backend.yml` and `update-all-nodes.yml`. Migration contract test extended (recursive include resolution) → 11 passed.

**#10110** — finished retiring the legacy NN-Name template as an identity SOURCE. The registry-driven generator (`inventory_builder.build_registry_inventory` via `playbook_executor._build_dynamic_inventory`) was already wired (host==`node.node_id`, `ansible_host`==registered IP, `local` connection for loopback). This PR closes the seeding leak: `seed-fleet-nodes.yml` no longer mints phantom NN-Name duplicates on co-located installs (registry-aware `when:` guard), and `slm-nodes.yml` is re-documented as legacy emergency fallback only. 38 inventory/utils tests pass.

## Verification
- `py_compile`/`yaml.safe_load` clean; contract test 11 passed; inventory tests 38 passed.
- Closes #10046, #10110.
- Follow-up noted on the issue: ~23 hardcoded NN-Name literals remain in standalone maintenance playbooks (separate parameterization pass).

## Model Used
Claude Opus 4.8 (devops-engineer subagent).