### PR TITLE
fix(models): rename SLM node AuditLog table to slm_node_audit_logs; UUID/org AuditLog canonical for audit_logs (#10764)

### DIFF
--- a/autobot-slm-backend/api/sso.py
+++ b/autobot-slm-backend/api/sso.py
@@ -133,7 +133,7 @@ async def get_providers_health(
 ) -> list[SSOProviderHealthResponse]:
     """Return per-provider health summary (failed-auth counts + last-success).
 
-    Aggregates audit_logs rows with category='sso', action='login' over the
+    Aggregates slm_node_audit_logs rows with category='sso', action='login' over the
     past SSO_HEALTH_WINDOW_DAYS days. Guarded by SECURITY_MANAGE permission.
     """
     context = TenantContext(is_platform_admin=True)

--- a/autobot-slm-backend/migrations/rename_audit_logs_to_slm_node_audit_logs.py
+++ b/autobot-slm-backend/migrations/rename_audit_logs_to_slm_node_audit_logs.py
@@ -1,0 +1,174 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Migration: Rename SLM node 'audit_logs' table to 'slm_node_audit_logs' (#10764).
+
+Two ORM models both declared ``__tablename__ = 'audit_logs'`` on separate
+``DeclarativeBase`` registries that bind to DIFFERENT PostgreSQL databases:
+
+* ``user_management.models.audit.AuditLog`` — UUID PK, org-aware (outcome/details)
+  → ``SLM_USERS_DATABASE_URL`` database (``slm_users``). **Canonical** owner of
+  ``audit_logs``; left untouched.
+* ``models.database.AuditLog`` — INTEGER PK (log_id/category/success/extra_data)
+  → ``settings.database_url`` (``SLM_DATABASE_URL``) database (``slm``).
+
+This was a LATENT name-clash (not a live single-table collision) because the two
+tables live in different databases. The startup collision checker only warned; it
+never raised. Reconciled by renaming the integer-PK SLM table.
+
+This migration runs via ``migrations.runner``, which connects with
+``settings.database_url`` — i.e. the ``slm`` database ONLY. It never touches the
+``slm_users`` database, so the canonical UUID ``audit_logs`` table is untouched.
+
+Safe to re-run: it only renames when an integer-PK ``audit_logs`` table is present
+and ``slm_node_audit_logs`` does not yet exist.
+"""
+
+import logging
+
+from migrations.runner import _parse_db_url
+
+logger = logging.getLogger(__name__)
+
+_OLD_NAME = "audit_logs"
+_NEW_NAME = "slm_node_audit_logs"
+
+
+def _connect(db_url: str):
+    import psycopg2
+
+    params = _parse_db_url(db_url)
+    if params.get("password") is None:
+        params.pop("password", None)
+    return psycopg2.connect(**params)
+
+
+def _audit_pk_type(cur, table: str) -> str | None:
+    """Return the data_type of ``table.id`` in the public schema, or None."""
+    cur.execute(
+        """
+        SELECT data_type
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = %s
+          AND column_name = 'id'
+        """,
+        (table,),
+    )
+    row = cur.fetchone()
+    return row[0].lower() if row else None
+
+
+def migrate(db_url: str) -> None:
+    """Rename the integer-PK SLM 'audit_logs' table to 'slm_node_audit_logs'.
+
+    Guards:
+    * Skip if the target 'slm_node_audit_logs' already exists (already migrated).
+    * Skip if no 'audit_logs' table exists on this (slm) database.
+    * Skip if the existing 'audit_logs' has a non-integer PK — that would be the
+      user_management (UUID) table and must NOT be touched. (It should never be
+      present on the slm database, but this is a belt-and-braces guard.)
+    """
+    conn = _connect(db_url)
+    try:
+        with conn.cursor() as cur:
+            new_pk = _audit_pk_type(cur, _NEW_NAME)
+            if new_pk is not None:
+                logger.info(
+                    "Table '%s' already exists — skipping rename (already migrated)",
+                    _NEW_NAME,
+                )
+                return
+
+            old_pk = _audit_pk_type(cur, _OLD_NAME)
+            if old_pk is None:
+                logger.info(
+                    "Table '%s' not found on this database — skipping rename "
+                    "(fresh install or already migrated)",
+                    _OLD_NAME,
+                )
+                return
+
+            if old_pk not in ("integer", "bigint", "smallint"):
+                logger.warning(
+                    "Table '%s' has PK type '%s' (not integer) — this is NOT the "
+                    "SLM node audit table; refusing to rename",
+                    _OLD_NAME,
+                    old_pk,
+                )
+                return
+
+            cur.execute(f"ALTER TABLE {_OLD_NAME} RENAME TO {_NEW_NAME}")
+            logger.info("Renamed table '%s' -> '%s'", _OLD_NAME, _NEW_NAME)
+
+            # Rename the default PK sequence if it follows the standard naming.
+            cur.execute(
+                """
+                SELECT relname FROM pg_class
+                WHERE relname = %s AND relkind = 'S'
+                """,
+                (f"{_OLD_NAME}_id_seq",),
+            )
+            if cur.fetchone():
+                cur.execute(
+                    f"ALTER SEQUENCE {_OLD_NAME}_id_seq RENAME TO {_NEW_NAME}_id_seq"
+                )
+                logger.info(
+                    "Renamed sequence '%s_id_seq' -> '%s_id_seq'", _OLD_NAME, _NEW_NAME
+                )
+
+        conn.commit()
+        logger.info("Migration rename_audit_logs_to_slm_node_audit_logs completed")
+    finally:
+        conn.close()
+
+
+def downgrade(db_url: str) -> None:
+    """Reverse the rename: 'slm_node_audit_logs' -> 'audit_logs'.
+
+    Only acts when 'slm_node_audit_logs' exists and 'audit_logs' does not, so it
+    is safe to re-run and will not clobber a canonical UUID audit table (which,
+    in any case, lives in the separate slm_users database).
+    """
+    conn = _connect(db_url)
+    try:
+        with conn.cursor() as cur:
+            new_pk = _audit_pk_type(cur, _NEW_NAME)
+            if new_pk is None:
+                logger.info(
+                    "Table '%s' not found — nothing to downgrade", _NEW_NAME
+                )
+                return
+
+            old_pk = _audit_pk_type(cur, _OLD_NAME)
+            if old_pk is not None:
+                logger.warning(
+                    "Table '%s' already exists — refusing to downgrade to avoid "
+                    "clobbering it",
+                    _OLD_NAME,
+                )
+                return
+
+            cur.execute(f"ALTER TABLE {_NEW_NAME} RENAME TO {_OLD_NAME}")
+            logger.info("Renamed table '%s' -> '%s'", _NEW_NAME, _OLD_NAME)
+
+            cur.execute(
+                """
+                SELECT relname FROM pg_class
+                WHERE relname = %s AND relkind = 'S'
+                """,
+                (f"{_NEW_NAME}_id_seq",),
+            )
+            if cur.fetchone():
+                cur.execute(
+                    f"ALTER SEQUENCE {_NEW_NAME}_id_seq RENAME TO {_OLD_NAME}_id_seq"
+                )
+                logger.info(
+                    "Renamed sequence '%s_id_seq' -> '%s_id_seq'", _NEW_NAME, _OLD_NAME
+                )
+
+        conn.commit()
+        logger.info("Downgrade rename_audit_logs_to_slm_node_audit_logs completed")
+    finally:
+        conn.close()

--- a/autobot-slm-backend/migrations/rename_audit_logs_to_slm_node_audit_logs.py
+++ b/autobot-slm-backend/migrations/rename_audit_logs_to_slm_node_audit_logs.py
@@ -84,8 +84,7 @@ def migrate(db_url: str) -> None:
             old_pk = _audit_pk_type(cur, _OLD_NAME)
             if old_pk is None:
                 logger.info(
-                    "Table '%s' not found on this database — skipping rename "
-                    "(fresh install or already migrated)",
+                    "Table '%s' not found on this database — skipping rename " "(fresh install or already migrated)",
                     _OLD_NAME,
                 )
                 return
@@ -111,12 +110,8 @@ def migrate(db_url: str) -> None:
                 (f"{_OLD_NAME}_id_seq",),
             )
             if cur.fetchone():
-                cur.execute(
-                    f"ALTER SEQUENCE {_OLD_NAME}_id_seq RENAME TO {_NEW_NAME}_id_seq"
-                )
-                logger.info(
-                    "Renamed sequence '%s_id_seq' -> '%s_id_seq'", _OLD_NAME, _NEW_NAME
-                )
+                cur.execute(f"ALTER SEQUENCE {_OLD_NAME}_id_seq RENAME TO {_NEW_NAME}_id_seq")
+                logger.info("Renamed sequence '%s_id_seq' -> '%s_id_seq'", _OLD_NAME, _NEW_NAME)
 
         conn.commit()
         logger.info("Migration rename_audit_logs_to_slm_node_audit_logs completed")
@@ -136,16 +131,13 @@ def downgrade(db_url: str) -> None:
         with conn.cursor() as cur:
             new_pk = _audit_pk_type(cur, _NEW_NAME)
             if new_pk is None:
-                logger.info(
-                    "Table '%s' not found — nothing to downgrade", _NEW_NAME
-                )
+                logger.info("Table '%s' not found — nothing to downgrade", _NEW_NAME)
                 return
 
             old_pk = _audit_pk_type(cur, _OLD_NAME)
             if old_pk is not None:
                 logger.warning(
-                    "Table '%s' already exists — refusing to downgrade to avoid "
-                    "clobbering it",
+                    "Table '%s' already exists — refusing to downgrade to avoid " "clobbering it",
                     _OLD_NAME,
                 )
                 return
@@ -161,12 +153,8 @@ def downgrade(db_url: str) -> None:
                 (f"{_NEW_NAME}_id_seq",),
             )
             if cur.fetchone():
-                cur.execute(
-                    f"ALTER SEQUENCE {_NEW_NAME}_id_seq RENAME TO {_OLD_NAME}_id_seq"
-                )
-                logger.info(
-                    "Renamed sequence '%s_id_seq' -> '%s_id_seq'", _NEW_NAME, _OLD_NAME
-                )
+                cur.execute(f"ALTER SEQUENCE {_NEW_NAME}_id_seq RENAME TO {_OLD_NAME}_id_seq")
+                logger.info("Renamed sequence '%s_id_seq' -> '%s_id_seq'", _NEW_NAME, _OLD_NAME)
 
         conn.commit()
         logger.info("Downgrade rename_audit_logs_to_slm_node_audit_logs completed")

--- a/autobot-slm-backend/migrations/runner.py
+++ b/autobot-slm-backend/migrations/runner.py
@@ -63,6 +63,9 @@ MIGRATIONS = [
     "add_failure_reason_to_fleet_sync_jobs",
     # Issue #5385: convert all TIMESTAMP columns to TIMESTAMPTZ (UTC-aware)
     "migrate_timestamps_to_timestamptz",
+    # Issue #10764: rename the integer-PK SLM node audit table off 'audit_logs'
+    # so the UUID/org-aware user_management model is the sole owner of that name.
+    "rename_audit_logs_to_slm_node_audit_logs",
 ]
 
 

--- a/autobot-slm-backend/models/database.py
+++ b/autobot-slm-backend/models/database.py
@@ -759,9 +759,15 @@ class PolicyStatus(str, enum.Enum):
 
 
 class AuditLog(Base):
-    """Audit log for tracking all user actions and system events."""
+    """SLM node/system audit log (integer-PK).
 
-    __tablename__ = "audit_logs"
+    Records SLM control-plane actions (node management, service control,
+    deployments, security events) on the main SLM database. Distinct from the
+    UUID/org-aware ``user_management.models.audit.AuditLog``, which owns the
+    ``audit_logs`` table on the ``slm_users`` database (#10764).
+    """
+
+    __tablename__ = "slm_node_audit_logs"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     log_id = Column(String(64), unique=True, nullable=False, index=True)

--- a/autobot-slm-backend/user_management/services/sso_rotation.py
+++ b/autobot-slm-backend/user_management/services/sso_rotation.py
@@ -108,7 +108,7 @@ async def _write_audit(
     """Append an audit row for this rotation event (best-effort).
 
     Reuses the canonical ``create_audit_log`` helper so the row matches the
-    ``audit_logs`` schema (``log_id``/``user_id``/``extra_data`` — there is no
+    ``slm_node_audit_logs`` schema (``log_id``/``user_id``/``extra_data`` — there is no
     ``actor_id``/``details`` column). A failure here never aborts the rotation.
     """
     try:


### PR DESCRIPTION
## Thinking Path
Two `AuditLog` ORM models both declared `__tablename__='audit_logs'` on separate Base registries. **Finding:** they bind to DIFFERENT Postgres databases — UUID/org model → `slm_users`, integer/node model → `slm` — so this was a *latent name-clash*, not a live single-table collision (the startup checker only warned). Per owner decision, keep the UUID/org-aware model canonical for `audit_logs` and rename the SLM integer table.

## What Changed
- `models/database.py`: `AuditLog.__tablename__` `audit_logs` → `slm_node_audit_logs` (+ clarified docstring). No FK/relationship/index on it, so nothing else to rewire.
- **New migration** `migrations/rename_audit_logs_to_slm_node_audit_logs.py` (repo's custom runner, not Alembic): renames table + `_id_seq` on the `slm` DB only (runner connects via `settings.database_url`=`SLM_DATABASE_URL`, so it cannot touch `slm_users`). Guards: skips if target exists, skips if no `audit_logs`, **refuses to rename a non-integer (UUID) PK** table — belt-and-braces so it can never clobber the canonical table. Idempotent; `downgrade()` included.
- Registered the migration in `migrations/runner.py` `MIGRATIONS`.
- Updated stale `audit_logs` docstrings in `api/sso.py`, `user_management/services/sso_rotation.py`.
- All writers/readers reference the ORM class (auto-follow the rename); no hardcoded SQL strings targeted the integer model.

## Verification
- `py_compile` clean; import check confirms SLM model now owns `slm_node_audit_logs` and `audit_logs` is no longer in SLM metadata, while the UUID model still owns `audit_logs`. Cross-Base shared-name set reduced `['audit_logs','roles']`→`['roles']`.
- 13/13 tests in the two touched test files pass.
- Migration signature matches the shipped `rename_users_to_slm_users.py` precedent (runner calls `migrate(db_url)`).

## Caveats (explicit)
- Not executed against a live Postgres (none in sandbox); it's a standard guarded `ALTER TABLE RENAME` modeled on an already-shipped migration — preserves rows + PK sequence on existing deploys, no-ops on fresh installs. `migration-matrix` CI exercises it.
- `downgrade()` is written but, per existing repo convention, the runner has no automated downgrade hook (manual only) — matching `rename_users_to_slm_users.py`.

## Model Used
Claude Opus 4.8 (orchestration) + database-engineer (Sonnet)

Closes #10764