### PR TITLE
fix(hardware): real local GPU/NPU status instead of static stub (#10717)

### DIFF
--- a/autobot-backend/api/monitoring_hardware.py
+++ b/autobot-backend/api/monitoring_hardware.py
@@ -3,16 +3,20 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Monitoring Hardware Stub - Placeholder for backward compatibility.
+Monitoring Hardware - Local hardware detection for analytics dashboards.
 
 Issue #729: Infrastructure monitoring moved to slm-server.
-This module provides stub implementations for local application metrics only.
-For infrastructure hardware monitoring, use slm-admin → Monitoring.
+Issue #10717: Replace static stubs with real local GPU/NPU detection.
 
-Note: This file is kept for backward compatibility with analytics.py and
-analytics_controller.py imports. It provides basic local system metrics only.
+GPU and NPU status are detected on the local machine using the existing
+HardwareAccelerationManager (hardware_acceleration.py), which probes
+nvidia-smi/rocm-smi/lspci for GPU and OpenVINO/lspci/device-files for NPU.
+Detection runs in a thread pool to avoid blocking the async event loop.
+
+For fleet-wide infrastructure monitoring, use SLM Admin → Monitoring.
 """
 
+import asyncio
 from typing import Any, Dict
 
 import psutil
@@ -22,12 +26,59 @@ from autobot_shared.logging_manager import get_logger
 logger = get_logger(__name__)
 
 
+def _detect_gpu_sync() -> Dict[str, Any]:
+    """Run GPU detection synchronously (called via asyncio.to_thread).
+
+    Reuses HardwareAccelerationManager which already handles NVIDIA/AMD/Intel
+    detection with graceful fallback on each tool being absent.
+    """
+    try:
+        from hardware_acceleration import AccelerationType, get_hardware_acceleration_manager
+
+        mgr = get_hardware_acceleration_manager()
+        if mgr.gpu_available:
+            info = mgr.available_devices.get(AccelerationType.GPU) or mgr._get_gpu_info()
+            return {
+                "available": True,
+                "vendor": info.get("vendor", "Unknown"),
+                "devices": info.get("devices", []),
+            }
+        return {"available": False}
+    except Exception as exc:
+        logger.warning("GPU detection error: %s", exc)
+        return {"available": False, "error": "Detection failed"}
+
+
+def _detect_npu_sync() -> Dict[str, Any]:
+    """Run NPU detection synchronously (called via asyncio.to_thread).
+
+    Reuses HardwareAccelerationManager which checks /dev/intel_npu*, lspci,
+    and OpenVINO device enumeration.
+    """
+    try:
+        from hardware_acceleration import AccelerationType, get_hardware_acceleration_manager
+
+        mgr = get_hardware_acceleration_manager()
+        if mgr.npu_available:
+            info = mgr.available_devices.get(AccelerationType.NPU) or mgr._get_npu_info()
+            return {
+                "available": True,
+                "devices": info.get("devices", []),
+                "openvino_support": info.get("openvino_support", False),
+            }
+        return {"available": False}
+    except Exception as exc:
+        logger.warning("NPU detection error: %s", exc)
+        return {"available": False, "error": "Detection failed"}
+
+
 class HardwareMonitorStub:
     """
-    Stub hardware monitor for application-level metrics only.
+    Hardware monitor providing local GPU/NPU detection for analytics dashboards.
 
-    Issue #729: Infrastructure monitoring moved to SLM server.
-    This stub provides basic local system info for analytics dashboards.
+    Issue #729: Fleet infrastructure monitoring lives in the SLM server.
+    Issue #10717: get_gpu_status / get_npu_status now detect real local hardware
+    via HardwareAccelerationManager instead of returning a hardcoded stub.
     """
 
     async def get_system_health(self) -> Dict[str, Any]:
@@ -83,26 +134,30 @@ class HardwareMonitorStub:
             return {"error": "Internal server error"}
 
     async def get_gpu_status(self) -> Dict[str, Any]:
-        """
-        Stub for GPU status - infrastructure monitoring moved to SLM.
+        """Detect local GPU availability via HardwareAccelerationManager (#10717).
 
-        Issue #729: GPU monitoring is now handled by slm-server for infrastructure nodes.
+        Returns real detection results (available, vendor, devices) when a GPU
+        is found via nvidia-smi, rocm-smi, or lspci. Falls back to
+        available=False on any error — never raises.
         """
-        return {
-            "available": False,
-            "note": "GPU monitoring moved to SLM Admin. Use slm-admin → Monitoring → Infrastructure.",
-        }
+        try:
+            return await asyncio.to_thread(_detect_gpu_sync)
+        except Exception as exc:
+            logger.warning("GPU status detection failed: %s", exc)
+            return {"available": False, "error": "Detection failed"}
 
     async def get_npu_status(self) -> Dict[str, Any]:
-        """
-        Stub for NPU status - infrastructure monitoring moved to SLM.
+        """Detect local NPU availability via HardwareAccelerationManager (#10717).
 
-        Issue #729: NPU monitoring is now handled by slm-server for infrastructure nodes.
+        Returns real detection results (available, devices, openvino_support)
+        when an Intel NPU is found via /dev, lspci, or OpenVINO. Falls back to
+        available=False on any error — never raises.
         """
-        return {
-            "available": False,
-            "note": "NPU monitoring moved to SLM Admin. Use slm-admin → Monitoring → Infrastructure.",
-        }
+        try:
+            return await asyncio.to_thread(_detect_npu_sync)
+        except Exception as exc:
+            logger.warning("NPU status detection failed: %s", exc)
+            return {"available": False, "error": "Detection failed"}
 
 
 # Global singleton instance for backward compatibility

--- a/autobot-backend/tests/test_monitoring_hardware.py
+++ b/autobot-backend/tests/test_monitoring_hardware.py
@@ -1,0 +1,273 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for api/monitoring_hardware.py — Issue #10717.
+
+Verifies that:
+1. get_gpu_status / get_npu_status proxy real detection results from the
+   HardwareAccelerationManager (via the _detect_*_sync helpers).
+2. Both async methods fall back to available=False on any error — never raise.
+3. Backward-compatible 'available' key is always present in every response.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(coro):
+    """Run a coroutine synchronously."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+GPU_DETECTED = {
+    "available": True,
+    "vendor": "NVIDIA",
+    "devices": ["RTX 4070 (12288MB)"],
+}
+
+NPU_DETECTED = {
+    "available": True,
+    "devices": ["NPU"],
+    "openvino_support": True,
+}
+
+GPU_ABSENT = {"available": False}
+NPU_ABSENT = {"available": False}
+FALLBACK_GPU = {"available": False, "error": "Detection failed"}
+FALLBACK_NPU = {"available": False, "error": "Detection failed"}
+
+
+# ---------------------------------------------------------------------------
+# Test: async methods proxy detection results and never raise
+# ---------------------------------------------------------------------------
+
+
+class TestGetGpuStatus:
+    """Unit tests for HardwareMonitorStub.get_gpu_status."""
+
+    def test_proxies_detected_gpu(self):
+        """When GPU is detected the response includes available=True + real fields."""
+        from api.monitoring_hardware import HardwareMonitorStub
+
+        stub = HardwareMonitorStub()
+        with patch("api.monitoring_hardware._detect_gpu_sync", return_value=GPU_DETECTED):
+            result = _run(stub.get_gpu_status())
+
+        assert result["available"] is True
+        assert result["vendor"] == "NVIDIA"
+        assert "RTX 4070" in result["devices"][0]
+
+    def test_proxies_absent_gpu(self):
+        """When no GPU is detected available=False is returned cleanly."""
+        from api.monitoring_hardware import HardwareMonitorStub
+
+        stub = HardwareMonitorStub()
+        with patch("api.monitoring_hardware._detect_gpu_sync", return_value=GPU_ABSENT):
+            result = _run(stub.get_gpu_status())
+
+        assert result["available"] is False
+        assert "error" not in result
+
+    def test_never_raises_on_detection_error(self):
+        """get_gpu_status must never propagate an exception from _detect_gpu_sync."""
+        from api.monitoring_hardware import HardwareMonitorStub
+
+        stub = HardwareMonitorStub()
+        with patch("api.monitoring_hardware._detect_gpu_sync", side_effect=RuntimeError("boom")):
+            try:
+                result = _run(stub.get_gpu_status())
+                # asyncio.to_thread can reraise; if the method itself doesn't
+                # swallow it the test catches it below.
+                assert "available" in result
+            except Exception:
+                pytest.fail("get_gpu_status raised — it must never propagate exceptions")
+
+    def test_available_key_always_present(self):
+        """'available' key must exist whether GPU is present or absent."""
+        from api.monitoring_hardware import HardwareMonitorStub
+
+        stub = HardwareMonitorStub()
+        for payload in (GPU_DETECTED, GPU_ABSENT, FALLBACK_GPU):
+            with patch("api.monitoring_hardware._detect_gpu_sync", return_value=payload):
+                result = _run(stub.get_gpu_status())
+            assert "available" in result, f"'available' missing for payload={payload}"
+
+
+# ---------------------------------------------------------------------------
+# Test: async methods proxy NPU detection results and never raise
+# ---------------------------------------------------------------------------
+
+
+class TestGetNpuStatus:
+    """Unit tests for HardwareMonitorStub.get_npu_status."""
+
+    def test_proxies_detected_npu(self):
+        """When NPU is detected the response includes available=True + real fields."""
+        from api.monitoring_hardware import HardwareMonitorStub
+
+        stub = HardwareMonitorStub()
+        with patch("api.monitoring_hardware._detect_npu_sync", return_value=NPU_DETECTED):
+            result = _run(stub.get_npu_status())
+
+        assert result["available"] is True
+        assert result["openvino_support"] is True
+        assert "NPU" in result["devices"]
+
+    def test_proxies_absent_npu(self):
+        """When no NPU is detected available=False is returned cleanly."""
+        from api.monitoring_hardware import HardwareMonitorStub
+
+        stub = HardwareMonitorStub()
+        with patch("api.monitoring_hardware._detect_npu_sync", return_value=NPU_ABSENT):
+            result = _run(stub.get_npu_status())
+
+        assert result["available"] is False
+        assert "error" not in result
+
+    def test_never_raises_on_detection_error(self):
+        """get_npu_status must never propagate an exception from _detect_npu_sync."""
+        from api.monitoring_hardware import HardwareMonitorStub
+
+        stub = HardwareMonitorStub()
+        with patch("api.monitoring_hardware._detect_npu_sync", side_effect=RuntimeError("boom")):
+            try:
+                result = _run(stub.get_npu_status())
+                assert "available" in result
+            except Exception:
+                pytest.fail("get_npu_status raised — it must never propagate exceptions")
+
+    def test_available_key_always_present(self):
+        """'available' key must exist whether NPU is present or absent."""
+        from api.monitoring_hardware import HardwareMonitorStub
+
+        stub = HardwareMonitorStub()
+        for payload in (NPU_DETECTED, NPU_ABSENT, FALLBACK_NPU):
+            with patch("api.monitoring_hardware._detect_npu_sync", return_value=payload):
+                result = _run(stub.get_npu_status())
+            assert "available" in result, f"'available' missing for payload={payload}"
+
+
+# ---------------------------------------------------------------------------
+# Test: _detect_gpu_sync helper (sync detection function)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectGpuSync:
+    """Unit tests for the synchronous _detect_gpu_sync helper."""
+
+    def test_returns_real_data_when_gpu_present(self):
+        """Correctly maps manager fields into the response dict."""
+        from api.monitoring_hardware import _detect_gpu_sync
+
+        mock_mgr = MagicMock()
+        mock_mgr.gpu_available = True
+
+        mock_accel_type = MagicMock()
+        mock_gpu_key = mock_accel_type.GPU
+        mock_mgr.available_devices = {
+            mock_gpu_key: {"vendor": "NVIDIA", "devices": ["RTX 4070 (12288MB)"]},
+        }
+
+        mock_hw_module = MagicMock()
+        mock_hw_module.AccelerationType = mock_accel_type
+        mock_hw_module.get_hardware_acceleration_manager.return_value = mock_mgr
+
+        with patch.dict("sys.modules", {"hardware_acceleration": mock_hw_module}):
+            result = _detect_gpu_sync()
+
+        assert result["available"] is True
+        assert result["vendor"] == "NVIDIA"
+
+    def test_returns_available_false_when_absent(self):
+        """Returns available=False without error when mgr.gpu_available is False."""
+        from api.monitoring_hardware import _detect_gpu_sync
+
+        mock_mgr = MagicMock()
+        mock_mgr.gpu_available = False
+        mock_mgr.available_devices = {}
+
+        mock_hw_module = MagicMock()
+        mock_hw_module.get_hardware_acceleration_manager.return_value = mock_mgr
+
+        with patch.dict("sys.modules", {"hardware_acceleration": mock_hw_module}):
+            result = _detect_gpu_sync()
+
+        assert result["available"] is False
+        assert "error" not in result
+
+    def test_returns_fallback_on_import_error(self):
+        """Returns available=False + error key when hardware_acceleration is missing."""
+        from api.monitoring_hardware import _detect_gpu_sync
+
+        with patch.dict("sys.modules", {"hardware_acceleration": None}):
+            result = _detect_gpu_sync()
+
+        assert result["available"] is False
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Test: _detect_npu_sync helper (sync detection function)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectNpuSync:
+    """Unit tests for the synchronous _detect_npu_sync helper."""
+
+    def test_returns_real_data_when_npu_present(self):
+        """Correctly maps manager fields into the response dict."""
+        from api.monitoring_hardware import _detect_npu_sync
+
+        mock_mgr = MagicMock()
+        mock_mgr.npu_available = True
+
+        mock_accel_type = MagicMock()
+        mock_npu_key = mock_accel_type.NPU
+        mock_mgr.available_devices = {
+            mock_npu_key: {"openvino_support": True, "devices": ["NPU"]},
+        }
+
+        mock_hw_module = MagicMock()
+        mock_hw_module.AccelerationType = mock_accel_type
+        mock_hw_module.get_hardware_acceleration_manager.return_value = mock_mgr
+
+        with patch.dict("sys.modules", {"hardware_acceleration": mock_hw_module}):
+            result = _detect_npu_sync()
+
+        assert result["available"] is True
+        assert result["openvino_support"] is True
+
+    def test_returns_available_false_when_absent(self):
+        """Returns available=False without error when mgr.npu_available is False."""
+        from api.monitoring_hardware import _detect_npu_sync
+
+        mock_mgr = MagicMock()
+        mock_mgr.npu_available = False
+        mock_mgr.available_devices = {}
+
+        mock_hw_module = MagicMock()
+        mock_hw_module.get_hardware_acceleration_manager.return_value = mock_mgr
+
+        with patch.dict("sys.modules", {"hardware_acceleration": mock_hw_module}):
+            result = _detect_npu_sync()
+
+        assert result["available"] is False
+        assert "error" not in result
+
+    def test_returns_fallback_on_import_error(self):
+        """Returns available=False + error key when hardware_acceleration is missing."""
+        from api.monitoring_hardware import _detect_npu_sync
+
+        with patch.dict("sys.modules", {"hardware_acceleration": None}):
+            result = _detect_npu_sync()
+
+        assert result["available"] is False
+        assert "error" in result


### PR DESCRIPTION
## Thinking Path
Umbrella #10714, T3. `monitoring_hardware.HardwareMonitorStub.get_gpu_status()`/`get_npu_status()` returned a hardcoded `{available: False, note: "moved to SLM Admin"}`. Premise check: #729 intentionally moved *fleet/infrastructure* monitoring to SLM — but the SLM exposes **no** GPU/NPU availability endpoint to proxy, and the static `available: False` is still a mockup. The user-backend already has full **local** hardware detection in `hardware_acceleration.py` (`HardwareAccelerationManager` — probes nvidia-smi/rocm-smi/intel_gpu_top/lspci for GPU, `/dev/intel_npu*`/lspci/OpenVINO for NPU). Self-detection of the backend's own machine is the right "real solution" (distinct from fleet monitoring, so #729 is respected).

## What Changed
- `get_gpu_status`/`get_npu_status` now call `_detect_gpu_sync`/`_detect_npu_sync` (lazy-import `HardwareAccelerationManager`) via `asyncio.to_thread` (no blocking the event loop on subprocess probes).
- try/except at both sync + async layers → graceful `{available: False, error}` on any failure; the `available` key is preserved in every response shape (backward-compatible).

## Verification
- 14 new unit tests pass (`14 passed in 0.26s`): real GPU+NPU detected & proxied; absent hardware → clean `available: False`; sync error → `available: False + error`; async-layer catch (error never propagates); `available` present in every shape.
- `py_compile` + `flake8 --max-line-length=120` clean; black/isort applied.

## Note
SLM's `_get_gpu_utilization` (ai_performance_analytics.py:341) reads live GPU util but isn't exposed as a route — a separate fleet-dashboard feature (follow-up), not needed here since local detection covers the backend's own machine.

Closes #10717.

## Model Used
Claude Opus 4.8 (1M context)