### PR TITLE
fix(lint): clear py-sync-requests-in-async cohort 1 → promote rule to BLOCK

### DIFF
--- a/autobot-backend/api/security_endpoints_e2e_test.py
+++ b/autobot-backend/api/security_endpoints_e2e_test.py
@@ -10,7 +10,6 @@ import os
 import signal
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 import aiohttp

--- a/autobot-backend/api/security_endpoints_e2e_test.py
+++ b/autobot-backend/api/security_endpoints_e2e_test.py
@@ -13,10 +13,37 @@ import sys
 import time
 from pathlib import Path
 
-import requests
+import aiohttp
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from tests.test_helpers import get_test_backend_url
+
+
+async def _poll_server_ready(timeout: float = 2.0) -> bool:
+    """Return True if /api/hello responds 200 within timeout seconds."""
+    try:
+        client_timeout = aiohttp.ClientTimeout(total=timeout)
+        async with aiohttp.ClientSession(timeout=client_timeout) as session:
+            async with session.get(get_test_backend_url() + "/api/hello") as resp:
+                return resp.status == 200
+    except Exception:
+        return False
+
+
+async def _get_json(session: aiohttp.ClientSession, url: str, timeout: float = 5.0):
+    """GET url and return (status, json_data, text). On error returns (None, None, str)."""
+    client_timeout = aiohttp.ClientTimeout(total=timeout)
+    try:
+        async with session.get(url, timeout=client_timeout) as resp:
+            status = resp.status
+            try:
+                data = await resp.json()
+            except Exception:
+                data = None
+            text = await resp.text() if data is None else None
+            return status, data, text
+    except Exception as exc:
+        return None, None, str(exc)
 
 
 async def test_security_endpoints():
@@ -41,94 +68,84 @@ async def test_security_endpoints():
         server_ready = False
 
         for attempt in range(max_attempts):
-            try:
-                response = requests.get(get_test_backend_url() + "/api/hello", timeout=2)
-                if response.status_code == 200:
-                    server_ready = True
-                    print(f"✅ Server ready after {attempt + 1} attempts")  # noqa: print
-                    break
-            except Exception:
-                pass
-            time.sleep(1)
+            if await _poll_server_ready():
+                server_ready = True
+                print(f"✅ Server ready after {attempt + 1} attempts")  # noqa: print
+                break
+            await asyncio.sleep(1)
 
         if not server_ready:
             print("❌ Server failed to start within timeout")  # noqa: print
             return
 
-        # Test security status endpoint
-        print("\n🔍 Testing security status endpoint...")  # noqa: print
-        try:
-            response = requests.get(get_test_backend_url() + "/api/security/status", timeout=5)
-            print(f"   Status code: {response.status_code}")  # noqa: print
+        base_timeout = aiohttp.ClientTimeout(total=5)
+        async with aiohttp.ClientSession(timeout=base_timeout) as session:
+            # Test security status endpoint
+            print("\n🔍 Testing security status endpoint...")  # noqa: print
+            try:
+                status, data, text = await _get_json(session, get_test_backend_url() + "/api/security/status")
+                print(f"   Status code: {status}")  # noqa: print
+                if status == 200:
+                    print("✅ Security status endpoint working")  # noqa: print
+                    print(f"   - Security enabled: {data.get('security_enabled')}")  # noqa: print
+                    print(f"   - Command security enabled: {data.get('command_security_enabled')}")  # noqa: print
+                    print(f"   - Docker sandbox enabled: {data.get('docker_sandbox_enabled')}")  # noqa: print
+                    print(f"   - Pending approvals: {len(data.get('pending_approvals', []))}")  # noqa: print
+                else:
+                    print(f"❌ Security status endpoint failed: {status}")  # noqa: print
+                    print(f"   Response: {text}")  # noqa: print
+            except Exception as e:
+                print(f"❌ Security status test failed: {e}")  # noqa: print
 
