### PR TITLE
perf(knowledge): structured_output for cognifier extraction, kept cacheable (#10665)

### DIFF
--- a/autobot-backend/knowledge/pipeline/cognifiers/causal_relationship_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/causal_relationship_extractor.py
@@ -308,7 +308,9 @@ class CausalRelationshipExtractor(BaseCognifier):
         """
         try:
             prompt = CAUSAL_EXTRACTION_PROMPT.format(text=chunk.content)
-            response = await self.llm.chat([{"role": "user", "content": prompt}], llm_type="extraction")
+            response = await self.llm.chat(
+                [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
+            )
             parsed = parse_llm_json_response(response.content)
             raw_edges = parsed if isinstance(parsed, list) else []
             return self._convert_to_causal_edges(raw_edges, chunk, context.document_id)

--- a/autobot-backend/knowledge/pipeline/cognifiers/entity_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/entity_extractor.py
@@ -262,7 +262,9 @@ class EntityExtractor(BaseCognifier):
         """Extract entities from a single chunk."""
         try:
             prompt = ENTITY_EXTRACTION_PROMPT.format(text=chunk.content)
-            response = await self.llm.chat([{"role": "user", "content": prompt}], llm_type="extraction")
+            response = await self.llm.chat(
+                [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
+            )
             parsed = parse_llm_json_response(response.content)
             raw_entities = parsed if isinstance(parsed, list) else []
             return self._convert_to_entities(raw_entities, chunk, context.document_id)

--- a/autobot-backend/knowledge/pipeline/cognifiers/event_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/event_extractor.py
@@ -106,7 +106,9 @@ class EventExtractor(BaseCognifier):
         """Extract events from a single chunk."""
         try:
             prompt = EVENT_EXTRACTION_PROMPT.format(text=chunk.content)
-            response = await self.llm.chat([{"role": "user", "content": prompt}], llm_type="extraction")
+            response = await self.llm.chat(
+                [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
+            )
             parsed = parse_llm_json_response(response.content)
             raw_events = parsed if isinstance(parsed, list) else []
             return self._convert_to_events(raw_events, chunk, entity_map, context)

--- a/autobot-backend/knowledge/pipeline/cognifiers/fact_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/fact_extractor.py
@@ -275,7 +275,9 @@ class FactExtractor(BaseCognifier):
         """
         blocks = "\n\n".join(f"Chunk {i}:\n{c.content[:MAX_CHUNK_CHARS]}" for i, c in enumerate(chunks))
         prompt = FACT_EXTRACTION_BATCH_PROMPT.format(chunks=blocks)
-        response = await self.llm.chat([{"role": "user", "content": prompt}], llm_type="extraction")
+        response = await self.llm.chat(
+            [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
+        )
         parsed = parse_llm_json_response(response.content)
         if not isinstance(parsed, dict):
             raise ValueError("batched fact response was not a JSON object")
@@ -300,7 +302,9 @@ class FactExtractor(BaseCognifier):
         """Extract facts from a single chunk using LLM."""
         try:
             prompt = FACT_EXTRACTION_PROMPT.format(text=chunk.content[:MAX_CHUNK_CHARS])
-            response = await self.llm.chat([{"role": "user", "content": prompt}], llm_type="extraction")
+            response = await self.llm.chat(
+                [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
+            )
             parsed = parse_llm_json_response(response.content)
             raw_facts = parsed if isinstance(parsed, list) else []
             return self._convert_to_facts(raw_facts, chunk, context.document_id)

--- a/autobot-backend/knowledge/pipeline/cognifiers/llm_type_wiring_test.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/llm_type_wiring_test.py
@@ -38,6 +38,7 @@ async def test_fact_extractor_uses_extraction_llm_type():
 
     _, kwargs = ext.llm.chat.call_args
     assert kwargs.get("llm_type") == "extraction"
+    assert kwargs.get("structured_output") is True  # #10665: forced JSON for reliable parsing
 
 
 @pytest.mark.asyncio
@@ -62,3 +63,4 @@ async def test_entity_extractor_uses_extraction_llm_type():
 
     _, kwargs = ext.llm.chat.call_args
     assert kwargs.get("llm_type") == "extraction"
+    assert kwargs.get("structured_output") is True  # #10665: forced JSON for reliable parsing

--- a/autobot-backend/knowledge/pipeline/cognifiers/relationship_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/relationship_extractor.py
@@ -244,7 +244,9 @@ class RelationshipExtractor(BaseCognifier):
         try:
             entity_list = self._format_entity_list(entities, chunk)
             prompt = RELATIONSHIP_EXTRACTION_PROMPT.format(entities=entity_list, text=chunk.content)
-            response = await self.llm.chat([{"role": "user", "content": prompt}], llm_type="extraction")
+            response = await self.llm.chat(
+                [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
+            )
             parsed = parse_llm_json_response(response.content)
             raw_rels = parsed if isinstance(parsed, list) else []
             return self._convert_to_relationships(raw_rels, chunk, entity_map)

--- a/autobot-backend/llm_shared/cache.py
+++ b/autobot-backend/llm_shared/cache.py
@@ -128,6 +128,7 @@ class LLMResponseCache:
         top_k: int = 40,
         top_p: float = 0.9,
         max_tokens: int | None = None,
+        structured_output: bool = False,
     ) -> str:
         """
         Generate cache key with high-performance xxhash (3-5x faster than MD5).
@@ -144,6 +145,9 @@ class LLMResponseCache:
             max_tokens: Output token ceiling — part of the key so calls that
                 differ only by max_tokens (e.g. a 1024-token extraction vs a
                 full-length chat) don't collide (#10597).
+            structured_output: Whether JSON output is forced — part of the key so
+                a structured request never reuses a free-text cached response,
+                and vice versa (#10665).
 
         Returns:
             Cache key string in format "llm_cache:{hash}"
@@ -156,6 +160,7 @@ class LLMResponseCache:
             top_k,
             top_p,
             max_tokens,
+            structured_output,
         )
 
         # xxhash is 3-5x faster than MD5 for cache key generation

--- a/autobot-backend/services/llm_service.py
+++ b/autobot-backend/services/llm_service.py
@@ -238,6 +238,7 @@ class LLMService:
                 start_time,
                 temperature=temp,
                 max_tokens=tokens,
+                structured_output=request.structured_output,
             )
             if cached is not None:
                 self._calculate_cache_hit_rate(cached)
@@ -1005,12 +1006,14 @@ class LLMService:
 
         Only near-deterministic, safely-reusable requests qualify: caching must
         be enabled, the response cache present, and the request must not stream,
-        use tools, force structured output, request extended thinking, or run at
-        a temperature above the configured determinism threshold.
+        use tools, request extended thinking, or run at a temperature above the
+        configured determinism threshold. Forced structured output IS cacheable
+        (#10665) — it's deterministic JSON and is part of the cache key, so a
+        structured request never reuses a free-text response.
         """
         if not (use_cache and config.llm_response_cache and self._response_cache is not None):
             return False
-        if request.stream or request.structured_output:
+        if request.stream:
             return False
         if getattr(request, "tools", None) or getattr(request, "tool_choice", None):
             return False
@@ -1065,13 +1068,15 @@ class LLMService:
         start_time: float,
         temperature: float = 0.7,
         max_tokens: int | None = None,
+        structured_output: bool = False,
     ) -> tuple:
         """Look up L1/L2 cache for a chat request.
 
         Mirrors the cache-check block in ``LLMInterface._check_cache``
         (interface.py line 765).  Shared by ``chat()`` (#10597) and the
-        optimized vLLM path; ``temperature`` and ``max_tokens`` are part of the
-        cache key so calls differing only in those don't collide.
+        optimized vLLM path; ``temperature``, ``max_tokens`` and
+        ``structured_output`` are part of the cache key so calls differing only
+        in those don't collide.
 
         Returns:
             ``(LLMResponse, cache_key)`` on hit; ``(None, cache_key)`` on miss.
@@ -1081,6 +1086,7 @@ class LLMService:
             model=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
+            structured_output=structured_output,
         )
         cached = await self._response_cache.get(cache_key)
         if cached is not None:

--- a/autobot-backend/tests/services/test_llm_service_caching.py
+++ b/autobot-backend/tests/services/test_llm_service_caching.py
@@ -97,9 +97,11 @@ class _FakeCache:
         self.gets = 0
         self.sets = 0
 
-    def generate_cache_key(self, messages, model, temperature, top_k=40, top_p=0.9, max_tokens=None) -> str:
+    def generate_cache_key(
+        self, messages, model, temperature, top_k=40, top_p=0.9, max_tokens=None, structured_output=False
+    ) -> str:
         last = messages[-1]["content"] if messages else ""
-        return f"{model}|{temperature}|{max_tokens}|{last}"
+        return f"{model}|{temperature}|{max_tokens}|{structured_output}|{last}"
 
     async def get(self, key):
         self.gets += 1
@@ -167,14 +169,26 @@ async def test_chat_use_cache_false_bypasses():
 
 
 @pytest.mark.asyncio
-async def test_chat_structured_output_not_cached():
+async def test_chat_low_temp_structured_output_is_cached():
+    # #10665: deterministic (low-temp) structured output IS cacheable.
     svc, provider, _ = _make_service()
     messages = [{"role": "user", "content": "give json"}]
 
     await svc.chat(messages, temperature=0.0, structured_output=True)
     await svc.chat(messages, temperature=0.0, structured_output=True)
-    # Structured-output responses are not safely reusable → not cached.
-    assert provider.calls == 2
+    assert provider.calls == 1  # second served from cache
+
+
+@pytest.mark.asyncio
+async def test_chat_structured_and_freetext_do_not_collide():
+    # #10665: structured_output is part of the key, so a structured request never
+    # reuses a free-text cached response.
+    svc, provider, _ = _make_service()
+    messages = [{"role": "user", "content": "same prompt"}]
+
+    await svc.chat(messages, temperature=0.0, structured_output=False)
+    await svc.chat(messages, temperature=0.0, structured_output=True)
+    assert provider.calls == 2  # different cache keys → no collision
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Thinking Path
Subtask 2.4 of #10598 (umbrella #10603, final "safe/additive" item). The 5 extractor cognifiers prompt for JSON and parse it, but didn't force structured output — a prose-wrapped/malformed response yields zero facts (lost recall). Enable `structured_output=True` on those calls, done **non-cache-breaking** so the #10643 low-temp caching still applies.

## What Changed
- **`structured_output=True`** on the 5 extractor cognifier `chat()` calls (fact ×2 incl. batched, entity, event, relationship, causal) → forced valid JSON.
- **Cache key** (`generate_cache_key`) now includes `structured_output` so a structured request never reuses a free-text cached response (and vice versa).
- **`_is_cacheable`** no longer blanket-skips `structured_output`; the low-temperature determinism guard already gates reusability, so deterministic structured extraction stays cacheable.
- **`chat()` / `_optimized_check_cache`** thread `structured_output` into the key.

## Verification
- 20 passing across cache + cognifier suites: low-temp structured **is** cached; structured vs free-text **don't collide**; extractor calls pass `structured_output=True`. Updated the prior "structured not cached" test to the new (cacheable) behavior.
- `flake8 --max-line-length=120` clean; `black`/`isort` clean.

## Note for reviewer
This relaxes the live `_is_cacheable` (from #10619) to permit low-temp structured caching and adds a key dimension — please sanity-check the no-collision logic.

Closes #10665. Part of #10598 / umbrella #10603.

## Model Used
Claude Opus 4.8 (1M context)