### PR TITLE
fix(ui): dashboards fill viewport height — widgets scale vertically (#10750)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -1005,8 +1005,11 @@ watch(selectedPeriod, () => {
 .code-quality-dashboard {
   padding: var(--spacing-6);
   background: var(--bg-primary);
-  /* #10750 C2: fill the scrolling .analytics-router-view, not the viewport */
+  /* #10750 C2: fill the scrolling .analytics-router-view, not the viewport.
+     #10750: flex column so the data grid grows to absorb vertical slack. */
   min-height: 100%;
+  display: flex;
+  flex-direction: column;
   color: var(--text-primary);
 }
 
@@ -1341,8 +1344,25 @@ watch(selectedPeriod, () => {
 .content-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  grid-auto-rows: 1fr;
   gap: var(--spacing-6);
   margin-bottom: var(--spacing-6);
+  /* #10750: primary data region — grow to fill remaining height. */
+  flex: 1;
+  min-height: 0;
+}
+
+/* #10750: the pattern/complexity panels grow; their content scrolls internally. */
+.content-grid .panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.content-grid .panel-content {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 @media (max-width: 1200px) {

--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
@@ -794,6 +794,9 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-6);
+  /* #10750: fill the scrolling .analytics-router-view; the issues grid grows
+     to absorb vertical slack instead of leaving dead space below. */
+  min-height: 100%;
 }
 
 /* Path Selection */
@@ -860,7 +863,25 @@ onMounted(() => {
 .content-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  grid-auto-rows: 1fr;
   gap: var(--spacing-6);
+  /* #10750: primary data region — grow to fill remaining height. */
+  flex: 1;
+  min-height: 0;
+}
+
+/* #10750: issues panel is the grower; its list scrolls internally instead of
+   the shared fixed 400px cap. */
+.content-grid .panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.content-grid .panel-content {
+  flex: 1;
+  min-height: 0;
+  max-height: none;
 }
 
 /* Filter Tabs */

--- a/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
+++ b/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
@@ -326,7 +326,11 @@ onMounted(() => {
 .conversation-flow-dashboard {
   padding: var(--spacing-6);
   background: var(--bg-primary);
+  /* #10750: min-h-full flex column — parent .analytics-router-view is the
+     scroll container; the data grid grows to absorb vertical slack. */
   min-height: 100%;
+  display: flex;
+  flex-direction: column;
   color: var(--text-primary);
 }
 
@@ -470,7 +474,11 @@ onMounted(() => {
 .content-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  grid-auto-rows: 1fr;
   gap: var(--spacing-6);
+  /* #10750: grow to fill the vertical slack; panels scroll internally. */
+  flex: 1;
+  min-height: 0;
 }
 
 .panel {
@@ -478,6 +486,9 @@ onMounted(() => {
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-xl);
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .panel-header {
@@ -509,7 +520,9 @@ onMounted(() => {
 
 .panel-content {
   padding: var(--spacing-4);
-  max-height: 400px;
+  /* #10750: fill the panel and scroll internally rather than a fixed cap. */
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 

--- a/autobot-frontend/src/components/analytics/LogPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LogPatternDashboard.vue
@@ -360,7 +360,11 @@ onUnmounted(() => {
 .log-pattern-dashboard {
   padding: var(--spacing-6);
   background: var(--bg-primary);
-  min-height: 100vh;
+  /* #10750: was 100vh (overflowed the shell region). min-h-full flex column —
+     parent .analytics-router-view scrolls; the pattern grid grows to fill. */
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
   color: var(--text-primary);
 }
 
@@ -486,7 +490,11 @@ onUnmounted(() => {
 .content-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  grid-auto-rows: 1fr;
   gap: var(--spacing-6);
+  /* #10750: grow to fill remaining height; panels scroll internally. */
+  flex: 1;
+  min-height: 0;
 }
 
 /* Panels */
@@ -495,6 +503,9 @@ onUnmounted(() => {
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-xl);
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .patterns-panel {
@@ -531,7 +542,9 @@ onUnmounted(() => {
 
 .panel-content {
   padding: var(--spacing-4);
-  max-height: 600px;
+  /* #10750: fill the panel and scroll internally rather than a fixed cap. */
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 

--- a/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
@@ -605,6 +605,9 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-6);
+  /* #10750: fill the scrolling .analytics-router-view; the issues grid grows
+     to absorb vertical slack instead of leaving dead space below. */
+  min-height: 100%;
 }
 
 /* Path Selection */
@@ -723,7 +726,25 @@ onMounted(() => {
 .content-grid {
   display: grid;
   grid-template-columns: 1.5fr 1fr;
+  grid-auto-rows: 1fr;
   gap: var(--spacing-6);
+  /* #10750: primary data region — grow to fill remaining height. */
+  flex: 1;
+  min-height: 0;
+}
+
+/* #10750: issues panel is the grower; its list scrolls internally instead of
+   the shared fixed 400px cap. */
+.content-grid .panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.content-grid .panel-content {
+  flex: 1;
+  min-height: 0;
+  max-height: none;
 }
 
 /* Category Tabs */

--- a/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
+++ b/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
@@ -839,7 +839,11 @@ watch(selectedPeriod, () => {
 .technical-debt-dashboard {
   padding: var(--spacing-lg);
   background: var(--bg-primary);
+  /* #10750: min-h-full flex column — parent .analytics-router-view scrolls;
+     the debt inventory table grows to fill the vertical slack. */
   min-height: 100%;
+  display: flex;
+  flex-direction: column;
   color: var(--text-primary);
 }
 
@@ -1508,7 +1512,18 @@ watch(selectedPeriod, () => {
 
 /* Table Panel */
 .table-panel {
-  margin-bottom: var(--spacing-lg);
+  /* #10750: primary data widget — grow to absorb remaining vertical space. */
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.table-panel .panel-content {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .table-filters {
@@ -1542,7 +1557,10 @@ watch(selectedPeriod, () => {
 }
 
 .debt-table-container {
-  overflow-x: auto;
+  /* #10750: internal scroll so the table fills its grown panel. */
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
 }
 
 .debt-table {

--- a/autobot-frontend/src/views/llc/CompanyDashboard.vue
+++ b/autobot-frontend/src/views/llc/CompanyDashboard.vue
@@ -227,168 +227,182 @@ watch(lastMessage, (msg) => {
 </script>
 
 <template>
-  <div class="p-4 space-y-6 max-w-7xl mx-auto">
-    <!-- Header -->
-    <div class="flex items-center justify-between">
-      <h1 class="text-2xl font-bold text-autobot-text-primary">{{ $t('llc.dashboard.title') }}</h1>
-      <button
-        class="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors text-sm font-medium"
-        @click="launchCeoChat"
-      >
-        {{ $t('llc.dashboard.ceoChat') }}
-      </button>
-    </div>
-
-    <div v-if="!companyId" class="text-center py-12 text-autobot-text-muted">
-      {{ $t('llc.dashboard.selectCompany') }}
-    </div>
-
-    <template v-else>
-      <div v-if="error" class="rounded-lg bg-red-50 border border-red-200 p-4 text-red-700 text-sm">
-        {{ error }}
-        <button class="ml-4 underline" @click="fetchDashboardData">{{ $t('llc.dashboard.retry') }}</button>
+  <!--
+    Full-height scroll container: the shell now gives dashboards a full-height
+    content region (#10897). `min-h-full` on the inner wrapper makes short
+    content still reach the bottom edge, and the live Activity Feed grows to
+    absorb the vertical slack instead of leaving dead space (#10750).
+  -->
+  <div class="h-full overflow-y-auto">
+    <div class="min-h-full flex flex-col gap-6 p-4 max-w-7xl mx-auto">
+      <!-- Header -->
+      <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-bold text-autobot-text-primary">{{ $t('llc.dashboard.title') }}</h1>
+        <button
+          class="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors text-sm font-medium"
+          @click="launchCeoChat"
+        >
+          {{ $t('llc.dashboard.ceoChat') }}
+        </button>
       </div>
 
-      <div v-if="isLoading" class="text-center py-12 text-autobot-text-muted">{{ $t('llc.dashboard.loading') }}</div>
+      <div v-if="!companyId" class="text-center py-12 text-autobot-text-muted">
+        {{ $t('llc.dashboard.selectCompany') }}
+      </div>
 
       <template v-else>
-        <!-- Pending Approvals -->
-        <section v-if="pendingApprovals.length > 0">
-          <div class="flex items-center gap-2 mb-3">
-            <h2 class="text-lg font-semibold text-autobot-text-primary">{{ $t('llc.dashboard.pendingApprovals') }}</h2>
-            <span class="bg-amber-100 text-amber-800 text-xs font-semibold px-2 py-0.5 rounded-full">
-              {{ pendingApprovals.length }}
-            </span>
-          </div>
-          <div class="space-y-2">
-            <div
-              v-for="approval in pendingApprovals"
-              :key="approval.id"
-              class="flex items-center justify-between bg-autobot-bg-card rounded-lg border border-autobot-border p-3"
-            >
-              <div>
-                <p class="text-sm font-medium text-autobot-text-primary">{{ approval.title }}</p>
-                <p class="text-xs text-autobot-text-muted">{{ $t('llc.dashboard.requestedBy', { name: approval.requested_by }) }} · {{ formatTime(approval.created_at) }}</p>
-              </div>
-              <button
-                class="px-3 py-1.5 bg-green-600 text-white text-xs rounded hover:bg-green-700 transition-colors"
-                @click="quickApprove(approval.id)"
-              >
-                {{ $t('llc.dashboard.approve') }}
-              </button>
-            </div>
-          </div>
-        </section>
+        <div v-if="error" class="rounded-lg bg-red-50 border border-red-200 p-4 text-red-700 text-sm">
+          {{ error }}
+          <button class="ml-4 underline" @click="fetchDashboardData">{{ $t('llc.dashboard.retry') }}</button>
+        </div>
 
-        <!-- Budget Gauges -->
-        <section>
-          <h2 class="text-lg font-semibold text-autobot-text-primary mb-3">{{ $t('llc.dashboard.budget') }}</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            <div
-              v-for="budget in budgets"
-              :key="budget.label"
-              class="bg-autobot-bg-card rounded-lg border border-autobot-border p-4"
-            >
-              <div class="flex justify-between items-center mb-2">
-                <span class="text-sm font-medium text-autobot-text-secondary">{{ budget.label }}</span>
-                <span class="text-xs text-autobot-text-muted">{{ budgetPercent(budget) }}%</span>
-              </div>
-              <div class="w-full bg-autobot-bg-tertiary rounded-full h-2">
-                <div
-                  class="h-2 rounded-full transition-all"
-                  :class="budgetBarColor(budget)"
-                  :style="{ width: `${budgetPercent(budget)}%` }"
-                />
-              </div>
-              <p class="text-xs text-autobot-text-muted mt-1">{{ budget.spent }} / {{ budget.total }}</p>
-            </div>
-          </div>
-        </section>
+        <div v-if="isLoading" class="text-center py-12 text-autobot-text-muted">{{ $t('llc.dashboard.loading') }}</div>
 
-        <!-- Agent Status Grid -->
-        <section>
-          <h2 class="text-lg font-semibold text-autobot-text-primary mb-3">
-            {{ $t('llc.dashboard.agents') }}
-            <span class="text-sm font-normal text-autobot-text-muted ml-1">({{ agents.length }})</span>
-          </h2>
-          <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
-            <div
-              v-for="agent in agents"
-              :key="agent.id"
-              class="bg-autobot-bg-card rounded-lg border border-autobot-border p-3 flex flex-col gap-1"
-            >
-              <div class="flex items-center gap-2">
-                <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" :class="agentStatusColor(agent.status)" />
-                <span class="text-sm font-medium text-autobot-text-primary truncate">{{ agent.name }}</span>
-              </div>
-              <span class="text-xs text-autobot-text-muted truncate">{{ agent.title }}</span>
-              <span class="text-xs bg-autobot-bg-tertiary text-autobot-text-secondary rounded px-1.5 py-0.5 self-start">
-                {{ agent.adapter_type }}
+        <!-- Content wrapper is itself a full-height column so the feed can grow. -->
+        <div v-else class="flex flex-col gap-6 flex-1 min-h-0">
+          <!-- Pending Approvals -->
+          <section v-if="pendingApprovals.length > 0">
+            <div class="flex items-center gap-2 mb-3">
+              <h2 class="text-lg font-semibold text-autobot-text-primary">{{ $t('llc.dashboard.pendingApprovals') }}</h2>
+              <span class="bg-amber-100 text-amber-800 text-xs font-semibold px-2 py-0.5 rounded-full">
+                {{ pendingApprovals.length }}
               </span>
             </div>
-          </div>
-        </section>
-
-        <!-- Live Heartbeat Runs -->
-        <section>
-          <h2 class="text-lg font-semibold text-autobot-text-primary mb-3">{{ $t('llc.dashboard.recentRuns') }}</h2>
-          <div class="overflow-x-auto rounded-lg border border-autobot-border">
-            <table class="min-w-full divide-y divide-autobot-border text-sm">
-              <thead class="bg-autobot-bg-surface">
-                <tr>
-                  <th class="px-4 py-2 text-left text-xs font-semibold text-autobot-text-secondary uppercase tracking-wider">{{ $t('llc.dashboard.colAgent') }}</th>
-                  <th class="px-4 py-2 text-left text-xs font-semibold text-autobot-text-secondary uppercase tracking-wider">{{ $t('llc.dashboard.colStatus') }}</th>
-                  <th class="px-4 py-2 text-left text-xs font-semibold text-autobot-text-secondary uppercase tracking-wider">{{ $t('llc.dashboard.colStarted') }}</th>
-                  <th class="px-4 py-2 text-left text-xs font-semibold text-autobot-text-secondary uppercase tracking-wider">{{ $t('llc.dashboard.colDuration') }}</th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-autobot-border bg-autobot-bg-card">
-                <tr v-for="run in heartbeatRuns" :key="run.run_id">
-                  <td class="px-4 py-2 text-autobot-text-primary font-medium">{{ run.agent_name }}</td>
-                  <td class="px-4 py-2">
-                    <span
-                      class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
-                      :class="{
-                        'bg-green-100 text-green-800': run.status === 'done',
-                        'bg-blue-100 text-blue-800': run.status === 'running',
-                        'bg-red-100 text-red-800': run.status === 'failed',
-                      }"
-                    >
-                      {{ run.status }}
-                    </span>
-                  </td>
-                  <td class="px-4 py-2 text-autobot-text-muted">{{ formatTime(run.started_at) }}</td>
-                  <td class="px-4 py-2 text-autobot-text-muted">{{ formatDuration(run.duration_ms) }}</td>
-                </tr>
-                <tr v-if="heartbeatRuns.length === 0">
-                  <td colspan="4" class="px-4 py-4 text-center text-autobot-text-muted text-sm">{{ $t('llc.dashboard.noRuns') }}</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </section>
-
-        <!-- Activity Feed -->
-        <section>
-          <h2 class="text-lg font-semibold text-autobot-text-primary mb-3">{{ $t('llc.dashboard.liveActivity') }}</h2>
-          <div class="bg-autobot-bg-card rounded-lg border border-autobot-border divide-y divide-autobot-border max-h-72 overflow-y-auto">
-            <div
-              v-for="event in activityFeed"
-              :key="event.id"
-              class="px-4 py-2 flex items-start gap-3"
-            >
-              <span class="text-xs text-autobot-text-muted w-16 flex-shrink-0 pt-0.5">{{ formatTime(event.timestamp) }}</span>
-              <div class="flex-1 min-w-0">
-                <span class="text-xs text-indigo-600 dark:text-indigo-400 font-medium mr-1">{{ event.agent_name ?? $t('llc.dashboard.system') }}</span>
-                <span class="text-sm text-autobot-text-secondary">{{ event.summary }}</span>
+            <div class="space-y-2">
+              <div
+                v-for="approval in pendingApprovals"
+                :key="approval.id"
+                class="flex items-center justify-between bg-autobot-bg-card rounded-lg border border-autobot-border p-3"
+              >
+                <div>
+                  <p class="text-sm font-medium text-autobot-text-primary">{{ approval.title }}</p>
+                  <p class="text-xs text-autobot-text-muted">{{ $t('llc.dashboard.requestedBy', { name: approval.requested_by }) }} · {{ formatTime(approval.created_at) }}</p>
+                </div>
+                <button
+                  class="px-3 py-1.5 bg-green-600 text-white text-xs rounded hover:bg-green-700 transition-colors"
+                  @click="quickApprove(approval.id)"
+                >
+                  {{ $t('llc.dashboard.approve') }}
+                </button>
               </div>
             </div>
-            <div v-if="activityFeed.length === 0" class="px-4 py-4 text-center text-autobot-text-muted text-sm">
-              {{ $t('llc.dashboard.waitingActivity') }}
+          </section>
+
+          <!-- Budget Gauges -->
+          <section>
+            <h2 class="text-lg font-semibold text-autobot-text-primary mb-3">{{ $t('llc.dashboard.budget') }}</h2>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 auto-rows-fr">
+              <div
+                v-for="budget in budgets"
+                :key="budget.label"
+                class="bg-autobot-bg-card rounded-lg border border-autobot-border p-4"
+              >
+                <div class="flex justify-between items-center mb-2">
+                  <span class="text-sm font-medium text-autobot-text-secondary">{{ budget.label }}</span>
+                  <span class="text-xs text-autobot-text-muted">{{ budgetPercent(budget) }}%</span>
+                </div>
+                <div class="w-full bg-autobot-bg-tertiary rounded-full h-2">
+                  <div
+                    class="h-2 rounded-full transition-all"
+                    :class="budgetBarColor(budget)"
+                    :style="{ width: `${budgetPercent(budget)}%` }"
+                  />
+                </div>
+                <p class="text-xs text-autobot-text-muted mt-1">{{ budget.spent }} / {{ budget.total }}</p>
+              </div>
             </div>
-          </div>
-        </section>
+          </section>
+
+          <!-- Agent Status Grid -->
+          <section>
+            <h2 class="text-lg font-semibold text-autobot-text-primary mb-3">
+              {{ $t('llc.dashboard.agents') }}
+              <span class="text-sm font-normal text-autobot-text-muted ml-1">({{ agents.length }})</span>
+            </h2>
+            <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3 auto-rows-fr">
+              <div
+                v-for="agent in agents"
+                :key="agent.id"
+                class="bg-autobot-bg-card rounded-lg border border-autobot-border p-3 flex flex-col gap-1"
+              >
+                <div class="flex items-center gap-2">
+                  <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" :class="agentStatusColor(agent.status)" />
+                  <span class="text-sm font-medium text-autobot-text-primary truncate">{{ agent.name }}</span>
+                </div>
+                <span class="text-xs text-autobot-text-muted truncate">{{ agent.title }}</span>
+                <span class="text-xs bg-autobot-bg-tertiary text-autobot-text-secondary rounded px-1.5 py-0.5 self-start">
+                  {{ agent.adapter_type }}
+                </span>
+              </div>
+            </div>
+          </section>
+
+          <!-- Live Heartbeat Runs -->
+          <section>
+            <h2 class="text-lg font-semibold text-autobot-text-primary mb-3">{{ $t('llc.dashboard.recentRuns') }}</h2>
+            <div class="overflow-x-auto rounded-lg border border-autobot-border">
+              <table class="min-w-full divide-y divide-autobot-border text-sm">
+                <thead class="bg-autobot-bg-surface">
+                  <tr>
+                    <th class="px-4 py-2 text-left text-xs font-semibold text-autobot-text-secondary uppercase tracking-wider">{{ $t('llc.dashboard.colAgent') }}</th>
+                    <th class="px-4 py-2 text-left text-xs font-semibold text-autobot-text-secondary uppercase tracking-wider">{{ $t('llc.dashboard.colStatus') }}</th>
+                    <th class="px-4 py-2 text-left text-xs font-semibold text-autobot-text-secondary uppercase tracking-wider">{{ $t('llc.dashboard.colStarted') }}</th>
+                    <th class="px-4 py-2 text-left text-xs font-semibold text-autobot-text-secondary uppercase tracking-wider">{{ $t('llc.dashboard.colDuration') }}</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-autobot-border bg-autobot-bg-card">
+                  <tr v-for="run in heartbeatRuns" :key="run.run_id">
+                    <td class="px-4 py-2 text-autobot-text-primary font-medium">{{ run.agent_name }}</td>
+                    <td class="px-4 py-2">
+                      <span
+                        class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                        :class="{
+                          'bg-green-100 text-green-800': run.status === 'done',
+                          'bg-blue-100 text-blue-800': run.status === 'running',
+                          'bg-red-100 text-red-800': run.status === 'failed',
+                        }"
+                      >
+                        {{ run.status }}
+                      </span>
+                    </td>
+                    <td class="px-4 py-2 text-autobot-text-muted">{{ formatTime(run.started_at) }}</td>
+                    <td class="px-4 py-2 text-autobot-text-muted">{{ formatDuration(run.duration_ms) }}</td>
+                  </tr>
+                  <tr v-if="heartbeatRuns.length === 0">
+                    <td colspan="4" class="px-4 py-4 text-center text-autobot-text-muted text-sm">{{ $t('llc.dashboard.noRuns') }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <!--
+            Activity Feed — the primary live-data widget and the designated
+            "grower": `flex-1 min-h-0` lets it absorb the remaining vertical
+            space, and the inner list scrolls internally instead of a fixed
+            `max-h-72` cap. Keeps an empty state that fills down to the bottom.
+          -->
+          <section class="flex flex-col flex-1 min-h-0">
+            <h2 class="text-lg font-semibold text-autobot-text-primary mb-3">{{ $t('llc.dashboard.liveActivity') }}</h2>
+            <div class="flex-1 min-h-0 bg-autobot-bg-card rounded-lg border border-autobot-border divide-y divide-autobot-border overflow-y-auto">
+              <div
+                v-for="event in activityFeed"
+                :key="event.id"
+                class="px-4 py-2 flex items-start gap-3"
+              >
+                <span class="text-xs text-autobot-text-muted w-16 flex-shrink-0 pt-0.5">{{ formatTime(event.timestamp) }}</span>
+                <div class="flex-1 min-w-0">
+                  <span class="text-xs text-indigo-600 dark:text-indigo-400 font-medium mr-1">{{ event.agent_name ?? $t('llc.dashboard.system') }}</span>
+                  <span class="text-sm text-autobot-text-secondary">{{ event.summary }}</span>
+                </div>
+              </div>
+              <div v-if="activityFeed.length === 0" class="px-4 py-4 text-center text-autobot-text-muted text-sm">
+                {{ $t('llc.dashboard.waitingActivity') }}
+              </div>
+            </div>
+          </section>
+        </div>
       </template>
-    </template>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## Thinking Path

The app shell now gives dashboard views a full-height content region (ErrorBoundary `h-full`, #10897), but the dashboards clumped their widgets at the top and left large dead grey space below when content was short. This is a layout/responsiveness pass — no visual re-skin. Existing theme tokens, spacing scale, and card styling are untouched. The taste is in *how the vertical space is distributed*: header + stat/agent grids stay at natural height near the top, and the primary data widget grows to absorb the remaining height (scrolling internally when tall) so there is never dead space.

Two distinct height chains required two variants of the same pattern:
- **CompanyDashboard** renders directly into the shell router-view (its `.llc-company-content` parent is a bounded flex column that delegates scrolling to the child), so its root is its own scroll container: `h-full overflow-y-auto` + inner `min-h-full flex flex-col`.
- **Analytics dashboards** render inside `AnalyticsView`'s `.analytics-router-view`, which is *already* the scroll container (`flex:1; overflow-y:auto`). So their roots must NOT add a nested scroll — they use `min-height:100%` + `display:flex; flex-direction:column` and let overflow spill to the parent.

## What Changed

Pattern per file (grower = the primary data widget that expands with `flex:1; min-height:0` and scrolls internally; stat/small cards keep natural height; card grids get `auto-rows-fr`/`grid-auto-rows:1fr` for equal-height rows):

- **CompanyDashboard.vue** — root → `h-full overflow-y-auto`; inner wrapper `min-h-full flex flex-col gap-6`. **Grower: Activity Feed** (`flex-1 min-h-0`, `max-h-72` cap removed, inner list scrolls). Budget + Agent grids get `auto-rows-fr`.
- **ConversationFlowDashboard.vue** — root → `min-h-full` flex column. **Grower: the 2×2 content grid** (balanced equal panels, no single primary) — `flex:1`, `grid-auto-rows:1fr`; panels flex, `panel-content` `max-height:400px` cap → `flex:1` internal scroll.
- **LogPatternDashboard.vue** — root `min-height:100vh` (a bug — overflowed the shell region) → `min-height:100%` flex column. **Grower: content grid** (left `patterns-panel` spans 2 rows) — `flex:1`; `panel-content` `600px` cap → internal flex scroll.
- **TechnicalDebtDashboard.vue** — root → `min-h-full` flex column. **Grower: the debt inventory `table-panel`** (bottom, full-width) — `flex:1`, `debt-table-container` becomes the internal scroll.
- **CodeQualityDashboard.vue** — root (already `min-height:100%`) → flex column. **Grower: content grid** (pattern-distribution + complexity panels) — `flex:1`, `grid-auto-rows:1fr`, `panel-content` scrolls internally; the fixed-SVG `trends-panel` stays natural at the bottom.
- **CodeReviewDashboard.vue** — root (already flex column) → add `min-height:100%`. **Grower: content grid** (issues-list + chart) — `flex:1`; scoped override of the shared `dashboard-common.css` `.panel-content` 400px cap → `flex:1` internal scroll (scoped to this component only, so `PrecommitHookDashboard` which shares that stylesheet is unaffected).
- **PerformanceAnalysisDashboard.vue** — same as CodeReview. **Grower: content grid** (issues-list + detail/hotspots).

Quality floor kept: responsive grids preserved down to mobile; all `$t()` i18n keys and behavior unchanged; no new colors/tokens; keyboard focus and reduced-motion untouched.

## Verification

- `npx vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (0 errors).
- `npx eslint` on all 7 files → exit 0 (0 errors; 17 pre-existing `no-explicit-any`/`no-unused-vars` warnings in untouched `<script>` sections).
- Changes are template/CSS-only (112 insertions across analytics; CompanyDashboard template restructure). No `node_modules` staged.

## Model Used

Opus 4.8 (1M context).

Refs #10750.