### PR TITLE
fix(ui): suppress ResizeObserver app-error + restore Company OS to primary nav

### DIFF
--- a/autobot-frontend/src/config/navItems.ts
+++ b/autobot-frontend/src/config/navItems.ts
@@ -73,14 +73,16 @@ export const navItems: NavItem[] = [
   // (BROWSE group) — see KnowledgeView.vue. Routes live under /knowledge/* now;
   // legacy /documents and /transcriber paths redirect there (router/index.ts).
   { to: '/knowledge', labelKey: 'nav.knowledge', icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z' },
+  // Company OS (LLC) — kept high in the order so it stays in the primary nav rail,
+  // not pushed into the overflow menu (a major feature must be directly reachable).
+  { to: '/llc/select-company', labelKey: 'nav.companyOs', icon: 'M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4', iconStroke: true },
   { to: '/automation', labelKey: 'nav.automation', icon: 'M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z', iconRule: 'evenodd' },
   { to: '/analytics', labelKey: 'nav.analytics', iconPaths: ['M2 10a8 8 0 018-8v8h8a8 8 0 11-16 0z', 'M12 2.252A8.014 8.014 0 0117.748 8H12V2.252z'] },
   // Agents nav entry removed (TASK 1c): /agents/registry duplicates SLM Admin's
   // /slm/agents/local-agents. Route is kept in router/index.ts for deep links.
   // GH#8748: LLC views consolidated to one "Company OS" entry (was 5 separate items)
-  // GH#9627: entry point is the company selector; LLC sub-views are reached
-  // via the contextual LLC sidebar once a company is selected.
-  { to: '/llc/select-company', labelKey: 'nav.companyOs', icon: 'M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4', iconStroke: true },
+  // GH#9627: entry point is the company selector; LLC sub-views are reached via the
+  // contextual LLC sidebar once a company is selected. (Entry moved up — see above.)
   // Issue #9890: Vision Automation is reachable via Workflow Builder sidebar + direct route.
   // It is NOT in the primary nav rail. To gate a future entry, add a `featureFlag`
   // (and `featureDefaultVisible: true` only if it should ship visible by default).

--- a/autobot-frontend/src/plugins/errorHandler.ts
+++ b/autobot-frontend/src/plugins/errorHandler.ts
@@ -55,6 +55,16 @@ class GlobalErrorHandler {
 
     // Catch JavaScript errors
     window.addEventListener('error', (event) => {
+      // ResizeObserver loop notices are benign browser warnings — both the old
+      // "loop limit exceeded" and the newer Chromium "loop completed with
+      // undelivered notifications" variants. Never surface them as an Application
+      // Error notification (they fire during normal responsive layout).
+      const rawMessage = event.message || event.error?.message || ''
+      if (typeof rawMessage === 'string' && rawMessage.includes('ResizeObserver loop')) {
+        event.preventDefault()
+        return
+      }
+
       logger.error('Global JavaScript error:', event.error)
 
       this.addNotification({


### PR DESCRIPTION
## Thinking Path
Two live UX bugs reported by the operator.

## What Changed
- **ResizeObserver 'Application Error'**: the global `window 'error'` listener (`plugins/errorHandler.ts`) notified on every JS error; its friendly-message map only matched the old `ResizeObserver loop limit exceeded` string, so the newer Chromium variant `ResizeObserver loop completed with undelivered notifications` leaked through as a red Application Error. Now early-returns on any `ResizeObserver loop` message (benign browser notice during normal responsive layout).
- **Company OS missing from main menu**: `nav.companyOs` was item #8, past the ~7-item primary-rail cap, so it landed in the overflow menu. Moved it up (after Knowledge) so a major feature stays directly reachable.

## Verification
- `vue-tsc --noEmit` → 0 errors; `nav-items-coverage` → 9 passed; eslint clean.

## Model Used
Opus 4.8

Related #10488