### PR TITLE
fix(llc): keep sidebar on Goals/Org-Chart/Dashboard via in-layout child routes (#10750 B3)

### DIFF
--- a/autobot-frontend/src/components/llc/LlcSidebar.vue
+++ b/autobot-frontend/src/components/llc/LlcSidebar.vue
@@ -6,9 +6,10 @@
   GH#9627: Contextual LLC sidebar — navigation spine for company-scoped views.
 
   Rendered by LlcCompanyLayout inside /llc/companies/:companyId/… routes.
-  Links only routes that exist in router/index.ts:
-    - Dashboard / Goals / Org Chart are query-scoped (?company=) views (#9861)
-    - Backlog / Approvals / Costs / CEO Chat / Heartbeat are :companyId-scoped
+  Every link targets a :companyId-scoped child route so the layout — and this
+  sidebar — stays mounted on navigation (#10750 B3). Dashboard / Goals /
+  Org Chart resolve the active company from :companyId (via
+  useLlcCompanyContext, which still falls back to ?company= for back-compat).
   Sprint & Kanban boards need a :boardId and are reached via the Backlog.
 -->
 <script setup lang="ts">
@@ -35,16 +36,16 @@ interface SidebarLink {
 const links = computed<SidebarLink[]>(() => {
   const id = companyId.value
   return [
-    // Query-scoped views (resolve company via ?company= — see #9861)
-    { labelKey: 'nav.llcDashboard', to: { path: '/llc/dashboard', query: { company: id } } },
-    // Company-scoped views (/llc/companies/:companyId/…)
+    // All views are company-scoped (/llc/companies/:companyId/…) so the
+    // LlcCompanyLayout — and therefore this sidebar — stays mounted (#10750 B3).
+    { labelKey: 'nav.llcDashboard', to: { path: `/llc/companies/${id}/dashboard` } },
     { labelKey: 'nav.llcBacklog', to: { path: `/llc/companies/${id}/backlog` } },
     { labelKey: 'nav.llcBoards', to: { path: `/llc/companies/${id}/boards` } },
     { labelKey: 'nav.llcReviewInbox', to: { path: `/llc/companies/${id}/reviews` } },
     { labelKey: 'nav.llcPortfolios', to: { path: `/llc/companies/${id}/portfolios` } },
     { labelKey: 'nav.llcTimeline', to: { path: `/llc/companies/${id}/timeline` } },
-    { labelKey: 'nav.llcGoals', to: { path: '/llc/goals', query: { company: id } } },
-    { labelKey: 'nav.llcOrgChart', to: { path: '/llc/org-chart', query: { company: id } } },
+    { labelKey: 'nav.llcGoals', to: { path: `/llc/companies/${id}/goals` } },
+    { labelKey: 'nav.llcOrgChart', to: { path: `/llc/companies/${id}/org-chart` } },
     { labelKey: 'nav.llcMembers', to: { path: `/llc/companies/${id}/members` } },
     { labelKey: 'nav.llcApprovals', to: { path: `/llc/companies/${id}/approvals` } },
     { labelKey: 'nav.llcCosts', to: { path: `/llc/companies/${id}/costs` } },
@@ -54,6 +55,8 @@ const links = computed<SidebarLink[]>(() => {
 })
 
 function isActive(link: SidebarLink): boolean {
+  // All links are now plain company-scoped paths (#10750 B3); compare the
+  // resolved route path only (query no longer participates in scoping).
   return route.path === link.to.path
 }
 

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -1175,6 +1175,13 @@ export const routes: RouteRecordRaw[] = [
       { path: 'heartbeat', name: 'llc-heartbeat', component: () => import('@/views/llc/HeartbeatMonitor.vue'), props: true, meta: { title: 'Heartbeat Monitor', requiresAuth: true } },
       { path: 'ceo-chat', name: 'llc-ceo-chat', component: () => import('@/views/llc/CeoChatView.vue'), props: true, meta: { title: 'CEO Chat', requiresAuth: true } },
       { path: 'members', name: 'llc-members', component: () => import('@/views/llc/MembersView.vue'), props: true, meta: { title: 'Members', requiresAuth: true } },
+      // GH#10750 (B3): in-layout variants of the formerly top-level dashboard/
+      // goals/org-chart views so the LlcSidebar stays mounted on navigation.
+      // The views resolve the active company from :companyId via
+      // useLlcCompanyContext (param -> ?company= fallback for back-compat).
+      { path: 'dashboard', name: 'llc-company-dashboard', component: () => import('@/views/llc/CompanyDashboard.vue'), props: true, meta: { title: 'Company Dashboard', requiresAuth: true } },
+      { path: 'goals', name: 'llc-company-goals', component: () => import('@/views/llc/GoalTree.vue'), props: true, meta: { title: 'Goal Tree', requiresAuth: true } },
+      { path: 'org-chart', name: 'llc-company-org-chart', component: () => import('@/views/llc/OrgChart.vue'), props: true, meta: { title: 'Org Chart', requiresAuth: true } },
     ],
   },
   // Issue #9044: Transcriber — audio/video transcription module


### PR DESCRIPTION
## Thinking Path
The Company OS `LlcSidebar` is rendered by `LlcCompanyLayout`, the component of the `/llc/companies/:companyId` route. The Dashboard/Goals/Org-Chart links pointed at the TOP-LEVEL routes `/llc/dashboard`, `/llc/goals`, `/llc/org-chart` (which use the same view components but sit outside `LlcCompanyLayout`), so navigating to them unmounted the sidebar. The other ~9 links are `:companyId`-scoped children and keep the sidebar. Fix: give those three views in-layout child routes and repoint the sidebar. The three views already resolve the active company through `useLlcCompanyContext`, which reads `route.params.companyId` first and falls back to `?company=`, so no view logic changes are needed and existing deep links stay valid.

## What Changed
- `src/router/index.ts`: added three child routes under `/llc/companies/:companyId` (component `LlcCompanyLayout`), each `props: true`, `meta: { requiresAuth: true }`:
  - `dashboard` → `llc-company-dashboard` → `CompanyDashboard.vue`
  - `goals` → `llc-company-goals` → `GoalTree.vue`
  - `org-chart` → `llc-company-org-chart` → `OrgChart.vue`
  - Kept the pre-existing top-level `/llc/dashboard|goals|org-chart` routes for back-compat (no deep links broken).
- `src/components/llc/LlcSidebar.vue`: repointed the Dashboard/Goals/Org-Chart links to `/llc/companies/${id}/dashboard|goals|org-chart` (no `?company=` query — companyId is the route param). Updated the file header comment. `isActive()` now works for all links since every link is a plain company-scoped path and the correct child route path matches `route.path`.

No view changes required: `GoalTree.vue`, `OrgChart.vue`, `CompanyDashboard.vue` all consume `useLlcCompanyContext().resolveCompanyId()`, whose resolution order is route param → `?company=` query → selector store → first company, so they load the right company from `:companyId` and fall back to the query for back-compat.

## Verification
- `npx vue-tsc --noEmit -p tsconfig.app.json`: 8 errors total, all pre-existing in generated files (`src/types/api-contract.ts`, `src/types/generated/api.ts`); **0 new** errors, none in changed files. (node_modules symlinked to run, removed before commit.)
- `npx eslint src/router/index.ts src/components/llc/LlcSidebar.vue`: 0 warnings/errors.
- Confirmed by reading the three views that `/llc/companies/:id/dashboard|goals|org-chart` load that company's data and stay within `LlcCompanyLayout` (sidebar present).

## Model Used
Opus 4.8 (1M context)

Part of #10750 (B3)