### PR TITLE
fix(bandit): nosec B105 on SSO secret-type label — unblock base code-quality

### DIFF
--- a/autobot-slm-backend/user_management/services/sso_secrets.py
+++ b/autobot-slm-backend/user_management/services/sso_secrets.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 SENSITIVE_FIELDS: list[str] = ["client_secret", "bind_password"]
 
 # Vault secret type label stored with each secret entry.
-_SECRET_TYPE = "sso-credential"
+_SECRET_TYPE = "sso-credential"  # nosec B105 - secret-TYPE label, not a hardcoded password
 
 
 def _vault_name(provider_id: uuid.UUID, field: str) -> str:


### PR DESCRIPTION
## Thinking Path
PR #10509 squash-merged without my `# nosec` line (autofix-race during rebase), leaving `_SECRET_TYPE = "sso-credential"` bare in `sso_secrets.py:48`. Bandit's B105 flags it (a secret-TYPE category label, not a password) — a false positive now in base that fails `code-quality` on every subsequent PR.

## What Changed
- `autobot-slm-backend/user_management/services/sso_secrets.py:48` — added `# nosec B105` with justification.

## Verification
- `py_compile` OK; bandit no longer flags the line (nosec honored).

## Model Used
Claude Opus 4.8.
