### PR TITLE
fix(deploy): restore autobot_shared symlinks in code-sync + pin AUTOBOT_DATA_DIR so JWT key survives deploys (#10911, #10912)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -266,16 +266,19 @@
 
 - name: Create backend directories
   ansible.builtin.file:
-    path: "{{ item }}"
+    path: "{{ item.path }}"
     state: directory
-    mode: "0755"
+    mode: "{{ item.mode }}"
     owner: "{{ backend_user }}"
     group: "{{ backend_group }}"
   loop:
-    - "{{ backend_install_dir }}"
-    - "{{ backend_log_dir }}"
-    - "{{ backend_data_dir }}"
-    - "{{ backend_data_dir }}/conversation_files"
+    - {path: "{{ backend_install_dir }}", mode: "0755"}
+    - {path: "{{ backend_log_dir }}", mode: "0755"}
+    - {path: "{{ backend_data_dir }}", mode: "0755"}
+    - {path: "{{ backend_data_dir }}/conversation_files", mode: "0755"}
+    # #10911: service-keys holds the durable RSA JWT keypair; 0700 so only the
+    # backend user can read the private key.
+    - {path: "{{ backend_data_dir }}/service-keys", mode: "0700"}
 
 - name: Sync autobot-backend code from code_source
   ansible.posix.synchronize:

--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -13,6 +13,12 @@ AUTOBOT_BASE_DIR={{ backend_code_dir }}
 AUTOBOT_SCHEMA_DIR={{ backend_code_dir }}/database/schemas
 AUTOBOT_DB_PATH=/var/lib/autobot/conversation_files.db
 AUTOBOT_STORAGE_DIR=/var/lib/autobot/conversation_files
+# #10911: Pin data_dir to an absolute path outside any rsync'd component dir so
+# the durable RSA JWT keypair (service-keys/jwt_rsa_private.pem) survives deploys.
+# backend_data_dir defaults to /var/lib/autobot (roles/backend/defaults/main.yml).
+# The service-keys subdir is provisioned at 0700 by the "Create backend directories"
+# task so the key is readable only by the backend user.
+AUTOBOT_DATA_DIR={{ backend_data_dir }}
 
 # Redis (Issue #2953: use AUTOBOT_REDIS_* names so SSOT config picks them up)
 AUTOBOT_REDIS_HOST={{ backend_redis_host }}

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -881,6 +881,46 @@ async def _restart_component_services(component: str, steps: List[str]) -> None:
             steps.append(f"restart {service}: error: {exc}")
 
 
+# Canonical base path for all deployed components (#10912).
+_AUTOBOT_DEPLOY_BASE = "/opt/autobot"
+
+# Python backend components that embed an autobot_shared symlink (#10912).
+_BACKEND_COMPONENTS = frozenset(_COMPONENT_PIP_PATHS.keys())
+
+
+async def _ensure_autobot_shared_symlink(component: str, steps: List[str]) -> None:
+    """Restore /opt/autobot/<component>/autobot_shared → /opt/autobot/autobot_shared (#10912).
+
+    The deploy rsync uses --delete, which removes the symlink because it is not
+    present in the code_source tree. Without it the backend process crashes on
+    import with ModuleNotFoundError. This helper recreates the symlink so the
+    component restarts cleanly.
+
+    Only acts on Python backend components (autobot-backend, autobot-slm-backend).
+    Non-fatal: errors are logged and a step note is appended, but the sync is not
+    aborted — a missing symlink is survivable until the next restart.
+    """
+    if component not in _BACKEND_COMPONENTS:
+        return
+    shared_target = Path(_AUTOBOT_DEPLOY_BASE) / "autobot_shared"
+    if not shared_target.exists():
+        steps.append(f"symlink: {shared_target} not found — skipped")
+        return
+    link_path = Path(_AUTOBOT_DEPLOY_BASE) / component / "autobot_shared"
+    try:
+        if link_path.is_symlink() and link_path.resolve() == shared_target.resolve():
+            steps.append(f"symlink: {link_path} already correct")
+            return
+        if link_path.is_symlink() or link_path.exists():
+            link_path.unlink()
+        link_path.symlink_to(shared_target)
+        logger.info("drift resolve: restored autobot_shared symlink for %s", component)
+        steps.append(f"symlink: {link_path} -> {shared_target} (restored)")
+    except Exception as exc:
+        logger.error("drift resolve: symlink restore failed for %s: %s", component, exc)
+        steps.append(f"symlink: restore failed for {component}: {exc}")
+
+
 async def _run_post_sync_steps(
     component: str,
     source_dir: str,
@@ -894,9 +934,10 @@ async def _run_post_sync_steps(
     post-rsync to reflect what the operator sees after the sync.
 
     Component routing:
-      - Python backend (autobot-backend, autobot-slm-backend): pip install + restart
+      - Python backend (autobot-backend, autobot-slm-backend): pip install +
+        symlink restore (#10912) + restart
       - Frontend (autobot-frontend, autobot-slm-frontend): npm ci + build + nginx reload
-      - autobot_shared: pure library — no service or build step, no-op
+      - autobot_shared: restore BOTH backends' symlinks (#10912) + restart dependents
     """
     steps: List[str] = []
 
@@ -908,6 +949,9 @@ async def _run_post_sync_steps(
 
     if component in _COMPONENT_PIP_PATHS:
         await _install_pip_deps_for_component(component, steps)
+        # Restore symlink BEFORE restart so the process imports the correct shared
+        # code the moment it starts (#10912).
+        await _ensure_autobot_shared_symlink(component, steps)
         await _restart_component_services(component, steps)
     elif component in _COMPONENT_FRONTEND_DIRS:
         await _build_npm_frontend_for_component(component, steps)
@@ -915,6 +959,9 @@ async def _run_post_sync_steps(
     elif component in _COMPONENT_SERVICES:
         # Library component (autobot_shared): no build step, but every service
         # that imports it must restart so the new shared code is loaded (#10248).
+        # Restore both backends' symlinks first so services start cleanly (#10912).
+        for backend in sorted(_BACKEND_COMPONENTS):
+            await _ensure_autobot_shared_symlink(backend, steps)
         await _restart_component_services(component, steps)
     else:
         steps.append(f"post-sync: no service or build step for {component}")

--- a/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
@@ -78,10 +78,10 @@ from api.code_sync import (  # noqa: E402
     _run_post_sync_steps,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helper
 # ---------------------------------------------------------------------------
+
 
 def _run(coro):
     return asyncio.get_event_loop().run_until_complete(coro)
@@ -90,6 +90,7 @@ def _run(coro):
 # ---------------------------------------------------------------------------
 # _BACKEND_COMPONENTS covers exactly the pip-backend components
 # ---------------------------------------------------------------------------
+
 
 def test_backend_components_match_pip_paths() -> None:
     """_BACKEND_COMPONENTS must equal the pip-backend set so no component is missed."""
@@ -105,6 +106,7 @@ def test_backend_components_are_pip_backends() -> None:
 # _ensure_autobot_shared_symlink — filesystem-level behaviour
 # ---------------------------------------------------------------------------
 
+
 def test_symlink_created_when_missing(tmp_path) -> None:
     """Symlink is created when the link path does not yet exist."""
     shared_target = tmp_path / "autobot_shared"
@@ -114,9 +116,7 @@ def test_symlink_created_when_missing(tmp_path) -> None:
     link_path = tmp_path / component / "autobot_shared"
 
     steps: list = []
-    with __import__("unittest.mock", fromlist=["patch"]).patch(
-        "api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)
-    ):
+    with __import__("unittest.mock", fromlist=["patch"]).patch("api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)):
         _run(_ensure_autobot_shared_symlink(component, steps))
 
     assert link_path.is_symlink()
@@ -193,6 +193,7 @@ def test_skipped_when_shared_target_missing(tmp_path) -> None:
 # _run_post_sync_steps — pip backend path calls symlink restore before restart
 # ---------------------------------------------------------------------------
 
+
 def test_pip_backend_emits_symlink_step(tmp_path) -> None:
     """Symlink step is emitted for pip backend components via _run_post_sync_steps."""
     from unittest.mock import patch
@@ -214,19 +215,18 @@ def test_pip_backend_emits_symlink_step(tmp_path) -> None:
             patch("api.code_sync._install_pip_deps_for_component", AsyncMock()),
             patch("api.code_sync._restart_component_services", AsyncMock()),
         ):
-            _, steps = _run(
-                _run_post_sync_steps(component, f"/src/{component}", f"/opt/autobot/{component}")
-            )
+            _, steps = _run(_run_post_sync_steps(component, f"/src/{component}", f"/opt/autobot/{component}"))
             steps_collected.extend(steps)
 
-        assert any(f"symlink-called:{component}" in s for s in steps_collected), (
-            f"No symlink call for {component}: {steps_collected}"
-        )
+        assert any(
+            f"symlink-called:{component}" in s for s in steps_collected
+        ), f"No symlink call for {component}: {steps_collected}"
 
 
 # ---------------------------------------------------------------------------
 # _run_post_sync_steps — autobot_shared path restores BOTH backends' symlinks
 # ---------------------------------------------------------------------------
+
 
 def test_autobot_shared_component_restores_both_backends(tmp_path) -> None:
     """When syncing autobot_shared, _ensure_autobot_shared_symlink called for each backend."""
@@ -251,6 +251,4 @@ def test_autobot_shared_component_restores_both_backends(tmp_path) -> None:
             )
         )
 
-    assert set(called_for) == _BACKEND_COMPONENTS, (
-        f"Expected symlinks for {_BACKEND_COMPONENTS}, got {set(called_for)}"
-    )
+    assert set(called_for) == _BACKEND_COMPONENTS, f"Expected symlinks for {_BACKEND_COMPONENTS}, got {set(called_for)}"

--- a/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
@@ -1,0 +1,256 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the autobot_shared symlink-restore step (#10912).
+
+The builtin code-sync drift/resolve rsyncs with --delete, which removes the
+autobot_shared symlink inside each Python backend component dir because the
+symlink is not present in the code_source tree. Without the symlink the
+restarted process dies with ModuleNotFoundError.
+
+_ensure_autobot_shared_symlink() recreates the symlink after rsync and before
+the service restart.  _run_post_sync_steps() calls it at the right points:
+  - for pip backend components: after pip install, before service restart
+  - for autobot_shared: before restarting all dependent services
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock  # MagicMock used in sys.modules guard below
+
+# ---------------------------------------------------------------------------
+# Dev-host stub: models.schemas contains real Pydantic models in CI but on
+# the dev box (no SLM venv) it is a MagicMock that makes FastAPI's
+# response_model validation fail at decoration time.  Pre-populate the module
+# with minimal real BaseModel subclasses so the router can be imported.
+# Must happen before the api.code_sync import below.
+# ---------------------------------------------------------------------------
+if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMock):
+    from pydantic import BaseModel as _BM
+
+    def _pydantic_stub(name: str, **fields) -> type:
+        return type(name, (_BM,), {"__annotations__": {k: type(v) for k, v in fields.items()}, **fields})
+
+    _schemas = types.ModuleType("models.schemas")
+    # Enumerate every name imported from models.schemas in api/code_sync.py.
+    for _cls in [
+        "CodeSyncStatusResponse",
+        "CodeSyncRefreshResponse",
+        "CodeVersionNotification",
+        "CodeVersionNotificationResponse",
+        "DriftResolveRequest",
+        "DriftResolveResponse",
+        "FileDriftReport",
+        "FleetSyncJobStatus",
+        "FleetSyncNodeStatus",
+        "FleetSyncRequest",
+        "FleetSyncResponse",
+        "MarkSyncedResponse",
+        "NodeSyncRequest",
+        "NodeSyncResponse",
+        "PendingNodeResponse",
+        "PendingNodesResponse",
+        "ScheduleCreate",
+        "ScheduleResponse",
+        "ScheduleRunResponse",
+        "ScheduleUpdate",
+    ]:
+        setattr(_schemas, _cls, _pydantic_stub(_cls))
+    _models = sys.modules.get("models") or types.ModuleType("models")
+    _models.schemas = _schemas  # type: ignore[attr-defined]
+    sys.modules["models"] = _models
+    sys.modules["models.schemas"] = _schemas
+
+# Add autobot-slm-backend to path so api.code_sync imports resolve.
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+import asyncio  # noqa: E402
+
+from api.code_sync import (  # noqa: E402
+    _BACKEND_COMPONENTS,
+    _COMPONENT_PIP_PATHS,
+    _ensure_autobot_shared_symlink,
+    _run_post_sync_steps,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# _BACKEND_COMPONENTS covers exactly the pip-backend components
+# ---------------------------------------------------------------------------
+
+def test_backend_components_match_pip_paths() -> None:
+    """_BACKEND_COMPONENTS must equal the pip-backend set so no component is missed."""
+    assert _BACKEND_COMPONENTS == frozenset(_COMPONENT_PIP_PATHS.keys())
+
+
+def test_backend_components_are_pip_backends() -> None:
+    assert "autobot-backend" in _BACKEND_COMPONENTS
+    assert "autobot-slm-backend" in _BACKEND_COMPONENTS
+
+
+# ---------------------------------------------------------------------------
+# _ensure_autobot_shared_symlink — filesystem-level behaviour
+# ---------------------------------------------------------------------------
+
+def test_symlink_created_when_missing(tmp_path) -> None:
+    """Symlink is created when the link path does not yet exist."""
+    shared_target = tmp_path / "autobot_shared"
+    shared_target.mkdir()
+    component = "autobot-backend"
+    (tmp_path / component).mkdir()
+    link_path = tmp_path / component / "autobot_shared"
+
+    steps: list = []
+    with __import__("unittest.mock", fromlist=["patch"]).patch(
+        "api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)
+    ):
+        _run(_ensure_autobot_shared_symlink(component, steps))
+
+    assert link_path.is_symlink()
+    assert link_path.resolve() == shared_target.resolve()
+    assert any("restored" in s for s in steps)
+
+
+def test_symlink_replaced_when_wrong_target(tmp_path) -> None:
+    """A symlink pointing at the wrong target is replaced."""
+    from unittest.mock import patch
+
+    shared_target = tmp_path / "autobot_shared"
+    shared_target.mkdir()
+    component = "autobot-slm-backend"
+    comp_dir = tmp_path / component
+    comp_dir.mkdir()
+    wrong_dir = tmp_path / "wrong"
+    wrong_dir.mkdir()
+    link_path = comp_dir / "autobot_shared"
+    link_path.symlink_to(wrong_dir)
+
+    steps: list = []
+    with patch("api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)):
+        _run(_ensure_autobot_shared_symlink(component, steps))
+
+    assert link_path.is_symlink()
+    assert link_path.resolve() == shared_target.resolve()
+    assert any("restored" in s for s in steps)
+
+
+def test_symlink_noop_when_already_correct(tmp_path) -> None:
+    """No-op (step says 'already correct') when the symlink is already correct."""
+    from unittest.mock import patch
+
+    shared_target = tmp_path / "autobot_shared"
+    shared_target.mkdir()
+    component = "autobot-backend"
+    comp_dir = tmp_path / component
+    comp_dir.mkdir()
+    link_path = comp_dir / "autobot_shared"
+    link_path.symlink_to(shared_target)
+
+    steps: list = []
+    with patch("api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)):
+        _run(_ensure_autobot_shared_symlink(component, steps))
+
+    assert link_path.is_symlink()
+    assert any("already correct" in s for s in steps)
+
+
+def test_skipped_for_non_backend_component(tmp_path) -> None:
+    """Helper is a no-op for non-pip-backend components."""
+    from unittest.mock import patch
+
+    steps: list = []
+    with patch("api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)):
+        _run(_ensure_autobot_shared_symlink("autobot-slm-frontend", steps))
+    assert steps == []
+
+
+def test_skipped_when_shared_target_missing(tmp_path) -> None:
+    """If /opt/autobot/autobot_shared doesn't exist, helper skips gracefully."""
+    from unittest.mock import patch
+
+    component = "autobot-backend"
+    (tmp_path / component).mkdir()
+    steps: list = []
+    with patch("api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)):
+        _run(_ensure_autobot_shared_symlink(component, steps))
+    assert any("not found" in s for s in steps)
+
+
+# ---------------------------------------------------------------------------
+# _run_post_sync_steps — pip backend path calls symlink restore before restart
+# ---------------------------------------------------------------------------
+
+def test_pip_backend_emits_symlink_step(tmp_path) -> None:
+    """Symlink step is emitted for pip backend components via _run_post_sync_steps."""
+    from unittest.mock import patch
+
+    for component in ("autobot-backend", "autobot-slm-backend"):
+        shared_target = tmp_path / "autobot_shared"
+        shared_target.mkdir(exist_ok=True)
+        (tmp_path / component).mkdir(exist_ok=True)
+
+        steps_collected: list[str] = []
+
+        async def _fake_ensure(comp: str, steps: list) -> None:
+            steps.append(f"symlink-called:{comp}")
+
+        with (
+            patch("api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)),
+            patch("api.code_sync._ensure_autobot_shared_symlink", side_effect=_fake_ensure),
+            patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+            patch("api.code_sync._install_pip_deps_for_component", AsyncMock()),
+            patch("api.code_sync._restart_component_services", AsyncMock()),
+        ):
+            _, steps = _run(
+                _run_post_sync_steps(component, f"/src/{component}", f"/opt/autobot/{component}")
+            )
+            steps_collected.extend(steps)
+
+        assert any(f"symlink-called:{component}" in s for s in steps_collected), (
+            f"No symlink call for {component}: {steps_collected}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _run_post_sync_steps — autobot_shared path restores BOTH backends' symlinks
+# ---------------------------------------------------------------------------
+
+def test_autobot_shared_component_restores_both_backends(tmp_path) -> None:
+    """When syncing autobot_shared, _ensure_autobot_shared_symlink called for each backend."""
+    from unittest.mock import patch
+
+    called_for: list[str] = []
+
+    async def _fake_ensure(component: str, steps: list) -> None:
+        called_for.append(component)
+
+    with (
+        patch("api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)),
+        patch("api.code_sync._ensure_autobot_shared_symlink", side_effect=_fake_ensure),
+        patch("api.code_sync._restart_component_services", AsyncMock()),
+        patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+    ):
+        _run(
+            _run_post_sync_steps(
+                "autobot_shared",
+                "/src/autobot_shared",
+                "/opt/autobot/autobot_shared",
+            )
+        )
+
+    assert set(called_for) == _BACKEND_COMPONENTS, (
+        f"Expected symlinks for {_BACKEND_COMPONENTS}, got {set(called_for)}"
+    )


### PR DESCRIPTION
## Thinking Path

Two production incidents, root causes already diagnosed — no re-investigation needed:

**#10912 (symlink loss):** drift/resolve syncs component dirs from code_source with the delete flag set, which removes the `autobot_shared` symlink inside the component dir because the symlink is absent from the code_source tree. The SLM backend's symlink was not restored post-deploy, causing 839 crash-restarts with `ModuleNotFoundError`.

**#10911 (JWT key drift):** `AUTOBOT_DATA_DIR` was absent from the deployed backend env. `ssot_config.py` resolves `data_dir` relative to `AUTOBOT_BASE_DIR` when not absolute; `AUTOBOT_BASE_DIR` is set to `backend_code_dir` which changed value across releases. The durable RSA JWT keypair (`service-keys/jwt_rsa_private.pem`) therefore landed at a different absolute path on consecutive deploys, causing the backend to fall back to a fresh ephemeral key on each restart and 401-ing all users.

## What Changed

### `autobot-slm-backend/api/code_sync.py` (#10912)

Two new module-level constants:
- `_AUTOBOT_DEPLOY_BASE = "/opt/autobot"` — single literal, consistent with rsync targets elsewhere in the file
- `_BACKEND_COMPONENTS = frozenset(_COMPONENT_PIP_PATHS.keys())` — derived from the existing map so it stays in sync automatically

New helper `_ensure_autobot_shared_symlink(component, steps)` (~28 lines):
- Only acts on `_BACKEND_COMPONENTS` (autobot-backend, autobot-slm-backend)
- Guards on `/opt/autobot/autobot_shared` existing before touching anything
- Unlinks and recreates the link when it is missing or points at the wrong target; no-op when already correct
- Non-fatal: errors are logged and appended to steps, sync is not aborted

Updated `_run_post_sync_steps()`:
- **pip-backend branch**: calls `_ensure_autobot_shared_symlink` after pip install and before `_restart_component_services`
- **autobot_shared branch**: calls it for every backend component in `_BACKEND_COMPONENTS` before restarting dependents

### `autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2` (#10911)

Added `AUTOBOT_DATA_DIR={{ backend_data_dir }}` in the Application Paths section. `backend_data_dir` defaults to `/var/lib/autobot` in `roles/backend/defaults/main.yml` and is already provisioned by the existing "Create backend directories" task. This pins `config.path.data_path` to a stable absolute path outside any rsynced component tree.

### `autobot-slm-backend/ansible/roles/backend/tasks/main.yml` (#10911)

Extended "Create backend directories" loop to also provision `{{ backend_data_dir }}/service-keys` at mode `0700` (owner: backend user). The durable RSA JWT private key is written to `service-keys/jwt_rsa_private.pem`; 0700 ensures only the backend process can read it.

### `autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py` (new)

9 unit tests covering both the helper and its call sites:
- Symlink created when missing, replaced when wrong target, no-op when correct
- Skipped for non-backend components and when `/opt/autobot/autobot_shared` is absent
- pip-backend path emits the symlink step before restart
- autobot_shared path calls restore for every `_BACKEND_COMPONENTS` entry

## Verification

```
pytest autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py -v
# 9 passed in 0.68s

ruff check autobot-slm-backend/api/code_sync.py
# 1 pre-existing E402 at line 2443 (predates this PR), 0 new errors

ruff check autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
# All checks passed!

python3 -c "import yaml; yaml.safe_load(open('autobot-slm-backend/ansible/roles/backend/tasks/main.yml').read()); print('OK')"
# OK
```

**Migration caveat (#10911):** Boxes already provisioned with `data_dir` resolved to a location other than `/var/lib/autobot` (e.g. `/opt/autobot/data`) will have `config.path.data_path` shift to `/var/lib/autobot` on the next deploy. `auth_middleware._get_rs256_keypair` generates a fresh keypair when the pem is absent, so the first restart after this change will issue a new key and invalidate active JWTs — users log in once. This is the same disruption that was already happening on every deploy due to path drift; pinning stops the recurrence permanently.

## Model Used

claude-sonnet-4-6

Closes #10911, #10912
