### PR TITLE
fix(api): telemetry + version GET public — stop load-time 401s (#10750 A13)

### DIFF
--- a/autobot-backend/api/services.py
+++ b/autobot-backend/api/services.py
@@ -326,8 +326,12 @@ async def get_vms_status(admin_check: bool = Depends(check_admin_permission)):
     operation="get_version",
     error_code_prefix="SERVICES",
 )
-async def get_version(admin_check: bool = Depends(check_admin_permission)):
+async def get_version():
     """Get application version and system information
+
+    Public: returns only version/build/environment/services_count/name (no
+    sensitive data). Called at app load before auth, so requiring admin caused
+    spurious 401s (#10750 A13).
 
     Issue #744: Requires admin authentication.
     """

--- a/autobot-backend/api/settings.py
+++ b/autobot-backend/api/settings.py
@@ -962,10 +962,13 @@ async def update_hardware_priority(
     operation="get_telemetry_settings",
     error_code_prefix="SETTINGS",
 )
-async def get_telemetry_settings(
-    current_user: dict = Depends(get_current_user),
-):
+async def get_telemetry_settings():
     """Get current telemetry settings (Issue #9035).
+
+    Public: returns only global, non-sensitive telemetry config (enabled flags +
+    first-run-prompt state). Checked at app load before auth is established, so
+    gating it behind get_current_user caused spurious 401s (#10750 A13). The
+    consent-changing POST /telemetry remains authenticated.
 
     Returns telemetry opt-in/opt-out status and whether the first-run
     prompt has been shown.


### PR DESCRIPTION
Part of #10750 (A13). GET /api/settings/telemetry (global consent flags) + GET /api/services/version (version/build/env, non-sensitive) are fetched at app load before auth → 401 (now non-fatal after A12 #10794, but still noisy + breaks the telemetry-consent check). Make both public; POST /telemetry stays authed. py_compile OK.