### PR TITLE
fix(frontend): source model lists from API instead of hardcoded DEFAULT_MODELS (#10718)

### DIFF
--- a/autobot-frontend/src/components/chat/MultiModelChat.vue
+++ b/autobot-frontend/src/components/chat/MultiModelChat.vue
@@ -97,23 +97,15 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
-import { ref, watch, computed } from 'vue'
+import { ref, watch, computed, onMounted } from 'vue'
 import { useMultiModelCompare } from '@/composables/useMultiModelCompare'
 // GH#8990: show per-model context window in picker
 import { useAvailableModels } from '@/composables/useAvailableModels'
 
-// ---------------------------------------------------------------------------
-// Defaults — user can change via the picker
-// ---------------------------------------------------------------------------
-const DEFAULT_MODELS = [
-  'ollama/llama3',
-  'ollama/mistral',
-  'openai/gpt-4o-mini',
-]
-
 const { responses, selectedModels, isComparing, compare, reset } = useMultiModelCompare()
-const { models: llmModels, fetchModels } = useAvailableModels()
-fetchModels().catch(() => {})
+// #10718: source the model list from the live /api/models endpoint — no
+// hardcoded defaults that masquerade as real availability.
+const { models: llmModels, availableModelNames, fetchModels } = useAvailableModels()
 
 const promptText = ref('')
 
@@ -132,26 +124,24 @@ const contextWindowLabel = computed(() => {
   return map
 })
 
-// Populate defaults on first mount if localStorage is empty
-if (selectedModels.value.length === 0) {
-  selectedModels.value = [...DEFAULT_MODELS]
-}
-
-// Available models for the picker: union of defaults + any extra stored choices
-const availableModels = ref<string[]>([...DEFAULT_MODELS])
-
-// Keep availableModels in sync with selectedModels (in case user has stored extras)
-watch(
-  selectedModels,
-  (current) => {
-    for (const m of current) {
-      if (!availableModels.value.includes(m)) {
-        availableModels.value.push(m)
-      }
-    }
-  },
-  { immediate: true },
+// Picker list: live available models plus any previously-stored selections
+// (so a persisted choice stays selectable even if a provider is briefly down).
+// Before the fetch resolves this is empty — the picker renders no fake models.
+const availableModels = computed<string[]>(() =>
+  Array.from(new Set<string>([...availableModelNames.value, ...selectedModels.value])),
 )
+
+// Seed the selection from the live list once it loads, but only when the user
+// has no persisted choice yet. The watcher handles the async fetch timing.
+watch(availableModelNames, (names) => {
+  if (selectedModels.value.length === 0 && names.length > 0) {
+    selectedModels.value = [...names]
+  }
+})
+
+onMounted(() => {
+  fetchModels().catch(() => {})
+})
 
 async function onSend(): Promise<void> {
   if (!promptText.value.trim() || selectedModels.value.length === 0 || isComparing.value) return

--- a/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
@@ -332,16 +332,25 @@ async function handleInteract(payload: { action: string; params: Record<string, 
 
 // ── Board helpers (Issue #3242) ───────────────────────────────────────────
 
-async function fetchBoards(): Promise<void> {
+async function fetchBoards(retry = true): Promise<void> {
   try {
     const data = await ApiClient.get<any>(`${getApiBase()}/knowledge_base/boards`) as { boards?: Board[] }
     if (Array.isArray(data.boards)) {
       boards.value = data.boards
     }
   } catch (e) {
-    logger.warn('Failed to fetch knowledge boards (non-critical):', e)
-    // Keep default __global__ board so research still works
-    boards.value = [{ board_id: '__global__', name: 'Global (all boards)' }]
+    logger.warn('Failed to fetch knowledge boards:', e)
+    // Issue #10718: retry once before falling back so a transient blip doesn't
+    // silently strand the user on the all-boards sentinel.
+    if (retry) {
+      await fetchBoards(false)
+      return
+    }
+    // Persistent failure: keep the legitimate __global__ all-boards mode so
+    // research still works, but surface a non-blocking notice — the load
+    // failure must not be silent.
+    boards.value = [{ board_id: '__global__', name: t('knowledge.research.globalAllBoards') }]
+    errorMsg.value = t('knowledge.research.errorBoardsLoad')
   }
 }
 

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -3869,7 +3869,9 @@
       "statusReady": "Ready",
       "statusSearching": "Searching...",
       "statusStarting": "Starting...",
-      "statusStopped": "Stopped"
+      "statusStopped": "Stopped",
+      "globalAllBoards": "Global (all boards)",
+      "errorBoardsLoad": "Could not load research boards — using all boards"
     },
     "scopeSelector": {
       "group": "Group",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -3869,7 +3869,9 @@
       "statusReady": "Ready",
       "statusSearching": "Searching...",
       "statusStarting": "Starting...",
-      "statusStopped": "Stopped"
+      "statusStopped": "Stopped",
+      "globalAllBoards": "Global (all boards)",
+      "errorBoardsLoad": "Could not load research boards — using all boards"
     },
     "scopeSelector": {
       "group": "Group",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -3836,7 +3836,9 @@
       "statusReady": "Ready",
       "statusSearching": "Searching...",
       "statusStarting": "Starting...",
-      "statusStopped": "Stopped"
+      "statusStopped": "Stopped",
+      "globalAllBoards": "Global (all boards)",
+      "errorBoardsLoad": "Could not load research boards — using all boards"
     },
     "scopeSelector": {
       "group": "Group",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -3869,7 +3869,9 @@
       "statusReady": "Ready",
       "statusSearching": "Searching...",
       "statusStarting": "Starting...",
-      "statusStopped": "Stopped"
+      "statusStopped": "Stopped",
+      "globalAllBoards": "Global (all boards)",
+      "errorBoardsLoad": "Could not load research boards — using all boards"
     },
     "scopeSelector": {
       "group": "Group",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -3327,7 +3327,9 @@
       "boardLabel": "Research Board",
       "statusAssessed": "Assessed {domain} — relevance: {score}",
       "statusExtracted": "Extracted content from {domain}",
-      "statusStored": "Stored result from {domain}"
+      "statusStored": "Stored result from {domain}",
+      "globalAllBoards": "Global (all boards)",
+      "errorBoardsLoad": "Could not load research boards — using all boards"
     },
     "mainCategories": {
       "populate": "Populate",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -3869,7 +3869,9 @@
       "statusReady": "Ready",
       "statusSearching": "Searching...",
       "statusStarting": "Starting...",
-      "statusStopped": "Stopped"
+      "statusStopped": "Stopped",
+      "globalAllBoards": "Global (all boards)",
+      "errorBoardsLoad": "Could not load research boards — using all boards"
     },
     "scopeSelector": {
       "group": "Group",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -3327,7 +3327,9 @@
       "boardLabel": "Research Board",
       "statusAssessed": "Assessed {domain} — relevance: {score}",
       "statusExtracted": "Extracted content from {domain}",
-      "statusStored": "Stored result from {domain}"
+      "statusStored": "Stored result from {domain}",
+      "globalAllBoards": "Global (all boards)",
+      "errorBoardsLoad": "Could not load research boards — using all boards"
     },
     "mainCategories": {
       "populate": "Populate",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -3869,7 +3869,9 @@
       "statusReady": "Ready",
       "statusSearching": "Searching...",
       "statusStarting": "Starting...",
-      "statusStopped": "Stopped"
+      "statusStopped": "Stopped",
+      "globalAllBoards": "Global (all boards)",
+      "errorBoardsLoad": "Could not load research boards — using all boards"
     },
     "scopeSelector": {
       "group": "Group",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -3869,7 +3869,9 @@
       "statusReady": "Ready",
       "statusSearching": "Searching...",
       "statusStarting": "Starting...",
-      "statusStopped": "Stopped"
+      "statusStopped": "Stopped",
+      "globalAllBoards": "Global (all boards)",
+      "errorBoardsLoad": "Could not load research boards — using all boards"
     },
     "scopeSelector": {
       "group": "Group",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -3869,7 +3869,9 @@
       "statusReady": "Ready",
       "statusSearching": "Searching...",
       "statusStarting": "Starting...",
-      "statusStopped": "Stopped"
+      "statusStopped": "Stopped",
+      "globalAllBoards": "Global (all boards)",
+      "errorBoardsLoad": "Could not load research boards — using all boards"
     },
     "scopeSelector": {
       "group": "Group",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -3327,7 +3327,9 @@
       "boardLabel": "Research Board",
       "statusAssessed": "Assessed {domain} — relevance: {score}",
       "statusExtracted": "Extracted content from {domain}",
-      "statusStored": "Stored result from {domain}"
+      "statusStored": "Stored result from {domain}",
+      "globalAllBoards": "Global (all boards)",
+      "errorBoardsLoad": "Could not load research boards — using all boards"
     },
     "mainCategories": {
       "populate": "Populate",

--- a/autobot-frontend/src/views/BenchmarkView.vue
+++ b/autobot-frontend/src/views/BenchmarkView.vue
@@ -159,7 +159,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { ApexOptions } from 'apexcharts'
 import ApiClient from '@/utils/ApiClient'
@@ -181,8 +181,6 @@ import {
 const { t } = useI18n()
 const logger = createLogger('BenchmarkView')
 
-const DEFAULT_MODELS = ['ollama/llama3', 'ollama/mistral', 'openai/gpt-4o-mini']
-
 const { responses, selectedModels, isComparing, compare } = useMultiModelCompare()
 const { availableModelNames, fetchModels } = useAvailableModels()
 
@@ -199,11 +197,20 @@ const filterSince = ref('')
 
 const promptTypes = ['rag', 'code', 'summarization', 'reasoning', 'custom']
 
-if (selectedModels.value.length === 0) selectedModels.value = [...DEFAULT_MODELS]
-
+// #10718: build the picker from the live /api/models list (+ any already-selected
+// model) — no hardcoded seed masquerading as real availability. Before fetch
+// resolves the list is empty; the picker renders no fake models.
 const availableModels = computed<string[]>(() => {
-  const union = new Set<string>([...DEFAULT_MODELS, ...availableModelNames.value, ...selectedModels.value])
+  const union = new Set<string>([...availableModelNames.value, ...selectedModels.value])
   return Array.from(union)
+})
+
+// Seed the selection once the live list loads, but only when the user has no
+// persisted choice yet. The watcher handles the async fetch timing.
+watch(availableModelNames, (names) => {
+  if (selectedModels.value.length === 0 && names.length > 0) {
+    selectedModels.value = [...names]
+  }
 })
 
 const currentPromptType = computed(


### PR DESCRIPTION
## Thinking Path
Umbrella #10714, T4. `MultiModelChat.vue` and `BenchmarkView.vue` hardcoded `DEFAULT_MODELS = ['ollama/llama3','ollama/mistral','openai/gpt-4o-mini']`, so users saw stale model names masquerading as live availability. `KnowledgeResearchPanel.vue` silently fell back to a fabricated board on fetch failure.

## What Changed
- **MultiModelChat.vue**: removed `DEFAULT_MODELS`; `availableModels` is now `computed` from `useAvailableModels().availableModelNames` (+ persisted selections so a stored choice survives a provider blip). `fetchModels()` in `onMounted`; a watcher seeds selection once the live list loads. Empty (not fake) until loaded.
- **BenchmarkView.vue**: removed `DEFAULT_MODELS`; picker union built only from `availableModelNames` + selected; watcher seeds selection on load.
- **KnowledgeResearchPanel.vue**: `fetchBoards` retries once before falling back; keeps the legitimate `__global__` all-boards sentinel but now surfaces a non-blocking error (`t(...)`) instead of failing silently.

## i18n
Two new `knowledge.research` keys (`globalAllBoards`, `errorBoardsLoad`) added to **all 11 locales** (ar, de, en, es, fa, fr, he, lv, pl, pt, ur).

## Verification
- No `console.*` (uses `createLogger`); no dangling imports; `availableModels` stays `string[]`.
- No Linux npm on this box — types verified by reading the composable's `ComputedRef<string[]>`; CI vue-tsc gate is the final validator.

Closes #10718.

## Model Used
Claude Opus 4.8 (1M context)