### PR TITLE
refactor(agent): B4 — eliminate infix enhanced from api/agent.py handlers + route paths (#10746)

### DIFF
--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -7,10 +7,10 @@ Agent API with basic orchestrator functionality and AI Stack multi-agent integra
 
 This module provides:
 - Basic agent operations (goal execution, pause/resume, command approval)
-- Enhanced AI Stack capabilities (multi-agent coordination, research tasks)
+- AI Stack capabilities (multi-agent coordination, research tasks)
 - Development analysis and optimization features
 
-Consolidated from agent.py and agent_enhanced.py per Issue #708.
+Consolidated from agent.py and the AI Stack agent module per Issue #708.
 """
 
 import asyncio
@@ -60,7 +60,7 @@ logger = get_logger(__name__)
 prometheus_metrics = get_metrics_manager()
 
 # ====================================================================
-# Constants for Enhanced Agent Operations (Issue #708 consolidation)
+# Constants for AI Stack Agent Operations (Issue #708 consolidation)
 # ====================================================================
 
 # Performance optimization: O(1) lookup for coordination keywords (Issue #326)
@@ -885,7 +885,7 @@ async def execute_command(
 
 
 # ====================================================================
-# Enhanced Agent Functions with AI Stack Integration (Issue #708 consolidation)
+# AI Stack Agent Functions (Issue #708 consolidation)
 # ====================================================================
 
 
@@ -967,7 +967,7 @@ async def _enhance_context_with_kb(payload, knowledge_base) -> str | None:
         knowledge_base: Knowledge base instance or None
 
     Returns:
-        Enhanced context string or original context
+        Augmented context string or original context
     """
     if not (payload.use_knowledge_base and knowledge_base):
         return payload.context
@@ -995,24 +995,24 @@ def _determine_coordination_mode(payload, selected_agents: list) -> str:
 
 
 # ====================================================================
-# Enhanced Agent Endpoints (Issue #708 consolidation)
+# AI Stack Agent Endpoints (Issue #708 consolidation)
 # ====================================================================
 
 
-@router.post("/goal/enhanced", response_model=DataResponse[GoalData])
+@router.post("/goal/advanced", response_model=DataResponse[GoalData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="execute_enhanced_goal",
+    operation="execute_goal_advanced",
     error_code_prefix="AGENT",
 )
-async def execute_enhanced_goal(
+async def execute_goal_advanced(
     payload: GoalPayload,
     request: Request,
     config=Depends(get_config),
     knowledge_base=Depends(get_knowledge_base),
     current_user: dict = Depends(get_current_user),
 ):
-    """Execute goal using enhanced AI Stack multi-agent coordination.
+    """Execute goal using AI Stack multi-agent coordination.
 
     Issue #398: refactored.
     Issue #744: Requires authenticated user.
@@ -1029,7 +1029,7 @@ async def execute_enhanced_goal(
 
     # Issue #398: Use extracted helpers
     selected_agents = await _select_agents_for_goal(ai_client, payload, available_agents)
-    enhanced_context = await _enhance_context_with_kb(payload, knowledge_base)
+    kb_context = await _enhance_context_with_kb(payload, knowledge_base)
     coordination_mode = _determine_coordination_mode(payload, selected_agents)
 
     execution_start = time.monotonic()
@@ -1051,14 +1051,14 @@ async def execute_enhanced_goal(
                 "execution_time": execution_time,
                 "priority": payload.priority,
                 "result": result,
-                "enhanced_context_used": enhanced_context is not None,
+                "context_used": kb_context is not None,
                 "knowledge_base_integrated": payload.use_knowledge_base,
                 "timestamp": utc_timestamp(),
             }
         )
 
     except AIStackError as e:
-        await handle_ai_stack_error(e, "Enhanced goal execution")
+        await handle_ai_stack_error(e, "Advanced goal execution")
 
 
 @router.post("/multi-agent/coordinate", response_model=DataResponse[MultiAgentCoordinationData])
@@ -1149,20 +1149,20 @@ async def comprehensive_research_task(
             research_agents.append("npu_code_search")
 
         # Add knowledge base context
-        enhanced_query = request_data.research_query
+        research_query = request_data.research_query
         if knowledge_base:
             try:
                 kb_results = await knowledge_base.search(query=request_data.research_query, top_k=3)
                 if kb_results:
                     kb_context = "\n".join([f"- {item.get('content', '')[:150]}..." for item in kb_results])
-                    enhanced_query = f"{request_data.research_query}\n\nExisting" f"knowledge:\n{kb_context}"
+                    research_query = f"{request_data.research_query}\n\nExisting" f"knowledge:\n{kb_context}"
 
             except Exception as e:
                 logger.warning("KB context failed: %s", e)
 
         # Execute research using multiple agents
         research_result = await ai_client.multi_agent_query(
-            query=enhanced_query, agents=research_agents, coordination_mode="sequential"
+            query=research_query, agents=research_agents, coordination_mode="sequential"
         )
 
         return create_success_response(
@@ -1240,7 +1240,7 @@ async def list_available_agents():
         # Issue #281: Use module-level constant for agent capabilities
         # Combine available agents with capability info
         available_list = agents_info.get("agents", [])
-        enhanced_list = []
+        agents_with_caps = []
 
         for agent in available_list:
             # Get capabilities from module constant, with fallback for unknown agents
@@ -1253,12 +1253,12 @@ async def list_available_agents():
             ).copy()  # Copy to avoid modifying the constant
             agent_info["name"] = agent
             agent_info["status"] = "available"
-            enhanced_list.append(agent_info)
+            agents_with_caps.append(agent_info)
 
         return create_success_response(
             {
-                "total_agents": len(enhanced_list),
-                "agents": enhanced_list,
+                "total_agents": len(agents_with_caps),
+                "agents": agents_with_caps,
                 "coordination_modes": ["parallel", "sequential", "intelligent"],
                 "multi_agent_support": True,
             }
@@ -1304,14 +1304,14 @@ async def get_agents_status():
         await handle_ai_stack_error(e, "Agent status check")
 
 
-@router.get("/health/enhanced", response_model=AgentHealthResponse)
+@router.get("/health/detailed", response_model=AgentHealthResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="agent_health",
     error_code_prefix="AGENT",
 )
 async def agent_health():
-    """Enhanced health check for agent services."""
+    """Detailed health check for agent services."""
     try:
         ai_client = await get_ai_stack_client()
         health_status = await ai_client.health_check()
@@ -1320,7 +1320,7 @@ async def agent_health():
             "status": health_status["status"],
             "ai_stack_available": health_status["status"] == "healthy",
             "multi_agent_coordination": health_status["status"] == "healthy",
-            "enhanced_capabilities": health_status["status"] == "healthy",
+            "advanced_capabilities": health_status["status"] == "healthy",
             "timestamp": utc_timestamp(),
         }
 
@@ -1329,7 +1329,7 @@ async def agent_health():
             "status": "degraded",
             "ai_stack_available": False,
             "multi_agent_coordination": False,
-            "enhanced_capabilities": False,
+            "advanced_capabilities": False,
             "error": "Internal server error",
             "timestamp": utc_timestamp(),
         }

--- a/autobot-backend/api/api_endpoint_migrations_test.py
+++ b/autobot-backend/api/api_endpoint_migrations_test.py
@@ -11119,55 +11119,55 @@ class TestBatch69AgentTerminalMigrations(unittest.TestCase):
         self.assertIn("session_id=session_id", source)
 
 
-class TestBatch70AgentEnhancedMigrations(unittest.TestCase):
-    """Test batch 70 migrations: agent_enhanced.py first 3 endpoints"""
+class TestBatch70AgentMigrations(unittest.TestCase):
+    """Test batch 70 migrations: agent.py first 3 endpoints"""
 
-    # Test 1: execute_enhanced_goal decorator presence
-    def test_execute_enhanced_goal_decorator_present(self):
-        """Test execute_enhanced_goal has @with_error_handling decorator"""
-        from api.agent import execute_enhanced_goal
+    # Test 1: execute_goal_advanced decorator presence
+    def test_execute_goal_advanced_decorator_present(self):
+        """Test execute_goal_advanced has @with_error_handling decorator"""
+        from api.agent import execute_goal_advanced
 
-        source = inspect.getsource(execute_enhanced_goal)
+        source = inspect.getsource(execute_goal_advanced)
         self.assertIn(
             "@with_error_handling",
             source,
-            "execute_enhanced_goal should have @with_error_handling decorator",
+            "execute_goal_advanced should have @with_error_handling decorator",
         )
         self.assertIn(
             "ErrorCategory.SERVER_ERROR",
             source,
-            "execute_enhanced_goal should use SERVER_ERROR category",
+            "execute_goal_advanced should use SERVER_ERROR category",
         )
         self.assertIn(
-            'error_code_prefix="AGENT_ENHANCED"',
+            'error_code_prefix="AGENT"',
             source,
-            "execute_enhanced_goal should use AGENT_ENHANCED error code prefix",
+            "execute_goal_advanced should use AGENT error code prefix",
         )
 
-    # Test 2: execute_enhanced_goal Mixed Pattern compliance
-    def test_execute_enhanced_goal_mixed_pattern(self):
-        """Test execute_enhanced_goal uses Mixed Pattern - preserves nested try-catches"""
-        from api.agent import execute_enhanced_goal
+    # Test 2: execute_goal_advanced Mixed Pattern compliance
+    def test_execute_goal_advanced_mixed_pattern(self):
+        """Test execute_goal_advanced uses Mixed Pattern - preserves nested try-catches"""
+        from api.agent import execute_goal_advanced
 
-        source = inspect.getsource(execute_enhanced_goal)
+        source = inspect.getsource(execute_goal_advanced)
         # Should have nested try-catches for: agent list, KB enhancement, AIStackError
         try_count = source.count("    try:")
         self.assertGreaterEqual(
             try_count,
             3,
-            "execute_enhanced_goal should have at least 3 nested try-catch blocks (agent list, KB, AIStackError)",
+            "execute_goal_advanced should have at least 3 nested try-catch blocks (agent list, KB, AIStackError)",
         )
         # Should have AIStackError handling
         self.assertIn("except AIStackError", source)
         # Should have fallback for agent list
         self.assertIn('available_agents = ["chat", "rag", "research"]', source)
 
-    # Test 3: execute_enhanced_goal business logic preserved
-    def test_execute_enhanced_goal_business_logic(self):
-        """Test execute_enhanced_goal preserves business logic - HTTPException for unavailable agents"""
-        from api.agent import execute_enhanced_goal
+    # Test 3: execute_goal_advanced business logic preserved
+    def test_execute_goal_advanced_business_logic(self):
+        """Test execute_goal_advanced preserves business logic - HTTPException for unavailable agents"""
+        from api.agent import execute_goal_advanced
 
-        source = inspect.getsource(execute_enhanced_goal)
+        source = inspect.getsource(execute_goal_advanced)
         # Should raise HTTPException for unavailable agents
         self.assertIn("if not selected_agents:", source)
         self.assertIn("raise HTTPException", source)
@@ -11194,9 +11194,9 @@ class TestBatch70AgentEnhancedMigrations(unittest.TestCase):
             "coordinate_multi_agent_task should use SERVER_ERROR category",
         )
         self.assertIn(
-            'error_code_prefix="AGENT_ENHANCED"',
+            'error_code_prefix="AGENT"',
             source,
-            "coordinate_multi_agent_task should use AGENT_ENHANCED error code prefix",
+            "coordinate_multi_agent_task should use AGENT error code prefix",
         )
 
     # Test 5: coordinate_multi_agent_task Mixed Pattern compliance
@@ -11241,9 +11241,9 @@ class TestBatch70AgentEnhancedMigrations(unittest.TestCase):
             "comprehensive_research_task should use SERVER_ERROR category",
         )
         self.assertIn(
-            'error_code_prefix="AGENT_ENHANCED"',
+            'error_code_prefix="AGENT"',
             source,
-            "comprehensive_research_task should use AGENT_ENHANCED error code prefix",
+            "comprehensive_research_task should use AGENT error code prefix",
         )
 
     # Test 8: comprehensive_research_task Mixed Pattern compliance
@@ -11284,11 +11284,11 @@ class TestBatch70AgentEnhancedMigrations(unittest.TestCase):
         from api.agent import (
             comprehensive_research_task,
             coordinate_multi_agent_task,
-            execute_enhanced_goal,
+            execute_goal_advanced,
         )
 
         for endpoint in [
-            execute_enhanced_goal,
+            execute_goal_advanced,
             coordinate_multi_agent_task,
             comprehensive_research_task,
         ]:
@@ -11301,23 +11301,23 @@ class TestBatch70AgentEnhancedMigrations(unittest.TestCase):
 
     # Test 11: Batch 70 consistency - all endpoints use same error code prefix
     def test_batch70_error_prefix_consistency(self):
-        """Test all batch 70 endpoints use AGENT_ENHANCED error code prefix"""
+        """Test all batch 70 endpoints use AGENT error code prefix"""
         from api.agent import (
             comprehensive_research_task,
             coordinate_multi_agent_task,
-            execute_enhanced_goal,
+            execute_goal_advanced,
         )
 
         for endpoint in [
-            execute_enhanced_goal,
+            execute_goal_advanced,
             coordinate_multi_agent_task,
             comprehensive_research_task,
         ]:
             source = inspect.getsource(endpoint)
             self.assertIn(
-                'error_code_prefix="AGENT_ENHANCED"',
+                'error_code_prefix="AGENT"',
                 source,
-                f"{endpoint.__name__} should use AGENT_ENHANCED error code prefix",
+                f"{endpoint.__name__} should use AGENT error code prefix",
             )
 
     # Test 12: Batch 70 consistency - all endpoints follow Mixed Pattern
@@ -11326,11 +11326,11 @@ class TestBatch70AgentEnhancedMigrations(unittest.TestCase):
         from api.agent import (
             comprehensive_research_task,
             coordinate_multi_agent_task,
-            execute_enhanced_goal,
+            execute_goal_advanced,
         )
 
         for endpoint in [
-            execute_enhanced_goal,
+            execute_goal_advanced,
             coordinate_multi_agent_task,
             comprehensive_research_task,
         ]:
@@ -11348,11 +11348,11 @@ class TestBatch70AgentEnhancedMigrations(unittest.TestCase):
         from api.agent import (
             comprehensive_research_task,
             coordinate_multi_agent_task,
-            execute_enhanced_goal,
+            execute_goal_advanced,
         )
 
         for endpoint in [
-            execute_enhanced_goal,
+            execute_goal_advanced,
             coordinate_multi_agent_task,
             comprehensive_research_task,
         ]:
@@ -11371,11 +11371,11 @@ class TestBatch70AgentEnhancedMigrations(unittest.TestCase):
         from api.agent import (
             comprehensive_research_task,
             coordinate_multi_agent_task,
-            execute_enhanced_goal,
+            execute_goal_advanced,
         )
 
         for endpoint in [
-            execute_enhanced_goal,
+            execute_goal_advanced,
             coordinate_multi_agent_task,
             comprehensive_research_task,
         ]:
@@ -11393,8 +11393,8 @@ class TestBatch70AgentEnhancedMigrations(unittest.TestCase):
             )
 
 
