### PR TITLE
fix(reliability): make silent LLM/monitoring fallbacks observable (#10726)

### DIFF
--- a/autobot-backend/llm_shared/mock_providers.py
+++ b/autobot-backend/llm_shared/mock_providers.py
@@ -38,12 +38,13 @@ class LocalLLM:
         if self._ollama_available:
             logger.info("LocalLLM initialized with Ollama at %s", self._ollama_url)
         else:
-            # Issue #665: More informative warning - LocalLLM is optional
-            logger.debug(
-                "LocalLLM (Ollama) not configured - this provider will use mock responses. "
-                "This only affects the 'local' LLM provider. Other providers (OpenAI, Anthropic, "
-                "Google) work independently. To enable local Ollama: set AUTOBOT_OLLAMA_ENDPOINT "
-                "in .env file."
+            # #10726: Raised to WARNING — a missing AUTOBOT_OLLAMA_ENDPOINT means the
+            # 'local' provider silently serves mock text, masking a prod misconfiguration.
+            logger.warning(
+                "LocalLLM (Ollama) not configured — AUTOBOT_OLLAMA_ENDPOINT is unset or empty. "
+                "The 'local' provider will return MOCK responses until Ollama is configured. "
+                "Other providers (OpenAI, Anthropic, Google) work independently. "
+                "Set AUTOBOT_OLLAMA_ENDPOINT in .env to enable real local inference."
             )
 
     def _create_mock_response(self, prompt: str) -> dict:
@@ -119,7 +120,11 @@ class LocalLLM:
             Dict with response in OpenAI-compatible format
         """
         if not self._ollama_available:
-            logger.debug("Using mock response (Ollama not configured)")
+            # #10726: WARNING so each mock-response generation is observable in prod logs.
+            logger.warning(
+                "LocalLLM.generate called but Ollama is not configured — returning MOCK response. "
+                "Set AUTOBOT_OLLAMA_ENDPOINT to route to a real model."
+            )
             await asyncio.sleep(TimingConstants.MICRO_DELAY)
             return self._create_mock_response(prompt)
 
@@ -162,12 +167,25 @@ class MockPalm:
     class QuotaExceededError(Exception):
         """Exception raised when API quota is exceeded."""
 
+    # #10726: MockPalm is instantiated unconditionally at module load (the module-level
+    # ``palm`` global below), so a warning in __init__ would fire on every import and be
+    # pure noise. The actionable signal is when the mock is actually *used* on a request
+    # path — so the warning lives in the methods (get_quota_status / generate_text) instead.
+    _mock_use_warned = False
+
     def __init__(self):
-        """Initialize MockPalm with debug message about mock usage."""
-        # Issue #665: Changed to debug - MockPalm is a fallback, not an error condition
-        logger.debug(
-            "MockPalm provider instantiated (mock fallback). "
-            "For real Google AI, configure GOOGLE_API_KEY in .env file."
+        """Initialize MockPalm (a no-op mock stub; see class note and _warn_mock_use)."""
+
+    @classmethod
+    def _warn_mock_use(cls) -> None:
+        """Warn once per process when MockPalm is actually exercised on a request path."""
+        if cls._mock_use_warned:
+            return
+        cls._mock_use_warned = True
+        logger.warning(
+            "MockPalm is being USED to serve a request — this is a MOCK stub with no real "
+            "Google AI calls and exists for backward compatibility only. "
+            "Configure GOOGLE_API_KEY and use a real Vertex/Gemini provider for production."
         )
 
     async def get_quota_status(self):
@@ -177,6 +195,7 @@ class MockPalm:
         Returns:
             MockQuotaStatus with simulated quota information
         """
+        self._warn_mock_use()
         await asyncio.sleep(TimingConstants.STREAMING_CHUNK_DELAY)
 
         class MockQuotaStatus:
@@ -197,6 +216,7 @@ class MockPalm:
         Returns:
             Dict with mock generated text
         """
+        self._warn_mock_use()
         await asyncio.sleep(TimingConstants.MICRO_DELAY)
 
         prompt = kwargs.get("prompt", "")

--- a/autobot-backend/voice_interface.py
+++ b/autobot-backend/voice_interface.py
@@ -869,11 +869,13 @@ if __name__ == "__main__":
             yaml.safe_dump(cfg, f, indent=2)
 
     async def test_voice_interface():
-        """Test voice interface with speech recognition and TTS demos."""
-        # Test function placeholder - VoiceInterface initialization removed
-        # to avoid unused variable warning
-        pass  # Placeholder function
+        """Test voice interface with speech recognition and TTS demos.
 
+        #10726: This function is only reachable via `python voice_interface.py` (the
+        `if __name__ == "__main__"` guard below). It has ZERO production callers.
+        All real VoiceInterface calls are commented out pending a real test fixture;
+        the live logger.info lines below serve as breadcrumbs only.
+        """
         logger.info("\n--- Testing Speech Recognition (speak into mic) ---")
         # result = await vi.listen_and_convert_to_text()
         # if result["status"] == "success":

--- a/autobot_shared/monitoring/prometheus_query.py
+++ b/autobot_shared/monitoring/prometheus_query.py
@@ -146,6 +146,12 @@ async def list_metric_names() -> List[str]:
                 return []
             body = await resp.json()
             if body.get("status") != "success":
+                # #10726: was silent; now observable so callers know metric names are stale.
+                logger.warning(
+                    "Prometheus label-values non-success: status=%r error=%r",
+                    body.get("status"),
+                    body.get("error"),
+                )
                 return []
             return body.get("data", [])
     except aiohttp.ClientError as exc:


### PR DESCRIPTION
## Thinking Path
Part of #10714. Three audit-flagged "intentional" fallbacks — the keep-vs-harden call. Per the owner's fail-loud default, silent degradation that can mask a prod misconfig should be observable.

## What Changed
**Site 1 — mock LLM providers (`llm_shared/mock_providers.py`):** `LocalLLM` CAN silently serve mock text on a prod path when `AUTOBOT_OLLAMA_ENDPOINT` is unset (it backs MockHandler + TransformersProvider). Promoted the unconfigured-init and per-generate mock paths from DEBUG→WARNING. `MockPalm`: warning moved from `__init__` (which fired on every import via the module-level `palm` global — pure noise) to a **warn-once-on-use** helper in `get_quota_status`/`generate_text`, so it only fires when the mock actually serves a request.

**Site 2 — `autobot_shared/monitoring/prometheus_query.py`:** the one silent `return []` (list_metric_names, non-success status) now logs a WARNING with status+error before degrading. All other prometheus/message_bus failure paths already logged; `message_bus.py` line 146 is a valid empty-result (not a failure) — left as-is.

**Site 3 — `voice_interface.py`:** the `pass  # Placeholder function` was misleading (it sat under a `__main__`-only guard with live logic after it, zero prod callers). Removed the stale pass+comment; replaced with a docstring marking it `__main__`-only scaffold. No behavior change.

## Verification
- `py_compile` OK for all three files.
- `test_voice_503_guard.py` 4/4 passed.

## Model Used
Opus 4.8

Closes #10726. Part of #10714.