### PR TITLE
fix(deps): wire requirements-ci/ai-ml.txt to constraints + close guard glob gap (#10524)

### DIFF
--- a/requirements-ci/ai-ml.txt
+++ b/requirements-ci/ai-ml.txt
@@ -3,5 +3,6 @@ openai==2.6.1
 tiktoken==0.11.0
 transformers==5.3.0
 sentence-transformers==5.3.0
-numpy>=2.4.3,<3.0.0
+-c ../constraints/shared.txt  # single source of truth for shared versions (#10524)
+numpy  # version from constraints/shared.txt
 pillow==12.2.0

--- a/scripts/check_constraint_drift.py
+++ b/scripts/check_constraint_drift.py
@@ -46,12 +46,17 @@ def constrained_packages() -> set[str]:
 
 def requirement_files() -> list[pathlib.Path]:
     files = []
-    for p in pathlib.Path(".").rglob("requirements*.txt"):
-        if any(part in _EXCLUDE_DIRS for part in p.parts):
-            continue
-        if p == CONSTRAINTS:
-            continue
-        files.append(p)
+    seen = set()
+    # `requirements*.txt` anywhere, plus every *.txt inside a `requirements*` directory
+    # (e.g. requirements-ci/ai-ml.txt, which is a requirements file not named requirements*).
+    for pattern in ("requirements*.txt", "requirements*/*.txt"):
+        for p in pathlib.Path(".").rglob(pattern):
+            if any(part in _EXCLUDE_DIRS for part in p.parts):
+                continue
+            if p == CONSTRAINTS or p in seen:
+                continue
+            seen.add(p)
+            files.append(p)
     return sorted(files)
 
 


### PR DESCRIPTION
## Thinking Path

Post-merge audit of #10556 caught a premature-closure gap: `requirements-ci/ai-ml.txt` still pinned `numpy>=2.4.3,<3.0.0` (a CI requirements file consumed by ~10 workflows), so numpy was **not** actually single-sourced. The drift guard missed it because its glob only matched `requirements*.txt` — not `ai-ml.txt` inside the `requirements-ci/` directory. Both the drift and the guard's blind spot needed fixing.

## What Changed

- **`requirements-ci/ai-ml.txt`** — replaced the numpy pin with `-c ../constraints/shared.txt` + bare `numpy`. (CI installs with the full repo tree, so the relative `-c` resolves.)
- **`scripts/check_constraint_drift.py`** — also scans `requirements*/*.txt`, covering all 13 `requirements-ci/` files (and any future `requirements*`-named dir).

## Verification

```
# guard now scans requirements-ci/*.txt (13 files) — 27 requirement files total
# POSITIVE:
$ python3 scripts/check_constraint_drift.py
OK: no constraint drift. Guarded packages: numpy            # exit 0
# NEGATIVE — inject numpy==1.0.0 into requirements-ci/agent.txt:
  requirements-ci/agent.txt:4: 'numpy==1.0.0' re-pins a constrained package   # exit 1
```
- `grep -rnE '^\s*numpy\s*(>=|==|<)' --include='*.txt'` → **only** `constraints/shared.txt`. numpy is declared in exactly one place repo-wide.
- `../constraints/shared.txt` resolves from `requirements-ci/`.

## Model Used

Claude Opus 4.8 (1M context)

Closes #10524
