### PR TITLE
perf(llm): wire response cache + default prompt caching into LLMService.chat() (#10597)

### DIFF
--- a/autobot-backend/llm_shared/cache.py
+++ b/autobot-backend/llm_shared/cache.py
@@ -127,6 +127,7 @@ class LLMResponseCache:
         temperature: float,
         top_k: int = 40,
         top_p: float = 0.9,
+        max_tokens: int | None = None,
     ) -> str:
         """
         Generate cache key with high-performance xxhash (3-5x faster than MD5).
@@ -140,6 +141,9 @@ class LLMResponseCache:
             temperature: LLM temperature setting
             top_k: Top-k sampling parameter
             top_p: Top-p (nucleus) sampling parameter
+            max_tokens: Output token ceiling — part of the key so calls that
+                differ only by max_tokens (e.g. a 1024-token extraction vs a
+                full-length chat) don't collide (#10597).
 
         Returns:
             Cache key string in format "llm_cache:{hash}"
@@ -151,6 +155,7 @@ class LLMResponseCache:
             temperature,
             top_k,
             top_p,
+            max_tokens,
         )
 
         # xxhash is 3-5x faster than MD5 for cache key generation

--- a/autobot-backend/llm_shared/providers/anthropic.py
+++ b/autobot-backend/llm_shared/providers/anthropic.py
@@ -197,10 +197,12 @@ class AnthropicProvider(BaseProvider):
             "temperature": request.temperature,
         }
         if system_content:
-            # Prompt caching (#8171): when enable_prompt_cache=True is set in
-            # request metadata the system message is sent as a content-block
-            # list so Anthropic can cache it across repeated requests.
-            if request.metadata.get("enable_prompt_cache"):
+            # Prompt caching (#8171, #10597): the system message is sent as a
+            # content-block list so Anthropic can cache it across repeated
+            # requests.  Defaults on via config.llm_prompt_cache_default (pure
+            # cost win on the large static system prompt); a caller may still
+            # opt out per-request with enable_prompt_cache=False.
+            if request.metadata.get("enable_prompt_cache", config.llm_prompt_cache_default):
                 kwargs["system"] = [{"type": "text", "text": system_content, "cache_control": {"type": "ephemeral"}}]
             else:
                 kwargs["system"] = system_content

--- a/autobot-backend/services/llm_service.py
+++ b/autobot-backend/services/llm_service.py
@@ -43,6 +43,7 @@ from typing import Any, AsyncIterator, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.ssot_config import config
 from autobot_shared.tracing import get_tracer
 from llm_shared import ProviderRegistry, get_provider_registry
 from llm_shared.cache import CachedResponse, get_llm_cache
@@ -196,24 +197,45 @@ class LLMService:
             LLMResponse.  ``response.error`` is set (non-empty) on failure.
         """
         self._request_count += 1
+        start_time = time.time()
         resolved_type = _normalize_llm_type(llm_type)
         temp, tokens = _apply_task_defaults(resolved_type, temperature, max_tokens)
+
+        # #10597: when the caller doesn't pin a model, optionally select one via
+        # task-type/complexity routing (gated off by default; precision-sensitive).
+        selected_model = model_name or self._select_chat_model(messages, resolved_type)
 
         request = LLMRequest(
             messages=messages,
             llm_type=resolved_type,
-            model_name=model_name,
+            model_name=selected_model,
             temperature=temp,
             max_tokens=tokens,
             timeout=timeout,
             **kwargs,
         )
 
+        # #10597: serve identical requests from the L1/L2 response cache before
+        # hitting any provider.  Streaming has its own path and is not cached.
+        cache_key: str | None = None
+        if self._response_cache is not None:
+            cached, cache_key = await self._optimized_check_cache(
+                messages,
+                selected_model or "",
+                provider_name or "auto",
+                request.request_id,
+                start_time,
+                temperature=temp,
+            )
+            if cached is not None:
+                self._calculate_cache_hit_rate(cached)
+                return cached
+
         # GH#8998: Track attempted models to avoid infinite loops
         attempted_models = []
         fallback_manager = get_fallback_chain_manager()
         current_provider_name = provider_name
