### PR TITLE
fix(async): non-blocking subprocess on async paths in vnc_mcp (#10783 B)

### DIFF
--- a/autobot-backend/api/vnc_mcp.py
+++ b/autobot-backend/api/vnc_mcp.py
@@ -460,7 +460,9 @@ async def desktop_mouse_click_mcp(request: DesktopMouseClickRequest) -> Metadata
     button_map = {"left": "1", "middle": "2", "right": "3"}
     button_num = button_map.get(request.button, "1")
 
-    result = _run_xdotool_cmd(["mousemove", str(request.x), str(request.y), "click", button_num])
+    result = await asyncio.to_thread(  # nosec B603 B607 - fixed argv, validated by _run_xdotool_cmd
+        _run_xdotool_cmd, ["mousemove", str(request.x), str(request.y), "click", button_num]
+    )
 
     return {
         "success": result["status"] == "success",
@@ -484,7 +486,9 @@ async def desktop_keyboard_type_mcp(request: DesktopKeyboardTypeRequest) -> Meta
     """
     from api.vnc_manager import _run_xdotool_cmd
 
-    result = _run_xdotool_cmd(["type", "--", request.text])
+    result = await asyncio.to_thread(  # nosec B603 B607 - fixed argv, validated by _run_xdotool_cmd
+        _run_xdotool_cmd, ["type", "--", request.text]
+    )
 
     return {
         "success": result["status"] == "success",
@@ -507,7 +511,9 @@ async def desktop_special_key_mcp(request: DesktopSpecialKeyRequest) -> Metadata
     """
     from api.vnc_manager import _run_xdotool_cmd
 
-    result = _run_xdotool_cmd(["key", request.key])
+    result = await asyncio.to_thread(  # nosec B603 B607 - fixed argv, validated by _run_xdotool_cmd
+        _run_xdotool_cmd, ["key", request.key]
+    )
 
     return {
         "success": result["status"] == "success",

--- a/autobot-backend/tests/test_vnc_mcp_async.py
+++ b/autobot-backend/tests/test_vnc_mcp_async.py
@@ -94,6 +94,14 @@ def _install_stubs() -> dict:
     # so it does NOT require api to be a real importable package.
     _stub("api")
 
+    # api.vnc_manager — stub _run_xdotool_cmd so that the lazy imports inside
+    # desktop_mouse_click_mcp / desktop_keyboard_type_mcp / desktop_special_key_mcp
+    # resolve without needing the real module (which has its own heavy deps).
+    def _run_xdotool_cmd(args, timeout=5):  # pragma: no cover
+        return {"status": "success", "message": "Action completed"}
+
+    _stub("api.vnc_manager", _run_xdotool_cmd=_run_xdotool_cmd)
+
     # api.schemas_system — exact names imported by vnc_mcp.py lines 28-45
     _schema_attrs = {
         n: MagicMock
@@ -295,3 +303,62 @@ class TestSubprocessDispatchedViaToThread:
         kw = calls[1].kwargs
         assert kw.get("env") == {"DISPLAY": ":1"}
         assert kw.get("timeout") == 5
+
+
+class TestXdotoolMcpDispatchedViaToThread:
+    """
+    Verify desktop_mouse_click_mcp, desktop_keyboard_type_mcp, and
+    desktop_special_key_mcp dispatch _run_xdotool_cmd via asyncio.to_thread
+    (#10783 Category B fix).
+    """
+
+    @pytest.mark.asyncio
+    async def test_mouse_click_dispatches_via_to_thread(self, vnc_mcp_module):
+        """desktop_mouse_click_mcp wraps _run_xdotool_cmd in asyncio.to_thread."""
+        fake_result = {"status": "success", "message": "Action completed"}
+        request_mock = MagicMock()
+        request_mock.x = 100
+        request_mock.y = 200
+        request_mock.button = "left"
+
+        with patch("asyncio.to_thread", new_callable=AsyncMock, return_value=fake_result) as mock_tt:
+            result = await vnc_mcp_module.desktop_mouse_click_mcp(request_mock)
+
+        assert mock_tt.called, "asyncio.to_thread was never called in desktop_mouse_click_mcp"
+        assert result["success"] is True
+        first_positional = mock_tt.call_args_list[0].args
+        # First arg to to_thread must be the sync _run_xdotool_cmd function
+        assert callable(first_positional[0]), "First arg to asyncio.to_thread must be callable (_run_xdotool_cmd)"
+        assert first_positional[0].__name__ == "_run_xdotool_cmd"
+
+    @pytest.mark.asyncio
+    async def test_keyboard_type_dispatches_via_to_thread(self, vnc_mcp_module):
+        """desktop_keyboard_type_mcp wraps _run_xdotool_cmd in asyncio.to_thread."""
+        fake_result = {"status": "success", "message": "Action completed"}
+        request_mock = MagicMock()
+        request_mock.text = "hello world"
+
+        with patch("asyncio.to_thread", new_callable=AsyncMock, return_value=fake_result) as mock_tt:
+            result = await vnc_mcp_module.desktop_keyboard_type_mcp(request_mock)
+
+        assert mock_tt.called, "asyncio.to_thread was never called in desktop_keyboard_type_mcp"
+        assert result["success"] is True
+        first_positional = mock_tt.call_args_list[0].args
+        assert callable(first_positional[0]), "First arg to asyncio.to_thread must be callable (_run_xdotool_cmd)"
+        assert first_positional[0].__name__ == "_run_xdotool_cmd"
+
+    @pytest.mark.asyncio
+    async def test_special_key_dispatches_via_to_thread(self, vnc_mcp_module):
+        """desktop_special_key_mcp wraps _run_xdotool_cmd in asyncio.to_thread."""
+        fake_result = {"status": "success", "message": "Action completed"}
+        request_mock = MagicMock()
+        request_mock.key = "Return"
+
+        with patch("asyncio.to_thread", new_callable=AsyncMock, return_value=fake_result) as mock_tt:
+            result = await vnc_mcp_module.desktop_special_key_mcp(request_mock)
+
+        assert mock_tt.called, "asyncio.to_thread was never called in desktop_special_key_mcp"
+        assert result["success"] is True
+        first_positional = mock_tt.call_args_list[0].args
+        assert callable(first_positional[0]), "First arg to asyncio.to_thread must be callable (_run_xdotool_cmd)"
+        assert first_positional[0].__name__ == "_run_xdotool_cmd"


### PR DESCRIPTION
Closes #10919.

## Thinking Path
Umbrella #10783 Category B. `api/vnc_mcp.py` called the sync `_run_xdotool_cmd` (which runs `subprocess.run`) directly inside `async def` MCP handlers, blocking the event loop per command. (The 4 originally-cited lines were already wrapped by a prior pass; an audit found 3 other genuine blocking sites.)

## What Changed
Wrapped 3 xdotool calls in `asyncio.to_thread` (preserves `_run_xdotool_cmd`'s validation, TimeoutExpired handling, dict return, and 5s timeout):
- `desktop_mouse_click_mcp` (mousemove+click), `desktop_keyboard_type_mcp` (type), `desktop_special_key_mcp` (key).
Chose `to_thread` over native async-subprocess to preserve the existing sync helper's full behavior in one line. No bare `subprocess.run` remains inside any `async def`.

## Verification
- `py_compile` + `flake8 -F` clean.
- `test_vnc_mcp_async.py`: 9 passed (6 pre-existing + 3 new to_thread-dispatch tests).

## Model Used
Opus 4.8

Part of #10783 (Category B).