### PR TITLE
fix(canonical): waive py-adhoc-db-engine cohort + promote to BLOCK (#10627)

### DIFF
--- a/autobot-backend/llc/tests/test_agent_id_keyspace.py
+++ b/autobot-backend/llc/tests/test_agent_id_keyspace.py
@@ -36,7 +36,9 @@ _SPRINT = uuid.uuid4()
 
 @pytest_asyncio.fixture
 async def engine():  # noqa: ANN201
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
+    eng = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        "sqlite+aiosqlite:///:memory:"
+    )
     await harness.create_loop_schema(eng)
     yield eng
     await eng.dispose()
@@ -44,7 +46,9 @@ async def engine():  # noqa: ANN201
 
 @pytest_asyncio.fixture
 async def session_factory(engine):  # noqa: ANN001, ANN201
-    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    return async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
 
 
 async def _seed_node_and_item(

--- a/autobot-backend/llc/tests/test_backlog_reorder.py
+++ b/autobot-backend/llc/tests/test_backlog_reorder.py
@@ -318,7 +318,9 @@ _item_counter = 0
 
 @pytest_asyncio.fixture
 async def backlog_engine():  # noqa: ANN201
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
+    eng = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        "sqlite+aiosqlite:///:memory:"
+    )
     await harness.create_loop_schema(eng)
     yield eng
     await eng.dispose()
@@ -326,7 +328,9 @@ async def backlog_engine():  # noqa: ANN201
 
 @pytest_asyncio.fixture
 async def backlog_session_factory(backlog_engine):  # noqa: ANN001, ANN201
-    return async_sessionmaker(backlog_engine, expire_on_commit=False, class_=AsyncSession)
+    return async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+        backlog_engine, expire_on_commit=False, class_=AsyncSession
+    )
 
 
 async def _seed_backlog_item(

--- a/autobot-backend/llc/tests/test_budget_provision.py
+++ b/autobot-backend/llc/tests/test_budget_provision.py
@@ -39,7 +39,9 @@ _COST_MODEL = "claude-haiku-4-5-20251001"
 
 @pytest_asyncio.fixture
 async def engine():  # noqa: ANN201
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
+    eng = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        "sqlite+aiosqlite:///:memory:"
+    )
     await harness.create_loop_schema(eng)
     yield eng
     await eng.dispose()
@@ -47,7 +49,9 @@ async def engine():  # noqa: ANN201
 
 @pytest_asyncio.fixture
 async def session_factory(engine):  # noqa: ANN001, ANN201
-    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    return async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
 
 
 @pytest_asyncio.fixture

--- a/autobot-backend/llc/tests/test_budget_token_mode.py
+++ b/autobot-backend/llc/tests/test_budget_token_mode.py
@@ -39,7 +39,9 @@ from llc.tests import _e2e_harness as harness
 
 @pytest_asyncio.fixture
 async def engine():  # noqa: ANN201
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
+    eng = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        "sqlite+aiosqlite:///:memory:"
+    )
     await harness.create_loop_schema(eng)
     yield eng
     await eng.dispose()
@@ -47,7 +49,9 @@ async def engine():  # noqa: ANN201
 
 @pytest_asyncio.fixture
 async def session_factory(engine):  # noqa: ANN001, ANN201
-    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    return async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
 
 
 @pytest_asyncio.fixture

--- a/autobot-backend/llc/tests/test_llc_e2e_loop.py
+++ b/autobot-backend/llc/tests/test_llc_e2e_loop.py
@@ -78,7 +78,9 @@ _COST_MODEL = "claude-haiku-4-5-20251001"
 @pytest_asyncio.fixture
 async def engine():  # noqa: ANN201
     """In-memory SQLite engine with the loop schema created."""
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
+    eng = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        "sqlite+aiosqlite:///:memory:"
+    )
     await harness.create_loop_schema(eng)
     yield eng
     await eng.dispose()
@@ -86,7 +88,9 @@ async def engine():  # noqa: ANN201
 
 @pytest_asyncio.fixture
 async def session_factory(engine):  # noqa: ANN001, ANN201
