### PR TITLE
fix(api): only clear session on 401 for token-bearing requests, not background calls (#10750 A12)

### DIFF
--- a/autobot-frontend/src/utils/ApiClient.ts
+++ b/autobot-frontend/src/utils/ApiClient.ts
@@ -234,8 +234,17 @@ export class ApiClient {
     }
   }
 
-  // Handle 401 — clear stored auth and redirect to login (#827)
-  private _handleUnauthorized(endpoint: string): void {
+  // Handle 401 — clear stored auth and redirect to login (#827).
+  // Only destructive when the request carried a bearer token (#10750 A12):
+  // a 401 on a token-less background call is not a session rejection.
+  private _handleUnauthorized(endpoint: string, tokenWasAttached: boolean): void {
+    if (!tokenWasAttached) {
+      logger.debug(
+        '401 on token-less request — not clearing session (no session to invalidate):',
+        endpoint
+      );
+      return;
+    }
     logger.warn('401 Unauthorized, clearing auth:', endpoint);
     localStorage.removeItem('autobot_auth');
     localStorage.removeItem('autobot_user');
@@ -334,12 +343,16 @@ export class ApiClient {
       const response = await fetch(url, fetchOptions);
       cleanup();
 
-      // Handle 401 — redirect to login (skip for auth endpoints)
+      // Handle 401 — redirect to login (skip for auth endpoints).
+      // Pass whether THIS request actually carried a bearer token so the handler
+      // only clears + redirects on a genuine rejection of an authenticated request
+      // (#10750 A12). Token-less background/optional probes (e.g. the load-time
+      // telemetry-consent check or version poll) that 401 must NOT log the user out.
       if (
         response.status === 401 &&
         !endpoint.includes(`${getApiBase()}/auth/`)
       ) {
-        this._handleUnauthorized(endpoint);
+        this._handleUnauthorized(endpoint, authToken != null);
       }
 
       return response;


### PR DESCRIPTION
## Thinking Path

The user-frontend `ApiClient` logged the user out + redirected to `/login` on **any** 401 (except `/auth/` endpoints). Load-time optional probes — the telemetry-consent check (`/api/settings/telemetry`) and version poll (`/api/services/version`) — fire before/without a valid session context and can 401. Those 401s are **not** a rejection of the user's session (no token was sent), yet they triggered the destructive clear+redirect, spuriously nuking a valid session (session-stability bug, umbrella A12).

Root cause: `rawRequest()` attaches the bearer token conditionally (`_getAuthToken()` → only sets `Authorization` when a non-expired token exists), but the 401 branch ignored whether a token was actually attached. A token-less request that 401s has no session to invalidate.

## What Changed

`autobot-frontend/src/utils/ApiClient.ts`:
- The 401 branch in `rawRequest()` now passes `authToken != null` (whether this specific request carried an `Authorization: Bearer` header) into `_handleUnauthorized(endpoint, tokenWasAttached)`.
- `_handleUnauthorized` gained a `tokenWasAttached` param. When `false`, it logs at debug level and returns early — **no** localStorage clear, **no** Pinia logout, **no** redirect.
- Preserved: the existing `/auth/` skip; and for a genuinely authenticated request whose token is expired/invalid (`tokenWasAttached === true`), the full clear+redirect still fires (#827 / #972 intent).

No allowlist was added — the token-attached gate alone fully covers the background/optional-probe case, so an endpoint allowlist would be redundant surface area.

## Verification

- `npx vue-tsc --noEmit -p tsconfig.app.json`: **0 errors in ApiClient.ts**. The only remaining errors (4) are all in `src/types/generated/api.ts` (pre-existing base, tracked as #10776) — this change adds none.
- `npx eslint src/utils/ApiClient.ts`: clean (exit 0, 0 warnings).
- node_modules symlinked from the main checkout to run the checks, removed before commit (only `ApiClient.ts` is in the diff).

## Model Used

Opus 4.8 (1M context)

Part of #10750 (A12)