### PR TITLE
feat(lint): catch Enhanced/Unified/Consolidated INFIX names + route paths (#10746)

### DIFF
--- a/repo_tests/lint/canonical/fixtures/py_banned_route_path/negative.py
+++ b/repo_tests/lint/canonical/fixtures/py_banned_route_path/negative.py
@@ -1,0 +1,20 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Negative fixture: descriptive + domain-adjective paths — no violations."""
+
+router = object()
+
+
+@router.post("/goal/orchestrated")
+async def goal_orchestrated():
+    pass
+
+
+@router.get("/search/multi-source")
+def search_multi_source():
+    pass
+
+
+@router.get("/advanced-stats")
+def advanced_stats():
+    """Domain adjective, not an era-marker synonym-swap — allowed."""

--- a/repo_tests/lint/canonical/fixtures/py_banned_route_path/positive.py
+++ b/repo_tests/lint/canonical/fixtures/py_banned_route_path/positive.py
@@ -1,0 +1,15 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Positive fixture: era-marker route paths — two violations."""
+
+router = object()  # placeholder; only decorators are parsed
+
+
+@router.post("/goal/enhanced")
+async def goal_enhanced():
+    pass
+
+
+@router.get("/search/unified")
+def search_unified():
+    pass

--- a/repo_tests/lint/canonical/fixtures/py_banned_route_path/waiver.py
+++ b/repo_tests/lint/canonical/fixtures/py_banned_route_path/waiver.py
@@ -1,0 +1,10 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Waiver fixture: era-marker route suppressed via inline waiver."""
+
+router = object()
+
+
+@router.post("/goal/enhanced")  # canonical: ignore py-banned-route-path — legacy alias (#10746)
+async def goal_enhanced():
+    pass

--- a/repo_tests/lint/canonical/fixtures/py_duplicate_concept/negative.py
+++ b/repo_tests/lint/canonical/fixtures/py_duplicate_concept/negative.py
@@ -1,11 +1,16 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
-"""Negative fixture: EnhancedBar has no base Bar in the same file."""
+"""Negative fixture: canonical names + allow-listed git 'unified diff' term."""
 
 
-class EnhancedBar:
+class Foo:
     pass
 
 
 class Baz:
     pass
+
+
+def condense_unified_diff(text: str) -> str:
+    """'unified diff' is a git format term — allow-listed, not an era marker."""
+    return text

--- a/repo_tests/lint/canonical/fixtures/py_duplicate_concept/positive_infix.py
+++ b/repo_tests/lint/canonical/fixtures/py_duplicate_concept/positive_infix.py
@@ -1,0 +1,16 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Positive fixture: infix + standalone era-markers, no coexisting base needed."""
+
+
+class AIStackEnhancedSearchData:
+    """Infix 'Enhanced' — the old prefix-anchored check missed this."""
+
+
+class KnowledgeUnifiedSearchResponse:
+    """Infix 'Unified'."""
+
+
+def get_consolidated_stats() -> dict:
+    """Function name carrying 'Consolidated'."""
+    return {}

--- a/repo_tests/lint/canonical/rules/test_py_banned_route_path.py
+++ b/repo_tests/lint/canonical/rules/test_py_banned_route_path.py
@@ -1,0 +1,41 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the py-banned-route-path rule."""
+
+import ast
+from pathlib import Path
+
+from tools.lint.canonical.context import Context
+from tools.lint.canonical.rules import py_banned_route_path
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "py_banned_route_path"
+
+
+def _check(name: str) -> list:
+    path = FIXTURES / name
+    ctx = Context(repo_root=path.parent)
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return py_banned_route_path.check(path, tree, ctx)
+
+
+def test_positive_flags_era_marker_paths():
+    diags = _check("positive.py")
+    assert len(diags) == 2
+    tokens = sorted(d.message.split("'")[3] for d in diags)
+    assert tokens == ["enhanced", "unified"]
+    assert all(d.severity == "block" for d in diags)
+
+
+def test_negative_fixture_produces_no_diagnostics():
+    # Descriptive paths + domain adjective (/advanced-stats) -> no diagnostics.
+    assert _check("negative.py") == []
+
+
+def test_waiver_fixture_produces_no_diagnostics():
+    assert _check("waiver.py") == []
+
+
+def test_rule_metadata_present():
+    for attr in ("RULE_ID", "ISSUE", "SEVERITY", "TARGETS", "DESCRIPTION", "FIX_HINT"):
+        assert hasattr(py_banned_route_path, attr), f"missing {attr}"
+    assert py_banned_route_path.SEVERITY == "block"

--- a/repo_tests/lint/canonical/rules/test_py_duplicate_concept.py
+++ b/repo_tests/lint/canonical/rules/test_py_duplicate_concept.py
@@ -26,7 +26,20 @@ def test_positive_flags_enhanced_with_base():
     assert "EnhancedFoo" in diags[0].message
 
 
+def test_positive_flags_infix_and_standalone():
+    """Infix (AIStackEnhancedSearchData) + function names fire without a base."""
+    diags = _check("positive_infix.py")
+    names = {d.message.split("'")[1] for d in diags}
+    assert names == {
+        "AIStackEnhancedSearchData",
+        "KnowledgeUnifiedSearchResponse",
+        "get_consolidated_stats",
+    }
+    assert all(d.severity == "block" for d in diags)
+
+
 def test_negative_fixture_produces_no_diagnostics():
+    # Canonical names + allow-listed 'unified diff' git term -> no diagnostics.
     assert _check("negative.py") == []
 
 

--- a/tools/lint/canonical/rules/py_banned_route_path.py
+++ b/tools/lint/canonical/rules/py_banned_route_path.py
@@ -1,0 +1,100 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""py-banned-route-path — flag Enhanced/Unified/Consolidated era-markers in route paths.
+
+A route like ``@router.post("/goal/enhanced")`` or ``@router.get("/search/unified")``
+bakes an era-marker into the public API surface — the same canonical-debt as an
+``EnhancedX`` class name, but on the wire. When a route is genuinely distinct it
+must say WHAT it does (``/goal/orchestrated``, ``/search/multi-source``); when it
+merely shadows a base route, fold it into the base and drop the segment.
+
+BLOCK severity — the backend / slm-backend routers are clean of these tokens
+(verified #10746). Only the hard era-markers are matched; domain adjectives such
+as ``/advanced-stats`` or ``/advanced_search`` (pre-existing RAG feature) are NOT
+flagged — synonym judgement is left to review, not the linter. See #10569 / #10746.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+from tools.lint.canonical.context import Context
+from tools.lint.canonical.diagnostic import Diagnostic
+
+RULE_ID = "py-banned-route-path"
+ISSUE = "#10746"
+SEVERITY = "block"
+TARGETS = ["autobot-backend", "autobot-slm-backend"]
+DESCRIPTION = "Enhanced/Unified/Consolidated era-marker in a route path — rename to a descriptive path"
+FIX_HINT = (
+    "Rename the route to describe what it does, or fold it into the base route:\n"
+    "    @router.post('/goal/enhanced')   ->  @router.post('/goal/orchestrated')\n"
+    "    @router.get('/search/unified')   ->  @router.get('/search/multi-source')\n"
+    "  Never a synonym (/advanced, /aggregated). Suppress with:\n"
+    "    # canonical: ignore py-banned-route-path — <reason> (#NNNN)"
+)
+
+_HTTP_METHODS = frozenset({"get", "post", "put", "patch", "delete", "options", "head"})
+_BANNED_TOKENS = ("enhanced", "unified", "consolidated")
+_WAIVER = re.compile(r"#\s*canonical:\s*ignore\s+py-banned-route-path\b")
+
+
+def _is_test_file(file_path: Path) -> bool:
+    """Tests may define fixture routes with legacy paths for migration coverage."""
+    name = file_path.name
+    return name.endswith("_test.py") or name.startswith("test_") or "tests" in file_path.parts
+
+
+def _route_path(decorator: ast.expr) -> str | None:
+    """Return the path string of an @router.<method>("...") decorator, else None."""
+    if not isinstance(decorator, ast.Call):
+        return None
+    func = decorator.func
+    if not isinstance(func, ast.Attribute) or func.attr.lower() not in _HTTP_METHODS:
+        return None
+    if not decorator.args:
+        return None
+    first = decorator.args[0]
+    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+        return first.value
+    return None
+
+
+def check(file_path: Path, tree: ast.AST, ctx: Context) -> list[Diagnostic]:
+    if _is_test_file(file_path):
+        return []
+    try:
+        lines = file_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    diagnostics: list[Diagnostic] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for decorator in node.decorator_list:
+            path = _route_path(decorator)
+            if path is None:
+                continue
+            lowered = path.lower()
+            token = next((t for t in _BANNED_TOKENS if t in lowered), None)
+            if token is None:
+                continue
+            idx = decorator.lineno - 1
+            if 0 <= idx < len(lines) and _WAIVER.search(lines[idx]):
+                continue
+            diagnostics.append(
+                Diagnostic(
+                    rule_id=RULE_ID,
+                    issue=ISSUE,
+                    severity=SEVERITY,
+                    file=file_path,
+                    line=decorator.lineno,
+                    col=decorator.col_offset,
+                    message=f"route path '{path}' carries era-marker '{token}' — rename to a descriptive path",
+                    snippet=(lines[idx].strip()[:120] if 0 <= idx < len(lines) else ""),
+                    fix_hint=FIX_HINT,
+                )
+            )
+    return diagnostics

--- a/tools/lint/canonical/rules/py_duplicate_concept.py
+++ b/tools/lint/canonical/rules/py_duplicate_concept.py
@@ -1,12 +1,21 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
-"""py-duplicate-concept — flag Enhanced*/Unified* class names that shadow a base.
+"""py-duplicate-concept — flag Enhanced/Unified/Consolidated era-marker names.
 
-An ``EnhancedFoo`` next to ``Foo`` (or ``UnifiedFoo`` next to ``Foo``) is a
-canonical-debt signal: instead of extending the original in place, a prefixed
-fork was created. The prefixed classes should be renamed or merged into the
-canonical module. WARN severity — 30+ existing instances must be migrated
-before this can be promoted to BLOCK. See canonical-debt umbrella #10569.
+An ``EnhancedFoo`` / ``UnifiedFoo`` / ``ConsolidatedFoo`` name is canonical-debt:
+instead of extending the original concept in place, a prefixed (or infixed) fork
+was created. This fires on the banned era-marker token appearing anywhere in a
+class OR function name — **prefix, infix, or standalone** — not only when a base
+concept coexists in the same file. That closes the gap where infix names like
+``AIStackEnhancedSearchData`` or ``KnowledgeUnifiedSearchResponse`` slipped past
+the old prefix-anchored check (audit gap on #10746).
+
+BLOCK severity — the backend / slm-backend / autobot_shared **production** source
+is clean of these tokens (verified #10746), so any new occurrence must be renamed
+to a descriptive canonical name (never a synonym like Advanced/Aggregated). Test
+files are out of scope: migration / back-compat tests legitimately reference the
+old names by design. Git's ``unified diff`` format term is allow-listed.
+See canonical-debt umbrella #10569.
 """
 
 from __future__ import annotations
@@ -22,38 +31,58 @@ RULE_ID = "py-duplicate-concept"
 ISSUE = "#10577"
 SEVERITY = "block"
 TARGETS = ["autobot-backend", "autobot-slm-backend", "autobot_shared"]
-DESCRIPTION = "Enhanced*/Unified* class shadows a base concept — merge into the canonical class"
+DESCRIPTION = "Enhanced/Unified/Consolidated era-marker in a class/function name — rename to the canonical concept"
 FIX_HINT = (
-    "Rename or fold EnhancedX/UnifiedX into the canonical X class:\n"
-    "  - If the prefix adds behaviour, extend the canonical class via inheritance.\n"
-    "  - If they have diverged, consolidate and delete the prefixed fork.\n"
+    "Rename the Enhanced/Unified/Consolidated name to the plain canonical concept:\n"
+    "  - Fold the fork's behaviour into the base class/function and migrate callers.\n"
+    "  - Use a DESCRIPTIVE name for a genuinely distinct concept (MultiSource, Combined,\n"
+    "    Composite, ...), never a synonym (Advanced/Aggregated are also banned).\n"
     "  Suppress with:  # canonical: ignore py-duplicate-concept — <reason> (#NNNN)"
 )
 
-_PREFIXES = ("Enhanced", "Unified")
+# Era-marker tokens that signal canonical drift. Matched case-insensitively as a
+# substring so prefix (EnhancedX), infix (XEnhancedY) and standalone all fire.
+_BANNED_TOKENS = ("enhanced", "unified", "consolidated")
+# Allow-list: substrings whose presence makes an otherwise-matching name legitimate.
+# "unified diff" is a git output format, not an era marker.
+_ALLOWLIST = ("unified_diff",)
 _WAIVER = re.compile(r"#\s*canonical:\s*ignore\s+py-duplicate-concept\b")
 
 
-def _class_names(tree: ast.AST) -> set[str]:
-    return {node.name for node in ast.walk(tree) if isinstance(node, ast.ClassDef)}
+def _is_test_file(file_path: Path) -> bool:
+    """Migration / back-compat tests legitimately reference the old era-marker names."""
+    name = file_path.name
+    return name.endswith("_test.py") or name.startswith("test_") or "tests" in file_path.parts
+
+
+def _banned_token(name: str) -> str | None:
+    lowered = name.lower()
+    if any(allowed in lowered for allowed in _ALLOWLIST):
+        return None
+    for token in _BANNED_TOKENS:
+        if token in lowered:
+            return token
+    return None
 
 
 def check(file_path: Path, tree: ast.AST, ctx: Context) -> list[Diagnostic]:
+    if _is_test_file(file_path):
+        return []
     try:
         lines = file_path.read_text(encoding="utf-8").splitlines()
     except OSError:
         return []
-    all_names = _class_names(tree)
     diagnostics: list[Diagnostic] = []
     for node in ast.walk(tree):
-        if not isinstance(node, ast.ClassDef):
+        if not isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
-        base_name = _strip_prefix(node.name)
-        if base_name is None or base_name not in all_names:
+        token = _banned_token(node.name)
+        if token is None:
             continue
         idx = node.lineno - 1
         if 0 <= idx < len(lines) and _WAIVER.search(lines[idx]):
             continue
+        kind = "class" if isinstance(node, ast.ClassDef) else "function"
         diagnostics.append(
             Diagnostic(
                 rule_id=RULE_ID,
@@ -62,16 +91,9 @@ def check(file_path: Path, tree: ast.AST, ctx: Context) -> list[Diagnostic]:
                 file=file_path,
                 line=node.lineno,
                 col=node.col_offset,
-                message=f"'{node.name}' shadows base concept '{base_name}' — merge into the canonical class",
+                message=f"{kind} '{node.name}' carries era-marker '{token}' — rename to the canonical concept",
                 snippet=(lines[idx].strip()[:120] if 0 <= idx < len(lines) else ""),
                 fix_hint=FIX_HINT,
             )
         )
     return diagnostics
-
-
-def _strip_prefix(name: str) -> str | None:
-    for prefix in _PREFIXES:
-        if name.startswith(prefix) and len(name) > len(prefix):
-            return name[len(prefix):]
-    return None


### PR DESCRIPTION
## Thinking Path
The #10746 infix audit exposed a gap in the self-enforcing canonical linter: `py-duplicate-concept` was **prefix-anchored** (`name.startswith("Enhanced"/"Unified")`) and only fired when a base class coexisted in the same file. Infix names like `AIStackEnhancedSearchData` / `KnowledgeUnifiedSearchResponse` and standalone forks slipped straight through — exactly the residue the sweep had to clean by hand. Without hardening the rule, the debt recurs.

## What Changed
- **`py-duplicate-concept` broadened**: matches the banned era-marker token (`Enhanced`/`Unified`/`Consolidated`, case-insensitive) anywhere in a **class OR function** name — prefix, infix, or standalone — with no coexisting-base requirement. Allow-lists git's `unified_diff` format term.
- **New rule `py-banned-route-path`**: flags `@router.<method>("/…/enhanced|unified|consolidated")` era-markers in the public route surface. Auto-discovered by the existing rule registry (no runner edits — the #10577 self-enforcing design).
- Both **BLOCK**, **production-scoped** (mirrors `py-hardcoded-url._is_test_file`): migration / back-compat tests legitimately reference the old names. Domain adjectives (`/advanced-stats`, `/advanced_search`) are **not** flagged — synonym judgement stays with human review, not the linter.

## Verification
- `python3 tools/lint/canonical_check.py --all` → **0 block findings** across `autobot-backend` / `autobot-slm-backend` / `autobot_shared` (production clean after the #10746 renames).
- **9 rule unit tests pass** (`test_py_duplicate_concept.py` + new `test_py_banned_route_path.py`), incl. new infix + standalone + route + allow-list + waiver fixtures.
- `black --check` clean; `flake8 --config=.flake8` → 0.

## Model Used
Claude Opus 4.8 (1M context)