-        current_model = model_name
+        current_model = selected_model
         max_fallback_attempts = 10  # Safety limit
 
         while len(attempted_models) < max_fallback_attempts:
@@ -269,6 +291,9 @@ class LLMService:
                         primary_provider=primary_provider_name,
                         fallback_provider=provider.provider_name,
                     )
+                # #10597: cache successful responses for identical future requests.
+                if cache_key and response.content:
+                    await self._optimized_store_cache(cache_key, response, request.request_id)
                 self._track_usage(response, conversation_id)
                 return response
 
@@ -957,6 +982,31 @@ class LLMService:
     # Internal helpers
     # ------------------------------------------------------------------
 
+    def _select_chat_model(self, messages: List[Dict[str, str]], resolved_type: LLMType) -> str | None:
+        """Pick a model when the caller didn't pin one (#10597).
+
+        Gated behind ``config.chat_tiered_routing`` (default off) because model
+        downgrade is precision-sensitive — enable only after rag_benchmarks
+        validation.  Returns None to fall through to the registry default.
+        """
+        if not config.chat_tiered_routing:
+            return None
+        # Task-type pin: classification/extraction are reliably cheap tasks.
+        cheap = {
+            LLMType.CLASSIFICATION: config.classification_model,
+            LLMType.EXTRACTION: config.light_processing_model,
+        }.get(resolved_type)
+        if cheap:
+            return cheap
+        # Otherwise defer to complexity-based tier routing.
+        if self._tier_router is not None:
+            try:
+                selected, _ = self._tier_router.route(messages)
+                return selected or None
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("Tier routing failed, using registry default: %s", exc)
+        return None
+
     def _calculate_cache_hit_rate(self, response: LLMResponse) -> None:
         """Attach vLLM prefix-cache hit rate to response metadata.
 
@@ -977,11 +1027,14 @@ class LLMService:
         provider: str,
         request_id: str,
         start_time: float,
+        temperature: float = 0.7,
     ) -> tuple:
-        """Look up L1/L2 cache for an optimized chat request.
+        """Look up L1/L2 cache for a chat request.
 
         Mirrors the cache-check block in ``LLMInterface._check_cache``
-        (interface.py line 765) but scoped to the optimized-chat path.
+        (interface.py line 765).  Shared by ``chat()`` (#10597) and the
+        optimized vLLM path; ``temperature`` is part of the cache key so calls
+        with different sampling temperatures don't collide.
 
         Returns:
             ``(LLMResponse, cache_key)`` on hit; ``(None, cache_key)`` on miss.
@@ -989,7 +1042,7 @@ class LLMService:
         cache_key = self._response_cache.generate_cache_key(
             messages=messages,
             model=model_name,
-            temperature=0.7,
+            temperature=temperature,
         )
         cached = await self._response_cache.get(cache_key)
         if cached is not None:

--- a/autobot-backend/services/llm_service.py
+++ b/autobot-backend/services/llm_service.py
@@ -171,6 +171,7 @@ class LLMService:
         temperature: float | None = None,
         max_tokens: int | None = None,
         timeout: int = 60,
+        use_cache: bool = True,
         **kwargs: Any,
     ) -> LLMResponse:
         """
@@ -191,6 +192,8 @@ class LLMService:
             temperature: Override temperature for this call.
             max_tokens: Override max_tokens for this call.
             timeout: Request timeout in seconds.
+            use_cache: When True (default) a near-deterministic request may be
+                served from / stored in the response cache (#10597).
             **kwargs: Additional fields forwarded to LLMRequest.
 
         Returns:
@@ -216,9 +219,11 @@ class LLMService:
         )
 
         # #10597: serve identical requests from the L1/L2 response cache before
-        # hitting any provider.  Streaming has its own path and is not cached.
+        # hitting any provider — but only when the request is safely reusable:
+        # caching off, streaming, tool/structured/thinking calls, or
+        # higher-temperature (non-deterministic) requests are never cached.
         cache_key: str | None = None
