### PR TITLE
fix(startup): security_layer use canonical config.user_mode — fixes #10705 base smoke-test regression

### DIFF
--- a/autobot-backend/security_layer.py
+++ b/autobot-backend/security_layer.py
@@ -46,9 +46,6 @@ def _resolve_audit_log_file() -> str:
 
 _AUDIT_LOG_FILE = _resolve_audit_log_file()
 
-# Performance optimization: O(1) lookup for boolean string values (Issue #326)
-BOOLEAN_TRUE_VALUES = {"true", "1", "yes"}
-
 # Performance optimization: O(1) lookup for deprecated privileged roles (Issue #326)
 DEPRECATED_PRIVILEGED_ROLES = {"god", "superuser", "root"}
 
@@ -95,8 +92,10 @@ class SecurityLayer:
         # Use centralized config manager
         self.security_config = get_config_manager().get("security_config", {})
 
-        # Check for single-user mode (development/personal use)
-        self.single_user_mode = str(config.single_user_mode).lower() in BOOLEAN_TRUE_VALUES
+        # Check for single-user mode (development/personal use).
+        # #10705: config.single_user_mode was removed by the #10666 consolidation;
+        # derive from the canonical AUTOBOT_USER_MODE string (#10636) instead.
+        self.single_user_mode = config.user_mode == "single_user"
 
         # If single-user mode is enabled, disable all authentication
         # Issue #745: Added security warning for production awareness
@@ -104,7 +103,7 @@ class SecurityLayer:
             self.enable_auth = False
             logger.warning(
                 "SECURITY: Single-user mode enabled - authentication disabled. "
-                "Set AUTOBOT_SINGLE_USER_MODE=false for production deployments."
+                "Set AUTOBOT_USER_MODE to a non-single_user value for production deployments."
             )
         else:
             # Issue #745: Default to True for production security


### PR DESCRIPTION
## Thinking Path
**P0 base fix.** `Dev_new_gui` smoke-test has been red since #10700 (#10666 consolidation): the backend lifespan aborts with `AttributeError: 'AutoBotConfig' object has no attribute 'single_user_mode'` → "CRITICAL INITIALIZATION FAILED" → backend unhealthy. Root-caused from the smoke-test `failure-logs` artifact (bisect: green at #10702, red at #10700).

`security_layer.__init__` read `config.single_user_mode`, but that attribute was removed by the #10666 consolidation; the canonical config is `AUTOBOT_USER_MODE` / `config.user_mode` (a string, per #10636).

## What Changed
- `security_layer.py`: `self.single_user_mode = config.user_mode == "single_user"` (was `str(config.single_user_mode)...`). Uses the canonical, existing attribute.
- Updated the stale `AUTOBOT_SINGLE_USER_MODE` hint → `AUTOBOT_USER_MODE`.
- Removed the now-unused `BOOLEAN_TRUE_VALUES` constant.

## Verification
- `py_compile` + `flake8` clean.
- **The real test is this PR's `smoke-test`** — if the backend reaches healthy, the base regression is fixed. (`startup-import-smoke` was already green; this is a runtime access, which is why it slipped past required checks.)
- Only caller of `single_user_mode` is this file (grep-confirmed); no other dangling references to #10700-removed symbols.

## Note
Filed #10706 to make smoke-test print backend logs inline on failure (they were only available as a downloadable artifact, which is why this took digging to diagnose).

Fixes #10705.

## Model Used
Claude Opus 4.8 (1M context)