### PR TITLE
fix(llc): company-creation wizard payload contract + footer button visibility (#10728)

### DIFF
--- a/autobot-frontend/src/views/llc/CompanyCreationWizard.vue
+++ b/autobot-frontend/src/views/llc/CompanyCreationWizard.vue
@@ -452,8 +452,10 @@ async function createCompany() {
 
     logger.info('Company created successfully', { companyId: createdCompany.id })
 
-    // Redirect to company dashboard
-    await router.push('/llc/dashboard')
+    // Redirect into the new company's PM workspace (LlcCompanyLayout → backlog,
+    // boards, sprints, etc. with the sidebar) rather than the sidebar-less
+    // standalone /llc/dashboard, which left all PM features unreachable.
+    await router.push(`/llc/companies/${createdCompany.id}`)
   } catch (err: any) {
     logger.error('Failed to create company', err)
     error.value = err?.response?.data?.detail || err?.message || 'Failed to create company'

--- a/autobot-frontend/src/views/llc/CompanyCreationWizard.vue
+++ b/autobot-frontend/src/views/llc/CompanyCreationWizard.vue
@@ -397,19 +397,38 @@ function getDefaultIcon(cat: TemplateCategory): string {
   return icons[cat] || 'building'
 }
 
+/**
+ * Derive a backend-valid company slug from the company name.
+ * Backend requires slug matching ^[a-z0-9-]+$ (CompanyBase). We lowercase,
+ * collapse runs of non-alphanumeric chars to a single dash, and strip
+ * leading/trailing dashes. Falls back to a timestamp-based slug if empty.
+ */
+function slugify(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return slug || `company-${Date.now()}`
+}
+
 async function createCompany() {
   loading.value = true
   error.value = null
 
   try {
-    // Step 1: Create the company
+    // Step 1: Create the company.
+    // Field names must match the backend CompanyCreate/CompanyBase schema
+    // (autobot-backend/llc/models/company.py): slug is required, the budget key
+    // is budget_monthly_cents, the mission maps to description, and llc_status
+    // is left to the backend default (ONBOARDING) — do not send a bogus status.
     const companyPayload = {
       name: companyConfig.value.name,
+      slug: slugify(companyConfig.value.name),
       issue_prefix: companyConfig.value.issue_prefix,
-      mission: companyConfig.value.mission || undefined,
-      monthly_budget_cents: companyConfig.value.monthly_budget_cents,
+      description: companyConfig.value.mission || undefined,
+      budget_monthly_cents: companyConfig.value.monthly_budget_cents,
       brand_color: companyConfig.value.brand_color,
-      status: 'active',
     }
 
     logger.info('Creating company', companyPayload)
@@ -446,13 +465,19 @@ async function createCompany() {
 
 <style scoped>
 .company-creation-wizard {
+  /* Fill the available space provided by the app layout's <main> element
+     (App.vue: main.flex-1.min-h-0 + router-view.h-full). Using 100vh here
+     overflowed past the viewport by the header height and pushed the footer
+     action buttons (Back/Next/Create) out of view. */
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: 100%;
+  min-height: 0;
   background: var(--bg-primary);
 }
 
 .wizard-header {
+  flex-shrink: 0;
   padding: var(--spacing-6) var(--spacing-4);
   border-bottom: 1px solid var(--border-color);
   background: var(--bg-elevated);
@@ -523,6 +548,7 @@ async function createCompany() {
 
 .wizard-content {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: var(--spacing-6) var(--spacing-4);
 }
@@ -795,6 +821,7 @@ async function createCompany() {
 }
 
 .wizard-actions {
+  flex-shrink: 0;
   display: flex;
   justify-content: space-between;
   gap: var(--spacing-3);

--- a/autobot-frontend/src/views/llc/CompanySelectorView.vue
+++ b/autobot-frontend/src/views/llc/CompanySelectorView.vue
@@ -32,7 +32,9 @@ async function selectCompany(company: LlcCompany): Promise<void> {
     await router.push(redirect)
     return
   }
-  await router.push({ path: '/llc/dashboard', query: { company: company.id } })
+  // Enter the company's PM workspace (LlcCompanyLayout with sidebar → backlog,
+  // boards, sprints…), not the sidebar-less standalone /llc/dashboard.
+  await router.push(`/llc/companies/${company.id}`)
 }
 
 onMounted(async () => {


### PR DESCRIPTION
## Thinking Path
Company creation was broken several ways once Company OS became reachable: backend 422 on missing slug, budget/status/mission silently dropped due to wrong field names, and the footer Back/Next/Create buttons rendered off-screen.

## What Changed (CompanyCreationWizard.vue)
- **Payload contract**: send `slug` (slugify(name): lower/trim/[^a-z0-9]+→-, strip -, fallback company-<ts>; matches backend ^[a-z0-9-]+\$), rename outgoing `monthly_budget_cents`→`budget_monthly_cents`, map `mission`→`description` (was dropped), remove bogus `status:active` (backend defaults llc_status=ONBOARDING).
- **Layout**: `.company-creation-wizard` height 100vh→100% + min-height:0 (fills layout-provided height instead of overflowing app chrome); `flex-shrink:0` on header/actions so the footer buttons stay visible; `min-height:0` on content so it remains the sole scroll region.
- **Filters**: TemplateBrowser filter logic verified correct — breakage was the upstream /api/llc/templates/built-in 422 (fixed in #10708), data-only.

## Verification
vue-tsc --noEmit -p tsconfig.app.json → 0 errors; eslint → 0 errors (1 pre-existing any-cast warning, not in diff). Pairs with backend slug derivation (#10729).

## Model Used
Claude Opus 4.8 (1M context) + frontend-engineer agent

Closes #10728