### PR TITLE
fix(ui): ErrorBoundary slot wrapper h-full — views fill viewport height (#10897)

### DIFF
--- a/autobot-frontend/src/components/common/ErrorBoundary.vue
+++ b/autobot-frontend/src/components/common/ErrorBoundary.vue
@@ -45,7 +45,7 @@
       </div>
     </div>
   </div>
-  <div v-else>
+  <div v-else class="h-full">
     <slot />
   </div>
 </template>


### PR DESCRIPTION
## Thinking Path
User reported large dead space below content on the Company OS Backlog (and 'multiple places'). Two nested divs neither stretching. Traced the height chain from App.vue's `<main class="flex-1 min-h-0">` down: LoadingBoundary has `h-full`, but **ErrorBoundary's no-error branch** `<div v-else><slot/></div>` had no height — so `<router-view class="h-full">` resolved `h-full` against a content-height parent and every view collapsed. ErrorBoundary wraps every route → bug is global.

## What Changed
- `ErrorBoundary.vue`: add `class="h-full"` to the `<div v-else>` slot wrapper. One line; restores the height chain for every routed view.

## Verification
- Chain now: `main (flex-1 min-h-0)` → `LoadingBoundary (.loading-boundary h-full)` → `ErrorBoundary <div v-else h-full>` → `router-view h-full` → view `height:100%`. All links have a resolved height.
- Fixes the reported Backlog dead-space and the same collapse on other views (LlcCompanyLayout, dashboards) that rely on `height:100%`.

## Model Used
Opus 4.8 (1M context)

Closes #10897.