### PR TITLE
refactor(api-routes): B7 — strip Enhanced*/Consolidated*/Unified* prefixes from route handler functions + rename enhanced_search.py → search.py

### DIFF
--- a/autobot-backend/api/__init__.py
+++ b/autobot-backend/api/__init__.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-# Enhanced API modules with NPU semantic search and analytics
 """
 AutoBot REST API package — all router modules exported here.
 
@@ -20,7 +19,7 @@ __all__ = [
     # Issue #567: base_terminal archived — endpoints migrated to terminal.py
     # Issue #3332: base_terminal removed from public API surface
     "websockets",
-    "enhanced_search",  # New NPU-accelerated search API
-    "analytics",  # Enhanced backend analytics API
+    "search",  # NPU-accelerated search API (#10666 B7)
+    "analytics",  # Backend analytics API
     "live_events",  # Issue #1408: scoped real-time event channels
 ]

--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -1307,10 +1307,10 @@ async def get_agents_status():
 @router.get("/health/enhanced", response_model=AgentHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_agent_health",
+    operation="agent_health",
     error_code_prefix="AGENT",
 )
-async def enhanced_agent_health():
+async def agent_health():
     """Enhanced health check for agent services."""
     try:
         ai_client = await get_ai_stack_client()

--- a/autobot-backend/api/ai_stack_integration.py
+++ b/autobot-backend/api/ai_stack_integration.py
@@ -191,10 +191,10 @@ async def analyze_documents(documents: List[Metadata], admin_check: bool = Depen
 @router.post("/chat/enhanced", response_model=DataResponse[ChatResult])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_chat",
+    operation="chat",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-async def enhanced_chat(
+async def chat(
     request: ChatRequest,
     admin_check: bool = Depends(check_admin_permission),
     knowledge_base=Depends(get_knowledge_base),
@@ -264,10 +264,10 @@ async def extract_knowledge(
 @router.post("/knowledge/enhanced-search", response_model=DataResponse[KnowledgeSearchData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_knowledge_search",
+    operation="knowledge_search",
     error_code_prefix="AI_STACK_INTEGRATION",
 )
-async def enhanced_knowledge_search(
+async def knowledge_search(
     query: str,
     search_type: str = "comprehensive",
     max_results: int = 10,
@@ -647,4 +647,4 @@ async def legacy_enhanced_chat(
     Issue #744: Requires admin authentication.
     """
     request = ChatRequest(message=message, context=context)
-    return await enhanced_chat(request)
+    return await chat(request)

--- a/autobot-backend/api/api_endpoint_migrations_test.py
+++ b/autobot-backend/api/api_endpoint_migrations_test.py
@@ -11620,7 +11620,7 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
 
     def test_enhanced_agent_health_decorator_present(self):
         """Test enhanced_agent_health has @with_error_handling decorator"""
-        from api.agent import enhanced_agent_health
+        from api.agent import agent_health as enhanced_agent_health
 
         source = inspect.getsource(enhanced_agent_health)
         self.assertIn("@with_error_handling", source)
@@ -11629,7 +11629,7 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
 
     def test_enhanced_agent_health_mixed_pattern(self):
         """Test enhanced_agent_health uses Mixed Pattern - preserves outer try-catch"""
-        from api.agent import enhanced_agent_health
+        from api.agent import agent_health as enhanced_agent_health
 
         source = inspect.getsource(enhanced_agent_health)
         # Should preserve outer try-catch for degraded status business logic
@@ -11639,7 +11639,7 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
 
     def test_enhanced_agent_health_degraded_logic(self):
         """Test enhanced_agent_health preserves degraded status business logic"""
-        from api.agent import enhanced_agent_health
+        from api.agent import agent_health as enhanced_agent_health
 
         source = inspect.getsource(enhanced_agent_health)
         # Should return degraded status on exception
@@ -11648,7 +11648,7 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
 
     def test_batch72_decorator_placement(self):
         """Test batch 72 endpoints have decorators in correct order"""
-        from api.agent import enhanced_agent_health, receive_goal_compat
+        from api.agent import agent_health as enhanced_agent_health, receive_goal_compat
 
         for endpoint in [receive_goal_compat, enhanced_agent_health]:
             source = inspect.getsource(endpoint)
@@ -11663,7 +11663,7 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
 
     def test_batch72_error_category_consistency(self):
         """Test batch 72 endpoints all use ErrorCategory.SERVER_ERROR"""
-        from api.agent import enhanced_agent_health, receive_goal_compat
+        from api.agent import agent_health as enhanced_agent_health, receive_goal_compat
 
         for endpoint in [receive_goal_compat, enhanced_agent_health]:
             source = inspect.getsource(endpoint)
@@ -11675,7 +11675,7 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
 
     def test_batch72_error_prefix_consistency(self):
         """Test batch 72 endpoints all use AGENT_ENHANCED prefix"""
-        from api.agent import enhanced_agent_health, receive_goal_compat
+        from api.agent import agent_health as enhanced_agent_health, receive_goal_compat
 
         for endpoint in [receive_goal_compat, enhanced_agent_health]:
             source = inspect.getsource(endpoint)
@@ -11687,7 +11687,7 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
 
     def test_batch72_mixed_pattern_consistency(self):
         """Test batch 72 endpoints all use Mixed Pattern (preserve outer try-catch)"""
-        from api.agent import enhanced_agent_health, receive_goal_compat
+        from api.agent import agent_health as enhanced_agent_health, receive_goal_compat
 
         for endpoint in [receive_goal_compat, enhanced_agent_health]:
             source = inspect.getsource(endpoint)
@@ -11700,7 +11700,7 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
 
     def test_batch72_business_logic_preservation(self):
         """Test batch 72 endpoints preserve business logic (fallback/degraded responses)"""
-        from api.agent import enhanced_agent_health, receive_goal_compat
+        from api.agent import agent_health as enhanced_agent_health, receive_goal_compat
 
         # receive_goal_compat should have fallback logic
         compat_source = inspect.getsource(receive_goal_compat)
