### PR TITLE
fix(monitoring): flag system_health_score as unavailable on degraded data (#10779)

### DIFF
--- a/autobot-slm-backend/monitoring/business_intelligence_dashboard.py
+++ b/autobot-slm-backend/monitoring/business_intelligence_dashboard.py
@@ -88,7 +88,12 @@ _DASHBOARD_HTML_TEMPLATE = """
         <div class="metrics-grid">
             <div class="metric-card">
                 <div class="metric-title">Overall System Health</div>
+                {% if health_data_available %}
                 <div class="health-score">{{ health_score }}/100</div>
+                {% else %}
+                <div class="health-score" style="font-size:16px;color:#999">
+                Unavailable — backend metrics not yet collected</div>
+                {% endif %}
             </div>
 
             <div class="metric-card">
@@ -120,11 +125,18 @@ _DASHBOARD_HTML_TEMPLATE = """
         <div class="metrics-grid">
             <div class="metric-card">
                 <h3>System Health Breakdown</h3>
+                {% if not health_data_available %}
+                <p style="color:#999;font-style:italic">Performance, efficiency and
+                satisfaction scores unavailable (Redis metrics not yet collected)</p>
+                {% endif %}
                 <p>Availability: {{ availability_score }}/100</p>
-                <p>Performance: {{ performance_score }}/100</p>
+                <p>Performance: {{ performance_score }}/100
+                {% if not health_data_available %} (unavailable){% endif %}</p>
                 <p>Security: {{ security_score }}/100</p>
-                <p>Efficiency: {{ efficiency_score }}/100</p>
-                <p>User Satisfaction: {{ user_satisfaction_score }}/100</p>
+                <p>Efficiency: {{ efficiency_score }}/100
+                {% if not health_data_available %} (unavailable){% endif %}</p>
+                <p>User Satisfaction: {{ user_satisfaction_score }}/100
+                {% if not health_data_available %} (unavailable){% endif %}</p>
             </div>
 
             <div class="metric-card">
@@ -214,6 +226,10 @@ class SystemHealthScore:
     efficiency_score: float
     user_satisfaction_score: float
     improvement_areas: List[str]
+    # True when both utilization and historical performance sources returned real data.
+    # False when Redis was unavailable; consumers must show "unavailable" instead of
+    # presenting the zeroed sub-scores as if they were measured values (#10779).
+    data_available: bool
 
 
 # ---------------------------------------------------------------------------
@@ -811,13 +827,16 @@ class BusinessIntelligenceDashboard:
         """Calculate comprehensive system health score."""
         try:
             utilization_raw = await self._get_current_utilization()
+            utilization_available = utilization_raw.get("available", True)
             utilization_data = (
-                {k: v for k, v in utilization_raw.items() if k != "available"}
-                if utilization_raw.get("available", True)
-                else {}
+                {k: v for k, v in utilization_raw.items() if k != "available"} if utilization_available else {}
             )
 
             performance_data = await self._get_historical_performance_data()
+            performance_available = performance_data.get("available", True)
+
+            # data_available is False when ANY required source is degraded (#10779).
+            data_available = utilization_available and performance_available
 
             services_data = []
             if self.redis_client:
@@ -830,10 +849,13 @@ class BusinessIntelligenceDashboard:
                     self.logger.error("Redis error reading services data for health score: %s", e)
 
             availability_score = self._calculate_availability_score(services_data)
-            performance_score = self._calculate_performance_score(utilization_data)
-            efficiency_score = self._calculate_efficiency_score(utilization_data)
+            # Guard: avoid fabricated 35.0/80.0 defaults when source data is missing (#10779).
+            performance_score = self._calculate_performance_score(utilization_data) if utilization_available else 0.0
+            efficiency_score = self._calculate_efficiency_score(utilization_data) if utilization_available else 0.0
             security_score = 85.0
-            user_satisfaction = self._calculate_user_satisfaction_score(performance_data)
+            user_satisfaction = (
+                self._calculate_user_satisfaction_score(performance_data) if performance_available else 0.0
+            )
 
             scores = [
                 availability_score,
@@ -861,6 +883,7 @@ class BusinessIntelligenceDashboard:
                 efficiency_score=efficiency_score,
                 user_satisfaction_score=user_satisfaction,
                 improvement_areas=improvement_areas,
+                data_available=data_available,
             )
 
         except Exception as e:
@@ -874,6 +897,7 @@ class BusinessIntelligenceDashboard:
                 efficiency_score=0.0,
                 user_satisfaction_score=0.0,
                 improvement_areas=["System Health Calculation Failed"],
+                data_available=False,
             )
 
     async def generate_comprehensive_dashboard_report(self) -> Dict[str, Any]:
