### PR TITLE
fix(ansible): backend Wait-for-API uses nginx /api/health not port 8443 (#10650)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -668,7 +668,9 @@
 
     - name: "[PLAY 2] Backend | Wait for API to be ready"
       uri:
-        url: "https://{{ ansible_host }}:8443/api/health"
+        # Backend serves via nginx on 443 (and uvicorn on 8001); there is no
+        # 8443 listener — probe the nginx-proxied endpoint like the SLM does.
+        url: "https://{{ ansible_host }}/api/health"
         validate_certs: false
         status_code: 200
       register: backend_health_check


### PR DESCRIPTION
## Thinking Path
During #10636 the backend deployed healthy (8001 + nginx 443 both 200) but `[PLAY 2] Backend | Wait for API to be ready` false-failed probing `https://HOST:8443/api/health` (no 8443 listener), aborting Play 2 before frontend/NPU under any_errors_fatal.

## What Changed
- `update-all-nodes.yml`: backend readiness URL `:8443/api/health` -> `/api/health` (nginx 443), matching the SLM wait task pattern.

## Verification
`--syntax-check` exit 0. Live: `https://127.0.0.1/api/health` returns 200 on the running backend.

## Model Used
Claude Opus 4.8 (1M context)

Closes #10650