### PR TITLE
fix(llc): i18n work-item type/priority/sprint-status enum badges (#10818)

### DIFF
--- a/autobot-frontend/src/composables/useWorkItemLabels.ts
+++ b/autobot-frontend/src/composables/useWorkItemLabels.ts
@@ -1,0 +1,31 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * Work-item enum label composable (#10818).
+ *
+ * LLC board views (Sprint Board, Backlog, Work Item Detail) render work-item
+ * type / priority / sprint-status enum values directly in the UI. This maps
+ * those closed enum sets to localized labels under `llc.enums.*`, falling back
+ * to the humanized raw value for any value without a translation key (board
+ * statuses are configurable, so a missing key must not surface a raw key path).
+ */
+
+import { useI18n } from 'vue-i18n'
+
+export function useWorkItemLabels() {
+  const { t, te } = useI18n()
+
+  const label = (namespace: string, value: string | null | undefined): string => {
+    if (!value) return ''
+    const key = `llc.enums.${namespace}.${value}`
+    return te(key) ? t(key) : value.replace(/_/g, ' ')
+  }
+
+  return {
+    workItemTypeLabel: (value: string | null | undefined) => label('workItemType', value),
+    priorityLabel: (value: string | null | undefined) => label('priority', value),
+    sprintStatusLabel: (value: string | null | undefined) => label('sprintStatus', value),
+  }
+}

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8131,6 +8131,30 @@
     "reviewInbox": {
       "breadcrumbCompanyOs": "Company OS",
       "breadcrumbMyReviews": "My Reviews"
+    },
+    "enums": {
+      "workItemType": {
+        "epic": "Epic",
+        "feature": "Feature",
+        "pbi": "PBI",
+        "task": "Task",
+        "bug": "Bug",
+        "spike": "Spike",
+        "subtask": "Subtask",
+        "risk": "Risk"
+      },
+      "priority": {
+        "critical": "Critical",
+        "high": "High",
+        "medium": "Medium",
+        "low": "Low"
+      },
+      "sprintStatus": {
+        "planning": "Planning",
+        "active": "Active",
+        "review": "Review",
+        "closed": "Closed"
+      }
     }
   },
   "code": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8131,6 +8131,30 @@
     "reviewInbox": {
       "breadcrumbCompanyOs": "Company OS",
       "breadcrumbMyReviews": "Meine Prüfungen"
+    },
+    "enums": {
+      "workItemType": {
+        "epic": "Epic",
+        "feature": "Feature",
+        "pbi": "PBI",
+        "task": "Aufgabe",
+        "bug": "Fehler",
+        "spike": "Spike",
+        "subtask": "Teilaufgabe",
+        "risk": "Risiko"
+      },
+      "priority": {
+        "critical": "Kritisch",
+        "high": "Hoch",
+        "medium": "Mittel",
+        "low": "Niedrig"
+      },
+      "sprintStatus": {
+        "planning": "Planung",
+        "active": "Aktiv",
+        "review": "Überprüfung",
+        "closed": "Geschlossen"
+      }
     }
   },
   "code": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8120,6 +8120,30 @@
     "reviewInbox": {
       "breadcrumbCompanyOs": "Company OS",
       "breadcrumbMyReviews": "My Reviews"
+    },
+    "enums": {
+      "workItemType": {
+        "epic": "Epic",
+        "feature": "Feature",
+        "pbi": "PBI",
+        "task": "Task",
+        "bug": "Bug",
+        "spike": "Spike",
+        "subtask": "Subtask",
+        "risk": "Risk"
+      },
+      "priority": {
+        "critical": "Critical",
+        "high": "High",
+        "medium": "Medium",
+        "low": "Low"
+      },
+      "sprintStatus": {
+        "planning": "Planning",
+        "active": "Active",
+        "review": "Review",
+        "closed": "Closed"
+      }
     }
   },
   "mobile": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8131,6 +8131,30 @@
     "reviewInbox": {
       "breadcrumbCompanyOs": "Company OS",
       "breadcrumbMyReviews": "Mis revisiones"
+    },
+    "enums": {
+      "workItemType": {
+        "epic": "Épica",
+        "feature": "Función",
+        "pbi": "PBI",
+        "task": "Tarea",
+        "bug": "Error",
+        "spike": "Spike",
+        "subtask": "Subtarea",
+        "risk": "Riesgo"
+      },
+      "priority": {
+        "critical": "Crítica",
+        "high": "Alta",
+        "medium": "Media",
+        "low": "Baja"
+      },
+      "sprintStatus": {
+        "planning": "Planificación",
+        "active": "Activo",
+        "review": "Revisión",
+        "closed": "Cerrado"
+      }
     }
   },
   "code": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8131,6 +8131,30 @@
     "reviewInbox": {
       "breadcrumbCompanyOs": "Company OS",
       "breadcrumbMyReviews": "My Reviews"
+    },
+    "enums": {
+      "workItemType": {
+        "epic": "Epic",
+        "feature": "Feature",
+        "pbi": "PBI",
+        "task": "Task",
+        "bug": "Bug",
+        "spike": "Spike",
+        "subtask": "Subtask",
+        "risk": "Risk"
+      },
+      "priority": {
+        "critical": "Critical",
+        "high": "High",
+        "medium": "Medium",
+        "low": "Low"
+      },
+      "sprintStatus": {
+        "planning": "Planning",
+        "active": "Active",
+        "review": "Review",
+        "closed": "Closed"
+      }
     }
   },
   "code": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8131,6 +8131,30 @@
     "reviewInbox": {
       "breadcrumbCompanyOs": "Company OS",
       "breadcrumbMyReviews": "Mes révisions"
+    },
+    "enums": {
+      "workItemType": {
+        "epic": "Épopée",
+        "feature": "Fonctionnalité",
+        "pbi": "PBI",
+        "task": "Tâche",
+        "bug": "Anomalie",
+        "spike": "Spike",
+        "subtask": "Sous-tâche",
+        "risk": "Risque"
+      },
+      "priority": {
+        "critical": "Critique",
+        "high": "Élevée",
+        "medium": "Moyenne",
+        "low": "Basse"
+      },
+      "sprintStatus": {
+        "planning": "Planification",
+        "active": "Actif",
+        "review": "Révision",
+        "closed": "Clôturé"
+      }
     }
   },
   "code": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8131,6 +8131,30 @@
     "reviewInbox": {
       "breadcrumbCompanyOs": "Company OS",
       "breadcrumbMyReviews": "My Reviews"
+    },
+    "enums": {
+      "workItemType": {
+        "epic": "Epic",
+        "feature": "Feature",
+        "pbi": "PBI",
+        "task": "Task",
+        "bug": "Bug",
+        "spike": "Spike",
+        "subtask": "Subtask",
+        "risk": "Risk"
+      },
+      "priority": {
+        "critical": "Critical",
+        "high": "High",
+        "medium": "Medium",
+        "low": "Low"
+      },
+      "sprintStatus": {
+        "planning": "Planning",
+        "active": "Active",
+        "review": "Review",
+        "closed": "Closed"
+      }
     }
   },
   "code": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8131,6 +8131,30 @@
     "reviewInbox": {
       "breadcrumbCompanyOs": "Company OS",
       "breadcrumbMyReviews": "My Reviews"
+    },
+    "enums": {
+      "workItemType": {
+        "epic": "Epic",
+        "feature": "Feature",
+        "pbi": "PBI",
+        "task": "Task",
+        "bug": "Bug",
+        "spike": "Spike",
+        "subtask": "Subtask",
+        "risk": "Risk"
+      },
+      "priority": {
+        "critical": "Critical",
+        "high": "High",
+        "medium": "Medium",
+        "low": "Low"
+      },
+      "sprintStatus": {
+        "planning": "Planning",
+        "active": "Active",
+        "review": "Review",
+        "closed": "Closed"
+      }
     }
   },
   "code": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8131,6 +8131,30 @@
     "reviewInbox": {
       "breadcrumbCompanyOs": "Company OS",
       "breadcrumbMyReviews": "My Reviews"
+    },
+    "enums": {
+      "workItemType": {
+        "epic": "Epic",
+        "feature": "Feature",
+        "pbi": "PBI",
+        "task": "Task",
+        "bug": "Bug",
+        "spike": "Spike",
+        "subtask": "Subtask",
+        "risk": "Risk"
+      },
+      "priority": {
+        "critical": "Critical",
+        "high": "High",
+        "medium": "Medium",
+        "low": "Low"
+      },
+      "sprintStatus": {
+        "planning": "Planning",
+        "active": "Active",
+        "review": "Review",
+        "closed": "Closed"
+      }
     }
   },
   "code": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8131,6 +8131,30 @@
     "reviewInbox": {
       "breadcrumbCompanyOs": "Company OS",
       "breadcrumbMyReviews": "Minhas revisões"
+    },
+    "enums": {
+      "workItemType": {
+        "epic": "Épico",
+        "feature": "Funcionalidade",
+        "pbi": "PBI",
+        "task": "Tarefa",
+        "bug": "Erro",
+        "spike": "Spike",
+        "subtask": "Subtarefa",
+        "risk": "Risco"
+      },
+      "priority": {
+        "critical": "Crítica",
+        "high": "Alta",
+        "medium": "Média",
+        "low": "Baixa"
+      },
+      "sprintStatus": {
+        "planning": "Planejamento",
+        "active": "Ativo",
+        "review": "Revisão",
+        "closed": "Fechado"
+      }
     }
   },
   "code": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8131,6 +8131,30 @@
     "reviewInbox": {
       "breadcrumbCompanyOs": "Company OS",
       "breadcrumbMyReviews": "My Reviews"
+    },
+    "enums": {
+      "workItemType": {
+        "epic": "Epic",
+        "feature": "Feature",
+        "pbi": "PBI",
+        "task": "Task",
+        "bug": "Bug",
+        "spike": "Spike",
+        "subtask": "Subtask",
+        "risk": "Risk"
+      },
+      "priority": {
+        "critical": "Critical",
+        "high": "High",
+        "medium": "Medium",
+        "low": "Low"
+      },
+      "sprintStatus": {
+        "planning": "Planning",
+        "active": "Active",
+        "review": "Review",
+        "closed": "Closed"
+      }
     }
   },
   "code": {

--- a/autobot-frontend/src/views/llc/BacklogView.vue
+++ b/autobot-frontend/src/views/llc/BacklogView.vue
@@ -93,12 +93,12 @@
               <span class="item-identifier">{{ item.identifier }}</span>
             </td>
             <td class="col-type">
-              <span class="type-badge" :class="`type-${item.type}`">{{ item.type }}</span>
+              <span class="type-badge" :class="`type-${item.type}`">{{ workItemTypeLabel(item.type) }}</span>
             </td>
             <td class="col-title">{{ item.title }}</td>
             <td class="col-priority">
               <span class="priority-badge" :class="`priority-${item.priority}`">
-                {{ item.priority }}
+                {{ priorityLabel(item.priority) }}
               </span>
             </td>
             <td class="col-points">{{ item.story_points ?? '—' }}</td>
@@ -220,6 +220,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { useWorkItemLabels } from '@/composables/useWorkItemLabels'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import WorkItemDetail from './WorkItemDetail.vue'
@@ -228,6 +229,7 @@ const logger = createLogger('BacklogView')
 const api = useApiClient()
 const route = useRoute()
 const { t } = useI18n()
+const { workItemTypeLabel, priorityLabel } = useWorkItemLabels()
 
 const companyId = computed(() => route.params.companyId as string)
 

--- a/autobot-frontend/src/views/llc/SprintBoardView.vue
+++ b/autobot-frontend/src/views/llc/SprintBoardView.vue
@@ -8,7 +8,7 @@
       <div class="sprint-info">
         <h2 class="sprint-title">{{ sprint.name }}</h2>
         <span class="sprint-dates">{{ formatDate(sprint.start_date) }} – {{ formatDate(sprint.end_date) }}</span>
-        <span class="sprint-status-badge" :class="`status-${sprint.status}`">{{ sprint.status }}</span>
+        <span class="sprint-status-badge" :class="`status-${sprint.status}`">{{ sprintStatusLabel(sprint.status) }}</span>
       </div>
       <div class="sprint-stats">
         <div class="stat">
@@ -52,11 +52,11 @@
             >
               <div class="card-header">
                 <span class="card-identifier">{{ item.identifier }}</span>
-                <span class="card-type-badge" :class="`type-${item.type}`">{{ item.type }}</span>
+                <span class="card-type-badge" :class="`type-${item.type}`">{{ workItemTypeLabel(item.type) }}</span>
               </div>
               <p class="card-title">{{ item.title }}</p>
               <div class="card-footer">
-                <span class="priority-dot" :class="`priority-${item.priority}`" :title="item.priority" />
+                <span class="priority-dot" :class="`priority-${item.priority}`" :title="priorityLabel(item.priority)" />
                 <span v-if="item.story_points" class="card-points">{{ item.story_points }}</span>
                 <span v-if="item.assignee_name" class="card-assignee" :title="item.assignee_name">
                   {{ initials(item.assignee_name) }}
@@ -114,11 +114,13 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
+import { useWorkItemLabels } from '@/composables/useWorkItemLabels'
 import WorkItemDetail from './WorkItemDetail.vue'
 
 const logger = createLogger('SprintBoardView')
 const api = useApiClient()
 const route = useRoute()
+const { workItemTypeLabel, priorityLabel, sprintStatusLabel } = useWorkItemLabels()
 
 const companyId = computed(() => route.params.companyId as string)
 const boardId = computed(() => route.params.boardId as string)

--- a/autobot-frontend/src/views/llc/WorkItemDetail.vue
+++ b/autobot-frontend/src/views/llc/WorkItemDetail.vue
@@ -8,7 +8,7 @@
       <div class="drawer-header">
         <div class="header-left">
           <span class="item-identifier">{{ item.identifier }}</span>
-          <span class="type-badge" :class="`type-${item.type}`">{{ item.type }}</span>
+          <span class="type-badge" :class="`type-${item.type}`">{{ workItemTypeLabel(item.type) }}</span>
           <span class="status-badge" :class="`status-${item.status}`">{{ item.status.replace('_', ' ') }}</span>
         </div>
         <button class="close-btn" @click="$emit('close')" :aria-label="$t('common.close')">
@@ -240,10 +240,12 @@ import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import HandoffModal from '@/components/llc/HandoffModal.vue'
 import { useCompanyPeople } from '@/composables/llc/useCompanyPeople'
+import { useWorkItemLabels } from '@/composables/useWorkItemLabels'
 
 const logger = createLogger('WorkItemDetail')
 const api = useApiClient()
 const { t } = useI18n()
+const { workItemTypeLabel } = useWorkItemLabels()
 
 import type { WorkItem } from './workItemTypes'
 


### PR DESCRIPTION
## Thinking Path
#10818 reported SprintBoardView.vue as "0 \$t() calls throughout." On inspection that premise was **stale** — #10839 (#10750 B4) already wrapped every static UI string in `\$t('llc.sprint.*')` (12 calls, all keys resolve in all 11 locales). The one genuine remaining gap: **raw enum values rendered directly as user-facing badge labels**, which bypass i18n. The same pattern exists in the sibling board views (BacklogView, WorkItemDetail) sharing the identical work-item enums, so a shared solution is the right fix rather than a per-view one.

## What Changed
- **New shared keys** `llc.enums.{workItemType,priority,sprintStatus}` added to **all 11 locales** — real translations for `de/es/fr/pt`, English-value fallback for `en/pl/lv/ar/fa/he/ur` (mirrors the existing `llc.sprint` convention from #10839).
- **New composable** `useWorkItemLabels` — maps the three closed enum sets to localized labels via `te`-guarded `t()`, falling back to the humanized raw value so an unmapped/board-configurable value never surfaces a raw key path.
- **Wired the enum display sites** (display-only, no logic change):
  - `SprintBoardView.vue` — sprint status badge, work-item type badge, priority tooltip (3 sites; the #10818 target)
  - `BacklogView.vue` — type + priority badges (2 sites)
  - `WorkItemDetail.vue` — type badge (1 site)
- Left `WorkItemDetail`'s work-item **status** badge raw (it is board-configurable/open-ended and already humanized via `.replace('_',' ')` — not a fixed enum, so a fixed key map would be wrong).

## Verification
- All 11 locale JSONs valid; `llc.enums` key parity confirmed across every locale.
- Locale diffs are pure additions (2-space indent round-trip verified — no reformatting churn).
- No remaining raw-enum display sites in the three views (verified by grep); no `console.*` added.
- vue-tsc / frontend build verified via CI (`vue-tsc-baseline`, `smoke-test`) — no Linux npm on the dev box.

## Model Used
Claude Opus 4.8 (1M context)

Closes #10818