### PR TITLE
feat(llc): create buttons + real error/empty states + toasts (#10750 B1,C3)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -6810,14 +6810,17 @@
         "trigger": "Extract Text",
         "regionsFound": "{count} text region(s) found",
         "noRegions": "No text regions detected",
-        "empty": "Press Extract Text to run OCR on the current screen"
+        "empty": "Press Extract Text to run OCR on the current screen",
+        "fieldConfidence": "Confidence",
+        "fieldBbox": "Bounds"
       },
       "opportunities": {
         "cardTitle": "Automation Opportunities",
         "trigger": "Scan for Opportunities",
         "total": "Total Opportunities",
         "empty": "No automation opportunities found",
-        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements",
+        "fieldUntyped": "Opportunity"
       }
     }
   },
@@ -7939,5 +7942,53 @@
     "viewAll": "View all",
     "saveHintPrefix": "Save an AI response from the",
     "saveHintSuffix": "to create a document."
+  },
+  "llcBrowser": {
+    "retry": "Retry",
+    "cancel": "Cancel",
+    "createAction": "Create",
+    "nameLabel": "Name",
+    "namePlaceholder": "Name",
+    "descriptionLabel": "Description (optional)",
+    "descriptionPlaceholder": "Add a short description",
+    "portfolios": {
+      "title": "Portfolios",
+      "count": "{count} portfolios",
+      "loading": "Loading portfolios…",
+      "empty": "No portfolios yet.",
+      "loadError": "Failed to load portfolios.",
+      "create": "New Portfolio",
+      "createTitle": "Create Portfolio",
+      "createError": "Failed to create portfolio."
+    },
+    "programs": {
+      "title": "Programs",
+      "count": "{count} programs",
+      "loading": "Loading programs…",
+      "empty": "No programs yet.",
+      "loadError": "Failed to load programs.",
+      "create": "New Program",
+      "createTitle": "Create Program",
+      "createError": "Failed to create program."
+    },
+    "projects": {
+      "title": "Projects",
+      "count": "{count} projects",
+      "loading": "Loading projects…",
+      "empty": "No projects yet.",
+      "loadError": "Failed to load projects.",
+      "create": "New Project",
+      "createTitle": "Create Project",
+      "createError": "Failed to create project."
+    },
+    "approvals": {
+      "decideError": "Failed to record your decision. Please try again."
+    },
+    "ceoChat": {
+      "sendError": "Failed to send your message. It has been restored so you can retry."
+    },
+    "timeline": {
+      "rescheduleError": "Failed to save the new schedule. The change was reverted."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -6810,14 +6810,17 @@
         "trigger": "Extract Text",
         "regionsFound": "{count} text region(s) found",
         "noRegions": "No text regions detected",
-        "empty": "Press Extract Text to run OCR on the current screen"
+        "empty": "Press Extract Text to run OCR on the current screen",
+        "fieldConfidence": "Konfidenz",
+        "fieldBbox": "Begrenzung"
       },
       "opportunities": {
         "cardTitle": "Automation Opportunities",
         "trigger": "Scan for Opportunities",
         "total": "Total Opportunities",
         "empty": "No automation opportunities found",
-        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements",
+        "fieldUntyped": "Gelegenheit"
       }
     }
   },
@@ -7939,5 +7942,53 @@
     "viewAll": "View all",
     "saveHintPrefix": "Save an AI response from the",
     "saveHintSuffix": "to create a document."
+  },
+  "llcBrowser": {
+    "retry": "Erneut versuchen",
+    "cancel": "Abbrechen",
+    "createAction": "Erstellen",
+    "nameLabel": "Name",
+    "namePlaceholder": "Name",
+    "descriptionLabel": "Beschreibung (optional)",
+    "descriptionPlaceholder": "Kurze Beschreibung hinzufügen",
+    "portfolios": {
+      "title": "Portfolios",
+      "count": "{count} Portfolios",
+      "loading": "Portfolios werden geladen…",
+      "empty": "Noch keine Portfolios.",
+      "loadError": "Portfolios konnten nicht geladen werden.",
+      "create": "Neues Portfolio",
+      "createTitle": "Portfolio erstellen",
+      "createError": "Portfolio konnte nicht erstellt werden."
+    },
+    "programs": {
+      "title": "Programme",
+      "count": "{count} Programme",
+      "loading": "Programme werden geladen…",
+      "empty": "Noch keine Programme.",
+      "loadError": "Programme konnten nicht geladen werden.",
+      "create": "Neues Programm",
+      "createTitle": "Programm erstellen",
+      "createError": "Programm konnte nicht erstellt werden."
+    },
+    "projects": {
+      "title": "Projekte",
+      "count": "{count} Projekte",
+      "loading": "Projekte werden geladen…",
+      "empty": "Noch keine Projekte.",
+      "loadError": "Projekte konnten nicht geladen werden.",
+      "create": "Neues Projekt",
+      "createTitle": "Projekt erstellen",
+      "createError": "Projekt konnte nicht erstellt werden."
+    },
+    "approvals": {
+      "decideError": "Ihre Entscheidung konnte nicht gespeichert werden. Bitte versuchen Sie es erneut."
+    },
+    "ceoChat": {
+      "sendError": "Ihre Nachricht konnte nicht gesendet werden. Sie wurde wiederhergestellt, damit Sie es erneut versuchen können."
+    },
+    "timeline": {
+      "rescheduleError": "Der neue Zeitplan konnte nicht gespeichert werden. Die Änderung wurde rückgängig gemacht."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -6817,14 +6817,17 @@
         "trigger": "Extract Text",
         "regionsFound": "{count} text region(s) found",
         "noRegions": "No text regions detected",
-        "empty": "Press Extract Text to run OCR on the current screen"
+        "empty": "Press Extract Text to run OCR on the current screen",
+        "fieldConfidence": "Confidence",
+        "fieldBbox": "Bounds"
       },
       "opportunities": {
         "cardTitle": "Automation Opportunities",
         "trigger": "Scan for Opportunities",
         "total": "Total Opportunities",
         "empty": "No automation opportunities found",
-        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements",
+        "fieldUntyped": "Opportunity"
       }
     }
   },
@@ -7939,5 +7942,53 @@
     "viewAll": "View all",
     "saveHintPrefix": "Save an AI response from the",
     "saveHintSuffix": "to create a document."
+  },
+  "llcBrowser": {
+    "retry": "Retry",
+    "cancel": "Cancel",
+    "createAction": "Create",
+    "nameLabel": "Name",
+    "namePlaceholder": "Name",
+    "descriptionLabel": "Description (optional)",
+    "descriptionPlaceholder": "Add a short description",
+    "portfolios": {
+      "title": "Portfolios",
+      "count": "{count} portfolios",
+      "loading": "Loading portfolios…",
+      "empty": "No portfolios yet.",
+      "loadError": "Failed to load portfolios.",
+      "create": "New Portfolio",
+      "createTitle": "Create Portfolio",
+      "createError": "Failed to create portfolio."
+    },
+    "programs": {
+      "title": "Programs",
+      "count": "{count} programs",
+      "loading": "Loading programs…",
+      "empty": "No programs yet.",
+      "loadError": "Failed to load programs.",
+      "create": "New Program",
+      "createTitle": "Create Program",
+      "createError": "Failed to create program."
+    },
+    "projects": {
+      "title": "Projects",
+      "count": "{count} projects",
+      "loading": "Loading projects…",
+      "empty": "No projects yet.",
+      "loadError": "Failed to load projects.",
+      "create": "New Project",
+      "createTitle": "Create Project",
+      "createError": "Failed to create project."
+    },
+    "approvals": {
+      "decideError": "Failed to record your decision. Please try again."
+    },
+    "ceoChat": {
+      "sendError": "Failed to send your message. It has been restored so you can retry."
+    },
+    "timeline": {
+      "rescheduleError": "Failed to save the new schedule. The change was reverted."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -6810,14 +6810,17 @@
         "trigger": "Extract Text",
         "regionsFound": "{count} text region(s) found",
         "noRegions": "No text regions detected",
-        "empty": "Press Extract Text to run OCR on the current screen"
+        "empty": "Press Extract Text to run OCR on the current screen",
+        "fieldConfidence": "Confianza",
+        "fieldBbox": "Límites"
       },
       "opportunities": {
         "cardTitle": "Automation Opportunities",
         "trigger": "Scan for Opportunities",
         "total": "Total Opportunities",
         "empty": "No automation opportunities found",
-        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements",
+        "fieldUntyped": "Oportunidad"
       }
     }
   },
