### PR TITLE
chore(deps): hard-ignore protobuf>=7 + websockets>=16 in dependabot (#10615)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,13 +41,16 @@ updates:
       - dependency-name: "torch"
         update-types: ["version-update:semver-major"]
       - dependency-name: "protobuf"
-        # #10474: cap <7.0 — opentelemetry-proto (otel 1.42) requires protobuf<7.0.
-        # Dependabot's 7.x bump is unsatisfiable; unblock when otel supports it.
-        update-types: ["version-update:semver-major"]
+        # #10474/#10615/#10616: cap <7.0 — opentelemetry-proto (otel 1.42) requires
+        # protobuf<7.0. semver-major ignore alone did NOT stop the grouped
+        # all-dependencies bump from re-proposing 7.x (unsatisfiable → ResolutionImpossible
+        # on every PR). Hard-exclude >=7.0.0 so it stops. Unblock when otel supports 7.x.
+        versions: [">=7.0.0"]
       - dependency-name: "websockets"
-        # #10474: cap <16 — langgraph-sdk 0.4.2 requires websockets >=14,<16.
-        # The 16.x bump is unsatisfiable; unblock when langgraph-sdk supports it.
-        update-types: ["version-update:semver-major"]
+        # #10474/#10386: cap <16 — langgraph-sdk 0.4.2 requires websockets >=14,<16.
+        # semver-major ignore alone did not stop the grouped bump from re-proposing 16.x.
+        # Hard-exclude >=16.0.0. Unblock when langgraph-sdk supports 16.x.
+        versions: [">=16.0.0"]
 
   - package-ecosystem: "pip"
     directory: "/autobot_shared"


### PR DESCRIPTION
## Thinking Path
Dependabot repeatedly proposes `protobuf>=7.35.1` and `websockets>=16.0` in the `all-dependencies` group (#10615/#10616+), despite dependabot.yml ignoring them via `update-types: [semver-major]`. Grouped updates don't reliably honor that, so each such PR fails required `smoke-test` with `ResolutionImpossible` (otel needs protobuf<7.0 #4061; langgraph-sdk needs websockets<16 #10386). Root cause of the recurring un-mergeable dependabot PRs.

## What Changed
`.github/dependabot.yml`: protobuf/websockets ignore switched from `update-types` to explicit `versions: [">=7.0.0"]` / `[">=16.0.0"]` hard-exclusion (honored inside groups).

## Verification
YAML validated. Base already pins satisfiable `protobuf>=6.33.6,<7.0.0` / `websockets>=15.0,<16`; this only stops dependabot proposing past the caps. Reverse when otel/langgraph-sdk add support.

## Model Used
Claude Opus 4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)