### PR TITLE
fix(knowledge): guard VectorWriteBuffer flush against malformed/empty record sets to stop vector loss (#10941)

### DIFF
--- a/autobot-backend/knowledge/write_buffer.py
+++ b/autobot-backend/knowledge/write_buffer.py
@@ -109,7 +109,19 @@ class VectorWriteBuffer:
         document: str,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Buffer a vector write. If the buffer is full, flush immediately."""
+        """Buffer a vector write. If the buffer is full, flush immediately.
+
+        Issue #10941: Reject entries with empty/None embeddings — they cause
+        IndexError in chroma normalize_insert_record_set and contaminate the
+        entire flush batch, silently dropping all valid vectors alongside them.
+        """
+        if not embedding:
+            logger.warning(
+                "VectorWriteBuffer.write: dropping id=%r — embedding is empty/None "
+                "(embedding generation failed upstream); vector will NOT be stored",
+                id,
+            )
+            return
         async with self._lock:
             self._buffer[id] = BufferedWrite(
                 id=id,
@@ -171,10 +183,32 @@ def make_chromadb_flush_fn(vector_store: Any) -> Callable[[List[BufferedWrite]],
     Uses vector_store.add(nodes) to preserve LlamaIndex internal metadata fields
     (_node_content, _node_type, ref_doc_id) needed for NodeWithScore reconstruction.
     Direct collection.upsert() bypasses these fields — Issue #8401.
+
+    Issue #10941: Filters out entries with empty/None embeddings before calling
+    vector_store.add so a single failed embedding cannot raise IndexError inside
+    chroma normalize_insert_record_set and drop the entire flush batch.
     """
 
     async def _flush(batch: List[BufferedWrite]) -> None:
         from llama_index.core.schema import TextNode
+
+        valid: List[BufferedWrite] = []
+        for e in batch:
+            if e.embedding:
+                valid.append(e)
+            else:
+                logger.warning(
+                    "make_chromadb_flush_fn: skipping id=%r — embedding is empty/None; "
+                    "vector will NOT be stored in ChromaDB",
+                    e.id,
+                )
+
+        if not valid:
+            logger.warning(
+                "make_chromadb_flush_fn: all %d entries had empty embeddings — skipping vector_store.add",
+                len(batch),
+            )
+            return
 
         nodes = [
             TextNode(
@@ -183,7 +217,7 @@ def make_chromadb_flush_fn(vector_store: Any) -> Callable[[List[BufferedWrite]],
                 embedding=e.embedding,
                 metadata=e.metadata,
             )
-            for e in batch
+            for e in valid
         ]
         await asyncio.to_thread(vector_store.add, nodes)
 

--- a/autobot-backend/knowledge/write_buffer_test.py
+++ b/autobot-backend/knowledge/write_buffer_test.py
@@ -19,7 +19,6 @@ import pytest
 
 from knowledge.write_buffer import BufferedWrite, VectorWriteBuffer, make_chromadb_flush_fn
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/autobot-backend/knowledge/write_buffer_test.py
+++ b/autobot-backend/knowledge/write_buffer_test.py
@@ -1,0 +1,210 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for VectorWriteBuffer flush guards — Issue #10941.
+
+Covers:
+  - write() rejects entries with empty embedding at enqueue time
+  - make_chromadb_flush_fn filters empty-embedding entries at flush time
+  - valid entries in a mixed batch are NOT dropped alongside malformed ones
+  - all-empty batch skips vector_store.add entirely
+  - empty batch short-circuits before vector_store.add
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge.write_buffer import BufferedWrite, VectorWriteBuffer, make_chromadb_flush_fn
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+VALID_EMBEDDING = [0.1, 0.2, 0.3]
+
+
+def _make_entry(id_: str, embedding: list) -> BufferedWrite:
+    return BufferedWrite(id=id_, embedding=embedding, document="doc", metadata={})
+
+
+# ---------------------------------------------------------------------------
+# VectorWriteBuffer.write — upstream guard (Issue #10941)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteRejectsEmptyEmbedding:
+    """write() must not enqueue entries with empty or None embeddings."""
+
+    @pytest.mark.asyncio
+    async def test_empty_list_is_rejected(self):
+        flush_fn = AsyncMock()
+        buf = VectorWriteBuffer(flush_fn=flush_fn, flush_size=1)
+        await buf.write(id="bad", embedding=[], document="text")
+        # flush_size=1 means a valid entry would trigger immediate flush;
+        # since nothing was enqueued, flush_fn must NOT be called.
+        flush_fn.assert_not_called()
+        assert buf.pending_count == 0
+
+    @pytest.mark.asyncio
+    async def test_none_embedding_is_rejected(self):
+        flush_fn = AsyncMock()
+        buf = VectorWriteBuffer(flush_fn=flush_fn, flush_size=1)
+        await buf.write(id="bad", embedding=None, document="text")  # type: ignore[arg-type]
+        flush_fn.assert_not_called()
+        assert buf.pending_count == 0
+
+    @pytest.mark.asyncio
+    async def test_valid_embedding_is_accepted(self):
+        flush_fn = AsyncMock()
+        buf = VectorWriteBuffer(flush_fn=flush_fn, flush_size=100)
+        await buf.write(id="good", embedding=VALID_EMBEDDING, document="text")
+        assert buf.pending_count == 1
+
+    @pytest.mark.asyncio
+    async def test_write_count_not_incremented_for_rejected_entry(self):
+        flush_fn = AsyncMock()
+        buf = VectorWriteBuffer(flush_fn=flush_fn)
+        await buf.write(id="bad", embedding=[], document="text")
+        # _write_count is incremented only for accepted entries
+        assert buf._write_count == 0
+
+
+# ---------------------------------------------------------------------------
+# make_chromadb_flush_fn — flush-time guard (Issue #10941)
+# ---------------------------------------------------------------------------
+
+
+class TestMakeChromadbFlushFn:
+    """Defense-in-depth: flush fn filters malformed entries without raising."""
+
+    @pytest.mark.asyncio
+    async def test_empty_embedding_entry_is_skipped(self):
+        """A batch containing one empty-embedding entry must not call vector_store.add."""
+        vector_store = MagicMock()
+        vector_store.add = MagicMock(return_value=[])
+
+        flush_fn = make_chromadb_flush_fn(vector_store)
+        batch = [_make_entry("bad", [])]
+
+        with patch("asyncio.to_thread", new=AsyncMock(side_effect=lambda fn, *a, **kw: fn(*a, **kw))):
+            await flush_fn(batch)
+
+        vector_store.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_none_embedding_entry_is_skipped(self):
+        vector_store = MagicMock()
+        vector_store.add = MagicMock(return_value=[])
+
+        flush_fn = make_chromadb_flush_fn(vector_store)
+        bad = BufferedWrite(id="bad", embedding=None, document="doc", metadata={})  # type: ignore[arg-type]
+
+        with patch("asyncio.to_thread", new=AsyncMock(side_effect=lambda fn, *a, **kw: fn(*a, **kw))):
+            await flush_fn([bad])
+
+        vector_store.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_valid_entries_in_mixed_batch_are_not_dropped(self):
+        """Valid entries must reach vector_store.add even when the batch also contains
+        malformed entries — this is the core data-loss regression guard."""
+        vector_store = MagicMock()
+        captured_nodes: list = []
+
+        def _fake_add(nodes):
+            captured_nodes.extend(nodes)
+            return [n.node_id for n in nodes]
+
+        vector_store.add = _fake_add
+
+        flush_fn = make_chromadb_flush_fn(vector_store)
+        batch = [
+            _make_entry("bad1", []),
+            _make_entry("good1", VALID_EMBEDDING),
+            _make_entry("bad2", None),  # type: ignore[arg-type]
+            _make_entry("good2", [0.4, 0.5, 0.6]),
+        ]
+
+        with patch("asyncio.to_thread", new=AsyncMock(side_effect=lambda fn, *a, **kw: fn(*a, **kw))):
+            await flush_fn(batch)
+
+        node_ids = [n.node_id for n in captured_nodes]
+        assert "good1" in node_ids, "good1 must be stored"
+        assert "good2" in node_ids, "good2 must be stored"
+        assert "bad1" not in node_ids, "bad1 must be skipped"
+        assert "bad2" not in node_ids, "bad2 must be skipped"
+        assert len(captured_nodes) == 2
+
+    @pytest.mark.asyncio
+    async def test_all_valid_batch_passes_through_unchanged(self):
+        """Happy path: an all-valid batch must call vector_store.add with all nodes."""
+        vector_store = MagicMock()
+        captured: list = []
+        vector_store.add = lambda nodes: captured.extend(nodes) or []
+
+        flush_fn = make_chromadb_flush_fn(vector_store)
+        batch = [
+            _make_entry("a", [0.1]),
+            _make_entry("b", [0.2]),
+        ]
+
+        with patch("asyncio.to_thread", new=AsyncMock(side_effect=lambda fn, *a, **kw: fn(*a, **kw))):
+            await flush_fn(batch)
+
+        assert len(captured) == 2
+        assert {n.node_id for n in captured} == {"a", "b"}
+
+    @pytest.mark.asyncio
+    async def test_all_empty_batch_skips_add(self):
+        """An all-malformed batch must skip vector_store.add entirely (no IndexError)."""
+        vector_store = MagicMock()
+        vector_store.add = MagicMock(side_effect=IndexError("list index out of range"))
+
+        flush_fn = make_chromadb_flush_fn(vector_store)
+        batch = [_make_entry("x", []), _make_entry("y", [])]
+
+        # Must not raise, must not call add
+        with patch("asyncio.to_thread", new=AsyncMock(side_effect=lambda fn, *a, **kw: fn(*a, **kw))):
+            await flush_fn(batch)
+
+        vector_store.add.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# VectorWriteBuffer._flush — end-to-end with make_chromadb_flush_fn
+# ---------------------------------------------------------------------------
+
+
+class TestFlushEndToEnd:
+    """Verify the buffer + flush function together stop data loss."""
+
+    @pytest.mark.asyncio
+    async def test_no_error_logged_when_all_embeddings_valid(self):
+        """flush() on an all-valid buffer must succeed without calling on_flush_error."""
+        on_error = AsyncMock()
+        calls: list = []
+
+        async def flush_fn(batch):
+            calls.append(batch)
+
+        buf = VectorWriteBuffer(flush_fn=flush_fn, flush_size=100, on_flush_error=on_error)
+        await buf.write("id1", VALID_EMBEDDING, "doc1")
+        await buf.flush_now()
+
+        assert len(calls) == 1
+        on_error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_embedding_write_never_reaches_flush_fn(self):
+        """A write() with empty embedding must not enqueue, so flush_fn is never
+        given a malformed entry even if the upstream guard were bypassed."""
+        flush_fn = AsyncMock()
+        buf = VectorWriteBuffer(flush_fn=flush_fn, flush_size=100)
+        await buf.write("bad", [], "doc")
+        await buf.flush_now()
+        # Nothing to flush — flush_fn not called
+        flush_fn.assert_not_called()


### PR DESCRIPTION
## Thinking Path

The log showed `IndexError: list index out of range in add` inside ChromaDB's `normalize_insert_record_set`. Traced the call stack:

1. `_generate_embedding_with_npu_fallback` returns `[]` (empty list) when all embedding backends are unavailable — this is documented in its docstring.
2. That empty list is stored in `BufferedWrite.embedding` with no validation.
3. At flush time, `make_chromadb_flush_fn` builds `TextNode(embedding=[])` for those entries.
4. `ChromaVectorStore.add()` builds `embeddings=[[]]` and calls `collection.add(embeddings=[[]])`.
5. Inside ChromaDB, `normalize_embeddings([[]])` checks `target[0]` → `[]`, then evaluates `target[0][0]` → `IndexError: list index out of range`.
6. A single malformed entry crashes the entire flush, so **all** valid entries in that batch are dropped too. This recurred ~12× in the error log, each time dropping 40–78 vectors permanently.

## What Changed

`autobot-backend/knowledge/write_buffer.py` — two guards, both required:

**Upstream guard in `VectorWriteBuffer.write()`**: reject entries with empty/`None` embedding at enqueue time. Logs a `WARNING` naming the entry's `id` so the upstream failure is visible. This is the primary fix — bad data never enters the buffer.

**Flush-time guard in `make_chromadb_flush_fn`**: filter any remaining empty-embedding entries before building `TextNode` objects. Logs a `WARNING` per skipped entry. Short-circuits entirely (no `vector_store.add` call) when the filtered batch is empty. This is defense-in-depth for entries that enter the buffer through any path not covered by the upstream guard (e.g. direct `BufferedWrite` construction in tests or future callers).

`autobot-backend/knowledge/write_buffer_test.py` — new file, 11 tests:
- `TestWriteRejectsEmptyEmbedding`: `write()` blocks empty and `None` embeddings, does not enqueue, does not increment `_write_count`
- `TestMakeChromadbFlushFn`: flush fn skips empty/`None` entries, calls `vector_store.add` only with the valid subset, never raises `IndexError`, skips `add` entirely for all-bad batches
- `TestFlushEndToEnd`: buffer + flush function together: valid-only batch succeeds; empty-embedding write produces zero calls to the flush function

## Verification

```
ruff check knowledge/write_buffer.py knowledge/write_buffer_test.py
# → All checks passed!

pytest knowledge/write_buffer_test.py -v
# → 11 passed in 1.69s
```

Static verification only (no live ChromaDB in CI). The `normalize_embeddings` IndexError path is exercised by `test_all_empty_batch_skips_add` which mocks `vector_store.add` to raise `IndexError` and asserts it is never called.

## Model Used

claude-sonnet-4-6

Closes #10941