### PR TITLE
fix(ci): silence Bandit B105 false positive on _SECRET_TYPE (#10515)

### DIFF
--- a/autobot-slm-backend/user_management/services/sso_secrets.py
+++ b/autobot-slm-backend/user_management/services/sso_secrets.py
@@ -44,8 +44,10 @@ logger = logging.getLogger(__name__)
 # Sensitive fields extracted from provider config before persistence.
 SENSITIVE_FIELDS: list[str] = ["client_secret", "bind_password"]
 
-# Vault secret type label stored with each secret entry.
-_SECRET_TYPE = "sso-credential"
+# Vault secret type label stored with each secret entry. This is a category
+# label for the `secret_type` API field, NOT a credential — Bandit B105 fires
+# only because the variable name contains "SECRET".
+_SECRET_TYPE = "sso-credential"  # nosec B105 - type label, not a hardcoded secret
 
 
 def _vault_name(provider_id: uuid.UUID, field: str) -> str:


### PR DESCRIPTION
## Thinking Path
Bandit **B105 (hardcoded_password_string)** fires a false positive on `sso_secrets.py:48` — `_SECRET_TYPE = "sso-credential"` — because the variable name contains "SECRET". The value is a category label for the unified-secrets `secret_type` API field, not a credential. The line landed in #10498 and now fails the **required `code-quality`** check on base.

## What Changed
- `autobot-slm-backend/user_management/services/sso_secrets.py:48`: added `# nosec B105` with an explanatory comment. One line; no behaviour change.

## Verification
- `bandit -t B105 sso_secrets.py` → **No issues identified** (1 skipped via `#nosec`).

## Model Used
Claude Opus 4.8 (1M context).

Closes #10515
