### PR TITLE
ci(types): required generated-types freshness gate (#10817)

### DIFF
--- a/.github/workflows/verify-generated-types.yml
+++ b/.github/workflows/verify-generated-types.yml
@@ -1,0 +1,102 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generated Types Freshness Gate (GH#10817)
+# autobot-frontend/src/types/generated/api.ts is generated from the backend
+# OpenAPI schema (`npm run gen:types`). Nothing gated its freshness, so it
+# silently drifted: #10746 hand-found 12 dead Enhanced* schemas and #10776
+# cleaned dead aliases, both because a stale api.ts still type-checks.
+#
+# This job regenerates api.ts from the authoritative backend schema
+# (app.openapi(), same recipe as the API wiring audit) using the pinned
+# openapi-typescript, then `git diff --exit-code`. If it drifts, the diff is
+# non-empty and this gate goes red — run `npm run gen:types` against a running
+# backend and commit the result.
+#
+# Runs on GitHub-hosted ubuntu-latest (not the self-hosted runner) so it adds
+# no load to the single self-hosted runner.
+
+name: Verify Generated Types
+
+on:
+  push:
+    branches: [ main, Dev_new_gui ]
+    paths: &paths
+      - 'autobot-backend/**/*.py'
+      - 'autobot-frontend/src/types/generated/api.ts'
+      - 'autobot-frontend/package.json'
+      - 'autobot-frontend/package-lock.json'
+      - 'scripts/audit_api_wiring.py'
+      - 'requirements*.txt'
+      - '.github/workflows/verify-generated-types.yml'
+  pull_request:
+    branches: [ main, Dev_new_gui ]
+    paths: *paths
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify-generated-types:
+    name: verify-generated-types
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements*.txt
+            autobot-backend/requirements*.txt
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r requirements-ci.txt --prefer-binary
+
+      - name: Dump authoritative OpenAPI schema
+        run: |
+          set -o pipefail
+          export PYTHONPATH="$PWD:$PWD/autobot-backend:${PYTHONPATH:-}"
+          mkdir -p data logs static config
+          if ! python scripts/audit_api_wiring.py --dump-openapi openapi.raw.json; then
+            echo "::error::Backend app.openapi() build failed — cannot verify generated types."
+            echo "This usually means the backend does not import cleanly in CI (see startup-import-smoke)."
+            exit 1
+          fi
+          # Strip the audit-only x-websocket-paths extension so the schema matches
+          # exactly what the live server serves to `npm run gen:types`.
+          python -c "import json; s=json.load(open('openapi.raw.json')); s.pop('x-websocket-paths', None); json.dump(s, open('openapi.json','w'))"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: autobot-frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: autobot-frontend
+        run: npm ci
+
+      - name: Regenerate api.ts from authoritative schema
+        working-directory: autobot-frontend
+        run: npx --no-install openapi-typescript ../openapi.json -o src/types/generated/api.ts --additional-properties
+
+      - name: Fail if generated types drifted
+        run: |
+          if ! git diff --exit-code autobot-frontend/src/types/generated/api.ts; then
+            echo "::error::autobot-frontend/src/types/generated/api.ts is stale."
+            echo "The backend OpenAPI schema changed but the committed generated types were not updated."
+            echo "Fix: run 'npm run gen:types' against a running backend and commit src/types/generated/api.ts."
+            exit 1
+          fi
+          echo "Generated types are fresh."


### PR DESCRIPTION
## Thinking Path
`autobot-frontend/src/types/generated/api.ts` is generated from the backend OpenAPI schema (`npm run gen:types`), but nothing gated its freshness. The only existing `verify:types` step (in the required "Unit & Integration Tests" job) runs `git diff --exit-code` on a **clean checkout without regenerating**, so it can never detect drift — a stale `api.ts` still type-checks. That invisible drift is why #10746 had to hand-find 12 dead `Enhanced*` schemas and #10776 had to clean dead aliases.

`vue-tsc` (issue option 2) can't catch this either: a stale `api.ts` compiles fine. The only reliable detection is to **regenerate from the current backend schema and diff** (issue option 1).

## What Changed
New workflow `verify-generated-types.yml` (job `verify-generated-types`):
1. Dumps the authoritative backend schema via `scripts/audit_api_wiring.py --dump-openapi` (`app.openapi()` — same proven recipe as the API-wiring audit; fails loudly if the app can't build).
2. Strips the audit-only `x-websocket-paths` root extension so the schema exactly matches what the live server serves to `gen:types`.
3. Regenerates `api.ts` with the **pinned** `openapi-typescript` (`npm ci` + `npx --no-install`, not latest) so formatting can't cause false drift.
4. `git diff --exit-code` → red if stale, with a fix hint (`npm run gen:types` + commit).

Runs on **GitHub-hosted ubuntu-latest**, so it adds **no load to the single self-hosted runner**.

## Verification
- YAML validated (`yaml.safe_load`).
- No untrusted input in any `run:` (no injection surface).
- The `verify-generated-types` job runs on this PR (touches the workflow + backend/frontend paths); a green run here proves the gate passes against current `main`/`Dev_new_gui`. Once green, the check is promoted to **required** on `Dev_new_gui` (the remaining half of #10817).
- If this job reds, it means `api.ts` is *currently* drifted — the fix is to commit the regenerated file (the gate working as intended).

## Model Used
Claude Opus 4.8 (1M context)

Refs #10817 (closed once the check is promoted to required)