-    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    return async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
 
 
 @pytest_asyncio.fixture

--- a/autobot-backend/llc/tests/test_llc_org_chart.py
+++ b/autobot-backend/llc/tests/test_llc_org_chart.py
@@ -54,7 +54,9 @@ _FIXED_USER_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
 
 @pytest_asyncio.fixture
 async def engine():  # noqa: ANN201
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
+    eng = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        "sqlite+aiosqlite:///:memory:"
+    )
     await harness.create_loop_schema(eng)
     yield eng
     await eng.dispose()
@@ -62,7 +64,9 @@ async def engine():  # noqa: ANN201
 
 @pytest_asyncio.fixture
 async def session_factory(engine):  # noqa: ANN001, ANN201
-    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    return async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
 
 
 @pytest_asyncio.fixture

--- a/autobot-backend/llc/tests/test_org_chart_enrichment.py
+++ b/autobot-backend/llc/tests/test_org_chart_enrichment.py
@@ -38,7 +38,9 @@ _FIXED_USER_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
 
 @pytest_asyncio.fixture
 async def engine():  # noqa: ANN201
-    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
+    eng = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        "sqlite+aiosqlite:///:memory:"
+    )
     await harness.create_loop_schema(eng)
     yield eng
     await eng.dispose()
@@ -46,7 +48,9 @@ async def engine():  # noqa: ANN201
 
 @pytest_asyncio.fixture
 async def session_factory(engine):  # noqa: ANN001, ANN201
-    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    return async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
 
 
 @pytest_asyncio.fixture

--- a/autobot-backend/routers/model_management.py
+++ b/autobot-backend/routers/model_management.py
@@ -50,7 +50,9 @@ def _get_sync_session():
 
                 from user_management.database import get_async_engine
 
-                _sync_session_factory = sessionmaker(bind=get_async_engine().sync_engine)
+                _sync_session_factory = sessionmaker(  # canonical: ignore py-adhoc-db-engine
+                    bind=get_async_engine().sync_engine  # sync wrapper over canonical engine (thread context)
+                )
     return session_scope(_sync_session_factory)
 
 

--- a/autobot-backend/services/feedback_tracker.py
+++ b/autobot-backend/services/feedback_tracker.py
@@ -38,7 +38,9 @@ class FeedbackTracker:
         # so we share the same connection pool instead of creating a second engine (#10570).
         # FeedbackTracker is used from sync context (routers/feedback.py background
         # tasks) so a sync session is genuinely required here.
-        self.SessionLocal = sessionmaker(bind=get_async_engine().sync_engine)
+        self.SessionLocal = sessionmaker(  # canonical: ignore py-adhoc-db-engine
+            bind=get_async_engine().sync_engine  # sync wrapper over canonical engine (sync bg-task context)
+        )
 
         # Redis for time-series caching
         self.redis_client = get_redis_client(async_client=False, database="main")

--- a/autobot-backend/services/incremental_trainer.py
+++ b/autobot-backend/services/incremental_trainer.py
@@ -56,7 +56,9 @@ class IncrementalTrainer:
         # Derive a sync sessionmaker from the canonical async engine's sync_engine
         # so we share the same connection pool instead of creating a second engine (#10570).
         # IncrementalTrainer.update_from_feedback is called from sync background tasks.
-        self.SessionLocal = sessionmaker(bind=get_async_engine().sync_engine)
+        self.SessionLocal = sessionmaker(  # canonical: ignore py-adhoc-db-engine
+            bind=get_async_engine().sync_engine  # sync wrapper over canonical engine (sync bg-task context)
+        )
 
         # Incremental learning parameters
         self.learning_rate = 1e-5  # Lower LR for fine-tuning

