### PR TITLE
fix(security): block unapproved sudo fallback in production elevation path (#10799)

### DIFF
--- a/autobot-backend/elevation_wrapper.py
+++ b/autobot-backend/elevation_wrapper.py
@@ -193,29 +193,62 @@ class ElevationWrapper:
                 "return_code": -1,
             }
 
+    def _sudo_fallback_permitted(self) -> bool:
+        """Return True only when direct-sudo fallback is safe to use.
+
+        Permitted when ANY of the following is true:
+        - AUTOBOT_ENVIRONMENT != "production"  (development / staging / etc.)
+        - CI env var is set (headless runner with NOPASSWD service account)
+        - AUTOBOT_ALLOW_UNAPPROVED_SUDO=true   (explicit operator opt-in)
+
+        The default AUTOBOT_ENVIRONMENT is "development", so new deployments
+        that forget to configure an elevation_client are still safe — they only
+        break when AUTOBOT_ENVIRONMENT=production is set without a client.
+        Issue #10799.
+        """
+        if config.environment != "production":
+            return True
+        if config.misc.ci:
+            return True
+        return bool(config.misc.allow_unapproved_sudo)
+
     async def _execute_elevated(self, command: str, session_token: str) -> Dict:
         """Execute command with elevation using session token.
 
         Primary path: delegates to ``elevation_client.execute_elevated_command``
-        when a GUI elevation client is configured (production).
+        when a GUI elevation client is configured.
 
-        Fallback path: runs ``sudo <command>`` directly when no client is
-        present.  This fallback is intentional for headless/CI environments
-        where no GUI is available, but it bypasses the GUI approval flow.
-        Security note: ensure the fallback path is not reachable in
-        multi-user deployments — configure an elevation_client instead.
+        Fallback path: runs ``sudo <command>`` directly only when
+        ``_sudo_fallback_permitted()`` returns True (dev/CI/explicit opt-in).
+        In production with no client the call is blocked and a structured
+        failure is returned — privilege escalation via misconfiguration is
+        prevented.  Issue #10799.
         """
         try:
             if self.elevation_client:
