### PR TITLE
fix(ansible): grant autobot_app schema-public privs + explicit PG reload (#10636)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/provision-backend-db-single-box.yml
+++ b/autobot-slm-backend/ansible/playbooks/provision-backend-db-single-box.yml
@@ -76,6 +76,19 @@
         login_unix_socket: /var/run/postgresql
       become_user: postgres
 
+    # PG15+: the `public` schema no longer grants CREATE to non-owners, so the
+    # database-level grant above is not enough for Alembic to create tables.
+    # Grant schema-level privileges so the backend migrations can run.
+    - name: "Grant autobot_app privileges on schema public"
+      community.postgresql.postgresql_privs:
+        database: "{{ autobot_db_name }}"
+        type: schema
+        objs: public
+        privs: ALL
+        role: "{{ autobot_db_user }}"
+        login_unix_socket: /var/run/postgresql
+      become_user: postgres
+
     # Add ONLY autobot_app's entries, leaving every existing line (the SLM's
     # slm_app local/host and any remote-access entries) untouched. This is
     # non-destructive — unlike rendering the whole template — so the live SLM
@@ -98,7 +111,16 @@
         - "127.0.0.1/32"
         - "::1/128"
       become_user: postgres
-      notify: Reload PostgreSQL
+
+    # Explicit reload (not a handler): handlers only fire on change and are
+    # flushed at play end, so an idempotent rerun (or a play that fails after
+    # editing pg_hba) would leave the running server with stale auth. Reload
+    # unconditionally so the verify below tests the live config. (#10636)
+    - name: "Reload PostgreSQL to apply pg_hba"
+      ansible.builtin.systemd:
+        name: postgresql
+        state: reloaded
+      changed_when: false
 
     - name: "Write autobot-db-credentials.env (separate from SLM creds)"
       ansible.builtin.copy:
@@ -124,9 +146,3 @@
         login_password: "{{ autobot_db_password }}"
         login_host: 127.0.0.1
       no_log: true
-
-  handlers:
-    - name: Reload PostgreSQL
-      ansible.builtin.systemd:
-        name: postgresql
-        state: reloaded


### PR DESCRIPTION
## Thinking Path
Live Task 4 of #10636: after autobot_app could connect, Alembic failed with `permission denied for schema public` creating `alembic_version`. PostgreSQL 15+ removed the implicit CREATE-on-public grant for non-owners, so a DB-level grant is insufficient. Separately, the pg_hba reload was a handler that did not fire on an idempotent rerun, leaving the running server with stale auth.

## What Changed
- `provision-backend-db-single-box.yml`: add `GRANT ALL ON SCHEMA public` to autobot_app (postgresql_privs type=schema); replace the Reload handler with an explicit unconditional reload task placed before the connectivity verify.

## Verification
`--syntax-check` exit 0; full provisioning + connect-as-autobot_app verified live during the deploy.

## Model Used
Claude Opus 4.8 (1M context)

Refs #10636