### PR TITLE
refactor(schemas): consolidate ChatMessage + ChatHealthData pairs in schemas_chat.py (#10654)

### DIFF
--- a/autobot-backend/api/api_endpoint_migrations_test.py
+++ b/autobot-backend/api/api_endpoint_migrations_test.py
@@ -24335,7 +24335,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
         from api import chat_enhanced
 
         source = inspect.getsource(chat_enhanced.compatible_chat_message)
-        self.assertIn("EnhancedChatMessage", source)
+        self.assertIn("ChatMessage", source)
         self.assertIn("use_ai_stack", source)
         self.assertIn("use_knowledge_base", source)
 

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -42,8 +42,6 @@ from api.schemas_chat import (
     DetectLanguageRequest,
     EnhancedChatCapabilitiesData,
     EnhancedChatData,
-    EnhancedChatHealthData,
-    EnhancedChatMessage,
     TranslateData,
     TranslateRequest,
 )
@@ -1585,7 +1583,7 @@ async def send_direct_chat_response(
 
 
 async def _store_enhanced_user_message(
-    message: EnhancedChatMessage,
+    message: ChatMessage,
     session_id: str,
     chat_history_manager,
 ) -> str:
@@ -1622,7 +1620,7 @@ async def _store_enhanced_user_message(
 
 
 async def _get_enhanced_chat_context(
-    message: EnhancedChatMessage,
+    message: ChatMessage,
     session_id: str,
     chat_history_manager,
 ) -> list:
@@ -1645,7 +1643,7 @@ async def _get_enhanced_chat_context(
 
 
 async def _enhance_with_knowledge_base(
-    message: EnhancedChatMessage,
+    message: ChatMessage,
     knowledge_base,
 ) -> tuple:
     """Enhance context with knowledge base search."""
@@ -1682,7 +1680,7 @@ def _get_ai_stack_message_limit(chat_history_manager, model_name: str | None) ->
 
 
 async def _generate_ai_stack_chat_response(
-    message: EnhancedChatMessage,
+    message: ChatMessage,
     chat_context: list,
     enhanced_context: str | None,
     chat_history_manager,
@@ -1796,7 +1794,7 @@ async def _store_enhanced_ai_response(
 
 
 async def _execute_enhanced_chat_pipeline(
-    message: EnhancedChatMessage,
+    message: ChatMessage,
     session_id: str,
     chat_history_manager,
     knowledge_base,
@@ -1844,7 +1842,7 @@ async def _execute_enhanced_chat_pipeline(
 
 
 async def process_enhanced_chat_message(
-    message: EnhancedChatMessage,
+    message: ChatMessage,
     chat_history_manager,
     knowledge_base,
     config: Metadata,
@@ -1890,7 +1888,7 @@ def _format_sse_event(data: dict) -> str:
 
 
 async def _stream_ai_stack_response(
-    message: EnhancedChatMessage,
+    message: ChatMessage,
     session_id: str,
     chat_history_manager,
     request_id: str,
@@ -1951,7 +1949,7 @@ def _stream_enhanced_fallback_response(session_id: str):
 
 
 async def _generate_enhanced_stream(
-    message: EnhancedChatMessage,
+    message: ChatMessage,
     request: Request,
     request_id: str,
     preferences: ChatPreferences | None,
@@ -1997,7 +1995,7 @@ async def _generate_enhanced_stream(
 )
 async def enhanced_chat(
     current_user: dict = Depends(get_current_user),
-    message: EnhancedChatMessage = None,
+    message: ChatMessage = None,
     request: Request = None,
     preferences: ChatPreferences | None = None,
     config=Depends(get_config),
@@ -2065,7 +2063,7 @@ async def enhanced_chat(
 )
 async def stream_enhanced_chat(
     current_user: dict = Depends(get_current_user),
-    message: EnhancedChatMessage = None,
+    message: ChatMessage = None,
     request: Request = None,
     preferences: ChatPreferences | None = None,
 ):
@@ -2091,7 +2089,7 @@ async def stream_enhanced_chat(
     )
 
 
-@router.get("/health-enhanced", response_model=EnhancedChatHealthData)
+@router.get("/health-enhanced", response_model=ChatHealthData)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="enhanced_chat_health_check",

--- a/autobot-backend/api/chat_phase2_test.py
+++ b/autobot-backend/api/chat_phase2_test.py
@@ -5,7 +5,7 @@
 """Phase 2 backend persistence consolidation tests (Issue #7572).
 
 Pins four acceptance criteria from the SSOT design:
-  1. ChatMessage / EnhancedChatMessage require session_id (→ 422 when absent)
+  1. ChatMessage requires session_id (→ 422 when absent)
   2. process_enhanced_chat_message returns HTTP 422 for invalid session_id format
   3. chat:recent sorted-set has TTL applied after every zadd
   4. save_session writes disk before updating Redis cache
@@ -24,7 +24,7 @@ from pydantic import ValidationError
 
 
 class TestSessionIdRequired:
-    """ChatMessage and EnhancedChatMessage must reject requests missing session_id."""
+    """ChatMessage must reject requests missing session_id."""
 
     def test_chat_message_without_session_id_raises_422_schema_error(self):
         from api.schemas_chat import ChatMessage
@@ -38,10 +38,11 @@ class TestSessionIdRequired:
         ), "Pydantic must flag session_id as missing — FastAPI surfaces this as HTTP 422"
 
     def test_enhanced_chat_message_without_session_id_raises_422_schema_error(self):
-        from api.schemas_chat import EnhancedChatMessage
+        # Consolidated into ChatMessage (#10654); same validation applies
+        from api.schemas_chat import ChatMessage
 
         with pytest.raises(ValidationError) as exc_info:
-            EnhancedChatMessage(content="hello")
+            ChatMessage(content="hello")
 
         errors = exc_info.value.errors()
         assert any(e["loc"] == ("session_id",) for e in errors)
@@ -53,9 +54,10 @@ class TestSessionIdRequired:
         assert msg.session_id == "abc-123"
 
     def test_enhanced_chat_message_with_session_id_is_accepted(self):
-        from api.schemas_chat import EnhancedChatMessage
+        # Consolidated into ChatMessage (#10654); same validation applies
+        from api.schemas_chat import ChatMessage
 
-        msg = EnhancedChatMessage(content="hello", session_id="abc-123")
+        msg = ChatMessage(content="hello", session_id="abc-123")
         assert msg.session_id == "abc-123"
 
 
@@ -64,7 +66,7 @@ class TestSessionIdRequired:
 # ---------------------------------------------------------------------------
 
 
-class TestEnhancedChatMessage422:
+class TestEnhancedChatSession422:
     """process_enhanced_chat_message raises HTTPException(422) for bad format."""
 
     @pytest.mark.asyncio
@@ -72,10 +74,10 @@ class TestEnhancedChatMessage422:
         from fastapi import HTTPException
 
         from api.chat import process_enhanced_chat_message
-        from api.schemas_chat import EnhancedChatMessage
+        from api.schemas_chat import ChatMessage
 
         with patch("api.chat.validate_chat_session_id", return_value=False):
-            msg = EnhancedChatMessage(content="hello", session_id="BAD_FORMAT")
+            msg = ChatMessage(content="hello", session_id="BAD_FORMAT")
             with pytest.raises(HTTPException) as exc_info:
                 await process_enhanced_chat_message(
                     message=msg,

--- a/autobot-backend/api/schemas_chat.py
+++ b/autobot-backend/api/schemas_chat.py
@@ -208,22 +208,30 @@ class ChatMessageData(BaseModel):
 
 
 class ChatHealthComponents(BaseModel):
-    """Component health subsection of ChatHealthData."""
+    """Component health subsection of ChatHealthData (kept for import compat)."""
 
     chat_history_manager: str
     llm_service: str
 
 
 class ChatHealthData(BaseModel):
-    """Response shape for GET /chat/health (#6497).
+    """Response shape for GET /chat/health and GET /health-enhanced (#6497, #10654).
 
-    Wire format is the model itself — no DataResponse envelope. The route
-    declares response_model=ChatHealthData directly.
+    Canonical model for both health endpoints. Wire format is the model itself —
+    no DataResponse envelope. ``components`` is Dict[str, Any] so it handles
+    both the fixed {chat_history_manager, llm_service} shape from /chat/health
+    and the heterogeneous per-component map from /health-enhanced.
+    ``error`` is only populated on the /health-enhanced error path.
     """
 
     status: str
     timestamp: str
-    components: ChatHealthComponents
+    components: Dict[str, Any]
+    error: str | None = None
+
+
+# Backward-compat alias — existing imports of EnhancedChatHealthData keep working.
+EnhancedChatHealthData = ChatHealthData
 
 
 class ChatStatsData(BaseModel):
@@ -267,20 +275,6 @@ class EnhancedChatData(BaseModel):
     timestamp: str | None = None
     metadata: Dict[str, Any] | None = None
     knowledge_sources: List[Dict[str, Any]] | None = None
-
-
-class EnhancedChatHealthData(BaseModel):
-    """Response shape for GET /health-enhanced (#6497).
-
-    Wire format is the model itself — no DataResponse envelope. The
-    components map is heterogeneous (per-component status strings keyed
-    by component name) so it is typed as Dict[str, Any].
-    """
-
-    status: str
-    timestamp: str
-    components: Dict[str, Any]
-    error: str | None = None
 
 
 class EnhancedChatCapabilitiesData(BaseModel):
@@ -459,7 +453,14 @@ class ChatResetRequest(BaseModel):
 
 
 class ChatMessage(BaseModel):
-    """Chat message model for requests"""
+    """Chat message model for requests — canonical for both /chat and /enhanced (#10654).
+
+    All ``EnhancedChatMessage``-only fields (use_ai_stack, use_knowledge_base,
+    response_style, include_sources) carry defaults so a plain /chat request
+    that omits them validates without change. ``reasoning_effort`` is used by
+    /chat only and is also optional, so /enhanced requests that omit it still
+    validate.
+    """
 
     content: str = Field(..., min_length=1, max_length=50000, description="Message content")
     role: str = Field(
@@ -475,6 +476,12 @@ class ChatMessage(BaseModel):
         description="Preferred response language code (e.g. 'en', 'es', 'de'). "
         "Overrides personality language when set.",
     )
+    # AI Stack fields (used by /enhanced endpoints; defaulted so /chat requests omit safely)
+    use_ai_stack: bool = Field(True, description="Whether to use AI Stack for enhanced responses")
+    use_knowledge_base: bool = Field(True, description="Whether to include knowledge base context")
+    response_style: str = Field("conversational", description="Response style preference")
+    include_sources: bool = Field(True, description="Whether to include source citations")
+    # Thinking / reasoning fields (shared by both /chat and /enhanced)
     thinking_mode_enabled: bool | None = Field(
         None,
         description="Enable extended thinking mode for reasoning models (Claude 3.7+, DeepSeek R1). "
@@ -496,6 +503,10 @@ class ChatMessage(BaseModel):
     )
 
 
+# Backward-compat alias — existing imports of EnhancedChatMessage keep working.
+EnhancedChatMessage = ChatMessage
+
+
 class ChatResponse(BaseModel):
     """Chat response model"""
 
@@ -515,41 +526,6 @@ class MessageHistory(BaseModel):
     total_count: int
     page: int = 1
     per_page: int = 50
-
-
-class EnhancedChatMessage(BaseModel):
-    """Enhanced chat message with AI Stack integration."""
-
-    content: str = Field(..., min_length=1, max_length=50000, description="Message content")
-    role: str = Field(
-        default=CategoryDefaults.ROLE_USER,
-        pattern="^(user|assistant|system)$",
-        description="Message role",
-    )
-    session_id: str = Field(..., description="Chat session ID")
-    message_type: str | None = Field("text", description="Message type")
-    metadata: Metadata | None = Field(default_factory=dict, description="Additional metadata")
-    language: str | None = Field(
-        None,
-        description="Preferred response language code (e.g. 'en', 'es', 'de'). "
-        "Overrides personality language when set.",
-    )
-    use_ai_stack: bool = Field(True, description="Whether to use AI Stack for enhanced responses")
-    use_knowledge_base: bool = Field(True, description="Whether to include knowledge base context")
-    response_style: str = Field("conversational", description="Response style preference")
-    include_sources: bool = Field(True, description="Whether to include source citations")
-    thinking_mode_enabled: bool | None = Field(
-        None,
-        description="Enable extended thinking mode for reasoning models (Claude 3.7+, DeepSeek R1). "
-        "When enabled, the model performs chain-of-thought reasoning before responding.",
-    )
-    thinking_budget_tokens: int | None = Field(
-        None,
-        ge=1000,
-        le=128000,
-        description="Thinking budget in tokens (e.g., 1000, 5000, 10000, 63000). "
-        "Only used when thinking_mode_enabled=True. Limits the amount of reasoning tokens.",
-    )
 
 
 class ChatPreferences(BaseModel):

--- a/autobot-backend/api/schemas_chat.py
+++ b/autobot-backend/api/schemas_chat.py
@@ -230,10 +230,6 @@ class ChatHealthData(BaseModel):
     error: str | None = None
 
 
-# Backward-compat alias — existing imports of EnhancedChatHealthData keep working.
-EnhancedChatHealthData = ChatHealthData
-
-
 class ChatStatsData(BaseModel):
     """data payload for GET /chat/stats (#6490).
 
@@ -455,7 +451,7 @@ class ChatResetRequest(BaseModel):
 class ChatMessage(BaseModel):
     """Chat message model for requests — canonical for both /chat and /enhanced (#10654).
 
-    All ``EnhancedChatMessage``-only fields (use_ai_stack, use_knowledge_base,
+    Fields from the former enhanced variant (use_ai_stack, use_knowledge_base,
     response_style, include_sources) carry defaults so a plain /chat request
     that omits them validates without change. ``reasoning_effort`` is used by
     /chat only and is also optional, so /enhanced requests that omit it still
@@ -501,10 +497,6 @@ class ChatMessage(BaseModel):
         "Overrides the user's account-level default. Omit to use the user default. "
         "When 'auto' or absent the provider's own defaults are used (#9017).",
     )
-
-
-# Backward-compat alias — existing imports of EnhancedChatMessage keep working.
-EnhancedChatMessage = ChatMessage
 
 
 class ChatResponse(BaseModel):


### PR DESCRIPTION
## Thinking Path

Two \`py-duplicate-concept\` pairs existed in \`autobot-backend/api/schemas_chat.py\`. Both prefixed names (\`EnhancedChatMessage\`, \`EnhancedChatHealthData\`) are the tech debt — they are removed entirely (no class, no alias, no import anywhere).

**Pair 1 — REQUEST models:** \`ChatMessage\` vs \`EnhancedChatMessage\`
- Mapped all usages: \`ChatMessage\` used in \`/chat\`, \`/chat/message\`, Telegram, WhatsApp; \`EnhancedChatMessage\` used in \`/enhanced\`, \`/stream-enhanced\`, and 9 internal helper signatures in \`chat.py\`
- Field audit: \`ChatMessage\` had \`reasoning_effort\` (absent in Enhanced). \`EnhancedChatMessage\` had \`use_ai_stack\`, \`use_knowledge_base\`, \`response_style\`, \`include_sources\` (absent in base). All extra fields have defaults — backward-compat proven field-by-field.
- Result: \`ChatMessage\` is the canonical with all fields. \`EnhancedChatMessage\` removed everywhere.

**Pair 2 — RESPONSE models:** \`ChatHealthData\` vs \`EnhancedChatHealthData\`
- Both endpoints return \`JSONResponse\` directly — \`response_model=\` is OpenAPI docs only, not wire format.
- \`ChatHealthData.components\` widened from \`ChatHealthComponents\` to \`Dict[str, Any]\` (superset — any dict the typed model produced satisfies this). \`error: str | None = None\` added (additive). \`ChatHealthComponents\` kept for direct imports.
- Result: \`ChatHealthData\` is the canonical. \`EnhancedChatHealthData\` removed everywhere.

## What Changed

4 files changed (-32/+24 net):

- **\`autobot-backend/api/schemas_chat.py\`**: \`ChatMessage\` gains the 4 AI Stack fields with defaults; \`ChatHealthData\` gains \`components: Dict[str, Any]\` and \`error: str | None\`. Both Enhanced class definitions removed. No aliases.
- **\`autobot-backend/api/chat.py\`**: import block drops \`EnhancedChatMessage\` + \`EnhancedChatHealthData\`; all 11 \`EnhancedChatMessage\` type annotations → \`ChatMessage\`; \`response_model=EnhancedChatHealthData\` → \`response_model=ChatHealthData\` on \`GET /health-enhanced\`.
- **\`autobot-backend/api/chat_phase2_test.py\`**: imports, class name, docstrings updated to use \`ChatMessage\`.
- **\`autobot-backend/api/api_endpoint_migrations_test.py\`**: dead batch-145 assertIn updated from \`"EnhancedChatMessage"\` → \`"ChatMessage"\` (test always skips — \`api.chat_enhanced\` module does not exist).

## Verification

\`\`\`
# Zero-grep proof
git grep -rn "EnhancedChatMessage|EnhancedChatHealthData" -- autobot-backend/
→ 0 hits

# py-duplicate-concept
python3 tools/lint/canonical_check.py --all | grep py-duplicate-concept | grep chat
→ 0 hits in schemas_chat.py

# startup import smoke
pytest autobot-backend/tests/test_startup_imports.py -q
→ 339 passed

# schema validation tests
pytest autobot-backend/api/chat_phase2_test.py -v
→ 6 passed, 1 pre-existing failure (TestChatRecentZremrangebyrank — identical on base)

# flake8
flake8 --config=.flake8 autobot-backend/api/schemas_chat.py autobot-backend/api/chat.py autobot-backend/api/chat_phase2_test.py
→ exit 0

# line-length
awk 'length>120' <changed files>
→ empty
\`\`\`

## Model Used

claude-sonnet-4-6

Part of #10654