### PR TITLE
fix(ansible): backend readiness probe uses http :8001 not nginx TLS in update-all-nodes (#10650)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -696,10 +696,11 @@
 
     - name: "[PLAY 2] Backend | Wait for API to be ready"
       uri:
-        # Backend serves via nginx on 443 (and uvicorn on 8001); there is no
-        # 8443 listener — probe the nginx-proxied endpoint like the SLM does.
-        url: "https://{{ ansible_host }}/api/health"
-        validate_certs: false
+        # uvicorn binds plain HTTP on localhost:8001 (backend_port); nginx holds
+        # TLS on 443. There is NO 8443 listener (#957/#10378). Probe the direct
+        # backend on the loopback — it does not depend on nginx (deployed after
+        # this task) and needs no cert validation (#10650).
+        url: "http://127.0.0.1:8001/api/health"
         status_code: 200
       register: backend_health_check
       until: backend_health_check.status == 200


### PR DESCRIPTION
## Thinking Path
update-all-nodes PLAY 2 backend readiness probe hit a non-listening endpoint and (being any_errors_fatal) aborted the play before frontend/NPU deploy.

## What Changed
`update-all-nodes.yml:697` — backend readiness probe → `http://127.0.0.1:8001/api/health` (direct uvicorn loopback, delegate_to localhost), replacing the fragile nginx-proxied probe that ran before nginx is deployed in the same play. Other 8443 references are legit nginx-TLS config, left intact.

## Verification
yaml.safe_load OK; confirmed setup-user-backend.yml + update-node.yml probes already correct. Closes #10650.

## Model Used
Claude Opus 4.8 (devops-engineer subagent).
