### PR TITLE
fix(deps): bump js-yaml to patched 4.2.0/4.3.0 for DoS advisory (supersedes #10843)

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -3223,9 +3223,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.34.15",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.15.tgz",
-      "integrity": "sha512-HAwCnNyKcs5XGQqms+9t7OdAPM/5TDstmhF+0i7tdCFato2QKuYIlyWETwkXd8c5zbltr1oB+6y9NTeQLr2d6Q==",
+      "version": "1.34.17",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.17.tgz",
+      "integrity": "sha512-wsV2keCt6B806XpSdezbWZ9aFJYf14YVh+XQf0ESt7M90yqVuxH9//PxvtC70sgj9OCkRM3nRaLfu4MsGQZRig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3234,7 +3234,7 @@
         "colorette": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -9674,10 +9674,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/autobot-infrastructure/shared/mcp/tools/mcp-task-manager-server/package-lock.json
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-task-manager-server/package-lock.json
@@ -2944,10 +2944,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
## Thinking Path
Dependabot #10843 (js-yaml DoS advisory) opened against `main` — security updates bypass `dependabot.yml`'s `target-branch`, so the **deployed** branch `Dev_new_gui` stays unpatched. Retarget + `@dependabot rebase` just reverts base to `main`. `Dev_new_gui`'s lockfiles are at the identical baseline as #10843's base, so the npm-validated hunks apply cleanly here.

## What Changed
- `autobot-frontend/package-lock.json`: `js-yaml` 4.1.1 → **4.2.0** (+ `@redocly/openapi-core` 1.34.15 → 1.34.17, which pins js-yaml exactly).
- `autobot-infrastructure/.../mcp-task-manager-server/package-lock.json`: `js-yaml` 4.1.1 → **4.3.0**.
- Lockfile-only; both js-yaml usages are transitive + `dev`/build-time. Dropped an unrelated `license: ISC→GPL-3.0-only` metadata flip from the Dependabot diff to keep this security-focused.

## Verification
- Advisory: js-yaml `>=4.0.0,<=4.1.1` MODERATE quadratic-complexity DoS in merge-key handling → patched 4.2.0. Confirmed via GH `securityVulnerabilities` API.
- Both lockfiles parse as valid JSON; zero `js-yaml-4.1.1.tgz` refs remain.
- Hunks are byte-identical to Dependabot's npm output (integrity hashes match registry).

## Model Used
Opus 4.8 (1M context)

Supersedes #10843 (closed as mis-targeted at `main`).