### PR TITLE
perf(reliability): make FailurePatternDetector async-native Redis (#10635)

### DIFF
--- a/autobot-backend/services/failure_pattern_detector.py
+++ b/autobot-backend/services/failure_pattern_detector.py
@@ -243,7 +243,9 @@ class FailurePatternDetector(AsyncRedisClientMixin):
         try:
             redis = await self._get_redis()
 
-            pattern_hashes = await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT) or set()
+            pattern_hashes = (
+                await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT) or set()
+            )
 
             if not pattern_hashes:
                 return {
@@ -302,7 +304,9 @@ class FailurePatternDetector(AsyncRedisClientMixin):
         """
         try:
             redis = await self._get_redis()
-            pattern_hashes = await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT) or set()
+            pattern_hashes = (
+                await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT) or set()
+            )
 
             patterns: List[FailurePattern] = []
 
@@ -327,7 +331,9 @@ class FailurePatternDetector(AsyncRedisClientMixin):
         """Clear all learned patterns (for testing or reset)."""
         try:
             redis = await self._get_redis()
-            pattern_hashes = await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT) or set()
+            pattern_hashes = (
+                await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT) or set()
+            )
 
             for pattern_hash in pattern_hashes:
                 pattern_key = f"{PATTERN_KEY_PREFIX}{pattern_hash}"

--- a/autobot-backend/services/failure_pattern_detector.py
+++ b/autobot-backend/services/failure_pattern_detector.py
@@ -12,13 +12,14 @@ improving recovery recommendations through feedback loops.
 Issue #2154: Pattern-based error recovery optimization.
 """
 
+import asyncio
 import hashlib
 import json
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from autobot_shared.time_utils import now_utc
 from constants.ttl_constants import TTL_30_DAYS
 
@@ -29,6 +30,10 @@ PATTERN_KEY_PREFIX = "failure:pattern:"
 PATTERN_STATS_SUFFIX = ":stats"
 PATTERN_HISTORY_SUFFIX = ":history"
 KNOWN_PATTERNS_KEY = "failure:patterns:known"
+
+# Maximum seconds to wait for any single Redis operation on the failure path.
+# Keeps a slow/hung Redis from stalling workflow error handling.
+_REDIS_OP_TIMEOUT: float = 2.0
 
 
 @dataclass
@@ -75,7 +80,7 @@ class FailurePattern:
         )
 
 
-class FailurePatternDetector:
+class FailurePatternDetector(AsyncRedisClientMixin):
     """
     Detects and learns failure patterns from error causal chains.
 
@@ -83,16 +88,14 @@ class FailurePatternDetector:
     - Pattern matching for new errors
     - Confidence scoring based on historical resolution data
     - Feedback loop for improving recommendations over time
+
+    All Redis I/O is async-native (``await redis.<op>``) via
+    ``AsyncRedisClientMixin``.  Each operation is bounded by
+    ``_REDIS_OP_TIMEOUT`` seconds so a slow Redis cannot stall the
+    workflow failure path.
     """
 
-    def __init__(self) -> None:
-        self._redis: Any | None = None
-
-    def _get_redis(self) -> Any:
-        """Lazy-init sync Redis client."""
-        if self._redis is None:
-            self._redis = get_redis_client(async_client=False, database="main")
-        return self._redis
+    _redis_database = "main"
 
     def hash_causal_chain(self, causal_chain: str) -> str:
         """Hash a causal chain for pattern matching."""
@@ -112,33 +115,29 @@ class FailurePatternDetector:
         pattern_hash = self.hash_causal_chain(causal_chain)
 
         try:
-            redis = self._get_redis()
+            redis = await self._get_redis()
             pattern_key = f"{PATTERN_KEY_PREFIX}{pattern_hash}"
 
-            # Check if pattern exists
-            pattern_data = redis.get(pattern_key)
+            pattern_data = await asyncio.wait_for(redis.get(pattern_key), timeout=_REDIS_OP_TIMEOUT)
             if not pattern_data:
                 return None
 
-            # Deserialize pattern
             try:
-                pattern_dict = json.loads(pattern_data)
-                pattern = FailurePattern.from_dict(pattern_dict)
-
-                # Update last_seen timestamp
-                pattern.last_seen = now_utc().isoformat()
-                self._store_pattern(pattern_hash, pattern)
-
-                logger.debug(
-                    "Found known pattern: hash=%s, count=%d, success_rate=%.2f",
-                    pattern_hash,
-                    pattern.occurrence_count,
-                    pattern.resolution_success_rate,
-                )
-                return pattern
+                pattern = FailurePattern.from_dict(json.loads(pattern_data))
             except (json.JSONDecodeError, KeyError) as exc:
                 logger.warning("Corrupt pattern data for hash=%s: %s", pattern_hash, exc)
                 return None