@@ -14239,7 +14239,7 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
 
     def test_enhanced_chat_decorator_present(self):
         """Test enhanced_chat has @with_error_handling decorator"""
-        from api.ai_stack_integration import enhanced_chat
+        from api.ai_stack_integration import chat as enhanced_chat
 
         source = inspect.getsource(enhanced_chat)
         self.assertIn("@with_error_handling", source)
@@ -14259,7 +14259,7 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
         """Test batch 87 endpoints use correct patterns (2 Simple, 1 Mixed)"""
         from api.ai_stack_integration import (
             analyze_documents,
-            enhanced_chat,
+            chat as enhanced_chat,
             extract_knowledge,
         )
 
@@ -14289,7 +14289,7 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
 
     def test_enhanced_chat_kb_context_enhancement_preserved(self):
         """Test enhanced_chat preserves knowledge base context enhancement logic"""
-        from api.ai_stack_integration import enhanced_chat
+        from api.ai_stack_integration import chat as enhanced_chat
 
         source = inspect.getsource(enhanced_chat)
         # Should have KB context enhancement try-catch preserved
@@ -14316,13 +14316,13 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
         """Test batch 87 endpoints have correct operation names in decorator"""
         from api.ai_stack_integration import (
             analyze_documents,
-            enhanced_chat,
+            chat as enhanced_chat,
             extract_knowledge,
         )
 
         endpoints = [
             (analyze_documents, "analyze_documents"),
-            (enhanced_chat, "enhanced_chat"),
+            (enhanced_chat, "chat"),
             (extract_knowledge, "extract_knowledge"),
         ]
 
@@ -14357,7 +14357,7 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
 
     def test_batch_87_business_logic_preserved(self):
         """Test batch 87 Mixed Pattern endpoint preserves business logic"""
-        from api.ai_stack_integration import enhanced_chat
+        from api.ai_stack_integration import chat as enhanced_chat
 
         source = inspect.getsource(enhanced_chat)
 
@@ -14369,7 +14369,7 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
 
     def test_batch_87_kb_context_enhancement_logic(self):
         """Test batch 87 knowledge base context enhancement logic is preserved"""
-        from api.ai_stack_integration import enhanced_chat
+        from api.ai_stack_integration import chat as enhanced_chat
 
         source = inspect.getsource(enhanced_chat)
 
@@ -14390,7 +14390,7 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
         """Test batch 87 endpoints have correct decorator parameters"""
         from api.ai_stack_integration import (
             analyze_documents,
-            enhanced_chat,
+            chat as enhanced_chat,
             extract_knowledge,
         )
 
@@ -14409,7 +14409,7 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
         """Test batch 87 endpoints don't call handle_ai_stack_error"""
         from api.ai_stack_integration import (
             analyze_documents,
-            enhanced_chat,
+            chat as enhanced_chat,
             extract_knowledge,
         )
 
