### PR TITLE
fix(ansible): retry mark-synced after restart (#10634 item 4)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -402,7 +402,15 @@
         body: "{}"
         body_format: json
         validate_certs: false
+        timeout: 30
         status_code: [200, 404]
+      register: slm_mark_synced_play1
+      # The SLM API is briefly slow on this endpoint right after a restart, so a
+      # single attempt read-times-out and the node never gets marked synced
+      # (#10634). Retry until it answers; still non-fatal if it never does.
+      until: slm_mark_synced_play1.status | default(-1) in [200, 404]
+      retries: 6
+      delay: 10
       delegate_to: localhost
       ignore_errors: true
       when: slm_login_play1.status == 200
@@ -946,7 +954,14 @@
         body: "{}"
         body_format: json
         validate_certs: false
+        timeout: 30
         status_code: [200, 404]
+      register: node_mark_synced
+      # Retry the briefly-slow post-restart endpoint instead of one-shot
+      # timing out so the node actually gets marked synced (#10634).
+      until: node_mark_synced.status | default(-1) in [200, 404]
+      retries: 6
+      delay: 10
       delegate_to: localhost
       ignore_errors: true
       when: slm_token | default('') | length > 0


### PR DESCRIPTION
## Thinking Path
Last open item of #10634. The mark-synced POST is briefly slow right after a service restart, so the single attempt read-timed-out (28s, seen repeatedly during #10636 deploys) and the node was never marked synced — only ignore_errors hid it.

## What Changed
- update-all-nodes.yml Play 1 + Play 2 mark-synced tasks: add `timeout: 30` + `register`/`until`/`retries: 6`/`delay: 10` so a slow post-restart response retries instead of one-shot failing. Still `ignore_errors` (non-fatal) if it never answers.

## Verification
ansible --syntax-check exit 0.

## Model Used
Claude Opus 4.8 (1M context)

Closes #10634