### PR TITLE
fix(backend): commit seeded admin + reconcile missing updated_at columns (#10636)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1342,6 +1342,10 @@ async def _seed_default_admin() -> None:
 
         async with get_async_session_factory()() as session:
             await seed_default_admin(session)
+            # seed_default_admin (via UserService) only flushes; without an
+            # explicit commit the created admin is rolled back on session
+            # exit and never persists (#10636).
+            await session.commit()
     except Exception as e:
         logger.warning("Default admin seeding failed (non-critical): %s", e)
 

--- a/autobot-backend/migrations/versions/20260629_063_add_missing_updated_at_drift.py
+++ b/autobot-backend/migrations/versions/20260629_063_add_missing_updated_at_drift.py
@@ -1,0 +1,77 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Add missing updated_at columns (Base timestamp drift) (#10636).
+
+``user_management.models.base.Base`` gives every model both ``created_at`` and
+``updated_at``, but the initial migration (20251224_001) and a few later ones
+created some tables without ``updated_at``. Because the ORM still emits
+``RETURNING ... updated_at`` for those mapped classes, any write fails with
+``column "updated_at" does not exist`` — most visibly when seeding the default
+platform admin (which writes ``audit_logs``), so full-user-management logins
+had no admin account to authenticate against.
+
+This reconciles the drift idempotently: add ``updated_at`` to every affected
+table if it is missing. Safe on fresh, partially-migrated, or already-patched
+databases (``IF NOT EXISTS`` + ``has_table`` guard).
+
+Revision ID: 20260629_063
+Revises: 20260623_062
+Create Date: 2026-06-29
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from migrations.guards import has_table
+
+# revision identifiers, used by Alembic.
+revision: str = "20260629_063"
+down_revision: Union[str, None] = "20260623_062"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Tables observed missing ``updated_at`` despite inheriting Base's timestamp
+# columns (or being written through the audited service layer). Listed
+# explicitly so the reconciliation is reviewable and deterministic.
+_TABLES_MISSING_UPDATED_AT: tuple[str, ...] = (
+    "agent_connections",
+    "agent_task_history",
+    "audit_logs",
+    "chat_shared_links",
+    "completion_feedback",
+    "desktop_mobile_devices",
+    "heartbeat_run_events",
+    "llc_activity_log",
+    "llc_agent_api_keys",
+    "llc_heartbeat_runs",
+    "llc_routine_runs",
+    "llc_run_replay_logs",
+    "mesh_edges",
+    "mesh_evolution_log",
+    "mesh_nodes",
+    "mesh_nodes_archive",
+    "push_subscriptions",
+    "role_permissions",
+    "task_approval_links",
+    "user_voice_bundle",
+    "workflow_audit_log",
+)
+
+
+def upgrade() -> None:
+    for table in _TABLES_MISSING_UPDATED_AT:
+        if has_table(table):
+            op.execute(
+                f'ALTER TABLE "{table}" '
+                "ADD COLUMN IF NOT EXISTS updated_at "
+                "TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()"
+            )
+
+
+def downgrade() -> None:
+    # Forward-only drift reconciliation: dropping ``updated_at`` again would
+    # re-break the ORM write paths these columns fix, so downgrade is a no-op.
+    pass


### PR DESCRIPTION
## Thinking Path
Live #10636 Task 4 follow-up: full-user-management /login had no admin account. Two root-cause bugs, both only hit in company mode:
1. The startup admin seed never committed (UserService only flushes) -> created admin rolled back on session exit.
2. Schema drift: Base defines created_at+updated_at for every model, but the initial migration created several tables (audit_logs, llc_*, mesh_*, role_permissions, etc.) without updated_at, so audited writes (admin seed -> audit_logs insert) failed with column updated_at does not exist.

## What Changed
- initialization/lifespan.py: add await session.commit() in _seed_default_admin.
- migrations/versions/20260629_063_add_missing_updated_at_drift.py: idempotently ADD COLUMN IF NOT EXISTS updated_at (has_table-guarded) to the 21 affected tables.

## Verification
py_compile OK both files. Verified live on the box: after adding audit_logs.updated_at and running the seed with commit, the admin persisted and POST /api/auth/login returns 200. Migration is idempotent (IF NOT EXISTS) so safe on the already-patched box and fresh installs.

## Model Used
Claude Opus 4.8 (1M context)

Refs #10636 (Task 4 follow-up: fixes A seed-commit + B schema-drift)