-class TestBatch71AgentEnhancedMigrations(unittest.TestCase):
-    """Test batch 71 migrations: agent_enhanced.py next 3 endpoints"""
+class TestBatch71AgentMigrations(unittest.TestCase):
+    """Test batch 71 migrations: agent.py next 3 endpoints"""
 
     def test_analyze_development_task_decorator_present(self):
         """Test analyze_development_task has @with_error_handling decorator"""
@@ -11403,7 +11403,7 @@ class TestBatch71AgentEnhancedMigrations(unittest.TestCase):
         source = inspect.getsource(analyze_development_task)
         self.assertIn("@with_error_handling", source)
         self.assertIn("ErrorCategory.SERVER_ERROR", source)
-        self.assertIn('error_code_prefix="AGENT_ENHANCED"', source)
+        self.assertIn('error_code_prefix="AGENT"', source)
 
     def test_analyze_development_task_mixed_pattern(self):
         """Test analyze_development_task uses Mixed Pattern - preserves nested try-catch"""
@@ -11430,7 +11430,7 @@ class TestBatch71AgentEnhancedMigrations(unittest.TestCase):
         source = inspect.getsource(list_available_agents)
         self.assertIn("@with_error_handling", source)
         self.assertIn("ErrorCategory.SERVER_ERROR", source)