@@ -7939,5 +7942,53 @@
     "viewAll": "View all",
     "saveHintPrefix": "Save an AI response from the",
     "saveHintSuffix": "to create a document."
+  },
+  "llcBrowser": {
+    "retry": "Reintentar",
+    "cancel": "Cancelar",
+    "createAction": "Crear",
+    "nameLabel": "Nombre",
+    "namePlaceholder": "Nombre",
+    "descriptionLabel": "Descripción (opcional)",
+    "descriptionPlaceholder": "Añade una breve descripción",
+    "portfolios": {
+      "title": "Carteras",
+      "count": "{count} carteras",
+      "loading": "Cargando carteras…",
+      "empty": "Aún no hay carteras.",
+      "loadError": "No se pudieron cargar las carteras.",
+      "create": "Nueva cartera",
+      "createTitle": "Crear cartera",
+      "createError": "No se pudo crear la cartera."
+    },
+    "programs": {
+      "title": "Programas",
+      "count": "{count} programas",
+      "loading": "Cargando programas…",
+      "empty": "Aún no hay programas.",
+      "loadError": "No se pudieron cargar los programas.",
+      "create": "Nuevo programa",
+      "createTitle": "Crear programa",
+      "createError": "No se pudo crear el programa."
+    },
+    "projects": {
+      "title": "Proyectos",
+      "count": "{count} proyectos",
+      "loading": "Cargando proyectos…",
+      "empty": "Aún no hay proyectos.",
+      "loadError": "No se pudieron cargar los proyectos.",
+      "create": "Nuevo proyecto",
+      "createTitle": "Crear proyecto",
+      "createError": "No se pudo crear el proyecto."
+    },
+    "approvals": {
+      "decideError": "No se pudo registrar tu decisión. Inténtalo de nuevo."
+    },
+    "ceoChat": {
+      "sendError": "No se pudo enviar tu mensaje. Se ha restaurado para que puedas reintentarlo."
+    },
+    "timeline": {
+      "rescheduleError": "No se pudo guardar la nueva planificación. El cambio se revirtió."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -5996,14 +5996,17 @@
         "trigger": "Extract Text",
         "regionsFound": "{count} text region(s) found",
         "noRegions": "No text regions detected",
-        "empty": "Press Extract Text to run OCR on the current screen"
+        "empty": "Press Extract Text to run OCR on the current screen",
+        "fieldConfidence": "Confidence",
+        "fieldBbox": "Bounds"
       },
       "opportunities": {
         "cardTitle": "Automation Opportunities",
         "trigger": "Scan for Opportunities",
         "total": "Total Opportunities",
         "empty": "No automation opportunities found",
-        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements",
+        "fieldUntyped": "Opportunity"
       }
     }
   },
@@ -7939,5 +7942,53 @@
     "viewAll": "View all",
     "saveHintPrefix": "Save an AI response from the",
     "saveHintSuffix": "to create a document."
+  },
+  "llcBrowser": {
+    "retry": "Retry",
+    "cancel": "Cancel",
+    "createAction": "Create",
+    "nameLabel": "Name",
+    "namePlaceholder": "Name",
+    "descriptionLabel": "Description (optional)",
+    "descriptionPlaceholder": "Add a short description",
+    "portfolios": {
+      "title": "Portfolios",
+      "count": "{count} portfolios",
+      "loading": "Loading portfolios…",
+      "empty": "No portfolios yet.",
+      "loadError": "Failed to load portfolios.",
+      "create": "New Portfolio",
+      "createTitle": "Create Portfolio",
+      "createError": "Failed to create portfolio."
+    },
+    "programs": {
+      "title": "Programs",
+      "count": "{count} programs",
+      "loading": "Loading programs…",
+      "empty": "No programs yet.",
+      "loadError": "Failed to load programs.",
+      "create": "New Program",
+      "createTitle": "Create Program",
+      "createError": "Failed to create program."
+    },
+    "projects": {
+      "title": "Projects",
+      "count": "{count} projects",
+      "loading": "Loading projects…",
+      "empty": "No projects yet.",
+      "loadError": "Failed to load projects.",
+      "create": "New Project",
+      "createTitle": "Create Project",
+      "createError": "Failed to create project."
+    },
+    "approvals": {
+      "decideError": "Failed to record your decision. Please try again."
+    },
+    "ceoChat": {
+      "sendError": "Failed to send your message. It has been restored so you can retry."
+    },
+    "timeline": {
+      "rescheduleError": "Failed to save the new schedule. The change was reverted."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -6810,14 +6810,17 @@
         "trigger": "Extract Text",
         "regionsFound": "{count} text region(s) found",
         "noRegions": "No text regions detected",
-        "empty": "Press Extract Text to run OCR on the current screen"
+        "empty": "Press Extract Text to run OCR on the current screen",
+        "fieldConfidence": "Confiance",
+        "fieldBbox": "Limites"
       },
       "opportunities": {
         "cardTitle": "Automation Opportunities",
         "trigger": "Scan for Opportunities",
         "total": "Total Opportunities",
         "empty": "No automation opportunities found",
-        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements",
+        "fieldUntyped": "Opportunité"
       }
     }
   },
@@ -7939,5 +7942,53 @@
     "viewAll": "View all",
     "saveHintPrefix": "Save an AI response from the",
     "saveHintSuffix": "to create a document."
+  },
+  "llcBrowser": {
+    "retry": "Réessayer",
+    "cancel": "Annuler",
+    "createAction": "Créer",
+    "nameLabel": "Nom",
+    "namePlaceholder": "Nom",
+    "descriptionLabel": "Description (facultatif)",
+    "descriptionPlaceholder": "Ajouter une brève description",
+    "portfolios": {
+      "title": "Portefeuilles",
+      "count": "{count} portefeuilles",
+      "loading": "Chargement des portefeuilles…",
+      "empty": "Aucun portefeuille pour le moment.",
+      "loadError": "Échec du chargement des portefeuilles.",
+      "create": "Nouveau portefeuille",
+      "createTitle": "Créer un portefeuille",
+      "createError": "Échec de la création du portefeuille."
+    },
+    "programs": {
+      "title": "Programmes",
+      "count": "{count} programmes",
+      "loading": "Chargement des programmes…",
+      "empty": "Aucun programme pour le moment.",
+      "loadError": "Échec du chargement des programmes.",
+      "create": "Nouveau programme",
+      "createTitle": "Créer un programme",
+      "createError": "Échec de la création du programme."
+    },
+    "projects": {
+      "title": "Projets",
+      "count": "{count} projets",
+      "loading": "Chargement des projets…",
+      "empty": "Aucun projet pour le moment.",
+      "loadError": "Échec du chargement des projets.",
+      "create": "Nouveau projet",
+      "createTitle": "Créer un projet",
+      "createError": "Échec de la création du projet."
+    },
+    "approvals": {
+      "decideError": "Échec de l'enregistrement de votre décision. Veuillez réessayer."
+    },
+    "ceoChat": {
+      "sendError": "Échec de l'envoi de votre message. Il a été restauré pour que vous puissiez réessayer."
+    },
+    "timeline": {
+      "rescheduleError": "Échec de l'enregistrement du nouveau planning. La modification a été annulée."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -5996,14 +5996,17 @@
         "trigger": "Extract Text",
         "regionsFound": "{count} text region(s) found",
         "noRegions": "No text regions detected",
-        "empty": "Press Extract Text to run OCR on the current screen"
+        "empty": "Press Extract Text to run OCR on the current screen",
+        "fieldConfidence": "Confidence",
+        "fieldBbox": "Bounds"
       },
       "opportunities": {
         "cardTitle": "Automation Opportunities",
         "trigger": "Scan for Opportunities",
         "total": "Total Opportunities",
         "empty": "No automation opportunities found",
-        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements",
+        "fieldUntyped": "Opportunity"
       }
     }
   },
@@ -7939,5 +7942,53 @@
     "viewAll": "View all",
     "saveHintPrefix": "Save an AI response from the",
     "saveHintSuffix": "to create a document."
