### PR TITLE
test(analytics): exercise real analyze_diff for gather-ordering coverage (#10814)

### DIFF
--- a/autobot-backend/api/analytics_code_review_test.py
+++ b/autobot-backend/api/analytics_code_review_test.py
@@ -15,7 +15,7 @@ Tests the following functionality:
 import sys
 import types
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -178,74 +178,118 @@ class TestSourceIdGuardLogic:
 
 
 class TestAnalyzeDiffGather:
-    """Tests for analyze_diff gather refactor (Issue #10811).
+    """Tests for analyze_diff gather ordering (Issues #10811 / #10814).
 
-    Verifies that the two gather points in analyze_diff produce the same result
-    as the previous sequential version:
-    1. source_root + diff_content resolved in parallel, both values present.
-    2. redis.set + redis.lpush run in parallel; ltrim + expire follow lpush.
+    Both tests call the REAL analyze_diff with mocked I/O dependencies so that
+    a regression in the gather structure (e.g. collapsing both gathers into one)
+    is detected by these tests rather than silently passing.
+
+    Gather sites under test:
+    1. source_root + diff_content — both obtained inside the first gather.
+    2. redis.set + redis.lpush — first gather; redis.ltrim + redis.expire — second
+       gather (the second gather depends on lpush having created the list key first).
     """
 
     @pytest.mark.asyncio
     async def test_source_root_and_diff_content_both_resolved(self):
-        """Both source_root and diff_content must be populated after the gather."""
-        import asyncio
+        """Real analyze_diff must call both _resolve_source_root_or_404 and get_git_diff (site 1 gather)."""
+        resolve_calls: list = []
+        diff_calls: list = []
 
-        results = {}
-
-        async def fake_resolve_root(source_id):
-            results["source_root_called"] = True
+        async def fake_resolve(source_id):
+            resolve_calls.append(source_id)
             return None
 
         async def fake_get_diff(commit_range):
-            results["diff_called"] = True
-            return ""
+            diff_calls.append(commit_range)
+            return ""  # empty diff → early no_data return; Redis section not entered
 
-        source_root, diff_content = await asyncio.gather(
-            fake_resolve_root(None),
-            fake_get_diff(None),
-        )
+        with (
+            patch("api.analytics_code_review._resolve_source_root_or_404", fake_resolve),
+            patch("api.analytics_code_review.get_git_diff", fake_get_diff),
+        ):
+            from api.analytics_code_review import analyze_diff
 
-        assert results.get("source_root_called")
-        assert results.get("diff_called")
-        assert source_root is None
-        assert diff_content == ""
+            result = await analyze_diff(admin_check=True, commit_range=None, source_id=None)
+
+        assert len(resolve_calls) == 1, "_resolve_source_root_or_404 not called by analyze_diff"
+        assert len(diff_calls) == 1, "get_git_diff not called by analyze_diff"
+        assert result["status"] == "no_data"
 
     @pytest.mark.asyncio
     async def test_redis_persist_call_order(self):
-        """set+lpush run in parallel; ltrim+expire only after lpush completes."""
-        import asyncio
+        """lpush must be fully committed before ltrim and expire start (two-gather contract)."""
+        import asyncio as real_asyncio
 
-        call_log = []
+        # A minimal diff whose file path does not exist on disk — parse_diff produces
+        # one entry but file_path.exists() returns False, so the inner file loop is
+        # skipped and all_comments stays empty.  This lets us reach the Redis
+        # persistence block without touching the real filesystem.
+        fake_diff = "diff --git a/zzz_no_exist_autobot_test.py b/zzz_no_exist_autobot_test.py\n" "@@ -1 +1 @@\n" "+x\n"
 
-        def make_sync_fn(name):
-            def fn(*args, **kwargs):
-                call_log.append(name)
-
-            return fn
-
+        call_log: list[str] = []
         redis_mock = MagicMock()
-        redis_mock.set = make_sync_fn("set")
-        redis_mock.lpush = make_sync_fn("lpush")
-        redis_mock.ltrim = make_sync_fn("ltrim")
-        redis_mock.expire = make_sync_fn("expire")
 
-        # Simulate the two gather calls from analyze_diff
-        await asyncio.gather(
-            asyncio.to_thread(redis_mock.set, "result_key", "payload", "ex", 604800),
-            asyncio.to_thread(redis_mock.lpush, "history_key", "entry"),
-        )
-        await asyncio.gather(
-            asyncio.to_thread(redis_mock.ltrim, "history_key", 0, 99),
-            asyncio.to_thread(redis_mock.expire, "history_key", 604800),
-        )
+        # Build a name-lookup table keyed by the mock's own attribute objects.
+        # MagicMock returns the same child object on every attribute access, so
+        # identity comparison is stable and survives the lazy `from ... import`
+        # inside analyze_diff's try block.
+        fn_to_name = {
+            redis_mock.set: "set",
+            redis_mock.lpush: "lpush",
+            redis_mock.ltrim: "ltrim",
+            redis_mock.expire: "expire",
+        }
 
-        # set and lpush must both have been called
-        assert "set" in call_log
-        assert "lpush" in call_log
-        # ltrim and expire must come after lpush
+        async def tracking_to_thread(fn, *args, **kwargs):
+            """Drop-in for asyncio.to_thread that records Redis call order.
+
+            For lpush we yield once to the event loop.  If ltrim/expire share
+            the SAME gather as lpush (broken code), they will run during that
+            yield and appear before lpush in call_log — failing the ordering
+            assertion.  With two separate gathers (correct code) there are no
+            other pending tasks when lpush yields inside the first gather, so
+            lpush resumes immediately and completes before the second gather
+            starts.
+            """
+            name = fn_to_name.get(fn)
+            if name == "lpush":
+                # Deliberately yield so that any tasks in the same gather that
+                # do NOT yield can overtake us.  This is the canary: ltrim and
+                # expire must NOT be in the same gather.
+                await real_asyncio.sleep(0)
+            result = fn(*args, **kwargs)
+            if name:
+                call_log.append(name)
+            return result
+
+        with (
+            patch("api.analytics_code_review._resolve_source_root_or_404", AsyncMock(return_value=None)),
+            patch("api.analytics_code_review.get_git_diff", AsyncMock(return_value=fake_diff)),
+            patch("autobot_shared.redis_client.get_redis_client", return_value=redis_mock),
+            patch("asyncio.to_thread", tracking_to_thread),
+        ):
+            from api.analytics_code_review import analyze_diff
+
+            result = await analyze_diff(admin_check=True, commit_range=None, source_id=None)
+
+        assert result["status"] == "success"
+
+        # All four Redis persistence operations must have been called by analyze_diff.
+        assert "set" in call_log, "redis.set was not called"
+        assert "lpush" in call_log, "redis.lpush was not called"
+        assert "ltrim" in call_log, "redis.ltrim was not called"
+        assert "expire" in call_log, "redis.expire was not called"
+
+        # Ordering guarantee: lpush creates the history list key; ltrim and expire
+        # must only run after lpush has completed (i.e. they belong to the second
+        # gather, which only starts after the first gather's await returns).
         lpush_idx = call_log.index("lpush")
         ltrim_idx = call_log.index("ltrim")
         expire_idx = call_log.index("expire")
-        assert ltrim_idx > lpush_idx
-        assert expire_idx > lpush_idx
+        assert ltrim_idx > lpush_idx, (
+            f"ltrim (call #{ltrim_idx}) must follow lpush (call #{lpush_idx}); " f"full call order: {call_log}"
+        )
+        assert expire_idx > lpush_idx, (
+            f"expire (call #{expire_idx}) must follow lpush (call #{lpush_idx}); " f"full call order: {call_log}"
+        )


### PR DESCRIPTION
## Thinking Path
Follow-up to #10812 review. The two `analyze_diff` gather tests re-implemented the pattern inline and asserted on that — they didn't call `analyze_diff`, so a collapsed gather (breaking lpush→ltrim/expire ordering) would pass.

## What Changed
- Both tests now call the real `analyze_diff(...)` with mocked `_resolve_source_root_or_404`/`get_git_diff`/redis. Test 1 asserts both first-gather calls happen (empty-diff → no_data). Test 2 uses an `asyncio.to_thread` shim with a `sleep(0)` canary on `lpush`: in the correct two-gather structure lpush resumes before ltrim/expire; a collapsed single gather would interleave them → assertions `ltrim/expire index > lpush index` fail.

## Verification
- 13 tests pass; flake8 clean. Now genuinely protects the production ordering guarantee.

Closes #10814.

## Model Used
Claude Opus 4.8 (1M context)