-        self.assertIn('error_code_prefix="AGENT_ENHANCED"', source)
+        self.assertIn('error_code_prefix="AGENT"', source)
 
     def test_list_available_agents_mixed_pattern(self):
         """Test list_available_agents uses Mixed Pattern - preserves nested try-catch"""
@@ -11457,7 +11457,7 @@ class TestBatch71AgentEnhancedMigrations(unittest.TestCase):
         source = inspect.getsource(get_agents_status)
         self.assertIn("@with_error_handling", source)
         self.assertIn("ErrorCategory.SERVER_ERROR", source)
-        self.assertIn('error_code_prefix="AGENT_ENHANCED"', source)
+        self.assertIn('error_code_prefix="AGENT"', source)
 
     def test_get_agents_status_mixed_pattern(self):
         """Test get_agents_status uses Mixed Pattern - preserves nested try-catch"""
@@ -11521,7 +11521,7 @@ class TestBatch71AgentEnhancedMigrations(unittest.TestCase):
             )
 
     def test_batch71_error_prefix_consistency(self):
-        """Test batch 71 endpoints all use AGENT_ENHANCED prefix"""
+        """Test batch 71 endpoints all use AGENT prefix"""
         from api.agent import (
             analyze_development_task,
             get_agents_status,
@@ -11535,9 +11535,9 @@ class TestBatch71AgentEnhancedMigrations(unittest.TestCase):
         ]:
             source = inspect.getsource(endpoint)
             self.assertIn(
-                'error_code_prefix="AGENT_ENHANCED"',
+                'error_code_prefix="AGENT"',
                 source,
-                f"{endpoint.__name__} should use AGENT_ENHANCED prefix",
+                f"{endpoint.__name__} should use AGENT prefix",
             )
 
     def test_batch71_mixed_pattern_consistency(self):
