### PR TITLE
fix(auth): JWT iat must be integer timestamp not ISO string (#10701)

### DIFF
--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -364,7 +364,11 @@ class AuthenticationMiddleware:
             "username": user_data["username"],
             "role": user_data["role"],
             "email": user_data.get("email", ""),
-            "iat": datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
+            # iat MUST be a numeric (integer) Unix timestamp — PyJWT >=2.10
+            # rejects a non-integer iat on decode ("Issued At claim (iat) must
+            # be an integer"), which silently broke JWT verification (every
+            # /api/auth/me 401'd → login redirect loop) once real auth ran.
+            "iat": int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp()),
         }
 
         # Issue #684: Include org/user hierarchy in token


### PR DESCRIPTION
## Thinking Path
User-app (172.16.168.20/) was stuck in a login redirect loop. Traced it: \`/api/auth/me\` 401s even with a valid, freshly-issued login token. Root cause: \`create_jwt_token\` sets \`iat\` to \`datetime.isoformat()\` (a string); PyJWT 2.13.0 rejects non-integer \`iat\` on decode, so verify_jwt_token always fails. Masked until single_company made /api/auth/me actually verify (single_user returned a synthetic admin without verifying).

## What Changed
- autobot-backend/auth_middleware.py: \`iat\` now \`int(datetime.now(tz=utc).timestamp())\`.

## Verification
In-process on the deployed backend: isoformat iat → \`JWTDecodeError: Issued At claim (iat) must be an integer\`; int iat → decodes OK (iat=1782766890, int).

## Model Used
Claude Opus 4.8 (1M context)

Closes #10701