### PR TITLE
refactor(logs): B7 — rename LogUnified* → LogAggregated*, /unified → /aggregated (#10746)

### DIFF
--- a/autobot-backend/api/api_endpoint_migrations_test.py
+++ b/autobot-backend/api/api_endpoint_migrations_test.py
@@ -26648,14 +26648,14 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
         self.assertIn('operation="read_container_logs"', source)
         self.assertIn('error_code_prefix="LOGS"', source)
 
-    def test_batch_157_get_unified_logs_simple_pattern(self):
-        """Verify get_unified_logs endpoint uses Simple Pattern"""
+    def test_batch_157_get_aggregated_logs_simple_pattern(self):
+        """Verify get_aggregated_logs endpoint uses Simple Pattern"""
         from api import logs
 
-        source = inspect.getsource(logs.get_unified_logs)
+        source = inspect.getsource(logs.get_aggregated_logs)
         self.assertIn("@with_error_handling", source)
         self.assertIn("category=ErrorCategory.SERVER_ERROR", source)
-        self.assertIn('operation="get_unified_logs"', source)
+        self.assertIn('operation="get_aggregated_logs"', source)
         self.assertIn('error_code_prefix="LOGS"', source)
 
     def test_batch_157_stream_log_simple_pattern(self):
@@ -26698,7 +26698,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
             logs.list_logs,
             logs.read_log,
             logs.read_container_logs,
-            logs.get_unified_logs,
+            logs.get_aggregated_logs,
             logs.stream_log,
             logs.search_logs,
             logs.clear_log,
@@ -26722,7 +26722,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
             logs.list_logs,
             logs.read_log,
             logs.read_container_logs,
-            logs.get_unified_logs,
+            logs.get_aggregated_logs,
             logs.stream_log,
             logs.search_logs,
             logs.clear_log,
@@ -26807,7 +26807,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
 
         # Verify parse_file_log_line exists and is used
         self.assertTrue(hasattr(logs, "parse_file_log_line"))
-        unified_source = inspect.getsource(logs.get_unified_logs)
+        unified_source = inspect.getsource(logs.get_aggregated_logs)
         self.assertIn("parse_file_log_line", unified_source)
 
     def test_batch_157_migration_preserves_streaming_response(self):
@@ -26842,12 +26842,12 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
         self.assertIn("case_sensitive", search_source)
         self.assertIn("max_results", search_source)
 
-    def test_batch_157_migration_preserves_unified_log_merging(self):
-        """Verify migration preserves unified log merging by timestamp"""
+    def test_batch_157_migration_preserves_aggregated_log_merging(self):
+        """Verify migration preserves aggregated log merging by timestamp"""
         from api import logs
 
-        # Verify get_unified_logs merges logs
-        unified_source = inspect.getsource(logs.get_unified_logs)
+        # Verify get_aggregated_logs merges logs
+        unified_source = inspect.getsource(logs.get_aggregated_logs)
         self.assertIn("all_logs", unified_source)
         self.assertIn("sort", unified_source)
         self.assertIn("timestamp", unified_source)
@@ -27115,11 +27115,11 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
         self.assertIn("_cache_timestamp", metrics_source)
         self.assertIn("_cache_ttl", metrics_source)
 
-        """Verify migration preserves unified log merging by timestamp"""
+        """Verify migration preserves aggregated log merging by timestamp"""
         from api import logs
 
-        # Verify get_unified_logs merges logs
-        unified_source = inspect.getsource(logs.get_unified_logs)
+        # Verify get_aggregated_logs merges logs
+        unified_source = inspect.getsource(logs.get_aggregated_logs)
         self.assertIn("all_logs", unified_source)
         self.assertIn("sort", unified_source)
         self.assertIn("timestamp", unified_source)
@@ -28905,7 +28905,7 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
             logs.list_logs,
             logs.read_log,
             logs.read_container_logs,
-            logs.get_unified_logs,
+            logs.get_aggregated_logs,
             logs.stream_log,
             logs.tail_log,
             logs.search_logs,

--- a/autobot-backend/api/logs.py
+++ b/autobot-backend/api/logs.py
@@ -23,12 +23,12 @@ from fastapi.responses import StreamingResponse
 
 from api.schemas_agent import LogFileMetadata
 from api.schemas_code import (
+    LogAggregatedResponse,
     LogContainerResponse,
     LogReadResponse,
     LogRecentResponse,
     LogSearchResponse,
     LogSourcesResponse,
-    LogAggregatedResponse,
 )
 from api.schemas_common import AgentMessageResponse
 from auth_middleware import check_admin_permission

--- a/autobot-backend/api/logs.py
+++ b/autobot-backend/api/logs.py
@@ -28,7 +28,7 @@ from api.schemas_code import (
     LogRecentResponse,
     LogSearchResponse,
     LogSourcesResponse,
-    LogUnifiedResponse,
+    LogAggregatedResponse,
 )
 from api.schemas_common import AgentMessageResponse
 from auth_middleware import check_admin_permission
@@ -101,12 +101,12 @@ CONTAINER_LOGS = {
 
 
 # Forward declaration for parse functions (defined later in file)
-def _parse_file_log_line_for_unified(line: str, source: str) -> Metadata:
+def _parse_file_log_line_for_aggregated(line: str, source: str) -> Metadata:
     """Forward declaration - actual implementation uses parse_file_log_line."""
     pass  # Replaced at module load
 
 
-def _parse_docker_log_line_for_unified(line: str, service: str) -> Metadata:
+def _parse_docker_log_line_for_aggregated(line: str, service: str) -> Metadata:
     """Forward declaration - actual implementation uses parse_docker_log_line."""
     pass  # Replaced at module load
 
@@ -724,19 +724,19 @@ def parse_docker_log_line(line: str, service: str) -> Metadata:
     return parsed
 
 
-@router.get("/unified", response_model=LogUnifiedResponse)
+@router.get("/aggregated", response_model=LogAggregatedResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="get_unified_logs",
+    operation="get_aggregated_logs",
     error_code_prefix="LOGS",
 )
-async def get_unified_logs(
+async def get_aggregated_logs(
     admin_check: bool = Depends(check_admin_permission),
     lines: int = Query(100, ge=1, le=1000, description="Total number of lines to return"),
     level: str | None = Query(None, description="Filter by log level"),
     sources: str | None = Query(None, description="Comma-separated list of sources"),
 ):
-    """Get unified logs from all sources, merged by timestamp.
+    """Get aggregated logs from all sources, merged by timestamp.
 
     Issue #744: Requires admin authentication.
     """
@@ -764,7 +764,7 @@ async def get_unified_logs(
         }
 
     except Exception as e:
-        logger.error("Error getting unified logs: %s", e)
+        logger.error("Error getting aggregated logs: %s", e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/autobot-backend/api/schemas_code.py
+++ b/autobot-backend/api/schemas_code.py
@@ -247,8 +247,8 @@ class LogContainerResponse(BaseModel):
     source_type: str
 
 
-class LogUnifiedResponse(BaseModel):
-    """Response for GET /logs/unified."""
+class LogAggregatedResponse(BaseModel):
+    """Response for GET /logs/aggregated."""
 
     logs: List[Any]
     total_count: int

--- a/autobot-frontend/src/models/repositories/SystemRepository.ts
+++ b/autobot-frontend/src/models/repositories/SystemRepository.ts
@@ -285,8 +285,8 @@ export class SystemRepository extends ApiRepository {
   }
 
   async downloadLogs(): Promise<Blob> {
-    // Issue #552: Backend uses /api/logs/read/{filename}
-    const response = await this.get(`${getApiBase()}/logs/unified`)
+    // Issue #552: Backend uses /api/logs/aggregated
+    const response = await this.get(`${getApiBase()}/logs/aggregated`)
     return response.data as Blob
   }
 

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -30572,7 +30572,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/logs/unified": {
+    "/api/logs/aggregated": {
         parameters: {
             query?: never;
             header?: never;
@@ -30580,12 +30580,12 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Unified Logs
-         * @description Get unified logs from all sources, merged by timestamp.
+         * Get Aggregated Logs
+         * @description Get aggregated logs from all sources, merged by timestamp.
          *
          *     Issue #744: Requires admin authentication.
          */
-        get: operations["get_unified_logs_api_logs_unified_get"];
+        get: operations["get_aggregated_logs_api_logs_aggregated_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -77916,10 +77916,10 @@ export interface components {
             [key: string]: unknown;
         };
         /**
-         * LogUnifiedResponse
-         * @description Response for GET /logs/unified.
+         * LogAggregatedResponse
+         * @description Response for GET /logs/aggregated.
          */
-        LogUnifiedResponse: {
+        LogAggregatedResponse: {
             /** Logs */
             logs: unknown[];
             /** Total Count */
@@ -137803,7 +137803,7 @@ export interface operations {
             };
         };
     };
-    get_unified_logs_api_logs_unified_get: {
+    get_aggregated_logs_api_logs_aggregated_get: {
         parameters: {
             query?: {
                 /** @description Total number of lines to return */
@@ -137825,7 +137825,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["LogUnifiedResponse"];
+                    "application/json": components["schemas"]["LogAggregatedResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Thinking Path

B7 of issue #10746 (infix-rename sweep). The log-aggregation subsystem used `Unified` as an era-marker (multi-source merge), not a domain term. Owner confirmed in the Decisions comment: `LogUnifiedResponse → LogAggregatedResponse`, `get_unified_logs → get_aggregated_logs`, `/unified → /aggregated`.

Collision check for each canonical target:
- `LogAggregatedResponse`: no pre-existing class anywhere in backend or slm-backend.
- `get_aggregated_logs`: no pre-existing function in `api/logs.py` or any backend module.
- `_parse_file_log_line_for_aggregated` / `_parse_docker_log_line_for_aggregated`: no pre-existing.
- `/aggregated` route in the logs router (`/api/logs`): no existing `/aggregated` path.

No aliases, no stubs — wire-in before delete, all in one commit.

## What Changed

**`autobot-backend/api/schemas_code.py`**
- `LogUnifiedResponse` → `LogAggregatedResponse` (class name + docstring)

**`autobot-backend/api/logs.py`**
- Import updated: `LogUnifiedResponse` → `LogAggregatedResponse`
- Route: `@router.get("/unified")` → `@router.get("/aggregated")`; `response_model` updated
- `operation="get_unified_logs"` → `operation="get_aggregated_logs"`
- `async def get_unified_logs` → `async def get_aggregated_logs`
- Docstring + error log message updated to "aggregated"
- Forward declarations: `_parse_file_log_line_for_unified` → `_parse_file_log_line_for_aggregated`, `_parse_docker_log_line_for_unified` → `_parse_docker_log_line_for_aggregated`

**`autobot-backend/api/api_endpoint_migrations_test.py`**
- All `logs.get_unified_logs` refs → `logs.get_aggregated_logs` (6 occurrences across batch-157 + batch-166 test methods)
- `operation="get_unified_logs"` assertion → `operation="get_aggregated_logs"`
- Test method names updated: `test_batch_157_get_unified_logs_simple_pattern` → `test_batch_157_get_aggregated_logs_simple_pattern`, `test_batch_157_migration_preserves_unified_log_merging` → `test_batch_157_migration_preserves_aggregated_log_merging`

**`autobot-frontend/src/models/repositories/SystemRepository.ts`**
- `downloadLogs()` call: `/logs/unified` → `/logs/aggregated`; updated comment

**`autobot-frontend/src/types/generated/api.ts`** (committed generated file, follows prior route-rename pattern)
- Path key `"/api/logs/unified"` → `"/api/logs/aggregated"`
- JSDoc: "Get Unified Logs" → "Get Aggregated Logs"
- Operation ref: `get_unified_logs_api_logs_unified_get` → `get_aggregated_logs_api_logs_aggregated_get`
- Schema key `LogUnifiedResponse` → `LogAggregatedResponse` (definition + response reference)

## Verification

**Zero-grep (hard rule):**
```
git grep -wE "LogUnifiedResponse|get_unified_logs|_parse_file_log_line_for_unified|_parse_docker_log_line_for_unified" → 0 results
git grep -E "logs/unified|api/logs/unified" → 0 results
```

**Module import check:**
```
LogAggregatedResponse imported OK: <class 'api.schemas_code.LogAggregatedResponse'>
LogUnifiedResponse correctly gone: cannot import name 'LogUnifiedResponse' from 'api.schemas_code'
get_aggregated_logs: True
get_unified_logs: False
_parse_file_log_line_for_aggregated: True
_parse_docker_log_line_for_aggregated: True
```

**Lint:**
- `black --line-length=120 --check`: "2 files would be left unchanged"
- `flake8 --config=.flake8`: exit 0 for both changed py files and test file
- `awk 'length>120'` → empty (no lines > 120 chars)

**Startup imports:**
```
tests/test_startup_imports.py: 339 passed, 83 warnings
```

## Model Used

Claude Sonnet 4.6

Part of #10746