-            if response.status_code == 200:
-                data = response.json()
-                print("✅ Security status endpoint working")  # noqa: print
-                print(f"   - Security enabled: {data.get('security_enabled')}")  # noqa: print  # noqa: print
-                print(f"   - Command security enabled: {data.get('command_security_enabled')}")  # noqa: print
-                print(f"   - Docker sandbox enabled: {data.get('docker_sandbox_enabled')}")  # noqa: print
-                print(f"   - Pending approvals: {len(data.get('pending_approvals', []))}")  # noqa: print
-            else:
-                print(f"❌ Security status endpoint failed: {response.status_code}")  # noqa: print  # noqa: print
-                print(f"   Response: {response.text}")  # noqa: print
+            # Test command history endpoint
+            print("\n📋 Testing command history endpoint...")  # noqa: print
+            try:
+                status, data, text = await _get_json(session, get_test_backend_url() + "/api/security/command-history")
+                print(f"   Status code: {status}")  # noqa: print
+                if status == 200:
+                    print("✅ Command history endpoint working")  # noqa: print
+                    print(f"   - History entries: {data.get('count', 0)}")  # noqa: print
+                    if data.get("count", 0) > 0:
+                        print("   - Sample entries:")  # noqa: print
+                        for entry in data.get("command_history", [])[:3]:
+                            print(
+                                f"     * {entry.get('timestamp', 'N/A')} - {entry.get('action', 'N/A')}"
+                            )  # noqa: print
+                else:
+                    print(f"❌ Command history endpoint failed: {status}")  # noqa: print
+                    print(f"   Response: {text}")  # noqa: print
+            except Exception as e:
+                print(f"❌ Command history test failed: {e}")  # noqa: print
 
-        except Exception as e:
-            print(f"❌ Security status test failed: {e}")  # noqa: print
+            # Test pending approvals endpoint
+            print("\n⏳ Testing pending approvals endpoint...")  # noqa: print
+            try:
+                status, data, text = await _get_json(
+                    session, get_test_backend_url() + "/api/security/pending-approvals"
+                )
+                print(f"   Status code: {status}")  # noqa: print
+                if status == 200:
+                    print("✅ Pending approvals endpoint working")  # noqa: print
+                    print(f"   - Pending count: {data.get('count', 0)}")  # noqa: print
+                else:
+                    print(f"❌ Pending approvals endpoint failed: {status}")  # noqa: print
+                    print(f"   Response: {text}")  # noqa: print
+            except Exception as e:
+                print(f"❌ Pending approvals test failed: {e}")  # noqa: print
 
-        # Test command history endpoint
-        print("\n📋 Testing command history endpoint...")  # noqa: print
-        try:
-            response = requests.get(get_test_backend_url() + "/api/security/command-history", timeout=5)
-            print(f"   Status code: {response.status_code}")  # noqa: print
-
-            if response.status_code == 200:
-                data = response.json()
-                print("✅ Command history endpoint working")  # noqa: print
-                print(f"   - History entries: {data.get('count', 0)}")  # noqa: print
-                if data.get("count", 0) > 0:
-                    print("   - Sample entries:")  # noqa: print
-                    for entry in data.get("command_history", [])[:3]:
-                        print(f"     * {entry.get('timestamp', 'N/A')} - {entry.get('action', 'N/A')}")  # noqa: print
-            else:
-                print(f"❌ Command history endpoint failed: {response.status_code}")  # noqa: print  # noqa: print
-                print(f"   Response: {response.text}")  # noqa: print
-
-        except Exception as e:
-            print(f"❌ Command history test failed: {e}")  # noqa: print
-
-        # Test pending approvals endpoint
-        print("\n⏳ Testing pending approvals endpoint...")  # noqa: print
-        try:
-            response = requests.get(get_test_backend_url() + "/api/security/pending-approvals", timeout=5)
-            print(f"   Status code: {response.status_code}")  # noqa: print
-
-            if response.status_code == 200:
-                data = response.json()
-                print("✅ Pending approvals endpoint working")  # noqa: print
-                print(f"   - Pending count: {data.get('count', 0)}")  # noqa: print
-            else:
-                print(f"❌ Pending approvals endpoint failed: {response.status_code}")  # noqa: print  # noqa: print
-                print(f"   Response: {response.text}")  # noqa: print
-
-        except Exception as e:
-            print(f"❌ Pending approvals test failed: {e}")  # noqa: print
-
-        # Test audit log endpoint
-        print("\n📜 Testing audit log endpoint...")  # noqa: print
-        try:
-            response = requests.get(get_test_backend_url() + "/api/security/audit-log", timeout=5)
-            print(f"   Status code: {response.status_code}")  # noqa: print
-
-            if response.status_code == 200:
-                data = response.json()
-                print("✅ Audit log endpoint working")  # noqa: print
-                print(f"   - Audit entries: {data.get('count', 0)}")  # noqa: print
-            else:
-                print(f"❌ Audit log endpoint failed: {response.status_code}")  # noqa: print  # noqa: print
-                print(f"   Response: {response.text}")  # noqa: print
-
-        except Exception as e:
-            print(f"❌ Audit log test failed: {e}")  # noqa: print
+            # Test audit log endpoint
+            print("\n📜 Testing audit log endpoint...")  # noqa: print
+            try:
+                status, data, text = await _get_json(session, get_test_backend_url() + "/api/security/audit-log")
+                print(f"   Status code: {status}")  # noqa: print
+                if status == 200:
+                    print("✅ Audit log endpoint working")  # noqa: print
+                    print(f"   - Audit entries: {data.get('count', 0)}")  # noqa: print
+                else:
+                    print(f"❌ Audit log endpoint failed: {status}")  # noqa: print
+                    print(f"   Response: {text}")  # noqa: print
+            except Exception as e:
+                print(f"❌ Audit log test failed: {e}")  # noqa: print
 
         # Test secure terminal WebSocket (basic connection test)
         print("\n🖥️  Testing secure terminal WebSocket availability...")  # noqa: print