-        if self._response_cache is not None:
+        if self._is_cacheable(request, temp, use_cache):
             cached, cache_key = await self._optimized_check_cache(
                 messages,
                 selected_model or "",
@@ -226,6 +231,7 @@ class LLMService:
                 request.request_id,
                 start_time,
                 temperature=temp,
+                max_tokens=tokens,
             )
             if cached is not None:
                 self._calculate_cache_hit_rate(cached)
@@ -982,6 +988,24 @@ class LLMService:
     # Internal helpers
     # ------------------------------------------------------------------
 
+    def _is_cacheable(self, request: LLMRequest, temperature: float, use_cache: bool) -> bool:
+        """Whether a chat request may be served from / stored in the cache (#10597).
+
+        Only near-deterministic, safely-reusable requests qualify: caching must
+        be enabled, the response cache present, and the request must not stream,
+        use tools, force structured output, request extended thinking, or run at
+        a temperature above the configured determinism threshold.
+        """
+        if not (use_cache and config.llm_response_cache and self._response_cache is not None):
+            return False
+        if request.stream or request.structured_output:
+            return False
+        if getattr(request, "tools", None) or getattr(request, "tool_choice", None):
+            return False
+        if request.metadata.get("api_kwargs"):  # extended-thinking / provider-specific knobs
+            return False
+        return temperature is not None and temperature <= config.llm_cache_max_temperature
+
     def _select_chat_model(self, messages: List[Dict[str, str]], resolved_type: LLMType) -> str | None:
         """Pick a model when the caller didn't pin one (#10597).
 
@@ -1028,13 +1052,14 @@ class LLMService:
         request_id: str,
         start_time: float,
         temperature: float = 0.7,
+        max_tokens: int | None = None,
     ) -> tuple:
         """Look up L1/L2 cache for a chat request.
 
         Mirrors the cache-check block in ``LLMInterface._check_cache``
         (interface.py line 765).  Shared by ``chat()`` (#10597) and the
-        optimized vLLM path; ``temperature`` is part of the cache key so calls
-        with different sampling temperatures don't collide.
+        optimized vLLM path; ``temperature`` and ``max_tokens`` are part of the
+        cache key so calls differing only in those don't collide.
 
         Returns:
             ``(LLMResponse, cache_key)`` on hit; ``(None, cache_key)`` on miss.
@@ -1043,6 +1068,7 @@ class LLMService:
             messages=messages,
             model=model_name,
             temperature=temperature,
+            max_tokens=max_tokens,
         )
         cached = await self._response_cache.get(cache_key)
         if cached is not None:

--- a/autobot-backend/tests/services/test_llm_service_caching.py
+++ b/autobot-backend/tests/services/test_llm_service_caching.py
@@ -97,9 +97,9 @@ class _FakeCache:
         self.gets = 0
         self.sets = 0
 
-    def generate_cache_key(self, messages, model, temperature, top_k=40, top_p=0.9) -> str:
+    def generate_cache_key(self, messages, model, temperature, top_k=40, top_p=0.9, max_tokens=None) -> str:
         last = messages[-1]["content"] if messages else ""
-        return f"{model}|{temperature}|{last}"
+        return f"{model}|{temperature}|{max_tokens}|{last}"
 
     async def get(self, key):
         self.gets += 1
@@ -123,14 +123,58 @@ async def test_chat_cache_hit_short_circuits_provider():
     svc, provider, cache = _make_service()
     messages: List[Dict[str, str]] = [{"role": "user", "content": "hi there"}]
 
-    r1 = await svc.chat(messages)
+    # temperature=0 → deterministic → cacheable.
+    r1 = await svc.chat(messages, temperature=0.0)
     assert r1.content == "hello world"
     assert provider.calls == 1
     assert cache.sets == 1  # stored on success
 
-    r2 = await svc.chat(messages)
+    r2 = await svc.chat(messages, temperature=0.0)
     assert provider.calls == 1  # served from cache, provider untouched
     assert r2.cached is True
