### PR TITLE
fix(judges): force structured_output + tolerant JSON parse (#10672)

### DIFF
--- a/autobot-backend/judges/__init__.py
+++ b/autobot-backend/judges/__init__.py
@@ -27,6 +27,24 @@ from autobot_shared.logging_manager import get_logger
 logger = get_logger(__name__)
 
 
+def _extract_json_object(raw_text: str) -> Dict[str, Any]:
+    """Parse a JSON object from an LLM response, tolerating markdown code fences (#10672).
+
+    structured_output=True makes supporting providers emit valid JSON; providers
+    that ignore it may still wrap the object in a ```json fence, so strip that
+    before parsing. Raises json.JSONDecodeError on genuinely unparseable text.
+    """
+    try:
+        return json.loads(raw_text)
+    except json.JSONDecodeError:
+        if "```" in raw_text:
+            block = raw_text.split("```", 2)[1]
+            if block.lstrip().lower().startswith("json"):
+                block = block.lstrip()[4:]
+            return json.loads(block.strip())
+        raise
+
+
 class JudgmentConfidence(Enum):
     """Confidence levels for LLM judgments"""
 
@@ -164,7 +182,9 @@ class BaseLLMJudge:
                     {"role": "system", "content": self._get_system_prompt()},
                     {"role": "user", "content": prompt},
                 ],
+                llm_type="analysis",
                 temperature=0.1,  # Low temperature for consistent judgments
+                structured_output=True,  # #10672: force valid JSON so judgments aren't dropped
             )
 
             return response
@@ -214,7 +234,7 @@ Be precise, objective, and helpful in your judgments."""
                 raw_text = llm_response
             else:
                 raw_text = llm_response.get("content", "")
-            evaluation = json.loads(raw_text)
+            evaluation = _extract_json_object(raw_text)
 
             # Parse criterion scores
             criterion_scores = []

--- a/autobot-backend/judges/judge_json_parsing_test.py
+++ b/autobot-backend/judges/judge_json_parsing_test.py
@@ -1,0 +1,46 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Judge JSON parsing + structured_output wiring (#10672).
+
+Forcing structured output and tolerating code fences stops valid judgments from
+being silently turned into error/REJECT results by a bare json.loads().
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+from judges import BaseLLMJudge, _extract_json_object
+
+
+def test_extract_json_bare():
+    assert _extract_json_object('{"overall_score": 0.9}') == {"overall_score": 0.9}
+
+
+def test_extract_json_fenced():
+    assert _extract_json_object('```json\n{"a": 1}\n```') == {"a": 1}
+    assert _extract_json_object('```\n{"a": 2}\n```') == {"a": 2}
+
+
+def test_extract_json_raises_on_unparseable():
+    with pytest.raises(json.JSONDecodeError):
+        _extract_json_object("this is not json")
+
+
+@pytest.mark.asyncio
+async def test_judge_call_forces_structured_output():
+    judge = BaseLLMJudge.__new__(BaseLLMJudge)  # bypass heavy __init__
+    judge.judge_type = "test"
+    judge.llm_interface = types.SimpleNamespace(chat=AsyncMock(return_value=types.SimpleNamespace(content="{}")))
+
+    await judge._get_llm_evaluation("evaluate this")
+
+    _, kwargs = judge.llm_interface.chat.call_args
+    assert kwargs.get("structured_output") is True
+    assert kwargs.get("llm_type") == "analysis"

--- a/autobot-backend/judges/judge_json_parsing_test.py
+++ b/autobot-backend/judges/judge_json_parsing_test.py
@@ -33,6 +33,12 @@ def test_extract_json_raises_on_unparseable():
         _extract_json_object("this is not json")
 
 
+def test_extract_json_fenced_but_invalid_raises():
+    # a fenced block whose body isn't valid JSON must still raise, not return junk
+    with pytest.raises(json.JSONDecodeError):
+        _extract_json_object("```json\nnot valid json\n```")
+
+
 @pytest.mark.asyncio
 async def test_judge_call_forces_structured_output():
     judge = BaseLLMJudge.__new__(BaseLLMJudge)  # bypass heavy __init__


### PR DESCRIPTION
## Thinking Path
Subtask 3.4 of #10599 (umbrella #10603). The base judge (`judges/__init__.py`) called the LLM with no `structured_output` and parsed with a bare `json.loads(raw_text)`. A prose-wrapped/malformed response raised → the judge became a false REJECT via `_create_error_judgment`, silently losing real judgments (audit precision finding #7).

## What Changed
- Base judge LLM call now passes `structured_output=True` (+ `llm_type="analysis"`), so supporting providers (Ollama) emit valid JSON. One change point → covers all judge subclasses.
- New `_extract_json_object()` tolerates ```json code fences (for providers that ignore the flag); raises on genuinely unparseable text.

## Verification
- `judges/judge_json_parsing_test.py` — bare/fenced JSON parsed; garbage raises `JSONDecodeError`; judge call passes `structured_output=True` + `llm_type="analysis"` (4 passing).
- 15 pre-existing LLM-path judge-test failures are env-stub artifacts (stubbed `get_llm_service`) — **identical count with/without this PR** (verified on clean base); filed as #10681.
- `flake8 --max-line-length=120` clean; `black`/`isort` clean.

Closes #10672. Part of #10599 / umbrella #10603.

## Model Used
Claude Opus 4.8 (1M context)