@@ -138,7 +155,7 @@ async def test_security_endpoints():
 
             ws_url = get_test_backend_url().replace("http://", "ws://") + "/api/terminal/ws/secure/test_session"
             print(f"   WebSocket URL: {ws_url}")  # noqa: print
-            print("   ℹ️  WebSocket functionality requires separate testing")  # noqa: print  # noqa: print
+            print("   ℹ️  WebSocket functionality requires separate testing")  # noqa: print
         except Exception as e:
             print(f"   ℹ️  WebSocket test skipped: {e}")  # noqa: print
 

--- a/autobot-backend/api/simple_terminal_e2e_test.py
+++ b/autobot-backend/api/simple_terminal_e2e_test.py
@@ -125,17 +125,19 @@ async def test_sessions_api():
     print("\n🧪 Testing Simple Sessions API")  # noqa: print
     print("=" * 40)  # noqa: print
 
-    import requests
+    import aiohttp
 
     try:
-        response = requests.get(get_test_backend_url() + "/api/terminal/sessions", timeout=5)
-        if response.status_code == 200:
-            sessions = response.json()
-            print(f"✅ Simple sessions API working: {json.dumps(sessions, indent=2)}")  # noqa: print  # noqa: print
-            return True
-        else:
-            print(f"❌ Sessions API failed: {response.status_code}")  # noqa: print
-            return False
+        timeout = aiohttp.ClientTimeout(total=5)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(get_test_backend_url() + "/api/terminal/sessions") as response:
+                if response.status == 200:
+                    sessions = await response.json()
+                    print(f"✅ Simple sessions API working: {json.dumps(sessions, indent=2)}")  # noqa: print
+                    return True
+                else:
+                    print(f"❌ Sessions API failed: {response.status}")  # noqa: print
+                    return False
     except Exception as e:
         print(f"❌ Sessions API error: {e}")  # noqa: print
         return False

--- a/autobot-backend/monitoring/monitoring_and_alerts_test.py
+++ b/autobot-backend/monitoring/monitoring_and_alerts_test.py
@@ -35,7 +35,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-import requests
+import aiohttp
 
 from autobot_shared.ssot_config import config
 
@@ -208,23 +208,28 @@ class MonitoringAndAlertingTester:
         for service_name, endpoint in health_endpoints:
             start_time = time.time()
             try:
-                response = requests.get(endpoint, timeout=10)
-                response_time = time.time() - start_time
+                _timeout = aiohttp.ClientTimeout(total=10)
+                async with aiohttp.ClientSession(timeout=_timeout) as _session:
+                    async with _session.get(endpoint) as response:
+                        response_time = time.time() - start_time
 
-                if response.status_code == 200:
-                    try:
-                        data = response.json()
-                        status = "PASS"
-                        message = "Health endpoint accessible with valid JSON"
-                        details = {"response_keys": (list(data.keys()) if isinstance(data, dict) else "non-dict")}
-                    except json.JSONDecodeError:
-                        status = "WARNING"
-                        message = "Health endpoint accessible but returned non-JSON"
-                        details = {"content_length": len(response.text)}
-                else:
-                    status = "FAIL"
-                    message = f"Health endpoint returned HTTP {response.status_code}"
-                    details = {"status_code": response.status_code}
+                        if response.status == 200:
+                            try:
+                                data = await response.json()
+                                status = "PASS"
+                                message = "Health endpoint accessible with valid JSON"
+                                details = {
+                                    "response_keys": (list(data.keys()) if isinstance(data, dict) else "non-dict")
+                                }
+                            except Exception:
+                                status = "WARNING"
+                                message = "Health endpoint accessible but returned non-JSON"
+                                text = await response.text()
+                                details = {"content_length": len(text)}
+                        else:
+                            status = "FAIL"
+                            message = f"Health endpoint returned HTTP {response.status}"
+                            details = {"status_code": response.status}
 
             except Exception:
                 response_time = time.time() - start_time
