### PR TITLE
fix(backend): default user mode to full user management, never single_user (#10636)

### DIFF
--- a/autobot-backend/user_management/config.py
+++ b/autobot-backend/user_management/config.py
@@ -6,16 +6,21 @@
 Deployment Mode Configuration for User Management System
 
 Supports 4 deployment modes:
-- single_user: No auth required, personal/dev use
-- single_company: One org with users and teams
+- single_user: DEPRECATED (#10636) — not a supported runtime mode; AutoBot
+  always runs full Postgres-backed user management. Enum retained only while
+  remaining call sites are removed.
+- single_company: One org with users and teams (default)
 - multi_company: Multiple orgs (multi-tenant), isolated data
 - provider: Full multi-tenant with billing, quotas, social login
 """
 
+import logging
 from dataclasses import dataclass, field
 from enum import Enum
 
 from autobot_shared.ssot_config import config
+
+logger = logging.getLogger(__name__)
 
 
 def _get_default_postgres_host() -> str:
@@ -167,8 +172,15 @@ def get_deployment_config() -> DeploymentConfig:
     try:
         mode = DeploymentMode(mode_str)
     except ValueError:
-        # Default to single_user for invalid values
-        mode = DeploymentMode.SINGLE_USER
+        # AutoBot always runs full, Postgres-backed user management (#10636).
+        # An unset/invalid AUTOBOT_USER_MODE defaults to single_company —
+        # never single_user, which is being retired as a runtime mode.
+        if mode_str:
+            logger.warning(
+                "AUTOBOT_USER_MODE=%r is invalid; defaulting to single_company (full user management)",
+                mode_str,
+            )
+        mode = DeploymentMode.SINGLE_COMPANY
 
     # Get feature flags for this mode
     features = MODE_FEATURES[mode]


### PR DESCRIPTION
## Thinking Path
Task 5 of #10636 (no single_user mode). The backend resolved an unset/invalid AUTOBOT_USER_MODE (ssot default is empty string) to **single_user** — silently disabling auth + Postgres. This is the silent fallback the owner directive forbids. This PR removes that fallback; full excision of the enum + auth-bypass + requires_postgres gates is decomposed as follow-up PRs (security-sensitive — see issue).

## What Changed
- `user_management/config.py`: unset/invalid `AUTOBOT_USER_MODE` -> `single_company` (full user management) with a warning, instead of `SINGLE_USER`. Docstring marks single_user deprecated. Added module logger.

## Verification
`py_compile` OK; `SINGLE_COMPANY` is a valid enum with MODE_FEATURES entry; no existing test pinned the old single_user default.

## Model Used
Claude Opus 4.8 (1M context)

Refs #10636 (Task 5)