### PR TITLE
fix(release): guarantee GitHub Release creation despite protected-main changelog push (#10608)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,21 @@ jobs:
             git commit -m "chore(release): changelog and fragments for ${VERSION}"
           fi
           git tag -a "${VERSION}" -m "Release ${VERSION}"
-          git push origin main --follow-tags
+          # Push the tag first and on its own. Tags are not branch-protected, so
+          # this always lands and guarantees the "Create GitHub Release" step
+          # below has a ref to release from (#10608).
+          git push origin "refs/tags/${VERSION}"
+          # The changelog commit targets the protected main branch via a direct
+          # bot push, which main's required status checks reject (#10608). That
+          # rejection must NOT abort the job, or the tag exists with no GitHub
+          # Release. Make the changelog push best-effort and surface it as a
+          # warning (not a silent swallow); the changelog is still published on
+          # the Release via body_path below.
+          if git push origin HEAD:main; then
+            echo "Changelog commit landed on main."
+          else
+            echo "::warning::Changelog commit push to main was rejected by branch protection (expected, #10608). Tag ${VERSION} and the GitHub Release are still created; the changelog is attached to the Release. Full fix (bypass token / changelog-PR) tracked in #10608."
+          fi
 
       - name: Create GitHub Release
         if: steps.check.outputs.release_needed == 'true'


### PR DESCRIPTION
## Thinking Path
release.yml half-completes every release: it creates the tag, then its `git push origin main --follow-tags` for the changelog commit is rejected by main's required status checks, and the job exits 1 **before** `action-gh-release` — so the tag exists but no GitHub Release is ever created (observed on v0.5.0, run 28320583504). Implemented the issue's sanctioned Option 3.

## What Changed
`.github/workflows/release.yml`, "Commit changelog files and tag" step:
- Push the **tag on its own** (`git push origin refs/tags/${VERSION}`) first — tags aren't branch-protected, so the ref the Release needs always lands.
- Make the changelog commit push to protected main **best-effort**: `git push origin HEAD:main` failure emits a `::warning::` (not a silent swallow) instead of aborting the job. The "Create GitHub Release" step then always runs; the changelog is still published on the Release via `body_path`.

## Verification
- YAML validated (`yaml.safe_load` OK).
- Only `${VERSION}` (computed semver from `steps.check.outputs.version`) is interpolated — no untrusted input, no injection surface.
- Behavior: tag + Release now guaranteed; changelog-on-main push no longer fatal.

## Follow-up (not this PR)
Fully landing the changelog **on main** needs a bypass token or a changelog-PR flow (issue Options 1/2) — requires a secret/app, so left as a fast-follow noted on #10608. This PR removes the critical "no Release created" failure.

## Model Used
Claude Opus 4.8 (1M context)

Closes #10608