@@ -257,57 +262,59 @@ class MonitoringAndAlertingTester:
             start_time = time.time()
             try:
                 url = f"http://{service_config['host']}:{service_config['port']}{service_config['metrics_endpoint']}"
-                response = requests.get(url, timeout=10)
-                response_time = time.time() - start_time
+                _timeout = aiohttp.ClientTimeout(total=10)
+                async with aiohttp.ClientSession(timeout=_timeout) as _session:
+                    async with _session.get(url) as response:
+                        response_time = time.time() - start_time
 
-                if response.status_code == 200:
-                    try:
-                        metrics_data = response.json()
-                        collected_metrics[service_name] = metrics_data
+                        if response.status == 200:
+                            try:
+                                metrics_data = await response.json()
+                                collected_metrics[service_name] = metrics_data
 
-                        # Validate expected metric fields
-                        expected_fields = ["cpu", "memory", "response_time", "status"]
-                        available_fields = []
+                                # Validate expected metric fields
+                                expected_fields = ["cpu", "memory", "response_time", "status"]
+                                available_fields = []
 
-                        def extract_fields(data, prefix=""):
-                            if isinstance(data, dict):
-                                for key, value in data.items():
-                                    field_name = f"{prefix}.{key}" if prefix else key
-                                    available_fields.append(field_name.lower())
-                                    if isinstance(value, dict):
-                                        extract_fields(value, field_name)
+                                def extract_fields(data, prefix=""):
+                                    if isinstance(data, dict):
+                                        for key, value in data.items():
+                                            field_name = f"{prefix}.{key}" if prefix else key
+                                            available_fields.append(field_name.lower())
+                                            if isinstance(value, dict):
+                                                extract_fields(value, field_name)
 
-                        extract_fields(metrics_data)
+                                extract_fields(metrics_data)
 
-                        found_fields = sum(
-                            1 for field in expected_fields if any(field in af for af in available_fields)
-                        )
+                                found_fields = sum(
+                                    1 for field in expected_fields if any(field in af for af in available_fields)
+                                )
 
-                        if found_fields >= 2:
-                            status = "PASS"
-                            message = f"Metrics collected successfully ({found_fields}/4 expected fields)"
-                        elif found_fields >= 1:
-                            status = "WARNING"
-                            message = f"Partial metrics collected ({found_fields}/4 expected fields)"
+                                if found_fields >= 2:
+                                    status = "PASS"
+                                    message = f"Metrics collected successfully ({found_fields}/4 expected fields)"
+                                elif found_fields >= 1:
+                                    status = "WARNING"
+                                    message = f"Partial metrics collected ({found_fields}/4 expected fields)"
+                                else:
+                                    status = "FAIL"
+                                    message = "No expected metric fields found"
+
+                                details = {
+                                    "available_fields": available_fields[:10],  # Limit output
+                                    "found_expected": found_fields,
+                                    "total_fields": len(available_fields),
+                                }
+
+                            except Exception:
+                                status = "WARNING"
+                                message = "Metrics endpoint returned non-JSON data"
+                                details = {"content_type": response.headers.get("content-type", "unknown")}
+
                         else:
                             status = "FAIL"
-                            message = "No expected metric fields found"
-
-                        details = {
-                            "available_fields": available_fields[:10],  # Limit output
-                            "found_expected": found_fields,
-                            "total_fields": len(available_fields),
-                        }
-
-                    except json.JSONDecodeError:
-                        status = "WARNING"
-                        message = "Metrics endpoint returned non-JSON data"
-                        details = {"content_type": response.headers.get("content-type", "unknown")}
-
-                else:
-                    status = "FAIL"
-                    message = f"Metrics endpoint returned HTTP {response.status_code}"
-                    details = {"status_code": response.status_code}
+                            message = f"Metrics endpoint returned HTTP {response.status}"
+                            details = {"status_code": response.status}
 
             except Exception:
                 response_time = time.time() - start_time