@@ -11587,8 +11587,8 @@ class TestBatch71AgentEnhancedMigrations(unittest.TestCase):
             )
 
 
-class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
-    """Test batch 72 migrations: agent_enhanced.py final 2 endpoints"""
+class TestBatch72AgentMigrations(unittest.TestCase):
+    """Test batch 72 migrations: agent.py final 2 endpoints"""
 
     def test_receive_goal_compat_decorator_present(self):
         """Test receive_goal_compat has @with_error_handling decorator"""
@@ -11597,7 +11597,7 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
         source = inspect.getsource(receive_goal_compat)
         self.assertIn("@with_error_handling", source)
         self.assertIn("ErrorCategory.SERVER_ERROR", source)
-        self.assertIn('error_code_prefix="AGENT_ENHANCED"', source)
+        self.assertIn('error_code_prefix="AGENT"', source)
 
     def test_receive_goal_compat_mixed_pattern(self):
         """Test receive_goal_compat uses Mixed Pattern - preserves outer try-catch"""
@@ -11618,40 +11618,39 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
         self.assertIn("except Exception", source)
         self.assertIn("fallback", source.lower())
 
-    def test_enhanced_agent_health_decorator_present(self):
-        """Test enhanced_agent_health has @with_error_handling decorator"""
-        from api.agent import agent_health as enhanced_agent_health
+    def test_agent_health_decorator_present(self):
+        """Test agent_health has @with_error_handling decorator"""
+        from api.agent import agent_health
 
