### PR TITLE
docs(frontend): factual comments on already-wired views (#10725)

### DIFF
--- a/autobot-frontend/src/views/ErrorMonitoringView.vue
+++ b/autobot-frontend/src/views/ErrorMonitoringView.vue
@@ -5,9 +5,8 @@
   Author: mrveiss
 
   Error Monitoring Dashboard
-  Issue #9891 - Wire error-monitoring UI to backend /api/errors/* endpoints
-  Issue #9983 - Restore timeline / top-errors / summary / resolve UI on the
-                reimplemented (Prometheus + Redis) /api/errors/metrics/* endpoints
+  Backed by /api/errors/* and the /api/errors/metrics/* (Prometheus + Redis)
+  endpoints: timeline, top-errors, summary, and resolve. (Wired per #9891, #9983.)
 -->
 <template>
   <div class="error-monitoring-view">

--- a/autobot-frontend/src/views/FailureAnalysisDashboard.vue
+++ b/autobot-frontend/src/views/FailureAnalysisDashboard.vue
@@ -5,7 +5,8 @@
   SPDX-License-Identifier: Apache-2.0
 
   Failure Analysis Dashboard
-  Issue #9892: Wire causal-inference engine (analyze-failure) to the frontend.
+  Backed by the causal-inference engine via POST /api/diagnostics/analyze-failure
+  (wired per #9892).
 -->
 <template>
   <div class="failure-analysis-view">

--- a/autobot-frontend/src/views/VisionAutomationView.vue
+++ b/autobot-frontend/src/views/VisionAutomationView.vue
@@ -1,7 +1,7 @@
 <!-- Copyright 2025-2026 mrveiss -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <!-- AutoBot - AI-Powered Automation Platform -->
-<!-- Issue #9890: Wire vision automation panel to /api/vision endpoints -->
+<!-- Vision automation panel — backed by /api/vision/* endpoints (wired per #9890). -->
 <script setup lang="ts">
 /**
  * VisionAutomationView — Screen analysis, element detection, OCR, and


### PR DESCRIPTION
## Thinking Path
Umbrella #10714, T11 (trivial cleanup). Three views carried stale "Wire X to backend endpoints" header comments that read as unfinished mockups, but the #10714 audit confirmed all three are fully wired to real endpoints.

## What Changed
- `ErrorMonitoringView.vue`, `VisionAutomationView.vue`, `FailureAnalysisDashboard.vue` — replaced imperative "Wire..." TODO comments with factual descriptions of the backing endpoints (kept #9890/#9891/#9892/#9983 as history). **Comment-only, zero logic change.**

## Verification
- No code paths touched; CI frontend build validates parse. No `console.*`, no user-facing strings added.

Closes #10725.

## Model Used
Claude Opus 4.8 (1M context)