@@ -894,6 +918,8 @@ class BusinessIntelligenceDashboard:
                     "total_optimization_potential": sum(ca.optimization_potential_usd for ca in cost_analysis),
                     # Surfaced explicitly so consumers can show "unavailable" rather than fake numbers
                     "operations_data_available": roi_metrics.operations_data_available,
+                    # False when Redis/utilization data was unavailable during health calculation (#10779)
+                    "system_health_data_available": health_score.data_available,
                 },
                 "roi_analysis": asdict(roi_metrics),
                 "cost_efficiency": [asdict(ca) for ca in cost_analysis],
@@ -953,16 +979,19 @@ class BusinessIntelligenceDashboard:
         summary = report.get("summary", {})
         health = report.get("system_health", {})
 
-        health_score = round(health.get("overall_score", 0), 1)
-        health_color = "#28a745" if health_score >= 80 else "#ffc107" if health_score >= 60 else "#dc3545"
+        # data_available=False means scores are zeroed placeholders, not real measurements (#10779)
+        health_data_available = health.get("data_available", True)
+        health_score_raw = round(health.get("overall_score", 0), 1)
+        health_color = "#28a745" if health_score_raw >= 80 else "#ffc107" if health_score_raw >= 60 else "#dc3545"
 
         roi_percent = round(summary.get("total_roi_percent", 0), 1)
         roi_class = "roi-positive" if roi_percent > 0 else "roi-negative"
 
         return {
             "timestamp": report.get("timestamp", ""),
-            "health_score": health_score,
+            "health_score": health_score_raw,
             "health_color": health_color,
+            "health_data_available": health_data_available,
             "roi_percent": roi_percent,
             "roi_class": roi_class,
             "break_even_months": round(summary.get("break_even_months", 0), 1),
@@ -1042,6 +1071,11 @@ if __name__ == "__main__":
             logger.info("Performance: %s/100", f"{health_score.performance_score:.1f}")
             logger.info("Security: %s/100", f"{health_score.security_score:.1f}")
             logger.info("Efficiency: %s/100", f"{health_score.efficiency_score:.1f}")
+            if not health_score.data_available:
+                logger.warning(
+                    "System health score: unavailable (Redis/utilization data not collected"
+                    " — scores are zeroed, not real measurements)"
+                )
 
         elif args.generate:
             logger.info("Generating comprehensive BI dashboard...")
@@ -1056,5 +1090,7 @@ if __name__ == "__main__":
             logger.info("  Optimization Potential: $%s/month", f"{optimization_potential:.2f}")
             if not summary.get("operations_data_available", True):
                 logger.warning("  Monthly operations count: unavailable (Prometheus unreachable)")
+            if not summary.get("system_health_data_available", True):
+                logger.warning("  System health scores: unavailable (Redis/utilization data not collected)")
 
     asyncio.run(main())

--- a/autobot-slm-backend/tests/test_bi_dashboard.py
+++ b/autobot-slm-backend/tests/test_bi_dashboard.py
@@ -433,3 +433,114 @@ class TestRedisFallbacks:
         result = await d._get_historical_performance_data()
         assert result["available"] is True
         assert "api_response_times" in result
+
+
+# ---------------------------------------------------------------------------
+# Part 4: SystemHealthScore.data_available — honesty flag (#10779)
+# ---------------------------------------------------------------------------
+
+
+class TestSystemHealthScoreDataAvailable:
+    """Verify calculate_system_health_score never emits confident defaults when data is absent."""
+
+    @pytest.mark.asyncio
+    async def test_data_available_true_when_both_sources_present(self):
+        """data_available=True and scores are non-zero when utilization + performance data exist."""
+        d = _make_dashboard()
+        util = {
+            "available": True,
+            "cpu": 50.0,
+            "gpu": 40.0,
+            "npu": 30.0,
+            "memory": 60.0,
+            "storage": 50.0,
+            "network": 30.0,
+        }
+        perf = {
+            "available": True,
+            "api_response_times": [1.2, 1.3, 1.1, 1.4, 1.2],
+            "cpu_utilization": [],
+            "memory_utilization": [],
+            "service_availability": [],
+        }
+        d._get_current_utilization = AsyncMock(return_value=util)
+        d._get_historical_performance_data = AsyncMock(return_value=perf)
+
+        result = await d.calculate_system_health_score()
+
+        assert result.data_available is True
+        # performance_score must NOT be the empty-dict artifact (35.0)
+        assert result.performance_score != 35.0
+        # user_satisfaction_score must NOT be the bare default (80.0 returned when api_times=[])
+        assert result.user_satisfaction_score != 80.0 or len(perf["api_response_times"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_data_available_false_when_utilization_unavailable(self):
+        """When utilization data is unavailable, data_available=False and no fabricated 35.0 score."""
+        d = _make_dashboard()
+        d._get_current_utilization = AsyncMock(return_value={"available": False, "error": "redis_unavailable"})
+        d._get_historical_performance_data = AsyncMock(
+            return_value={"available": True, "api_response_times": [], "cpu_utilization": [], "memory_utilization": []}
+        )
+
+        result = await d.calculate_system_health_score()
+
+        assert result.data_available is False
+        # Must be 0.0, not the fabricated 35.0 from empty-dict arithmetic
+        assert result.performance_score == 0.0, f"Expected 0.0, got {result.performance_score}"
+        assert result.efficiency_score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_data_available_false_when_performance_data_unavailable(self):
+        """When performance history is unavailable, data_available=False and no fabricated 80.0."""
+        d = _make_dashboard()
+        d._get_current_utilization = AsyncMock(
+            return_value={
+                "available": True,
+                "cpu": 50.0,
+                "gpu": 40.0,
+                "npu": 30.0,
+                "memory": 60.0,
+                "storage": 50.0,
+                "network": 30.0,
+            }
+        )
+        d._get_historical_performance_data = AsyncMock(return_value={"available": False, "error": "redis_unavailable"})
+
+        result = await d.calculate_system_health_score()
+
+        assert result.data_available is False
+        # Must be 0.0, not the bare 80.0 default returned when api_times is missing
+        assert result.user_satisfaction_score == 0.0, f"Expected 0.0, got {result.user_satisfaction_score}"
+
+    @pytest.mark.asyncio
+    async def test_no_fabricated_scores_when_no_redis(self):
+        """No Redis → both sources unavailable → data_available=False; no 35.0 or 80.0 defaults."""
+        d = _make_dashboard()
+        # redis_client=None: both helpers return available=False naturally
+        result = await d.calculate_system_health_score()
+
+        assert result.data_available is False
+        assert result.performance_score == 0.0, f"Got fabricated performance_score={result.performance_score}"
+        assert (
+            result.user_satisfaction_score == 0.0
+        ), f"Got fabricated user_satisfaction={result.user_satisfaction_score}"
+        assert result.efficiency_score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_data_available_in_comprehensive_report_summary(self):
+        """generate_comprehensive_dashboard_report surfaces system_health_data_available in summary."""
+        d = _make_dashboard()
+        d._get_current_utilization = AsyncMock(return_value={"available": False, "error": "redis_unavailable"})
+        d._get_historical_performance_data = AsyncMock(return_value={"available": False, "error": "redis_unavailable"})
+        d._get_monthly_operations = AsyncMock(return_value=(0, False))
+        d._store_dashboard_report = AsyncMock()
+        d._generate_visual_dashboard = AsyncMock()
+        # Stub calculate_performance_improvement since it depends on performance_data
+        d._calculate_performance_improvement = AsyncMock(return_value=0.0)
+
+        report = await d.generate_comprehensive_dashboard_report()
+
+        summary = report.get("summary", {})
+        assert "system_health_data_available" in summary, "system_health_data_available must be in summary"
+        assert summary["system_health_data_available"] is False


### PR DESCRIPTION
## Thinking Path
Follow-up to #10720/#10768. `calculate_system_health_score` still emitted confident scores when Redis was down: `_calculate_performance_score({})`→35.0 and `_calculate_user_satisfaction_score`→80.0 default — the same "default-as-real" pattern #10720 killed for ops/cost.

## What Changed
- `SystemHealthScore` gains `data_available: bool` (mirrors `ROIMetrics.operations_data_available`).
- `calculate_system_health_score` tracks utilization/performance availability separately; when a source is unavailable it uses `0.0` instead of a fabricated default and sets `data_available=False`. Error path also sets it False.
- Surfaced in the report summary (`system_health_data_available`) + HTML ("Unavailable — backend metrics not yet collected", breakdown scores annotated `(unavailable)`) + CLI warnings.

## Verification
- 24 tests pass (5 new): real→data_available True; utilization/performance unavailable→False + 0.0 (not 35/80); no-redis→no fabricated scores; summary key present.
- flake8 clean.

Closes #10779.

## Model Used
Claude Opus 4.8 (1M context)