### PR TITLE
refactor(monitoring): rename HardwareMonitorStub → LocalHardwareMonitor (real since #10717) (#10781)

### DIFF
--- a/autobot-backend/api/analytics.py
+++ b/autobot-backend/api/analytics.py
@@ -64,7 +64,7 @@ from tasks.analytics_tasks import run_dashboard_analysis
 from utils.celery_task_status import celery_result_to_status, store_latest_task_id
 
 # Import existing monitoring infrastructure (extracted to monitoring_hardware.py - Issue #213)
-from .monitoring_hardware import hardware_monitor
+from .monitoring_hardware import local_hardware_monitor
 
 logger = get_logger(__name__)
 router = APIRouter(tags=["analytics"])
@@ -133,7 +133,7 @@ async def get_dashboard_overview(current_user: Dict = Depends(get_current_user))
     timestamp = datetime.now(tz=timezone.utc).isoformat()
 
     results = await asyncio.gather(
-        hardware_monitor.get_system_health(),
+        local_hardware_monitor.get_system_health(),
         analytics_controller.collect_performance_metrics(),
         analytics_controller.analyze_communication_patterns(),
         analytics_controller.get_usage_statistics(),
@@ -189,7 +189,7 @@ async def _check_service(client, service_name: str, service_url: str) -> Tuple[s
 def _check_resource_alerts(system_resources: Dict) -> List[Dict[str, Any]]:
     """Generate resource alerts based on thresholds (Issue #398: extracted).
 
-    Issue #596: Fixed key names to match hardware_monitor.get_system_resources() output.
+    Issue #596: Fixed key names to match local_hardware_monitor.get_system_resources() output.
     - CPU key: usage_percent (not percent_overall)
     - Memory key: usage_percent (not percent)
     """
@@ -229,7 +229,7 @@ def _check_resource_alerts(system_resources: Dict) -> List[Dict[str, Any]]:
 )
 async def get_detailed_system_health(current_user: Dict = Depends(get_current_user)):
     """Get detailed system health with enhanced analytics (Issue #398: refactored)."""
-    base_health = await hardware_monitor.get_system_health()
+    base_health = await local_hardware_monitor.get_system_health()
 
     detailed_health = {
         "base_health": base_health,
@@ -270,7 +270,7 @@ async def get_detailed_system_health(current_user: Dict = Depends(get_current_us
         detailed_health["service_connectivity"]["redis"] = "checked_via_redis"
 
     # Resource alerts using helper (Issue #430: await async)
-    system_resources = await hardware_monitor.get_system_resources()
+    system_resources = await local_hardware_monitor.get_system_resources()
     detailed_health["resource_alerts"] = _check_resource_alerts(system_resources)
 
     return detailed_health
@@ -431,7 +431,7 @@ async def _collect_realtime_metrics_data() -> Dict[str, Any]:
     # Issue #619: Parallelize independent metrics collection
     current_metrics, system_resources = await asyncio.gather(
         analytics_controller.metrics_collector.collect_all_metrics(),
-        hardware_monitor.get_system_resources(),
+        local_hardware_monitor.get_system_resources(),
     )
 
     realtime_data: Dict[str, Any] = {
@@ -454,7 +454,7 @@ async def _collect_realtime_metrics_data() -> Dict[str, Any]:
                 if parse_utc_iso(call["timestamp"]) > datetime.now(tz=timezone.utc) - timedelta(minutes=1)
             ]
         ),
-        # Issue #596: Fixed key names to match hardware_monitor.get_system_resources() output
+        # Issue #596: Fixed key names to match local_hardware_monitor.get_system_resources() output
         "performance_snapshot": {
             "cpu_percent": system_resources.get("cpu", {}).get("usage_percent", 0),
             "memory_percent": system_resources.get("memory", {}).get("usage_percent", 0),

--- a/autobot-backend/api/analytics_controller.py
+++ b/autobot-backend/api/analytics_controller.py
@@ -35,7 +35,7 @@ from type_defs.common import Metadata
 from utils.system_metrics import get_metrics_collector
 
 # Import existing monitoring infrastructure
-from .monitoring_hardware import hardware_monitor
+from .monitoring_hardware import local_hardware_monitor
 
 logger = get_logger(__name__)
 
@@ -424,8 +424,8 @@ class AnalyticsController:
 
     async def _collect_hardware_performance(self) -> Dict:
         """Helper for collect_performance_metrics. Ref: #1088."""
-        gpu_status = await hardware_monitor.get_gpu_status()
-        npu_status = await hardware_monitor.get_npu_status()
+        gpu_status = await local_hardware_monitor.get_gpu_status()
+        npu_status = await local_hardware_monitor.get_npu_status()
         return {
             "gpu": gpu_status,
             "npu": npu_status,

--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -27,7 +27,7 @@ from fastapi import (
 from fastapi.responses import JSONResponse, StreamingResponse
 
 # Hardware monitor moved to monitoring_hardware.py (Issue #213)
-from api.monitoring_hardware import hardware_monitor
+from api.monitoring_hardware import local_hardware_monitor
 
 # Import monitoring utility functions
 from api.monitoring_utils import (
@@ -1181,7 +1181,7 @@ async def get_hardware_npu_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
     """Get NPU hardware status. Issue #729: infrastructure monitoring on SLM server."""
-    return await hardware_monitor.get_npu_status()
+    return await local_hardware_monitor.get_npu_status()
 
 
 @router.get("/hardware/gpu", response_model=dict)
@@ -1194,7 +1194,7 @@ async def get_hardware_gpu_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
     """Get GPU hardware status. Issue #729: infrastructure monitoring on SLM server."""
-    return await hardware_monitor.get_gpu_status()
+    return await local_hardware_monitor.get_gpu_status()
 
 
 @router.get("/hardware/system", response_model=dict)
@@ -1207,7 +1207,7 @@ async def get_hardware_system_status(
     admin_check: bool = Depends(check_admin_permission),
 ):
     """Get system resource metrics (CPU, memory, disk)."""
-    return await hardware_monitor.get_system_resources()
+    return await local_hardware_monitor.get_system_resources()
 
 
 # External API status endpoints — extracted from monitoring_compat.py (Issue #1283)

--- a/autobot-backend/api/monitoring_hardware.py
+++ b/autobot-backend/api/monitoring_hardware.py
@@ -72,13 +72,17 @@ def _detect_npu_sync() -> Dict[str, Any]:
         return {"available": False, "error": "Detection failed"}
 
 
-class HardwareMonitorStub:
+class LocalHardwareMonitor:
     """
     Hardware monitor providing local GPU/NPU detection for analytics dashboards.
 
     Issue #729: Fleet infrastructure monitoring lives in the SLM server.
-    Issue #10717: get_gpu_status / get_npu_status now detect real local hardware
-    via HardwareAccelerationManager instead of returning a hardcoded stub.
+    Issue #10717: get_gpu_status / get_npu_status detect real local hardware
+    via HardwareAccelerationManager (nvidia-smi / rocm-smi / lspci / OpenVINO).
+
+    Distinct from utils/hardware_metrics.HardwarePerformanceMonitor, which
+    collects continuous perf-dashboard metrics (GPU utilisation, buffers, alerts).
+    This class answers point-in-time availability queries for analytics endpoints.
     """
 
     async def get_system_health(self) -> Dict[str, Any]:
@@ -160,5 +164,8 @@ class HardwareMonitorStub:
             return {"available": False, "error": "Detection failed"}
 
 
-# Global singleton instance for backward compatibility
-hardware_monitor = HardwareMonitorStub()
+# Singleton for this node's point-in-time hardware availability queries.
+# Named local_hardware_monitor to distinguish from
+# utils/hardware_metrics.hardware_monitor (HardwarePerformanceMonitor),
+# which handles continuous perf-dashboard collection.
+local_hardware_monitor = LocalHardwareMonitor()

--- a/autobot-backend/tasks/analytics_tasks.py
+++ b/autobot-backend/tasks/analytics_tasks.py
@@ -342,11 +342,11 @@ def run_dashboard_analysis(self) -> dict:
             _get_realtime_metrics,
             _handle_task_exception,
             analytics_controller,
-            hardware_monitor,
+            local_hardware_monitor,
         )
 
         results = await asyncio.gather(
-            hardware_monitor.get_system_health(),
+            local_hardware_monitor.get_system_health(),
             analytics_controller.collect_performance_metrics(),
             analytics_controller.analyze_communication_patterns(),
             analytics_controller.get_usage_statistics(),

--- a/autobot-backend/tests/test_monitoring_hardware.py
+++ b/autobot-backend/tests/test_monitoring_hardware.py
@@ -44,13 +44,13 @@ FALLBACK_NPU = {"available": False, "error": "Detection failed"}
 
 
 class TestGetGpuStatus:
-    """Unit tests for HardwareMonitorStub.get_gpu_status."""
+    """Unit tests for LocalHardwareMonitor.get_gpu_status."""
 
     async def test_proxies_detected_gpu(self):
         """When GPU is detected the response includes available=True + real fields."""
-        from api.monitoring_hardware import HardwareMonitorStub
+        from api.monitoring_hardware import LocalHardwareMonitor
 
-        stub = HardwareMonitorStub()
+        stub = LocalHardwareMonitor()
         with patch("api.monitoring_hardware._detect_gpu_sync", return_value=GPU_DETECTED):
             result = await stub.get_gpu_status()
 
@@ -60,9 +60,9 @@ class TestGetGpuStatus:
 
     async def test_proxies_absent_gpu(self):
         """When no GPU is detected available=False is returned cleanly."""
-        from api.monitoring_hardware import HardwareMonitorStub
+        from api.monitoring_hardware import LocalHardwareMonitor
 
-        stub = HardwareMonitorStub()
+        stub = LocalHardwareMonitor()
         with patch("api.monitoring_hardware._detect_gpu_sync", return_value=GPU_ABSENT):
             result = await stub.get_gpu_status()
 
@@ -71,9 +71,9 @@ class TestGetGpuStatus:
 
     async def test_never_raises_on_detection_error(self):
         """get_gpu_status must never propagate an exception from _detect_gpu_sync."""
-        from api.monitoring_hardware import HardwareMonitorStub
+        from api.monitoring_hardware import LocalHardwareMonitor
 
-        stub = HardwareMonitorStub()
+        stub = LocalHardwareMonitor()
         with patch("api.monitoring_hardware._detect_gpu_sync", side_effect=RuntimeError("boom")):
             try:
                 result = await stub.get_gpu_status()
@@ -85,9 +85,9 @@ class TestGetGpuStatus:
 
     async def test_available_key_always_present(self):
         """'available' key must exist whether GPU is present or absent."""
-        from api.monitoring_hardware import HardwareMonitorStub
+        from api.monitoring_hardware import LocalHardwareMonitor
 
-        stub = HardwareMonitorStub()
+        stub = LocalHardwareMonitor()
         for payload in (GPU_DETECTED, GPU_ABSENT, FALLBACK_GPU):
             with patch("api.monitoring_hardware._detect_gpu_sync", return_value=payload):
                 result = await stub.get_gpu_status()
@@ -100,13 +100,13 @@ class TestGetGpuStatus:
 
 
 class TestGetNpuStatus:
-    """Unit tests for HardwareMonitorStub.get_npu_status."""
+    """Unit tests for LocalHardwareMonitor.get_npu_status."""
 
     async def test_proxies_detected_npu(self):
         """When NPU is detected the response includes available=True + real fields."""
-        from api.monitoring_hardware import HardwareMonitorStub
+        from api.monitoring_hardware import LocalHardwareMonitor
 
-        stub = HardwareMonitorStub()
+        stub = LocalHardwareMonitor()
         with patch("api.monitoring_hardware._detect_npu_sync", return_value=NPU_DETECTED):
             result = await stub.get_npu_status()
 
@@ -116,9 +116,9 @@ class TestGetNpuStatus:
 
     async def test_proxies_absent_npu(self):
         """When no NPU is detected available=False is returned cleanly."""
-        from api.monitoring_hardware import HardwareMonitorStub
+        from api.monitoring_hardware import LocalHardwareMonitor
 
-        stub = HardwareMonitorStub()
+        stub = LocalHardwareMonitor()
         with patch("api.monitoring_hardware._detect_npu_sync", return_value=NPU_ABSENT):
             result = await stub.get_npu_status()
 
@@ -127,9 +127,9 @@ class TestGetNpuStatus:
 
     async def test_never_raises_on_detection_error(self):
         """get_npu_status must never propagate an exception from _detect_npu_sync."""
-        from api.monitoring_hardware import HardwareMonitorStub
+        from api.monitoring_hardware import LocalHardwareMonitor
 
-        stub = HardwareMonitorStub()
+        stub = LocalHardwareMonitor()
         with patch("api.monitoring_hardware._detect_npu_sync", side_effect=RuntimeError("boom")):
             try:
                 result = await stub.get_npu_status()
@@ -139,9 +139,9 @@ class TestGetNpuStatus:
 
     async def test_available_key_always_present(self):
         """'available' key must exist whether NPU is present or absent."""
-        from api.monitoring_hardware import HardwareMonitorStub
+        from api.monitoring_hardware import LocalHardwareMonitor
 
-        stub = HardwareMonitorStub()
+        stub = LocalHardwareMonitor()
         for payload in (NPU_DETECTED, NPU_ABSENT, FALLBACK_NPU):
             with patch("api.monitoring_hardware._detect_npu_sync", return_value=payload):
                 result = await stub.get_npu_status()


### PR DESCRIPTION
## Thinking Path
Follow-up to #10717. After #10717 the class does real local GPU/NPU detection, so `HardwareMonitorStub` is a misnomer (canonical-naming). Also two module-level `hardware_monitor` symbols (this one + `utils/hardware_metrics.py`'s perf collector) shared a confusing name.

## What Changed
- `monitoring_hardware.py`: `HardwareMonitorStub` → `LocalHardwareMonitor`; singleton `hardware_monitor` → `local_hardware_monitor` (disambiguates from the perf-dashboard `hardware_monitor` in hardware_metrics.py, which is unchanged). Docstring documents the distinction.
- Updated all importers: `api/monitoring.py`, `api/analytics.py`, `api/analytics_controller.py`, `tasks/analytics_tasks.py`, + tests.
- Rename only — no logic change.

## Verification
- grep-confirmed zero `HardwareMonitorStub` refs + zero `hardware_monitor` imports from monitoring_hardware remain.
- 14 tests pass; py_compile on all 6 touched files; flake8 clean.

Closes #10781.

## Model Used
Claude Opus 4.8 (1M context)