@@ -412,24 +419,24 @@ class MonitoringAndAlertingTester:
                 "/api/monitoring/simulate",
             ]
 
-            for endpoint in test_endpoints:
-                try:
-                    response = requests.post(
-                        f"{backend_url}{endpoint}",
-                        json={
-                            "metric": test_config["metric"],
-                            "value": test_config["simulated_value"],
-                            "test": True,
-                        },
-                        timeout=5,
-                    )
+            _timeout = aiohttp.ClientTimeout(total=5)
+            async with aiohttp.ClientSession(timeout=_timeout) as _session:
+                for endpoint in test_endpoints:
+                    try:
+                        async with _session.post(
+                            f"{backend_url}{endpoint}",
+                            json={
+                                "metric": test_config["metric"],
+                                "value": test_config["simulated_value"],
+                                "test": True,
+                            },
+                        ) as response:
+                            if response.status in [200, 201, 202]:
+                                # Check if alert was triggered (simplified simulation)
+                                return test_config["simulated_value"] > 80.0  # Basic threshold simulation
 
-                    if response.status_code in [200, 201, 202]:
-                        # Check if alert was triggered (simplified simulation)
-                        return test_config["simulated_value"] > 80.0  # Basic threshold simulation
-
-                except requests.RequestException:
-                    continue  # Try next endpoint
+                    except aiohttp.ClientError:
+                        continue  # Try next endpoint
 
             # If no test endpoint available, simulate based on thresholds
             metric_config = next(
@@ -456,19 +463,21 @@ class MonitoringAndAlertingTester:
         baseline_time = None
 
         # Collect baseline response times
-        for i in range(5):
-            start_time = time.time()
-            try:
-                response = requests.get(get_test_backend_url() + "/api/health", timeout=10)
-                response_time = time.time() - start_time
+        _timeout = aiohttp.ClientTimeout(total=10)
+        async with aiohttp.ClientSession(timeout=_timeout) as _session:
+            for i in range(5):
+                start_time = time.time()
+                try:
+                    async with _session.get(get_test_backend_url() + "/api/health") as response:
+                        response_time = time.time() - start_time
 
-                if response.status_code == 200:
-                    response_time_tests.append(response_time)
+                        if response.status == 200:
+                            response_time_tests.append(response_time)
 
-                await asyncio.sleep(0.5)  # Wait between requests
+                    await asyncio.sleep(0.5)  # Wait between requests
 
-            except Exception:
-                pass  # Skip failed requests
+                except Exception:
+                    pass  # Skip failed requests
 
         if response_time_tests:
             baseline_time = statistics.mean(response_time_tests)
@@ -529,67 +538,69 @@ class MonitoringAndAlertingTester:
         for dashboard_name, url in dashboard_urls:
             start_time = time.time()
             try:
-                response = requests.get(url, timeout=10)
-                response_time = time.time() - start_time
+                _timeout = aiohttp.ClientTimeout(total=10)
+                async with aiohttp.ClientSession(timeout=_timeout) as _session:
+                    async with _session.get(url) as response:
+                        response_time = time.time() - start_time
 
-                accessibility = response.status_code == 200
+                        accessibility = response.status == 200
 
-                # Check data accuracy (presence of expected fields)
-                data_accuracy = False
-                widget_count = 0
+                        # Check data accuracy (presence of expected fields)
+                        data_accuracy = False
+                        widget_count = 0
 
-                if accessibility:
-                    try:
-                        data = response.json()
-                        if isinstance(data, dict):
-                            # Count data fields as "widgets"
-                            widget_count = len(data)
+                        if accessibility:
+                            try:
+                                data = await response.json()
+                                if isinstance(data, dict):
+                                    # Count data fields as "widgets"
+                                    widget_count = len(data)
 
-                            # Check for expected dashboard data
-                            expected_keys = [
-                                "status",
-                                "health",
-                                "services",
-                                "metrics",
-                                "timestamp",
-                            ]
-                            found_keys = sum(
-                                1 for key in expected_keys if any(k for k in data.keys() if key in k.lower())
-                            )
+                                    # Check for expected dashboard data
+                                    expected_keys = [
+                                        "status",
+                                        "health",
+                                        "services",
+                                        "metrics",
+                                        "timestamp",
+                                    ]
+                                    found_keys = sum(
+                                        1 for key in expected_keys if any(k for k in data.keys() if key in k.lower())
+                                    )
 
-                            data_accuracy = found_keys >= 1
+                                    data_accuracy = found_keys >= 1
+                                else:
+                                    data_accuracy = True  # Non-dict response might be valid HTML dashboard
+                                    widget_count = 1
+
+                            except Exception:
+                                # Might be HTML dashboard
+                                content = await response.text()
+                                if "dashboard" in content.lower() or "chart" in content.lower():
+                                    data_accuracy = True
+                                    widget_count = content.count("chart") + content.count("widget")
+
+                        dashboard_result = DashboardValidation(
+                            dashboard_name=dashboard_name,
+                            url=url,
+                            accessibility=accessibility,
+                            data_accuracy=data_accuracy,
+                            response_time=response_time,
+                            widget_count=widget_count,
+                        )
+
+                        if accessibility and data_accuracy:
+                            status = "PASS"
+                            message = f"Dashboard accessible with valid data ({widget_count} elements)"
+                            severity = "info"
+                        elif accessibility:
+                            status = "WARNING"
+                            message = "Dashboard accessible but data validation failed"
+                            severity = "warning"
                         else:
-                            data_accuracy = True  # Non-dict response might be valid HTML dashboard
-                            widget_count = 1
-
-                    except json.JSONDecodeError:
-                        # Might be HTML dashboard
-                        content = response.text
-                        if "dashboard" in content.lower() or "chart" in content.lower():
-                            data_accuracy = True
-                            widget_count = content.count("chart") + content.count("widget")
-
-                dashboard_result = DashboardValidation(
-                    dashboard_name=dashboard_name,
-                    url=url,
-                    accessibility=accessibility,
-                    data_accuracy=data_accuracy,
-                    response_time=response_time,
-                    widget_count=widget_count,
-                )
-
-                if accessibility and data_accuracy:
-                    status = "PASS"
-                    message = f"Dashboard accessible with valid data ({widget_count} elements)"
-                    severity = "info"
-                elif accessibility:
-                    status = "WARNING"
-                    message = "Dashboard accessible but data validation failed"
-                    severity = "warning"
-                else:
-                    status = "FAIL"
-                    message = f"Dashboard not accessible (HTTP {response.status_code})"
-                    severity = "critical"
+                            status = "FAIL"
+                            message = f"Dashboard not accessible (HTTP {response.status})"
+                            severity = "critical"
 
             except Exception:
                 response_time = time.time() - start_time
@@ -849,23 +860,23 @@ class MonitoringAndAlertingTester:
                 "/api/incident/trigger",
             ]
 
