### PR TITLE
feat(secrets): move LLM API Keys into the Secrets menu (#10488)

### DIFF
--- a/autobot-frontend/src/config/navItems.ts
+++ b/autobot-frontend/src/config/navItems.ts
@@ -106,8 +106,7 @@ export const profileMenuItems: NavItem[] = [
 export const adminMenuItems: NavItem[] = [
   // Issue #1440: AutoResearch experiment dashboard
   { to: '/experiments', labelKey: 'nav.experiments', icon: 'M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z' },
-  // Issue #6590: Virtual LLM API keys admin view
-  { to: '/admin/llm-keys', labelKey: 'nav.llmApiKeys', icon: 'M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z', iconRule: 'evenodd' },
+  // Issue #6590/#10488: Virtual LLM API keys relocated under the Secrets section (/secrets/llm-keys)
   // Issue #7773: Sandbox file inspector
   { to: '/admin/sandbox', labelKey: 'nav.adminSandbox', icon: 'M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z', iconStroke: true },
   // Issue #7513: Host inventory management

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -5672,7 +5672,8 @@
     },
     "secrets": {
       "noticeTitle": "Security Notice",
-      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes."
+      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes.",
+      "tabsLabel": "أقسام الأسرار"
     },
     "vision": {
       "title": "Vision & Multimodal AI",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -5672,7 +5672,8 @@
     },
     "secrets": {
       "noticeTitle": "Security Notice",
-      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes."
+      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes.",
+      "tabsLabel": "Geheimnisbereiche"
     },
     "vision": {
       "title": "Vision & Multimodal AI",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -5679,7 +5679,8 @@
     },
     "secrets": {
       "noticeTitle": "Security Notice",
-      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes."
+      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes.",
+      "tabsLabel": "Secrets sections"
     },
     "vision": {
       "title": "Vision & Multimodal AI",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -5672,7 +5672,8 @@
     },
     "secrets": {
       "noticeTitle": "Security Notice",
-      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes."
+      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes.",
+      "tabsLabel": "Secciones de secretos"
     },
     "vision": {
       "title": "Vision & Multimodal AI",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -6307,7 +6307,8 @@
     },
     "secrets": {
       "noticeTitle": "Security Notice",
-      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes."
+      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes.",
+      "tabsLabel": "بخش‌های اسرار"
     },
     "about": {
       "title": "This is an about page",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -5672,7 +5672,8 @@
     },
     "secrets": {
       "noticeTitle": "Security Notice",
-      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes."
+      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes.",
+      "tabsLabel": "Sections des secrets"
     },
     "vision": {
       "title": "Vision & Multimodal AI",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -6307,7 +6307,8 @@
     },
     "secrets": {
       "noticeTitle": "Security Notice",
-      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes."
+      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes.",
+      "tabsLabel": "מקטעי סודות"
     },
     "about": {
       "title": "This is an about page",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -5672,7 +5672,8 @@
     },
     "secrets": {
       "noticeTitle": "Security Notice",
-      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes."
+      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes.",
+      "tabsLabel": "Noslēpumu sadaļas"
     },
     "vision": {
       "title": "Vision & Multimodal AI",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -5672,7 +5672,8 @@
     },
     "secrets": {
       "noticeTitle": "Security Notice",
-      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes."
+      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes.",
+      "tabsLabel": "Sekcje sekretów"
     },
     "vision": {
       "title": "Vision & Multimodal AI",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -5672,7 +5672,8 @@
     },
     "secrets": {
       "noticeTitle": "Security Notice",
-      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes."
+      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes.",
+      "tabsLabel": "Seções de segredos"
     },
     "vision": {
       "title": "Vision & Multimodal AI",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -6307,7 +6307,8 @@
     },
     "secrets": {
       "noticeTitle": "Security Notice",
-      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes."
+      "noticeText": "Secrets are encrypted at rest and in transit. Only authorized users can view or modify secrets. All access is logged for audit purposes.",
+      "tabsLabel": "خفیہ معلومات کے حصے"
     },
     "about": {
       "title": "This is an about page",

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -851,19 +851,6 @@ export const routes: RouteRecordRaw[] = [
       hideInNav: true,
     },
   },
-  // Issue #6590: Virtual LLM API Keys admin view
-  {
-    path: '/admin/llm-keys',
-    name: 'llm-api-keys',
-    component: () => import('@/views/LLMApiKeysView.vue'),
-    meta: {
-      title: 'LLM API Keys',
-      description: 'Manage virtual LLM API keys with per-key budgets',
-      requiresAuth: true,
-      admin: true,
-      hideInNav: true,
-    },
-  },
   // Issue #1801: Admin User Management
   {
     path: '/admin/users',
@@ -1048,6 +1035,19 @@ export const routes: RouteRecordRaw[] = [
         component: () => import('@/components/security/SecretsManager.vue'),
         meta: {
           title: 'Secrets Manager',
+          hideInNav: true
+        }
+      },
+      // Issue #6590/#10488: Virtual LLM API Keys — relocated under Secrets section
+      {
+        path: 'llm-keys',
+        name: 'secrets-llm-keys',
+        component: () => import('@/views/secrets/LlmApiKeysView.vue'),
+        meta: {
+          title: 'LLM API Keys',
+          description: 'Manage virtual LLM API keys with per-key budgets',
+          requiresAuth: true,
+          admin: true,
           hideInNav: true
         }
       }

--- a/autobot-frontend/src/views/SecretsView.vue
+++ b/autobot-frontend/src/views/SecretsView.vue
@@ -25,6 +25,7 @@
           {{ $t('nav.secrets') }}
         </router-link>
         <router-link
+          v-if="userStore.isAdmin"
           :to="{ name: 'secrets-llm-keys' }"
           class="secrets-tab"
           active-class="secrets-tab--active"
@@ -44,6 +45,12 @@
 // Issue #753: Design token usage instead of Tailwind utilities
 // Issue #10488: Sub-navigation hosts Secrets Manager + LLM API Keys
 import Icon from '@/components/ui/Icon.vue'
+import { useUserStore } from '@/stores/useUserStore'
+
+// LLM API keys are admin-managed (the /secrets/llm-keys route + backend are
+// admin-gated) — only show that tab to admins so non-admins don't see a tab
+// that redirects. (#10488)
+const userStore = useUserStore()
 </script>
 
 <style scoped>

--- a/autobot-frontend/src/views/SecretsView.vue
+++ b/autobot-frontend/src/views/SecretsView.vue
@@ -14,7 +14,26 @@
         </div>
       </div>
 
-      <!-- Secrets content will be handled by the existing secrets component -->
+      <!-- Sub-navigation: switch between Secrets and LLM API Keys -->
+      <nav class="secrets-tabs" :aria-label="$t('views.secrets.tabsLabel')">
+        <router-link
+          :to="{ name: 'secrets-manager' }"
+          class="secrets-tab"
+          active-class="secrets-tab--active"
+          exact-active-class="secrets-tab--active"
+        >
+          {{ $t('nav.secrets') }}
+        </router-link>
+        <router-link
+          :to="{ name: 'secrets-llm-keys' }"
+          class="secrets-tab"
+          active-class="secrets-tab--active"
+        >
+          {{ $t('nav.llmApiKeys') }}
+        </router-link>
+      </nav>
+
+      <!-- Child views (secrets manager / LLM API keys) -->
       <router-view />
     </div>
   </div>
@@ -23,10 +42,8 @@
 <script setup lang="ts">
 // View-level component for secrets management layout
 // Issue #753: Design token usage instead of Tailwind utilities
-import { useI18n } from 'vue-i18n'
+// Issue #10488: Sub-navigation hosts Secrets Manager + LLM API Keys
 import Icon from '@/components/ui/Icon.vue'
-
-const { t } = useI18n()
 </script>
 
 <style scoped>
@@ -79,5 +96,37 @@ const { t } = useI18n()
   font-size: var(--text-sm);
   color: var(--color-warning);
   margin: var(--spacing-0);
+}
+
+/* ============================================
+ * SUB-NAVIGATION TABS
+ * ============================================ */
+
+.secrets-tabs {
+  display: flex;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-xl);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.secrets-tab {
+  padding: var(--spacing-2) var(--spacing-4);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color var(--duration-150) ease, border-color var(--duration-150) ease;
+}
+
+.secrets-tab:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.secrets-tab--active {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
 }
 </style>

--- a/autobot-frontend/src/views/secrets/LlmApiKeysView.vue
+++ b/autobot-frontend/src/views/secrets/LlmApiKeysView.vue
@@ -173,7 +173,7 @@ import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 
 const { t } = useI18n()
-const logger = createLogger('LLMApiKeysView')
+const logger = createLogger('LlmApiKeysView')
 
 interface KeyRow {
   key_id: string


### PR DESCRIPTION
## Thinking Path
Per operator: **credentials belong in the Secrets menu** ('this is where we store all our secrets'). LLM API keys were a standalone `/admin/llm-keys` page — moved them under `/secrets` where secrets live.

## What Changed (autobot-frontend only)
- Moved `views/LLMApiKeysView.vue` → `views/secrets/LlmApiKeysView.vue` (issue/list/revoke/rotate logic + `/api/llm-keys/*` calls unchanged).
- Added child route `/secrets/llm-keys` (name `secrets-llm-keys`, admin-gated) under the existing `/secrets` layout.
- Added a sub-nav tab bar in `SecretsView.vue` (Secrets Manager · LLM API Keys), using design tokens; the LLM Keys tab is **admin-gated** (`v-if="userStore.isAdmin"`) since the route + backend are admin-only.
- Removed the standalone `/admin/llm-keys` route + `nav.llmApiKeys` navItem (credentials no longer a top-level admin link). i18n keys retained.
- `/secrets` is reached via the profile dropdown (`nav.secrets`); the new tab sits within it.

## Verification (local)
- `vue-tsc --noEmit` → **0 errors**; `eslint` (changed files) → **0 errors**; `nav-items-coverage` → **9 passed**; `vite build` → **✓**.

## Model Used
Opus 4.8

Related #10488 · #10503