--- a/autobot-backend/tests/integration/test_budget_hard_stop.py
+++ b/autobot-backend/tests/integration/test_budget_hard_stop.py
@@ -40,7 +40,7 @@ from services.budget_policy import (
 @pytest.fixture
 async def async_db_session():
     """Create an in-memory SQLite database for testing."""
-    engine = create_async_engine(
+    engine = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
         "sqlite+aiosqlite:///:memory:",
         echo=False,
     )
@@ -51,7 +51,9 @@ async def async_db_session():
 
         await conn.run_sync(Base.metadata.create_all)
 
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    factory = async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
     configure_session_factory(factory)
 
     async with factory() as session:

--- a/autobot-backend/tests/integration/test_mobile_pairing.py
+++ b/autobot-backend/tests/integration/test_mobile_pairing.py
@@ -41,7 +41,7 @@ TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
 @pytest.fixture
 async def test_db_engine():
     """Create an in-memory test database engine."""
-    engine = create_async_engine(
+    engine = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
         TEST_DB_URL,
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
@@ -59,7 +59,7 @@ async def test_db_engine():
 @pytest.fixture
 async def test_db_session(test_db_engine) -> AsyncGenerator[AsyncSession, None]:
     """Create a test database session."""
-    async_session = async_sessionmaker(
+    async_session = async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
         test_db_engine,
         class_=AsyncSession,
         expire_on_commit=False,

--- a/autobot-backend/tests/integration/test_mobile_push.py
+++ b/autobot-backend/tests/integration/test_mobile_push.py
@@ -39,7 +39,7 @@ TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
 @pytest.fixture
 async def test_db_engine():
     """Create an in-memory test database engine."""
-    engine = create_async_engine(
+    engine = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
         TEST_DB_URL,
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
@@ -57,7 +57,7 @@ async def test_db_engine():
 @pytest.fixture
 async def test_db_session(test_db_engine) -> AsyncGenerator[AsyncSession, None]:
     """Create a test database session."""
-    async_session = async_sessionmaker(
+    async_session = async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
         test_db_engine,
         class_=AsyncSession,
         expire_on_commit=False,

--- a/autobot-backend/tests/integration/test_paused_agent_wake.py
+++ b/autobot-backend/tests/integration/test_paused_agent_wake.py
@@ -136,10 +136,12 @@ HeartbeatScheduler = _sched_mod.HeartbeatScheduler
 
 @pytest.fixture
 async def db_factory():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)  # canonical: ignore py-adhoc-db-engine
     async with engine.begin() as conn:
         await conn.run_sync(_Base.metadata.create_all)
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    factory = async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
     yield factory
     await engine.dispose()
 

--- a/autobot-backend/tests/integration/test_paused_agent_wakeup_drain.py
+++ b/autobot-backend/tests/integration/test_paused_agent_wakeup_drain.py
@@ -129,10 +129,12 @@ HeartbeatScheduler = _sched_mod.HeartbeatScheduler
 @pytest.fixture
 async def db_factory():
     """In-memory SQLite DB with heartbeat ORM tables (JSONB replaced with JSON)."""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)  # canonical: ignore py-adhoc-db-engine
     async with engine.begin() as conn:
         await conn.run_sync(_Base.metadata.create_all)
-    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    factory = async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
     yield factory
     await engine.dispose()
 

--- a/autobot-backend/tests/integration/test_retention_policies_api.py
+++ b/autobot-backend/tests/integration/test_retention_policies_api.py
@@ -37,7 +37,7 @@ TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
 @pytest.fixture
 async def test_db_engine():
     """Create an in-memory test database engine."""
-    engine = create_async_engine(
+    engine = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
         TEST_DB_URL,
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
@@ -55,7 +55,7 @@ async def test_db_engine():
 @pytest.fixture
 async def test_db_session(test_db_engine) -> AsyncGenerator[AsyncSession, None]:
     """Create a test database session."""
-    async_session = async_sessionmaker(
+    async_session = async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
         test_db_engine,
         class_=AsyncSession,
         expire_on_commit=False,

--- a/autobot-backend/training/data_loader.py
+++ b/autobot-backend/training/data_loader.py
@@ -103,7 +103,9 @@ class PatternDataset(Dataset):
         # so we share the same connection pool instead of creating a second engine (#10570).
         # PatternDataset.__getitem__ is called from torch DataLoader worker threads
         # (sync context), so a sync session is genuinely required here.
-        self._SessionLocal = sessionmaker(bind=get_async_engine().sync_engine)
+        self._SessionLocal = sessionmaker(  # canonical: ignore py-adhoc-db-engine
+            bind=get_async_engine().sync_engine  # sync wrapper over canonical engine (DataLoader worker threads)
+        )
 
         # Load patterns from database
         self.patterns = self._load_patterns()

--- a/autobot-slm-backend/scripts/encrypt_sso_secrets.py
+++ b/autobot-slm-backend/scripts/encrypt_sso_secrets.py
@@ -44,7 +44,7 @@ def main() -> int:
         logger.error("Import error: %s — run from autobot-slm-backend/ with its venv active.", exc)
         return 1
 
-    engine = create_engine(get_db_url(), future=True)
+    engine = create_engine(get_db_url(), future=True)  # canonical: ignore py-adhoc-db-engine (standalone admin script)
     updated = 0
     skipped = 0
     errors = 0

--- a/autobot-slm-backend/tests/conftest.py
+++ b/autobot-slm-backend/tests/conftest.py
@@ -22,7 +22,7 @@ from models.database import Base as SLMBase  # noqa: E402
 @pytest.fixture(scope="function")
 def in_memory_db():
     """Create an in-memory SQLite database for testing."""
-    engine = create_engine("sqlite:///:memory:", echo=False)
+    engine = create_engine("sqlite:///:memory:", echo=False)  # canonical: ignore py-adhoc-db-engine (test-local engine)
     # Use SLM Base for SLM tests
     SLMBase.metadata.create_all(engine)
     return engine
@@ -31,7 +31,7 @@ def in_memory_db():
 @pytest.fixture(scope="function")
 def db_session(in_memory_db):
     """Create a database session for testing."""
-    SessionLocal = sessionmaker(bind=in_memory_db)
+    SessionLocal = sessionmaker(bind=in_memory_db)  # canonical: ignore py-adhoc-db-engine (test-local session factory)
     session = SessionLocal()
     try:
         yield session

--- a/autobot-slm-backend/tests/services/code_version_test.py
+++ b/autobot-slm-backend/tests/services/code_version_test.py
@@ -18,9 +18,9 @@ from models.database import Base, CodeStatus, Node  # noqa: E402, F401
 @pytest.fixture(scope="function")
 def slm_db_session():
     """Create an in-memory SQLite database for SLM models."""
-    engine = create_engine("sqlite:///:memory:", echo=False)
+    engine = create_engine("sqlite:///:memory:", echo=False)  # canonical: ignore py-adhoc-db-engine (test-local engine)
     Base.metadata.create_all(engine)
-    SessionLocal = sessionmaker(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)  # canonical: ignore py-adhoc-db-engine (test-local session factory)
     session = SessionLocal()
     try:
         yield session

--- a/autobot-slm-backend/user_management/services/sso_e2e_test.py
+++ b/autobot-slm-backend/user_management/services/sso_e2e_test.py
@@ -26,12 +26,14 @@ from services.encryption import encrypt_data
 @pytest.fixture
 async def async_session():
     """Create an async test database session."""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)  # canonical: ignore py-adhoc-db-engine
 
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
-    async_session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async_session_maker = sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
 
     async with async_session_maker() as session:
         yield session

--- a/autobot-slm-backend/user_management/services/sso_secrets_test.py
+++ b/autobot-slm-backend/user_management/services/sso_secrets_test.py
@@ -29,14 +29,16 @@ from services.encryption import decrypt_data
 @pytest.fixture
 async def async_session():
     """Create an async test database session."""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)  # canonical: ignore py-adhoc-db-engine
 
     # Create tables
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
     # Create session factory
-    async_session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async_session_maker = sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local session factory)
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
 
     async with async_session_maker() as session:
         yield session

--- a/docs/developer/CANONICAL_RULES.md
+++ b/docs/developer/CANONICAL_RULES.md
@@ -29,7 +29,7 @@ Added in PR for issue #10577 (umbrella #10569). All rules are Python AST rules r
 
 | Rule ID | Issue | Layer | Severity | Description | Repo-wide count (2026-06-28) |
 |---|---|---|---|---|---|
-| `py-adhoc-db-engine` | #10570 | Python | warn | `create_engine`/`sessionmaker` outside the canonical async factory | 39 (includes tests; migrate via #10570) |
+| `py-adhoc-db-engine` | #10570 | Python | block | `create_engine`/`sessionmaker` outside the canonical async factory | 0 (promoted to BLOCK in #10627: 4 prod waived as sync-over-canonical, 1 script waived, 34 test sites waived) |
 | `py-hardcoded-url` | #10573 | Python | block | `http://localhost\|127.0.0.1:PORT` literal — resolve via `ssot_config` | 0 (promoted to BLOCK after #10627 cleaned all 87 sites: 5 prod fixed, 6 prod waived, 76 test waived) |
 | `py-banned-suffix-filename` | #10575 | Python | block | Source file named `_fix`/`_v2`/`_old`/`_copy` — edit canonical module | 0 (clean after sibling PRs; BLOCK safe) |
 | `py-sync-requests-in-async` | #10576 | Python | block | Blocking `requests.*` inside `async def` — use async HTTP client | 0 (promoted to BLOCK after #10627 cohort 1 cleared all 14 sites) |
@@ -38,6 +38,7 @@ Added in PR for issue #10577 (umbrella #10569). All rules are Python AST rules r
 **Severity rationale:**
 
 - `py-banned-suffix-filename` → **block**: repo-wide scan on 2026-06-28 found 0 violations after sibling PR #10575 cleaned all `_fix`-named scripts. Safe to fail-fast on new introductions.
+- `py-adhoc-db-engine` → **block**: all 39 violations resolved in #10627 py-adhoc-db-engine cohort (2026-06-29): 4 prod services waived as sync-sessionmaker over canonical engine (background thread context), 1 standalone admin script waived, 34 test-local in-memory engine/session sites waived. Safe to fail-fast on new introductions.
 - `py-sync-requests-in-async` → **block**: all 14 violations cleared by PR for #10627 cohort 1 (2026-06-28). Four files converted to `aiohttp.ClientSession`. Safe to fail-fast on new introductions.
 - `py-hardcoded-url` → **block**: all 87 violations resolved by #10627 (2026-06-29): 5 prod sites fixed via `config.llm.ollama_endpoint` / `config.slm_url`, 6 prod sites waived (bootstrap fallbacks + embedded templates + instructional log text), 76 test sites waived (fixture URLs, mock data, test-only port values). Safe to fail-fast on new introductions.
 - All others → **warn**: pre-existing violations exist across the codebase. Each rule's tracking issue owns the migration. Promote to BLOCK once the issue is closed and a follow-up repo-wide scan is clean.

--- a/tools/lint/canonical/rules/py_adhoc_db_engine.py
+++ b/tools/lint/canonical/rules/py_adhoc_db_engine.py
@@ -8,7 +8,11 @@ Production code must obtain sessions from the canonical async session factory
 the async-first contract. Migration code and the canonical factory itself are
 exempt. See canonical-debt umbrella #10569.
 
-WARN until the call sites in #10570 are migrated, then promote to BLOCK.
+Promoted to BLOCK in #10627 (py-adhoc-db-engine cohort): all 39 pre-existing
+call sites have been either migrated to the canonical factory or waived with
+``# canonical: ignore py-adhoc-db-engine`` where the sync wrapper over the
+canonical engine (background threads / DataLoader workers) or a test-local
+in-memory engine is genuinely required.
 """
 
 from __future__ import annotations
@@ -22,7 +26,7 @@ from tools.lint.canonical.diagnostic import Diagnostic
 
 RULE_ID = "py-adhoc-db-engine"
 ISSUE = "#10570"
-SEVERITY = "warn"
+SEVERITY = "block"
 TARGETS = ["autobot-backend", "autobot-slm-backend"]
 DESCRIPTION = "Ad-hoc create_engine/sessionmaker — use the canonical async session factory"
 FIX_HINT = (


### PR DESCRIPTION
## Thinking Path

Ran `canonical_check.py --all | grep py-adhoc-db-engine` → 39 findings across 19 files. Categorised:

- **PROD non-migration** (5): `feedback_tracker.py`, `incremental_trainer.py`, `data_loader.py`, `model_management.py` — all already use `sessionmaker(bind=get_async_engine().sync_engine)`, i.e. a sync wrapper over the canonical async engine (required because background training threads cannot await an async session). `scripts/encrypt_sso_secrets.py` — standalone one-shot admin script that must build its own engine from `get_db_url()`.
- **TEST files** (34 call sites, 17 files): all create `create_async_engine("sqlite+aiosqlite:///:memory:")` + `async_sessionmaker(...)` for isolated in-memory unit/integration testing. Legitimate by design.

No migration files were involved (rule already exempts `migrations/`/`alembic/` path parts).

All 39 sites waived with `# canonical: ignore py-adhoc-db-engine` plus a one-line reason. Lines restructured where needed to remain within 120-char limit. Rule then promoted `warn` → `block`.

## What Changed

**Prod waivers (5 call sites, 5 files):**
- `autobot-backend/services/feedback_tracker.py` — sync wrapper over canonical engine
- `autobot-backend/services/incremental_trainer.py` — sync wrapper over canonical engine
- `autobot-backend/training/data_loader.py` — sync wrapper over canonical engine (DataLoader worker threads)
- `autobot-backend/routers/model_management.py` — sync wrapper over canonical engine (BackgroundTasks thread)
- `autobot-slm-backend/scripts/encrypt_sso_secrets.py` — standalone admin script

**Test waivers (34 call sites, 17 files):**
- `autobot-backend/llc/tests/test_agent_id_keyspace.py`
- `autobot-backend/llc/tests/test_backlog_reorder.py`
- `autobot-backend/llc/tests/test_budget_provision.py`
- `autobot-backend/llc/tests/test_budget_token_mode.py`
- `autobot-backend/llc/tests/test_llc_e2e_loop.py`
- `autobot-backend/llc/tests/test_llc_org_chart.py`
- `autobot-backend/llc/tests/test_org_chart_enrichment.py`
- `autobot-backend/tests/integration/test_budget_hard_stop.py`
- `autobot-backend/tests/integration/test_mobile_pairing.py`
- `autobot-backend/tests/integration/test_mobile_push.py`
- `autobot-backend/tests/integration/test_paused_agent_wake.py`
- `autobot-backend/tests/integration/test_paused_agent_wakeup_drain.py`
- `autobot-backend/tests/integration/test_retention_policies_api.py`
- `autobot-slm-backend/tests/conftest.py`
- `autobot-slm-backend/tests/services/code_version_test.py`
- `autobot-slm-backend/user_management/services/sso_e2e_test.py`
- `autobot-slm-backend/user_management/services/sso_secrets_test.py`

**Rule + docs:**
- `tools/lint/canonical/rules/py_adhoc_db_engine.py`: `SEVERITY = "warn"` → `"block"`, updated docstring
- `docs/developer/CANONICAL_RULES.md`: table row updated to `block`/`0`, rationale added

## Verification

```
# Before
python3 tools/lint/canonical_check.py --all | grep py-adhoc-db-engine | wc -l
39

# After
python3 tools/lint/canonical_check.py --all | grep py-adhoc-db-engine | wc -l
0

# No BLOCK violations (promoted rule fires on 0 sites)
python3 tools/lint/canonical_check.py --all | grep -E "^(BLOCK|ERROR)"
(no output)

# flake8 CI-equivalent scan (excludes tests/ dir per .flake8 exclude)
flake8 --config=.flake8 autobot-backend/ autobot-slm-backend/ autobot_shared/
Exit: 0

# black
black --line-length=120 <all 22 changed files>
22 files left unchanged.

# No changed file has lines > 120
awk 'length>120' <each file> → no output

# Startup imports
pytest autobot-backend/tests/test_startup_imports.py -q
339 passed, 83 warnings
```

## Model Used

claude-sonnet-4-6

Part of #10627