### PR TITLE
feat(orchestration): surface agent recommendation scores (#10660)

### DIFF
--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -271,8 +271,10 @@ async def recommend_agents(
         if not capabilities_needed:
             raise HTTPException(status_code=400, detail="No valid capabilities specified")
 
-        # Get recommendations
-        recommendations = await orchestrator.get_agent_recommendations(capabilities_needed)
+        # Get recommendations with ranking scores (#10660); names preserved for
+        # backward compatibility, scores surfaced as an additive field.
+        scored = await orchestrator.get_agent_recommendations_scored(capabilities_needed)
+        recommendations = [agent for agent, _ in scored]
 
         return JSONResponse(
             status_code=200,
@@ -282,6 +284,7 @@ async def recommend_agents(
                 "capabilities_requested": request.capabilities_needed,
                 "recommended_agents": recommendations,
                 "agent_count": len(recommendations),
+                "agent_scores": [{"agent": agent, "score": round(score, 4)} for agent, score in scored],
             },
         )
 

--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -2615,6 +2615,8 @@ class OrchestrationAgentRecommendResponse(BaseModel):
     capabilities_requested: List[str] = Field(default_factory=list)
     recommended_agents: List[Any] = Field(default_factory=list)
     agent_count: int = 0
+    # #10660: ranking scores [{agent, score}] for the recommended agents.
+    agent_scores: List[Dict[str, Any]] = Field(default_factory=list)
 
 
 class OrchestrationActiveWorkflowsResponse(BaseModel):

--- a/autobot-backend/enhanced_orchestration/agent_router.py
+++ b/autobot-backend/enhanced_orchestration/agent_router.py
@@ -10,7 +10,7 @@ it from ``agents.agent_orchestration.routing.AgentRouter`` (522 LOC, user-reques
 *user-request* routing.  The old name is retained as an alias for backward compatibility.
 """
 
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Set, Tuple
 
 from autobot_shared.logging_manager import get_logger
 from orchestration import AgentCapability
@@ -39,8 +39,15 @@ class TaskAgentScorer:
         self._perf = performance_tracker
         self._agent_client_registry = agent_registry
 
-    async def get_agent_recommendations(self, capabilities_needed: Set) -> List[str]:
-        suitable = []
+    async def get_agent_recommendations_scored(self, capabilities_needed: Set) -> List[Tuple[str, float]]:
+        """Return (agent, score) pairs ranked best-first (#10660).
+
+        Score blends reliability (0.5), capability-coverage (0.3) and experience
+        (0.2). Previously the score was computed then discarded; callers that
+        want the ranking confidence use this, while get_agent_recommendations
+        keeps returning a plain name list for backward compatibility.
+        """
+        suitable: List[Tuple[str, float]] = []
         for agent, caps in self.agent_capabilities.items():
             if not capabilities_needed.issubset(caps):
                 continue
@@ -54,7 +61,11 @@ class TaskAgentScorer:
             )
             suitable.append((agent, score))
         suitable.sort(key=lambda x: x[1], reverse=True)
-        return [a for a, _ in suitable]
+        return suitable
+
+    async def get_agent_recommendations(self, capabilities_needed: Set) -> List[str]:
+        scored = await self.get_agent_recommendations_scored(capabilities_needed)
+        return [agent for agent, _ in scored]
 
     async def get_agent_instance(self, agent_type: str) -> Any | None:
         agent = self._agent_client_registry.get_agent(agent_type)

--- a/autobot-backend/enhanced_orchestration/workflow_runner.py
+++ b/autobot-backend/enhanced_orchestration/workflow_runner.py
@@ -17,7 +17,7 @@ orchestration.WorkflowExecutor remains canonical for the legacy step-based path.
 
 import asyncio
 import time
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Set, Tuple
 
 from autobot_shared.logging_manager import get_logger
 from enhanced_orchestration.agent_router import AgentRouter
@@ -128,6 +128,9 @@ class WorkflowRunner:
 
     async def get_agent_recommendations(self, capabilities_needed: Set) -> List[str]:
         return await self._agent_router.get_agent_recommendations(capabilities_needed)
+
+    async def get_agent_recommendations_scored(self, capabilities_needed: Set) -> List[Tuple[str, float]]:
+        return await self._agent_router.get_agent_recommendations_scored(capabilities_needed)
 
     def get_blocked_plan_resumer(self) -> Any:
         """Return the BlockedPlanResumer for this runner (lazy-constructed).

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -33,7 +33,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Set, Tuple
 
 from autobot_shared.logging_manager import get_logger
 from config.manager import get_config_manager as _get_config_manager
@@ -678,6 +678,10 @@ class Orchestrator(_DeprecatedRequestMixin):
     async def get_agent_recommendations(self, capabilities_needed: Set) -> List[str]:
         """Get recommended agents for a task. Delegates to WorkflowRunner (#5058)."""
         return await self._runner.get_agent_recommendations(capabilities_needed)
+
+    async def get_agent_recommendations_scored(self, capabilities_needed: Set) -> List[Tuple[str, float]]:
+        """Get (agent, score) recommendations. Delegates to WorkflowRunner (#10660)."""
+        return await self._runner.get_agent_recommendations_scored(capabilities_needed)
 
     def get_performance_report(self) -> Dict[str, Any]:
         """Performance report. Delegates to WorkflowRunner (#5058)."""

--- a/autobot-backend/tests/enhanced_orchestration/test_agent_scores.py
+++ b/autobot-backend/tests/enhanced_orchestration/test_agent_scores.py
@@ -1,0 +1,44 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""TaskAgentScorer surfaces ranking scores instead of discarding them (#10660)."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from enhanced_orchestration.agent_router import TaskAgentScorer
+
+
+def _scorer():
+    perf = types.SimpleNamespace(
+        agent_performance={
+            "agent_a": types.SimpleNamespace(reliability_score=0.9, total_tasks=50),
+            "agent_b": types.SimpleNamespace(reliability_score=0.5, total_tasks=10),
+        }
+    )
+    caps = {"agent_a": {"x", "y"}, "agent_b": {"x", "y"}}
+    return TaskAgentScorer(caps, perf, agent_registry=None)
+
+
+@pytest.mark.asyncio
+async def test_scored_returns_ranked_tuples():
+    scored = await _scorer().get_agent_recommendations_scored({"x"})
+    assert [a for a, _ in scored] == ["agent_a", "agent_b"]  # higher reliability ranks first
+    assert all(isinstance(s, float) for _, s in scored)
+    assert scored[0][1] > scored[1][1]  # descending by score
+
+
+@pytest.mark.asyncio
+async def test_names_only_variant_preserves_order_and_contract():
+    names = await _scorer().get_agent_recommendations({"x"})
+    assert names == ["agent_a", "agent_b"]  # still List[str], same ranking
+
+
+@pytest.mark.asyncio
+async def test_unmatched_capabilities_excluded():
+    scored = await _scorer().get_agent_recommendations_scored({"z"})  # no agent has 'z'
+    assert scored == []


### PR DESCRIPTION
## Thinking Path
Subtask 6.6 of #10602 (umbrella #10603, "safe/additive" scope). `TaskAgentScorer.get_agent_recommendations` computed a reliability/capability/experience score per agent, sorted by it, then **discarded the scores** (`return [a for a, _ in suitable]`). Purely additive wire-in: surface the computed ranking confidence without changing any existing contract.

## What Changed
- **`get_agent_recommendations_scored()`** (`enhanced_orchestration/agent_router.py`) returns `[(agent, score)]` ranked best-first. `get_agent_recommendations` now delegates to it and still returns `List[str]` — internal callers (`WorkflowRunner:130`, `Orchestrator:680`) are byte-for-byte unchanged.
- **Passthroughs** added on `WorkflowRunner` and `Orchestrator`.
- **`POST /agents/recommend`** returns an additive `agent_scores` field (`[{agent, score}]`); `recommended_agents` unchanged. `OrchestrationAgentRecommendResponse` gains the field.

No behavior change to existing paths; no `_v2`.

## Verification
- `tests/enhanced_orchestration/test_agent_scores.py` — scored returns descending `(agent, score)` tuples; names-only variant preserves order + `List[str]` contract; unmatched capabilities excluded (3 passing).
- `flake8 --max-line-length=120` clean; `black`/`isort` clean; `py_compile` clean.

Closes #10660. Part of #10602 / umbrella #10603.

## Model Used
Claude Opus 4.8 (1M context)