### PR TITLE
fix(backend): recommend_agents 400-masking, ansible backend readiness port, chromadb client cache key (#10662, #10650, #10625)

### DIFF
--- a/autobot-backend/api/orchestration.py
+++ b/autobot-backend/api/orchestration.py
@@ -288,6 +288,8 @@ async def recommend_agents(
             },
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("Agent recommendation error: %s", e)
         raise HTTPException(status_code=500, detail="Failed to get recommendations")

--- a/autobot-backend/utils/async_chromadb_client.py
+++ b/autobot-backend/utils/async_chromadb_client.py
@@ -465,7 +465,11 @@ async def get_async_chromadb_client(
     import chromadb  # noqa: F811
     from chromadb.config import Settings as ChromaSettings
 
-    cache_key = f"http://{_CHROMADB_HOST}:{_CHROMADB_PORT}" if _CHROMADB_HOST else db_path
+    cache_key = (
+        f"http://{_CHROMADB_HOST}:{_CHROMADB_PORT}" if _CHROMADB_HOST else db_path,
+        allow_reset,
+        anonymized_telemetry,
+    )
 
     if cache_key in _async_client_cache:
         return _async_client_cache[cache_key]

--- a/autobot-backend/utils/chromadb_client.py
+++ b/autobot-backend/utils/chromadb_client.py
@@ -339,7 +339,11 @@ def get_chromadb_client(
 
     # #10601: return the cached client instead of rebuilding it (and re-running
     # the legacy migrations below) on every call. Mirrors _async_client_cache.
-    cache_key = f"http://{_CHROMADB_HOST}:{_CHROMADB_PORT}" if _CHROMADB_HOST else (db_path or "data/chromadb")
+    cache_key = (
+        f"http://{_CHROMADB_HOST}:{_CHROMADB_PORT}" if _CHROMADB_HOST else (db_path or "data/chromadb"),
+        allow_reset,
+        anonymized_telemetry,
+    )
     cached = _sync_client_cache.get(cache_key)
     if cached is not None:
         return cached

--- a/autobot-slm-backend/ansible/playbooks/deploy-service-auth.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-service-auth.yml
@@ -51,8 +51,8 @@
   tasks:
     - name: Wait for backend to be ready
       ansible.builtin.uri:
-        url: "{{ backend_protocol | default('https') }}://{{ ansible_host }}:{{ backend_port | default(8443) }}/api/health"
-        validate_certs: "{{ validate_backend_certs | default(false) }}"
+        url: "http://127.0.0.1:8001/api/health"
+        validate_certs: false
         return_content: true
       register: health_check
       retries: 6

--- a/autobot-slm-backend/ansible/setup-user-backend.yml
+++ b/autobot-slm-backend/ansible/setup-user-backend.yml
@@ -113,7 +113,7 @@
 
     - name: Check backend health
       uri:
-        url: "https://{{ ansible_host }}:{{ backend_https_port }}/api/health"
+        url: "http://127.0.0.1:8001/api/health"
         validate_certs: false
         status_code: [200, 404]
         timeout: 10


### PR DESCRIPTION
## Thinking Path
Three pre-existing, self-contained backend bugs surfaced in prior reviews; batched into one PR per owner's batch-cohesive-issues guidance.

## What Changed
- **#10662** `api/orchestration.py` `recommend_agents`: added `except HTTPException: raise` before the generic `except Exception` so the 400 ("No valid capabilities specified") and real error details propagate instead of being masked as 500.
- **#10650** ansible backend readiness: two tasks (`deploy-service-auth.yml`, `setup-user-backend.yml`) probed `:8443` where nothing listens; repointed to `http://127.0.0.1:8001/api/health` (actual uvicorn). Unrelated nginx/TLS 8443 refs untouched.
- **#10625** ChromaDB client cache: `get_chromadb_client` + `get_async_chromadb_client` now key the client cache on `(host_or_path, allow_reset, anonymized_telemetry)` so callers with different reset/telemetry settings no longer receive a stale first-cached client.

## Verification
- `python -m py_compile` clean on all 3 changed Python files.
- Diffs reviewed: HTTPException re-raise ordering correct; cache keys are hashable tuples used for both get+set; ansible edits scoped to the backend readiness probes only.

## Model Used
Claude Opus 4.8 (orchestration) + Sonnet 4.6 (implementation)

Closes #10662, #10650, #10625