### PR TITLE
refactor(memory): fully retire EnhancedMemoryManager class — fold into UnifiedMemoryManager (#10572)

### DIFF
--- a/autobot-backend/memory/__init__.py
+++ b/autobot-backend/memory/__init__.py
@@ -40,7 +40,6 @@ from .cache import LRUCacheManager
 
 # Backward Compatibility Wrappers
 from .compat import (
-    EnhancedMemoryManager,
     LongTermMemoryManager,
     get_enhanced_memory_manager,
     get_long_term_memory_manager,
@@ -89,7 +88,6 @@ __all__ = [
     # Main Manager
     "UnifiedMemoryManager",
     # Compatibility Wrappers
-    "EnhancedMemoryManager",
     "LongTermMemoryManager",
     # Global Instances
     "get_enhanced_memory_manager",

--- a/autobot-backend/memory/compat.py
+++ b/autobot-backend/memory/compat.py
@@ -4,274 +4,27 @@
 # Author: mrveiss
 """
 Backward Compatibility Wrappers - Drop-in replacements for legacy APIs
+
+#10572: EnhancedMemoryManager subclass removed — all sync convenience
+methods (create_task_record, start_task, complete_task, fail_task,
+fail_task, log_task_execution, get_task_history_sync, add_markdown_reference,
+_get_embedding_cache_size, cleanup_old_data) now live on UnifiedMemoryManager
+directly.  get_enhanced_memory_manager() is retained as an alias so
+existing call-sites that import it by name continue to work unchanged;
+it now returns a plain UnifiedMemoryManager instance.
 """
 
-import hashlib
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 
-from .enums import MemoryCategory, TaskPriority, TaskStatus
+from .enums import MemoryCategory, TaskStatus
 from .manager import UnifiedMemoryManager
 from .models import MemoryEntry, TaskExecutionRecord
 
 logger = get_logger(__name__)
-
-
-class EnhancedMemoryManager(UnifiedMemoryManager):
-    """
-    Backward compatibility wrapper for enhanced_memory_manager.py
-
-    All existing code using EnhancedMemoryManager continues to work
-    without any changes. This is a drop-in replacement.
-
-    Used by 7 files:
-    - src/voice_processing_system.py
-    - src/context_aware_decision_system.py
-    - src/markdown_reference_system.py
-    - src/computer_vision_system.py
-    - src/takeover_manager.py
-    - src/modern_ai_integration.py
-    - backend/api/enhanced_memory.py
-    """
-
-    def __init__(self, db_path: str = "data/enhanced_memory.db"):
-        """Initialize with enhanced_memory_manager.py defaults"""
-        super().__init__(db_path=db_path, enable_cache=True, enable_monitoring=False)
-        logger.info("EnhancedMemoryManager compatibility wrapper initialized")
-
-    def log_task_execution(self, record: TaskExecutionRecord) -> str:
-        """
-        Alias for log_task (backward compatibility)
-
-        ⚠️ WARNING: This is a synchronous method. DO NOT call from async code.
-        For async code, create UnifiedMemoryManager directly and use:
-            await manager.log_task(record)
-        """
-        return self.log_task_sync(record)
-
-    def _run_sync(self, coro):
-        """
-        Run async coroutine synchronously (Issue #742 - backward compat helper).
-
-        #7469: this helper now delegates to ``autobot_shared.async_compat.run_or_schedule``
-        which carries the same try-loop / threadpool defensive pattern,
-        deduplicated across the codebase. Behavior is identical; one
-        source of truth ensures all callers stay in sync if the pattern
-        ever needs an update.
-        """
-        from autobot_shared.async_compat import run_or_schedule
-
-        return run_or_schedule(coro)
-
-    def create_task_record(
-        self,
-        task_name: str,
-        description: str,
-        priority: TaskPriority = TaskPriority.MEDIUM,
-        agent_type: str | None = None,
-        inputs: Dict | None = None,
-        parent_task_id: str | None = None,
-        metadata: Dict | None = None,
-    ) -> str:
-        """
-        Create a new task with auto-generated task_id (Issue #742).
-
-        Args:
-            task_name: Name of the task
-            description: Task description
-            priority: Task priority (default: MEDIUM)
-            agent_type: Type of agent executing task
-            inputs: Task inputs dictionary
-            parent_task_id: Parent task ID if this is a subtask
-            metadata: Additional metadata
-
-        Returns:
-            Generated task_id
-
-        ⚠️ WARNING: This is a synchronous method. DO NOT call from async code.
-        """
-        # Generate task_id using same pattern as enhanced_memory_manager.py
-        task_id = hashlib.sha256(f"{task_name}_{datetime.now(tz=timezone.utc).isoformat()}".encode()).hexdigest()[:16]
-
-        # Create TaskExecutionRecord
-        record = TaskExecutionRecord(
-            task_id=task_id,
-            task_name=task_name,
-            description=description,
-            status=TaskStatus.PENDING,
-            priority=priority,
-            created_at=datetime.now(tz=timezone.utc),
-            agent_type=agent_type,
-            inputs=inputs,
-            parent_task_id=parent_task_id,
-            metadata=metadata,
-        )
-
-        # Log task synchronously
-        self.log_task_sync(record)
-        logger.info("Created task record: %s - %s", task_id, task_name)
-        return task_id
-
-    def start_task(self, task_id: str) -> bool:
-        """
-        Mark task as started (Issue #742).
-
-        Args:
-            task_id: Task identifier
-
-        Returns:
-            True if updated successfully, False otherwise
-
-        ⚠️ WARNING: This is a synchronous method. DO NOT call from async code.
-        """
-        result = self._run_sync(
-            self.update_task_status(
-                task_id,
-                TaskStatus.IN_PROGRESS,
-                started_at=datetime.now(tz=timezone.utc),
-            )
-        )
-        if result:
-            logger.info("Started task: %s", task_id)
-        else:
-            logger.warning("Task not found for start: %s", task_id)
-        return result
-
-    def complete_task(
-        self,
-        task_id: str,
-        outputs: Dict | None = None,
-        status: TaskStatus = TaskStatus.COMPLETED,
-    ) -> bool:
-        """
-        Mark task as completed (Issue #742).
-
-        Args:
-            task_id: Task identifier
-            outputs: Optional task outputs
-            status: Task status (default: COMPLETED)
-
-        Returns:
-            True if updated successfully, False otherwise
-
-        ⚠️ WARNING: This is a synchronous method. DO NOT call from async code.
-        """
-        # Calculate duration by fetching task and computing from started_at
-        task = self._run_sync(self.get_task(task_id))
-        if not task:
-            logger.warning("Task not found for completion: %s", task_id)
-            return False
-
-        completed_at = datetime.now(tz=timezone.utc)
-        duration = None
-        if task.started_at:
-            duration = (completed_at - task.started_at).total_seconds()
-
-        result = self._run_sync(
-            self.update_task_status(
-                task_id,
-                status,
-                completed_at=completed_at,
-                duration_seconds=duration,
-                outputs=outputs,
-            )
-        )
-
-        if result:
-            logger.info("Completed task: %s (duration: %ss)", task_id, duration)
-        return result
-
-    def fail_task(self, task_id: str, error_message: str, retry_count: int = 0) -> bool:
-        """
-        Mark task as failed (Issue #742).
-
-        Args:
-            task_id: Task identifier
-            error_message: Error description
-            retry_count: Number of retries attempted
-
-        Returns:
-            True if updated successfully, False otherwise
-
-        ⚠️ WARNING: This is a synchronous method. DO NOT call from async code.
-        """
-        result = self._run_sync(
-            self.update_task_status(
-                task_id,
-                TaskStatus.FAILED,
-                completed_at=datetime.now(tz=timezone.utc),
-                error_message=error_message,
-                retry_count=retry_count,
-            )
-        )
-
-        if result:
-            logger.error("Failed task: %s - %s", task_id, error_message)
-        else:
-            logger.warning("Task not found for failure: %s", task_id)
-        return result
-
-    def get_task_history_sync(
-        self,
-        agent_type: str | None = None,
-        status: TaskStatus | None = None,
-        limit: int = 100,
-        days_back: int = 30,
-    ) -> List[TaskExecutionRecord]:
-        """
-        Query task history synchronously (Issue #742).
-
-        Args:
-            agent_type: Filter by agent type
-            status: Filter by task status
-            limit: Maximum results
-            days_back: How many days back to search
-
-        Returns:
-            List of TaskExecutionRecord matching filters
-
-        ⚠️ WARNING: This is a synchronous method. DO NOT call from async code.
-        """
-        # Convert days_back to start_date
-        start_date = datetime.now(tz=timezone.utc) - timedelta(days=days_back)
-
-        return self._run_sync(
-            self.get_task_history(
-                agent_type=agent_type,
-                status=status,
-                priority=None,
-                start_date=start_date,
-                end_date=None,
-                limit=limit,
-            )
-        )
-
-    def cleanup_old_data(self, days_to_keep: int = 90) -> Dict:
-        """
-        Cleanup old records (Issue #742).
-
-        Args:
-            days_to_keep: Retention period in days
-
-        Returns:
-            Dictionary with cleanup statistics (matches original API):
-            - tasks_deleted: Number of old tasks/memories deleted
-            - embeddings_deleted: Number of old embeddings deleted (0 in unified manager)
-
-        ⚠️ WARNING: This is a synchronous method. DO NOT call from async code.
-        """
-        memories_deleted = self._run_sync(self.cleanup_old_memories(days_to_keep))
-
-        # Match original enhanced_memory_manager.py return structure
-        result = {
-            "tasks_deleted": memories_deleted,
-            "embeddings_deleted": 0,  # Unified manager doesn't track embeddings separately
-        }
-        logger.info("Cleanup completed: %s", result)
-        return result
 
 
 class LongTermMemoryManager:
@@ -367,14 +120,15 @@ class LongTermMemoryManager:
 
 # ============================================================================
 # GLOBAL INSTANCES (for drop-in replacement)
+# get_enhanced_memory_manager retained for call-site backward compatibility;
+# now returns a plain UnifiedMemoryManager instance (#10572).
 # ============================================================================
 
-get_enhanced_memory_manager = lazy_singleton(EnhancedMemoryManager)
+get_enhanced_memory_manager = lazy_singleton(UnifiedMemoryManager)
 get_long_term_memory_manager = lazy_singleton(LongTermMemoryManager)
 
 
 __all__ = [
-    "EnhancedMemoryManager",
     "LongTermMemoryManager",
     "get_enhanced_memory_manager",
     "get_long_term_memory_manager",

--- a/autobot-backend/memory/compat.py
+++ b/autobot-backend/memory/compat.py
@@ -14,15 +14,14 @@ existing call-sites that import it by name continue to work unchanged;
 it now returns a plain UnifiedMemoryManager instance.
 """
 
-from datetime import datetime, timedelta, timezone
 from typing import Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 
-from .enums import MemoryCategory, TaskStatus
+from .enums import MemoryCategory
 from .manager import UnifiedMemoryManager
-from .models import MemoryEntry, TaskExecutionRecord
+from .models import MemoryEntry
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/memory/manager.py
+++ b/autobot-backend/memory/manager.py
@@ -820,5 +820,37 @@ class UnifiedMemoryManager:
         logger.info("cleanup_old_data completed: %s", result)
         return result
 
+    def log_task_execution(self, record: "TaskExecutionRecord") -> str:
+        """Alias for log_task_sync for backward compatibility (sync wrapper).
+
+        Do NOT call from async code — use await log_task() instead.
+        """
+        return self.log_task_sync(record)
+
+    def get_task_history_sync(
+        self,
+        agent_type: str | None = None,
+        status: "TaskStatus | None" = None,
+        limit: int = 100,
+        days_back: int = 30,
+    ) -> List:
+        """Query task history synchronously (sync wrapper).
+
+        Do NOT call from async code — use await get_task_history() instead.
+        """
+        from datetime import timedelta
+
+        start_date = datetime.now(tz=timezone.utc) - timedelta(days=days_back)
+        return self._run_sync(
+            self.get_task_history(
+                agent_type=agent_type,
+                status=status,
+                priority=None,
+                start_date=start_date,
+                end_date=None,
+                limit=limit,
+            )
+        )
+
 
 __all__ = ["UnifiedMemoryManager"]

--- a/autobot-backend/memory/memory_package_test.py
+++ b/autobot-backend/memory/memory_package_test.py
@@ -21,7 +21,6 @@ from pathlib import Path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from memory import (
-    EnhancedMemoryManager,
     LongTermMemoryManager,
     MemoryCategory,
     MemoryEntry,
@@ -39,7 +38,6 @@ def test_1_import_verification():
 
     # Verify classes
     assert UnifiedMemoryManager is not None
-    assert EnhancedMemoryManager is not None
     assert LongTermMemoryManager is not None
 
     # Verify enums
@@ -192,14 +190,14 @@ async def test_5_strategy_pattern():
 
 
 def test_6_backward_compatibility_enhanced():
-    """Test 6: EnhancedMemoryManager compatibility wrapper"""
-    print("\n[TEST 6] EnhancedMemoryManager backward compatibility...")  # noqa: print
+    """Test 6: UnifiedMemoryManager sync compatibility methods (log_task_execution, log_task_sync)"""
+    print("\n[TEST 6] UnifiedMemoryManager sync-wrapper backward compatibility...")  # noqa: print
 
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "test_enhanced.db"
 
-        # Use old API (should work without changes)
-        manager = EnhancedMemoryManager(str(db_path))
+        # UnifiedMemoryManager carries all sync wrappers formerly on EnhancedMemoryManager
+        manager = UnifiedMemoryManager(str(db_path))
         assert manager is not None
 
         # Create task record
@@ -228,7 +226,7 @@ def test_6_backward_compatibility_enhanced():
         task_id2 = manager.log_task_execution(record2)
         assert task_id2 == "bc-002"
 
-    print("✅ PASSED: EnhancedMemoryManager backward compatibility works")  # noqa: print
+    print("✅ PASSED: UnifiedMemoryManager sync-wrapper backward compatibility works")  # noqa: print
 
 
 async def test_7_backward_compatibility_longterm():
@@ -347,7 +345,6 @@ def test_10_all_features_preserved():
     assert hasattr(manager, "get_statistics")
 
     # Backward compatibility
-    assert EnhancedMemoryManager is not None
     assert LongTermMemoryManager is not None
 
     print("✅ PASSED: All features from 3 managers preserved")  # noqa: print

--- a/autobot-backend/performance_benchmarks_test.py
+++ b/autobot-backend/performance_benchmarks_test.py
@@ -19,7 +19,7 @@ import psutil
 import pytest
 
 from knowledge import KnowledgeBase
-from memory.compat import EnhancedMemoryManager
+from memory import UnifiedMemoryManager
 
 # Import components to benchmark
 from orchestrator import Orchestrator
@@ -366,9 +366,7 @@ class TestMemorySystemPerformance:
         """Set up test environment"""
         self.benchmark = PerformanceBenchmark()
 
-        # EnhancedMemoryManager now delegates to UnifiedMemoryManager (memory.compat)
-        # which does not use global_config_manager — construct directly.
-        self.memory_manager = EnhancedMemoryManager()
+        self.memory_manager = UnifiedMemoryManager()
 
     async def test_memory_storage_performance(self):
         """Benchmark memory storage operations"""
@@ -460,7 +458,7 @@ class TestSystemIntegrationPerformance:
         with (
             patch("orchestrator.Orchestrator") as mock_orchestrator_class,
             patch("knowledge_base.KnowledgeBase") as mock_kb_class,
-            patch("memory.compat.EnhancedMemoryManager") as mock_memory_class,
+            patch("memory.manager.UnifiedMemoryManager") as mock_memory_class,
         ):
             # Set up mocks
             mock_orchestrator = MagicMock()

--- a/autobot-backend/phase7_enhanced_memory_test.py
+++ b/autobot-backend/phase7_enhanced_memory_test.py
@@ -13,10 +13,8 @@ from pathlib import Path
 # Add project root to Python path
 sys.path.append(str(Path(__file__).parent))
 
-from memory import TaskPriority, UnifiedMemoryManager
-from memory import TaskPriority, UnifiedMemoryManager
-
 from markdown_reference_system import MarkdownReferenceSystem
+from memory import TaskPriority, UnifiedMemoryManager
 from task_execution_tracker import TaskExecutionTracker
 
 

--- a/autobot-backend/phase7_enhanced_memory_test.py
+++ b/autobot-backend/phase7_enhanced_memory_test.py
@@ -13,8 +13,10 @@ from pathlib import Path
 # Add project root to Python path
 sys.path.append(str(Path(__file__).parent))
 
+from memory import TaskPriority, UnifiedMemoryManager
+from memory import TaskPriority, UnifiedMemoryManager
+
 from markdown_reference_system import MarkdownReferenceSystem
-from memory import EnhancedMemoryManager, TaskPriority
 from task_execution_tracker import TaskExecutionTracker
 
 
@@ -25,7 +27,7 @@ async def test_enhanced_memory_system():
 
     # Test 1: Enhanced Memory Manager
     print("\n1. Testing Enhanced Memory Manager...")  # noqa: print
-    memory_manager = EnhancedMemoryManager(db_path="data/test_enhanced_memory.db")
+    memory_manager = UnifiedMemoryManager(db_path="data/test_enhanced_memory.db")
 
     # Create a test task
     task_id = memory_manager.create_task_record(
@@ -132,7 +134,7 @@ async def test_embedding_system():
     """Test the embedding storage system"""
     print("\n6. Testing Embedding Storage System...")  # noqa: print
 
-    memory_manager = EnhancedMemoryManager(db_path="data/test_enhanced_memory.db")
+    memory_manager = UnifiedMemoryManager(db_path="data/test_enhanced_memory.db")
 
     # Test embedding storage
     test_content = "This is a test document for embedding storage validation"

--- a/autobot-backend/system_benchmarks_performance_test.py
+++ b/autobot-backend/system_benchmarks_performance_test.py
@@ -11,9 +11,10 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import psutil
 import pytest
+from memory import UnifiedMemoryManager
+from memory import UnifiedMemoryManager
 
 from config.manager import ConfigManager as ConfigManager
-from memory import EnhancedMemoryManager
 from multimodal_processor import (
     ModalityType,
     MultiModalInput,
@@ -175,7 +176,7 @@ class TestSystemPerformanceBenchmarks:
 
     def test_memory_manager_performance(self):
         """Test memory manager performance"""
-        memory_manager = EnhancedMemoryManager()
+        memory_manager = UnifiedMemoryManager()
 
         # Test memory usage during task storage
         def store_multiple_tasks():
@@ -260,7 +261,7 @@ class TestSystemPerformanceBenchmarks:
 
         # Test memory manager startup
         start_time = time.time()
-        EnhancedMemoryManager()
+        UnifiedMemoryManager()
         memory_startup_time = (time.time() - start_time) * 1000
 
         assert memory_startup_time < 200.0, f"Memory manager startup too slow: {memory_startup_time}ms"

--- a/autobot-backend/system_benchmarks_performance_test.py
+++ b/autobot-backend/system_benchmarks_performance_test.py
@@ -11,10 +11,9 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import psutil
 import pytest
-from memory import UnifiedMemoryManager
-from memory import UnifiedMemoryManager
 
 from config.manager import ConfigManager as ConfigManager
+from memory import UnifiedMemoryManager
 from multimodal_processor import (
     ModalityType,
     MultiModalInput,

--- a/autobot-backend/tests/memory/test_compat_singletons.py
+++ b/autobot-backend/tests/memory/test_compat_singletons.py
@@ -27,8 +27,7 @@ def test_get_enhanced_memory_manager_returns_instance_not_callable():
     with patch.object(UnifiedMemoryManager, "__init__", return_value=None):
         result = get_enhanced_memory_manager()
     assert not inspect.isfunction(result), (
-        f"get_enhanced_memory_manager() returned {type(result).__name__!r}; "
-        "expected UnifiedMemoryManager instance"
+        f"get_enhanced_memory_manager() returned {type(result).__name__!r}; " "expected UnifiedMemoryManager instance"
     )
     assert isinstance(result, UnifiedMemoryManager)
 
@@ -38,8 +37,7 @@ def test_get_long_term_memory_manager_returns_instance_not_callable():
     with patch.object(UnifiedMemoryManager, "__init__", return_value=None):
         result = get_long_term_memory_manager()
     assert not inspect.isfunction(result), (
-        f"get_long_term_memory_manager() returned {type(result).__name__!r}; "
-        "expected LongTermMemoryManager instance"
+        f"get_long_term_memory_manager() returned {type(result).__name__!r}; " "expected LongTermMemoryManager instance"
     )
     assert isinstance(result, LongTermMemoryManager)
 

--- a/autobot-backend/tests/memory/test_compat_singletons.py
+++ b/autobot-backend/tests/memory/test_compat_singletons.py
@@ -2,17 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Tests for memory/compat.py singleton accessors (Bug #5622).
+"""Tests for memory/compat.py singleton accessors (Bug #5622, updated #10572).
 
 get_enhanced_memory_manager() and get_long_term_memory_manager() must return
 class instances, not the lazy_singleton callable.
+
+#10572: EnhancedMemoryManager class removed; get_enhanced_memory_manager() now
+returns a UnifiedMemoryManager instance (the canonical manager).
 """
 
 import inspect
 from unittest.mock import patch
 
 from memory.compat import (
-    EnhancedMemoryManager,
     LongTermMemoryManager,
     get_enhanced_memory_manager,
     get_long_term_memory_manager,
@@ -21,13 +23,14 @@ from memory.manager import UnifiedMemoryManager
 
 
 def test_get_enhanced_memory_manager_returns_instance_not_callable():
-    """get_enhanced_memory_manager() must return EnhancedMemoryManager, not a function."""
+    """get_enhanced_memory_manager() must return UnifiedMemoryManager, not a function."""
     with patch.object(UnifiedMemoryManager, "__init__", return_value=None):
         result = get_enhanced_memory_manager()
     assert not inspect.isfunction(result), (
-        f"get_enhanced_memory_manager() returned {type(result).__name__!r}; " "expected EnhancedMemoryManager instance"
+        f"get_enhanced_memory_manager() returned {type(result).__name__!r}; "
+        "expected UnifiedMemoryManager instance"
     )
-    assert isinstance(result, EnhancedMemoryManager)
+    assert isinstance(result, UnifiedMemoryManager)
 
 
 def test_get_long_term_memory_manager_returns_instance_not_callable():
@@ -35,7 +38,8 @@ def test_get_long_term_memory_manager_returns_instance_not_callable():
     with patch.object(UnifiedMemoryManager, "__init__", return_value=None):
         result = get_long_term_memory_manager()
     assert not inspect.isfunction(result), (
-        f"get_long_term_memory_manager() returned {type(result).__name__!r}; " "expected LongTermMemoryManager instance"
+        f"get_long_term_memory_manager() returned {type(result).__name__!r}; "
+        "expected LongTermMemoryManager instance"
     )
     assert isinstance(result, LongTermMemoryManager)
 


### PR DESCRIPTION
## Thinking Path

PR #10614 (merged) migrated `api/enhanced_memory.py` and 4 test files. This PR completes the retirement: the `EnhancedMemoryManager` class itself is deleted from `memory/compat.py`.

**Behavioral equivalence verified before deleting:**
- 7 of 9 compat-override methods were already on `UnifiedMemoryManager` with identical logic: `__init__`, `_run_sync`, `create_task_record`, `start_task`, `complete_task`, `fail_task`, `cleanup_old_data`.
- 2 missing: `log_task_execution` (alias for `log_task_sync`) and `get_task_history_sync` (sync wrapper for `get_task_history`) — folded in.
- `get_enhanced_memory_manager` retained as `lazy_singleton(UnifiedMemoryManager)` alias for call-site backward compatibility.

## What Changed

- `autobot-backend/memory/manager.py`: Added `log_task_execution()` and `get_task_history_sync()`.
- `autobot-backend/memory/compat.py`: `EnhancedMemoryManager` class deleted (251 lines, 9 sync methods). `get_enhanced_memory_manager` now aliases `lazy_singleton(UnifiedMemoryManager)`.
- `autobot-backend/memory/__init__.py`: `EnhancedMemoryManager` removed from imports and `__all__`.
- `autobot-backend/memory/memory_package_test.py`: Migrated — test_6 now uses `UnifiedMemoryManager` directly.
- `autobot-backend/tests/memory/test_compat_singletons.py`: Assert `get_enhanced_memory_manager()` returns `UnifiedMemoryManager`.
- `autobot-backend/performance_benchmarks_test.py`, `phase7_enhanced_memory_test.py`, `system_benchmarks_performance_test.py`: Import/instantiate `UnifiedMemoryManager`.

## Verification

```
# Zero EnhancedMemoryManager CLASS references (only comments/docstrings):
grep -rn "EnhancedMemoryManager" autobot-backend --include="*.py" | grep -v Async
# → only comments in manager.py/compat.py/test docstrings

# Startup imports: 340/340 passed:
python3 -m pytest autobot-backend/tests/test_startup_imports.py -q
# 340 passed, 83 warnings

# Memory tests: 43/45 passed (2 pre-existing failures on base):
python3 -m pytest autobot-backend/tests/memory/ -q
# 2 failed (test_cache_hit_skips_kb, test_store_sets_key_with_default_ttl — pre-existing)
# 43 passed
```

## Model Used

claude-sonnet-4-6

Closes #10572