### PR TITLE
fix(llc): migration 065 — create 8 missing feature tables (#10750 A2)

### DIFF
--- a/autobot-backend/migrations/versions/20260630_065_llc_missing_feature_tables.py
+++ b/autobot-backend/migrations/versions/20260630_065_llc_missing_feature_tables.py
@@ -1,0 +1,530 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Create 8 LLC feature tables missing from the live DB (#10750 A2).
+
+The following tables are declared in ORM models (and/or raw-SQL services) but
+were never reachable via the canonical Alembic chain — they only existed in the
+orphaned ``database/migrations/`` chain which was never applied:
+
+  llc_labels                 — per-company label definitions
+  llc_work_item_labels       — M:N join: work items ↔ labels
+  llc_work_item_attachments  — file attachment metadata for work items
+  llc_ceo_chat_threads       — one CEO Chat thread per decision/conversation
+  llc_ceo_chat_messages      — ordered messages within a CEO Chat thread
+  llc_template_library       — platform-level template index
+  llc_template_tags          — join: templates ↔ tags
+  llc_kb_collections         — ChromaDB collection lifecycle registry
+
+Without these tables every request that touches labels, attachments, CEO-chat,
+custom templates, or the KB-collection registry raises
+``UndefinedTableError`` (500 on those endpoints).
+
+Source of truth for columns/types/FKs/indexes:
+  - ORM models in ``llc/models/`` (label, attachment, ceo_chat)
+  - Raw-SQL service code (template.py) + orphaned DDL (005_create_llc_template_library.py)
+  - Orphaned DDL (004_create_llc_kb_collections_table.py) for llc_kb_collections
+
+``user_management.models.base.Base`` adds implicit ``created_at``/``updated_at``
+to every ORM model.  Tables whose models do NOT explicitly re-declare
+``updated_at`` still have the column (from Base) — migration 063 already
+adds it to existing tables via ``ADD COLUMN IF NOT EXISTS``; this migration
+creates the new tables with the column included from the start to keep the
+ORM fully satisfied.
+
+Idempotent: every ``op.create_table`` is guarded by ``has_table``.
+No PostgreSQL ENUM types are needed (all status/category columns use VARCHAR).
+
+Revision ID: 20260630_065
+Revises: 20260630_064
+Create Date: 2026-06-30
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from migrations.guards import has_table
+
+# ---------------------------------------------------------------------------
+# Revision identifiers
+# ---------------------------------------------------------------------------
+
+revision: str = "20260630_065"
+down_revision: Union[str, None] = "20260630_064"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# ---------------------------------------------------------------------------
+# upgrade
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. llc_labels
+    #    Source: llc/models/label.py :: LLCLabel
+    #    Columns: id, company_id, name, color, description,
+    #             created_at (explicit override of Base),
+    #             created_by,
+    #             updated_at (from Base — not explicitly in model but ORM maps it)
+    #    Constraints: PK(id), UQ(company_id, name)
+    #    Indexes: ix_llc_labels_company_id
+    #    Note: orphaned 005_create_llc_labels_tables.py omits updated_at;
+    #          we add it here so migration 063 ADD COLUMN IF NOT EXISTS is a no-op.
+    # ------------------------------------------------------------------
+    if not has_table("llc_labels"):
+        op.create_table(
+            "llc_labels",
+            sa.Column(
+                "id",
+                UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column("company_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("name", sa.String(128), nullable=False),
+            sa.Column("color", sa.String(7), nullable=False),
+            sa.Column("description", sa.Text, nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column("created_by", sa.String(255), nullable=True),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.UniqueConstraint("company_id", "name", name="uq_llc_labels_company_name"),
+        )
+        op.create_index("ix_llc_labels_company_id", "llc_labels", ["company_id"])
+
+    # ------------------------------------------------------------------
+    # 2. llc_work_item_labels
+    #    Source: llc/models/label.py :: LLCWorkItemLabel
+    #    Columns: work_item_id, label_id, assigned_at, assigned_by
+    #             created_at, updated_at (from Base)
+    #    Constraints: PK(work_item_id, label_id), UQ(work_item_id, label_id)
+    #                 FK work_item_id → llc_work_items.id CASCADE
+    #                 FK label_id → llc_labels.id CASCADE
+    #    Note: the model's PK is composite (work_item_id, label_id) which
+    #          makes the UQ redundant but we declare it to match the ORM.
+    # ------------------------------------------------------------------
+    if not has_table("llc_work_item_labels"):
+        op.create_table(
+            "llc_work_item_labels",
+            sa.Column(
+                "work_item_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("llc_work_items.id", ondelete="CASCADE"),
+                primary_key=True,
+                nullable=False,
+            ),
+            sa.Column(
+                "label_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("llc_labels.id", ondelete="CASCADE"),
+                primary_key=True,
+                nullable=False,
+            ),
+            sa.Column(
+                "assigned_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column("assigned_by", sa.String(255), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.UniqueConstraint("work_item_id", "label_id", name="uq_llc_work_item_labels"),
+        )
+
+    # ------------------------------------------------------------------
+    # 3. llc_work_item_attachments
+    #    Source: llc/models/attachment.py :: LLCWorkItemAttachment
+    #    Columns: id, company_id, work_item_id, uploaded_by_agent_id,
+    #             uploaded_by_user_id, filename, content_type, size_bytes,
+    #             storage_path, text_extracted, extracted_text,
+    #             created_at (explicit override),
+    #             updated_at (from Base)
+    #    Indexes: ix_llc_work_item_attachments_company_id,
+    #             ix_llc_work_item_attachments_work_item_id
+    # ------------------------------------------------------------------
+    if not has_table("llc_work_item_attachments"):
+        op.create_table(
+            "llc_work_item_attachments",
+            sa.Column(
+                "id",
+                UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column("company_id", UUID(as_uuid=True), nullable=False),
+            sa.Column(
+                "work_item_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("llc_work_items.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("uploaded_by_agent_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("uploaded_by_user_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("filename", sa.Text, nullable=False),
+            sa.Column("content_type", sa.Text, nullable=False),
+            sa.Column("size_bytes", sa.Integer, nullable=False),
+            sa.Column("storage_path", sa.Text, nullable=False),
+            sa.Column(
+                "text_extracted",
+                sa.Boolean,
+                nullable=False,
+                server_default=sa.text("false"),
+            ),
+            sa.Column("extracted_text", sa.Text, nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+        op.create_index(
+            "ix_llc_work_item_attachments_company_id",
+            "llc_work_item_attachments",
+            ["company_id"],
+        )
+        op.create_index(
+            "ix_llc_work_item_attachments_work_item_id",
+            "llc_work_item_attachments",
+            ["work_item_id"],
+        )
+
+    # ------------------------------------------------------------------
+    # 4. llc_ceo_chat_threads
+    #    Source: llc/models/ceo_chat.py :: LLCCeoChatThread
+    #    Columns: id, company_id, title, resolved_entity_type,
+    #             resolved_entity_id, created_by_user_id, created_at, updated_at
+    #    Indexes: ix_llc_ceo_chat_threads_company_id,
+    #             ix_llc_ceo_chat_threads_created_by_user_id
+    #    FK: created_by_user_id → users.id SET NULL
+    # ------------------------------------------------------------------
+    if not has_table("llc_ceo_chat_threads"):
+        op.create_table(
+            "llc_ceo_chat_threads",
+            sa.Column(
+                "id",
+                UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column("company_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("title", sa.Text, nullable=False),
+            sa.Column("resolved_entity_type", sa.Text, nullable=True),
+            sa.Column("resolved_entity_id", UUID(as_uuid=True), nullable=True),
+            sa.Column(
+                "created_by_user_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("users.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+        )
+        op.create_index(
+            "ix_llc_ceo_chat_threads_company_id",
+            "llc_ceo_chat_threads",
+            ["company_id"],
+        )
+        op.create_index(
+            "ix_llc_ceo_chat_threads_created_by_user_id",
+            "llc_ceo_chat_threads",
+            ["created_by_user_id"],
+        )
+
+    # ------------------------------------------------------------------
+    # 5. llc_ceo_chat_messages
+    #    Source: llc/models/ceo_chat.py :: LLCCeoChatMessage
+    #    Columns: id, thread_id, author_type, author_user_id, body,
+    #             created_at (explicit override),
+    #             updated_at (from Base)
+    #    FK: thread_id → llc_ceo_chat_threads.id CASCADE
+    #        author_user_id → users.id SET NULL
+    #    Indexes: ix_llc_ceo_chat_messages_thread_id
+    # ------------------------------------------------------------------
+    if not has_table("llc_ceo_chat_messages"):
+        op.create_table(
+            "llc_ceo_chat_messages",
+            sa.Column(
+                "id",
+                UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column(
+                "thread_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("llc_ceo_chat_threads.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("author_type", sa.String(16), nullable=False),
+            sa.Column(
+                "author_user_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("users.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("body", sa.Text, nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+        op.create_index(
+            "ix_llc_ceo_chat_messages_thread_id",
+            "llc_ceo_chat_messages",
+            ["thread_id"],
+        )
+
+    # ------------------------------------------------------------------
+    # 6. llc_template_library
+    #    Source: orphaned 005_create_llc_template_library.py + services/template.py
+    #    No SQLAlchemy ORM model exists — service uses raw SQL exclusively.
+    #    Columns match the SQL INSERT/SELECT in template.py:
+    #      id, name, description, category, template_json,
+    #      created_by_company_id, is_public, usage_count,
+    #      source_template_id, created_at, updated_at
+    #    Indexes: ix_llc_template_library_category,
+    #             ix_llc_template_library_is_public,
+    #             ix_llc_template_library_created_by,
+    #             ix_llc_template_library_created_at
+    # ------------------------------------------------------------------
+    if not has_table("llc_template_library"):
+        op.create_table(
+            "llc_template_library",
+            sa.Column(
+                "id",
+                UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column("name", sa.String(256), nullable=False),
+            sa.Column("description", sa.Text, nullable=True),
+            sa.Column(
+                "category",
+                sa.String(50),
+                nullable=False,
+                comment="company | project | agent_role | workflow",
+            ),
+            sa.Column(
+                "template_json",
+                JSONB,
+                nullable=False,
+                comment="Scrubbed export JSON — no raw secrets",
+            ),
+            sa.Column(
+                "created_by_company_id",
+                UUID(as_uuid=True),
+                nullable=True,
+                comment="Owning company; null for platform-seeded templates",
+            ),
+            sa.Column(
+                "is_public",
+                sa.Boolean,
+                nullable=False,
+                server_default="false",
+                comment="Public templates visible to all companies",
+            ),
+            sa.Column(
+                "usage_count",
+                sa.Integer,
+                nullable=False,
+                server_default="0",
+                comment="Incremented on each successful import",
+            ),
+            sa.Column(
+                "source_template_id",
+                UUID(as_uuid=True),
+                nullable=True,
+                comment="Provenance: set when imported from another template",
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+        op.create_index(
+            "ix_llc_template_library_category",
+            "llc_template_library",
+            ["category"],
+        )
+        op.create_index(
+            "ix_llc_template_library_is_public",
+            "llc_template_library",
+            ["is_public"],
+        )
+        op.create_index(
+            "ix_llc_template_library_created_by",
+            "llc_template_library",
+            ["created_by_company_id"],
+        )
+        op.create_index(
+            "ix_llc_template_library_created_at",
+            "llc_template_library",
+            ["created_at"],
+        )
+
+    # ------------------------------------------------------------------
+    # 7. llc_template_tags
+    #    Source: orphaned 005_create_llc_template_library.py + _upsert_tags() in template.py
+    #    No ORM model — service uses raw SQL.
+    #    Columns: template_id (PK+FK), tag (PK)
+    #    FK: template_id → llc_template_library.id CASCADE
+    #    Index: ix_llc_template_tags_tag
+    # ------------------------------------------------------------------
+    if not has_table("llc_template_tags"):
+        op.create_table(
+            "llc_template_tags",
+            sa.Column(
+                "template_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("llc_template_library.id", ondelete="CASCADE"),
+                primary_key=True,
+                nullable=False,
+            ),
+            sa.Column(
+                "tag",
+                sa.String(100),
+                primary_key=True,
+                nullable=False,
+            ),
+        )
+        op.create_index(
+            "ix_llc_template_tags_tag",
+            "llc_template_tags",
+            ["tag"],
+        )
+
+    # ------------------------------------------------------------------
+    # 8. llc_kb_collections
+    #    Source: orphaned 004_create_llc_kb_collections_table.py
+    #    No ORM model — KbCollectionManager uses ChromaDB directly;
+    #    this table is the Postgres-side lifecycle registry.
+    #    Columns: id, collection_name (UNIQUE), entity_type, entity_id,
+    #             status, created_at, archived_at
+    #    Indexes: ix_llc_kb_collections_entity (entity_type, entity_id),
+    #             ix_llc_kb_collections_status,
+    #             ix_llc_kb_collections_created_at
+    # ------------------------------------------------------------------
+    if not has_table("llc_kb_collections"):
+        op.create_table(
+            "llc_kb_collections",
+            sa.Column(
+                "id",
+                UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column(
+                "collection_name",
+                sa.String(512),
+                nullable=False,
+                unique=True,
+                comment="ChromaDB collection name (entity_type:entity_id[:suffix])",
+            ),
+            sa.Column(
+                "entity_type",
+                sa.String(50),
+                nullable=False,
+                comment="Type: company, project, sprint, work_item, agent",
+            ),
+            sa.Column("entity_id", UUID(as_uuid=True), nullable=False),
+            sa.Column(
+                "status",
+                sa.String(20),
+                nullable=False,
+                server_default="active",
+                comment="active or archived",
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.create_index(
+            "ix_llc_kb_collections_entity",
+            "llc_kb_collections",
+            ["entity_type", "entity_id"],
+        )
+        op.create_index(
+            "ix_llc_kb_collections_status",
+            "llc_kb_collections",
+            ["status"],
+        )
+        op.create_index(
+            "ix_llc_kb_collections_created_at",
+            "llc_kb_collections",
+            ["created_at"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# downgrade — forward-only, consistent with 063/064
+# ---------------------------------------------------------------------------
+
+
+def downgrade() -> None:
+    # Forward-only: dropping these tables re-breaks every endpoint that
+    # touches labels, attachments, CEO-chat, templates, and KB collections.
+    # Consistent with the forward-only approach used in 063 and 064.
+    pass


### PR DESCRIPTION
## Thinking Path

1. Confirmed current Alembic head is `20260630_064` by listing `migrations/versions/`.
2. Discovered `llc_template_library`, `llc_template_tags`, and `llc_kb_collections` have **no SQLAlchemy ORM model** — the template service uses raw SQL; authoritative schema comes from the orphaned DDL scripts + service SQL.
3. For ORM-backed tables (`llc_labels`, `llc_work_item_labels`, `llc_work_item_attachments`, `llc_ceo_chat_threads`, `llc_ceo_chat_messages`): read each model file, matched every `mapped_column` to a migration column.
4. Discovered `user_management.models.base.Base` implicitly adds `created_at` + `updated_at` to **every** model. Orphaned scripts omitted `updated_at` — this migration includes it so migration 063's `ADD COLUMN IF NOT EXISTS` is a no-op on fresh DBs.
5. FK ordering: `llc_labels` → `llc_work_item_labels`; `llc_work_items` and `users` already exist (migrations 022 and 001). `llc_ceo_chat_threads` → `llc_ceo_chat_messages`; `llc_template_library` → `llc_template_tags`.
6. No Postgres ENUM types needed — all status/category fields use `VARCHAR`.
7. `py_compile` passes. Idempotent via `has_table` guards.

## What Changed

- **New file:** `autobot-backend/migrations/versions/20260630_065_llc_missing_feature_tables.py`
  - `revision = "20260630_065"`, `down_revision = "20260630_064"`
  - Creates 8 tables in FK-safe order: `llc_labels` → `llc_work_item_labels` → `llc_work_item_attachments` → `llc_ceo_chat_threads` → `llc_ceo_chat_messages` → `llc_template_library` → `llc_template_tags` → `llc_kb_collections`
  - Each guarded by `if not has_table(...)` — safe on partial or already-applied DBs
  - Forward-only `downgrade()` (no-op), consistent with 063/064

### Per-table column audit (model → migration)

**llc_labels** (`llc/models/label.py :: LLCLabel`):
| Model column | Migration column |
|---|---|
| id UUID PK gen_random_uuid() | id |
| company_id UUID NOT NULL index | company_id + ix_llc_labels_company_id |
| name String(128) NOT NULL | name |
| color String(7) NOT NULL | color |
| description Text nullable | description |
| created_at DateTime tz NOT NULL | created_at |
| created_by String(255) nullable | created_by |
| updated_at (from Base) | updated_at |
| UQ(company_id, name) | uq_llc_labels_company_name |

Discrepancy vs orphaned 005: orphaned script omitted `updated_at` — migration 065 includes it.

**llc_work_item_labels** (`llc/models/label.py :: LLCWorkItemLabel`):
| Model column | Migration column |
|---|---|
| work_item_id UUID PK FK(llc_work_items CASCADE) | work_item_id |
| label_id UUID PK FK(llc_labels CASCADE) | label_id |
| assigned_at DateTime tz NOT NULL | assigned_at |
| assigned_by String(255) nullable | assigned_by |
| created_at (from Base) | created_at |
| updated_at (from Base) | updated_at |
| UQ(work_item_id, label_id) | uq_llc_work_item_labels |

Discrepancy vs orphaned 005: orphaned script omitted `created_at` and `updated_at` (Base columns) — 065 includes them.

**llc_work_item_attachments** (`llc/models/attachment.py :: LLCWorkItemAttachment`):
| Model column | Migration column |
|---|---|
| id UUID PK | id |
| company_id UUID NOT NULL index | company_id + ix_llc_work_item_attachments_company_id |
| work_item_id UUID NOT NULL FK(CASCADE) index | work_item_id + ix_llc_work_item_attachments_work_item_id |
| uploaded_by_agent_id UUID nullable | uploaded_by_agent_id |
| uploaded_by_user_id UUID nullable | uploaded_by_user_id |
| filename Text NOT NULL | filename |
| content_type Text NOT NULL | content_type |
| size_bytes Integer NOT NULL | size_bytes |
| storage_path Text NOT NULL | storage_path |
| text_extracted Boolean NOT NULL default false | text_extracted |
| extracted_text Text nullable | extracted_text |
| created_at DateTime tz NOT NULL | created_at |
| updated_at (from Base) | updated_at |

Discrepancy vs orphaned 005: orphaned script omitted `updated_at` — 065 includes it.

**llc_ceo_chat_threads** (`llc/models/ceo_chat.py :: LLCCeoChatThread`):
| Model column | Migration column |
|---|---|
| id UUID PK | id |
| company_id UUID NOT NULL index | company_id + ix_llc_ceo_chat_threads_company_id |
| title Text NOT NULL | title |
| resolved_entity_type Text nullable | resolved_entity_type |
| resolved_entity_id UUID nullable | resolved_entity_id |
| created_by_user_id UUID nullable FK(users SET NULL) index | created_by_user_id + ix_llc_ceo_chat_threads_created_by_user_id |
| created_at DateTime tz NOT NULL | created_at |
| updated_at DateTime tz NOT NULL | updated_at |

No orphaned migration existed for this table — model is sole source of truth.

**llc_ceo_chat_messages** (`llc/models/ceo_chat.py :: LLCCeoChatMessage`):
| Model column | Migration column |
|---|---|
| id UUID PK | id |
| thread_id UUID NOT NULL FK(llc_ceo_chat_threads CASCADE) index | thread_id + ix_llc_ceo_chat_messages_thread_id |
| author_type String(16) NOT NULL | author_type |
| author_user_id UUID nullable FK(users SET NULL) | author_user_id |
| body Text NOT NULL | body |
| created_at DateTime tz NOT NULL | created_at |
| updated_at (from Base) | updated_at |

No orphaned migration existed for this table.

**llc_template_library** (no ORM model; raw SQL in `llc/services/template.py`):
Columns sourced from orphaned 005_create_llc_template_library.py + INSERT/SELECT in service:
`id, name, description, category, template_json (JSONB), created_by_company_id, is_public, usage_count, source_template_id, created_at, updated_at`
Indexes: category, is_public, created_by_company_id, created_at.

**llc_template_tags** (no ORM model; raw SQL in `_upsert_tags`):
Columns: `template_id (PK+FK → llc_template_library CASCADE), tag String(100) PK`
Index: ix_llc_template_tags_tag.

**llc_kb_collections** (no ORM model; ChromaDB lifecycle registry):
Columns: `id, collection_name String(512) UNIQUE, entity_type String(50), entity_id UUID, status String(20) default 'active', created_at, archived_at nullable`
Indexes: (entity_type, entity_id), status, created_at.

### Model↔Orphaned-DDL discrepancies
- All three ORM-backed tables had `updated_at` missing from orphaned scripts (Base adds it implicitly) — fixed in 065.
- `llc_work_item_labels` orphaned DDL also omitted `created_at` — fixed.
- No orphaned DDL existed for `llc_ceo_chat_threads` or `llc_ceo_chat_messages`.

### FK ordering used
`llc_labels` (no FK to other new tables) → `llc_work_item_labels` (FK → llc_labels + llc_work_items) → `llc_work_item_attachments` (FK → llc_work_items) → `llc_ceo_chat_threads` (FK → users) → `llc_ceo_chat_messages` (FK → llc_ceo_chat_threads + users) → `llc_template_library` (no FK) → `llc_template_tags` (FK → llc_template_library) → `llc_kb_collections` (no FK)

### Enums created
None — all status/category fields use VARCHAR.

## Verification

- `python3 -m py_compile autobot-backend/migrations/versions/20260630_065_llc_missing_feature_tables.py` → **COMPILE OK**
- Column-by-column audit against models above confirms 1:1 match including Base's implicit `updated_at`
- FK targets `llc_work_items` (migration 022) and `users` (migration 001) confirmed present in chain
- `has_table` guard on each of the 8 tables makes re-run safe

## Model Used

claude-sonnet-4-6

Part of #10750 (A2)