### PR TITLE
ci(smoke-test): print compose logs inline on failure (#10706)

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -164,7 +164,12 @@ jobs:
 
       - name: Collect logs on failure
         if: failure()
-        run: docker compose --env-file docker/.env.docker logs > failure-logs.txt
+        run: |
+          # Print inline (diagnosable without downloading the artifact) AND keep the
+          # artifact. Grouped so it collapses in the UI. (#10706)
+          echo "::group::docker compose logs (backend / slm / frontend)"
+          docker compose --env-file docker/.env.docker logs --no-color | tee failure-logs.txt
+          echo "::endgroup::"
 
       - name: Upload failure logs
         if: failure()


### PR DESCRIPTION
## Thinking Path
`docker-smoke-test.yml`'s "Collect logs on failure" step wrote logs to an artifact but not to the run log — so diagnosing a red smoke-test (backend/SLM unhealthy) required downloading the artifact. That cost real time twice this session (the #10705 P0 and the #10778 SLM startup crash, both import-smoke-green/smoke-test-red where the container traceback was only in the artifact).

## What Changed
- The failure step now `tee`s `docker compose logs --no-color` to **both stdout (inside a collapsible `::group::`) and `failure-logs.txt`** (artifact retained). Static command, no untrusted input (no injection risk).

## Verification
- YAML validates. Behavior: on smoke-test failure the container logs are now visible directly in the Actions run log.

Closes #10706.

## Model Used
Claude Opus 4.8 (1M context)