### PR TITLE
fix(concurrency): guard remaining lazy singletons + monitoring WS connect/disconnect race (#10916, #10924)

### DIFF
--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -307,27 +307,40 @@ class MonitoringWebSocketManager:
         self.active_connections: List[WebSocket] = []
         self.update_task: asyncio.Task | None = None
         self.update_interval = 2.0  # Send updates every 2 seconds
+        # Issue #10924: asyncio.Lock serialises the append+check+create_task
+        # sequence so two concurrent connects cannot both see len==1 and each
+        # spawn a duplicate update task.  disconnect() uses the same lock for
+        # the remove+check+cancel sequence to avoid a TOCTOU there too.
+        self._connect_lock = asyncio.Lock()
 
     async def connect(self, websocket: WebSocket):
         """Accept WebSocket connection and start periodic update task if first."""
         await websocket.accept()
-        self.active_connections.append(websocket)
-        logger.info(f"WebSocket connected. Active connections: {len(self.active_connections)}")
+        async with self._connect_lock:
+            self.active_connections.append(websocket)
+            logger.info(
+                "WebSocket connected. Active connections: %d",
+                len(self.active_connections),
+            )
+            # Start update task if this is the first connection.
+            # Guarded inside the lock so two concurrent connects cannot both
+            # observe len==1 and each call create_task().
+            if len(self.active_connections) == 1 and not self.update_task:
+                self.update_task = asyncio.create_task(self._send_periodic_updates())
 
-        # Start update task if this is the first connection
-        if len(self.active_connections) == 1 and not self.update_task:
-            self.update_task = asyncio.create_task(self._send_periodic_updates())
-
-    def disconnect(self, websocket: WebSocket):
+    async def disconnect(self, websocket: WebSocket):
         """Remove WebSocket connection and cancel update task if last."""
-        if websocket in self.active_connections:
-            self.active_connections.remove(websocket)
-        logger.info(f"WebSocket disconnected. Active connections: {len(self.active_connections)}")
-
-        # Stop update task if no connections
-        if len(self.active_connections) == 0 and self.update_task:
-            self.update_task.cancel()
-            self.update_task = None
+        async with self._connect_lock:
+            if websocket in self.active_connections:
+                self.active_connections.remove(websocket)
+            logger.info(
+                "WebSocket disconnected. Active connections: %d",
+                len(self.active_connections),
+            )
+            # Stop update task if no connections remain.
+            if len(self.active_connections) == 0 and self.update_task:
+                self.update_task.cancel()
+                self.update_task = None
 
     async def broadcast_update(self, data: Metadata):
         """Broadcast update to all connected clients"""
@@ -344,9 +357,9 @@ class MonitoringWebSocketManager:
                 logger.warning("Failed to send WebSocket message: %s", e)
                 disconnected.append(connection)
 
-        # Remove disconnected connections
+        # Remove disconnected connections (disconnect is now async — Issue #10924)
         for connection in disconnected:
-            self.disconnect(connection)
+            await self.disconnect(connection)
 
     async def _send_periodic_updates(self):
         """Send periodic performance updates to connected clients"""
@@ -1133,10 +1146,10 @@ async def realtime_monitoring_websocket(websocket: WebSocket):
                 logger.debug("Invalid JSON in monitoring WebSocket: %s", e)
 
     except WebSocketDisconnect:
-        ws_manager.disconnect(websocket)
+        await ws_manager.disconnect(websocket)
     except Exception as e:
         logger.error("WebSocket error: %s", e)
-        ws_manager.disconnect(websocket)
+        await ws_manager.disconnect(websocket)
 
 
 # Helper functions

--- a/autobot-backend/llm_shared/optimization/flash_attention.py
+++ b/autobot-backend/llm_shared/optimization/flash_attention.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Tuple
 
+import threading
+
 from autobot_shared.logging_manager import get_logger
 
 if TYPE_CHECKING:
@@ -30,16 +32,21 @@ logger = get_logger(__name__)
 
 # Issue #3009: Lazy-load torch on first use so importing this module does not
 # require torch to be installed (NPU/GPU subsystem is feature-flagged).
+# Issue #10916: double-checked lock prevents two threads from both racing past
+# the None check and importing torch concurrently.
 _torch: Any = None
+_torch_lock = threading.Lock()
 
 
 def _get_torch() -> Any:
-    """Return the torch module, importing it on first call."""
+    """Return the torch module, importing it on first call (thread-safe)."""
     global _torch  # noqa: PLW0603
     if _torch is None:
-        import torch
+        with _torch_lock:
+            if _torch is None:
+                import torch
 
-        _torch = torch
+                _torch = torch
     return _torch
 
 
@@ -190,14 +197,19 @@ def _build_repeat_kv_fn():
 
 # Issue #3009: repeat_kv is built lazily on first use so that importing this
 # module does not trigger a torch import at startup.
+# Issue #10916: double-checked lock prevents concurrent threads from each
+# calling _build_repeat_kv_fn() and compiling the JIT function multiple times.
 _repeat_kv_fn = None
+_repeat_kv_fn_lock = threading.Lock()
 
 
 def repeat_kv(kv: Any, n_rep: int) -> Any:
     """Expand KV heads for GQA — thin wrapper around the JIT-compiled version."""
     global _repeat_kv_fn  # noqa: PLW0603
     if _repeat_kv_fn is None:
-        _repeat_kv_fn = _build_repeat_kv_fn()
+        with _repeat_kv_fn_lock:
+            if _repeat_kv_fn is None:
+                _repeat_kv_fn = _build_repeat_kv_fn()
     return _repeat_kv_fn(kv, n_rep)
 
 

--- a/autobot-backend/llm_shared/optimization/flash_attention.py
+++ b/autobot-backend/llm_shared/optimization/flash_attention.py
@@ -17,11 +17,10 @@ Issue #1955: Flash Attention v2 with variable-length sequence optimization.
 # so torch types in dataclass fields / function signatures are strings at runtime.
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Tuple
-
-import threading
 
 from autobot_shared.logging_manager import get_logger
 

--- a/autobot-backend/llm_shared/optimization/ssm_kernels.py
+++ b/autobot-backend/llm_shared/optimization/ssm_kernels.py
@@ -30,6 +30,7 @@ Issue #10724: real SSM/linear/hybrid kernels replacing NOT_APPLICABLE stubs.
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, List
@@ -38,20 +39,25 @@ from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
 
+# Issue #10916: double-checked lock prevents two threads from racing past the
+# None check and importing torch concurrently.
 _torch: Any = None
+_torch_lock = threading.Lock()
 
 
 def _get_torch() -> Any:
-    """Return the torch module, importing it lazily on first use."""
+    """Return the torch module, importing it lazily on first use (thread-safe)."""
     global _torch  # noqa: PLW0603
     if _torch is None:
-        try:
-            import torch  # noqa: PLC0415
-        except ImportError as exc:  # pragma: no cover - env-dependent
-            raise ImportError(
-                "torch is required for SSM/linear/hybrid kernels. Install with: pip install torch>=2.0.0"
-            ) from exc
-        _torch = torch
+        with _torch_lock:
+            if _torch is None:
+                try:
+                    import torch  # noqa: PLC0415
+                except ImportError as exc:  # pragma: no cover - env-dependent
+                    raise ImportError(
+                        "torch is required for SSM/linear/hybrid kernels. Install with: pip install torch>=2.0.0"
+                    ) from exc
+                _torch = torch
     return _torch
 
 

--- a/autobot-backend/media/audio/ffmpeg_service.py
+++ b/autobot-backend/media/audio/ffmpeg_service.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Optional
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 
 logger = get_logger(__name__)
 
@@ -215,17 +216,15 @@ class FFmpegService:
             raise RuntimeError(f"Failed to get audio duration: {exc}")
 
 
-# Singleton instance
-_ffmpeg_service: Optional[FFmpegService] = None
+# Issue #10916: lazy_singleton provides double-checked locking so concurrent
+# callers cannot each create a separate FFmpegService instance.
+_get_ffmpeg_service_singleton = lazy_singleton(FFmpegService)
 
 
 def get_ffmpeg_service() -> FFmpegService:
-    """Get or create FFmpeg service singleton.
+    """Get or create FFmpeg service singleton (thread-safe).
 
     Returns:
         FFmpegService instance
     """
-    global _ffmpeg_service
-    if _ffmpeg_service is None:
-        _ffmpeg_service = FFmpegService()
-    return _ffmpeg_service
+    return _get_ffmpeg_service_singleton()

--- a/autobot-backend/media/audio/pipeline.py
+++ b/autobot-backend/media/audio/pipeline.py
@@ -13,6 +13,7 @@ import asyncio
 import base64
 import os
 import tempfile
+import threading
 from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
@@ -30,25 +31,33 @@ except ImportError:
 
 logger = get_logger(__name__)
 
-# Lazy singleton for the Whisper pipeline (expensive to load)
+# Lazy singleton for the Whisper pipeline (expensive to load).
+# Issue #10916: _whisper_pipeline_lock prevents two threads from both finding
+# _whisper_pipeline is None and each calling hf_pipeline() concurrently.
+# _WHISPER_LOADED sentinel distinguishes "not yet tried" from "tried but None".
 _whisper_pipeline: Any | None = None
+_whisper_pipeline_lock = threading.Lock()
+_WHISPER_LOADED = False
 _WHISPER_MODEL = "openai/whisper-base"
 
 
 def _get_whisper_pipeline() -> Any | None:
-    """Lazy-load Whisper pipeline; returns None if unavailable."""
-    global _whisper_pipeline
+    """Lazy-load Whisper pipeline; returns None if unavailable (thread-safe)."""
+    global _whisper_pipeline, _WHISPER_LOADED  # noqa: PLW0603
     if not _TRANSFORMERS_AVAILABLE:
         return None
-    if _whisper_pipeline is None:
-        try:
-            _whisper_pipeline = hf_pipeline(
-                "automatic-speech-recognition",
-                model=_WHISPER_MODEL,
-            )
-            logger.info("Whisper pipeline loaded: %s", _WHISPER_MODEL)
-        except Exception as exc:
-            logger.warning("Failed to load Whisper pipeline: %s", exc)
+    if not _WHISPER_LOADED:
+        with _whisper_pipeline_lock:
+            if not _WHISPER_LOADED:
+                try:
+                    _whisper_pipeline = hf_pipeline(
+                        "automatic-speech-recognition",
+                        model=_WHISPER_MODEL,
+                    )
+                    logger.info("Whisper pipeline loaded: %s", _WHISPER_MODEL)
+                except Exception as exc:
+                    logger.warning("Failed to load Whisper pipeline: %s", exc)
+                _WHISPER_LOADED = True
     return _whisper_pipeline
 
 

--- a/autobot-backend/media/manager.py
+++ b/autobot-backend/media/manager.py
@@ -11,6 +11,7 @@
 from typing import Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from media.audio.pipeline import AudioPipeline
 from media.core.pipeline import MediaPipeline
 from media.core.types import MediaInput, MediaType, ProcessingResult
@@ -130,8 +131,9 @@ class MediaPipelineManager:
         logger.info("All pipeline metrics reset")
 
 
-# Singleton instance for global access
-_manager_instance: MediaPipelineManager | None = None
+# Issue #10916: lazy_singleton provides double-checked locking so concurrent
+# callers cannot each create a separate MediaPipelineManager instance.
+_get_media_pipeline_manager_singleton = lazy_singleton(MediaPipelineManager)
 
 
 def get_media_pipeline_manager() -> MediaPipelineManager:
@@ -141,7 +143,4 @@ def get_media_pipeline_manager() -> MediaPipelineManager:
     Returns:
         MediaPipelineManager singleton
     """
-    global _manager_instance
-    if _manager_instance is None:
-        _manager_instance = MediaPipelineManager()
-    return _manager_instance
+    return _get_media_pipeline_manager_singleton()

--- a/autobot-backend/orchestration/subagent_dispatcher.py
+++ b/autobot-backend/orchestration/subagent_dispatcher.py
@@ -10,10 +10,9 @@ orchestration.subagent_dispatcher (issue #10666 B3).
 
 import asyncio
 import json
+import threading
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List
-
-import threading
 
 from autobot_shared.logging_manager import get_logger
 from orchestration.primitives import bounded_gather

--- a/autobot-backend/orchestration/subagent_dispatcher.py
+++ b/autobot-backend/orchestration/subagent_dispatcher.py
@@ -13,6 +13,8 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List
 
+import threading
+
 from autobot_shared.logging_manager import get_logger
 from orchestration.primitives import bounded_gather
 
@@ -230,12 +232,17 @@ class SubagentDispatcher:
             return result_text
 
 
+# Issue #10916: _orchestrator_lock + double-checked pattern prevents two
+# threads from each constructing a SubagentDispatcher concurrently.
 _orchestrator_instance: SubagentDispatcher | None = None
+_orchestrator_lock = threading.Lock()
 
 
 def get_subagent_dispatcher(max_parallel: int = 10) -> SubagentDispatcher:
-    """Get or create global dispatcher instance."""
-    global _orchestrator_instance
+    """Get or create global dispatcher instance (thread-safe)."""
+    global _orchestrator_instance  # noqa: PLW0603
     if _orchestrator_instance is None:
-        _orchestrator_instance = SubagentDispatcher(max_parallel=max_parallel)
+        with _orchestrator_lock:
+            if _orchestrator_instance is None:
+                _orchestrator_instance = SubagentDispatcher(max_parallel=max_parallel)
     return _orchestrator_instance

--- a/autobot-backend/plugin_manager.py
+++ b/autobot-backend/plugin_manager.py
@@ -11,6 +11,7 @@ Issue #730 - Plugin SDK for extensible tool architecture.
 """
 
 import json
+import threading
 from pathlib import Path
 from typing import Dict, List
 
@@ -35,24 +36,29 @@ logger = get_logger(__name__)
 
 router = APIRouter()
 
-# Global plugin loader instance
+# Global plugin loader instance.
+# Issue #10916: _plugin_loader_lock + double-checked pattern prevents two
+# threads from each constructing a PluginLoader (which scans the filesystem).
 _plugin_loader: PluginLoader | None = None
+_plugin_loader_lock = threading.Lock()
 
 
 def get_plugin_loader() -> PluginLoader:
-    """Get or create plugin loader instance."""
-    global _plugin_loader
+    """Get or create plugin loader instance (thread-safe)."""
+    global _plugin_loader  # noqa: PLW0603
     if _plugin_loader is None:
-        # Define plugin directories using SSOT config (#3397)
-        plugins_root = config.path.plugins_path
-        plugin_dirs = [
-            plugins_root / "core-plugins",
-            plugins_root / "community-plugins",
-            # Development fallback
-            Path("plugins/core-plugins"),
-            Path("plugins/community-plugins"),
-        ]
-        _plugin_loader = PluginLoader(plugin_dirs)
+        with _plugin_loader_lock:
+            if _plugin_loader is None:
+                # Define plugin directories using SSOT config (#3397)
+                plugins_root = config.path.plugins_path
+                plugin_dirs = [
+                    plugins_root / "core-plugins",
+                    plugins_root / "community-plugins",
+                    # Development fallback
+                    Path("plugins/core-plugins"),
+                    Path("plugins/community-plugins"),
+                ]
+                _plugin_loader = PluginLoader(plugin_dirs)
     return _plugin_loader
 
 


### PR DESCRIPTION
Closes #10916, #10924.

## Thinking Path
Follow-ons from the #10783 sweep — apply the now-established concurrency patterns to the remaining unprotected sites.

## What Changed
**#10916 — lazy singletons** (verified each; `utils/io_executor.py` was already safe → skipped):
- `flash_attention.py` (_torch, _repeat_kv_fn), `ssm_kernels.py` (_torch): double-checked `threading.Lock`.
- `media/manager.py`, `media/audio/ffmpeg_service.py`: `lazy_singleton()`.
- `media/audio/pipeline.py` (_whisper_pipeline): threading.Lock + loaded-sentinel (preserves the !TRANSFORMERS_AVAILABLE early-return that must NOT cache).
- `orchestration/subagent_dispatcher.py`, `plugin_manager.py`: inline double-checked `threading.Lock` (tests reset the global / factory needs config args, so lazy_singleton() wasn't a fit).

**#10924 — MonitoringWebSocketManager connect/disconnect race** (`api/monitoring.py`):
- Added `self._connect_lock = asyncio.Lock()`. `connect()` accepts the socket BEFORE the lock (accept must not block under lock), then guards append + `len==1` check + `create_task()`. `disconnect()` made async and guards remove + `len==0` + task cancel. Updated all callers (broadcast_update loop + route handler except-blocks) to `await`.

## Verification
- `py_compile` + `flake8 -F` clean (9 files).
- `test_concurrency_global_locks.py` 6/6; `test_subagent_dispatcher_reflection` singleton tests 2/2.
- Confirmed all 3 `disconnect()` callers in monitoring.py are awaited (analytics_quality's manager is a distinct class, unaffected).

## Model Used
Opus 4.8

Closes #10916, #10924. Part of #10783 follow-up.