### PR TITLE
build(python): align tooling/config to Python 3.14 (#10872 Tier 1)

### DIFF
--- a/.github/actions/setup-python-ci/action.yml
+++ b/.github/actions/setup-python-ci/action.yml
@@ -11,7 +11,7 @@
 # Usage:
 #   - uses: ./.github/actions/setup-python-ci
 #     with:
-#       python-version: '3.12'
+#       python-version: '3.14'
 #       requirements-file: 'requirements-ci.txt'
 #       extra-packages: 'pytest pytest-asyncio mypy'
 
@@ -20,9 +20,9 @@ description: 'Set up Python with pip caching, upgrade pip/setuptools/wheel, and 
 
 inputs:
   python-version:
-    description: 'Python version to install (e.g. "3.12")'
+    description: 'Python version to install (e.g. "3.14")'
     required: false
-    default: '3.12'
+    default: '3.14'
   requirements-file:
     description: 'Path to requirements file to install (relative to repo root). Empty to skip.'
     required: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
     hooks:
       - id: black
         args: [--line-length=120]
-        language_version: python3.12
+        language_version: python3.14
         exclude: ^autobot-infrastructure/
 
   # Python import sorting with isort

--- a/autobot_shared/pyproject.toml
+++ b/autobot_shared/pyproject.toml
@@ -12,7 +12,7 @@ name = "autobot_shared"
 version = "1.0.0"
 description = "Shared utilities for AutoBot platform"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.14"
 authors = [{ name = "mrveiss" }]
 license = { text = "Apache-2.0" }
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [tool.black]
 line-length = 120
+# Stays py312 (NOT py314): the NPU/OpenVINO worker runs Python 3.11, and py314
+# target makes black emit PEP 758 unparenthesized `except A, B:` which is a
+# SyntaxError on 3.11 shared code. Bump only when the worker leaves 3.11 (#10877).
 target-version = ["py312"]
 
 [tool.isort]
@@ -9,7 +12,7 @@ src_paths = ["autobot-backend", "autobot_shared", "autobot-slm-backend"]
 known_first_party = ["autobot_shared"]
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.14"
 ignore_missing_imports = true
 # Exclude test files — loose typing in tests is expected; this baseline
 # mirrors the pre-existing state tracked in GH#7105.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,5 +1,5 @@
 # CI requirements — role-based split for isolated dependency management (#1655)
-# Python version: 3.12 (installed via actions/setup-python@v5 on ubuntu-latest)
+# Python version: 3.14 (installed via actions/setup-python@v5 on ubuntu-latest)
 #
 # Each file groups tightly-coupled packages so version conflicts
 # stay contained within their ecosystem. To debug a conflict,

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,8 +42,8 @@ opentelemetry-instrumentation-aiohttp-client>=0.64b0
 
 # FAISS - Vector Similarity Search (Issue #387, #856)
 # Provides efficient vector similarity search operations
-# Using CPU version for Python 3.12 compatibility (GPU version requires conda)
-# For GPU acceleration: conda install -c conda-forge faiss-gpu (Python 3.12)
+# Using CPU version for Python 3.14 compatibility (GPU version requires conda)
+# For GPU acceleration: conda install -c conda-forge faiss-gpu (Python 3.14)
 faiss-cpu>=1.14.3
 aiosqlite>=0.22.1
 


### PR DESCRIPTION
Closes #10883.

## Thinking Path
Runtime Docker images (backend + SLM) and all CI workflows already run Python 3.14, but tooling/config still targeted 3.12 — so mypy checked against the wrong interpreter and `requires-python` was inconsistent across packages.

## What Changed
- `pyproject.toml`: mypy `python_version` 3.12→3.14
- `autobot_shared/pyproject.toml`: `requires-python` >=3.12 → >=3.14 (matches sibling packages)
- `.pre-commit-config.yaml`: black hook `language_version` python3.12→python3.14 (black now *runs* under 3.14)
- `.github/actions/setup-python-ci/action.yml`: default `'3.12'`→`'3.14'` (every caller already overrides; stale default)
- `requirements-ci.txt` / `requirements.txt`: interpreter-version comments 3.12→3.14 (dependency pins untouched)

## Deliberately NOT changed: black `target-version` stays `py312`
Bumping black target to `py314` makes black emit **PEP 758** unparenthesized `except A, B:` across 146 files. That syntax is a **SyntaxError under Python 3.11**, and the **NPU/OpenVINO worker runs 3.11** on shared code. Holding `target-version = ["py312"]` keeps emitted syntax compatible across the mixed 3.11–3.14 fleet. Tracked in #10877 (unblock when the worker leaves 3.11). `language_version: python3.14` is safe because target-version — not the runtime — controls emitted syntax.

## Verification
- YAML + TOML parse OK.
- Confirmed the auto-fix-formatting workflow runs `black` with no `--target-version`, so it honors pyproject `py312` → no PEP 758 rewrite (verified: a py314-target autofix produced a 146-file diff; reverted).
- Dependency/CVE notes (aiohttp, numpy<2, protobuf<7, graspologic) left unchanged.

## Model Used
Opus 4.8

Part of #10872 (Tier 1). Discoveries: #10877 (black target vs 3.11 NPU fleet).