### PR TITLE
fix(voice): pre-warm TTS DEFAULT_VOICE at startup + use selected library/uploaded voice in /speak & realtime (#10561)

### DIFF
--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -29,6 +29,7 @@ from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from services.realtime_mcp_bridge import get_realtime_bridge
+from services.personality_service import resolve_voice_id
 from services.tts_client import get_tts_client
 
 router = APIRouter(
@@ -162,7 +163,13 @@ async def voice_listen_api(request: Request, user_role: str = Form("user")):
     operation="voice_speak_api",
     error_code_prefix="VOICE",
 )
-async def voice_speak_api(request: Request, text: str = Form(...), user_role: str = Form("user")):
+async def voice_speak_api(
+    request: Request,
+    text: str = Form(...),
+    voice_id: str = Form(""),
+    language: str = Form(""),
+    user_role: str = Form("user"),
+):
     """Converts text to speech and plays it."""
     security_layer = request.app.state.security_layer
     if not security_layer.check_permission(user_role, "allow_voice_speak"):
@@ -183,7 +190,8 @@ async def voice_speak_api(request: Request, text: str = Form(...), user_role: st
     # instead of a misleading 503 that implies TTS is uninstalled.
     voice_interface = getattr(request.app.state, "voice_interface", None)
     if voice_interface is None:
-        wav_bytes = await get_tts_client().synthesize(text)
+        resolved_voice = resolve_voice_id(voice_id, language)
+        wav_bytes = await get_tts_client().synthesize(text, voice_id=resolved_voice, language=language)
         security_layer.audit_log("voice_speak", user_role, "success", {"via": "tts_worker", "text_preview": text[:50]})
         return Response(
             content=wav_bytes,
@@ -231,7 +239,8 @@ async def voice_synthesize_api(
         )
 
     tts = get_tts_client()
-    wav_bytes = await tts.synthesize(text, voice_id=voice_id, language=language)
+    resolved_voice = resolve_voice_id(voice_id, language)
+    wav_bytes = await tts.synthesize(text, voice_id=resolved_voice, language=language)
     security_layer.audit_log("voice_synthesize", user_role, "success", {"text_preview": text[:50]})
     return Response(
         content=wav_bytes,

--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -28,8 +28,8 @@ from api.schemas_code import (
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
-from services.realtime_mcp_bridge import get_realtime_bridge
 from services.personality_service import resolve_voice_id
+from services.realtime_mcp_bridge import get_realtime_bridge
 from services.tts_client import get_tts_client
 
 router = APIRouter(

--- a/autobot-backend/api/voice_stream.py
+++ b/autobot-backend/api/voice_stream.py
@@ -38,6 +38,7 @@ from starlette.websockets import WebSocketState
 from autobot_shared.env_utils import env_int_clamped
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from services.personality_service import resolve_voice_id
 from services.tts_client import get_tts_client
 
 logger = get_logger(__name__)
@@ -366,22 +367,23 @@ async def _handle_ws_message(
             await ctx["set_state"]("processing")
 
     elif msg_type == "speak":
+        language = msg.get("language", "")
         result = await _start_tts_stream(
             ws,
             msg.get("text", "").strip(),
             ctx["cancel_tts"],
             ctx["set_state"],
             ctx["get_state"],
-            voice_id=msg.get("voice_id", ""),
-            language=msg.get("language", ""),
+            voice_id=resolve_voice_id(msg.get("voice_id", ""), language),
+            language=language,
         )
         if result is not None:
             tts_task = result
 
     elif msg_type == "speak_sentence":
         text = msg.get("text", "").strip()
-        voice_id = msg.get("voice_id", "")
         language = msg.get("language", "")
+        voice_id = resolve_voice_id(msg.get("voice_id", ""), language)
         if text:
             await ctx["sentence_queue"].put((text, voice_id, language))
 

--- a/autobot-backend/services/personality_service.py
+++ b/autobot-backend/services/personality_service.py
@@ -365,3 +365,23 @@ def get_personality_manager() -> PersonalityManager:
     if _manager is None:
         _manager = PersonalityManager()
     return _manager
+
+
+def resolve_voice_id(request_voice_id: str = "", language: str = "") -> str:
+    """Resolve the TTS voice id from request, active personality, or default.
+
+    Priority: explicit request voice_id > active profile per-language
+    voice_ids[language] > active profile voice_id > "" (worker DEFAULT_VOICE).
+    The voice id is a library/builtin name or an uploaded ``.safetensors``
+    profile id; never the user's STT input audio (#10561, #1135, #1333).
+    """
+    if request_voice_id:
+        return request_voice_id
+    try:
+        profile = get_personality_manager().get_active_profile()
+        if profile:
+            per_lang = profile.voice_ids.get(language) if language else None
+            return per_lang or profile.voice_id or ""
+    except Exception:
+        pass
+    return ""

--- a/autobot-backend/tests/test_voice_503_guard.py
+++ b/autobot-backend/tests/test_voice_503_guard.py
@@ -54,15 +54,21 @@ class TestVoice503Guard:
         assert "message" in body
         assert "not available" in body["message"].lower()
 
-    def test_speak_returns_503_when_interface_absent(self):
-        """POST /api/voice/speak must return 503 (not 500/AttributeError)."""
+    def test_speak_synthesizes_via_worker_when_interface_absent(self):
+        """POST /api/voice/speak now synthesizes via the TTS worker (200 audio/wav)
+        when the optional local pyttsx3 voice_interface is absent — the canonical
+        TTS is the pocket-tts worker, so a 503 here would be misleading (#10561)."""
+        import unittest.mock as mock
+
         app = _make_app(with_voice_interface=False)
         client = TestClient(app, raise_server_exceptions=False)
-        response = client.post("/api/voice/speak", data={"text": "hello", "user_role": "user"})
-        assert response.status_code == 503
-        body = response.json()
-        assert "message" in body
-        assert "not available" in body["message"].lower()
+        fake = mock.MagicMock()
+        fake.synthesize = mock.AsyncMock(return_value=b"RIFFfakewavdata")
+        with mock.patch("api.voice.get_tts_client", return_value=fake):
+            response = client.post("/api/voice/speak", data={"text": "hello", "user_role": "user"})
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "audio/wav"
+        assert response.content == b"RIFFfakewavdata"
 
     def test_listen_does_not_raise_attribute_error_when_interface_absent(self):
         """The old behaviour raised AttributeError (500). Confirm it no longer does."""
@@ -76,8 +82,14 @@ class TestVoice503Guard:
         assert response.status_code == 503
 
     def test_speak_does_not_raise_attribute_error_when_interface_absent(self):
-        """Confirm AttributeError is not raised for /speak either."""
+        """Confirm AttributeError is not raised for /speak when interface absent
+        (it falls through to worker synthesis, not the AttributeError site)."""
+        import unittest.mock as mock
+
         app = _make_app(with_voice_interface=False)
         client = TestClient(app, raise_server_exceptions=True)
-        response = client.post("/api/voice/speak", data={"text": "hello", "user_role": "user"})
-        assert response.status_code == 503
+        fake = mock.MagicMock()
+        fake.synthesize = mock.AsyncMock(return_value=b"RIFFfakewavdata")
+        with mock.patch("api.voice.get_tts_client", return_value=fake):
+            response = client.post("/api/voice/speak", data={"text": "hello", "user_role": "user"})
+        assert response.status_code == 200

--- a/autobot-slm-backend/ansible/roles/tts-worker/templates/tts-worker.py.j2
+++ b/autobot-slm-backend/ansible/roles/tts-worker/templates/tts-worker.py.j2
@@ -57,12 +57,14 @@ _voice_cache: dict = {}  # voice_id -> voice_state
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Load Pocket TTS model on startup."""
+    """Load Pocket TTS model and pre-warm DEFAULT_VOICE on startup."""
     global _model_loaded, _model_error
     loop = asyncio.get_event_loop()
     success, err = await loop.run_in_executor(None, _load_model)
     _model_loaded = success
     _model_error = err
+    if success:
+        await loop.run_in_executor(None, _prewarm_default_voice)
     yield
 
 
@@ -193,6 +195,19 @@ def _get_voice_state(voice_id: str):
 
     _voice_cache[voice_id] = state
     return state
+
+
+def _prewarm_default_voice() -> None:
+    """Pre-compute DEFAULT_VOICE state so the first synthesis is hot (#10561).
+
+    Non-fatal: a failure here only forgoes the latency win, it must not
+    block worker startup or mark the model unhealthy.
+    """
+    try:
+        _get_voice_state(DEFAULT_VOICE)
+        logger.info("Pre-warmed default voice state: %s", DEFAULT_VOICE)
+    except Exception as e:
+        logger.warning("Failed to pre-warm default voice %s: %s", DEFAULT_VOICE, e)
 
 
 def _get_metadata_path() -> Path:


### PR DESCRIPTION
## Thinking Path
Returning TTS bug: responses take too long; the older variant used a sampled/user voice instead of a library/uploaded one. Root cause traced to a cold voice-state cache at worker startup + /speak never passing the user's selected voice.

## What Changed
- **Worker** (tts-worker.py.j2): `lifespan` now pre-warms `_get_voice_state(DEFAULT_VOICE)` after model load (executor, non-fatal) so the first synthesis is hot.
- **Backend**: new `resolve_voice_id(request_voice_id, language)` reuses the active **personality profile** voice (`personality_service` `voice_id`/per-language `voice_ids`, #1135/#1333); wired into `/speak`, `/synthesize`, and the realtime `voice_stream` speak/speak_sentence paths so a library or uploaded voice is used (falls back to DEFAULT_VOICE).
- Confirmed `clone_voice`/`/voices/create` are reachable ONLY from explicit cloning/upload endpoints — the response path never samples the user's STT audio.
- Updated stale `test_voice_503_guard` /speak tests to assert the new worker-synthesis 200 audio/wav contract.

## Verification
py_compile + .j2 strip-render OK; `test_voice_503_guard.py` 4/4 pass. First-response latency delta needs a live worker+model to measure.

## Model Used
Claude Opus 4.8 (multimodal-engineer subagent).
