### PR TITLE
fix(audit): display routable host instead of bind-all 0.0.0.0 in audit dashboard (#10502 #11)

### DIFF
--- a/autobot-backend/api/audit.py
+++ b/autobot-backend/api/audit.py
@@ -187,7 +187,9 @@ async def get_audit_statistics(request: Request, admin_check: bool = Depends(che
             success=True,
             statistics=stats,
             vm_info={
-                "vm_source": audit_logger.vm_source,
+                # display_host resolves a routable host when vm_source is a
+                # bind-all/loopback address (e.g. 0.0.0.0 in prod) — #10502 #11.
+                "vm_source": audit_logger.display_host,
                 "vm_name": audit_logger.vm_name,
             },
         )

--- a/autobot-backend/services/audit_logger.py
+++ b/autobot-backend/services/audit_logger.py
@@ -51,6 +51,10 @@ from utils.async_initializable import AsyncInitializable
 
 logger = get_logger(__name__)
 
+# Bind-all / loopback placeholders that are not routable hosts and must not be
+# shown as the backend address in the audit dashboard (#10502 item #11).
+_NON_ROUTABLE_HOSTS = frozenset({"0.0.0.0", "::", "127.0.0.1", "::1", "localhost", ""})
+
 # Audit result types
 AuditResult = Literal["success", "denied", "failed", "error"]
 
@@ -256,6 +260,20 @@ class AuditLogger(AsyncInitializable):
             NetworkConstants.BROWSER_VM_IP: "browser",
         }
         return vm_mapping.get(self.vm_source, socket.gethostname())
+
+    @property
+    def display_host(self) -> str:
+        """Routable host label for UIs (#10502 item #11).
+
+        vm_source is the configured bind address (config.vm.main =
+        AUTOBOT_BACKEND_HOST), which in production is 0.0.0.0 (bind-all) or a
+        loopback — not a real, routable host. Show the machine FQDN/hostname
+        instead so the audit dashboard displays where the backend actually runs.
+        """
+        source = (self.vm_source or "").strip()
+        if source.lower() in _NON_ROUTABLE_HOSTS:
+            return socket.getfqdn() or socket.gethostname()
+        return source
 
     async def _get_audit_db(self) -> async_redis.Redis | None:
         """Get Redis audit database (DB 10)"""


### PR DESCRIPTION
## Thinking Path
Live re-triage of #10502's 11 defects found 8 already fixed since the 2026-06-26 triage and 3 runtime/data (not code). Only item **#11** was a real code bug: the audit dashboard shows the backend's *bind* address (`config.vm.main` = `AUTOBOT_BACKEND_HOST`, set to `0.0.0.0` in prod) as if it were the host.

## What Changed
- `services/audit_logger.py`: new `display_host` property — returns the machine FQDN/hostname when `vm_source` is a bind-all/loopback placeholder (`0.0.0.0`, `::`, `127.0.0.1`, `::1`, `localhost`, empty), else the configured value unchanged. Module-level `_NON_ROUTABLE_HOSTS` set. `socket` already imported.
- `api/audit.py`: audit-statistics `vm_info.vm_source` now returns `display_host` (backend-only; no frontend/type change — the label already renders this field).

## Verification
- `python -m py_compile` clean on both files.
- Behavior check: `0.0.0.0`/empty → resolved FQDN; a real IP (`10.0.0.5`) passes through untouched.

## Model Used
Claude Opus 4.8 (1M context)

Closes #10502 — item #11 is the final code-actionable defect; #1-#5,#7,#8 were already fixed since the 2026-06-26 triage and #6/#9/#10 are runtime/data (not code), per the detailed re-triage comment on the issue.