### PR TITLE
fix(claude-adapter): pass path not dict to GracefulDegradationManager so autobot_claude_adapter initializes (#10930)

### DIFF
--- a/autobot-backend/tests/test_claude_api_batch_manager_init.py
+++ b/autobot-backend/tests/test_claude_api_batch_manager_init.py
@@ -1,0 +1,42 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Regression test for #10930: GracefulDegradationManager was called with {} instead of
+a str/PathLike cache_dir, causing Path({}) to raise TypeError on every startup.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from utils.claude_api_integration import ClaudeAPIBatchManager, ClaudeAPIConfig
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        None,
+        ClaudeAPIConfig(enable_graceful_degradation=True),
+        ClaudeAPIConfig(enable_graceful_degradation=False),
+    ],
+    ids=["default_config", "degradation_on", "degradation_off"],
+)
+def test_batch_manager_init_does_not_raise(config, tmp_path):
+    """ClaudeAPIBatchManager.__init__ must not raise TypeError for any ClaudeAPIConfig.
+
+    Regression: GracefulDegradationManager({}) caused Path(dict) TypeError (#10930).
+    The empty-dict argument has been removed; the manager now uses the default cache_dir.
+    We patch mkdir so no real directories are created during testing.
+    """
+    with patch("utils.graceful_degradation.Path.mkdir"):
+        manager = ClaudeAPIBatchManager(config)
+
+    # If degradation is enabled, the manager should be a GracefulDegradationManager instance
+    if config is None or getattr(config, "enable_graceful_degradation", True):
+        from utils.graceful_degradation import GracefulDegradationManager
+
+        assert isinstance(manager.degradation_manager, GracefulDegradationManager)
+    else:
+        assert manager.degradation_manager is None

--- a/autobot-backend/utils/claude_api_integration.py
+++ b/autobot-backend/utils/claude_api_integration.py
@@ -129,7 +129,7 @@ class ClaudeAPIBatchManager:
         self.payload_optimizer = PayloadOptimizer() if self.config.enable_payload_optimization else None
 
         # Optional components (folded from suite, #10796)
-        self.degradation_manager = GracefulDegradationManager({}) if self.config.enable_graceful_degradation else None
+        self.degradation_manager = GracefulDegradationManager() if self.config.enable_graceful_degradation else None
         self.todowrite_optimizer = (
             get_todowrite_optimizer(
                 {


### PR DESCRIPTION
## Thinking Path

1. Read the error message: `argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'dict'` — immediately points to `Path(some_dict)`.
2. Traced `_initialize_impl` → `create_claude_api_manager` → `ClaudeAPIBatchManager.__init__`.
3. Found line 132: `GracefulDegradationManager({})` — the `{}` is the dict.
4. Checked `GracefulDegradationManager.__init__` signature: `def __init__(self, cache_dir: str = "data/cache/claude_responses")`. The dict is passed positionally as `cache_dir`.
5. `CachedResponseStrategy(cache_dir)` inherits that dict and calls `Path(cache_dir)` → TypeError.
6. Fix: remove the `{}` argument; the default string is correct.

## What Changed

**`autobot-backend/utils/claude_api_integration.py` line 132:**

```python
# Before (broken)
self.degradation_manager = GracefulDegradationManager({}) if ...

# After (fixed)
self.degradation_manager = GracefulDegradationManager() if ...
```

**`autobot-backend/tests/test_claude_api_batch_manager_init.py` (new):**
Parametrised regression test covering `default_config`, `degradation_on`, and `degradation_off` — all three pass without TypeError.

## Verification

```
tests/test_claude_api_batch_manager_init.py::test_batch_manager_init_does_not_raise[default_config] PASSED
tests/test_claude_api_batch_manager_init.py::test_batch_manager_init_does_not_raise[degradation_on]  PASSED
tests/test_claude_api_batch_manager_init.py::test_batch_manager_init_does_not_raise[degradation_off] PASSED

3 passed in 0.44s
```

`ruff check utils/claude_api_integration.py utils/graceful_degradation.py` → `All checks passed!`

No other behaviour changed: the manager still initialises `CachedResponseStrategy` with the default `"data/cache/claude_responses"` cache directory.

Closes #10930

## Model Used

claude-sonnet-4-6