### PR TITLE
fix(frontend): migrate --color-* CSS vars to canonical semantic tokens — revives theming (#10750 C1)

### DIFF
--- a/autobot-frontend/src/assets/tailwind.css
+++ b/autobot-frontend/src/assets/tailwind.css
@@ -183,6 +183,16 @@
   @apply bg-transparent text-autobot-text-primary border border-autobot-border hover:bg-autobot-bg-hover hover:text-autobot-text-primary;
 }
 
+/* Small button modifier — pairs with `btn` for compact controls. */
+@utility btn-sm {
+  @apply py-1 px-2 text-xs;
+}
+
+/* Icon-only button — square padding, centered glyph; theme-aware surface. */
+@utility btn-icon {
+  @apply inline-flex items-center justify-center p-2 rounded text-autobot-text-secondary hover:text-autobot-text-primary hover:bg-autobot-bg-hover transition-all duration-150 ease-linear;
+}
+
 @utility card {
   @apply relative flex flex-col min-w-0 wrap-break-word bg-autobot-bg-card rounded-lg shadow-xl-soft;
 }
@@ -207,8 +217,43 @@
   @apply border-0 px-3 py-3 placeholder-autobot-text-muted text-autobot-text-primary bg-autobot-bg-input rounded text-sm shadow focus:outline-none focus:ring-2 focus:ring-autobot-primary w-full ease-linear transition-all duration-150;
 }
 
