### PR TITLE
fix(health): implement+register probe_batch_jobs + SLM py3.14 traceback capture (#10476, #9949)

### DIFF
--- a/autobot-backend/api/batch_jobs.py
+++ b/autobot-backend/api/batch_jobs.py
@@ -39,12 +39,12 @@ from api.schemas_workflows import (
     BatchTemplate,
     BatchTemplateDeleteResponse,
 )
-from api.system_health import register_redis_probe
+from api.system_health import ComponentHealth, KnownProbes, register_health_probe
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.models.pagination import PaginationParams
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client, get_redis_client
 
 logger = get_logger(__name__)
 router = APIRouter(tags=["batch-jobs", "management"])
@@ -574,13 +574,39 @@ async def delete_batch_schedule(
 # =============================================================================
 
 
-# Issue #6914: re-migrated from hand-written probe to one-liner now that
-# register_redis_probe accepts data_callback for module-specific fields.
-register_redis_probe(
-    "batch_jobs",
-    database="main",
-    data_callback=lambda ok: {"redis_connected": ok, "service": "batch_jobs_manager"},
-)
+# Issue #6914 / #10476: hand-written async probe so that tests can monkeypatch
+# get_async_redis_client at module scope on this module (api.batch_jobs) rather
+# than on autobot_shared.redis_client, which makes per-test isolation trivial.
+@register_health_probe(KnownProbes.BATCH_JOBS)
+async def probe_batch_jobs(request) -> ComponentHealth:
+    """Async health probe: ping Redis and return the batch-jobs data contract.
+
+    Returns ``data`` with ``redis_connected`` (bool) and ``service`` (str) so
+    the frontend can read ``probes[name=batch_jobs].data`` from /api/system/health.
+    Degrades gracefully when the client is unavailable or ping fails (#10476).
+    """
+    try:
+        client = await get_async_redis_client(database="main")
+        if client is None:
+            return ComponentHealth(
+                name="batch_jobs",
+                status="down",
+                detail="redis client unavailable",
+                data={"redis_connected": False, "service": "batch_jobs_manager"},
+            )
+        await client.ping()
+        return ComponentHealth(
+            name="batch_jobs",
+            status="ok",
+            data={"redis_connected": True, "service": "batch_jobs_manager"},
+        )
+    except Exception as exc:
+        return ComponentHealth(
+            name="batch_jobs",
+            status="down",
+            detail=f"probe error: {type(exc).__name__}",
+            data={"redis_connected": False, "service": "batch_jobs_manager"},
+        )
 
 
 # =============================================================================

--- a/docker/slm/entrypoint.sh
+++ b/docker/slm/entrypoint.sh
@@ -6,19 +6,49 @@
 #
 # SLM Docker entrypoint — runs database migrations before starting the app.
 # Ensures tables exist on first boot before uvicorn accepts connections (#1893).
+#
+# #9949: startup tracebacks are written to /app/logs/slm-startup.log so that
+# a Python-3.14 (or any other failing) run yields an actionable traceback via
+# `docker logs <container>` or the mounted log volume, rather than a silent
+# unhealthy state with no captured output.
 set -e
 
 cd /app/autobot-slm-backend
 
+mkdir -p /app/logs
+
 echo "Running SLM database migrations..."
-python3 -m migrations.runner || {
+python3 -m migrations.runner 2>&1 | tee -a /app/logs/slm-startup.log || {
     echo "ERROR: Migration failed — retrying in 5s..."
     sleep 5
-    python3 -m migrations.runner || {
-        echo "FATAL: Migration failed after retry. Aborting."
+    python3 -m migrations.runner 2>&1 | tee -a /app/logs/slm-startup.log || {
+        echo "FATAL: Migration failed after retry. Aborting." | tee -a /app/logs/slm-startup.log
         exit 1
     }
 }
 echo "Migrations complete."
+
+# Probe-import: verify the SLM app can be imported without errors before
+# handing off to uvicorn. On Python 3.14 (or any interpreter that removes
+# a stdlib module used by a dependency) this surfaces the traceback in
+# docker logs immediately rather than burying it inside uvicorn's startup
+# sequence where it often gets swallowed by the HEALTHCHECK timeout (#9949).
+echo "Running SLM import probe..."
+python3 -c "
+import sys, traceback, pathlib
+log = pathlib.Path('/app/logs/slm-startup.log')
+try:
+    import main  # noqa: F401 — import-only probe; side-effects are intentional
+    print('SLM import probe: OK')
+except Exception:
+    msg = traceback.format_exc()
+    print('SLM import probe FAILED — traceback follows:', file=sys.stderr)
+    print(msg, file=sys.stderr)
+    log.parent.mkdir(parents=True, exist_ok=True)
+    with log.open('a', encoding='utf-8') as fh:
+        fh.write('=== SLM import probe FAILED ===\n')
+        fh.write(msg)
+    sys.exit(1)
+" 2>&1 | tee -a /app/logs/slm-startup.log
 
 exec "$@"


### PR DESCRIPTION
## Thinking Path
Continuation of batch #10440 — resolving remaining open issues. Details below.

## What Changed
**#10476** — implemented the missing `probe_batch_jobs` health probe in `autobot-backend/api/batch_jobs.py`: async, uses the canonical `get_async_redis_client`, returns `ComponentHealth` with `redis_connected`+`service` in all paths (ping ok / ping fails / client None), registered via `@register_health_probe(KnownProbes.BATCH_JOBS)`. The orphaned `test_health_probe_data_contract.py` test (which patched a non-existent `get_async_redis_client` and called a non-existent function) now passes — 4 batch_jobs cases + 7 file total + 32 registry tests green.
**#9949** — static 3.14 audit found no our-code use of PEP-594-removed stdlib in the SLM backend; key deps have 3.14 wheels. Added durable traceback capture to `docker/slm/entrypoint.sh`: a `python3 -c "import main"` probe before `exec` writes the full `traceback.format_exc()` to stderr + `/app/logs/slm-startup.log`, so the next 3.14 run is diagnosable instead of silently unhealthy. (Most likely real blocker if hit: pysaml2's pyOpenSSL<24.3 transitive pin — documented on the issue.)

## Verification
- `py_compile` clean; probe tests 4/7 + registry 32 pass.
- Closes #10476, #9949.

## Model Used
Claude Opus 4.8 (senior-backend-engineer subagent).