### PR TITLE
fix(ansible): codify full-user-management into clean-install path (#10636)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -664,7 +664,7 @@
     databases:
       - "{{ backend_postgres_db | default('autobot_users') }}"
     postgresql_listen_addresses: "localhost"
-  when: (backend_user_mode | default('single_user')) != 'single_user'
+  when: (backend_user_mode | default('single_company')) != 'single_user'
   tags: ['backend', 'postgresql']
 
 # ==========================================================
@@ -714,6 +714,43 @@
   loop:
     - /etc/autobot/certs/server-key.pem
     - /etc/autobot/certs/server-cert.pem
+
+# #10636: full-user-management secrets for the runtime .env. The DB password
+# is created by the postgresql role above (db_password); the internal service
+# API key and the initial-admin password (which seeds the default admin on
+# first boot) come from /etc/autobot/slm-secrets.env (written by slm_manager).
+# Without these the clean-install .env has no DB password / admin → /login has
+# no account, matching the deploy-path wiring in update-all-nodes.yml.
+- name: "Backend | Read AUTOBOT_INTERNAL_API_KEY for .env (#10636)"
+  ansible.builtin.shell:
+    cmd: >-
+      grep -oP '^AUTOBOT_INTERNAL_API_KEY=\K.*'
+      /etc/autobot/slm-secrets.env 2>/dev/null || true
+  register: _backend_internal_api_key
+  changed_when: false
+  failed_when: false
+  no_log: true
+  tags: ['backend', 'config']
+
+- name: "Backend | Read admin seed password (AUTOBOT_ADMIN_PASSWORD, fallback SLM_ADMIN_PASSWORD) (#10636)"
+  ansible.builtin.shell:
+    cmd: >-
+      grep -oP '^AUTOBOT_ADMIN_PASSWORD=\K.*' /etc/autobot/slm-secrets.env 2>/dev/null
+      || grep -oP '^SLM_ADMIN_PASSWORD=\K.*' /etc/autobot/slm-secrets.env 2>/dev/null
+      || true
+  register: _backend_admin_password
+  changed_when: false
+  failed_when: false
+  no_log: true
+  tags: ['backend', 'config']
+
+- name: "Backend | Set full-user-management .env facts (#10636)"
+  ansible.builtin.set_fact:
+    autobot_internal_api_key: "{{ _backend_internal_api_key.stdout | default('') | trim }}"
+    autobot_admin_password: "{{ _backend_admin_password.stdout | default('') | trim }}"
+    backend_postgres_password: "{{ db_password | default(backend_postgres_password | default('')) }}"
+  no_log: true
+  tags: ['backend', 'config']
 
 # Issue #2824: Deploy .env to backend_code_dir so the systemd
 # EnvironmentFile directive can find it.  Previous code deployed to

--- a/autobot-slm-backend/ansible/roles/backend/templates/config.yaml.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/config.yaml.j2
@@ -8,6 +8,6 @@
 ---
 
 deployment:
-  mode: "{{ backend_user_mode | default('single_user') }}"
+  mode: "{{ backend_user_mode | default('single_company') }}"
   host: "{{ backend_redis_host | default('127.0.0.1') }}"
   port: {{ backend_port | default(8001) }}

--- a/autobot-slm-backend/ansible/roles/postgresql/tasks/configure.yml
+++ b/autobot-slm-backend/ansible/roles/postgresql/tasks/configure.yml
@@ -26,6 +26,28 @@
   become: true
   notify: Restart PostgreSQL
 
+# On a collapsed single-box deploy one Postgres instance serves several app
+# users (slm_app + autobot_app). Discover every existing login role so the
+# rendered pg_hba keeps them ALL — rendering for this role's db_user alone
+# would drop the others and cut off (e.g.) the SLM database (#10636).
+- name: Discover existing app login roles
+  community.postgresql.postgresql_query:
+    query: >-
+      SELECT rolname FROM pg_roles
+      WHERE rolcanlogin AND rolname <> 'postgres' AND rolname NOT LIKE 'pg\_%'
+    login_unix_socket: /var/run/postgresql
+  become: true
+  become_user: postgres
+  register: _existing_login_roles
+  changed_when: false
+  failed_when: false
+
+- name: Compute pg_hba app users (existing roles + this role's db_user)
+  ansible.builtin.set_fact:
+    postgresql_app_users: >-
+      {{ ((_existing_login_roles.query_result | default([]) | map(attribute='rolname') | list)
+          + [db_user]) | unique }}
+
 - name: Deploy pg_hba.conf
   ansible.builtin.template:
     src: pg_hba.conf.j2

--- a/autobot-slm-backend/ansible/roles/postgresql/tasks/configure.yml
+++ b/autobot-slm-backend/ansible/roles/postgresql/tasks/configure.yml
@@ -40,7 +40,10 @@
   become_user: postgres
   register: _existing_login_roles
   changed_when: false
-  failed_when: false
+  # Fail loud: if we cannot determine the existing app users we must NOT
+  # proceed to render pg_hba, since falling back to [db_user] alone would
+  # drop the sibling user (e.g. slm_app) — the exact clobber this avoids.
+  # Postgres is already installed+started by install.yml before configure.
 
 - name: Compute pg_hba app users (existing roles + this role's db_user)
   ansible.builtin.set_fact:

--- a/autobot-slm-backend/ansible/roles/postgresql/tasks/databases.yml
+++ b/autobot-slm-backend/ansible/roles/postgresql/tasks/databases.yml
@@ -73,6 +73,21 @@
   become_user: postgres
   loop: "{{ databases }}"
 
+# PG15+ no longer grants CREATE on schema public to non-owners, so the
+# database-level grant above is not enough for Alembic to create tables.
+# Grant schema-level privileges so app migrations can run (#10636).
+- name: Grant schema-public privileges
+  community.postgresql.postgresql_privs:
+    database: "{{ item }}"
+    type: schema
+    objs: public
+    privs: ALL
+    role: "{{ db_user }}"
+    login_unix_socket: /var/run/postgresql
+  become: true
+  become_user: postgres
+  loop: "{{ databases }}"
+
 - name: Save credentials to file
   ansible.builtin.template:
     src: db-credentials.env.j2


### PR DESCRIPTION
## Thinking Path
Manual patches that unblocked full-user-management login on the live box were only codified into the DEPLOY path (update-all-nodes). The CLEAN-INSTALL path (setup-user-backend.yml -> backend role -> postgresql role) lacked them, so a wipe + clean install would regress: SLM pg_hba clobbered, permission denied for schema public, no admin, missing internal key. This wires it all into the shared roles.

## What Changed
- **postgresql role** (shared w/ SLM): configure.yml discovers existing app login roles and renders pg_hba for all of them + the current db_user (non-destructive on the shared single-box instance; multi-VM unchanged since discovery returns just db_user). databases.yml adds GRANT ALL ON SCHEMA public (PG15+).
- **backend role**: reads AUTOBOT_INTERNAL_API_KEY + admin password (AUTOBOT_ADMIN_PASSWORD, fallback SLM_ADMIN_PASSWORD) and uses the postgresql-role db_password, emitting them into the runtime .env; gate default single_user->single_company.

## Verification
YAML valid; all 3 postgresql-role consumers (setup-user-backend, update-all-nodes, deploy-user-management-db) pass --syntax-check. Mirrors the live-verified manual fixes.

## Model Used
Claude Opus 4.8 (1M context)

Refs #10636 (codify clean-install reproducibility)