### PR TITLE
fix(types): clear vue-tsc-baseline — drop dead api-contract search aliases + dedupe get_system_health operationId (#10776)

### DIFF
--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -262,10 +262,24 @@ async def get_frontend_config(admin_check: bool = Depends(check_admin_permission
 
 # #10502: include HEAD so the frontend ServiceDiscovery liveness probe
 # (HEAD /api/system/health) resolves instead of 405 → false "backend offline".
-@router.api_route("/health", methods=["GET", "HEAD"], response_model=SystemHealthResponse)
-@router.api_route(
-    "/system/health", methods=["GET", "HEAD"], response_model=SystemHealthResponse
-)  # Frontend compatibility alias
+# #10776: split GET/HEAD into single-method routes with distinct explicit
+# operation_ids. A single api_route carrying both methods makes FastAPI reuse
+# ONE unique_id for both operations, producing a colliding operationId that
+# openapi-typescript emits twice (duplicate identifier → vue-tsc-baseline red).
+@router.api_route("/health", methods=["GET"], response_model=SystemHealthResponse, operation_id="get_system_health")
+@router.api_route("/health", methods=["HEAD"], response_model=SystemHealthResponse, operation_id="head_system_health")
+@router.api_route(  # Frontend compatibility alias
+    "/system/health",
+    methods=["GET"],
+    response_model=SystemHealthResponse,
+    operation_id="get_system_health_alias",
+)
+@router.api_route(  # Frontend compatibility alias
+    "/system/health",
+    methods=["HEAD"],
+    response_model=SystemHealthResponse,
+    operation_id="head_system_health_alias",
+)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="get_system_health",

--- a/autobot-frontend/src/types/api-contract.ts
+++ b/autobot-frontend/src/types/api-contract.ts
@@ -272,18 +272,6 @@ export type TestCategoriesResponse = components['schemas']['TestCategoriesRespon
 /** `POST /search` response. */
 export type KnowledgeSearchResponse = components['schemas']['KnowledgeSearchResponse']
 
-/** `POST /search/enhanced` response. */
-export type EnhancedSearchResponse = components['schemas']['EnhancedSearchResponse']
-
-/** `POST /search/rag` response. */
-export type RagSearchResponse = components['schemas']['RagSearchResponse']
-
-/** `POST /search/similarity` response. */
-export type SimilaritySearchResponse = components['schemas']['SimilaritySearchResponse']
-
-/** `POST /search/enhanced/v2` response. */
-export type EnhancedSearchV2Response = components['schemas']['EnhancedSearchV2Response']
-
 /** `GET /search/analytics` response. */
 export type SearchAnalyticsResponse = components['schemas']['SearchAnalyticsResponse']
 

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -1924,7 +1924,7 @@ export interface paths {
          *     Probe execution is bounded at ~2s by the registry's per-probe timeout,
          *     so the uncached aggregator is acceptable on its own.
          */
-        get: operations["get_system_health_api_system_system_health_head"];
+        get: operations["get_system_health_alias"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1947,7 +1947,7 @@ export interface paths {
          *     Probe execution is bounded at ~2s by the registry's per-probe timeout,
          *     so the uncached aggregator is acceptable on its own.
          */
-        head: operations["get_system_health_api_system_system_health_head"];
+        head: operations["head_system_health_alias"];
         patch?: never;
         trace?: never;
     };
@@ -1976,7 +1976,7 @@ export interface paths {
          *     Probe execution is bounded at ~2s by the registry's per-probe timeout,
          *     so the uncached aggregator is acceptable on its own.
          */
-        get: operations["get_system_health_api_system_health_head"];
+        get: operations["get_system_health"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1999,7 +1999,7 @@ export interface paths {
          *     Probe execution is bounded at ~2s by the registry's per-probe timeout,
          *     so the uncached aggregator is acceptable on its own.
          */
-        head: operations["get_system_health_api_system_health_head"];
+        head: operations["head_system_health"];
         patch?: never;
         trace?: never;
     };
@@ -2744,6 +2744,11 @@ export interface paths {
         /**
          * Get Telemetry Settings
          * @description Get current telemetry settings (Issue #9035).
+         *
+         *     Public: returns only global, non-sensitive telemetry config (enabled flags +
+         *     first-run-prompt state). Checked at app load before auth is established, so
+         *     gating it behind get_current_user caused spurious 401s (#10750 A13). The
+         *     consent-changing POST /telemetry remains authenticated.
          *
          *     Returns telemetry opt-in/opt-out status and whether the first-run
          *     prompt has been shown.
@@ -34138,6 +34143,10 @@ export interface paths {
          * Get Version
          * @description Get application version and system information
          *
+         *     Public: returns only version/build/environment/services_count/name (no
+         *     sensitive data). Called at app load before auth, so requiring admin caused
+         *     spurious 401s (#10750 A13).
+         *
          *     Issue #744: Requires admin authentication.
          */
         get: operations["get_version_api_services_version_get"];
@@ -60462,7 +60471,7 @@ export interface components {
             /**
              * Codebase Path
              * @description Path to codebase to index
-             * @default /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-10746-b16
+             * @default /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-10776
              */
             codebase_path: string;
             /**
@@ -74398,7 +74407,7 @@ export interface components {
              * Source Paths
              * @description Paths to populate from
              * @default [
-             *       "/home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-10746-b16"
+             *       "/home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-10776"
              *     ]
              */
             source_paths: string[];
@@ -82510,7 +82519,7 @@ export interface components {
             /**
              * Path
              * @description Path to analyze (defaults to project root)
-             * @default /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-10746-b16
+             * @default /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-10776
              */
             path: string;
             /**
@@ -89043,7 +89052,7 @@ export interface components {
              * Scan Paths
              * @description Paths to scan
              * @default [
-             *       "/home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-10746-b16"
+             *       "/home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-10776"
              *     ]
              */
             scan_paths: string[];
@@ -94017,7 +94026,7 @@ export interface components {
             /**
              * Test Path
              * @description Path to test directory
-             * @default /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-10746-b16/autobot-backend
+             * @default /home/martins/AutoBot-Ai/AutoBot-AI/.worktrees/issue-10776/autobot-backend
              */
             test_path: string;
             /**
@@ -101950,7 +101959,7 @@ export interface operations {
             };
         };
     };
-    get_system_health_api_system_system_health_head: {
+    get_system_health_alias: {
         parameters: {
             query?: never;
             header?: never;
@@ -101970,7 +101979,7 @@ export interface operations {
             };
         };
     };
-    get_system_health_api_system_system_health_head: {
+    head_system_health_alias: {
         parameters: {
             query?: never;
             header?: never;
@@ -101990,7 +101999,7 @@ export interface operations {
             };
         };
     };
-    get_system_health_api_system_health_head: {
+    get_system_health: {
         parameters: {
             query?: never;
             header?: never;
@@ -102010,7 +102019,7 @@ export interface operations {
             };
         };
     };
-    get_system_health_api_system_health_head: {
+    head_system_health: {
         parameters: {
             query?: never;
             header?: never;


### PR DESCRIPTION
## Thinking Path

`vue-tsc-baseline` was red on `Dev_new_gui` with 8 errors from two independent root causes: 4 dead type aliases in `api-contract.ts` referencing schema keys removed by the #10746 ai-stack refactor, and 4 duplicate-identifier errors in the generated `api.ts` caused by a single `api_route` decorator carrying both GET and HEAD (FastAPI reuses ONE `unique_id` across both method-operations → colliding operationId emitted twice by openapi-typescript). Fixed both at source and regenerated the types.

## What Changed

- **`autobot-frontend/src/types/api-contract.ts`** — deleted 4 dead aliases (`EnhancedSearchResponse`, `RagSearchResponse`, `SimilaritySearchResponse`, `EnhancedSearchV2Response`). These aliased `components['schemas'][...]` keys that no longer exist after #10746 removed/renamed the `/search/enhanced`, `/search/similarity`, `/search/enhanced/v2` routes and reshaped `/search/rag`. `git grep` confirmed no consumer imports them from `@/types/api-contract`. The real `RagSearchResponse` used by `KnowledgeSearch.vue` is a separate local interface in `KnowledgeRepository.ts:69` and is untouched.
- **`autobot-backend/api/system.py`** — split the stacked `@router.api_route("/health"/"/system/health", methods=["GET","HEAD"])` decorators into four single-method routes with distinct explicit `operation_id`s (`get_system_health`, `head_system_health`, `get_system_health_alias`, `head_system_health_alias`). Both paths still expose GET and HEAD; the HEAD on `/api/system/health` is the frontend liveness probe (#10502).
- **`autobot-frontend/src/types/generated/api.ts`** — regenerated from the fresh OpenAPI dump (openapi-typescript 7.13.0).

## Verification

- `cd autobot-frontend && npx vue-tsc --noEmit -p tsconfig.app.json` → **8 errors → 0 errors**
- OpenAPI regen: `get_system_health` "Duplicate Operation ID" warning gone; all four operationIds unique across both paths/methods
- `black --line-length=120` reformatted `system.py`; `flake8 --config=.flake8` clean
- `python3 -m pytest autobot-backend/tests/test_startup_imports.py -q` → **339 passed**
- Regenerated `api.ts` confirms `/api/system/health` and `/api/system/system/health` each still expose GET + HEAD

## Model Used

Claude Opus 4.8 (1M context)

Closes #10776