+
+            pattern.last_seen = now_utc().isoformat()
+            await self._store_pattern(pattern_hash, pattern)
+
+            logger.debug(
+                "Found known pattern: hash=%s, count=%d, success_rate=%.2f",
+                pattern_hash,
+                pattern.occurrence_count,
+                pattern.resolution_success_rate,
+            )
+            return pattern
 
         except Exception as exc:
             logger.warning("Failed to detect pattern: %s", exc)
@@ -164,11 +163,10 @@ class FailurePatternDetector:
         pattern_hash = self.hash_causal_chain(causal_chain)
 
         try:
-            redis = self._get_redis()
+            redis = await self._get_redis()
             pattern_key = f"{PATTERN_KEY_PREFIX}{pattern_hash}"
 
-            # Try to load existing pattern
-            pattern_data = redis.get(pattern_key)
+            pattern_data = await asyncio.wait_for(redis.get(pattern_key), timeout=_REDIS_OP_TIMEOUT)
             if pattern_data:
                 try:
                     pattern = FailurePattern.from_dict(json.loads(pattern_data))
@@ -177,27 +175,21 @@ class FailurePatternDetector:
             else:
                 pattern = self._create_new_pattern(pattern_hash, causal_chain)
 
-            # Update pattern with new observation
             if error_type not in pattern.error_types:
                 pattern.error_types.append(error_type)
 
             pattern.occurrence_count += 1
             pattern.last_seen = now_utc().isoformat()
 
-            # Update resolution stats if action succeeded
             if successful_action:
                 if successful_action not in pattern.successful_resolutions:
                     pattern.successful_resolutions.append(successful_action)
-
-                # Recompute success rate
                 if pattern.occurrence_count > 0:
                     success_count = len(pattern.successful_resolutions)
                     pattern.resolution_success_rate = success_count / pattern.occurrence_count
-                    # Boost confidence if we have good resolution history
                     pattern.confidence = min(1.0, 0.7 + (pattern.resolution_success_rate * 0.3))
 
-            # Store pattern back to Redis
-            self._store_pattern(pattern_hash, pattern)
+            await self._store_pattern(pattern_hash, pattern)
 
             logger.info(
                 "Updated pattern: hash=%s, count=%d, success_rate=%.2f, confidence=%.2f",
@@ -206,12 +198,10 @@ class FailurePatternDetector:
                 pattern.resolution_success_rate,
                 pattern.confidence,
             )
-
             return pattern
 
         except Exception as exc:
             logger.warning("Failed to learn pattern: %s", exc)
-            # Return a minimal pattern on failure
             return FailurePattern(
                 pattern_id=pattern_hash,
                 causal_chain=causal_chain,
@@ -232,22 +222,18 @@ class FailurePatternDetector:
             last_seen=now_utc().isoformat(),
         )
 
-    def _store_pattern(self, pattern_hash: str, pattern: FailurePattern) -> None:
-        """Store a pattern to Redis."""
+    async def _store_pattern(self, pattern_hash: str, pattern: FailurePattern) -> None:
+        """Store a pattern to Redis (async-native, bounded by _REDIS_OP_TIMEOUT)."""
         try:
-            redis = self._get_redis()
+            redis = await self._get_redis()
             pattern_key = f"{PATTERN_KEY_PREFIX}{pattern_hash}"
 
