### PR TITLE
build(slm): bump autobot-slm image to Python 3.14 (#10611)

### DIFF
--- a/docker/slm/Dockerfile
+++ b/docker/slm/Dockerfile
@@ -8,7 +8,7 @@
 # Author: mrveiss
 
 # ---- Dependencies stage ----
-ARG PYTHON_VERSION=3.12
+ARG PYTHON_VERSION=3.14
 FROM python:${PYTHON_VERSION}-slim-bookworm AS deps
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -34,7 +34,7 @@ RUN grep -v -E "(autobot_shared|^-r )" /tmp/requirements.txt > /app/requirements
 # ---- Production stage ----
 FROM python:${PYTHON_VERSION}-slim-bookworm AS production
 # Re-declare after FROM so it is in scope for the COPY paths below.
-ARG PYTHON_VERSION=3.12
+ARG PYTHON_VERSION=3.14
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Thinking Path
The SLM image was the **last component on Python 3.12** — backend + all agent images (`docker/backend`, chat/knowledge/rag/research agents) and CI are already on 3.14. `docker/slm/Dockerfile` was intentionally built so a 3.14 bump changes only the `PYTHON_VERSION` ARG.

## What Changed
- `docker/slm/Dockerfile`: `ARG PYTHON_VERSION=3.12` → `3.14` in both the `deps` and `production` stages (the `COPY /usr/local/lib/python${PYTHON_VERSION}` site-packages path tracks it automatically). No compose/CI build-arg overrides it (verified).

## Why this isn't blocked by #9825
The backend dep-tree blocker (#9825: ml-dtypes/torch) doesn't apply — the SLM has no ML deps (that's why #9949 split the SLM bump out as independently actionable). SLM deps (uvicorn, authlib, ldap3, paramiko, pysaml2, psycopg2-binary, cryptography≥49, ansible-runner) all ship 3.14 wheels.

## Verification
- CI `smoke-test` builds the SLM image on 3.14 **and starts the container** — this PR's smoke-test IS the validation. If the 3.14 build or startup fails, the traceback will surface there and I'll fix it in this PR (the #9949/#10611 "capture + fix startup traceback" step).

Closes #10611.

## Model Used
Claude Opus 4.8 (1M context)