+  },
+  "llcBrowser": {
+    "retry": "Retry",
+    "cancel": "Cancel",
+    "createAction": "Create",
+    "nameLabel": "Name",
+    "namePlaceholder": "Name",
+    "descriptionLabel": "Description (optional)",
+    "descriptionPlaceholder": "Add a short description",
+    "portfolios": {
+      "title": "Portfolios",
+      "count": "{count} portfolios",
+      "loading": "Loading portfolios…",
+      "empty": "No portfolios yet.",
+      "loadError": "Failed to load portfolios.",
+      "create": "New Portfolio",
+      "createTitle": "Create Portfolio",
+      "createError": "Failed to create portfolio."
+    },
+    "programs": {
+      "title": "Programs",
+      "count": "{count} programs",
+      "loading": "Loading programs…",
+      "empty": "No programs yet.",
+      "loadError": "Failed to load programs.",
+      "create": "New Program",
+      "createTitle": "Create Program",
+      "createError": "Failed to create program."
+    },
+    "projects": {
+      "title": "Projects",
+      "count": "{count} projects",
+      "loading": "Loading projects…",
+      "empty": "No projects yet.",
+      "loadError": "Failed to load projects.",
+      "create": "New Project",
+      "createTitle": "Create Project",
+      "createError": "Failed to create project."
+    },
+    "approvals": {
+      "decideError": "Failed to record your decision. Please try again."
+    },
+    "ceoChat": {
+      "sendError": "Failed to send your message. It has been restored so you can retry."
+    },
+    "timeline": {
+      "rescheduleError": "Failed to save the new schedule. The change was reverted."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -6810,14 +6810,17 @@
         "trigger": "Extract Text",
         "regionsFound": "{count} text region(s) found",
         "noRegions": "No text regions detected",
-        "empty": "Press Extract Text to run OCR on the current screen"
+        "empty": "Press Extract Text to run OCR on the current screen",
+        "fieldConfidence": "Pārliecība",
+        "fieldBbox": "Robežas"
       },
       "opportunities": {
         "cardTitle": "Automation Opportunities",
         "trigger": "Scan for Opportunities",
         "total": "Total Opportunities",
         "empty": "No automation opportunities found",
-        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements",
+        "fieldUntyped": "Iespēja"
       }
     }
   },
@@ -7939,5 +7942,53 @@
     "viewAll": "View all",
     "saveHintPrefix": "Save an AI response from the",
     "saveHintSuffix": "to create a document."
+  },
+  "llcBrowser": {
+    "retry": "Mēģināt vēlreiz",
+    "cancel": "Atcelt",
+    "createAction": "Izveidot",
+    "nameLabel": "Nosaukums",
+    "namePlaceholder": "Nosaukums",
+    "descriptionLabel": "Apraksts (neobligāts)",
+    "descriptionPlaceholder": "Pievienojiet īsu aprakstu",
+    "portfolios": {
+      "title": "Portfeļi",
+      "count": "{count} portfeļi",
+      "loading": "Ielādē portfeļus…",
+      "empty": "Vēl nav portfeļu.",
+      "loadError": "Neizdevās ielādēt portfeļus.",
+      "create": "Jauns portfelis",
+      "createTitle": "Izveidot portfeli",
+      "createError": "Neizdevās izveidot portfeli."
+    },
+    "programs": {
+      "title": "Programmas",
+      "count": "{count} programmas",
+      "loading": "Ielādē programmas…",
+      "empty": "Vēl nav programmu.",
+      "loadError": "Neizdevās ielādēt programmas.",
+      "create": "Jauna programma",
+      "createTitle": "Izveidot programmu",
+      "createError": "Neizdevās izveidot programmu."
+    },
+    "projects": {
+      "title": "Projekti",
+      "count": "{count} projekti",
+      "loading": "Ielādē projektus…",
+      "empty": "Vēl nav projektu.",
+      "loadError": "Neizdevās ielādēt projektus.",
+      "create": "Jauns projekts",
+      "createTitle": "Izveidot projektu",
+      "createError": "Neizdevās izveidot projektu."
+    },
+    "approvals": {
+      "decideError": "Neizdevās saglabāt jūsu lēmumu. Lūdzu, mēģiniet vēlreiz."
+    },
+    "ceoChat": {
+      "sendError": "Neizdevās nosūtīt jūsu ziņojumu. Tas ir atjaunots, lai jūs varētu mēģināt vēlreiz."
+    },
+    "timeline": {
+      "rescheduleError": "Neizdevās saglabāt jauno grafiku. Izmaiņas tika atceltas."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -6810,14 +6810,17 @@
         "trigger": "Extract Text",
         "regionsFound": "{count} text region(s) found",
         "noRegions": "No text regions detected",
-        "empty": "Press Extract Text to run OCR on the current screen"
+        "empty": "Press Extract Text to run OCR on the current screen",
+        "fieldConfidence": "Pewność",
+        "fieldBbox": "Granice"
       },
       "opportunities": {
         "cardTitle": "Automation Opportunities",
         "trigger": "Scan for Opportunities",
         "total": "Total Opportunities",
         "empty": "No automation opportunities found",
-        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements",
+        "fieldUntyped": "Możliwość"
       }
     }
   },
@@ -7939,5 +7942,53 @@
     "viewAll": "View all",
     "saveHintPrefix": "Save an AI response from the",
     "saveHintSuffix": "to create a document."
+  },
+  "llcBrowser": {
+    "retry": "Spróbuj ponownie",
+    "cancel": "Anuluj",
+    "createAction": "Utwórz",
+    "nameLabel": "Nazwa",
+    "namePlaceholder": "Nazwa",
+    "descriptionLabel": "Opis (opcjonalnie)",
+    "descriptionPlaceholder": "Dodaj krótki opis",
+    "portfolios": {
+      "title": "Portfele",
+      "count": "{count} portfeli",
+      "loading": "Ładowanie portfeli…",
+      "empty": "Brak portfeli.",
+      "loadError": "Nie udało się załadować portfeli.",
+      "create": "Nowy portfel",
+      "createTitle": "Utwórz portfel",
+      "createError": "Nie udało się utworzyć portfela."
+    },
+    "programs": {
+      "title": "Programy",
+      "count": "{count} programów",
+      "loading": "Ładowanie programów…",
+      "empty": "Brak programów.",
+      "loadError": "Nie udało się załadować programów.",
+      "create": "Nowy program",
+      "createTitle": "Utwórz program",
+      "createError": "Nie udało się utworzyć programu."
+    },
+    "projects": {
+      "title": "Projekty",
+      "count": "{count} projektów",
+      "loading": "Ładowanie projektów…",
+      "empty": "Brak projektów.",
+      "loadError": "Nie udało się załadować projektów.",
+      "create": "Nowy projekt",
+      "createTitle": "Utwórz projekt",
+      "createError": "Nie udało się utworzyć projektu."
+    },
+    "approvals": {
+      "decideError": "Nie udało się zapisać Twojej decyzji. Spróbuj ponownie."
+    },
+    "ceoChat": {
+      "sendError": "Nie udało się wysłać wiadomości. Została przywrócona, aby można było spróbować ponownie."
+    },
+    "timeline": {
+      "rescheduleError": "Nie udało się zapisać nowego harmonogramu. Zmiana została cofnięta."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -6810,14 +6810,17 @@
         "trigger": "Extract Text",
         "regionsFound": "{count} text region(s) found",
         "noRegions": "No text regions detected",
-        "empty": "Press Extract Text to run OCR on the current screen"
+        "empty": "Press Extract Text to run OCR on the current screen",
+        "fieldConfidence": "Confiança",
+        "fieldBbox": "Limites"
       },
       "opportunities": {
         "cardTitle": "Automation Opportunities",
         "trigger": "Scan for Opportunities",
         "total": "Total Opportunities",
         "empty": "No automation opportunities found",
-        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements",
+        "fieldUntyped": "Oportunidade"
       }
     }
   },
@@ -7939,5 +7942,53 @@
     "viewAll": "View all",
     "saveHintPrefix": "Save an AI response from the",
     "saveHintSuffix": "to create a document."