-            for endpoint in incident_endpoints:
-                try:
-                    response = requests.post(
-                        f"{backend_url}{endpoint}",
-                        json={
-                            "type": scenario["trigger"],
-                            "severity": "warning",
-                            "test": True,
-                        },
-                        timeout=5,
-                    )
+            _timeout = aiohttp.ClientTimeout(total=5)
+            async with aiohttp.ClientSession(timeout=_timeout) as _session:
+                for endpoint in incident_endpoints:
+                    try:
+                        async with _session.post(
+                            f"{backend_url}{endpoint}",
+                            json={
+                                "type": scenario["trigger"],
+                                "severity": "warning",
+                                "test": True,
+                            },
+                        ) as response:
+                            if response.status in [200, 201, 202]:
+                                return True
 
-                    if response.status_code in [200, 201, 202]:
-                        return True
-
-                except requests.RequestException:
-                    continue
+                    except aiohttp.ClientError:
+                        continue
 
             # If no test endpoint, simulate success based on scenario type
             return scenario["trigger"] in [
@@ -889,32 +900,33 @@ class MonitoringAndAlertingTester:
                 "/api/monitoring/responses",
             ]
 
-            for endpoint in response_endpoints:
-                try:
-                    response = requests.get(f"{backend_url}{endpoint}", timeout=5)
+            _timeout = aiohttp.ClientTimeout(total=5)
+            async with aiohttp.ClientSession(timeout=_timeout) as _session:
+                for endpoint in response_endpoints:
+                    try:
+                        async with _session.get(f"{backend_url}{endpoint}") as response:
+                            if response.status == 200:
+                                data = await response.json()
 
-                    if response.status_code == 200:
-                        data = response.json()
+                                # Look for recent incident responses
+                                if isinstance(data, dict):
+                                    # Check if any incident response data exists
+                                    response_indicators = [
+                                        "incidents",
+                                        "responses",
+                                        "actions",
+                                        "triggered",
+                                    ]
 
