### PR TITLE
test(hardware): replace deprecated get_event_loop().run_until_complete (#10744)

### DIFF
--- a/autobot-backend/tests/test_monitoring_hardware.py
+++ b/autobot-backend/tests/test_monitoring_hardware.py
@@ -12,20 +12,13 @@ Verifies that:
 3. Backward-compatible 'available' key is always present in every response.
 """
 
-import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Fixtures / shared payloads
 # ---------------------------------------------------------------------------
-
-
-def _run(coro):
-    """Run a coroutine synchronously."""
-    return asyncio.get_event_loop().run_until_complete(coro)
-
 
 GPU_DETECTED = {
     "available": True,
@@ -53,51 +46,51 @@ FALLBACK_NPU = {"available": False, "error": "Detection failed"}
 class TestGetGpuStatus:
     """Unit tests for HardwareMonitorStub.get_gpu_status."""
 
-    def test_proxies_detected_gpu(self):
+    async def test_proxies_detected_gpu(self):
         """When GPU is detected the response includes available=True + real fields."""
         from api.monitoring_hardware import HardwareMonitorStub
 
         stub = HardwareMonitorStub()
         with patch("api.monitoring_hardware._detect_gpu_sync", return_value=GPU_DETECTED):
-            result = _run(stub.get_gpu_status())
+            result = await stub.get_gpu_status()
 
         assert result["available"] is True
         assert result["vendor"] == "NVIDIA"
         assert "RTX 4070" in result["devices"][0]
 
-    def test_proxies_absent_gpu(self):
+    async def test_proxies_absent_gpu(self):
         """When no GPU is detected available=False is returned cleanly."""
         from api.monitoring_hardware import HardwareMonitorStub
 
         stub = HardwareMonitorStub()
         with patch("api.monitoring_hardware._detect_gpu_sync", return_value=GPU_ABSENT):
-            result = _run(stub.get_gpu_status())
+            result = await stub.get_gpu_status()
 
         assert result["available"] is False
         assert "error" not in result
 
-    def test_never_raises_on_detection_error(self):
+    async def test_never_raises_on_detection_error(self):
         """get_gpu_status must never propagate an exception from _detect_gpu_sync."""
         from api.monitoring_hardware import HardwareMonitorStub
 
         stub = HardwareMonitorStub()
         with patch("api.monitoring_hardware._detect_gpu_sync", side_effect=RuntimeError("boom")):
             try:
-                result = _run(stub.get_gpu_status())
+                result = await stub.get_gpu_status()
                 # asyncio.to_thread can reraise; if the method itself doesn't
                 # swallow it the test catches it below.
                 assert "available" in result
             except Exception:
                 pytest.fail("get_gpu_status raised — it must never propagate exceptions")
 
-    def test_available_key_always_present(self):
+    async def test_available_key_always_present(self):
         """'available' key must exist whether GPU is present or absent."""
         from api.monitoring_hardware import HardwareMonitorStub
 
         stub = HardwareMonitorStub()
         for payload in (GPU_DETECTED, GPU_ABSENT, FALLBACK_GPU):
             with patch("api.monitoring_hardware._detect_gpu_sync", return_value=payload):
-                result = _run(stub.get_gpu_status())
+                result = await stub.get_gpu_status()
             assert "available" in result, f"'available' missing for payload={payload}"
 
 
@@ -109,49 +102,49 @@ class TestGetGpuStatus:
 class TestGetNpuStatus:
     """Unit tests for HardwareMonitorStub.get_npu_status."""
 
-    def test_proxies_detected_npu(self):
+    async def test_proxies_detected_npu(self):
         """When NPU is detected the response includes available=True + real fields."""
         from api.monitoring_hardware import HardwareMonitorStub
 
         stub = HardwareMonitorStub()
         with patch("api.monitoring_hardware._detect_npu_sync", return_value=NPU_DETECTED):
-            result = _run(stub.get_npu_status())
+            result = await stub.get_npu_status()
 
         assert result["available"] is True
         assert result["openvino_support"] is True
         assert "NPU" in result["devices"]
 
-    def test_proxies_absent_npu(self):
+    async def test_proxies_absent_npu(self):
         """When no NPU is detected available=False is returned cleanly."""
         from api.monitoring_hardware import HardwareMonitorStub
 
         stub = HardwareMonitorStub()
         with patch("api.monitoring_hardware._detect_npu_sync", return_value=NPU_ABSENT):
-            result = _run(stub.get_npu_status())
+            result = await stub.get_npu_status()
 
         assert result["available"] is False
         assert "error" not in result
 
-    def test_never_raises_on_detection_error(self):
+    async def test_never_raises_on_detection_error(self):
         """get_npu_status must never propagate an exception from _detect_npu_sync."""
         from api.monitoring_hardware import HardwareMonitorStub
 
         stub = HardwareMonitorStub()
         with patch("api.monitoring_hardware._detect_npu_sync", side_effect=RuntimeError("boom")):
             try:
-                result = _run(stub.get_npu_status())
+                result = await stub.get_npu_status()
                 assert "available" in result
             except Exception:
                 pytest.fail("get_npu_status raised — it must never propagate exceptions")
 
-    def test_available_key_always_present(self):
+    async def test_available_key_always_present(self):
         """'available' key must exist whether NPU is present or absent."""
         from api.monitoring_hardware import HardwareMonitorStub
 
         stub = HardwareMonitorStub()
         for payload in (NPU_DETECTED, NPU_ABSENT, FALLBACK_NPU):
             with patch("api.monitoring_hardware._detect_npu_sync", return_value=payload):
-                result = _run(stub.get_npu_status())
+                result = await stub.get_npu_status()
             assert "available" in result, f"'available' missing for payload={payload}"
 
 


### PR DESCRIPTION
## Thinking Path
Follow-up from #10741 review (umbrella #10714). `test_monitoring_hardware.py` used `asyncio.get_event_loop().run_until_complete` — deprecated on 3.12+ and brittle on the py3.14 track.

## What Changed
- Converted the 8 async-method tests to bare `async def` + `await` (repo's `pytest.ini` has `asyncio_mode=auto`); removed the `_run` helper + `import asyncio`. The 6 sync-function tests unchanged.

## Verification
- 14 tests before/after, all pass; no DeprecationWarning (verified with `-W error::DeprecationWarning`).
- flake8 clean.

Closes #10744.

## Model Used
Claude Opus 4.8 (1M context)