+  },
+  "llcBrowser": {
+    "retry": "Tentar novamente",
+    "cancel": "Cancelar",
+    "createAction": "Criar",
+    "nameLabel": "Nome",
+    "namePlaceholder": "Nome",
+    "descriptionLabel": "Descrição (opcional)",
+    "descriptionPlaceholder": "Adicione uma breve descrição",
+    "portfolios": {
+      "title": "Portfólios",
+      "count": "{count} portfólios",
+      "loading": "Carregando portfólios…",
+      "empty": "Ainda não há portfólios.",
+      "loadError": "Falha ao carregar os portfólios.",
+      "create": "Novo portfólio",
+      "createTitle": "Criar portfólio",
+      "createError": "Falha ao criar o portfólio."
+    },
+    "programs": {
+      "title": "Programas",
+      "count": "{count} programas",
+      "loading": "Carregando programas…",
+      "empty": "Ainda não há programas.",
+      "loadError": "Falha ao carregar os programas.",
+      "create": "Novo programa",
+      "createTitle": "Criar programa",
+      "createError": "Falha ao criar o programa."
+    },
+    "projects": {
+      "title": "Projetos",
+      "count": "{count} projetos",
+      "loading": "Carregando projetos…",
+      "empty": "Ainda não há projetos.",
+      "loadError": "Falha ao carregar os projetos.",
+      "create": "Novo projeto",
+      "createTitle": "Criar projeto",
+      "createError": "Falha ao criar o projeto."
+    },
+    "approvals": {
+      "decideError": "Falha ao registrar sua decisão. Tente novamente."
+    },
+    "ceoChat": {
+      "sendError": "Falha ao enviar sua mensagem. Ela foi restaurada para que você possa tentar novamente."
+    },
+    "timeline": {
+      "rescheduleError": "Falha ao salvar o novo cronograma. A alteração foi revertida."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -5996,14 +5996,17 @@
         "trigger": "Extract Text",
         "regionsFound": "{count} text region(s) found",
         "noRegions": "No text regions detected",
-        "empty": "Press Extract Text to run OCR on the current screen"
+        "empty": "Press Extract Text to run OCR on the current screen",
+        "fieldConfidence": "Confidence",
+        "fieldBbox": "Bounds"
       },
       "opportunities": {
         "cardTitle": "Automation Opportunities",
         "trigger": "Scan for Opportunities",
         "total": "Total Opportunities",
         "empty": "No automation opportunities found",
-        "emptyHint": "Press Scan for Opportunities to discover interactive elements"
+        "emptyHint": "Press Scan for Opportunities to discover interactive elements",
+        "fieldUntyped": "Opportunity"
       }
     }
   },
@@ -7939,5 +7942,53 @@
     "viewAll": "View all",
     "saveHintPrefix": "Save an AI response from the",
     "saveHintSuffix": "to create a document."
+  },
+  "llcBrowser": {
+    "retry": "Retry",
+    "cancel": "Cancel",
+    "createAction": "Create",
+    "nameLabel": "Name",
+    "namePlaceholder": "Name",
+    "descriptionLabel": "Description (optional)",
+    "descriptionPlaceholder": "Add a short description",
+    "portfolios": {
+      "title": "Portfolios",
+      "count": "{count} portfolios",
+      "loading": "Loading portfolios…",
+      "empty": "No portfolios yet.",
+      "loadError": "Failed to load portfolios.",
+      "create": "New Portfolio",
+      "createTitle": "Create Portfolio",
+      "createError": "Failed to create portfolio."
+    },
+    "programs": {
+      "title": "Programs",
+      "count": "{count} programs",
+      "loading": "Loading programs…",
+      "empty": "No programs yet.",
+      "loadError": "Failed to load programs.",
+      "create": "New Program",
+      "createTitle": "Create Program",
+      "createError": "Failed to create program."
+    },
+    "projects": {
+      "title": "Projects",
+      "count": "{count} projects",
+      "loading": "Loading projects…",
+      "empty": "No projects yet.",
+      "loadError": "Failed to load projects.",
+      "create": "New Project",
+      "createTitle": "Create Project",
+      "createError": "Failed to create project."
+    },
+    "approvals": {
+      "decideError": "Failed to record your decision. Please try again."
+    },
+    "ceoChat": {
+      "sendError": "Failed to send your message. It has been restored so you can retry."
+    },
+    "timeline": {
+      "rescheduleError": "Failed to save the new schedule. The change was reverted."
+    }
   }
 }

--- a/autobot-frontend/src/views/FailureAnalysisDashboard.vue
+++ b/autobot-frontend/src/views/FailureAnalysisDashboard.vue
@@ -128,10 +128,10 @@
       </section>
 
       <!-- Causal chain -->
-      <section v-if="result.causal_chain.length" class="result-section">
+      <section v-if="(result.causal_chain ?? []).length" class="result-section">
         <h3 class="section-title">
           {{ $t('analytics.failureAnalysis.result.causalChain') }}
-          <span class="count-badge">{{ result.causal_chain.length }}</span>
+          <span class="count-badge">{{ (result.causal_chain ?? []).length }}</span>
         </h3>
         <ol class="causal-chain-list">
           <li v-for="(event, idx) in result.causal_chain" :key="String(event.event_id || idx)" class="chain-item">
@@ -149,10 +149,10 @@
       </section>
 
       <!-- Interventions -->
-      <section v-if="result.interventions.length" class="result-section">
+      <section v-if="(result.interventions ?? []).length" class="result-section">
         <h3 class="section-title">
           {{ $t('analytics.failureAnalysis.result.interventions') }}
-          <span class="count-badge">{{ result.interventions.length }}</span>
+          <span class="count-badge">{{ (result.interventions ?? []).length }}</span>
         </h3>
         <div class="interventions-grid">
           <div
@@ -191,10 +191,10 @@
       </section>
 
       <!-- Confounders -->
-      <section v-if="result.confounders.length" class="result-section">
+      <section v-if="(result.confounders ?? []).length" class="result-section">
         <h3 class="section-title">
           {{ $t('analytics.failureAnalysis.result.confounders') }}
-          <span class="count-badge">{{ result.confounders.length }}</span>
+          <span class="count-badge">{{ (result.confounders ?? []).length }}</span>
         </h3>
         <div class="confounders-list">
           <div v-for="(conf, idx) in result.confounders" :key="String(conf.event_id || idx)" class="event-card">
@@ -213,7 +213,7 @@
       </section>
 
       <!-- Recommendations -->
-      <section v-if="result.recommendations.length" class="result-section">
+      <section v-if="(result.recommendations ?? []).length" class="result-section">
         <h3 class="section-title">{{ $t('analytics.failureAnalysis.result.recommendations') }}</h3>
         <ul class="recommendations-list">
           <li v-for="(rec, idx) in result.recommendations" :key="idx">{{ rec }}</li>

--- a/autobot-frontend/src/views/VisionAutomationView.vue
+++ b/autobot-frontend/src/views/VisionAutomationView.vue
@@ -68,6 +68,33 @@ async function handleFetchOpportunities(): Promise<void> {
   await fetchOpportunities(sessionId.value || undefined)
 }
 
+// --- Structured field accessors -------------------------------------------
+// OCR text regions and automation opportunities are loosely-typed dicts
+// (backend returns bare JSON). These helpers safely pull the fields we render
+// instead of dumping raw JSON at the user (#10750 C3).
+function fieldString(obj: Record<string, unknown>, key: string): string {
+  const v = obj[key]
+  return typeof v === 'string' ? v : ''
+}
+
+function fieldNumber(obj: Record<string, unknown>, key: string): number | null {
+  const v = obj[key]
+  return typeof v === 'number' ? v : null
+}
+
+function formatBbox(obj: Record<string, unknown>): string {
+  const bbox = obj.bbox
+  if (!bbox || typeof bbox !== 'object') return ''
+  const b = bbox as Record<string, unknown>
+  const num = (k: string): number => (typeof b[k] === 'number' ? (b[k] as number) : 0)
+  return `${Math.round(num('x'))}, ${Math.round(num('y'))} · ${Math.round(num('width'))}×${Math.round(num('height'))}`
+}
+
+function asPercent(value: number): number {
+  // Confidence is a 0..1 fraction; render as a whole-number percentage.
+  return Math.round(value * 100)
+}
+
 onMounted(async () => {
   await fetchStatus()
 })