-                        # Look for recent incident responses
-                        if isinstance(data, dict):
-                            # Check if any incident response data exists
-                            response_indicators = [
-                                "incidents",
-                                "responses",
-                                "actions",
-                                "triggered",
-                            ]
+                                    for indicator in response_indicators:
+                                        if indicator in str(data).lower():
+                                            return True
 
-                            for indicator in response_indicators:
-                                if indicator in str(data).lower():
-                                    return True
+                                elif isinstance(data, list) and len(data) > 0:
+                                    return True  # Non-empty incident list
 
-                        elif isinstance(data, list) and len(data) > 0:
-                            return True  # Non-empty incident list
-
-                except requests.RequestException:
-                    continue
+                    except aiohttp.ClientError:
+                        continue
 
             # Default to positive response for test scenarios
             return True

--- a/autobot-backend/services/settings_debug_test.py
+++ b/autobot-backend/services/settings_debug_test.py
@@ -10,7 +10,7 @@ import os
 import sys
 import time
 
-import requests
+import aiohttp
 
 # Add the project root to Python path
 sys.path.insert(0, os.getcwd())
@@ -69,26 +69,30 @@ async def test_api_endpoint():
     """Test the API endpoint directly"""
     print("Testing API endpoint with timeout...")  # noqa: print
 
+    start_time = time.time()
     try:
-        start_time = time.time()
-        response = requests.get(get_test_backend_url() + "/api/settings/", timeout=10)
-        end_time = time.time()
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(get_test_backend_url() + "/api/settings/") as response:
+                end_time = time.time()
 
-        if response.status_code == 200:
-            print(f"✅ API endpoint responded in {end_time - start_time:.2f} seconds")  # noqa: print  # noqa: print
-            data = response.json()
-            print(f"Response keys: {list(data.keys()) if isinstance(data, dict) else 'Not a dict'}")  # noqa: print
-            return True
-        else:
-            print(f"❌ API endpoint returned status {response.status_code}")  # noqa: print  # noqa: print
-            return False
-    except requests.exceptions.Timeout:
+                if response.status == 200:
+                    print(f"✅ API endpoint responded in {end_time - start_time:.2f} seconds")  # noqa: print
+                    data = await response.json()
+                    print(
+                        f"Response keys: {list(data.keys()) if isinstance(data, dict) else 'Not a dict'}"
+                    )  # noqa: print
+                    return True
+                else:
+                    print(f"❌ API endpoint returned status {response.status}")  # noqa: print
+                    return False
+    except asyncio.TimeoutError:
         end_time = time.time()
-        print(f"❌ API endpoint timed out after {end_time - start_time:.2f} seconds")  # noqa: print  # noqa: print
+        print(f"❌ API endpoint timed out after {end_time - start_time:.2f} seconds")  # noqa: print
         return False
     except Exception as e:
         end_time = time.time()
-        print(f"❌ API endpoint error after {end_time - start_time:.2f} seconds: {e}")  # noqa: print  # noqa: print
+        print(f"❌ API endpoint error after {end_time - start_time:.2f} seconds: {e}")  # noqa: print
         return False
 
 

--- a/docs/developer/CANONICAL_RULES.md
+++ b/docs/developer/CANONICAL_RULES.md
@@ -32,12 +32,13 @@ Added in PR for issue #10577 (umbrella #10569). All rules are Python AST rules r
 | `py-adhoc-db-engine` | #10570 | Python | warn | `create_engine`/`sessionmaker` outside the canonical async factory | 39 (includes tests; migrate via #10570) |
 | `py-hardcoded-url` | #10573 | Python | warn | `http://localhost\|127.0.0.1:PORT` literal — resolve via `ssot_config` | 87 (migrate via #10573) |
 | `py-banned-suffix-filename` | #10575 | Python | block | Source file named `_fix`/`_v2`/`_old`/`_copy` — edit canonical module | 0 (clean after sibling PRs; BLOCK safe) |
