### PR TITLE
refactor(secrets): B8 — eliminate infix unified/enhanced from credential/secrets helpers (#10746)

### DIFF
--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -18,25 +18,25 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 from services.credential_read import load_imported_credential
-from services.credential_write import delete_credential_from_unified, mirror_credential_to_unified
+from services.credential_write import delete_credential_from_vault, mirror_credential_to_vault
 
 logger = get_logger(__name__)
 
 # Feature flags (expand/contract cutover — #10088 Task 3c-2), both default off → behaviour
-# is byte-identical to before. READ: reads try the unified envelope store first (matching the
+# is byte-identical to before. READ: reads try the vault envelope store first (matching the
 # legacy id via the ``imported_from_sqlite`` marker) and fall back to SQLite. WRITE: every
-# write also best-effort mirrors into the unified store (SQLite stays canonical). The two are
-# independent so dual-write can be enabled first to populate the unified store, then read.
-UNIFIED_READ_ENV = "AUTOBOT_SECRETS_UNIFIED_READ"
-UNIFIED_WRITE_ENV = "AUTOBOT_SECRETS_UNIFIED_WRITE"
+# write also best-effort mirrors into the vault store (SQLite stays canonical). The two are
+# independent so dual-write can be enabled first to populate the vault store, then read.
+VAULT_READ_ENV = "AUTOBOT_SECRETS_UNIFIED_READ"
+VAULT_WRITE_ENV = "AUTOBOT_SECRETS_UNIFIED_WRITE"
 
 
-def _unified_read_enabled() -> bool:
-    return os.environ.get(UNIFIED_READ_ENV, "false").strip().lower() in ("1", "true", "yes")
+def _vault_read_enabled() -> bool:
+    return os.environ.get(VAULT_READ_ENV, "false").strip().lower() in ("1", "true", "yes")
 
 
-def _unified_write_enabled() -> bool:
-    return os.environ.get(UNIFIED_WRITE_ENV, "false").strip().lower() in ("1", "true", "yes")
+def _vault_write_enabled() -> bool:
+    return os.environ.get(VAULT_WRITE_ENV, "false").strip().lower() in ("1", "true", "yes")
 
 
 _AUTH_TYPE_TO_SECRET_TYPE: dict = {
@@ -97,8 +97,8 @@ class ConnectorCredentialStore:
                 created_by=owner_id,
             ),
         )
