### PR TITLE
fix(backend): knowledge-maintenance cleanup signature + durable JWT signing key (#10750 E1,E2)

### DIFF
--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -9,8 +9,10 @@ Provides JWT-based authentication, session management, and role-based access con
 
 import datetime
 import json
+import os
 import secrets
 from datetime import timezone
+from pathlib import Path
 from typing import Dict, Tuple
 
 from fastapi import HTTPException, Request, status
@@ -114,16 +116,30 @@ class AuthenticationMiddleware:
             # Still return the secure secret even if we can't store it
             return secure_secret
 
+    @staticmethod
+    def _jwt_key_file() -> Path:
+        """Return the durable RSA private key file path.
+
+        The file lives in ``{AUTOBOT_DATA_DIR}/service-keys/jwt_rsa_private.pem``,
+        which is outside the code directory (``autobot-backend/``) and therefore
+        survives code-sync rsyncs and process restarts (#10750 E2).
+        """
+        return ssot_config.path.data_path / "service-keys" / "jwt_rsa_private.pem"
+
     def _get_rs256_keypair(self) -> Tuple[str, str, str]:
         """Load or auto-generate the RS256 keypair for signing user JWTs (#10196).
 
         Priority order:
-        1. ``AUTOBOT_JWT_PRIVATE_KEY`` env var (PEM string)
-        2. Auto-generate a 2048-bit RSA keypair, persist in security config
-           (mirrors the existing HS256 generated-secret pattern)
+        1. ``AUTOBOT_JWT_PRIVATE_KEY`` env var (PEM string) — highest precedence.
+        2. Durable key file at ``{AUTOBOT_DATA_DIR}/service-keys/jwt_rsa_private.pem``
+           — survives restarts and code-sync deploys (#10750 E2).
+        3. In-memory security config dict (``jwt_private_key_pem``) — written by
+           a previous process; migrated to the durable file on first access.
+        4. Auto-generate RSA-2048 and write to the durable file so the next
+           restart reuses the same key.
 
-        The public key is always derived from the private key so they are
-        guaranteed to be consistent even when only the private key is supplied.
+        The public key is always derived from the private key so the pair is
+        guaranteed to be consistent.
 
         Returns:
             Tuple of (pem_private_key, pem_public_key, kid).
@@ -133,48 +149,70 @@ class AuthenticationMiddleware:
         from cryptography.hazmat.primitives.asymmetric import rsa
 
         kid = ssot_config.misc.jwt_kid or "autobot-1"
+        key_file = self._jwt_key_file()
 
-        # 1. Check env var for private key
+        def _derive_public(private_key) -> str:
+            return private_key.public_key().public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo,
+            ).decode("utf-8")
+
+        def _load_pem(pem: str):
+            return serialization.load_pem_private_key(
+                pem.encode("utf-8"),
+                password=None,
+                backend=default_backend(),
+            )
+
+        def _write_key_file(pem: str) -> None:
+            """Write PEM to the durable file with mode 0600."""
+            try:
+                key_file.parent.mkdir(parents=True, exist_ok=True)
+                key_file.write_text(pem, encoding="utf-8")
+                os.chmod(key_file, 0o600)
+                logger.info("RS256 private key written to durable file %s", key_file)
+            except Exception as exc:
+                logger.error(
+                    "Failed to write RS256 key to %s: %s — key will be ephemeral this session",
+                    key_file,
+                    exc,
+                )
+
+        # Tier 1: env var
         pem_private = ssot_config.misc.jwt_private_key
         if pem_private:
             try:
-                private_key = serialization.load_pem_private_key(
-                    pem_private.encode("utf-8"),
-                    password=None,
-                    backend=default_backend(),
-                )
-                public_key = private_key.public_key()
-                pem_public = public_key.public_bytes(
-                    encoding=serialization.Encoding.PEM,
-                    format=serialization.PublicFormat.SubjectPublicKeyInfo,
-                ).decode("utf-8")
+                private_key = _load_pem(pem_private)
                 logger.info("RS256 private key loaded from AUTOBOT_JWT_PRIVATE_KEY")
-                return pem_private, pem_public, kid
+                return pem_private, _derive_public(private_key), kid
             except Exception as exc:
                 logger.error("Failed to load AUTOBOT_JWT_PRIVATE_KEY: %s — will auto-generate", exc)
 
-        # 2. Check security config for a previously persisted keypair
+        # Tier 2: durable file (survives restart and code-sync deploys)
+        if key_file.exists():
+            try:
+                pem_private = key_file.read_text(encoding="utf-8")
+                private_key = _load_pem(pem_private)
+                logger.info("RS256 private key loaded from durable file %s", key_file)
+                return pem_private, _derive_public(private_key), kid
+            except Exception as exc:
+                logger.warning("Durable RS256 key file %s is invalid: %s — regenerating", key_file, exc)
+
+        # Tier 3: in-memory security config (previous process wrote it without persisting to file)
         stored_pem = self.security_config.get("jwt_private_key_pem", "")
         if stored_pem:
             try:
-                private_key = serialization.load_pem_private_key(
-                    stored_pem.encode("utf-8"),
-                    password=None,
-                    backend=default_backend(),
-                )
-                public_key = private_key.public_key()
-                pem_public = public_key.public_bytes(
-                    encoding=serialization.Encoding.PEM,
-                    format=serialization.PublicFormat.SubjectPublicKeyInfo,
-                ).decode("utf-8")
-                logger.info("RS256 keypair loaded from security config (previously auto-generated)")
-                return stored_pem, pem_public, kid
+                private_key = _load_pem(stored_pem)
+                # Migrate to the durable file so the next restart reuses it
+                _write_key_file(stored_pem)
+                logger.info("RS256 keypair migrated from security config to durable file")
+                return stored_pem, _derive_public(private_key), kid
             except Exception as exc:
                 logger.warning("Stored RS256 keypair in config is invalid: %s — regenerating", exc)
 
-        # 3. Auto-generate a fresh RSA-2048 keypair and persist it
+        # Tier 4: auto-generate and persist to durable file
         logger.warning(
-            "No RS256 private key configured. Auto-generating RSA-2048 keypair. "
+            "No RS256 private key found. Auto-generating RSA-2048 keypair. "
             "Set AUTOBOT_JWT_PRIVATE_KEY to use a stable externally-managed key."
         )
         private_key = rsa.generate_private_key(
@@ -182,23 +220,14 @@ class AuthenticationMiddleware:
             key_size=2048,
             backend=default_backend(),
         )
-        public_key = private_key.public_key()
-
         pem_private = private_key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.TraditionalOpenSSL,
             encryption_algorithm=serialization.NoEncryption(),
         ).decode("utf-8")
-        pem_public = public_key.public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        ).decode("utf-8")
+        pem_public = _derive_public(private_key)
 
-        try:
-            config.set_nested("security_config.jwt_private_key_pem", pem_private)
-            logger.info("Auto-generated RS256 keypair persisted in security config")
-        except Exception as exc:
-            logger.error("Failed to persist RS256 keypair in config: %s — keypair is ephemeral", exc)
+        _write_key_file(pem_private)
 
         return pem_private, pem_public, kid
 

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -152,10 +152,14 @@ class AuthenticationMiddleware:
         key_file = self._jwt_key_file()
 
         def _derive_public(private_key) -> str:
-            return private_key.public_key().public_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PublicFormat.SubjectPublicKeyInfo,
-            ).decode("utf-8")
+            return (
+                private_key.public_key()
+                .public_bytes(
+                    encoding=serialization.Encoding.PEM,
+                    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+                )
+                .decode("utf-8")
+            )
 
         def _load_pem(pem: str):
             return serialization.load_pem_private_key(

--- a/autobot-backend/knowledge/bulk.py
+++ b/autobot-backend/knowledge/bulk.py
@@ -1245,9 +1245,7 @@ class BulkOperationsMixin:
             logger.error("Bulk category update failed: %s", e)
             return {"status": "error", "message": "Bulk operation failed"}
 
-    async def _scan_facts_for_issues(
-        self, remove_empty: bool, fix_metadata: bool
-    ) -> tuple[list[str], list[str]]:
+    async def _scan_facts_for_issues(self, remove_empty: bool, fix_metadata: bool) -> tuple[list[str], list[str]]:
         """Scan all fact keys and return (empty_fact_ids, malformed_metadata_fact_ids).
 
         Uses a single Redis pipeline pass to minimise round-trips.

--- a/autobot-backend/knowledge/bulk.py
+++ b/autobot-backend/knowledge/bulk.py
@@ -1245,32 +1245,144 @@ class BulkOperationsMixin:
             logger.error("Bulk category update failed: %s", e)
             return {"status": "error", "message": "Bulk operation failed"}
 
-    async def cleanup(self, remove_orphaned_vectors: bool = True, verify_integrity: bool = True) -> Dict[str, Any]:
+    async def _scan_facts_for_issues(
+        self, remove_empty: bool, fix_metadata: bool
+    ) -> tuple[list[str], list[str]]:
+        """Scan all fact keys and return (empty_fact_ids, malformed_metadata_fact_ids).
+
+        Uses a single Redis pipeline pass to minimise round-trips.
         """
-        Cleanup knowledge base (remove orphaned data, verify integrity).
+        empty_ids: list[str] = []
+        malformed_ids: list[str] = []
+        if not (remove_empty or fix_metadata):
+            return empty_ids, malformed_ids
+
+        fact_keys = await self._scan_redis_keys_async("fact:*")
+        if not fact_keys:
+            return empty_ids, malformed_ids
+
+        def _pipeline_hmget(keys: list[str]) -> list:
+            pipe = self.redis_client.pipeline()
+            for k in keys:
+                pipe.hmget(k, "content", "metadata")
+            return pipe.execute()
+
+        raw_pairs = await asyncio.to_thread(_pipeline_hmget, fact_keys)
+
+        for key_str, pair in zip(fact_keys, raw_pairs):
+            fact_id = key_str.split(":")[-1]
+            content_raw = pair[0] or b""
+            if isinstance(content_raw, bytes):
+                content_raw = content_raw.decode("utf-8", errors="replace")
+            metadata_raw = pair[1] or b""
+            if isinstance(metadata_raw, bytes):
+                metadata_raw = metadata_raw.decode("utf-8", errors="replace")
+
+            if remove_empty and not content_raw.strip():
+                empty_ids.append(fact_id)
+
+            if fix_metadata and metadata_raw.strip():
+                try:
+                    json.loads(metadata_raw)
+                except (json.JSONDecodeError, ValueError):
+                    malformed_ids.append(fact_id)
+
+        return empty_ids, malformed_ids
+
+    async def _find_orphaned_tags(self) -> list[str]:
+        """Return names of tags that have zero associated facts."""
+        result = await self.list_all_tags()
+        return [t["tag"] for t in result.get("tags", []) if t.get("fact_count", 1) == 0]
+
+    async def cleanup(
+        self,
+        remove_empty: bool = True,
+        remove_orphaned_tags: bool = True,
+        fix_metadata: bool = True,
+        dry_run: bool = True,
+        # Legacy kwargs — previously accepted; kept for backward compatibility
+        remove_orphaned_vectors: bool = True,
+        verify_integrity: bool = True,
+    ) -> Dict[str, Any]:
+        """Clean up the knowledge base.
+
+        Implements the full semantics expected by ``POST /knowledge-maintenance/cleanup``
+        (#10750 E1): removes empty-content facts, orphaned tags, and repairs malformed
+        metadata JSON.  When ``dry_run=True`` only counts issues without mutating data.
 
         Args:
-            remove_orphaned_vectors: Remove vectors without Redis facts
-            verify_integrity: Verify data integrity
+            remove_empty: Delete facts whose content is blank or whitespace-only.
+            remove_orphaned_tags: Delete tag index keys that reference no facts.
+            fix_metadata: Reset malformed (non-JSON) metadata fields to ``{}``.
+            dry_run: Report counts only — do not apply any fixes.
+            remove_orphaned_vectors: Legacy kwarg, accepted but unused.
+            verify_integrity: Legacy kwarg, accepted but unused.
 
         Returns:
-            Dict with cleanup results
+            Dict matching ``CleanupKnowledgeBaseResponse`` shape.
         """
         try:
-            results = {"removed_vectors": 0, "verified_facts": 0, "errors": []}
+            empty_ids, malformed_ids = await self._scan_facts_for_issues(remove_empty, fix_metadata)
+            orphaned_tag_names = await self._find_orphaned_tags() if remove_orphaned_tags else []
 
-            # Verify stats consistency if requested
-            if verify_integrity:
-                consistency = await self._verify_stats_consistency(auto_correct=True)
-                results["stats_consistency"] = consistency
+            issues_found: Dict[str, int] = {
+                "empty_facts": len(empty_ids),
+                "orphaned_tags": len(orphaned_tag_names),
+                "malformed_metadata": len(malformed_ids),
+            }
 
-            return {"status": "success", "results": results}
+            if dry_run:
+                return {
+                    "status": "success",
+                    "dry_run": True,
+                    "issues_found": issues_found,
+                    "issues_details": {
+                        "empty_fact_ids": empty_ids[:50],
+                        "orphaned_tag_names": orphaned_tag_names[:50],
+                        "malformed_fact_ids": malformed_ids[:50],
+                    },
+                    "fixes_applied": None,
+                }
+
+            # Apply fixes using existing mixin methods
+            removed_empty = 0
+            if empty_ids:
+                bulk_result = await self.bulk_delete(empty_ids)
+                removed_empty = bulk_result.get("deleted", 0)
+
+            fixed_metadata = 0
+            for fact_id in malformed_ids:
+                r = await self.update_fact(fact_id, metadata={})
+                if r.get("status") == "success":
+                    fixed_metadata += 1
+
+            removed_tags = 0
+            for tag_name in orphaned_tag_names:
+                r = await self.delete_tag_globally(tag_name)
+                if r.get("success"):
+                    removed_tags += 1
+
+            return {
+                "status": "success",
+                "dry_run": False,
+                "issues_found": issues_found,
+                "issues_details": None,
+                "fixes_applied": {
+                    "empty_facts_removed": removed_empty,
+                    "orphaned_tags_removed": removed_tags,
+                    "metadata_fixed": fixed_metadata,
+                },
+            }
 
         except Exception as e:
             logger.error("Cleanup failed: %s", e)
-            return {"status": "error", "message": "Bulk operation failed"}
+            return {"status": "error", "message": "Cleanup operation failed"}
 
     # Method references needed from other mixins
+    async def _scan_redis_keys_async(self, pattern: str) -> List[str]:
+        """Scan Redis keys by pattern — implemented in KnowledgeBaseCore."""
+        raise NotImplementedError("Should be implemented in composed class")
+
     async def get_all_facts(self):
         """Get all facts - implemented in facts mixin"""
         raise NotImplementedError("Should be implemented in composed class")
@@ -1289,6 +1401,14 @@ class BulkOperationsMixin:
 
     async def _verify_stats_consistency(self, auto_correct: bool = True):
         """Verify stats consistency - implemented in stats mixin"""
+        raise NotImplementedError("Should be implemented in composed class")
+
+    async def list_all_tags(self) -> Dict[str, Any]:
+        """List all tags with fact counts — implemented in TagsMixin."""
+        raise NotImplementedError("Should be implemented in composed class")
+
+    async def delete_tag_globally(self, tag: str) -> Dict[str, Any]:
+        """Delete a tag from the global index — implemented in TagsMixin."""
         raise NotImplementedError("Should be implemented in composed class")
 
     # ===== BACKUP AND RESTORE OPERATIONS (Issue #419) =====

--- a/autobot-backend/tests/knowledge/test_cleanup_endpoint.py
+++ b/autobot-backend/tests/knowledge/test_cleanup_endpoint.py
@@ -1,0 +1,240 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for BulkOperationsMixin.cleanup() — #10750 E1.
+
+Verifies:
+- cleanup() accepts all kwargs the endpoint sends (no TypeError regression)
+- dry_run=True returns issues_found + issues_details, fixes_applied=None
+- dry_run=False returns fixes_applied, issues_details=None
+- Empty KB returns zeroed counts
+
+Heavy dependencies (Redis, ChromaDB, llama_index) are stubbed via
+sys.modules patching so these tests run without a live backend.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub heavy imports before pulling in knowledge.bulk
+# ---------------------------------------------------------------------------
+
+for _mod in (
+    "llama_index",
+    "llama_index.core",
+    "llama_index.vector_stores",
+    "llama_index.vector_stores.chroma",
+    "llama_index.llms",
+    "llama_index.llms.ollama",
+    "llama_index.embeddings",
+    "llama_index.embeddings.ollama",
+    "chromadb",
+    "redis",
+    "redis.asyncio",
+):
+    sys.modules.setdefault(_mod, types.ModuleType(_mod))
+
+# Minimal stubs for symbols referenced at module load
+_redis_mod = sys.modules["redis"]
+_redis_mod.RedisError = Exception  # type: ignore[attr-defined]
+_redis_mod.Redis = MagicMock  # type: ignore[attr-defined]
+
+_aioredis_mod = sys.modules["redis.asyncio"]
+_aioredis_mod.Redis = MagicMock  # type: ignore[attr-defined]
+
+from knowledge.bulk import BulkOperationsMixin  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fake composed KB that drives BulkOperationsMixin without a real Redis
+# ---------------------------------------------------------------------------
+
+
+class _FakeKB(BulkOperationsMixin):
+    """Minimal KB stub exercising cleanup() with controllable in-memory data."""
+
+    def __init__(self, facts: list[dict], tags: list[dict]) -> None:
+        """
+        Args:
+            facts: List of {key, content, metadata_raw} dicts representing Redis hashes.
+            tags:  List of {tag, fact_count} dicts for list_all_tags result.
+        """
+        self._facts = facts
+        self._tags = tags
+        self.redis_client = MagicMock()
+        self._deleted: list[str] = []
+        self._updated: list[tuple[str, dict]] = []
+        self._tags_deleted: list[str] = []
+
+    # ---- abstract stubs implemented for the test ----
+
+    async def _scan_redis_keys_async(self, pattern: str) -> list[str]:
+        return [f["key"] for f in self._facts]
+
+    async def list_all_tags(self) -> dict:
+        return {"status": "success", "tags": list(self._tags)}
+
+    async def delete_tag_globally(self, tag: str) -> dict:
+        self._tags_deleted.append(tag)
+        # Remove from internal list so repeated calls work correctly
+        self._tags = [t for t in self._tags if t["tag"] != tag]
+        return {"success": True}
+
+    async def bulk_delete(self, fact_ids: list[str]) -> dict:
+        self._deleted.extend(fact_ids)
+        return {"status": "success", "deleted": len(fact_ids), "errors": 0, "total": len(fact_ids)}
+
+    async def update_fact(self, fact_id: str, **kwargs) -> dict:
+        self._updated.append((fact_id, kwargs))
+        return {"status": "success", "fact_id": fact_id}
+
+    def _schedule_bm25_refresh(self) -> None:
+        pass
+
+    # ---- pipeline mock wired to self._facts ----
+
+    def _setup_pipeline(self) -> None:
+        """Wire redis_client.pipeline() to return pairs from self._facts."""
+        results = []
+        for f in self._facts:
+            content = f.get("content", "").encode("utf-8")
+            raw_meta = f.get("metadata_raw", "")
+            meta = raw_meta.encode("utf-8") if raw_meta else b""
+            results.append([content, meta])
+
+        pipe_mock = MagicMock()
+        pipe_mock.hmget.return_value = None
+        pipe_mock.execute.return_value = results
+        self.redis_client.pipeline.return_value = pipe_mock
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _make_kb(facts=None, tags=None) -> _FakeKB:
+    kb = _FakeKB(facts or [], tags or [])
+    kb._setup_pipeline()
+    return kb
+
+
+# ---------------------------------------------------------------------------
+# Tests — dry_run=True (default)
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupDryRun:
+    @pytest.mark.asyncio
+    async def test_empty_kb_returns_zero_counts(self):
+        kb = _make_kb()
+        result = await kb.cleanup(dry_run=True)
+
+        assert result["status"] == "success"
+        assert result["dry_run"] is True
+        assert result["issues_found"] == {"empty_facts": 0, "orphaned_tags": 0, "malformed_metadata": 0}
+        assert result["fixes_applied"] is None
+
+    @pytest.mark.asyncio
+    async def test_detects_empty_content_fact(self):
+        kb = _make_kb(facts=[{"key": "fact:abc", "content": "  ", "metadata_raw": "{}"}])
+        result = await kb.cleanup(remove_empty=True, dry_run=True)
+
+        assert result["issues_found"]["empty_facts"] == 1
+        assert "abc" in result["issues_details"]["empty_fact_ids"]
+        assert result["fixes_applied"] is None
+
+    @pytest.mark.asyncio
+    async def test_detects_orphaned_tag(self):
+        kb = _make_kb(tags=[{"tag": "stale-tag", "fact_count": 0}])
+        result = await kb.cleanup(remove_orphaned_tags=True, dry_run=True)
+
+        assert result["issues_found"]["orphaned_tags"] == 1
+        assert "stale-tag" in result["issues_details"]["orphaned_tag_names"]
+
+    @pytest.mark.asyncio
+    async def test_detects_malformed_metadata(self):
+        kb = _make_kb(
+            facts=[{"key": "fact:xyz", "content": "hello", "metadata_raw": "not-json!!"}]
+        )
+        result = await kb.cleanup(fix_metadata=True, dry_run=True)
+
+        assert result["issues_found"]["malformed_metadata"] == 1
+        assert "xyz" in result["issues_details"]["malformed_fact_ids"]
+
+    @pytest.mark.asyncio
+    async def test_dry_run_does_not_mutate(self):
+        kb = _make_kb(
+            facts=[{"key": "fact:e1", "content": "", "metadata_raw": "bad"}],
+            tags=[{"tag": "ghost", "fact_count": 0}],
+        )
+        await kb.cleanup(remove_empty=True, remove_orphaned_tags=True, fix_metadata=True, dry_run=True)
+
+        assert kb._deleted == []
+        assert kb._updated == []
+        assert kb._tags_deleted == []
+
+    @pytest.mark.asyncio
+    async def test_accepts_all_endpoint_kwargs_no_type_error(self):
+        """Regression: the old signature raised TypeError on these kwargs."""
+        kb = _make_kb()
+        # Must not raise — this is the exact call the endpoint makes
+        result = await kb.cleanup(
+            remove_empty=True,
+            remove_orphaned_tags=True,
+            fix_metadata=True,
+            dry_run=True,
+        )
+        assert result["status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# Tests — dry_run=False (apply fixes)
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupApplyFixes:
+    @pytest.mark.asyncio
+    async def test_removes_empty_facts(self):
+        kb = _make_kb(facts=[{"key": "fact:empty1", "content": "", "metadata_raw": "{}"}])
+        result = await kb.cleanup(remove_empty=True, dry_run=False)
+
+        assert "empty1" in kb._deleted
+        assert result["fixes_applied"]["empty_facts_removed"] == 1
+        assert result["issues_details"] is None
+
+    @pytest.mark.asyncio
+    async def test_removes_orphaned_tags(self):
+        kb = _make_kb(tags=[{"tag": "dead-tag", "fact_count": 0}])
+        result = await kb.cleanup(remove_orphaned_tags=True, dry_run=False)
+
+        assert "dead-tag" in kb._tags_deleted
+        assert result["fixes_applied"]["orphaned_tags_removed"] == 1
+
+    @pytest.mark.asyncio
+    async def test_fixes_malformed_metadata(self):
+        kb = _make_kb(
+            facts=[{"key": "fact:bad-meta", "content": "some content", "metadata_raw": "{bad json"}]
+        )
+        result = await kb.cleanup(fix_metadata=True, dry_run=False)
+
+        assert any(fid == "bad-meta" for fid, _ in kb._updated)
+        assert result["fixes_applied"]["metadata_fixed"] == 1
+
+    @pytest.mark.asyncio
+    async def test_valid_metadata_not_touched(self):
+        kb = _make_kb(
+            facts=[{"key": "fact:ok", "content": "content", "metadata_raw": json.dumps({"k": "v"})}]
+        )
+        result = await kb.cleanup(fix_metadata=True, dry_run=False)
+
+        assert kb._updated == []
+        assert result["fixes_applied"]["metadata_fixed"] == 0

--- a/autobot-backend/tests/knowledge/test_cleanup_endpoint.py
+++ b/autobot-backend/tests/knowledge/test_cleanup_endpoint.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import json
 import sys
 import types
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -51,7 +51,6 @@ _aioredis_mod = sys.modules["redis.asyncio"]
 _aioredis_mod.Redis = MagicMock  # type: ignore[attr-defined]
 
 from knowledge.bulk import BulkOperationsMixin  # noqa: E402
-
 
 # ---------------------------------------------------------------------------
 # Fake composed KB that drives BulkOperationsMixin without a real Redis
@@ -162,9 +161,7 @@ class TestCleanupDryRun:
 
     @pytest.mark.asyncio
     async def test_detects_malformed_metadata(self):
-        kb = _make_kb(
-            facts=[{"key": "fact:xyz", "content": "hello", "metadata_raw": "not-json!!"}]
-        )
+        kb = _make_kb(facts=[{"key": "fact:xyz", "content": "hello", "metadata_raw": "not-json!!"}])
         result = await kb.cleanup(fix_metadata=True, dry_run=True)
 
         assert result["issues_found"]["malformed_metadata"] == 1
@@ -221,9 +218,7 @@ class TestCleanupApplyFixes:
 
     @pytest.mark.asyncio
     async def test_fixes_malformed_metadata(self):
-        kb = _make_kb(
-            facts=[{"key": "fact:bad-meta", "content": "some content", "metadata_raw": "{bad json"}]
-        )
+        kb = _make_kb(facts=[{"key": "fact:bad-meta", "content": "some content", "metadata_raw": "{bad json"}])
         result = await kb.cleanup(fix_metadata=True, dry_run=False)
 
         assert any(fid == "bad-meta" for fid, _ in kb._updated)
@@ -231,9 +226,7 @@ class TestCleanupApplyFixes:
 
     @pytest.mark.asyncio
     async def test_valid_metadata_not_touched(self):
-        kb = _make_kb(
-            facts=[{"key": "fact:ok", "content": "content", "metadata_raw": json.dumps({"k": "v"})}]
-        )
+        kb = _make_kb(facts=[{"key": "fact:ok", "content": "content", "metadata_raw": json.dumps({"k": "v"})}])
         result = await kb.cleanup(fix_metadata=True, dry_run=False)
 
         assert kb._updated == []

--- a/autobot-backend/tests/security/test_jwt_key_durable.py
+++ b/autobot-backend/tests/security/test_jwt_key_durable.py
@@ -1,0 +1,192 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for durable RS256 keypair persistence — #10750 E2.
+
+Root-cause tested: previously config.set_nested() stored the auto-generated key
+in-memory only; after the fix the key is written to / read from a file outside
+the code directory so it survives process restarts and code-sync rsyncs.
+
+Strategy: import the real auth_middleware module (not the conftest stub) by
+removing the stub entry from sys.modules before import, then call the
+_get_rs256_keypair() / _jwt_key_file() methods directly on a minimal stub object
+that bypasses the expensive __init__ side-effects (Redis, SecurityLayer, etc.).
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch  # noqa: F401 — patch used via patch.object
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Import the real auth_middleware module, bypassing the conftest stub.
+# conftest.py guards with ``if "auth_middleware" not in sys.modules``, so we
+# pop the stub, import the real module, then restore it after this module is
+# collected so other tests keep their stub.
+# ---------------------------------------------------------------------------
+
+
+def _load_real_auth_middleware():
+    """Return the real auth_middleware module, side-stepping the conftest stub."""
+    _saved = sys.modules.pop("auth_middleware", None)
+    try:
+        mod = importlib.import_module("auth_middleware")
+        return mod
+    finally:
+        # Restore: put the real module back so subsequent imports in THIS test
+        # file also get the real one, not the stub.
+        # Other test files that want the stub are unaffected because each
+        # pytest process collects once and conftest guards with `if not in sys.modules`.
+        sys.modules["auth_middleware"] = mod  # real module stays
+
+
+_real_auth = _load_real_auth_middleware()
+_RealAuthMW = _real_auth.AuthenticationMiddleware
+
+
+# ---------------------------------------------------------------------------
+# Minimal stub that lets us call instance methods without running __init__
+# ---------------------------------------------------------------------------
+
+
+class _MinimalMW(_RealAuthMW):
+    """Bypass __init__ — we only want to call _get_rs256_keypair()."""
+
+    def __new__(cls):
+        # Skip __init__ entirely
+        return object.__new__(cls)
+
+    def __init__(self):
+        self.security_config: dict = {}  # tier-3 in-memory config (empty)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_ssot(tmp_path: Path, jwt_private_key: str = ""):
+    """Return a context-manager that patches auth_middleware.ssot_config."""
+    mock_ssot = MagicMock()
+    mock_ssot.misc.jwt_private_key = jwt_private_key
+    mock_ssot.misc.jwt_kid = "autobot-test"
+    mock_ssot.path.data_path = tmp_path
+    return patch.object(_real_auth, "ssot_config", mock_ssot)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDurableJwtKey:
+    """_get_rs256_keypair() must produce a durable key that survives restart."""
+
+    def test_second_call_reuses_key_from_file(self, tmp_path):
+        """First call generates + writes; second call must load the same PEM."""
+        with _patch_ssot(tmp_path):
+            mw1 = _MinimalMW()
+            pem1, _, _ = mw1._get_rs256_keypair()
+
+        key_file = tmp_path / "service-keys" / "jwt_rsa_private.pem"
+        assert key_file.exists(), "durable file must be written on first call"
+
+        with _patch_ssot(tmp_path):
+            mw2 = _MinimalMW()
+            pem2, _, _ = mw2._get_rs256_keypair()
+
+        assert pem1 == pem2, (
+            "Second call must return the same private key as the first "
+            "(simulates process restart reading the durable file)"
+        )
+
+    def test_key_file_has_restricted_permissions(self, tmp_path):
+        """Key file must be written with mode 0600."""
+        with _patch_ssot(tmp_path):
+            mw = _MinimalMW()
+            mw._get_rs256_keypair()
+
+        key_file = tmp_path / "service-keys" / "jwt_rsa_private.pem"
+        assert key_file.exists()
+        mode = oct(os.stat(key_file).st_mode & 0o777)
+        assert mode == oct(0o600), f"Expected 0600, got {mode}"
+
+    def test_env_var_key_takes_precedence_over_file(self, tmp_path):
+        """When AUTOBOT_JWT_PRIVATE_KEY is set it beats the durable file."""
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        def _gen_pem() -> str:
+            k = rsa.generate_private_key(65537, 2048, default_backend())
+            return k.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.TraditionalOpenSSL,
+                serialization.NoEncryption(),
+            ).decode("utf-8")
+
+        env_pem = _gen_pem()
+        file_pem = _gen_pem()
+
+        # Pre-populate durable file with a different key
+        key_file = tmp_path / "service-keys" / "jwt_rsa_private.pem"
+        key_file.parent.mkdir(parents=True, exist_ok=True)
+        key_file.write_text(file_pem, encoding="utf-8")
+
+        with _patch_ssot(tmp_path, jwt_private_key=env_pem):
+            mw = _MinimalMW()
+            pem_result, _, _ = mw._get_rs256_keypair()
+
+        assert pem_result == env_pem, "Env var must override the durable file"
+
+    def test_invalid_file_falls_through_to_generate(self, tmp_path):
+        """Corrupt key file must be ignored and a fresh key generated."""
+        key_dir = tmp_path / "service-keys"
+        key_dir.mkdir(parents=True)
+        bad_file = key_dir / "jwt_rsa_private.pem"
+        bad_file.write_text("NOT A VALID PEM", encoding="utf-8")
+
+        with _patch_ssot(tmp_path):
+            mw = _MinimalMW()
+            pem_result, _, _ = mw._get_rs256_keypair()
+
+        assert pem_result != "NOT A VALID PEM"
+        assert "BEGIN RSA PRIVATE KEY" in pem_result or "BEGIN PRIVATE KEY" in pem_result
+
+    def test_jwt_key_file_path_uses_data_path(self, tmp_path):
+        """_jwt_key_file() must resolve under AUTOBOT_DATA_DIR/service-keys/."""
+        with _patch_ssot(tmp_path):
+            key_file = _RealAuthMW._jwt_key_file()
+
+        assert key_file == tmp_path / "service-keys" / "jwt_rsa_private.pem"
+
+    def test_in_memory_config_key_migrated_to_file(self, tmp_path):
+        """If security_config holds a jwt_private_key_pem, it must be migrated to disk."""
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        k = rsa.generate_private_key(65537, 2048, default_backend())
+        in_memory_pem = k.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        ).decode("utf-8")
+
+        with _patch_ssot(tmp_path):
+            mw = _MinimalMW()
+            mw.security_config = {"jwt_private_key_pem": in_memory_pem}
+            pem_result, _, _ = mw._get_rs256_keypair()
+
+        assert pem_result == in_memory_pem
+        key_file = tmp_path / "service-keys" / "jwt_rsa_private.pem"
+        assert key_file.exists(), "In-memory key must be migrated to the durable file"
+        assert key_file.read_text(encoding="utf-8") == in_memory_pem

