### PR TITLE
fix(monitoring): real/config-driven BI metrics instead of fabricated values (#10720)

### DIFF
--- a/autobot-slm-backend/monitoring/business_intelligence_dashboard.py
+++ b/autobot-slm-backend/monitoring/business_intelligence_dashboard.py
@@ -4,6 +4,15 @@
 """
 AutoBot Business Intelligence Dashboard
 Advanced analytics, ROI tracking, and performance insights for the distributed system.
+
+Issue #10720: Replaced fabricated usage constants and hardcoded component costs with:
+- Real usage counts sourced from Prometheus (autobot_llm_requests_total,
+  autobot_knowledge_search_requests_total) via query_instant(); explicit
+  "unavailable" signal returned when Prometheus is unreachable.
+- Config-driven component cost model (CostModelConfig in ssot_config.py) so
+  operators supply deployment-specific values without editing source code.
+- Redis-failure paths now return a degradation-shaped dict (available=False +
+  error key) instead of an indistinguishable empty dict.
 """
 
 import asyncio
@@ -14,7 +23,7 @@ import statistics
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import aiofiles
 import matplotlib
@@ -24,12 +33,21 @@ import numpy as np
 from jinja2 import Template
 from performance_monitor import ALERT_THRESHOLDS
 
+from autobot_shared.monitoring.prometheus_query import query_instant
 from autobot_shared.network_constants import NetworkConstants
+from autobot_shared.ssot_config import get_config
 
 logger = logging.getLogger(__name__)
 
 # Issue #380: Module-level tuple for numeric type checks
 _NUMERIC_TYPES = (int, float)
+
+# Sentinel – returned by helpers when data is not available (Redis down, etc.)
+# Callers check for the ``available`` key being False before consuming data.
+_UNAVAILABLE: Dict[str, Any] = {"available": False}
+
+_cfg = get_config()
+_cost = _cfg.cost_model  # CostModelConfig — operator-supplied, env-overridable
 
 # HTML template for visual dashboard
 _DASHBOARD_HTML_TEMPLATE = """
@@ -62,8 +80,8 @@ _DASHBOARD_HTML_TEMPLATE = """
 <body>
     <div class="dashboard">
         <div class="header">
-            <h1>🤖 AutoBot Business Intelligence Dashboard</h1>
-            <p>Distributed System Performance & ROI Analytics</p>
+            <h1>AutoBot Business Intelligence Dashboard</h1>
+            <p>Distributed System Performance &amp; ROI Analytics</p>
             <p class="timestamp">Generated: {{ timestamp }}</p>
         </div>
 
@@ -112,7 +130,8 @@ _DASHBOARD_HTML_TEMPLATE = """
             <div class="metric-card">
                 <h3>Cost Efficiency Analysis</h3>
                 {% for cost in cost_analysis %}
-                <p>{{ cost.component }}: {{ cost.efficiency_score }}% efficient</p>
+                <p>{{ cost.component }}: {{ cost.efficiency_score }}% efficient
+                    {% if cost.cost_is_estimate %}(estimated cost){% endif %}</p>
                 {% endfor %}
             </div>
 
@@ -150,6 +169,8 @@ class ROIMetrics:
     productivity_gain_hours_per_month: float
     break_even_months: float
     total_roi_percent: float
+    # True when monthly_operations came from a real source; False = Prometheus unavailable
+    operations_data_available: bool
 
 
 @dataclass
@@ -163,6 +184,8 @@ class CostAnalysis:
     cost_per_hour: float
     efficiency_score: float
     optimization_potential_usd: float
+    # False when cost came from config defaults (estimates); True if operator-overridden
+    cost_is_estimate: bool
 
 
 @dataclass
@@ -191,6 +214,34 @@ class SystemHealthScore:
     efficiency_score: float
     user_satisfaction_score: float
     improvement_areas: List[str]
+
+
+# ---------------------------------------------------------------------------
+# Prometheus usage helpers
+# ---------------------------------------------------------------------------
+
+# PromQL: 30-day increase in total LLM requests (all providers/models)
+_PROMQL_LLM_REQUESTS_30D = "increase(autobot_llm_requests_total[30d])"
+# PromQL: 30-day increase in knowledge-base search requests (all types/collections)
+_PROMQL_KB_SEARCHES_30D = "increase(autobot_knowledge_search_requests_total[30d])"
+
+
+async def _sum_prometheus_increase(promql: str) -> Optional[float]:
+    """Return the sum of all series for a 30-day increase PromQL expression.
+
+    Returns None when Prometheus is unreachable or returns no data.
+    """
+    data = await query_instant(promql)
+    if not data:
+        return None
+    results = data.get("result", [])
+    if not results:
+        return None
+    try:
+        return sum(float(r["value"][1]) for r in results if len(r.get("value", [])) == 2)
+    except (KeyError, ValueError, TypeError) as exc:
+        logger.warning("Could not parse Prometheus result for %r: %s", promql, exc)
+        return None
 
 
 class BusinessIntelligenceDashboard:
@@ -235,7 +286,7 @@ class BusinessIntelligenceDashboard:
     async def initialize_redis_connection(self):
         """Initialize Redis connection for BI metrics using canonical utility."""
         try:
-            # Use canonical Redis utility following CLAUDE.md "🔴 REDIS CLIENT USAGE" policy
+            # Use canonical Redis utility following CLAUDE.md "REDIS CLIENT USAGE" policy
             from autobot_shared.redis_client import get_redis_client
 
             self.redis_client = get_redis_client(database="metrics")
@@ -243,9 +294,9 @@ class BusinessIntelligenceDashboard:
                 raise Exception("Redis client initialization returned None")
 
             self.redis_client.ping()
-            self.logger.info("✅ Redis connection established for BI Dashboard")
+            self.logger.info("Redis connection established for BI Dashboard")
         except Exception as e:
-            self.logger.error(f"❌ Failed to connect to Redis for BI: {e}")
+            self.logger.error("Failed to connect to Redis for BI: %s", e)
             self.redis_client = None
 
     def _compute_savings_and_roi(
@@ -271,6 +322,28 @@ class BusinessIntelligenceDashboard:
         )
         return break_even_months, total_roi
 
+    async def _get_monthly_operations(self) -> tuple:
+        """Query real 30-day operation counts from Prometheus.
+
+        Returns:
+            Tuple of (total_monthly_operations: int, data_available: bool).
+            data_available=False means Prometheus was unreachable; the caller
+            must NOT present the returned count as real data in that case.
+        """
+        llm_count = await _sum_prometheus_increase(_PROMQL_LLM_REQUESTS_30D)
+        kb_count = await _sum_prometheus_increase(_PROMQL_KB_SEARCHES_30D)
+
+        if llm_count is None and kb_count is None:
+            self.logger.warning(
+                "Prometheus unreachable — monthly operation count unavailable (#10720). "
+                "Deploy a Prometheus scrape target for autobot_llm_requests_total and "
+                "autobot_knowledge_search_requests_total to get real usage data."
+            )
+            return 0, False
+
+        total = int((llm_count or 0) + (kb_count or 0))
+        return total, True
+
     async def calculate_roi_metrics(self) -> ROIMetrics:
         """Calculate comprehensive ROI metrics."""
         try:
@@ -282,7 +355,7 @@ class BusinessIntelligenceDashboard:
 
             productivity_gain_hours = self._estimate_productivity_gains(performance_improvement)
 
-            total_monthly_operations = await self._estimate_monthly_operations()
+            total_monthly_operations, ops_available = await self._get_monthly_operations()
             cost_per_operation = (
                 monthly_operational_cost / total_monthly_operations if total_monthly_operations > 0 else 0
             )
@@ -300,10 +373,11 @@ class BusinessIntelligenceDashboard:
                 productivity_gain_hours_per_month=productivity_gain_hours,
                 break_even_months=break_even_months,
                 total_roi_percent=total_roi,
+                operations_data_available=ops_available,
             )
 
         except Exception as e:
-            self.logger.error(f"Error calculating ROI metrics: {e}")
+            self.logger.error("Error calculating ROI metrics: %s", e)
             return ROIMetrics(
                 timestamp=datetime.now(timezone.utc).isoformat(),
                 hardware_investment_usd=0.0,
@@ -313,59 +387,61 @@ class BusinessIntelligenceDashboard:
                 productivity_gain_hours_per_month=0.0,
                 break_even_months=0.0,
                 total_roi_percent=0.0,
+                operations_data_available=False,
             )
 
-    async def _get_historical_performance_data(self) -> Dict[str, List[float]]:
+    async def _get_historical_performance_data(self) -> Dict[str, Any]:
         """Get historical performance data for analysis."""
+        if not self.redis_client:
+            self.logger.warning("Redis unavailable — historical performance data cannot be read (#10720)")
+            return {"available": False, "error": "redis_unavailable"}
+
         try:
-            if not self.redis_client:
-                return {}
-
-            # Get performance history from Redis
             history = self.redis_client.lrange("autobot:performance:history", 0, 99)
-
-            performance_data = {
-                "api_response_times": [],
-                "cpu_utilization": [],
-                "memory_utilization": [],
-                "service_availability": [],
-            }
-
-            for entry in history:
-                try:
-                    data = json.loads(entry)
-                    metrics = data.get("data", {})
-
-                    # Extract relevant metrics
-                    services = metrics.get("services", [])
-                    if services:
-                        avg_response_time = statistics.mean(
-                            [s.response_time for s in services if hasattr(s, "response_time")]
-                        )
-                        performance_data["api_response_times"].append(avg_response_time)
-
-                    system = metrics.get("system")
-                    if system:
-                        if hasattr(system, "cpu_percent"):
-                            performance_data["cpu_utilization"].append(system.cpu_percent)
-                        if hasattr(system, "memory_percent"):
-                            performance_data["memory_utilization"].append(system.memory_percent)
-
-                except Exception:
-                    continue  # nosec B112
-
-            return performance_data
-
         except Exception as e:
-            self.logger.error(f"Error getting historical performance data: {e}")
-            return {}
+            self.logger.error("Redis error reading performance history: %s", e)
+            return {"available": False, "error": str(e)}
 
-    async def _calculate_performance_improvement(self, performance_data: Dict[str, List[float]]) -> float:
+        performance_data: Dict[str, Any] = {
+            "available": True,
+            "api_response_times": [],
+            "cpu_utilization": [],
+            "memory_utilization": [],
+            "service_availability": [],
+        }
+
+        for entry in history:
+            try:
+                data = json.loads(entry)
+                metrics = data.get("data", {})
+
+                services = metrics.get("services", [])
+                if services:
+                    avg_response_time = statistics.mean(
+                        [s.response_time for s in services if hasattr(s, "response_time")]
+                    )
+                    performance_data["api_response_times"].append(avg_response_time)
+
+                system = metrics.get("system")
+                if system:
+                    if hasattr(system, "cpu_percent"):
+                        performance_data["cpu_utilization"].append(system.cpu_percent)
+                    if hasattr(system, "memory_percent"):
+                        performance_data["memory_utilization"].append(system.memory_percent)
+
+            except Exception:
+                continue  # nosec B112
+
+        return performance_data
+
+    async def _calculate_performance_improvement(self, performance_data: Dict[str, Any]) -> float:
         """Calculate overall performance improvement percentage."""
         try:
+            if not performance_data.get("available", True):
+                return 0.0
+
             improvements = []
 
-            # API response time improvement
             api_times = performance_data.get("api_response_times", [])
             if len(api_times) >= 10:
                 recent_avg = statistics.mean(api_times[-10:])
@@ -373,81 +449,66 @@ class BusinessIntelligenceDashboard:
                 improvement = max(0, (baseline - recent_avg) / baseline * 100)
                 improvements.append(improvement)
 
-            # CPU efficiency improvement
             cpu_utils = performance_data.get("cpu_utilization", [])
             if len(cpu_utils) >= 10:
                 recent_avg = statistics.mean(cpu_utils[-10:])
-                # Lower CPU utilization for same workload is better
                 improvement = max(0, (80 - recent_avg) / 80 * 100)  # 80% baseline
                 improvements.append(improvement)
 
             return statistics.mean(improvements) if improvements else 0.0
 
         except Exception as e:
-            self.logger.error(f"Error calculating performance improvement: {e}")
+            self.logger.error("Error calculating performance improvement: %s", e)
             return 0.0
 
     def _estimate_productivity_gains(self, performance_improvement: float) -> float:
         """Estimate productivity gains in hours per month."""
         try:
-            # Base calculation: performance improvement translates to time saved
             base_hours_per_month = 160  # 40 hours/week * 4 weeks
             time_saved_ratio = performance_improvement / 100
             productivity_gain = base_hours_per_month * time_saved_ratio * 0.1  # Conservative estimate
-
             return min(productivity_gain, 40)  # Cap at 40 hours/month
-
         except Exception as e:
-            self.logger.error(f"Error estimating productivity gains: {e}")
+            self.logger.error("Error estimating productivity gains: %s", e)
             return 0.0
 
-    async def _estimate_monthly_operations(self) -> int:
-        """Estimate total monthly operations."""
-        try:
-            # Estimate based on typical usage patterns
-            daily_api_calls = 1000  # Conservative estimate
-            daily_knowledge_searches = 500
-            daily_llm_requests = 200
-
-            total_daily_operations = daily_api_calls + daily_knowledge_searches + daily_llm_requests
-            return total_daily_operations * 30  # Monthly
-
-        except Exception as e:
-            self.logger.error(f"Error estimating monthly operations: {e}")
-            return 0
-
     def _build_component_definitions(self, utilization_data: Dict[str, float]) -> Dict[str, Dict]:
-        """Helper for analyze_cost_efficiency. Ref: #1088."""
+        """Build per-component cost/efficiency dict from config (not hardcoded literals).
+
+        Costs are read from CostModelConfig (env-overridable via AUTOBOT_COST_*).
+        All cost values are marked as estimates unless the operator has overridden them.
+        Helper for analyze_cost_efficiency. Ref: #1088, #10720.
+        """
         return {
             "cpu": {
-                "monthly_cost": 50,  # Portion of total operational cost
+                "monthly_cost": _cost.cpu_monthly_usd,
                 "utilization": utilization_data.get("cpu", 0),
-                "baseline_efficiency": 70,
+                "baseline_efficiency": _cost.cpu_baseline_efficiency,
             },
             "gpu": {
-                "monthly_cost": 80,  # Higher due to power consumption
+                "monthly_cost": _cost.gpu_monthly_usd,
                 "utilization": utilization_data.get("gpu", 0),
-                "baseline_efficiency": 60,
+                "baseline_efficiency": _cost.gpu_baseline_efficiency,
             },
             "npu": {
-                "monthly_cost": 30,
+                "monthly_cost": _cost.npu_monthly_usd,
                 "utilization": utilization_data.get("npu", 0),
-                "baseline_efficiency": 50,
+                "baseline_efficiency": _cost.npu_baseline_efficiency,
             },
             "memory": {
-                "monthly_cost": 20,
+                "monthly_cost": _cost.memory_monthly_usd,
                 "utilization": utilization_data.get("memory", 0),
-                "baseline_efficiency": 80,
+                "baseline_efficiency": _cost.memory_baseline_efficiency,
             },
             "storage": {
-                "monthly_cost": 25,
+                "monthly_cost": _cost.storage_monthly_usd,
                 "utilization": utilization_data.get("storage", 0),
-                "baseline_efficiency": 60,
+                "baseline_efficiency": _cost.storage_baseline_efficiency,
             },
             "network": {
-                "monthly_cost": 80,  # Internet costs
+                "monthly_cost": _cost.network_monthly_usd,
                 "utilization": utilization_data.get("network", 0),
-                "baseline_efficiency": 40,
+                "baseline_efficiency": _cost.network_baseline_efficiency,
             },
         }
 
@@ -456,15 +517,22 @@ class BusinessIntelligenceDashboard:
         cost_analyses = []
 
         try:
-            # Get current utilization data
-            utilization_data = await self._get_current_utilization()
+            utilization_data_raw = await self._get_current_utilization()
+            if not utilization_data_raw.get("available", True):
+                self.logger.warning(
+                    "Utilization data unavailable (Redis down) — cost efficiency skipped (#10720)"
+                )
+                return cost_analyses
+
+            # Strip the sentinel key before passing to component builder
+            utilization_data = {k: v for k, v in utilization_data_raw.items() if k != "available"}
+
             components = self._build_component_definitions(utilization_data)
 
             for component, data in components.items():
                 utilization = data["utilization"]
                 efficiency_score = min(utilization / data["baseline_efficiency"] * 100, 100)
 
-                # Calculate optimization potential
                 if efficiency_score < 70:
                     optimization_potential = data["monthly_cost"] * (70 - efficiency_score) / 100
                 else:
@@ -476,80 +544,89 @@ class BusinessIntelligenceDashboard:
                         component=component,
                         monthly_cost_usd=data["monthly_cost"],
                         utilization_percent=utilization,
-                        cost_per_hour=data["monthly_cost"] / (30 * 24),  # $/hour
+                        cost_per_hour=data["monthly_cost"] / (30 * 24),
                         efficiency_score=efficiency_score,
                         optimization_potential_usd=optimization_potential,
+                        cost_is_estimate=True,  # always an operator estimate — label it
                     )
                 )
 
         except Exception as e:
-            self.logger.error(f"Error analyzing cost efficiency: {e}")
+            self.logger.error("Error analyzing cost efficiency: %s", e)
 
         return cost_analyses
 
-    async def _get_current_utilization(self) -> Dict[str, float]:
-        """Get current system utilization metrics."""
+    async def _get_current_utilization(self) -> Dict[str, Any]:
+        """Get current system utilization metrics.
+
+        Returns a dict with available=False on Redis errors so callers can
+        distinguish "no data yet" from "backend error" (#10720).
+        """
+        if not self.redis_client:
+            self.logger.warning("Redis unavailable — current utilization cannot be read (#10720)")
+            return {"available": False, "error": "redis_unavailable"}
+
         try:
-            if not self.redis_client:
-                return {}
-
-            # Get latest performance metrics
             latest_data = self.redis_client.hget("autobot:performance:latest", "data")
-            if not latest_data:
-                return {}
-
-            metrics = json.loads(latest_data)
-            system = metrics.get("system", {})
-
-            utilization = {
-                "cpu": (
-                    system.get("cpu_percent", 0) if isinstance(system.get("cpu_percent"), _NUMERIC_TYPES) else 0
-                ),  # Issue #380
-                "memory": (
-                    system.get("memory_percent", 0) if isinstance(system.get("memory_percent"), _NUMERIC_TYPES) else 0
-                ),  # Issue #380
-                "storage": (
-                    system.get("disk_percent", 0) if isinstance(system.get("disk_percent"), _NUMERIC_TYPES) else 0
-                ),  # Issue #380
-                "gpu": (system.get("gpu_utilization", 0) if system.get("gpu_utilization") is not None else 0),
-                "npu": (system.get("npu_utilization", 0) if system.get("npu_utilization") is not None else 0),
-                "network": 30.0,  # Estimated network utilization
-            }
-
-            return utilization
-
         except Exception as e:
-            self.logger.error(f"Error getting current utilization: {e}")
-            return {}
+            self.logger.error("Redis error reading latest utilization: %s", e)
+            return {"available": False, "error": str(e)}
+
+        if not latest_data:
+            return {"available": False, "error": "no_data"}
+
+        try:
+            metrics = json.loads(latest_data)
+        except (json.JSONDecodeError, TypeError) as e:
+            self.logger.error("Could not decode utilization JSON: %s", e)
+            return {"available": False, "error": "decode_error"}
+
+        system = metrics.get("system", {})
+
+        return {
+            "available": True,
+            "cpu": (
+                system.get("cpu_percent", 0) if isinstance(system.get("cpu_percent"), _NUMERIC_TYPES) else 0
+            ),  # Issue #380
+            "memory": (
+                system.get("memory_percent", 0) if isinstance(system.get("memory_percent"), _NUMERIC_TYPES) else 0
+            ),  # Issue #380
+            "storage": (
+                system.get("disk_percent", 0) if isinstance(system.get("disk_percent"), _NUMERIC_TYPES) else 0
+            ),  # Issue #380
+            "gpu": (system.get("gpu_utilization", 0) if system.get("gpu_utilization") is not None else 0),
+            "npu": (system.get("npu_utilization", 0) if system.get("npu_utilization") is not None else 0),
+            "network": 30.0,  # Actual network utilisation is not yet scraped; marked as estimate
+        }
 
     async def generate_performance_predictions(self) -> List[PerformancePrediction]:
         """Generate predictive performance insights using historical data."""
         predictions = []
 
         try:
-            # Get historical data for trend analysis
             performance_data = await self._get_historical_performance_data()
 
-            # Predict CPU utilization
+            if not performance_data.get("available", True):
+                self.logger.warning("Performance predictions skipped — historical data unavailable (#10720)")
+                return predictions
+
             cpu_data = performance_data.get("cpu_utilization", [])
             if len(cpu_data) >= 10:
                 cpu_prediction = await self._predict_metric_trend(cpu_data, "cpu_utilization")
                 predictions.append(cpu_prediction)
 
-            # Predict API response times
             api_data = performance_data.get("api_response_times", [])
             if len(api_data) >= 10:
                 api_prediction = await self._predict_metric_trend(api_data, "api_response_time")
                 predictions.append(api_prediction)
 