-        if _unified_write_enabled():
-            await mirror_credential_to_unified(result["id"], owner_id, value, name=name, secret_type=secret_type)
+        if _vault_write_enabled():
+            await mirror_credential_to_vault(result["id"], owner_id, value, name=name, secret_type=secret_type)
         return result["id"], sanitized
 
     async def load(
@@ -113,11 +113,11 @@ class ConnectorCredentialStore:
         Raises PermissionError when owner_id does not match the stored secret.
         Raises LookupError when secret_id is not found or has expired.
 
-        When the unified-read flag is on, the unified envelope store is tried first
+        When the vault-read flag is on, the vault envelope store is tried first
         (by the legacy-id marker) and the SQLite store is the fallback.
         """
         secret = None
-        if _unified_read_enabled():
+        if _vault_read_enabled():
             secret = await load_imported_credential(secret_id, owner_id)
         if secret is None:
             secret = await asyncio.get_running_loop().run_in_executor(
@@ -167,8 +167,8 @@ class ConnectorCredentialStore:
                 updated_by=owner_id,
             ),
         )
-        if _unified_write_enabled():
-            await mirror_credential_to_unified(secret_id, owner_id, new_value)
+        if _vault_write_enabled():
+            await mirror_credential_to_vault(secret_id, owner_id, new_value)
 
     async def revoke(self, secret_id: str, owner_id: str) -> None:
         """Delete the secret. Called on connector delete."""
@@ -179,8 +179,8 @@ class ConnectorCredentialStore:
                 deleted_by=owner_id,
             ),
         )
-        if _unified_write_enabled():
-            await delete_credential_from_unified(secret_id, owner_id)
+        if _vault_write_enabled():
+            await delete_credential_from_vault(secret_id, owner_id)
 
     # ------------------------------------------------------------------
     # OAuth 2.0 authorization-code tokens (ADR-007 §7 / GH#9019)
@@ -217,8 +217,8 @@ class ConnectorCredentialStore:
                 metadata={"provider": provider, "connector_id": connector_id},
             ),
         )
-        if _unified_write_enabled():
-            await mirror_credential_to_unified(
+        if _vault_write_enabled():
+            await mirror_credential_to_vault(
                 result["id"],
                 owner_id,
                 value,
@@ -275,8 +275,8 @@ class ConnectorCredentialStore:
                 updated_by=owner_id,
             ),
         )
-        if _unified_write_enabled():
-            await mirror_credential_to_unified(secret_id, owner_id, value)
+        if _vault_write_enabled():
+            await mirror_credential_to_vault(secret_id, owner_id, value)
         return creds["access_token"]
 
     # ------------------------------------------------------------------

--- a/autobot-backend/services/credential_write.py
+++ b/autobot-backend/services/credential_write.py
@@ -104,10 +104,8 @@ def _root_key_or_none():
         return None  # envelope store not configured on this deployment
 
 
-async def mirror_credential_to_unified(
-    sqlite_id: str, owner_id: str, value: str, *, name=None, secret_type=None
-) -> None:
-    """Best-effort upsert of a credential's envelope copy. Never raises."""
+async def mirror_credential_to_vault(sqlite_id: str, owner_id: str, value: str, *, name=None, secret_type=None) -> None:
+    """Best-effort upsert of a credential's envelope vault copy. Never raises."""
     try:
         root_key = _root_key_or_none()
         if root_key is None:
@@ -121,8 +119,8 @@ async def mirror_credential_to_unified(
         logger.warning("Envelope mirror failed for credential %s (owner %s): %s", sqlite_id, owner_id, exc)
 
 
-async def delete_credential_from_unified(sqlite_id: str, owner_id: str) -> None:
-    """Best-effort delete of a credential's envelope copy by marker. Never raises.
+async def delete_credential_from_vault(sqlite_id: str, owner_id: str) -> None:
+    """Best-effort delete of a credential's envelope vault copy by marker. Never raises.
 
     Logged at ERROR (not WARNING): a swallowed delete leaves an active envelope copy of a
     credential already revoked in SQLite, which read-first would serve — see #10088 (the

--- a/autobot-backend/services/sqlite_secrets_importer.py
+++ b/autobot-backend/services/sqlite_secrets_importer.py
@@ -75,8 +75,8 @@ async def _existing_markers(session: AsyncSession) -> set[str]:
     return {r for r in rows if r}
 
 
-def _build_unified(row: dict, plaintext: bytes, owner: uuid.UUID, root_key: bytes) -> tuple[Secret, SecretGrant]:
-    """Seal *plaintext* and build the new unified Secret + owner grant for a legacy SQLite row."""
+def _build_secret_grant(row: dict, plaintext: bytes, owner: uuid.UUID, root_key: bytes) -> tuple[Secret, SecretGrant]:
+    """Seal *plaintext* and build the new vault Secret + owner grant for a legacy SQLite row."""
     new_id = uuid.uuid4()
     sid = str(new_id)
     vault = VaultRef(VaultKind.USER, str(owner))
@@ -140,7 +140,7 @@ async def import_sqlite_secrets(
             # Per-row SAVEPOINT so one bad row (FK/unique violation, or dirty data
             # that overflows a PG column → DataError) is reported without aborting the batch.
             async with session.begin_nested():
-                secret, grant = _build_unified(row, plaintext, owner, root_key)
+                secret, grant = _build_secret_grant(row, plaintext, owner, root_key)
                 session.add(secret)
                 session.add(grant)
                 await session.flush()

--- a/autobot-backend/tests/migrations/test_credential_reconcile.py
+++ b/autobot-backend/tests/migrations/test_credential_reconcile.py
@@ -52,7 +52,7 @@ async def session(fresh_db_url):
     await engine.dispose()
 
 
-async def _seed_unified(session, marker: str, value: str):
+async def _seed_vault(session, marker: str, value: str):
     svc = EnvelopeSecretsService(root_key=_ROOT)
     secret = await svc.create(
         session,
@@ -82,10 +82,10 @@ async def test_reconcile_fixes_drift(session, tmp_path):
             # "orphan" deliberately absent from SQLite
         ],
     )
-    await _seed_unified(session, "rev", "x")
-    await _seed_unified(session, "drift", "old")
-    await _seed_unified(session, "ok", "same")
-    await _seed_unified(session, "orphan", "y")
+    await _seed_vault(session, "rev", "x")
+    await _seed_vault(session, "drift", "old")
+    await _seed_vault(session, "ok", "same")
+    await _seed_vault(session, "orphan", "y")
     await session.commit()
 
     report = await reconcile_connector_credentials(session, sqlite_path=db, fernet=_FERNET, root_key=_ROOT)
@@ -101,7 +101,7 @@ async def test_reconcile_fixes_drift(session, tmp_path):
 
 async def test_reconcile_aborts_when_sqlite_missing(session, tmp_path):
     # No SQLite file → must abort and delete NOTHING (a missing canonical store is not "all revoked").
-    await _seed_unified(session, "keep", "v")
+    await _seed_vault(session, "keep", "v")
     await session.commit()
     report = await reconcile_connector_credentials(
         session, sqlite_path=str(tmp_path / "nope.db"), fernet=_FERNET, root_key=_ROOT
@@ -116,7 +116,7 @@ async def test_reconcile_aborts_on_empty_canonical_table(session, tmp_path):
     # a populated mirror against an empty canonical store must abort, never mass-delete.
     db = str(tmp_path / "secrets.db")
     _make_db(db, [])  # table exists, zero rows
-    await _seed_unified(session, "keep", "v")
+    await _seed_vault(session, "keep", "v")
     await session.commit()
     report = await reconcile_connector_credentials(session, sqlite_path=db, fernet=_FERNET, root_key=_ROOT)
     await session.commit()
@@ -128,8 +128,8 @@ async def test_reconcile_aborts_on_total_wipe(session, tmp_path):
     # Canonical has other secrets but every mirrored copy is revoked → "delete all" is suspicious → abort.
     db = str(tmp_path / "secrets.db")
     _make_db(db, [{"id": "rev1", "active": 0, "value": "a"}, {"id": "rev2", "active": 0, "value": "b"}])
-    await _seed_unified(session, "rev1", "a")
-    await _seed_unified(session, "rev2", "b")
+    await _seed_vault(session, "rev1", "a")
+    await _seed_vault(session, "rev2", "b")
     await session.commit()
     report = await reconcile_connector_credentials(session, sqlite_path=db, fernet=_FERNET, root_key=_ROOT)
     await session.commit()

--- a/autobot-backend/tests/unit/knowledge/connectors/test_credential_store_unified_read.py
+++ b/autobot-backend/tests/unit/knowledge/connectors/test_credential_store_unified_read.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Routing tests for the ConnectorCredentialStore unified-read flag (#10088 / Task 3c-2).
+"""Routing tests for the ConnectorCredentialStore vault-read flag (#10088 / Task 3c-2).
 
 Verifies the expand-phase feature flag: off → SQLite only (byte-identical to before);
-on → unified store first with SQLite fallback. The unified core itself is exercised
+on → vault envelope store first with SQLite fallback. The vault core itself is exercised
 against Postgres in tests/migrations/test_credential_store_unified_read.py.
 """
 
@@ -28,21 +28,21 @@ class _FakeSvc:
 
 
 def test_flag_parsing(monkeypatch):
-    monkeypatch.delenv(cs.UNIFIED_READ_ENV, raising=False)
-    assert cs._unified_read_enabled() is False
+    monkeypatch.delenv(cs.VAULT_READ_ENV, raising=False)
+    assert cs._vault_read_enabled() is False
     for v in ("true", "1", "YES", " True "):
-        monkeypatch.setenv(cs.UNIFIED_READ_ENV, v)
-        assert cs._unified_read_enabled() is True
+        monkeypatch.setenv(cs.VAULT_READ_ENV, v)
+        assert cs._vault_read_enabled() is True
     for v in ("false", "0", "", "nope"):
-        monkeypatch.setenv(cs.UNIFIED_READ_ENV, v)
-        assert cs._unified_read_enabled() is False
+        monkeypatch.setenv(cs.VAULT_READ_ENV, v)
+        assert cs._vault_read_enabled() is False
 
 
 async def test_load_flag_off_uses_sqlite_only(monkeypatch):
-    monkeypatch.setattr(cs, "_unified_read_enabled", lambda: False)
+    monkeypatch.setattr(cs, "_vault_read_enabled", lambda: False)
 
     async def _boom(*a, **k):
-        raise AssertionError("unified path must not be consulted when flag is off")
+        raise AssertionError("vault path must not be consulted when flag is off")
 
     monkeypatch.setattr(cs, "load_imported_credential", _boom)
     svc = _FakeSvc({"created_by": "u1", "value": json.dumps({"token": "sqlite"})})
@@ -50,20 +50,20 @@ async def test_load_flag_off_uses_sqlite_only(monkeypatch):
     assert out == {"host": "h", "token": "sqlite"} and svc.get_calls == 1
 
 
-async def test_load_flag_on_prefers_unified(monkeypatch):
-    monkeypatch.setattr(cs, "_unified_read_enabled", lambda: True)
+async def test_load_flag_on_prefers_vault(monkeypatch):
+    monkeypatch.setattr(cs, "_vault_read_enabled", lambda: True)
 
-    async def _unified(secret_id, owner_id):
-        return {"created_by": owner_id, "value": json.dumps({"token": "unified"})}
+    async def _vault(secret_id, owner_id):
+        return {"created_by": owner_id, "value": json.dumps({"token": "vault"})}
 
-    monkeypatch.setattr(cs, "load_imported_credential", _unified)
+    monkeypatch.setattr(cs, "load_imported_credential", _vault)
     svc = _FakeSvc({"created_by": "u1", "value": json.dumps({"token": "sqlite"})})
     out = await ConnectorCredentialStore(svc).load("sid", {"host": "h"}, object, "u1")
-    assert out == {"host": "h", "token": "unified"} and svc.get_calls == 0  # SQLite untouched
+    assert out == {"host": "h", "token": "vault"} and svc.get_calls == 0  # SQLite untouched
 
 
 async def test_load_flag_on_falls_back_when_not_imported(monkeypatch):
-    monkeypatch.setattr(cs, "_unified_read_enabled", lambda: True)
+    monkeypatch.setattr(cs, "_vault_read_enabled", lambda: True)
 
     async def _none(secret_id, owner_id):
         return None

--- a/autobot-backend/tests/unit/knowledge/connectors/test_credential_store_unified_write.py
+++ b/autobot-backend/tests/unit/knowledge/connectors/test_credential_store_unified_write.py
@@ -4,8 +4,8 @@
 # Author: mrveiss
 """Routing tests for the ConnectorCredentialStore dual-write flag (#10088 / Task 3c-2).
 
-Verifies the expand-phase write flag: off → no unified mirror (byte-identical to before);
-on → each write also mirrors/deletes in the unified store. The mirror core itself is
+Verifies the expand-phase write flag: off → no vault mirror (byte-identical to before);
+on → each write also mirrors/deletes in the vault store. The mirror core itself is
 exercised against Postgres in tests/migrations/test_credential_mirror.py.
 """
 
@@ -34,57 +34,57 @@ class _FakeSvc:
 
 
 def test_write_flag_parsing(monkeypatch):
-    monkeypatch.delenv(cs.UNIFIED_WRITE_ENV, raising=False)
-    assert cs._unified_write_enabled() is False
-    monkeypatch.setenv(cs.UNIFIED_WRITE_ENV, "true")
-    assert cs._unified_write_enabled() is True
-    monkeypatch.setenv(cs.UNIFIED_WRITE_ENV, "0")
-    assert cs._unified_write_enabled() is False
+    monkeypatch.delenv(cs.VAULT_WRITE_ENV, raising=False)
+    assert cs._vault_write_enabled() is False
+    monkeypatch.setenv(cs.VAULT_WRITE_ENV, "true")
+    assert cs._vault_write_enabled() is True
+    monkeypatch.setenv(cs.VAULT_WRITE_ENV, "0")
+    assert cs._vault_write_enabled() is False
 
 
 async def test_store_flag_off_no_mirror(monkeypatch):
-    monkeypatch.setattr(cs, "_unified_write_enabled", lambda: False)
+    monkeypatch.setattr(cs, "_vault_write_enabled", lambda: False)
     calls = []
 
     async def _m(*a, **k):
         calls.append(a)
 
-    monkeypatch.setattr(cs, "mirror_credential_to_unified", _m)
+    monkeypatch.setattr(cs, "mirror_credential_to_vault", _m)
     sid, sanitized = await ConnectorCredentialStore(_FakeSvc()).store("c1", "u1", _Auth, {"token": "t", "host": "h"})
     assert sid == "sid-1" and sanitized == {"host": "h"} and calls == []
 
 
 async def test_store_flag_on_mirrors_with_name(monkeypatch):
-    monkeypatch.setattr(cs, "_unified_write_enabled", lambda: True)
+    monkeypatch.setattr(cs, "_vault_write_enabled", lambda: True)
     calls = []
 
     async def _m(sqlite_id, owner_id, value, *, name=None, secret_type=None):
         calls.append((sqlite_id, owner_id, name, json.loads(value)))
 
-    monkeypatch.setattr(cs, "mirror_credential_to_unified", _m)
+    monkeypatch.setattr(cs, "mirror_credential_to_vault", _m)
     await ConnectorCredentialStore(_FakeSvc()).store("c1", "u1", _Auth, {"token": "t", "host": "h"})
     assert calls == [("sid-1", "u1", "connector:c1:auth", {"token": "t"})]  # only the sensitive field
 
 
 async def test_rotate_flag_on_mirrors_update(monkeypatch):
-    monkeypatch.setattr(cs, "_unified_write_enabled", lambda: True)
+    monkeypatch.setattr(cs, "_vault_write_enabled", lambda: True)
     calls = []
 
     async def _m(sqlite_id, owner_id, value, *, name=None, secret_type=None):
         calls.append((sqlite_id, owner_id, name, json.loads(value)))
 
-    monkeypatch.setattr(cs, "mirror_credential_to_unified", _m)
+    monkeypatch.setattr(cs, "mirror_credential_to_vault", _m)
     await ConnectorCredentialStore(_FakeSvc()).rotate("sid-9", {"token": "new"}, "u1")
     assert calls == [("sid-9", "u1", None, {"token": "new"})]  # update path → no name
 
 
 async def test_revoke_flag_on_deletes(monkeypatch):
-    monkeypatch.setattr(cs, "_unified_write_enabled", lambda: True)
+    monkeypatch.setattr(cs, "_vault_write_enabled", lambda: True)
     calls = []
 
     async def _d(sqlite_id, owner_id):
         calls.append((sqlite_id, owner_id))
 
-    monkeypatch.setattr(cs, "delete_credential_from_unified", _d)
+    monkeypatch.setattr(cs, "delete_credential_from_vault", _d)
     await ConnectorCredentialStore(_FakeSvc()).revoke("sid-9", "u1")
     assert calls == [("sid-9", "u1")]


### PR DESCRIPTION
## Thinking Path

Batch B8 of umbrella #10746: eliminate infix `unified` from the credential/secrets helpers. Owner decision: use `vault`/`secrets` (the named store), not a bare strip.

Identified 5 production entities + 1 test helper to rename. Collision-checked all targets — zero collisions in the codebase. Env var *values* (`AUTOBOT_SECRETS_UNIFIED_READ`, `AUTOBOT_SECRETS_UNIFIED_WRITE`) are external interface and preserved unchanged; only the Python constant *names* change.

## What Changed

**`autobot-backend/services/credential_write.py`**
- `mirror_credential_to_unified` → `mirror_credential_to_vault`
- `delete_credential_from_unified` → `delete_credential_from_vault`

**`autobot-backend/knowledge/connectors/credential_store.py`**
- `UNIFIED_READ_ENV` → `VAULT_READ_ENV` (value unchanged: `"AUTOBOT_SECRETS_UNIFIED_READ"`)
- `UNIFIED_WRITE_ENV` → `VAULT_WRITE_ENV` (value unchanged: `"AUTOBOT_SECRETS_UNIFIED_WRITE"`)
- `_unified_read_enabled` → `_vault_read_enabled`
- `_unified_write_enabled` → `_vault_write_enabled`
- Import + 6 call-sites updated atomically

**`autobot-backend/services/sqlite_secrets_importer.py`**
- `_build_unified` → `_build_secret_grant` (descriptive per plan)

**`autobot-backend/tests/migrations/test_credential_reconcile.py`**
- `_seed_unified` → `_seed_vault` (all 8 call-sites)

**`autobot-backend/tests/unit/knowledge/connectors/test_credential_store_unified_read.py`**
- `UNIFIED_READ_ENV` → `VAULT_READ_ENV`, `_unified_read_enabled` → `_vault_read_enabled`
- `test_load_flag_on_prefers_unified` → `test_load_flag_on_prefers_vault`

**`autobot-backend/tests/unit/knowledge/connectors/test_credential_store_unified_write.py`**
- `UNIFIED_WRITE_ENV` → `VAULT_WRITE_ENV`, `_unified_write_enabled` → `_vault_write_enabled`
- `mirror_credential_to_unified` → `mirror_credential_to_vault`, `delete_credential_from_unified` → `delete_credential_from_vault`

## Verification

**Zero-grep proof** (B8 infix names in autobot-backend, excluding __pycache__):
```
grep -rn "mirror_credential_to_unified|delete_credential_from_unified|_unified_read_enabled|_unified_write_enabled|_build_unified|_seed_unified|UNIFIED_READ_ENV|UNIFIED_WRITE_ENV" --include="*.py" autobot-backend/
# → 0 hits (only analytics_reporting._build_unified_report_response remains — B6 scope)
```

**Security preservation**: Every owner-mismatch PermissionError check, LookupError guard, best-effort swallow (mirror failure logged at WARNING, delete failure at ERROR), and access-control path is byte-identical — only Python identifiers changed.

**flake8**: clean on all 6 changed files.

**Black** (`--line-length=120`): reformatted `credential_write.py` (function sig folded to 1 line); others unchanged.

**Line lengths**: `awk 'length>120'` empty on all changed files.

**Tests**: `pytest tests/test_startup_imports.py -q` → 339/339 passed; `pytest tests/unit/knowledge/connectors/test_credential_store_unified_read.py tests/unit/knowledge/connectors/test_credential_store_unified_write.py -v` → 9/9 passed.

Part of #10746

## Model Used

claude-sonnet-4-6