### PR TITLE
refactor(types): consolidate duplicate ArchitectureFamily enum to one canonical (#10892)

### DIFF
--- a/autobot-backend/llm_shared/model_param_registry.py
+++ b/autobot-backend/llm_shared/model_param_registry.py
@@ -28,13 +28,15 @@ Moved from llm_providers/ as part of Phase 2 consolidation (MVA-178 / GH#7637).
 
 from __future__ import annotations
 
-from enum import Enum
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
+
+# Canonical architecture-family enum (#10892 — single source of truth).
+from .types import ArchitectureFamily
 
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
@@ -58,22 +60,13 @@ _FALLBACK_KWARGS: Dict[str, Any] = {
 # ---------------------------------------------------------------------------
 # Architecture family
 # ---------------------------------------------------------------------------
-
-
-class ArchitectureFamily(str, Enum):
-    """Model architecture families (GH#7347).
-
-    Used by NPU dispatch and tiered routing to select the correct inference
-    backend.  New families can be added here without any code change — just
-    add the value to the YAML entry for the model.
-    """
-
-    TRANSFORMER = "transformer"
-    SSM = "ssm"
-    LINEAR_ATTENTION = "linear_attention"
-    HYBRID = "hybrid"
-    MOE = "moe"
-
+#
+# ``ArchitectureFamily`` is imported from ``llm_shared.types`` (#10892 — the
+# single canonical definition).  It is re-exported below so existing
+# ``from llm_shared.model_param_registry import ArchitectureFamily`` importers
+# keep working.  NPU dispatch and tiered routing select the inference backend
+# from the model's ``architecture_family`` string value; new families can be
+# added to the enum + the YAML entry with no other code change.
 
 # model_type strings found in HuggingFace config.json → ArchitectureFamily
 _MODEL_TYPE_MAP: Dict[str, str] = {

--- a/autobot-backend/llm_shared/optimization/attention_backend.py
+++ b/autobot-backend/llm_shared/optimization/attention_backend.py
@@ -156,9 +156,13 @@ class ModelConfig:
 # register a new family — select_backend() needs no modification.
 ARCH_DISPATCH_TABLE: dict[ArchitectureFamily, str] = {
     ArchitectureFamily.TRANSFORMER: "_handle_transformer",
+    # State-space family has two live serialized spellings (#10892); both route
+    # to the SSM selective-scan handler.
     ArchitectureFamily.STATE_SPACE: "_handle_ssm",
+    ArchitectureFamily.SSM: "_handle_ssm",
     ArchitectureFamily.LINEAR_ATTENTION: "_handle_linear_attention",
     ArchitectureFamily.HYBRID: "_handle_hybrid",
+    ArchitectureFamily.MOE: "_handle_transformer",
 }
 
 

--- a/autobot-backend/llm_shared/types.py
+++ b/autobot-backend/llm_shared/types.py
@@ -12,15 +12,30 @@ from enum import Enum
 
 
 class ArchitectureFamily(str, Enum):
-    """Model architecture family — governs attention backend and context window policy.
+    """Model architecture family — governs attention backend, NPU dispatch, and
+    context-window policy.
+
+    Single canonical source of truth (#10892): previously duplicated as a
+    separate enum in ``model_param_registry`` with a divergent member name
+    (``SSM``).  Both classes are now this one.
 
     Issue #7347: positive family signal replacing substring-match heuristics.
+
+    State-space serialized values: the state-space family has two live,
+    persisted ``.value`` spellings across the codebase — ``"state_space"``
+    (attention-backend dispatch + structured logs) and ``"ssm"`` (YAML
+    ``architecture_family`` entries, NPU registry, and tiered long-context
+    routing).  Both are retained as distinct members so value-based matching
+    against either persisted string keeps working; ``STATE_SPACE`` is the
+    canonical descriptive name and both route to the SSM handler.
     """
 
     TRANSFORMER = "transformer"
-    STATE_SPACE = "state_space"  # Mamba / S4 family
+    STATE_SPACE = "state_space"  # Mamba / S4 family — canonical name
+    SSM = "ssm"  # Persisted alias value for state-space (YAML/registry/routing)
     LINEAR_ATTENTION = "linear_attention"
     HYBRID = "hybrid"  # Jamba-style mixed architectures
+    MOE = "moe"  # Mixture-of-Experts (from NPU registry, #10892)
 
 
 class ProviderType(Enum):


### PR DESCRIPTION
## Thinking Path
Two `ArchitectureFamily(str, Enum)` classes modeled the same concept — `types.py` (STATE_SPACE) and `model_param_registry.py` (SSM). Two classes = the actual debt (drift risk, violates canonical-source rule).

## What Changed
- **One canonical class** in `llm_shared/types.py`; `model_param_registry.py` deletes its duplicate and re-exports `from .types import ArchitectureFamily` (both import styles still resolve to the single class — verified `is` identity).
- Merged the registry's extra `MOE` member into the canonical enum.
- **Kept STATE_SPACE="state_space" AND SSM="ssm" as distinct members** — these are two *live serialized value strings* in different subsystems (attention-backend dispatch + structured logs use "state_space"; YAML `architecture_family`, `_MODEL_TYPE_MAP` for mamba/rwkv, and long-context routing use "ssm"). Unifying the *values* would break YAML/routing matching — that's a separate risky data migration (flagged as follow-up). This is a data-contract value-alias, not a Python `SSM = STATE_SPACE` debt-alias. Dispatch routes both to `_handle_ssm`; MOE → transformer path.

## Verification
- `py_compile` + `flake8` clean (3 files).
- Runtime: single class identity across all 3 modules; `.value` strings preserved (state_space/ssm/moe); `_MODEL_TYPE_MAP` + routing frozensets intact; attention_backend_test.py:601 "state_space" assertion still valid.
- Registry/context-window tests identical to base (pre-existing conftest-mock failures unchanged).

## Model Used
Opus 4.8

Closes #10892.