### PR TITLE
fix(celery): register unregistered beat tasks (credential/snapshot/mobile/transcriber) (#10934)

### DIFF
--- a/autobot-backend/tasks/__init__.py
+++ b/autobot-backend/tasks/__init__.py
@@ -22,6 +22,7 @@ from .analytics_tasks import (
 )
 from .audit_log_retention import cleanup_expired_audit_logs
 from .chat_retention import cleanup_expired_chats
+from .credential_reconcile import reconcile_credentials
 from .file_retention import cleanup_expired_files
 from .knowledge_retention import cleanup_expired_kb_entries
 from .knowledge_tasks import (
@@ -39,7 +40,10 @@ from .memory_tasks import (
     update_graph_task,
     write_verbatim_task,
 )
+from .mobile_device_tasks import cleanup_stale_mobile_devices
+from .snapshot_cleanup import cleanup_expired_snapshots
 from .system_tasks import check_available_updates, initialize_rbac, run_system_update
+from .transcriber_tasks import transcribe_recording
 from .workspace_cleanup import cleanup_stale_workspaces
 
 __all__ = [
@@ -75,4 +79,11 @@ __all__ = [
     "cleanup_expired_files",
     "cleanup_expired_audit_logs",
     "cleanup_expired_kb_entries",
+    # Previously unregistered: worker never imported these modules, so their
+    # @celery_app.task decorators never ran and beat-scheduled runs raised
+    # "Received unregistered task of type ...".
+    "reconcile_credentials",
+    "cleanup_expired_snapshots",
+    "cleanup_stale_mobile_devices",
+    "transcribe_recording",
 ]


### PR DESCRIPTION
## Thinking Path
Error-hunt loop iter 3: celery-error.log dominated by `Received unregistered task of type 'tasks.reconcile_credentials'` (127×) + snapshot/mobile variants — beat schedules them but the worker never registers them, so credential-reconcile, snapshot-cleanup and mobile-device-cleanup periodic jobs never run.

## What Changed
- `tasks/__init__.py`: import `credential_reconcile`, `snapshot_cleanup`, `mobile_device_tasks`, `transcriber_tasks` (+ `__all__`). Celery autodiscover imports the package `__init__`, so a task registers only when its module is imported here; these four were missing.

## Verification
- `py_compile` OK; all 4 task fns confirmed present; imports alphabetical (isort-clean); all 4 modules import cleanly against the live venv.
- `startup-import-smoke` CI exercises the import.

## Model Used
Opus 4.8 (1M context)

Closes #10934. Note: `tasks.reconcile_unified_credentials` (old pre-#10746 name, 26× errors) is a stale persisted celerybeat-schedule entry — clear the beat DB at deploy to stop it.