### PR TITLE
deploy(backend): single_company mode — surfaces Company OS + enables LLC

### DIFF
--- a/autobot-slm-backend/ansible/inventory/group_vars/backend.yml
+++ b/autobot-slm-backend/ansible/inventory/group_vars/backend.yml
@@ -5,6 +5,22 @@
 # Services: FastAPI, Python 3.12+, Log aggregation
 
 # ==========================================
+# USER-MANAGEMENT MODE
+# ==========================================
+# single_company enables the full PostgreSQL-backed userbase + RBAC and the
+# Company OS (LLC) module. Flipping off single_user (the role default):
+#   * auto-provisions a local PostgreSQL instance (backend role includes the
+#     postgresql role when this is not single_user) and runs `alembic upgrade
+#     head` on first start (#9759);
+#   * activates RBAC — the FIRST user to register becomes the admin, and the
+#     single_user synthetic-admin auth bypass (#6838) no longer applies, so
+#     real authentication is required;
+#   * makes the "Company OS" nav item visible (gated on company mode via
+#     /api/frontend-config → company_os_enabled, #10502).
+# Apply with an Ansible sync once PostgreSQL is acceptable on the backend node.
+backend_user_mode: "single_company"
+
+# ==========================================
 # FIREWALL CONFIGURATION (Issue #894)
 # ==========================================
 
@@ -117,7 +133,7 @@ backend:
 
     # Deployment settings
     AUTOBOT_DEPLOYMENT_MODE: "production"  # Infrastructure mode: local/hybrid/distributed/production
-    AUTOBOT_USER_MODE: "single_user"       # User management: single_user/single_company/multi_company/provider
+    AUTOBOT_USER_MODE: "single_company"    # User management: single_user/single_company/multi_company/provider
     AUTOBOT_BACKEND_HOST: "0.0.0.0"
     AUTOBOT_BACKEND_PORT: 8001
 


### PR DESCRIPTION
## Thinking Path
You reported Company OS isn't on the main menu and that single_user mode was "supposed [to be] removed." Tracing it: Company OS **is already in the menu** ([navItems.ts](autobot-frontend/src/config/navItems.ts) → `nav.companyOs`), but it's gated on `company_os_enabled` from `/api/frontend-config`, which is `get_deployment_config().postgres_enabled` — `true` only when `AUTOBOT_USER_MODE != single_user`. The backend group pinned `single_user`, so the item is hidden and LLC 503s. This flips the deployment to company mode.

## What Changed
`inventory/group_vars/backend.yml`: set **`backend_user_mode: single_company`** (was the role's `single_user` default) + aligned the documentation env entry. This is the designed single-var flip:
- the backend role **auto-provisions a local PostgreSQL** (it includes the `postgresql` role when mode `!= single_user`);
- the entrypoint runs **`alembic upgrade head`** on first start (#9759) — schema bootstraps itself;
- `/api/frontend-config` → `company_os_enabled=true` → **Company OS appears in the main menu** and its endpoints work (no more 503).

## ⚠️ Operational implications (read before applying)
- **Real authentication becomes required.** RBAC activates — the **first user to register becomes admin**, and the single_user synthetic-admin bypass (#6838, `AUTOBOT_DEV_AUTH_BYPASS`) no longer applies.
- **PostgreSQL** is provisioned on the backend node (local, `listen_addresses=localhost`).
- Existing single_user (SQLite) user data is **not auto-migrated** to the Postgres userbase — company mode starts a fresh userbase.
- Applies on the next **Ansible sync**; nothing changes until you run it. The role default stays `single_user` for personal/dev installs.

## Verification
- YAML validates; change is scoped to the backend group_vars (not the shared role default). The flip mechanism (postgres role include + entrypoint alembic) already exists and is exercised by docker-compose's documented `single_company` path.

## Model Used
Claude Opus 4.8
