### PR TITLE
fix(secrets): accept X-Internal-API-Key on System-vault routes (Option A) + SLM LLM key→vault (#10492, #10503)

### DIFF
--- a/autobot-backend/api/unified_secrets.py
+++ b/autobot-backend/api/unified_secrets.py
@@ -70,19 +70,37 @@ async def principal(request: Request) -> tuple[uuid.UUID, set[str]]:
 
 
 async def service_principal(request: Request) -> str:
-    """Validate HMAC service auth (X-Service-* headers) and return the service_id.
+    """Resolve service identity for System-vault access; 401 on failure.
 
-    A service identity is scoped STRICTLY to the system vault — any attempt to
-    access a user/company/team/role vault via this path is rejected (403) at the
-    endpoint level, not here, so the audit log always sees the attempt.
+    Two accepted auth schemes (Option A — #10492):
+    1. Shared ``X-Internal-API-Key`` header (``AUTOBOT_INTERNAL_API_KEY``) → maps to
+       the synthetic service_id ``"slm-backend"``.  This is the credential the SLM
+       already sends to other autobot-backend endpoints, so no new key provisioning is
+       required.
+    2. HMAC ``X-Service-*`` headers (per-service key in Redis ``service:key:{id}``) —
+       the pre-existing path; left intact for forward-compatibility.
+
+    Either path is scoped STRICTLY to the system vault.  Non-system vault access is
+    rejected at the endpoint level so the audit log always sees the attempt.
     """
+    from autobot_shared.ssot_config import config as _ssot
+
+    _internal_key = _ssot.misc.internal_api_key
+    if _internal_key and request.headers.get("X-Internal-API-Key") == _internal_key:
+        service_id = "slm-backend"
+        logger.info(
+            "service principal authenticated via X-Internal-API-Key",
+            extra={"service_id": service_id, "path": request.url.path, "method": request.method},
+        )
+        return service_id
+
     try:
         info = await validate_service_auth(request)
     except HTTPException:
         raise
-    service_id: str = info["service_id"]
+    service_id = info["service_id"]
     logger.info(
-        "service principal authenticated for secrets API",
+        "service principal authenticated via HMAC for secrets API",
         extra={"service_id": service_id, "path": request.url.path, "method": request.method},
     )
     return service_id

--- a/autobot-slm-backend/api/llm_config.py
+++ b/autobot-slm-backend/api/llm_config.py
@@ -23,10 +23,9 @@ from autobot_shared.auth.permissions import Permission
 from models.database import Node, Setting
 from services.auth import require_permission
 from services.database import get_db
-from services.encryption import decrypt_data, encrypt_data
+from services.encryption import decrypt_data
 from services.playbook_executor import get_playbook_executor
 from user_management.services.llm_secrets import (
-    delete_provider_api_key,
     retrieve_provider_api_key,
     store_provider_api_key,
 )

--- a/autobot-slm-backend/api/llm_config.py
+++ b/autobot-slm-backend/api/llm_config.py
@@ -25,6 +25,11 @@ from services.auth import require_permission
 from services.database import get_db
 from services.encryption import decrypt_data, encrypt_data
 from services.playbook_executor import get_playbook_executor
+from user_management.services.llm_secrets import (
+    delete_provider_api_key,
+    retrieve_provider_api_key,
+    store_provider_api_key,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/settings/admin/llm", tags=["llm-config"])
@@ -110,7 +115,7 @@ def _mask_api_key(key: str) -> str:
 
 
 def _decrypt_provider_key(encrypted_key: str) -> str:
-    """Decrypt a provider API key. Helper for _load_llm_config (#2371)."""
+    """Decrypt a legacy inline-encrypted provider API key. Helper for _load_llm_config (#2371)."""
     if not encrypted_key:
         return ""
     try:
@@ -122,6 +127,8 @@ def _decrypt_provider_key(encrypted_key: str) -> str:
 async def _load_llm_config(db: AsyncSession) -> LLMConfig:
     """Load LLM config from Setting table.
 
+    API keys are resolved via the unified-secrets vault when configured (#10503);
+    inline-encrypted values are used as a backward-compatible fallback.
     Helper for get/put endpoints (Issue #2371).
     """
     result = await db.execute(select(Setting).where(Setting.key.startswith(_PREFIX)))
@@ -131,7 +138,7 @@ async def _load_llm_config(db: AsyncSession) -> LLMConfig:
     if providers_raw:
         parsed = json.loads(providers_raw)
         for p in parsed:
-            p["api_key"] = _decrypt_provider_key(p.get("api_key", ""))
+            p["api_key"] = await retrieve_provider_api_key(p.get("name", ""), p)
         providers = [LLMProviderConfig(**p) for p in parsed]
     else:
         providers = []
@@ -198,12 +205,13 @@ async def save_llm_config(
 
     API keys are encrypted before storage via services.encryption.
     """
-    # Encrypt API keys before persisting to Setting table
+    # Store API keys via unified-secrets vault (#10503); fall back to inline
+    # encryption when vault is not yet configured (rollout window).
     providers_data = []
     for p in config.providers:
         d = p.model_dump()
-        if d.get("api_key") and not d["api_key"].startswith("gAAA"):
-            d["api_key"] = encrypt_data(d["api_key"])
+        if d.get("api_key"):
+            d = await store_provider_api_key(p.name, d)
         providers_data.append(d)
 
     settings_map = {

--- a/autobot-slm-backend/tests/services/test_llm_secrets.py
+++ b/autobot-slm-backend/tests/services/test_llm_secrets.py
@@ -1,0 +1,235 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for LLM provider api_key vault integration (#10503).
+
+Loads ``llm_secrets.py`` directly via importlib, stubs out the
+``unified_vault_client`` module, and drives the public functions in isolation
+so no live autobot-backend or DB is required.
+
+Stub strategy: the lazy imports inside llm_secrets.py resolve from
+``sys.modules[_UVC_KEY]`` at call time.  All tests operate on the *live*
+stub object retrieved via ``sys.modules[_UVC_KEY]`` (the ``uvc`` fixture),
+not on a stale module-level reference, so the tests work regardless of
+whether test_sso_vault_client.py registered its own stub first.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_BACKEND = Path(__file__).parent.parent.parent
+_UVC_KEY = "user_management.services.unified_vault_client"
+
+# ---------------------------------------------------------------------------
+# One-time sys.modules stubs (idempotent — safe to run alongside other test
+# files that install their own stubs for the same keys).
+# ---------------------------------------------------------------------------
+
+if "aiohttp" not in sys.modules:
+    sys.modules["aiohttp"] = MagicMock()
+
+if "autobot_shared.http_client" not in sys.modules:
+    _hs = types.ModuleType("autobot_shared.http_client")
+    _hs.sign_request = lambda *a, **kw: {}  # type: ignore[attr-defined]
+    sys.modules["autobot_shared.http_client"] = _hs
+    sys.modules.setdefault("autobot_shared", types.ModuleType("autobot_shared"))
+
+if _UVC_KEY not in sys.modules:
+    _stub = types.ModuleType(_UVC_KEY)
+    sys.modules[_UVC_KEY] = _stub
+
+# Ensure required attributes exist on whatever stub is live.
+_live = sys.modules[_UVC_KEY]
+for _attr, _default in [
+    ("vault_create", AsyncMock()),
+    ("vault_rotate", AsyncMock()),
+    ("vault_read", AsyncMock()),
+    ("vault_delete", AsyncMock()),
+    ("vault_list", AsyncMock()),
+    ("UnifiedVaultClientError", Exception),
+    ("UnifiedVaultSecretNotFound", Exception),
+    ("is_configured", lambda: False),
+]:
+    if not hasattr(_live, _attr):
+        setattr(_live, _attr, _default)
+
+sys.modules.setdefault("user_management.services", types.ModuleType("user_management.services"))
+sys.modules.setdefault("user_management", types.ModuleType("user_management"))
+
+# Always install the real-behaviour encryption stub so decrypt_data / encrypt_data
+# return strings, not MagicMock instances, even if another test file already put
+# a MagicMock at this key.
+_enc = types.ModuleType("services.encryption")
+_enc.encrypt_data = lambda v: f"ENC[{v}]"  # type: ignore[attr-defined]
+_enc.decrypt_data = lambda v: v[4:-1] if v.startswith("ENC[") else v  # type: ignore[attr-defined]
+sys.modules["services.encryption"] = _enc
+sys.modules.setdefault("services", types.ModuleType("services"))
+
+# ---------------------------------------------------------------------------
+# Load the module under test
+# ---------------------------------------------------------------------------
+
+
+def _load_llm_secrets():
+    spec = importlib.util.spec_from_file_location(
+        "_llm_secrets_under_test",
+        _BACKEND / "user_management/services/llm_secrets.py",
+    )
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_llm_sec = _load_llm_secrets()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def uvc():
+    """Return the live unified_vault_client stub from sys.modules."""
+    return sys.modules[_UVC_KEY]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _provider(name: str, api_key: str = "", **extra) -> dict:
+    return {"name": name, "api_key": api_key, **extra}
+
+
+# ---------------------------------------------------------------------------
+# store_provider_api_key
+# ---------------------------------------------------------------------------
+
+
+class TestStoreProviderApiKey:
+    @pytest.mark.asyncio
+    async def test_no_api_key_returns_dict_unchanged(self, uvc, monkeypatch):
+        monkeypatch.setattr(uvc, "is_configured", lambda: True)
+        d = _provider("openai")
+        result = await _llm_sec.store_provider_api_key("openai", d)
+        assert result == d
+
+    @pytest.mark.asyncio
+    async def test_vault_create_called_for_new_key(self, uvc, monkeypatch):
+        new_id = uuid.uuid4()
+        monkeypatch.setattr(uvc, "is_configured", lambda: True)
+        monkeypatch.setattr(uvc, "vault_create", AsyncMock(return_value={"id": str(new_id)}))
+
+        result = await _llm_sec.store_provider_api_key("openai", _provider("openai", api_key="sk-abc"))
+
+        uvc.vault_create.assert_called_once()
+        assert "llm:provider:openai:api_key" in uvc.vault_create.call_args.args
+        assert "api_key" not in result
+        assert result["api_key_vault_id"] == str(new_id)
+        assert result["api_key_ref"] == "llm:provider:openai:api_key"
+
+    @pytest.mark.asyncio
+    async def test_vault_rotate_called_for_existing_vault_id(self, uvc, monkeypatch):
+        existing_id = uuid.uuid4()
+        monkeypatch.setattr(uvc, "is_configured", lambda: True)
+        monkeypatch.setattr(uvc, "vault_rotate", AsyncMock(return_value={"id": str(existing_id), "version": 2}))
+
+        d = _provider("anthropic", api_key="new-key", api_key_vault_id=str(existing_id))
+        result = await _llm_sec.store_provider_api_key("anthropic", d)
+
+        uvc.vault_rotate.assert_called_once()
+        assert result["api_key_vault_id"] == str(existing_id)
+        assert "api_key" not in result
+
+    @pytest.mark.asyncio
+    async def test_fallback_inline_encrypt_when_not_configured(self, uvc, monkeypatch):
+        monkeypatch.setattr(uvc, "is_configured", lambda: False)
+        result = await _llm_sec.store_provider_api_key("openai", _provider("openai", api_key="sk-plain"))
+        assert result["api_key"].startswith("ENC[")
+
+    @pytest.mark.asyncio
+    async def test_vault_error_propagates(self, uvc, monkeypatch):
+        monkeypatch.setattr(uvc, "is_configured", lambda: True)
+        monkeypatch.setattr(uvc, "vault_create", AsyncMock(side_effect=uvc.UnifiedVaultClientError("boom")))
+        with pytest.raises(uvc.UnifiedVaultClientError):
+            await _llm_sec.store_provider_api_key("openai", _provider("openai", api_key="sk-x"))
+
+
+# ---------------------------------------------------------------------------
+# retrieve_provider_api_key
+# ---------------------------------------------------------------------------
+
+
+class TestRetrieveProviderApiKey:
+    @pytest.mark.asyncio
+    async def test_reads_from_vault_by_id(self, uvc, monkeypatch):
+        vid = uuid.uuid4()
+        monkeypatch.setattr(uvc, "is_configured", lambda: True)
+        monkeypatch.setattr(uvc, "vault_read", AsyncMock(return_value="secret-from-vault"))
+        d = {"name": "openai", "api_key_vault_id": str(vid)}
+        result = await _llm_sec.retrieve_provider_api_key("openai", d)
+        assert result == "secret-from-vault"
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_inline_when_not_configured(self, uvc, monkeypatch):
+        monkeypatch.setattr(uvc, "is_configured", lambda: False)
+        d = {"name": "openai", "api_key": "ENC[my-secret]"}
+        result = await _llm_sec.retrieve_provider_api_key("openai", d)
+        assert result == "my-secret"
+
+    @pytest.mark.asyncio
+    async def test_empty_string_when_no_key(self, uvc, monkeypatch):
+        monkeypatch.setattr(uvc, "is_configured", lambda: False)
+        d = {"name": "openai"}
+        result = await _llm_sec.retrieve_provider_api_key("openai", d)
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_vault_not_found_falls_back_to_legacy(self, uvc, monkeypatch):
+        vid = uuid.uuid4()
+        monkeypatch.setattr(uvc, "is_configured", lambda: True)
+        monkeypatch.setattr(uvc, "vault_read", AsyncMock(side_effect=uvc.UnifiedVaultSecretNotFound("gone")))
+        monkeypatch.setattr(uvc, "vault_list", AsyncMock(return_value=[]))
+        d = {"name": "openai", "api_key_vault_id": str(vid), "api_key": "ENC[fallback]"}
+        result = await _llm_sec.retrieve_provider_api_key("openai", d)
+        assert result == "fallback"
+
+
+# ---------------------------------------------------------------------------
+# delete_provider_api_key
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteProviderApiKey:
+    @pytest.mark.asyncio
+    async def test_delete_calls_vault_delete(self, uvc, monkeypatch):
+        vid = uuid.uuid4()
+        monkeypatch.setattr(uvc, "is_configured", lambda: True)
+        monkeypatch.setattr(uvc, "vault_delete", AsyncMock())
+        await _llm_sec.delete_provider_api_key("openai", {"api_key_vault_id": str(vid)})
+        uvc.vault_delete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_not_configured(self, uvc, monkeypatch):
+        monkeypatch.setattr(uvc, "is_configured", lambda: False)
+        monkeypatch.setattr(uvc, "vault_delete", AsyncMock())
+        await _llm_sec.delete_provider_api_key("openai", {"api_key_vault_id": str(uuid.uuid4())})
+        uvc.vault_delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_no_vault_id(self, uvc, monkeypatch):
+        monkeypatch.setattr(uvc, "is_configured", lambda: True)
+        monkeypatch.setattr(uvc, "vault_delete", AsyncMock())
+        await _llm_sec.delete_provider_api_key("openai", {})
+        uvc.vault_delete.assert_not_called()

--- a/autobot-slm-backend/tests/services/test_sso_vault_client.py
+++ b/autobot-slm-backend/tests/services/test_sso_vault_client.py
@@ -72,6 +72,7 @@ _uvc_stub.vault_list = AsyncMock()  # type: ignore[attr-defined]
 _uvc_stub.vault_create = AsyncMock()  # type: ignore[attr-defined]
 _uvc_stub.UnifiedVaultClientError = Exception  # type: ignore[attr-defined]
 _uvc_stub.UnifiedVaultSecretNotFound = Exception  # type: ignore[attr-defined]
+_uvc_stub.is_configured = lambda: False  # type: ignore[attr-defined]
 sys.modules["user_management.services.unified_vault_client"] = _uvc_stub
 
 # Load unified_vault_client directly (reads real module code)
@@ -112,30 +113,63 @@ def _mock_provider(provider_id: uuid.UUID, config: dict) -> MagicMock:
 
 
 class TestUnifiedVaultClientConfig:
-    def test_check_configured_raises_when_key_missing(self, monkeypatch):
+    # --- legacy HMAC path ---
+
+    def test_check_configured_raises_when_both_keys_missing(self, monkeypatch):
         monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "")
-        with pytest.raises(_vault_client_mod.UnifiedVaultClientError, match="SLM_SERVICE_KEY"):
+        monkeypatch.setattr(_vault_client_mod, "_INTERNAL_API_KEY", "")
+        with pytest.raises(_vault_client_mod.UnifiedVaultClientError, match="AUTOBOT_INTERNAL_API_KEY"):
             _vault_client_mod._check_configured()
 
-    def test_check_configured_passes_with_key(self, monkeypatch):
+    def test_check_configured_passes_with_service_key(self, monkeypatch):
         monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "aabbcc" * 10)
-        # Should not raise
-        _vault_client_mod._check_configured()
+        monkeypatch.setattr(_vault_client_mod, "_INTERNAL_API_KEY", "")
+        _vault_client_mod._check_configured()  # must not raise
 
-    def test_is_configured_false_without_key(self, monkeypatch):
+    def test_is_configured_false_without_either_key(self, monkeypatch):
         monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "")
+        monkeypatch.setattr(_vault_client_mod, "_INTERNAL_API_KEY", "")
         assert _vault_client_mod.is_configured() is False
 
-    def test_is_configured_true_with_key(self, monkeypatch):
+    def test_is_configured_true_with_service_key(self, monkeypatch):
         monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "aabbcc" * 10)
+        monkeypatch.setattr(_vault_client_mod, "_INTERNAL_API_KEY", "")
         assert _vault_client_mod.is_configured() is True
 
-    def test_auth_headers_returns_three_keys(self, monkeypatch):
+    def test_auth_headers_returns_hmac_three_keys_when_no_internal_key(self, monkeypatch):
+        monkeypatch.setattr(_vault_client_mod, "_INTERNAL_API_KEY", "")
         monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "aabbcc" * 10)
         monkeypatch.setattr(_vault_client_mod, "_SERVICE_ID", "test-slm")
         headers = _vault_client_mod._auth_headers("POST", "/api/v2/secrets/system")
         assert set(headers.keys()) == {"X-Service-ID", "X-Service-Signature", "X-Service-Timestamp"}
         assert headers["X-Service-ID"] == "test-slm"
+
+    # --- Option A: X-Internal-API-Key path (#10492) ---
+
+    def test_is_configured_true_with_internal_api_key(self, monkeypatch):
+        monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "")
+        monkeypatch.setattr(_vault_client_mod, "_INTERNAL_API_KEY", "shared-secret-key")
+        assert _vault_client_mod.is_configured() is True
+
+    def test_check_configured_passes_with_internal_api_key(self, monkeypatch):
+        monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "")
+        monkeypatch.setattr(_vault_client_mod, "_INTERNAL_API_KEY", "shared-secret-key")
+        _vault_client_mod._check_configured()  # must not raise
+
+    def test_auth_headers_prefers_internal_api_key_over_hmac(self, monkeypatch):
+        """When AUTOBOT_INTERNAL_API_KEY is set it wins over SLM_SERVICE_KEY (Option A)."""
+        monkeypatch.setattr(_vault_client_mod, "_INTERNAL_API_KEY", "my-shared-key")
+        monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "aabbcc" * 10)
+        headers = _vault_client_mod._auth_headers("GET", "/api/v2/secrets/system")
+        assert set(headers.keys()) == {"X-Internal-API-Key"}
+        assert headers["X-Internal-API-Key"] == "my-shared-key"
+
+    def test_auth_headers_only_internal_key_no_hmac_fields(self, monkeypatch):
+        monkeypatch.setattr(_vault_client_mod, "_INTERNAL_API_KEY", "only-this-key")
+        monkeypatch.setattr(_vault_client_mod, "_SERVICE_KEY", "")
+        headers = _vault_client_mod._auth_headers("POST", "/api/v2/secrets/system")
+        assert "X-Service-Signature" not in headers
+        assert headers.get("X-Internal-API-Key") == "only-this-key"
 
     @pytest.mark.asyncio
     async def test_request_raises_secret_not_found_on_404(self, monkeypatch):

--- a/autobot-slm-backend/user_management/services/llm_secrets.py
+++ b/autobot-slm-backend/user_management/services/llm_secrets.py
@@ -1,0 +1,185 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""LLM provider api_key storage via the unified-secrets System vault (#10503).
+
+Mirrors the pattern from ``sso_secrets.py``: sensitive fields are extracted from
+LLM provider config before persistence, stored in the unified vault, and
+replaced with a ``{field}_vault_id`` reference.  A backward-compatible read path
+falls back to the legacy inline-encrypted value (``services.encryption``) during
+the rollout window.
+
+Secret naming in the vault:
+    ``llm:provider:{provider_name}:api_key``
+
+The vault ``secret_id`` (UUID) is cached as ``api_key_vault_id`` in the provider
+dict so subsequent reads and rotations address the secret directly.
+
+Never log secret values.  Never expose them in exception messages.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# The only sensitive field in an LLM provider config entry.
+_SENSITIVE_FIELD = "api_key"
+_SECRET_TYPE = "llm-api-key"  # nosec B105 - type label, not a hardcoded secret
+_VAULT_ID_KEY = "api_key_vault_id"
+
+
+def _vault_name(provider_name: str) -> str:
+    """Canonical vault secret name for an LLM provider api_key."""
+    return f"llm:provider:{provider_name}:api_key"
+
+
+# ---------------------------------------------------------------------------
+# Legacy fallback helpers (inline AES-GCM encrypted value)
+# ---------------------------------------------------------------------------
+
+
+def _encrypt(value: str) -> str:
+    from services.encryption import encrypt_data
+
+    return encrypt_data(value)
+
+
+def _decrypt(encrypted: str) -> str:
+    from services.encryption import decrypt_data
+
+    return decrypt_data(encrypted)
+
+
+# ---------------------------------------------------------------------------
+# Public interface
+# ---------------------------------------------------------------------------
+
+
+async def store_provider_api_key(provider_name: str, provider_dict: dict[str, Any]) -> dict[str, Any]:
+    """Extract ``api_key`` from *provider_dict*, write to vault, return sanitized copy.
+
+    The returned dict has ``api_key`` removed, ``api_key_vault_id`` set to the
+    vault UUID string, and ``api_key_ref`` set to the canonical vault name.
+    Idempotent: rotates an existing vault entry when ``api_key_vault_id`` is
+    already present.
+
+    Falls back to legacy inline encryption when the vault is not configured.
+    """
+    from user_management.services.unified_vault_client import (
+        UnifiedVaultClientError,
+        is_configured,
+        vault_create,
+        vault_rotate,
+    )
+
+    api_key = provider_dict.get(_SENSITIVE_FIELD)
+    if not api_key:
+        return provider_dict
+
+    sanitized = provider_dict.copy()
+
+    if not is_configured():
+        # Rollout fallback: encrypt inline as before.
+        if not api_key.startswith("gAAA"):
+            sanitized[_SENSITIVE_FIELD] = _encrypt(api_key)
+        return sanitized
+
+    name = _vault_name(provider_name)
+    existing_vault_id = provider_dict.get(_VAULT_ID_KEY)
+    try:
+        if existing_vault_id:
+            import uuid
+
+            await vault_rotate(uuid.UUID(existing_vault_id), api_key)
+            logger.info("unified-vault: rotated LLM api_key for provider=%s", provider_name)
+        else:
+            meta = await vault_create(name, _SECRET_TYPE, api_key)
+            existing_vault_id = str(meta["id"])
+            logger.info("unified-vault: stored LLM api_key for provider=%s", provider_name)
+    except UnifiedVaultClientError as exc:
+        logger.error("unified-vault: failed to store LLM api_key provider=%s: %s", provider_name, type(exc).__name__)
+        raise
+
+    sanitized[_VAULT_ID_KEY] = existing_vault_id
+    sanitized["api_key_ref"] = name
+    sanitized.pop(_SENSITIVE_FIELD, None)
+    return sanitized
+
+
+async def retrieve_provider_api_key(provider_name: str, provider_dict: dict[str, Any]) -> str:
+    """Return plaintext api_key for a provider.
+
+    Primary: vault (via ``api_key_vault_id``).
+    Fallback: legacy inline-encrypted value during migration window.
+    Returns ``""`` when no key is stored.
+    """
+    from user_management.services.unified_vault_client import (
+        UnifiedVaultClientError,
+        UnifiedVaultSecretNotFound,
+        is_configured,
+        vault_list,
+        vault_read,
+    )
+
+    if not is_configured():
+        raw = provider_dict.get(_SENSITIVE_FIELD, "")
+        return _decrypt(raw) if raw else ""
+
+    vault_id_str = provider_dict.get(_VAULT_ID_KEY)
+    if vault_id_str:
+        import uuid
+
+        try:
+            return await vault_read(uuid.UUID(vault_id_str))
+        except UnifiedVaultSecretNotFound:
+            logger.warning("unified-vault: LLM api_key not found provider=%s, falling back", provider_name)
+        except UnifiedVaultClientError as exc:
+            logger.error(
+                "unified-vault: read failed provider=%s: %s; falling back", provider_name, type(exc).__name__
+            )
+    else:
+        # Scan vault by name (slow path for entries that predate vault_id caching).
+        target = _vault_name(provider_name)
+        try:
+            entries = await vault_list()
+            for entry in entries:
+                if entry.get("name") == target:
+                    import uuid
+
+                    return await vault_read(uuid.UUID(entry["id"]))
+        except UnifiedVaultClientError:
+            pass
+
+    # Legacy inline fallback.
+    raw = provider_dict.get(_SENSITIVE_FIELD, "")
+    return _decrypt(raw) if raw else ""
+
+
+async def delete_provider_api_key(provider_name: str, provider_dict: dict[str, Any]) -> None:
+    """Delete the vault secret for a provider's api_key (best-effort, no-op if absent)."""
+    from user_management.services.unified_vault_client import (
+        UnifiedVaultClientError,
+        UnifiedVaultSecretNotFound,
+        is_configured,
+        vault_delete,
+    )
+
+    if not is_configured():
+        return
+
+    vault_id_str = provider_dict.get(_VAULT_ID_KEY)
+    if not vault_id_str:
+        return
+    import uuid
+
+    try:
+        await vault_delete(uuid.UUID(vault_id_str))
+        logger.info("unified-vault: deleted LLM api_key for provider=%s", provider_name)
+    except UnifiedVaultSecretNotFound:
+        pass
+    except UnifiedVaultClientError as exc:
+        logger.warning("unified-vault: delete failed provider=%s: %s", provider_name, type(exc).__name__)

--- a/autobot-slm-backend/user_management/services/llm_secrets.py
+++ b/autobot-slm-backend/user_management/services/llm_secrets.py
@@ -138,9 +138,7 @@ async def retrieve_provider_api_key(provider_name: str, provider_dict: dict[str,
         except UnifiedVaultSecretNotFound:
             logger.warning("unified-vault: LLM api_key not found provider=%s, falling back", provider_name)
         except UnifiedVaultClientError as exc:
-            logger.error(
-                "unified-vault: read failed provider=%s: %s; falling back", provider_name, type(exc).__name__
-            )
+            logger.error("unified-vault: read failed provider=%s: %s; falling back", provider_name, type(exc).__name__)
     else:
         # Scan vault by name (slow path for entries that predate vault_id caching).
         target = _vault_name(provider_name)

--- a/autobot-slm-backend/user_management/services/unified_vault_client.py
+++ b/autobot-slm-backend/user_management/services/unified_vault_client.py
@@ -2,23 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""HTTP client for the autobot-backend unified-secrets System vault (#10153).
+"""HTTP client for the autobot-backend unified-secrets System vault (#10153, #10492).
 
-The SLM Manager is a *client* of the unified-secrets API.  It uses its
-registered service identity (``SLM_SERVICE_ID`` / ``SLM_SERVICE_KEY``) and the
-HMAC ``sign_request`` helper from ``autobot_shared.http_client`` to reach the
-System-vault endpoints at ``/api/v2/secrets/system`` on autobot-backend.
+The SLM Manager is a *client* of the unified-secrets API.  Auth priority:
 
-Integration shape: option (a) — HTTP client with X-Service-* HMAC auth.
-The SLM and autobot-backend may run on separate machines (distributed topology),
-so sharing the DB session directly is not guaranteed; the HTTP boundary is the
-safe canonical choice.
+1. ``AUTOBOT_INTERNAL_API_KEY`` (Option A — #10492): the shared internal-API key
+   that the SLM already uses for voice/personality proxying.  Sent as
+   ``X-Internal-API-Key`` header; the backend maps it to synthetic service_id
+   ``"slm-backend"``.  This is the default and requires no extra provisioning.
+2. HMAC ``X-Service-*`` (legacy / per-service key): used when ``SLM_SERVICE_KEY``
+   is set but ``AUTOBOT_INTERNAL_API_KEY`` is absent.  Present for
+   forward-compatibility with future per-service key deployments.
+
+``is_configured()`` returns True when *either* credential is available, so the
+unified-vault path activates on any standard deployment that sets
+``AUTOBOT_INTERNAL_API_KEY`` (no ``SLM_SERVICE_KEY`` provisioning needed).
 
 Configuration (read from env at module import):
-    SLM_SERVICE_ID      — service identifier registered in the backend's Redis
-                          key registry (default: "slm-backend").
-    SLM_SERVICE_KEY     — 256-bit hex-encoded HMAC secret (must match the key
-                          the backend stored under service:key:{service_id}).
+    AUTOBOT_INTERNAL_API_KEY — shared internal API key (primary; set on both services).
+    SLM_SERVICE_ID      — service identifier for HMAC path (default: "slm-backend").
+    SLM_SERVICE_KEY     — 256-bit hex-encoded HMAC secret (HMAC path fallback).
     SLM_AUTHORITY_BASE_URL — base URL of autobot-backend (e.g. http://127.0.0.1:8001).
 
 Never log the service key or any secret value.
@@ -41,8 +44,9 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Module-level configuration — read once from env, never hard-coded.
 # ---------------------------------------------------------------------------
+_INTERNAL_API_KEY: str = os.getenv("AUTOBOT_INTERNAL_API_KEY", "")  # primary auth (#10492 Option A)
 _SERVICE_ID: str = os.getenv("SLM_SERVICE_ID", "slm-backend")
-_SERVICE_KEY: str = os.getenv("SLM_SERVICE_KEY", "")
+_SERVICE_KEY: str = os.getenv("SLM_SERVICE_KEY", "")  # HMAC fallback
 _BACKEND_BASE_URL: str = os.getenv("SLM_AUTHORITY_BASE_URL", "http://127.0.0.1:8001").rstrip("/")
 _SYSTEM_VAULT_PATH = "/api/v2/secrets/system"
 _REQUEST_TIMEOUT_SECONDS: float = float(os.getenv("SLM_VAULT_CLIENT_TIMEOUT", "10"))
@@ -57,26 +61,32 @@ class UnifiedVaultSecretNotFound(UnifiedVaultClientError):
 
 
 def is_configured() -> bool:
-    """Return True when a service key is present so the client can authenticate.
+    """Return True when either auth credential is available.
 
-    Callers use this to decide whether the unified vault is the active store
-    (configured) or whether to fall back to the legacy SLM-local store during
-    the rollout window (not yet configured).
+    Option A (#10492): ``AUTOBOT_INTERNAL_API_KEY`` (primary, no extra provisioning).
+    HMAC fallback: ``SLM_SERVICE_KEY`` (per-service key stored in Redis).
+    Callers use this to gate the unified-vault path vs the legacy local store.
     """
-    return bool(_SERVICE_KEY)
+    return bool(_INTERNAL_API_KEY or _SERVICE_KEY)
 
 
 def _check_configured() -> None:
-    """Raise early with a clear message when the service key is absent."""
-    if not _SERVICE_KEY:
+    """Raise early with a clear message when no auth credential is configured."""
+    if not (_INTERNAL_API_KEY or _SERVICE_KEY):
         raise UnifiedVaultClientError(
-            "SLM_SERVICE_KEY is not set; unified-vault client cannot authenticate. "
-            "Set SLM_SERVICE_KEY (hex-encoded 256-bit) and SLM_SERVICE_ID in slm-secrets.env."
+            "No vault auth credential configured; set AUTOBOT_INTERNAL_API_KEY (shared internal key) "
+            "or SLM_SERVICE_KEY (hex-encoded 256-bit HMAC key) in slm-secrets.env."
         )
 
 
 def _auth_headers(method: str, path: str) -> dict[str, str]:
-    """Build HMAC auth headers for a single request."""
+    """Build auth headers for a single request.
+
+    Preference order: X-Internal-API-Key (Option A, #10492) when available; fall
+    back to HMAC X-Service-* headers when only SLM_SERVICE_KEY is set.
+    """
+    if _INTERNAL_API_KEY:
+        return {"X-Internal-API-Key": _INTERNAL_API_KEY}
     return sign_request(_SERVICE_ID, _SERVICE_KEY, method, path, int(time.time()))
 
 

--- a/docs/superpowers/specs/2026-06-15-enterprise-sso-federation-design.md
+++ b/docs/superpowers/specs/2026-06-15-enterprise-sso-federation-design.md
@@ -61,13 +61,25 @@ and (c) reconcile with the unified-secrets umbrella #10088.
   locks out SSO is worse than a stale secret). Admin-initiated rotation always available.
 - **Audit**: every rotation (who, which provider/secret, KEK-vs-value, when) is logged.
 
-### 4.1 Cross-backend boundary (design risk)
+### 4.1 Cross-backend boundary — **RESOLVED: Option A (X-Internal-API-Key) (#10492)**
+
 The unified store and `UnifiedSecretsService` live in **autobot-backend**
-(`services/unified_secrets_service.py`, `autobot_shared/secrets_envelope.py`), while SSO lives in
-**autobot-slm-backend** (the control plane). Phase C therefore crosses a backend boundary. The SLM must
-not embed a second copy of the store; it consumes the unified store as a client (service API or the
-shared envelope primitives in `autobot_shared`). The exact integration surface is a **Phase C
-prerequisite** to settle with the #10088 owner before C1.
+(`services/unified_secrets_service.py`, `autobot_shared/secrets_envelope.py`), while SSO (and LLM
+config) live in **autobot-slm-backend** (the control plane). Phase C crosses a backend boundary via
+HTTP; the SLM is a client of the unified-secrets API.
+
+**Decision: Option A — shared `X-Internal-API-Key` → synthetic `service_id = "slm-backend"`.**
+
+- `autobot-backend/api/unified_secrets.py` `service_principal` dependency now accepts the existing
+  `X-Internal-API-Key` header (validated against `ssot_config.misc.internal_api_key`) in addition to
+  the pre-existing HMAC `X-Service-*` path. Either path yields a `service_id` string; the
+  `_require_system_vault` double-fence continues to enforce System-vault-only scoping.
+- `autobot-slm-backend/user_management/services/unified_vault_client.py` `_auth_headers()` now prefers
+  `X-Internal-API-Key` when `AUTOBOT_INTERNAL_API_KEY` is set. `is_configured()` gates on either
+  credential. No `SLM_SERVICE_KEY` provisioning is required on standard deployments.
+- **Trade-off**: coarser identity than per-service HMAC — all callers with the shared key appear as
+  `"slm-backend"`. Acceptable for v1: the key is already a privileged secret; System-vault scoping
+  provides the authorization fence. Per-service HMAC keys remain available as an upgrade path.
 
 ## 5. Phased task tree (sub-umbrella under #9930)
 


### PR DESCRIPTION
## Thinking Path
#10436's System-vault service routes required HMAC X-Service-* auth, but the SLM has no signer (only the shared X-Internal-API-Key) — so #10153's vault path was uncallable by the SLM. Implemented the issue's recommended Option A.

## What Changed
Backend `service_principal` now also accepts a valid `X-Internal-API-Key` → synthetic `service_id=slm-backend` (HMAC path preserved; `_require_system_vault` double-fence untouched). SLM `unified_vault_client` sends X-Internal-API-Key + `is_configured()` gates on AUTOBOT_INTERNAL_API_KEY. New `llm_secrets.py` routes SLM provider api_key through the vault (mirrors sso_secrets, inline fallback). Option A documented in the SSO design spec §4.1.

## Verification
41 tests pass (29 vault-client + 12 llm-secrets); System-vault scoping preserved. Full round-trip needs both services + shared key live. Closes #10492, #10503; unblocks #10153/#10154.

## Model Used
Claude Opus 4.8 (subagent).
