### PR TITLE
style: black-format test_jwt_key_durable.py (pre-existing repo-wide code-quality red)

### DIFF
--- a/autobot-backend/tests/security/test_jwt_key_durable.py
+++ b/autobot-backend/tests/security/test_jwt_key_durable.py
@@ -22,7 +22,6 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch  # noqa: F401 — patch used via patch.object
 
-
 # ---------------------------------------------------------------------------
 # Import the real auth_middleware module, bypassing the conftest stub.
 # conftest.py guards with ``if "auth_middleware" not in sys.modules``, so we


### PR DESCRIPTION
## Thinking Path
Discovered while merging follow-up PRs: `code-quality` (Black `--check` repo-wide, line-length 120) was failing on **every** PR because of one pre-existing unformatted base file — `autobot-backend/tests/security/test_jwt_key_durable.py` ("1 file would be reformatted"). Per Rule 6, fix the pre-existing issue rather than admin-bypass it forever.

## What Changed
- `black --line-length 120` reformat of that one file (1-line diff). Confirmed clean vs the repo config; it was the only file CI flagged.

## Verification
- `black --check --line-length=120` on the file → clean. This unblocks the `code-quality` required check platform-wide (no more per-PR admin-bypass for this).

## Model Used
Claude Opus 4.8 (1M context)