### PR TITLE
feat(api): send X-Organization-Id (selected company) on all requests (#10750 A5)

### DIFF
--- a/autobot-frontend/src/utils/ApiClient.ts
+++ b/autobot-frontend/src/utils/ApiClient.ts
@@ -3,6 +3,7 @@
 import appConfig from '@/config/AppConfig.js';
 import { createLogger } from '@/utils/debugUtils';
 import { getApiBase } from '@/config/ssot-config';
+import { getSelectedCompanyId } from '@/utils/orgContext';
 
 // Create scoped logger for ApiClient
 const logger = createLogger('ApiClient');
@@ -309,6 +310,16 @@ export class ApiClient {
       if (authToken) {
         const hdrs = fetchOptions.headers as Record<string, string>;
         hdrs['Authorization'] = `Bearer ${authToken}`;
+      }
+
+      // Inject the selected company as org/tenant context (#10750 A5). Omitted
+      // when no company is selected, so non-LLC requests are unaffected.
+      const orgId = getSelectedCompanyId();
+      if (orgId) {
+        const orgHdrs = fetchOptions.headers as Record<string, string>;
+        if (!orgHdrs['X-Organization-Id']) {
+          orgHdrs['X-Organization-Id'] = orgId;
+        }
       }
 
       // Handle body — support FormData (don't stringify, remove Content-Type)

--- a/autobot-frontend/src/utils/fetchWithAuth.ts
+++ b/autobot-frontend/src/utils/fetchWithAuth.ts
@@ -10,7 +10,11 @@
  * exists to fix existing raw fetch() call-sites without a full refactor.
  *
  * Issue #979: JWT token not attached to backend API requests.
+ * Issue #10750 (A5): also attach the selected company as X-Organization-Id so
+ * org-scoped Company OS endpoints resolve tenant context.
  */
+
+import { applyOrgHeader } from '@/utils/orgContext'
 
 export function getAuthToken(): string | null {
   try {
@@ -27,21 +31,21 @@ export function getAuthToken(): string | null {
 }
 
 /**
- * Wraps native fetch() with Bearer-token injection.
- * If no valid token is found, the request proceeds unauthenticated
- * (matches pre-existing behaviour; let the server decide).
+ * Wraps native fetch() with Bearer-token injection and the X-Organization-Id
+ * header for the selected company. If no valid token is found the request still
+ * proceeds (matches pre-existing behaviour; let the server decide), and the org
+ * header is omitted when no company is selected.
  */
 export async function fetchWithAuth(url: string, options: RequestInit = {}): Promise<Response> {
   const token = getAuthToken()
-  if (!token) {
-    return fetch(url, options)
-  }
 
   // Build a new Headers object so we don't mutate the caller's options.
   const headers = new Headers(options.headers)
-  if (!headers.has('Authorization')) {
+  if (token && !headers.has('Authorization')) {
     headers.set('Authorization', `Bearer ${token}`)
   }
+  // Attach the selected company id as org context (#10750 A5); no-op when none.
+  applyOrgHeader(headers)
 
   return fetch(url, { ...options, headers })
 }

--- a/autobot-frontend/src/utils/orgContext.ts
+++ b/autobot-frontend/src/utils/orgContext.ts
@@ -1,0 +1,76 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * orgContext — resolves the currently-selected LLC company id so it can be
+ * attached as the `X-Organization-Id` header on every backend request.
+ *
+ * Org-scoped Company OS endpoints resolve tenant context from this header;
+ * without it they reject with 400 "Organization context required" (#10750 A5).
+ *
+ * Resolution order (single source of truth = the llcCompany Pinia store):
+ *   1. live Pinia store  — `useLlcCompanyStore().selectedCompanyId`
+ *   2. persisted value   — localStorage key written by the store's
+ *      pinia-plugin-persistedstate config (`pick: ['selectedCompanyId']`)
+ *
+ * The store cannot be imported at the ApiClient/fetchWithAuth layer (the store
+ * imports ApiClient → circular), so when Pinia is not yet active we read the
+ * persisted selection directly. Both paths return the SAME value.
+ */
+
+import { getActivePinia } from 'pinia'
+
+// Must match the `persist.key` in useLlcCompanyStore.ts.
+const LLC_COMPANY_STORAGE_KEY = 'autobot-llc-company'
+
+/** Read the persisted selection written by pinia-plugin-persistedstate. */
+function readPersistedCompanyId(): string {
+  try {
+    if (typeof localStorage === 'undefined') return ''
+    const stored = localStorage.getItem(LLC_COMPANY_STORAGE_KEY)
+    if (!stored) return ''
+    const parsed: { selectedCompanyId?: unknown } = JSON.parse(stored)
+    return typeof parsed.selectedCompanyId === 'string' ? parsed.selectedCompanyId : ''
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Returns the selected company id, or '' when none is selected / unavailable
+ * (SSR, no Pinia, no persisted value). Prefers the live store; falls back to
+ * the persisted localStorage value so it works at the low-level request layer.
+ */
+export function getSelectedCompanyId(): string {
+  try {
+    const pinia = getActivePinia()
+    if (pinia) {
+      // Defer import to call time so this module has no static dependency on
+      // the store (which imports ApiClient — would be circular at the header
+      // injection sites). require-style dynamic access keeps it synchronous.
+      const stores = (pinia as unknown as {
+        _s?: Map<string, { selectedCompanyId?: unknown }>
+      })._s
+      const store = stores?.get('llcCompany')
+      if (store && typeof store.selectedCompanyId === 'string') {
+        return store.selectedCompanyId
+      }
+    }
+  } catch {
+    // fall through to persisted value
+  }
+  return readPersistedCompanyId()
+}
+
+/**
+ * Mutates the given Headers object to include `X-Organization-Id` when a
+ * company is selected. No-op (header omitted) when none is selected so non-LLC
+ * requests and unauthenticated flows are unaffected. Does not overwrite a
+ * header the caller already set.
+ */
+export function applyOrgHeader(headers: Headers): void {
+  if (headers.has('X-Organization-Id')) return
+  const companyId = getSelectedCompanyId()
+  if (companyId) {
+    headers.set('X-Organization-Id', companyId)
+  }
+}


### PR DESCRIPTION
## Thinking Path

Org-scoped Company OS endpoints resolve tenant context from an `X-Organization-Id` request header (backend companion PR). The frontend sent nothing, so every org-scoped LLC request returned `400 "Organization context required"`. The fix is to inject the header at the same central place(s) where the `Authorization` bearer token is attached, so all `/api` requests get it consistently. There are two request chokepoints, plus the axios-style repository path which routes through one of them:

- `ApiClient.rawRequest()` — used by `useApiClient`, `useLlcCompanyStore`, and the LLC views.
- `fetchWithAuth()` — used by many composables and by `ApiRepository.request()` (the chat/axios-style path), so covering it covers the repository layer too.

The selected company lives in the `llcCompany` Pinia store (`useLlcCompanyStore.selectedCompanyId`), persisted via `pinia-plugin-persistedstate` (`pick: ['selectedCompanyId']`, key `autobot-llc-company`). The store imports `ApiClient`, so importing the store back into `ApiClient`/`fetchWithAuth` would be circular. The new helper therefore prefers the live store (via the active Pinia instance) and falls back to the persisted localStorage value — both return the same id.

## What Changed

- **New** `autobot-frontend/src/utils/orgContext.ts`
  - `getSelectedCompanyId()` — reads the selected company id from the active Pinia `llcCompany` store, falling back to the persisted localStorage value (`autobot-llc-company` → `{ selectedCompanyId }`). Returns `''` when none selected / SSR / no store.
  - `applyOrgHeader(headers: Headers)` — sets `X-Organization-Id` on a `Headers` object when a company is selected; never overwrites a header the caller set.
- **`autobot-frontend/src/utils/ApiClient.ts`** — in `rawRequest()`, immediately after the bearer-token injection, set `X-Organization-Id` from `getSelectedCompanyId()` when present (record-style headers).
- **`autobot-frontend/src/utils/fetchWithAuth.ts`** — switched to always build a `Headers` object, attach the bearer token when present, then call `applyOrgHeader()`.

The header is omitted entirely when no company is selected, so non-LLC and unauthenticated requests are unaffected. Nothing is hardcoded.

## Verification

- `npx vue-tsc --noEmit -p tsconfig.app.json`: **0 new errors**. The only error reported is pre-existing on the base (`src/services/LiveEventService.ts(315,27)` `apiUrl` — confirmed identical with my changes stashed). My three files introduce no TS errors. (node_modules was symlinked from the main checkout to run the check, then removed before committing.)
- `npx eslint src/utils/orgContext.ts src/utils/ApiClient.ts src/utils/fetchWithAuth.ts`: exit 0, **0 warnings**.

## Model Used

Opus 4.8 (1M context)

Part of #10750 (A5, frontend half)