### PR TITLE
build(deps): single-source shared dep versions via constraints/shared.txt + drift guard (#10524)

### DIFF
--- a/.github/workflows/constraint-drift.yml
+++ b/.github/workflows/constraint-drift.yml
@@ -1,0 +1,45 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+#
+# Constraint drift guard (#10524).
+#
+# Shared dependency versions (currently numpy) live in ONE place:
+# constraints/shared.txt. Components reference it via `-c <rel>/constraints/shared.txt`
+# and list the package bare. This guard fails any PR that re-declares a version for a
+# constrained package in a component requirements file — preventing the per-file
+# version skew that breaks pip when Ansible co-locates roles on one host and corrupts
+# the numpy ABI for shared .npy / pickled embeddings.
+#
+# Security: no untrusted event data is interpolated into run: commands.
+
+name: constraint-drift
+
+on:
+  pull_request:
+    paths:
+      - '**/requirements*.txt'
+      - 'constraints/shared.txt'
+      - 'scripts/check_constraint_drift.py'
+      - '.github/workflows/constraint-drift.yml'
+  push:
+    branches: [Dev_new_gui]
+    paths:
+      - '**/requirements*.txt'
+      - 'constraints/shared.txt'
+      - 'scripts/check_constraint_drift.py'
+
+permissions:
+  contents: read
+
+jobs:
+  constraint-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Check single-source constraint compliance
+        run: python3 scripts/check_constraint_drift.py

--- a/autobot-backend/code_analysis/requirements.txt
+++ b/autobot-backend/code_analysis/requirements.txt
@@ -4,7 +4,8 @@
 redis>=8.0.0
 
 # Data Processing and ML
-numpy>=2.4.6,<3.0.0
+-c ../../constraints/shared.txt  # single source of truth for shared versions (#10524)
+numpy  # version from constraints/shared.txt
 scikit-learn>=1.9.0
 pandas>=3.0.3
 

--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -1,4 +1,5 @@
 -e ../autobot_shared
+-c ../constraints/shared.txt  # single source of truth for shared versions (#10524); pins transitive numpy
 
 # Core
 apscheduler>=3.11.2             # Issue #6590: hourly LLM key rotation job

--- a/autobot-infrastructure/autobot-npu-worker/docker/requirements-npu.txt
+++ b/autobot-infrastructure/autobot-npu-worker/docker/requirements-npu.txt
@@ -16,8 +16,8 @@ transformers>=5.12.1
 huggingface-hub>=1.20.1
 
 # Tensor Operations (NPU optimized)
-numpy>=2.5.0,<3.0.0
-
+-c ../../../constraints/shared.txt  # single source of truth for shared versions (#10524)
+numpy  # version from constraints/shared.txt
 # HTTP and API
 aiohttp>=3.14.1  # GH#8323: zip bomb, request smuggling CVEs
 httpx>=0.28.1

--- a/autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt
+++ b/autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt
@@ -22,7 +22,8 @@ huggingface-hub>=1.20.1
 tiktoken>=0.13.0
 
 # Tensor Operations
-numpy>=2.5.0,<3.0.0
+-c ../../../../constraints/shared.txt  # single source of truth for shared versions (#10524)
+numpy  # version from constraints/shared.txt
 torch>=2.12.1
 torchvision>=0.27.1
 torchaudio>=2.11.0

--- a/autobot-npu-worker/requirements.txt
+++ b/autobot-npu-worker/requirements.txt
@@ -3,4 +3,5 @@
 # NPU/AI
 openvino>=2026.2.1
 torch>=2.12.1
-numpy>=2.5.0,<3.0.0
+-c ../constraints/shared.txt  # single source of truth for shared versions (#10524)
+numpy  # version from constraints/shared.txt

--- a/autobot-npu-worker/resources/windows-npu-worker/requirements.txt
+++ b/autobot-npu-worker/resources/windows-npu-worker/requirements.txt
@@ -57,7 +57,8 @@ torch>=2.6.0  # GH#8324: CVE-2025-32434 — torch.load RCE via weights_only=True
 # =============================================================================
 # Scientific Computing
 # =============================================================================
-numpy>=2.4.3,<3.0.0
+-c ../../../constraints/shared.txt  # single source of truth for shared versions (#10524)
+numpy  # version from constraints/shared.txt
 scikit-learn>=1.3.0
 
 # Structured Logging

--- a/autobot-tts-worker/requirements.txt
+++ b/autobot-tts-worker/requirements.txt
@@ -3,7 +3,8 @@ uvicorn[standard]>=0.49.0
 transformers>=5.12.1
 torch>=2.12.1
 soundfile>=0.14.0
-numpy>=2.5.0,<3.0.0
+-c ../constraints/shared.txt  # single source of truth for shared versions (#10524)
+numpy  # version from constraints/shared.txt
 huggingface_hub>=1.20.1
 aiofiles>=25.1.0
 python-multipart>=0.0.32          # SECURITY UPDATE - arbitrary file write fix

--- a/constraints/shared.txt
+++ b/constraints/shared.txt
@@ -1,0 +1,15 @@
+# Single source of truth for shared Python dependency versions (#10524).
+#
+# Every component requirements file references this via:
+#     -c <relative-path>/constraints/shared.txt
+# Change a version HERE, once. NEVER re-declare a constrained library's version in a
+# component requirements file — a CI guard (constraint-drift workflow) fails any PR
+# that does, and pip would otherwise resolve different versions per component.
+#
+# Why a single version is mandatory (not just hygiene): Ansible can co-locate or
+# relocate roles (backend, tts-worker, npu-worker, ai-stack) onto one host. Two roles
+# with conflicting pins in the same environment make pip unsatisfiable, and numpy ABI
+# skew corrupts .npy / pickled embeddings written by one role and read by another.
+
+# numpy unified at 2.x across all roles after graspologic (numpy<2) was removed (#10524).
+numpy>=2.5.0,<3.0.0

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -25,19 +25,25 @@ RUN python3 -m pip install --no-cache-dir /app/autobot_shared
 # Copy root requirements (referenced by backend via -r ../requirements.txt)
 COPY requirements.txt /app/requirements-root.txt
 
+# Single source of truth for shared dep versions (#10524). The backend references it via
+# `-c ../constraints/shared.txt`, whose relative path is invalid in the flattened image
+# layout — so (like `-r ../requirements.txt`) it is stripped below and re-applied by
+# absolute path with pip's -c flag, constraining the backend's transitive numpy.
+COPY constraints/shared.txt /app/constraints/shared.txt
+
 # Install backend dependencies (filter out local refs, install root deps separately).
 # torch/torchvision are excluded from the filtered list and installed explicitly from
 # the CPU index, so the default-PyPI CUDA build (libtorch_cuda.so) is never pulled into
 # this CPU image (#10251). vLLM + its CUDA stack are no longer default deps; GPU
 # deployments add them via requirements-gpu.txt.
 COPY autobot-backend/requirements.txt /tmp/requirements.txt
-RUN grep -v -E "(autobot.shared|^-r |^torch==|^torchvision==)" /tmp/requirements.txt \
+RUN grep -v -E "(autobot.shared|^-r |^-c |^torch==|^torchvision==)" /tmp/requirements.txt \
         > /app/requirements-filtered.txt \
-    && python3 -m pip install --no-cache-dir -r /app/requirements-root.txt \
+    && python3 -m pip install --no-cache-dir -c /app/constraints/shared.txt -r /app/requirements-root.txt \
     && python3 -m pip install --no-cache-dir \
         torch==2.12.1 torchvision==0.27.1 \
         --index-url https://download.pytorch.org/whl/cpu \
-    && python3 -m pip install --no-cache-dir -r /app/requirements-filtered.txt
+    && python3 -m pip install --no-cache-dir -c /app/constraints/shared.txt -r /app/requirements-filtered.txt
 
 
 # ---- Production stage ----

--- a/scripts/check_constraint_drift.py
+++ b/scripts/check_constraint_drift.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Guard: shared dependency versions live in ONE place (#10524).
+
+`constraints/shared.txt` is the single source of truth for libraries that must be
+identical across all components (Ansible can co-locate roles on one host, so a
+version split makes pip unsatisfiable and skews the numpy ABI on shared embeddings).
+
+This guard fails if any component requirements file re-declares a *version* for a
+library that the constraints file already pins. Components must reference the
+constraint (``-c <rel>/constraints/shared.txt``) and list the package bare (``numpy``).
+
+Run from the repo root:  python3 scripts/check_constraint_drift.py
+"""
+
+import pathlib
+import re
+import sys
+
+CONSTRAINTS = pathlib.Path("constraints/shared.txt")
+# A requirement line carrying a version specifier for some package.
+_SPEC = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)\s*(==|>=|<=|~=|!=|>|<)")
+_EXCLUDE_DIRS = ("node_modules", ".worktrees", ".git", "__pycache__")
+
+
+def _norm(name: str) -> str:
+    """PEP 503 normalization so Numpy / numpy / NUMPY compare equal."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def constrained_packages() -> set[str]:
+    """Package names that constraints/shared.txt pins a version for."""
+    pkgs = set()
+    for line in CONSTRAINTS.read_text(encoding="utf-8").splitlines():
+        line = line.split("#", 1)[0].strip()
+        if not line or line.startswith("-"):
+            continue
+        m = _SPEC.match(line)
+        if m:
+            pkgs.add(_norm(m.group(1)))
+    return pkgs
+
+
+def requirement_files() -> list[pathlib.Path]:
+    files = []
+    for p in pathlib.Path(".").rglob("requirements*.txt"):
+        if any(part in _EXCLUDE_DIRS for part in p.parts):
+            continue
+        if p == CONSTRAINTS:
+            continue
+        files.append(p)
+    return sorted(files)
+
+
+def main() -> int:
+    if not CONSTRAINTS.exists():
+        print(f"ERROR: {CONSTRAINTS} not found (run from repo root).", file=sys.stderr)
+        return 2
+
+    pinned = constrained_packages()
+    if not pinned:
+        print(f"ERROR: {CONSTRAINTS} pins no packages — nothing to guard.", file=sys.stderr)
+        return 2
+
+    violations: list[str] = []
+    for f in requirement_files():
+        for n, raw in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+            line = raw.split("#", 1)[0].strip()
+            if not line or line.startswith("-"):
+                continue
+            m = _SPEC.match(line)
+            if m and _norm(m.group(1)) in pinned:
+                violations.append(f"{f}:{n}: '{raw.strip()}' re-pins a constrained package")
+
+    if violations:
+        print("Constraint drift — these versions belong ONLY in constraints/shared.txt:\n", file=sys.stderr)
+        for v in violations:
+            print(f"  {v}", file=sys.stderr)
+        print(
+            f"\nFix: remove the version and reference the constraint instead, e.g.\n"
+            f"    -c <relative-path>/constraints/shared.txt\n"
+            f"    {sorted(pinned)[0]}\n",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: no constraint drift. Guarded packages: {', '.join(sorted(pinned))}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Thinking Path

Completes #10524 (Tasks 2+3) after Task 1 (#10530, merged) removed graspologic and unblocked numpy 2.x in the backend. numpy was declared in **6 files with 3 different floors** (`>=2.4.3`/`>=2.4.6`/`>=2.5.0`) and pulled transitively in the backend with no shared bound. Because Ansible can **co-locate or relocate roles** (backend, tts-worker, npu-worker, ai-stack) onto one host, a per-file version split makes pip unsatisfiable in a shared env and skews the numpy ABI on `.npy`/pickled embeddings passed between roles. Fix: one source of truth + a guard so it can't re-drift.

## What Changed

- **`constraints/shared.txt`** — single source of truth; `numpy>=2.5.0,<3.0.0` declared **once**.
- **7 requirements files** (6 components + backend) now carry `-c <rel>/constraints/shared.txt` and list `numpy` bare. numpy's version appears in exactly one place in the repo.
- **`scripts/check_constraint_drift.py`** — fails if any requirements file re-pins a constrained package (PEP 503-normalized names; ignores comments/`-` lines).
- **`.github/workflows/constraint-drift.yml`** — runs the guard on any `requirements*.txt` / constraints change.

## Verification

```
$ python3 scripts/check_constraint_drift.py
OK: no constraint drift. Guarded packages: numpy          # exit 0

# negative test — inject `numpy==1.99.0` into a component file:
Constraint drift — these versions belong ONLY in constraints/shared.txt:
  autobot-tts-worker/requirements.txt:11: 'numpy==1.99.0' re-pins a constrained package   # exit 1
```
- Every `-c` relative path verified to resolve to `constraints/shared.txt` from its file's directory (script-checked).
- No Dockerfile COPYs these files (none of the component dirs have one) — they install via Ansible pip with the full repo tree present, so root-relative `-c` resolves everywhere. The repo's existing proven `-r ../requirements.txt` pattern confirms pip resolves nested refs relative to the file.
- `grep` confirms numpy version is declared in exactly one file. Both workflow YAMLs parse.

Future shared libs (scipy, opencv) can be added to `constraints/shared.txt` the same way; the guard covers them automatically.

## Model Used

Claude Opus 4.8 (1M context)


Closes #10524
