### PR TITLE
fix(scripts): await now-async record_api_call in phase migration scripts (#10798)

### DIFF
--- a/autobot-infrastructure/shared/scripts/test_phase2_migration.py
+++ b/autobot-infrastructure/shared/scripts/test_phase2_migration.py
@@ -61,7 +61,7 @@ async def test_phase2_migration():
     claude_monitor = ClaudeAPIMonitor()
 
     # Record API call (should push to Prometheus)
-    claude_monitor.record_api_call(
+    await claude_monitor.record_api_call(
         payload_size=1024,
         response_size=512,
         response_time=0.5,

--- a/autobot-infrastructure/shared/scripts/test_phase5_cleanup.py
+++ b/autobot-infrastructure/shared/scripts/test_phase5_cleanup.py
@@ -14,6 +14,7 @@ Validates that:
 5. Grafana integration is functional
 """
 
+import asyncio
 import sys
 import warnings
 from pathlib import Path
@@ -164,7 +165,7 @@ def test_claude_api_monitor_deprecation():
         warnings.simplefilter("always")
         from monitoring.claude_api_monitor import record_api_call
 
-        record_api_call(payload_size=100)
+        asyncio.run(record_api_call(payload_size=100))
         deprecation_warnings = [warning for warning in w if issubclass(warning.category, DeprecationWarning)]
         if deprecation_warnings:
             print("  ✅ record_api_call() emits DeprecationWarning")


### PR DESCRIPTION
## Thinking Path
Follow-up to #10797. After #10721 made `record_api_call` async, two manual migration scripts called it synchronously → un-awaited coroutine (no-op + RuntimeWarning), and phase5's DeprecationWarning assertion silently never fired.

## What Changed
- `test_phase2_migration.py:64` — added `await` (call was already inside an `async def`).
- `test_phase5_cleanup.py` — `import asyncio` + `asyncio.run(record_api_call(...))` (sync caller) so the coroutine actually runs and the `DeprecationWarning` fires → the `catch_warnings` assertion now works as intended.
- Confirmed zero `.github/` references (manual scripts).

## Verification
- `py_compile` + flake8 clean; black/isort unchanged.

Closes #10798.

## Model Used
Claude Opus 4.8 (1M context)