### PR TITLE
fix(knowledge): semantic cache key sync, fail-loud cognifier extractors, doc-context [Source N] citations (#10669, #10645, #10658)

### DIFF
--- a/autobot-backend/knowledge/pipeline/cognifiers/causal_relationship_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/causal_relationship_extractor.py
@@ -306,17 +306,17 @@ class CausalRelationshipExtractor(BaseCognifier):
         Returns:
             List of causal edges from chunk
         """
+        prompt = CAUSAL_EXTRACTION_PROMPT.format(text=chunk.content)
         try:
-            prompt = CAUSAL_EXTRACTION_PROMPT.format(text=chunk.content)
             response = await self.llm.chat(
                 [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
             )
-            parsed = parse_llm_json_response(response.content)
-            raw_edges = parsed if isinstance(parsed, list) else []
-            return self._convert_to_causal_edges(raw_edges, chunk, context.document_id)
         except Exception as e:
-            logger.error("Causal extraction failed for chunk: %s", e)
+            logger.error("Causal extraction LLM call failed (transient): %s", e)
             return []
+        parsed = parse_llm_json_response(response.content, strict=True)
+        raw_edges = parsed if isinstance(parsed, list) else []
+        return self._convert_to_causal_edges(raw_edges, chunk, context.document_id)
 
     def _convert_to_causal_edges(
         self, raw_edges: List[Dict[str, Any]], chunk: ProcessedChunk, document_id

--- a/autobot-backend/knowledge/pipeline/cognifiers/entity_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/entity_extractor.py
@@ -259,18 +259,24 @@ class EntityExtractor(BaseCognifier):
         return entities
 
     async def _extract_from_chunk(self, chunk: ProcessedChunk, context: PipelineContext) -> List[Entity]:
-        """Extract entities from a single chunk."""
+        """Extract entities from a single chunk.
+
+        Transient LLM errors (network, timeout) are caught and return an empty
+        list so the pipeline can continue.  Format errors (bad prompt template →
+        KeyError) and parse errors (malformed JSON → JSONDecodeError) are
+        re-raised so they surface as bugs rather than silent empties (#10645).
+        """
+        prompt = ENTITY_EXTRACTION_PROMPT.format(text=chunk.content)
         try:
-            prompt = ENTITY_EXTRACTION_PROMPT.format(text=chunk.content)
             response = await self.llm.chat(
                 [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
             )
-            parsed = parse_llm_json_response(response.content)
-            raw_entities = parsed if isinstance(parsed, list) else []
-            return self._convert_to_entities(raw_entities, chunk, context.document_id)
         except Exception as e:
-            logger.error("Entity extraction failed: %s", e)
+            logger.error("Entity extraction LLM call failed (transient): %s", e)
             return []
+        parsed = parse_llm_json_response(response.content, strict=True)
+        raw_entities = parsed if isinstance(parsed, list) else []
+        return self._convert_to_entities(raw_entities, chunk, context.document_id)
 
     def _convert_to_entities(
         self,

--- a/autobot-backend/knowledge/pipeline/cognifiers/event_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/event_extractor.py
@@ -103,18 +103,22 @@ class EventExtractor(BaseCognifier):
         entity_map: Dict[str, Entity],
         context: PipelineContext,
     ) -> List[TemporalEvent]:
-        """Extract events from a single chunk."""
+        """Extract events from a single chunk.
+
+        Transient LLM errors are caught and return an empty list.
+        Format and parse errors are re-raised (#10645).
+        """
+        prompt = EVENT_EXTRACTION_PROMPT.format(text=chunk.content)
         try:
-            prompt = EVENT_EXTRACTION_PROMPT.format(text=chunk.content)
             response = await self.llm.chat(
                 [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
             )
-            parsed = parse_llm_json_response(response.content)
-            raw_events = parsed if isinstance(parsed, list) else []
-            return self._convert_to_events(raw_events, chunk, entity_map, context)
         except Exception as e:
-            logger.error("Event extraction failed: %s", e)
+            logger.error("Event extraction LLM call failed (transient): %s", e)
             return []
+        parsed = parse_llm_json_response(response.content, strict=True)
+        raw_events = parsed if isinstance(parsed, list) else []
+        return self._convert_to_events(raw_events, chunk, entity_map, context)
 
     def _parse_llm_response(self, content: str) -> list:
         """

--- a/autobot-backend/knowledge/pipeline/cognifiers/fact_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/fact_extractor.py
@@ -299,18 +299,22 @@ class FactExtractor(BaseCognifier):
         return facts
 
     async def _extract_from_chunk(self, chunk: ProcessedChunk, context: PipelineContext) -> List[AtomicFact]:
-        """Extract facts from a single chunk using LLM."""
+        """Extract facts from a single chunk using LLM.
+
+        Transient LLM errors are caught and return an empty list.
+        Format and parse errors are re-raised (#10645).
+        """
+        prompt = FACT_EXTRACTION_PROMPT.format(text=chunk.content[:MAX_CHUNK_CHARS])
         try:
-            prompt = FACT_EXTRACTION_PROMPT.format(text=chunk.content[:MAX_CHUNK_CHARS])
             response = await self.llm.chat(
                 [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
             )
-            parsed = parse_llm_json_response(response.content)
-            raw_facts = parsed if isinstance(parsed, list) else []
-            return self._convert_to_facts(raw_facts, chunk, context.document_id)
         except Exception as e:
-            logger.error("Fact extraction failed for chunk %s: %s", chunk.id, e)
+            logger.error("Fact extraction LLM call failed (transient) for chunk %s: %s", chunk.id, e)
             return []
+        parsed = parse_llm_json_response(response.content, strict=True)
+        raw_facts = parsed if isinstance(parsed, list) else []
+        return self._convert_to_facts(raw_facts, chunk, context.document_id)
 
     def _convert_to_facts(
         self,

--- a/autobot-backend/knowledge/pipeline/cognifiers/llm_utils.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/llm_utils.py
@@ -21,6 +21,7 @@ def parse_llm_json_response(
     content: str,
     *,
     fallback_dict: bool = False,
+    strict: bool = False,
 ) -> List[Dict[str, Any]] | Dict[str, Any]:
     """Parse LLM response as JSON, handling markdown code fences.
 
@@ -28,6 +29,10 @@ def parse_llm_json_response(
         content: Raw LLM response text.
         fallback_dict: If True, return a dict fallback on parse failure
                        (used by summarizer). Otherwise return empty list.
+        strict: If True, re-raise ``json.JSONDecodeError`` instead of
+                returning an empty fallback — callers that must not swallow
+                parse failures (e.g. cognifier extractors) use this so
+                malformed LLM responses surface as errors (#10645).
 
     Returns:
         Parsed JSON (list or dict depending on LLM output).
@@ -41,6 +46,8 @@ def parse_llm_json_response(
         if "```" in content:
             json_str = content.split("```")[1].split("```")[0].strip()
             return json.loads(json_str)
+        if strict:
+            raise
         logger.warning("Could not parse LLM response as JSON")
         if fallback_dict:
             return {"summary": content, "key_topics": [], "key_entities": []}

--- a/autobot-backend/knowledge/pipeline/cognifiers/relationship_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/relationship_extractor.py
@@ -240,19 +240,23 @@ class RelationshipExtractor(BaseCognifier):
         entities: List[Entity],
         entity_map: Dict[str, Entity],
     ) -> List[Relationship]:
-        """Extract relationships from a single chunk."""
+        """Extract relationships from a single chunk.
+
+        Transient LLM errors are caught and return an empty list.
+        Format and parse errors are re-raised (#10645).
+        """
+        entity_list = self._format_entity_list(entities, chunk)
+        prompt = RELATIONSHIP_EXTRACTION_PROMPT.format(entities=entity_list, text=chunk.content)
         try:
-            entity_list = self._format_entity_list(entities, chunk)
-            prompt = RELATIONSHIP_EXTRACTION_PROMPT.format(entities=entity_list, text=chunk.content)
             response = await self.llm.chat(
                 [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
             )
-            parsed = parse_llm_json_response(response.content)
-            raw_rels = parsed if isinstance(parsed, list) else []
-            return self._convert_to_relationships(raw_rels, chunk, entity_map)
         except Exception as e:
-            logger.error("Relationship extraction failed: %s", e)
+            logger.error("Relationship extraction LLM call failed (transient): %s", e)
             return []
+        parsed = parse_llm_json_response(response.content, strict=True)
+        raw_rels = parsed if isinstance(parsed, list) else []
+        return self._convert_to_relationships(raw_rels, chunk, entity_map)
 
     def _parse_llm_response(self, content: str) -> list:
         """

--- a/autobot-backend/llm_shared/semantic_cache.py
+++ b/autobot-backend/llm_shared/semantic_cache.py
@@ -72,9 +72,30 @@ class SemanticLLMCache:
     # Public API
     # ------------------------------------------------------------------
 
-    def generate_cache_key(self, messages, model, temperature, top_k=40, top_p=0.9):
-        """Delegate key generation to the wrapped exact cache."""
-        return self._exact.generate_cache_key(messages, model, temperature, top_k, top_p)
+    def generate_cache_key(
+        self,
+        messages,
+        model,
+        temperature,
+        top_k: int = 40,
+        top_p: float = 0.9,
+        max_tokens: int | None = None,
+        structured_output: bool = False,
+    ):
+        """Delegate key generation to the wrapped exact cache.
+
+        Signature mirrors LLMResponseCache.generate_cache_key exactly so the
+        two classes can never diverge on key dimensions (#10669).
+        """
+        return self._exact.generate_cache_key(
+            messages,
+            model,
+            temperature,
+            top_k,
+            top_p,
+            max_tokens,
+            structured_output,
+        )
 
     async def get(self, cache_key: str, prompt: str | None = None) -> Any | None:
         """

--- a/autobot-backend/services/knowledge/service.py
+++ b/autobot-backend/services/knowledge/service.py
@@ -620,10 +620,34 @@ class ChatKnowledgeService:
             categories=effective_categories,
         )
 
-        # Issue #1261: Also search indexed documentation (autobot_docs)
-        doc_context = self._retrieve_documentation_context(query)
-        if doc_context:
-            context_string = doc_context + "\n\n" + context_string if context_string else doc_context
+        # Issue #1261, #10658: Search indexed documentation (autobot_docs) and
+        # label each chunk as [Source N] continuing from KB source numbering so
+        # citation indices are contiguous and the frontend can resolve them.
+        doc_results = self._retrieve_raw_doc_results(query)
+        if doc_results:
+            kb_count = len(citations)
+            doc_lines: List[str] = []
+            for offset, result in enumerate(doc_results, 1):
+                source_n = kb_count + offset
+                content = result.get("content", "").strip()
+                doc_lines.append(f"[Source {source_n}] {content}")
+                citations.append(
+                    {
+                        "id": f"doc_{offset}",
+                        "content": content,
+                        "score": result.get("score", 0.0),
+                        "source": result.get("file_path", ""),
+                        "title": result.get("section", ""),
+                        "rank": source_n,
+                        "metadata": {
+                            "doc_type": result.get("doc_type", "documentation"),
+                            "section": result.get("section", ""),
+                            "subsection": result.get("subsection", ""),
+                        },
+                    }
+                )
+            doc_block = "AUTOBOT DOCUMENTATION CONTEXT:\n" + "\n".join(doc_lines)
+            context_string = doc_block + "\n\n" + context_string if context_string else doc_block
 
         logger.info(
             "[Conversation RAG] Completed in %.3fs - %d citations, " "enhanced=%s, categories=%s, docs=%s",
@@ -631,7 +655,7 @@ class ChatKnowledgeService:
             len(citations),
             enhanced_query.enhancement_applied,
             effective_categories or "all",
-            bool(doc_context),
+            bool(doc_results),
         )
         return context_string, citations, intent_result, enhanced_query
 
@@ -676,6 +700,35 @@ class ChatKnowledgeService:
         except Exception as e:
             logger.warning("[Doc Search] Failed: %s", e)
             return ""
+
+    def _retrieve_raw_doc_results(
+        self, query: str, n_results: int = 3, score_threshold: float = 0.3
+    ) -> List[Dict[str, Any]]:
+        """Return raw doc-search results without pre-formatting (#10658).
+
+        Used by ``conversation_aware_retrieve`` to build [Source N] labels that
+        continue from the KB citation count, keeping citation indices contiguous.
+        """
+        if not self.doc_searcher:
+            return []
+        try:
+            if not self.doc_searcher.is_documentation_query(query):
+                return []
+            results = self.doc_searcher.search(
+                query=query,
+                n_results=n_results,
+                score_threshold=score_threshold,
+            )
+            if results:
+                logger.info(
+                    "[Doc Search] Retrieved %d raw documentation chunks for: '%s...'",
+                    len(results),
+                    query[:50],
+                )
+            return results
+        except Exception as e:
+            logger.warning("[Doc Search] Raw retrieval failed: %s", e)
+            return []
 
     def _search_and_format_documentation(
         self,


### PR DESCRIPTION
## Thinking Path
Three pre-existing knowledge-subsystem correctness bugs from prior reviews, batched into one PR.

## What Changed
- **#10669** `llm_shared/semantic_cache.py`: `generate_cache_key` now mirrors canonical `LLMResponseCache.generate_cache_key` exactly — adds `max_tokens` + `structured_output` and forwards all 7 dimensions (positional order verified against `cache.py:123`), so the wrapper can't drift and reintroduce key collisions if wired onto LLMService.
- **#10645** cognifier extractors (entity/relationship/event/fact/causal): prompt `.format()` (KeyError) and `parse_llm_json_response(..., strict=True)` (JSONDecodeError) now run OUTSIDE the try and propagate as hard errors — a malformed prompt/parse no longer silently yields an empty graph. Only the transient LLM transport call stays wrapped (returns `[]` to continue). New `strict` kwarg on `parse_llm_json_response` in `llm_utils.py`.
- **#10658** `services/knowledge/service.py`: new `_retrieve_raw_doc_results()` — doc chunks are now labelled `[Source N]` continuing KB numbering (`len(kb_citations)+1`) AND each gets a matching citation dict appended to `citations`, so every `[Source N]` the model emits resolves to the right source in the frontend.

## Verification
- `python -m py_compile` clean on all 8 changed files.
- Canonical key signature order confirmed to match the forwarding call.
- Extractor restructure reviewed: format/parse outside try, transport inside.

## Model Used
Claude Opus 4.8 (orchestration) + Sonnet 4.6 (implementation)

Closes #10669, #10645, #10658