### PR TITLE
fix(backend): analytics project-root resolution in deployed layout + wire kb-not-initialized into /search (#10730, #10693)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
@@ -32,6 +32,7 @@ from utils.io_executor import get_analytics_executor
 
 from ..duplicate_detector import DuplicateCodeDetector, detect_duplicates_async
 from ..storage import get_code_collection
+from .shared import resolve_project_root
 
 logger = get_logger(__name__)
 
@@ -45,8 +46,8 @@ _duplicate_cache: dict[str, dict] = {}
 
 
 def _get_project_root() -> str:
-    """Get project root path (4 levels up from this file)."""
-    return str(Path(__file__).resolve().parents[4])
+    """Get project root path — delegates to shared resolver (#10730)."""
+    return resolve_project_root()
 
 
 async def _run_semantic_analysis(project_root: str, min_similarity: float):
@@ -509,7 +510,7 @@ async def detect_config_duplicates_endpoint(
     Returns:
         JSONResponse with duplicate detection results
     """
-    project_root = Path(__file__).resolve().parents[4]
+    project_root = Path(resolve_project_root())
     if source_id:
         try:
             from api.codebase_analytics.source_storage import get_source

--- a/autobot-backend/api/codebase_analytics/endpoints/environment.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/environment.py
@@ -23,6 +23,7 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import QUALITY_MODEL
 
 from ..analyzers import normalize_hardcode_record
+from .shared import resolve_project_root
 
 logger = get_logger(__name__)
 
@@ -37,8 +38,8 @@ _env_analysis_cache_lock = asyncio.Lock()
 
 
 def _get_project_root() -> str:
-    """Get project root path (4 levels up from this file)."""
-    return str(Path(__file__).resolve().parents[4])
+    """Get project root path — delegates to shared resolver (#10730)."""
+    return resolve_project_root()
 
 
 def _validate_env_path_security(path: str, project_root: str) -> JSONResponse | None:

--- a/autobot-backend/api/codebase_analytics/endpoints/ownership.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/ownership.py
@@ -22,6 +22,8 @@ from fastapi.responses import JSONResponse
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 
+from .shared import resolve_project_root
+
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/ownership", tags=["ownership"])
@@ -69,8 +71,8 @@ def _get_ownership_analyzer():
 
 
 def _get_project_root() -> str:
-    """Get project root path (4 levels up from this file)."""
-    return str(Path(__file__).resolve().parents[4])
+    """Get project root path — delegates to shared resolver (#10730)."""
+    return resolve_project_root()
 
 
 def _validate_path_security(path: str, project_root: str) -> JSONResponse | None:

--- a/autobot-backend/api/codebase_analytics/endpoints/shared.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/shared.py
@@ -186,6 +186,48 @@ def get_project_root() -> Path:
     return Path(__file__).resolve().parents[4]
 
 
+def resolve_project_root() -> str:
+    """
+    Resolve the real git repository root robustly for dev and deployed layouts.
+
+    Issue #10730: In the deployed layout autobot-backend is a standalone rsync
+    dir under /opt/autobot, so ``parents[4]`` resolves to /opt/autobot which is
+    NOT a git repo.  The actual repository lives in the sibling code_source dir.
+
+    Strategy (first match wins):
+    1. Walk up from this file looking for a directory containing `.git`.
+    2. If no git repo found walking up, look for a sibling/child ``code_source``
+       directory that itself contains ``.git`` (deployed layout).
+    3. Fall back to ``parents[4]`` so dev checkouts keep working unchanged.
+
+    Returns:
+        str: Absolute path to the resolved project root.
+    """
+    current = Path(__file__).resolve()
+
+    # Walk up the directory tree looking for a .git entry
+    for parent in current.parents:
+        if (parent / ".git").exists():
+            logger.debug("resolve_project_root: found git root via walk-up: %s", parent)
+            return str(parent)
+
+    # No .git found walking up — check for deployed-layout sibling code_source
+    # The walk exhausted all parents; the last ``parent`` is the filesystem root.
+    # Re-anchor from the hard-coded parents[4] candidate and look around it.
+    candidate = Path(__file__).resolve().parents[4]
+    for probe in (
+        candidate / "code_source",          # /opt/autobot/code_source
+        candidate.parent / "code_source",   # one level higher, just in case
+    ):
+        if (probe / ".git").exists():
+            logger.debug("resolve_project_root: found git root via code_source probe: %s", probe)
+            return str(probe)
+
+    # Final fallback: original parents[4] (works in dev checkout)
+    logger.debug("resolve_project_root: falling back to parents[4]: %s", candidate)
+    return str(candidate)
+
+
 def filter_problems_by_file_existence(
     problems: list[dict],
     root_path: "Path | str | None" = None,

--- a/autobot-backend/api/codebase_analytics/endpoints/shared.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/shared.py
@@ -216,8 +216,8 @@ def resolve_project_root() -> str:
     # Re-anchor from the hard-coded parents[4] candidate and look around it.
     candidate = Path(__file__).resolve().parents[4]
     for probe in (
-        candidate / "code_source",          # /opt/autobot/code_source
-        candidate.parent / "code_source",   # one level higher, just in case
+        candidate / "code_source",  # /opt/autobot/code_source
+        candidate.parent / "code_source",  # one level higher, just in case
     ):
         if (probe / ".git").exists():
             logger.debug("resolve_project_root: found git root via code_source probe: %s", probe)

--- a/autobot-backend/api/knowledge_search.py
+++ b/autobot-backend/api/knowledge_search.py
@@ -562,6 +562,11 @@ async def search(request: SearchRequest, req: Request):
     if kb_to_use is None:
         return error_response
 
+    # Guard: KB object exists but initialization failed (#10693 wire-in)
+    if hasattr(kb_to_use, "initialized") and not kb_to_use.initialized:
+        logger.warning("search: KB instance exists but is not initialized — returning not-initialized response")
+        return _build_kb_not_initialized_response()
+
     query = request.query
     logger.info("Search: %s", request.get_log_summary())
 

--- a/autobot-backend/tasks/analytics_tasks.py
+++ b/autobot-backend/tasks/analytics_tasks.py
@@ -17,6 +17,7 @@ import asyncio
 import hashlib
 import json
 from datetime import datetime, timezone
+from pathlib import Path
 
 from autobot_shared.logging_manager import get_logger
 from celery_app import celery_app
@@ -112,9 +113,9 @@ def run_import_tree_analysis(self) -> dict:
             _build_module_to_file_mapping,
             _build_summary,
         )
-        from api.codebase_analytics.endpoints.shared import get_project_root
+        from api.codebase_analytics.endpoints.shared import resolve_project_root
 
-        project_root = get_project_root()
+        project_root = Path(resolve_project_root())
         excluded = {"__pycache__", "node_modules", ".venv", "venv", ".env", "archive", "dist", "build"}
         python_files = await asyncio.to_thread(lambda: list(project_root.rglob("*.py")))
         python_files = [f for f in python_files if not any(ex in f.parts for ex in excluded)]
@@ -148,12 +149,12 @@ def run_duplicate_analysis(self) -> dict:
     async def _work():
         from api.codebase_analytics.endpoints.duplicates import (
             _build_timeout_response,
-            _get_project_root,
             _process_and_cache_analysis,
             _run_duplicate_analysis,
         )
+        from api.codebase_analytics.endpoints.shared import resolve_project_root
 
-        project_root = _get_project_root()
+        project_root = resolve_project_root()
         analysis = await _run_duplicate_analysis(project_root, 0.5, False)
         if analysis is None:
             return _build_timeout_response()


### PR DESCRIPTION
## Thinking Path
Two self-contained backend bugs batched into one PR.

## What Changed
- **#10730** codebase-analytics returned 0 files in the deployed layout because `_get_project_root()` hardcoded `Path(__file__).resolve().parents[4]` = `/opt/autobot` (not a git repo; real repo is sibling `/opt/autobot/code_source`). Added one authoritative `resolve_project_root()` in `codebase_analytics/endpoints/shared.py`: walk up for `.git` (dev), else probe `code_source` (deployed), else fall back to `parents[4]`. `ownership.py`, `duplicates.py`, `environment.py` and `tasks/analytics_tasks.py` all delegate to it — no copy-paste.
- **#10693** `_build_kb_not_initialized_response()` lost its only caller when #10688 folded the deprecated search endpoints. Per the never-delete rule, WIRED IT IN instead of deleting: the unified `/search` handler now returns it when `kb_to_use.initialized` is False (verified `KnowledgeBase.initialized` is a real attribute, base.py:127). Frontend api.ts regen deferred to a separate task (see #10693 note).

## Verification
- `python -m py_compile` clean on all changed files.
- `_build_kb_not_initialized_response` now has 1 caller (def line 258, call line ~568); guard reachability confirmed against `KnowledgeBase.initialized`.
- resolve_project_root fallback preserves dev-checkout behavior.

## Model Used
Claude Opus 4.8 (orchestration) + Sonnet 4.6 (implementation)

Closes #10730