### PR TITLE
refactor(gateway): resolve UnifiedMessage clash → GatewayMessage + ChannelMessage

### DIFF
--- a/autobot-backend/api/telegram_bot_test.py
+++ b/autobot-backend/api/telegram_bot_test.py
@@ -10,7 +10,7 @@ These verify the inbound path is actually reachable and dispatched:
   integration registry, which would double-mount the routes),
 - the webhook/config routes are exposed,
 - the gateway TelegramAdapter normalizes a raw Telegram Update into a
-  UnifiedMessage (text, command, and file attachments),
+  GatewayMessage (text, command, and file attachments),
 - command handling produces the expected replies.
 """
 

--- a/autobot-backend/api/webhook_authentication_security_test.py
+++ b/autobot-backend/api/webhook_authentication_security_test.py
@@ -138,7 +138,7 @@ class TestTelegramWebhookAuthentication:
         ):
             mock_gateway.normalize_message = AsyncMock(
                 return_value=type(
-                    "UnifiedMessage",
+                    "GatewayMessage",
                     (),
                     {
                         "user_id": "123",

--- a/autobot-backend/services/gateway/__init__.py
+++ b/autobot-backend/services/gateway/__init__.py
@@ -7,6 +7,7 @@
 from .adapters import (
     BaseAdapter,
     DiscordAdapter,
+    GatewayMessage,
     IMessageAdapter,
     MatrixAdapter,
     NormalizedResponse,
@@ -14,7 +15,6 @@ from .adapters import (
     SlackAdapter,
     TeamsAdapter,
     TelegramAdapter,
-    UnifiedMessage,
     WebAdapter,
     WhatsAppAdapter,
 )
@@ -26,7 +26,7 @@ __all__ = [
     "MessageQueue",
     "RateLimiter",
     "BaseAdapter",
-    "UnifiedMessage",
+    "GatewayMessage",
     "NormalizedResponse",
     "SlackAdapter",
     "DiscordAdapter",

--- a/autobot-backend/services/gateway/adapters/__init__.py
+++ b/autobot-backend/services/gateway/adapters/__init__.py
@@ -4,7 +4,7 @@
 # Author: mrveiss
 """Platform adapters for unified message gateway."""
 
-from .base_adapter import BaseAdapter, NormalizedResponse, UnifiedMessage
+from .base_adapter import BaseAdapter, GatewayMessage, NormalizedResponse
 from .discord_adapter import DiscordAdapter
 from .imessage_adapter import IMessageAdapter
 from .matrix_adapter import MatrixAdapter
@@ -17,7 +17,7 @@ from .whatsapp_adapter import WhatsAppAdapter
 
 __all__ = [
     "BaseAdapter",
-    "UnifiedMessage",
+    "GatewayMessage",
     "NormalizedResponse",
     "SlackAdapter",
     "DiscordAdapter",

--- a/autobot-backend/services/gateway/adapters/base_adapter.py
+++ b/autobot-backend/services/gateway/adapters/base_adapter.py
@@ -19,8 +19,8 @@ logger = get_logger(__name__)
 
 
 @dataclass
-class UnifiedMessage:
-    """Unified message schema normalized from all platforms."""
+class GatewayMessage:
+    """Raw inbound platform payload normalized from all platform adapters."""
 
     user_id: str
     platform: str  # 'web', 'slack', 'discord', 'whatsapp', 'teams'
@@ -56,7 +56,7 @@ class BaseAdapter(ABC):
         self.logger = get_logger(f"{__name__}.{platform_name}")
 
     @abstractmethod
-    async def normalize_message(self, raw_message: Dict[str, Any]) -> UnifiedMessage:
+    async def normalize_message(self, raw_message: Dict[str, Any]) -> GatewayMessage:
         """
         Convert platform-specific message to unified schema.
 
@@ -64,7 +64,7 @@ class BaseAdapter(ABC):
             raw_message: Platform-specific message object
 
         Returns:
-            UnifiedMessage in normalized format
+            GatewayMessage in normalized format
         """
 
     @abstractmethod

--- a/autobot-backend/services/gateway/adapters/discord_adapter.py
+++ b/autobot-backend/services/gateway/adapters/discord_adapter.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
 
-from .base_adapter import BaseAdapter, NormalizedResponse, UnifiedMessage
+from .base_adapter import BaseAdapter, GatewayMessage, NormalizedResponse
 
 logger = get_logger(__name__)
 
@@ -19,13 +19,13 @@ class DiscordAdapter(BaseAdapter):
     def __init__(self) -> None:
         super().__init__("discord")
 
-    async def normalize_message(self, raw_message: Dict[str, Any]) -> UnifiedMessage:
+    async def normalize_message(self, raw_message: Dict[str, Any]) -> GatewayMessage:
         """Convert Discord message to unified schema."""
         metadata = await self.extract_metadata(raw_message)
         metadata["message_id"] = raw_message.get("id")
         metadata["referenced_message"] = raw_message.get("referenced_message")
 
-        return UnifiedMessage(
+        return GatewayMessage(
             user_id=raw_message["author"]["id"],
             platform="discord",
             channel_id=raw_message["channel_id"],

--- a/autobot-backend/services/gateway/adapters/imessage_adapter.py
+++ b/autobot-backend/services/gateway/adapters/imessage_adapter.py
@@ -17,7 +17,7 @@ from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
 
-from .base_adapter import BaseAdapter, NormalizedResponse, UnifiedMessage
+from .base_adapter import BaseAdapter, GatewayMessage, NormalizedResponse
 
 logger = get_logger(__name__)
 
@@ -42,7 +42,7 @@ class IMessageAdapter(BaseAdapter):
         elif not IMESSAGE_ENABLED:
             logger.info("IMessageAdapter loaded; set AUTOBOT_IMESSAGE_ENABLED=true on a macOS host to enable sends")
 
-    async def normalize_message(self, raw_message: Dict[str, Any]) -> UnifiedMessage:
+    async def normalize_message(self, raw_message: Dict[str, Any]) -> GatewayMessage:
         """Convert macOS relay webhook payload to unified schema."""
         metadata = await self.extract_metadata(raw_message)
 
@@ -54,7 +54,7 @@ class IMessageAdapter(BaseAdapter):
         sender = raw_message.get("sender") or raw_message.get("from", "")
         chat_id = raw_message.get("chat_id") or raw_message.get("room_name") or sender
 
-        return UnifiedMessage(
+        return GatewayMessage(
             user_id=sender,
             platform="imessage",
             channel_id=chat_id,

--- a/autobot-backend/services/gateway/adapters/matrix_adapter.py
+++ b/autobot-backend/services/gateway/adapters/matrix_adapter.py
@@ -14,7 +14,7 @@ from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
 
-from .base_adapter import BaseAdapter, NormalizedResponse, UnifiedMessage
+from .base_adapter import BaseAdapter, GatewayMessage, NormalizedResponse
 
 logger = get_logger(__name__)
 
@@ -33,7 +33,7 @@ class MatrixAdapter(BaseAdapter):
         super().__init__("matrix")
         self._e2ee = MATRIX_E2EE_ENABLED
 
-    async def normalize_message(self, raw_message: Dict[str, Any]) -> UnifiedMessage:
+    async def normalize_message(self, raw_message: Dict[str, Any]) -> GatewayMessage:
         """Convert matrix-nio RoomMessage event dict to unified schema."""
         metadata = await self.extract_metadata(raw_message)
 
@@ -52,7 +52,7 @@ class MatrixAdapter(BaseAdapter):
             relates_to.get("m.in_reply_to", {}).get("event_id") if relates_to.get("rel_type") != "m.thread" else None
         )
 
-        return UnifiedMessage(
+        return GatewayMessage(
             user_id=sender,
             platform="matrix",
             channel_id=room_id,

--- a/autobot-backend/services/gateway/adapters/signal_adapter.py
+++ b/autobot-backend/services/gateway/adapters/signal_adapter.py
@@ -15,7 +15,7 @@ from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
 
-from .base_adapter import BaseAdapter, NormalizedResponse, UnifiedMessage
+from .base_adapter import BaseAdapter, GatewayMessage, NormalizedResponse
 
 logger = get_logger(__name__)
 
@@ -36,7 +36,7 @@ class SignalAdapter(BaseAdapter):
         if not self._enabled:
             logger.info("SignalAdapter loaded but AUTOBOT_SIGNAL_ENABLED is not set — outbound sends disabled")
 
-    async def normalize_message(self, raw_message: Dict[str, Any]) -> UnifiedMessage:
+    async def normalize_message(self, raw_message: Dict[str, Any]) -> GatewayMessage:
         """Convert signal-cli envelope/semaphore webhook to unified schema."""
         metadata = await self.extract_metadata(raw_message)
 
@@ -53,7 +53,7 @@ class SignalAdapter(BaseAdapter):
 
         channel_id = group_info.get("groupId") or source
 
-        return UnifiedMessage(
+        return GatewayMessage(
             user_id=source,
             platform="signal",
             channel_id=channel_id,

--- a/autobot-backend/services/gateway/adapters/slack_adapter.py
+++ b/autobot-backend/services/gateway/adapters/slack_adapter.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
 
-from .base_adapter import BaseAdapter, NormalizedResponse, UnifiedMessage
+from .base_adapter import BaseAdapter, GatewayMessage, NormalizedResponse
 
 logger = get_logger(__name__)
 
@@ -19,13 +19,13 @@ class SlackAdapter(BaseAdapter):
     def __init__(self) -> None:
         super().__init__("slack")
 
-    async def normalize_message(self, raw_message: Dict[str, Any]) -> UnifiedMessage:
+    async def normalize_message(self, raw_message: Dict[str, Any]) -> GatewayMessage:
         """Convert Slack message to unified schema."""
         metadata = await self.extract_metadata(raw_message)
         metadata["thread_ts"] = raw_message.get("thread_ts")
         metadata["is_thread_reply"] = bool(raw_message.get("thread_ts"))
 
-        return UnifiedMessage(
+        return GatewayMessage(
             user_id=raw_message["user_id"],
             platform="slack",
             channel_id=raw_message["channel_id"],

--- a/autobot-backend/services/gateway/adapters/teams_adapter.py
+++ b/autobot-backend/services/gateway/adapters/teams_adapter.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
 
-from .base_adapter import BaseAdapter, NormalizedResponse, UnifiedMessage
+from .base_adapter import BaseAdapter, GatewayMessage, NormalizedResponse
 
 logger = get_logger(__name__)
 
@@ -19,13 +19,13 @@ class TeamsAdapter(BaseAdapter):
     def __init__(self) -> None:
         super().__init__("teams")
 
-    async def normalize_message(self, raw_message: Dict[str, Any]) -> UnifiedMessage:
+    async def normalize_message(self, raw_message: Dict[str, Any]) -> GatewayMessage:
         """Convert Teams message to unified schema."""
         metadata = await self.extract_metadata(raw_message)
         metadata["message_id"] = raw_message.get("id")
         metadata["reply_to_id"] = raw_message.get("replyToId")
 
-        return UnifiedMessage(
+        return GatewayMessage(
             user_id=raw_message["from"]["id"],
             platform="teams",
             channel_id=raw_message["channelData"]["channel"]["id"],

--- a/autobot-backend/services/gateway/adapters/telegram_adapter.py
+++ b/autobot-backend/services/gateway/adapters/telegram_adapter.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 
 from autobot_shared.logging_manager import get_logger
 
-from .base_adapter import BaseAdapter, NormalizedResponse, UnifiedMessage
+from .base_adapter import BaseAdapter, GatewayMessage, NormalizedResponse
 
 logger = get_logger(__name__)
 
@@ -19,7 +19,7 @@ class TelegramAdapter(BaseAdapter):
     def __init__(self) -> None:
         super().__init__("telegram")
 
-    async def normalize_message(self, raw_message: Dict[str, Any]) -> UnifiedMessage:
+    async def normalize_message(self, raw_message: Dict[str, Any]) -> GatewayMessage:
         """
         Convert Telegram Update/Message object to unified schema.
 
