### PR TITLE
refactor(config): rename AUTOBOT_CHAT_GROUNDING → CHAT_CITATION_INSTRUCTION (clarity, back-compat) (#10736)

### DIFF
--- a/autobot-backend/services/chat_knowledge_service_test.py
+++ b/autobot-backend/services/chat_knowledge_service_test.py
@@ -182,10 +182,10 @@ def test_format_knowledge_context_empty(mock_rag_service) -> None:
 def test_format_knowledge_context_includes_grounding_instruction(
     mock_rag_service, sample_search_results, monkeypatch
 ) -> None:
-    """#10652: grounding instruction is prepended when the flag is on."""
+    """#10652: citation instruction is prepended when the flag is on."""
     from autobot_shared.ssot_config import config
 
-    monkeypatch.setattr(config, "chat_grounding_enabled", True, raising=False)
+    monkeypatch.setattr(config, "chat_citation_instruction_enabled", True, raising=False)
     service = ChatKnowledgeService(mock_rag_service)
     context = service.format_knowledge_context(sample_search_results[:1])
     assert "[Source N]" in context  # instruction tells the model how to cite
@@ -198,7 +198,7 @@ def test_format_knowledge_context_grounding_can_be_disabled(
     """#10652: instruction omitted when flag off; source labels stay."""
     from autobot_shared.ssot_config import config
 
-    monkeypatch.setattr(config, "chat_grounding_enabled", False, raising=False)
+    monkeypatch.setattr(config, "chat_citation_instruction_enabled", False, raising=False)
     service = ChatKnowledgeService(mock_rag_service)
     context = service.format_knowledge_context(sample_search_results[:1])
     assert "say you don't know" not in context
@@ -206,11 +206,11 @@ def test_format_knowledge_context_grounding_can_be_disabled(
 
 
 def test_build_grounded_context_shared_builder(monkeypatch) -> None:
-    """#10652: the shared builder (reused by the compression path) labels + grounds."""
+    """#10652: the shared builder (reused by the compression path) labels + cites."""
     from autobot_shared.ssot_config import config
     from services.knowledge.service import build_grounded_context
 
-    monkeypatch.setattr(config, "chat_grounding_enabled", True, raising=False)
+    monkeypatch.setattr(config, "chat_citation_instruction_enabled", True, raising=False)
     ctx = build_grounded_context(["fact one", "fact two"])
     assert "[Source 1] fact one" in ctx
     assert "[Source 2] fact two" in ctx
@@ -830,13 +830,13 @@ async def test_budget_grounded_context_all_trimmed_returns_empty():
 
 @pytest.mark.asyncio
 async def test_budget_grounded_context_grounding_disabled_omits_instruction(monkeypatch):
-    """chat_grounding_enabled=False → grounding instruction absent; [Source N] still present."""
+    """chat_citation_instruction_enabled=False → citation instruction absent; [Source N] still present."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
     from autobot_shared.ssot_config import config
     from services.knowledge.service import budget_grounded_context
 
-    monkeypatch.setattr(config, "chat_grounding_enabled", False, raising=False)
+    monkeypatch.setattr(config, "chat_citation_instruction_enabled", False, raising=False)
 
     mock_cwm = MagicMock()
     mock_cwm.estimate_tokens.return_value = 5
@@ -845,7 +845,7 @@ async def test_budget_grounded_context_grounding_disabled_omits_instruction(monk
     mock_cwm.config = {"models": {}}
 
     with patch("context_window_manager.ContextWindowManager", return_value=mock_cwm):
-        result = await budget_grounded_context([_kb("some fact")])
+        ctx, _kb_list = await budget_grounded_context([_kb("some fact")])
 
-    assert "some fact" in result
-    assert "Answer the user" not in result
+    assert "some fact" in ctx
+    assert "Answer the user" not in ctx

--- a/autobot-backend/services/chat_knowledge_service_test.py
+++ b/autobot-backend/services/chat_knowledge_service_test.py
@@ -748,7 +748,7 @@ async def test_budget_grounded_context_empty_returns_empty():
     from services.knowledge.service import budget_grounded_context
 
     with patch("context_window_manager.ContextWindowManager", side_effect=AssertionError("must not init")):
-        result = await budget_grounded_context([])
+        result, _trimmed = await budget_grounded_context([])
     assert result == ""
 
 
@@ -766,7 +766,7 @@ async def test_budget_grounded_context_small_unchanged(monkeypatch):
     mock_cwm.config = {"models": {}}
 
     with patch("context_window_manager.ContextWindowManager", return_value=mock_cwm):
-        result = await budget_grounded_context([_kb("short fact")], model_name=None)
+        result, _trimmed = await budget_grounded_context([_kb("short fact")], model_name=None)
 
     assert "short fact" in result
     assert "[Source 1]" in result
@@ -796,7 +796,7 @@ async def test_budget_grounded_context_oversized_compressed(monkeypatch):
         patch("context_window_manager.ContextWindowManager", return_value=mock_cwm),
         patch("services.memory.compression.ContextCompressionService", return_value=mock_svc),
     ):
-        result = await budget_grounded_context(kb_results, model_name="llama3")
+        result, _trimmed = await budget_grounded_context(kb_results, model_name="llama3")
 
     mock_svc.compress_kb_results.assert_called_once()
     assert "fact A" in result
@@ -823,7 +823,7 @@ async def test_budget_grounded_context_all_trimmed_returns_empty():
         patch("context_window_manager.ContextWindowManager", return_value=mock_cwm),
         patch("services.memory.compression.ContextCompressionService", return_value=mock_svc),
     ):
-        result = await budget_grounded_context([_kb("huge fact" * 1000)])
+        result, _trimmed = await budget_grounded_context([_kb("huge fact" * 1000)])
 
     assert result == ""
 

--- a/autobot-backend/services/knowledge/service.py
+++ b/autobot-backend/services/knowledge/service.py
@@ -22,8 +22,9 @@ from .doc_searcher import DocumentationSearcher, get_documentation_searcher
 from .intent_detector import get_query_intent_detector
 from .types import Query, QueryIntentResult, QueryKnowledgeIntent
 
-# #10652: prepended to the KB context to ground chat answers in cited sources.
-GROUNDING_INSTRUCTION = (
+# #10652, #10736: prepended to the KB context to instruct the model to cite sources.
+# Controlled by chat_citation_instruction_enabled (AUTOBOT_CHAT_CITATION_INSTRUCTION).
+CITATION_INSTRUCTION = (
     "Answer the user's question using the knowledge sources below. Cite the sources "
     "you rely on inline as [Source N]. If the sources do not contain the answer, say "
     "you don't know rather than guessing."
@@ -40,8 +41,8 @@ def build_grounded_context(contents: List[str]) -> str:
     if not contents:
         return ""
     lines: List[str] = []
-    if config.chat_grounding_enabled:
-        lines.append(GROUNDING_INSTRUCTION)
+    if config.chat_citation_instruction_enabled:
+        lines.append(CITATION_INSTRUCTION)
     lines.append("KNOWLEDGE CONTEXT:")
     for i, content in enumerate(contents, 1):
         lines.append(f"[Source {i}] {content.strip()}")

--- a/autobot-backend/tests/unit/chat_workflow/test_async_chat_workflow_budgeting.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_async_chat_workflow_budgeting.py
@@ -89,16 +89,16 @@ class TestBudgetKbContextSmallResults:
         assert "[Source 1]" in result
 
     async def test_grounding_disabled_omits_instruction_but_returns_context(self):
-        """(c) Grounding instruction omitted when chat_grounding_enabled=False.
+        """(c) Citation instruction omitted when chat_citation_instruction_enabled=False.
 
         build_grounded_context still returns the [Source N] block with content —
-        the grounding *instruction* (Answer the user…) is the only thing suppressed.
+        the citation *instruction* (Answer the user…) is the only thing suppressed.
         """
         from async_chat_workflow import AsyncChatWorkflow
 
         kb_results = [_make_kb_result("some fact")]
         mock_cfg = MagicMock()
-        mock_cfg.chat_grounding_enabled = False
+        mock_cfg.chat_citation_instruction_enabled = False
 
         mock_cwm = MagicMock()
         mock_cwm.estimate_tokens.return_value = 5

--- a/autobot-backend/tests/unit/chat_workflow/test_async_chat_workflow_grounding.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_async_chat_workflow_grounding.py
@@ -76,12 +76,12 @@ class TestGenerateLlmResponseGrounding:
         assert "KNOWLEDGE CONTEXT" not in system_msg.content
 
     async def test_no_kb_context_when_grounding_disabled(self, workflow):
-        """(c) Grounding disabled via config → KB context not injected."""
+        """(c) Citation instruction disabled via config → instruction omitted."""
         kb_results = [_make_workflow_kb_result("grounding fact")]
         mock_llm = MagicMock()
         mock_llm.chat_completion = AsyncMock(return_value=_make_llm_response())
         mock_cfg = MagicMock()
-        mock_cfg.chat_grounding_enabled = False
+        mock_cfg.chat_citation_instruction_enabled = False
 
         with patch(f"{_SVC_MODULE}.config", mock_cfg):
             await workflow._generate_llm_response("question", mock_llm, kb_results)

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -45,7 +45,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Dict, List
 
-from pydantic import Field, field_validator
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -198,10 +198,18 @@ class LLMConfig(BaseSettings):
     # Above this temperature responses must vary, so they are never cached.
     llm_response_cache: bool = Field(default=True, alias="AUTOBOT_LLM_RESPONSE_CACHE")
     llm_cache_max_temperature: float = Field(default=0.3, alias="AUTOBOT_LLM_CACHE_MAX_TEMPERATURE")
-    # Ground chat answers in retrieved KB sources: instruct the model to answer
-    # from the provided [Source N] context, cite them, and admit when the context
-    # is insufficient (#10652). Reversible flag; changes answer style.
-    chat_grounding_enabled: bool = Field(default=True, alias="AUTOBOT_CHAT_GROUNDING")
+    # Prepend the [Source N] citation instruction to the KB context block (#10652,
+    # #10736). When True the prompt includes "Answer … cite as [Source N]"; when
+    # False the [Source N] labels still render but the instruction is omitted.
+    # Renamed from chat_grounding_enabled (AUTOBOT_CHAT_GROUNDING) — old env var
+    # still accepted for backward-compat via AliasChoices.
+    chat_citation_instruction_enabled: bool = Field(
+        default=True,
+        validation_alias=AliasChoices(
+            "AUTOBOT_CHAT_CITATION_INSTRUCTION",
+            "AUTOBOT_CHAT_GROUNDING",
+        ),
+    )
 
     # Provider-specific endpoints (each provider can have its own URL)
     ollama_endpoint: str = Field(default="http://127.0.0.1:11434", alias="AUTOBOT_OLLAMA_ENDPOINT")

--- a/autobot_shared/ssot_config_test.py
+++ b/autobot_shared/ssot_config_test.py
@@ -373,3 +373,67 @@ class TestProjectRoot:
 
         assert PROJECT_ROOT.exists()
         assert PROJECT_ROOT.is_dir()
+
+
+class TestChatCitationInstructionAliasChoices:
+    """#10736: Both env vars set chat_citation_instruction_enabled correctly."""
+
+    def test_canonical_env_var_sets_flag_false(self, monkeypatch) -> None:
+        """AUTOBOT_CHAT_CITATION_INSTRUCTION=false → chat_citation_instruction_enabled=False."""
+        from pydantic import AliasChoices, Field
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+
+        class _IsolatedLLMConfig(BaseSettings):
+            model_config = SettingsConfigDict(extra="ignore")
+            chat_citation_instruction_enabled: bool = Field(
+                default=True,
+                validation_alias=AliasChoices(
+                    "AUTOBOT_CHAT_CITATION_INSTRUCTION",
+                    "AUTOBOT_CHAT_GROUNDING",
+                ),
+            )
+
+        monkeypatch.setenv("AUTOBOT_CHAT_CITATION_INSTRUCTION", "false")
+        monkeypatch.delenv("AUTOBOT_CHAT_GROUNDING", raising=False)
+        cfg = _IsolatedLLMConfig()
+        assert cfg.chat_citation_instruction_enabled is False
+
+    def test_legacy_env_var_sets_flag_false(self, monkeypatch) -> None:
+        """AUTOBOT_CHAT_GROUNDING=false → chat_citation_instruction_enabled=False (back-compat)."""
+        from pydantic import AliasChoices, Field
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+
+        class _IsolatedLLMConfig(BaseSettings):
+            model_config = SettingsConfigDict(extra="ignore")
+            chat_citation_instruction_enabled: bool = Field(
+                default=True,
+                validation_alias=AliasChoices(
+                    "AUTOBOT_CHAT_CITATION_INSTRUCTION",
+                    "AUTOBOT_CHAT_GROUNDING",
+                ),
+            )
+
+        monkeypatch.delenv("AUTOBOT_CHAT_CITATION_INSTRUCTION", raising=False)
+        monkeypatch.setenv("AUTOBOT_CHAT_GROUNDING", "false")
+        cfg = _IsolatedLLMConfig()
+        assert cfg.chat_citation_instruction_enabled is False
+
+    def test_default_when_neither_env_var_set(self, monkeypatch) -> None:
+        """Default=True when neither env var is set."""
+        from pydantic import AliasChoices, Field
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+
+        class _IsolatedLLMConfig(BaseSettings):
+            model_config = SettingsConfigDict(extra="ignore")
+            chat_citation_instruction_enabled: bool = Field(
+                default=True,
+                validation_alias=AliasChoices(
+                    "AUTOBOT_CHAT_CITATION_INSTRUCTION",
+                    "AUTOBOT_CHAT_GROUNDING",
+                ),
+            )
+
+        monkeypatch.delenv("AUTOBOT_CHAT_CITATION_INSTRUCTION", raising=False)
+        monkeypatch.delenv("AUTOBOT_CHAT_GROUNDING", raising=False)
+        cfg = _IsolatedLLMConfig()
+        assert cfg.chat_citation_instruction_enabled is True


### PR DESCRIPTION
## Thinking Path
Owner decision (#10736): the chat `use_knowledge` toggle (→ `use_knowledge_base`) is the real per-request grounding control; the env flag only toggles the `[Source N]` cite-instruction in `build_grounded_context` — its name (`AUTOBOT_CHAT_GROUNDING`) was misleading. Rename for clarity, no behavior change, keep the old env var working.

## What Changed
- `ssot_config.py`: `chat_grounding_enabled` → `chat_citation_instruction_enabled`; env binding now `validation_alias=AliasChoices("AUTOBOT_CHAT_CITATION_INSTRUCTION", "AUTOBOT_CHAT_GROUNDING")` — canonical new name + legacy fallback (no deployment breaks).
- `services/knowledge/service.py`: `GROUNDING_INSTRUCTION` → `CITATION_INSTRUCTION`; consumer updated. Behavior identical (flag True→append cite instruction; False→omit instruction, sources still render).
- Updated all test references; **also fixed a pre-existing broken assertion** (`chat_knowledge_service_test.py` asserted against the `(str,list)` tuple from #10837 — now unpacks correctly).

## Verification
- New `TestChatCitationInstructionAliasChoices` (3/3): both env vars set the field, neither → default. grounding 5/5, budgeting 17/17, chat_knowledge 5/5, ssot_config 32/32.
- flake8 clean; no straggling old names in non-test code.

Closes #10736.

## Model Used
Claude Opus 4.8 (1M context)