### PR TITLE
refactor(schemas): consolidate SearchRequest/EnhancedSearchRequest into canonical (#10654)

### DIFF
--- a/autobot-backend/api/knowledge_search.py
+++ b/autobot-backend/api/knowledge_search.py
@@ -22,7 +22,8 @@ from typing import Any, Dict, List
 
 from fastapi import APIRouter, HTTPException, Request
 
-from api.schemas_knowledge import ConsolidatedSearchRequest, SearchRequest as EnhancedSearchRequest
+from api.schemas_knowledge import ConsolidatedSearchRequest
+from api.schemas_knowledge import SearchRequest as EnhancedSearchRequest
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from knowledge.schemas import (

--- a/autobot-backend/api/knowledge_search.py
+++ b/autobot-backend/api/knowledge_search.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, List
 
 from fastapi import APIRouter, HTTPException, Request
 
-from api.schemas_knowledge import ConsolidatedSearchRequest, EnhancedSearchRequest
+from api.schemas_knowledge import ConsolidatedSearchRequest, SearchRequest as EnhancedSearchRequest
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from knowledge.schemas import (

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -1022,23 +1022,12 @@ class FactIdValidator(BaseModel):
 
 
 class SearchRequest(BaseModel):
-    """Request model for search endpoints"""
+    """Canonical request model for knowledge-base vector/document search (Issue #78, #685, #10654).
 
-    query: str = Field(..., min_length=1, max_length=1000)
-    limit: int = Field(default=QueryDefaults.DEFAULT_SEARCH_LIMIT, ge=1, le=100)
-    category: str | None = Field(default=None, max_length=100)
-
-    @field_validator("category")
-    @classmethod
-    def validate_category(cls, v):
-        """Validate category format"""
-        if v and not _ALNUM_ID_RE.match(v):
-            raise ValueError("Invalid category format")
-        return v
-
-
-class EnhancedSearchRequest(BaseModel):
-    """Enhanced search request with tag filtering and hybrid mode (Issue #78, #685)"""
+    Consolidates the former bare SearchRequest (3-field, dead) and EnhancedSearchRequest into one
+    model. All added fields carry defaults, so existing callers that only set query/limit/category
+    remain fully backward-compatible.
+    """
 
     query: str = Field(..., min_length=1, max_length=1000, description="Search query")
     limit: int = Field(
@@ -1060,7 +1049,7 @@ class EnhancedSearchRequest(BaseModel):
     )
     mode: str = Field(
         default=CategoryDefaults.SEARCH_MODE_HYBRID,
-        description="Search mode: 'semantic' (vector only), 'keyword' (text only), " "'hybrid' (both)",
+        description="Search mode: 'semantic' (vector only), 'keyword' (text only), 'hybrid' (both)",
     )
     enable_reranking: bool = Field(
         default=False,
@@ -1081,7 +1070,7 @@ class EnhancedSearchRequest(BaseModel):
     board_id: str | None = Field(
         default=None,
         max_length=100,
-        description=("Project-scoped board ID for namespaced search. " "None / '__global__' searches all boards."),
+        description="Project-scoped board ID for namespaced search. None / '__global__' searches all boards.",
     )
 
     @field_validator("category")
@@ -1156,6 +1145,10 @@ class EnhancedSearchRequest(BaseModel):
     def get_safe_mode(self, valid_modes: set) -> str:
         """Get mode with fallback if not in valid modes (Issue #372)."""
         return self.mode if self.mode in valid_modes else "auto"
+
+
+# Backward-compat alias — all callers have been migrated to SearchRequest (#10654)
+EnhancedSearchRequest = SearchRequest
 
 
 class ConsolidatedSearchRequest(BaseModel):
@@ -4561,7 +4554,7 @@ class EventSearchRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class UnifiedSearchRequest(BaseModel):
+class UnifiedSearchRequest(BaseModel):  # canonical: ignore py-duplicate-concept — multi-source search (#10654)
     """Request model for unified knowledge search."""
 
     query: str = Field(..., description="Search query text")


### PR DESCRIPTION
## Thinking Path

The `py-duplicate-concept` rule flagged two hits in `schemas_knowledge.py`:
1. `EnhancedSearchRequest` (line 1040) — shadows base `SearchRequest` (line 1024)
2. `UnifiedSearchRequest` (line 4564) — shadows base `SearchRequest`

**Schema map built before touching anything:**

| Schema | Fields | External usages | Status |
|---|---|---|---|
| `SearchRequest` (old, :1024) | query, limit, category | Zero — no external imports | Dead |
| `EnhancedSearchRequest` (:1040) | query, limit, offset, category, tags, tags_match_any, mode, enable_reranking, min_score, access_level, board_id + 4 methods | `knowledge_search.py` x2 (enhanced_search endpoint + _enhanced_search_fallback) | Live — canonical |
| `ConsolidatedSearchRequest` (:1161) | query, top_k (not limit!), category, mode, enable_rag, reformulate_query, return_context, tags, tags_match_any, min_score, offset, date filters, exclude_terms, require_terms, include_documentation, include_relations, board_id, track_analytics, session_id | `knowledge_search.py` x4 (primary /search endpoint + 3 helpers) | Live — distinct concept: full-featured primary search with RAG and analytics |
| `UnifiedSearchRequest` (:4564) | query, top_k, doc_results, expand_relations, score_threshold, include_sources | `knowledge_search_aggregator.py` x1 | Live — distinct concept: multi-source search |

**Decision rationale:**
- `SearchRequest` (old 3-field) is dead: never imported anywhere. Absorb fields into canonical.
- `EnhancedSearchRequest` IS the canonical for vector/document search (full feature set).
- `ConsolidatedSearchRequest` is NOT the same concept — uses `top_k` (not `limit`), has RAG params (`enable_rag`, `reformulate_query`, `return_context`), date filters, analytics tracking. Collapsing it would break the `/search` API contract. Kept as-is.
- `UnifiedSearchRequest` is multi-source (facts + relations + docs + graph expansion) — legitimately different domain concept. Waiver added.

## What Changed

**`autobot-backend/api/schemas_knowledge.py`**
- Removed dead 3-field `SearchRequest` class
- Expanded `EnhancedSearchRequest` body → now named `SearchRequest` (canonical); docstring updated with consolidation note and issue refs
- Added `EnhancedSearchRequest = SearchRequest` module-level alias (assignment, not class def → rule no longer fires; alias preserves any external code that imports by the old name)
- Added `# canonical: ignore py-duplicate-concept` waiver on `UnifiedSearchRequest` (111 chars, ≤120)

**`autobot-backend/api/knowledge_search.py`**
- Import updated to `from api.schemas_knowledge import ConsolidatedSearchRequest, SearchRequest as EnhancedSearchRequest` — preserves existing local type annotations without touching any function signatures

## Verification

**py-duplicate-concept hits in schemas_knowledge.py:**
- Before: 2 (`EnhancedSearchRequest` + `UnifiedSearchRequest`)
- After: 0

Remaining hits (schemas_agent.py + schemas_chat.py x2) are out of scope — separate PRs per issue.

**Backward-compat proof:**
```
SearchRequest is EnhancedSearchRequest: True
minimal call OK: hello 10 None      # old 3-field callers still validate
enhanced alias OK: hello 5 semantic  # EnhancedSearchRequest alias works
consolidated OK: test 10             # ConsolidatedSearchRequest untouched
All OK
```

**Startup imports:** `pytest autobot-backend/tests/test_startup_imports.py` → 339 passed, 83 warnings

**flake8 --config=.flake8** on changed files → 0 warnings/errors

**black --line-length=120** → both files left unchanged

**awk 'length>120'** on changed files → empty (no long lines)

## Model Used

claude-sonnet-4-6

Part of #10654