--- a/autobot-backend/tests/security/test_jwt_key_durable.py
+++ b/autobot-backend/tests/security/test_jwt_key_durable.py
@@ -20,10 +20,7 @@ import importlib
 import os
 import sys
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock, patch  # noqa: F401 — patch used via patch.object
-
-import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -36,7 +33,7 @@ import pytest
 
 def _load_real_auth_middleware():
     """Return the real auth_middleware module, side-stepping the conftest stub."""
-    _saved = sys.modules.pop("auth_middleware", None)
+    sys.modules.pop("auth_middleware", None)
     try:
         mod = importlib.import_module("auth_middleware")
         return mod


### PR DESCRIPTION
## Thinking Path

**E1:** The endpoint `POST /api/knowledge-maintenance/cleanup` passed `remove_empty`, `remove_orphaned_tags`, `fix_metadata`, `dry_run` to `kb.cleanup()`, but `BulkOperationsMixin.cleanup()` only accepted `remove_orphaned_vectors` and `verify_integrity` → `TypeError` → 500. Implemented the full endpoint semantics using existing mixin APIs: `bulk_delete` for empty facts, `list_all_tags`/`delete_tag_globally` for orphaned tags, `update_fact(metadata={})` for malformed JSON; honours `dry_run` by scanning without mutating.

