### PR TITLE
refactor(knowledge): extract shared kb-result mapper (dedupe #10715/#10716) (#10740)

### DIFF
--- a/autobot-backend/ai_hardware_accelerator.py
+++ b/autobot-backend/ai_hardware_accelerator.py
@@ -34,6 +34,7 @@ from constants.threshold_constants import (
     ResourceThresholds,
     TimingConstants,
 )
+from knowledge.search import map_kb_result_to_dict  # Issue #10740 shared mapper
 
 if TYPE_CHECKING:
     import torch as _torch_type  # noqa: F401
@@ -88,19 +89,6 @@ def _get_pil_image():
 
 # Default top-k for semantic search when not specified by caller. Issue #10716.
 _DEFAULT_SEMANTIC_SEARCH_TOP_K: int = 5
-
-
-def _map_kb_results(raw: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Map raw knowledge-base search rows to the accelerator result shape. Issue #10716."""
-    return [
-        {
-            "content": r.get("content", ""),
-            "source": r.get("node_id", r.get("doc_id", "")),
-            "score": r.get("score", 0.0),
-            "metadata": r.get("metadata", {}),
-        }
-        for r in raw
-    ]
 
 
 def _get_gpu_metrics_with_pynvml() -> Dict[str, Any] | None:
@@ -850,7 +838,7 @@ class AIHardwareAccelerator:
             raw: List[Dict[str, Any]] = await kb.search(query=query, top_k=top_k)
             elapsed_ms = (time.perf_counter() - t0) * 1000.0
 
-            results = _map_kb_results(raw)
+            results = [map_kb_result_to_dict(r) for r in raw]  # Issue #10740
             return {
                 "search_results": results,
                 "total_results": len(results),

--- a/autobot-backend/async_chat_workflow.py
+++ b/autobot-backend/async_chat_workflow.py
@@ -19,6 +19,7 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 from constants.threshold_constants import TimingConstants
 from dependency_container import inject_services
+from knowledge.search import map_kb_result_to_dict
 from knowledge_base_factory import get_knowledge_base
 from llm_shared.models import ChatMessage, LLMResponse  # Phase 2D #3185
 from retry_mechanism import RetryConfig, RetryStrategy, with_retry
@@ -227,15 +228,7 @@ class AsyncChatWorkflow:
             raw: List[Dict[str, Any]] = await kb.search(query=query, top_k=5)
             if not raw:
                 return KnowledgeStatus.MISSING, []
-            results = [
-                {
-                    "content": r.get("content", ""),
-                    "source": r.get("node_id", r.get("doc_id", "")),
-                    "score": r.get("score", 0.0),
-                    "metadata": r.get("metadata", {}),
-                }
-                for r in raw
-            ]
+            results = [map_kb_result_to_dict(r) for r in raw]  # Issue #10740
             return KnowledgeStatus.FOUND, results
         except Exception as exc:
             logger.error("Knowledge base search failed: %s", exc)

--- a/autobot-backend/knowledge/search.py
+++ b/autobot-backend/knowledge/search.py
@@ -71,6 +71,20 @@ _score_fact_by_terms = score_fact_by_terms
 _build_search_result = build_search_result
 
 
+def map_kb_result_to_dict(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Map one raw KB search row to the canonical result shape. Issue #10740.
+
+    Keys: content, source (node_id with doc_id fallback), score, metadata.
+    Single-item mapper; callers apply it with a list comprehension.
+    """
+    return {
+        "content": raw.get("content", ""),
+        "source": raw.get("node_id", raw.get("doc_id", "")),
+        "score": raw.get("score", 0.0),
+        "metadata": raw.get("metadata", {}),
+    }
+
+
 class SearchMixin:
     """
     Search functionality mixin for knowledge base.

--- a/autobot-backend/tests/unit/knowledge/test_kb_result_mapper.py
+++ b/autobot-backend/tests/unit/knowledge/test_kb_result_mapper.py
@@ -1,0 +1,79 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for knowledge.search.map_kb_result_to_dict. Issue #10740.
+
+Verifies:
+  - All four keys present in the output (content, source, score, metadata)
+  - node_id used as source when present
+  - doc_id used as source fallback when node_id absent
+  - Empty string source when neither node_id nor doc_id present
+  - Score and metadata defaults on missing keys
+  - Empty input dict produces all-default values (no crash)
+"""
+
+import pytest
+
+from knowledge.search import map_kb_result_to_dict
+
+
+class TestMapKbResultToDict:
+    """Tests for the canonical single-row KB result mapper."""
+
+    def test_all_keys_present_in_output(self):
+        raw = {"content": "hello", "node_id": "n1", "score": 0.8, "metadata": {"k": "v"}}
+        result = map_kb_result_to_dict(raw)
+        assert set(result.keys()) == {"content", "source", "score", "metadata"}
+
+    def test_content_mapped(self):
+        result = map_kb_result_to_dict({"content": "fact text", "node_id": "n1", "score": 0.5, "metadata": {}})
+        assert result["content"] == "fact text"
+
+    def test_source_prefers_node_id(self):
+        raw = {"content": "x", "node_id": "node-abc", "doc_id": "doc-xyz", "score": 0.7, "metadata": {}}
+        assert map_kb_result_to_dict(raw)["source"] == "node-abc"
+
+    def test_source_falls_back_to_doc_id_when_no_node_id(self):
+        raw = {"content": "x", "doc_id": "doc-xyz", "score": 0.7, "metadata": {}}
+        assert map_kb_result_to_dict(raw)["source"] == "doc-xyz"
+
+    def test_source_empty_string_when_neither_id_present(self):
+        raw = {"content": "x", "score": 0.5, "metadata": {}}
+        assert map_kb_result_to_dict(raw)["source"] == ""
+
+    def test_score_mapped(self):
+        result = map_kb_result_to_dict({"content": "", "node_id": "n", "score": 0.92, "metadata": {}})
+        assert result["score"] == pytest.approx(0.92)
+
+    def test_metadata_mapped(self):
+        meta = {"fact_id": "abc", "source": "readme"}
+        result = map_kb_result_to_dict({"content": "", "node_id": "n", "score": 0.1, "metadata": meta})
+        assert result["metadata"] == meta
+
+    def test_empty_dict_returns_all_defaults(self):
+        result = map_kb_result_to_dict({})
+        assert result == {"content": "", "source": "", "score": 0.0, "metadata": {}}
+
+    def test_score_default_zero_when_missing(self):
+        result = map_kb_result_to_dict({"content": "c", "node_id": "n"})
+        assert result["score"] == 0.0
+
+    def test_metadata_default_empty_dict_when_missing(self):
+        result = map_kb_result_to_dict({"content": "c", "node_id": "n", "score": 0.5})
+        assert result["metadata"] == {}
+
+    def test_content_default_empty_string_when_missing(self):
+        result = map_kb_result_to_dict({"node_id": "n", "score": 0.5, "metadata": {}})
+        assert result["content"] == ""
+
+    def test_list_comprehension_maps_multiple_rows(self):
+        rows = [
+            {"content": f"doc {i}", "node_id": f"node-{i}", "score": 0.9 - i * 0.1, "metadata": {}} for i in range(3)
+        ]
+        results = [map_kb_result_to_dict(r) for r in rows]
+        assert len(results) == 3
+        for i, r in enumerate(results):
+            assert r["content"] == f"doc {i}"
+            assert r["source"] == f"node-{i}"


### PR DESCRIPTION
## Thinking Path
Follow-up to #10739 review. The KB-result→dict mapping (`{content, source(node_id→doc_id), score, metadata}`) was duplicated verbatim in `async_chat_workflow._execute_kb_search` (#10715) and `ai_hardware_accelerator._map_kb_results` (#10716) — drift risk.

## What Changed
- New `map_kb_result_to_dict(raw)` in `knowledge/search.py` (next to the search that produces these rows).
- Both callers import + use it; removed the duplicated inline logic + the local `_map_kb_results`. Behavior identical.

## Verification
- 25 tests pass: 12 new mapper tests (all keys, node_id→doc_id fallback, empty/missing-key defaults, list mapping) + 8 async_chat_workflow + 5 gpu-search (both unchanged).
- flake8 clean; isort-sorted imports.

Closes #10740.

## Model Used
Claude Opus 4.8 (1M context)