-            # Predict memory utilization
             memory_data = performance_data.get("memory_utilization", [])
             if len(memory_data) >= 10:
                 memory_prediction = await self._predict_metric_trend(memory_data, "memory_utilization")
                 predictions.append(memory_prediction)
 
         except Exception as e:
-            self.logger.error(f"Error generating performance predictions: {e}")
+            self.logger.error("Error generating performance predictions: %s", e)
 
         return predictions
 
@@ -620,7 +697,7 @@ class BusinessIntelligenceDashboard:
             )
 
         except Exception as e:
-            self.logger.error(f"Error predicting trend for {metric_name}: {e}")
+            self.logger.error("Error predicting trend for %s: %s", metric_name, e)
             return PerformancePrediction(
                 timestamp=datetime.now(timezone.utc).isoformat(),
                 metric_name=metric_name,
@@ -634,7 +711,6 @@ class BusinessIntelligenceDashboard:
 
     def _generate_metric_recommendation(self, metric_name: str, trend: str, predicted_value: float) -> str:
         """Generate recommendations based on metric trends."""
-        # Get thresholds from centralized config
         cpu_threshold = ALERT_THRESHOLDS.get("cpu_percent", 80.0)
         memory_threshold = ALERT_THRESHOLDS.get("memory_percent", 85.0)
 
@@ -697,14 +773,16 @@ class BusinessIntelligenceDashboard:
         ]
         return statistics.mean([max(c, 0) for c in efficiency_components])
 
-    def _calculate_user_satisfaction_score(self, performance_data: Dict[str, List[float]]) -> float:
+    def _calculate_user_satisfaction_score(self, performance_data: Dict[str, Any]) -> float:
         """Calculate user satisfaction score from response times.
 
         Helper for calculate_system_health_score.
         """
         api_times = performance_data.get("api_response_times", [])
         if api_times:
-            avg_response_time = statistics.mean(api_times[-10:]) if len(api_times) >= 10 else statistics.mean(api_times)
+            avg_response_time = (
+                statistics.mean(api_times[-10:]) if len(api_times) >= 10 else statistics.mean(api_times)
+            )
             return max(0, 100 - (avg_response_time - 1.0) * 20)
         return 80.0
 
@@ -736,15 +814,24 @@ class BusinessIntelligenceDashboard:
     async def calculate_system_health_score(self) -> SystemHealthScore:
         """Calculate comprehensive system health score."""
         try:
-            utilization_data = await self._get_current_utilization()
+            utilization_raw = await self._get_current_utilization()
+            utilization_data = (
+                {k: v for k, v in utilization_raw.items() if k != "available"}
+                if utilization_raw.get("available", True)
+                else {}
+            )
+
             performance_data = await self._get_historical_performance_data()
 
             services_data = []
             if self.redis_client:
-                latest_data = self.redis_client.hget("autobot:performance:latest", "data")
-                if latest_data:
-                    metrics = json.loads(latest_data)
-                    services_data = metrics.get("services", [])
+                try:
+                    latest_data = self.redis_client.hget("autobot:performance:latest", "data")
+                    if latest_data:
+                        metrics = json.loads(latest_data)
+                        services_data = metrics.get("services", [])
+                except Exception as e:
+                    self.logger.error("Redis error reading services data for health score: %s", e)
 
             availability_score = self._calculate_availability_score(services_data)
             performance_score = self._calculate_performance_score(utilization_data)
@@ -781,7 +868,7 @@ class BusinessIntelligenceDashboard:
             )
 
         except Exception as e:
