### PR TITLE
fix(chat): wire knowledge base search into async chat workflow (#10715)

### DIFF
--- a/autobot-backend/async_chat_workflow.py
+++ b/autobot-backend/async_chat_workflow.py
@@ -19,6 +19,7 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 from constants.threshold_constants import TimingConstants
 from dependency_container import inject_services
+from knowledge_base_factory import get_knowledge_base
 from llm_shared.models import ChatMessage, LLMResponse  # Phase 2D #3185
 from retry_mechanism import RetryConfig, RetryStrategy, with_retry
 
@@ -148,7 +149,7 @@ class AsyncChatWorkflow:
             message_type = await self._workflow_classify(user_message, workflow_steps)
 
             # Stage 2: Knowledge search
-            knowledge_status, kb_results = await self._workflow_knowledge_search()
+            knowledge_status, kb_results = await self._workflow_knowledge_search(user_message)
 
             # Stage 3: LLM response generation
             llm_response = await self._workflow_llm_generate(user_message, llm, workflow_steps)
@@ -199,11 +200,11 @@ class AsyncChatWorkflow:
 
     async def _workflow_knowledge_search(
         self,
+        query: str,
     ) -> tuple[KnowledgeStatus, List[Dict[str, Any]]]:
-        """Search knowledge base. Issue #281: Extracted helper."""
+        """Search knowledge base using the canonical KB facade. Issue #10715."""
         await self.add_workflow_message("debug", "🔍 WORKFLOW: Searching knowledge base...", step="knowledge_search")
-        knowledge_status = KnowledgeStatus.BYPASSED  # Simplified for now
-        kb_results: List[Dict[str, Any]] = []
+        knowledge_status, kb_results = await self._execute_kb_search(query)
         await self.add_workflow_message(
             "utility",
             "📚 Knowledge base search completed",
@@ -211,6 +212,33 @@ class AsyncChatWorkflow:
             results_count=len(kb_results),
         )
         return knowledge_status, kb_results
+
+    async def _execute_kb_search(
+        self,
+        query: str,
+    ) -> tuple[KnowledgeStatus, List[Dict[str, Any]]]:
+        """Call the KB facade and map results; returns (status, results). Issue #10715."""
+        try:
+            kb = await get_knowledge_base()
+            if kb is None:
+                logger.warning("Knowledge base unavailable; skipping search for query: %.80s", query)
+                return KnowledgeStatus.MISSING, []
+            raw: List[Dict[str, Any]] = await kb.search(query=query, top_k=5)
+            if not raw:
+                return KnowledgeStatus.MISSING, []
+            results = [
+                {
+                    "content": r.get("content", ""),
+                    "source": r.get("node_id", r.get("doc_id", "")),
+                    "score": r.get("score", 0.0),
+                    "metadata": r.get("metadata", {}),
+                }
+                for r in raw
+            ]
+            return KnowledgeStatus.FOUND, results
+        except Exception as exc:
+            logger.error("Knowledge base search failed: %s", exc)
+            return KnowledgeStatus.MISSING, []
 
     async def _workflow_llm_generate(self, user_message: str, llm, workflow_steps: List[Dict[str, Any]]) -> LLMResponse:
         """Generate LLM response and log workflow step. Issue #281: Extracted helper."""

--- a/autobot-backend/tests/unit/chat_workflow/test_async_chat_workflow_kb_search.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_async_chat_workflow_kb_search.py
@@ -1,0 +1,172 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for AsyncChatWorkflow._execute_kb_search and _workflow_knowledge_search.
+
+Issue #10715: Wire knowledge base search into async chat workflow.
+Tests assert correct KnowledgeStatus mapping and kb_results shape across
+three scenarios: populated KB, empty KB, and search raising an exception.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MODULE = "async_chat_workflow"
+
+
+def _make_kb_result(content: str = "fact text", score: float = 0.9) -> dict:
+    """Return a minimal raw KB search result dict matching the facade output."""
+    return {
+        "content": content,
+        "score": score,
+        "metadata": {"fact_id": "abc123"},
+        "node_id": "node-1",
+        "doc_id": "node-1",
+    }
+
+
+# ---------------------------------------------------------------------------
+# _execute_kb_search
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteKbSearch:
+    """Unit tests for AsyncChatWorkflow._execute_kb_search."""
+
+    @pytest.fixture()
+    def workflow(self):
+        from async_chat_workflow import AsyncChatWorkflow
+
+        return AsyncChatWorkflow()
+
+    async def test_found_when_results_returned(self, workflow):
+        """Populated KB returns FOUND status and non-empty kb_results."""
+        from async_chat_workflow import KnowledgeStatus
+
+        mock_kb = MagicMock()
+        mock_kb.search = AsyncMock(return_value=[_make_kb_result("doc A", 0.95)])
+
+        with patch(f"{_MODULE}.get_knowledge_base", AsyncMock(return_value=mock_kb)):
+            status, results = await workflow._execute_kb_search("what is autobot")
+
+        assert status is KnowledgeStatus.FOUND
+        assert len(results) == 1
+        assert results[0]["content"] == "doc A"
+        assert results[0]["score"] == 0.95
+        assert results[0]["source"] == "node-1"
+
+    async def test_missing_when_empty_results(self, workflow):
+        """Empty KB search returns MISSING status and empty list."""
+        from async_chat_workflow import KnowledgeStatus
+
+        mock_kb = MagicMock()
+        mock_kb.search = AsyncMock(return_value=[])
+
+        with patch(f"{_MODULE}.get_knowledge_base", AsyncMock(return_value=mock_kb)):
+            status, results = await workflow._execute_kb_search("unknown query")
+
+        assert status is KnowledgeStatus.MISSING
+        assert results == []
+
+    async def test_missing_when_search_raises(self, workflow):
+        """Search raising an exception returns MISSING with no propagation."""
+        from async_chat_workflow import KnowledgeStatus
+
+        mock_kb = MagicMock()
+        mock_kb.search = AsyncMock(side_effect=RuntimeError("chroma unreachable"))
+
+        with patch(f"{_MODULE}.get_knowledge_base", AsyncMock(return_value=mock_kb)):
+            status, results = await workflow._execute_kb_search("any query")
+
+        assert status is KnowledgeStatus.MISSING
+        assert results == []
+
+    async def test_missing_when_kb_unavailable(self, workflow):
+        """get_knowledge_base returning None yields MISSING."""
+        from async_chat_workflow import KnowledgeStatus
+
+        with patch(f"{_MODULE}.get_knowledge_base", AsyncMock(return_value=None)):
+            status, results = await workflow._execute_kb_search("any query")
+
+        assert status is KnowledgeStatus.MISSING
+        assert results == []
+
+    async def test_multiple_results_mapped_correctly(self, workflow):
+        """Multiple results are mapped with correct keys."""
+        from async_chat_workflow import KnowledgeStatus
+
+        raw = [_make_kb_result(f"doc {i}", 0.9 - i * 0.1) for i in range(3)]
+        mock_kb = MagicMock()
+        mock_kb.search = AsyncMock(return_value=raw)
+
+        with patch(f"{_MODULE}.get_knowledge_base", AsyncMock(return_value=mock_kb)):
+            status, results = await workflow._execute_kb_search("query")
+
+        assert status is KnowledgeStatus.FOUND
+        assert len(results) == 3
+        for r in results:
+            assert "content" in r
+            assert "source" in r
+            assert "score" in r
+            assert "metadata" in r
+
+
+# ---------------------------------------------------------------------------
+# _workflow_knowledge_search (integration of both helpers)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowKnowledgeSearch:
+    """Tests for _workflow_knowledge_search delegating to _execute_kb_search."""
+
+    @pytest.fixture()
+    def workflow(self):
+        from async_chat_workflow import AsyncChatWorkflow
+
+        return AsyncChatWorkflow()
+
+    async def test_found_propagates_from_execute(self, workflow):
+        """FOUND status and results propagate through _workflow_knowledge_search."""
+        from async_chat_workflow import KnowledgeStatus
+
+        mock_kb = MagicMock()
+        mock_kb.search = AsyncMock(return_value=[_make_kb_result()])
+
+        with patch(f"{_MODULE}.get_knowledge_base", AsyncMock(return_value=mock_kb)):
+            status, results = await workflow._workflow_knowledge_search("hello")
+
+        assert status is KnowledgeStatus.FOUND
+        assert len(results) == 1
+
+    async def test_missing_propagates_on_empty(self, workflow):
+        """MISSING status propagates through _workflow_knowledge_search."""
+        from async_chat_workflow import KnowledgeStatus
+
+        mock_kb = MagicMock()
+        mock_kb.search = AsyncMock(return_value=[])
+
+        with patch(f"{_MODULE}.get_knowledge_base", AsyncMock(return_value=mock_kb)):
+            status, results = await workflow._workflow_knowledge_search("unknown")
+
+        assert status is KnowledgeStatus.MISSING
+        assert results == []
+
+    async def test_error_does_not_propagate(self, workflow):
+        """Exception in search does not escape _workflow_knowledge_search."""
+        from async_chat_workflow import KnowledgeStatus
+
+        mock_kb = MagicMock()
+        mock_kb.search = AsyncMock(side_effect=Exception("boom"))
+
+        with patch(f"{_MODULE}.get_knowledge_base", AsyncMock(return_value=mock_kb)):
+            status, results = await workflow._workflow_knowledge_search("query")
+
+        assert status is KnowledgeStatus.MISSING
+        assert results == []


### PR DESCRIPTION
## Thinking Path
Umbrella #10714 (mockups→real), task T1. `async_chat_workflow.py:_workflow_knowledge_search` hardcoded `KnowledgeStatus.BYPASSED  # Simplified for now` and returned `[]` — the async chat workflow **never searched the knowledge base**, silently undercutting RAG/grounding/precision.

## What Changed
- `_workflow_knowledge_search` now accepts the `query` and delegates to a new `_execute_kb_search` helper that calls the canonical `get_knowledge_base()` factory (same path `advanced_rag_optimizer` uses) and searches.
- Call site updated: `await self._workflow_knowledge_search(user_message)`.
- `kb_results` mapped to `{content, source, score, metadata}` — keys dictated by the real downstream consumers (`api/chat.py:1658`, `api/agent.py:978`, `api/ai_stack_integration.py:130`).
- Status: `FOUND` when results, `MISSING` when none/unavailable. `BYPASSED` removed from the happy path. No new config flag (none exists in ssot_config).
- Graceful degradation: a search error logs + returns `(MISSING, [])` — never crashes the chat workflow. Async-first; both new methods ≤30 lines.

## Verification
- 8 new unit tests pass (`8 passed in 0.28s`): FOUND/MISSING/error-no-propagate at both the `_execute_kb_search` and `_workflow_knowledge_search` levels.
- `py_compile` + `flake8 --max-line-length=120` clean; black/isort applied.

Closes #10715.

## Model Used
Claude Opus 4.8 (1M context)