### PR TITLE
fix(security): apply security headers to CSRF-rejection 401 responses (#10846)

### DIFF
--- a/autobot-slm-backend/middleware/security_headers.py
+++ b/autobot-slm-backend/middleware/security_headers.py
@@ -78,10 +78,12 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
                     request.method,
                     request.url.path,
                 )
-                return JSONResponse(
+                rejection = JSONResponse(
                     status_code=401,
                     content={"detail": "Authorization header required"},
                 )
+                _add_security_headers(rejection)
+                return rejection
 
         response = await call_next(request)
         _add_security_headers(response)


### PR DESCRIPTION
## Thinking Path
Discovered in #10778. `SecurityHeadersMiddleware.dispatch` returned the CSRF-rejection `JSONResponse(401)` directly, skipping `_add_security_headers` (the normal pass-through path had it) — so rejected/unauthenticated state-changing requests missed the security headers.

## What Changed
- `middleware/security_headers.py`: the 401 rejection response now runs through `_add_security_headers(...)` before return. Normal path untouched.

## Verification
- `test_security_headers_on_rejected_request` now passes (the failure was purely the missing call — no test-isolation issue; confirmed 40/40 when run with test_bi_dashboard.py).
- security-headers suite 16/16; flake8 clean.

Closes #10846.

## Model Used
Claude Opus 4.8 (1M context)