-        source = inspect.getsource(enhanced_agent_health)
+        source = inspect.getsource(agent_health)
         self.assertIn("@with_error_handling", source)
         self.assertIn("ErrorCategory.SERVER_ERROR", source)
-        self.assertIn('error_code_prefix="AGENT_ENHANCED"', source)
+        self.assertIn('error_code_prefix="AGENT"', source)
 
-    def test_enhanced_agent_health_mixed_pattern(self):
-        """Test enhanced_agent_health uses Mixed Pattern - preserves outer try-catch"""
-        from api.agent import agent_health as enhanced_agent_health
+    def test_agent_health_mixed_pattern(self):
+        """Test agent_health uses Mixed Pattern - preserves outer try-catch"""
+        from api.agent import agent_health
 
-        source = inspect.getsource(enhanced_agent_health)
+        source = inspect.getsource(agent_health)
         # Should preserve outer try-catch for degraded status business logic
         try_count = source.count("    try:")
         self.assertGreaterEqual(try_count, 1, "Should preserve outer try-catch for degraded status logic")
         self.assertIn("except Exception", source)
 
-    def test_enhanced_agent_health_degraded_logic(self):
-        """Test enhanced_agent_health preserves degraded status business logic"""
-        from api.agent import agent_health as enhanced_agent_health
+    def test_agent_health_degraded_logic(self):
+        """Test agent_health preserves degraded status business logic"""
+        from api.agent import agent_health
 
-        source = inspect.getsource(enhanced_agent_health)
+        source = inspect.getsource(agent_health)
         # Should return degraded status on exception
         self.assertIn("except Exception", source)
         self.assertIn('"status": "degraded"', source)
 
     def test_batch72_decorator_placement(self):
         """Test batch 72 endpoints have decorators in correct order"""
-        from api.agent import agent_health as enhanced_agent_health
-        from api.agent import receive_goal_compat
+        from api.agent import agent_health, receive_goal_compat
 
-        for endpoint in [receive_goal_compat, enhanced_agent_health]:
+        for endpoint in [receive_goal_compat, agent_health]:
             source = inspect.getsource(endpoint)
             # Router decorator should come before error handling decorator
             router_pos = source.find("@router")
@@ -11664,10 +11663,9 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
 
     def test_batch72_error_category_consistency(self):
         """Test batch 72 endpoints all use ErrorCategory.SERVER_ERROR"""
-        from api.agent import agent_health as enhanced_agent_health
-        from api.agent import receive_goal_compat
+        from api.agent import agent_health, receive_goal_compat
 
-        for endpoint in [receive_goal_compat, enhanced_agent_health]:
+        for endpoint in [receive_goal_compat, agent_health]:
             source = inspect.getsource(endpoint)
             self.assertIn(
                 "ErrorCategory.SERVER_ERROR",
@@ -11676,24 +11674,22 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
             )
 
     def test_batch72_error_prefix_consistency(self):
