### PR TITLE
docs(rules): fix pre-existing issues discovered along the way (Rule 6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Correctness → Speed → Maintainability. No wasted motion. No speculative work
 3. **Standardize** — ≤30-line functions; no `_v2`/`_fix` suffixes
 4. **Clarify** — confirm architecture before coding
 5. **Verify** — show evidence (test output, curl, build) before claiming done
-6. **Report** — file GitHub issues for every discovered bug, even off-task
+6. **Report & Fix** — file GitHub issues for every discovered bug, even off-task, and **fix pre-existing issues discovered along the way** (same PR when in-scope; fast-follow when larger). ASK only for large refactors / product decisions / risky blast radius. See [`CLAUDE_RULES.md`](docs/developer/CLAUDE_RULES.md) Rule 6.
 
 ---
 

--- a/docs/developer/CLAUDE_RULES.md
+++ b/docs/developer/CLAUDE_RULES.md
@@ -254,22 +254,23 @@ The pre-commit wrapper (`scripts/hooks/pre-commit-branch-guard-wrapper`) runs `p
 
 **"It was already there" is never a reason to ignore a problem.**
 
-Every bug, inconsistency, security issue, hardcoded value, or tech debt found must be reported:
-
-- Create a GitHub issue immediately with description, severity, and location
-- Report to the user and ask for direction: fix now, fix after current task, or defer
+Every bug, inconsistency, security issue, hardcoded value, or tech debt found must be reported **AND, by default, FIXED**. "It was already there" is never a reason to leave it. File a tracking issue for visibility, then fix it — in the **same PR when it's in-scope**, or a **fast-follow PR** when larger. Do not merely file-and-move-on.
 
 **Classification:**
 
-Fix immediately WITHOUT asking:
-- Security vulnerability in code you're modifying
-- Data corruption risk, syntax error breaking tests, import error blocking changes
+Fix along the way WITHOUT asking (file a tracking issue, then fix — same PR when in-scope):
+- Any pre-existing bug in a file/module you are already modifying
+- A pre-existing defect that nullifies or undermines the change you're making (e.g. a missing `await` that makes the code you just optimized a silent no-op; a mangled list entry that disables a security check)
+- Security vulnerability, data-corruption risk, syntax/import error, swallowed exception, or other correctness bug
+- Low-risk correctness fixes with a clear root cause — always add a regression test
 
 Create issue + ASK before fixing:
-- Performance problem, code smell, missing documentation, refactoring opportunity
+- Large refactors, architecture/product decisions, or feature builds (PRD-gated) — surface with a recommendation, don't build unilaterally
+- Fixes with a wide/risky blast radius or genuinely ambiguous intended behavior
 
 Create issue + DEFER (don't ask):
-- Minor style issues, optimization opportunities, unrelated bugs
+- Genuinely unrelated bugs far from the current change
+- Speculative optimizations with no measured impact (e.g. bounded analyzer loops)
 
 **One Issue Per Session Rule:**
 When an issue is complete, wait for explicit user instruction before starting new work.


### PR DESCRIPTION
## Thinking Path
Owner directive: "we need to fix any preexisting issues if discovered along way, add to rules." Rule 6 previously said file-an-issue-and-ask; this codifies that the default is to **fix** discovered pre-existing issues, not just report them.

## What Changed
- `docs/developer/CLAUDE_RULES.md` Rule 6 — reframed to "report AND fix by default"; expanded the fix-without-asking category to cover any pre-existing bug in a file you're modifying + defects that nullify your change (concrete examples: missing `await` making optimized code a no-op; mangled list entry disabling a security check). ASK reserved for large refactors / product decisions / risky blast radius.
- `CLAUDE.md` Core Rule 6 — "Report" → "Report & Fix" with a pointer to Rule 6.

## Verification
- Docs-only; reflects behavior already applied this session (fixed the `_get_redis` no-op and the dnf/zypper elevation gap as fast in-scope fixes rather than filing-and-deferring).

## Model Used
Claude Opus 4.8 (1M context)