### PR TITLE
refactor(orchestration): B10 — eliminate infix enhanced/unified from orchestration/workflow

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1518,7 +1518,7 @@ async def _wire_scheduler_executor() -> None:
         orchestrator = get_orchestrator_sync()
 
         async def _orchestration_executor(workflow: ScheduledWorkflow):
-            """Adapter: ScheduledWorkflow → Orchestrator.execute_enhanced_workflow.
+            """Adapter: ScheduledWorkflow → Orchestrator.run_workflow (#10746).
 
             Routes template-based workflows to the template executor and
             non-template workflows through the full orchestration pipeline.
@@ -1537,7 +1537,7 @@ async def _wire_scheduler_executor() -> None:
                 "auto_approve": workflow.auto_approve,
                 "scheduled": True,
             }
-            result = await orchestrator.execute_enhanced_workflow(
+            result = await orchestrator.run_workflow(
                 user_request=workflow.user_message,
                 context=context,
                 auto_document=True,

--- a/autobot-backend/orchestration/orchestrator_legacy_api.py
+++ b/autobot-backend/orchestration/orchestrator_legacy_api.py
@@ -54,7 +54,7 @@ class _DeprecatedRequestMixin:
         """Process user request.
 
         .. deprecated::
-            No live callers exist. Call execute_enhanced_workflow directly (GH#7423).
+            No live callers exist. Call run_workflow directly (GH#7423).
         """
         from autobot_shared.status_enums import Priority as TaskPriority
         from orchestrator import OrchestrationMode
@@ -65,7 +65,7 @@ class _DeprecatedRequestMixin:
             priority = TaskPriority.NORMAL
 
         warnings.warn(
-            "process_user_request is deprecated and has no live callers — use execute_enhanced_workflow directly. (GH#7423)",  # noqa: E501
+            "process_user_request is deprecated and has no live callers — use run_workflow directly. (GH#7423)",  # noqa: E501
             DeprecationWarning,
             stacklevel=2,
         )
@@ -81,7 +81,7 @@ class _DeprecatedRequestMixin:
             if mode == OrchestrationMode.SIMPLE:
                 result = await self._process_simple_request(user_message, task_id, target_llm_model, context)
             else:
-                result = await self.execute_enhanced_workflow(user_request=user_message, context=context or {})
+                result = await self.run_workflow(user_request=user_message, context=context or {})
 
             processing_time = time.time() - start_time
             self._update_success_metrics(processing_time)

--- a/autobot-backend/orchestration/workflow_planner.py
+++ b/autobot-backend/orchestration/workflow_planner.py
@@ -85,14 +85,13 @@ class WorkflowPlanner:
         self.agent_registry = agent_registry
         self._find_best_agent = find_best_agent_callback
 
-    async def plan_enhanced_workflow_steps(
+    async def plan_workflow_steps_with_agents(
         self,
         user_request: str,
         complexity: TaskComplexity,
         context: Dict[str, Any],
     ) -> List[Dict[str, Any]]:
-        """
-        Plan workflow steps with intelligent agent assignment.
+        """Plan workflow steps with intelligent agent assignment.
 
         Consults the TrajectoryStore (GH#7357) before building from scratch:
         if similar high-reward trajectories exist, logs them for the caller to
@@ -105,7 +104,7 @@ class WorkflowPlanner:
             context: Additional context for planning
 
         Returns:
-            List of enhanced workflow steps with agent assignments
+            List of workflow steps with agent assignments
         """
         # GH#7357: consult trajectory store for similar solved tasks
         await self._annotate_context_with_trajectories(user_request, context)
@@ -113,7 +112,7 @@ class WorkflowPlanner:
         # Get base workflow steps from original orchestrator
         base_steps = self.base_orchestrator.plan_workflow_steps(user_request, complexity)
 
-        enhanced_steps = []
+        steps_with_agents = []
 
         for step in base_steps:
             # Determine required capabilities for each step
@@ -125,7 +124,7 @@ class WorkflowPlanner:
                 required_capabilities=required_capabilities,
             )
 
-            enhanced_step = {
+            assigned_step = {
                 "id": step.id,
                 "agent_type": step.agent_type,
                 "assigned_agent": assigned_agent,
@@ -138,9 +137,9 @@ class WorkflowPlanner:
                 "status": "planned",
             }
 
-            enhanced_steps.append(enhanced_step)
+            steps_with_agents.append(assigned_step)
 
-        return enhanced_steps
+        return steps_with_agents
 
     def determine_step_capabilities(self, action: str, agent_type: str) -> Set[AgentCapability]:
         """

--- a/autobot-backend/orchestration/workflow_runner.py
+++ b/autobot-backend/orchestration/workflow_runner.py
@@ -486,7 +486,7 @@ class WorkflowRunner:
                 agent = await self._agent_router.get_agent_instance(task.agent_type)
                 if not agent:
                     raise Exception(f"Agent {task.agent_type} not available")
-                enhanced_inputs = task.get_enhanced_inputs(context)
+                enhanced_inputs = task.get_inputs(context)
                 result = await asyncio.wait_for(
                     agent.process_request({"action": task.action, "payload": enhanced_inputs}),
                     timeout=task.timeout_seconds,
@@ -533,7 +533,7 @@ class WorkflowRunner:
                 f"Failing step per ADR-006 'fail-don't-reroute' policy."
             )
 
-        enhanced_inputs = task.get_enhanced_inputs(context)
+        enhanced_inputs = task.get_inputs(context)
         action = task.skill_action or "execute"
         result = await asyncio.wait_for(
             skill.execute(action, enhanced_inputs),

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -15,7 +15,7 @@ implementations:
 Refactored in #5058: god-class decomposed into collaborators.
   - WorkflowRunner  (orchestration/workflow_runner.py) — execution engine (#10666 B3 moved)
   - PerformanceTracker (orchestration/performance_tracker.py) — metrics
-  - Three execution entry points unified: process_user_request → execute_enhanced_workflow
+  - Three execution entry points unified: process_user_request → run_workflow
     → create_workflow_plan + WorkflowRunner.execute_workflow
 
 Primitives extracted in #5060:
@@ -154,7 +154,7 @@ class Orchestrator(_DeprecatedRequestMixin):
             "average_response_time": 0,
         }
 
-    def _init_enhanced_components(self) -> None:
+    def _init_components(self) -> None:
         self.agent_registry: Dict[str, AgentProfile] = {}
         # GH #6820: AgentRegistry — structured profile store with capability-based lookup.
         # Runs alongside the plain-dict self.agent_registry for structured queries.
@@ -247,7 +247,7 @@ class Orchestrator(_DeprecatedRequestMixin):
     def __init__(self, config_mgr=None):
         self._init_core_components(config_mgr)
         self._init_task_state()
-        self._init_enhanced_components()
+        self._init_components()
         self._init_classification_agent()
         self._initialize_default_agents()
         self._init_strategy_components()
@@ -452,17 +452,17 @@ class Orchestrator(_DeprecatedRequestMixin):
     # _update_success_metrics, _classify_task, _select_model_for_task,
     # _process_simple_request) are inherited from _DeprecatedRequestMixin (#5060).
 
-    # ------------------------------------------------- execute_enhanced_workflow
+    # ------------------------------------------------- run_workflow
 
-    def _get_enhanced_documenter(self) -> WorkflowDocumenter:
-        if not hasattr(self, "_enh_documenter") or self._enh_documenter is None:
-            self._enh_documenter = WorkflowDocumenter(
+    def _get_documenter(self) -> WorkflowDocumenter:
+        if not hasattr(self, "_documenter") or self._documenter is None:
+            self._documenter = WorkflowDocumenter(
                 knowledge_base=self.knowledge_base,
                 llm_service=self.llm_service,
             )
-        return self._enh_documenter
+        return self._documenter
 
-    async def execute_enhanced_workflow(
+    async def run_workflow(
         self,
         user_request: str,
         context: Dict[str, Any] | None = None,
@@ -481,7 +481,7 @@ class Orchestrator(_DeprecatedRequestMixin):
         start_time = time.time()
         context = context or {}
         workflow_id = str(uuid.uuid4())
-        logger.info("Starting enhanced workflow %s: %s", workflow_id, user_request[:80])
+        logger.info("Starting workflow %s: %s", workflow_id, user_request[:80])
 
         # GH #6820: WorkflowMemory — shared KV store for cross-step coordination.
         shared_memory = WorkflowMemory(workflow_id=workflow_id)
@@ -492,7 +492,7 @@ class Orchestrator(_DeprecatedRequestMixin):
             logger.debug("WorkflowMemory init store skipped: %s", _mem_exc)
 
         if auto_document:
-            documenter = self._get_enhanced_documenter()
+            documenter = self._get_documenter()
             doc = documenter.create_workflow_doc(
                 workflow_id=workflow_id,
                 title=f"Workflow: {user_request[:50]}...",
@@ -516,14 +516,14 @@ class Orchestrator(_DeprecatedRequestMixin):
             self.workflow_metrics["average_execution_time"] = ((cur_avg * (total - 1)) + elapsed) / total
 
             if auto_document:
-                documenter = self._get_enhanced_documenter()
+                documenter = self._get_documenter()
                 await documenter.generate_workflow_documentation(workflow_id, exec_result)
                 doc = documenter.get_doc(workflow_id)
                 if doc:
                     self.workflow_documentation[workflow_id] = doc
 
             if self.knowledge_extraction_enabled:
-                documenter = self._get_enhanced_documenter()
+                documenter = self._get_documenter()
                 await documenter.extract_workflow_knowledge(workflow_id, user_request, exec_result, self.agent_registry)
 
             return {
@@ -537,9 +537,9 @@ class Orchestrator(_DeprecatedRequestMixin):
             }
 
         except Exception as e:
-            logger.error("Enhanced workflow %s failed: %s", workflow_id, e)
+            logger.error("Workflow %s failed: %s", workflow_id, e)
             if auto_document:
-                documenter = self._get_enhanced_documenter()
+                documenter = self._get_documenter()
                 await documenter.document_workflow_failure(workflow_id, str(e))
                 doc = documenter.get_doc(workflow_id)
                 if doc:

--- a/autobot-backend/phase_progression_manager.py
+++ b/autobot-backend/phase_progression_manager.py
@@ -368,7 +368,7 @@ class PhaseProgressionManager:
             },
         }
 
-    def _get_enhanced_interface_rule(self) -> Dict[str, Dict[str, Any]]:
+    def _get_interface_rule(self) -> Dict[str, Dict[str, Any]]:
         """Get rule for Phase 8: Enhanced Interface and Web Control Panel. Issue #620."""
         return {
             "Phase 8: Enhanced Interface and Web Control Panel": {
@@ -433,7 +433,7 @@ class PhaseProgressionManager:
         rules: Dict[str, Dict[str, Any]] = {}
         rules.update(self._get_agent_orchestrator_rule())
         rules.update(self._get_memory_enhancement_rule())
-        rules.update(self._get_enhanced_interface_rule())
+        rules.update(self._get_interface_rule())
         rules.update(self._get_local_intelligence_rule())
         rules.update(self._get_openvino_acceleration_rule())
         return rules

--- a/autobot-backend/services/advanced_workflow/coordinator.py
+++ b/autobot-backend/services/advanced_workflow/coordinator.py
@@ -103,8 +103,8 @@ class WorkflowCoordinator:
             intelligence = await self._build_workflow_intelligence(workflow_id, optimized_steps)
             self.workflow_intelligence[workflow_id] = intelligence
 
-            # Step 5: Create enhanced workflow
-            await self._create_enhanced_workflow(workflow_id, user_request, optimized_steps, session_id, intelligence)
+            # Step 5: Create workflow
+            await self._create_workflow(workflow_id, user_request, optimized_steps, session_id, intelligence)
 
             # Step 6: Learn from workflow generation
             await self.learning_model.record_workflow_generation(user_request, intent_analysis, optimized_steps)
@@ -119,7 +119,7 @@ class WorkflowCoordinator:
             logger.error("Failed to generate intelligent workflow: %s", e)
             raise
 
-    async def _create_enhanced_workflow(
+    async def _create_workflow(
         self,
         workflow_id: str,
         user_request: str,
@@ -127,7 +127,7 @@ class WorkflowCoordinator:
         session_id: str,
         intelligence: WorkflowIntelligence,
     ) -> str:
-        """Create enhanced workflow with AI intelligence"""
+        """Create workflow with AI intelligence."""
         # Convert SmartWorkflowSteps to regular WorkflowSteps for compatibility
         regular_steps = []
         for smart_step in steps:

--- a/autobot_shared/workflow/types.py
+++ b/autobot_shared/workflow/types.py
@@ -213,8 +213,8 @@ class WorkflowTask:
         """Increment retry counter."""
         self.retry_count += 1
 
-    def get_enhanced_inputs(self, context: Dict[str, Any]) -> Dict[str, Any]:
-        """Get inputs enhanced with context (forwarded into agent dispatch)."""
+    def get_inputs(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Get inputs merged with context (forwarded into agent dispatch)."""
         return {
             **self.inputs,
             "context": context,

--- a/autobot_shared/workflow/types_test.py
+++ b/autobot_shared/workflow/types_test.py
@@ -336,18 +336,18 @@ def test_workflow_task_retry_methods() -> None:
     assert not t.can_retry()  # 2 == 2
 
 
-def test_workflow_task_get_enhanced_inputs_merges_context() -> None:
-    """get_enhanced_inputs() returns inputs + context + task_id + workflow_metadata."""
+def test_workflow_task_get_inputs_merges_context() -> None:
+    """get_inputs() returns inputs + context + task_id + workflow_metadata."""
     t = WorkflowTask(
         task_id="t1",
         inputs={"x": 1},
         metadata={"workflow_id": "wf1"},
     )
-    enhanced = t.get_enhanced_inputs({"runtime_key": "v"})
-    assert enhanced["x"] == 1
-    assert enhanced["context"] == {"runtime_key": "v"}
-    assert enhanced["task_id"] == "t1"
-    assert enhanced["workflow_metadata"] == {"workflow_id": "wf1"}
+    merged = t.get_inputs({"runtime_key": "v"})
+    assert merged["x"] == 1
+    assert merged["context"] == {"runtime_key": "v"}
+    assert merged["task_id"] == "t1"
+    assert merged["workflow_metadata"] == {"workflow_id": "wf1"}
 
 
 def test_workflow_task_to_completed_result_shape() -> None:


### PR DESCRIPTION
## Thinking Path

B10 of umbrella #10746: seven infix-era identifiers in `orchestrator.py`, `orchestration/workflow_planner.py`, `phase_progression_manager.py`, `services/advanced_workflow/coordinator.py`, and `autobot_shared/workflow/types.py`.

**Collision resolutions:**
- `execute_enhanced_workflow → run_workflow` (not `execute_workflow`): the enhanced variant takes `user_request: str` and creates+runs a full plan; the existing `execute_workflow(plan: WorkflowPlan)` takes an already-built plan. Different signatures/purposes — distinct descriptive name chosen.
- `plan_enhanced_workflow_steps → plan_workflow_steps_with_agents` (not `plan_workflow_steps`): the enhanced variant adds trajectory store lookup + agent assignment on top of base planning; the existing `plan_workflow_steps` is the base planner method it calls internally. Distinct descriptive name chosen.

All other five renames had no collisions.

## What Changed

| Old name | New name | File |
|---|---|---|
| `get_enhanced_inputs` | `get_inputs` | `autobot_shared/workflow/types.py` |
| `execute_enhanced_workflow` | `run_workflow` | `autobot-backend/orchestrator.py` |
| `_init_enhanced_components` | `_init_components` | `autobot-backend/orchestrator.py` |
| `_get_enhanced_documenter` | `_get_documenter` | `autobot-backend/orchestrator.py` |
| `plan_enhanced_workflow_steps` | `plan_workflow_steps_with_agents` | `autobot-backend/orchestration/workflow_planner.py` |
| `_get_enhanced_interface_rule` | `_get_interface_rule` | `autobot-backend/phase_progression_manager.py` |
| `_create_enhanced_workflow` | `_create_workflow` | `autobot-backend/services/advanced_workflow/coordinator.py` |

Callers updated across:
- `autobot-backend/orchestration/workflow_runner.py` (2 × `get_inputs`)
- `autobot-backend/orchestration/orchestrator_legacy_api.py` (2 × `run_workflow` in docstring + call)
- `autobot-backend/initialization/lifespan.py` (1 × `run_workflow`)
- `autobot_shared/workflow/types_test.py` (test renamed + variable renamed)

## Verification

- `grep -rn "execute_enhanced_workflow|plan_enhanced_workflow_steps|_init_enhanced_components|_get_enhanced_documenter|_get_enhanced_interface_rule|_create_enhanced_workflow|get_enhanced_inputs"` → **0 matches** in worktree
- `pytest autobot-backend/tests/test_startup_imports.py -q` → **339 passed**
- `pytest autobot_shared/workflow/types_test.py -q` → **33 passed**
- `black --line-length=120` → **9 files unchanged** (already conforming)
- `flake8 --config=.flake8` → **clean** on all 9 changed files
- 13 pre-existing failures in `orchestration/` (Redis/LLM infra, `create_workflow_response` missing) confirmed identical on base branch before this change

## Model Used

Claude Sonnet 4.6

Part of #10746