### PR TITLE
fix(plugins/terminal): explicit types on xterm onResize/onData callbacks (#10497)

### DIFF
--- a/autobot-plugins/terminal/src/components/BaseXTerminal.vue
+++ b/autobot-plugins/terminal/src/components/BaseXTerminal.vue
@@ -157,7 +157,7 @@ const initTerminal = async () => {
     await nextTick()
     fitAddon.value.fit()
     terminal.value.onData(handleTerminalData)
-    terminal.value.onResize(({ cols, rows }) => emit('resize', cols, rows))
+    terminal.value.onResize(({ cols, rows }: { cols: number; rows: number }) => emit('resize', cols, rows))
     emit('ready', terminal.value)
     logger.debug('Terminal initialized', { sessionId: props.sessionId })
   } catch (error) {

--- a/autobot-plugins/terminal/src/components/SshTerminal.vue
+++ b/autobot-plugins/terminal/src/components/SshTerminal.vue
@@ -138,8 +138,8 @@ const initTerminal = () => {
 
   nextTick(() => { fitAddon?.fit() })
 
-  terminal.onData((data) => { sendToServer({ type: 'input', text: data }) })
-  terminal.onResize(({ cols, rows }) => { sendToServer({ type: 'resize', cols, rows }) })
+  terminal.onData((data: string) => { sendToServer({ type: 'input', text: data }) })
+  terminal.onResize(({ cols, rows }: { cols: number; rows: number }) => { sendToServer({ type: 'resize', cols, rows }) })
 
   logger.info('Terminal initialized')
 }


### PR DESCRIPTION
## Thinking Path
Plugin `autobot-plugins/terminal` had pre-existing TS errors (surfaced in #10493) — implicit-any on xterm callback params.

## What Changed
`BaseXTerminal.vue` + `SshTerminal.vue`: explicit `{ cols: number; rows: number }` on `onResize` callbacks and `(data: string)` on `onData` (TS7031/TS7006). `terminalContainer` kept — it is bound as a template ref (`ref="terminalContainer"`), so it is used, not dead.

## Verification
Mechanical type annotations; no behavior change. (No Linux npm on this box to run vue-tsc; types match @xterm/xterm signatures.)

## Model Used
Claude Opus 4.8.
