### PR TITLE
fix(ansible): drop local pg_hba rule for autobot_app provisioning (#10636)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/provision-backend-db-single-box.yml
+++ b/autobot-slm-backend/ansible/playbooks/provision-backend-db-single-box.yml
@@ -80,20 +80,23 @@
     # slm_app local/host and any remote-access entries) untouched. This is
     # non-destructive — unlike rendering the whole template — so the live SLM
     # database is never cut off. (#10636, review of #10640)
+    # Only host (TCP) rules: the backend connects to 127.0.0.1 via asyncpg, not
+    # the unix socket, so no `local` rule is needed (and postgresql_pg_hba
+    # rejects an address on a local rule). slm_app's existing rules are left
+    # untouched.
     - name: "Add pg_hba entries for autobot_app (non-destructive)"
       community.postgresql.postgresql_pg_hba:
         dest: "{{ pg_hba_path }}"
-        contype: "{{ item.contype }}"
+        contype: host
         users: "{{ autobot_db_user }}"
         databases: all
-        address: "{{ item.address | default(omit) }}"
+        address: "{{ item }}"
         method: scram-sha-256
         state: present
         backup: true
       loop:
-        - { contype: local }
-        - { contype: host, address: "127.0.0.1/32" }
-        - { contype: host, address: "::1/128" }
+        - "127.0.0.1/32"
+        - "::1/128"
       become_user: postgres
       notify: Reload PostgreSQL
 


### PR DESCRIPTION
## Thinking Path
Live Task 4 provisioning run failed: `postgresql_pg_hba` rejects a `local` contype that carries an address (`Rule can't contain an address and netmask if the connection-type is local`), aborting before the creds file was written. The backend connects to Postgres over TCP (`127.0.0.1` via asyncpg), not the unix socket, so a `local` rule is unnecessary.

## What Changed
- `provision-backend-db-single-box.yml`: the pg_hba task now adds only `host` (TCP) rules for `127.0.0.1/32` + `::1/128`; removed the failing `local` loop item. slm_app entries remain untouched (still non-destructive).

## Verification
`ansible-playbook ... --syntax-check` exit 0. Full run during the live provisioning step.

## Model Used
Claude Opus 4.8 (1M context)

Refs #10636