-            self.logger.error(f"Error calculating system health score: {e}")
+            self.logger.error("Error calculating system health score: %s", e)
             return SystemHealthScore(
                 timestamp=datetime.now(timezone.utc).isoformat(),
                 overall_score=0.0,
@@ -796,13 +883,11 @@ class BusinessIntelligenceDashboard:
     async def generate_comprehensive_dashboard_report(self) -> Dict[str, Any]:
         """Generate comprehensive business intelligence dashboard report."""
         try:
-            # Collect all BI metrics
             roi_metrics = await self.calculate_roi_metrics()
             cost_analysis = await self.analyze_cost_efficiency()
             predictions = await self.generate_performance_predictions()
             health_score = await self.calculate_system_health_score()
 
-            # Compile comprehensive report
             dashboard_report = {
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "summary": {
@@ -811,6 +896,8 @@ class BusinessIntelligenceDashboard:
                     "monthly_operational_cost": roi_metrics.operational_cost_monthly_usd,
                     "break_even_months": roi_metrics.break_even_months,
                     "total_optimization_potential": sum(ca.optimization_potential_usd for ca in cost_analysis),
+                    # Surfaced explicitly so consumers can show "unavailable" rather than fake numbers
+                    "operations_data_available": roi_metrics.operations_data_available,
                 },
                 "roi_analysis": asdict(roi_metrics),
                 "cost_efficiency": [asdict(ca) for ca in cost_analysis],
@@ -820,16 +907,13 @@ class BusinessIntelligenceDashboard:
                 "operational_costs": self.operational_costs,
             }
 
-            # Store the dashboard report
             await self._store_dashboard_report(dashboard_report)
-
-            # Generate visual dashboard (HTML)
             await self._generate_visual_dashboard(dashboard_report)
 
             return dashboard_report
 
         except Exception as e:
-            self.logger.error(f"Error generating dashboard report: {e}")
+            self.logger.error("Error generating dashboard report: %s", e)
             return {
                 "error": "Failed to generate dashboard report",
                 "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -839,7 +923,6 @@ class BusinessIntelligenceDashboard:
         """Store dashboard report in Redis and files."""
         timestamp = datetime.now(timezone.utc).isoformat()
 
-        # Store in Redis
         if self.redis_client:
             try:
                 self.redis_client.hset(
@@ -849,25 +932,22 @@ class BusinessIntelligenceDashboard:
                         "data": json.dumps(report, default=str),
                     },
                 )
-
                 self.redis_client.lpush(
                     "autobot:bi_dashboard:history",
                     json.dumps({"timestamp": timestamp, "data": report}, default=str),
                 )
                 self.redis_client.ltrim("autobot:bi_dashboard:history", 0, 99)
-
             except Exception as e:
-                self.logger.error(f"Error storing dashboard report in Redis: {e}")
+                self.logger.error("Error storing dashboard report in Redis: %s", e)
 
-        # Store in local file
         try:
             report_file = self.dashboard_data_path / f"bi_dashboard_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
             async with aiofiles.open(report_file, "w", encoding="utf-8") as f:
                 await f.write(json.dumps(report, indent=2, default=str))
         except OSError as e:
-            self.logger.error(f"Failed to write dashboard report to {report_file}: {e}")
+            self.logger.error("Failed to write dashboard report to %s: %s", report_file, e)
         except Exception as e:
-            self.logger.error(f"Error storing dashboard report to file: {e}")
+            self.logger.error("Error storing dashboard report to file: %s", e)
 
     def _prepare_dashboard_template_vars(self, report: Dict[str, Any]) -> Dict[str, Any]:
         """Prepare template variables for dashboard rendering.
@@ -911,9 +991,9 @@ class BusinessIntelligenceDashboard:
         try:
             async with aiofiles.open(dashboard_file, "w", encoding="utf-8") as f:
                 await f.write(dashboard_html)
-            self.logger.info(f"📊 Dashboard saved to: {dashboard_file}")
+            self.logger.info("Dashboard saved to: %s", dashboard_file)
         except OSError as e:
-            self.logger.error(f"Failed to save dashboard HTML to {dashboard_file}: {e}")
+            self.logger.error("Failed to save dashboard HTML to %s: %s", dashboard_file, e)
 
     async def _generate_visual_dashboard(self, report: Dict[str, Any]):
         """Generate HTML visual dashboard."""
@@ -926,7 +1006,7 @@ class BusinessIntelligenceDashboard:
             await self._save_dashboard_html(dashboard_html, dashboard_file)
 
         except Exception as e:
-            self.logger.error(f"Error generating visual dashboard: {e}")
+            self.logger.error("Error generating visual dashboard: %s", e)
 
 
 if __name__ == "__main__":
@@ -950,31 +1030,35 @@ if __name__ == "__main__":
 
         if args.roi:
             roi_metrics = await bi_dashboard.calculate_roi_metrics()
-            logger.info("📈 ROI Analysis:")
-            logger.info(f"Total Hardware Investment: ${roi_metrics.hardware_investment_usd:,.2f}")
-            logger.info(f"Monthly Operational Cost: ${roi_metrics.operational_cost_monthly_usd:,.2f}")
-            logger.info(f"Total ROI: {roi_metrics.total_roi_percent:.1f}%")
-            logger.info(f"Break Even: {roi_metrics.break_even_months:.1f} months")
+            logger.info("ROI Analysis:")
+            logger.info("Total Hardware Investment: $%s", f"{roi_metrics.hardware_investment_usd:,.2f}")
+            logger.info("Monthly Operational Cost: $%s", f"{roi_metrics.operational_cost_monthly_usd:,.2f}")
+            logger.info("Total ROI: %s%%", f"{roi_metrics.total_roi_percent:.1f}")
+            logger.info("Break Even: %s months", f"{roi_metrics.break_even_months:.1f}")
+            if not roi_metrics.operations_data_available:
+                logger.warning("Monthly operation count: unavailable (Prometheus unreachable)")
 
         elif args.health:
             health_score = await bi_dashboard.calculate_system_health_score()
-            logger.info("🏥 System Health Score:")
-            logger.info(f"Overall: {health_score.overall_score:.1f}/100")
-            logger.info(f"Availability: {health_score.availability_score:.1f}/100")
-            logger.info(f"Performance: {health_score.performance_score:.1f}/100")
-            logger.info(f"Security: {health_score.security_score:.1f}/100")
-            logger.info(f"Efficiency: {health_score.efficiency_score:.1f}/100")
+            logger.info("System Health Score:")
+            logger.info("Overall: %s/100", f"{health_score.overall_score:.1f}")
+            logger.info("Availability: %s/100", f"{health_score.availability_score:.1f}")
+            logger.info("Performance: %s/100", f"{health_score.performance_score:.1f}")
+            logger.info("Security: %s/100", f"{health_score.security_score:.1f}")
+            logger.info("Efficiency: %s/100", f"{health_score.efficiency_score:.1f}")
 
         elif args.generate:
-            logger.info("🚀 Generating comprehensive BI dashboard...")
+            logger.info("Generating comprehensive BI dashboard...")
             report = await bi_dashboard.generate_comprehensive_dashboard_report()
-            logger.info("✅ Dashboard generated successfully!")
-            logger.info("📊 Report summary:")
+            logger.info("Dashboard generated successfully!")
+            logger.info("Report summary:")
             summary = report.get("summary", {})
-            logger.info(f"  Overall Health: {summary.get('overall_health_score', 0):.1f}/100")
-            logger.info(f"  Total ROI: {summary.get('total_roi_percent', 0):.1f}%")
-            logger.info(f"  Monthly Cost: ${summary.get('monthly_operational_cost', 0):.2f}")
+            logger.info("  Overall Health: %s/100", f"{summary.get('overall_health_score', 0):.1f}")
+            logger.info("  Total ROI: %s%%", f"{summary.get('total_roi_percent', 0):.1f}")
+            logger.info("  Monthly Cost: $%s", f"{summary.get('monthly_operational_cost', 0):.2f}")
             optimization_potential = summary.get("total_optimization_potential", 0)
-            logger.info(f"  Optimization Potential: ${optimization_potential:.2f}/month")
+            logger.info("  Optimization Potential: $%s/month", f"{optimization_potential:.2f}")
+            if not summary.get("operations_data_available", True):
+                logger.warning("  Monthly operations count: unavailable (Prometheus unreachable)")
 
     asyncio.run(main())

--- a/autobot-slm-backend/monitoring/business_intelligence_dashboard.py
+++ b/autobot-slm-backend/monitoring/business_intelligence_dashboard.py
@@ -519,9 +519,7 @@ class BusinessIntelligenceDashboard:
         try:
             utilization_data_raw = await self._get_current_utilization()
             if not utilization_data_raw.get("available", True):
-                self.logger.warning(
-                    "Utilization data unavailable (Redis down) — cost efficiency skipped (#10720)"
-                )
+                self.logger.warning("Utilization data unavailable (Redis down) — cost efficiency skipped (#10720)")
                 return cost_analyses
 
             # Strip the sentinel key before passing to component builder
@@ -780,9 +778,7 @@ class BusinessIntelligenceDashboard:
         """
         api_times = performance_data.get("api_response_times", [])
         if api_times:
-            avg_response_time = (
-                statistics.mean(api_times[-10:]) if len(api_times) >= 10 else statistics.mean(api_times)
-            )
+            avg_response_time = statistics.mean(api_times[-10:]) if len(api_times) >= 10 else statistics.mean(api_times)
             return max(0, 100 - (avg_response_time - 1.0) * 20)
         return 80.0
 

--- a/autobot-slm-backend/tests/test_bi_dashboard.py
+++ b/autobot-slm-backend/tests/test_bi_dashboard.py
@@ -1,0 +1,435 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for business_intelligence_dashboard.py — Issue #10720.
+
+Covers:
+- Real usage path: Prometheus returns data → operations_data_available=True
+- Unavailable usage path: Prometheus unreachable → operations_data_available=False
+  and no fabricated numbers presented as real.
+- Config-driven costs: CostModelConfig values are reflected in CostAnalysis.
+- Redis-failure degradation: _get_current_utilization and
+  _get_historical_performance_data return available=False, not silent empty dict.
+"""
+
+import importlib.util
+import json
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub all heavy deps BEFORE importing the module under test.
+# We load the .py file directly so the monitoring package __init__ is bypassed.
+# ---------------------------------------------------------------------------
+
+# matplotlib stub
+_matplotlib = types.ModuleType("matplotlib")
+_matplotlib.use = lambda *a, **kw: None
+sys.modules.setdefault("matplotlib", _matplotlib)
+_matplotlib_pyplot = types.ModuleType("matplotlib.pyplot")
+sys.modules.setdefault("matplotlib.pyplot", _matplotlib_pyplot)
+
+# numpy stub — only polyfit/arange/std/array are exercised
+import numpy as _real_numpy  # noqa: E402 — numpy is available in test env
+
+sys.modules.setdefault("numpy", _real_numpy)
+
+# aiofiles stub
+_aiofiles = types.ModuleType("aiofiles")
+sys.modules.setdefault("aiofiles", _aiofiles)
+
+# jinja2 stub
+_jinja2 = types.ModuleType("jinja2")
+
+
+class _FakeTemplate:
+    def __init__(self, src):
+        self._src = src
+
+    def render(self, **kwargs):
+        return self._src
+
+
+_jinja2.Template = _FakeTemplate
+sys.modules.setdefault("jinja2", _jinja2)
+
+# performance_monitor stub (local SLM dep)
+_pm = types.ModuleType("performance_monitor")
+_pm.ALERT_THRESHOLDS = {"cpu_percent": 80.0, "memory_percent": 85.0}
+sys.modules["performance_monitor"] = _pm
+
+# autobot_shared stubs
+_shared = types.ModuleType("autobot_shared")
+sys.modules.setdefault("autobot_shared", _shared)
+
+_nc = types.ModuleType("autobot_shared.network_constants")
+
+
+class _NC:
+    REDIS_VM_IP = "127.0.0.1"
+
+
+_nc.NetworkConstants = _NC
+sys.modules["autobot_shared.network_constants"] = _nc
+
+# prometheus_query stub — patched per-test via patch()
+_pq = types.ModuleType("autobot_shared.monitoring.prometheus_query")
+_pq.query_instant = AsyncMock(return_value=None)
+_monitoring_pkg = types.ModuleType("autobot_shared.monitoring")
+sys.modules["autobot_shared.monitoring"] = _monitoring_pkg
+sys.modules["autobot_shared.monitoring.prometheus_query"] = _pq
+
+_rc = types.ModuleType("autobot_shared.redis_client")
+sys.modules["autobot_shared.redis_client"] = _rc
+
+_http = types.ModuleType("autobot_shared.http_client")
+sys.modules["autobot_shared.http_client"] = _http
+
+_lm = types.ModuleType("autobot_shared.logging_manager")
+_lm.get_logger = logging.getLogger
+sys.modules["autobot_shared.logging_manager"] = _lm
+
+
+# ---------------------------------------------------------------------------
+# Stub CostModelConfig and ssot_config
+# ---------------------------------------------------------------------------
+
+
+class _StubCostModel:
+    cpu_monthly_usd = 55.0
+    gpu_monthly_usd = 85.0
+    npu_monthly_usd = 35.0
+    memory_monthly_usd = 22.0
+    storage_monthly_usd = 28.0
+    network_monthly_usd = 90.0
+    cpu_baseline_efficiency = 70.0
+    gpu_baseline_efficiency = 60.0
+    npu_baseline_efficiency = 50.0
+    memory_baseline_efficiency = 80.0
+    storage_baseline_efficiency = 60.0
+    network_baseline_efficiency = 40.0
+
+
+class _StubConfig:
+    cost_model = _StubCostModel()
+
+
+_ssot = types.ModuleType("autobot_shared.ssot_config")
+_ssot.get_config = lambda: _StubConfig()
+sys.modules["autobot_shared.ssot_config"] = _ssot
+
+# ---------------------------------------------------------------------------
+# Load the module under test directly from its file path
+# ---------------------------------------------------------------------------
+
+_slm_root = Path(__file__).parent.parent
+_dashboard_path = _slm_root / "monitoring" / "business_intelligence_dashboard.py"
+_spec = importlib.util.spec_from_file_location("business_intelligence_dashboard", _dashboard_path)
+_bid_mod = importlib.util.module_from_spec(_spec)
+sys.modules["business_intelligence_dashboard"] = _bid_mod
+_spec.loader.exec_module(_bid_mod)
+
+BusinessIntelligenceDashboard = _bid_mod.BusinessIntelligenceDashboard
+_sum_prometheus_increase = _bid_mod._sum_prometheus_increase
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_dashboard() -> BusinessIntelligenceDashboard:
+    """Return a dashboard instance with Redis disabled and a temp data path."""
+    dash = object.__new__(BusinessIntelligenceDashboard)
+    dash.logger = logging.getLogger("test_bid")
+    dash.redis_client = None
+    dash.redis_host = "127.0.0.1"
+    dash.redis_port = 6379
+    dash.dashboard_data_path = Path("/tmp/test_bi_dashboard")  # test-only temp path
+    dash.hardware_investments = {
+        "intel_ultra_9_185h": {"cost": 800, "category": "cpu"},
+    }
+    dash.operational_costs = {"electricity": 150, "internet": 80}
+    dash.performance_baselines = {
+        "api_response_time": 2.0,
+        "knowledge_search_time": 300,
+        "llm_tokens_per_second": 20.0,
+        "system_uptime": 99.5,
+        "npu_utilization": 60.0,
+    }
+    return dash
+
+
+# ---------------------------------------------------------------------------
+# Part 1: Monthly operation counts — real usage vs unavailable
+# ---------------------------------------------------------------------------
+
+
+class TestMonthlyOperations:
+    @pytest.mark.asyncio
+    async def test_real_usage_path_returns_data_available_true(self):
+        """When Prometheus returns counts, operations_data_available is True."""
+        dash = _make_dashboard()
+
+        async def _fake_get_monthly_operations():
+            return 51_000, True
+
+        dash._get_monthly_operations = _fake_get_monthly_operations
+        dash._get_historical_performance_data = AsyncMock(return_value={"available": False})
+        dash._calculate_performance_improvement = AsyncMock(return_value=0.0)
+
+        roi = await dash.calculate_roi_metrics()
+
+        assert roi.operations_data_available is True
+        # cost_per_operation must be non-zero when ops count is real
+        assert roi.cost_per_operation > 0
+
+    @pytest.mark.asyncio
+    async def test_prometheus_unavailable_returns_data_available_false(self):
+        """When Prometheus is unreachable, operations_data_available is False."""
+        dash = _make_dashboard()
+
+        async def _fake_get_monthly_operations():
+            return 0, False
+
+        dash._get_monthly_operations = _fake_get_monthly_operations
+        dash._get_historical_performance_data = AsyncMock(return_value={"available": False})
+        dash._calculate_performance_improvement = AsyncMock(return_value=0.0)
+
+        roi = await dash.calculate_roi_metrics()
+
+        assert roi.operations_data_available is False
+        # cost_per_operation must be 0 — no ops means undefined, not fake
+        assert roi.cost_per_operation == 0
+
+    @pytest.mark.asyncio
+    async def test_sum_prometheus_increase_none_when_no_data(self):
+        """_sum_prometheus_increase returns None when Prometheus returns None."""
+        with patch.object(_bid_mod, "query_instant", new=AsyncMock(return_value=None)):
+            result = await _sum_prometheus_increase("fake_metric[30d]")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_sum_prometheus_increase_none_when_empty_result(self):
+        """_sum_prometheus_increase returns None when result list is empty."""
+        empty = {"resultType": "vector", "result": []}
+        with patch.object(_bid_mod, "query_instant", new=AsyncMock(return_value=empty)):
+            result = await _sum_prometheus_increase("autobot_llm_requests_total[30d]")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_sum_prometheus_increase_sums_all_series(self):
+        """_sum_prometheus_increase sums across label dimensions."""
+        fake_data = {
+            "resultType": "vector",
+            "result": [
+                {"metric": {"provider": "ollama"}, "value": [1234567890, "300"]},
+                {"metric": {"provider": "openai"}, "value": [1234567890, "200"]},
+            ],
+        }
+        with patch.object(_bid_mod, "query_instant", new=AsyncMock(return_value=fake_data)):
+            result = await _sum_prometheus_increase("autobot_llm_requests_total[30d]")
+        assert result == pytest.approx(500.0)
+
+    @pytest.mark.asyncio
+    async def test_get_monthly_operations_both_sources_available(self):
+        """_get_monthly_operations combines LLM + KB counts when both Prometheus series exist."""
+        llm_data = {
+            "resultType": "vector",
+            "result": [{"metric": {}, "value": [0, "1000"]}],
+        }
+        kb_data = {
+            "resultType": "vector",
+            "result": [{"metric": {}, "value": [0, "500"]}],
+        }
+
+        call_count = 0
+
+        async def _mock_query(promql):
+            nonlocal call_count
+            call_count += 1
+            if "llm" in promql:
+                return llm_data
+            return kb_data
+
+        with patch.object(_bid_mod, "query_instant", side_effect=_mock_query):
+            total, available = await dash._get_monthly_operations()
+
+        assert available is True
+        assert total == 1500
+
+    @pytest.mark.asyncio
+    async def test_get_monthly_operations_both_unavailable(self):
+        """_get_monthly_operations returns (0, False) when both Prometheus calls fail."""
+        with patch.object(_bid_mod, "query_instant", new=AsyncMock(return_value=None)):
+            total, available = await dash._get_monthly_operations()
+        assert available is False
+        assert total == 0
+
+
+# Shared fixture for some tests
+dash = _make_dashboard()
+
+
+# ---------------------------------------------------------------------------
+# Part 2: Config-driven component costs
+# ---------------------------------------------------------------------------
+
+
+class TestConfigDrivenCosts:
+    def test_build_component_definitions_uses_config_values(self):
+        """_build_component_definitions reads from _cost (CostModelConfig), not literals."""
+        d = _make_dashboard()
+        defs = d._build_component_definitions(
+            {"cpu": 45.0, "gpu": 0, "npu": 0, "memory": 0, "storage": 0, "network": 0}
+        )
+        assert defs["cpu"]["monthly_cost"] == _StubCostModel.cpu_monthly_usd
+        assert defs["gpu"]["monthly_cost"] == _StubCostModel.gpu_monthly_usd
+        assert defs["npu"]["monthly_cost"] == _StubCostModel.npu_monthly_usd
+        assert defs["memory"]["monthly_cost"] == _StubCostModel.memory_monthly_usd
+        assert defs["storage"]["monthly_cost"] == _StubCostModel.storage_monthly_usd
+        assert defs["network"]["monthly_cost"] == _StubCostModel.network_monthly_usd
+
+    def test_build_component_definitions_uses_config_efficiency(self):
+        """baseline_efficiency values come from config, not hardcoded literals."""
+        d = _make_dashboard()
+        defs = d._build_component_definitions({})
+        assert defs["cpu"]["baseline_efficiency"] == _StubCostModel.cpu_baseline_efficiency
+        assert defs["gpu"]["baseline_efficiency"] == _StubCostModel.gpu_baseline_efficiency
+
+    @pytest.mark.asyncio
+    async def test_cost_analysis_cost_is_estimate_always_true(self):
+        """CostAnalysis.cost_is_estimate is True because costs are operator estimates."""
+        d = _make_dashboard()
+        util = {
+            "available": True,
+            "cpu": 50.0,
+            "gpu": 40.0,
+            "npu": 30.0,
+            "memory": 60.0,
+            "storage": 50.0,
+            "network": 30.0,
+        }
+        d._get_current_utilization = AsyncMock(return_value=util)
+        analyses = await d.analyze_cost_efficiency()
+        assert analyses, "Expected at least one CostAnalysis"
+        for ca in analyses:
+            assert ca.cost_is_estimate is True
+
+    @pytest.mark.asyncio
+    async def test_cost_analysis_uses_config_monthly_cost(self):
+        """CostAnalysis.monthly_cost_usd matches the config value for each component."""
+        d = _make_dashboard()
+        util = {
+            "available": True,
+            "cpu": 50.0,
+            "gpu": 40.0,
+            "npu": 30.0,
+            "memory": 60.0,
+            "storage": 50.0,
+            "network": 30.0,
+        }
+        d._get_current_utilization = AsyncMock(return_value=util)
+        analyses = await d.analyze_cost_efficiency()
+        costs_by_component = {ca.component: ca.monthly_cost_usd for ca in analyses}
+        assert costs_by_component["cpu"] == _StubCostModel.cpu_monthly_usd
+        assert costs_by_component["network"] == _StubCostModel.network_monthly_usd
+
+    @pytest.mark.asyncio
+    async def test_cost_analysis_empty_when_utilization_unavailable(self):
+        """analyze_cost_efficiency returns [] when utilization data is unavailable (Redis down)."""
+        d = _make_dashboard()
+        d._get_current_utilization = AsyncMock(return_value={"available": False, "error": "redis_unavailable"})
+        analyses = await d.analyze_cost_efficiency()
+        assert analyses == []
+
+
+# ---------------------------------------------------------------------------
+# Part 3: Redis-failure degradation signals
+# ---------------------------------------------------------------------------
+
+
+class TestRedisFallbacks:
+    @pytest.mark.asyncio
+    async def test_get_current_utilization_no_redis_returns_available_false(self):
+        """_get_current_utilization returns {available:False} (not {}) when redis_client is None."""
+        d = _make_dashboard()
+        result = await d._get_current_utilization()
+        assert result.get("available") is False
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_get_current_utilization_redis_error_returns_available_false(self):
+        """_get_current_utilization returns {available:False} on Redis command error."""
+        d = _make_dashboard()
+        mock_redis = MagicMock()
+        mock_redis.hget.side_effect = Exception("connection refused")
+        d.redis_client = mock_redis
+
+        result = await d._get_current_utilization()
+        assert result.get("available") is False
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_get_current_utilization_no_data_returns_available_false(self):
+        """_get_current_utilization returns {available:False} when key missing in Redis."""
+        d = _make_dashboard()
+        mock_redis = MagicMock()
+        mock_redis.hget.return_value = None
+        d.redis_client = mock_redis
+
+        result = await d._get_current_utilization()
+        assert result.get("available") is False
+
+    @pytest.mark.asyncio
+    async def test_get_current_utilization_happy_path(self):
+        """_get_current_utilization returns available=True with real metrics on success."""
+        d = _make_dashboard()
+        mock_redis = MagicMock()
+        mock_redis.hget.return_value = json.dumps(
+            {"system": {"cpu_percent": 45.0, "memory_percent": 60.0, "disk_percent": 30.0}}
+        )
+        d.redis_client = mock_redis
+
+        result = await d._get_current_utilization()
+        assert result["available"] is True
+        assert result["cpu"] == 45.0
+        assert result["memory"] == 60.0
+
+    @pytest.mark.asyncio
+    async def test_get_historical_performance_data_no_redis_returns_available_false(self):
+        """_get_historical_performance_data returns {available:False} when redis_client is None."""
+        d = _make_dashboard()
+        result = await d._get_historical_performance_data()
+        assert result.get("available") is False
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_get_historical_performance_data_redis_error_returns_available_false(self):
+        """_get_historical_performance_data returns {available:False} on Redis command error."""
+        d = _make_dashboard()
+        mock_redis = MagicMock()
+        mock_redis.lrange.side_effect = Exception("timeout")
+        d.redis_client = mock_redis
+
+        result = await d._get_historical_performance_data()
+        assert result.get("available") is False
+
+    @pytest.mark.asyncio
+    async def test_get_historical_performance_data_happy_path(self):
+        """_get_historical_performance_data returns available=True with empty lists on no history."""
+        d = _make_dashboard()
+        mock_redis = MagicMock()
+        mock_redis.lrange.return_value = []
+        d.redis_client = mock_redis
+
+        result = await d._get_historical_performance_data()
+        assert result["available"] is True
+        assert "api_response_times" in result

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1642,6 +1642,93 @@ class FeatureConfig(BaseSettings):
     mcp: bool = Field(default=True, alias="AUTOBOT_FEATURE_MCP")
 
 
+class CostModelConfig(BaseSettings):
+    """Operator-supplied monthly cost estimates for hardware components.
+
+    Issue #10720: Replaces hardcoded literals in business_intelligence_dashboard.py
+    so operators can supply deployment-specific costs without editing source code.
+
+    All fields represent USD/month and are documented as ESTIMATES; the dashboard
+    renders them with an "estimated" label when the defaults are in use.
+
+    Override via environment variables, e.g.:
+        AUTOBOT_COST_CPU_MONTHLY_USD=75
+        AUTOBOT_COST_GPU_MONTHLY_USD=120
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=str(PROJECT_ROOT / ".env"),
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    # Per-component monthly cost estimates (USD).
+    # Defaults reflect a single-host deployment with a discrete GPU;
+    # operators MUST override these to reflect actual electricity + depreciation.
+    cpu_monthly_usd: float = Field(
+        default=50.0,
+        alias="AUTOBOT_COST_CPU_MONTHLY_USD",
+        description="Estimated monthly cost apportioned to CPU (USD). Operator-supplied estimate.",
+    )
+    gpu_monthly_usd: float = Field(
+        default=80.0,
+        alias="AUTOBOT_COST_GPU_MONTHLY_USD",
+        description="Estimated monthly cost apportioned to GPU incl. higher power draw (USD). Operator estimate.",
+    )
+    npu_monthly_usd: float = Field(
+        default=30.0,
+        alias="AUTOBOT_COST_NPU_MONTHLY_USD",
+        description="Estimated monthly cost apportioned to NPU (USD). Operator-supplied estimate.",
+    )
+    memory_monthly_usd: float = Field(
+        default=20.0,
+        alias="AUTOBOT_COST_MEMORY_MONTHLY_USD",
+        description="Estimated monthly cost apportioned to RAM (USD). Operator-supplied estimate.",
+    )
+    storage_monthly_usd: float = Field(
+        default=25.0,
+        alias="AUTOBOT_COST_STORAGE_MONTHLY_USD",
+        description="Estimated monthly cost apportioned to NVMe storage (USD). Operator-supplied estimate.",
+    )
+    network_monthly_usd: float = Field(
+        default=80.0,
+        alias="AUTOBOT_COST_NETWORK_MONTHLY_USD",
+        description="Estimated monthly internet cost (USD). Operator-supplied estimate.",
+    )
+
+    # Baseline utilization efficiency targets (percent) per component.
+    cpu_baseline_efficiency: float = Field(
+        default=70.0,
+        alias="AUTOBOT_COST_CPU_BASELINE_EFFICIENCY",
+        description="Target CPU utilisation percent for efficiency scoring.",
+    )
+    gpu_baseline_efficiency: float = Field(
+        default=60.0,
+        alias="AUTOBOT_COST_GPU_BASELINE_EFFICIENCY",
+        description="Target GPU utilisation percent for efficiency scoring.",
+    )
+    npu_baseline_efficiency: float = Field(
+        default=50.0,
+        alias="AUTOBOT_COST_NPU_BASELINE_EFFICIENCY",
+        description="Target NPU utilisation percent for efficiency scoring.",
+    )
+    memory_baseline_efficiency: float = Field(
+        default=80.0,
+        alias="AUTOBOT_COST_MEMORY_BASELINE_EFFICIENCY",
+        description="Target memory utilisation percent for efficiency scoring.",
+    )
+    storage_baseline_efficiency: float = Field(
+        default=60.0,
+        alias="AUTOBOT_COST_STORAGE_BASELINE_EFFICIENCY",
+        description="Target storage utilisation percent for efficiency scoring.",
+    )
+    network_baseline_efficiency: float = Field(
+        default=40.0,
+        alias="AUTOBOT_COST_NETWORK_BASELINE_EFFICIENCY",
+        description="Target network utilisation percent for efficiency scoring.",
+    )
+
+
 class TelemetryConfig(BaseSettings):
     """
     Telemetry and analytics opt-out configuration.
@@ -1726,6 +1813,7 @@ class AutoBotConfig(BaseSettings):
     )  # Issue #3397; alias avoids collision with system PATH env var
     misc: MiscConfig = Field(default_factory=MiscConfig)  # GH#7437: Unmapped env vars
     telemetry: TelemetryConfig = Field(default_factory=TelemetryConfig)  # Issue #9035
+    cost_model: CostModelConfig = Field(default_factory=CostModelConfig)  # Issue #10720
 
     # Top-level settings
     deployment_mode: str = Field(default="distributed", alias="AUTOBOT_DEPLOYMENT_MODE")


### PR DESCRIPTION
## Thinking Path
Umbrella #10714, T6. `business_intelligence_dashboard.py` reported fabricated usage (hardcoded 1000/500/200), hardcoded per-component costs, and silently returned `{}` on Redis failure — fake numbers presented as real.

## What Changed
- **Usage (real source):** `_estimate_monthly_operations` → `_get_monthly_operations` queries real Prometheus counters (`autobot_llm_requests_total` + `autobot_knowledge_search_requests_total`, `increase(...[30d])` via existing `prometheus_query.query_instant`). New `ROIMetrics.operations_data_available` flag → dashboard shows "unavailable" instead of a fake number when Prometheus is down. (No generic HTTP API counter exists yet → follow-up.)
- **Costs (config-driven):** added `CostModelConfig` to `ssot_config.py` (12 env-overridable fields `AUTOBOT_COST_*`, current values as documented defaults). `_build_component_definitions` reads config, not literals. `CostAnalysis.cost_is_estimate=True` + template renders "(estimated cost)".
- **Redis fallbacks:** the 5 silent `return {}` now return `{available: False, error: ...}`; all callers check `available` before consuming → no silent zero-as-real.

## Verification
- 19 unit tests pass (`19 passed in 1.01s`): real Prometheus path, unavailable path, config-driven costs, all Redis-failure degradation paths.
- `py_compile` + `flake8 --max-line-length=120` clean; black/isort applied.

## Follow-ups identified
Generic `autobot_api_requests_total` counter; real network-utilization metric (still 30.0% placeholder); per-tenant cost config.

Closes #10720.

## Model Used
Claude Opus 4.8 (1M context)