### PR TITLE
fix(security): retire single_user auth-disable branch; auth always follows security_config (#10713)

### DIFF
--- a/autobot-backend/security_layer.py
+++ b/autobot-backend/security_layer.py
@@ -83,8 +83,8 @@ class SecurityLayer:
     """Security layer with RBAC, audit logging, and command execution controls.
 
     Combines role-based access control, authentication, and secure command execution
-    in a single cohesive class. Single-user mode disables authentication for
-    development/personal use. Multi-user mode enables authentication by default.
+    in a single cohesive class. Authentication is always derived from security_config;
+    there is no single-user bypass (#10713, #10636).
     """
 
     def __init__(self):
@@ -92,24 +92,12 @@ class SecurityLayer:
         # Use centralized config manager
         self.security_config = get_config_manager().get("security_config", {})
 
-        # Check for single-user mode (development/personal use).
-        # #10705: config.single_user_mode was removed by the #10666 consolidation;
-        # derive from the canonical AUTOBOT_USER_MODE string (#10636) instead.
-        self.single_user_mode = config.user_mode == "single_user"
-
-        # If single-user mode is enabled, disable all authentication
-        # Issue #745: Added security warning for production awareness
-        if self.single_user_mode:
-            self.enable_auth = False
-            logger.warning(
-                "SECURITY: Single-user mode enabled - authentication disabled. "
-                "Set AUTOBOT_USER_MODE to a non-single_user value for production deployments."
-            )
-        else:
-            # Issue #745: Default to True for production security
-            # Authentication should be enabled unless explicitly disabled
-            self.enable_auth = self.security_config.get("enable_auth", True)
-            logger.info("Multi-user mode - authentication enabled by default")
+        # Issue #745: Default to True for production security.
+        # Authentication is always enabled unless explicitly disabled in security_config.
+        # single_user auth-disable branch removed per #10713 (originally retired by #10636,
+        # accidentally revived by #10666, now permanently retired).
+        self.enable_auth = self.security_config.get("enable_auth", True)
+        logger.info("Authentication enabled: %s", self.enable_auth)
 
         self.audit_log_file = self.security_config.get("audit_log_file") or _AUDIT_LOG_FILE
         self.roles = self.security_config.get("roles", {})

--- a/autobot-backend/security_layer_test.py
+++ b/autobot-backend/security_layer_test.py
@@ -33,7 +33,6 @@ class TestSecurityLayer:
             patch("security_layer.get_config_manager") as mock_get_cm,
             patch("security_layer.config") as mock_ssot_config,
         ):
-            mock_ssot_config.single_user_mode = "false"
             mock_ssot_config.audit_log_file = self.temp_audit_file.name
             mock_config = mock_get_cm.return_value
             mock_config.get.return_value = {
@@ -76,7 +75,6 @@ class TestSecurityLayer:
             patch("security_layer.get_config_manager") as mock_get_cm,
             patch("security_layer.config") as mock_ssot_config,
         ):
-            mock_ssot_config.single_user_mode = "false"
             mock_ssot_config.audit_log_file = ""
             mock_config = mock_get_cm.return_value
             mock_config.get.return_value = {
@@ -473,7 +471,6 @@ class TestSecurityLayerIntegration:
             patch("security_layer.get_config_manager") as mock_get_cm,
             patch("security_layer.config") as mock_ssot_config,
         ):
-            mock_ssot_config.single_user_mode = "false"
             mock_ssot_config.audit_log_file = ""
             mock_config = mock_get_cm.return_value
             mock_config.get.return_value = {


### PR DESCRIPTION
## Thinking Path
#10636 intentionally retired single_user mode (removed the auth-disable branch, stating "auth always follows security_config"); #10666's consolidation accidentally revived that branch (`security_layer.py`, `single_user_mode` → `enable_auth=False`, referencing the removed `config.single_user_mode` → #10705 crash). Per owner decision (Option A) + the standing "always full user management — no single_user" rule, permanently retire the branch.

## What Changed
- `security_layer.py`: removed the `self.single_user_mode` assignment and the if/else auth-disable branch. `enable_auth` is now unconditionally `security_config.get("enable_auth", True)` — auth defaults ON and can only be disabled by an explicit `security_config` key, never by a user-mode flag. Docstring updated.
- `security_layer_test.py`: removed 3 dead `single_user_mode` mock assignments.

## Security Verification
- **Before:** `user_mode=="single_user"` → `enable_auth=False` (auth silently OFF).
- **After:** `enable_auth = security_config.get("enable_auth", True)` → default True (auth ON); no path leaves it unset or silently False.
- grep: zero `config.single_user_mode` / `self.single_user_mode` / `AUTOBOT_SINGLE_USER_MODE` reads remain in the backend auth path (removes the #10705 crash risk).
- `python -m py_compile` clean.

## Scope
Backend auth layer only. The remaining non-auth `single_user` references (a collaboration-mode string literal, a test name) are left for the #10636 umbrella to triage — they don't touch auth or read removed config.

## Model Used
Claude Opus 4.8 (orchestration) + senior-backend-engineer (Sonnet)

Closes #10713