### PR TITLE
fix(frontend): scroll containment — flex min-h-0 layout chain + modal body scroll (#10750 C2)

### DIFF
--- a/autobot-frontend/src/assets/styles/theme.css
+++ b/autobot-frontend/src/assets/styles/theme.css
@@ -72,9 +72,9 @@
    * LAYOUT VARIABLES
    * ============================================ */
 
-  --header-height: 80px;
+  /* #10750 C2: --header-height + --view-min-height are canonical in
+     design-tokens.css (56px, the real header height). Duplicate 80px removed. */
   --sidebar-width: 256px;
-  --view-min-height: calc(100vh - var(--header-height));
 
   /* Content constraints */
   --content-max-width: 1280px;

--- a/autobot-frontend/src/components/analytics/CodeGenerationDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeGenerationDashboard.vue
@@ -529,7 +529,7 @@ onMounted(() => {
 .code-generation-dashboard {
   padding: var(--spacing-6);
   background: var(--bg-primary);
-  min-height: 100vh;
+  min-height: 100%;
   color: var(--text-primary);
 }
 

--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -1005,7 +1005,8 @@ watch(selectedPeriod, () => {
 .code-quality-dashboard {
   padding: var(--spacing-6);
   background: var(--bg-primary);
-  min-height: 100vh;
+  /* #10750 C2: fill the scrolling .analytics-router-view, not the viewport */
+  min-height: 100%;
   color: var(--text-primary);
 }
 

--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -954,8 +954,8 @@ onUnmounted(() => {
   padding: var(--spacing-5);
   background: var(--bg-primary);
   color: var(--text-primary);
-  min-height: 100vh;
-  overflow-y: auto;
+  /* #10750 C2: fill scrolling parent; drop inner overflow to avoid double scroll */
+  min-height: 100%;
   overflow-x: hidden;
 }
 

--- a/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
+++ b/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
@@ -328,7 +328,7 @@ onMounted(() => {
 .conversation-flow-dashboard {
   padding: var(--spacing-6);
   background: var(--bg-primary);
-  min-height: 100vh;
+  min-height: 100%;
   color: var(--text-primary);
 }
 

--- a/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
@@ -495,7 +495,7 @@ onMounted(() => {
 .llm-pattern-dashboard {
   padding: var(--spacing-6);
   background: var(--bg-primary);
-  min-height: 100vh;
+  min-height: 100%;
   color: var(--text-primary);
 }
 

--- a/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
+++ b/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
@@ -839,7 +839,7 @@ watch(selectedPeriod, () => {
 .technical-debt-dashboard {
   padding: var(--spacing-lg);
   background: var(--bg-primary);
-  min-height: 100vh;
+  min-height: 100%;
   color: var(--text-primary);
 }
 

--- a/autobot-frontend/src/components/chat/ChatSettingsModal.vue
+++ b/autobot-frontend/src/components/chat/ChatSettingsModal.vue
@@ -146,7 +146,10 @@ function updateEffort() {
   width: 90%;
   max-width: 500px;
   max-height: 80vh;
-  overflow: auto;
+  /* #10750 C2: keep header fixed; scroll only the body (below) */
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .settings-header {
@@ -181,6 +184,9 @@ function updateEffort() {
 
 .settings-body {
   padding: 1.5rem;
+  /* #10750 C2: this is the single scroll region */
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .setting-group {

--- a/autobot-frontend/src/components/knowledge/ChromaDBExplorer.vue
+++ b/autobot-frontend/src/components/knowledge/ChromaDBExplorer.vue
@@ -437,6 +437,11 @@ onMounted(() => {
   padding: var(--spacing-6);
   max-width: 1400px;
   margin: 0 auto;
+  /* #10750 C2: fill the bounded .knowledge-content scroller; panels scroll internally */
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 /* ============================================
@@ -520,7 +525,9 @@ onMounted(() => {
   display: grid;
   grid-template-columns: 320px 1fr;
   gap: var(--spacing-4);
-  min-height: 600px;
+  /* #10750 C2: take remaining height so panels resolve max-height:100% */
+  flex: 1;
+  min-height: 0;
 }
 
 /* ============================================
@@ -533,7 +540,9 @@ onMounted(() => {
   border-radius: var(--radius-lg);
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 200px);
+  /* #10750 C2: bounded by grid cell, not the viewport */
+  min-height: 0;
+  max-height: 100%;
   overflow: hidden;
   transition: all var(--duration-200) ease;
 }
@@ -719,7 +728,9 @@ onMounted(() => {
   border-radius: var(--radius-lg);
   padding: var(--spacing-5);
   overflow-y: auto;
-  max-height: calc(100vh - 200px);
+  /* #10750 C2: bounded by grid cell, not the viewport */
+  min-height: 0;
+  max-height: 100%;
 }
 
 .details-header {

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -360,7 +360,8 @@ onUnmounted(() => {
   padding: var(--spacing-6);
   max-width: 1400px;
   margin: 0 auto;
-  min-height: calc(100vh - 200px);
+  /* #10750 C2: fill the bounded .knowledge-content scroller instead of viewport magic */
+  min-height: 100%;
 }
 
 /* Category Selection View */

--- a/autobot-frontend/src/components/llc/TemplateBrowser.vue
+++ b/autobot-frontend/src/components/llc/TemplateBrowser.vue
@@ -576,7 +576,8 @@ onMounted(() => {
   top: 0;
   right: 0;
   width: 480px;
-  height: 100vh;
+  /* #10750 C2: cap height so long previews scroll internally (.preview-body) */
+  max-height: 90vh;
   background: var(--bg-elevated);
   box-shadow: -4px 0 24px rgba(0, 0, 0, 0.2);
   display: flex;

--- a/autobot-frontend/src/components/modals/TelemetryConsentModal.vue
+++ b/autobot-frontend/src/components/modals/TelemetryConsentModal.vue
@@ -184,6 +184,10 @@ function handleBackdropClick(event: MouseEvent) {
   max-width: 500px;
   width: 100%;
   border: 1px solid var(--border-color);
+  /* #10750 C2: cap height so header/actions stay fixed and body scrolls */
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .modal-header {
@@ -211,6 +215,9 @@ function handleBackdropClick(event: MouseEvent) {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
+  /* #10750 C2: scroll long consent text; keep header/actions in view */
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .consent-intro {

--- a/autobot-frontend/src/components/plugins/PluginInstallModal.vue
+++ b/autobot-frontend/src/components/plugins/PluginInstallModal.vue
@@ -241,6 +241,8 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   box-shadow: var(--shadow-xl);
+  /* #10750 C2: cap height so header/tabs/footer stay fixed and body scrolls */
+  max-height: 90vh;
 }
 
 .modal-header {
@@ -305,6 +307,9 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
+  /* #10750 C2: scroll long install forms; keep chrome in view */
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .hint {

--- a/autobot-frontend/src/components/profile/ProfileModal.vue
+++ b/autobot-frontend/src/components/profile/ProfileModal.vue
@@ -384,7 +384,10 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   width: 90%;
   max-width: 600px;
   max-height: 90vh;
-  overflow-y: auto;
+  /* #10750 C2: keep header fixed; scroll only .modal-body */
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   box-shadow: var(--shadow-xl);
 }
 
@@ -461,6 +464,9 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 
 .modal-body {
   padding: var(--spacing-6);
+  /* #10750 C2: single scroll region */
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .profile-section {

--- a/autobot-frontend/src/components/terminal/Terminal.vue
+++ b/autobot-frontend/src/components/terminal/Terminal.vue
@@ -795,8 +795,8 @@ onUnmounted(() => {
 /* ADDED: Ensure terminal works well in flex layouts */
 @media (min-width: 769px) {
   .working-terminal {
-    /* Ensure terminal adapts to container height on larger screens */
-    max-height: 100vh; /* Don't exceed viewport */
+    /* #10750 C2: adapt to the flex parent height, not the raw viewport */
+    max-height: 100%;
   }
 }
 </style>

--- a/autobot-frontend/src/components/terminal/TerminalWindow.vue
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.vue
@@ -1489,7 +1489,8 @@ export default {
 .terminal-window-standalone {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  /* #10750 C2: fill the flex parent (viewport - header) instead of full viewport */
+  height: 100%;
   background-color: #000;
   color: #ffffff;
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;

--- a/autobot-frontend/src/components/ui/BaseModal.vue
+++ b/autobot-frontend/src/components/ui/BaseModal.vue
@@ -220,7 +220,9 @@ if (import.meta.env.DEV) {
   max-width: 1200px;
 }
 
-.dialog-scrollable {
+/* #10750 C2: scroll only .dialog-content, never the whole .dialog
+   (overflow on both created a double scrollbar + header/actions scrolling away) */
+.dialog-scrollable .dialog-content {
   overflow-y: auto;
 }
 
@@ -267,7 +269,7 @@ if (import.meta.env.DEV) {
 /* Content */
 .dialog-content {
   flex: 1;
-  overflow-y: auto;
+  min-height: 0;
   padding: var(--spacing-6);
 }
 

--- a/autobot-frontend/src/views/AdminUsersView.vue
+++ b/autobot-frontend/src/views/AdminUsersView.vue
@@ -809,6 +809,10 @@ onMounted(loadUsers)
   width: 100%;
   max-width: 480px;
   box-shadow: var(--shadow-2xl);
+  /* #10750 C2: cap height + flex column so header stays fixed and body scrolls */
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .modal-sm {
@@ -839,6 +843,9 @@ onMounted(loadUsers)
 
 .modal-body {
   padding: var(--spacing-5);
+  /* #10750 C2: scroll long forms so footer buttons stay reachable */
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .form-group {

--- a/autobot-frontend/src/views/BudgetPolicies.vue
+++ b/autobot-frontend/src/views/BudgetPolicies.vue
@@ -904,7 +904,10 @@ onMounted(loadPolicies)
   width: 100%;
   max-width: 560px;
   max-height: 90vh;
-  overflow-y: auto;
+  /* #10750 C2: keep header fixed; scroll only the form body (below) */
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .modal-card-sm {
@@ -930,6 +933,9 @@ onMounted(loadPolicies)
   display: flex;
   flex-direction: column;
   gap: var(--spacing-4);
+  /* #10750 C2: single scroll region beneath the fixed header */
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .form-row {

--- a/autobot-frontend/src/views/CustomDashboard.vue
+++ b/autobot-frontend/src/views/CustomDashboard.vue
@@ -1049,6 +1049,8 @@ defineExpose({ stopDashboardPolling })
   padding: var(--spacing-6);
   overflow-y: auto;
   flex: 1;
+  /* #10750 C2: allow the flex child to shrink so overflow actually scrolls */
+  min-height: 0;
 }
 
 .form-group {

--- a/autobot-frontend/src/views/EvolutionView.vue
+++ b/autobot-frontend/src/views/EvolutionView.vue
@@ -758,7 +758,10 @@ onMounted(async () => {
   width: 90%;
   max-width: 600px;
   max-height: 90vh;
-  overflow: auto;
+  /* #10750 C2: keep header/footer fixed; scroll only .modal-body */
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   box-shadow: var(--shadow-2xl);
 }
 
@@ -791,6 +794,9 @@ onMounted(async () => {
 
 .modal-body {
   padding: var(--spacing-5);
+  /* #10750 C2: single scroll region */
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .modal-footer {

--- a/autobot-frontend/src/views/OnboardingWizard.vue
+++ b/autobot-frontend/src/views/OnboardingWizard.vue
@@ -446,7 +446,9 @@ onMounted(async () => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  min-height: 100vh;
+  /* #10750 C2: .view-container already clamps to viewport-header and scrolls;
+     100vh forced the wizard-footer (Back/Next/Apply) below the fold */
+  min-height: 100%;
   padding: 2rem 1rem;
   background: var(--color-bg-primary, #0f1117);
 }

--- a/autobot-frontend/src/views/PermissionDeniedView.vue
+++ b/autobot-frontend/src/views/PermissionDeniedView.vue
@@ -77,7 +77,8 @@ const contactAdmin = computed(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 100vh;
+  /* #10750 C2: .view-container-centered already clamps to viewport-header */
+  min-height: 100%;
   background: var(--bg-primary);
 }
 </style>

--- a/autobot-frontend/src/views/llc/GanttTimelineView.vue
+++ b/autobot-frontend/src/views/llc/GanttTimelineView.vue
@@ -487,6 +487,9 @@ onBeforeUnmount(() => {
 }
 
 .gantt-scroll {
+  /* #10750 C2: fill remaining height of the flex-column view and scroll internally */
+  flex: 1;
+  min-height: 0;
   overflow: auto;
   border: 1px solid var(--color-border, #e5e7eb);
   border-radius: 8px;

--- a/autobot-frontend/src/views/llc/KanbanBoardView.vue
+++ b/autobot-frontend/src/views/llc/KanbanBoardView.vue
@@ -308,6 +308,7 @@ onUnmounted(() => ws?.close())
   display: flex;
   gap: 0.75rem;
   flex: 1;
+  min-height: 0;
   overflow-x: auto;
   align-items: flex-start;
 }
@@ -319,7 +320,9 @@ onUnmounted(() => ws?.close())
   border: 1px solid var(--color-border, #e5e7eb);
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 160px);
+  /* #10750 C2: bounded by .board-layout height, not the viewport */
+  min-height: 0;
+  max-height: 100%;
 }
 
 .column-header {
@@ -362,6 +365,7 @@ onUnmounted(() => ws?.close())
 
 .column-cards {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 0.5rem;
   display: flex;

--- a/autobot-frontend/src/views/llc/LlcCompanyLayout.vue
+++ b/autobot-frontend/src/views/llc/LlcCompanyLayout.vue
@@ -32,14 +32,26 @@ onMounted(() => {
 </template>
 
 <style scoped>
+/*
+  Height chain (#10750 C2): App.vue passes `h-full` to this component's root
+  via <router-view class="h-full">, so `.llc-company-layout` has a real,
+  bounded height. `height: 100%` here makes that explicit so routed board
+  views can resolve their own `height: 100%` and contain their own scroll
+  region instead of relying on calc(100vh - N) viewport magic.
+*/
 .llc-company-layout {
   display: flex;
   align-items: stretch;
-  min-height: 100%;
+  height: 100%;
+  min-height: 0;
 }
 
 .llc-company-content {
   flex: 1;
   min-width: 0;
+  /* Bounded flex column so children resolve height:100% and scroll internally */
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 </style>

--- a/autobot-frontend/src/views/llc/SprintBoardView.vue
+++ b/autobot-frontend/src/views/llc/SprintBoardView.vue
@@ -360,6 +360,7 @@ onUnmounted(() => {
   display: flex;
   gap: 0.75rem;
   flex: 1;
+  min-height: 0;
   overflow-x: auto;
   align-items: flex-start;
 }
@@ -371,7 +372,9 @@ onUnmounted(() => {
   border: 1px solid var(--color-border, #e5e7eb);
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 220px);
+  /* #10750 C2: bounded by .board-columns height, not the viewport (unify w/ Kanban) */
+  min-height: 0;
+  max-height: 100%;
 }
 
 .column-header {
@@ -395,6 +398,7 @@ onUnmounted(() => {
 
 .column-cards {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 0.5rem;
   display: flex;


### PR DESCRIPTION
## Thinking Path
The user's #1 complaint — "can't scroll when content overflows the div" — traces to two structural CSS anti-patterns across the app:
1. **Viewport-magic heights** (`height/min-height: 100vh`, `max-height: calc(100vh - N)`) that ignore the 56px app header (`App.vue` mounts `<main class="flex-1 min-h-0 overflow-hidden">` = viewport − header), so content is pushed below the fold or a nested scroll double-scrolls.
2. **Whole-modal scroll** — `overflow-y:auto` on the modal container makes the header/footer scroll away and buttons unreachable.

The fix everywhere is the AdminLTE pattern: fixed chrome + ONE inner region that scrolls, wired via a flex chain with `min-height: 0` at each level instead of hard-coded viewport offsets.

## What Changed
**LLC height chain + boards** (the root unblocker)
- `LlcCompanyLayout.vue` — `.llc-company-layout` explicit `height:100%; min-height:0` (it receives `h-full` from `<router-view class="h-full">`); `.llc-company-content` → `display:flex; flex-direction:column; min-height:0`. This gives every routed board a real bounded height so `height:100%` resolves.
- `KanbanBoardView.vue` / `SprintBoardView.vue` — column `max-height: calc(100vh - N)` → `min-height:0; max-height:100%` (bounded by the board layout, not the viewport); `min-height:0` added to `.board-layout`/`.board-columns` and the card scroll regions. Kept the fixed `flex: 0 0 Npx` column widths (adding `flex:1` there would collapse the fixed-width columns).
- `GanttTimelineView.vue` — `.gantt-scroll` → `flex:1; min-height:0`.
- `TemplateBrowser.vue` — preview panel `height:100vh` → `max-height:90vh` (body already scrolls).

**Analytics dashboards** (rendered inside `.analytics-router-view{overflow-y:auto}`)
- Root `min-height:100vh` → `min-height:100%` in CodeQuality, Codebase (also removed its inner `overflow-y:auto` double-scroll), CodeGeneration, TechnicalDebt, LLMPattern, ConversationFlow.

**Terminal + knowledge**
- `TerminalWindow.vue` `height:100vh`→`100%`; `Terminal.vue` `max-height:100vh`→`100%`.
- `ChromaDBExplorer.vue` — explorer becomes a bounded flex column; panels `calc(100vh-200px)`→`min-height:0; max-height:100%` (scroll inside the `.knowledge-content` scroller). `KnowledgeCategories.vue` `calc(100vh-200px)`→`min-height:100%`.

**Modals (scroll containment)**
- `AdminUsersView.vue` [HIGH] — `.modal` `max-height:90vh; flex column`; `.modal-body` `overflow-y:auto; min-height:0` (create-user/assign-bundle buttons were unreachable).
- `TelemetryConsentModal.vue`, `PluginInstallModal.vue` — `max-height:90vh` + scrolling body.
- Whole-modal-scroll fix (header/footer now fixed, scroll moved to body): `ChatSettingsModal.vue`, `ProfileModal.vue`, `EvolutionView.vue`, `CustomDashboard.vue` (added `min-height:0`), `BudgetPolicies.vue`.
- `BaseModal.vue` — removed the redundant double-scroll: `.dialog-scrollable` no longer scrolls the whole dialog; scroll lives only on `.dialog-content` (+`min-height:0`).

**Header-height token dedup** (feeds `--view-min-height` used by every `.view-container`)
- Removed the duplicate `--header-height: 80px` (+ duplicate `--view-min-height`) from `theme.css`; the canonical `56px` in `design-tokens.css` (imported later, already winning) is now the sole source.
- `OnboardingWizard.vue` / `PermissionDeniedView.vue` — root `min-height:100vh` → `100%` (their `.view-container`/`.view-container-centered` wrappers already clamp to viewport−header and scroll; the wizard footer buttons were below the fold).

All changes are CSS-only; no component logic was restructured.

## Verification
- `npx vue-tsc --noEmit -p tsconfig.app.json` — 0 NEW errors (remaining errors are pre-existing in `src/types/api-contract.ts` and `src/types/generated/api.ts` generated files).
- `eslint` on all 27 changed files — 0 errors, 0 new warnings (41 pre-existing `<script>`/`<template>` warnings unrelated to these `<style>`-only edits).
- Re-read each changed `<style>`: confirmed each scroll region has a bounded ancestor + `min-height:0` on every flex level. The `LlcCompanyLayout` chain (`h-full` from router-view → `height:100%; min-height:0` layout → `flex-column; min-height:0` content) now gives Kanban/Sprint/Gantt boards a real bounded height.

## Model Used
Opus 4.8 (1M context)

Part of #10750 (C2)