### PR TITLE
fix(ansible): wire backend full-user-management deploy; drop single_user default (#10636, #10634)

### DIFF
--- a/autobot-slm-backend/ansible/_shared/tasks/pre_migration_backup.yml
+++ b/autobot-slm-backend/ansible/_shared/tasks/pre_migration_backup.yml
@@ -39,6 +39,8 @@
     mode: "0750"
 
 # Local fast path — full cluster dump from the on-node Postgres.
+# Runs as root so `su - postgres` needs no password (#10636 — the connection
+# user is autobot, which cannot su to postgres without authentication).
 - name: "Pre-migration backup | Local pg_dumpall (#10026, #10045)"
   ansible.builtin.shell: |
     set -o pipefail
@@ -46,6 +48,7 @@
       | gzip > /opt/autobot/backups/pre-migration/backend-$(date +%s).sql.gz
   args:
     executable: /bin/bash
+  become: true
   when: pre_migration_pg_dir.stat.exists
 
 # Remote path — Postgres lives on another node (colocated on the SLM server).

--- a/autobot-slm-backend/ansible/ansible.cfg
+++ b/autobot-slm-backend/ansible/ansible.cfg
@@ -61,7 +61,6 @@ retry_files_save_path = ~/.ansible/retry
 ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o IdentitiesOnly=yes
 pipelining = True
 control_path_dir = ~/.ansible/cp
-control_path = /tmp/.ansible-cp/ansible-ssh-%%h-%%p-%%r
 
 # Privilege Escalation
 [privilege_escalation]

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -573,6 +573,36 @@
       no_log: true
       tags: [backend, env]
 
+    # Internal service API key — backend must use the same key the SLM expects.
+    # Written by the backend role into /etc/autobot/autobot-backend.env (#10632).
+    - name: "[PLAY 2] Backend | Read AUTOBOT_INTERNAL_API_KEY (#10636)"
+      ansible.builtin.shell:
+        cmd: >-
+          grep -oP '^AUTOBOT_INTERNAL_API_KEY=\K.*'
+          /etc/autobot/autobot-backend.env 2>/dev/null || true
+      register: existing_internal_api_key
+      become: true
+      when: "'backend' in group_names"
+      failed_when: false
+      changed_when: false
+      no_log: true
+      tags: [backend, env]
+
+    # Full user management requires the autobot_app DB password, written by the
+    # single-box provisioning play into autobot-db-credentials.env (#10636).
+    - name: "[PLAY 2] Backend | Read autobot_app DB password (#10636)"
+      ansible.builtin.shell:
+        cmd: >-
+          grep -oP '^AUTOBOT_DB_PASSWORD=\K.*'
+          /etc/autobot/autobot-db-credentials.env 2>/dev/null || true
+      register: existing_autobot_db_password
+      become: true
+      when: "'backend' in group_names"
+      failed_when: false
+      changed_when: false
+      no_log: true
+      tags: [backend, env]
+
     - name: "[PLAY 2] Backend | Load shared backend env vars (#2727)"
       ansible.builtin.include_vars:
         file: vars/backend-env.yml
@@ -594,6 +624,10 @@
         backend_secret_key: "{{ existing_secret_key.stdout | default(lookup('env', 'AUTOBOT_SECRET_KEY') | default('autobot-dev-secret-' + (9999999999 | random | string), true), true) }}"
         # #10400: prefer SLM_SECRET_KEY when present, else keep the role default.
         backend_jwt_secret: "{{ (existing_slm_secret_key.stdout | default('') | trim) if (existing_slm_secret_key.stdout | default('') | trim) | length > 0 else (existing_secret_key.stdout | default('') | trim) }}"
+        # #10636: internal service API key + full-user-management DB password,
+        # read from /etc/autobot above (no longer undefined / single_user).
+        autobot_internal_api_key: "{{ existing_internal_api_key.stdout | default('') | trim }}"
+        backend_postgres_password: "{{ existing_autobot_db_password.stdout | default('') | trim }}"
       tags: [backend, env]
 
     - name: "[PLAY 2] Backend | Read backend user mode (#10001)"

--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -36,9 +36,10 @@ backend_redis_port: 6379
 backend_redis_password: ""
 
 # User management mode (Issue #2953)
-# single_user: no auth, no PostgreSQL (default for single-host installs)
-# single_company/multi_company/provider: requires PostgreSQL
-backend_user_mode: "single_user"
+# AutoBot always runs full, Postgres-backed user management (#10636).
+# single_company/multi_company/provider — all require PostgreSQL.
+# There is no single_user mode; do not reintroduce it as a fallback.
+backend_user_mode: "single_company"
 
 # PostgreSQL for non-single_user modes (Issue #2953)
 backend_postgres_host: "127.0.0.1"

--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -84,10 +84,11 @@ AUTOBOT_AI_STACK_PORT={{ backend_ai_stack_port }}
 AUTOBOT_CHROMADB_HOST={{ backend_chromadb_host }}
 AUTOBOT_CHROMADB_PORT={{ backend_chromadb_port }}
 
-# Deployment / user management mode (Issue #2953)
-AUTOBOT_USER_MODE={{ backend_user_mode | default('single_user') }}
+# User management mode (#2953, #10636). AutoBot always runs full,
+# Postgres-backed user management — single_user is not a supported mode.
+AUTOBOT_USER_MODE={{ backend_user_mode | default('single_company') }}
 
-# PostgreSQL for user management (only used in non-single_user modes)
+# PostgreSQL for user management (always required — full user management)
 AUTOBOT_POSTGRES_HOST={{ backend_postgres_host | default('127.0.0.1') }}
 AUTOBOT_POSTGRES_PORT={{ backend_postgres_port | default('5432') }}
 AUTOBOT_POSTGRES_DB={{ backend_postgres_db | default('autobot_users') }}


### PR DESCRIPTION
## Thinking Path
Project #10636 — AutoBot always runs full, Postgres-backed user management; there is no `single_user` mode. Two things stood between the codebase and a working full-user-management backend deploy: (1) the deploy path didn't actually wire the values the backend `.env` needs in company mode (it left `autobot_internal_api_key` undefined and `AUTOBOT_POSTGRES_PASSWORD` empty — exactly the failures seen when deploying to the box), and (2) the defaults still fell back to `single_user`. This PR closes those gaps and fixes the deploy-reliability bugs that surface once migrations always run.

## What Changed
- **`update-all-nodes.yml` Play 2**: read `AUTOBOT_INTERNAL_API_KEY` (from `/etc/autobot/autobot-backend.env`) and the `autobot_app` DB password (from `/etc/autobot/autobot-db-credentials.env`, written by the single-box provisioning play) and pass both into the `.env` regen. Fixes the `AnsibleUndefinedVariable: autobot_internal_api_key` abort (#10634) and the empty `AUTOBOT_POSTGRES_PASSWORD` that blocked DB auth.
- **`backend.env.j2` + `roles/backend/defaults/main.yml`**: default `AUTOBOT_USER_MODE` to `single_company` (full user management), not `single_user`.
- **`_shared/tasks/pre_migration_backup.yml`**: run the local `pg_dumpall` with `become: true` so `su - postgres` needs no password (#10634).
- **`ansible.cfg`**: drop the explicit `control_path` pointing at an uncreated `/tmp/.ansible-cp`; rely on auto-created `control_path_dir` — fixes the UNREACHABLE socket-bind error (#10634).

## Verification
```
$ ansible-playbook -i inventory/slm-nodes.yml playbooks/update-all-nodes.yml --syntax-check   # exit 0
$ python3 -c "jinja2 ... backend.env.j2"   # j2 OK
YAML validity OK for all edited task files
```
Full end-to-end runs during the gated deploy (Task 4 of #10636), after provisioning, against a DB backup.

## Model Used
Claude Opus 4.8 (1M context)

Refs #10636. Addresses #10634 items 1–3 (mark-synced readiness remains).
