### PR TITLE
fix(ui): migrate residual hardcoded colors to semantic tokens (#10750 C1b)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -19,8 +19,8 @@
               :title="getSystemStatusTooltip()"
               :aria-label="getSystemStatusAriaLabel()"
             >
-              <div class="relative w-8 h-8 bg-white rounded flex items-center justify-center">
-                <span class="text-slate-800 font-bold text-sm font-mono">AB</span>
+              <div class="relative w-8 h-8 bg-autobot-bg-card rounded flex items-center justify-center">
+                <span class="text-autobot-text-primary font-bold text-sm font-mono">AB</span>
                 <!-- System status indicator dot -->
                 <div
                   :class="{

--- a/autobot-frontend/src/components/agents/AgentSettingsPanel.vue
+++ b/autobot-frontend/src/components/agents/AgentSettingsPanel.vue
@@ -256,7 +256,7 @@ onMounted(() => {
             >
               <span
                 :class="[
-                  'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                  'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-autobot-bg-card shadow ring-0 transition duration-200 ease-in-out',
                   settings.memory.enabled ? 'translate-x-5' : 'translate-x-0'
                 ]"
               />
@@ -359,7 +359,7 @@ onMounted(() => {
               >
                 <span
                   :class="[
-                    'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                    'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-autobot-bg-card shadow ring-0 transition duration-200 ease-in-out',
                     settings.execution.parallelExecution ? 'translate-x-5' : 'translate-x-0'
                   ]"
                 />
@@ -382,7 +382,7 @@ onMounted(() => {
               >
                 <span
                   :class="[
-                    'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                    'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-autobot-bg-card shadow ring-0 transition duration-200 ease-in-out',
                     settings.execution.priorityQueue ? 'translate-x-5' : 'translate-x-0'
                   ]"
                 />

--- a/autobot-frontend/src/components/autoresearch/ApprovalCard.vue
+++ b/autobot-frontend/src/components/autoresearch/ApprovalCard.vue
@@ -50,15 +50,15 @@ async function handleReject() {
 
     <div v-if="approval.metrics" class="mb-3 grid grid-cols-2 gap-2 text-sm">
       <div>
-        <span class="text-neutral-500">Baseline val_bpb:</span>
+        <span class="text-autobot-text-muted">Baseline val_bpb:</span>
         <span class="ml-1 font-mono">{{ approval.metrics.baseline_val_bpb?.toFixed(4) ?? '---' }}</span>
       </div>
       <div>
-        <span class="text-neutral-500">Result val_bpb:</span>
+        <span class="text-autobot-text-muted">Result val_bpb:</span>
         <span class="ml-1 font-mono">{{ approval.metrics.result_val_bpb?.toFixed(4) ?? '---' }}</span>
       </div>
       <div v-if="approval.metrics.improvement_pct != null" class="col-span-2">
-        <span class="text-neutral-500">Improvement:</span>
+        <span class="text-autobot-text-muted">Improvement:</span>
         <span class="ml-1 font-mono text-green-600 dark:text-green-400">
           {{ approval.metrics.improvement_pct.toFixed(2) }}%
         </span>

--- a/autobot-frontend/src/components/autoresearch/ExperimentTimeline.vue
+++ b/autobot-frontend/src/components/autoresearch/ExperimentTimeline.vue
@@ -44,14 +44,14 @@ function getApproval(experimentId: string) {
 
 <template>
   <div class="space-y-3">
-    <div v-if="sortedExperiments.length === 0" class="py-8 text-center text-neutral-500">
+    <div v-if="sortedExperiments.length === 0" class="py-8 text-center text-autobot-text-muted">
       No experiments yet
     </div>
 
     <div
       v-for="exp in sortedExperiments"
       :key="exp.id"
-      class="rounded-lg border border-neutral-200 p-4 dark:border-neutral-700"
+      class="rounded-lg border border-autobot-border p-4"
     >
       <div class="mb-2 flex items-center justify-between">
         <div class="flex items-center gap-2">
@@ -61,14 +61,14 @@ function getApproval(experimentId: string) {
           ></span>
           <span class="text-sm font-medium capitalize">{{ exp.state }}</span>
         </div>
-        <span class="text-xs text-neutral-500">{{ formatTime(exp.created_at) }}</span>
+        <span class="text-xs text-autobot-text-muted">{{ formatTime(exp.created_at) }}</span>
       </div>
 
-      <p class="mb-2 text-sm text-neutral-700 dark:text-neutral-300">
+      <p class="mb-2 text-sm text-autobot-text-secondary">
         {{ exp.hypothesis || 'No hypothesis' }}
       </p>
 
-      <div v-if="exp.result" class="flex gap-4 text-xs text-neutral-500">
+      <div v-if="exp.result" class="flex gap-4 text-xs text-autobot-text-muted">
         <span v-if="exp.result.val_bpb != null">
           val_bpb: <span class="font-mono">{{ exp.result.val_bpb.toFixed(4) }}</span>
         </span>

--- a/autobot-frontend/src/components/autoresearch/InsightsPanel.vue
+++ b/autobot-frontend/src/components/autoresearch/InsightsPanel.vue
@@ -37,7 +37,7 @@ function confidenceColor(confidence: number): string {
       <input
         v-model="searchQuery"
         placeholder="Search insights..."
-        class="flex-1 rounded-md border px-3 py-1.5 text-sm dark:border-neutral-600 dark:bg-neutral-800"
+        class="flex-1 rounded-md border px-3 py-1.5 text-sm"
         @keyup.enter="handleSearch"
       />
       <button
@@ -49,7 +49,7 @@ function confidenceColor(confidence: number): string {
     </div>
 
     <!-- Insights list -->
-    <div v-if="insights.length === 0" class="py-4 text-center text-sm text-neutral-500">
+    <div v-if="insights.length === 0" class="py-4 text-center text-sm text-autobot-text-muted">
       No insights yet. Run experiments and trigger synthesis.
     </div>
 
@@ -57,20 +57,20 @@ function confidenceColor(confidence: number): string {
       <div
         v-for="insight in insights"
         :key="insight.id"
-        class="rounded-md border p-3 dark:border-neutral-700"
+        class="rounded-md border p-3"
       >
         <div class="mb-1 flex items-center justify-between">
           <span :class="confidenceColor(insight.confidence)" class="text-xs font-medium">
             {{ (insight.confidence * 100).toFixed(0) }}% confidence
           </span>
-          <span class="text-xs text-neutral-500">
+          <span class="text-xs text-autobot-text-muted">
             {{ insight.related_hyperparams.join(', ') }}
           </span>
         </div>
-        <p class="text-sm text-neutral-700 dark:text-neutral-300">
+        <p class="text-sm text-autobot-text-secondary">
           {{ insight.statement }}
         </p>
-        <div class="mt-1 text-xs text-neutral-400">
+        <div class="mt-1 text-xs text-autobot-text-muted">
           Based on {{ insight.supporting_experiments.length }} experiment(s)
         </div>
       </div>

--- a/autobot-frontend/src/components/autoresearch/PromptOptimizerPanel.vue
+++ b/autobot-frontend/src/components/autoresearch/PromptOptimizerPanel.vue
@@ -42,20 +42,20 @@ function submitScore(variantId: string) {
     <!-- Start/Cancel controls -->
     <div v-if="!session" class="mb-4 flex items-end gap-3">
       <div>
-        <label class="mb-1 block text-xs text-neutral-500">Target Agent</label>
+        <label class="mb-1 block text-xs text-autobot-text-muted">Target Agent</label>
         <input
           v-model="agentName"
-          class="rounded-md border px-3 py-1.5 text-sm dark:border-neutral-600 dark:bg-neutral-800"
+          class="rounded-md border px-3 py-1.5 text-sm"
         />
       </div>
       <div>
-        <label class="mb-1 block text-xs text-neutral-500">Max Rounds</label>
+        <label class="mb-1 block text-xs text-autobot-text-muted">Max Rounds</label>
         <input
           v-model.number="maxRounds"
           type="number"
           min="1"
           max="10"
-          class="w-20 rounded-md border px-3 py-1.5 text-sm dark:border-neutral-600 dark:bg-neutral-800"
+          class="w-20 rounded-md border px-3 py-1.5 text-sm"
         />
       </div>
       <button
@@ -71,7 +71,7 @@ function submitScore(variantId: string) {
         <span class="text-sm">
           Status: <span class="font-medium capitalize">{{ session.status }}</span>
         </span>
-        <span class="text-sm text-neutral-500">
+        <span class="text-sm text-autobot-text-muted">
           Round {{ session.rounds_completed }}/{{ session.max_rounds }}
         </span>
         <button
@@ -92,13 +92,13 @@ function submitScore(variantId: string) {
       <div
         v-for="variant in variants"
         :key="variant.id"
-        class="rounded-md border p-3 text-sm dark:border-neutral-700"
+        class="rounded-md border p-3 text-sm"
       >
         <div class="mb-1 flex items-center justify-between">
-          <span class="font-mono text-xs text-neutral-500">{{ variant.id.slice(0, 8) }}</span>
+          <span class="font-mono text-xs text-autobot-text-muted">{{ variant.id.slice(0, 8) }}</span>
           <span class="font-medium">Score: {{ variant.final_score.toFixed(3) }}</span>
         </div>
-        <p class="mb-2 text-neutral-600 dark:text-neutral-400">
+        <p class="mb-2 text-autobot-text-secondary">
           {{ variant.prompt_text.slice(0, 200) }}{{ variant.prompt_text.length > 200 ? '...' : '' }}
         </p>
 
@@ -109,12 +109,12 @@ function submitScore(variantId: string) {
             type="number"
             min="0"
             max="10"
-            class="w-16 rounded border px-2 py-1 text-sm dark:border-neutral-600 dark:bg-neutral-800"
+            class="w-16 rounded border px-2 py-1 text-sm"
           />
           <input
             v-model="reviewComment"
             placeholder="Comment..."
-            class="flex-1 rounded border px-2 py-1 text-sm dark:border-neutral-600 dark:bg-neutral-800"
+            class="flex-1 rounded border px-2 py-1 text-sm"
           />
           <button
             class="rounded bg-green-600 px-3 py-1 text-sm text-white"

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -1284,7 +1284,7 @@ onMounted(async () => {
 }
 
 .summary-content {
-  @apply mt-2 pt-2 border-t border-blue-200 text-sm text-gray-700;
+  @apply mt-2 pt-2 border-t border-blue-200 text-sm text-autobot-text-secondary;
 }
 
 /* ============================================
@@ -1444,7 +1444,7 @@ onMounted(async () => {
 
 /* TERMINAL OUTPUT MESSAGES - Always-dark (intentional terminal aesthetic) */
 .message-wrapper.type-terminal_output {
-  @apply bg-gray-900 text-gray-100;
+  @apply bg-autobot-bg-primary text-autobot-text-primary;
   border-color: rgba(16, 185, 129, 0.5);
 }
 
@@ -1457,7 +1457,7 @@ onMounted(async () => {
 }
 
 .message-wrapper.type-terminal_output .message-time {
-  @apply text-gray-400;
+  @apply text-autobot-text-muted;
 }
 
 .message-wrapper.type-terminal_output .message-text {
@@ -1466,7 +1466,7 @@ onMounted(async () => {
 }
 
 .message-wrapper.type-terminal_output .message-content {
-  @apply text-gray-100;
+  @apply text-autobot-text-primary;
 }
 
 /* COMMAND APPROVAL REQUEST - Warning theme-aware */

--- a/autobot-frontend/src/components/collaboration/ActivityFeed.vue
+++ b/autobot-frontend/src/components/collaboration/ActivityFeed.vue
@@ -49,7 +49,7 @@ const getActivityColor = (type: string): string => {
     case 'file': return 'text-blue-400'
     case 'browser': return 'text-purple-400'
     case 'desktop': return 'text-orange-400'
-    default: return 'text-gray-400'
+    default: return 'text-autobot-text-muted'
   }
 }
 

--- a/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
+++ b/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
@@ -248,22 +248,22 @@
         </div>
 
         <!-- Loading state while VNC URL is being fetched -->
-        <div v-if="!vncUrl" class="w-full h-full flex items-center justify-center bg-gray-900 text-white">
+        <div v-if="!vncUrl" class="w-full h-full flex items-center justify-center bg-autobot-bg-primary text-white">
           <div class="text-center p-8">
             <Icon name="robot" class="text-6xl mb-4 text-blue-400" />
             <h3 class="text-xl font-semibold mb-2">{{ $t('desktop.popoutBrowser.headlessBrowserMode') }}</h3>
-            <p class="text-gray-300 mb-4">
+            <p class="text-autobot-text-muted mb-4">
               {{ $t('desktop.popoutBrowser.headlessDesc') }}
             </p>
-            <p class="text-sm text-gray-400 mb-4">
+            <p class="text-sm text-autobot-text-muted mb-4">
               {{ $t('desktop.popoutBrowser.headlessInstructions') }}
             </p>
-            <div class="bg-gray-800 rounded p-4 text-left max-w-md mx-auto">
-              <div class="text-xs text-gray-400 mb-2">{{ $t('desktop.popoutBrowser.currentStatus') }}</div>
+            <div class="bg-autobot-bg-secondary rounded p-4 text-left max-w-md mx-auto">
+              <div class="text-xs text-autobot-text-muted mb-2">{{ $t('desktop.popoutBrowser.currentStatus') }}</div>
               <div class="text-sm">
                 <div>{{ $t('desktop.popoutBrowser.statusLabel') }} <span class="text-green-400">{{ browserStatus }}</span></div>
                 <div v-if="currentUrl">{{ $t('desktop.popoutBrowser.urlLabel') }} <span class="text-blue-300">{{ currentUrl }}</span></div>
-                <div v-if="pageTitle">{{ $t('desktop.popoutBrowser.titleLabel') }} <span class="text-gray-200">{{ pageTitle }}</span></div>
+                <div v-if="pageTitle">{{ $t('desktop.popoutBrowser.titleLabel') }} <span class="text-autobot-text-primary">{{ pageTitle }}</span></div>
               </div>
             </div>
           </div>
@@ -374,10 +374,10 @@
       </LoadingBoundary>
 
       <!-- Developer Tools Overlay -->
-      <div v-if="showDevTools" class="absolute bottom-0 left-0 right-0 h-1/3 bg-gray-900 border-t border-gray-600">
-        <div class="flex items-center justify-between bg-gray-800 p-2 text-white text-sm">
+      <div v-if="showDevTools" class="absolute bottom-0 left-0 right-0 h-1/3 bg-autobot-bg-primary border-t border-autobot-border-strong">
+        <div class="flex items-center justify-between bg-autobot-bg-secondary p-2 text-white text-sm">
           <span>{{ $t('desktop.popoutBrowser.developerConsole') }}</span>
-          <button @click="showDevTools = false" class="text-gray-400 hover:text-white" :aria-label="$t('common.close')">
+          <button @click="showDevTools = false" class="text-autobot-text-muted hover:text-white" :aria-label="$t('common.close')">
             <Icon name="times" />
           </button>
         </div>

--- a/autobot-frontend/src/components/mobile/PairDeviceDialog.vue
+++ b/autobot-frontend/src/components/mobile/PairDeviceDialog.vue
@@ -86,7 +86,7 @@ watch(isPaired, (paired) => {
           <p class="text-sm text-autobot-text-secondary">{{ $t('mobile.pairing.instructionsDetail') }}</p>
         </div>
 
-        <div class="flex justify-center bg-white p-4 rounded-lg border border-autobot-border">
+        <div class="flex justify-center bg-autobot-bg-card p-4 rounded-lg border border-autobot-border">
           <img
             :src="qrDataUrl"
             :alt="$t('mobile.pairing.instructions')"

--- a/autobot-frontend/src/components/secrets/SecretAuditLog.vue
+++ b/autobot-frontend/src/components/secrets/SecretAuditLog.vue
@@ -195,7 +195,7 @@ const getActionStyle = (action: SecretAction): { color: string; icon: string } =
     case 'delete':
       return { color: 'text-red-400 bg-red-400/10', icon: 'trash' }
     default:
-      return { color: 'text-gray-400 bg-gray-400/10', icon: 'info-circle' }
+      return { color: 'text-autobot-text-muted bg-gray-400/10', icon: 'info-circle' }
   }
 }
 
@@ -221,10 +221,10 @@ const prevPage = async () => {
 </script>
 
 <template>
-  <div class="secret-audit-log h-full flex flex-col bg-gray-800 rounded-lg">
+  <div class="secret-audit-log h-full flex flex-col bg-autobot-bg-secondary rounded-lg">
     <!-- Header -->
-    <div class="px-4 py-3 border-b border-gray-700">
-      <h3 class="text-lg font-semibold text-gray-200 flex items-center gap-2">
+    <div class="px-4 py-3 border-b border-autobot-border-strong">
+      <h3 class="text-lg font-semibold text-autobot-text-primary flex items-center gap-2">
         <i class="bi bi-clipboard-data" />
         {{ $t('secrets.auditLog.title') }}
       </h3>
@@ -233,7 +233,7 @@ const prevPage = async () => {
       <div class="mt-3 flex items-center gap-2">
         <select
           v-model="filterAction"
-          class="px-3 py-1.5 text-xs bg-gray-700 border border-gray-600 rounded text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          class="px-3 py-1.5 text-xs bg-autobot-bg-secondary border border-autobot-border-strong rounded text-autobot-text-muted focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
           <option value="all">{{ $t('secrets.auditLog.allActions') }}</option>
           <option value="access">{{ $t('secrets.auditLog.access') }}</option>
@@ -247,7 +247,7 @@ const prevPage = async () => {
         </select>
         <select
           v-model="filterUser"
-          class="px-3 py-1.5 text-xs bg-gray-700 border border-gray-600 rounded text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          class="px-3 py-1.5 text-xs bg-autobot-bg-secondary border border-autobot-border-strong rounded text-autobot-text-muted focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
           <option value="all">{{ $t('secrets.auditLog.allUsers') }}</option>
           <option v-for="user in uniqueUsers" :key="user.id" :value="user.id">
@@ -266,7 +266,7 @@ const prevPage = async () => {
         <div class="inline-block">
           <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
         </div>
-        <div class="mt-2 text-sm text-gray-400">{{ $t('common.loading') }}</div>
+        <div class="mt-2 text-sm text-autobot-text-muted">{{ $t('common.loading') }}</div>
       </div>
     </div>
 
@@ -296,7 +296,7 @@ const prevPage = async () => {
         <div
           v-for="entry in filteredLog"
           :key="entry.id"
-          class="flex items-start gap-3 p-3 bg-gray-700/50 rounded-lg hover:bg-gray-700 transition-colors"
+          class="flex items-start gap-3 p-3 bg-autobot-bg-secondary/50 rounded-lg hover:bg-autobot-bg-hover transition-colors"
         >
           <!-- Icon -->
           <div
@@ -312,24 +312,24 @@ const prevPage = async () => {
           <div class="flex-1 min-w-0">
             <div class="flex items-start justify-between gap-2 mb-1">
               <div class="flex-1">
-                <div class="text-sm font-medium text-gray-200">
+                <div class="text-sm font-medium text-autobot-text-primary">
                   {{ entry.secretName }}
                 </div>
-                <div class="text-xs text-gray-400">
+                <div class="text-xs text-autobot-text-muted">
                   <span class="capitalize">{{ entry.action }}</span> {{ $t('secrets.auditLog.by') }}
                   <span class="font-medium">{{ entry.username }}</span>
                 </div>
               </div>
-              <span class="text-xs text-gray-500 flex-shrink-0">
+              <span class="text-xs text-autobot-text-muted flex-shrink-0">
                 {{ formatTime(entry.timestamp) }}
               </span>
             </div>
 
             <!-- Metadata -->
-            <div v-if="entry.metadata && Object.keys(entry.metadata).length > 0" class="text-xs text-gray-500 mt-1">
+            <div v-if="entry.metadata && Object.keys(entry.metadata).length > 0" class="text-xs text-autobot-text-muted mt-1">
               <details class="cursor-pointer">
-                <summary class="hover:text-gray-400">{{ $t('secrets.auditLog.details') }}</summary>
-                <pre class="mt-1 p-2 bg-gray-800 rounded text-xs overflow-x-auto">{{ JSON.stringify(entry.metadata, null, 2) }}</pre>
+                <summary class="hover:text-autobot-text-muted">{{ $t('secrets.auditLog.details') }}</summary>
+                <pre class="mt-1 p-2 bg-autobot-bg-secondary rounded text-xs overflow-x-auto">{{ JSON.stringify(entry.metadata, null, 2) }}</pre>
               </details>
             </div>
           </div>
@@ -339,11 +339,11 @@ const prevPage = async () => {
       <!-- Empty state -->
       <div
         v-if="filteredLog.length === 0"
-        class="flex flex-col items-center justify-center py-12 text-gray-500"
+        class="flex flex-col items-center justify-center py-12 text-autobot-text-muted"
       >
         <i class="bi bi-clipboard-data text-4xl mb-3" />
         <div class="text-sm font-medium mb-1">{{ $t('secrets.auditLog.noEntries') }}</div>
-        <div class="text-xs text-gray-600">
+        <div class="text-xs text-autobot-text-secondary">
           {{ $t('secrets.auditLog.noEntriesHint') }}
         </div>
       </div>
@@ -352,9 +352,9 @@ const prevPage = async () => {
     <!-- Pagination Controls -->
     <div
       v-if="!auditApi.loading.value && !auditApi.error.value && auditApi.entries.value.length > 0"
-      class="px-4 py-3 border-t border-gray-700 flex items-center justify-between"
+      class="px-4 py-3 border-t border-autobot-border-strong flex items-center justify-between"
     >
-      <div class="text-xs text-gray-400">
+      <div class="text-xs text-autobot-text-muted">
         {{ $t('common.page') }}: {{ currentPage + 1 }}
         <span v-if="auditApi.hasMore.value"> ({{ $t('common.hasMore') }})</span>
       </div>
@@ -362,14 +362,14 @@ const prevPage = async () => {
         <button
           :disabled="currentPage === 0"
           @click="prevPage"
-          class="px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed border border-gray-600 rounded text-gray-300 transition-colors"
+          class="px-3 py-1.5 text-xs bg-autobot-bg-secondary hover:bg-autobot-bg-hover disabled:opacity-50 disabled:cursor-not-allowed border border-autobot-border-strong rounded text-autobot-text-muted transition-colors"
         >
           {{ $t('common.previous') }}
         </button>
         <button
           :disabled="!auditApi.hasMore.value"
           @click="nextPage"
-          class="px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed border border-gray-600 rounded text-gray-300 transition-colors"
+          class="px-3 py-1.5 text-xs bg-autobot-bg-secondary hover:bg-autobot-bg-hover disabled:opacity-50 disabled:cursor-not-allowed border border-autobot-border-strong rounded text-autobot-text-muted transition-colors"
         >
           {{ $t('common.next') }}
         </button>

--- a/autobot-frontend/src/components/secrets/SecretVault.vue
+++ b/autobot-frontend/src/components/secrets/SecretVault.vue
@@ -148,7 +148,7 @@ const getScopeBadge = (scope: string): { color: string; label: string } => {
     case 'shared':
       return { color: 'bg-purple-500/20 text-purple-400', label: t('secrets.vault.scopeShared') }
     default:
-      return { color: 'bg-gray-500/20 text-gray-400', label: scope }
+      return { color: 'bg-gray-500/20 text-autobot-text-muted', label: scope }
   }
 }
 
@@ -244,7 +244,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="secret-vault h-full flex flex-col bg-gray-800 rounded-lg">
+  <div class="secret-vault h-full flex flex-col bg-autobot-bg-secondary rounded-lg">
     <!-- Error/Success Messages -->
     <div v-if="error" class="px-4 py-2 bg-red-900/50 text-red-300 text-sm border-b border-red-700">
       <i class="bi bi-exclamation-circle mr-2" />
@@ -256,9 +256,9 @@ onMounted(() => {
     </div>
 
     <!-- Header -->
-    <div class="px-4 py-3 border-b border-gray-700">
+    <div class="px-4 py-3 border-b border-autobot-border-strong">
       <div class="flex items-center justify-between mb-3">
-        <h3 class="text-lg font-semibold text-gray-200">
+        <h3 class="text-lg font-semibold text-autobot-text-primary">
           <i class="bi bi-shield-lock mr-2" />
           {{ $t('secrets.vault.title') }}
         </h3>
@@ -277,12 +277,12 @@ onMounted(() => {
       <div class="space-y-2">
         <!-- Search -->
         <div class="relative">
-          <i class="bi bi-search absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <i class="bi bi-search absolute left-3 top-1/2 -translate-y-1/2 text-autobot-text-muted" />
           <input
             v-model="searchQuery"
             type="text"
             :placeholder="$t('secrets.vault.searchPlaceholder')"
-            class="w-full pl-10 pr-4 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-200 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+            class="w-full pl-10 pr-4 py-2 bg-autobot-bg-secondary border border-autobot-border-strong rounded-lg text-autobot-text-primary placeholder-autobot-text-muted focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
           >
         </div>
 
@@ -295,7 +295,7 @@ onMounted(() => {
               'px-3 py-1 text-xs rounded-full whitespace-nowrap transition-colors',
               filterType === option.value
                 ? 'bg-blue-500 text-white'
-                : 'bg-gray-700 text-gray-400 hover:bg-gray-600'
+                : 'bg-autobot-bg-secondary text-autobot-text-muted hover:bg-autobot-bg-hover'
             ]"
             @click="filterType = option.value"
           >
@@ -308,23 +308,23 @@ onMounted(() => {
     <!-- Secret list with virtual scrolling -->
     <div ref="containerRef" class="flex-1 overflow-y-auto custom-scrollbar relative">
       <!-- Loading state -->
-      <div v-if="isLoading" class="absolute inset-0 flex items-center justify-center bg-gray-800/50">
+      <div v-if="isLoading" class="absolute inset-0 flex items-center justify-center bg-autobot-bg-secondary/50">
         <div class="flex flex-col items-center gap-3">
           <div class="animate-spin">
             <i class="bi bi-hourglass text-2xl text-blue-400" />
           </div>
-          <div class="text-sm text-gray-400">{{ $t('secrets.vault.loading') }}</div>
+          <div class="text-sm text-autobot-text-muted">{{ $t('secrets.vault.loading') }}</div>
         </div>
       </div>
 
       <!-- Empty state -->
       <div
         v-else-if="allSecrets.length === 0"
-        class="absolute inset-0 flex flex-col items-center justify-center text-gray-500"
+        class="absolute inset-0 flex flex-col items-center justify-center text-autobot-text-muted"
       >
         <i class="bi bi-shield-lock text-4xl mb-3" />
         <div class="text-sm font-medium mb-1">{{ $t('secrets.vault.noSecrets') }}</div>
-        <div class="text-xs text-gray-600">
+        <div class="text-xs text-autobot-text-secondary">
           {{ searchQuery ? $t('secrets.vault.noSecretsSearch') : $t('secrets.vault.noSecretsHint') }}
         </div>
       </div>
@@ -335,17 +335,17 @@ onMounted(() => {
           <div
             v-for="virtualItem in visibleItems"
             :key="virtualItem.data.id"
-            class="bg-gray-700/50 rounded-lg p-4 hover:bg-gray-700 transition-colors border border-gray-600"
+            class="bg-autobot-bg-secondary/50 rounded-lg p-4 hover:bg-autobot-bg-hover transition-colors border border-autobot-border-strong"
             :style="{ transform: `translateY(${virtualItem.offset}px)` }"
           >
           <!-- Header -->
           <div class="flex items-start justify-between mb-3">
             <div class="flex items-start gap-3 flex-1 min-w-0">
-              <div class="w-10 h-10 rounded-lg bg-gray-600 flex items-center justify-center text-lg flex-shrink-0">
-                <i :class="`bi bi-${getTypeIcon(virtualItem.data.type)}`" class="text-gray-300" />
+              <div class="w-10 h-10 rounded-lg bg-autobot-bg-tertiary flex items-center justify-center text-lg flex-shrink-0">
+                <i :class="`bi bi-${getTypeIcon(virtualItem.data.type)}`" class="text-autobot-text-muted" />
               </div>
               <div class="flex-1 min-w-0">
-                <h4 class="text-sm font-medium text-gray-200 truncate">
+                <h4 class="text-sm font-medium text-autobot-text-primary truncate">
                   {{ virtualItem.data.name }}
                 </h4>
                 <div class="flex items-center gap-2 mt-1 flex-wrap">
@@ -357,7 +357,7 @@ onMounted(() => {
                   >
                     {{ getScopeBadge(virtualItem.data.scope).label }}
                   </span>
-                  <span class="text-xs text-gray-500">
+                  <span class="text-xs text-autobot-text-muted">
                     {{ virtualItem.data.type }}
                   </span>
                 </div>
@@ -372,10 +372,10 @@ onMounted(() => {
                 :type="revealedSecrets.has(virtualItem.data.id) ? 'text' : 'password'"
                 :value="virtualItem.data.value || '••••••••'"
                 readonly
-                class="w-full px-3 py-2 bg-gray-800 border border-gray-600 rounded text-xs text-gray-300 font-mono"
+                class="w-full px-3 py-2 bg-autobot-bg-secondary border border-autobot-border-strong rounded text-xs text-autobot-text-muted font-mono"
               >
               <button
-                class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 transition-colors"
+                class="absolute right-2 top-1/2 -translate-y-1/2 text-autobot-text-muted hover:text-autobot-text-primary transition-colors"
                 :aria-label="revealedSecrets.has(virtualItem.data.id) ? $t('secrets.vault.hideSecret') : $t('secrets.vault.revealSecret')"
                 @click="toggleReveal(virtualItem.data.id)"
               >
@@ -385,7 +385,7 @@ onMounted(() => {
           </div>
 
           <!-- Metadata -->
-          <div class="flex items-center gap-4 text-xs text-gray-500 mb-3">
+          <div class="flex items-center gap-4 text-xs text-autobot-text-muted mb-3">
             <span v-if="virtualItem.data.created_at">
               <i class="bi bi-calendar mr-1" />
               {{ $t('secrets.vault.created', { date: formatDate(virtualItem.data.created_at) }) }}
@@ -397,14 +397,14 @@ onMounted(() => {
           </div>
 
           <!-- Description if available -->
-          <div v-if="virtualItem.data.description" class="text-xs text-gray-400 mb-3">
+          <div v-if="virtualItem.data.description" class="text-xs text-autobot-text-muted mb-3">
             {{ virtualItem.data.description }}
           </div>
 
           <!-- Actions -->
           <div class="flex items-center gap-2 flex-wrap">
             <button
-              class="px-3 py-1.5 text-xs rounded bg-gray-600 hover:bg-gray-500 text-gray-200 transition-colors flex items-center gap-1 disabled:opacity-50"
+              class="px-3 py-1.5 text-xs rounded bg-autobot-bg-tertiary hover:bg-autobot-bg-hover text-autobot-text-primary transition-colors flex items-center gap-1 disabled:opacity-50"
               :aria-label="$t('secrets.vault.copyAriaLabel')"
               :disabled="isLoading"
               @click="copySecret(virtualItem.data)"

--- a/autobot-frontend/src/components/terminal/Terminal.vue
+++ b/autobot-frontend/src/components/terminal/Terminal.vue
@@ -616,15 +616,15 @@ onUnmounted(() => {
 
 /* Terminal body with dark theme */
 .terminal-body {
-  @apply flex-1 flex flex-col bg-gray-900 overflow-hidden;
+  @apply flex-1 flex flex-col bg-autobot-bg-primary overflow-hidden;
 }
 
 .terminal-status {
-  @apply px-4 py-2 bg-gray-800 text-gray-300 text-sm flex items-center gap-2 border-b border-gray-700;
+  @apply px-4 py-2 bg-autobot-bg-secondary text-autobot-text-muted text-sm flex items-center gap-2 border-b border-autobot-border-strong;
 }
 
 .terminal-output {
-  @apply flex-1 p-4 bg-gray-900 text-green-400 overflow-y-auto text-sm leading-relaxed min-h-0;
+  @apply flex-1 p-4 bg-autobot-bg-primary text-green-400 overflow-y-auto text-sm leading-relaxed min-h-0;
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
 }
 
@@ -637,15 +637,15 @@ onUnmounted(() => {
 }
 
 .terminal-output::-webkit-scrollbar-track {
-  @apply bg-gray-800;
+  @apply bg-autobot-bg-secondary;
 }
 
 .terminal-output::-webkit-scrollbar-thumb {
-  @apply bg-gray-600 rounded;
+  @apply bg-autobot-bg-tertiary rounded;
 }
 
 .terminal-output::-webkit-scrollbar-thumb:hover {
-  @apply bg-gray-500;
+  @apply bg-autobot-bg-tertiary;
 }
 
 .terminal-line {
@@ -720,7 +720,7 @@ onUnmounted(() => {
 }
 
 .line-prefix {
-  @apply text-gray-500 select-none mr-2;
+  @apply text-autobot-text-muted select-none mr-2;
 }
 
 .command {
@@ -745,7 +745,7 @@ onUnmounted(() => {
 }
 
 .terminal-prompt {
-  @apply flex items-center mt-2 pt-2 border-t border-gray-700;
+  @apply flex items-center mt-2 pt-2 border-t border-autobot-border-strong;
 }
 
 .prompt {
@@ -759,7 +759,7 @@ onUnmounted(() => {
 }
 
 .command-input::placeholder {
-  @apply text-gray-500;
+  @apply text-autobot-text-muted;
 }
 
 .command-input:disabled {

--- a/autobot-frontend/src/components/terminal/TerminalSettings.vue
+++ b/autobot-frontend/src/components/terminal/TerminalSettings.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="terminal-settings p-4 bg-gray-800 rounded-lg">
+  <div class="terminal-settings p-4 bg-autobot-bg-secondary rounded-lg">
     <h3 class="text-white text-lg mb-4">{{ $t('terminal.settings') }}</h3>
 
     <div class="space-y-4">
       <!-- Font Size -->
       <div class="flex items-center justify-between">
-        <label class="text-gray-300">{{ $t('terminal.fontSize') }}</label>
+        <label class="text-autobot-text-muted">{{ $t('terminal.fontSize') }}</label>
         <div class="flex items-center gap-2">
           <input
             type="range"
@@ -15,16 +15,16 @@
             class="w-24 accent-blue-500"
             data-testid="font-size-slider"
           />
-          <span class="text-gray-400 w-8 text-right">{{ settings.fontSize }}</span>
+          <span class="text-autobot-text-muted w-8 text-right">{{ settings.fontSize }}</span>
         </div>
       </div>
 
       <!-- Theme -->
       <div class="flex items-center justify-between">
-        <label class="text-gray-300">{{ $t('terminal.theme') }}</label>
+        <label class="text-autobot-text-muted">{{ $t('terminal.theme') }}</label>
         <select
           v-model="settings.theme"
-          class="bg-gray-700 text-white rounded px-2 py-1 border border-gray-600 focus:border-blue-500 focus:outline-none"
+          class="bg-autobot-bg-secondary text-white rounded px-2 py-1 border border-autobot-border-strong focus:border-blue-500 focus:outline-none"
           data-testid="theme-select"
         >
           <option value="dark">{{ $t('terminal.dark') }}</option>
@@ -34,10 +34,10 @@
 
       <!-- Cursor Style -->
       <div class="flex items-center justify-between">
-        <label class="text-gray-300">{{ $t('terminal.cursorStyle') }}</label>
+        <label class="text-autobot-text-muted">{{ $t('terminal.cursorStyle') }}</label>
         <select
           v-model="settings.cursorStyle"
-          class="bg-gray-700 text-white rounded px-2 py-1 border border-gray-600 focus:border-blue-500 focus:outline-none"
+          class="bg-autobot-bg-secondary text-white rounded px-2 py-1 border border-autobot-border-strong focus:border-blue-500 focus:outline-none"
           data-testid="cursor-style-select"
         >
           <option value="block">{{ $t('terminal.block') }}</option>
@@ -48,7 +48,7 @@
 
       <!-- Cursor Blink -->
       <div class="flex items-center justify-between">
-        <label class="text-gray-300">{{ $t('terminal.cursorBlink') }}</label>
+        <label class="text-autobot-text-muted">{{ $t('terminal.cursorBlink') }}</label>
         <input
           type="checkbox"
           v-model="settings.cursorBlink"

--- a/autobot-frontend/src/components/ui/TouchFriendlyButton.vue
+++ b/autobot-frontend/src/components/ui/TouchFriendlyButton.vue
@@ -151,7 +151,7 @@ const createRipple = (event: TouchEvent) => {
 }
 
 .ripple-effect {
-  @apply absolute w-12 h-12 bg-white/30 rounded-full;
+  @apply absolute w-12 h-12 bg-autobot-bg-card/30 rounded-full;
   animation: ripple 0.6s ease-out;
   pointer-events: none;
 }

--- a/autobot-frontend/src/views/AgentRegistryView.vue
+++ b/autobot-frontend/src/views/AgentRegistryView.vue
@@ -63,7 +63,7 @@ const colorMap: Record<string, string> = {
   green: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
   yellow: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
   purple: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
-  gray: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
+  gray: 'bg-autobot-bg-tertiary text-autobot-text-primary',
 }
 
 function getColorClasses(color: string): string {
@@ -253,7 +253,7 @@ onMounted(async () => {
                 <span
                   v-for="task in agent.tasks.slice(0, 3)"
                   :key="task"
-                  class="inline-block px-1.5 py-0.5 text-[10px] rounded bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+                  class="inline-block px-1.5 py-0.5 text-[10px] rounded bg-autobot-bg-tertiary text-autobot-text-secondary"
                 >
                   {{ task }}
                 </span>
@@ -336,7 +336,7 @@ onMounted(async () => {
                 <span
                   v-for="tool in agent.tools.slice(0, 4)"
                   :key="tool"
-                  class="inline-block px-1.5 py-0.5 text-[10px] rounded bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+                  class="inline-block px-1.5 py-0.5 text-[10px] rounded bg-autobot-bg-tertiary text-autobot-text-secondary"
                 >
                   {{ tool }}
                 </span>
@@ -380,7 +380,7 @@ onMounted(async () => {
               </span>
               <h3 class="text-lg font-semibold text-primary">{{ selectedAgent.name }}</h3>
             </div>
-            <div v-else class="h-6 w-48 bg-gray-200 dark:bg-gray-700 rounded animate-pulse"></div>
+            <div v-else class="h-6 w-48 bg-autobot-bg-tertiary rounded animate-pulse"></div>
             <button
               @click="closeDetailModal"
               class="text-secondary hover:text-primary"
@@ -403,7 +403,7 @@ onMounted(async () => {
                   {{ selectedAgent.category }}
                 </span>
                 <span v-for="tool in selectedAgent.tools" :key="tool"
-                  class="inline-flex items-center px-2 py-0.5 rounded-sm text-xs font-medium bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300"
+                  class="inline-flex items-center px-2 py-0.5 rounded-sm text-xs font-medium bg-autobot-bg-tertiary text-autobot-text-secondary"
                 >
                   {{ tool }}
                 </span>
@@ -412,7 +412,7 @@ onMounted(async () => {
               <!-- System Prompt -->
               <div class="mt-4">
                 <h4 class="text-sm font-medium text-primary mb-2">{{ $t('agent.registry.systemPrompt') }}</h4>
-                <pre class="text-xs text-secondary bg-gray-50 dark:bg-gray-800 rounded p-4 overflow-x-auto whitespace-pre-wrap max-h-96 overflow-y-auto">{{ selectedAgent.system_prompt }}</pre>
+                <pre class="text-xs text-secondary bg-autobot-bg-surface rounded p-4 overflow-x-auto whitespace-pre-wrap max-h-96 overflow-y-auto">{{ selectedAgent.system_prompt }}</pre>
               </div>
             </div>
           </div>

--- a/autobot-frontend/src/views/ExperimentDashboard.vue
+++ b/autobot-frontend/src/views/ExperimentDashboard.vue
@@ -69,28 +69,28 @@ async function handleReject(sessionId: string, experimentId: string) {
 
     <!-- Stats Header -->
     <div v-if="stats" class="grid grid-cols-2 gap-4 sm:grid-cols-4">
-      <div class="rounded-lg border p-4 dark:border-neutral-700">
+      <div class="rounded-lg border p-4">
         <div class="text-2xl font-bold">{{ stats.total_experiments }}</div>
-        <div class="text-sm text-neutral-500">Total Experiments</div>
+        <div class="text-sm text-autobot-text-muted">Total Experiments</div>
       </div>
-      <div class="rounded-lg border p-4 dark:border-neutral-700">
+      <div class="rounded-lg border p-4">
         <div class="text-2xl font-bold text-emerald-600">{{ stats.kept }}</div>
-        <div class="text-sm text-neutral-500">Kept</div>
+        <div class="text-sm text-autobot-text-muted">Kept</div>
       </div>
-      <div class="rounded-lg border p-4 dark:border-neutral-700">
+      <div class="rounded-lg border p-4">
         <div class="text-2xl font-bold text-orange-600">{{ stats.discarded }}</div>
-        <div class="text-sm text-neutral-500">Discarded</div>
+        <div class="text-sm text-autobot-text-muted">Discarded</div>
       </div>
-      <div class="rounded-lg border p-4 dark:border-neutral-700">
+      <div class="rounded-lg border p-4">
         <div class="text-2xl font-bold font-mono">
           {{ stats.best_val_bpb?.toFixed(4) ?? '---' }}
         </div>
-        <div class="text-sm text-neutral-500">Best val_bpb</div>
+        <div class="text-sm text-autobot-text-muted">Best val_bpb</div>
       </div>
     </div>
 
     <!-- Loading indicator -->
-    <div v-if="loading" class="py-4 text-center text-neutral-500">
+    <div v-if="loading" class="py-4 text-center text-autobot-text-muted">
       Loading experiments...
     </div>
 

--- a/autobot-frontend/src/views/llc/ApprovalsInbox.vue
+++ b/autobot-frontend/src/views/llc/ApprovalsInbox.vue
@@ -333,7 +333,7 @@ onUnmounted(() => {
   min-width: 1.5rem;
   height: 1.5rem;
   padding: 0 0.4rem;
-  background: #ef4444;
+  background: var(--color-error);
   color: white;
   font-size: 0.75rem;
   font-weight: 700;
@@ -484,9 +484,9 @@ onUnmounted(() => {
   transition: opacity 0.15s;
 }
 
-.btn-approve { background: #10b981; color: white; }
-.btn-reject { background: #ef4444; color: white; }
-.btn-changes { background: #f59e0b; color: white; }
+.btn-approve { background: var(--color-success); color: white; }
+.btn-reject { background: var(--color-error); color: white; }
+.btn-changes { background: var(--color-warning); color: white; }
 
 .btn-approve:disabled,
 .btn-reject:disabled,

--- a/autobot-frontend/src/views/llc/CompanyDashboard.vue
+++ b/autobot-frontend/src/views/llc/CompanyDashboard.vue
@@ -230,7 +230,7 @@ watch(lastMessage, (msg) => {
   <div class="p-4 space-y-6 max-w-7xl mx-auto">
     <!-- Header -->
     <div class="flex items-center justify-between">
-      <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ $t('llc.dashboard.title') }}</h1>
+      <h1 class="text-2xl font-bold text-autobot-text-primary">{{ $t('llc.dashboard.title') }}</h1>
       <button
         class="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors text-sm font-medium"
         @click="launchCeoChat"
@@ -239,7 +239,7 @@ watch(lastMessage, (msg) => {
       </button>
     </div>
 
-    <div v-if="!companyId" class="text-center py-12 text-gray-500">
+    <div v-if="!companyId" class="text-center py-12 text-autobot-text-muted">
       {{ $t('llc.dashboard.selectCompany') }}
     </div>
 
@@ -249,13 +249,13 @@ watch(lastMessage, (msg) => {
         <button class="ml-4 underline" @click="fetchDashboardData">{{ $t('llc.dashboard.retry') }}</button>
       </div>
 
-      <div v-if="isLoading" class="text-center py-12 text-gray-500">{{ $t('llc.dashboard.loading') }}</div>
+      <div v-if="isLoading" class="text-center py-12 text-autobot-text-muted">{{ $t('llc.dashboard.loading') }}</div>
 
       <template v-else>
         <!-- Pending Approvals -->
         <section v-if="pendingApprovals.length > 0">
           <div class="flex items-center gap-2 mb-3">
-            <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200">{{ $t('llc.dashboard.pendingApprovals') }}</h2>
+            <h2 class="text-lg font-semibold text-autobot-text-primary">{{ $t('llc.dashboard.pendingApprovals') }}</h2>
             <span class="bg-amber-100 text-amber-800 text-xs font-semibold px-2 py-0.5 rounded-full">
               {{ pendingApprovals.length }}
             </span>
@@ -264,11 +264,11 @@ watch(lastMessage, (msg) => {
             <div
               v-for="approval in pendingApprovals"
               :key="approval.id"
-              class="flex items-center justify-between bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3"
+              class="flex items-center justify-between bg-autobot-bg-card rounded-lg border border-autobot-border p-3"
             >
               <div>
-                <p class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ approval.title }}</p>
-                <p class="text-xs text-gray-500">{{ $t('llc.dashboard.requestedBy', { name: approval.requested_by }) }} · {{ formatTime(approval.created_at) }}</p>
+                <p class="text-sm font-medium text-autobot-text-primary">{{ approval.title }}</p>
+                <p class="text-xs text-autobot-text-muted">{{ $t('llc.dashboard.requestedBy', { name: approval.requested_by }) }} · {{ formatTime(approval.created_at) }}</p>
               </div>
               <button
                 class="px-3 py-1.5 bg-green-600 text-white text-xs rounded hover:bg-green-700 transition-colors"
@@ -282,47 +282,47 @@ watch(lastMessage, (msg) => {
 
         <!-- Budget Gauges -->
         <section>
-          <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-3">{{ $t('llc.dashboard.budget') }}</h2>
+          <h2 class="text-lg font-semibold text-autobot-text-primary mb-3">{{ $t('llc.dashboard.budget') }}</h2>
           <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             <div
               v-for="budget in budgets"
               :key="budget.label"
-              class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4"
+              class="bg-autobot-bg-card rounded-lg border border-autobot-border p-4"
             >
               <div class="flex justify-between items-center mb-2">
-                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ budget.label }}</span>
-                <span class="text-xs text-gray-500">{{ budgetPercent(budget) }}%</span>
+                <span class="text-sm font-medium text-autobot-text-secondary">{{ budget.label }}</span>
+                <span class="text-xs text-autobot-text-muted">{{ budgetPercent(budget) }}%</span>
               </div>
-              <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+              <div class="w-full bg-autobot-bg-tertiary rounded-full h-2">
                 <div
                   class="h-2 rounded-full transition-all"
                   :class="budgetBarColor(budget)"
                   :style="{ width: `${budgetPercent(budget)}%` }"
                 />
               </div>
-              <p class="text-xs text-gray-500 mt-1">{{ budget.spent }} / {{ budget.total }}</p>
+              <p class="text-xs text-autobot-text-muted mt-1">{{ budget.spent }} / {{ budget.total }}</p>
             </div>
           </div>
         </section>
 
         <!-- Agent Status Grid -->
         <section>
-          <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-3">
+          <h2 class="text-lg font-semibold text-autobot-text-primary mb-3">
             {{ $t('llc.dashboard.agents') }}
-            <span class="text-sm font-normal text-gray-500 ml-1">({{ agents.length }})</span>
+            <span class="text-sm font-normal text-autobot-text-muted ml-1">({{ agents.length }})</span>
           </h2>
           <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
             <div
               v-for="agent in agents"
               :key="agent.id"
-              class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3 flex flex-col gap-1"
+              class="bg-autobot-bg-card rounded-lg border border-autobot-border p-3 flex flex-col gap-1"
             >
               <div class="flex items-center gap-2">
                 <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" :class="agentStatusColor(agent.status)" />
-                <span class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{{ agent.name }}</span>
+                <span class="text-sm font-medium text-autobot-text-primary truncate">{{ agent.name }}</span>
               </div>
-              <span class="text-xs text-gray-500 truncate">{{ agent.title }}</span>
-              <span class="text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded px-1.5 py-0.5 self-start">
+              <span class="text-xs text-autobot-text-muted truncate">{{ agent.title }}</span>
+              <span class="text-xs bg-autobot-bg-tertiary text-autobot-text-secondary rounded px-1.5 py-0.5 self-start">
                 {{ agent.adapter_type }}
               </span>
             </div>
@@ -331,20 +331,20 @@ watch(lastMessage, (msg) => {
 
         <!-- Live Heartbeat Runs -->
         <section>
-          <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-3">{{ $t('llc.dashboard.recentRuns') }}</h2>
-          <div class="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
-            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
-              <thead class="bg-gray-50 dark:bg-gray-900">
+          <h2 class="text-lg font-semibold text-autobot-text-primary mb-3">{{ $t('llc.dashboard.recentRuns') }}</h2>
+          <div class="overflow-x-auto rounded-lg border border-autobot-border">
+            <table class="min-w-full divide-y divide-autobot-border text-sm">
+              <thead class="bg-autobot-bg-surface">
                 <tr>
-                  <th class="px-4 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">{{ $t('llc.dashboard.colAgent') }}</th>
-                  <th class="px-4 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">{{ $t('llc.dashboard.colStatus') }}</th>
-                  <th class="px-4 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">{{ $t('llc.dashboard.colStarted') }}</th>
-                  <th class="px-4 py-2 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">{{ $t('llc.dashboard.colDuration') }}</th>
+                  <th class="px-4 py-2 text-left text-xs font-semibold text-autobot-text-secondary uppercase tracking-wider">{{ $t('llc.dashboard.colAgent') }}</th>
+                  <th class="px-4 py-2 text-left text-xs font-semibold text-autobot-text-secondary uppercase tracking-wider">{{ $t('llc.dashboard.colStatus') }}</th>
+                  <th class="px-4 py-2 text-left text-xs font-semibold text-autobot-text-secondary uppercase tracking-wider">{{ $t('llc.dashboard.colStarted') }}</th>
+                  <th class="px-4 py-2 text-left text-xs font-semibold text-autobot-text-secondary uppercase tracking-wider">{{ $t('llc.dashboard.colDuration') }}</th>
                 </tr>
               </thead>
-              <tbody class="divide-y divide-gray-100 dark:divide-gray-800 bg-white dark:bg-gray-800">
+              <tbody class="divide-y divide-autobot-border bg-autobot-bg-card">
                 <tr v-for="run in heartbeatRuns" :key="run.run_id">
-                  <td class="px-4 py-2 text-gray-900 dark:text-gray-100 font-medium">{{ run.agent_name }}</td>
+                  <td class="px-4 py-2 text-autobot-text-primary font-medium">{{ run.agent_name }}</td>
                   <td class="px-4 py-2">
                     <span
                       class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
@@ -357,11 +357,11 @@ watch(lastMessage, (msg) => {
                       {{ run.status }}
                     </span>
                   </td>
-                  <td class="px-4 py-2 text-gray-500">{{ formatTime(run.started_at) }}</td>
-                  <td class="px-4 py-2 text-gray-500">{{ formatDuration(run.duration_ms) }}</td>
+                  <td class="px-4 py-2 text-autobot-text-muted">{{ formatTime(run.started_at) }}</td>
+                  <td class="px-4 py-2 text-autobot-text-muted">{{ formatDuration(run.duration_ms) }}</td>
                 </tr>
                 <tr v-if="heartbeatRuns.length === 0">
-                  <td colspan="4" class="px-4 py-4 text-center text-gray-400 text-sm">{{ $t('llc.dashboard.noRuns') }}</td>
+                  <td colspan="4" class="px-4 py-4 text-center text-autobot-text-muted text-sm">{{ $t('llc.dashboard.noRuns') }}</td>
                 </tr>
               </tbody>
             </table>
@@ -370,20 +370,20 @@ watch(lastMessage, (msg) => {
 
         <!-- Activity Feed -->
         <section>
-          <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-3">{{ $t('llc.dashboard.liveActivity') }}</h2>
-          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-700 max-h-72 overflow-y-auto">
+          <h2 class="text-lg font-semibold text-autobot-text-primary mb-3">{{ $t('llc.dashboard.liveActivity') }}</h2>
+          <div class="bg-autobot-bg-card rounded-lg border border-autobot-border divide-y divide-autobot-border max-h-72 overflow-y-auto">
             <div
               v-for="event in activityFeed"
               :key="event.id"
               class="px-4 py-2 flex items-start gap-3"
             >
-              <span class="text-xs text-gray-400 w-16 flex-shrink-0 pt-0.5">{{ formatTime(event.timestamp) }}</span>
+              <span class="text-xs text-autobot-text-muted w-16 flex-shrink-0 pt-0.5">{{ formatTime(event.timestamp) }}</span>
               <div class="flex-1 min-w-0">
                 <span class="text-xs text-indigo-600 dark:text-indigo-400 font-medium mr-1">{{ event.agent_name ?? $t('llc.dashboard.system') }}</span>
-                <span class="text-sm text-gray-700 dark:text-gray-300">{{ event.summary }}</span>
+                <span class="text-sm text-autobot-text-secondary">{{ event.summary }}</span>
               </div>
             </div>
-            <div v-if="activityFeed.length === 0" class="px-4 py-4 text-center text-gray-400 text-sm">
+            <div v-if="activityFeed.length === 0" class="px-4 py-4 text-center text-autobot-text-muted text-sm">
               {{ $t('llc.dashboard.waitingActivity') }}
             </div>
           </div>

--- a/autobot-frontend/src/views/llc/CompanyTreeNode.vue
+++ b/autobot-frontend/src/views/llc/CompanyTreeNode.vue
@@ -36,13 +36,13 @@ const budgetBarColor = (node: CompanyNode) => {
 <template>
   <div>
     <div
-      class="group flex items-center gap-3 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-3 cursor-pointer hover:border-indigo-300 dark:hover:border-indigo-600 transition-colors"
+      class="group flex items-center gap-3 bg-autobot-bg-card rounded-lg border border-autobot-border p-3 cursor-pointer hover:border-indigo-300 dark:hover:border-indigo-600 transition-colors"
       :style="{ marginLeft: `${(depth ?? 0) * 24}px` }"
       @click="emit('navigate', node)"
     >
       <button
         v-if="node.children.length > 0"
-        class="w-5 h-5 flex items-center justify-center text-gray-400 hover:text-gray-600 flex-shrink-0"
+        class="w-5 h-5 flex items-center justify-center text-autobot-text-muted hover:text-autobot-text-secondary flex-shrink-0"
         @click.stop="emit('toggle', node)"
       >
         <svg class="w-4 h-4 transition-transform" :class="node.expanded ? 'rotate-90' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -52,17 +52,17 @@ const budgetBarColor = (node: CompanyNode) => {
       <span v-else class="w-5 flex-shrink-0" />
 
       <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" :class="companyStatusColor(node.status)" />
-      <span class="flex-1 font-semibold text-sm text-gray-900 dark:text-gray-100">{{ node.name }}</span>
+      <span class="flex-1 font-semibold text-sm text-autobot-text-primary">{{ node.name }}</span>
 
       <div class="flex items-center gap-2 w-32">
-        <div class="flex-1 bg-gray-200 dark:bg-gray-700 rounded-full h-1.5">
+        <div class="flex-1 bg-autobot-bg-tertiary rounded-full h-1.5">
           <div class="h-1.5 rounded-full" :class="budgetBarColor(node)" :style="{ width: `${budgetPercent(node)}%` }" />
         </div>
-        <span class="text-xs text-gray-400 w-8 text-right">{{ budgetPercent(node) }}%</span>
+        <span class="text-xs text-autobot-text-muted w-8 text-right">{{ budgetPercent(node) }}%</span>
       </div>
 
-      <span v-if="node.agent_count != null" class="text-xs text-gray-500">{{ t('llc.companyTree.agentCount', { count: node.agent_count }) }}</span>
-      <svg class="w-4 h-4 text-gray-300 group-hover:text-indigo-400 transition-colors flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <span v-if="node.agent_count != null" class="text-xs text-autobot-text-muted">{{ t('llc.companyTree.agentCount', { count: node.agent_count }) }}</span>
+      <svg class="w-4 h-4 text-autobot-text-muted group-hover:text-indigo-400 transition-colors flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
       </svg>
     </div>

--- a/autobot-frontend/src/views/llc/CostDashboard.vue
+++ b/autobot-frontend/src/views/llc/CostDashboard.vue
@@ -602,13 +602,13 @@ onMounted(async () => {
 
 .gauge-fill {
   height: 100%;
-  background: #10b981;
+  background: var(--color-success);
   border-radius: 9999px;
   transition: width 0.3s;
 }
 
-.gauge-warn { background: #f59e0b; }
-.gauge-over { background: #ef4444; }
+.gauge-warn { background: var(--color-warning); }
+.gauge-over { background: var(--color-error); }
 
 .gauge-label {
   min-width: 3.5rem;
@@ -616,7 +616,7 @@ onMounted(async () => {
   font-size: 0.8rem;
 }
 
-.text-warn { color: #f59e0b; font-weight: 600; }
+.text-warn { color: var(--color-warning); font-weight: 600; }
 
 .budget-amounts {
   min-width: 12rem;
@@ -774,9 +774,9 @@ onMounted(async () => {
 
 .modal-error {
   font-size: 0.825rem;
-  color: #ef4444;
+  color: var(--color-error);
   padding: 0.5rem 0.75rem;
-  background: #fef2f2;
+  background: var(--color-error-bg);
   border-radius: 0.375rem;
 }
 

--- a/autobot-frontend/src/views/llc/GoalTree.vue
+++ b/autobot-frontend/src/views/llc/GoalTree.vue
@@ -93,7 +93,7 @@ const itemStatusColor = (status: string) => {
   if (status === 'done') return 'text-green-600'
   if (status === 'in_progress') return 'text-blue-600'
   if (status === 'blocked') return 'text-red-500'
-  return 'text-gray-500'
+  return 'text-autobot-text-muted'
 }
 
 onMounted(fetchGoals)
@@ -101,16 +101,16 @@ onMounted(fetchGoals)
 
 <template>
   <div class="p-4 max-w-5xl mx-auto">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">{{ t('llc.goals.title') }}</h1>
+    <h1 class="text-2xl font-bold text-autobot-text-primary mb-6">{{ t('llc.goals.title') }}</h1>
 
     <div v-if="error" class="rounded-lg bg-red-50 border border-red-200 p-4 text-red-700 text-sm mb-4">
       {{ error }}
       <button class="ml-4 underline" @click="fetchGoals">{{ t('llc.goals.retry') }}</button>
     </div>
 
-    <div v-if="isLoading" class="text-center py-12 text-gray-500">{{ t('llc.goals.loading') }}</div>
+    <div v-if="isLoading" class="text-center py-12 text-autobot-text-muted">{{ t('llc.goals.loading') }}</div>
 
-    <div v-else-if="goals.length === 0 && !error" class="text-center py-12 text-gray-400">{{ t('llc.goals.empty') }}</div>
+    <div v-else-if="goals.length === 0 && !error" class="text-center py-12 text-autobot-text-muted">{{ t('llc.goals.empty') }}</div>
 
     <div v-else class="space-y-1">
       <GoalTreeNode
@@ -128,27 +128,27 @@ onMounted(fetchGoals)
     <transition name="fade">
       <div
         v-if="selectedGoal"
-        class="mt-6 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4"
+        class="mt-6 bg-autobot-bg-card rounded-lg border border-autobot-border p-4"
       >
         <div class="flex items-center justify-between mb-3">
-          <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100">
+          <h2 class="text-base font-semibold text-autobot-text-primary">
             {{ t('llc.goals.linkedItemsFor') }} <span class="text-indigo-600">{{ selectedGoal.title }}</span>
           </h2>
-          <button class="text-gray-400 hover:text-gray-600 text-sm" @click="selectedGoal = null">✕</button>
+          <button class="text-autobot-text-muted hover:text-autobot-text-secondary text-sm" @click="selectedGoal = null">✕</button>
         </div>
 
-        <div v-if="selectedGoal.loading_items" class="text-sm text-gray-400">{{ t('llc.goals.loadingItems') }}</div>
-        <div v-else-if="!selectedGoal.linked_items || selectedGoal.linked_items.length === 0" class="text-sm text-gray-400">
+        <div v-if="selectedGoal.loading_items" class="text-sm text-autobot-text-muted">{{ t('llc.goals.loadingItems') }}</div>
+        <div v-else-if="!selectedGoal.linked_items || selectedGoal.linked_items.length === 0" class="text-sm text-autobot-text-muted">
           {{ t('llc.goals.noLinkedItems') }}
         </div>
         <ul v-else class="space-y-1">
           <li
             v-for="item in selectedGoal.linked_items"
             :key="item.id"
-            class="flex items-center justify-between text-sm py-1 border-b border-gray-100 dark:border-gray-700 last:border-0"
+            class="flex items-center justify-between text-sm py-1 border-b border-autobot-border-subtle last:border-0"
           >
-            <span class="text-gray-800 dark:text-gray-200">
-              <span class="text-xs text-gray-400 mr-1">{{ item.identifier }}</span>
+            <span class="text-autobot-text-primary">
+              <span class="text-xs text-autobot-text-muted mr-1">{{ item.identifier }}</span>
               {{ item.title }}
             </span>
             <span class="text-xs font-medium" :class="itemStatusColor(item.status)">{{ item.status }}</span>

--- a/autobot-frontend/src/views/llc/GoalTreeNode.vue
+++ b/autobot-frontend/src/views/llc/GoalTreeNode.vue
@@ -26,12 +26,12 @@ const { t } = useI18n()
 const levelBadgeClass = (level?: string) => {
   if (level === 'company') return 'bg-purple-100 text-purple-700'
   if (level === 'team') return 'bg-blue-100 text-blue-700'
-  return 'bg-gray-100 text-gray-600'
+  return 'bg-autobot-bg-tertiary text-autobot-text-secondary'
 }
 
 const statusBadgeClass = (status: string) => {
   if (status === 'active') return 'bg-green-100 text-green-700'
-  if (status === 'done') return 'bg-gray-100 text-gray-500'
+  if (status === 'done') return 'bg-autobot-bg-tertiary text-autobot-text-muted'
   if (status === 'paused') return 'bg-yellow-100 text-yellow-700'
   return 'bg-red-100 text-red-600'
 }
@@ -43,13 +43,13 @@ const statusBadgeClass = (status: string) => {
       class="flex items-center gap-2 py-2 px-3 rounded-lg cursor-pointer transition-colors"
       :class="selectedId === goal.id
         ? 'bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-700'
-        : 'hover:bg-gray-50 dark:hover:bg-gray-800'"
+        : 'hover:bg-autobot-bg-hover'"
       :style="{ paddingLeft: `${(depth ?? 0) * 20 + 12}px` }"
       @click="emit('select', goal)"
     >
       <button
         v-if="goal.children.length > 0"
-        class="w-4 h-4 flex items-center justify-center text-gray-400 hover:text-gray-600 flex-shrink-0"
+        class="w-4 h-4 flex items-center justify-center text-autobot-text-muted hover:text-autobot-text-secondary flex-shrink-0"
         @click.stop="emit('toggle', goal)"
       >
         <svg class="w-3 h-3 transition-transform" :class="goal.expanded ? 'rotate-90' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -61,8 +61,8 @@ const statusBadgeClass = (status: string) => {
       <span class="text-xs font-semibold px-1.5 py-0.5 rounded" :class="levelBadgeClass(goal.level)">
         {{ goal.level }}
       </span>
-      <span class="flex-1 text-sm font-medium text-gray-900 dark:text-gray-100">{{ goal.title }}</span>
-      <span v-if="goal.owner" class="text-xs text-gray-400">{{ goal.owner }}</span>
+      <span class="flex-1 text-sm font-medium text-autobot-text-primary">{{ goal.title }}</span>
+      <span v-if="goal.owner" class="text-xs text-autobot-text-muted">{{ goal.owner }}</span>
       <span class="text-xs px-1.5 py-0.5 rounded" :class="statusBadgeClass(goal.status)">
         {{ goal.status }}
       </span>

--- a/autobot-frontend/src/views/llc/OrgChart.vue
+++ b/autobot-frontend/src/views/llc/OrgChart.vue
@@ -84,7 +84,7 @@ onMounted(fetchTree)
 <template>
   <div class="p-4 max-w-7xl mx-auto">
     <div class="flex items-center justify-between mb-6">
-      <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ t('llc.orgChart.title') }}</h1>
+      <h1 class="text-2xl font-bold text-autobot-text-primary">{{ t('llc.orgChart.title') }}</h1>
       <button
         v-if="companyId"
         class="px-3 py-1.5 rounded-md bg-indigo-600 text-white text-sm hover:bg-indigo-700"
@@ -106,9 +106,9 @@ onMounted(fetchTree)
       <button class="ml-4 underline" @click="fetchTree">{{ t('llc.orgChart.retry') }}</button>
     </div>
 
-    <div v-if="isLoading" class="text-center py-12 text-gray-500">{{ t('llc.orgChart.loading') }}</div>
+    <div v-if="isLoading" class="text-center py-12 text-autobot-text-muted">{{ t('llc.orgChart.loading') }}</div>
 
-    <div v-else-if="tree.length === 0 && !error" class="text-center py-12 text-gray-400">{{ t('llc.orgChart.empty') }}</div>
+    <div v-else-if="tree.length === 0 && !error" class="text-center py-12 text-autobot-text-muted">{{ t('llc.orgChart.empty') }}</div>
 
     <div v-else class="overflow-x-auto">
       <div class="min-w-max flex gap-6 items-start">
@@ -126,11 +126,11 @@ onMounted(fetchTree)
     <transition name="slide">
       <div
         v-if="drawerOpen && selectedNode"
-        class="fixed inset-y-0 right-0 w-80 bg-white dark:bg-gray-900 shadow-2xl border-l border-gray-200 dark:border-gray-700 z-50 flex flex-col"
+        class="fixed inset-y-0 right-0 w-80 bg-autobot-bg-card shadow-2xl border-l border-autobot-border z-50 flex flex-col"
       >
-        <div class="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-gray-700">
-          <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{{ t('llc.orgChart.agentDetail') }}</h2>
-          <button class="text-gray-400 hover:text-gray-600" @click="closeDrawer">
+        <div class="flex items-center justify-between px-5 py-4 border-b border-autobot-border">
+          <h2 class="text-lg font-semibold text-autobot-text-primary">{{ t('llc.orgChart.agentDetail') }}</h2>
+          <button class="text-autobot-text-muted hover:text-autobot-text-secondary" @click="closeDrawer">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -145,37 +145,37 @@ onMounted(fetchTree)
               {{ selectedNode.name.charAt(0).toUpperCase() }}
             </div>
             <div>
-              <p class="font-semibold text-gray-900 dark:text-gray-100">{{ selectedNode.name }}</p>
-              <p class="text-sm text-gray-500">{{ selectedNode.title }}</p>
+              <p class="font-semibold text-autobot-text-primary">{{ selectedNode.name }}</p>
+              <p class="text-sm text-autobot-text-muted">{{ selectedNode.title }}</p>
             </div>
           </div>
 
           <dl class="space-y-2 text-sm">
             <div class="flex justify-between">
-              <dt class="text-gray-500">{{ t('llc.orgChart.adapter') }}</dt>
-              <dd class="text-gray-900 dark:text-gray-100 font-medium">{{ selectedNode.adapter_type }}</dd>
+              <dt class="text-autobot-text-muted">{{ t('llc.orgChart.adapter') }}</dt>
+              <dd class="text-autobot-text-primary font-medium">{{ selectedNode.adapter_type }}</dd>
             </div>
             <div class="flex justify-between">
-              <dt class="text-gray-500">{{ t('llc.orgChart.type') }}</dt>
-              <dd class="text-gray-900 dark:text-gray-100">{{ selectedNode.is_human ? t('llc.orgChart.human') : t('llc.orgChart.aiAgent') }}</dd>
+              <dt class="text-autobot-text-muted">{{ t('llc.orgChart.type') }}</dt>
+              <dd class="text-autobot-text-primary">{{ selectedNode.is_human ? t('llc.orgChart.human') : t('llc.orgChart.aiAgent') }}</dd>
             </div>
             <div class="flex justify-between">
-              <dt class="text-gray-500">{{ t('llc.orgChart.lastHeartbeat') }}</dt>
-              <dd class="text-gray-900 dark:text-gray-100">{{ formatTime(selectedNode.last_heartbeat) }}</dd>
+              <dt class="text-autobot-text-muted">{{ t('llc.orgChart.lastHeartbeat') }}</dt>
+              <dd class="text-autobot-text-primary">{{ formatTime(selectedNode.last_heartbeat) }}</dd>
             </div>
             <div class="flex justify-between">
-              <dt class="text-gray-500">{{ t('llc.orgChart.budget') }}</dt>
-              <dd class="text-gray-900 dark:text-gray-100">
+              <dt class="text-autobot-text-muted">{{ t('llc.orgChart.budget') }}</dt>
+              <dd class="text-autobot-text-primary">
                 {{ selectedNode.budget_spent }} / {{ selectedNode.budget_total }}
               </dd>
             </div>
             <div class="flex justify-between">
-              <dt class="text-gray-500">{{ t('llc.orgChart.assignedItems') }}</dt>
-              <dd class="text-gray-900 dark:text-gray-100">{{ selectedNode.assigned_item_count }}</dd>
+              <dt class="text-autobot-text-muted">{{ t('llc.orgChart.assignedItems') }}</dt>
+              <dd class="text-autobot-text-primary">{{ selectedNode.assigned_item_count }}</dd>
             </div>
           </dl>
         </div>
-        <div class="px-5 py-4 border-t border-gray-200 dark:border-gray-700">
+        <div class="px-5 py-4 border-t border-autobot-border">
           <button
             class="w-full py-2 rounded-lg text-sm font-medium transition-colors"
             :class="selectedNode.status === 'paused'

--- a/autobot-frontend/src/views/llc/OrgTreeNode.vue
+++ b/autobot-frontend/src/views/llc/OrgTreeNode.vue
@@ -30,7 +30,7 @@ const emit = defineEmits<{ select: [node: OrgNode] }>()
   <div class="flex flex-col items-center gap-1">
     <div
       class="relative cursor-pointer rounded-xl border-2 p-3 min-w-[130px] text-center transition-shadow hover:shadow-md"
-      :class="node.is_human ? 'border-blue-300 bg-blue-50 dark:bg-blue-900/20' : 'border-indigo-200 bg-white dark:bg-gray-800'"
+      :class="node.is_human ? 'border-blue-300 bg-blue-50 dark:bg-blue-900/20' : 'border-indigo-200 bg-autobot-bg-card'"
       @click="emit('select', node)"
     >
       <div class="flex justify-center mb-1">
@@ -41,19 +41,19 @@ const emit = defineEmits<{ select: [node: OrgNode] }>()
           {{ node.name.charAt(0).toUpperCase() }}
         </div>
       </div>
-      <p class="text-xs font-semibold text-gray-900 dark:text-gray-100 truncate">{{ node.name }}</p>
-      <p class="text-xs text-gray-500 truncate">{{ node.title }}</p>
+      <p class="text-xs font-semibold text-autobot-text-primary truncate">{{ node.name }}</p>
+      <p class="text-xs text-autobot-text-muted truncate">{{ node.title }}</p>
       <div class="flex justify-center items-center gap-1 mt-1">
         <span class="w-2 h-2 rounded-full" :class="agentStatusColor(node.status)" />
-        <span class="text-xs text-gray-400">{{ node.adapter_type }}</span>
+        <span class="text-xs text-autobot-text-muted">{{ node.adapter_type }}</span>
       </div>
     </div>
 
     <template v-if="node.children.length > 0">
-      <div class="w-px h-4 bg-gray-300" />
+      <div class="w-px h-4 bg-autobot-border" />
       <div class="flex gap-4">
         <div v-for="child in node.children" :key="child.id" class="flex flex-col items-center">
-          <div class="w-px h-4 bg-gray-300" />
+          <div class="w-px h-4 bg-autobot-border" />
           <OrgTreeNode :node="child" :depth="(depth ?? 0) + 1" @select="emit('select', $event)" />
         </div>
       </div>

--- a/autobot-frontend/src/views/llc/SubCompanyTree.vue
+++ b/autobot-frontend/src/views/llc/SubCompanyTree.vue
@@ -84,16 +84,16 @@ onMounted(fetchTree)
 
 <template>
   <div class="p-4 max-w-5xl mx-auto">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">{{ t('llc.companyTree.title') }}</h1>
+    <h1 class="text-2xl font-bold text-autobot-text-primary mb-6">{{ t('llc.companyTree.title') }}</h1>
 
     <div v-if="error" class="rounded-lg bg-red-50 border border-red-200 p-4 text-red-700 text-sm mb-4">
       {{ error }}
       <button class="ml-4 underline" @click="fetchTree">{{ t('llc.companyTree.retry') }}</button>
     </div>
 
-    <div v-if="isLoading" class="text-center py-12 text-gray-500">{{ t('llc.companyTree.loading') }}</div>
+    <div v-if="isLoading" class="text-center py-12 text-autobot-text-muted">{{ t('llc.companyTree.loading') }}</div>
 
-    <div v-else-if="tree.length === 0 && !error" class="text-center py-12 text-gray-400">{{ t('llc.companyTree.empty') }}</div>
+    <div v-else-if="tree.length === 0 && !error" class="text-center py-12 text-autobot-text-muted">{{ t('llc.companyTree.empty') }}</div>
 
     <div v-else class="space-y-2">
       <CompanyTreeNode

--- a/autobot-frontend/src/views/secrets/LlmApiKeysView.vue
+++ b/autobot-frontend/src/views/secrets/LlmApiKeysView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="p-6 max-w-7xl mx-auto">
     <div class="flex items-center justify-between mb-6">
-      <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
+      <h1 class="text-2xl font-bold text-autobot-text-primary">
         {{ t('llmKeys.title') }}
       </h1>
       <button
@@ -24,16 +24,16 @@
         {{ t('llmKeys.rawKeyWarning') }}
       </p>
       <div class="flex items-center gap-2">
-        <code class="flex-1 text-sm font-mono bg-white dark:bg-gray-800 px-2 py-1 rounded border">{{ newRawKey }}</code>
+        <code class="flex-1 text-sm font-mono bg-autobot-bg-card px-2 py-1 rounded border">{{ newRawKey }}</code>
         <button class="btn-secondary text-xs" @click="copyRawKey">{{ t('common.copy') }}</button>
       </div>
       <button class="mt-2 text-xs text-yellow-600 underline" @click="newRawKey = ''">{{ t('common.dismiss') }}</button>
     </div>
 
     <!-- Keys table -->
-    <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-x-auto">
+    <div class="bg-autobot-bg-card rounded-lg shadow overflow-x-auto">
       <table class="w-full text-sm">
-        <thead class="bg-gray-50 dark:bg-gray-700 text-gray-500 dark:text-gray-400 uppercase text-xs">
+        <thead class="bg-autobot-bg-surface text-autobot-text-muted uppercase text-xs">
           <tr>
             <th class="px-4 py-3 text-left">{{ t('llmKeys.col.prefix') }}</th>
             <th class="px-4 py-3 text-left">{{ t('llmKeys.col.team') }}</th>
@@ -46,21 +46,21 @@
             <th class="px-4 py-3 text-left">{{ t('common.actions') }}</th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+        <tbody class="divide-y divide-autobot-border">
           <tr v-if="loading">
-            <td colspan="9" class="px-4 py-8 text-center text-gray-400">{{ t('common.loading') }}</td>
+            <td colspan="9" class="px-4 py-8 text-center text-autobot-text-muted">{{ t('common.loading') }}</td>
           </tr>
           <tr v-else-if="keys.length === 0">
-            <td colspan="9" class="px-4 py-8 text-center text-gray-400">{{ t('llmKeys.empty') }}</td>
+            <td colspan="9" class="px-4 py-8 text-center text-autobot-text-muted">{{ t('llmKeys.empty') }}</td>
           </tr>
           <tr
             v-for="key in keys"
             :key="key.key_id"
-            class="hover:bg-gray-50 dark:hover:bg-gray-750"
+            class="hover:bg-autobot-bg-hover"
           >
             <td class="px-4 py-3 font-mono text-xs">{{ key.key_prefix }}</td>
             <td class="px-4 py-3">{{ key.team_id }}</td>
-            <td class="px-4 py-3 text-gray-600 dark:text-gray-300">{{ key.label || '—' }}</td>
+            <td class="px-4 py-3 text-autobot-text-secondary">{{ key.label || '—' }}</td>
             <td class="px-4 py-3 text-right">
               {{ key.monthly_budget_usd > 0 ? '$' + key.monthly_budget_usd.toFixed(2) : t('llmKeys.unlimited') }}
             </td>
@@ -82,7 +82,7 @@
                 {{ key.revoked ? t('llmKeys.status.revoked') : t('llmKeys.status.active') }}
               </span>
             </td>
-            <td class="px-4 py-3 text-xs text-gray-500">
+            <td class="px-4 py-3 text-xs text-autobot-text-muted">
               {{ key.expires_at ? new Date(key.expires_at * 1000).toLocaleDateString() : '—' }}
             </td>
             <td class="px-4 py-3">
@@ -125,12 +125,12 @@
             <div>
               <label class="form-label">{{ t('llmKeys.form.budget') }}</label>
               <input v-model.number="form.monthly_budget_usd" type="number" step="0.01" min="0" class="form-input" />
-              <p class="text-xs text-gray-500 mt-1">{{ t('llmKeys.form.budgetHint') }}</p>
+              <p class="text-xs text-autobot-text-muted mt-1">{{ t('llmKeys.form.budgetHint') }}</p>
             </div>
             <div>
               <label class="form-label">{{ t('llmKeys.form.models') }}</label>
               <input v-model="form.allowed_models_raw" class="form-input" placeholder='["gpt-4", "claude-*"]' />
-              <p class="text-xs text-gray-500 mt-1">{{ t('llmKeys.form.modelsHint') }}</p>
+              <p class="text-xs text-autobot-text-muted mt-1">{{ t('llmKeys.form.modelsHint') }}</p>
             </div>
             <div>
               <label class="form-label">{{ t('llmKeys.form.expiresAt') }}</label>
@@ -153,7 +153,7 @@
     <div v-if="revokeKeyId" class="modal-overlay" @click.self="revokeKeyId = ''">
       <div class="modal-content w-full max-w-sm">
         <h2 class="text-lg font-semibold mb-2">{{ t('llmKeys.revokeConfirm.title') }}</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+        <p class="text-sm text-autobot-text-secondary mb-4">
           {{ t('llmKeys.revokeConfirm.body', { id: revokeKeyId }) }}
         </p>
         <div class="flex justify-end gap-3">
@@ -203,7 +203,7 @@ const form = reactive({
 })
 
 function spendClass(key: KeyRow): string {
-  if (key.monthly_budget_usd <= 0) return 'text-gray-700 dark:text-gray-300'
+  if (key.monthly_budget_usd <= 0) return 'text-autobot-text-secondary'
   const ratio = key.spend_usd_this_month / key.monthly_budget_usd
   if (ratio >= 0.9) return 'text-red-600 font-semibold'
   if (ratio >= 0.7) return 'text-yellow-600 font-semibold'


### PR DESCRIPTION
## Thinking Path

C1 (#10816) migrated 628 `--color-*` token refs to the canonical `--text-*/--bg-*/--border-default` namespace. C1b finishes the design-token migration by cleaning up what C1's scripted rename didn't cover in the USER frontend (`autobot-frontend`), in the task's priority order: palette utility classes → dead `dark:` variants → residual hardcoded hex.

Audit findings shaped the scope:
- The task's raw hex baseline grep (2856) is dominated by **`var(--token, #fallback)` fallbacks (~950)** and **issue-number comments (`#749`)** — neither is theme-breaking, so they were intentionally left.
- **Gray/slate/neutral palette classes (338)** and **gray-family `dark:` variants** are the real theme-breakers: under the CSS-var token system (`@variant dark` wired to `[data-theme]` in `tailwind.css`), a `text-gray-900 dark:text-gray-100` pair is redundant because `text-autobot-text-primary` already adapts per theme.
- Status-color badge palettes (`bg-red-100 dark:bg-red-900`) and categorical type/status/priority palettes are semantic data-viz coloring — kept per the data-viz exclusion.

## What Changed

**Palette classes + dead `dark:` variants (25 files):** collapsed gray/slate/neutral utility classes and their paired `dark:` variants into single theme-adaptive `autobot-*` token utilities (`text-autobot-text-primary/secondary/muted`, `bg-autobot-bg-card/surface/tertiary/secondary/primary/hover`, `border-autobot-border[-subtle|-strong]`, `divide-autobot-border`).
- Gray/slate palette classes: **338 → 2** (2 remaining are `bg-gray-500/20` / `bg-gray-400/10` alpha status chips — deliberate keeps)
- Gray-family `dark:` variants: **99 stripped** (145 → 46; the 46 remaining are status-color badges — deliberate keeps)

**Semantic status hex → tokens (2 files):** `CostDashboard` gauges/warnings and `ApprovalsInbox` action buttons hardcoded the exact hex of the semantic tokens (`#10b981`/`#f59e0b`/`#ef4444`) → now `var(--color-success/warning/error)` + `var(--color-error-bg)`, so they theme-adapt.

**Deliberate keeps:**
- `text-white` — readable foreground on fixed colored surfaces (`bg-blue-600` buttons, gradient headers, badges); `text-inverse` is dark (`#0f172a`) and would render invisible there.
- Status-color badge/pill palettes and categorical type/status/priority color maps (epic=purple, bug=red, gauge thresholds, `stateColors`) — semantic data-viz coloring.
- xterm/terminal `ITheme` color schemes, SVG/diagram/gradient hex, and `var(--token, #hex)` fallbacks.

## Verification

- `npx vue-tsc --noEmit -p tsconfig.app.json` → **exit 0, 0 errors**
- `npx eslint src/` → **1 error, all pre-existing** (`vitest/prefer-called-exactly-once-with` in `useInlineEdit.test.ts`, outside this diff); no new errors/warnings introduced
- Gray/slate palette classes: 338 → 2 · `dark:` variants: 145 → 46
- `node_modules` symlink (used only for local vue-tsc/eslint) removed before commit; not staged

## Model Used

Claude Opus 4.8 (1M context)

Refs #10750