### PR TITLE
fix(backend): use RLock for LoggingManager to fix startup deadlock (#10632)

### DIFF
--- a/autobot_shared/logging_manager.py
+++ b/autobot_shared/logging_manager.py
@@ -45,7 +45,11 @@ class LoggingManager:
 
     _initialized = False
     _loggers: Dict[str, logging.Logger] = {}
-    _lock = threading.Lock()
+    # Re-entrant: get_logger() holds this lock while the lazy config-manager
+    # import chain it triggers (config -> network_constants -> redis -> metrics
+    # -> monitoring) calls get_logger() again on the same thread. A plain Lock
+    # self-deadlocks there (#10632); RLock lets the same thread re-acquire.
+    _lock = threading.RLock()
 
     @classmethod
     def get_logger(cls, name: str, log_type: str = "backend") -> logging.Logger:


### PR DESCRIPTION
## Thinking Path
Updating the local install to latest `Dev_new_gui` (#10624) broke `autobot-backend`: it restart-looped (502) and the SLM UI menus failed because they call the down backend. A `faulthandler` thread dump on the box showed `startup_validation.py` deadlocks during import.

Root cause: #10624 changed `startup_validation.py` to call `get_logger()` at module top-level. `get_logger()` holds the non-reentrant `LoggingManager._lock` while the lazy config-manager import chain it triggers (`config` → `network_constants` → redis stats `_update_stats` → first-time `import monitoring.prometheus_metrics` → `prometheus_query.py: get_logger()`) re-enters `get_logger()` on the **same thread** → self-deadlock. Old #10555 used `print()` at import, so it never tripped this latent re-entrancy.

## What Changed
- `autobot_shared/logging_manager.py`: `LoggingManager._lock` changed from `threading.Lock()` to `threading.RLock()` so same-thread re-acquisition during the import chain is allowed. (1 line + explanatory comment.)

## Verification
On the deployed #10624 backend venv:
- Unpatched (`threading.Lock`): `./venv/bin/python startup_validation.py` hangs, killed at timeout (exit 124); `faulthandler` dump shows the re-entrant `get_logger` → `_lock` chain.
- Patched in-memory (`LoggingManager._lock = threading.RLock()` then `import startup_validation`): completes, **no deadlock**, exit 0.

```
lock before: lock
lock after : RLock
RESULT: import completed, NO deadlock
EXIT=0
```

Closes #10632

## Model Used
Claude Opus 4.8 (1M context)