@@ -330,7 +357,18 @@ onMounted(async () => {
                 :key="idx"
                 class="ocr-region-item"
               >
-                <pre class="region-pre">{{ JSON.stringify(region, null, 2) }}</pre>
+                <p v-if="fieldString(region, 'text')" class="region-text">
+                  {{ fieldString(region, 'text') }}
+                </p>
+                <div class="region-meta">
+                  <span v-if="fieldNumber(region, 'confidence') !== null" class="region-chip">
+                    {{ t('vision.visionAutomation.ocr.fieldConfidence') }}:
+                    {{ asPercent(fieldNumber(region, 'confidence') as number) }}%
+                  </span>
+                  <span v-if="formatBbox(region)" class="region-chip">
+                    {{ t('vision.visionAutomation.ocr.fieldBbox') }}: {{ formatBbox(region) }}
+                  </span>
+                </div>
               </div>
             </div>
             <div v-else class="empty-state">
@@ -375,7 +413,17 @@ onMounted(async () => {
                 :key="idx"
                 class="opportunity-item card"
               >
-                <pre class="region-pre">{{ JSON.stringify(opp, null, 2) }}</pre>
+                <div class="opportunity-head">
+                  <span class="opportunity-type">
+                    {{ fieldString(opp, 'type') || t('vision.visionAutomation.opportunities.fieldUntyped') }}
+                  </span>
+                  <span v-if="fieldNumber(opp, 'confidence') !== null" class="opportunity-confidence">
+                    {{ asPercent(fieldNumber(opp, 'confidence') as number) }}%
+                  </span>
+                </div>
+                <p v-if="fieldString(opp, 'description')" class="opportunity-desc">
+                  {{ fieldString(opp, 'description') }}
+                </p>
               </div>
             </div>
             <div v-else class="empty-state">
@@ -716,13 +764,54 @@ onMounted(async () => {
   padding: 0.5rem;
 }
 
-.region-pre {
-  font-family: monospace;
-  font-size: 0.8125rem;
-  white-space: pre-wrap;
+.region-text {
+  margin: 0 0 0.375rem;
+  font-size: 0.875rem;
+  color: var(--text-primary);
   word-break: break-word;
-  margin: 0;
-  color: var(--text-primary, #111827);
+}
+
+.region-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.region-chip {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  background: var(--bg-hover);
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+}
+
+.opportunity-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.opportunity-type {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-transform: capitalize;
+}
+
+.opportunity-confidence {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: var(--bg-hover);
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+}
+
+.opportunity-desc {
+  margin: 0.375rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
 }
 
 .opportunities-list {

--- a/autobot-frontend/src/views/llc/ApprovalsInbox.vue
+++ b/autobot-frontend/src/views/llc/ApprovalsInbox.vue
@@ -144,11 +144,15 @@ import { useRoute } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import { useUserStore } from '@/stores/useUserStore'
+import { useI18n } from 'vue-i18n'
+import { useNotificationBus } from '@/composables/useNotificationBus'
 
 const logger = createLogger('ApprovalsInbox')
 const api = useApiClient()
 const route = useRoute()
 const userStore = useUserStore()
+const { t } = useI18n()
+const { showToast } = useNotificationBus()
 
 const props = defineProps<{ companyId?: string }>()
 const companyId = computed(() => (route.params.companyId as string) ?? props.companyId ?? '')
@@ -249,6 +253,7 @@ async function decide(id: string, decision: string, note?: string) {
     await fetchApprovals()
   } catch (err) {
     logger.error('Decision failed', err)
+    showToast(t('llcBrowser.approvals.decideError'), 'error')
   } finally {
     const s = new Set(processing.value)
     s.delete(id)

--- a/autobot-frontend/src/views/llc/CeoChatView.vue
+++ b/autobot-frontend/src/views/llc/CeoChatView.vue
@@ -117,10 +117,14 @@ import { ref, computed, nextTick, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
+import { useI18n } from 'vue-i18n'
+import { useNotificationBus } from '@/composables/useNotificationBus'
 
 const logger = createLogger('CeoChatView')
 const api = useApiClient()
 const route = useRoute()
+const { t } = useI18n()
+const { showToast } = useNotificationBus()
 
 const props = defineProps<{ companyId?: string }>()
 const companyId = computed(() => (route.params.companyId as string) ?? props.companyId ?? '')
@@ -218,7 +222,9 @@ async function sendMessage() {
     scrollToBottom()
   } catch (err) {
     logger.error('Failed to send message', err)
+    // Restore the message so the user can retry rather than losing it silently.
     inputText.value = body
+    showToast(t('llcBrowser.ceoChat.sendError'), 'error')
   } finally {
     sending.value = false
   }

--- a/autobot-frontend/src/views/llc/GanttTimelineView.vue
+++ b/autobot-frontend/src/views/llc/GanttTimelineView.vue
@@ -137,10 +137,14 @@ import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useRoute } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
+import { useI18n } from 'vue-i18n'
+import { useNotificationBus } from '@/composables/useNotificationBus'
 
 const logger = createLogger('GanttTimelineView')
 const api = useApiClient()
 const route = useRoute()
+const { t } = useI18n()
+const { showToast } = useNotificationBus()
 
 const LABEL_W = 120
 const HEADER_H = 32
@@ -340,6 +344,7 @@ async function onDragEnd() {
     })
   } catch (err) {
     logger.error('Failed to persist reschedule', err)
+    showToast(t('llcBrowser.timeline.rescheduleError'), 'error')
     await loadTimeline()
   }
 }

--- a/autobot-frontend/src/views/llc/PortfolioBrowserView.vue
+++ b/autobot-frontend/src/views/llc/PortfolioBrowserView.vue
@@ -4,19 +4,37 @@
 <!--
   PortfolioBrowserView (GH#9628) — top level of the LLC work hierarchy.
   Lists a company's portfolios as a responsive card grid; clicking a card
-  drills down into that portfolio's programs.
+  drills down into that portfolio's programs. A header "Create" action opens a
+  modal that POSTs a new portfolio and prepends it to the list (#10750 B1).
 -->
 <template>
   <div class="llc-browser">
     <LlcBreadcrumb :items="breadcrumb" />
 
     <header class="browser-header">
-      <h2 class="browser-title">Portfolios</h2>
-      <span class="browser-count">{{ portfolios.length }} portfolios</span>
+      <div class="browser-heading">
+        <h2 class="browser-title">{{ t('llcBrowser.portfolios.title') }}</h2>
+        <span class="browser-count">
+          {{ t('llcBrowser.portfolios.count', { count: portfolios.length }) }}
+        </span>
+      </div>
+      <BaseButton variant="primary" :disabled="!companyId" @click="openCreate">
+        {{ t('llcBrowser.portfolios.create') }}
+      </BaseButton>
     </header>
 
-    <div v-if="loading" class="browser-state">Loading portfolios…</div>
-    <div v-else-if="!portfolios.length" class="browser-state">No portfolios yet.</div>
+    <div v-if="loading" class="browser-state">{{ t('llcBrowser.portfolios.loading') }}</div>
+
+    <template v-else-if="loadError">
+      <ErrorBanner :message="t('llcBrowser.portfolios.loadError')" class="browser-error" />
+      <BaseButton variant="secondary" size="sm" @click="loadPortfolios">
+        {{ t('llcBrowser.retry') }}
+      </BaseButton>
+    </template>
+
+    <div v-else-if="!portfolios.length" class="browser-state">
+      {{ t('llcBrowser.portfolios.empty') }}
+    </div>
 
     <div v-else class="card-grid">
       <button
@@ -37,15 +55,61 @@
         </p>
       </button>
     </div>
+
+    <BaseModal
+      v-model="showCreate"
+      :title="t('llcBrowser.portfolios.createTitle')"
+      size="sm"
+    >
+      <ErrorBanner v-if="createError" :message="createError" class="browser-error" />
+      <div class="create-form">
+        <BaseInput
+          v-model="form.name"
+          :label="t('llcBrowser.nameLabel')"
+          :placeholder="t('llcBrowser.namePlaceholder')"
+          required
+        />
+        <div class="create-field">
+          <label class="create-label" for="portfolio-description">
+            {{ t('llcBrowser.descriptionLabel') }}
+          </label>
+          <textarea
+            id="portfolio-description"
+            v-model="form.description"
+            class="create-textarea"
+            rows="3"
+            :placeholder="t('llcBrowser.descriptionPlaceholder')"
+          />
+        </div>
+      </div>
+      <template #actions>
+        <BaseButton variant="secondary" :disabled="creating" @click="showCreate = false">
+          {{ t('llcBrowser.cancel') }}
+        </BaseButton>
+        <BaseButton
+          variant="primary"
+          :loading="creating"
+          :disabled="!form.name.trim() || creating"
+          @click="createPortfolio"
+        >
+          {{ t('llcBrowser.createAction') }}
+        </BaseButton>
+      </template>
+    </BaseModal>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import LlcBreadcrumb, { type BreadcrumbItem } from '@/components/llc/LlcBreadcrumb.vue'
+import BaseButton from '@/components/base/BaseButton.vue'
+import BaseInput from '@/components/base/BaseInput.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import ErrorBanner from '@/components/base/ErrorBanner.vue'
 
 interface PortfolioResponse {
   id: string
@@ -62,12 +126,19 @@ const logger = createLogger('PortfolioBrowserView')
 const api = useApiClient()
 const route = useRoute()
 const router = useRouter()
+const { t } = useI18n()
 
 const companyId = computed(() => route.params.companyId as string)
 const portfolios = ref<PortfolioResponse[]>([])
 const loading = ref(false)
+const loadError = ref(false)
 
-const breadcrumb = computed<BreadcrumbItem[]>(() => [{ label: 'Portfolios' }])
+const showCreate = ref(false)
+const creating = ref(false)
+const createError = ref('')
+const form = ref({ name: '', description: '' })
+
+const breadcrumb = computed<BreadcrumbItem[]>(() => [{ label: t('llcBrowser.portfolios.title') }])
 
 function formatDate(value: string): string {
   const ms = Date.parse(value)
@@ -77,15 +148,48 @@ function formatDate(value: string): string {
 
 async function loadPortfolios(): Promise<void> {
   loading.value = true
+  loadError.value = false
   try {
     portfolios.value = await api.get<PortfolioResponse[]>(
       `/api/llc/companies/${companyId.value}/portfolios`,
     )
   } catch (err) {
     logger.error('Failed to load portfolios', err)
+    loadError.value = true
     portfolios.value = []
   } finally {
     loading.value = false
+  }
+}
+
+function openCreate(): void {
+  form.value = { name: '', description: '' }
+  createError.value = ''
+  showCreate.value = true
+}
+
+async function createPortfolio(): Promise<void> {
+  const name = form.value.name.trim()
+  if (!name || !companyId.value) return
+  creating.value = true
+  createError.value = ''
+  try {
+    // PortfolioCreate: company_id (required) + name + optional description.
+    const created = await api.post<PortfolioResponse>(
+      `/api/llc/companies/${companyId.value}/portfolios`,
+      {
+        company_id: companyId.value,
+        name,
+        description: form.value.description.trim() || undefined,
+      },
+    )
+    portfolios.value.unshift(created)
+    showCreate.value = false
+  } catch (err) {
+    logger.error('Failed to create portfolio', err)
+    createError.value = t('llcBrowser.portfolios.createError')
+  } finally {
+    creating.value = false
   }
 }
 
@@ -106,26 +210,37 @@ onMounted(loadPortfolios)
 
 .browser-header {
   display: flex;
-  align-items: baseline;
+  align-items: flex-start;
+  justify-content: space-between;
   gap: 0.75rem;
   margin-bottom: 1rem;
+}
+
+.browser-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
 }
 
 .browser-title {
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
   margin: 0;
 }
 
 .browser-count {
   font-size: 0.875rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
 }
 
 .browser-state {
   padding: 2rem 0;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
+}
+
+.browser-error {
+  margin-bottom: 0.75rem;
 }
 
 .card-grid {
@@ -142,8 +257,8 @@ onMounted(loadPortfolios)
   text-align: left;
   cursor: pointer;
   border-radius: var(--radius-md, 8px);
-  border: 1px solid var(--border-default, #e5e7eb);
-  background: var(--bg-surface, #ffffff);
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
@@ -162,13 +277,13 @@ onMounted(loadPortfolios)
 .card-name {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
   margin: 0;
 }
 
 .card-desc {
   font-size: 0.875rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
   margin: 0;
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -179,7 +294,7 @@ onMounted(loadPortfolios)
 
 .card-meta {
   font-size: 0.75rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
   margin: 0;
 }
 
@@ -191,7 +306,36 @@ onMounted(loadPortfolios)
   letter-spacing: 0.03em;
   padding: 0.125rem 0.5rem;
   border-radius: 999px;
-  background: var(--bg-hover, #f3f4f6);
-  color: var(--text-secondary, #6b7280);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+.create-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.create-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.create-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.create-textarea {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-md, 8px);
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  resize: vertical;
 }
 </style>

--- a/autobot-frontend/src/views/llc/ProgramBrowserView.vue
+++ b/autobot-frontend/src/views/llc/ProgramBrowserView.vue
@@ -4,19 +4,37 @@
 <!--
   ProgramBrowserView (GH#9628) — middle tier of the LLC work hierarchy.
   Lists the programs under a portfolio as a card grid; clicking a card
-  drills down into that program's projects.
+  drills down into that program's projects. A header "Create" action opens a
+  modal that POSTs a new program and prepends it to the list (#10750 B1).
 -->
 <template>
   <div class="llc-browser">
     <LlcBreadcrumb :items="breadcrumb" />
 
     <header class="browser-header">
-      <h2 class="browser-title">Programs</h2>
-      <span class="browser-count">{{ programs.length }} programs</span>
+      <div class="browser-heading">
+        <h2 class="browser-title">{{ t('llcBrowser.programs.title') }}</h2>
+        <span class="browser-count">
+          {{ t('llcBrowser.programs.count', { count: programs.length }) }}
+        </span>
+      </div>
+      <BaseButton variant="primary" :disabled="!portfolioId" @click="openCreate">
+        {{ t('llcBrowser.programs.create') }}
+      </BaseButton>
     </header>
 
-    <div v-if="loading" class="browser-state">Loading programs…</div>
-    <div v-else-if="!programs.length" class="browser-state">No programs yet.</div>
+    <div v-if="loading" class="browser-state">{{ t('llcBrowser.programs.loading') }}</div>
+
+    <template v-else-if="loadError">
+      <ErrorBanner :message="t('llcBrowser.programs.loadError')" class="browser-error" />
+      <BaseButton variant="secondary" size="sm" @click="loadPrograms">
+        {{ t('llcBrowser.retry') }}
+      </BaseButton>
+    </template>
+
+    <div v-else-if="!programs.length" class="browser-state">
+      {{ t('llcBrowser.programs.empty') }}
+    </div>
 
     <div v-else class="card-grid">
       <button
@@ -34,15 +52,61 @@
         <p class="card-meta">{{ p.project_count }} {{ p.project_count === 1 ? 'project' : 'projects' }}</p>
       </button>
     </div>
+
+    <BaseModal
+      v-model="showCreate"
+      :title="t('llcBrowser.programs.createTitle')"
+      size="sm"
+    >
+      <ErrorBanner v-if="createError" :message="createError" class="browser-error" />
+      <div class="create-form">
+        <BaseInput
+          v-model="form.name"
+          :label="t('llcBrowser.nameLabel')"
+          :placeholder="t('llcBrowser.namePlaceholder')"
+          required
+        />
+        <div class="create-field">
+          <label class="create-label" for="program-description">
+            {{ t('llcBrowser.descriptionLabel') }}
+          </label>
+          <textarea
+            id="program-description"
+            v-model="form.description"
+            class="create-textarea"
+            rows="3"
+            :placeholder="t('llcBrowser.descriptionPlaceholder')"
+          />
+        </div>
+      </div>
+      <template #actions>
+        <BaseButton variant="secondary" :disabled="creating" @click="showCreate = false">
+          {{ t('llcBrowser.cancel') }}
+        </BaseButton>
+        <BaseButton
+          variant="primary"
+          :loading="creating"
+          :disabled="!form.name.trim() || creating"
+          @click="createProgram"
+        >
+          {{ t('llcBrowser.createAction') }}
+        </BaseButton>
+      </template>
+    </BaseModal>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import LlcBreadcrumb, { type BreadcrumbItem } from '@/components/llc/LlcBreadcrumb.vue'
+import BaseButton from '@/components/base/BaseButton.vue'
+import BaseInput from '@/components/base/BaseInput.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import ErrorBanner from '@/components/base/ErrorBanner.vue'
 
 interface ProgramResponse {
   id: string
@@ -60,31 +124,72 @@ const logger = createLogger('ProgramBrowserView')
 const api = useApiClient()
 const route = useRoute()
 const router = useRouter()
+const { t } = useI18n()
 
 const companyId = computed(() => route.params.companyId as string)
 const portfolioId = computed(() => route.params.portfolioId as string)
 const programs = ref<ProgramResponse[]>([])
 const loading = ref(false)
+const loadError = ref(false)
+
+const showCreate = ref(false)
+const creating = ref(false)
+const createError = ref('')
+const form = ref({ name: '', description: '' })
 
 const breadcrumb = computed<BreadcrumbItem[]>(() => [
   {
-    label: 'Portfolios',
+    label: t('llcBrowser.portfolios.title'),
     to: { name: 'llc-portfolios', params: { companyId: companyId.value } },
   },
-  { label: 'Programs' },
+  { label: t('llcBrowser.programs.title') },
 ])
 
 async function loadPrograms(): Promise<void> {
   loading.value = true
+  loadError.value = false
   try {
     programs.value = await api.get<ProgramResponse[]>(
       `/api/llc/portfolios/${portfolioId.value}/programs`,
     )
   } catch (err) {
     logger.error('Failed to load programs', err)
+    loadError.value = true
     programs.value = []
   } finally {
     loading.value = false
+  }
+}
+
+function openCreate(): void {
+  form.value = { name: '', description: '' }
+  createError.value = ''
+  showCreate.value = true
+}
+
+async function createProgram(): Promise<void> {
+  const name = form.value.name.trim()
+  if (!name || !portfolioId.value) return
+  creating.value = true
+  createError.value = ''
+  try {
+    // ProgramCreate: company_id (required) + name + optional description; the
+    // server derives the true tenant from the parent portfolio (#10261).
+    const created = await api.post<ProgramResponse>(
+      `/api/llc/portfolios/${portfolioId.value}/programs`,
+      {
+        company_id: companyId.value,
+        name,
+        description: form.value.description.trim() || undefined,
+      },
+    )
+    programs.value.unshift(created)
+    showCreate.value = false
+  } catch (err) {
+    logger.error('Failed to create program', err)
+    createError.value = t('llcBrowser.programs.createError')
+  } finally {
+    creating.value = false
   }
 }
 
@@ -105,26 +210,37 @@ onMounted(loadPrograms)
 
 .browser-header {
   display: flex;
-  align-items: baseline;
+  align-items: flex-start;
+  justify-content: space-between;
   gap: 0.75rem;
   margin-bottom: 1rem;
+}
+
+.browser-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
 }
 
 .browser-title {
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
   margin: 0;
 }
 
 .browser-count {
   font-size: 0.875rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
 }
 
 .browser-state {
   padding: 2rem 0;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
+}
+
+.browser-error {
+  margin-bottom: 0.75rem;
 }
 
 .card-grid {
@@ -141,8 +257,8 @@ onMounted(loadPrograms)
   text-align: left;
   cursor: pointer;
   border-radius: var(--radius-md, 8px);
-  border: 1px solid var(--border-default, #e5e7eb);
-  background: var(--bg-surface, #ffffff);
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
@@ -161,13 +277,13 @@ onMounted(loadPrograms)
 .card-name {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
   margin: 0;
 }
 
 .card-desc {
   font-size: 0.875rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
   margin: 0;
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -178,7 +294,7 @@ onMounted(loadPrograms)
 
 .card-meta {
   font-size: 0.75rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
   margin: 0;
 }
 
@@ -190,7 +306,36 @@ onMounted(loadPrograms)
   letter-spacing: 0.03em;
   padding: 0.125rem 0.5rem;
   border-radius: 999px;
-  background: var(--bg-hover, #f3f4f6);
-  color: var(--text-secondary, #6b7280);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+.create-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.create-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.create-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.create-textarea {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-md, 8px);
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  resize: vertical;
 }
 </style>

--- a/autobot-frontend/src/views/llc/ProjectBrowserView.vue
+++ b/autobot-frontend/src/views/llc/ProjectBrowserView.vue
@@ -4,19 +4,37 @@
 <!--
   ProjectBrowserView (GH#9628) — leaf tier of the LLC work hierarchy.
   Lists the projects under a program as a card grid. Each card links out to
-  the company-scoped Backlog and Timeline views.
+  the company-scoped Backlog and Timeline views. A header "Create" action opens
+  a modal that POSTs a new project and prepends it to the list (#10750 B1).
 -->
 <template>
   <div class="llc-browser">
     <LlcBreadcrumb :items="breadcrumb" />
 
     <header class="browser-header">
-      <h2 class="browser-title">Projects</h2>
-      <span class="browser-count">{{ projects.length }} projects</span>
+      <div class="browser-heading">
+        <h2 class="browser-title">{{ t('llcBrowser.projects.title') }}</h2>
+        <span class="browser-count">
+          {{ t('llcBrowser.projects.count', { count: projects.length }) }}
+        </span>
+      </div>
+      <BaseButton variant="primary" :disabled="!programId" @click="openCreate">
+        {{ t('llcBrowser.projects.create') }}
+      </BaseButton>
     </header>
 
-    <div v-if="loading" class="browser-state">Loading projects…</div>
-    <div v-else-if="!projects.length" class="browser-state">No projects yet.</div>
+    <div v-if="loading" class="browser-state">{{ t('llcBrowser.projects.loading') }}</div>
+
+    <template v-else-if="loadError">
+      <ErrorBanner :message="t('llcBrowser.projects.loadError')" class="browser-error" />
+      <BaseButton variant="secondary" size="sm" @click="loadProjects">
+        {{ t('llcBrowser.retry') }}
+      </BaseButton>
+    </template>
+
+    <div v-else-if="!projects.length" class="browser-state">
+      {{ t('llcBrowser.projects.empty') }}
+    </div>
 
     <div v-else class="card-grid">
       <article v-for="p in projects" :key="p.id" class="entity-card">
@@ -44,16 +62,62 @@
         </div>
       </article>
     </div>
+
+    <BaseModal
+      v-model="showCreate"
+      :title="t('llcBrowser.projects.createTitle')"
+      size="sm"
+    >
+      <ErrorBanner v-if="createError" :message="createError" class="browser-error" />
+      <div class="create-form">
+        <BaseInput
+          v-model="form.name"
+          :label="t('llcBrowser.nameLabel')"
+          :placeholder="t('llcBrowser.namePlaceholder')"
+          required
+        />
+        <div class="create-field">
+          <label class="create-label" for="project-description">
+            {{ t('llcBrowser.descriptionLabel') }}
+          </label>
+          <textarea
+            id="project-description"
+            v-model="form.description"
+            class="create-textarea"
+            rows="3"
+            :placeholder="t('llcBrowser.descriptionPlaceholder')"
+          />
+        </div>
+      </div>
+      <template #actions>
+        <BaseButton variant="secondary" :disabled="creating" @click="showCreate = false">
+          {{ t('llcBrowser.cancel') }}
+        </BaseButton>
+        <BaseButton
+          variant="primary"
+          :loading="creating"
+          :disabled="!form.name.trim() || creating"
+          @click="createProject"
+        >
+          {{ t('llcBrowser.createAction') }}
+        </BaseButton>
+      </template>
+    </BaseModal>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import LlcBreadcrumb, { type BreadcrumbItem } from '@/components/llc/LlcBreadcrumb.vue'
 import Sparkline from '@/components/llc/Sparkline.vue'
+import BaseButton from '@/components/base/BaseButton.vue'
+import BaseInput from '@/components/base/BaseInput.vue'
+import BaseModal from '@/components/ui/BaseModal.vue'
+import ErrorBanner from '@/components/base/ErrorBanner.vue'
 
 interface ProjectResponse {
   id: string
@@ -80,13 +144,20 @@ interface VelocityHistory {
 const logger = createLogger('ProjectBrowserView')
 const api = useApiClient()
 const route = useRoute()
+const { t } = useI18n()
 
 const companyId = computed(() => route.params.companyId as string)
 const programId = computed(() => route.params.programId as string)
 const projects = ref<ProjectResponse[]>([])
 const loading = ref(false)
+const loadError = ref(false)
 // project id → chronological velocity series (oldest→newest) for the sparkline.
 const velocities = ref<Record<string, number[]>>({})
+
+const showCreate = ref(false)
+const creating = ref(false)
+const createError = ref('')
+const form = ref({ name: '', description: '' })
 
 function velocityFor(projectId: string): number[] {
   return velocities.value[projectId] ?? []
@@ -94,11 +165,11 @@ function velocityFor(projectId: string): number[] {
 
 const breadcrumb = computed<BreadcrumbItem[]>(() => [
   {
-    label: 'Portfolios',
+    label: t('llcBrowser.portfolios.title'),
     to: { name: 'llc-portfolios', params: { companyId: companyId.value } },
   },
-  { label: 'Programs' },
-  { label: 'Projects' },
+  { label: t('llcBrowser.programs.title') },
+  { label: t('llcBrowser.projects.title') },
 ])
 
 function formatDate(value: string | null): string {
@@ -110,6 +181,7 @@ function formatDate(value: string | null): string {
 
 async function loadProjects(): Promise<void> {
   loading.value = true
+  loadError.value = false
   try {
     projects.value = await api.get<ProjectResponse[]>(
       `/api/llc/programs/${programId.value}/projects`,
@@ -117,6 +189,7 @@ async function loadProjects(): Promise<void> {
     void loadVelocities()
   } catch (err) {
     logger.error('Failed to load projects', err)
+    loadError.value = true
     projects.value = []
   } finally {
     loading.value = false
@@ -139,6 +212,38 @@ async function loadVelocities(): Promise<void> {
   )
 }
 
+function openCreate(): void {
+  form.value = { name: '', description: '' }
+  createError.value = ''
+  showCreate.value = true
+}
+
+async function createProject(): Promise<void> {
+  const name = form.value.name.trim()
+  if (!name || !programId.value) return
+  creating.value = true
+  createError.value = ''
+  try {
+    // ProjectCreate: company_id (required) + name + optional description; the
+    // server derives the true tenant from the parent program (#10261).
+    const created = await api.post<ProjectResponse>(
+      `/api/llc/programs/${programId.value}/projects`,
+      {
+        company_id: companyId.value,
+        name,
+        description: form.value.description.trim() || undefined,
+      },
+    )
+    projects.value.unshift(created)
+    showCreate.value = false
+  } catch (err) {
+    logger.error('Failed to create project', err)
+    createError.value = t('llcBrowser.projects.createError')
+  } finally {
+    creating.value = false
+  }
+}
+
 onMounted(loadProjects)
 </script>
 
@@ -149,26 +254,37 @@ onMounted(loadProjects)
 
 .browser-header {
   display: flex;
-  align-items: baseline;
+  align-items: flex-start;
+  justify-content: space-between;
   gap: 0.75rem;
   margin-bottom: 1rem;
+}
+
+.browser-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
 }
 
 .browser-title {
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
   margin: 0;
 }
 
 .browser-count {
   font-size: 0.875rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
 }
 
 .browser-state {
   padding: 2rem 0;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
+}
+
+.browser-error {
+  margin-bottom: 0.75rem;
 }
 
 .card-grid {
@@ -183,8 +299,8 @@ onMounted(loadProjects)
   gap: 0.5rem;
   padding: 1rem;
   border-radius: var(--radius-md, 8px);
-  border: 1px solid var(--border-default, #e5e7eb);
-  background: var(--bg-surface, #ffffff);
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
 }
 
 .card-top {
@@ -197,13 +313,13 @@ onMounted(loadProjects)
 .card-name {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
   margin: 0;
 }
 
 .card-desc {
   font-size: 0.875rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
   margin: 0;
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -214,7 +330,7 @@ onMounted(loadProjects)
 
 .card-meta {
   font-size: 0.75rem;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
   margin: 0;
 }
 
@@ -227,8 +343,8 @@ onMounted(loadProjects)
 .stat {
   font-size: 0.75rem;
   font-weight: 500;
-  color: var(--text-secondary, #6b7280);
-  background: var(--bg-hover, #f3f4f6);
+  color: var(--text-secondary);
+  background: var(--bg-hover);
   padding: 0.125rem 0.5rem;
   border-radius: 999px;
 }
@@ -243,7 +359,7 @@ onMounted(loadProjects)
   font-size: 0.6875rem;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  color: var(--text-secondary, #9ca3af);
+  color: var(--text-secondary);
 }
 
 .status-badge {
@@ -254,8 +370,8 @@ onMounted(loadProjects)
   letter-spacing: 0.03em;
   padding: 0.125rem 0.5rem;
   border-radius: 999px;
-  background: var(--bg-hover, #f3f4f6);
-  color: var(--text-secondary, #6b7280);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
 }
 
 .card-actions {
@@ -263,7 +379,7 @@ onMounted(loadProjects)
   gap: 0.75rem;
   margin-top: 0.25rem;
   padding-top: 0.5rem;
-  border-top: 1px solid var(--border-default, #e5e7eb);
+  border-top: 1px solid var(--border-default);
 }
 
 .action-link {
@@ -275,5 +391,34 @@ onMounted(loadProjects)
 
 .action-link:hover {
   text-decoration: underline;
+}
+
+.create-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.create-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.create-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.create-textarea {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-md, 8px);
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  resize: vertical;
 }
 </style>


### PR DESCRIPTION
## Thinking Path
Umbrella #10750 flagged the LLC/Company-OS browsers as read-only (B1) and their failure handling as indistinguishable from empty results (C3). Confirmed the backend create schemas in `autobot-backend/llc/api/sprints.py`, then mirrored the existing `BacklogView.vue` create pattern and the `MembersView.vue` ErrorBanner pattern rather than hand-rolling new primitives.

## What Changed
**B1 — Create actions (Portfolio / Program / Project browsers)**
- Header `BaseButton` "Create" → `BaseModal` form (`BaseInput` name + tokenized textarea) → POST → prepend result to the list.
- Request bodies (from backend `*Create` Pydantic models — all three require `company_id`):
  - Portfolio: `POST /api/llc/companies/{companyId}/portfolios` → `{ company_id, name, description? }`
  - Program: `POST /api/llc/portfolios/{portfolioId}/programs` → `{ company_id, name, description? }` (server derives tenant from parent per #10261)
  - Project: `POST /api/llc/programs/{programId}/projects` → `{ company_id, name, description? }` (server derives tenant from parent per #10261)
- Create failures surface an inline `ErrorBanner` inside the modal (matches `MembersView`).

**C3 — Real error/empty states + action-failure feedback**
- Portfolio/Program/Project browsers: `loadError` flag → `ErrorBanner` + Retry button, distinct from the genuine "No X yet." empty state.
- Toasts via `useNotificationBus` (the app's preferred wrapper over `useToast`, already used by `CompanyPortabilityView`):
  - `ApprovalsInbox.vue` — approve/reject failure toast.
  - `CeoChatView.vue` — send-message failure toast; message already restored to the input for retry.
  - `GanttTimelineView.vue` — reschedule-persist failure toast; bar already reverted via `loadTimeline()`.
- `VisionAutomationView.vue` — replaced raw `JSON.stringify` `<pre>` dumps with structured fields (OCR: text/confidence/bounds; opportunity: type/confidence/description).
- `FailureAnalysisDashboard.vue` — null-guarded `.length` on `causal_chain`/`interventions`/`confounders`/`recommendations`.
- New strings i18n'd across all 11 locales under a new `llcBrowser` namespace + `vision.visionAutomation` additions.

## Verification
- `npx vue-tsc --noEmit -p tsconfig.app.json`: 0 errors in changed files (only the pre-existing generated-file errors in `types/api-contract.ts` / `types/generated/api.ts` remain).
- `npx eslint` on all changed `.vue` files: 0 warnings/errors.
- All 11 locale JSONs validate; diffs are additive only.
- CSS uses canonical `--text-*/--bg-*/--border-default` tokens + Base components; preserved pre-existing `--color-accent` hex fallbacks (only defined in the ember theme) to avoid a non-ember regression.

## Model Used
Opus 4.8 (1M context)

Part of #10750 (B1,C3)