-| `py-sync-requests-in-async` | #10576 | Python | warn | Blocking `requests.*` inside `async def` — use async HTTP client | 14 (migrate separately) |
+| `py-sync-requests-in-async` | #10576 | Python | block | Blocking `requests.*` inside `async def` — use async HTTP client | 0 (promoted to BLOCK after #10627 cohort 1 cleared all 14 sites) |
 | `py-duplicate-concept` | #10577 | Python | warn | `Enhanced*`/`Unified*` class shadows a base-name class in the same file | 5 (merge into canonical class) |
 
 **Severity rationale:**
 
 - `py-banned-suffix-filename` → **block**: repo-wide scan on 2026-06-28 found 0 violations after sibling PR #10575 cleaned all `_fix`-named scripts. Safe to fail-fast on new introductions.
+- `py-sync-requests-in-async` → **block**: all 14 violations cleared by PR for #10627 cohort 1 (2026-06-28). Four files converted to `aiohttp.ClientSession`. Safe to fail-fast on new introductions.
 - All others → **warn**: pre-existing violations exist across the codebase. Each rule's tracking issue owns the migration. Promote to BLOCK once the issue is closed and a follow-up repo-wide scan is clean.
 
 ## Waivers

--- a/tools/lint/canonical/rules/py_sync_requests_in_async.py
+++ b/tools/lint/canonical/rules/py_sync_requests_in_async.py
@@ -18,7 +18,7 @@ from tools.lint.canonical.diagnostic import Diagnostic
 
 RULE_ID = "py-sync-requests-in-async"
 ISSUE = "#10576"
-SEVERITY = "warn"
+SEVERITY = "block"
 TARGETS = ["autobot-backend", "autobot-slm-backend"]
 DESCRIPTION = "Blocking requests.* inside async def — use an async HTTP client"
 FIX_HINT = "Replace requests.* with aiohttp/httpx.AsyncClient and await the call."


### PR DESCRIPTION
## Thinking Path

All 14 `py-sync-requests-in-async` violations were in standalone E2E/debug test scripts — not pytest-collected tests — that called `requests.*` inside `async def` functions, stalling the event loop on each HTTP call. `aiohttp` is already declared in `requirements.txt` and is the canonical async HTTP client used in sibling E2E scripts (`complete_system_e2e_test.py`, `npu_integration_e2e_test.py`, etc.).

The fix: replace every `requests.get/post` with `aiohttp.ClientSession` + `async with session.get/post(...)` + `await resp.json()/text()`. API surface differences handled precisely: `.status_code` → `.status`, `requests.RequestException` → `aiohttp.ClientError`, `json.JSONDecodeError` catch on `response.json()` → bare `Exception` on `await resp.json()`.

No false positives found — every flagged call was genuinely blocking inside an async function body (not inside a nested sync `def` or inside a `run_in_executor`).

## What Changed

**4 files fixed (14 violations cleared):**
- `autobot-backend/monitoring/monitoring_and_alerts_test.py` — 7 violations across 5 async methods (`test_health_monitoring_endpoints`, `test_metrics_collection`, `_simulate_threshold_breach`, `test_performance_degradation_detection`, `test_dashboard_monitoring`, `_simulate_incident`, `_check_incident_response`). Extracted shared session where methods loop over multiple endpoints; preserved `aiohttp.ClientError` continue-on-failure semantics matching original `requests.RequestException` catch.
- `autobot-backend/api/security_endpoints_e2e_test.py` — 5 violations in one large `async def`. Extracted `_poll_server_ready()` and `_get_json()` helpers; replaced sync startup poll loop's `time.sleep(1)` with `asyncio.sleep(1)`. One shared `ClientSession` for all 4 endpoint tests.
- `autobot-backend/api/simple_terminal_e2e_test.py` — 1 violation (inline `import requests` inside `async def`). Replaced with inline `import aiohttp` + session.
- `autobot-backend/services/settings_debug_test.py` — 1 violation. `requests.exceptions.Timeout` → `asyncio.TimeoutError`.

**Rule promoted:**
- `tools/lint/canonical/rules/py_sync_requests_in_async.py`: `SEVERITY = "warn"` → `SEVERITY = "block"`
- `docs/developer/CANONICAL_RULES.md`: table row updated (warn → block, count 14 → 0); rationale section updated.

## Verification

```
# Before
py-sync-requests-in-async violations: 14

# After
py-sync-requests-in-async violations: 0
canonical_check.py --all → block=0, exit 0

# Startup imports
autobot-backend/tests/test_startup_imports.py — 339 passed, 0 failures

# black --line-length=120 on all 4 Python files → clean
```

No `# canonical: ignore` waivers were needed — all 14 sites were genuine blocking calls with straightforward aiohttp replacements.

## Model Used

claude-sonnet-4-6

Part of #10627