### PR TITLE
refactor(cache): B9 — eliminate infix unified from CacheCoordinator (#10746)

### DIFF
--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -126,7 +126,7 @@ class SystemMetricsResponse(BaseModel):
 class SystemCacheCoordinatorStatsResponse(BaseModel):
     """Response for GET /api/cache/stats.
 
-    Shape is defined by CacheCoordinator.get_unified_stats() — opaque.
+    Shape is defined by CacheCoordinator.get_cache_stats() — opaque.
     """
 
     model_config = {"extra": "allow"}

--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -945,7 +945,7 @@ async def get_cache_coordinator_stats(
         from cache import get_cache_coordinator
 
         coordinator = await get_cache_coordinator()
-        return coordinator.get_unified_stats()
+        return coordinator.get_cache_stats()
     except Exception as e:
         logger.error("Error getting cache coordinator stats: %s", str(e))
         raise HTTPException(status_code=500, detail="Error getting cache coordinator stats")

--- a/autobot-backend/cache/__init__.py
+++ b/autobot-backend/cache/__init__.py
@@ -17,7 +17,7 @@ Usage:
 
     # Get coordinator for stats/eviction
     coordinator = await get_cache_coordinator()
-    stats = coordinator.get_unified_stats()
+    stats = coordinator.get_cache_stats()
 """
 
 from typing import Callable, List, Tuple

--- a/autobot-backend/cache/coordinator.py
+++ b/autobot-backend/cache/coordinator.py
@@ -38,7 +38,7 @@ class CacheCoordinator(AsyncInitializable):
         coordinator = await get_cache_coordinator()
         coordinator.register(my_cache)
         await coordinator.check_pressure()
-        stats = coordinator.get_unified_stats()
+        stats = coordinator.get_cache_stats()
     """
 
     _instance: "CacheCoordinator" | None = None
@@ -140,7 +140,7 @@ class CacheCoordinator(AsyncInitializable):
                 logger.info(f"Evicted {evicted} items from {name}")
         return results
 
-    def get_unified_stats(self) -> Dict[str, Any]:
+    def get_cache_stats(self) -> Dict[str, Any]:
         """
         Aggregate stats from all registered caches.
 

--- a/autobot-backend/cache/coordinator_test.py
+++ b/autobot-backend/cache/coordinator_test.py
@@ -87,11 +87,11 @@ class TestCacheCoordinatorAsyncInit:
         coord = await get_cache_coordinator()
         mock_cache = _make_mock_cache("my_cache")
         coord.register(mock_cache)
-        stats = coord.get_unified_stats()
+        stats = coord.get_cache_stats()
         assert stats["registered_count"] == 1
         removed = coord.unregister("my_cache")
         assert removed is True
-        assert coord.get_unified_stats()["registered_count"] == 0
+        assert coord.get_cache_stats()["registered_count"] == 0
 
     @pytest.mark.asyncio
     async def test_pressure_threshold_loaded_from_config(self):


### PR DESCRIPTION
## Thinking Path

B9 is the smallest batch in #10746: one method on `CacheCoordinator` carries the infix `unified`.

The plan (§2H, collision group §5 item 2) flags `get_unified_stats` → `get_cache_stats`:
- The name `get_unified_stats` is ERA: the word "unified" refers to the coordinator aggregating multiple caches, but the domain name for that operation is simply "cache stats" — the same term already used by the route handler (`get_cache_stats` in `api/system.py`) and three other `get_cache_stats` methods in sibling classes (`ProviderHealthManager`, `AdaptiveMemoryManager`, `WebResearcher`).
- No collision on `CacheCoordinator`: the class has no existing `get_cache_stats` method.

7 refs across 5 files, all updated atomically. No aliases.

## What Changed

| File | Change |
|---|---|
| `autobot-backend/cache/coordinator.py` | Renamed method `get_unified_stats` → `get_cache_stats`; updated class docstring usage example |
| `autobot-backend/cache/coordinator_test.py` | Updated 2 call sites in `test_register_and_unregister_cache` |
| `autobot-backend/cache/__init__.py` | Updated module docstring usage example |
| `autobot-backend/api/system.py` | Updated call `coordinator.get_unified_stats()` → `coordinator.get_cache_stats()` |
| `autobot-backend/api/schemas_system.py` | Updated comment referencing the method name |

## Verification

- Zero-grep: `git grep get_unified_stats -- autobot-backend/ autobot_shared/ autobot-slm-backend/` → empty
- `black --line-length=120` — 5 files left unchanged
- `flake8 --config=.flake8 autobot-backend/` — exit 0
- `awk 'length>120'` on all changed files — empty
- `pytest tests/test_startup_imports.py -q` — **339 passed**
- `pytest cache/coordinator_test.py -v` — **9/9 passed**

## Model Used

Claude Sonnet 4.6

Part of #10746