**E2:** `config.set_nested()` in `_get_rs256_keypair()` writes to `ConfigManager._config` (in-memory dict) but never calls `save_settings()` — confirmed in `config/sync_ops.py`. On every restart the dict is cleared and a new RSA key is generated → all live JWTs rejected. Fix: persist the auto-generated key to `{AUTOBOT_DATA_DIR}/service-keys/jwt_rsa_private.pem` (chmod 0600), which lives outside `/opt/autobot/autobot-backend/` (the rsync target) and therefore survives both process restarts and code-sync deploys.

## What Changed

### `autobot-backend/knowledge/bulk.py`
- Replaced `cleanup(remove_orphaned_vectors, verify_integrity)` with `cleanup(remove_empty, remove_orphaned_tags, fix_metadata, dry_run, ...)` — old kwargs kept as ignored backward-compat params.
- Added `_scan_facts_for_issues()`: single Redis pipeline pass to detect empty-content facts and malformed-metadata facts.
- Added `_find_orphaned_tags()`: delegates to `list_all_tags()` (TagsMixin).
- Added abstract stubs for `_scan_redis_keys_async`, `list_all_tags`, `delete_tag_globally`.
- Response shape matches `CleanupKnowledgeBaseResponse`: `issues_found` + `issues_details` (dry_run) or `fixes_applied` (live).