@@ -14427,7 +14427,7 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
         from api.ai_stack_integration import (
             ai_stack_health_check,
             analyze_documents,
-            enhanced_chat,
+            chat as enhanced_chat,
             extract_knowledge,
             list_ai_agents,
             rag_query,
@@ -14457,13 +14457,13 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
         """Comprehensive test for all batch 87 migrations"""
         from api.ai_stack_integration import (
             analyze_documents,
-            enhanced_chat,
+            chat as enhanced_chat,
             extract_knowledge,
         )
 
         endpoints = [
             ("analyze_documents", analyze_documents, "Simple"),
-            ("enhanced_chat", enhanced_chat, "Mixed"),
+            ("chat", enhanced_chat, "Mixed"),
             ("extract_knowledge", extract_knowledge, "Simple"),
         ]
 
@@ -14502,8 +14502,8 @@ class TestBatch88AIStackIntegrationMigrations(unittest.TestCase):
             ai_stack_health_check,
             analyze_documents,
             comprehensive_research,
-            enhanced_chat,
-            enhanced_knowledge_search,
+            chat as enhanced_chat,
+            knowledge_search as enhanced_knowledge_search,
             extract_knowledge,
             get_system_knowledge,
             list_ai_agents,
@@ -14537,7 +14537,7 @@ class TestBatch88AIStackIntegrationMigrations(unittest.TestCase):
         """Test batch 88 endpoints use correct patterns (2 Simple, 2 Mixed)"""
         from api.ai_stack_integration import (
             comprehensive_research,
-            enhanced_knowledge_search,
+            knowledge_search as enhanced_knowledge_search,
             get_system_knowledge,
             web_research,
         )
@@ -14566,17 +14566,17 @@ class TestBatch88AIStackIntegrationMigrations(unittest.TestCase):
 
     def test_batch_88_enhanced_knowledge_search_has_decorator(self):
         """Test enhanced_knowledge_search has @with_error_handling decorator"""
-        from api.ai_stack_integration import enhanced_knowledge_search
+        from api.ai_stack_integration import knowledge_search as enhanced_knowledge_search
 
         source = inspect.getsource(enhanced_knowledge_search)
         self.assertIn("@with_error_handling", source)
         self.assertIn("ErrorCategory.SERVER_ERROR", source)
-        self.assertIn('operation="enhanced_knowledge_search"', source)
+        self.assertIn('operation="knowledge_search"', source)
         self.assertIn('error_code_prefix="AI_STACK"', source)
 
     def test_batch_88_enhanced_knowledge_search_preserves_kb_fallback(self):
         """Test enhanced_knowledge_search preserves KB search fallback (Mixed Pattern)"""
-        from api.ai_stack_integration import enhanced_knowledge_search
+        from api.ai_stack_integration import knowledge_search as enhanced_knowledge_search
 
         source = inspect.getsource(enhanced_knowledge_search)
         # Should preserve inner try-catch for KB fallback
@@ -14652,7 +14652,7 @@ class TestBatch88AIStackIntegrationMigrations(unittest.TestCase):
         """Test all batch 88 endpoints use AI_STACK error code prefix"""
         from api.ai_stack_integration import (
             comprehensive_research,
-            enhanced_knowledge_search,
+            knowledge_search as enhanced_knowledge_search,
             get_system_knowledge,
             web_research,
         )
@@ -14672,14 +14672,14 @@ class TestBatch88AIStackIntegrationMigrations(unittest.TestCase):
         """Test batch 88 endpoints removed outer try-catch blocks"""
         from api.ai_stack_integration import (
             comprehensive_research,
-            enhanced_knowledge_search,
+            knowledge_search as enhanced_knowledge_search,
             get_system_knowledge,
             web_research,
         )
 
         # All endpoints should have decorator at function level, not nested in try
         endpoints_info = [
-            ("enhanced_knowledge_search", enhanced_knowledge_search),
+            ("knowledge_search", enhanced_knowledge_search),
             ("get_system_knowledge", get_system_knowledge),
             ("comprehensive_research", comprehensive_research),
             ("web_research", web_research),
@@ -14724,13 +14724,13 @@ class TestBatch88AIStackIntegrationMigrations(unittest.TestCase):
         """Test all batch 88 endpoints comprehensively"""
         from api.ai_stack_integration import (
             comprehensive_research,
-            enhanced_knowledge_search,
+            knowledge_search as enhanced_knowledge_search,
             get_system_knowledge,
             web_research,
         )
 
         endpoints_info = [
-            ("enhanced_knowledge_search", enhanced_knowledge_search, "Mixed"),
+            ("knowledge_search", enhanced_knowledge_search, "Mixed"),
             ("get_system_knowledge", get_system_knowledge, "Simple"),
             ("comprehensive_research", comprehensive_research, "Mixed"),
             ("web_research", web_research, "Simple"),
@@ -14795,8 +14795,8 @@ class TestBatch89AIStackIntegrationMigrations(unittest.TestCase):
             analyze_documents,
             classify_content,
             comprehensive_research,
-            enhanced_chat,
-            enhanced_knowledge_search,
+            chat as enhanced_chat,
+            knowledge_search as enhanced_knowledge_search,
             extract_knowledge,
             get_system_knowledge,
             list_ai_agents,
@@ -15082,8 +15082,8 @@ class TestBatch90AIStackIntegrationMigrations(unittest.TestCase):
             analyze_documents,
             classify_content,
             comprehensive_research,
-            enhanced_chat,
-            enhanced_knowledge_search,
+            chat as enhanced_chat,
+            knowledge_search as enhanced_knowledge_search,
             extract_knowledge,
             get_system_knowledge,
             legacy_enhanced_chat,
@@ -15132,8 +15132,8 @@ class TestBatch90AIStackIntegrationMigrations(unittest.TestCase):
             analyze_documents,
             classify_content,
             comprehensive_research,
-            enhanced_chat,
-            enhanced_knowledge_search,
+            chat as enhanced_chat,
+            knowledge_search as enhanced_knowledge_search,
             extract_knowledge,
             get_system_knowledge,
             legacy_enhanced_chat,
@@ -15382,8 +15382,8 @@ class TestBatch90AIStackIntegrationMigrations(unittest.TestCase):
             analyze_documents,
             classify_content,
             comprehensive_research,
-            enhanced_chat,
-            enhanced_knowledge_search,
+            chat as enhanced_chat,
+            knowledge_search as enhanced_knowledge_search,
             extract_knowledge,
             get_system_knowledge,
             legacy_enhanced_chat,
@@ -25074,17 +25074,17 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
 
     def test_batch_150_enhanced_semantic_search_simple_pattern(self):
         """Verify enhanced_semantic_search endpoint uses Simple Pattern"""
-        from api import enhanced_search
+        from api import search as enhanced_search
 
-        source = inspect.getsource(enhanced_search.enhanced_semantic_search)
+        source = inspect.getsource(enhanced_search.semantic_search)
         self.assertIn("@with_error_handling", source)
         self.assertIn("category=ErrorCategory.SERVER_ERROR", source)
-        self.assertIn('operation="enhanced_semantic_search"', source)
+        self.assertIn('operation="semantic_search"', source)
         self.assertIn('error_code_prefix="ENHANCED_SEARCH"', source)
 
     def test_batch_150_get_hardware_status_simple_pattern(self):
         """Verify get_hardware_status endpoint uses Simple Pattern"""
-        from api import enhanced_search
+        from api import search as enhanced_search
 
         source = inspect.getsource(enhanced_search.get_hardware_status)
         self.assertIn("@with_error_handling", source)
@@ -25094,7 +25094,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
 
     def test_batch_150_benchmark_search_performance_simple_pattern(self):
         """Verify benchmark_search_performance endpoint uses Simple Pattern"""
-        from api import enhanced_search
+        from api import search as enhanced_search
 
         source = inspect.getsource(enhanced_search.benchmark_search_performance)
         self.assertIn("@with_error_handling", source)
@@ -25104,7 +25104,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
 
     def test_batch_150_optimize_search_engine_simple_pattern(self):
         """Verify optimize_search_engine endpoint uses Simple Pattern"""
-        from api import enhanced_search
+        from api import search as enhanced_search
 
         source = inspect.getsource(enhanced_search.optimize_search_engine)
         self.assertIn("@with_error_handling", source)
@@ -25114,7 +25114,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
 
     def test_batch_150_get_performance_analytics_simple_pattern(self):
         """Verify get_performance_analytics endpoint uses Simple Pattern"""
-        from api import enhanced_search
+        from api import search as enhanced_search
 
         source = inspect.getsource(enhanced_search.get_performance_analytics)
         self.assertIn("@with_error_handling", source)
@@ -25124,7 +25124,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
 
     def test_batch_150_test_npu_connectivity_simple_pattern(self):
         """Verify test_npu_connectivity endpoint uses Simple Pattern"""
-        from api import enhanced_search
+        from api import search as enhanced_search
 
         source = inspect.getsource(enhanced_search.test_npu_connectivity)
         self.assertIn("@with_error_handling", source)
@@ -25134,7 +25134,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
 
     def test_batch_150_health_check_simple_pattern(self):
         """Verify health_check endpoint uses Simple Pattern"""
-        from api import enhanced_search
+        from api import search as enhanced_search
 
         source = inspect.getsource(enhanced_search.health_check)
         self.assertIn("@with_error_handling", source)
@@ -25144,10 +25144,10 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
 
     def test_batch_150_all_enhanced_search_endpoints_have_decorator(self):
         """Verify all enhanced_search endpoints have @with_error_handling decorator"""
-        from api import enhanced_search
+        from api import search as enhanced_search
 
         endpoint_functions = [
-            enhanced_search.enhanced_semantic_search,
+            enhanced_search.semantic_search,
             enhanced_search.get_hardware_status,
             enhanced_search.benchmark_search_performance,
             enhanced_search.optimize_search_engine,
@@ -25166,10 +25166,10 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
 
     def test_batch_150_enhanced_search_100_percent_milestone(self):
         """Verify enhanced_search.py has reached 100% migration"""
-        from api import enhanced_search
+        from api import search as enhanced_search
 
         endpoint_functions = [
-            enhanced_search.enhanced_semantic_search,
+            enhanced_search.semantic_search,
             enhanced_search.get_hardware_status,
             enhanced_search.benchmark_search_performance,
             enhanced_search.optimize_search_engine,
@@ -25191,33 +25191,33 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
 
     def test_batch_150_migration_preserves_npu_semantic_search(self):
         """Verify migration preserves NPU semantic search functionality"""
-        from api import enhanced_search
+        from api import search as enhanced_search
 
-        source = inspect.getsource(enhanced_search.enhanced_semantic_search)
+        source = inspect.getsource(enhanced_search.semantic_search)
         self.assertIn("get_npu_search_engine", source)
         self.assertIn("enhanced_search", source)
         self.assertIn("enable_npu_acceleration", source)
 
     def test_batch_150_migration_preserves_hardware_device_enum(self):
         """Verify migration preserves HardwareDevice enum handling"""
-        from api import enhanced_search
+        from api import search as enhanced_search
 
-        source = inspect.getsource(enhanced_search.enhanced_semantic_search)
+        source = inspect.getsource(enhanced_search.semantic_search)
         self.assertIn("HardwareDevice", source)
         self.assertIn("force_device", source)
 
     def test_batch_150_migration_preserves_search_metrics(self):
         """Verify migration preserves SearchMetrics and SearchResult models"""
-        from api import enhanced_search
+        from api import search as enhanced_search
 
-        source = inspect.getsource(enhanced_search.enhanced_semantic_search)
+        source = inspect.getsource(enhanced_search.semantic_search)
         self.assertIn("SearchResponse", source)
         self.assertIn("metrics", source)
         self.assertIn("results_data", source)
 
     def test_batch_150_migration_preserves_benchmark_functionality(self):
         """Verify migration preserves benchmark functionality"""
-        from api import enhanced_search
+        from api import search as enhanced_search
 
         source = inspect.getsource(enhanced_search.benchmark_search_performance)
         self.assertIn("benchmark_search_performance", source)
@@ -25226,7 +25226,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
 
     def test_batch_150_migration_preserves_optimization_workload_types(self):
         """Verify migration preserves optimization workload types"""
-        from api import enhanced_search
+        from api import search as enhanced_search
 
         source = inspect.getsource(enhanced_search.optimize_search_engine)
         self.assertIn("optimize_for_workload", source)
@@ -25234,7 +25234,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
 
     def test_batch_150_migration_preserves_performance_recommendations(self):
         """Verify migration preserves performance recommendation helpers"""
-        from api import enhanced_search
+        from api import search as enhanced_search
 
         # Verify helper functions exist
         self.assertTrue(hasattr(enhanced_search, "_generate_performance_recommendations"))
@@ -25656,10 +25656,10 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
         """Verify enhanced_search endpoint uses Simple Pattern"""
         from api import knowledge_ai_stack
 
-        source = inspect.getsource(knowledge_ai_stack.enhanced_search)
+        source = inspect.getsource(knowledge_ai_stack.search)
         self.assertIn("@with_error_handling", source)
         self.assertIn("category=ErrorCategory.SERVER_ERROR", source)
-        self.assertIn('operation="enhanced_search"', source)
+        self.assertIn('operation="search"', source)
         self.assertIn('error_code_prefix="KNOWLEDGE_ENHANCED"', source)
 
     def test_batch_153_rag_search_simple_pattern(self):
@@ -25726,10 +25726,10 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
         """Verify enhanced_knowledge_health endpoint uses Simple Pattern"""
         from api import knowledge_ai_stack
 
-        source = inspect.getsource(knowledge_ai_stack.enhanced_knowledge_health)
+        source = inspect.getsource(knowledge_ai_stack.knowledge_health)
         self.assertIn("@with_error_handling", source)
         self.assertIn("category=ErrorCategory.SERVER_ERROR", source)
-        self.assertIn('operation="enhanced_knowledge_health"', source)
+        self.assertIn('operation="knowledge_health"', source)
         self.assertIn('error_code_prefix="KNOWLEDGE_ENHANCED"', source)
 
     def test_batch_153_all_knowledge_ai_stack_endpoints_have_decorator(self):
@@ -25737,14 +25737,14 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
         from api import knowledge_ai_stack
 
         endpoint_functions = [
-            knowledge_ai_stack.enhanced_search,
+            knowledge_ai_stack.search,
             knowledge_ai_stack.rag_search,
             knowledge_ai_stack.extract_knowledge,
             knowledge_ai_stack.analyze_documents,
             knowledge_ai_stack.reformulate_query,
             knowledge_ai_stack.get_system_knowledge_insights,
             knowledge_ai_stack.get_enhanced_stats,
-            knowledge_ai_stack.enhanced_knowledge_health,
+            knowledge_ai_stack.knowledge_health,
         ]
 
         for func in endpoint_functions:
@@ -25760,14 +25760,14 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
         from api import knowledge_ai_stack
 
         endpoint_functions = [
-            knowledge_ai_stack.enhanced_search,
+            knowledge_ai_stack.search,
             knowledge_ai_stack.rag_search,
             knowledge_ai_stack.extract_knowledge,
             knowledge_ai_stack.analyze_documents,
             knowledge_ai_stack.reformulate_query,
             knowledge_ai_stack.get_system_knowledge_insights,
             knowledge_ai_stack.get_enhanced_stats,
-            knowledge_ai_stack.enhanced_knowledge_health,
+            knowledge_ai_stack.knowledge_health,
         ]
 
         migrated_count = sum(1 for func in endpoint_functions if "@with_error_handling" in inspect.getsource(func))
@@ -25786,7 +25786,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
         from api import knowledge_ai_stack
 
         # Verify AI Stack client dependency injection
-        enhanced_search_source = inspect.getsource(knowledge_ai_stack.enhanced_search)
+        enhanced_search_source = inspect.getsource(knowledge_ai_stack.search)
         self.assertIn("get_ai_stack_client", enhanced_search_source)
         self.assertIn("ai_client", enhanced_search_source)
 
@@ -25804,7 +25804,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
         self.assertIn("documents", rag_source)
 
         # Verify enhanced search combines RAG
-        enhanced_source = inspect.getsource(knowledge_ai_stack.enhanced_search)
+        enhanced_source = inspect.getsource(knowledge_ai_stack.search)
         self.assertIn("include_rag", enhanced_source)
         self.assertIn("rag_enhanced", enhanced_source)
 
@@ -25851,7 +25851,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
         self.assertTrue(hasattr(knowledge_ai_stack, "RAGQueryRequest"))
 
         # Verify models are used in endpoints
-        enhanced_search_source = inspect.getsource(knowledge_ai_stack.enhanced_search)
+        enhanced_search_source = inspect.getsource(knowledge_ai_stack.search)
         self.assertIn("AIStackSearchRequest", enhanced_search_source)
 
     # ==============================================

--- a/autobot-backend/api/api_endpoint_migrations_test.py
+++ b/autobot-backend/api/api_endpoint_migrations_test.py
@@ -11648,7 +11648,8 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
 
     def test_batch72_decorator_placement(self):
         """Test batch 72 endpoints have decorators in correct order"""
-        from api.agent import agent_health as enhanced_agent_health, receive_goal_compat
+        from api.agent import agent_health as enhanced_agent_health
+        from api.agent import receive_goal_compat
 
         for endpoint in [receive_goal_compat, enhanced_agent_health]:
             source = inspect.getsource(endpoint)
@@ -11663,7 +11664,8 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
 
     def test_batch72_error_category_consistency(self):
         """Test batch 72 endpoints all use ErrorCategory.SERVER_ERROR"""
-        from api.agent import agent_health as enhanced_agent_health, receive_goal_compat
+        from api.agent import agent_health as enhanced_agent_health
+        from api.agent import receive_goal_compat
 
         for endpoint in [receive_goal_compat, enhanced_agent_health]:
             source = inspect.getsource(endpoint)
@@ -11675,7 +11677,8 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
 
     def test_batch72_error_prefix_consistency(self):
         """Test batch 72 endpoints all use AGENT_ENHANCED prefix"""
-        from api.agent import agent_health as enhanced_agent_health, receive_goal_compat
+        from api.agent import agent_health as enhanced_agent_health
+        from api.agent import receive_goal_compat
 
         for endpoint in [receive_goal_compat, enhanced_agent_health]:
             source = inspect.getsource(endpoint)
@@ -11687,7 +11690,8 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
 
     def test_batch72_mixed_pattern_consistency(self):
         """Test batch 72 endpoints all use Mixed Pattern (preserve outer try-catch)"""
-        from api.agent import agent_health as enhanced_agent_health, receive_goal_compat
+        from api.agent import agent_health as enhanced_agent_health
+        from api.agent import receive_goal_compat
 
         for endpoint in [receive_goal_compat, enhanced_agent_health]:
             source = inspect.getsource(endpoint)
@@ -11700,7 +11704,8 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
 
     def test_batch72_business_logic_preservation(self):
         """Test batch 72 endpoints preserve business logic (fallback/degraded responses)"""
-        from api.agent import agent_health as enhanced_agent_health, receive_goal_compat
+        from api.agent import agent_health as enhanced_agent_health
+        from api.agent import receive_goal_compat
 
         # receive_goal_compat should have fallback logic
         compat_source = inspect.getsource(receive_goal_compat)
@@ -14259,7 +14264,9 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
         """Test batch 87 endpoints use correct patterns (2 Simple, 1 Mixed)"""
         from api.ai_stack_integration import (
             analyze_documents,
-            chat as enhanced_chat,
+        )
+        from api.ai_stack_integration import chat as enhanced_chat
+        from api.ai_stack_integration import (
             extract_knowledge,
         )
 
@@ -14316,7 +14323,9 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
         """Test batch 87 endpoints have correct operation names in decorator"""
         from api.ai_stack_integration import (
             analyze_documents,
-            chat as enhanced_chat,
+        )
+        from api.ai_stack_integration import chat as enhanced_chat
+        from api.ai_stack_integration import (
             extract_knowledge,
         )
 
@@ -14390,7 +14399,9 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
         """Test batch 87 endpoints have correct decorator parameters"""
         from api.ai_stack_integration import (
             analyze_documents,
-            chat as enhanced_chat,
+        )
+        from api.ai_stack_integration import chat as enhanced_chat
+        from api.ai_stack_integration import (
             extract_knowledge,
         )
 
@@ -14409,7 +14420,9 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
         """Test batch 87 endpoints don't call handle_ai_stack_error"""
         from api.ai_stack_integration import (
             analyze_documents,
-            chat as enhanced_chat,
+        )
+        from api.ai_stack_integration import chat as enhanced_chat
+        from api.ai_stack_integration import (
             extract_knowledge,
         )
 
@@ -14427,7 +14440,9 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
         from api.ai_stack_integration import (
             ai_stack_health_check,
             analyze_documents,
-            chat as enhanced_chat,
+        )
+        from api.ai_stack_integration import chat as enhanced_chat
+        from api.ai_stack_integration import (
             extract_knowledge,
             list_ai_agents,
             rag_query,
@@ -14457,7 +14472,9 @@ class TestBatch87AIStackIntegrationMigrations(unittest.TestCase):
         """Comprehensive test for all batch 87 migrations"""
         from api.ai_stack_integration import (
             analyze_documents,
-            chat as enhanced_chat,
+        )
+        from api.ai_stack_integration import chat as enhanced_chat
+        from api.ai_stack_integration import (
             extract_knowledge,
         )
 
@@ -14501,11 +14518,15 @@ class TestBatch88AIStackIntegrationMigrations(unittest.TestCase):
         from api.ai_stack_integration import (
             ai_stack_health_check,
             analyze_documents,
+        )
+        from api.ai_stack_integration import chat as enhanced_chat
+        from api.ai_stack_integration import (
             comprehensive_research,
-            chat as enhanced_chat,
-            knowledge_search as enhanced_knowledge_search,
             extract_knowledge,
             get_system_knowledge,
+        )
+        from api.ai_stack_integration import knowledge_search as enhanced_knowledge_search
+        from api.ai_stack_integration import (
             list_ai_agents,
             rag_query,
             reformulate_query,
@@ -14537,8 +14558,10 @@ class TestBatch88AIStackIntegrationMigrations(unittest.TestCase):
         """Test batch 88 endpoints use correct patterns (2 Simple, 2 Mixed)"""
         from api.ai_stack_integration import (
             comprehensive_research,
-            knowledge_search as enhanced_knowledge_search,
             get_system_knowledge,
+        )
+        from api.ai_stack_integration import knowledge_search as enhanced_knowledge_search
+        from api.ai_stack_integration import (
             web_research,
         )
 
@@ -14652,8 +14675,10 @@ class TestBatch88AIStackIntegrationMigrations(unittest.TestCase):
         """Test all batch 88 endpoints use AI_STACK error code prefix"""
         from api.ai_stack_integration import (
             comprehensive_research,
-            knowledge_search as enhanced_knowledge_search,
             get_system_knowledge,
+        )
+        from api.ai_stack_integration import knowledge_search as enhanced_knowledge_search
+        from api.ai_stack_integration import (
             web_research,
         )
 
@@ -14672,8 +14697,10 @@ class TestBatch88AIStackIntegrationMigrations(unittest.TestCase):
         """Test batch 88 endpoints removed outer try-catch blocks"""
         from api.ai_stack_integration import (
             comprehensive_research,
-            knowledge_search as enhanced_knowledge_search,
             get_system_knowledge,
+        )
+        from api.ai_stack_integration import knowledge_search as enhanced_knowledge_search
+        from api.ai_stack_integration import (
             web_research,
         )
 
@@ -14724,8 +14751,10 @@ class TestBatch88AIStackIntegrationMigrations(unittest.TestCase):
         """Test all batch 88 endpoints comprehensively"""
         from api.ai_stack_integration import (
             comprehensive_research,
-            knowledge_search as enhanced_knowledge_search,
             get_system_knowledge,
+        )
+        from api.ai_stack_integration import knowledge_search as enhanced_knowledge_search
+        from api.ai_stack_integration import (
             web_research,
         )
 
@@ -14793,12 +14822,16 @@ class TestBatch89AIStackIntegrationMigrations(unittest.TestCase):
             ai_stack_health_check,
             analyze_development_speedup,
             analyze_documents,
+        )
+        from api.ai_stack_integration import chat as enhanced_chat
+        from api.ai_stack_integration import (
             classify_content,
             comprehensive_research,
-            chat as enhanced_chat,
-            knowledge_search as enhanced_knowledge_search,
             extract_knowledge,
             get_system_knowledge,
+        )
+        from api.ai_stack_integration import knowledge_search as enhanced_knowledge_search
+        from api.ai_stack_integration import (
             list_ai_agents,
             rag_query,
             reformulate_query,
@@ -15080,12 +15113,16 @@ class TestBatch90AIStackIntegrationMigrations(unittest.TestCase):
             ai_stack_health_check,
             analyze_development_speedup,
             analyze_documents,
+        )
+        from api.ai_stack_integration import chat as enhanced_chat
+        from api.ai_stack_integration import (
             classify_content,
             comprehensive_research,
-            chat as enhanced_chat,
-            knowledge_search as enhanced_knowledge_search,
             extract_knowledge,
             get_system_knowledge,
+        )
+        from api.ai_stack_integration import knowledge_search as enhanced_knowledge_search
+        from api.ai_stack_integration import (
             legacy_enhanced_chat,
             legacy_rag_search,
             list_ai_agents,
@@ -15130,12 +15167,16 @@ class TestBatch90AIStackIntegrationMigrations(unittest.TestCase):
             ai_stack_health_check,
             analyze_development_speedup,
             analyze_documents,
+        )
+        from api.ai_stack_integration import chat as enhanced_chat
+        from api.ai_stack_integration import (
             classify_content,
             comprehensive_research,
-            chat as enhanced_chat,
-            knowledge_search as enhanced_knowledge_search,
             extract_knowledge,
             get_system_knowledge,
+        )
+        from api.ai_stack_integration import knowledge_search as enhanced_knowledge_search
+        from api.ai_stack_integration import (
             legacy_enhanced_chat,
             legacy_rag_search,
             list_ai_agents,
@@ -15380,12 +15421,16 @@ class TestBatch90AIStackIntegrationMigrations(unittest.TestCase):
             ai_stack_health_check,
             analyze_development_speedup,
             analyze_documents,
+        )
+        from api.ai_stack_integration import chat as enhanced_chat
+        from api.ai_stack_integration import (
             classify_content,
             comprehensive_research,
-            chat as enhanced_chat,
-            knowledge_search as enhanced_knowledge_search,
             extract_knowledge,
             get_system_knowledge,
+        )
+        from api.ai_stack_integration import knowledge_search as enhanced_knowledge_search
+        from api.ai_stack_integration import (
             legacy_enhanced_chat,
             legacy_rag_search,
             list_ai_agents,

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -1990,10 +1990,10 @@ async def _generate_enhanced_stream(
 @router.post("/enhanced", response_model=DataResponse[ChatData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_chat",
+    operation="chat_enhanced",
     error_code_prefix="CHAT",
 )
-async def enhanced_chat(
+async def chat_enhanced(
     current_user: dict = Depends(get_current_user),
     message: ChatMessage = None,
     request: Request = None,
@@ -2092,10 +2092,10 @@ async def stream_enhanced_chat(
 @router.get("/health-enhanced", response_model=ChatHealthData)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_chat_health_check",
+    operation="chat_health_enhanced",
     error_code_prefix="CHAT",
 )
-async def enhanced_chat_health_check(
+async def chat_health_enhanced(
     current_user: dict = Depends(get_current_user),
 ):
     """

--- a/autobot-backend/api/developer.py
+++ b/autobot-backend/api/developer.py
@@ -167,8 +167,8 @@ async def get_system_info():
 
 
 # Custom exception handler for 404 errors with developer mode enhancements
-async def enhanced_404_handler(request: Request, exc: HTTPException):
-    """Enhanced 404 handler that provides helpful suggestions in developer mode"""
+async def not_found_handler(request: Request, exc: HTTPException):
+    """404 handler that provides helpful suggestions in developer mode"""
     developer_mode = unified_config_manager.get_nested("developer.enabled", False)
     enhanced_errors = unified_config_manager.get_nested("developer.enhanced_errors", True)
 
@@ -199,8 +199,8 @@ async def enhanced_404_handler(request: Request, exc: HTTPException):
 
 
 # Custom exception handler for 405 errors (Method Not Allowed)
-async def enhanced_405_handler(request: Request, exc: HTTPException):
-    """Enhanced 405 handler for developer mode"""
+async def method_not_allowed_handler(request: Request, exc: HTTPException):
+    """405 handler for developer mode"""
     developer_mode = unified_config_manager.get_nested("developer.enabled", False)
     enhanced_errors = unified_config_manager.get_nested("developer.enhanced_errors", True)
 

--- a/autobot-backend/api/knowledge_ai_stack.py
+++ b/autobot-backend/api/knowledge_ai_stack.py
@@ -263,10 +263,10 @@ async def _run_all_search_sources(
 @router.post("/search/enhanced", response_model=DataResponse[AIStackEnhancedSearchData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_search",
+    operation="search",
     error_code_prefix="KNOWLEDGE_AI_STACK",
 )
-async def enhanced_search(
+async def search(
     request_data: AIStackEnhancedSearchRequest,
     req: Request,
     knowledge_base=Depends(get_knowledge_base),
@@ -663,10 +663,10 @@ async def get_enhanced_stats(
 @router.get("/health/enhanced", response_model=DataResponse[AIStackEnhancedHealthData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_knowledge_health",
+    operation="knowledge_health",
     error_code_prefix="KNOWLEDGE_AI_STACK",
 )
-async def enhanced_knowledge_health(
+async def knowledge_health(
     current_user: dict = Depends(get_current_user),
 ):
     """

--- a/autobot-backend/api/knowledge_search.py
+++ b/autobot-backend/api/knowledge_search.py
@@ -532,10 +532,10 @@ async def _execute_basic_search_with_reranking(request: SearchRequest, kb_to_use
 @router.post("/search", response_model=KnowledgeSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="consolidated_search",
+    operation="search",
     error_code_prefix="KNOWLEDGE_SEARCH",
 )
-async def consolidated_search(request: SearchRequest, req: Request):
+async def search(request: SearchRequest, req: Request):
     """
     Consolidated knowledge base search endpoint (Issue #555).
 
@@ -722,10 +722,10 @@ def _enhanced_search_not_initialized_response() -> dict:
 @router.post("/enhanced_search", deprecated=True, response_model=KBSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_search",
+    operation="search_enhanced",
     error_code_prefix="KNOWLEDGE_SEARCH",
 )
-async def enhanced_search(request: SearchRequest, req: Request):
+async def search_enhanced(request: SearchRequest, req: Request):
     """
     **[DEPRECATED]** Use POST /search with appropriate parameters instead.
 
@@ -984,10 +984,10 @@ async def _fallback_to_enhanced_search(kb_to_use, params: dict):
 @router.post("/enhanced_search_v2", deprecated=True, response_model=KBSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_search_v2",
+    operation="search_enhanced_v2",
     error_code_prefix="KNOWLEDGE_SEARCH",
 )
-async def enhanced_search_v2(request: dict, req: Request):
+async def search_enhanced_v2(request: dict, req: Request):
     """
     **[DEPRECATED]** Use POST /search with appropriate parameters instead.
 

--- a/autobot-backend/api/knowledge_search_aggregator.py
+++ b/autobot-backend/api/knowledge_search_aggregator.py
@@ -320,10 +320,10 @@ def _search_documentation(query: str, doc_results_count: int, score_threshold: f
 @router.post("/search", response_model=KnowledgeUnifiedSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="unified_search",
+    operation="search",
     error_code_prefix="KNOWLEDGE_SEARCH_AGGREGATOR",
 )
-async def unified_search(req: Request, body: SearchRequest):
+async def search(req: Request, body: SearchRequest):
     """
     Search across all knowledge sources in a unified query.
 
@@ -363,10 +363,10 @@ async def unified_search(req: Request, body: SearchRequest):
 @router.get("/stats", response_model=KnowledgeUnifiedStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="unified_stats",
+    operation="stats",
     error_code_prefix="KNOWLEDGE_SEARCH_AGGREGATOR",
 )
-async def unified_stats(req: Request):
+async def stats(req: Request):
     """Get statistics from all unified knowledge sources (KB facts, relations, docs). Ref: #1088."""
     kb = await get_or_create_knowledge_base(req.app, force_refresh=False)
 

--- a/autobot-backend/api/search.py
+++ b/autobot-backend/api/search.py
@@ -4,7 +4,7 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Enhanced Search API with NPU Acceleration
+Search API with NPU Acceleration
 Provides NPU-accelerated semantic search endpoints for AutoBot
 """
 
@@ -34,9 +34,9 @@ from autobot_shared.logging_manager import get_llm_logger
 from npu_semantic_search import get_npu_search_engine
 from type_defs.common import Metadata
 
-logger = get_llm_logger("enhanced_search_api")
+logger = get_llm_logger("search_api")
 
-router = APIRouter(tags=["Enhanced Search"])
+router = APIRouter(tags=["Search"])
 
 
 def _parse_force_device(force_device_str: str | None) -> HardwareDevice | None:
@@ -98,10 +98,10 @@ def _convert_metrics_to_api_format(metrics) -> dict:
 @router.post("/semantic", response_model=NPUSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="enhanced_semantic_search",
+    operation="semantic_search",
     error_code_prefix="ENHANCED_SEARCH",
 )
-async def enhanced_semantic_search(request: NPUSearchRequest):
+async def semantic_search(request: NPUSearchRequest):
     """
     Perform NPU-enhanced semantic search.
 
@@ -465,7 +465,7 @@ def _generate_system_recommendations(statistics: Metadata, hardware_status: Meta
     return recommendations
 
 
-register_singleton_probe("enhanced_search", get_npu_search_engine, async_getter=True)
+register_singleton_probe("search", get_npu_search_engine, async_getter=True)
 
 
 # Health check endpoint

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -342,12 +342,12 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["cache"],
         "cache_management",
     ),
-    # Enhanced features
+    # NPU-accelerated search (#10666 B7: renamed from enhanced_search)
     (
-        "api.enhanced_search",
+        "api.search",
         "/enhanced-search",
         ["enhanced-search"],
-        "enhanced_search",
+        "search",
     ),
     (
         "api.enhanced_memory",


### PR DESCRIPTION
## Thinking Path

B7 of umbrella #10666. B1 (api-schemas) already merged. This batch strips `enhanced_`/`consolidated_`/`unified_`/`_v2` prefixes from **route handler functions** and renames `api/enhanced_search.py` → `api/search.py`.

**In-module collision resolution (§3.F):**

`knowledge_search.py` has three sibling handlers that all want `search` after prefix-stripping:
- `consolidated_search` (POST `/search`) → **`search`** — primary canonical endpoint
- `enhanced_search` (POST `/enhanced_search`, deprecated) → **`search_enhanced`** — distinct descriptive name (route is `/enhanced_search`, still deprecated)
- `enhanced_search_v2` (POST `/enhanced_search_v2`, deprecated) → **`search_enhanced_v2`** — distinct descriptive name

`chat.py` has a collision with the existing `chat_health_check` (GET `/chat/health`):
- `enhanced_chat` (POST `/enhanced`) → **`chat_enhanced`** — no collision with existing `send_message` handler
- `enhanced_chat_health_check` (GET `/health-enhanced`) → **`chat_health_enhanced`** — avoids collision with `chat_health_check` at GET `/chat/health`

**Per-handler disposition:**

| Old name | New name | Module | Collision? |
|---|---|---|---|
| `enhanced_agent_health` | `agent_health` | agent.py | No |
| `enhanced_chat` | `chat` | ai_stack_integration.py | No |
| `enhanced_knowledge_search` | `knowledge_search` | ai_stack_integration.py | No |
| `enhanced_chat` | `chat_enhanced` | chat.py | No |
| `enhanced_chat_health_check` | `chat_health_enhanced` | chat.py | YES — distinct name chosen |
| `enhanced_404_handler` | `not_found_handler` | developer.py | No |
| `enhanced_405_handler` | `method_not_allowed_handler` | developer.py | No |
| `enhanced_semantic_search` | `semantic_search` | enhanced_search.py→search.py | No |
| `enhanced_search` | `search` | knowledge_ai_stack.py | No |
| `enhanced_knowledge_health` | `knowledge_health` | knowledge_ai_stack.py | No |
| `consolidated_search` | `search` | knowledge_search.py | No |
| `enhanced_search` | `search_enhanced` | knowledge_search.py | YES — 3-way sibling, distinct name |
| `enhanced_search_v2` | `search_enhanced_v2` | knowledge_search.py | YES — 3-way sibling, distinct name |
| `unified_search` | `search` | knowledge_search_aggregator.py | No |
| `unified_stats` | `stats` | knowledge_search_aggregator.py | No |
| **File** `enhanced_search.py` | `search.py` | api/ | No conflict |

## What Changed

- `api/enhanced_search.py` → `api/search.py` (git mv, 97% similarity)
- `enhanced_semantic_search` → `semantic_search` in new `api/search.py`
- `api/__init__.py`: `"enhanced_search"` → `"search"` in `__all__`
- `initialization/router_registry/feature_routers.py`: `"api.enhanced_search"` → `"api.search"`
- 15 route handler function renames across 7 api files (def + operation= string)
- `api_endpoint_migrations_test.py`: updated all imports to use aliases (`chat as enhanced_chat`, `agent_health as enhanced_agent_health`, etc.) and fixed operation= string assertions
- Zero URL path changes — all `@router.get/post/...("/path")` decorators unchanged

## Verification

- `pytest autobot-backend/tests/test_startup_imports.py -q`: **339 passed, 82 warnings**
- `python3 -m flake8 --config=.flake8 <changed files>`: **0 errors**
- `awk 'length>120'` on all changed files: **0 lines**
- Zero-grep for old function defs: `git grep -wE "^async def enhanced_agent_health|^async def enhanced_chat|..."` → **empty**
- Route table unchanged: `git diff HEAD -- api/agent.py ... | grep @router` shows only file-rename additions, no path changes

## Model Used

claude-sonnet-4-6

Part of #10666