+/* form-input — alias of input-field so views using either name render styled. */
+@utility form-input {
+  @apply input-field;
+}
+
+/* form-group — vertical field wrapper with label/control spacing. */
+@utility form-group {
+  @apply flex flex-col gap-1.5 mb-4;
+}
+
 @utility label {
   @apply block uppercase text-autobot-text-secondary text-xs font-bold mb-2;
+}
+
+/* ============================================================================
+ * Modal primitives — shared theme-aware overlay + dialog scaffold.
+ * Components that need bespoke layout should migrate to ui/BaseModal (C2b);
+ * these exist so referenced classes never render unstyled.
+ * ========================================================================== */
+@utility modal-overlay {
+  @apply fixed inset-0 z-modal-backdrop flex items-center justify-center p-4 bg-[var(--bg-overlay,rgba(0,0,0,0.5))];
+}
+
+@utility modal {
+  @apply relative z-modal flex flex-col w-full max-w-lg max-h-[90vh] overflow-hidden rounded-lg border border-autobot-border bg-autobot-bg-elevated text-autobot-text-primary shadow-2xl;
+}
+
+@utility modal-header {
+  @apply flex items-center justify-between px-6 py-4 border-b border-autobot-border;
+}
+
+@utility modal-body {
+  @apply flex-1 overflow-y-auto px-6 py-4;
+}
+
+@utility modal-footer {
+  @apply flex items-center justify-end gap-3 px-6 py-4 border-t border-autobot-border;
 }
 
 @layer base {

--- a/autobot-frontend/src/components/artifact-cells/ImageCell.vue
+++ b/autobot-frontend/src/components/artifact-cells/ImageCell.vue
@@ -231,9 +231,9 @@ const downloadImage = (url: string, index: number) => {
   align-items: center;
   justify-content: center;
   padding: 2rem;
-  border: 1px dashed var(--color-border, #e5e7eb);
+  border: 1px dashed var(--border-default, #e5e7eb);
   border-radius: 0.5rem;
-  color: var(--color-text-muted, #6b7280);
+  color: var(--text-muted, #6b7280);
 }
 
 .placeholder-content {
@@ -262,7 +262,7 @@ const downloadImage = (url: string, index: number) => {
   padding: 0.125rem 0.5rem;
   border-radius: 9999px;
   background: var(--color-surface-2, #f3f4f6);
-  color: var(--color-text-muted, #6b7280);
+  color: var(--text-muted, #6b7280);
   font-weight: 500;
 }
 
@@ -339,7 +339,7 @@ const downloadImage = (url: string, index: number) => {
   align-items: center;
   justify-content: center;
   background: var(--color-surface-2, #f3f4f6);
-  color: var(--color-text-muted, #6b7280);
+  color: var(--text-muted, #6b7280);
   gap: 0.5rem;
   font-size: 0.875rem;
 }
@@ -349,7 +349,7 @@ const downloadImage = (url: string, index: number) => {
   align-items: flex-start;
   gap: 0.375rem;
   font-size: 0.8125rem;
-  color: var(--color-text-muted, #6b7280);
+  color: var(--text-muted, #6b7280);
   font-style: italic;
   line-height: 1.4;
   margin: 0;
@@ -367,10 +367,10 @@ const downloadImage = (url: string, index: number) => {
   gap: 0.25rem;
   padding: 0.25rem 0.625rem;
   font-size: 0.75rem;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.375rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text, #374151);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary, #374151);
   cursor: pointer;
   transition: background 0.15s;
 }

--- a/autobot-frontend/src/components/artifact-cells/VideoCell.vue
+++ b/autobot-frontend/src/components/artifact-cells/VideoCell.vue
@@ -164,9 +164,9 @@ const copyVideoUrl = async (url: string) => {
   align-items: center;
   justify-content: center;
   padding: 2rem;
-  border: 1px dashed var(--color-border, #e5e7eb);
+  border: 1px dashed var(--border-default, #e5e7eb);
   border-radius: 0.5rem;
-  color: var(--color-text-muted, #6b7280);
+  color: var(--text-muted, #6b7280);
 }
 
 .placeholder-content {
@@ -195,7 +195,7 @@ const copyVideoUrl = async (url: string) => {
   padding: 0.125rem 0.5rem;
   border-radius: 9999px;
   background: var(--color-surface-2, #f3f4f6);
-  color: var(--color-text-muted, #6b7280);
+  color: var(--text-muted, #6b7280);
   font-weight: 500;
 }
 
@@ -219,7 +219,7 @@ const copyVideoUrl = async (url: string) => {
   align-items: center;
   gap: 0.5rem;
   padding: 1.5rem;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.5rem;
   max-width: 640px;
 }
@@ -249,7 +249,7 @@ const copyVideoUrl = async (url: string) => {
 
 .progress-label {
   font-size: 0.8125rem;
-  color: var(--color-text-muted, #6b7280);
+  color: var(--text-muted, #6b7280);
 }
 
 .video-error {
@@ -259,7 +259,7 @@ const copyVideoUrl = async (url: string) => {
   padding: 1rem;
   border-radius: 0.5rem;
   background: var(--color-surface-2, #f3f4f6);
-  color: var(--color-danger, #dc2626);
+  color: var(--color-error, #dc2626);
   font-size: 0.875rem;
   max-width: 640px;
 }
@@ -269,7 +269,7 @@ const copyVideoUrl = async (url: string) => {
   align-items: flex-start;
   gap: 0.375rem;
   font-size: 0.8125rem;
-  color: var(--color-text-muted, #6b7280);
+  color: var(--text-muted, #6b7280);
   font-style: italic;
   line-height: 1.4;
   margin: 0;
@@ -287,10 +287,10 @@ const copyVideoUrl = async (url: string) => {
   gap: 0.25rem;
   padding: 0.25rem 0.625rem;
   font-size: 0.75rem;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.375rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text, #374151);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary, #374151);
   cursor: pointer;
   text-decoration: none;
   transition: background 0.15s;

--- a/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
+++ b/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
@@ -286,7 +286,7 @@ function submitType() {
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-text-muted, #9ca3af);
+  color: var(--text-muted, #9ca3af);
   font-size: var(--text-sm);
 }
 
@@ -294,8 +294,8 @@ function submitType() {
   display: flex;
   gap: var(--spacing-1);
   padding: var(--spacing-1) var(--spacing-2);
-  background: var(--color-surface, #1e1e2e);
-  border-top: 1px solid var(--color-border, #333);
+  background: var(--bg-surface, #1e1e2e);
+  border-top: 1px solid var(--border-default, #333);
 }
 
 .toolbar-btn {
@@ -307,7 +307,7 @@ function submitType() {
   border: none;
   border-radius: var(--radius-default);
   background: transparent;
-  color: var(--color-text-secondary, #a1a1aa);
+  color: var(--text-secondary, #a1a1aa);
   cursor: pointer;
   font-size: var(--text-xs);
   transition: background var(--duration-150), color var(--duration-150);
@@ -315,7 +315,7 @@ function submitType() {
 
 .toolbar-btn:hover:not(:disabled) {
   background: var(--color-hover, rgba(255, 255, 255, 0.1));
-  color: var(--color-text, #e4e4e7);
+  color: var(--text-primary, #e4e4e7);
 }
 
 .toolbar-btn:disabled {
@@ -327,17 +327,17 @@ function submitType() {
   display: flex;
   gap: var(--spacing-1);
   padding: var(--spacing-1) var(--spacing-2);
-  background: var(--color-surface, #1e1e2e);
-  border-top: 1px solid var(--color-border, #333);
+  background: var(--bg-surface, #1e1e2e);
+  border-top: 1px solid var(--border-default, #333);
 }
 
 .type-input {
   flex: 1;
   padding: var(--spacing-1) var(--spacing-2);
-  border: 1px solid var(--color-border, #333);
+  border: 1px solid var(--border-default, #333);
   border-radius: var(--radius-default);
   background: var(--color-bg, #121212);
-  color: var(--color-text, #e4e4e7);
+  color: var(--text-primary, #e4e4e7);
   font-size: 0.8rem;
   outline: none;
 }

--- a/autobot-frontend/src/components/canvas/CodeCell.vue
+++ b/autobot-frontend/src/components/canvas/CodeCell.vue
@@ -212,7 +212,7 @@ button:focus-visible {
 /* Highlight.js theme: dark mode */
 .hljs-dark {
   background-color: var(--color-bg-card);
-  color: var(--color-text-primary);
+  color: var(--text-primary);
 }
 
 .hljs-dark :deep(.hljs-attr),
@@ -251,7 +251,7 @@ button:focus-visible {
 /* Highlight.js theme: light mode */
 .hljs-light {
   background-color: var(--color-bg-card);
-  color: var(--color-text-primary);
+  color: var(--text-primary);
 }
 
 .hljs-light :deep(.hljs-attr),

--- a/autobot-frontend/src/components/charts/EvolutionTimelineChart.vue
+++ b/autobot-frontend/src/components/charts/EvolutionTimelineChart.vue
@@ -119,7 +119,7 @@ const chartOptions = computed<ApexOptions>(() => ({
     horizontalAlign: 'left',
   },
   grid: {
-    borderColor: 'var(--color-border, #2d3748)',
+    borderColor: 'var(--border-default, #2d3748)',
     strokeDashArray: 4,
   },
   colors: ['#10b981', '#3b82f6', '#f59e0b', '#ef4444', '#8b5cf6'],

--- a/autobot-frontend/src/components/charts/PatternEvolutionChart.vue
+++ b/autobot-frontend/src/components/charts/PatternEvolutionChart.vue
@@ -120,7 +120,7 @@ const chartOptions = computed<ApexOptions>(() => ({
     },
   },
   grid: {
-    borderColor: 'var(--color-border, #2d3748)',
+    borderColor: 'var(--border-default, #2d3748)',
     strokeDashArray: 4,
   },
   colors: [

--- a/autobot-frontend/src/components/chat/ChatInput.vue
+++ b/autobot-frontend/src/components/chat/ChatInput.vue
@@ -1539,7 +1539,7 @@ onUnmounted(() => {
 }
 
 .image-gen-dialog {
-  background: var(--color-surface, #fff);
+  background: var(--bg-surface, #fff);
   border-radius: 0.75rem;
   padding: 1.5rem;
   width: 100%;
@@ -1556,26 +1556,26 @@ onUnmounted(() => {
   gap: 0.5rem;
   font-size: 1rem;
   font-weight: 600;
-  color: var(--color-text, #111827);
+  color: var(--text-primary, #111827);
   margin: 0;
 }
 
 .image-gen-label {
   font-size: 0.8125rem;
   font-weight: 500;
-  color: var(--color-text-muted, #6b7280);
+  color: var(--text-muted, #6b7280);
 }
 
 .image-gen-prompt {
   width: 100%;
   padding: 0.625rem 0.75rem;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.5rem;
   font-size: 0.875rem;
   resize: none;
   font-family: inherit;
-  color: var(--color-text, #111827);
-  background: var(--color-surface, #fff);
+  color: var(--text-primary, #111827);
+  background: var(--bg-surface, #fff);
 }
 
 .image-gen-prompt:focus {
@@ -1596,7 +1596,7 @@ onUnmounted(() => {
   gap: 0.375rem;
   font-size: 0.8125rem;
   cursor: pointer;
-  color: var(--color-text, #111827);
+  color: var(--text-primary, #111827);
 }
 
 .image-gen-actions {
@@ -1608,12 +1608,12 @@ onUnmounted(() => {
 
 .image-gen-cancel {
   padding: 0.5rem 1rem;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.5rem;
   background: transparent;
   font-size: 0.875rem;
   cursor: pointer;
-  color: var(--color-text-muted, #6b7280);
+  color: var(--text-muted, #6b7280);
 }
 
 .image-gen-submit {

--- a/autobot-frontend/src/components/chat/CitationsDisplay.vue
+++ b/autobot-frontend/src/components/chat/CitationsDisplay.vue
@@ -384,7 +384,7 @@ const citationTitle = (citation: Citation): string => {
 
 .reliability-low {
   background: rgba(239, 68, 68, 0.15);
-  color: var(--color-danger, #ef4444);
+  color: var(--color-error, #ef4444);
 }
 
 /* Transition */

--- a/autobot-frontend/src/components/chat/MultiModelChat.vue
+++ b/autobot-frontend/src/components/chat/MultiModelChat.vue
@@ -173,7 +173,7 @@ defineExpose({ reset })
 .multi-model-chat__picker-label {
   font-size: 0.8125rem;
   font-weight: 600;
-  color: var(--color-text-muted, #9ca3af);
+  color: var(--text-muted, #9ca3af);
   white-space: nowrap;
 }
 
@@ -189,7 +189,7 @@ defineExpose({ reset })
   gap: var(--spacing-1, 0.25rem);
   cursor: pointer;
   font-size: 0.8125rem;
-  color: var(--color-text-primary, #e5e7eb);
+  color: var(--text-primary, #e5e7eb);
 }
 
 .multi-model-chat__model-name {
@@ -200,7 +200,7 @@ defineExpose({ reset })
 .multi-model-chat__model-ctx {
   font-size: 0.6875rem;
   font-family: ui-monospace, monospace;
-  color: var(--color-text-muted, #9ca3af);
+  color: var(--text-muted, #9ca3af);
   background: var(--color-bg-tertiary, #1a1a2e);
   border-radius: 0.25rem;
   padding: 0 0.25rem;
@@ -217,8 +217,8 @@ defineExpose({ reset })
   flex: 1;
   resize: vertical;
   background: var(--color-bg-input, #2a2a3e);
-  color: var(--color-text-primary, #e5e7eb);
-  border: 1px solid var(--color-border, #374151);
+  color: var(--text-primary, #e5e7eb);
+  border: 1px solid var(--border-default, #374151);
   border-radius: var(--radius-md, 0.375rem);
   padding: var(--spacing-2, 0.5rem) var(--spacing-3, 0.75rem);
   font-size: 0.875rem;
@@ -271,7 +271,7 @@ defineExpose({ reset })
 
 .multi-model-chat__response-card {
   background: var(--color-bg-secondary, #13131f);
-  border: 1px solid var(--color-border, #374151);
+  border: 1px solid var(--border-default, #374151);
   border-radius: var(--radius-md, 0.375rem);
   overflow: hidden;
   display: flex;
@@ -288,14 +288,14 @@ defineExpose({ reset })
   justify-content: space-between;
   padding: var(--spacing-2, 0.5rem) var(--spacing-3, 0.75rem);
   background: var(--color-bg-tertiary, #1a1a2e);
-  border-bottom: 1px solid var(--color-border, #374151);
+  border-bottom: 1px solid var(--border-default, #374151);
   gap: var(--spacing-2, 0.5rem);
 }
 
 .multi-model-chat__response-model {
   font-family: ui-monospace, monospace;
   font-size: 0.75rem;
-  color: var(--color-text-muted, #9ca3af);
+  color: var(--text-muted, #9ca3af);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -335,7 +335,7 @@ defineExpose({ reset })
   margin: var(--spacing-0);
   font-family: ui-monospace, monospace;
   font-size: 0.8125rem;
-  color: var(--color-text-primary, #e5e7eb);
+  color: var(--text-primary, #e5e7eb);
   white-space: pre-wrap;
   word-break: break-word;
   line-height: 1.6;

--- a/autobot-frontend/src/components/chat/PresetFormBody.vue
+++ b/autobot-frontend/src/components/chat/PresetFormBody.vue
@@ -269,7 +269,7 @@ async function executeDelete(id: string): Promise<void> {
   padding: var(--spacing-3) var(--spacing-4);
   margin-bottom: var(--spacing-4);
   background: var(--color-danger-subtle, #fef2f2);
-  color: var(--color-danger, #dc2626);
+  color: var(--color-error, #dc2626);
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
 }
@@ -321,7 +321,7 @@ async function executeDelete(id: string): Promise<void> {
 
 .field-input[aria-invalid="true"],
 .field-textarea[aria-invalid="true"] {
-  border-color: var(--color-danger, #dc2626);
+  border-color: var(--color-error, #dc2626);
 }
 
 .field-textarea {
@@ -331,7 +331,7 @@ async function executeDelete(id: string): Promise<void> {
 
 .field-error {
   font-size: var(--text-xs);
-  color: var(--color-danger, #dc2626);
+  color: var(--color-error, #dc2626);
 }
 
 .form-actions {

--- a/autobot-frontend/src/components/chat/ReasoningTrace.vue
+++ b/autobot-frontend/src/components/chat/ReasoningTrace.vue
@@ -112,7 +112,7 @@ import Icon from '@/components/ui/Icon.vue'
 
 <style scoped>
 .reasoning-trace {
-  border: 1px solid var(--color-border, #334155);
+  border: 1px solid var(--border-default, #334155);
   border-radius: var(--radius-lg);
   margin-bottom: var(--spacing-2);
   background: var(--color-bg-subtle, #0f172a);
@@ -134,13 +134,13 @@ import Icon from '@/components/ui/Icon.vue'
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--color-text-muted, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   text-align: left;
   user-select: none;
 }
 
 .reasoning-trace__header:hover {
-  color: var(--color-text, #e2e8f0);
+  color: var(--text-primary, #e2e8f0);
 }
 
 .reasoning-trace__icon {
@@ -162,7 +162,7 @@ import Icon from '@/components/ui/Icon.vue'
 
 .reasoning-trace__count {
   font-size: 0.7rem;
-  background: var(--color-border, #334155);
+  background: var(--border-default, #334155);
   border-radius: var(--radius-full);
   padding: 0 0.4rem;
   line-height: 1.4rem;
@@ -175,7 +175,7 @@ import Icon from '@/components/ui/Icon.vue'
 
 /* Body */
 .reasoning-trace__body {
-  border-top: 1px solid var(--color-border, #334155);
+  border-top: 1px solid var(--border-default, #334155);
   max-height: 18rem;
   overflow-y: auto;
   padding: var(--spacing-1) var(--spacing-0);
@@ -219,7 +219,7 @@ import Icon from '@/components/ui/Icon.vue'
 }
 
 .reasoning-trace__entry-icon {
-  color: var(--color-text-muted, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   width: 0.9rem;
   text-align: center;
   flex-shrink: 0;
@@ -232,19 +232,19 @@ import Icon from '@/components/ui/Icon.vue'
 }
 
 .reasoning-trace__entry-label {
-  color: var(--color-text, #e2e8f0);
+  color: var(--text-primary, #e2e8f0);
   overflow-wrap: anywhere;
 }
 
 .reasoning-trace__entry-detail {
   display: block;
-  color: var(--color-text-muted, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   font-size: 0.7rem;
   overflow-wrap: anywhere;
 }
 
 .reasoning-trace__entry-duration {
-  color: var(--color-text-muted, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   flex-shrink: 0;
   font-size: 0.7rem;
   margin-left: auto;

--- a/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
+++ b/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
@@ -121,7 +121,7 @@
       </button>
     </div>
     <!-- AI goal input strip (MVA-1380) -->
-    <div v-if="markRegionsMode && showAiGoalInput" class="flex items-center gap-2 px-3 py-2 border-b" style="border-color: var(--color-border); background: var(--color-bg-secondary)">
+    <div v-if="markRegionsMode && showAiGoalInput" class="flex items-center gap-2 px-3 py-2 border-b" style="border-color: var(--border-default); background: var(--color-bg-secondary)">
       <input
         v-model="aiGoalText"
         type="text"

--- a/autobot-frontend/src/components/documents/AIDocumentEditor.vue
+++ b/autobot-frontend/src/components/documents/AIDocumentEditor.vue
@@ -260,8 +260,8 @@ const formattedUpdatedAt = computed(() => {
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: var(--color-background, #1e1e1e);
-  color: var(--color-text, #e0e0e0);
+  background: var(--bg-primary, #1e1e1e);
+  color: var(--text-primary, #e0e0e0);
   border-radius: var(--radius-lg);
   overflow: hidden;
 }
@@ -271,7 +271,7 @@ const formattedUpdatedAt = computed(() => {
   align-items: center;
   justify-content: space-between;
   padding: var(--spacing-3) var(--spacing-4);
-  border-bottom: 1px solid var(--color-border, #333);
+  border-bottom: 1px solid var(--border-default, #333);
   gap: var(--spacing-3);
 }
 
@@ -334,7 +334,7 @@ const formattedUpdatedAt = computed(() => {
 
 .refine-panel {
   padding: var(--spacing-3) var(--spacing-4);
-  border-bottom: 1px solid var(--color-border, #333);
+  border-bottom: 1px solid var(--border-default, #333);
   background: var(--color-background-secondary, #252525);
   display: flex;
   flex-direction: column;
@@ -346,7 +346,7 @@ const formattedUpdatedAt = computed(() => {
   resize: vertical;
   background: var(--color-background-input, #2a2a2a);
   color: inherit;
-  border: 1px solid var(--color-border, #444);
+  border: 1px solid var(--border-default, #444);
   border-radius: var(--radius-default);
   padding: var(--spacing-2);
   font-size: 0.9rem;
@@ -399,8 +399,8 @@ const formattedUpdatedAt = computed(() => {
   gap: var(--spacing-4);
   padding: var(--spacing-1-5) var(--spacing-4);
   font-size: var(--text-xs);
-  color: var(--color-text-muted, #888);
-  border-top: 1px solid var(--color-border, #333);
+  color: var(--text-muted, #888);
+  border-top: 1px solid var(--border-default, #333);
 }
 
 .source-facts-count {

--- a/autobot-frontend/src/components/knowledge/ChromaDBExplorer.vue
+++ b/autobot-frontend/src/components/knowledge/ChromaDBExplorer.vue
@@ -490,7 +490,7 @@ onMounted(() => {
   background: var(--color-danger-bg);
   border: 1px solid var(--color-danger-border);
   border-radius: var(--radius-md);
-  color: var(--color-danger);
+  color: var(--color-error);
   margin-bottom: var(--spacing-4);
 }
 
@@ -507,7 +507,7 @@ onMounted(() => {
 .error-alert button {
   background: none;
   border: none;
-  color: var(--color-danger);
+  color: var(--color-error);
   cursor: pointer;
   padding: var(--spacing-1);
 }

--- a/autobot-frontend/src/components/llc/AdapterTypeSelect.vue
+++ b/autobot-frontend/src/components/llc/AdapterTypeSelect.vue
@@ -67,6 +67,6 @@ onMounted(loadAdapters)
   border-radius: 6px;
   border: 1px solid var(--border-default, #d1d5db);
   background: var(--bg-surface, #fff);
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
 }
 </style>

--- a/autobot-frontend/src/components/llc/HandoffModal.vue
+++ b/autobot-frontend/src/components/llc/HandoffModal.vue
@@ -129,7 +129,7 @@ async function submit(): Promise<void> {
 .handoff-title {
   font-size: 1.0625rem;
   font-weight: 600;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
   margin: 0;
 }
 .handoff-label {
@@ -137,7 +137,7 @@ async function submit(): Promise<void> {
   flex-direction: column;
   gap: 0.375rem;
   font-size: 0.8125rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 .handoff-select,
 .handoff-notes {
@@ -146,11 +146,11 @@ async function submit(): Promise<void> {
   border: 1px solid var(--border-default, #e5e7eb);
   border-radius: var(--radius-md, 8px);
   background: var(--bg-input, #fff);
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
 }
 .handoff-error {
   font-size: 0.8125rem;
-  color: var(--color-danger, #cb3326);
+  color: var(--color-error, #cb3326);
   margin: 0;
 }
 .handoff-actions {
@@ -174,6 +174,6 @@ async function submit(): Promise<void> {
 }
 .handoff-cancel {
   border: 1px solid var(--border-default, #e5e7eb);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 </style>

--- a/autobot-frontend/src/components/llc/HireAgentModal.vue
+++ b/autobot-frontend/src/components/llc/HireAgentModal.vue
@@ -118,7 +118,7 @@ async function submit(): Promise<void> {
   margin: 0 0 1rem;
   font-size: 1.1rem;
   font-weight: 600;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
 }
 
 .hire-form {
@@ -138,7 +138,7 @@ async function submit(): Promise<void> {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .field-input {
@@ -146,13 +146,13 @@ async function submit(): Promise<void> {
   border-radius: 6px;
   border: 1px solid var(--border-default, #d1d5db);
   background: var(--bg-surface, #fff);
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
 }
 
 .form-error {
   margin: 0;
   font-size: 0.8rem;
-  color: var(--color-danger, #dc2626);
+  color: var(--color-error, #dc2626);
 }
 
 .form-actions {
@@ -173,7 +173,7 @@ async function submit(): Promise<void> {
 .btn-ghost {
   background: transparent;
   border-color: var(--border-default, #d1d5db);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .btn-primary {

--- a/autobot-frontend/src/components/llc/LlcBreadcrumb.vue
+++ b/autobot-frontend/src/components/llc/LlcBreadcrumb.vue
@@ -57,11 +57,11 @@ defineProps<{
 }
 
 .crumb-current {
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
   font-weight: 600;
 }
 
 .crumb-sep {
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 </style>

--- a/autobot-frontend/src/components/plugins/CapabilityApprovalDialog.vue
+++ b/autobot-frontend/src/components/plugins/CapabilityApprovalDialog.vue
@@ -257,7 +257,7 @@ watch(() => props.open, (isOpen) => {
 }
 
 .capability-approval-dialog {
-  background: var(--color-background);
+  background: var(--bg-primary);
   border-radius: 8px;
   max-width: 600px;
   width: 90%;
@@ -272,14 +272,14 @@ watch(() => props.open, (isOpen) => {
   justify-content: space-between;
   align-items: center;
   padding: 1.5rem;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--border-default);
 }
 
 .dialog-header h2 {
   margin: 0;
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--color-text-primary);
+  color: var(--text-primary);
 }
 
 .close-btn {
@@ -287,7 +287,7 @@ watch(() => props.open, (isOpen) => {
   border: none;
   padding: 0.5rem;
   cursor: pointer;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   border-radius: 4px;
   transition: background-color 0.2s;
 }
@@ -308,7 +308,7 @@ watch(() => props.open, (isOpen) => {
   justify-content: center;
   gap: 0.75rem;
   padding: 2rem;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 
 .dialog-error {
@@ -343,7 +343,7 @@ watch(() => props.open, (isOpen) => {
   margin: 0;
   font-size: 1.125rem;
   font-weight: 600;
-  color: var(--color-text-primary);
+  color: var(--text-primary);
 }
 
 .trust-tier-badge {
@@ -376,7 +376,7 @@ watch(() => props.open, (isOpen) => {
 
 .approval-description {
   margin-bottom: 1.5rem;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   font-size: 0.875rem;
 }
 
@@ -387,7 +387,7 @@ watch(() => props.open, (isOpen) => {
 }
 
 .capability-item {
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--border-default);
   border-radius: 6px;
   padding: 0.75rem;
   transition: background-color 0.2s;
@@ -413,21 +413,21 @@ watch(() => props.open, (isOpen) => {
 
 .capability-name {
   font-weight: 600;
-  color: var(--color-text-primary);
+  color: var(--text-primary);
   font-family: monospace;
 }
 
 .capability-description {
   display: block;
   margin-left: 1.65rem;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   font-size: 0.875rem;
 }
 
 .no-pending {
   text-align: center;
   padding: 2rem;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 
 .dialog-actions {
@@ -435,7 +435,7 @@ watch(() => props.open, (isOpen) => {
   justify-content: flex-end;
   gap: 0.75rem;
   padding: 1.5rem;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--border-default);
 }
 
 .btn {
@@ -455,7 +455,7 @@ watch(() => props.open, (isOpen) => {
 
 .btn-secondary {
   background-color: var(--color-background-secondary);
-  color: var(--color-text-primary);
+  color: var(--text-primary);
 }
 
 .btn-secondary:hover:not(:disabled) {

--- a/autobot-frontend/src/components/plugins/CapabilityAuditLog.vue
+++ b/autobot-frontend/src/components/plugins/CapabilityAuditLog.vue
@@ -172,7 +172,7 @@ onMounted(() => {
   margin: 0;
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--color-text-primary);
+  color: var(--text-primary);
 }
 
 .audit-controls {
@@ -183,10 +183,10 @@ onMounted(() => {
 
 .filter-input {
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--border-default);
   border-radius: 6px;
-  background-color: var(--color-background);
-  color: var(--color-text-primary);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 0.875rem;
   min-width: 200px;
 }
@@ -199,10 +199,10 @@ onMounted(() => {
 .btn-refresh {
   padding: 0.5rem;
   background: none;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--border-default);
   border-radius: 6px;
   cursor: pointer;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   transition: all 0.2s;
 }
 
@@ -237,7 +237,7 @@ onMounted(() => {
   justify-content: center;
   gap: 0.75rem;
   padding: 3rem;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 
 .spinner {
@@ -269,7 +269,7 @@ onMounted(() => {
   align-items: center;
   justify-content: center;
   padding: 3rem;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 
 .empty-icon {
@@ -281,7 +281,7 @@ onMounted(() => {
 
 .audit-table-container {
   overflow-x: auto;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--border-default);
   border-radius: 6px;
 }
 
@@ -292,20 +292,20 @@ onMounted(() => {
 
 .audit-table th {
   background-color: var(--color-background-secondary);
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   font-weight: 600;
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   padding: 0.75rem 1rem;
   text-align: left;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--border-default);
 }
 
 .audit-table td {
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--color-border);
-  color: var(--color-text-primary);
+  border-bottom: 1px solid var(--border-default);
+  color: var(--text-primary);
   font-size: 0.875rem;
 }
 
@@ -327,7 +327,7 @@ onMounted(() => {
 
 .timestamp {
   font-family: monospace;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   white-space: nowrap;
 }
 
@@ -344,7 +344,7 @@ onMounted(() => {
 }
 
 .operation {
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 
 .status-badge {

--- a/autobot-frontend/src/components/profile/DeviceManagementPanel.vue
+++ b/autobot-frontend/src/components/profile/DeviceManagementPanel.vue
@@ -218,7 +218,7 @@ function formatRelativeTime(dateStr: string): string {
 
 .empty-icon {
   font-size: 3rem;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   margin-bottom: 1rem;
   display: block;
 }
@@ -230,7 +230,7 @@ function formatRelativeTime(dateStr: string): string {
 }
 
 .empty-state p {
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   margin-bottom: 1.5rem;
 }
 
@@ -255,7 +255,7 @@ function formatRelativeTime(dateStr: string): string {
 }
 
 .device-card {
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--border-default);
   border-radius: 8px;
   padding: 1.25rem;
   background: var(--color-bg);
@@ -283,7 +283,7 @@ function formatRelativeTime(dateStr: string): string {
   align-items: center;
   justify-content: center;
   font-size: 1.25rem;
-  color: var(--color-text-primary);
+  color: var(--text-primary);
 }
 
 .device-info {
@@ -300,12 +300,12 @@ function formatRelativeTime(dateStr: string): string {
 
 .device-platform {
   font-size: 0.875rem;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 
 .device-meta {
   font-size: 0.875rem;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
@@ -327,7 +327,7 @@ function formatRelativeTime(dateStr: string): string {
 .spinner {
   width: 32px;
   height: 32px;
-  border: 3px solid var(--color-border);
+  border: 3px solid var(--border-default);
   border-top-color: var(--color-primary);
   border-radius: 50%;
   animation: spin 0.6s linear infinite;
@@ -337,7 +337,7 @@ function formatRelativeTime(dateStr: string): string {
 .spinner-tiny {
   width: 12px;
   height: 12px;
-  border: 2px solid var(--color-border);
+  border: 2px solid var(--border-default);
   border-top-color: var(--color-primary);
   border-radius: 50%;
   animation: spin 0.6s linear infinite;
@@ -352,10 +352,10 @@ function formatRelativeTime(dateStr: string): string {
   display: flex;
   gap: 1rem;
   padding: 1rem;
-  border: 1px solid var(--color-danger);
+  border: 1px solid var(--color-error);
   border-radius: 6px;
   background: var(--color-danger-bg);
-  color: var(--color-danger);
+  color: var(--color-error);
 }
 
 .error-alert strong {
@@ -392,7 +392,7 @@ function formatRelativeTime(dateStr: string): string {
 
 .modal-header {
   padding: 1.5rem;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--border-default);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -409,7 +409,7 @@ function formatRelativeTime(dateStr: string): string {
   border: none;
   font-size: 1.5rem;
   cursor: pointer;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   padding: 0;
 }
 
@@ -423,7 +423,7 @@ function formatRelativeTime(dateStr: string): string {
 
 .qr-step p {
   margin: 0 0 1.5rem 0;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 
 .qr-display {
@@ -442,7 +442,7 @@ function formatRelativeTime(dateStr: string): string {
 
 .modal-footer {
   padding: 1rem 1.5rem;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--border-default);
   display: flex;
   justify-content: flex-end;
   gap: 0.5rem;
@@ -478,8 +478,8 @@ function formatRelativeTime(dateStr: string): string {
 
 .btn-secondary {
   background: var(--color-bg-secondary);
-  border-color: var(--color-border);
-  color: var(--color-text-primary);
+  border-color: var(--border-default);
+  color: var(--text-primary);
 }
 
 .btn-secondary:hover {
@@ -488,8 +488,8 @@ function formatRelativeTime(dateStr: string): string {
 
 .btn-danger {
   background: transparent;
-  border-color: var(--color-danger);
-  color: var(--color-danger);
+  border-color: var(--color-error);
+  color: var(--color-error);
 }
 
 .btn-danger:hover {
@@ -510,7 +510,7 @@ function formatRelativeTime(dateStr: string): string {
 
 .instructions-list li {
   margin: 0.5rem 0;
-  color: var(--color-text-primary);
+  color: var(--text-primary);
 }
 
 /* Info Box */

--- a/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
+++ b/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
@@ -305,7 +305,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
   gap: var(--spacing-lg, 24px);
   margin-bottom: var(--spacing-lg, 24px);
   padding-bottom: var(--spacing-md, 16px);
-  border-bottom: 1px solid var(--color-border, #333);
+  border-bottom: 1px solid var(--border-default, #333);
 }
 
 .step-dot {
@@ -326,7 +326,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  background: var(--color-border, #444);
+  background: var(--border-default, #444);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -346,7 +346,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
 
 .step-label {
   font-size: var(--text-xs);
-  color: var(--color-text-secondary, #999);
+  color: var(--text-secondary, #999);
 }
 
 .step-content {
@@ -354,7 +354,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
 }
 
 .step-description {
-  color: var(--color-text-secondary, #999);
+  color: var(--text-secondary, #999);
   margin-bottom: var(--spacing-md, 16px);
 }
 
@@ -369,7 +369,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
   align-items: center;
   gap: var(--spacing-md, 16px);
   padding: var(--spacing-md, 16px);
-  border: 1px solid var(--color-border, #333);
+  border: 1px solid var(--border-default, #333);
   border-radius: var(--radius-md, 8px);
   cursor: pointer;
   transition: border-color var(--duration-200);
@@ -406,7 +406,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
 
 .role-desc {
   font-size: 0.85rem;
-  color: var(--color-text-secondary, #999);
+  color: var(--text-secondary, #999);
 }
 
 .key-list {
@@ -416,7 +416,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
 }
 
 .key-card {
-  border: 1px solid var(--color-border, #333);
+  border: 1px solid var(--border-default, #333);
   border-radius: var(--radius-md, 8px);
   overflow: hidden;
 }
@@ -440,7 +440,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
 }
 
 .status-missing {
-  color: var(--color-danger, #ef4444);
+  color: var(--color-error, #ef4444);
 }
 
 .status-warning {
@@ -460,18 +460,18 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
 }
 
 .key-badge.required {
-  background: var(--color-danger, #ef4444);
+  background: var(--color-error, #ef4444);
   color: #fff;
 }
 
 .key-badge.optional {
-  background: var(--color-border, #444);
-  color: var(--color-text-secondary, #999);
+  background: var(--border-default, #444);
+  color: var(--text-secondary, #999);
 }
 
 .key-role {
   font-size: 0.8rem;
-  color: var(--color-text-secondary, #999);
+  color: var(--text-secondary, #999);
 }
 
 .key-body {
@@ -481,7 +481,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
 .key-desc {
   margin-bottom: var(--spacing-sm, 8px);
   font-size: 0.9rem;
-  color: var(--color-text-secondary, #999);
+  color: var(--text-secondary, #999);
 }
 
 .license-link {
@@ -510,19 +510,19 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
 .key-input {
   flex: 1;
   padding: var(--spacing-sm, 8px);
-  border: 1px solid var(--color-border, #333);
+  border: 1px solid var(--border-default, #333);
   border-radius: var(--radius-sm, 4px);
   background: var(--bg-primary, #0f0f23);
-  color: var(--color-text, #e0e0e0);
+  color: var(--text-primary, #e0e0e0);
   font-family: monospace;
 }
 
 .toggle-visibility {
   padding: var(--spacing-sm, 8px);
-  border: 1px solid var(--color-border, #333);
+  border: 1px solid var(--border-default, #333);
   border-radius: var(--radius-sm, 4px);
   background: var(--bg-secondary, #1a1a2e);
-  color: var(--color-text-secondary, #999);
+  color: var(--text-secondary, #999);
   cursor: pointer;
 }
 
@@ -538,7 +538,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
   align-items: center;
   gap: var(--spacing-sm, 8px);
   padding: var(--spacing-sm, 8px) var(--spacing-md, 16px);
-  border: 1px solid var(--color-border, #333);
+  border: 1px solid var(--border-default, #333);
   border-radius: var(--radius-sm, 4px);
 }
 
@@ -550,7 +550,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
 
 .summary-status {
   font-size: 0.85rem;
-  color: var(--color-text-secondary, #999);
+  color: var(--text-secondary, #999);
 }
 
 .secrets-link {
@@ -570,7 +570,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
 .empty-state {
   text-align: center;
   padding: var(--spacing-xl, 32px);
-  color: var(--color-text-secondary, #999);
+  color: var(--text-secondary, #999);
 }
 
 .empty-state i {
@@ -608,7 +608,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
 
 .btn-secondary {
   background: transparent;
-  border: 1px solid var(--color-border, #333);
-  color: var(--color-text, #e0e0e0);
+  border: 1px solid var(--border-default, #333);
+  color: var(--text-primary, #e0e0e0);
 }
 </style>

--- a/autobot-frontend/src/components/settings/TelegramSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/TelegramSettingsPanel.vue
@@ -292,10 +292,10 @@ onMounted(loadConfig)
   align-items: center;
   gap: var(--spacing-sm);
   padding: var(--spacing-sm) var(--spacing-md);
-  background: color-mix(in srgb, var(--color-danger) 12%, transparent);
+  background: color-mix(in srgb, var(--color-error) 12%, transparent);
   border-radius: var(--radius-md);
   font-size: var(--font-size-sm);
-  color: var(--color-danger);
+  color: var(--color-error);
 }
 
 .panel-actions {

--- a/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
+++ b/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
@@ -522,7 +522,7 @@ function resetEdit(): void {
   align-items: center;
   gap: var(--spacing-1, 0.25rem);
   font-size: 0.8125rem;
-  color: var(--color-danger, #ef4444);
+  color: var(--color-error, #ef4444);
   margin: var(--spacing-0);
 }
 

--- a/autobot-frontend/src/components/terminal/TerminalWindow.vue
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.vue
@@ -1546,7 +1546,7 @@ export default {
 }
 
 .control-button.danger:hover:not(:disabled) {
-  background-color: var(--color-danger);
+  background-color: var(--color-error);
 }
 
 .terminal-status-bar {
@@ -1576,7 +1576,7 @@ export default {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background-color: var(--color-danger);
+  background-color: var(--color-error);
 }
 
 .connection-status.connected .status-dot {
@@ -1789,7 +1789,7 @@ export default {
 }
 
 .btn-danger {
-  background-color: var(--color-danger);
+  background-color: var(--color-error);
   color: var(--text-on-error);
 }
 
@@ -1872,7 +1872,7 @@ export default {
 }
 
 .confirmation-modal.emergency {
-  border-color: var(--color-danger);
+  border-color: var(--color-error);
   box-shadow: 0 10px 30px var(--color-danger-bg);
 }
 
@@ -1962,7 +1962,7 @@ export default {
 .risk-level.critical {
   background-color: var(--color-danger-bg);
   color: var(--color-error-light);
-  border: 1px solid var(--color-danger);
+  border: 1px solid var(--color-error);
   animation: pulse-danger 2s infinite;
 }
 
@@ -2048,7 +2048,7 @@ export default {
 }
 
 .line-command.critical {
-  border-left: 3px solid var(--color-danger);
+  border-left: 3px solid var(--color-error);
   background-color: var(--color-danger-bg);
 }
 

--- a/autobot-frontend/src/components/transcriber/AsrProviderSelector.vue
+++ b/autobot-frontend/src/components/transcriber/AsrProviderSelector.vue
@@ -164,7 +164,7 @@ onMounted(load)
 }
 
 .asr-selector-error {
-  color: var(--color-error, var(--color-danger));
+  color: var(--color-error, var(--color-error));
 }
 
 .asr-selector-control {

--- a/autobot-frontend/src/components/ui/ConfirmDialog.vue
+++ b/autobot-frontend/src/components/ui/ConfirmDialog.vue
@@ -138,7 +138,7 @@ watch(dialogVisible, (visible) => {
 }
 
 .confirm-btn-confirm {
-  background: var(--color-danger, var(--color-primary));
+  background: var(--color-error, var(--color-primary));
   color: var(--text-inverse, #fff);
 }
 

--- a/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
@@ -351,15 +351,15 @@ watch(saveSuccess, (val) => {
 .field-label {
   font-size: var(--text-sm);
   font-weight: 500;
-  color: var(--color-text-primary, #e2e8f0);
+  color: var(--text-primary, #e2e8f0);
 }
 
 .field-input {
   padding: var(--spacing-2) var(--spacing-3);
-  border: 1px solid var(--color-border, #374151);
+  border: 1px solid var(--border-default, #374151);
   border-radius: var(--radius-md);
   background: var(--color-bg-secondary, #1e293b);
-  color: var(--color-text-primary, #e2e8f0);
+  color: var(--text-primary, #e2e8f0);
   font-size: var(--text-sm);
   transition: border-color var(--duration-150);
 }
@@ -375,7 +375,7 @@ watch(saveSuccess, (val) => {
 
 .field-hint {
   font-size: var(--text-xs);
-  color: var(--color-text-secondary, #94a3b8);
+  color: var(--text-secondary, #94a3b8);
 }
 
 .toggle-section {
@@ -400,7 +400,7 @@ watch(saveSuccess, (val) => {
 .toggle-text {
   font-size: var(--text-sm);
   font-weight: 500;
-  color: var(--color-text-primary, #e2e8f0);
+  color: var(--text-primary, #e2e8f0);
 }
 
 .config-fieldset {
@@ -419,7 +419,7 @@ watch(saveSuccess, (val) => {
 .section-heading {
   font-size: var(--text-sm);
   font-weight: 600;
-  color: var(--color-text-primary, #e2e8f0);
+  color: var(--text-primary, #e2e8f0);
   margin: var(--spacing-0);
 }
 
@@ -427,7 +427,7 @@ watch(saveSuccess, (val) => {
 .routing-matrix {
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--color-border, #374151);
+  border: 1px solid var(--border-default, #374151);
   border-radius: var(--radius-md);
   overflow: hidden;
   margin-top: var(--spacing-2);
@@ -439,7 +439,7 @@ watch(saveSuccess, (val) => {
 }
 
 .matrix-row:not(:last-child) {
-  border-bottom: 1px solid var(--color-border, #374151);
+  border-bottom: 1px solid var(--border-default, #374151);
 }
 
 .matrix-header {
@@ -448,7 +448,7 @@ watch(saveSuccess, (val) => {
   font-size: var(--text-xs);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--color-text-secondary, #94a3b8);
+  color: var(--text-secondary, #94a3b8);
 }
 
 .matrix-cell {
@@ -462,11 +462,11 @@ watch(saveSuccess, (val) => {
   flex: 2;
   text-align: left;
   font-weight: 500;
-  color: var(--color-text-primary, #e2e8f0);
+  color: var(--text-primary, #e2e8f0);
 }
 
 .matrix-channel-header {
-  color: var(--color-text-secondary, #94a3b8);
+  color: var(--text-secondary, #94a3b8);
 }
 
 .matrix-checkbox {
@@ -518,7 +518,7 @@ watch(saveSuccess, (val) => {
   align-items: center;
   gap: var(--spacing-2);
   font-size: var(--text-sm);
-  color: var(--color-text-secondary, #94a3b8);
+  color: var(--text-secondary, #94a3b8);
   padding: var(--spacing-3) var(--spacing-0);
 }
 

--- a/autobot-frontend/src/views/AdminUsersView.vue
+++ b/autobot-frontend/src/views/AdminUsersView.vue
@@ -535,7 +535,7 @@ onMounted(loadUsers)
 
 .page-subtitle {
   font-size: var(--text-sm);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   margin: var(--spacing-0);
 }
 
@@ -574,21 +574,21 @@ onMounted(loadUsers)
   left: 0.75rem;
   top: 50%;
   transform: translateY(-50%);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .search-input {
   width: 100%;
   padding: var(--spacing-2) var(--spacing-3) var(--spacing-2) var(--spacing-9);
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
   box-sizing: border-box;
 }
 
 .table-section {
-  background: var(--color-surface, #fff);
-  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-surface, #fff);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: var(--radius-xl);
   overflow: hidden;
 }
@@ -596,7 +596,7 @@ onMounted(loadUsers)
 .loading-state {
   padding: var(--spacing-8);
   text-align: center;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .data-table {
@@ -611,14 +611,14 @@ onMounted(loadUsers)
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   background: var(--color-surface-alt, #f9fafb);
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
 }
 
 .data-table td {
   padding: var(--spacing-3) var(--spacing-4);
-  border-bottom: 1px solid var(--color-border, #f3f4f6);
+  border-bottom: 1px solid var(--border-default, #f3f4f6);
   font-size: var(--text-sm);
 }
 
@@ -671,7 +671,7 @@ onMounted(loadUsers)
 
 .bundle-loading {
   font-size: var(--text-xs);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .bundle-user-name {
@@ -681,7 +681,7 @@ onMounted(loadUsers)
 
 .role-select {
   padding: var(--spacing-1) var(--spacing-2);
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: var(--radius-md);
   font-size: 0.8125rem;
   background: transparent;
@@ -726,7 +726,7 @@ onMounted(loadUsers)
 
 .empty-row {
   text-align: center;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   padding: 2rem !important;
 }
 
@@ -736,12 +736,12 @@ onMounted(loadUsers)
   justify-content: center;
   gap: var(--spacing-4);
   padding: var(--spacing-3);
-  border-top: 1px solid var(--color-border, #e5e7eb);
+  border-top: 1px solid var(--border-default, #e5e7eb);
 }
 
 .btn-page {
   padding: var(--spacing-1-5) var(--spacing-3);
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: var(--radius-md);
   background: transparent;
   cursor: pointer;
@@ -754,7 +754,7 @@ onMounted(loadUsers)
 
 .page-info {
   font-size: var(--text-sm);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .btn-action-primary,
@@ -778,8 +778,8 @@ onMounted(loadUsers)
 
 .btn-action-secondary {
   background: transparent;
-  border-color: var(--color-border, #d1d5db);
-  color: var(--color-text, #111827);
+  border-color: var(--border-default, #d1d5db);
+  color: var(--text-primary, #111827);
 }
 
 .btn-action-danger {
@@ -804,7 +804,7 @@ onMounted(loadUsers)
 }
 
 .modal {
-  background: var(--color-surface, #fff);
+  background: var(--bg-surface, #fff);
   border-radius: var(--radius-xl);
   width: 100%;
   max-width: 480px;
@@ -824,7 +824,7 @@ onMounted(loadUsers)
   align-items: center;
   justify-content: space-between;
   padding: var(--spacing-4) var(--spacing-5);
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
 }
 
 .modal-header h3 {
@@ -837,7 +837,7 @@ onMounted(loadUsers)
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   font-size: var(--text-sm);
 }
 
@@ -862,7 +862,7 @@ onMounted(loadUsers)
 .form-input {
   width: 100%;
   padding: var(--spacing-2) var(--spacing-3);
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
   box-sizing: border-box;

--- a/autobot-frontend/src/views/BudgetPolicies.vue
+++ b/autobot-frontend/src/views/BudgetPolicies.vue
@@ -554,7 +554,7 @@ onMounted(loadPolicies)
 
 .page-subtitle {
   font-size: var(--text-sm);
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   margin: 0;
 }
 
@@ -569,7 +569,7 @@ onMounted(loadPolicies)
   align-items: center;
   gap: var(--spacing-2);
   background: var(--color-danger-bg, #fee2e2);
-  color: var(--color-danger, #dc2626);
+  color: var(--color-error, #dc2626);
   border: 1px solid var(--color-danger-border, #fca5a5);
   border-radius: var(--radius-md);
   padding: var(--spacing-3) var(--spacing-4);
@@ -602,23 +602,23 @@ onMounted(loadPolicies)
 .filter-label {
   font-size: var(--text-xs);
   font-weight: 500;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 
 .filter-select {
   padding: var(--spacing-2) var(--spacing-3);
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   background: var(--color-bg-input);
-  color: var(--color-text);
+  color: var(--text-primary);
   font-size: var(--text-sm);
   cursor: pointer;
 }
 
 .table-section {
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
   overflow: hidden;
 }
@@ -627,7 +627,7 @@ onMounted(loadPolicies)
 .empty-state {
   padding: var(--spacing-12);
   text-align: center;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   font-size: var(--text-sm);
   display: flex;
   flex-direction: column;
@@ -654,7 +654,7 @@ onMounted(loadPolicies)
   padding: var(--spacing-3) var(--spacing-4);
   text-align: left;
   font-weight: 500;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   font-size: var(--text-xs);
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -664,7 +664,7 @@ onMounted(loadPolicies)
 .data-table td {
   padding: var(--spacing-3) var(--spacing-4);
   vertical-align: middle;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--border-default);
 }
 
 .data-table tbody tr:hover {
@@ -683,7 +683,7 @@ onMounted(loadPolicies)
 
 .policy-desc {
   font-size: var(--text-xs);
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 
 .monospace {
@@ -717,12 +717,12 @@ onMounted(loadPolicies)
 
 .badge-inactive {
   background: var(--color-bg-subtle);
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 
 .badge-danger {
   background: var(--color-danger-bg, #fee2e2);
-  color: var(--color-danger, #dc2626);
+  color: var(--color-error, #dc2626);
 }
 
 .badge-warning {
@@ -766,8 +766,8 @@ onMounted(loadPolicies)
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-4);
   background: var(--color-bg-input);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
   font-weight: 500;
@@ -785,7 +785,7 @@ onMounted(loadPolicies)
   align-items: center;
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-4);
-  background: var(--color-danger, #dc2626);
+  background: var(--color-error, #dc2626);
   color: white;
   border: none;
   border-radius: var(--radius-md);
@@ -809,13 +809,13 @@ onMounted(loadPolicies)
   border: none;
   cursor: pointer;
   background: transparent;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   transition: background 0.15s, color 0.15s;
 }
 
 .btn-icon:hover {
   background: var(--color-bg-hover);
-  color: var(--color-text);
+  color: var(--text-primary);
 }
 
 .btn-icon.btn-primary:hover {
@@ -825,12 +825,12 @@ onMounted(loadPolicies)
 
 .btn-icon.btn-danger:hover {
   background: var(--color-danger-bg, #fee2e2);
-  color: var(--color-danger, #dc2626);
+  color: var(--color-error, #dc2626);
 }
 
 /* Agent pause status section */
 .section-card {
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
   padding: var(--spacing-5);
 }
@@ -850,10 +850,10 @@ onMounted(loadPolicies)
 .text-input {
   flex: 1;
   padding: var(--spacing-2) var(--spacing-3);
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   background: var(--color-bg-input);
-  color: var(--color-text);
+  color: var(--text-primary);
   font-size: var(--text-sm);
 }
 
@@ -879,7 +879,7 @@ onMounted(loadPolicies)
   min-width: 70px;
 }
 
-.text-danger { color: var(--color-danger, #dc2626); font-weight: 500; }
+.text-danger { color: var(--color-error, #dc2626); font-weight: 500; }
 .text-success { color: var(--color-success, #16a34a); font-weight: 500; }
 
 .mt-2 { margin-top: var(--spacing-2); }
@@ -919,7 +919,7 @@ onMounted(loadPolicies)
   align-items: center;
   justify-content: space-between;
   padding: var(--spacing-5) var(--spacing-6);
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--border-default);
 }
 
 .modal-header h3 {
@@ -953,11 +953,11 @@ onMounted(loadPolicies)
 .form-label {
   font-size: var(--text-sm);
   font-weight: 500;
-  color: var(--color-text);
+  color: var(--text-primary);
 }
 
 .required {
-  color: var(--color-danger, #dc2626);
+  color: var(--color-error, #dc2626);
 }
 
 .checkbox-label {
@@ -979,13 +979,13 @@ onMounted(loadPolicies)
   justify-content: flex-end;
   gap: var(--spacing-2);
   padding-top: var(--spacing-2);
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--border-default);
 }
 
 .modal-body-text {
   padding: var(--spacing-5) var(--spacing-6);
   font-size: var(--text-sm);
-  color: var(--color-text);
+  color: var(--text-primary);
   margin: 0;
 }
 </style>

--- a/autobot-frontend/src/views/DocumentsView.vue
+++ b/autobot-frontend/src/views/DocumentsView.vue
@@ -316,8 +316,8 @@ function showError(msg: string) {
 .documents-view {
   display: flex;
   height: 100%;
-  background: var(--color-background, #1a1a1a);
-  color: var(--color-text, #e0e0e0);
+  background: var(--bg-primary, #1a1a1a);
+  color: var(--text-primary, #e0e0e0);
   position: relative;
   overflow: hidden;
 }
@@ -329,7 +329,7 @@ function showError(msg: string) {
   max-width: 360px;
   display: flex;
   flex-direction: column;
-  border-right: 1px solid var(--color-border, #333);
+  border-right: 1px solid var(--border-default, #333);
   background: var(--color-background-secondary, #222);
   overflow: hidden;
 }
@@ -339,7 +339,7 @@ function showError(msg: string) {
   align-items: center;
   justify-content: space-between;
   padding: var(--spacing-3-5) var(--spacing-4);
-  border-bottom: 1px solid var(--color-border, #333);
+  border-bottom: 1px solid var(--border-default, #333);
   flex-shrink: 0;
 }
 
@@ -360,19 +360,19 @@ function showError(msg: string) {
   gap: var(--spacing-2);
   padding: var(--spacing-6);
   text-align: center;
-  color: var(--color-text-muted, #888);
+  color: var(--text-muted, #888);
   font-size: 0.9rem;
 }
 
 .empty-icon {
   font-size: 2rem;
   margin-bottom: var(--spacing-2);
-  color: var(--color-text-muted, #555);
+  color: var(--text-muted, #555);
 }
 
 .empty-hint {
   font-size: 0.8rem;
-  color: var(--color-text-muted, #666);
+  color: var(--text-muted, #666);
 }
 
 .chat-link {
@@ -398,7 +398,7 @@ function showError(msg: string) {
   flex-direction: column;
   padding: var(--spacing-2-5) var(--spacing-4);
   cursor: pointer;
-  border-bottom: 1px solid var(--color-border, #2a2a2a);
+  border-bottom: 1px solid var(--border-default, #2a2a2a);
   gap: var(--spacing-0-5);
   position: relative;
   transition: background 0.12s;
@@ -424,7 +424,7 @@ function showError(msg: string) {
 
 .doc-meta {
   font-size: 0.72rem;
-  color: var(--color-text-muted, #888);
+  color: var(--text-muted, #888);
 }
 
 .delete-btn {
@@ -447,13 +447,13 @@ function showError(msg: string) {
   align-items: center;
   justify-content: space-between;
   padding: var(--spacing-2) var(--spacing-3);
-  border-top: 1px solid var(--color-border, #333);
+  border-top: 1px solid var(--border-default, #333);
   font-size: 0.8rem;
   flex-shrink: 0;
 }
 
 .page-info {
-  color: var(--color-text-muted, #888);
+  color: var(--text-muted, #888);
 }
 
 /* Main panel */
@@ -471,13 +471,13 @@ function showError(msg: string) {
   align-items: center;
   justify-content: center;
   gap: var(--spacing-3);
-  color: var(--color-text-muted, #888);
+  color: var(--text-muted, #888);
   font-size: 0.95rem;
 }
 
 .no-selection-icon {
   font-size: var(--text-5xl);
-  color: var(--color-text-muted, #444);
+  color: var(--text-muted, #444);
 }
 
 /* TASK 12: rich empty state */
@@ -532,7 +532,7 @@ function showError(msg: string) {
 
 .modal-card {
   background: var(--color-background-secondary, #252525);
-  border: 1px solid var(--color-border, #444);
+  border: 1px solid var(--border-default, #444);
   border-radius: var(--radius-lg);
   padding: var(--spacing-6);
   width: 360px;
@@ -548,7 +548,7 @@ function showError(msg: string) {
 .modal-body {
   margin: var(--spacing-0) var(--spacing-0) var(--spacing-5);
   font-size: 0.9rem;
-  color: var(--color-text-muted, #bbb);
+  color: var(--text-muted, #bbb);
   line-height: 1.5;
 }
 

--- a/autobot-frontend/src/views/OnboardingWizard.vue
+++ b/autobot-frontend/src/views/OnboardingWizard.vue
@@ -450,7 +450,7 @@ onMounted(async () => {
      100vh forced the wizard-footer (Back/Next/Apply) below the fold */
   min-height: 100%;
   padding: 2rem 1rem;
-  background: var(--color-bg-primary, #0f1117);
+  background: var(--bg-primary, #0f1117);
 }
 
 .wizard-header {
@@ -484,9 +484,9 @@ onMounted(async () => {
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  border: 2px solid var(--color-border, #2a2d3a);
+  border: 2px solid var(--border-default, #2a2d3a);
   background: transparent;
-  color: var(--color-text-muted, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   font-size: 0.75rem;
   font-weight: 600;
   display: flex;
@@ -498,7 +498,7 @@ onMounted(async () => {
 .step-label {
   font-size: 0.65rem;
   font-weight: 500;
-  color: var(--color-text-muted, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   white-space: nowrap;
   transition: color 0.2s;
 }
@@ -510,7 +510,7 @@ onMounted(async () => {
 }
 
 .step-item.active .step-label {
-  color: var(--color-text, #e2e8f0);
+  color: var(--text-primary, #e2e8f0);
 }
 
 .step-item.done .step-circle {
@@ -526,7 +526,7 @@ onMounted(async () => {
 .step-connector {
   width: 2rem;
   height: 2px;
-  background: var(--color-border, #2a2d3a);
+  background: var(--border-default, #2a2d3a);
   margin-bottom: 1.1rem;
   flex-shrink: 0;
 }
@@ -541,8 +541,8 @@ onMounted(async () => {
 }
 
 .wizard-card {
-  background: var(--color-bg-elevated, #1a1d27);
-  border: 1px solid var(--color-border, #2a2d3a);
+  background: var(--bg-elevated, #1a1d27);
+  border: 1px solid var(--border-default, #2a2d3a);
   border-radius: 12px;
   padding: 2rem;
   width: 100%;
@@ -560,7 +560,7 @@ onMounted(async () => {
 .wizard-step-title {
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--color-text, #e2e8f0);
+  color: var(--text-primary, #e2e8f0);
   margin-bottom: 1.5rem;
 }
 
@@ -613,7 +613,7 @@ onMounted(async () => {
   align-items: center;
   justify-content: center;
   padding: 3rem 0;
-  color: var(--color-text-muted, #94a3b8);
+  color: var(--text-muted, #94a3b8);
 }
 
 /* Doctor sections */
@@ -624,7 +624,7 @@ onMounted(async () => {
 .section-title {
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--color-text-muted, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin-bottom: 0.75rem;
@@ -637,8 +637,8 @@ onMounted(async () => {
 }
 
 .metric-card {
-  background: var(--color-bg-primary, #0f1117);
-  border: 1px solid var(--color-border, #2a2d3a);
+  background: var(--bg-primary, #0f1117);
+  border: 1px solid var(--border-default, #2a2d3a);
   border-radius: 8px;
   padding: 0.75rem 1rem;
   display: flex;
@@ -647,19 +647,19 @@ onMounted(async () => {
 
 .metric-label {
   font-size: 0.75rem;
-  color: var(--color-text-muted, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   margin-bottom: 0.25rem;
 }
 
 .metric-value {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--color-text, #e2e8f0);
+  color: var(--text-primary, #e2e8f0);
 }
 
 .metric-sub {
   font-size: 0.75rem;
-  color: var(--color-text-muted, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   margin-top: 0.125rem;
 }
 
@@ -674,11 +674,11 @@ onMounted(async () => {
   align-items: center;
   gap: 0.75rem;
   padding: 0.5rem 0;
-  border-bottom: 1px solid var(--color-border, #2a2d3a);
+  border-bottom: 1px solid var(--border-default, #2a2d3a);
 }
 
 .service-name {
-  color: var(--color-text, #e2e8f0);
+  color: var(--text-primary, #e2e8f0);
   font-size: 0.875rem;
   min-width: 80px;
 }
@@ -730,8 +730,8 @@ onMounted(async () => {
 
 .preset-card {
   position: relative;
-  background: var(--color-bg-primary, #0f1117);
-  border: 1px solid var(--color-border, #2a2d3a);
+  background: var(--bg-primary, #0f1117);
+  border: 1px solid var(--border-default, #2a2d3a);
   border-radius: 10px;
   padding: 1rem;
   cursor: pointer;
@@ -759,12 +759,12 @@ onMounted(async () => {
 .preset-title {
   font-weight: 600;
   font-size: 0.9rem;
-  color: var(--color-text, #e2e8f0);
+  color: var(--text-primary, #e2e8f0);
 }
 
 .preset-description {
   font-size: 0.8rem;
-  color: var(--color-text-muted, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   line-height: 1.5;
   margin-bottom: 0.6rem;
 }
@@ -777,11 +777,11 @@ onMounted(async () => {
 
 .tag {
   font-size: 0.7rem;
-  background: var(--color-bg-elevated, #1a1d27);
-  color: var(--color-text-muted, #94a3b8);
+  background: var(--bg-elevated, #1a1d27);
+  color: var(--text-muted, #94a3b8);
   padding: 0.1rem 0.4rem;
   border-radius: 4px;
-  border: 1px solid var(--color-border, #2a2d3a);
+  border: 1px solid var(--border-default, #2a2d3a);
 }
 
 .tag-more {
@@ -797,8 +797,8 @@ onMounted(async () => {
 
 /* Review */
 .review-box {
-  background: var(--color-bg-primary, #0f1117);
-  border: 1px solid var(--color-border, #2a2d3a);
+  background: var(--bg-primary, #0f1117);
+  border: 1px solid var(--border-default, #2a2d3a);
   border-radius: 10px;
   padding: 1.25rem;
 }
@@ -808,7 +808,7 @@ onMounted(async () => {
   align-items: flex-start;
   gap: 1rem;
   padding: 0.5rem 0;
-  border-bottom: 1px solid var(--color-border, #2a2d3a);
+  border-bottom: 1px solid var(--border-default, #2a2d3a);
   font-size: 0.875rem;
 }
 
@@ -817,13 +817,13 @@ onMounted(async () => {
 }
 
 .review-label {
-  color: var(--color-text-muted, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   min-width: 90px;
   flex-shrink: 0;
 }
 
 .review-value {
-  color: var(--color-text, #e2e8f0);
+  color: var(--text-primary, #e2e8f0);
 }
 
 /* Wizard footer */
@@ -832,7 +832,7 @@ onMounted(async () => {
   align-items: center;
   margin-top: 2rem;
   padding-top: 1.25rem;
-  border-top: 1px solid var(--color-border, #2a2d3a);
+  border-top: 1px solid var(--border-default, #2a2d3a);
   gap: 0.75rem;
 }
 
@@ -861,8 +861,8 @@ onMounted(async () => {
 
 .btn-secondary {
   background: transparent;
-  color: var(--color-text-muted, #94a3b8);
-  border: 1px solid var(--color-border, #2a2d3a);
+  color: var(--text-muted, #94a3b8);
+  border: 1px solid var(--border-default, #2a2d3a);
   border-radius: 6px;
   padding: 0.5rem 1.25rem;
   font-size: 0.875rem;
@@ -874,7 +874,7 @@ onMounted(async () => {
 
 .btn-secondary:hover:not(:disabled) {
   border-color: var(--color-accent, #6366f1);
-  color: var(--color-text, #e2e8f0);
+  color: var(--text-primary, #e2e8f0);
 }
 
 .btn-secondary:disabled {

--- a/autobot-frontend/src/views/SettingsView.vue
+++ b/autobot-frontend/src/views/SettingsView.vue
@@ -690,7 +690,7 @@ function onApiKeysSaved(): void {
 }
 
 .backend-check-status.status-fail {
-  color: var(--color-danger, #dc2626);
+  color: var(--color-error, #dc2626);
   background: var(--color-danger-bg, rgba(220, 38, 38, 0.1));
 }
 

--- a/autobot-frontend/src/views/VisionAutomationView.vue
+++ b/autobot-frontend/src/views/VisionAutomationView.vue
@@ -413,13 +413,13 @@ onMounted(async () => {
 .page-title {
   font-size: 1.375rem;
   font-weight: 700;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
   margin: 0;
 }
 
 .page-subtitle {
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   margin: 0.25rem 0 0;
 }
 
@@ -431,7 +431,7 @@ onMounted(async () => {
 }
 
 .status-label {
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .session-card {
@@ -441,7 +441,7 @@ onMounted(async () => {
 .tab-nav {
   display: flex;
   gap: 0.25rem;
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
   padding-bottom: 0;
   flex-wrap: wrap;
 }
@@ -453,7 +453,7 @@ onMounted(async () => {
   padding: 0.5rem 1rem;
   font-size: 0.875rem;
   font-weight: 500;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
@@ -462,7 +462,7 @@ onMounted(async () => {
 }
 
 .tab-btn:hover {
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
 }
 
 .tab-btn.active {
@@ -481,8 +481,8 @@ onMounted(async () => {
 }
 
 .card {
-  background: var(--color-surface, #fff);
-  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-surface, #fff);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.5rem;
   overflow: hidden;
 }
@@ -492,14 +492,14 @@ onMounted(async () => {
   align-items: center;
   justify-content: space-between;
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
   background: var(--color-surface-secondary, #f9fafb);
 }
 
 .card-title {
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
 }
 
 .card-body {
@@ -518,10 +518,10 @@ onMounted(async () => {
   min-width: 0;
   padding: 0.5rem 0.75rem;
   font-size: 0.875rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text-primary, #111827);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary, #111827);
 }
 
 .field-input--narrow {
@@ -533,7 +533,7 @@ onMounted(async () => {
   align-items: center;
   gap: 0.5rem;
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   white-space: nowrap;
 }
 
@@ -544,7 +544,7 @@ onMounted(async () => {
 
 .range-value {
   font-weight: 600;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
   min-width: 3rem;
 }
 
@@ -583,7 +583,7 @@ onMounted(async () => {
   align-items: center;
   padding: 0.5rem 1rem;
   background: var(--color-surface-secondary, #f9fafb);
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.5rem;
   min-width: 5rem;
 }
@@ -596,14 +596,14 @@ onMounted(async () => {
 
 .stat-label {
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   text-align: center;
 }
 
 .section-subheading {
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
   margin: 0 0 0.75rem;
 }
 
@@ -625,12 +625,12 @@ onMounted(async () => {
 .data-table td {
   padding: 0.5rem 0.75rem;
   text-align: left;
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
 }
 
 .data-table th {
   font-weight: 600;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   background: var(--color-surface-secondary, #f9fafb);
   font-size: 0.75rem;
   text-transform: uppercase;
@@ -640,7 +640,7 @@ onMounted(async () => {
 .cell-mono {
   font-family: monospace;
   font-size: 0.8125rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .cell-text {
@@ -682,7 +682,7 @@ onMounted(async () => {
 
 .badge-neutral {
   background: var(--color-surface-secondary, #f3f4f6);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .chip {
@@ -692,12 +692,12 @@ onMounted(async () => {
   background: var(--color-surface-secondary, #e5e7eb);
   border-radius: 0.25rem;
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #374151);
+  color: var(--text-secondary, #374151);
 }
 
 .result-summary {
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   margin: 0 0 0.75rem;
 }
 
@@ -711,7 +711,7 @@ onMounted(async () => {
 
 .ocr-region-item {
   background: var(--color-surface-secondary, #f9fafb);
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.375rem;
   padding: 0.5rem;
 }
@@ -722,7 +722,7 @@ onMounted(async () => {
   white-space: pre-wrap;
   word-break: break-word;
   margin: 0;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
 }
 
 .opportunities-list {
@@ -744,7 +744,7 @@ onMounted(async () => {
   align-items: center;
   gap: 0.5rem;
   padding: 2rem 1rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   font-size: 0.875rem;
   text-align: center;
 }

--- a/autobot-frontend/src/views/llc/ApprovalsInbox.vue
+++ b/autobot-frontend/src/views/llc/ApprovalsInbox.vue
@@ -299,8 +299,8 @@ onUnmounted(() => {
   height: 100%;
   padding: 1.5rem;
   gap: 1rem;
-  background: var(--color-background);
-  color: var(--color-text);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 .inbox-header {
@@ -338,7 +338,7 @@ onUnmounted(() => {
 .header-tabs {
   display: flex;
   gap: 0.25rem;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.375rem;
   overflow: hidden;
 }
@@ -348,7 +348,7 @@ onUnmounted(() => {
   font-size: 0.875rem;
   border: none;
   background: transparent;
-  color: var(--color-text);
+  color: var(--text-primary);
   cursor: pointer;
   transition: background 0.15s;
 }
@@ -367,10 +367,10 @@ onUnmounted(() => {
 .filter-select,
 .filter-search {
   padding: 0.4rem 0.75rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
   font-size: 0.875rem;
 }
 
@@ -390,14 +390,14 @@ onUnmounted(() => {
 .state-msg {
   text-align: center;
   padding: 3rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .approval-card {
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.5rem;
   padding: 1rem;
-  background: var(--color-surface, #fff);
+  background: var(--bg-surface, #fff);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -416,7 +416,7 @@ onUnmounted(() => {
 
 .card-meta {
   font-size: 0.8rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .type-badge,
@@ -444,15 +444,15 @@ onUnmounted(() => {
 .toggle-payload {
   font-size: 0.8rem;
   padding: 0.2rem 0.5rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.25rem;
-  background: var(--color-surface-elevated, #f9fafb);
+  background: var(--bg-elevated, #f9fafb);
   cursor: pointer;
 }
 
 .payload-json {
-  background: var(--color-surface-elevated, #f9fafb);
-  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-elevated, #f9fafb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.375rem;
   padding: 0.75rem;
   font-size: 0.8rem;
@@ -494,16 +494,16 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  border-top: 1px solid var(--color-border, #e5e7eb);
+  border-top: 1px solid var(--border-default, #e5e7eb);
   padding-top: 0.75rem;
 }
 
 .note-textarea {
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
   font-size: 0.875rem;
   resize: vertical;
 }
@@ -532,9 +532,9 @@ onUnmounted(() => {
 
 .btn-secondary {
   padding: 0.4rem 1rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text);
-  border: 1px solid var(--color-border, #d1d5db);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
   font-size: 0.875rem;
   font-weight: 500;

--- a/autobot-frontend/src/views/llc/BacklogView.vue
+++ b/autobot-frontend/src/views/llc/BacklogView.vue
@@ -431,8 +431,8 @@ onMounted(fetchBacklog)
   height: 100%;
   padding: 1.5rem;
   gap: 1rem;
-  background: var(--color-background);
-  color: var(--color-text);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 .backlog-header {
@@ -455,7 +455,7 @@ onMounted(fetchBacklog)
 
 .item-count {
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .header-actions {
@@ -472,10 +472,10 @@ onMounted(fetchBacklog)
 .filter-select,
 .filter-search {
   padding: 0.4rem 0.75rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
   font-size: 0.875rem;
 }
 
@@ -487,7 +487,7 @@ onMounted(fetchBacklog)
 .backlog-table-wrapper {
   flex: 1;
   overflow: auto;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.5rem;
 }
 
@@ -501,19 +501,19 @@ onMounted(fetchBacklog)
   padding: 0.625rem 0.75rem;
   text-align: left;
   font-weight: 600;
-  background: var(--color-surface-elevated, #f9fafb);
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-elevated, #f9fafb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
   white-space: nowrap;
 }
 
 .backlog-row {
-  border-bottom: 1px solid var(--color-border, #f3f4f6);
+  border-bottom: 1px solid var(--border-default, #f3f4f6);
   cursor: pointer;
   transition: background 0.1s;
 }
 
 .backlog-row:hover {
-  background: var(--color-surface-hover, #f9fafb);
+  background: var(--bg-hover, #f9fafb);
 }
 
 .backlog-row.selected {
@@ -535,7 +535,7 @@ onMounted(fetchBacklog)
 .item-identifier {
   font-family: monospace;
   font-size: 0.8rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .type-badge,
@@ -588,7 +588,7 @@ onMounted(fetchBacklog)
 .loading-state {
   text-align: center;
   padding: 2rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .modal-overlay {
@@ -602,7 +602,7 @@ onMounted(fetchBacklog)
 }
 
 .modal-panel {
-  background: var(--color-surface, #fff);
+  background: var(--bg-surface, #fff);
   border-radius: 0.75rem;
   padding: 1.5rem;
   width: 100%;
@@ -629,7 +629,7 @@ onMounted(fetchBacklog)
 .form-field label {
   font-size: 0.8rem;
   font-weight: 500;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .form-row {
@@ -645,10 +645,10 @@ onMounted(fetchBacklog)
 .form-select,
 .form-textarea {
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
   font-size: 0.875rem;
   width: 100%;
 }
@@ -672,15 +672,15 @@ onMounted(fetchBacklog)
 .ac-header label {
   font-size: 0.8rem;
   font-weight: 500;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .btn-suggest {
   font-size: 0.8rem;
   padding: 0.25rem 0.75rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
-  background: var(--color-surface-elevated, #f9fafb);
+  background: var(--bg-elevated, #f9fafb);
   cursor: pointer;
 }
 
@@ -694,9 +694,9 @@ onMounted(fetchBacklog)
   flex-direction: column;
   gap: 0.375rem;
   padding: 0.5rem;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.375rem;
-  background: var(--color-surface-elevated, #f9fafb);
+  background: var(--bg-elevated, #f9fafb);
 }
 
 .ac-item {
@@ -742,9 +742,9 @@ onMounted(fetchBacklog)
   align-items: center;
   gap: 0.375rem;
   padding: 0.5rem 1rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text);
-  border: 1px solid var(--color-border, #d1d5db);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
   font-size: 0.875rem;
   font-weight: 500;
@@ -753,7 +753,7 @@ onMounted(fetchBacklog)
 }
 
 .btn-secondary:hover {
-  background: var(--color-surface-hover, #f9fafb);
+  background: var(--bg-hover, #f9fafb);
 }
 
 .btn-icon {

--- a/autobot-frontend/src/views/llc/BoardsView.vue
+++ b/autobot-frontend/src/views/llc/BoardsView.vue
@@ -97,18 +97,18 @@ onMounted(loadBoards)
 .browser-title {
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
   margin: 0;
 }
 
 .browser-count {
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .browser-state {
   padding: 2rem 0;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .card-grid {
@@ -145,13 +145,13 @@ onMounted(loadBoards)
 .card-name {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
   margin: 0;
 }
 
 .card-meta {
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   margin: 0;
 }
 
@@ -164,7 +164,7 @@ onMounted(loadBoards)
   padding: 0.125rem 0.5rem;
   border-radius: 999px;
   background: var(--bg-hover, #f3f4f6);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .type-kanban {

--- a/autobot-frontend/src/views/llc/CeoChatView.vue
+++ b/autobot-frontend/src/views/llc/CeoChatView.vue
@@ -253,18 +253,18 @@ onMounted(() => {
 .ceo-chat-view {
   display: flex;
   height: 100%;
-  background: var(--color-background);
-  color: var(--color-text);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   overflow: hidden;
 }
 
 .thread-sidebar {
   width: 260px;
   flex-shrink: 0;
-  border-right: 1px solid var(--color-border, #e5e7eb);
+  border-right: 1px solid var(--border-default, #e5e7eb);
   display: flex;
   flex-direction: column;
-  background: var(--color-surface, #fff);
+  background: var(--bg-surface, #fff);
 }
 
 .sidebar-header {
@@ -272,7 +272,7 @@ onMounted(() => {
   align-items: center;
   justify-content: space-between;
   padding: 1rem;
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
 }
 
 .sidebar-title {
@@ -298,12 +298,12 @@ onMounted(() => {
 .thread-item {
   padding: 0.75rem 1rem;
   cursor: pointer;
-  border-bottom: 1px solid var(--color-border, #f3f4f6);
+  border-bottom: 1px solid var(--border-default, #f3f4f6);
   transition: background 0.1s;
 }
 
 .thread-item:hover {
-  background: var(--color-surface-hover, #f9fafb);
+  background: var(--bg-hover, #f9fafb);
 }
 
 .thread-item.active {
@@ -326,7 +326,7 @@ onMounted(() => {
 
 .thread-date {
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   margin-top: 0.125rem;
 }
 
@@ -342,7 +342,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .chat-header {
@@ -350,8 +350,8 @@ onMounted(() => {
   align-items: center;
   gap: 0.75rem;
   padding: 0.875rem 1.25rem;
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
-  background: var(--color-surface, #fff);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
+  background: var(--bg-surface, #fff);
 }
 
 .chat-title {
@@ -404,9 +404,9 @@ onMounted(() => {
 }
 
 .bubble-system {
-  background: var(--color-surface, #fff);
-  border: 1px solid var(--color-border, #e5e7eb);
-  color: var(--color-text);
+  background: var(--bg-surface, #fff);
+  border: 1px solid var(--border-default, #e5e7eb);
+  color: var(--text-primary);
   border-bottom-left-radius: 0.25rem;
 }
 
@@ -437,17 +437,17 @@ onMounted(() => {
   display: flex;
   gap: 0.5rem;
   padding: 0.875rem 1.25rem;
-  border-top: 1px solid var(--color-border, #e5e7eb);
-  background: var(--color-surface, #fff);
+  border-top: 1px solid var(--border-default, #e5e7eb);
+  background: var(--bg-surface, #fff);
 }
 
 .message-input {
   flex: 1;
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
-  background: var(--color-background);
-  color: var(--color-text);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 0.875rem;
   resize: none;
   line-height: 1.4;
@@ -473,7 +473,7 @@ onMounted(() => {
 .state-msg-sm {
   text-align: center;
   padding: 1.5rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   font-size: 0.875rem;
 }
 
@@ -488,7 +488,7 @@ onMounted(() => {
 }
 
 .modal-panel {
-  background: var(--color-surface, #fff);
+  background: var(--bg-surface, #fff);
   border-radius: 0.75rem;
   padding: 1.5rem;
   width: 100%;
@@ -513,15 +513,15 @@ onMounted(() => {
 .form-field label {
   font-size: 0.8rem;
   font-weight: 500;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .form-input {
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
   font-size: 0.875rem;
 }
 
@@ -549,9 +549,9 @@ onMounted(() => {
 
 .btn-secondary {
   padding: 0.5rem 1rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text);
-  border: 1px solid var(--color-border, #d1d5db);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
   font-size: 0.875rem;
   font-weight: 500;

--- a/autobot-frontend/src/views/llc/CompanyPortabilityView.vue
+++ b/autobot-frontend/src/views/llc/CompanyPortabilityView.vue
@@ -473,12 +473,12 @@ async function executeImport(): Promise<void> {
 .page-title {
   font-size: var(--font-size-xl);
   font-weight: var(--font-weight-bold);
-  color: var(--color-text-primary);
+  color: var(--text-primary);
   margin: 0 0 var(--spacing-xs);
 }
 
 .page-subtitle {
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   margin: 0;
 }
 
@@ -509,8 +509,8 @@ async function executeImport(): Promise<void> {
 }
 
 .portability-card {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
   padding: var(--spacing-lg);
 }
@@ -519,11 +519,11 @@ async function executeImport(): Promise<void> {
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
   margin: 0 0 var(--spacing-xs);
-  color: var(--color-text-primary);
+  color: var(--text-primary);
 }
 
 .card-desc {
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   margin: 0 0 var(--spacing-md);
 }
 
@@ -559,9 +559,9 @@ async function executeImport(): Promise<void> {
   align-items: center;
   gap: var(--spacing-xs);
   padding: var(--spacing-sm) var(--spacing-md);
-  background: var(--color-surface);
-  color: var(--color-text-primary);
-  border: 1px solid var(--color-border);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   cursor: pointer;
   font-size: var(--font-size-sm);
@@ -594,14 +594,14 @@ async function executeImport(): Promise<void> {
 
 .export-hint {
   font-size: var(--font-size-xs);
-  color: var(--color-text-tertiary, var(--color-text-secondary));
+  color: var(--color-text-tertiary, var(--text-secondary));
   margin: 0 0 var(--spacing-md);
 }
 
 /* Recent exports */
 .recent-exports {
   margin-top: var(--spacing-md);
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--border-default);
   padding-top: var(--spacing-md);
 }
 
@@ -609,7 +609,7 @@ async function executeImport(): Promise<void> {
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-semibold);
   margin: 0 0 var(--spacing-sm);
-  color: var(--color-text-primary);
+  color: var(--text-primary);
 }
 
 .export-table,
@@ -625,13 +625,13 @@ async function executeImport(): Promise<void> {
 .preview-table td {
   text-align: left;
   padding: var(--spacing-xs) var(--spacing-sm);
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--border-default);
 }
 
 .export-table th,
 .preview-table th {
   font-weight: var(--font-weight-semibold);
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 
 .download-link {
@@ -642,7 +642,7 @@ async function executeImport(): Promise<void> {
 
 /* Drop zone */
 .drop-zone {
-  border: 2px dashed var(--color-border);
+  border: 2px dashed var(--border-default);
   border-radius: var(--radius-md);
   padding: var(--spacing-xl) var(--spacing-md);
   text-align: center;
@@ -675,18 +675,18 @@ async function executeImport(): Promise<void> {
 }
 
 .drop-zone-label {
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   font-size: var(--font-size-sm);
 }
 
 .btn-clear-file {
   background: none;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   padding: 2px var(--spacing-xs);
   cursor: pointer;
   font-size: var(--font-size-xs);
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   margin-top: var(--spacing-xs);
 }
 
@@ -699,10 +699,10 @@ async function executeImport(): Promise<void> {
 
 /* Preview panel */
 .preview-panel {
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   padding: var(--spacing-md);
-  background: var(--color-background, var(--color-surface));
+  background: var(--bg-primary, var(--bg-surface));
   margin-top: var(--spacing-md);
 }
 
@@ -752,7 +752,7 @@ async function executeImport(): Promise<void> {
 
 /* Secret mapping */
 .secret-mapping {
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--border-default);
   padding-top: var(--spacing-md);
   margin-top: var(--spacing-md);
   margin-bottom: var(--spacing-md);
@@ -760,7 +760,7 @@ async function executeImport(): Promise<void> {
 
 .secret-hint {
   font-size: var(--font-size-xs);
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   margin: 0 0 var(--spacing-sm);
 }
 
@@ -774,18 +774,18 @@ async function executeImport(): Promise<void> {
 .secret-label {
   font-family: var(--font-family-mono, monospace);
   font-size: var(--font-size-sm);
-  color: var(--color-text-primary);
+  color: var(--text-primary);
   min-width: 180px;
 }
 
 .secret-input {
   flex: 1;
   padding: var(--spacing-xs) var(--spacing-sm);
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   font-size: var(--font-size-sm);
-  background: var(--color-surface);
-  color: var(--color-text-primary);
+  background: var(--bg-surface);
+  color: var(--text-primary);
 }
 
 /* Execute */
@@ -798,7 +798,7 @@ async function executeImport(): Promise<void> {
 
 .hint-text {
   font-size: var(--font-size-xs);
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 
 /* Import result */

--- a/autobot-frontend/src/views/llc/CompanySelectorView.vue
+++ b/autobot-frontend/src/views/llc/CompanySelectorView.vue
@@ -175,7 +175,7 @@ onMounted(async () => {
   padding: 0.75rem 1rem;
   border-radius: var(--radius-md, 8px);
   background: var(--color-danger-bg, #fae5e1);
-  color: var(--color-danger, #cb3326);
+  color: var(--color-error, #cb3326);
   font-size: 0.875rem;
 }
 

--- a/autobot-frontend/src/views/llc/CostDashboard.vue
+++ b/autobot-frontend/src/views/llc/CostDashboard.vue
@@ -476,8 +476,8 @@ onMounted(async () => {
   height: 100%;
   padding: 1.5rem;
   gap: 1.25rem;
-  background: var(--color-background);
-  color: var(--color-text);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   overflow-y: auto;
 }
 
@@ -495,9 +495,9 @@ onMounted(async () => {
 
 .btn-export {
   padding: 0.4rem 1rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text);
-  border: 1px solid var(--color-border, #d1d5db);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
   font-size: 0.875rem;
   cursor: pointer;
@@ -513,8 +513,8 @@ onMounted(async () => {
   flex: 1;
   min-width: 160px;
   padding: 1rem;
-  background: var(--color-surface, #fff);
-  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-surface, #fff);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.5rem;
   display: flex;
   flex-direction: column;
@@ -523,7 +523,7 @@ onMounted(async () => {
 
 .card-label {
   font-size: 0.8rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   font-weight: 500;
 }
 
@@ -534,7 +534,7 @@ onMounted(async () => {
 
 .card-sub {
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   word-break: break-all;
 }
 
@@ -546,8 +546,8 @@ onMounted(async () => {
 
 .budget-section,
 .chart-section {
-  background: var(--color-surface, #fff);
-  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-surface, #fff);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.5rem;
   padding: 1rem;
 }
@@ -593,7 +593,7 @@ onMounted(async () => {
 .gauge-track {
   flex: 1;
   height: 0.5rem;
-  background: var(--color-surface-elevated, #f3f4f6);
+  background: var(--bg-elevated, #f3f4f6);
   border-radius: 9999px;
   overflow: hidden;
 }
@@ -620,11 +620,11 @@ onMounted(async () => {
   min-width: 12rem;
   text-align: right;
   font-size: 0.8rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .shadow-cost {
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   font-size: 0.75rem;
   margin-left: 0.25rem;
 }
@@ -632,11 +632,11 @@ onMounted(async () => {
 .btn-settings {
   padding: 0.2rem 0.45rem;
   background: transparent;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.25rem;
   cursor: pointer;
   font-size: 0.85rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   opacity: 0.6;
   transition: opacity 0.15s;
 }
@@ -655,7 +655,7 @@ onMounted(async () => {
 }
 
 .modal-box {
-  background: var(--color-surface, #fff);
+  background: var(--bg-surface, #fff);
   border-radius: 0.75rem;
   padding: 1.5rem;
   width: 100%;
@@ -683,13 +683,13 @@ onMounted(async () => {
   border: none;
   cursor: pointer;
   font-size: 1rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   padding: 0.2rem;
 }
 
 .modal-agent-name {
   font-size: 0.85rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   margin-top: -0.5rem;
 }
 
@@ -707,7 +707,7 @@ onMounted(async () => {
 .mode-toggle {
   display: flex;
   gap: 0;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
   overflow: hidden;
 }
@@ -719,7 +719,7 @@ onMounted(async () => {
   border: none;
   cursor: pointer;
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   transition: background 0.15s, color 0.15s;
 }
 
@@ -731,25 +731,25 @@ onMounted(async () => {
 .input-prefix-wrap {
   display: flex;
   align-items: center;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
   overflow: hidden;
 }
 
 .input-prefix {
   padding: 0.45rem 0.6rem;
-  background: var(--color-surface-elevated, #f9fafb);
-  border-right: 1px solid var(--color-border, #d1d5db);
+  background: var(--bg-elevated, #f9fafb);
+  border-right: 1px solid var(--border-default, #d1d5db);
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .field-input {
   padding: 0.45rem 0.75rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
   font-size: 0.875rem;
   width: 100%;
 }
@@ -761,7 +761,7 @@ onMounted(async () => {
 
 .field-hint {
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   margin: 0;
 }
 
@@ -804,8 +804,8 @@ onMounted(async () => {
 .btn-secondary {
   padding: 0.45rem 1rem;
   background: transparent;
-  color: var(--color-text);
-  border: 1px solid var(--color-border, #d1d5db);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
   font-size: 0.875rem;
   cursor: pointer;
@@ -841,7 +841,7 @@ onMounted(async () => {
 
 .bar-label {
   font-size: 0.6rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   transform: rotate(-45deg);
   transform-origin: center;
   white-space: nowrap;
@@ -857,21 +857,21 @@ onMounted(async () => {
 .filter-select,
 .filter-date {
   padding: 0.4rem 0.75rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
   font-size: 0.875rem;
 }
 
 .date-sep {
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .table-wrapper {
   overflow: auto;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.5rem;
 }
 
@@ -885,14 +885,14 @@ onMounted(async () => {
   padding: 0.625rem 0.75rem;
   text-align: left;
   font-weight: 600;
-  background: var(--color-surface-elevated, #f9fafb);
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-elevated, #f9fafb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
   white-space: nowrap;
 }
 
 .cost-table td {
   padding: 0.5rem 0.75rem;
-  border-bottom: 1px solid var(--color-border, #f3f4f6);
+  border-bottom: 1px solid var(--border-default, #f3f4f6);
 }
 
 .num-cell {
@@ -903,6 +903,6 @@ onMounted(async () => {
 .state-msg {
   text-align: center;
   padding: 2rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 </style>

--- a/autobot-frontend/src/views/llc/GanttTimelineView.vue
+++ b/autobot-frontend/src/views/llc/GanttTimelineView.vue
@@ -455,22 +455,22 @@ onBeforeUnmount(() => {
   font-size: 0.65rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .gantt-select {
   padding: 0.3rem 0.5rem;
   border-radius: 6px;
-  border: 1px solid var(--color-border, #d1d5db);
-  background: var(--color-surface, #fff);
-  color: var(--color-text, #111827);
+  border: 1px solid var(--border-default, #d1d5db);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary, #111827);
 }
 
 .gantt-btn {
   padding: 0.4rem 0.8rem;
   border-radius: 6px;
-  border: 1px solid var(--color-border, #d1d5db);
-  background: var(--color-surface, #fff);
+  border: 1px solid var(--border-default, #d1d5db);
+  background: var(--bg-surface, #fff);
   cursor: pointer;
   font-size: 0.8rem;
 }
@@ -483,7 +483,7 @@ onBeforeUnmount(() => {
 .gantt-state {
   padding: 2rem;
   text-align: center;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .gantt-scroll {
@@ -491,25 +491,25 @@ onBeforeUnmount(() => {
   flex: 1;
   min-height: 0;
   overflow: auto;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 8px;
-  background: var(--color-surface, #fff);
+  background: var(--bg-surface, #fff);
 }
 
 .gantt-gridline {
-  stroke: var(--color-border, #e5e7eb);
+  stroke: var(--border-default, #e5e7eb);
   stroke-width: 1;
 }
 
 .gantt-axis-label {
   font-size: 10px;
-  fill: var(--color-text-secondary, #9ca3af);
+  fill: var(--text-secondary, #9ca3af);
 }
 
 .gantt-row-label {
   font-size: 10px;
   font-family: monospace;
-  fill: var(--color-text-secondary, #6b7280);
+  fill: var(--text-secondary, #6b7280);
 }
 
 .gantt-bar {
@@ -518,7 +518,7 @@ onBeforeUnmount(() => {
 }
 
 .gantt-bar--critical {
-  fill: var(--color-danger, #ef4444);
+  fill: var(--color-error, #ef4444);
 }
 
 .gantt-handle {
@@ -534,7 +534,7 @@ onBeforeUnmount(() => {
 
 .gantt-unscheduled {
   font-size: 10px;
-  fill: var(--color-text-secondary, #9ca3af);
+  fill: var(--text-secondary, #9ca3af);
   font-style: italic;
 }
 </style>

--- a/autobot-frontend/src/views/llc/HeartbeatMonitor.vue
+++ b/autobot-frontend/src/views/llc/HeartbeatMonitor.vue
@@ -422,8 +422,8 @@ onUnmounted(() => {
   height: 100%;
   padding: 1.5rem;
   gap: 1rem;
-  background: var(--color-background);
-  color: var(--color-text);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 .monitor-header {
@@ -440,18 +440,18 @@ onUnmounted(() => {
 
 .refresh-note {
   font-size: 0.8rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .state-msg {
   text-align: center;
   padding: 3rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .agent-grid-wrapper {
   overflow: auto;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.5rem;
   flex: 1;
 }
@@ -466,19 +466,19 @@ onUnmounted(() => {
   padding: 0.625rem 0.75rem;
   text-align: left;
   font-weight: 600;
-  background: var(--color-surface-elevated, #f9fafb);
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-elevated, #f9fafb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
   white-space: nowrap;
 }
 
 .agent-row {
-  border-bottom: 1px solid var(--color-border, #f3f4f6);
+  border-bottom: 1px solid var(--border-default, #f3f4f6);
   cursor: pointer;
   transition: background 0.1s;
 }
 
 .agent-row:hover {
-  background: var(--color-surface-hover, #f9fafb);
+  background: var(--bg-hover, #f9fafb);
 }
 
 .agent-grid td {
@@ -514,8 +514,8 @@ onUnmounted(() => {
 .status-failed.status-dot { background: #ef4444; }
 .status-timed_out { color: #ef4444; }
 .status-timed_out.status-dot { background: #ef4444; }
-.status-unknown { color: var(--color-text-secondary, #9ca3af); }
-.status-unknown.status-dot { background: var(--color-border, #d1d5db); }
+.status-unknown { color: var(--text-secondary, #9ca3af); }
+.status-unknown.status-dot { background: var(--border-default, #d1d5db); }
 
 .btn-trigger {
   padding: 0.3rem 0.75rem;
@@ -546,7 +546,7 @@ onUnmounted(() => {
   width: 480px;
   max-width: 100%;
   height: 100%;
-  background: var(--color-surface, #fff);
+  background: var(--bg-surface, #fff);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -557,7 +557,7 @@ onUnmounted(() => {
   align-items: center;
   justify-content: space-between;
   padding: 1rem 1.25rem;
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
 }
 
 .drawer-header h3 {
@@ -571,7 +571,7 @@ onUnmounted(() => {
   border: none;
   font-size: 1.125rem;
   cursor: pointer;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .run-list {
@@ -584,7 +584,7 @@ onUnmounted(() => {
 }
 
 .run-item {
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.375rem;
   padding: 0.75rem;
   display: flex;
@@ -602,22 +602,22 @@ onUnmounted(() => {
 .run-date,
 .run-duration {
   font-size: 0.8rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .toggle-payload {
   font-size: 0.8rem;
   padding: 0.2rem 0.5rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.25rem;
-  background: var(--color-surface-elevated, #f9fafb);
+  background: var(--bg-elevated, #f9fafb);
   cursor: pointer;
   align-self: flex-start;
 }
 
 .run-context {
-  background: var(--color-surface-elevated, #f9fafb);
-  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-elevated, #f9fafb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.375rem;
   padding: 0.75rem;
   font-size: 0.8rem;
@@ -637,16 +637,16 @@ onUnmounted(() => {
 .btn-replay,
 .btn-replay-log {
   padding: 0.2rem 0.5rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.25rem;
-  background: var(--color-surface-elevated, #f9fafb);
+  background: var(--bg-elevated, #f9fafb);
   cursor: pointer;
   font-size: 0.8rem;
 }
 
 .btn-replay:hover,
 .btn-replay-log:hover {
-  background: var(--color-surface-hover, #f3f4f6);
+  background: var(--bg-hover, #f3f4f6);
 }
 
 .btn-replay:disabled {
@@ -656,12 +656,12 @@ onUnmounted(() => {
 
 .btn-fixture {
   padding: 0.2rem 0.5rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.25rem;
-  background: var(--color-surface-elevated, #f9fafb);
+  background: var(--bg-elevated, #f9fafb);
   font-size: 0.8rem;
   text-decoration: none;
-  color: var(--color-text, #374151);
+  color: var(--text-primary, #374151);
 }
 
 .replay-panel {
@@ -699,7 +699,7 @@ onUnmounted(() => {
 }
 
 .meta-item {
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .event-browser {
@@ -717,9 +717,9 @@ onUnmounted(() => {
 
 .event-nav button {
   padding: 0.2rem 0.5rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.25rem;
-  background: var(--color-surface-elevated, #f9fafb);
+  background: var(--bg-elevated, #f9fafb);
   cursor: pointer;
   font-size: 0.8rem;
 }
@@ -730,8 +730,8 @@ onUnmounted(() => {
 }
 
 .event-detail {
-  background: var(--color-surface-elevated, #f9fafb);
-  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-elevated, #f9fafb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.375rem;
   padding: 0.75rem;
   font-size: 0.8rem;
@@ -758,8 +758,8 @@ onUnmounted(() => {
 }
 
 .diff-content {
-  background: var(--color-surface-elevated, #f9fafb);
-  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-elevated, #f9fafb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.375rem;
   padding: 0.75rem;
   font-size: 0.75rem;
@@ -771,6 +771,6 @@ onUnmounted(() => {
 }
 
 .diff-identical {
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 </style>

--- a/autobot-frontend/src/views/llc/KanbanBoardView.vue
+++ b/autobot-frontend/src/views/llc/KanbanBoardView.vue
@@ -279,8 +279,8 @@ onUnmounted(() => ws?.close())
   height: 100%;
   padding: 1.5rem;
   gap: 1rem;
-  background: var(--color-background);
-  color: var(--color-text);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 .kanban-header {
@@ -315,9 +315,9 @@ onUnmounted(() => ws?.close())
 
 .kanban-column {
   flex: 0 0 240px;
-  background: var(--color-surface-elevated, #f9fafb);
+  background: var(--bg-elevated, #f9fafb);
   border-radius: 0.5rem;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   display: flex;
   flex-direction: column;
   /* #10750 C2: bounded by .board-layout height, not the viewport */
@@ -332,7 +332,7 @@ onUnmounted(() => ws?.close())
   padding: 0.625rem 0.875rem;
   font-weight: 600;
   font-size: 0.875rem;
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.5rem 0.5rem 0 0;
   transition: background 0.15s;
 }
@@ -360,7 +360,7 @@ onUnmounted(() => ws?.close())
 
 .wip-limit {
   font-size: 0.7rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .column-cards {
@@ -374,7 +374,7 @@ onUnmounted(() => ws?.close())
 }
 
 .swimlane {
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
   padding: 0.5rem;
 }
 
@@ -388,7 +388,7 @@ onUnmounted(() => ws?.close())
   gap: 0.375rem;
   font-size: 0.7rem;
   font-weight: 600;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin-bottom: 0.375rem;
@@ -407,7 +407,7 @@ onUnmounted(() => ws?.close())
 
 .lane-empty {
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   text-align: center;
   padding: 0.5rem;
 }
@@ -421,8 +421,8 @@ onUnmounted(() => ws?.close())
 }
 
 .kanban-card-inner {
-  background: var(--color-surface, #fff);
-  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-surface, #fff);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.375rem;
   padding: 0.5rem 0.625rem;
   display: flex;
@@ -444,7 +444,7 @@ onUnmounted(() => ws?.close())
 .card-id {
   font-family: monospace;
   font-size: 0.65rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .card-type {
@@ -502,7 +502,7 @@ onUnmounted(() => ws?.close())
 .card-pts {
   font-size: 0.65rem;
   font-weight: 600;
-  background: var(--color-surface-elevated, #f3f4f6);
+  background: var(--bg-elevated, #f3f4f6);
   padding: 0.1rem 0.35rem;
   border-radius: 0.2rem;
 }
@@ -525,8 +525,8 @@ onUnmounted(() => ws?.close())
   text-align: center;
   padding: 1.5rem 0.5rem;
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #9ca3af);
-  border: 2px dashed var(--color-border, #e5e7eb);
+  color: var(--text-secondary, #9ca3af);
+  border: 2px dashed var(--border-default, #e5e7eb);
   border-radius: 0.375rem;
   margin: 0.5rem;
 }

--- a/autobot-frontend/src/views/llc/MembersView.vue
+++ b/autobot-frontend/src/views/llc/MembersView.vue
@@ -297,8 +297,8 @@ onMounted(() => {
   flex-direction: column;
   gap: 1.25rem;
   padding: 1.5rem;
-  background: var(--color-background);
-  color: var(--color-text);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 .members-header {
@@ -318,18 +318,18 @@ onMounted(() => {
 .members-subtitle {
   margin: 0.25rem 0 0;
   font-size: 0.875rem;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 
 .members-state {
   text-align: center;
   padding: 2.5rem;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 
 .members-empty {
   text-align: center;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 
 .members-error {
@@ -345,13 +345,13 @@ onMounted(() => {
 .members-table td {
   text-align: left;
   padding: 0.625rem 0.75rem;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--border-default);
   font-size: 0.875rem;
 }
 
 .members-table th {
   font-weight: 600;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   font-size: 0.6875rem;
@@ -382,22 +382,22 @@ onMounted(() => {
 .members-label {
   font-size: 0.8125rem;
   font-weight: 600;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 
 .members-select {
   width: 100%;
   padding: 0.5rem 0.75rem;
   border-radius: var(--radius-md, 8px);
-  border: 1px solid var(--color-border);
-  background: var(--color-surface);
-  color: var(--color-text);
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  color: var(--text-primary);
   font-size: 0.875rem;
 }
 
 .members-hint {
   margin: 0;
   font-size: 0.75rem;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
 }
 </style>

--- a/autobot-frontend/src/views/llc/PortfolioBrowserView.vue
+++ b/autobot-frontend/src/views/llc/PortfolioBrowserView.vue
@@ -114,18 +114,18 @@ onMounted(loadPortfolios)
 .browser-title {
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
   margin: 0;
 }
 
 .browser-count {
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .browser-state {
   padding: 2rem 0;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .card-grid {
@@ -162,13 +162,13 @@ onMounted(loadPortfolios)
 .card-name {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
   margin: 0;
 }
 
 .card-desc {
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   margin: 0;
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -179,7 +179,7 @@ onMounted(loadPortfolios)
 
 .card-meta {
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   margin: 0;
 }
 
@@ -192,6 +192,6 @@ onMounted(loadPortfolios)
   padding: 0.125rem 0.5rem;
   border-radius: 999px;
   background: var(--bg-hover, #f3f4f6);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 </style>

--- a/autobot-frontend/src/views/llc/ProgramBrowserView.vue
+++ b/autobot-frontend/src/views/llc/ProgramBrowserView.vue
@@ -113,18 +113,18 @@ onMounted(loadPrograms)
 .browser-title {
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
   margin: 0;
 }
 
 .browser-count {
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .browser-state {
   padding: 2rem 0;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .card-grid {
@@ -161,13 +161,13 @@ onMounted(loadPrograms)
 .card-name {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
   margin: 0;
 }
 
 .card-desc {
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   margin: 0;
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -178,7 +178,7 @@ onMounted(loadPrograms)
 
 .card-meta {
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   margin: 0;
 }
 
@@ -191,6 +191,6 @@ onMounted(loadPrograms)
   padding: 0.125rem 0.5rem;
   border-radius: 999px;
   background: var(--bg-hover, #f3f4f6);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 </style>

--- a/autobot-frontend/src/views/llc/ProjectBrowserView.vue
+++ b/autobot-frontend/src/views/llc/ProjectBrowserView.vue
@@ -157,18 +157,18 @@ onMounted(loadProjects)
 .browser-title {
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
   margin: 0;
 }
 
 .browser-count {
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .browser-state {
   padding: 2rem 0;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .card-grid {
@@ -197,13 +197,13 @@ onMounted(loadProjects)
 .card-name {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
   margin: 0;
 }
 
 .card-desc {
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   margin: 0;
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -214,7 +214,7 @@ onMounted(loadProjects)
 
 .card-meta {
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   margin: 0;
 }
 
@@ -227,7 +227,7 @@ onMounted(loadProjects)
 .stat {
   font-size: 0.75rem;
   font-weight: 500;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   background: var(--bg-hover, #f3f4f6);
   padding: 0.125rem 0.5rem;
   border-radius: 999px;
@@ -243,7 +243,7 @@ onMounted(loadProjects)
   font-size: 0.6875rem;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .status-badge {
@@ -255,7 +255,7 @@ onMounted(loadProjects)
   padding: 0.125rem 0.5rem;
   border-radius: 999px;
   background: var(--bg-hover, #f3f4f6);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .card-actions {

--- a/autobot-frontend/src/views/llc/ReviewInboxView.vue
+++ b/autobot-frontend/src/views/llc/ReviewInboxView.vue
@@ -100,16 +100,16 @@ onMounted(load)
 .inbox-title {
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
   margin: 0;
 }
 .inbox-count {
   font-size: 0.8125rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 .inbox-state {
   padding: 2rem 0;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 .review-list {
   list-style: none;
@@ -137,16 +137,16 @@ onMounted(load)
 .review-identifier {
   font-size: 0.75rem;
   font-weight: 600;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 .review-title {
   flex: 1;
   font-size: 0.9375rem;
-  color: var(--color-text-primary, #111827);
+  color: var(--text-primary, #111827);
 }
 .review-type {
   font-size: 0.6875rem;
   text-transform: uppercase;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 </style>

--- a/autobot-frontend/src/views/llc/SprintBoardView.vue
+++ b/autobot-frontend/src/views/llc/SprintBoardView.vue
@@ -267,8 +267,8 @@ onUnmounted(() => {
   height: 100%;
   padding: 1.5rem;
   gap: 1rem;
-  background: var(--color-background);
-  color: var(--color-text);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 .sprint-header {
@@ -277,7 +277,7 @@ onUnmounted(() => {
   justify-content: space-between;
   gap: 1.5rem;
   padding-bottom: 1rem;
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
 }
 
 .sprint-info {
@@ -295,7 +295,7 @@ onUnmounted(() => {
 
 .sprint-dates {
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .sprint-status-badge {
@@ -325,7 +325,7 @@ onUnmounted(() => {
 
 .stat-label {
   font-size: 0.7rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -345,7 +345,7 @@ onUnmounted(() => {
 }
 
 .sprint-header-skeleton {
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   font-size: 0.875rem;
 }
 
@@ -367,9 +367,9 @@ onUnmounted(() => {
 
 .board-column {
   flex: 0 0 260px;
-  background: var(--color-surface-elevated, #f9fafb);
+  background: var(--bg-elevated, #f9fafb);
   border-radius: 0.5rem;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
   display: flex;
   flex-direction: column;
   /* #10750 C2: bounded by .board-columns height, not the viewport (unify w/ Kanban) */
@@ -384,12 +384,12 @@ onUnmounted(() => {
   padding: 0.75rem 1rem;
   font-weight: 600;
   font-size: 0.875rem;
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
 }
 
 .column-count {
-  background: var(--color-surface, #fff);
-  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-surface, #fff);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 9999px;
   padding: 0 0.5rem;
   font-size: 0.75rem;
@@ -407,8 +407,8 @@ onUnmounted(() => {
 }
 
 .work-card {
-  background: var(--color-surface, #fff);
-  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-surface, #fff);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.375rem;
   padding: 0.625rem 0.75rem;
   cursor: grab;
@@ -435,7 +435,7 @@ onUnmounted(() => {
 .card-identifier {
   font-family: monospace;
   font-size: 0.7rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .card-type-badge {
@@ -459,7 +459,7 @@ onUnmounted(() => {
   margin: 0;
   font-size: 0.8rem;
   line-height: 1.4;
-  color: var(--color-text);
+  color: var(--text-primary);
 }
 
 .card-footer {
@@ -484,7 +484,7 @@ onUnmounted(() => {
 .card-points {
   font-size: 0.7rem;
   font-weight: 600;
-  background: var(--color-surface-elevated, #f3f4f6);
+  background: var(--bg-elevated, #f3f4f6);
   padding: 0.1rem 0.4rem;
   border-radius: 0.25rem;
 }
@@ -507,16 +507,16 @@ onUnmounted(() => {
   text-align: center;
   padding: 1.5rem 0.5rem;
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #9ca3af);
-  border: 2px dashed var(--color-border, #e5e7eb);
+  color: var(--text-secondary, #9ca3af);
+  border: 2px dashed var(--border-default, #e5e7eb);
   border-radius: 0.375rem;
 }
 
 .burndown-sidebar {
   width: 220px;
   flex-shrink: 0;
-  background: var(--color-surface-elevated, #f9fafb);
-  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-elevated, #f9fafb);
+  border: 1px solid var(--border-default, #e5e7eb);
   border-radius: 0.5rem;
   padding: 1rem;
   display: flex;
@@ -553,7 +553,7 @@ onUnmounted(() => {
 
 .chart-empty {
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   text-align: center;
   padding: 1rem 0;
 }

--- a/autobot-frontend/src/views/llc/WorkItemDetail.vue
+++ b/autobot-frontend/src/views/llc/WorkItemDetail.vue
@@ -555,8 +555,8 @@ onMounted(() => {
   width: 640px;
   max-width: 90vw;
   height: 100%;
-  background: var(--color-surface, #fff);
-  border-left: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-surface, #fff);
+  border-left: 1px solid var(--border-default, #e5e7eb);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -567,7 +567,7 @@ onMounted(() => {
   align-items: center;
   justify-content: space-between;
   padding: 1rem 1.25rem;
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
   flex-shrink: 0;
 }
 
@@ -580,7 +580,7 @@ onMounted(() => {
 .item-identifier {
   font-family: monospace;
   font-size: 0.8rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .type-badge,
@@ -614,13 +614,13 @@ onMounted(() => {
   border: none;
   cursor: pointer;
   padding: 0.25rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   border-radius: 0.25rem;
   transition: background 0.15s;
 }
 
 .close-btn:hover {
-  background: var(--color-surface-hover, #f3f4f6);
+  background: var(--bg-hover, #f3f4f6);
 }
 
 .close-icon {
@@ -633,15 +633,15 @@ onMounted(() => {
   align-items: center;
   gap: 0.375rem;
   padding: 0.5rem 1.25rem;
-  background: var(--color-surface-elevated, #f9fafb);
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  background: var(--bg-elevated, #f9fafb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   flex-shrink: 0;
 }
 
 .breadcrumb-sep {
-  color: var(--color-border, #d1d5db);
+  color: var(--border-default, #d1d5db);
 }
 
 .title-row {
@@ -664,8 +664,8 @@ onMounted(() => {
   border: 1px solid var(--color-primary, #3b82f6);
   border-radius: 0.25rem;
   padding: 0.25rem 0.5rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
 }
 
 .meta-row {
@@ -673,7 +673,7 @@ onMounted(() => {
   flex-wrap: wrap;
   gap: 1rem;
   padding: 0.5rem 1.25rem;
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
   flex-shrink: 0;
 }
 
@@ -685,7 +685,7 @@ onMounted(() => {
 
 .meta-label {
   font-size: 0.7rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -706,7 +706,7 @@ onMounted(() => {
 .assignee-chip {
   font-size: 0.8rem;
   padding: 0.1rem 0.5rem;
-  background: var(--color-surface-elevated, #f3f4f6);
+  background: var(--bg-elevated, #f3f4f6);
   border-radius: 9999px;
 }
 
@@ -718,7 +718,7 @@ onMounted(() => {
 
 .assignee-edit {
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   cursor: pointer;
 }
 
@@ -738,12 +738,12 @@ onMounted(() => {
 
 .assignee-cancel {
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .meta-empty {
   font-size: 0.8rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   font-style: italic;
 }
 
@@ -756,7 +756,7 @@ onMounted(() => {
 .label-chip {
   font-size: 0.7rem;
   padding: 0.1rem 0.45rem;
-  background: var(--color-surface-elevated, #f3f4f6);
+  background: var(--bg-elevated, #f3f4f6);
   border-radius: 9999px;
 }
 
@@ -764,7 +764,7 @@ onMounted(() => {
   display: flex;
   gap: 0.5rem;
   padding: 0.625rem 1.25rem;
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
   flex-wrap: wrap;
   flex-shrink: 0;
 }
@@ -773,15 +773,15 @@ onMounted(() => {
   font-size: 0.8rem;
   padding: 0.35rem 0.75rem;
   border-radius: 0.375rem;
-  border: 1px solid var(--color-border, #d1d5db);
-  background: var(--color-surface, #fff);
-  color: var(--color-text);
+  border: 1px solid var(--border-default, #d1d5db);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
   cursor: pointer;
   transition: background 0.15s;
 }
 
 .action-btn:hover:not(:disabled) {
-  background: var(--color-surface-hover, #f3f4f6);
+  background: var(--bg-hover, #f3f4f6);
 }
 
 .action-btn:disabled {
@@ -801,7 +801,7 @@ onMounted(() => {
 
 .tab-bar {
   display: flex;
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--border-default, #e5e7eb);
   flex-shrink: 0;
 }
 
@@ -811,7 +811,7 @@ onMounted(() => {
   font-weight: 500;
   border: none;
   background: none;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   cursor: pointer;
   border-bottom: 2px solid transparent;
   transition: color 0.15s, border-color 0.15s;
@@ -823,7 +823,7 @@ onMounted(() => {
 }
 
 .tab-btn:hover:not(.active) {
-  color: var(--color-text);
+  color: var(--text-primary);
 }
 
 .tab-content {
@@ -844,7 +844,7 @@ onMounted(() => {
 .section-label {
   font-size: 0.75rem;
   font-weight: 600;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -861,8 +861,8 @@ onMounted(() => {
   padding: 0.5rem;
   border: 1px solid var(--color-primary, #3b82f6);
   border-radius: 0.375rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
   font-size: 0.875rem;
   resize: vertical;
 }
@@ -883,7 +883,7 @@ onMounted(() => {
 
 .ac-done {
   text-decoration: line-through;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .comments-list {
@@ -932,7 +932,7 @@ onMounted(() => {
 
 .comment-time {
   font-size: 0.7rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
 }
 
 .agent-chip {
@@ -955,16 +955,16 @@ onMounted(() => {
   align-items: flex-end;
   flex-shrink: 0;
   padding-top: 0.5rem;
-  border-top: 1px solid var(--color-border, #e5e7eb);
+  border-top: 1px solid var(--border-default, #e5e7eb);
 }
 
 .comment-textarea {
   flex: 1;
   padding: 0.5rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--border-default, #d1d5db);
   border-radius: 0.375rem;
-  background: var(--color-surface, #fff);
-  color: var(--color-text);
+  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
   font-size: 0.875rem;
   resize: none;
 }
@@ -981,9 +981,9 @@ onMounted(() => {
   align-items: center;
   gap: 0.75rem;
   padding: 0.5rem 0.75rem;
-  background: var(--color-surface-elevated, #f9fafb);
+  background: var(--bg-elevated, #f9fafb);
   border-radius: 0.375rem;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: 1px solid var(--border-default, #e5e7eb);
 }
 
 .artifact-type-icon {
@@ -1004,7 +1004,7 @@ onMounted(() => {
 
 .artifact-type-label {
   font-size: 0.7rem;
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   text-transform: capitalize;
 }
 
@@ -1026,7 +1026,7 @@ onMounted(() => {
 }
 
 .activity-time {
-  color: var(--color-text-secondary, #9ca3af);
+  color: var(--text-secondary, #9ca3af);
   flex-shrink: 0;
   font-size: 0.7rem;
 }
@@ -1037,7 +1037,7 @@ onMounted(() => {
 }
 
 .activity-text {
-  color: var(--color-text);
+  color: var(--text-primary);
 }
 
 .handoff-brief {

--- a/autobot-frontend/src/views/transcriber/TranscriptView.vue
+++ b/autobot-frontend/src/views/transcriber/TranscriptView.vue
@@ -134,7 +134,7 @@ onMounted(load)
   align-items: center;
   gap: 0.75rem;
   padding: 2rem;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   text-align: center;
 }
 

--- a/autobot-frontend/src/views/voice/VoiceBundleInfo.vue
+++ b/autobot-frontend/src/views/voice/VoiceBundleInfo.vue
@@ -79,7 +79,7 @@ onMounted(() => {
   align-items: center;
   gap: var(--spacing-2);
   font-size: var(--text-sm);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .vbi-error {
@@ -97,7 +97,7 @@ onMounted(() => {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .vbi-value {
@@ -109,17 +109,17 @@ onMounted(() => {
 .vbi-bundle-name {
   font-size: var(--text-base);
   font-weight: 600;
-  color: var(--color-text, #111827);
+  color: var(--text-primary, #111827);
 }
 
 .vbi-tool-count {
   font-size: var(--text-sm);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 .vbi-resolution {
   font-size: var(--text-xs);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   display: flex;
   align-items: center;
   gap: var(--spacing-1);
@@ -145,6 +145,6 @@ onMounted(() => {
 
 .vbi-res--global_env {
   background: var(--color-surface-alt, #f9fafb);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 </style>


### PR DESCRIPTION
## Thinking Path
~450+ CSS refs across views/components used a `--color-*` namespace that **no** theme defines. `var(--color-text-secondary, #9ca3af)` silently fell back to the hardcoded hex and never responded to `data-theme` switching, so views rendered light-mode inside a dark app. Fix = rename the property NAME to the canonical semantic token that dark/light/ember actually define (`--text-secondary`, `--bg-surface`, `--border-default`, …), keeping the hex fallback untouched so the diff is a pure rename. Also added the shared `@utility` classes that views referenced but were never defined (silently-unstyled views + broken modals).

## What Changed
- Boundary-aware exact rename of 12 token names in `<style>` blocks of `src/views/**` + `src/components/**` (longest-first, negative-lookahead so sub-variants are untouched):
  - `--color-text-secondary`→`--text-secondary`, `--color-text-primary`→`--text-primary`, `--color-text-muted`→`--text-muted`
  - `--color-surface-elevated`/`--color-bg-elevated`→`--bg-elevated`, `--color-surface-hover`→`--bg-hover`, `--color-bg-primary`/`--color-background`→`--bg-primary`
  - `--color-text`→`--text-primary`, `--color-surface`→`--bg-surface`, `--color-border`→`--border-default`, `--color-danger`→`--color-error`
- **628 refs migrated across 53 `.vue` files.** Hex fallbacks preserved.
- `src/assets/tailwind.css`: added missing `@utility` classes — `form-input` (alias of `input-field`), `form-group`, `btn-icon`, `btn-sm`, and `modal-overlay`/`modal`/`modal-header`/`modal-body`/`modal-footer` primitives (all theme-token-driven, mirroring existing `btn`/`card`/`input-field`). None previously existed.

## Verification
- `npx vue-tsc --noEmit -p tsconfig.app.json`: 8 errors, all in generated files (`types/api-contract.ts`, `types/generated/api.ts`) — pre-existing on base, **0 in any touched `.vue` file**. Delta 0 (CSS-var renames don't affect TS).
- `npm run build`: ✓ 2556 modules transformed, built in 10.9s — confirms the new `@apply input-field` alias + modal utilities compile.
- eslint on 6 changed files: 0 errors, 1 pre-existing warning (unused i18n `t` in CapabilityAuditLog script — not touched by this rename).
- Spot-checked CostDashboard / ApiKeySetupWizard / ConfirmDialog / BoardsView — every renamed var now matches a token defined in dark/light/ember.

### Deferred to C1b (NOT touched here)
- Sub-variant `--color-*` families with no listed target: `--color-text-tertiary`, `--color-surface-secondary`/`-alt`/`-2`, `--color-border-hover`, `--color-bg-*` family (`-card/-input/-secondary/-tertiary/-subtle/-hover`), `--color-background-hover`/`-secondary`/`-input`, `--color-danger-bg`/`-border`/`-dark`/`-hover`/`-subtle`/`-600`.
- Tailwind-palette tokens (`--color-red-100`, `--color-blue-600`, `--color-purple-500` …) — need per-use semantic judgment.
- Literal hardcoded-hex badge palettes (WorkItemDetail/KanbanBoard/BoardsView/OnboardingWizard).
- `dark:`-prefix classes (ExperimentDashboard) — app themes via `data-theme`, not `dark:`.

## Model Used
Opus 4.8 (1M context)

Part of #10750 (C1)