+
+
+@pytest.mark.asyncio
+async def test_chat_different_max_tokens_do_not_collide():
+    svc, provider, _ = _make_service()
+    messages = [{"role": "user", "content": "same prompt"}]
+
+    await svc.chat(messages, temperature=0.0, max_tokens=100)
+    await svc.chat(messages, temperature=0.0, max_tokens=2000)
+    # Different max_tokens → different cache key → no stale collision.
+    assert provider.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_chat_high_temperature_not_cached():
+    svc, provider, _ = _make_service()
+    messages = [{"role": "user", "content": "be creative"}]
+
+    await svc.chat(messages, temperature=0.9)
+    await svc.chat(messages, temperature=0.9)
+    # Above the determinism threshold → never cached, responses may vary.
+    assert provider.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_chat_use_cache_false_bypasses():
+    svc, provider, _ = _make_service()
+    messages = [{"role": "user", "content": "x"}]
+
+    await svc.chat(messages, temperature=0.0, use_cache=False)
+    await svc.chat(messages, temperature=0.0, use_cache=False)
+    assert provider.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_chat_structured_output_not_cached():
+    svc, provider, _ = _make_service()
+    messages = [{"role": "user", "content": "give json"}]
+
+    await svc.chat(messages, temperature=0.0, structured_output=True)
+    await svc.chat(messages, temperature=0.0, structured_output=True)
+    # Structured-output responses are not safely reusable → not cached.
+    assert provider.calls == 2
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/tests/services/test_llm_service_caching.py
+++ b/autobot-backend/tests/services/test_llm_service_caching.py
@@ -1,0 +1,170 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for LLMService cost-machinery wiring (#10597).
+
+The test harness stubs ``services.llm_service`` in sys.modules (services/__init__
+pulls in the heavy npu/Redis stack).  We load the real module file under a
+private name so we can exercise ``chat()`` directly without replacing the
+session-wide stub other tests rely on.  ``llm_shared`` stays stubbed, so the
+import is lightweight (no provider SDKs, no Redis).
+
+Covers:
+- Response cache wired into chat(): a cache hit short-circuits the provider.
+- A successful response is written to the cache.
+- Chat tiered routing gated off by default (no model downgrade).
+- Task-type cheap-model pin when routing is explicitly enabled.
+- An explicit model_name always overrides routing.
+- Anthropic prompt caching defaults on via config.
+"""
+
+from __future__ import annotations
+
+import importlib.util as _ilu
+import pathlib
+import sys
+from typing import Any, Dict, List
+
+import pytest
+
+from autobot_shared.ssot_config import config
+from llm_shared.models import LLMRequest, LLMResponse
+from llm_shared.types import LLMType
+
+_BACKEND = pathlib.Path(__file__).resolve().parents[2]  # autobot-backend/
+
+
+def _load_real_module(private_name: str, relpath: str):
+    """Load a real module file under a private name (no sys.modules clobber)."""
+    spec = _ilu.spec_from_file_location(private_name, str(_BACKEND / relpath))
+    assert spec and spec.loader
+    mod = _ilu.module_from_spec(spec)
+    sys.modules[private_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Real submodule llm_service imports that the harness doesn't pre-load.
+if "llm_shared.rate_limit_backoff" not in sys.modules:
+    _load_real_module("llm_shared.rate_limit_backoff", "llm_shared/rate_limit_backoff.py")
+
+_llm_service_mod = _load_real_module("_real_llm_service_10597", "services/llm_service.py")
+LLMService = _llm_service_mod.LLMService
+
+
+class _FakeProvider:
+    """Minimal provider that records the request and returns a fixed reply."""
+
+    provider_name = "fake"
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.last_request: LLMRequest | None = None
+
+    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+        self.calls += 1
+        self.last_request = request
+        return LLMResponse(
+            content="hello world",
+            model=request.model_name or "fake-default",
+            provider=self.provider_name,
+            request_id=request.request_id,
+        )
+
+
+class _FakeRegistry:
+    """Registry stub returning a single fake provider."""
+
+    def __init__(self, provider: _FakeProvider) -> None:
+        self._provider = provider
+
+    async def get_provider_for_request(self, provider_name=None, conversation_id=None):
+        return self._provider
+
+    def get_provider_by_name(self, name: str):
+        return self._provider
+
+    def list_providers(self):
+        return [{"name": self._provider.provider_name}]
+
+
+class _FakeCache:
+    """In-memory stand-in for the L1/L2 response cache."""
+
+    def __init__(self) -> None:
+        self.store: Dict[str, Any] = {}
+        self.gets = 0
+        self.sets = 0
+
+    def generate_cache_key(self, messages, model, temperature, top_k=40, top_p=0.9) -> str:
+        last = messages[-1]["content"] if messages else ""
+        return f"{model}|{temperature}|{last}"
+
+    async def get(self, key):
+        self.gets += 1
+        return self.store.get(key)
+
+    async def set(self, key, response, skip_redis: bool = False) -> None:
+        self.sets += 1
+        self.store[key] = response
+
+
+def _make_service():
+    provider = _FakeProvider()
+    svc = LLMService(registry=_FakeRegistry(provider))
+    cache = _FakeCache()
+    svc._response_cache = cache
+    return svc, provider, cache
+
+
+@pytest.mark.asyncio
+async def test_chat_cache_hit_short_circuits_provider():
+    svc, provider, cache = _make_service()
+    messages: List[Dict[str, str]] = [{"role": "user", "content": "hi there"}]
+
+    r1 = await svc.chat(messages)
+    assert r1.content == "hello world"
+    assert provider.calls == 1
+    assert cache.sets == 1  # stored on success
+
+    r2 = await svc.chat(messages)
+    assert provider.calls == 1  # served from cache, provider untouched
+    assert r2.cached is True
+
+
+@pytest.mark.asyncio
+async def test_chat_does_not_route_by_default(monkeypatch):
+    monkeypatch.setattr(config, "chat_tiered_routing", False, raising=False)
+    svc, provider, _ = _make_service()
+
+    await svc.chat([{"role": "user", "content": "hi"}], llm_type=LLMType.CLASSIFICATION)
+    # No model pinned + routing off → registry default (model_name None).
+    assert provider.last_request.model_name is None
+
+
+@pytest.mark.asyncio
+async def test_chat_pins_cheap_model_when_routing_enabled(monkeypatch):
+    monkeypatch.setattr(config, "chat_tiered_routing", True, raising=False)
+    svc, provider, _ = _make_service()
+
+    await svc.chat([{"role": "user", "content": "classify this"}], llm_type=LLMType.CLASSIFICATION)
+    assert provider.last_request.model_name == config.classification_model
+
+
+@pytest.mark.asyncio
+async def test_explicit_model_overrides_routing(monkeypatch):
+    monkeypatch.setattr(config, "chat_tiered_routing", True, raising=False)
+    svc, provider, _ = _make_service()
+
+    await svc.chat(
+        [{"role": "user", "content": "x"}],
+        model_name="explicit-model",
+        llm_type=LLMType.CLASSIFICATION,
+    )
+    assert provider.last_request.model_name == "explicit-model"
+
+
+def test_prompt_cache_default_flag_on():
+    """Anthropic prompt caching is driven by this default (pure cost win)."""
+    assert config.llm_prompt_cache_default is True

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -193,6 +193,11 @@ class LLMConfig(BaseSettings):
     # validated via knowledge/rag_benchmarks.py.
     llm_prompt_cache_default: bool = Field(default=True, alias="AUTOBOT_LLM_PROMPT_CACHE_DEFAULT")
     chat_tiered_routing: bool = Field(default=False, alias="AUTOBOT_CHAT_TIERED_ROUTING")
+    # Response cache for chat(): only near-deterministic, safely-reusable
+    # requests are cached (low temperature, no tools/structured-output/thinking).
+    # Above this temperature responses must vary, so they are never cached.
+    llm_response_cache: bool = Field(default=True, alias="AUTOBOT_LLM_RESPONSE_CACHE")
+    llm_cache_max_temperature: float = Field(default=0.3, alias="AUTOBOT_LLM_CACHE_MAX_TEMPERATURE")
 
     # Provider-specific endpoints (each provider can have its own URL)
     ollama_endpoint: str = Field(default="http://127.0.0.1:11434", alias="AUTOBOT_OLLAMA_ENDPOINT")

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -187,6 +187,13 @@ class LLMConfig(BaseSettings):
     # Default provider for all models (can be overridden per-model)
     provider: str = Field(default="ollama", alias="AUTOBOT_LLM_PROVIDER")
 
+    # LLM cost-efficiency toggles (#10597)
+    # Prompt caching is a pure cost win → default on.  Chat tiered routing
+    # downgrades models by complexity (precision-sensitive) → default off until
+    # validated via knowledge/rag_benchmarks.py.
+    llm_prompt_cache_default: bool = Field(default=True, alias="AUTOBOT_LLM_PROMPT_CACHE_DEFAULT")
+    chat_tiered_routing: bool = Field(default=False, alias="AUTOBOT_CHAT_TIERED_ROUTING")
+
     # Provider-specific endpoints (each provider can have its own URL)
     ollama_endpoint: str = Field(default="http://127.0.0.1:11434", alias="AUTOBOT_OLLAMA_ENDPOINT")
     openai_endpoint: str = Field(default="https://api.openai.com/v1", alias="AUTOBOT_OPENAI_ENDPOINT")


### PR DESCRIPTION
## Thinking Path
A codebase efficiency audit (umbrella #10603) found AutoBot's LLM cost machinery is built but **bypassed by the hot path**: `LLMService.chat()` initializes `self._response_cache` and `self._tier_router` in `__init__` but never uses them, and Anthropic prompt caching only fired on escalation. This PR connects those wires — shipping the pure-cost-win pieces active by default and gating the precision-sensitive model-downgrade pieces behind validated-rollout flags.

## What Changed
- **Response cache wired into `chat()`** (`services/llm_service.py`): looks up the L1/L2 cache before any provider call and stores successful responses. Only **safely-reusable** requests are cached, via `_is_cacheable()`: gated by `config.llm_response_cache`, and skipping streaming, tool calls, `structured_output`, extended-thinking (`metadata.api_kwargs`), and any request above `config.llm_cache_max_temperature` (default 0.3). So low-temp classification/extraction/RAG benefit while creative chat (default temp 0.7) is never cached → no determinism regression. Per-call opt-out via `chat(use_cache=False)`.
- **Cache key now includes `max_tokens`** (`llm_shared/cache.py`): calls differing only by `max_tokens` no longer collide (e.g. a 1024-token extraction vs a full-length chat).
- **Anthropic prompt caching defaults on** (`llm_shared/providers/anthropic.py`): driven by new `config.llm_prompt_cache_default` (default `True`) — input-token discount on the large static system prompt. Callers may still opt out per-request with `enable_prompt_cache=False`.
- **Optional cheap-model routing** (`chat()` + `_select_chat_model`): when no model is pinned, route by task-type/complexity — gated behind `config.chat_tiered_routing` (**default OFF**; benchmark-gated enablement tracked in #10621).
- **Config flags** (`autobot_shared/ssot_config.py`): `AUTOBOT_LLM_PROMPT_CACHE_DEFAULT` (true), `AUTOBOT_CHAT_TIERED_ROUTING` (false), `AUTOBOT_LLM_RESPONSE_CACHE` (true), `AUTOBOT_LLM_CACHE_MAX_TEMPERATURE` (0.3).

No code deleted; duplicate cache logic converged (no `_v2`).

## Verification
- `tests/services/test_llm_service_caching.py` — 9 tests, all pass: cache hit short-circuits provider, store-on-success, different `max_tokens` don't collide, high-temperature not cached, `use_cache=False` bypasses, `structured_output` not cached, routing gated off by default, cheap-model pin when enabled, explicit model overrides routing, prompt-cache default flag on.
- `flake8 --max-line-length=120` clean; `black`/`isort` no changes.
- Code-reviewer pass addressed (cache-key scoping + cache-safety gating).
- Pre-existing local routing-test failures confirmed unrelated (exercise `ComplexityRouter`, untouched here).

## Model Used
Claude Opus 4.8 (1M context)

Closes #10597. Follow-up: #10621. Part of umbrella #10603.