### `autobot-backend/auth_middleware.py`
- Added `from pathlib import Path` and `import os` imports.
- Extracted `_jwt_key_file()` static method: returns `ssot_config.path.data_path / "service-keys" / "jwt_rsa_private.pem"`.
- `_get_rs256_keypair()` now has four tiers: (1) `AUTOBOT_JWT_PRIVATE_KEY` env, (2) durable file, (3) in-memory security_config (migrates to file), (4) auto-generate + write to file with `chmod 0600`.

### New tests
- `tests/knowledge/test_cleanup_endpoint.py`: 10 tests covering dry_run detection, apply-fixes, no-mutation guard, and regression against the old TypeError.
- `tests/security/test_jwt_key_durable.py`: 6 tests covering key reuse across restarts, file permissions, env-var precedence, corrupt-file fallthrough, and in-memory migration.

## Verification

```
python3 -m py_compile autobot-backend/auth_middleware.py      # OK
python3 -m py_compile autobot-backend/knowledge/bulk.py       # OK
python3 -m py_compile autobot-backend/tests/knowledge/test_cleanup_endpoint.py  # OK
python3 -m py_compile autobot-backend/tests/security/test_jwt_key_durable.py    # OK

pytest tests/knowledge/test_cleanup_endpoint.py tests/security/test_jwt_key_durable.py -v
# 16 passed in 1.24s

pytest tests/security/ tests/api/test_auth_login_bypass.py tests/api/test_auth_validate_rbac.py -v
# 55 passed, 1 warning
```

## Model Used

claude-sonnet-4-6

Part of #10750 (E1, E2)