### PR TITLE
fix(rbac): record org_id on permission-denied audit entries (#10763)

### DIFF
--- a/autobot-slm-backend/tests/test_rbac_permission_denied_audit.py
+++ b/autobot-slm-backend/tests/test_rbac_permission_denied_audit.py
@@ -198,3 +198,32 @@ class TestEmitPermissionDeniedAudit:
         entry = added_entries[0]
         assert entry.ip_address is None
         assert entry.user_agent is None
+
+    @pytest.mark.asyncio
+    async def test_org_id_is_recorded_on_entry(self):
+        """org_id passed by the caller is written to the AuditLog row."""
+        user_id = uuid.uuid4()
+        org_id = uuid.uuid4()
+
+        added_entries = []
+        session = MagicMock()
+        session.add = MagicMock(side_effect=added_entries.append)
+
+        with patch.object(_rbac_mod, "db_session_context", return_value=_make_session_ctx(session)):
+            await _rbac_mod._emit_permission_denied_audit(user_id, "admin.read", "/admin", org_id=org_id)
+
+        assert len(added_entries) == 1
+        assert added_entries[0].org_id == org_id
+
+    @pytest.mark.asyncio
+    async def test_none_org_id_is_accepted(self):
+        """org_id=None (platform-level or anonymous context) must not crash the audit call."""
+        added_entries = []
+        session = MagicMock()
+        session.add = MagicMock(side_effect=added_entries.append)
+
+        with patch.object(_rbac_mod, "db_session_context", return_value=_make_session_ctx(session)):
+            await _rbac_mod._emit_permission_denied_audit(uuid.uuid4(), "users.write", "/api/users", org_id=None)
+
+        assert len(added_entries) == 1
+        assert added_entries[0].org_id is None

--- a/autobot-slm-backend/user_management/middleware/rbac_middleware.py
+++ b/autobot-slm-backend/user_management/middleware/rbac_middleware.py
@@ -375,6 +375,7 @@ async def _emit_permission_denied_audit(
     permission: str,
     path: str,
     *,
+    org_id: uuid.UUID | None = None,
     ip_address: str | None = None,
     user_agent: str | None = None,
 ) -> None:
@@ -384,12 +385,13 @@ async def _emit_permission_denied_audit(
     denial is never silently lost.  A DB failure is caught, logged as an error,
     and does NOT propagate — the caller's 403 is unaffected.
     """
-    logger.warning("Permission denied: user=%s permission=%s path=%s", user_id, permission, path)
+    logger.warning("Permission denied: user=%s org=%s permission=%s path=%s", user_id, org_id, permission, path)
     try:
         async with db_session_context() as session:
             entry = AuditLog(
                 id=uuid.uuid4(),
                 user_id=user_id,
+                org_id=org_id,
                 action=AuditAction.PERMISSION_DENIED,
                 resource_type=AuditResourceType.ENDPOINT,
                 outcome="denied",
@@ -428,6 +430,7 @@ def require_permission(permission: str):
                     user_id,
                     perm_str,
                     str(request.url.path),
+                    org_id=org_id,
                     ip_address=request.client.host if request.client else None,
                     user_agent=request.headers.get("user-agent"),
                 )
@@ -460,6 +463,7 @@ def require_any_permission(permissions: List[str]):
                     user_id,
                     str(perm_strs),
                     str(request.url.path),
+                    org_id=org_id,
                     ip_address=request.client.host if request.client else None,
                     user_agent=request.headers.get("user-agent"),
                 )
@@ -492,6 +496,7 @@ def require_all_permissions(permissions: List[str]):
                     user_id,
                     str(perm_strs),
                     str(request.url.path),
+                    org_id=org_id,
                     ip_address=request.client.host if request.client else None,
                     user_agent=request.headers.get("user-agent"),
                 )


### PR DESCRIPTION
## Thinking Path
Follow-up to #10719 (umbrella #10714). `_emit_permission_denied_audit` wrote AuditLog rows with `org_id = NULL`, making the `idx_audit_org_created` (org_id, created_at) index useless for denial events — even though `_extract_user_context` already returns org_id.

## What Changed
- `rbac_middleware.py`: `_emit_permission_denied_audit` gains keyword-only `org_id: uuid.UUID | None = None`, forwarded to `AuditLog(org_id=...)`; all 3 decorators (require_permission/any/all) pass the `org_id` they already unpack. Nullable-safe. Failure-isolation unchanged.

## Verification
- 7 tests pass (5 existing + 2 new: org_id recorded; None org_id accepted).
- `py_compile` + flake8 clean.

Closes #10763.

## Model Used
Claude Opus 4.8 (1M context)