### PR TITLE
fix(voice): /voice/speak via worker when pyttsx3 absent + accurate warning (#10514)

### DIFF
--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -165,13 +165,6 @@ async def voice_listen_api(request: Request, user_role: str = Form("user")):
 async def voice_speak_api(request: Request, text: str = Form(...), user_role: str = Form("user")):
     """Converts text to speech and plays it."""
     security_layer = request.app.state.security_layer
-    voice_interface = getattr(request.app.state, "voice_interface", None)
-    if voice_interface is None:
-        logger.warning("voice_speak called but voice_interface is not initialized")
-        return JSONResponse(
-            status_code=503,
-            content={"message": "Voice interface is not available on this server."},
-        )
     if not security_layer.check_permission(user_role, "allow_voice_speak"):
         security_layer.audit_log(
             "voice_speak",
@@ -182,6 +175,20 @@ async def voice_speak_api(request: Request, text: str = Form(...), user_role: st
         return JSONResponse(
             status_code=403,
             content={"message": "Permission denied to speak via voice."},
+        )
+
+    # Canonical TTS is the pocket-tts worker (always available). The optional
+    # local pyttsx3 voice_interface only does *server-side* playback; when it is
+    # absent, synthesize via the worker and return WAV for the client to play —
+    # instead of a misleading 503 that implies TTS is uninstalled.
+    voice_interface = getattr(request.app.state, "voice_interface", None)
+    if voice_interface is None:
+        wav_bytes = await get_tts_client().synthesize(text)
+        security_layer.audit_log("voice_speak", user_role, "success", {"via": "tts_worker", "text_preview": text[:50]})
+        return Response(
+            content=wav_bytes,
+            media_type="audio/wav",
+            headers={"Content-Disposition": "attachment; filename=speech.wav"},
         )
 
     result = await voice_interface.speak_text(text)

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1435,10 +1435,13 @@ async def _wire_npu_task_queue() -> None:
 
 
 async def _init_voice_interface(app: FastAPI) -> None:
-    """Initialize VoiceInterface and attach it to app.state (#3848).
+    """Initialize the optional local VoiceInterface and attach it to app.state (#3848).
 
-    NON-CRITICAL: voice endpoints return 503 when this is unavailable.
-    Runs in Phase 2 because voice hardware is not required for core operation.
+    NON-CRITICAL and OPTIONAL: this is the legacy local (pyttsx3) interface for
+    *server-side* speak + speech-to-text (/voice/listen). Text-to-speech for
+    clients is served by the pocket-tts worker (tts_client) regardless, so its
+    absence does NOT disable TTS — /voice/synthesize, /voice/speak and
+    /voice/stream all work via the worker. Only local /voice/listen (STT) needs it.
     """
     logger.info("[ 99%%] Voice Interface: Initializing...")
     try:
@@ -1448,8 +1451,9 @@ async def _init_voice_interface(app: FastAPI) -> None:
         app.state.voice_interface = voice_interface
         logger.info("[ 99%%] Voice Interface: Initialized and attached to app.state")
     except Exception as e:
-        logger.warning(
-            "Voice interface initialization failed (non-critical): %s — " "voice endpoints will return 503",
+        logger.info(
+            "Local voice_interface unavailable (optional): %s — TTS still works via "
+            "the pocket-tts worker; only local speech-to-text (/voice/listen) is disabled.",
             e,
         )
         app.state.voice_interface = None


### PR DESCRIPTION
## Thinking Path
TTS works via the pocket-tts worker, but `/api/voice/speak` 503'd without the optional legacy pyttsx3 `voice_interface`, and lifespan warned 'voice endpoints will return 503' — falsely implying TTS is uninstalled.

## What Changed
- `api/voice.py`: `/voice/speak` synthesizes via `tts_client` (worker) and returns WAV when `voice_interface` is None, instead of 503; permission check moved first.
- `initialization/lifespan.py`: `_init_voice_interface` log clarifies TTS works via the worker; only local STT (/voice/listen) needs pyttsx3 — downgraded to INFO.

## Verification
Live: `/api/voice/speak` 503 → **200 audio/wav (34KB)**; voices=10; /voice/stream WS=101; misleading warning gone. py_compile clean.

## Model Used
Claude Opus 4.8