### PR TITLE
refactor(naming): B12 misc-helpers — drop infix Enhanced/Consolidated/v2 (#10746)

### DIFF
--- a/autobot-backend/context_aware_decision/examples_counterfactual.py
+++ b/autobot-backend/context_aware_decision/examples_counterfactual.py
@@ -316,7 +316,7 @@ async def example_database_exhaustion():
 # =============================================================================
 
 
-async def example_enhanced_decision():
+async def example_decision():
     """
     Show how to enhance Decision objects with counterfactual predictions.
 
@@ -392,7 +392,7 @@ async def main():
     """Run all examples."""
     await example_network_timeout()
     await example_database_exhaustion()
-    await example_enhanced_decision()
+    await example_decision()
 
 
 if __name__ == "__main__":

--- a/autobot-backend/services/command_approval_manager.py
+++ b/autobot-backend/services/command_approval_manager.py
@@ -458,16 +458,16 @@ class CommandApprovalManager:
         return False
 
     # =========================================================================
-    # Permission System v2 Integration (Claude Code-style)
+    # Permission System Integration (Claude Code-style)
     # =========================================================================
 
     @staticmethod
-    def is_permission_v2_enabled() -> bool:
+    def is_permission_system_enabled() -> bool:
         """
-        Check if permission system v2 (Claude Code-style) is enabled.
+        Check if the permission system (Claude Code-style) is enabled.
 
         Returns:
-            True if permission v2 is enabled
+            True if the permission system is enabled
         """
         try:
             from autobot_shared.ssot_config import config

--- a/autobot-backend/utils/timeout_migration_examples.py
+++ b/autobot-backend/utils/timeout_migration_examples.py
@@ -444,7 +444,7 @@ class ExistingOperationMigrator:
             operation_type=OperationType.COMPREHENSIVE_TEST_SUITE,
             name="Enhanced Comprehensive Test Suite",
             description="Migrate from fixed timeout to dynamic checkpoint-based testing",
-            operation_function=self._enhanced_test_suite_operation,
+            operation_function=self._test_suite_operation,
             priority=OperationPriority.HIGH,
             estimated_items=len(list(Path(f"{PATH.PROJECT_ROOT}/tests").rglob("test_*.py"))),
             execute_immediately=False,
@@ -453,9 +453,9 @@ class ExistingOperationMigrator:
         logger.info("Migrated comprehensive test suite operation: %s", operation_id)
         return operation_id
 
-    async def _enhanced_test_suite_operation(self, context: OperationExecutionContext) -> Dict[str, Any]:
+    async def _test_suite_operation(self, context: OperationExecutionContext) -> Dict[str, Any]:
         """
-        Enhanced test suite with checkpoint/resume and parallel execution.
+        Test suite with checkpoint/resume and parallel execution.
 
         Issue #620: Extracted from migrate_comprehensive_test_suite to reduce
         function length using Extract Method pattern. Issue #620.
@@ -910,9 +910,9 @@ def _create_progress_wrapper(context: OperationExecutionContext):
 
 
 # Decorator-based migration helpers
-def _create_enhanced_operation(func, args, kwargs, progress_callback):
+def _create_operation(func, args, kwargs, progress_callback):
     """
-    Create enhanced operation callable with progress tracking.
+    Create operation callable with progress tracking.
 
     Wraps the original function to inject progress callbacks and handle
     both sync and async functions appropriately. Issue #620.
@@ -966,7 +966,7 @@ def migrate_timeout_operation(
         async def wrapper(*args, **kwargs):
             """Execute operation with enhanced progress and timeout handling."""
             progress_callback = kwargs.pop("progress_callback", None)
-            enhanced_op = _create_enhanced_operation(func, args, kwargs, progress_callback)
+            enhanced_op = _create_operation(func, args, kwargs, progress_callback)
             items = _get_estimated_items(estimated_items, args)
 
             # Execute with operation manager if available

--- a/autobot-backend/utils/todowrite_optimizer.py
+++ b/autobot-backend/utils/todowrite_optimizer.py
@@ -382,7 +382,7 @@ class TodoWriteOptimizer:
 
             if len(similar_todos) > 1:
                 # Create consolidated todo
-                consolidated_content = self._create_consolidated_content(similar_todos)
+                consolidated_content = self._create_merged_content(similar_todos)
                 consolidated_todo = OptimizedTodoItem(
                     content=consolidated_content,
                     status=similar_todos[0].status,
@@ -399,8 +399,8 @@ class TodoWriteOptimizer:
 
         return consolidated
 
-    def _create_consolidated_content(self, similar_todos: List[OptimizedTodoItem]) -> str:
-        """Create consolidated content from similar todos"""
+    def _create_merged_content(self, similar_todos: List[OptimizedTodoItem]) -> str:
+        """Create merged content from similar todos"""
         if len(similar_todos) == 1:
             return similar_todos[0].content
 


### PR DESCRIPTION
## Thinking Path

B12 is the misc-helpers batch of issue #10746 (infix rename sweep). Five entities across four files, all in miscellaneous helper/utility modules with no cross-batch dependencies. Each entity was ERA-infix (not domain), no collisions on target names.

**`is_permission_v2_enabled`**: the task spec says "rename to descriptive non-v2 name — read its usage to pick a name". The method body reads `config.permission.enabled`; the v2 refers to a generation label, not a library version. Renamed to `is_permission_system_enabled`. Only 1 ref (the definition) — no callers in the repo.

**`condense_unified_diff`**: documented KEEP per plan §2K ("unified diff" = git domain term). Left untouched; 12 grep hits confirmed still present.

## What Changed

| Entity | File | Action | New name |
|---|---|---|---|
| `_create_consolidated_content` | `utils/todowrite_optimizer.py` | renamed | `_create_merged_content` |
| `example_enhanced_decision` | `context_aware_decision/examples_counterfactual.py` | renamed | `example_decision` |
| `_enhanced_test_suite_operation` | `utils/timeout_migration_examples.py` | renamed | `_test_suite_operation` |
| `_create_enhanced_operation` | `utils/timeout_migration_examples.py` | renamed | `_create_operation` |
| `is_permission_v2_enabled` | `services/command_approval_manager.py` | renamed | `is_permission_system_enabled` |
| `condense_unified_diff` | `services/tool_output_filter.py` | KEPT | git domain term |

All callers updated atomically in the same commit. No aliases.

## Verification

- `git grep` for all 5 renamed names returns **0 hits** after the change
- `condense_unified_diff` still present: 12 hits across `tool_output_filter.py` + `test_tool_output_filter.py`
- `black --line-length=120 --check` on all 4 changed files: **no reformatting needed**
- `flake8 --config=.flake8` on all 4 changed files: **0 errors**
- `pytest autobot-backend/tests/test_startup_imports.py -q`: **339 passed**
- `condense_unified_diff` test failures pre-exist on `Dev_new_gui` (confirmed via stash test before/after)

## Model Used

claude-sonnet-4-6

Part of #10746