### PR TITLE
fix(deploy): derive autobot_shared symlink base from AUTOBOT_BASE_DIR + generate SLM symlink in Ansible (#10912)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -278,6 +278,44 @@
   when: slm_requirements_stat.stat.exists
   tags: ['slm', 'backend']
 
+# Issue #10912: The drift/resolve sync removes the autobot_shared symlink
+# inside the SLM backend directory because the symlink is not present in the
+# code_source tree.  Without it the restarted process dies with
+# ModuleNotFoundError.  Ensure the symlink exists after every sync so that
+# code-sync restores are self-correcting even without Ansible.
+#
+# Step 1: Stat the embedded path to distinguish a real directory (must be
+# removed before a symlink can be created) from an existing symlink.
+- name: "SLM | Stat embedded autobot_shared path in SLM backend dir (#10912)"
+  ansible.builtin.stat:
+    path: "{{ slm_backend_dir }}/autobot_shared"
+  register: _slm_embedded_shared_stat
+  tags: ['slm', 'backend']
+
+# Step 2: Remove a stale real directory — ansible.builtin.file state:link
+# cannot replace a non-empty directory even with force: true.
+- name: "SLM | Remove stale embedded autobot_shared real-dir in SLM backend if present (#10912)"
+  ansible.builtin.file:
+    path: "{{ slm_backend_dir }}/autobot_shared"
+    state: absent
+  when:
+    - _slm_embedded_shared_stat.stat.exists
+    - not _slm_embedded_shared_stat.stat.islnk
+  tags: ['slm', 'backend']
+
+# Step 3: Create (or update) the symlink.  force: true replaces a wrong symlink.
+# Uses slm_shared_dir (= {{ slm_base_dir }}/autobot_shared) so the base is
+# governed by slm_base_dir — no hardcoded /opt/autobot path (#10912).
+- name: "SLM | Symlink embedded autobot_shared to canonical SLM copy (#10912)"
+  ansible.builtin.file:
+    src: "{{ slm_shared_dir }}"
+    dest: "{{ slm_backend_dir }}/autobot_shared"
+    state: link
+    force: true
+    owner: "{{ slm_user }}"
+    group: "{{ slm_group }}"
+  tags: ['slm', 'backend']
+
 - name: "SLM | Install autobot_shared in venv (editable)"
   ansible.builtin.command:
     cmd: "{{ slm_backend_dir }}/venv/bin/pip install -e {{ slm_base_dir }}/autobot_shared"

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -881,20 +881,39 @@ async def _restart_component_services(component: str, steps: List[str]) -> None:
             steps.append(f"restart {service}: error: {exc}")
 
 
-# Canonical base path for all deployed components (#10912).
-_AUTOBOT_DEPLOY_BASE = "/opt/autobot"
-
 # Python backend components that embed an autobot_shared symlink (#10912).
 _BACKEND_COMPONENTS = frozenset(_COMPONENT_PIP_PATHS.keys())
 
 
+def _get_deploy_base() -> Path:
+    """Return the installation base directory from config (AUTOBOT_BASE_DIR, default /opt/autobot).
+
+    Reads the value at call time so that tests can monkeypatch the environment
+    variable or the config object without needing to patch a module-level string.
+    Avoids importing autobot_shared.ssot_config at module load (bootstrap safety).
+    """
+    try:
+        from autobot_shared.ssot_config import get_config as _get_config
+
+        return Path(_get_config().path.base_dir)
+    except Exception:
+        # ssot_config unavailable at bootstrap — fall back to the env var directly.
+        import os
+
+        return Path(os.environ.get("AUTOBOT_BASE_DIR", "/opt/autobot"))
+
+
 async def _ensure_autobot_shared_symlink(component: str, steps: List[str]) -> None:
-    """Restore /opt/autobot/<component>/autobot_shared → /opt/autobot/autobot_shared (#10912).
+    """Restore <AUTOBOT_BASE_DIR>/<component>/autobot_shared → <AUTOBOT_BASE_DIR>/autobot_shared (#10912).
 
     The deploy rsync uses --delete, which removes the symlink because it is not
     present in the code_source tree. Without it the backend process crashes on
     import with ModuleNotFoundError. This helper recreates the symlink so the
     component restarts cleanly.
+
+    The base directory is read from AUTOBOT_BASE_DIR via PathConfig so that
+    non-standard deployments (e.g. AUTOBOT_BASE_DIR=/srv/autobot) work without
+    any code change (#10912 follow-up).
 
     Only acts on Python backend components (autobot-backend, autobot-slm-backend).
     Non-fatal: errors are logged and a step note is appended, but the sync is not
@@ -902,11 +921,12 @@ async def _ensure_autobot_shared_symlink(component: str, steps: List[str]) -> No
     """
     if component not in _BACKEND_COMPONENTS:
         return
-    shared_target = Path(_AUTOBOT_DEPLOY_BASE) / "autobot_shared"
+    base = _get_deploy_base()
+    shared_target = base / "autobot_shared"
     if not shared_target.exists():
         steps.append(f"symlink: {shared_target} not found — skipped")
         return
-    link_path = Path(_AUTOBOT_DEPLOY_BASE) / component / "autobot_shared"
+    link_path = base / component / "autobot_shared"
     try:
         if link_path.is_symlink() and link_path.resolve() == shared_target.resolve():
             steps.append(f"symlink: {link_path} already correct")

--- a/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
@@ -117,6 +117,7 @@ def test_get_deploy_base_honours_env_var(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("AUTOBOT_BASE_DIR", str(tmp_path))
     # Force ssot_config to be unavailable so we test the os.environ fallback path.
     import sys as _sys
+
     saved = _sys.modules.pop("autobot_shared.ssot_config", None)
     try:
         result = _get_deploy_base()

--- a/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
@@ -13,6 +13,10 @@ _ensure_autobot_shared_symlink() recreates the symlink after rsync and before
 the service restart.  _run_post_sync_steps() calls it at the right points:
   - for pip backend components: after pip install, before service restart
   - for autobot_shared: before restarting all dependent services
+
+The base directory is config-derived via _get_deploy_base() (AUTOBOT_BASE_DIR /
+PathConfig), so tests patch that function to a tmp_path to prove no /opt/autobot
+path is ever hardcoded.
 """
 
 from __future__ import annotations
@@ -75,6 +79,7 @@ from api.code_sync import (  # noqa: E402
     _BACKEND_COMPONENTS,
     _COMPONENT_PIP_PATHS,
     _ensure_autobot_shared_symlink,
+    _get_deploy_base,
     _run_post_sync_steps,
 )
 
@@ -103,12 +108,35 @@ def test_backend_components_are_pip_backends() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _get_deploy_base — config-derived, not hardcoded
+# ---------------------------------------------------------------------------
+
+
+def test_get_deploy_base_honours_env_var(monkeypatch, tmp_path) -> None:
+    """AUTOBOT_BASE_DIR env var (via PathConfig) is respected — not the /opt/autobot default."""
+    monkeypatch.setenv("AUTOBOT_BASE_DIR", str(tmp_path))
+    # Force ssot_config to be unavailable so we test the os.environ fallback path.
+    import sys as _sys
+    saved = _sys.modules.pop("autobot_shared.ssot_config", None)
+    try:
+        result = _get_deploy_base()
+    finally:
+        if saved is not None:
+            _sys.modules["autobot_shared.ssot_config"] = saved
+    assert result == tmp_path
+    assert str(result) != "/opt/autobot"
+
+
+# ---------------------------------------------------------------------------
 # _ensure_autobot_shared_symlink — filesystem-level behaviour
+# All tests patch _get_deploy_base to prove the symlink base is config-driven.
 # ---------------------------------------------------------------------------
 
 
 def test_symlink_created_when_missing(tmp_path) -> None:
-    """Symlink is created when the link path does not yet exist."""
+    """Symlink is created under the config-derived base (not a hardcoded /opt/autobot)."""
+    from unittest.mock import patch
+
     shared_target = tmp_path / "autobot_shared"
     shared_target.mkdir()
     component = "autobot-backend"
@@ -116,12 +144,35 @@ def test_symlink_created_when_missing(tmp_path) -> None:
     link_path = tmp_path / component / "autobot_shared"
 
     steps: list = []
-    with __import__("unittest.mock", fromlist=["patch"]).patch("api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)):
+    with patch("api.code_sync._get_deploy_base", return_value=tmp_path):
         _run(_ensure_autobot_shared_symlink(component, steps))
 
     assert link_path.is_symlink()
     assert link_path.resolve() == shared_target.resolve()
     assert any("restored" in s for s in steps)
+
+
+def test_symlink_created_under_non_default_base(tmp_path) -> None:
+    """Symlink is created under an arbitrary non-/opt/autobot base — proves no hardcoding."""
+    from unittest.mock import patch
+
+    custom_base = tmp_path / "srv" / "autobot"
+    custom_base.mkdir(parents=True)
+    shared_target = custom_base / "autobot_shared"
+    shared_target.mkdir()
+    component = "autobot-backend"
+    (custom_base / component).mkdir()
+    link_path = custom_base / component / "autobot_shared"
+
+    steps: list = []
+    with patch("api.code_sync._get_deploy_base", return_value=custom_base):
+        _run(_ensure_autobot_shared_symlink(component, steps))
+
+    assert link_path.is_symlink(), f"symlink not created under custom base {custom_base}"
+    assert link_path.resolve() == shared_target.resolve()
+    assert any("restored" in s for s in steps)
+    # Confirm the link lives under the custom base, never /opt/autobot
+    assert str(link_path).startswith(str(custom_base))
 
 
 def test_symlink_replaced_when_wrong_target(tmp_path) -> None:
@@ -139,7 +190,7 @@ def test_symlink_replaced_when_wrong_target(tmp_path) -> None:
     link_path.symlink_to(wrong_dir)
 
     steps: list = []
-    with patch("api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)):
+    with patch("api.code_sync._get_deploy_base", return_value=tmp_path):
         _run(_ensure_autobot_shared_symlink(component, steps))
 
     assert link_path.is_symlink()
@@ -160,7 +211,7 @@ def test_symlink_noop_when_already_correct(tmp_path) -> None:
     link_path.symlink_to(shared_target)
 
     steps: list = []
-    with patch("api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)):
+    with patch("api.code_sync._get_deploy_base", return_value=tmp_path):
         _run(_ensure_autobot_shared_symlink(component, steps))
 
     assert link_path.is_symlink()
@@ -172,19 +223,19 @@ def test_skipped_for_non_backend_component(tmp_path) -> None:
     from unittest.mock import patch
 
     steps: list = []
-    with patch("api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)):
+    with patch("api.code_sync._get_deploy_base", return_value=tmp_path):
         _run(_ensure_autobot_shared_symlink("autobot-slm-frontend", steps))
     assert steps == []
 
 
 def test_skipped_when_shared_target_missing(tmp_path) -> None:
-    """If /opt/autobot/autobot_shared doesn't exist, helper skips gracefully."""
+    """If <base>/autobot_shared doesn't exist, helper skips gracefully."""
     from unittest.mock import patch
 
     component = "autobot-backend"
     (tmp_path / component).mkdir()
     steps: list = []
-    with patch("api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)):
+    with patch("api.code_sync._get_deploy_base", return_value=tmp_path):
         _run(_ensure_autobot_shared_symlink(component, steps))
     assert any("not found" in s for s in steps)
 
@@ -209,7 +260,7 @@ def test_pip_backend_emits_symlink_step(tmp_path) -> None:
             steps.append(f"symlink-called:{comp}")
 
         with (
-            patch("api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)),
+            patch("api.code_sync._get_deploy_base", return_value=tmp_path),
             patch("api.code_sync._ensure_autobot_shared_symlink", side_effect=_fake_ensure),
             patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
             patch("api.code_sync._install_pip_deps_for_component", AsyncMock()),
@@ -238,7 +289,7 @@ def test_autobot_shared_component_restores_both_backends(tmp_path) -> None:
         called_for.append(component)
 
     with (
-        patch("api.code_sync._AUTOBOT_DEPLOY_BASE", str(tmp_path)),
+        patch("api.code_sync._get_deploy_base", return_value=tmp_path),
         patch("api.code_sync._ensure_autobot_shared_symlink", side_effect=_fake_ensure),
         patch("api.code_sync._restart_component_services", AsyncMock()),
         patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),


### PR DESCRIPTION
## Thinking Path

1. Examined `_AUTOBOT_DEPLOY_BASE = "/opt/autobot"` in `code_sync.py` — a module-level string that breaks non-standard installs (e.g. `AUTOBOT_BASE_DIR=/srv/autobot`).
2. Identified `autobot_shared.ssot_config.get_config().path.base_dir` (`PathConfig`, alias `AUTOBOT_BASE_DIR`, default `/opt/autobot`) as the canonical accessor — already used by `llm_config.py` in the SLM backend.
3. Replaced the module-level constant with `_get_deploy_base()` (called at invocation time) so tests can monkeypatch the env var without patching a module attribute; also safe at bootstrap because ssot_config import is deferred.
4. For Ansible, inspected `roles/slm_manager/defaults/main.yml` — `slm_shared_dir = {{ slm_base_dir }}/autobot_shared` and `slm_backend_dir = {{ slm_base_dir }}/autobot-slm-backend` are already defined; added the same 3-step stat/remove-real-dir/create-symlink pattern from the main backend role (#10020), using those vars so `slm_base_dir` governs the path.

## What Changed

**`autobot-slm-backend/api/code_sync.py`**
- Removed `_AUTOBOT_DEPLOY_BASE = "/opt/autobot"` module-level constant.
- Added `_get_deploy_base() -> Path` which reads `get_config().path.base_dir` (PathConfig / AUTOBOT_BASE_DIR env var), falling back to `os.environ.get("AUTOBOT_BASE_DIR", "/opt/autobot")` if ssot_config is unavailable at bootstrap.
- `_ensure_autobot_shared_symlink()` now calls `_get_deploy_base()` instead of `Path(_AUTOBOT_DEPLOY_BASE)`.
- Other hardcoded `/opt/autobot` literals in the file (rsync targets, pip paths) are out of scope for this PR and remain unchanged; they can be addressed in a follow-up.

**`autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py`**
- Updated all tests to patch `api.code_sync._get_deploy_base` (returning `tmp_path`) instead of the now-removed `_AUTOBOT_DEPLOY_BASE` string.
- Added `test_get_deploy_base_honours_env_var` — confirms `AUTOBOT_BASE_DIR` env var is respected when ssot_config is unavailable.
- Added `test_symlink_created_under_non_default_base` — proves symlinks are created under an arbitrary base (e.g. `tmp_path/srv/autobot`), not `/opt/autobot`.
- Exported `_get_deploy_base` from the import list.

**`autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml`**
- Added 3-step symlink task block immediately after `SLM | Sync autobot_shared to SLM server`:
  1. Stat `{{ slm_backend_dir }}/autobot_shared`
  2. Remove if it is a real directory (not a symlink)
  3. `ansible.builtin.file state: link force: true` pointing `{{ slm_backend_dir }}/autobot_shared` → `{{ slm_shared_dir }}` with `owner: {{ slm_user }} group: {{ slm_group }}`
- All variables (`slm_backend_dir`, `slm_shared_dir`, `slm_user`, `slm_group`) are defined in `roles/slm_manager/defaults/main.yml` and derive from `slm_base_dir` — no hardcoded paths.

## Verification

- `ruff check autobot-slm-backend/api/code_sync.py` — 0 new errors (1 pre-existing E402 on line ~2463 unchanged).
- `pytest tests/api/test_code_sync_symlink_restore.py -v` — **11/11 passed** (9 existing + 2 new).
- `ansible-playbook --syntax-check playbooks/deploy-slm-manager.yml` — passes (warnings: empty hosts list only, no errors).
- YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`.
- Zero commit trailers — both commits confirmed clean.

Closes #10912. Related: #10920.

## Model Used

claude-sonnet-4-6