### PR TITLE
feat(precision): ground chat answers in cited KB sources (#10652)

### DIFF
--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -807,14 +807,13 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
                         }
                     )
                     citations = await svc.compress_kb_results(citations, max_tokens=max_kb_tokens)
-                    # Rebuild knowledge context from trimmed citations
+                    # Rebuild knowledge context from trimmed citations via the shared
+                    # builder so the [Source N] labels + grounding instruction match
+                    # the uncompressed path (#10652, review of #10656).
                     if citations:
-                        lines = ["KNOWLEDGE CONTEXT:"]
-                        for i, c in enumerate(citations, 1):
-                            score = c.get("score", 0.0)
-                            content = c.get("content", "").strip()
-                            lines.append(f"{i}. [score: {score:.2f}] {content}")
-                        knowledge_context = "\n".join(lines)
+                        from services.knowledge.service import build_grounded_context
+
+                        knowledge_context = build_grounded_context([c.get("content", "") for c in citations])
                         logger.info(
                             "[#3770] KB compressed to %d citations (%d tokens)",
                             len(citations),

--- a/autobot-backend/services/chat_knowledge_service_test.py
+++ b/autobot-backend/services/chat_knowledge_service_test.py
@@ -205,6 +205,19 @@ def test_format_knowledge_context_grounding_can_be_disabled(
     assert "[Source 1]" in context  # source labels are unconditional
 
 
+def test_build_grounded_context_shared_builder(monkeypatch) -> None:
+    """#10652: the shared builder (reused by the compression path) labels + grounds."""
+    from autobot_shared.ssot_config import config
+    from services.knowledge.service import build_grounded_context
+
+    monkeypatch.setattr(config, "chat_grounding_enabled", True, raising=False)
+    ctx = build_grounded_context(["fact one", "fact two"])
+    assert "[Source 1] fact one" in ctx
+    assert "[Source 2] fact two" in ctx
+    assert "say you don't know" in ctx  # grounding instruction applied here too
+    assert build_grounded_context([]) == ""  # empty → no instruction, no header
+
+
 def test_format_citations(mock_rag_service, sample_search_results) -> None:
     """Test citation formatting."""
     service = ChatKnowledgeService(mock_rag_service)

--- a/autobot-backend/services/chat_knowledge_service_test.py
+++ b/autobot-backend/services/chat_knowledge_service_test.py
@@ -164,10 +164,10 @@ def test_format_knowledge_context(mock_rag_service, sample_search_results) -> No
     # Format first 2 results
     context = service.format_knowledge_context(sample_search_results[:2])
 
-    # Verify structure
+    # Verify structure — facts carry citable [Source N] labels (#10652)
     assert "KNOWLEDGE CONTEXT:" in context
-    assert "1. [score: 0.92]" in context
-    assert "2. [score: 0.82]" in context
+    assert "[Source 1]" in context
+    assert "[Source 2]" in context
     assert "Redis is configured" in context
     assert "redis-cli" in context
 
@@ -177,6 +177,32 @@ def test_format_knowledge_context_empty(mock_rag_service) -> None:
     service = ChatKnowledgeService(mock_rag_service)
     context = service.format_knowledge_context([])
     assert context == ""
+
+
+def test_format_knowledge_context_includes_grounding_instruction(
+    mock_rag_service, sample_search_results, monkeypatch
+) -> None:
+    """#10652: grounding instruction is prepended when the flag is on."""
+    from autobot_shared.ssot_config import config
+
+    monkeypatch.setattr(config, "chat_grounding_enabled", True, raising=False)
+    service = ChatKnowledgeService(mock_rag_service)
+    context = service.format_knowledge_context(sample_search_results[:1])
+    assert "[Source N]" in context  # instruction tells the model how to cite
+    assert "say you don't know" in context
+
+
+def test_format_knowledge_context_grounding_can_be_disabled(
+    mock_rag_service, sample_search_results, monkeypatch
+) -> None:
+    """#10652: instruction omitted when flag off; source labels stay."""
+    from autobot_shared.ssot_config import config
+
+    monkeypatch.setattr(config, "chat_grounding_enabled", False, raising=False)
+    service = ChatKnowledgeService(mock_rag_service)
+    context = service.format_knowledge_context(sample_search_results[:1])
+    assert "say you don't know" not in context
+    assert "[Source 1]" in context  # source labels are unconditional
 
 
 def test_format_citations(mock_rag_service, sample_search_results) -> None:

--- a/autobot-backend/services/knowledge/service.py
+++ b/autobot-backend/services/knowledge/service.py
@@ -14,12 +14,20 @@ from typing import Any, Dict, List, Tuple
 
 from advanced_rag_optimizer import SearchResult
 from autobot_shared.logging_manager import get_llm_logger
+from autobot_shared.ssot_config import config
 from services.rag_service import RAGService
 
 from .context_enhancer import get_context_enhancer
 from .doc_searcher import DocumentationSearcher, get_documentation_searcher
 from .intent_detector import get_query_intent_detector
 from .types import EnhancedQuery, QueryIntentResult, QueryKnowledgeIntent
+
+# #10652: prepended to the KB context to ground chat answers in cited sources.
+GROUNDING_INSTRUCTION = (
+    "Answer the user's question using the knowledge sources below. Cite the sources "
+    "you rely on inline as [Source N]. If the sources do not contain the answer, say "
+    "you don't know rather than guessing."
+)
 
 # Issue #556: Standard knowledge categories for chat RAG
 KNOWLEDGE_CATEGORIES = {
@@ -260,18 +268,19 @@ class ChatKnowledgeService:
         if not facts:
             return ""
 
-        # Build context header
-        context_lines = ["KNOWLEDGE CONTEXT:"]
+        # #10652: optional grounding instruction so the model answers from the
+        # cited sources and admits when they're insufficient (reversible flag).
+        context_lines: List[str] = []
+        if config.chat_grounding_enabled:
+            context_lines.append(GROUNDING_INSTRUCTION)
 
-        # Add each fact with ranking
+        context_lines.append("KNOWLEDGE CONTEXT:")
+
+        # #10652: label each fact "[Source N]" so the model can cite it; N aligns
+        # with the rank in format_citations() that the frontend displays.
         for i, fact in enumerate(facts, 1):
-            # Use rerank_score if available for display
-            score = fact.rerank_score if fact.rerank_score is not None else fact.hybrid_score
+            context_lines.append(f"[Source {i}] {fact.content.strip()}")
 
-            # Format: "1. [score: 0.95] Fact content here"
-            context_lines.append(f"{i}. [score: {score:.2f}] {fact.content.strip()}")
-
-        # Join with newlines
         return "\n".join(context_lines)
 
     def format_citations(self, facts: List[SearchResult]) -> List[Dict]:

--- a/autobot-backend/services/knowledge/service.py
+++ b/autobot-backend/services/knowledge/service.py
@@ -29,6 +29,25 @@ GROUNDING_INSTRUCTION = (
     "you don't know rather than guessing."
 )
 
+
+def build_grounded_context(contents: List[str]) -> str:
+    """Build the KB context block: optional grounding instruction + [Source N] labels (#10652).
+
+    Shared by ChatKnowledgeService.format_knowledge_context and the chat
+    compression rebuild (llm_handler) so the format + grounding instruction
+    never drift between the two paths.
+    """
+    if not contents:
+        return ""
+    lines: List[str] = []
+    if config.chat_grounding_enabled:
+        lines.append(GROUNDING_INSTRUCTION)
+    lines.append("KNOWLEDGE CONTEXT:")
+    for i, content in enumerate(contents, 1):
+        lines.append(f"[Source {i}] {content.strip()}")
+    return "\n".join(lines)
+
+
 # Issue #556: Standard knowledge categories for chat RAG
 KNOWLEDGE_CATEGORIES = {
     "system_knowledge": "OS commands, man pages, system configurations",
@@ -265,23 +284,11 @@ class ChatKnowledgeService:
         Returns:
             Formatted context string for LLM
         """
-        if not facts:
-            return ""
-
-        # #10652: optional grounding instruction so the model answers from the
-        # cited sources and admits when they're insufficient (reversible flag).
-        context_lines: List[str] = []
-        if config.chat_grounding_enabled:
-            context_lines.append(GROUNDING_INSTRUCTION)
-
-        context_lines.append("KNOWLEDGE CONTEXT:")
-
-        # #10652: label each fact "[Source N]" so the model can cite it; N aligns
-        # with the rank in format_citations() that the frontend displays.
-        for i, fact in enumerate(facts, 1):
-            context_lines.append(f"[Source {i}] {fact.content.strip()}")
-
-        return "\n".join(context_lines)
+        # #10652: delegate to the shared builder so the per-fact "[Source N]"
+        # labels and grounding instruction stay identical to the compression
+        # rebuild path in llm_handler. N aligns with the rank in
+        # format_citations() that the frontend displays.
+        return build_grounded_context([fact.content for fact in facts])
 
     def format_citations(self, facts: List[SearchResult]) -> List[Dict]:
         """

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -198,6 +198,10 @@ class LLMConfig(BaseSettings):
     # Above this temperature responses must vary, so they are never cached.
     llm_response_cache: bool = Field(default=True, alias="AUTOBOT_LLM_RESPONSE_CACHE")
     llm_cache_max_temperature: float = Field(default=0.3, alias="AUTOBOT_LLM_CACHE_MAX_TEMPERATURE")
+    # Ground chat answers in retrieved KB sources: instruct the model to answer
+    # from the provided [Source N] context, cite them, and admit when the context
+    # is insufficient (#10652). Reversible flag; changes answer style.
+    chat_grounding_enabled: bool = Field(default=True, alias="AUTOBOT_CHAT_GROUNDING")
 
     # Provider-specific endpoints (each provider can have its own URL)
     ollama_endpoint: str = Field(default="http://127.0.0.1:11434", alias="AUTOBOT_OLLAMA_ENDPOINT")


### PR DESCRIPTION
## Thinking Path
Subtasks 3.1 + 3.2 of #10599 (umbrella #10603). The chat KB context emitted `N. [score] content` — no citable source IDs and no instruction to ground on / cite the context or admit uncertainty, a hallucination risk flagged in the audit.

## What Changed
- **Source labels (`format_knowledge_context`)** — each fact is now `[Source N]`, where N aligns with the rank in `format_citations()` the frontend already displays, so a model citation `[Source N]` maps to a real shown source. Invisible to users on its own.
- **Grounding instruction** — when `config.chat_grounding_enabled` (`AUTOBOT_CHAT_GROUNDING`, default on) a short instruction is prepended: answer from the sources, cite `[Source N]`, and say "I don't know" rather than guessing when the sources are insufficient.
- **Reversible** — the instruction changes answer style (grounded + cites + acknowledges uncertainty), so it's behind a config flag. Default on to deliver the precision AC; set `AUTOBOT_CHAT_GROUNDING=false` to revert.

## Verification
- `services/chat_knowledge_service_test.py` — `[Source N]` labels present; grounding instruction present when flag on / absent when off; empty facts → `""` (4 new tests pass; 36 existing pass).
- One unrelated failure (`test_smart_retrieve...` citation count) is **pre-existing** on the clean base (stale threshold expectation) — filed as #10655.
- `flake8 --max-line-length=120` clean; `black`/`isort` clean.

## Note for reviewer
This changes how KB-backed answers read (inline `[Source N]` citations + "I don't know" on gaps). It's the intended knowledge-assistant behavior and fully reversible via the flag — flag default is the only product call here.

## Out of scope (rest of #10599)
3.3 inline judge loop, 3.4 structured_output on judges, 3.5 GroundedAgent routing.

Closes #10652. Part of #10599 / umbrella #10603.

## Model Used
Claude Opus 4.8 (1M context)