### PR TITLE
fix(auth): WebSocket auth uses singleton middleware (fixes Disconnected) (#10710)

### DIFF
--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -1001,8 +1001,10 @@ async def authenticate_websocket(websocket) -> dict | None:
     token = websocket.query_params.get("token")
     if token:
         try:
-            auth = AuthenticationMiddleware()
-            token_data = auth.verify_jwt_token(token)
+            # Use the singleton — a fresh AuthenticationMiddleware() generates a
+            # NEW ephemeral RS256 keypair, so it can't verify tokens signed by the
+            # singleton used at login → every WS handshake 403'd ("Disconnected").
+            token_data = get_auth_middleware().verify_jwt_token(token)
             if token_data:
                 result = {
                     "username": token_data["username"],


### PR DESCRIPTION
## Thinking Path
User-app showed "Disconnected". /api/ws handshake 403s even with a fresh valid token, while HTTP /api/auth/me works. Cause: authenticate_websocket() instantiates a NEW AuthenticationMiddleware() (fresh ephemeral RS256 keypair) to verify the token, instead of the login singleton get_auth_middleware() — so the keys never match and verify fails.

## What Changed
- auth_middleware.py authenticate_websocket(): verify via get_auth_middleware() singleton.

## Verification
py_compile OK. WS connect with a fresh token currently 403s (reproduced via websockets client); singleton verify works in-process (same path as HTTP /api/auth/me which returns 200). Live verify after deploy.

## Follow-up
Persist AUTOBOT_JWT_PRIVATE_KEY so tokens survive backend restarts (separate issue).

## Model Used
Claude Opus 4.8 (1M context)

Closes #10710