-        """Test batch 72 endpoints all use AGENT_ENHANCED prefix"""
-        from api.agent import agent_health as enhanced_agent_health
-        from api.agent import receive_goal_compat
+        """Test batch 72 endpoints all use AGENT prefix"""
+        from api.agent import agent_health, receive_goal_compat
 
-        for endpoint in [receive_goal_compat, enhanced_agent_health]:
+        for endpoint in [receive_goal_compat, agent_health]:
             source = inspect.getsource(endpoint)
             self.assertIn(
-                'error_code_prefix="AGENT_ENHANCED"',
+                'error_code_prefix="AGENT"',
                 source,
-                f"{endpoint.__name__} should use AGENT_ENHANCED prefix",
+                f"{endpoint.__name__} should use AGENT prefix",
             )
 
     def test_batch72_mixed_pattern_consistency(self):
         """Test batch 72 endpoints all use Mixed Pattern (preserve outer try-catch)"""
-        from api.agent import agent_health as enhanced_agent_health
-        from api.agent import receive_goal_compat
+        from api.agent import agent_health, receive_goal_compat
 
-        for endpoint in [receive_goal_compat, enhanced_agent_health]:
+        for endpoint in [receive_goal_compat, agent_health]:
             source = inspect.getsource(endpoint)
             try_count = source.count("    try:")
             self.assertGreaterEqual(
@@ -11704,16 +11700,15 @@ class TestBatch72AgentEnhancedMigrations(unittest.TestCase):
 
     def test_batch72_business_logic_preservation(self):
         """Test batch 72 endpoints preserve business logic (fallback/degraded responses)"""
-        from api.agent import agent_health as enhanced_agent_health
-        from api.agent import receive_goal_compat
+        from api.agent import agent_health, receive_goal_compat
 
         # receive_goal_compat should have fallback logic
         compat_source = inspect.getsource(receive_goal_compat)
         self.assertIn("except Exception", compat_source)
         self.assertIn("fallback", compat_source.lower())
 
-        # enhanced_agent_health should have degraded status logic
-        health_source = inspect.getsource(enhanced_agent_health)
+        # agent_health should have degraded status logic
+        health_source = inspect.getsource(agent_health)
         self.assertIn("except Exception", health_source)
         self.assertIn('"status": "degraded"', health_source)
 

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -42,12 +42,12 @@ class AgentCommandExecuteResponse(BaseModel):
 
 
 class AgentHealthResponse(BaseModel):
-    """Response for GET /health/enhanced."""
+    """Response for GET /health/detailed."""
 
     status: str
     ai_stack_available: bool
     multi_agent_coordination: bool
-    enhanced_capabilities: bool
+    advanced_capabilities: bool
     timestamp: str
     error: str | None = None
 
@@ -955,7 +955,7 @@ class AgentStatusData(BaseModel):
 
 
 class GoalExecutionResult(BaseModel):
-    """Result payload for enhanced goal execution via multi-agent coordination."""
+    """Result payload for advanced goal execution via multi-agent coordination."""
 
     model_config = {"extra": "allow"}
 
@@ -1007,12 +1007,12 @@ class AgentTaskData(BaseModel):
 
 
 class GoalData(AgentTaskData):
-    """data payload for POST /agent/goal/enhanced."""
+    """data payload for POST /agent/goal/advanced."""
 
     goal: str
     coordination_mode: str
     priority: str | None = None
-    enhanced_context_used: bool
+    context_used: bool
     knowledge_base_integrated: bool
     timestamp: str
     result: GoalExecutionResult | None = None
@@ -1553,10 +1553,10 @@ class OrganizationStatsResponse(BaseModel):
 
 
 class GoalPayload(BaseModel):
-    """Goal payload — unified from bare and enhanced variants (#10666 B1).
+    """Goal payload — unified from bare and advanced variants (#10666 B1).
 
     The simple /goal endpoint reads only ``goal``/``use_phi2``/``user_role``.
-    The /goal/enhanced endpoint also reads the remaining optional fields.
+    The /goal/advanced endpoint also reads the remaining optional fields.
     All added fields carry defaults, so existing callers that only send
     ``goal`` remain fully backward-compatible.
     """

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -15545,7 +15545,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/agent/goal/enhanced": {
+    "/api/agent/goal/advanced": {
         parameters: {
             query?: never;
             header?: never;
@@ -15555,13 +15555,13 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Execute Enhanced Goal
-         * @description Execute goal using enhanced AI Stack multi-agent coordination.
+         * Execute Goal Advanced
+         * @description Execute goal using AI Stack multi-agent coordination.
          *
          *     Issue #398: refactored.
          *     Issue #744: Requires authenticated user.
          */
-        post: operations["execute_enhanced_goal_api_agent_goal_enhanced_post"];
+        post: operations["execute_goal_advanced_api_agent_goal_advanced_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -15682,7 +15682,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/agent/health/enhanced": {
+    "/api/agent/health/detailed": {
         parameters: {
             query?: never;
             header?: never;
@@ -15690,10 +15690,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Enhanced Agent Health
-         * @description Enhanced health check for agent services.
+         * Agent Health Detailed
+         * @description Detailed health check for agent services.
          */
-        get: operations["enhanced_agent_health_api_agent_health_enhanced_get"];
+        get: operations["agent_health_detailed_api_agent_health_detailed_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -52157,7 +52157,7 @@ export interface components {
         };
         /**
          * AgentHealthResponse
-         * @description Response for GET /health/enhanced.
+         * @description Response for GET /health/detailed.
          */
         AgentHealthResponse: {
             /** Status */
@@ -52166,8 +52166,8 @@ export interface components {
             ai_stack_available: boolean;
             /** Multi Agent Coordination */
             multi_agent_coordination: boolean;
-            /** Enhanced Capabilities */
-            enhanced_capabilities: boolean;
+            /** Advanced Capabilities */
+            advanced_capabilities: boolean;
             /** Timestamp */
             timestamp: string;
             /** Error */
@@ -64626,14 +64626,14 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** DataResponse[EnhancedGoalData] */
-        DataResponse_EnhancedGoalData_: {
+        /** DataResponse[GoalData] */
+        DataResponse_GoalData_: {
             /**
              * Success
              * @default true
              */
             success: boolean;
-            data?: components["schemas"]["EnhancedGoalData"] | null;
+            data?: components["schemas"]["GoalData"] | null;
             /** Message */
             message?: string | null;
             /** Timestamp */
@@ -68911,10 +68911,10 @@ export interface components {
             [key: string]: unknown;
         };
         /**
-         * EnhancedGoalData
-         * @description data payload for POST /agent/goal/enhanced.
+         * GoalData
+         * @description data payload for POST /agent/goal/advanced.
          */
-        EnhancedGoalData: {
+        GoalData: {
             /** Agents Used */
             agents_used: string[];
             /** Execution Time */
@@ -68926,8 +68926,8 @@ export interface components {
             coordination_mode: string;
             /** Priority */
             priority?: string | null;
-            /** Enhanced Context Used */
-            enhanced_context_used: boolean;
+            /** Context Used */
+            context_used: boolean;
             /** Knowledge Base Integrated */
             knowledge_base_integrated: boolean;
             /** Timestamp */
@@ -118256,7 +118256,7 @@ export interface operations {
             };
         };
     };
-    execute_enhanced_goal_api_agent_goal_enhanced_post: {
+    execute_goal_advanced_api_agent_goal_advanced_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -118265,7 +118265,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["EnhancedGoalPayload"];
+                "application/json": components["schemas"]["GoalPayload"];
             };
         };
         responses: {
@@ -118275,7 +118275,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DataResponse_EnhancedGoalData_"];
+                    "application/json": components["schemas"]["DataResponse_GoalData_"];
                 };
             };
             /** @description Validation Error */
@@ -118428,7 +118428,7 @@ export interface operations {
             };
         };
     };
-    enhanced_agent_health_api_agent_health_enhanced_get: {
+    agent_health_detailed_api_agent_health_detailed_get: {
         parameters: {
             query?: never;
             header?: never;

--- a/libs/autobot-sdk-python/autobot_sdk/resources/agents.py
+++ b/libs/autobot-sdk-python/autobot_sdk/resources/agents.py
@@ -17,7 +17,7 @@ class AgentsResource:
         self._c = client
 
     async def health(self) -> AgentHealth:
-        raw = await self._c.get("/health/enhanced")
+        raw = await self._c.get("/health/detailed")
         return AgentHealth.model_validate(raw)
 
     async def get_config(self) -> DataResponse[AgentConfig]:

--- a/libs/autobot-sdk-ts/src/resources/agents.ts
+++ b/libs/autobot-sdk-ts/src/resources/agents.ts
@@ -9,7 +9,7 @@ export class AgentsResource {
   constructor(private readonly client: AutoBotHttpClient) {}
 
   health(): Promise<AgentHealth> {
-    return this.client.get("/health/enhanced");
+    return this.client.get("/health/detailed");
   }
 
   getConfig(): Promise<DataResponse<AgentConfig>> {


### PR DESCRIPTION
## Thinking Path

B4 of the infix-rename plan for #10746. Scope: `api/agent.py` — one handler (`execute_enhanced_goal`) + two route paths (`/goal/enhanced`, `/health/enhanced`) + all callers atomically (backend schemas, test classes, frontend generated types, Python/TS SDKs).

**Collision check (pre-work):**
- `/goal` already exists at line 650 — it is a simpler endpoint with a different response model (`AgentMessageResponse`) vs the multi-agent one (`DataResponse[GoalData]`). These are genuinely distinct. Chose `/goal/advanced` as the descriptive replacement.
- `/health` does NOT exist in the same router — no collision. Chose `/health/detailed` per task spec.
- `execute_goal_advanced` has no collision anywhere in the router or module.

**Pre-existing drift discovered:** tests (Batch 70-72) asserted `error_code_prefix="AGENT_ENHANCED"` but the actual source always had `error_code_prefix="AGENT"`. Fixed as part of this rename (tests were already skipped due to missing deps, but the assertions would fail when deps are present).

## What Changed

**Route path renames (intentional public URL changes):**
- `POST /api/agent/goal/enhanced` → `POST /api/agent/goal/advanced`
- `GET /api/agent/health/enhanced` → `GET /api/agent/health/detailed`

**Handler rename:**
- `execute_enhanced_goal` → `execute_goal_advanced` in `api/agent.py`
- Route handler `agent_health()` path updated (function name stays `agent_health`)
- `operation=` string updated to `execute_goal_advanced`

**Schema field renames (agent scope):**
- `GoalData.enhanced_context_used` → `context_used` (public JSON key)
- `AgentHealthResponse.enhanced_capabilities` → `advanced_capabilities` (public JSON key)

**Local variable renames (no API impact):**
- `enhanced_context` → `kb_context` in `execute_goal_advanced`
- `enhanced_query` → `research_query` in `comprehensive_research_task`
- `enhanced_list` → `agents_with_caps` in `list_available_agents`
- Response dict key `enhanced_context_used` → `context_used`
- Response dict keys `enhanced_capabilities` → `advanced_capabilities` (both success and error cases)

**Schema/generated type alignment (stale generated file catch-up):**
- `EnhancedGoalData` → `GoalData` in `generated/api.ts` (Python was already `GoalData`)
- `DataResponse_EnhancedGoalData_` → `DataResponse_GoalData_`
- Operation IDs updated to match new route paths
- `EnhancedGoalPayload` → `GoalPayload` in operation request body (Python schema already consolidated)

**Files changed:**
- `autobot-backend/api/agent.py`
- `autobot-backend/api/schemas_agent.py`
- `autobot-backend/api/api_endpoint_migrations_test.py` (TestBatch70/71/72 renamed + AGENT_ENHANCED→AGENT drift fixed)
- `autobot-frontend/src/types/generated/api.ts`
- `libs/autobot-sdk-ts/src/resources/agents.ts`
- `libs/autobot-sdk-python/autobot_sdk/resources/agents.py`

## Verification

**Zero-grep proof (agent scope):**
```
grep -rn "execute_enhanced_goal|/goal/enhanced|/health/enhanced|AGENT_ENHANCED|enhanced_context_used|enhanced_capabilities" \
  autobot-backend/api/agent.py autobot-backend/api/schemas_agent.py \
  autobot-backend/api/api_endpoint_migrations_test.py \
  libs/autobot-sdk-*/...agents.* \
  autobot-frontend/src/types/generated/api.ts  # filtered to agent scope
→ 0 results
```

**Startup imports:** `pytest tests/test_startup_imports.py -q` → 339 passed, 0 failed

**flake8:** `flake8 autobot-backend/api/agent.py autobot-backend/api/schemas_agent.py` → exit 0

**black:** `black --line-length=120 --check autobot-backend/api/agent.py autobot-backend/api/schemas_agent.py` → no changes needed

**B70-B72 tests:** all 39 skipped (expected — missing external deps: openai, sentence-transformers etc.; same behavior as before; no failures)

**Collision check:**
- `/goal` (existing) vs `/goal/advanced` (new) — different paths, different response models, no conflict
- No existing `/health/detailed` in agent router
- `execute_goal_advanced` not defined anywhere else

**Out-of-scope (correct B2 items left in place):**
- `knowledge.py:2962` comment about `/stats/enhanced`, `/health/enhanced` knowledge-aistack routes → B2
- `schemas_knowledge.py` `AIStackEnhanced*` → B2
- `schemas_agent.py` `enhanced_prompt` (LLM awareness schema), `enhanced-search` (knowledge) → separate batches

## Model Used

claude-sonnet-4-6

Part of #10746