### PR TITLE
test,docs: fix stubbed-mock test isolation + AsyncMock recovery + py3.14 doc sweep (#10870, #10879, #10876)

### DIFF
--- a/autobot-backend/knowledge/pipeline/cognifiers/cognifiers_test.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/cognifiers_test.py
@@ -8,6 +8,7 @@ Unit tests for cognifier _parse_llm_response and conversion logic.
 Issue #1075: Test coverage for knowledge pipeline cognifiers.
 """
 
+import contextlib
 import json
 import sys
 from datetime import datetime, timezone
@@ -17,29 +18,60 @@ from uuid import uuid4
 
 import pytest
 
-# Mock llm_shared before importing cognifiers
-_mock_llm = ModuleType("llm_shared")
-_mock_llm.LLMInterface = MagicMock
-sys.modules["llm_shared"] = _mock_llm
 
-# Mock autobot_shared.redis_client before importing cognifiers
-_mock_shared = ModuleType("autobot_shared")
-_mock_redis_mod = ModuleType("autobot_shared.redis_client")
-_mock_redis_mod.get_redis_client = MagicMock()
-sys.modules["autobot_shared"] = _mock_shared
-sys.modules["autobot_shared.redis_client"] = _mock_redis_mod
+@contextlib.contextmanager
+def _stubbed_import_modules():
+    """Install lightweight ``sys.modules`` stubs only while importing cognifiers.
 
-from knowledge.pipeline.cognifiers.entity_extractor import EntityExtractor  # noqa: E402
-from knowledge.pipeline.cognifiers.event_extractor import EventExtractor  # noqa: E402
-from knowledge.pipeline.cognifiers.relationship_extractor import (  # noqa: E402
-    SYMMETRIC_RELATIONS,
-    RelationshipExtractor,
-)
-from knowledge.pipeline.cognifiers.summarizer import (  # noqa: E402
-    HierarchicalSummarizer,
-)
-from knowledge.pipeline.models.chunk import ProcessedChunk  # noqa: E402
-from knowledge.pipeline.models.entity import Entity  # noqa: E402
+    ``llm_shared`` and ``autobot_shared.redis_client`` pull heavy runtime deps at
+    import time, so they are stubbed before the cognifier modules load.  These stubs
+    previously lived at module top level and leaked process-wide — when this file was
+    collected in the same pytest run as ``services/chat_knowledge_service_test.py`` the
+    leaked ``autobot_shared.redis_client`` stub lacked ``get_async_redis_client`` and
+    broke that module's import (#10879).  Scope them to the import window and restore
+    whatever the parent conftest installed on exit.
+
+    Only the ``autobot_shared.redis_client`` submodule is stubbed — never the
+    ``autobot_shared`` package itself — so sibling imports like
+    ``autobot_shared.logging_manager`` keep resolving through the real package.
+    """
+    saved = {name: sys.modules.get(name) for name in ("llm_shared", "autobot_shared.redis_client")}
+
+    _mock_llm = ModuleType("llm_shared")
+    _mock_llm.LLMInterface = MagicMock
+    sys.modules["llm_shared"] = _mock_llm
+
+    _mock_redis_mod = ModuleType("autobot_shared.redis_client")
+    _mock_redis_mod.get_redis_client = MagicMock()
+
+    async def _get_async_redis_client_stub(*_a, **_k):
+        return None
+
+    _mock_redis_mod.get_async_redis_client = _get_async_redis_client_stub
+    sys.modules["autobot_shared.redis_client"] = _mock_redis_mod
+
+    try:
+        yield
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+with _stubbed_import_modules():
+    from knowledge.pipeline.cognifiers.entity_extractor import EntityExtractor
+    from knowledge.pipeline.cognifiers.event_extractor import EventExtractor
+    from knowledge.pipeline.cognifiers.relationship_extractor import (
+        SYMMETRIC_RELATIONS,
+        RelationshipExtractor,
+    )
+    from knowledge.pipeline.cognifiers.summarizer import (
+        HierarchicalSummarizer,
+    )
+    from knowledge.pipeline.models.chunk import ProcessedChunk
+    from knowledge.pipeline.models.entity import Entity
 
 # --- Fixtures ---
 

--- a/autobot-backend/knowledge/pipeline/cognifiers/relationship_extractor_test.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/relationship_extractor_test.py
@@ -8,6 +8,7 @@ Unit tests for RelationshipExtractor NLP-mode additions.
 Issue #2026: Dual-mode relationship extraction — LLM + NLP.
 """
 
+import contextlib
 import sys
 from types import ModuleType
 from unittest.mock import MagicMock
@@ -15,24 +16,54 @@ from uuid import uuid4
 
 import pytest
 
-# Mock llm_shared before importing cognifiers
-_mock_llm = ModuleType("llm_shared")
-_mock_llm.LLMInterface = MagicMock
-sys.modules["llm_shared"] = _mock_llm
 
-# Mock autobot_shared before importing cognifiers
-_mock_shared = ModuleType("autobot_shared")
-_mock_redis_mod = ModuleType("autobot_shared.redis_client")
-_mock_redis_mod.get_redis_client = MagicMock()
-sys.modules["autobot_shared"] = _mock_shared
-sys.modules["autobot_shared.redis_client"] = _mock_redis_mod
+@contextlib.contextmanager
+def _stubbed_import_modules():
+    """Install lightweight ``sys.modules`` stubs only while importing cognifiers.
 
-from knowledge.pipeline.cognifiers.relationship_extractor import (  # noqa: E402
-    NLP_KEYWORD_PATTERNS,
-    RelationshipExtractor,
-)
-from knowledge.pipeline.models.chunk import ProcessedChunk  # noqa: E402
-from knowledge.pipeline.models.entity import Entity  # noqa: E402
+    ``llm_shared`` and ``autobot_shared.redis_client`` pull heavy runtime deps at
+    import time, so they are stubbed before the cognifier module loads.  These stubs
+    previously lived at module top level and leaked process-wide — the leaked
+    ``autobot_shared.redis_client`` stub lacked ``get_async_redis_client`` and broke
+    ``services/chat_knowledge_service_test.py`` when co-collected (#10879).  Scope them
+    to the import window and restore whatever the parent conftest installed on exit.
+
+    Only the ``autobot_shared.redis_client`` submodule is stubbed — never the
+    ``autobot_shared`` package itself — so sibling imports like
+    ``autobot_shared.logging_manager`` keep resolving through the real package.
+    """
+    saved = {name: sys.modules.get(name) for name in ("llm_shared", "autobot_shared.redis_client")}
+
+    _mock_llm = ModuleType("llm_shared")
+    _mock_llm.LLMInterface = MagicMock
+    sys.modules["llm_shared"] = _mock_llm
+
+    _mock_redis_mod = ModuleType("autobot_shared.redis_client")
+    _mock_redis_mod.get_redis_client = MagicMock()
+
+    async def _get_async_redis_client_stub(*_a, **_k):
+        return None
+
+    _mock_redis_mod.get_async_redis_client = _get_async_redis_client_stub
+    sys.modules["autobot_shared.redis_client"] = _mock_redis_mod
+
+    try:
+        yield
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+with _stubbed_import_modules():
+    from knowledge.pipeline.cognifiers.relationship_extractor import (
+        NLP_KEYWORD_PATTERNS,
+        RelationshipExtractor,
+    )
+    from knowledge.pipeline.models.chunk import ProcessedChunk
+    from knowledge.pipeline.models.entity import Entity
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -163,27 +194,34 @@ class TestKeywordPatternCreatesTypedRelationship:
 
 
 class TestAutoSelectsNlpForLargeInput:
-    """Issue #2026: auto mode switches to NLP when total chars exceed threshold."""
+    """Issue #2052: auto mode switches to NLP when the chunk count exceeds the threshold.
+
+    ``nlp_threshold`` is a *chunk count*, not a character count — RelationshipExtractor
+    uses the same unit as EntityExtractor so both extractors pick the same mode for the
+    same input (see ``RelationshipExtractor._select_mode``).  These cases were originally
+    written for the superseded #2026 char-count semantics; #10880 realigns them with the
+    chunk-count contract the code actually implements.
+    """
 
     def test_auto_selects_nlp_above_threshold(self):
-        extractor = RelationshipExtractor(mode="auto", nlp_threshold=10)
-        chunk = _chunk("A" * 20)  # 20 chars > threshold 10
+        extractor = RelationshipExtractor(mode="auto", nlp_threshold=5)
+        chunks = [_chunk(f"chunk {i}") for i in range(10)]  # 10 chunks > threshold 5
 
-        mode = extractor._select_mode([chunk])
+        mode = extractor._select_mode(chunks)
 
         assert mode == "nlp"
 
     def test_auto_selects_llm_below_threshold(self):
         extractor = RelationshipExtractor(mode="auto", nlp_threshold=500)
-        chunk = _chunk("Short chunk.")
+        chunks = [_chunk("Short chunk.")]  # 1 chunk < threshold 500
 
-        mode = extractor._select_mode([chunk])
+        mode = extractor._select_mode(chunks)
 
         assert mode == "llm"
 
     def test_auto_selects_nlp_multi_chunk_cumulative(self):
-        extractor = RelationshipExtractor(mode="auto", nlp_threshold=50)
-        chunks = [_chunk("A" * 30), _chunk("B" * 30)]  # 60 total > 50
+        extractor = RelationshipExtractor(mode="auto", nlp_threshold=2)
+        chunks = [_chunk("A"), _chunk("B"), _chunk("C")]  # 3 chunks > threshold 2
 
         mode = extractor._select_mode(chunks)
 
@@ -193,7 +231,8 @@ class TestAutoSelectsNlpForLargeInput:
         extractor = RelationshipExtractor(mode="nlp", nlp_threshold=500)
         chunk = _chunk("Tiny.")
 
-        # _select_mode would return "llm" for tiny input, but mode is forced
+        # _select_mode would return "llm" for a single chunk (1 < 500), but the
+        # explicit mode is what process() honours regardless of _select_mode.
         assert extractor.mode == "nlp"
         assert extractor._select_mode([chunk]) == "llm"
 

--- a/autobot-backend/tests/orchestration/test_causal_error_recovery.py
+++ b/autobot-backend/tests/orchestration/test_causal_error_recovery.py
@@ -13,25 +13,73 @@ Tests recovery recommendations for various error scenarios:
 - Pattern learning and feedback loop
 
 Issue #2154.
+
+Note (#10870): autobot-backend/conftest.py stubs the heavy causal/agent_loop/
+code_intelligence import chain (``orchestration.causal_error_recovery`` &co.) as
+MagicMocks so the lightweight, types-only orchestration tests can collect without
+the full backend stack.  This suite, however, exercises the *real* recovery logic
+(action scoring, leaf-vs-downstream classification, pattern feedback), so it must
+load the genuine modules.  We swap the stubs for the real implementations at import
+time and restore the stubs on teardown so sibling test modules that rely on them are
+unaffected — the same isolation contract used by ``tests/agent_loop/conftest.py``.
 """
 
+import sys
 from unittest.mock import MagicMock
 
 import pytest
 
-from orchestration.causal_error_analyzer import (
+# ---------------------------------------------------------------------------
+# Real-module loading (#10870).
+#
+# The parent conftest replaces the causal/agent_loop/code_intelligence packages
+# with MagicMock package stubs.  Awaiting the stubbed ``recommend_recovery`` raised
+# "object MagicMock can't be used in 'await' expression".  Drop the stubs, import the
+# real modules, then restore the exact objects we displaced so process-shared state is
+# left untouched for other test files.
+# ---------------------------------------------------------------------------
+_STUBBED_PREFIXES = ("orchestration", "agent_loop", "tools.parallel", "code_intelligence")
+_SAVED_STUBS: dict[str, object] = {
+    name: mod
+    for name, mod in list(sys.modules.items())
+    if name == "orchestration"
+    or name.startswith(tuple(f"{p}." for p in _STUBBED_PREFIXES))
+    or name in _STUBBED_PREFIXES
+}
+
+for _name in _SAVED_STUBS:
+    sys.modules.pop(_name, None)
+
+from orchestration.causal_error_analyzer import (  # noqa: E402
     CausalErrorAnalysis,
     CausalErrorAnalyzer,
 )
-from orchestration.causal_error_recovery import (
+from orchestration.causal_error_recovery import (  # noqa: E402
     CausalErrorRecovery,
     RecoveryAction,
     RecoveryPlan,
 )
-from services.failure_pattern_detector import (
+from services.failure_pattern_detector import (  # noqa: E402
     FailurePattern,
     FailurePatternDetector,
 )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _restore_conftest_stubs():
+    """Restore the parent-conftest MagicMock stubs after this module's tests.
+
+    Keeps the real modules loaded for the duration of this file, then puts the
+    original stub objects back so sibling type-only orchestration tests (which
+    depend on the stubbed import chain) see the state they expect.
+    """
+    yield
+    for _name in list(sys.modules):
+        if _name == "orchestration" or _name.startswith(tuple(f"{_p}." for _p in _STUBBED_PREFIXES)):
+            sys.modules.pop(_name, None)
+    for _name, _mod in _SAVED_STUBS.items():
+        sys.modules[_name] = _mod  # type: ignore[assignment]
+
 
 # =============================================================================
 # Test CausalErrorRecovery

--- a/autobot-infrastructure/shared/scripts/utilities/validate_ci_pipeline.py
+++ b/autobot-infrastructure/shared/scripts/utilities/validate_ci_pipeline.py
@@ -30,7 +30,6 @@ def validate_workflow():
 
         # Check required top-level keys (handle YAML parsing quirk with 'on')
         required_keys = ["name", "jobs"]
-        trigger_key = "on" if "on" in workflow else True  # YAML parses 'on:' as True sometimes
 
         for key in required_keys:
             if key in workflow:
@@ -78,7 +77,7 @@ def validate_workflow():
 
         print("\n🎯 Pipeline Features:")
         features = [
-            "Python 3.12 testing",
+            "Python 3.14 testing",
             "Security testing with bandit",
             "Code quality checks (black, isort, flake8)",
             "Unit and integration tests",

--- a/autobot-infrastructure/shared/tests/KNOWLEDGE_MANAGER_TESTS_README.md
+++ b/autobot-infrastructure/shared/tests/KNOWLEDGE_MANAGER_TESTS_README.md
@@ -201,7 +201,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/autobot-infrastructure/shared/tests/README_AGENT_OPTIMIZATION_TESTS.md
+++ b/autobot-infrastructure/shared/tests/README_AGENT_OPTIMIZATION_TESTS.md
@@ -256,7 +256,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       - name: Install dependencies
         run: |
           pip install pytest pytest-asyncio pytest-cov
@@ -429,5 +429,5 @@ Compare future runs against baseline to detect performance regressions.
 
 **Last Updated:** 2025-10-10
 **Test Suite Version:** 1.0.0
-**Python Version:** 3.12
+**Python Version:** 3.14
 **pytest Version:** >=7.0.0


### PR DESCRIPTION
## Thinking Path
Batch of test-infra + doc tech-debt discoveries filed during this session's tech-debt sweep. Each was a real, verified defect.

## What Changed
**#10870** — `test_causal_error_recovery.py`: the backend conftest stubs `CausalErrorRecovery` as a MagicMock (for lightweight type-only orchestration tests), so awaiting the stubbed `recommend_recovery` raised "MagicMock can't be used in await". Fix: module-scoped autouse fixture swaps in the real causal/agent_loop/tools modules and restores the exact stubs on teardown (same isolation contract as `tests/agent_loop/conftest.py`). **7/7 TestCausalErrorRecovery pass**, verified isolated both orders.

**#10879** — `cognifiers_test.py` (and the identical leak found in `relationship_extractor_test.py`): top-level `sys.modules` stubbing overwrote the conftest's good `redis_client` stub (which has `get_async_redis_client`), breaking `chat_knowledge_service_test` on co-collection. Fix: a `_stubbed_import_modules()` context manager that stubs ONLY `autobot_shared.redis_client` (not the parent package) around the imports and restores on exit. **96 passed co-run both orders** (was collection ImportError).

**#10876** — py3.14 doc sweep: `validate_ci_pipeline.py`, `KNOWLEDGE_MANAGER_TESTS_README.md`, `README_AGENT_OPTIMIZATION_TESTS.md` interpreter refs 3.12→3.14 (dependency pins / historical notes / OpenVINO 3.11 untouched). Also removed a pre-existing F841 in validate_ci_pipeline.py.

**#10880 (partial)** — `relationship_extractor_test.py::TestAutoSelectsNlpForLargeInput`: 2 tests asserted char-count auto-select but `_select_mode` uses **chunk count** (#2052). Realigned to chunk-count (mirrors EntityExtractor tests). **17/17 pass.** The judge_integration_test portion of #10880 is deferred (needs a full rewrite against the post-#1285 StepEvaluator delegation) — #10880 stays open with that scope.

## Verification
py_compile clean on all changed files; test counts above verified by the agent.

## Model Used
Opus 4.8

Closes #10870, #10879, #10876. Partially addresses #10880 (relationship_extractor part).