-            # Store pattern data
-            redis.set(
-                pattern_key,
-                json.dumps(pattern.to_dict()),
-                ex=TTL_30_DAYS,
+            await asyncio.wait_for(
+                redis.set(pattern_key, json.dumps(pattern.to_dict()), ex=TTL_30_DAYS),
+                timeout=_REDIS_OP_TIMEOUT,
             )
-
-            # Add to known patterns set (for enumeration)
-            redis.sadd(KNOWN_PATTERNS_KEY, pattern_hash)
-            redis.expire(KNOWN_PATTERNS_KEY, TTL_30_DAYS)
+            await asyncio.wait_for(redis.sadd(KNOWN_PATTERNS_KEY, pattern_hash), timeout=_REDIS_OP_TIMEOUT)
+            await asyncio.wait_for(redis.expire(KNOWN_PATTERNS_KEY, TTL_30_DAYS), timeout=_REDIS_OP_TIMEOUT)
 
         except Exception as exc:
             logger.warning("Failed to store pattern: %s", exc)
@@ -255,10 +241,9 @@ class FailurePatternDetector:
     async def get_pattern_statistics(self) -> Dict[str, Any]:
         """Get overall statistics about learned patterns."""
         try:
-            redis = self._get_redis()
+            redis = await self._get_redis()
 
-            # Get all known patterns
-            pattern_hashes = redis.smembers(KNOWN_PATTERNS_KEY) or set()
+            pattern_hashes = await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT) or set()
 
             if not pattern_hashes:
                 return {
@@ -274,7 +259,7 @@ class FailurePatternDetector:
 
             for pattern_hash in pattern_hashes:
                 pattern_key = f"{PATTERN_KEY_PREFIX}{pattern_hash}"
-                pattern_data = redis.get(pattern_key)
+                pattern_data = await asyncio.wait_for(redis.get(pattern_key), timeout=_REDIS_OP_TIMEOUT)
                 if pattern_data:
                     try:
                         pattern = FailurePattern.from_dict(json.loads(pattern_data))
@@ -316,14 +301,14 @@ class FailurePatternDetector:
             List of FailurePattern ordered by frequency
         """
         try:
-            redis = self._get_redis()
-            pattern_hashes = redis.smembers(KNOWN_PATTERNS_KEY) or set()
+            redis = await self._get_redis()
+            pattern_hashes = await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT) or set()
 
             patterns: List[FailurePattern] = []
 
             for pattern_hash in pattern_hashes:
                 pattern_key = f"{PATTERN_KEY_PREFIX}{pattern_hash}"
-                pattern_data = redis.get(pattern_key)
+                pattern_data = await asyncio.wait_for(redis.get(pattern_key), timeout=_REDIS_OP_TIMEOUT)
                 if pattern_data:
                     try:
                         pattern = FailurePattern.from_dict(json.loads(pattern_data))
@@ -331,9 +316,7 @@ class FailurePatternDetector:
                     except (json.JSONDecodeError, KeyError):
                         continue
 
-            # Sort by occurrence count (most frequent first)
             patterns.sort(key=lambda p: p.occurrence_count, reverse=True)
-
             return patterns[:limit]
 
         except Exception as exc:
@@ -343,14 +326,14 @@ class FailurePatternDetector:
     async def clear_patterns(self) -> None:
         """Clear all learned patterns (for testing or reset)."""
         try:
-            redis = self._get_redis()
-            pattern_hashes = redis.smembers(KNOWN_PATTERNS_KEY) or set()
+            redis = await self._get_redis()
+            pattern_hashes = await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT) or set()
 
             for pattern_hash in pattern_hashes:
                 pattern_key = f"{PATTERN_KEY_PREFIX}{pattern_hash}"
-                redis.delete(pattern_key)
+                await asyncio.wait_for(redis.delete(pattern_key), timeout=_REDIS_OP_TIMEOUT)
 
-            redis.delete(KNOWN_PATTERNS_KEY)
+            await asyncio.wait_for(redis.delete(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT)
             logger.info("Cleared %d failure patterns", len(pattern_hashes))
 
         except Exception as exc:


### PR DESCRIPTION
## Thinking Path
`FailurePatternDetector.detect_pattern`/`learn_pattern` were declared `async` but used a **sync** Redis client with blocking `redis.get/set/sadd`, so awaiting them blocked the event loop. Now reachable on the workflow failure path (workflow_runner.py:338-339).

## What Changed
- `FailurePatternDetector` now inherits `AsyncRedisClientMixin` (canonical lazy-init `_get_redis()` used by ~43 other services); dropped the custom sync client.
- All Redis I/O is async-native (`await redis.<op>`); `_store_pattern` converted to `async def`.
- Every Redis op bounded by `asyncio.wait_for(..., timeout=_REDIS_OP_TIMEOUT=2.0s)` so a slow/hung Redis can't stall workflow error handling (matches session_manager 2.0s pattern).

## Verification
- `python3 -m py_compile services/failure_pattern_detector.py` → OK
- `test_failure_pattern_wiring.py` → 6/6 passed
- Caller audit: only `workflow_runner.py:338-339` calls these; both already `await`.
- Redis-dependent tests fail identically before/after (Redis unreachable in local CI — pre-existing infra gap, not introduced here).

## Model Used
Opus 4.8

Closes #10635. Part of #10602.

Discovery filed: TestCausalErrorRecovery MagicMock-await bug (separate, pre-existing).