### PR TITLE
fix(sso): clear CodeQL clear-text-logging false positive in vault_create (#10528)

### DIFF
--- a/autobot-slm-backend/user_management/services/unified_vault_client.py
+++ b/autobot-slm-backend/user_management/services/unified_vault_client.py
@@ -101,7 +101,9 @@ async def _request(method: str, path: str, **kwargs: Any) -> Any:
 async def vault_create(name: str, secret_type: str, value: str) -> dict[str, Any]:
     """Create a secret in the system vault; returns the metadata dict."""
     payload = {"owner_vault": "system", "name": name, "secret_type": secret_type, "value": value}
-    logger.info("unified-vault: creating system secret name=%s type=%s", name, secret_type)
+    # Log only the (non-sensitive) type label — CodeQL taints `name` because this
+    # function also receives the secret `value`; the name is an identifier, not a value.
+    logger.info("unified-vault: creating system secret type=%s", secret_type)
     return await _request("POST", _SYSTEM_VAULT_PATH, json=payload)
 
 


### PR DESCRIPTION
## Thinking Path
CodeQL `py/clear-text-logging-sensitive-data` (high) flags `unified_vault_client.py` `vault_create`'s log because it passes `name` while the function also receives the secret `value`. `name` is an identifier (`sso:provider:{id}:{field}`), not a value — a false positive that landed in #10498 and fails CodeQL on every PR touching the file.

## What Changed
- `autobot-slm-backend/user_management/services/unified_vault_client.py`: log only the non-sensitive `secret_type` label; drop `name` from the `vault_create` log line. No behaviour change.

## Verification
- `py_compile` clean; cherry-picked cleanly onto latest base.

## Model Used
Claude Opus 4.8 (1M context).

Closes #10528