### PR TITLE
refactor(knowledge): B3 — KnowledgeUnified* → KnowledgeMultiSource* + /unified → /multi-source route prefix (#10746)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -2976,15 +2976,15 @@ try:
 except ImportError as e:
     logging.warning("Knowledge debug router not available: %s", e)
 
-# Unified Search - Combined search across all knowledge sources
-# Provides: /unified/search, /unified/stats, /unified/context, /unified/documentation/*,
-#           /unified/graph (for KnowledgeGraph.vue visualization)
+# Aggregated Search - Combined search across all knowledge sources
+# Provides: /aggregated/search, /aggregated/stats, /aggregated/context, /aggregated/documentation/*,
+#           /aggregated/graph (for KnowledgeGraph.vue visualization)
 try:
-    from api.knowledge_search_aggregator import router as unified_router
+    from api.knowledge_search_aggregator import router as aggregated_router
 
-    router.include_router(unified_router, tags=["knowledge-unified", "documentation"])
+    router.include_router(aggregated_router, tags=["knowledge-aggregated", "documentation"])
 except ImportError as e:
-    logging.warning("Unified knowledge search router not available: %s", e)
+    logging.warning("Aggregated knowledge search router not available: %s", e)
 
 
 # ===== KB WATCH FOLDERS (Issue #9000) =====

--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -2976,15 +2976,15 @@ try:
 except ImportError as e:
     logging.warning("Knowledge debug router not available: %s", e)
 
-# Aggregated Search - Combined search across all knowledge sources
-# Provides: /aggregated/search, /aggregated/stats, /aggregated/context, /aggregated/documentation/*,
-#           /aggregated/graph (for KnowledgeGraph.vue visualization)
+# Multi-Source Search - Combined search across all knowledge sources
+# Provides: /multi-source/search, /multi-source/stats, /multi-source/context, /multi-source/documentation/*,
+#           /multi-source/graph (for KnowledgeGraph.vue visualization)
 try:
-    from api.knowledge_search_aggregator import router as aggregated_router
+    from api.knowledge_search_aggregator import router as multi_source_router
 
-    router.include_router(aggregated_router, tags=["knowledge-aggregated", "documentation"])
+    router.include_router(multi_source_router, tags=["knowledge-multi-source", "documentation"])
 except ImportError as e:
-    logging.warning("Aggregated knowledge search router not available: %s", e)
+    logging.warning("Multi-source knowledge search router not available: %s", e)
 
 
 # ===== KB WATCH FOLDERS (Issue #9000) =====

--- a/autobot-backend/api/knowledge_search_aggregator.py
+++ b/autobot-backend/api/knowledge_search_aggregator.py
@@ -3,9 +3,9 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Aggregated Knowledge API - Single Entry Point for All Knowledge Retrieval
+Multi-Source Knowledge API - Single Entry Point for All Knowledge Retrieval
 
-This API provides an aggregated interface for searching across:
+This API provides a multi-source interface for searching across:
 - Knowledge Base facts (ChromaDB vectors in autobot_kb collection)
 - Fact relations (graph-based connections between facts)
 - Documentation (ChromaDB vectors in autobot_docs collection)
@@ -13,9 +13,9 @@ This API provides an aggregated interface for searching across:
 Issue #250 Integration: Combines documentation search with RAG and graph search.
 
 Endpoints:
-- POST /aggregated/search - Search across all knowledge sources
-- GET /aggregated/stats - Statistics from all sources
-- POST /aggregated/context - Get context for LLM prompts
+- POST /multi-source/search - Search across all knowledge sources
+- GET /multi-source/stats - Statistics from all sources
+- POST /multi-source/context - Get context for LLM prompts
 """
 
 import asyncio
@@ -26,12 +26,12 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from api.schemas_knowledge import (
     ContextRequest,
     GraphRequest,
-    KnowledgeAggregatedContextResponse,
-    KnowledgeAggregatedGraphResponse,
-    KnowledgeAggregatedSearchResponse,
-    KnowledgeAggregatedStatsResponse,
     KnowledgeDocumentationSearchResponse,
     KnowledgeDocumentationStatsResponse,
+    KnowledgeMultiSourceContextResponse,
+    KnowledgeMultiSourceGraphResponse,
+    KnowledgeMultiSourceSearchResponse,
+    KnowledgeMultiSourceStatsResponse,
     SearchRequest,
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -193,7 +193,7 @@ def _process_documentation_context(
     return total_length
 
 
-router = APIRouter(prefix="/aggregated", tags=["knowledge-aggregated"])
+router = APIRouter(prefix="/multi-source", tags=["knowledge-multi-source"])
 
 
 # ============================================================================
@@ -223,7 +223,7 @@ def get_documentation_searcher():
 
             _documentation_searcher = DocumentationSearcher()
             if _documentation_searcher.initialize():
-                logger.info("Documentation searcher initialized for aggregated API")
+                logger.info("Documentation searcher initialized for multi-source API")
                 return _documentation_searcher
             else:
                 logger.warning("Documentation searcher failed to initialize")
@@ -248,7 +248,7 @@ async def _search_facts(kb, query: str, top_k: int, result: dict) -> None:
     """
     Search facts via KnowledgeBase.
 
-    Issue #620: Extracted from aggregated search.
+    Issue #620: Extracted from multi-source search.
 
     Args:
         kb: Knowledge base instance
@@ -271,7 +271,7 @@ async def _search_relations(kb, result: dict) -> None:
     """
     Expand facts with graph relations.
 
-    Issue #620: Extracted from aggregated search.
+    Issue #620: Extracted from multi-source search.
 
     Args:
         kb: Knowledge base instance
@@ -293,7 +293,7 @@ def _search_documentation(query: str, doc_results_count: int, score_threshold: f
     """
     Search documentation collection.
 
-    Issue #620: Extracted from aggregated search.
+    Issue #620: Extracted from multi-source search.
 
     Args:
         query: Search query
@@ -317,7 +317,7 @@ def _search_documentation(query: str, doc_results_count: int, score_threshold: f
         logger.warning("Documentation search failed: %s", e)
 
 
-@router.post("/search", response_model=KnowledgeAggregatedSearchResponse)
+@router.post("/search", response_model=KnowledgeMultiSourceSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="search",
@@ -325,7 +325,7 @@ def _search_documentation(query: str, doc_results_count: int, score_threshold: f
 )
 async def search(req: Request, body: SearchRequest):
     """
-    Search across all knowledge sources in an aggregated query.
+    Search across all knowledge sources in a multi-source query.
 
     Issue #620: Refactored to use extracted helper methods.
 
@@ -360,14 +360,14 @@ async def search(req: Request, body: SearchRequest):
     return result
 
 
-@router.get("/stats", response_model=KnowledgeAggregatedStatsResponse)
+@router.get("/stats", response_model=KnowledgeMultiSourceStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="stats",
     error_code_prefix="KNOWLEDGE_SEARCH_AGGREGATOR",
 )
 async def stats(req: Request):
-    """Get statistics from all aggregated knowledge sources (KB facts, relations, docs). Ref: #1088."""
+    """Get statistics from all multi-source knowledge endpoints (KB facts, relations, docs). Ref: #1088."""
     kb = await get_or_create_knowledge_base(req.app, force_refresh=False)
 
     stats = {
@@ -428,7 +428,7 @@ async def stats(req: Request):
     return stats
 
 
-@router.post("/context", response_model=KnowledgeAggregatedContextResponse)
+@router.post("/context", response_model=KnowledgeMultiSourceContextResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_llm_context",
@@ -436,7 +436,7 @@ async def stats(req: Request):
 )
 async def get_llm_context(req: Request, body: ContextRequest):
     """
-    Get formatted context for LLM prompts from aggregated knowledge sources.
+    Get formatted context for LLM prompts from multi-source knowledge endpoints.
 
     Retrieves and formats knowledge from all sources into a context string
     suitable for inclusion in LLM prompts.
@@ -592,14 +592,14 @@ async def documentation_stats():
 
 
 # ============================================================================
-# Aggregated Knowledge Graph Endpoint (for KnowledgeGraph.vue)
+# Multi-Source Knowledge Graph Endpoint (for KnowledgeGraph.vue)
 # ============================================================================
 
 
 def _create_category_node(category: Dict[str, Any]) -> Dict[str, Any]:
     """Create a graph node from a category.
 
-    Issue #707: Extracted helper for aggregated graph building.
+    Issue #707: Extracted helper for multi-source graph building.
     """
     return {
         "id": f"cat_{category.get('id', category.get('name', 'unknown'))}",
@@ -619,7 +619,7 @@ def _create_category_node(category: Dict[str, Any]) -> Dict[str, Any]:
 def _create_fact_node(fact: Dict[str, Any]) -> Dict[str, Any]:
     """Create a graph node from a fact.
 
-    Issue #707: Extracted helper for aggregated graph building.
+    Issue #707: Extracted helper for multi-source graph building.
     """
     content = fact.get("content", "")
     # Truncate long content for node label
@@ -647,7 +647,7 @@ def _process_category_tree(
 ) -> None:
     """Recursively process category tree into nodes and edges.
 
-    Issue #707: Extracted helper for aggregated graph building.
+    Issue #707: Extracted helper for multi-source graph building.
     """
     for category in tree:
         node = _create_category_node(category)
@@ -673,7 +673,7 @@ def _process_category_tree(
 async def _get_facts_for_graph(kb: Any, category_filter: str | None, max_facts: int) -> List[Dict[str, Any]]:
     """Get facts for the graph with optional category filtering.
 
-    Issue #707: Extracted helper for aggregated graph building.
+    Issue #707: Extracted helper for multi-source graph building.
     """
     if category_filter:
         # Get facts from specific category
@@ -688,7 +688,7 @@ async def _get_facts_for_graph(kb: Any, category_filter: str | None, max_facts: 
 async def _get_fact_relations_for_graph(kb: Any, fact_ids: List[str], max_relations: int = 100) -> List[Dict[str, Any]]:
     """Get relations between facts for the graph.
 
-    Issue #707: Extracted helper for aggregated graph building.
+    Issue #707: Extracted helper for multi-source graph building.
     """
     relations = []
     relation_set = set()
@@ -774,7 +774,7 @@ async def _process_category_tree_for_graph(
 ) -> Dict[str, str]:
     """Process category tree and build category map.
 
-    Issue #665: Extracted from get_aggregated_graph.
+    Issue #665: Extracted from get_multi_source_graph.
 
     Args:
         kb: Knowledge base instance
@@ -814,7 +814,7 @@ def _process_facts_into_nodes(
 ) -> List[str]:
     """Process facts into graph nodes and create category edges.
 
-    Issue #665: Extracted from get_aggregated_graph.
+    Issue #665: Extracted from get_multi_source_graph.
 
     Args:
         facts: List of fact dictionaries
@@ -851,7 +851,7 @@ def _process_facts_into_nodes(
 def _update_category_fact_counts(nodes: List[Dict], facts: List[Dict[str, Any]]) -> None:
     """Update fact counts in category nodes.
 
-    Issue #665: Extracted from get_aggregated_graph.
+    Issue #665: Extracted from get_multi_source_graph.
 
     Args:
         nodes: List of graph nodes
@@ -865,15 +865,15 @@ def _update_category_fact_counts(nodes: List[Dict], facts: List[Dict[str, Any]])
             node["metadata"]["fact_count"] = count
 
 
-@router.post("/graph", response_model=KnowledgeAggregatedGraphResponse)
+@router.post("/graph", response_model=KnowledgeMultiSourceGraphResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="get_aggregated_graph",
+    operation="get_multi_source_graph",
     error_code_prefix="KNOWLEDGE_SEARCH_AGGREGATOR",
 )
-async def get_aggregated_graph(req: Request, body: GraphRequest):
+async def get_multi_source_graph(req: Request, body: GraphRequest):
     """
-    Get aggregated knowledge graph combining categories, facts, and relations.
+    Get multi-source knowledge graph combining categories, facts, and relations.
 
     This endpoint is designed for the KnowledgeGraph.vue component to visualize
     all knowledge sources in a single graph. It returns:
@@ -935,25 +935,25 @@ async def get_aggregated_graph(req: Request, body: GraphRequest):
     }
 
 
-@router.get("/graph", response_model=KnowledgeAggregatedGraphResponse)
+@router.get("/graph", response_model=KnowledgeMultiSourceGraphResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="get_aggregated_graph_simple",
+    operation="get_multi_source_graph_simple",
     error_code_prefix="KNOWLEDGE_SEARCH_AGGREGATOR",
 )
-async def get_aggregated_graph_simple(
+async def get_multi_source_graph_simple(
     req: Request,
     max_facts: int = Query(50, ge=1, le=200, description="Maximum facts to include"),
     include_categories: bool = Query(True, description="Include category nodes"),
 ):
     """
-    GET version of aggregated graph for simple requests.
+    GET version of multi-source graph for simple requests.
 
-    Returns an aggregated knowledge graph with default settings.
-    For more control, use POST /aggregated/graph with GraphRequest body.
+    Returns a multi-source knowledge graph with default settings.
+    For more control, use POST /multi-source/graph with GraphRequest body.
     """
     body = GraphRequest(
         max_facts=max_facts,
         include_categories=include_categories,
     )
-    return await get_aggregated_graph(req, body)
+    return await get_multi_source_graph(req, body)

--- a/autobot-backend/api/knowledge_search_aggregator.py
+++ b/autobot-backend/api/knowledge_search_aggregator.py
@@ -3,9 +3,9 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """
-Unified Knowledge API - Single Entry Point for All Knowledge Retrieval
+Aggregated Knowledge API - Single Entry Point for All Knowledge Retrieval
 
-This API provides a unified interface for searching across:
+This API provides an aggregated interface for searching across:
 - Knowledge Base facts (ChromaDB vectors in autobot_kb collection)
 - Fact relations (graph-based connections between facts)
 - Documentation (ChromaDB vectors in autobot_docs collection)
@@ -13,9 +13,9 @@ This API provides a unified interface for searching across:
 Issue #250 Integration: Combines documentation search with RAG and graph search.
 
 Endpoints:
-- POST /unified/search - Search across all knowledge sources
-- GET /unified/stats - Statistics from all sources
-- POST /unified/context - Get context for LLM prompts
+- POST /aggregated/search - Search across all knowledge sources
+- GET /aggregated/stats - Statistics from all sources
+- POST /aggregated/context - Get context for LLM prompts
 """
 
 import asyncio
@@ -26,12 +26,12 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from api.schemas_knowledge import (
     ContextRequest,
     GraphRequest,
+    KnowledgeAggregatedContextResponse,
+    KnowledgeAggregatedGraphResponse,
+    KnowledgeAggregatedSearchResponse,
+    KnowledgeAggregatedStatsResponse,
     KnowledgeDocumentationSearchResponse,
     KnowledgeDocumentationStatsResponse,
-    KnowledgeUnifiedContextResponse,
-    KnowledgeUnifiedGraphResponse,
-    KnowledgeUnifiedSearchResponse,
-    KnowledgeUnifiedStatsResponse,
     SearchRequest,
 )
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -193,7 +193,7 @@ def _process_documentation_context(
     return total_length
 
 
-router = APIRouter(prefix="/unified", tags=["knowledge-unified"])
+router = APIRouter(prefix="/aggregated", tags=["knowledge-aggregated"])
 
 
 # ============================================================================
@@ -223,7 +223,7 @@ def get_documentation_searcher():
 
             _documentation_searcher = DocumentationSearcher()
             if _documentation_searcher.initialize():
-                logger.info("Documentation searcher initialized for unified API")
+                logger.info("Documentation searcher initialized for aggregated API")
                 return _documentation_searcher
             else:
                 logger.warning("Documentation searcher failed to initialize")
@@ -248,7 +248,7 @@ async def _search_facts(kb, query: str, top_k: int, result: dict) -> None:
     """
     Search facts via KnowledgeBase.
 
-    Issue #620: Extracted from unified_search.
+    Issue #620: Extracted from aggregated search.
 
     Args:
         kb: Knowledge base instance
@@ -271,7 +271,7 @@ async def _search_relations(kb, result: dict) -> None:
     """
     Expand facts with graph relations.
 
-    Issue #620: Extracted from unified_search.
+    Issue #620: Extracted from aggregated search.
 
     Args:
         kb: Knowledge base instance
@@ -293,7 +293,7 @@ def _search_documentation(query: str, doc_results_count: int, score_threshold: f
     """
     Search documentation collection.
 
-    Issue #620: Extracted from unified_search.
+    Issue #620: Extracted from aggregated search.
 
     Args:
         query: Search query
@@ -317,7 +317,7 @@ def _search_documentation(query: str, doc_results_count: int, score_threshold: f
         logger.warning("Documentation search failed: %s", e)
 
 
-@router.post("/search", response_model=KnowledgeUnifiedSearchResponse)
+@router.post("/search", response_model=KnowledgeAggregatedSearchResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="search",
@@ -325,7 +325,7 @@ def _search_documentation(query: str, doc_results_count: int, score_threshold: f
 )
 async def search(req: Request, body: SearchRequest):
     """
-    Search across all knowledge sources in a unified query.
+    Search across all knowledge sources in an aggregated query.
 
     Issue #620: Refactored to use extracted helper methods.
 
@@ -360,14 +360,14 @@ async def search(req: Request, body: SearchRequest):
     return result
 
 
-@router.get("/stats", response_model=KnowledgeUnifiedStatsResponse)
+@router.get("/stats", response_model=KnowledgeAggregatedStatsResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="stats",
     error_code_prefix="KNOWLEDGE_SEARCH_AGGREGATOR",
 )
 async def stats(req: Request):
-    """Get statistics from all unified knowledge sources (KB facts, relations, docs). Ref: #1088."""
+    """Get statistics from all aggregated knowledge sources (KB facts, relations, docs). Ref: #1088."""
     kb = await get_or_create_knowledge_base(req.app, force_refresh=False)
 
     stats = {
@@ -428,7 +428,7 @@ async def stats(req: Request):
     return stats
 
 
-@router.post("/context", response_model=KnowledgeUnifiedContextResponse)
+@router.post("/context", response_model=KnowledgeAggregatedContextResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_llm_context",
@@ -436,7 +436,7 @@ async def stats(req: Request):
 )
 async def get_llm_context(req: Request, body: ContextRequest):
     """
-    Get formatted context for LLM prompts from unified knowledge sources.
+    Get formatted context for LLM prompts from aggregated knowledge sources.
 
     Retrieves and formats knowledge from all sources into a context string
     suitable for inclusion in LLM prompts.
@@ -592,14 +592,14 @@ async def documentation_stats():
 
 
 # ============================================================================
-# Unified Knowledge Graph Endpoint (for KnowledgeGraph.vue)
+# Aggregated Knowledge Graph Endpoint (for KnowledgeGraph.vue)
 # ============================================================================
 
 
 def _create_category_node(category: Dict[str, Any]) -> Dict[str, Any]:
     """Create a graph node from a category.
 
-    Issue #707: Extracted helper for unified graph building.
+    Issue #707: Extracted helper for aggregated graph building.
     """
     return {
         "id": f"cat_{category.get('id', category.get('name', 'unknown'))}",
@@ -619,7 +619,7 @@ def _create_category_node(category: Dict[str, Any]) -> Dict[str, Any]:
 def _create_fact_node(fact: Dict[str, Any]) -> Dict[str, Any]:
     """Create a graph node from a fact.
 
-    Issue #707: Extracted helper for unified graph building.
+    Issue #707: Extracted helper for aggregated graph building.
     """
     content = fact.get("content", "")
     # Truncate long content for node label
@@ -647,7 +647,7 @@ def _process_category_tree(
 ) -> None:
     """Recursively process category tree into nodes and edges.
 
-    Issue #707: Extracted helper for unified graph building.
+    Issue #707: Extracted helper for aggregated graph building.
     """
     for category in tree:
         node = _create_category_node(category)
@@ -673,7 +673,7 @@ def _process_category_tree(
 async def _get_facts_for_graph(kb: Any, category_filter: str | None, max_facts: int) -> List[Dict[str, Any]]:
     """Get facts for the graph with optional category filtering.
 
-    Issue #707: Extracted helper for unified graph building.
+    Issue #707: Extracted helper for aggregated graph building.
     """
     if category_filter:
         # Get facts from specific category
@@ -688,7 +688,7 @@ async def _get_facts_for_graph(kb: Any, category_filter: str | None, max_facts: 
 async def _get_fact_relations_for_graph(kb: Any, fact_ids: List[str], max_relations: int = 100) -> List[Dict[str, Any]]:
     """Get relations between facts for the graph.
 
-    Issue #707: Extracted helper for unified graph building.
+    Issue #707: Extracted helper for aggregated graph building.
     """
     relations = []
     relation_set = set()
@@ -774,7 +774,7 @@ async def _process_category_tree_for_graph(
 ) -> Dict[str, str]:
     """Process category tree and build category map.
 
-    Issue #665: Extracted from get_unified_graph.
+    Issue #665: Extracted from get_aggregated_graph.
 
     Args:
         kb: Knowledge base instance
@@ -814,7 +814,7 @@ def _process_facts_into_nodes(
 ) -> List[str]:
     """Process facts into graph nodes and create category edges.
 
-    Issue #665: Extracted from get_unified_graph.
+    Issue #665: Extracted from get_aggregated_graph.
 
     Args:
         facts: List of fact dictionaries
@@ -851,7 +851,7 @@ def _process_facts_into_nodes(
 def _update_category_fact_counts(nodes: List[Dict], facts: List[Dict[str, Any]]) -> None:
     """Update fact counts in category nodes.
 
-    Issue #665: Extracted from get_unified_graph.
+    Issue #665: Extracted from get_aggregated_graph.
 
     Args:
         nodes: List of graph nodes
@@ -865,15 +865,15 @@ def _update_category_fact_counts(nodes: List[Dict], facts: List[Dict[str, Any]])
             node["metadata"]["fact_count"] = count
 
 
-@router.post("/graph", response_model=KnowledgeUnifiedGraphResponse)
+@router.post("/graph", response_model=KnowledgeAggregatedGraphResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="get_unified_graph",
+    operation="get_aggregated_graph",
     error_code_prefix="KNOWLEDGE_SEARCH_AGGREGATOR",
 )
-async def get_unified_graph(req: Request, body: GraphRequest):
+async def get_aggregated_graph(req: Request, body: GraphRequest):
     """
-    Get unified knowledge graph combining categories, facts, and relations.
+    Get aggregated knowledge graph combining categories, facts, and relations.
 
     This endpoint is designed for the KnowledgeGraph.vue component to visualize
     all knowledge sources in a single graph. It returns:
@@ -935,25 +935,25 @@ async def get_unified_graph(req: Request, body: GraphRequest):
     }
 
 
-@router.get("/graph", response_model=KnowledgeUnifiedGraphResponse)
+@router.get("/graph", response_model=KnowledgeAggregatedGraphResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
-    operation="get_unified_graph_simple",
+    operation="get_aggregated_graph_simple",
     error_code_prefix="KNOWLEDGE_SEARCH_AGGREGATOR",
 )
-async def get_unified_graph_simple(
+async def get_aggregated_graph_simple(
     req: Request,
     max_facts: int = Query(50, ge=1, le=200, description="Maximum facts to include"),
     include_categories: bool = Query(True, description="Include category nodes"),
 ):
     """
-    GET version of unified graph for simple requests.
+    GET version of aggregated graph for simple requests.
 
-    Returns a unified knowledge graph with default settings.
-    For more control, use POST /unified/graph with GraphRequest body.
+    Returns an aggregated knowledge graph with default settings.
+    For more control, use POST /aggregated/graph with GraphRequest body.
     """
     body = GraphRequest(
         max_facts=max_facts,
         include_categories=include_categories,
     )
-    return await get_unified_graph(req, body)
+    return await get_aggregated_graph(req, body)

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -353,8 +353,8 @@ class KnowledgeCategorySearchResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class KnowledgeAggregatedSearchResponse(BaseModel):
-    """Response for POST /aggregated/search."""
+class KnowledgeMultiSourceSearchResponse(BaseModel):
+    """Response for POST /multi-source/search."""
 
     success: bool
     query: str
@@ -365,8 +365,8 @@ class KnowledgeAggregatedSearchResponse(BaseModel):
     total_results: int
 
 
-class KnowledgeAggregatedStatsResponse(BaseModel):
-    """Response for GET /aggregated/stats.
+class KnowledgeMultiSourceStatsResponse(BaseModel):
+    """Response for GET /multi-source/stats.
 
     Sections are populated dynamically — extra fields allowed.
     """
@@ -379,8 +379,8 @@ class KnowledgeAggregatedStatsResponse(BaseModel):
     documentation: Dict[str, Any]
 
 
-class KnowledgeAggregatedContextResponse(BaseModel):
-    """Response for POST /aggregated/context."""
+class KnowledgeMultiSourceContextResponse(BaseModel):
+    """Response for POST /multi-source/context."""
 
     success: bool
     context: str
@@ -390,7 +390,7 @@ class KnowledgeAggregatedContextResponse(BaseModel):
 
 
 class KnowledgeDocumentationSearchResponse(BaseModel):
-    """Response for GET /aggregated/documentation/search."""
+    """Response for GET /multi-source/documentation/search."""
 
     success: bool
     query: str | None = None
@@ -400,7 +400,7 @@ class KnowledgeDocumentationSearchResponse(BaseModel):
 
 
 class KnowledgeDocumentationStatsResponse(BaseModel):
-    """Response for GET /aggregated/documentation/stats."""
+    """Response for GET /multi-source/documentation/stats."""
 
     success: bool
     indexed: bool | None = None
@@ -410,8 +410,8 @@ class KnowledgeDocumentationStatsResponse(BaseModel):
     document_count: int | None = None
 
 
-class KnowledgeAggregatedGraphResponse(BaseModel):
-    """Response for POST /aggregated/graph and GET /aggregated/graph."""
+class KnowledgeMultiSourceGraphResponse(BaseModel):
+    """Response for POST /multi-source/graph and GET /multi-source/graph."""
 
     success: bool
     data: Dict[str, Any]
@@ -1125,11 +1125,11 @@ class SearchRequest(BaseModel):
         default=3,
         ge=0,
         le=10,
-        description="Max documentation results (aggregated multi-source search)",
+        description="Max documentation results (multi-source search)",
     )
     expand_relations: bool = Field(
         default=True,
-        description="Include related facts via graph (aggregated multi-source search)",
+        description="Include related facts via graph (multi-source search)",
     )
     include_sources: List[str] = Field(
         default=["facts", "relations", "documentation"],
@@ -4543,7 +4543,7 @@ class ContextRequest(BaseModel):
 
 
 class GraphRequest(BaseModel):
-    """Request model for aggregated knowledge graph."""
+    """Request model for multi-source knowledge graph."""
 
     max_facts: int = Field(50, ge=1, le=200, description="Maximum facts to include")
     max_depth: int = Field(2, ge=1, le=3, description="Maximum relation depth")

--- a/autobot-backend/api/schemas_knowledge.py
+++ b/autobot-backend/api/schemas_knowledge.py
@@ -353,8 +353,8 @@ class KnowledgeCategorySearchResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class KnowledgeUnifiedSearchResponse(BaseModel):
-    """Response for POST /unified/search."""
+class KnowledgeAggregatedSearchResponse(BaseModel):
+    """Response for POST /aggregated/search."""
 
     success: bool
     query: str
@@ -365,8 +365,8 @@ class KnowledgeUnifiedSearchResponse(BaseModel):
     total_results: int
 
 
-class KnowledgeUnifiedStatsResponse(BaseModel):
-    """Response for GET /unified/stats.
+class KnowledgeAggregatedStatsResponse(BaseModel):
+    """Response for GET /aggregated/stats.
 
     Sections are populated dynamically — extra fields allowed.
     """
@@ -379,8 +379,8 @@ class KnowledgeUnifiedStatsResponse(BaseModel):
     documentation: Dict[str, Any]
 
 
-class KnowledgeUnifiedContextResponse(BaseModel):
-    """Response for POST /unified/context."""
+class KnowledgeAggregatedContextResponse(BaseModel):
+    """Response for POST /aggregated/context."""
 
     success: bool
     context: str
@@ -390,7 +390,7 @@ class KnowledgeUnifiedContextResponse(BaseModel):
 
 
 class KnowledgeDocumentationSearchResponse(BaseModel):
-    """Response for GET /unified/documentation/search."""
+    """Response for GET /aggregated/documentation/search."""
 
     success: bool
     query: str | None = None
@@ -400,7 +400,7 @@ class KnowledgeDocumentationSearchResponse(BaseModel):
 
 
 class KnowledgeDocumentationStatsResponse(BaseModel):
-    """Response for GET /unified/documentation/stats."""
+    """Response for GET /aggregated/documentation/stats."""
 
     success: bool
     indexed: bool | None = None
@@ -410,8 +410,8 @@ class KnowledgeDocumentationStatsResponse(BaseModel):
     document_count: int | None = None
 
 
-class KnowledgeUnifiedGraphResponse(BaseModel):
-    """Response for POST /unified/graph and GET /unified/graph."""
+class KnowledgeAggregatedGraphResponse(BaseModel):
+    """Response for POST /aggregated/graph and GET /aggregated/graph."""
 
     success: bool
     data: Dict[str, Any]
@@ -1125,11 +1125,11 @@ class SearchRequest(BaseModel):
         default=3,
         ge=0,
         le=10,
-        description="Max documentation results (unified multi-source search)",
+        description="Max documentation results (aggregated multi-source search)",
     )
     expand_relations: bool = Field(
         default=True,
-        description="Include related facts via graph (unified multi-source search)",
+        description="Include related facts via graph (aggregated multi-source search)",
     )
     include_sources: List[str] = Field(
         default=["facts", "relations", "documentation"],
@@ -4543,7 +4543,7 @@ class ContextRequest(BaseModel):
 
 
 class GraphRequest(BaseModel):
-    """Request model for unified knowledge graph."""
+    """Request model for aggregated knowledge graph."""
 
     max_facts: int = Field(50, ge=1, le=200, description="Maximum facts to include")
     max_depth: int = Field(2, ge=1, le=3, description="Maximum relation depth")

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -349,7 +349,7 @@ def _get_knowledge_feature_routers() -> list:
         (
             knowledge_search_aggregator_router,
             "/knowledge_base",
-            ["knowledge-unified", "knowledge-search"],
+            ["knowledge-aggregated", "knowledge-search"],
             "knowledge_search_aggregator",
         ),
         (

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -349,7 +349,7 @@ def _get_knowledge_feature_routers() -> list:
         (
             knowledge_search_aggregator_router,
             "/knowledge_base",
-            ["knowledge-aggregated", "knowledge-search"],
+            ["knowledge-multi-source", "knowledge-search"],
             "knowledge_search_aggregator",
         ),
         (

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeEntityGraph.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeEntityGraph.ts
@@ -100,7 +100,7 @@ export function useKnowledgeEntityGraph(): UseKnowledgeEntityGraphReturn {
   async function _fetchGraphStats(): Promise<void> {
     try {
       const data = await apiClient.get<Record<string, unknown>>(
-        `${getApiBase()}/knowledge_base/aggregated/graph?max_facts=100`,
+        `${getApiBase()}/knowledge_base/multi-source/graph?max_facts=100`,
       )
       const graphData = (data as Record<string, unknown>)?.data ?? data
 

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeEntityGraph.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeEntityGraph.ts
@@ -100,7 +100,7 @@ export function useKnowledgeEntityGraph(): UseKnowledgeEntityGraphReturn {
   async function _fetchGraphStats(): Promise<void> {
     try {
       const data = await apiClient.get<Record<string, unknown>>(
-        `${getApiBase()}/knowledge_base/unified/graph?max_facts=100`,
+        `${getApiBase()}/knowledge_base/aggregated/graph?max_facts=100`,
       )
       const graphData = (data as Record<string, unknown>)?.data ?? data
 

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeGraph.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeGraph.ts
@@ -149,7 +149,7 @@ export function useKnowledgeGraph(): UseKnowledgeGraphReturn {
       try {
         const [unifiedData, memoryData] = await Promise.all([
           apiClient.get<Record<string, unknown>>(
-            `${getApiBase()}/knowledge_base/aggregated/graph?max_facts=100&include_categories=true`,
+            `${getApiBase()}/knowledge_base/multi-source/graph?max_facts=100&include_categories=true`,
           ),
           apiClient.get<Record<string, unknown>>(
             `${getApiBase()}/memory/entities/all`,

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeGraph.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeGraph.ts
@@ -149,7 +149,7 @@ export function useKnowledgeGraph(): UseKnowledgeGraphReturn {
       try {
         const [unifiedData, memoryData] = await Promise.all([
           apiClient.get<Record<string, unknown>>(
-            `${getApiBase()}/knowledge_base/unified/graph?max_facts=100&include_categories=true`,
+            `${getApiBase()}/knowledge_base/aggregated/graph?max_facts=100&include_categories=true`,
           ),
           apiClient.get<Record<string, unknown>>(
             `${getApiBase()}/memory/entities/all`,

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -5671,7 +5671,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/knowledge_base/unified/search": {
+    "/api/knowledge_base/aggregated/search": {
         parameters: {
             query?: never;
             header?: never;
@@ -5681,21 +5681,21 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Unified Search
-         * @description Search across all knowledge sources in a unified query.
+         * Aggregated Search
+         * @description Search across all knowledge sources in an aggregated query.
          *
          *     Issue #620: Refactored to use extracted helper methods.
          *
          *     Returns results from all sources with source attribution.
          */
-        post: operations["unified_search_api_knowledge_base_unified_search_post"];
+        post: operations["aggregated_search_api_knowledge_base_aggregated_search_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/knowledge_base/unified/stats": {
+    "/api/knowledge_base/aggregated/stats": {
         parameters: {
             query?: never;
             header?: never;
@@ -5703,10 +5703,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Unified Stats
-         * @description Get statistics from all unified knowledge sources (KB facts, relations, docs). Ref: #1088.
+         * Aggregated Stats
+         * @description Get statistics from all aggregated knowledge sources (KB facts, relations, docs). Ref: #1088.
          */
-        get: operations["unified_stats_api_knowledge_base_unified_stats_get"];
+        get: operations["aggregated_stats_api_knowledge_base_aggregated_stats_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5715,7 +5715,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/knowledge_base/unified/context": {
+    "/api/knowledge_base/aggregated/context": {
         parameters: {
             query?: never;
             header?: never;
@@ -5726,7 +5726,7 @@ export interface paths {
         put?: never;
         /**
          * Get Llm Context
-         * @description Get formatted context for LLM prompts from unified knowledge sources.
+         * @description Get formatted context for LLM prompts from aggregated knowledge sources.
          *
          *     Retrieves and formats knowledge from all sources into a context string
          *     suitable for inclusion in LLM prompts.
@@ -5736,14 +5736,14 @@ export interface paths {
          *     - Source citations
          *     - Metadata about retrieved content
          */
-        post: operations["get_llm_context_api_knowledge_base_unified_context_post"];
+        post: operations["get_llm_context_api_knowledge_base_aggregated_context_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/knowledge_base/unified/documentation/search": {
+    "/api/knowledge_base/aggregated/documentation/search": {
         parameters: {
             query?: never;
             header?: never;
@@ -5761,7 +5761,7 @@ export interface paths {
          *         n_results: Maximum results to return
          *         score_threshold: Minimum relevance score (0-1)
          */
-        get: operations["search_documentation_api_knowledge_base_unified_documentation_search_get"];
+        get: operations["search_documentation_api_knowledge_base_aggregated_documentation_search_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5770,7 +5770,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/knowledge_base/unified/documentation/stats": {
+    "/api/knowledge_base/aggregated/documentation/stats": {
         parameters: {
             query?: never;
             header?: never;
@@ -5783,7 +5783,7 @@ export interface paths {
          *
          *     Returns document count and indexing status.
          */
-        get: operations["documentation_stats_api_knowledge_base_unified_documentation_stats_get"];
+        get: operations["documentation_stats_api_knowledge_base_aggregated_documentation_stats_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5792,7 +5792,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/knowledge_base/unified/graph": {
+    "/api/knowledge_base/aggregated/graph": {
         parameters: {
             query?: never;
             header?: never;
@@ -5800,17 +5800,17 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Unified Graph Simple
-         * @description GET version of unified graph for simple requests.
+         * Get Aggregated Graph Simple
+         * @description GET version of aggregated graph for simple requests.
          *
-         *     Returns a unified knowledge graph with default settings.
-         *     For more control, use POST /unified/graph with GraphRequest body.
+         *     Returns an aggregated knowledge graph with default settings.
+         *     For more control, use POST /aggregated/graph with GraphRequest body.
          */
-        get: operations["get_unified_graph_simple_api_knowledge_base_unified_graph_get"];
+        get: operations["get_aggregated_graph_simple_api_knowledge_base_aggregated_graph_get"];
         put?: never;
         /**
-         * Get Unified Graph
-         * @description Get unified knowledge graph combining categories, facts, and relations.
+         * Get Aggregated Graph
+         * @description Get aggregated knowledge graph combining categories, facts, and relations.
          *
          *     This endpoint is designed for the KnowledgeGraph.vue component to visualize
          *     all knowledge sources in a single graph. It returns:
@@ -5823,7 +5823,7 @@ export interface paths {
          *     - entities: List of nodes with id, name, type, observations
          *     - relations: List of edges with from, to, type, strength
          */
-        post: operations["get_unified_graph_api_knowledge_base_unified_graph_post"];
+        post: operations["get_aggregated_graph_api_knowledge_base_aggregated_graph_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -72198,7 +72198,7 @@ export interface components {
         };
         /**
          * GraphRequest
-         * @description Request model for unified knowledge graph.
+         * @description Request model for aggregated knowledge graph.
          */
         GraphRequest: {
             /**
@@ -76007,10 +76007,10 @@ export interface components {
             [key: string]: unknown;
         };
         /**
-         * KnowledgeUnifiedContextResponse
-         * @description Response for POST /unified/context.
+         * KnowledgeAggregatedContextResponse
+         * @description Response for POST /aggregated/context.
          */
-        KnowledgeUnifiedContextResponse: {
+        KnowledgeAggregatedContextResponse: {
             /** Success */
             success: boolean;
             /** Context */
@@ -76025,10 +76025,10 @@ export interface components {
             [key: string]: unknown;
         };
         /**
-         * KnowledgeUnifiedGraphResponse
-         * @description Response for POST /unified/graph and GET /unified/graph.
+         * KnowledgeAggregatedGraphResponse
+         * @description Response for POST /aggregated/graph and GET /aggregated/graph.
          */
-        KnowledgeUnifiedGraphResponse: {
+        KnowledgeAggregatedGraphResponse: {
             /** Success */
             success: boolean;
             /** Data */
@@ -76043,10 +76043,10 @@ export interface components {
             [key: string]: unknown;
         };
         /**
-         * KnowledgeUnifiedSearchResponse
-         * @description Response for POST /unified/search.
+         * KnowledgeAggregatedSearchResponse
+         * @description Response for POST /aggregated/search.
          */
-        KnowledgeUnifiedSearchResponse: {
+        KnowledgeAggregatedSearchResponse: {
             /** Success */
             success: boolean;
             /** Query */
@@ -76065,12 +76065,12 @@ export interface components {
             [key: string]: unknown;
         };
         /**
-         * KnowledgeUnifiedStatsResponse
-         * @description Response for GET /unified/stats.
+         * KnowledgeAggregatedStatsResponse
+         * @description Response for GET /aggregated/stats.
          *
          *     Sections are populated dynamically — extra fields allowed.
          */
-        KnowledgeUnifiedStatsResponse: {
+        KnowledgeAggregatedStatsResponse: {
             /** Success */
             success: boolean;
             /** Knowledge Base */
@@ -105895,7 +105895,7 @@ export interface operations {
             };
         };
     };
-    unified_search_api_knowledge_base_unified_search_post: {
+    aggregated_search_api_knowledge_base_aggregated_search_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -105914,7 +105914,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["KnowledgeUnifiedSearchResponse"];
+                    "application/json": components["schemas"]["KnowledgeAggregatedSearchResponse"];
                 };
             };
             /** @description Validation Error */
@@ -105928,7 +105928,7 @@ export interface operations {
             };
         };
     };
-    unified_stats_api_knowledge_base_unified_stats_get: {
+    aggregated_stats_api_knowledge_base_aggregated_stats_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -105943,12 +105943,12 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["KnowledgeUnifiedStatsResponse"];
+                    "application/json": components["schemas"]["KnowledgeAggregatedStatsResponse"];
                 };
             };
         };
     };
-    get_llm_context_api_knowledge_base_unified_context_post: {
+    get_llm_context_api_knowledge_base_aggregated_context_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -105967,7 +105967,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["KnowledgeUnifiedContextResponse"];
+                    "application/json": components["schemas"]["KnowledgeAggregatedContextResponse"];
                 };
             };
             /** @description Validation Error */
@@ -105981,7 +105981,7 @@ export interface operations {
             };
         };
     };
-    search_documentation_api_knowledge_base_unified_documentation_search_get: {
+    search_documentation_api_knowledge_base_aggregated_documentation_search_get: {
         parameters: {
             query: {
                 query: string;
@@ -106014,7 +106014,7 @@ export interface operations {
             };
         };
     };
-    documentation_stats_api_knowledge_base_unified_documentation_stats_get: {
+    documentation_stats_api_knowledge_base_aggregated_documentation_stats_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -106034,7 +106034,7 @@ export interface operations {
             };
         };
     };
-    get_unified_graph_simple_api_knowledge_base_unified_graph_get: {
+    get_aggregated_graph_simple_api_knowledge_base_aggregated_graph_get: {
         parameters: {
             query?: {
                 /** @description Maximum facts to include */
@@ -106054,7 +106054,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["KnowledgeUnifiedGraphResponse"];
+                    "application/json": components["schemas"]["KnowledgeAggregatedGraphResponse"];
                 };
             };
             /** @description Validation Error */
@@ -106068,7 +106068,7 @@ export interface operations {
             };
         };
     };
-    get_unified_graph_api_knowledge_base_unified_graph_post: {
+    get_aggregated_graph_api_knowledge_base_aggregated_graph_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -106087,7 +106087,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["KnowledgeUnifiedGraphResponse"];
+                    "application/json": components["schemas"]["KnowledgeAggregatedGraphResponse"];
                 };
             };
             /** @description Validation Error */

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -5671,7 +5671,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/knowledge_base/aggregated/search": {
+    "/api/knowledge_base/multi-source/search": {
         parameters: {
             query?: never;
             header?: never;
@@ -5681,21 +5681,21 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Aggregated Search
-         * @description Search across all knowledge sources in an aggregated query.
+         * Multi-Source Search
+         * @description Search across all knowledge sources in a multi-source query.
          *
          *     Issue #620: Refactored to use extracted helper methods.
          *
          *     Returns results from all sources with source attribution.
          */
-        post: operations["aggregated_search_api_knowledge_base_aggregated_search_post"];
+        post: operations["multi_source_search_api_knowledge_base_multi_source_search_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/knowledge_base/aggregated/stats": {
+    "/api/knowledge_base/multi-source/stats": {
         parameters: {
             query?: never;
             header?: never;
@@ -5703,10 +5703,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Aggregated Stats
-         * @description Get statistics from all aggregated knowledge sources (KB facts, relations, docs). Ref: #1088.
+         * Multi-Source Stats
+         * @description Get statistics from all multi-source knowledge endpoints (KB facts, relations, docs). Ref: #1088.
          */
-        get: operations["aggregated_stats_api_knowledge_base_aggregated_stats_get"];
+        get: operations["multi_source_stats_api_knowledge_base_multi_source_stats_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5715,7 +5715,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/knowledge_base/aggregated/context": {
+    "/api/knowledge_base/multi-source/context": {
         parameters: {
             query?: never;
             header?: never;
@@ -5726,7 +5726,7 @@ export interface paths {
         put?: never;
         /**
          * Get Llm Context
-         * @description Get formatted context for LLM prompts from aggregated knowledge sources.
+         * @description Get formatted context for LLM prompts from multi-source knowledge endpoints.
          *
          *     Retrieves and formats knowledge from all sources into a context string
          *     suitable for inclusion in LLM prompts.
@@ -5736,14 +5736,14 @@ export interface paths {
          *     - Source citations
          *     - Metadata about retrieved content
          */
-        post: operations["get_llm_context_api_knowledge_base_aggregated_context_post"];
+        post: operations["get_llm_context_api_knowledge_base_multi_source_context_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/knowledge_base/aggregated/documentation/search": {
+    "/api/knowledge_base/multi-source/documentation/search": {
         parameters: {
             query?: never;
             header?: never;
@@ -5761,7 +5761,7 @@ export interface paths {
          *         n_results: Maximum results to return
          *         score_threshold: Minimum relevance score (0-1)
          */
-        get: operations["search_documentation_api_knowledge_base_aggregated_documentation_search_get"];
+        get: operations["search_documentation_api_knowledge_base_multi_source_documentation_search_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5770,7 +5770,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/knowledge_base/aggregated/documentation/stats": {
+    "/api/knowledge_base/multi-source/documentation/stats": {
         parameters: {
             query?: never;
             header?: never;
@@ -5783,7 +5783,7 @@ export interface paths {
          *
          *     Returns document count and indexing status.
          */
-        get: operations["documentation_stats_api_knowledge_base_aggregated_documentation_stats_get"];
+        get: operations["documentation_stats_api_knowledge_base_multi_source_documentation_stats_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5792,7 +5792,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/knowledge_base/aggregated/graph": {
+    "/api/knowledge_base/multi-source/graph": {
         parameters: {
             query?: never;
             header?: never;
@@ -5800,17 +5800,17 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Aggregated Graph Simple
-         * @description GET version of aggregated graph for simple requests.
+         * Get Multi-Source Graph Simple
+         * @description GET version of multi-source graph for simple requests.
          *
-         *     Returns an aggregated knowledge graph with default settings.
-         *     For more control, use POST /aggregated/graph with GraphRequest body.
+         *     Returns a multi-source knowledge graph with default settings.
+         *     For more control, use POST /multi-source/graph with GraphRequest body.
          */
-        get: operations["get_aggregated_graph_simple_api_knowledge_base_aggregated_graph_get"];
+        get: operations["get_multi_source_graph_simple_api_knowledge_base_multi_source_graph_get"];
         put?: never;
         /**
-         * Get Aggregated Graph
-         * @description Get aggregated knowledge graph combining categories, facts, and relations.
+         * Get Multi-Source Graph
+         * @description Get multi-source knowledge graph combining categories, facts, and relations.
          *
          *     This endpoint is designed for the KnowledgeGraph.vue component to visualize
          *     all knowledge sources in a single graph. It returns:
@@ -5823,7 +5823,7 @@ export interface paths {
          *     - entities: List of nodes with id, name, type, observations
          *     - relations: List of edges with from, to, type, strength
          */
-        post: operations["get_aggregated_graph_api_knowledge_base_aggregated_graph_post"];
+        post: operations["get_multi_source_graph_api_knowledge_base_multi_source_graph_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -72198,7 +72198,7 @@ export interface components {
         };
         /**
          * GraphRequest
-         * @description Request model for aggregated knowledge graph.
+         * @description Request model for multi-source knowledge graph.
          */
         GraphRequest: {
             /**
@@ -76007,10 +76007,10 @@ export interface components {
             [key: string]: unknown;
         };
         /**
-         * KnowledgeAggregatedContextResponse
-         * @description Response for POST /aggregated/context.
+         * KnowledgeMultiSourceContextResponse
+         * @description Response for POST /multi-source/context.
          */
-        KnowledgeAggregatedContextResponse: {
+        KnowledgeMultiSourceContextResponse: {
             /** Success */
             success: boolean;
             /** Context */
@@ -76025,10 +76025,10 @@ export interface components {
             [key: string]: unknown;
         };
         /**
-         * KnowledgeAggregatedGraphResponse
-         * @description Response for POST /aggregated/graph and GET /aggregated/graph.
+         * KnowledgeMultiSourceGraphResponse
+         * @description Response for POST /multi-source/graph and GET /multi-source/graph.
          */
-        KnowledgeAggregatedGraphResponse: {
+        KnowledgeMultiSourceGraphResponse: {
             /** Success */
             success: boolean;
             /** Data */
@@ -76043,10 +76043,10 @@ export interface components {
             [key: string]: unknown;
         };
         /**
-         * KnowledgeAggregatedSearchResponse
-         * @description Response for POST /aggregated/search.
+         * KnowledgeMultiSourceSearchResponse
+         * @description Response for POST /multi-source/search.
          */
-        KnowledgeAggregatedSearchResponse: {
+        KnowledgeMultiSourceSearchResponse: {
             /** Success */
             success: boolean;
             /** Query */
@@ -76065,12 +76065,12 @@ export interface components {
             [key: string]: unknown;
         };
         /**
-         * KnowledgeAggregatedStatsResponse
-         * @description Response for GET /aggregated/stats.
+         * KnowledgeMultiSourceStatsResponse
+         * @description Response for GET /multi-source/stats.
          *
          *     Sections are populated dynamically — extra fields allowed.
          */
-        KnowledgeAggregatedStatsResponse: {
+        KnowledgeMultiSourceStatsResponse: {
             /** Success */
             success: boolean;
             /** Knowledge Base */
@@ -105895,7 +105895,7 @@ export interface operations {
             };
         };
     };
-    aggregated_search_api_knowledge_base_aggregated_search_post: {
+    multi_source_search_api_knowledge_base_multi_source_search_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -105914,7 +105914,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["KnowledgeAggregatedSearchResponse"];
+                    "application/json": components["schemas"]["KnowledgeMultiSourceSearchResponse"];
                 };
             };
             /** @description Validation Error */
@@ -105928,7 +105928,7 @@ export interface operations {
             };
         };
     };
-    aggregated_stats_api_knowledge_base_aggregated_stats_get: {
+    multi_source_stats_api_knowledge_base_multi_source_stats_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -105943,12 +105943,12 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["KnowledgeAggregatedStatsResponse"];
+                    "application/json": components["schemas"]["KnowledgeMultiSourceStatsResponse"];
                 };
             };
         };
     };
-    get_llm_context_api_knowledge_base_aggregated_context_post: {
+    get_llm_context_api_knowledge_base_multi_source_context_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -105967,7 +105967,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["KnowledgeAggregatedContextResponse"];
+                    "application/json": components["schemas"]["KnowledgeMultiSourceContextResponse"];
                 };
             };
             /** @description Validation Error */
@@ -105981,7 +105981,7 @@ export interface operations {
             };
         };
     };
-    search_documentation_api_knowledge_base_aggregated_documentation_search_get: {
+    search_documentation_api_knowledge_base_multi_source_documentation_search_get: {
         parameters: {
             query: {
                 query: string;
@@ -106014,7 +106014,7 @@ export interface operations {
             };
         };
     };
-    documentation_stats_api_knowledge_base_aggregated_documentation_stats_get: {
+    documentation_stats_api_knowledge_base_multi_source_documentation_stats_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -106034,7 +106034,7 @@ export interface operations {
             };
         };
     };
-    get_aggregated_graph_simple_api_knowledge_base_aggregated_graph_get: {
+    get_multi_source_graph_simple_api_knowledge_base_multi_source_graph_get: {
         parameters: {
             query?: {
                 /** @description Maximum facts to include */
@@ -106054,7 +106054,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["KnowledgeAggregatedGraphResponse"];
+                    "application/json": components["schemas"]["KnowledgeMultiSourceGraphResponse"];
                 };
             };
             /** @description Validation Error */
@@ -106068,7 +106068,7 @@ export interface operations {
             };
         };
     };
-    get_aggregated_graph_api_knowledge_base_aggregated_graph_post: {
+    get_multi_source_graph_api_knowledge_base_multi_source_graph_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -106087,7 +106087,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["KnowledgeAggregatedGraphResponse"];
+                    "application/json": components["schemas"]["KnowledgeMultiSourceGraphResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Thinking Path

B3 of the infix-rename plan (#10746). Initial attempt used `Aggregated` — owner rejected it as equally vague. The correct name is `MultiSource` because the endpoint literally searches across **multiple knowledge sources** (facts, graph relations, documentation) and returns `sources_searched`. No collision: `KnowledgeMultiSource*` is brand-new in the repo.

## What Changed

**Classes renamed (backend + frontend types):**

| Old | New |
|---|---|
| `KnowledgeUnifiedSearchResponse` | `KnowledgeMultiSourceSearchResponse` |
| `KnowledgeUnifiedStatsResponse` | `KnowledgeMultiSourceStatsResponse` |
| `KnowledgeUnifiedContextResponse` | `KnowledgeMultiSourceContextResponse` |
| `KnowledgeUnifiedGraphResponse` | `KnowledgeMultiSourceGraphResponse` |

**Functions renamed:**

| Old | New |
|---|---|
| `get_unified_graph` | `get_multi_source_graph` |
| `get_unified_graph_simple` | `get_multi_source_graph_simple` |

**Router:**
- `APIRouter(prefix="/unified", tags=["knowledge-unified"])` → `prefix="/multi-source", tags=["knowledge-multi-source"]`

**Route URLs changed (7):**

| Old | New |
|---|---|
| `POST /api/knowledge_base/unified/search` | `POST /api/knowledge_base/multi-source/search` |
| `GET /api/knowledge_base/unified/stats` | `GET /api/knowledge_base/multi-source/stats` |
| `POST /api/knowledge_base/unified/context` | `POST /api/knowledge_base/multi-source/context` |
| `GET /api/knowledge_base/unified/documentation/search` | `GET /api/knowledge_base/multi-source/documentation/search` |
| `GET /api/knowledge_base/unified/documentation/stats` | `GET /api/knowledge_base/multi-source/documentation/stats` |
| `GET /api/knowledge_base/unified/graph` | `GET /api/knowledge_base/multi-source/graph` |
| `POST /api/knowledge_base/unified/graph` | `POST /api/knowledge_base/multi-source/graph` |

**Files changed:**
- `autobot-backend/api/schemas_knowledge.py` — 4 class renames + docstrings
- `autobot-backend/api/knowledge_search_aggregator.py` — imports, router, function names, operation strings, docstrings
- `autobot-backend/api/knowledge.py` — import alias + comments + tags
- `autobot-backend/initialization/router_registry/core_routers.py` — tag string
- `autobot-frontend/src/composables/knowledge/useKnowledgeGraph.ts` — URL
- `autobot-frontend/src/composables/knowledge/useKnowledgeEntityGraph.ts` — URL
- `autobot-frontend/src/types/generated/api.ts` — path keys, operation IDs, schema names, descriptions

## Verification

- `git grep -E "KnowledgeAggregated|KnowledgeUnified|/unified (knowledge)|/aggregated (knowledge)|knowledge-unified|knowledge-aggregated"` → 0 matches in B3 scope (remaining `/aggregated` hits are B7 logs endpoint and `workflow_metrics.py` dict key — both out of B3 scope)
- `pytest autobot-backend/tests/test_startup_imports.py -q` → **339 passed, 83 warnings**
- `black --line-length=120` → 4 Python files unchanged
- `flake8 --config=.flake8` → 0 violations
- Collision check: `KnowledgeMultiSource*` has zero prior definitions in the repo

Part of #10746

## Model Used

claude-sonnet-4-6