### PR TITLE
fix(llc): migration 064 — work_item reviewer cols + sprint kb_summary (fixes work-item/sprint 500s) (#10750)

### DIFF
--- a/autobot-backend/migrations/versions/20260630_064_llc_reviewer_cols_and_sprint_kb_summary.py
+++ b/autobot-backend/migrations/versions/20260630_064_llc_reviewer_cols_and_sprint_kb_summary.py
@@ -1,0 +1,50 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Add llc_work_items reviewer columns + llc_sprints.kb_summary (schema drift fix).
+
+The ORM models declare ``reviewer_user_id`` / ``reviewer_agent_id``
+(llc/models/work_item.py) and ``kb_summary`` (llc/models/sprint.py), but no
+migration ever added them, so every work-item and sprint read raised asyncpg
+``UndefinedColumnError`` (boards, backlog, sprint summary/close all 500'd).
+
+Forward-only drift reconciliation, idempotent (``ADD COLUMN IF NOT EXISTS``).
+
+Revision ID: 20260630_064
+Revises: 20260629_063
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+from migrations.guards import has_table
+
+# revision identifiers, used by Alembic.
+revision: str = "20260630_064"
+down_revision: Union[str, None] = "20260629_063"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    if has_table("llc_work_items"):
+        op.execute('ALTER TABLE "llc_work_items" ADD COLUMN IF NOT EXISTS reviewer_user_id UUID')
+        op.execute('ALTER TABLE "llc_work_items" ADD COLUMN IF NOT EXISTS reviewer_agent_id UUID')
+        op.execute(
+            'CREATE INDEX IF NOT EXISTS ix_llc_work_items_reviewer_user_id '
+            'ON "llc_work_items" (reviewer_user_id)'
+        )
+        op.execute(
+            'CREATE INDEX IF NOT EXISTS ix_llc_work_items_reviewer_agent_id '
+            'ON "llc_work_items" (reviewer_agent_id)'
+        )
+
+    if has_table("llc_sprints"):
+        op.execute('ALTER TABLE "llc_sprints" ADD COLUMN IF NOT EXISTS kb_summary TEXT')
+
+
+def downgrade() -> None:
+    # Forward-only drift reconciliation: dropping these re-breaks the ORM read
+    # paths they fix, so downgrade is a no-op (matches 20260629_063).
+    pass

--- a/autobot-backend/migrations/versions/20260630_064_llc_reviewer_cols_and_sprint_kb_summary.py
+++ b/autobot-backend/migrations/versions/20260630_064_llc_reviewer_cols_and_sprint_kb_summary.py
@@ -14,6 +14,7 @@ Forward-only drift reconciliation, idempotent (``ADD COLUMN IF NOT EXISTS``).
 Revision ID: 20260630_064
 Revises: 20260629_063
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -32,12 +33,10 @@ def upgrade() -> None:
         op.execute('ALTER TABLE "llc_work_items" ADD COLUMN IF NOT EXISTS reviewer_user_id UUID')
         op.execute('ALTER TABLE "llc_work_items" ADD COLUMN IF NOT EXISTS reviewer_agent_id UUID')
         op.execute(
-            'CREATE INDEX IF NOT EXISTS ix_llc_work_items_reviewer_user_id '
-            'ON "llc_work_items" (reviewer_user_id)'
+            "CREATE INDEX IF NOT EXISTS ix_llc_work_items_reviewer_user_id " 'ON "llc_work_items" (reviewer_user_id)'
         )
         op.execute(
-            'CREATE INDEX IF NOT EXISTS ix_llc_work_items_reviewer_agent_id '
-            'ON "llc_work_items" (reviewer_agent_id)'
+            "CREATE INDEX IF NOT EXISTS ix_llc_work_items_reviewer_agent_id " 'ON "llc_work_items" (reviewer_agent_id)'
         )
 
     if has_table("llc_sprints"):


### PR DESCRIPTION
## Thinking Path
Company OS audit (umbrella #10750) found the LLC schema is drifted: the ORM declares `llc_work_items.reviewer_user_id`/`reviewer_agent_id` and `llc_sprints.kb_summary`, but no Alembic migration ever added them (they only existed in an orphaned, never-run `database/migrations/` chain). Every work-item and sprint read 500s with `asyncpg UndefinedColumnError` — breaking boards, backlog, sprint summary/close. This is workstream **A1** (the highest-frequency 500s).

## What Changed
- New migration `20260630_064` (down_revision `20260629_063`): `ADD COLUMN IF NOT EXISTS` for the two reviewer columns (+ indexes) on `llc_work_items` and `kb_summary` on `llc_sprints`. Idempotent, `has_table`-guarded, forward-only (downgrade is a no-op, matching 063).

## Verification
py_compile OK. Applied via `alembic upgrade head` in the deployed venv (also applies the pending, already-committed `063`). Will confirm `GET /api/llc/work-items` and sprint reads return 200 after deploy.

## Model Used
Claude Opus 4.8 (1M context)

Part of #10750 (workstream A1). Follow-up A2 ports the 8 missing tables (labels/attachments/ceo-chat/templates/kb_collections).