-                result = await self.elevation_client.execute_elevated_command(command, session_token)
-                return result
-            else:
-                # Fallback: direct sudo — only reached when no GUI client is configured.
-                logger.warning(
-                    "No elevation client configured; falling back to direct sudo for command: %s",
+                return await self.elevation_client.execute_elevated_command(command, session_token)
+
+            if not self._sudo_fallback_permitted():
+                logger.error(
+                    "Elevation client is not configured and unapproved sudo fallback is blocked "
+                    "in production.  Set AUTOBOT_ALLOW_UNAPPROVED_SUDO=true or configure an "
+                    "elevation_client.  Command blocked: %s",
                     command,
                 )
-                return await self._execute_normal(f"sudo {command}")
+                return {
+                    "success": False,
+                    "error": (
+                        "Elevation client not configured; direct sudo is blocked in production. "
+                        "Configure an elevation_client or set AUTOBOT_ALLOW_UNAPPROVED_SUDO=true."
+                    ),
+                    "blocked": True,
+                }
+
+            logger.warning(
+                "No elevation client configured; falling back to direct sudo for command: %s",
+                command,
+            )
+            return await self._execute_normal(f"sudo {command}")
 
         except Exception as e:
             logger.error("Elevated execution failed: %s", e)

--- a/autobot-backend/elevation_wrapper_test.py
+++ b/autobot-backend/elevation_wrapper_test.py
@@ -167,3 +167,74 @@ async def test_execute_command_rejects_expired_session():
     # No client configured → falls through to "needs_elevation" error
     assert result["success"] is False
     assert result.get("needs_elevation") is True
+
+
+# ---------------------------------------------------------------------------
+# _execute_elevated: sudo fallback guard (issue #10799)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_elevated_with_client_delegates():
+    """elevation_client present → execute_elevated_command is called (unchanged path)."""
+    client = MagicMock()
+    client.execute_elevated_command = AsyncMock(return_value={"success": True, "output": "done"})
+    w = ElevationWrapper(elevation_client=client)
+
+    result = await w._execute_elevated("apt-get upgrade", "tok-abc")
+
+    client.execute_elevated_command.assert_called_once_with("apt-get upgrade", "tok-abc")
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_elevated_no_client_dev_env_permits_sudo():
+    """No client + development environment → direct sudo fallback is permitted."""
+    w = ElevationWrapper()  # no client
+
+    with patch("elevation_wrapper.config") as mock_cfg:
+        mock_cfg.environment = "development"
+        mock_cfg.misc.ci = ""
+        mock_cfg.misc.allow_unapproved_sudo = False
+        with patch.object(
+            w, "_execute_normal", new=AsyncMock(return_value={"success": True, "output": "ok"})
+        ) as mock_exec:
+            result = await w._execute_elevated("apt-get upgrade", "tok-dev")
+
+    mock_exec.assert_called_once_with("sudo apt-get upgrade")
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_elevated_no_client_production_blocks_sudo():
+    """No client + production environment → blocked; sudo is NOT executed. Issue #10799."""
+    w = ElevationWrapper()  # no client
+
+    with patch("elevation_wrapper.config") as mock_cfg:
+        mock_cfg.environment = "production"
+        mock_cfg.misc.ci = ""
+        mock_cfg.misc.allow_unapproved_sudo = False
+        with patch.object(w, "_execute_normal", new=AsyncMock()) as mock_exec:
+            result = await w._execute_elevated("apt-get upgrade", "tok-prod")
+
+    mock_exec.assert_not_called()
+    assert result["success"] is False
+    assert result.get("blocked") is True
+
+
+@pytest.mark.asyncio
+async def test_execute_elevated_no_client_production_explicit_allow():
+    """No client + production + AUTOBOT_ALLOW_UNAPPROVED_SUDO=true → fallback permitted."""
+    w = ElevationWrapper()  # no client
+
+    with patch("elevation_wrapper.config") as mock_cfg:
+        mock_cfg.environment = "production"
+        mock_cfg.misc.ci = ""
+        mock_cfg.misc.allow_unapproved_sudo = True
+        with patch.object(
+            w, "_execute_normal", new=AsyncMock(return_value={"success": True, "output": "ok"})
+        ) as mock_exec:
+            result = await w._execute_elevated("apt-get upgrade", "tok-allow")
+
+    mock_exec.assert_called_once_with("sudo apt-get upgrade")
+    assert result["success"] is True

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1288,6 +1288,16 @@ class MiscConfig(BaseSettings):
     autoresearch_staged_eval_threshold: float = Field(default=0.0, alias="AUTOBOT_AUTORESEARCH_STAGED_EVAL_THRESHOLD")
     autoresearch_timeout: int = Field(default=0, alias="AUTOBOT_AUTORESEARCH_TIMEOUT")
     ai_stack_enabled: bool = Field(default=True, alias="AUTOBOT_AI_STACK_ENABLED")
+    allow_unapproved_sudo: bool = Field(
+        default=False,
+        alias="AUTOBOT_ALLOW_UNAPPROVED_SUDO",
+        description=(
+            "Allow direct sudo fallback in elevation_wrapper when no GUI elevation client is "
+            "configured.  Safe default is False (block).  Set to true only in headless/CI "
+            "environments with a NOPASSWD service account.  Never set in production/multi-user "
+            "deployments — configure an elevation_client instead.  Issue #10799."
+        ),
+    )
     cache_enabled: bool = Field(default=False, alias="AUTOBOT_CACHE_ENABLED")
     cache_size: int = Field(default=0, alias="AUTOBOT_CACHE_SIZE")
     cache_l1_size: int = Field(


### PR DESCRIPTION
## Thinking Path
Follow-up to #10723. `_execute_elevated` fell back to direct `sudo <command>` when `elevation_client is None` — no approval gate. Fine headless/CI, but a prod misconfig (missing GUI client) would silently bypass the elevation-approval flow.

## What Changed
- New `_sudo_fallback_permitted()` — permits the sudo fallback only when `environment != "production"` OR `CI` truthy OR the new `AUTOBOT_ALLOW_UNAPPROVED_SUDO` flag (default **False** = safe). Reuses existing `config.environment`/`config.misc.ci`.
- `_execute_elevated` (client None): if not permitted → returns `{success: False, blocked: True, error}`, sudo is NEVER spawned. Default `AUTOBOT_ENVIRONMENT=development` keeps existing deployments working; block fires only when a prod deployment lacks a client.

## Verification
- 15 tests pass: client-present delegates; no-client+dev→sudo; no-client+prod→blocked (no sudo); no-client+prod+explicit-allow→permitted.
- flake8 clean; safe default.

Closes #10799.

## Model Used
Claude Opus 4.8 (1M context)