### PR TITLE
fix(kb): sanitize ChromaDB collection names to allowed charset (fixes company-create 500) (#10743)

### DIFF
--- a/autobot-backend/knowledge/backends/async_chromadb_adapter.py
+++ b/autobot-backend/knowledge/backends/async_chromadb_adapter.py
@@ -15,6 +15,7 @@ differences are ``async def`` and ``await``.
 from __future__ import annotations
 
 import asyncio
+import re
 from typing import Any, List, Sequence
 
 from autobot_shared.logging_manager import get_logger
@@ -22,6 +23,17 @@ from knowledge.backends.async_base import AsyncBaseClient, AsyncBaseCollection
 from knowledge.backends.base import Embedding, Metadata, Where, WhereDocument
 
 logger = get_logger(__name__)
+
+# ChromaDB 1.x rejects collection names containing characters outside
+# [a-zA-Z0-9._-] (e.g. the ':' the LLC layer uses in "company:<uuid>"). Map any
+# invalid character to '_' at the backend boundary so callers can keep their
+# logical naming. No-op for already-valid names (KB's own collections).
+_CHROMA_NAME_INVALID = re.compile(r"[^a-zA-Z0-9._-]")
+
+
+def _chroma_safe_name(name: str) -> str:
+    """Return a ChromaDB-valid collection name (#10743)."""
+    return _CHROMA_NAME_INVALID.sub("_", name)
 
 
 class AsyncChromaDBCollection(AsyncBaseCollection):
@@ -204,7 +216,7 @@ class AsyncChromaDBClient(AsyncBaseClient):
         if metadata:
             provenance.update(metadata)
         raw_col = await self._raw.get_or_create_collection(
-            name=name,
+            name=_chroma_safe_name(name),
             metadata=provenance,
             embedding_function=embedding_function,
         )
@@ -212,7 +224,7 @@ class AsyncChromaDBClient(AsyncBaseClient):
 
     async def get_collection(self, name: str) -> AsyncBaseCollection:
         try:
-            raw_col = await self._raw.get_collection(name=name)
+            raw_col = await self._raw.get_collection(name=_chroma_safe_name(name))
         except Exception as exc:  # ChromaDB raises its own exception type
             raise ValueError(f"no such collection: {name}") from exc
         return AsyncChromaDBCollection(raw_col)
@@ -231,7 +243,7 @@ class AsyncChromaDBClient(AsyncBaseClient):
             provenance.update(metadata)
         try:
             raw_col = await self._raw.create_collection(
-                name=name,
+                name=_chroma_safe_name(name),
                 metadata=provenance,
                 embedding_function=embedding_function,
             )
@@ -250,7 +262,7 @@ class AsyncChromaDBClient(AsyncBaseClient):
 
     async def delete_collection(self, name: str) -> None:
         try:
-            await self._raw.delete_collection(name=name)
+            await self._raw.delete_collection(name=_chroma_safe_name(name))
         except Exception as exc:
             raise ValueError(f"no such collection: {name}") from exc
 


### PR DESCRIPTION
## Thinking Path
After #10737 fixed the KB client, company creation reaches ChromaDB but 500s with `InvalidArgumentError` — ChromaDB 1.x rejects collection names containing `:`, and the LLC layer names collections `company:<uuid>`. The colon is also a logical separator (parsed via `.split(":")` in companies.py/inheritance.py) and a Redis channel delimiter, so changing the convention at the source spans ~8 files + fragile parsers. The safest fix is to enforce ChromaDB's name charset at the adapter boundary.

## What Changed
- `knowledge/backends/async_chromadb_adapter.py`: `_chroma_safe_name()` maps characters outside `[a-zA-Z0-9._-]` to `_`; applied in `get_or_create_collection`, `get_collection`, `create_collection`, `delete_collection`. Consistent on create + read; no-op for KB's colon-free names; LLC logical names and `:`-based parsers untouched.

## Verification
py_compile OK. Sanitizer maps `company:<uuid>` -> `company_<uuid>` (valid), `agent:xyz` -> `agent_xyz`, leaves `autobot_memory`/`autobot_docs` unchanged. Will verify company-create returns 201 after deploy.

## Model Used
Claude Opus 4.8 (1M context)

Closes #10743
