### PR TITLE
perf(runtime): OpenVINO CACHE_DIR + sync ChromaDB client cache + honor retry_after (#10623)

### DIFF
--- a/autobot-backend/code_embedding_generator.py
+++ b/autobot-backend/code_embedding_generator.py
@@ -13,6 +13,7 @@ Issue #207: NPU-Accelerated Semantic Code Search
 
 import asyncio
 import hashlib
+import os
 import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Tuple
@@ -27,6 +28,11 @@ logger = get_llm_logger("code_embedding_generator")
 
 # CodeBERT embedding dimension
 CODEBERT_EMBEDDING_DIM = 768
+
+# Persistent OpenVINO compiled-model cache (#10601): without CACHE_DIR the model
+# is re-converted + recompiled on every cold start (slow on NPU/GPU). Caching the
+# compiled blob lets subsequent starts skip recompilation.
+OPENVINO_CACHE_DIR = os.getenv("AUTOBOT_OPENVINO_CACHE_DIR", "data/openvino_cache")
 
 
 @dataclass
@@ -167,7 +173,9 @@ class CodeEmbeddingGenerator:
             else:
                 target_device = "CPU"
 
-            self.openvino_model = core.compile_model(ov_model, target_device)
+            # #10601: persist compiled blobs so cold starts skip recompilation.
+            os.makedirs(OPENVINO_CACHE_DIR, exist_ok=True)
+            self.openvino_model = core.compile_model(ov_model, target_device, {"CACHE_DIR": OPENVINO_CACHE_DIR})
             # Record the actual device so _compute_with_openvino reports correctly
             self._openvino_device = target_device.lower()
             logger.info(

--- a/autobot-backend/services/llm_service.py
+++ b/autobot-backend/services/llm_service.py
@@ -36,7 +36,9 @@ from autobot_shared.logging_manager import get_logger
 
 from __future__ import annotations
 
+import asyncio
 import json
+import os
 import time
 import uuid
 from typing import Any, AsyncIterator, Dict, List
@@ -66,6 +68,10 @@ except Exception:  # pragma: no cover
 _llm_tracer = get_tracer("autobot.llm")
 
 logger = get_logger(__name__)
+
+# Cap on honoring a provider-suggested Retry-After before a same-provider retry,
+# so a hostile/huge value can't stall the request indefinitely (#10601).
+_MAX_RETRY_AFTER_SECONDS = float(os.getenv("AUTOBOT_LLM_MAX_RETRY_AFTER_SECONDS", "30"))
 
 # Default parameters per task type.  These are applied when the caller does
 # not supply explicit temperature / max_tokens values.
@@ -304,7 +310,7 @@ class LLMService:
                 return response
 
             # GH#8998: Check if this is a rate limit error that should trigger fallback
-            is_rate_limited, _ = extract_rate_limit_info(response)
+            is_rate_limited, retry_after = extract_rate_limit_info(response)
 
             if is_rate_limited:
                 # Try to find a fallback model
@@ -322,8 +328,14 @@ class LLMService:
                         next_model,
                     )
                     current_model = next_model
+                    # #10601: when the fallback stays on the same (rate-limited)
+                    # provider, honor the server-suggested Retry-After (capped)
+                    # before retrying instead of hammering it immediately.
+                    same_provider = (not next_provider) or next_provider == current_provider_name
                     if next_provider:
                         current_provider_name = next_provider
+                    if retry_after and same_provider:
+                        await asyncio.sleep(min(retry_after, _MAX_RETRY_AFTER_SECONDS))
                     continue
                 else:
                     logger.warning(

--- a/autobot-backend/tests/services/test_llm_service_caching.py
+++ b/autobot-backend/tests/services/test_llm_service_caching.py
@@ -212,3 +212,76 @@ async def test_explicit_model_overrides_routing(monkeypatch):
 def test_prompt_cache_default_flag_on():
     """Anthropic prompt caching is driven by this default (pure cost win)."""
     assert config.llm_prompt_cache_default is True
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_honors_retry_after(monkeypatch):
+    """#10601: a same-provider fallback waits the parsed Retry-After before retrying."""
+
+    class _RateLimitedThenOk(_FakeProvider):
+        async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+            self.calls += 1
+            self.last_request = request
+            if self.calls == 1:
+                return LLMResponse(
+                    content="",
+                    provider=self.provider_name,
+                    request_id=request.request_id,
+                    error="rate limit exceeded; retry after 5 seconds",
+                )
+            return LLMResponse(content="ok", model="m", provider=self.provider_name, request_id=request.request_id)
+
+    provider = _RateLimitedThenOk()
+    svc = LLMService(registry=_FakeRegistry(provider))
+    svc._response_cache = _FakeCache()
+
+    class _SameProviderFallback:
+        def get_next_fallback(self, *args, **kwargs):
+            return ("fallback-model", None)  # None → stay on same provider
+
+    monkeypatch.setattr(_llm_service_mod, "get_fallback_chain_manager", lambda: _SameProviderFallback())
+    slept: List[float] = []
+
+    async def _record_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr(_llm_service_mod.asyncio, "sleep", _record_sleep)
+
+    result = await svc.chat([{"role": "user", "content": "hi"}], temperature=0.0)
+
+    assert provider.calls == 2  # rate-limited, then retried successfully
+    assert slept == [5.0]  # honored the parsed Retry-After (capped at 30)
+    assert result.content == "ok"
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_no_sleep_when_switching_provider(monkeypatch):
+    """A cross-provider fallback should NOT wait the primary's Retry-After."""
+
+    class _RateLimitedThenOk(_FakeProvider):
+        async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+            self.calls += 1
+            self.last_request = request
+            if self.calls == 1:
+                return LLMResponse(
+                    content="",
+                    provider=self.provider_name,
+                    request_id=request.request_id,
+                    error="429 too many requests; retry after 9 seconds",
+                )
+            return LLMResponse(content="ok", model="m", provider=self.provider_name, request_id=request.request_id)
+
+    provider = _RateLimitedThenOk()
+    svc = LLMService(registry=_FakeRegistry(provider))
+    svc._response_cache = _FakeCache()
+
+    class _OtherProviderFallback:
+        def get_next_fallback(self, *args, **kwargs):
+            return ("other-model", "other-provider")  # different provider
+
+    monkeypatch.setattr(_llm_service_mod, "get_fallback_chain_manager", lambda: _OtherProviderFallback())
+    slept: List[float] = []
+    monkeypatch.setattr(_llm_service_mod.asyncio, "sleep", lambda s: slept.append(s))
+
+    await svc.chat([{"role": "user", "content": "hi"}], temperature=0.0)
+    assert slept == []  # no wait when moving to a healthy different provider

--- a/autobot-backend/utils/chromadb_client.py
+++ b/autobot-backend/utils/chromadb_client.py
@@ -24,7 +24,7 @@ import json
 import pickle  # nosec B403 — reading ChromaDB internal pickle files only
 import sqlite3
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Dict
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config as _ssot_config
@@ -46,6 +46,10 @@ logger = get_logger(__name__)
 # Host remains os.getenv-based: empty string = use local PersistentClient (dev mode).
 _CHROMADB_HOST = _ssot_config.vm.chromadb
 _CHROMADB_PORT = _ssot_config.port.chromadb
+
+# Module-level client cache (singleton per key) — mirrors _async_client_cache so
+# the sync client isn't rebuilt, and legacy migrations re-run, on every call (#10601).
+_sync_client_cache: Dict[str, Any] = {}
 
 # Module exports
 __all__ = [
@@ -333,6 +337,13 @@ def get_chromadb_client(
     import chromadb  # noqa: F811
     from chromadb.config import Settings as ChromaSettings
 
+    # #10601: return the cached client instead of rebuilding it (and re-running
+    # the legacy migrations below) on every call. Mirrors _async_client_cache.
+    cache_key = f"http://{_CHROMADB_HOST}:{_CHROMADB_PORT}" if _CHROMADB_HOST else (db_path or "data/chromadb")
+    cached = _sync_client_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
     try:
         if _CHROMADB_HOST:
             client = chromadb.HttpClient(
@@ -347,6 +358,7 @@ def get_chromadb_client(
                 _CHROMADB_HOST,
                 _CHROMADB_PORT,
             )
+            _sync_client_cache[cache_key] = client
             return client
 
         # Fallback: local PersistentClient
@@ -364,6 +376,7 @@ def get_chromadb_client(
             ),
         )
         logger.info("ChromaDB persistent client at: %s", chroma_path)
+        _sync_client_cache[cache_key] = client
         return client
 
     except Exception as e:


### PR DESCRIPTION
## Thinking Path
Pure-win subset of #10601 (umbrella #10603) — three independent, low-risk runtime efficiency fixes surfaced by the codebase audit. The heavier #10601 items (async-DB router migration, ~50-site HTTP pooling, per-worker model dedup) stay tracked on #10601.

## What Changed
- **OpenVINO compiled-model caching** (`code_embedding_generator.py`): `core.compile_model(...)` now passes `{"CACHE_DIR": OPENVINO_CACHE_DIR}` so cold starts skip re-converting + recompiling CodeBERT (slow on NPU/GPU). Path from `AUTOBOT_OPENVINO_CACHE_DIR` env (default `data/openvino_cache`); dir created on demand.
- **Sync ChromaDB client cache** (`utils/chromadb_client.py`): `get_chromadb_client()` now memoizes the client per host/path (mirrors the existing `_async_client_cache`), so it no longer rebuilds the client and re-runs the legacy migration scans (`_migrate_legacy_collection_configs`, `_fix_*`) on every call.
- **Honor `Retry-After`** (`services/llm_service.py`): `chat()` now captures the `retry_after` already parsed by `extract_rate_limit_info` (previously discarded) and, when the fallback stays on the **same** rate-limited provider, `await asyncio.sleep(min(retry_after, AUTOBOT_LLM_MAX_RETRY_AFTER_SECONDS))` (cap default 30s) before retrying instead of hammering it. Cross-provider fallbacks don't wait.

No hardcoded values (env-backed constants); no code deleted; no `_v2`.

## Verification
- `tests/services/test_llm_service_caching.py` — 11 tests pass, incl. 2 new: same-provider fallback honors `retry_after` (sleeps 5.0s, capped at 30); cross-provider fallback does **not** sleep.
- `flake8 --max-line-length=120` clean; `black`/`isort` clean.
- `py_compile` clean on all three modules.
- OpenVINO `CACHE_DIR` requires NPU/GPU hardware to observe the cold-start speedup; verified the param is the OpenVINO-documented caching key (pattern already used in `autobot-npu-worker/openvino/openvino_validation_test.py:140`).

Closes #10623. Part of #10601 / umbrella #10603.

## Model Used
Claude Opus 4.8 (1M context)