@@ -60,7 +60,7 @@ class TelegramAdapter(BaseAdapter):
             metadata["command"] = command_info["command"]
             metadata["command_args"] = command_info["args"]
 
-        return UnifiedMessage(
+        return GatewayMessage(
             user_id=str(from_user.get("id", "")),
             platform="telegram",
             channel_id=str(chat.get("id", "")),

--- a/autobot-backend/services/gateway/adapters/web_adapter.py
+++ b/autobot-backend/services/gateway/adapters/web_adapter.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
 
-from .base_adapter import BaseAdapter, NormalizedResponse, UnifiedMessage
+from .base_adapter import BaseAdapter, GatewayMessage, NormalizedResponse
 
 logger = get_logger(__name__)
 
@@ -19,13 +19,13 @@ class WebAdapter(BaseAdapter):
     def __init__(self) -> None:
         super().__init__("web")
 
-    async def normalize_message(self, raw_message: Dict[str, Any]) -> UnifiedMessage:
+    async def normalize_message(self, raw_message: Dict[str, Any]) -> GatewayMessage:
         """Convert web message to unified schema."""
         metadata = await self.extract_metadata(raw_message)
         metadata["session_id"] = raw_message.get("session_id")
         metadata["user_agent"] = raw_message.get("user_agent")
 
-        return UnifiedMessage(
+        return GatewayMessage(
             user_id=raw_message["user_id"],
             platform="web",
             channel_id=raw_message.get("channel_id", "default"),

--- a/autobot-backend/services/gateway/adapters/whatsapp_adapter.py
+++ b/autobot-backend/services/gateway/adapters/whatsapp_adapter.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
 
-from .base_adapter import BaseAdapter, NormalizedResponse, UnifiedMessage
+from .base_adapter import BaseAdapter, GatewayMessage, NormalizedResponse
 
 logger = get_logger(__name__)
 
@@ -19,7 +19,7 @@ class WhatsAppAdapter(BaseAdapter):
     def __init__(self) -> None:
         super().__init__("whatsapp")
 
-    async def normalize_message(self, raw_message: Dict[str, Any]) -> UnifiedMessage:
+    async def normalize_message(self, raw_message: Dict[str, Any]) -> GatewayMessage:
         """Convert WhatsApp message to unified schema."""
         metadata = await self.extract_metadata(raw_message)
         metadata["message_id"] = raw_message.get("id")
@@ -31,7 +31,7 @@ class WhatsAppAdapter(BaseAdapter):
         if raw_message.get("media_id"):
             metadata["media_id"] = raw_message["media_id"]
 
-        return UnifiedMessage(
+        return GatewayMessage(
             user_id=raw_message["from"],
             platform="whatsapp",
             channel_id=raw_message["chat_id"],

--- a/autobot-backend/services/gateway/channel_adapters/base.py
+++ b/autobot-backend/services/gateway/channel_adapters/base.py
@@ -12,7 +12,7 @@ Defines the interface that all channel adapters must implement.
 from abc import ABC, abstractmethod
 from typing import Any, Dict
 
-from ..types import ChannelType, GatewaySession, UnifiedMessage
+from ..types import ChannelMessage, ChannelType, GatewaySession
 
 
 class BaseChannelAdapter(ABC):
@@ -35,7 +35,7 @@ class BaseChannelAdapter(ABC):
     @abstractmethod
     async def send_message(
         self,
-        message: UnifiedMessage,
+        message: ChannelMessage,
         session: GatewaySession,
         connection_context: Any | None = None,
     ) -> bool:
@@ -56,7 +56,7 @@ class BaseChannelAdapter(ABC):
         self,
         raw_data: Any,
         session: GatewaySession,
-    ) -> UnifiedMessage | None:
+    ) -> ChannelMessage | None:
         """
         Receive and parse a message from this channel.
 
@@ -65,7 +65,7 @@ class BaseChannelAdapter(ABC):
             session: Session associated with the message
 
         Returns:
-            UnifiedMessage if parsed successfully, None otherwise
+            ChannelMessage if parsed successfully, None otherwise
         """
 
     @abstractmethod

--- a/autobot-backend/services/gateway/channel_adapters/websocket_adapter.py
+++ b/autobot-backend/services/gateway/channel_adapters/websocket_adapter.py
@@ -17,7 +17,7 @@ from starlette.websockets import WebSocketState
 
 from autobot_shared.logging_manager import get_logger
 
-from ..types import ChannelType, GatewaySession, MessageType, UnifiedMessage
+from ..types import ChannelMessage, ChannelType, GatewaySession, MessageType
 from .base import BaseChannelAdapter
 
 logger = get_logger(__name__)
@@ -36,7 +36,7 @@ class WebSocketAdapter(BaseChannelAdapter):
 
     async def send_message(
         self,
-        message: UnifiedMessage,
+        message: ChannelMessage,
         session: GatewaySession,
         connection_context: Any | None = None,
     ) -> bool:
@@ -78,7 +78,7 @@ class WebSocketAdapter(BaseChannelAdapter):
         self,
         raw_data: Any,
         session: GatewaySession,
-    ) -> UnifiedMessage | None:
+    ) -> ChannelMessage | None:
         """
         Receive and parse WebSocket message.
 
@@ -87,7 +87,7 @@ class WebSocketAdapter(BaseChannelAdapter):
             session: Session receiving the message
 
         Returns:
-            Parsed UnifiedMessage or None
+            Parsed ChannelMessage or None
         """
         try:
             # Parse JSON if string
@@ -182,7 +182,7 @@ class WebSocketAdapter(BaseChannelAdapter):
         try:
             if websocket.client_state == WebSocketState.CONNECTED:
                 # Send ping (WebSocket protocol handles this automatically)
-                heartbeat_msg = UnifiedMessage(
+                heartbeat_msg = ChannelMessage(
                     session_id=session.session_id,
                     channel=ChannelType.WEBSOCKET,
                     message_type=MessageType.SESSION_HEARTBEAT,
@@ -195,9 +195,9 @@ class WebSocketAdapter(BaseChannelAdapter):
             logger.error("Heartbeat failed: %s", e)
             return False
 
-    def _to_websocket_format(self, message: UnifiedMessage) -> Dict[str, Any]:
+    def _to_websocket_format(self, message: ChannelMessage) -> Dict[str, Any]:
         """
-        Convert UnifiedMessage to WebSocket format.
+        Convert ChannelMessage to WebSocket format.
 
         Args:
             message: Unified message
@@ -237,16 +237,16 @@ class WebSocketAdapter(BaseChannelAdapter):
         self,
         data: Dict[str, Any],
         session: GatewaySession,
-    ) -> UnifiedMessage:
+    ) -> ChannelMessage:
         """
-        Convert WebSocket message to UnifiedMessage.
+        Convert WebSocket message to ChannelMessage.
 
         Args:
             data: WebSocket message data
             session: Associated session
 
         Returns:
-            UnifiedMessage
+            ChannelMessage
         """
         # Map legacy WebSocket event types to MessageType
         type_map = {
@@ -263,7 +263,7 @@ class WebSocketAdapter(BaseChannelAdapter):
         # Extract content
         content = data.get("data") or data.get("content") or data.get("message", "")
 
-        return UnifiedMessage(
+        return ChannelMessage(
             session_id=session.session_id,
             channel=ChannelType.WEBSOCKET,
             message_type=message_type,

--- a/autobot-backend/services/gateway/gateway.py
+++ b/autobot-backend/services/gateway/gateway.py
@@ -21,7 +21,7 @@ from .channel_adapters.base import BaseChannelAdapter
 from .config import GatewayConfig
 from .message_router import MessageRouter
 from .session_manager import SessionManager
-from .types import ChannelType, GatewaySession, MessageType, UnifiedMessage
+from .types import ChannelMessage, ChannelType, GatewaySession, MessageType
 
 logger = get_logger(__name__)
 
@@ -163,7 +163,7 @@ class Gateway:
         self._connection_contexts[session.session_id] = connection_context
 
         # Send session start message
-        start_message = UnifiedMessage(
+        start_message = ChannelMessage(
             session_id=session.session_id,
             channel=channel,
             message_type=MessageType.SESSION_START,
@@ -190,7 +190,7 @@ class Gateway:
             return False
 
         # Send session end message
-        end_message = UnifiedMessage(
+        end_message = ChannelMessage(
             session_id=session_id,
             channel=session.channel,
             message_type=MessageType.SESSION_END,
@@ -212,7 +212,7 @@ class Gateway:
         # Close session
         return await self.session_manager.close_session(session_id)
 
-    async def send_message(self, message: UnifiedMessage) -> bool:
+    async def send_message(self, message: ChannelMessage) -> bool:
         """
         Send a message through the Gateway.
 
@@ -260,7 +260,7 @@ class Gateway:
         self,
         raw_data: Any,
         session_id: str,
-    ) -> UnifiedMessage | None:
+    ) -> ChannelMessage | None:
         """
         Receive and parse a message from a channel.
 
@@ -269,7 +269,7 @@ class Gateway:
             session_id: Session receiving the message
 
         Returns:
-            Parsed UnifiedMessage or None
+            Parsed ChannelMessage or None
         """
         # Get session
         session = await self.session_manager.get_session(session_id)
@@ -281,7 +281,7 @@ class Gateway:
         if not await self.session_manager.consume_rate_limit(session_id):
             logger.warning("Rate limit exceeded for session %s", session_id)
             # Send rate limit error
-            error_msg = UnifiedMessage(
+            error_msg = ChannelMessage(
                 session_id=session_id,
                 channel=session.channel,
                 message_type=MessageType.SYSTEM_ERROR,
@@ -305,7 +305,7 @@ class Gateway:
 
     async def route_and_process(
         self,
-        message: UnifiedMessage,
+        message: ChannelMessage,
         context: Dict | None = None,
     ) -> Dict[str, Any]:
         """

--- a/autobot-backend/services/gateway/gateway_manager.py
+++ b/autobot-backend/services/gateway/gateway_manager.py
@@ -27,6 +27,7 @@ from autobot_shared.logging_manager import get_logger
 from .adapters import (
     BaseAdapter,
     DiscordAdapter,
+    GatewayMessage,
     IMessageAdapter,
     MatrixAdapter,
     NormalizedResponse,
@@ -34,7 +35,6 @@ from .adapters import (
     SlackAdapter,
     TeamsAdapter,
     TelegramAdapter,
-    UnifiedMessage,
     WebAdapter,
     WhatsAppAdapter,
 )
@@ -96,7 +96,7 @@ class GatewayManager:
         self.response_handlers[platform] = handler
         self.logger.info(f"Registered response handler for platform: {platform}")
 
-    async def normalize_message(self, raw_message: Dict[str, Any]) -> UnifiedMessage:
+    async def normalize_message(self, raw_message: Dict[str, Any]) -> GatewayMessage:
         """
         Normalize a raw platform-specific message to unified schema.
 
@@ -106,7 +106,7 @@ class GatewayManager:
             raw_message: Platform-specific message dict with 'platform' key
 
         Returns:
-            UnifiedMessage in normalized format
+            GatewayMessage in normalized format
 
         Raises:
             ValueError: If platform not supported or validation fails
@@ -162,8 +162,8 @@ class GatewayManager:
 
     async def route_message(
         self,
-        unified_message: UnifiedMessage,
-        agent_handler: Callable[[UnifiedMessage], Dict[str, Any]],
+        unified_message: GatewayMessage,
+        agent_handler: Callable[[GatewayMessage], Dict[str, Any]],
     ) -> None:
         """
         Route normalized message through agent and send response to platform.
@@ -208,7 +208,7 @@ class GatewayManager:
 
     async def start_processing(
         self,
-        agent_handler: Callable[[UnifiedMessage], Dict[str, Any]],
+        agent_handler: Callable[[GatewayMessage], Dict[str, Any]],
         workers: int = 5,
     ) -> None:
         """

--- a/autobot-backend/services/gateway/message_router.py
+++ b/autobot-backend/services/gateway/message_router.py
@@ -13,7 +13,7 @@ from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
 
-from .types import MessageType, RoutingDecision, UnifiedMessage
+from .types import ChannelMessage, MessageType, RoutingDecision
 
 logger = get_logger(__name__)
 
@@ -45,7 +45,7 @@ class MessageRouter:
         """
         self._agent_router = agent_router
 
-    async def _route_non_text_message(self, message: UnifiedMessage) -> RoutingDecision | None:
+    async def _route_non_text_message(self, message: ChannelMessage) -> RoutingDecision | None:
         """Helper for route_message. Ref: #1088."""
         if self._is_system_message(message):
             return RoutingDecision(
@@ -68,7 +68,7 @@ class MessageRouter:
         return None
 
     async def _delegate_to_agent_router(
-        self, message: UnifiedMessage, context: Dict[str, Any] | None
+        self, message: ChannelMessage, context: Dict[str, Any] | None
     ) -> RoutingDecision:
         """Helper for route_message. Ref: #1088."""
         try:
@@ -92,7 +92,7 @@ class MessageRouter:
 
     async def route_message(
         self,
-        message: UnifiedMessage,
+        message: ChannelMessage,
         context: Dict[str, Any] | None = None,
     ) -> RoutingDecision:
         """
@@ -120,7 +120,7 @@ class MessageRouter:
             reasoning="Default chat agent",
         )
 
-    def _is_system_message(self, message: UnifiedMessage) -> bool:
+    def _is_system_message(self, message: ChannelMessage) -> bool:
         """Check if message is a system control message."""
         return message.message_type in {
             MessageType.SYSTEM_STATUS,

--- a/autobot-backend/services/gateway/types.py
+++ b/autobot-backend/services/gateway/types.py
@@ -66,9 +66,9 @@ class SessionStatus(str, Enum):
 
 
 @dataclass
-class UnifiedMessage:
+class ChannelMessage:
     """
-    Unified message format across all channels.
+    Routed channel message format across all Gateway channels.
 
     Attributes:
         message_id: Unique message identifier
@@ -101,7 +101,7 @@ class UnifiedMessage:
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "UnifiedMessage":
+    def from_dict(cls, data: Dict[str, Any]) -> "ChannelMessage":
         """Create message from dictionary."""
         return cls(
             message_id=data.get("message_id", str(uuid4())),

--- a/autobot-backend/tests/test_gateway_manager.py
+++ b/autobot-backend/tests/test_gateway_manager.py
@@ -26,7 +26,7 @@ from services.gateway import (
     NormalizedResponse,
     SlackAdapter,
     TeamsAdapter,
-    UnifiedMessage,
+    GatewayMessage,
     WebAdapter,
     WhatsAppAdapter,
 )
@@ -52,7 +52,7 @@ class TestSlackAdapter:
 
         unified = await adapter.normalize_message(raw)
 
-        assert isinstance(unified, UnifiedMessage)
+        assert isinstance(unified, GatewayMessage)
         assert unified.user_id == "U123"
         assert unified.platform == "slack"
         assert unified.channel_id == "C456"
@@ -416,7 +416,7 @@ class TestGatewayManager:
     @pytest.mark.asyncio
     async def test_route_message(self, gateway):
         """Test routing message through agent."""
-        unified = UnifiedMessage(
+        unified = GatewayMessage(
             user_id="U123",
             platform="slack",
             channel_id="C456",

--- a/autobot-backend/tests/test_gateway_manager.py
+++ b/autobot-backend/tests/test_gateway_manager.py
@@ -23,10 +23,10 @@ import pytest
 from services.gateway import (
     DiscordAdapter,
     GatewayManager,
+    GatewayMessage,
     NormalizedResponse,
     SlackAdapter,
     TeamsAdapter,
-    GatewayMessage,
     WebAdapter,
     WhatsAppAdapter,
 )

--- a/autobot-backend/tests/test_new_channel_adapters.py
+++ b/autobot-backend/tests/test_new_channel_adapters.py
@@ -22,12 +22,12 @@ import pytest
 
 from services.gateway import (
     GatewayManager,
+    GatewayMessage,
     IMessageAdapter,
     MatrixAdapter,
     NormalizedResponse,
     SignalAdapter,
     TelegramAdapter,
-    GatewayMessage,
 )
 
 

--- a/autobot-backend/tests/test_new_channel_adapters.py
+++ b/autobot-backend/tests/test_new_channel_adapters.py
@@ -27,7 +27,7 @@ from services.gateway import (
     NormalizedResponse,
     SignalAdapter,
     TelegramAdapter,
-    UnifiedMessage,
+    GatewayMessage,
 )
 
 
@@ -50,7 +50,7 @@ class TestTelegramAdapter:
             }
         }
         unified = await adapter.normalize_message(raw)
-        assert isinstance(unified, UnifiedMessage)
+        assert isinstance(unified, GatewayMessage)
         assert unified.platform == "telegram"
         assert unified.user_id == "123456"
         assert unified.channel_id == "-9001"


### PR DESCRIPTION
## Thinking Path

Two dataclasses both named `UnifiedMessage` coexisted in the gateway module tree:

1. `adapters/base_adapter.py` — raw inbound platform payload (user_id, platform, channel_id, message, timestamp, metadata)
2. `types.py` — routed channel message (message_id, session_id, channel, message_type, content, created_at + to_dict/from_dict)

Any file importing `from services.gateway import UnifiedMessage` silently received whichever definition won the re-export chain. Owner decision: **two distinct names, no aliases**.

Reference disambiguation:
- Files importing via `base_adapter` path → **`GatewayMessage`** (14 files: 9 platform adapters + adapters `__init__` + gateway `__init__` + gateway_manager + 2 test files)
- Files importing via `types` path → **`ChannelMessage`** (6 files: channel_adapters/base, channel_adapters/websocket_adapter, gateway.py, message_router.py)
- API test files: 2 docstring/mock-class-name string references updated

No ambiguous star-import re-exports existed; all re-exports were named and resolved cleanly.

## What Changed

- `adapters/base_adapter.py`: class `UnifiedMessage` → `GatewayMessage`; docstring updated
- `types.py`: class `UnifiedMessage` → `ChannelMessage`; `from_dict` self-ref updated
- `adapters/__init__.py`: import + `__all__` updated to `GatewayMessage`
- `services/gateway/__init__.py`: import + `__all__` updated to `GatewayMessage`
- `gateway_manager.py`: import + all 5 usage sites → `GatewayMessage`
- `channel_adapters/base.py`: import + all 4 usage sites → `ChannelMessage`
- `channel_adapters/websocket_adapter.py`: import + all 8 usage sites → `ChannelMessage`
- `gateway.py`: import + all 6 usage sites → `ChannelMessage`
- `message_router.py`: import + all 5 usage sites → `ChannelMessage`
- 9 platform adapter files (discord, slack, teams, web, whatsapp, telegram, signal, matrix, imessage): all `UnifiedMessage` refs → `GatewayMessage`
- `tests/test_gateway_manager.py` + `tests/test_new_channel_adapters.py`: → `GatewayMessage`
- `api/telegram_bot_test.py` + `api/webhook_authentication_security_test.py`: docstring/mock-name → `GatewayMessage`

## Verification

```
# Zero-grep proof
git grep -w UnifiedMessage -- autobot-backend autobot-slm-backend autobot_shared
# (no output)

# Startup smoke
pytest autobot-backend/tests/test_startup_imports.py -q
# 339 passed

# Gateway tests
pytest autobot-backend/tests/test_gateway_manager.py autobot-backend/tests/test_new_channel_adapters.py -q
# 64 passed in 4.60s

# flake8 clean
python3 -m flake8 --config=.flake8 autobot-backend/services/gateway/ ...
# exit 0

# No new lines >120 chars introduced
```

Part of #10666

## Model Used

claude-sonnet-4-6