### PR TITLE
refactor(frontend): extract useModelPicker composable (dedupe #10718) (#10755)

### DIFF
--- a/autobot-frontend/src/components/chat/MultiModelChat.vue
+++ b/autobot-frontend/src/components/chat/MultiModelChat.vue
@@ -97,15 +97,15 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
-import { ref, watch, computed, onMounted } from 'vue'
+import { ref, computed } from 'vue'
 import { useMultiModelCompare } from '@/composables/useMultiModelCompare'
 // GH#8990: show per-model context window in picker
-import { useAvailableModels } from '@/composables/useAvailableModels'
+import { useModelPicker } from '@/composables/useModelPicker'
 
 const { responses, selectedModels, isComparing, compare, reset } = useMultiModelCompare()
-// #10718: source the model list from the live /api/models endpoint — no
-// hardcoded defaults that masquerade as real availability.
-const { models: llmModels, availableModelNames, fetchModels } = useAvailableModels()
+// #10755/#10718: source the model list from the live /api/models endpoint (no
+// hardcoded defaults) and seed the selection once it loads — shared wiring.
+const { models: llmModels, availableModels } = useModelPicker(selectedModels)
 
 const promptText = ref('')
 
@@ -122,25 +122,6 @@ const contextWindowLabel = computed(() => {
       : String(cw)
   }
   return map
-})
-
-// Picker list: live available models plus any previously-stored selections
-// (so a persisted choice stays selectable even if a provider is briefly down).
-// Before the fetch resolves this is empty — the picker renders no fake models.
-const availableModels = computed<string[]>(() =>
-  Array.from(new Set<string>([...availableModelNames.value, ...selectedModels.value])),
-)
-
-// Seed the selection from the live list once it loads, but only when the user
-// has no persisted choice yet. The watcher handles the async fetch timing.
-watch(availableModelNames, (names) => {
-  if (selectedModels.value.length === 0 && names.length > 0) {
-    selectedModels.value = [...names]
-  }
-})
-
-onMounted(() => {
-  fetchModels().catch(() => {})
 })
 
 async function onSend(): Promise<void> {

--- a/autobot-frontend/src/composables/useModelPicker.ts
+++ b/autobot-frontend/src/composables/useModelPicker.ts
@@ -1,0 +1,76 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * useModelPicker — shared multi-model picker wiring (#10755, dedupe #10718).
+ *
+ * Both MultiModelChat and BenchmarkView build a checkbox picker from the live
+ * /api/models list and seed the selection once that list loads. This composable
+ * centralises that identical wiring:
+ *   - fetch the model list on mount (fire-and-forget; empty until it resolves,
+ *     so the picker never renders fake/hardcoded models),
+ *   - expose `availableModels` = union of live names + any current selection
+ *     (a persisted choice stays selectable even if its provider is briefly down),
+ *   - seed `selectedModels` from the live list exactly once, and only while the
+ *     caller has no choice yet (default guard: selection is empty). Because
+ *     callers back `selectedModels` with a persisted (localStorage) ref via
+ *     useMultiModelCompare, this guard also respects a persisted choice.
+ *
+ * The `models` ref is re-exported for callers that need per-model metadata
+ * (e.g. MultiModelChat's context-window labels); BenchmarkView ignores it.
+ */
+
+import { computed, watch, onMounted, type ComputedRef, type Ref } from 'vue'
+import { useAvailableModels, type AvailableModel } from './useAvailableModels'
+
+export interface UseModelPickerOptions {
+  /**
+   * Seed the selection only when this returns true. Defaults to "selection is
+   * empty", which — with a persisted selection ref — also means "no persisted
+   * choice yet".
+   */
+  shouldSeed?: () => boolean
+}
+
+export interface UseModelPickerReturn {
+  /** Full model metadata list (name, provider, context_window, …). */
+  models: Ref<AvailableModel[]>
+  /** Names of models currently reported available. */
+  availableModelNames: ComputedRef<string[]>
+  /** Picker list: live available names ∪ current selection. */
+  availableModels: ComputedRef<string[]>
+  /** Re-fetch the live model list. */
+  fetchModels: () => Promise<void>
+}
+
+export function useModelPicker(
+  selectedModels: Ref<string[]>,
+  options: UseModelPickerOptions = {},
+): UseModelPickerReturn {
+  const { models, availableModelNames, fetchModels } = useAvailableModels()
+
+  const shouldSeed = options.shouldSeed ?? (() => selectedModels.value.length === 0)
+
+  // Picker list: live available models plus any previously-stored selections
+  // (so a persisted choice stays selectable even if a provider is briefly down).
+  // Before the fetch resolves this is empty — the picker renders no fake models.
+  const availableModels = computed<string[]>(() =>
+    Array.from(new Set<string>([...availableModelNames.value, ...selectedModels.value])),
+  )
+
+  // Seed the selection from the live list once it loads, but only when the user
+  // has no choice yet. The watcher handles the async fetch timing.
+  watch(availableModelNames, (names) => {
+    if (shouldSeed() && names.length > 0) {
+      selectedModels.value = [...names]
+    }
+  })
+
+  onMounted(() => {
+    fetchModels().catch(() => {})
+  })
+
+  return { models, availableModelNames, availableModels, fetchModels }
+}

--- a/autobot-frontend/src/views/BenchmarkView.vue
+++ b/autobot-frontend/src/views/BenchmarkView.vue
@@ -159,14 +159,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { ApexOptions } from 'apexcharts'
 import ApiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import { useMultiModelCompare } from '@/composables/useMultiModelCompare'
-import { useAvailableModels } from '@/composables/useAvailableModels'
+import { useModelPicker } from '@/composables/useModelPicker'
 import BaseChart from '@/components/charts/BaseChart.vue'
 import {
   type BenchmarkResultRow,
@@ -182,7 +182,8 @@ const { t } = useI18n()
 const logger = createLogger('BenchmarkView')
 
 const { responses, selectedModels, isComparing, compare } = useMultiModelCompare()
-const { availableModelNames, fetchModels } = useAvailableModels()
+// #10755/#10718: shared live-model picker wiring (fetch-on-mount + seeding).
+const { availableModels } = useModelPicker(selectedModels)
 
 const promptText = ref('')
 const selectedPromptSetId = ref('')
@@ -196,22 +197,6 @@ const filterPromptType = ref('')
 const filterSince = ref('')
 
 const promptTypes = ['rag', 'code', 'summarization', 'reasoning', 'custom']
-
-// #10718: build the picker from the live /api/models list (+ any already-selected
-// model) — no hardcoded seed masquerading as real availability. Before fetch
-// resolves the list is empty; the picker renders no fake models.
-const availableModels = computed<string[]>(() => {
-  const union = new Set<string>([...availableModelNames.value, ...selectedModels.value])
-  return Array.from(union)
-})
-
-// Seed the selection once the live list loads, but only when the user has no
-// persisted choice yet. The watcher handles the async fetch timing.
-watch(availableModelNames, (names) => {
-  if (selectedModels.value.length === 0 && names.length > 0) {
-    selectedModels.value = [...names]
-  }
-})
 
 const currentPromptType = computed(
   () => promptSets.value.find((s) => s.id === selectedPromptSetId.value)?.promptType ?? 'custom',
@@ -347,7 +332,6 @@ function formatDate(iso: string): string {
 }
 
 onMounted(() => {
-  fetchModels().catch(() => {})
   loadPromptSets()
   loadHistory()
 })


### PR DESCRIPTION
## Thinking Path
Follow-up to #10751 review. `MultiModelChat.vue` + `BenchmarkView.vue` (from #10718) carried near-identical `availableModels` computed + seeding watcher + fetch-on-mount over `useAvailableModels()`.

## What Changed
- New `src/composables/useModelPicker.ts` encapsulating: `availableModels` computed (union of live names + selection), the guarded seeding watcher, and `fetchModels()` on mount. Optional `shouldSeed` predicate defaults to the existing empty-check → behavior byte-for-byte identical.
- `MultiModelChat.vue` uses `{ models: llmModels, availableModels }` (keeps its context-window label off `models`); `BenchmarkView.vue` uses `{ availableModels }` (its onMounted now only loads prompt-sets/history — fetch moved into the composable). Removed the duplicated logic + now-unused `watch`/`onMounted` imports.

## Verification
- No Linux npm — types verified by reading (`availableModels: ComputedRef<string[]>` for v-for; `llmModels: Ref<AvailableModel[]>` matches prior usage); CI vue-tsc is the validator. No `console.*`, no dangling imports.

Closes #10755.

## Model Used
Claude Opus 4.8 (1M context)