### PR TITLE
refactor(analytics): B6 — eliminate infix unified from analytics (#10746)

### DIFF
--- a/autobot-backend/api/analytics_maintenance.py
+++ b/autobot-backend/api/analytics_maintenance.py
@@ -281,29 +281,29 @@ async def get_quick_wins(
 
 
 # ============================================================================
-# UNIFIED DASHBOARD ENDPOINTS
+# ANALYTICS DASHBOARD ENDPOINTS
 # ============================================================================
 
 
 @router.get("/dashboard", response_model=MaintenanceDashboardResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="get_unified_dashboard",
+    operation="get_analytics_dashboard",
     error_code_prefix="ANALYTICS_MAINTENANCE",
 )
-async def get_unified_dashboard(
+async def get_analytics_dashboard(
     days: int = Query(default=30, ge=1, le=365, description="Days to analyze"),
     admin_check: bool = Depends(check_admin_permission),
 ):
     """
-    Get unified analytics dashboard.
+    Get aggregated analytics dashboard.
 
     Aggregates all analytics sources into a single comprehensive view.
 
     Issue #744: Requires admin authentication.
     """
     service = get_analytics_service()
-    dashboard = await service.get_unified_dashboard(days)
+    dashboard = await service.get_analytics_dashboard(days)
 
     return dashboard
 

--- a/autobot-backend/api/analytics_reporting.py
+++ b/autobot-backend/api/analytics_reporting.py
@@ -3,7 +3,7 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Unified Analytics Report API (Issue #271)
+Analytics Report API (Issue #271)
 
 Provides a single endpoint that aggregates all analytics data from:
 - Code quality health score
@@ -32,7 +32,7 @@ from autobot_shared.time_utils import utc_timestamp
 
 logger = get_logger(__name__)
 # Issue #3355: prefix moved to router registry (analytics_routers.py)
-router = APIRouter(tags=["unified-analytics"])
+router = APIRouter(tags=["analytics"])
 
 
 async def fetch_quality_health() -> Dict[str, Any]:
@@ -135,14 +135,14 @@ async def fetch_performance_summary() -> Dict[str, Any]:
         return {"total_analyses": 0, "average_score": 0, "common_issues": []}
 
 
-def calculate_unified_health_score(
+def calculate_aggregated_health_score(
     quality_data: Dict[str, Any],
     charts_data: Dict[str, Any],
     debt_data: Dict[str, Any],
     performance_data: Dict[str, Any],
 ) -> float:
     """
-    Calculate unified health score from all sources.
+    Calculate aggregated health score from all analytics sources.
 
     Weights:
     - Quality score: 40%
@@ -236,14 +236,14 @@ def aggregate_categories(charts_data: Dict[str, Any]) -> Dict[str, Any]:
     return categories
 
 
-def _build_unified_report_response(
+def _build_report_response(
     health_score: float,
     quality_data: Dict[str, Any],
     charts_data: Dict[str, Any],
     debt_data: Dict[str, Any],
     performance_data: Dict[str, Any],
 ) -> Dict[str, Any]:
-    """Helper for get_unified_report. Ref: #1088.
+    """Helper for get_analytics_report. Ref: #1088.
 
     Assembles the full report dict from pre-computed analytics values.
     """
@@ -292,12 +292,12 @@ def _build_unified_report_response(
 @router.get("/report", response_model=DataResponse[AnalyticsReportingReportResponse])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="get_unified_report",
+    operation="get_analytics_report",
     error_code_prefix="ANALYTICS_REPORTING",
 )
-async def get_unified_report():
+async def get_analytics_report():
     """
-    Get unified analytics report aggregating all analytics sources.
+    Get aggregated analytics report from all analytics sources.
 
     Returns comprehensive code health overview including:
     - Overall health score
@@ -317,10 +317,10 @@ async def get_unified_report():
         fetch_performance_summary(),
     )
 
-    # Calculate unified health score
-    health_score = calculate_unified_health_score(quality_data, charts_data, debt_data, performance_data)
+    # Calculate aggregated health score
+    health_score = calculate_aggregated_health_score(quality_data, charts_data, debt_data, performance_data)
 
-    response = _build_unified_report_response(health_score, quality_data, charts_data, debt_data, performance_data)
+    response = _build_report_response(health_score, quality_data, charts_data, debt_data, performance_data)
 
     return JSONResponse(content=response)
 

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -579,7 +579,7 @@ class OptimizationQuickWinsResponse(BaseModel):
 class MaintenanceDashboardResponse(BaseModel):
     """Response for GET /maintenance/dashboard.
 
-    Shape from service.get_unified_dashboard() — opaque; extra allowed.
+    Shape from service.get_analytics_dashboard() — opaque; extra allowed.
     """
 
     model_config = {"extra": "allow"}

--- a/autobot-backend/services/analytics_service.py
+++ b/autobot-backend/services/analytics_service.py
@@ -174,11 +174,11 @@ class AnalyticsService(AsyncRedisClientMixin):
         return self._cost
 
     # =========================================================================
-    # UNIFIED DASHBOARD
+    # ANALYTICS DASHBOARD
     # =========================================================================
 
     def _build_agents_section(self, agent_metrics: List[Any]) -> Dict[str, Any]:
-        """Build agents section for unified dashboard (Issue #665: extracted helper)."""
+        """Build agents section for analytics dashboard (Issue #665: extracted helper)."""
         return {
             "total_agents": len(agent_metrics),
             "total_tasks": sum(m.total_tasks for m in agent_metrics),
@@ -191,7 +191,7 @@ class AnalyticsService(AsyncRedisClientMixin):
         }
 
     def _build_maintenance_section(self, maintenance_recs: List[Any]) -> Dict[str, Any]:
-        """Build maintenance section for unified dashboard (Issue #665: extracted helper)."""
+        """Build maintenance section for analytics dashboard (Issue #665: extracted helper)."""
         return {
             "total_recommendations": len(maintenance_recs),
             "critical_count": sum(1 for r in maintenance_recs if r.priority == MaintenancePriority.CRITICAL),
@@ -202,9 +202,9 @@ class AnalyticsService(AsyncRedisClientMixin):
             ][:5],
         }
 
-    async def get_unified_dashboard(self, days: int = 30) -> Dict[str, Any]:
+    async def get_analytics_dashboard(self, days: int = 30) -> Dict[str, Any]:
         """
-        Get unified dashboard data aggregating all analytics sources.
+        Get aggregated dashboard data from all analytics sources.
 
         Args:
             days: Number of days to include in analysis


### PR DESCRIPTION
## Thinking Path

B6 analytics batch from the infix rename plan (#10746). The analytics subsystem had 4 functions/methods with `unified` as an infix era-modifier. Collision-check required before each rename:

- `get_unified_dashboard` → bare `get_dashboard` risks ambiguity with `get_dashboard_overview`/`get_dashboard_status` in monitoring and validation modules — used `get_analytics_dashboard` (domain-qualified) instead.
- `calculate_unified_health_score` → `calculate_health_score` **collides** with `analytics_quality.calculate_health_score(metrics: dict[str, float]) -> HealthScore` (different signature, different semantics). Used `calculate_aggregated_health_score` as the distinct descriptive name.
- `_build_unified_report_response` → `_build_report_response` — no collision in same file. Direct rename.
- `get_unified_report` → `get_analytics_report` — distinct from `saved_reports_service.SavedReportsService.get_report(report_id)` (different class/context). No collision.

All callers migrated atomically (same file only — no cross-module callers found). No aliases left. Router tag `unified-analytics` → `analytics`.

## What Changed

- `autobot-backend/api/analytics_reporting.py`: rename `calculate_unified_health_score` → `calculate_aggregated_health_score`, `_build_unified_report_response` → `_build_report_response`, `get_unified_report` → `get_analytics_report`; fix router tag + operation strings + internal call sites + comments
- `autobot-backend/api/analytics_maintenance.py`: rename `get_unified_dashboard` route handler → `get_analytics_dashboard`; fix operation string, section comment, call to service method
- `autobot-backend/services/analytics_service.py`: rename `get_unified_dashboard` method → `get_analytics_dashboard`; fix helper docstrings + section comment
- `autobot-backend/api/schemas_analytics.py`: update docstring cross-reference to `get_analytics_dashboard`

## Verification

```
# Zero infix in identifiers (B6 files only):
grep -n "def.*unified\|def.*enhanced\|def.*consolidated" \
  autobot-backend/api/analytics_{maintenance,reporting}.py \
  autobot-backend/services/analytics_service.py
# → (empty)

# Smoke test: 339 passed
pytest autobot-backend/tests/test_startup_imports.py -q
# → 339 passed, 83 warnings

# Analytics tests: 23 passed
pytest autobot-backend/tests/api/ -k "analytics" -q
# → 23 passed

# Flake8 clean
flake8 --config=.flake8 <B6 files>
# → exit 0

# No lines >120 chars
awk 'length>120' <B6 files>
# → (empty)
```

## Model Used

claude-sonnet-4-6

Part of #10746