### PR TITLE
refactor(chat): B1 — drop infix enhanced from chat handlers, routes, schemas, and generated types (#10746)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -1578,16 +1578,16 @@ async def send_direct_chat_response(
 
 
 # ====================================================================
-# Enhanced Chat Functions with AI Stack Integration (Issue #708 consolidation)
+# AI Stack Chat Functions (Issue #708 consolidation)
 # ====================================================================
 
 
-async def _store_enhanced_user_message(
+async def _store_ai_stack_user_message(
     message: ChatMessage,
     session_id: str,
     chat_history_manager,
 ) -> str:
-    """Store user message and log event for enhanced chat."""
+    """Store user message and log event for AI Stack chat."""
     user_message_id = str(uuid4())
     user_message_data = {
         "id": user_message_id,
@@ -1606,7 +1606,7 @@ async def _store_enhanced_user_message(
         await chat_history_manager.add_messages_batch(session_id, [_to_persisted_message(user_message_data, "message")])
 
     log_chat_event(
-        "enhanced_message_received",
+        "ai_stack_message_received",
         session_id,
         {
             "message_id": user_message_id,
@@ -1619,12 +1619,12 @@ async def _store_enhanced_user_message(
     return user_message_id
 
 
-async def _get_enhanced_chat_context(
+async def _get_ai_stack_chat_context(
     message: ChatMessage,
     session_id: str,
     chat_history_manager,
 ) -> list:
-    """Retrieve chat context from history for enhanced chat."""
+    """Retrieve chat context from history for AI Stack chat."""
     chat_context = []
     if hasattr(chat_history_manager, "get_session_messages"):
         try:
@@ -1758,13 +1758,13 @@ def _enhance_response_with_sources(
         ai_response["metadata"]["sources"] = sources_info
 
 
-async def _store_enhanced_ai_response(
+async def _store_ai_stack_ai_response(
     ai_response: Metadata,
     session_id: str,
     request_id: str,
     chat_history_manager,
 ) -> str:
-    """Store AI response and log event for enhanced chat."""
+    """Store AI response and log event for AI Stack chat."""
     ai_message_id = str(uuid4())
     ai_message_data = {
         "id": ai_message_id,
@@ -1780,7 +1780,7 @@ async def _store_enhanced_ai_response(
         await chat_history_manager.add_messages_batch(session_id, [_to_persisted_message(ai_message_data, "response")])
 
     log_chat_event(
-        "enhanced_response_generated",
+        "ai_stack_response_generated",
         session_id,
         {
             "message_id": ai_message_id,
@@ -1793,7 +1793,7 @@ async def _store_enhanced_ai_response(
     return ai_message_id
 
 
-async def _execute_enhanced_chat_pipeline(
+async def _execute_ai_stack_chat_pipeline(
     message: ChatMessage,
     session_id: str,
     chat_history_manager,
@@ -1801,15 +1801,15 @@ async def _execute_enhanced_chat_pipeline(
     request_id: str,
     preferences: ChatPreferences | None,
 ) -> ChatData:
-    """Helper for process_enhanced_chat_message. Ref: #1088, #6502 (typed return).
+    """Helper for process_ai_stack_chat_message. Ref: #1088, #6502 (typed return).
 
-    Runs the full enhanced chat pipeline: store user message, retrieve context,
+    Runs the full AI Stack chat pipeline: store user message, retrieve context,
     enrich with knowledge base, generate AI response, attach sources, store response,
     and return the final result.
     """
-    await _store_enhanced_user_message(message, session_id, chat_history_manager)
+    await _store_ai_stack_user_message(message, session_id, chat_history_manager)
 
-    chat_context = await _get_enhanced_chat_context(message, session_id, chat_history_manager)
+    chat_context = await _get_ai_stack_chat_context(message, session_id, chat_history_manager)
 
     enhanced_context, knowledge_sources = await _enhance_with_knowledge_base(message, knowledge_base)
 
@@ -1828,7 +1828,7 @@ async def _execute_enhanced_chat_pipeline(
 
     _enhance_response_with_sources(ai_response, knowledge_sources, message.include_sources)
 
-    ai_message_id = await _store_enhanced_ai_response(ai_response, session_id, request_id, chat_history_manager)
+    ai_message_id = await _store_ai_stack_ai_response(ai_response, session_id, request_id, chat_history_manager)
 
     return ChatData(
         content=ai_response.get("content", ""),
@@ -1841,7 +1841,7 @@ async def _execute_enhanced_chat_pipeline(
     )
 
 
-async def process_enhanced_chat_message(
+async def process_ai_stack_chat_message(
     message: ChatMessage,
     chat_history_manager,
     knowledge_base,
@@ -1850,7 +1850,7 @@ async def process_enhanced_chat_message(
     preferences: ChatPreferences | None = None,
 ) -> ChatData:
     """
-    Process a chat message with AI Stack enhanced capabilities.
+    Process a chat message with AI Stack capabilities.
 
     This function combines local knowledge base search with AI Stack's
     intelligent chat agents for superior conversational experience.
@@ -1861,7 +1861,7 @@ async def process_enhanced_chat_message(
 
         session_id = message.session_id
 
-        return await _execute_enhanced_chat_pipeline(
+        return await _execute_ai_stack_chat_pipeline(
             message,
             session_id,
             chat_history_manager,
@@ -1873,12 +1873,12 @@ async def process_enhanced_chat_message(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error("Error processing enhanced chat message: %s", e)
-        raise HTTPException(status_code=500, detail="Failed to process enhanced chat message")
+        logger.error("Error processing AI Stack chat message: %s", e)
+        raise HTTPException(status_code=500, detail="Failed to process AI Stack chat message")
 
 
 # ====================================================================
-# Enhanced Chat Streaming Helpers (Issue #708 consolidation)
+# AI Stack Chat Streaming Helpers (Issue #708 consolidation)
 # ====================================================================
 
 
@@ -1896,7 +1896,7 @@ async def _stream_ai_stack_response(
 ):
     """Stream AI Stack enhanced response in chunks."""
     try:
-        response_data = await process_enhanced_chat_message(
+        response_data = await process_ai_stack_chat_message(
             message, chat_history_manager, None, {}, request_id, preferences
         )
 
@@ -1935,9 +1935,9 @@ async def _stream_ai_stack_response(
         )
 
 
-def _stream_enhanced_fallback_response(session_id: str):
+def _stream_ai_stack_fallback_response(session_id: str):
     """Stream fallback response when AI Stack not enabled."""
-    fallback_msg = "Thank you for your message. Enhanced streaming requires AI Stack " "integration."
+    fallback_msg = "Thank you for your message. AI Stack streaming requires AI Stack " "integration."
     return _format_sse_event(
         {
             "type": "chunk",
@@ -1948,7 +1948,7 @@ def _stream_enhanced_fallback_response(session_id: str):
     )
 
 
-async def _generate_enhanced_stream(
+async def _generate_ai_stack_stream(
     message: ChatMessage,
     request: Request,
     request_id: str,
@@ -1957,7 +1957,7 @@ async def _generate_enhanced_stream(
     """Generate streaming response with AI Stack integration."""
     try:
         session_id = message.session_id
-        yield _format_sse_event({"type": "start", "session_id": session_id, "enhanced": True})
+        yield _format_sse_event({"type": "start", "session_id": session_id, "ai_stack": True})
 
         chat_history_manager = get_chat_history_manager(request)
 
@@ -1967,7 +1967,7 @@ async def _generate_enhanced_stream(
             ):
                 yield event
         else:
-            yield _stream_enhanced_fallback_response(session_id)
+            yield _stream_ai_stack_fallback_response(session_id)
 
         yield _format_sse_event({"type": "end"})
 
@@ -1976,24 +1976,24 @@ async def _generate_enhanced_stream(
         yield _format_sse_event(
             {
                 "type": "error",
-                "content": "Error in enhanced streaming",
+                "content": "Error in AI Stack streaming",
                 "timestamp": utc_timestamp(),
             }
         )
 
 
 # ====================================================================
-# Enhanced Chat API Endpoints (Issue #708 consolidation)
+# AI Stack Chat API Endpoints (Issue #708 consolidation)
 # ====================================================================
 
 
-@router.post("/enhanced", response_model=DataResponse[ChatData])
+@router.post("/ai-stack", response_model=DataResponse[ChatData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="chat_enhanced",
+    operation="chat_ai_stack",
     error_code_prefix="CHAT",
 )
-async def chat_enhanced(
+async def chat_ai_stack(
     current_user: dict = Depends(get_current_user),
     message: ChatMessage = None,
     request: Request = None,
@@ -2002,10 +2002,10 @@ async def chat_enhanced(
     knowledge_base=Depends(get_knowledge_base),
 ):
     """
-    Enhanced chat endpoint with AI Stack integration.
+    AI Stack chat endpoint with knowledge base integration.
 
     This endpoint provides intelligent conversation with:
-    - AI Stack enhanced reasoning capabilities
+    - AI Stack reasoning capabilities
     - Knowledge base integration
     - Source citations
     - Customizable response preferences
@@ -2027,8 +2027,8 @@ async def chat_enhanced(
         # Get dependencies from request state
         chat_history_manager = get_chat_history_manager(request)
 
-        # Process the enhanced chat message
-        response_data = await process_enhanced_chat_message(
+        # Process the AI Stack chat message
+        response_data = await process_ai_stack_chat_message(
             message,
             chat_history_manager,
             knowledge_base,
@@ -2039,14 +2039,14 @@ async def chat_enhanced(
 
         return create_chat_response(
             response_data.model_dump(),
-            "Enhanced chat message processed successfully",
+            "AI Stack chat message processed successfully",
             request_id,
         )
 
     except HTTPException:
         raise
     except Exception as e:
-        logger.error("[%s] Enhanced chat error: %s", request_id, e)
+        logger.error("[%s] AI Stack chat error: %s", request_id, e)
         return create_error_response(
             error_code="INTERNAL_ERROR",
             message="Operation failed",
@@ -2055,22 +2055,22 @@ async def chat_enhanced(
         )
 
 
-@router.post("/stream-enhanced", response_model=None)  # StreamingResponse — no Pydantic schema
+@router.post("/stream-ai-stack", response_model=None)  # StreamingResponse — no Pydantic schema
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="stream_enhanced_chat",
+    operation="stream_ai_stack_chat",
     error_code_prefix="CHAT",
 )
-async def stream_enhanced_chat(
+async def stream_ai_stack_chat(
     current_user: dict = Depends(get_current_user),
     message: ChatMessage = None,
     request: Request = None,
     preferences: ChatPreferences | None = None,
 ):
     """
-    Stream enhanced chat response for real-time communication.
+    Stream AI Stack chat response for real-time communication.
 
-    Provides real-time streaming of AI Stack enhanced responses
+    Provides real-time streaming of AI Stack responses
     with knowledge base integration.
 
     Issue #744: Requires authenticated user.
@@ -2078,7 +2078,7 @@ async def stream_enhanced_chat(
     request_id = generate_request_id()
 
     return StreamingResponse(
-        _generate_enhanced_stream(message, request, request_id, preferences),
+        _generate_ai_stack_stream(message, request, request_id, preferences),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",
@@ -2089,17 +2089,17 @@ async def stream_enhanced_chat(
     )
 
 
-@router.get("/health-enhanced", response_model=ChatHealthData)
+@router.get("/health-ai-stack", response_model=ChatHealthData)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="chat_health_enhanced",
+    operation="chat_health_ai_stack",
     error_code_prefix="CHAT",
 )
-async def chat_health_enhanced(
+async def chat_health_ai_stack(
     current_user: dict = Depends(get_current_user),
 ):
     """
-    Health check for enhanced chat service including AI Stack connectivity.
+    Health check for AI Stack chat service including AI Stack connectivity.
 
     Issue #744: Requires authenticated user.
     """
@@ -2131,7 +2131,7 @@ async def chat_health_enhanced(
         )
 
     except Exception as e:
-        logger.error("Enhanced chat health check failed: %s", e)
+        logger.error("AI Stack chat health check failed: %s", e)
         return JSONResponse(
             status_code=503,
             media_type="application/json; charset=utf-8",
@@ -2146,14 +2146,14 @@ async def chat_health_enhanced(
 @router.get("/capabilities", response_model=DataResponse[ChatCapabilitiesData])
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="get_enhanced_chat_capabilities",
+    operation="get_chat_capabilities",
     error_code_prefix="CHAT",
 )
-async def get_enhanced_chat_capabilities(
+async def get_chat_capabilities(
     current_user: dict = Depends(get_current_user),
 ):
     """
-    Get enhanced chat capabilities and available features.
+    Get AI Stack chat capabilities and available features.
 
     Issue #744: Requires authenticated user.
     """
@@ -2180,7 +2180,7 @@ async def get_enhanced_chat_capabilities(
             "context_window": 10,
         }
 
-        return create_chat_response(capabilities, "Enhanced chat capabilities retrieved successfully")
+        return create_chat_response(capabilities, "Chat capabilities retrieved successfully")
 
     except Exception as e:
         logger.warning("Failed to get full capabilities: %s", e)

--- a/autobot-backend/api/chat_phase2_test.py
+++ b/autobot-backend/api/chat_phase2_test.py
@@ -6,7 +6,7 @@
 
 Pins four acceptance criteria from the SSOT design:
   1. ChatMessage requires session_id (→ 422 when absent)
-  2. process_enhanced_chat_message returns HTTP 422 for invalid session_id format
+  2. process_ai_stack_chat_message returns HTTP 422 for invalid session_id format
   3. chat:recent sorted-set has TTL applied after every zadd
   4. save_session writes disk before updating Redis cache
 """
@@ -62,24 +62,24 @@ class TestSessionIdRequired:
 
 
 # ---------------------------------------------------------------------------
-# 2. process_enhanced_chat_message returns HTTP 422 for invalid session_id
+# 2. process_ai_stack_chat_message returns HTTP 422 for invalid session_id
 # ---------------------------------------------------------------------------
 
 
-class TestEnhancedChatSession422:
-    """process_enhanced_chat_message raises HTTPException(422) for bad format."""
+class TestAiStackChatSession422:
+    """process_ai_stack_chat_message raises HTTPException(422) for bad format."""
 
     @pytest.mark.asyncio
     async def test_invalid_session_id_format_raises_422(self):
         from fastapi import HTTPException
 
-        from api.chat import process_enhanced_chat_message
+        from api.chat import process_ai_stack_chat_message
         from api.schemas_chat import ChatMessage
 
         with patch("api.chat.validate_chat_session_id", return_value=False):
             msg = ChatMessage(content="hello", session_id="BAD_FORMAT")
             with pytest.raises(HTTPException) as exc_info:
-                await process_enhanced_chat_message(
+                await process_ai_stack_chat_message(
                     message=msg,
                     chat_history_manager=MagicMock(),
                     knowledge_base=None,

--- a/autobot-backend/api/schemas_chat.py
+++ b/autobot-backend/api/schemas_chat.py
@@ -215,13 +215,13 @@ class ChatHealthComponents(BaseModel):
 
 
 class ChatHealthData(BaseModel):
-    """Response shape for GET /chat/health and GET /health-enhanced (#6497, #10654).
+    """Response shape for GET /chat/health and GET /health-ai-stack (#6497, #10654).
 
     Canonical model for both health endpoints. Wire format is the model itself —
     no DataResponse envelope. ``components`` is Dict[str, Any] so it handles
     both the fixed {chat_history_manager, llm_service} shape from /chat/health
-    and the heterogeneous per-component map from /health-enhanced.
-    ``error`` is only populated on the /health-enhanced error path.
+    and the heterogeneous per-component map from /health-ai-stack.
+    ``error`` is only populated on the /health-ai-stack error path.
     """
 
     status: str
@@ -258,10 +258,10 @@ class ChatDeleteData(BaseModel):
 
 
 class ChatData(BaseModel):
-    """data payload for POST /enhanced.
+    """data payload for POST /ai-stack.
 
     Mirrors ChatMessageData with an additional ``knowledge_sources``
-    field for KB-augmented enhanced chats.
+    field for KB-augmented AI Stack chats.
     """
 
     content: str

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -1298,7 +1298,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/enhanced": {
+    "/api/ai-stack": {
         parameters: {
             query?: never;
             header?: never;
@@ -1308,25 +1308,25 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Enhanced Chat
-         * @description Enhanced chat endpoint with AI Stack integration.
+         * AI Stack Chat
+         * @description AI Stack chat endpoint with knowledge base integration.
          *
          *     This endpoint provides intelligent conversation with:
-         *     - AI Stack enhanced reasoning capabilities
+         *     - AI Stack reasoning capabilities
          *     - Knowledge base integration
          *     - Source citations
          *     - Customizable response preferences
          *
          *     Issue #744: Requires authenticated user.
          */
-        post: operations["enhanced_chat_api_enhanced_post"];
+        post: operations["chat_ai_stack_api_ai_stack_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/stream-enhanced": {
+    "/api/stream-ai-stack": {
         parameters: {
             query?: never;
             header?: never;
@@ -1336,22 +1336,22 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Stream Enhanced Chat
-         * @description Stream enhanced chat response for real-time communication.
+         * Stream AI Stack Chat
+         * @description Stream AI Stack chat response for real-time communication.
          *
-         *     Provides real-time streaming of AI Stack enhanced responses
+         *     Provides real-time streaming of AI Stack responses
          *     with knowledge base integration.
          *
          *     Issue #744: Requires authenticated user.
          */
-        post: operations["stream_enhanced_chat_api_stream_enhanced_post"];
+        post: operations["stream_ai_stack_chat_api_stream_ai_stack_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/health-enhanced": {
+    "/api/health-ai-stack": {
         parameters: {
             query?: never;
             header?: never;
@@ -1359,12 +1359,12 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Enhanced Chat Health Check
-         * @description Health check for enhanced chat service including AI Stack connectivity.
+         * AI Stack Chat Health Check
+         * @description Health check for AI Stack chat service including AI Stack connectivity.
          *
          *     Issue #744: Requires authenticated user.
          */
-        get: operations["enhanced_chat_health_check_api_health_enhanced_get"];
+        get: operations["chat_health_ai_stack_api_health_ai_stack_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -56011,8 +56011,8 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** Body_enhanced_chat_api_enhanced_post */
-        Body_enhanced_chat_api_enhanced_post: {
+        /** Body_chat_ai_stack_api_ai_stack_post */
+        Body_chat_ai_stack_api_ai_stack_post: {
             message?: components["schemas"]["EnhancedChatMessage"];
             preferences?: components["schemas"]["ChatPreferences"] | null;
         } & {
@@ -56120,8 +56120,8 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** Body_stream_enhanced_chat_api_stream_enhanced_post */
-        Body_stream_enhanced_chat_api_stream_enhanced_post: {
+        /** Body_stream_ai_stack_chat_api_stream_ai_stack_post */
+        Body_stream_ai_stack_chat_api_stream_ai_stack_post: {
             message?: components["schemas"]["EnhancedChatMessage"];
             preferences?: components["schemas"]["ChatPreferences"] | null;
         } & {
@@ -64596,14 +64596,14 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** DataResponse[EnhancedChatData] */
-        DataResponse_EnhancedChatData_: {
+        /** DataResponse[ChatData] */
+        DataResponse_ChatData_: {
             /**
              * Success
              * @default true
              */
             success: boolean;
-            data?: components["schemas"]["EnhancedChatData"] | null;
+            data?: components["schemas"]["ChatData"] | null;
             /** Message */
             message?: string | null;
             /** Timestamp */
@@ -64611,14 +64611,14 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** DataResponse[EnhancedChatResult] */
-        DataResponse_EnhancedChatResult_: {
+        /** DataResponse[ChatResult] */
+        DataResponse_ChatResult_: {
             /**
              * Success
              * @default true
              */
             success: boolean;
-            data?: components["schemas"]["EnhancedChatResult"] | null;
+            data?: components["schemas"]["ChatResult"] | null;
             /** Message */
             message?: string | null;
             /** Timestamp */
@@ -68745,13 +68745,13 @@ export interface components {
             [key: string]: unknown;
         };
         /**
-         * EnhancedChatData
-         * @description data payload for POST /enhanced.
+         * ChatData
+         * @description data payload for POST /ai-stack.
          *
          *     Mirrors ChatMessageData with an additional ``knowledge_sources``
-         *     field for KB-augmented enhanced chats.
+         *     field for KB-augmented AI Stack chats.
          */
-        EnhancedChatData: {
+        ChatData: {
             /** Content */
             content: string;
             /** Role */
@@ -68774,14 +68774,14 @@ export interface components {
             [key: string]: unknown;
         };
         /**
-         * EnhancedChatHealthData
-         * @description Response shape for GET /health-enhanced (#6497).
+         * AiStackChatHealthData
+         * @description Response shape for GET /health-ai-stack (#6497).
          *
          *     Wire format is the model itself — no DataResponse envelope. The
          *     components map is heterogeneous (per-component status strings keyed
          *     by component name) so it is typed as Dict[str, Any].
          */
-        EnhancedChatHealthData: {
+        AiStackChatHealthData: {
             /** Status */
             status: string;
             /** Timestamp */
@@ -68895,10 +68895,10 @@ export interface components {
             [key: string]: unknown;
         };
         /**
-         * EnhancedChatResult
+         * ChatResult
          * @description Data payload for POST /ai-stack/chat.
          */
-        EnhancedChatResult: {
+        ChatResult: {
             /** Message */
             message?: string | null;
             /** Context Used */
@@ -100215,7 +100215,7 @@ export interface operations {
             };
         };
     };
-    enhanced_chat_api_enhanced_post: {
+    chat_ai_stack_api_ai_stack_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -100224,7 +100224,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                "application/json": components["schemas"]["Body_enhanced_chat_api_enhanced_post"];
+                "application/json": components["schemas"]["Body_chat_ai_stack_api_ai_stack_post"];
             };
         };
         responses: {
@@ -100234,7 +100234,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DataResponse_EnhancedChatData_"];
+                    "application/json": components["schemas"]["DataResponse_ChatData_"];
                 };
             };
             /** @description Validation Error */
@@ -100248,7 +100248,7 @@ export interface operations {
             };
         };
     };
-    stream_enhanced_chat_api_stream_enhanced_post: {
+    stream_ai_stack_chat_api_stream_ai_stack_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -100257,7 +100257,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                "application/json": components["schemas"]["Body_stream_enhanced_chat_api_stream_enhanced_post"];
+                "application/json": components["schemas"]["Body_stream_ai_stack_chat_api_stream_ai_stack_post"];
             };
         };
         responses: {
@@ -100281,7 +100281,7 @@ export interface operations {
             };
         };
     };
-    enhanced_chat_health_check_api_health_enhanced_get: {
+    chat_health_ai_stack_api_health_ai_stack_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -100296,7 +100296,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["EnhancedChatHealthData"];
+                    "application/json": components["schemas"]["AiStackChatHealthData"];
                 };
             };
         };


### PR DESCRIPTION
## Thinking Path

Analyzed chat.py (2340 lines) to identify all 11 functions and 3 route paths containing the infix `enhanced` word. Checked for same-module collisions before renaming:
- `chat_enhanced` → existing `chat` handler is on a different route path (`/chat`); named `chat_ai_stack` to avoid silent redefinition
- `process_enhanced_chat_message` → distinct from existing `process_chat_message` (different signature: takes `knowledge_base`+`preferences` vs `llm_service`+`memory_interface`); named `process_ai_stack_chat_message`
- `_get_enhanced_chat_context` → distinct from existing `_get_chat_context` (takes `message: ChatMessage` vs `model_name: str | None`); named `_get_ai_stack_chat_context`
- All 8 non-colliding functions: bare `enhanced`→`ai_stack` in name
- Route paths: `/enhanced`→`/ai-stack`, `/stream-enhanced`→`/stream-ai-stack`, `/health-enhanced`→`/health-ai-stack` (no existing routes collide)
- Generated api.ts schema collision: new `ChatHealthData` would collide with existing schema at line 58051 → named `AiStackChatHealthData`

## What Changed

**autobot-backend/api/chat.py** (11 function renames + 3 route path renames):
- Route paths: `/enhanced`→`/ai-stack`, `/stream-enhanced`→`/stream-ai-stack`, `/health-enhanced`→`/health-ai-stack`
- Handler: `chat_enhanced`→`chat_ai_stack`, `stream_enhanced_chat`→`stream_ai_stack_chat`, `chat_health_enhanced`→`chat_health_ai_stack`, `get_enhanced_chat_capabilities`→`get_chat_capabilities`
- Pipeline helpers: `process_enhanced_chat_message`→`process_ai_stack_chat_message`, `_execute_enhanced_chat_pipeline`→`_execute_ai_stack_chat_pipeline`
- Store/retrieve helpers: `_store_enhanced_user_message`→`_store_ai_stack_user_message`, `_get_enhanced_chat_context`→`_get_ai_stack_chat_context`, `_store_enhanced_ai_response`→`_store_ai_stack_ai_response`
- Stream helpers: `_stream_enhanced_fallback_response`→`_stream_ai_stack_fallback_response`, `_generate_enhanced_stream`→`_generate_ai_stack_stream`
- Log event keys: `enhanced_message_received`→`ai_stack_message_received`, `enhanced_response_generated`→`ai_stack_response_generated`
- `operation=` strings in `@with_error_handling` updated
- SSE start event key: `"enhanced": True`→`"ai_stack": True`

**autobot-backend/api/schemas_chat.py**:
- `ChatData` docstring: `POST /enhanced`→`POST /ai-stack`
- `ChatHealthData` docstring: `GET /health-enhanced`→`GET /health-ai-stack`

**autobot-backend/api/chat_phase2_test.py**:
- `TestEnhancedChatSession422`→`TestAiStackChatSession422`
- Import of `process_enhanced_chat_message`→`process_ai_stack_chat_message`
- Docstring updated

**autobot-frontend/src/types/generated/api.ts**:
- Path keys: `/api/enhanced`→`/api/ai-stack`, `/api/stream-enhanced`→`/api/stream-ai-stack`, `/api/health-enhanced`→`/api/health-ai-stack`
- Operation names: `enhanced_chat_api_enhanced_post`→`chat_ai_stack_api_ai_stack_post`, `stream_enhanced_chat_api_stream_enhanced_post`→`stream_ai_stack_chat_api_stream_ai_stack_post`, `enhanced_chat_health_check_api_health_enhanced_get`→`chat_health_ai_stack_api_health_ai_stack_get`
- Body schemas: `Body_enhanced_chat_api_enhanced_post`→`Body_chat_ai_stack_api_ai_stack_post`, `Body_stream_enhanced_chat_api_stream_enhanced_post`→`Body_stream_ai_stack_chat_api_stream_ai_stack_post`
- Data schemas: `EnhancedChatData`→`ChatData`, `EnhancedChatResult`→`ChatResult`, `DataResponse_EnhancedChatData_`→`DataResponse_ChatData_`, `DataResponse_EnhancedChatResult_`→`DataResponse_ChatResult_`
- Health schema: `EnhancedChatHealthData`→`AiStackChatHealthData` (kept distinct name to avoid collision with existing `ChatHealthData` schema at components.schemas line 58051 which has a different shape)

## Verification

- `flake8 --config=.flake8` on all 3 backend files: 0 violations
- `black --line-length=120 --check`: all 3 files unchanged
- AST parse confirms: all 11 new names present, 0 old names remain in definitions
- `pytest tests/test_startup_imports.py -q`: **339 passed** (0 new failures)
- `pytest api/chat_phase2_test.py -v`: 6 passed, 1 pre-existing failure (`TestChatRecentZremrangebyrank` unrelated to B1)
- Zero-grep of B1-scope identifiers in chat.py, test file, schemas_chat.py, generated/api.ts: confirmed clean
- No frontend code (repositories/composables) directly calls `/api/enhanced` or `/api/stream-enhanced` — only the generated type snapshot had the old paths

## Model Used

Claude Sonnet 4.6

Part of #10746