### PR TITLE
feat(backend): feed outbound Claude sends through claude_api_adapter + fix rate-limit no-op (#10849)

### DIFF
--- a/autobot-backend/llm_shared/providers/anthropic.py
+++ b/autobot-backend/llm_shared/providers/anthropic.py
@@ -35,6 +35,26 @@ import time
 from typing import Any, AsyncIterator, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+
+# ---------------------------------------------------------------------------
+# Adapter helpers — lazy so tests that don't boot the full app still work.
+# ---------------------------------------------------------------------------
+
+
+def _get_adapter_sync():
+    """Return the live AutoBotClaudeAPIAdapter singleton without awaiting init.
+
+    Returns None if the module has not been imported yet or the instance is
+    absent.  Callers must handle None gracefully (fail-safe path).
+    """
+    try:
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        return AutoBotClaudeAPIAdapter._instance
+    except Exception:
+        return None
+
+
 from autobot_shared.ssot_config import config
 from constants.model_constants import (
     ANTHROPIC_CLAUDE3_OPUS_DATED,
@@ -236,10 +256,36 @@ class AnthropicProvider(BaseProvider):
 
         Supports extended thinking when ``request.metadata["api_kwargs"]``
         contains a ``thinking`` key.
+
+        Issue #10849: outbound payload is routed through the AutoBotClaudeAPIAdapter
+        pre-send pipeline (rate-limit check, payload optimization, metric recording)
+        before being dispatched to the Anthropic API.  The adapter is accessed via
+        its module-level singleton; when absent the call proceeds unchanged (fail-safe).
         """
         self._total_requests += 1
         start = time.time()
         model = request.model_name or self._get_setting("default_model", ANTHROPIC_CLAUDE_SONNET4_6)
+
+        # --- Adapter pre-send: rate-limit + payload optimization (#10849) ----------
+        # Serialize the user-visible content for the adapter pipeline.
+        # The adapter operates on the text content; the full structured payload
+        # (tools, extra_headers, etc.) flows unchanged to the Anthropic SDK.
+        _adapter = _get_adapter_sync()
+        _context_type: str = request.llm_type.value if hasattr(request.llm_type, "value") else "general"
+        if _adapter is not None and _adapter.is_initialized:
+            try:
+                _raw_content = " ".join(m.get("content", "") for m in request.messages if isinstance(m, dict))
+                await _adapter.optimize_for_send(
+                    content=_raw_content,
+                    context_type=_context_type,
+                )
+            except Exception as _adapt_err:
+                logger.debug(
+                    "Claude adapter pre-send optimization skipped (fail-safe): %s",
+                    _adapt_err,
+                )
+        # --------------------------------------------------------------------------
+
         try:
             client = self._ensure_client()
             kwargs, extra_headers, preserve_reasoning = self._build_request_kwargs(model, request)
@@ -278,7 +324,7 @@ class AnthropicProvider(BaseProvider):
                 if thinking_tokens is not None and thinking_tokens > 0:
                     usage_dict["thinking_tokens"] = thinking_tokens
 
-            return LLMResponse(
+            llm_response = LLMResponse(
                 content=content,
                 model=response.model,
                 provider=self.provider_name,
@@ -293,14 +339,42 @@ class AnthropicProvider(BaseProvider):
                     total_tokens=total_tokens,
                 ),
             )
+            # --- Adapter post-send: metric recording (#10849) ---------------------
+            if _adapter is not None and _adapter.is_initialized:
+                try:
+                    _raw_len = sum(len(m.get("content", "")) for m in request.messages if isinstance(m, dict))
+                    await _adapter.record_send_result(
+                        context_type=_context_type,
+                        content_len=_raw_len,
+                        response_time=processing_time,
+                        success=True,
+                    )
+                except Exception as _rec_err:
+                    logger.debug("Claude adapter post-send record skipped: %s", _rec_err)
+            # ----------------------------------------------------------------------
+            return llm_response
         except Exception as exc:
             self._total_errors += 1
             logger.error("Anthropic chat_completion error: %s", exc)
+            processing_time = time.time() - start
+            # --- Adapter post-send: error metric recording (#10849) ---------------
+            if _adapter is not None and _adapter.is_initialized:
+                try:
+                    await _adapter.record_send_result(
+                        context_type=_context_type,
+                        content_len=sum(len(m.get("content", "")) for m in request.messages if isinstance(m, dict)),
+                        response_time=processing_time,
+                        success=False,
+                        error_message=str(exc),
+                    )
+                except Exception as _rec_err:
+                    logger.debug("Claude adapter post-send error record skipped: %s", _rec_err)
+            # ----------------------------------------------------------------------
             return LLMResponse(
                 content="",
                 model=model,
                 provider=self.provider_name,
-                processing_time=time.time() - start,
+                processing_time=processing_time,
                 request_id=request.request_id,
                 error=str(exc),
             )
@@ -310,9 +384,34 @@ class AnthropicProvider(BaseProvider):
 
         Supports extended thinking when ``request.metadata["api_kwargs"]``
         contains a ``thinking`` key.  Thinking blocks are not yielded.
+
+        Issue #10849: applies adapter pre-send optimization (rate-limit check,
+        payload optimization) before streaming begins.  Post-send metric recording
+        is not applied per-chunk; the adapter records the stream open as a single
+        individual request.  Streaming cannot be routed through submit_request()
+        which is non-streaming by design.
         """
         self._total_requests += 1
         model = request.model_name or self._get_setting("default_model", ANTHROPIC_CLAUDE_SONNET4_6)
+
+        # --- Adapter pre-send: rate-limit + payload optimization (#10849) ----------
+        _stream_adapter = _get_adapter_sync()
+        _stream_context_type = request.llm_type.value if hasattr(request.llm_type, "value") else "general"
+        if _stream_adapter is not None and _stream_adapter.is_initialized:
+            try:
+                _stream_raw = " ".join(m.get("content", "") for m in request.messages if isinstance(m, dict))
+                await _stream_adapter.optimize_for_send(
+                    content=_stream_raw,
+                    context_type=_stream_context_type,
+                )
+            except Exception as _sadapt_err:
+                logger.debug(
+                    "Claude adapter stream pre-send optimization skipped (fail-safe): %s",
+                    _sadapt_err,
+                )
+        # --------------------------------------------------------------------------
+
+        _stream_start = time.time()
         try:
             client = self._ensure_client()
             kwargs, extra_headers, _preserve = self._build_request_kwargs(model, request)
@@ -325,6 +424,19 @@ class AnthropicProvider(BaseProvider):
             async with client.messages.stream(**call_kwargs) as stream:
                 async for text in stream.text_stream:
                     yield text
+
+            # --- Adapter post-send: success metric (#10849) -----------------------
+            if _stream_adapter is not None and _stream_adapter.is_initialized:
+                try:
+                    await _stream_adapter.record_send_result(
+                        context_type=_stream_context_type,
+                        content_len=sum(len(m.get("content", "")) for m in request.messages if isinstance(m, dict)),
+                        response_time=time.time() - _stream_start,
+                        success=True,
+                    )
+                except Exception as _srec_err:
+                    logger.debug("Claude adapter stream post-send record skipped: %s", _srec_err)
+            # ----------------------------------------------------------------------
         except Exception as exc:
             self._total_errors += 1
             logger.error("Anthropic stream_completion error: %s", exc)

--- a/autobot-backend/tests/test_claude_adapter_wiring.py
+++ b/autobot-backend/tests/test_claude_adapter_wiring.py
@@ -1,0 +1,531 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for issue #10849: AnthropicProvider routes outbound sends through
+AutoBotClaudeAPIAdapter's pre-send optimization pipeline.
+
+Tests are split into two tiers:
+  - Tier 1 (always run): adapter-level methods (optimize_for_send,
+    record_send_result) and rate-limit dict-truthiness fix — no runtime deps
+    beyond the autobot-backend package.
+  - Tier 2 (skipped unless anthropic SDK installed): AnthropicProvider
+    integration — imported via pytest.importorskip so the suite still green
+    when anthropic is absent.
+
+Verifies:
+  - optimize_for_send is called when adapter is present and initialized
+  - record_send_result is called after a successful send
+  - record_send_result is called with success=False after an error
+  - everything is skipped (fail-safe) when adapter is absent or not initialized
+  - stream_completion calls optimize_for_send before streaming
+  - _check_and_apply_rate_limit correctly reads can_proceed from dict result
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal stubs for packages that are always optional in the test environment.
+# We install these before any module import that transitively requires them.
+# ---------------------------------------------------------------------------
+
+
+def _ensure_stubs() -> None:
+    if "xxhash" not in sys.modules:
+        xh = types.ModuleType("xxhash")
+        xh.xxh64 = MagicMock(return_value=MagicMock(hexdigest=MagicMock(return_value="0" * 16)))
+        sys.modules["xxhash"] = xh
+
+
+_ensure_stubs()
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — adapter-level tests (no anthropic SDK required)
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterNewMethods:
+    """Unit tests for the two new AutoBotClaudeAPIAdapter methods (#10849)."""
+
+    def setup_method(self) -> None:
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        AutoBotClaudeAPIAdapter.reset_instance()
+
+    def teardown_method(self) -> None:
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        AutoBotClaudeAPIAdapter.reset_instance()
+
+    @pytest.mark.asyncio
+    async def test_optimize_for_send_returns_optimized_content(self) -> None:
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        adapter = AutoBotClaudeAPIAdapter()
+        mock_manager = MagicMock()
+        mock_manager.is_running = True
+        mock_manager._increment_metric = AsyncMock()
+        mock_manager._check_and_apply_rate_limit = AsyncMock(return_value=True)
+        mock_manager._optimize_payload_if_enabled = AsyncMock(return_value="optimized content")
+        mock_manager.rate_limiter = None
+        adapter.manager = mock_manager
+        adapter._initialized = True
+
+        result = await adapter.optimize_for_send("original content", context_type="chat")
+        assert result == "optimized content"
+        mock_manager._optimize_payload_if_enabled.assert_awaited_once_with("original content")
+
+    @pytest.mark.asyncio
+    async def test_optimize_for_send_fail_safe_on_rate_limit(self) -> None:
+        """When rate-limited and no graceful degradation, returns original content."""
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        adapter = AutoBotClaudeAPIAdapter()
+        mock_manager = MagicMock()
+        mock_manager.is_running = True
+        mock_manager._increment_metric = AsyncMock()
+        mock_manager._check_and_apply_rate_limit = AsyncMock(return_value=False)
+        mock_manager.degradation_manager = None
+        adapter.manager = mock_manager
+        adapter._initialized = True
+
+        result = await adapter.optimize_for_send("original", context_type="general")
+        assert result == "original"
+
+    @pytest.mark.asyncio
+    async def test_optimize_for_send_noop_when_manager_absent(self) -> None:
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        adapter = AutoBotClaudeAPIAdapter()
+        adapter.manager = None
+        adapter._initialized = True
+
+        result = await adapter.optimize_for_send("content", context_type="chat")
+        assert result == "content"
+
+    @pytest.mark.asyncio
+    async def test_optimize_for_send_noop_when_manager_not_running(self) -> None:
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        adapter = AutoBotClaudeAPIAdapter()
+        mock_manager = MagicMock()
+        mock_manager.is_running = False
+        adapter.manager = mock_manager
+        adapter._initialized = True
+
+        result = await adapter.optimize_for_send("content", context_type="chat")
+        assert result == "content"
+
+    @pytest.mark.asyncio
+    async def test_record_send_result_increments_individual_on_success(self) -> None:
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        adapter = AutoBotClaudeAPIAdapter()
+        mock_manager = MagicMock()
+        mock_manager.is_running = True
+        mock_manager._increment_metric = AsyncMock()
+        mock_manager._update_response_time_metric = AsyncMock()
+        mock_manager.pattern_analyzer = None
+        adapter.manager = mock_manager
+        adapter._initialized = True
+
+        await adapter.record_send_result(
+            context_type="chat",
+            content_len=100,
+            response_time=0.5,
+            success=True,
+        )
+        mock_manager._increment_metric.assert_awaited_once_with("individual_requests")
+        mock_manager._update_response_time_metric.assert_awaited_once_with(0.5)
+
+    @pytest.mark.asyncio
+    async def test_record_send_result_increments_failed_on_error(self) -> None:
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        adapter = AutoBotClaudeAPIAdapter()
+        mock_manager = MagicMock()
+        mock_manager.is_running = True
+        mock_manager._increment_metric = AsyncMock()
+        mock_manager._update_response_time_metric = AsyncMock()
+        mock_manager.pattern_analyzer = None
+        adapter.manager = mock_manager
+        adapter._initialized = True
+
+        await adapter.record_send_result(
+            context_type="chat",
+            content_len=50,
+            response_time=1.0,
+            success=False,
+            error_message="timeout",
+        )
+        mock_manager._increment_metric.assert_awaited_once_with("failed_requests")
+        mock_manager._update_response_time_metric.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_record_send_result_noop_when_manager_absent(self) -> None:
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        adapter = AutoBotClaudeAPIAdapter()
+        adapter.manager = None
+        adapter._initialized = True
+
+        # Must not raise
+        await adapter.record_send_result(
+            context_type="chat",
+            content_len=10,
+            response_time=0.1,
+            success=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_record_send_result_calls_pattern_analyzer(self) -> None:
+        from utils.claude_api_integration import AutoBotClaudeAPIAdapter
+
+        adapter = AutoBotClaudeAPIAdapter()
+        mock_manager = MagicMock()
+        mock_manager.is_running = True
+        mock_manager._increment_metric = AsyncMock()
+        mock_manager._update_response_time_metric = AsyncMock()
+        mock_pattern = MagicMock()
+        mock_pattern.record_tool_call = MagicMock()
+        mock_manager.pattern_analyzer = mock_pattern
+        adapter.manager = mock_manager
+        adapter._initialized = True
+
+        await adapter.record_send_result(
+            context_type="general",
+            content_len=200,
+            response_time=1.2,
+            success=True,
+        )
+        mock_pattern.record_tool_call.assert_called_once()
+        call_kw = mock_pattern.record_tool_call.call_args.kwargs
+        assert call_kw["tool_name"] == "general"
+        assert call_kw["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit dict-truthiness fix (#10849)
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitDictHandling:
+    """_check_and_apply_rate_limit must honour the can_proceed key in a dict result."""
+
+    @pytest.mark.asyncio
+    async def test_dict_can_proceed_true_allows_request(self) -> None:
+        from utils.claude_api_integration import ClaudeAPIBatchManager, ClaudeAPIConfig, OptimizationMetrics
+
+        with patch("utils.graceful_degradation.Path.mkdir"):
+            mgr = ClaudeAPIBatchManager(ClaudeAPIConfig(enable_rate_limiting=True))
+        mgr.rate_limiter = MagicMock()
+        mgr.rate_limiter.can_make_request = MagicMock(return_value={"can_proceed": True})
+        mgr._lock = asyncio.Lock()
+        mgr._metrics = OptimizationMetrics()
+
+        result = await mgr._check_and_apply_rate_limit()
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_dict_can_proceed_false_blocks_request(self) -> None:
+        from utils.claude_api_integration import ClaudeAPIBatchManager, ClaudeAPIConfig, OptimizationMetrics
+
+        with patch("utils.graceful_degradation.Path.mkdir"):
+            mgr = ClaudeAPIBatchManager(ClaudeAPIConfig(enable_rate_limiting=True))
+        mgr.rate_limiter = MagicMock()
+        mgr.rate_limiter.can_make_request = MagicMock(return_value={"can_proceed": False})
+        mgr._lock = asyncio.Lock()
+        mgr._metrics = OptimizationMetrics()
+
+        result = await mgr._check_and_apply_rate_limit()
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_bool_true_allows_request(self) -> None:
+        from utils.claude_api_integration import ClaudeAPIBatchManager, ClaudeAPIConfig, OptimizationMetrics
+
+        with patch("utils.graceful_degradation.Path.mkdir"):
+            mgr = ClaudeAPIBatchManager(ClaudeAPIConfig(enable_rate_limiting=True))
+        mgr.rate_limiter = MagicMock()
+        mgr.rate_limiter.can_make_request = MagicMock(return_value=True)
+        mgr._lock = asyncio.Lock()
+        mgr._metrics = OptimizationMetrics()
+
+        result = await mgr._check_and_apply_rate_limit()
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_bool_false_blocks_request(self) -> None:
+        from utils.claude_api_integration import ClaudeAPIBatchManager, ClaudeAPIConfig, OptimizationMetrics
+
+        with patch("utils.graceful_degradation.Path.mkdir"):
+            mgr = ClaudeAPIBatchManager(ClaudeAPIConfig(enable_rate_limiting=True))
+        mgr.rate_limiter = MagicMock()
+        mgr.rate_limiter.can_make_request = MagicMock(return_value=False)
+        mgr._lock = asyncio.Lock()
+        mgr._metrics = OptimizationMetrics()
+
+        result = await mgr._check_and_apply_rate_limit()
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — AnthropicProvider integration (skipped if llm_shared not importable)
+# ---------------------------------------------------------------------------
+
+# Inject the anthropic SDK stub before attempting the provider import so that
+# the import itself succeeds even in the minimal test environment.
+if "anthropic" not in sys.modules:
+    _anthr_stub = types.ModuleType("anthropic")
+    _anthr_stub.AsyncAnthropic = MagicMock
+    sys.modules["anthropic"] = _anthr_stub
+
+try:
+    from llm_shared.providers.anthropic import AnthropicProvider as _AnthropicProvider  # noqa: E402
+    from llm_shared.providers.anthropic import _get_adapter_sync as _get_adapter_sync_fn
+
+    _ANTHROPIC_PROVIDER_AVAILABLE = True
+except Exception:
+    _AnthropicProvider = None  # type: ignore[assignment,misc]
+    _get_adapter_sync_fn = None  # type: ignore[assignment]
+    _ANTHROPIC_PROVIDER_AVAILABLE = False
+
+_skip_no_provider = pytest.mark.skipif(
+    not _ANTHROPIC_PROVIDER_AVAILABLE,
+    reason="llm_shared.providers.anthropic not importable in this environment",
+)
+
+
+def _make_request(**kwargs):
+    from llm_shared.models import LLMRequest
+
+    defaults = dict(
+        messages=[{"role": "user", "content": "Hello"}],
+        model_name="claude-sonnet-4-6-20251001",
+    )
+    defaults.update(kwargs)
+    return LLMRequest(**defaults)
+
+
+def _make_sdk_response(text: str = "pong") -> MagicMock:
+    block = MagicMock()
+    block.type = "text"
+    block.text = text
+    resp = MagicMock()
+    resp.content = [block]
+    resp.model = "claude-sonnet-4-6-20251001"
+    resp.stop_reason = "end_turn"
+    resp.usage = MagicMock(input_tokens=10, output_tokens=5, output_tokens_details=None)
+    return resp
+
+
+def _make_initialized_adapter() -> MagicMock:
+    adapter = MagicMock()
+    adapter.is_initialized = True
+    adapter.optimize_for_send = AsyncMock(return_value="Hello")
+    adapter.record_send_result = AsyncMock()
+    return adapter
+
+
+@_skip_no_provider
+class TestAnthropicProviderAdapterWiring:
+    """AnthropicProvider calls adapter hooks when adapter is present."""
+
+    def _make_provider(self):
+        return _AnthropicProvider(settings={"api_key": "test-key"})
+
+    @pytest.mark.asyncio
+    async def test_optimize_for_send_called_when_adapter_present(self) -> None:
+        provider = self._make_provider()
+        sdk_resp = _make_sdk_response("response text")
+        mock_adapter = _make_initialized_adapter()
+
+        with (
+            patch("llm_shared.providers.anthropic._get_adapter_sync", return_value=mock_adapter),
+            patch.object(provider, "_ensure_client") as mock_client_fn,
+        ):
+            mock_client = MagicMock()
+            mock_client.messages.create = AsyncMock(return_value=sdk_resp)
+            mock_client_fn.return_value = mock_client
+
+            req = _make_request()
+            await provider._chat_completion_impl(req)
+
+        mock_adapter.optimize_for_send.assert_awaited_once()
+        call_kwargs = mock_adapter.optimize_for_send.call_args.kwargs
+        assert call_kwargs["content"] == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_record_send_result_called_on_success(self) -> None:
+        provider = self._make_provider()
+        sdk_resp = _make_sdk_response("ok")
+        mock_adapter = _make_initialized_adapter()
+
+        with (
+            patch("llm_shared.providers.anthropic._get_adapter_sync", return_value=mock_adapter),
+            patch.object(provider, "_ensure_client") as mock_client_fn,
+        ):
+            mock_client = MagicMock()
+            mock_client.messages.create = AsyncMock(return_value=sdk_resp)
+            mock_client_fn.return_value = mock_client
+
+            await provider._chat_completion_impl(_make_request())
+
+        mock_adapter.record_send_result.assert_awaited_once()
+        kw = mock_adapter.record_send_result.call_args.kwargs
+        assert kw["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_record_send_result_called_on_api_error(self) -> None:
+        provider = self._make_provider()
+        mock_adapter = _make_initialized_adapter()
+
+        with (
+            patch("llm_shared.providers.anthropic._get_adapter_sync", return_value=mock_adapter),
+            patch.object(provider, "_ensure_client") as mock_client_fn,
+        ):
+            mock_client = MagicMock()
+            mock_client.messages.create = AsyncMock(side_effect=RuntimeError("api error"))
+            mock_client_fn.return_value = mock_client
+
+            resp = await provider._chat_completion_impl(_make_request())
+
+        assert resp.error
+        mock_adapter.record_send_result.assert_awaited_once()
+        kw = mock_adapter.record_send_result.call_args.kwargs
+        assert kw["success"] is False
+        assert "api error" in kw["error_message"]
+
+    @pytest.mark.asyncio
+    async def test_send_proceeds_when_adapter_absent(self) -> None:
+        """Fail-safe: no adapter present — provider sends directly, no exception."""
+        provider = self._make_provider()
+        sdk_resp = _make_sdk_response("direct")
+
+        with (
+            patch("llm_shared.providers.anthropic._get_adapter_sync", return_value=None),
+            patch.object(provider, "_ensure_client") as mock_client_fn,
+        ):
+            mock_client = MagicMock()
+            mock_client.messages.create = AsyncMock(return_value=sdk_resp)
+            mock_client_fn.return_value = mock_client
+
+            resp = await provider._chat_completion_impl(_make_request())
+
+        assert resp.content == "direct"
+        assert not resp.error
+
+    @pytest.mark.asyncio
+    async def test_send_proceeds_when_adapter_not_initialized(self) -> None:
+        """Fail-safe: adapter present but not yet initialized — skip optimization."""
+        provider = self._make_provider()
+        sdk_resp = _make_sdk_response("direct2")
+        mock_adapter = MagicMock()
+        mock_adapter.is_initialized = False
+
+        with (
+            patch("llm_shared.providers.anthropic._get_adapter_sync", return_value=mock_adapter),
+            patch.object(provider, "_ensure_client") as mock_client_fn,
+        ):
+            mock_client = MagicMock()
+            mock_client.messages.create = AsyncMock(return_value=sdk_resp)
+            mock_client_fn.return_value = mock_client
+
+            resp = await provider._chat_completion_impl(_make_request())
+
+        assert resp.content == "direct2"
+        mock_adapter.optimize_for_send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_optimize_exception_is_fail_safe(self) -> None:
+        """If optimize_for_send raises, send still proceeds (fail-safe)."""
+        provider = self._make_provider()
+        sdk_resp = _make_sdk_response("safe")
+        mock_adapter = _make_initialized_adapter()
+        mock_adapter.optimize_for_send = AsyncMock(side_effect=RuntimeError("optimizer boom"))
+
+        with (
+            patch("llm_shared.providers.anthropic._get_adapter_sync", return_value=mock_adapter),
+            patch.object(provider, "_ensure_client") as mock_client_fn,
+        ):
+            mock_client = MagicMock()
+            mock_client.messages.create = AsyncMock(return_value=sdk_resp)
+            mock_client_fn.return_value = mock_client
+
+            resp = await provider._chat_completion_impl(_make_request())
+
+        assert resp.content == "safe"
+        assert not resp.error
+
+
+@_skip_no_provider
+class TestAnthropicStreamAdapterWiring:
+    """AnthropicProvider.stream_completion calls adapter optimize_for_send."""
+
+    def _make_provider(self):
+        return _AnthropicProvider(settings={"api_key": "test-key"})
+
+    @pytest.mark.asyncio
+    async def test_optimize_for_send_called_before_stream(self) -> None:
+        provider = self._make_provider()
+        mock_adapter = _make_initialized_adapter()
+
+        async def _fake_text_stream():
+            yield "chunk1"
+            yield "chunk2"
+
+        mock_stream_ctx = MagicMock()
+        mock_stream_ctx.__aenter__ = AsyncMock(return_value=MagicMock(text_stream=_fake_text_stream()))
+        mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("llm_shared.providers.anthropic._get_adapter_sync", return_value=mock_adapter),
+            patch.object(provider, "_ensure_client") as mock_client_fn,
+        ):
+            mock_client = MagicMock()
+            mock_client.messages.stream = MagicMock(return_value=mock_stream_ctx)
+            mock_client_fn.return_value = mock_client
+
+            chunks = []
+            async for chunk in provider.stream_completion(_make_request()):
+                chunks.append(chunk)
+
+        assert chunks == ["chunk1", "chunk2"]
+        mock_adapter.optimize_for_send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stream_proceeds_when_adapter_absent(self) -> None:
+        provider = self._make_provider()
+
+        async def _fake_text_stream():
+            yield "direct-chunk"
+
+        mock_stream_ctx = MagicMock()
+        mock_stream_ctx.__aenter__ = AsyncMock(return_value=MagicMock(text_stream=_fake_text_stream()))
+        mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "llm_shared.providers.anthropic._get_adapter_sync",
+                return_value=None,
+            ),
+            patch.object(provider, "_ensure_client") as mock_client_fn,
+        ):
+            mock_client = MagicMock()
+            mock_client.messages.stream = MagicMock(return_value=mock_stream_ctx)
+            mock_client_fn.return_value = mock_client
+
+            chunks = []
+            async for chunk in provider.stream_completion(_make_request()):
+                chunks.append(chunk)
+
+        assert chunks == ["direct-chunk"]

--- a/autobot-backend/utils/claude_api_integration.py
+++ b/autobot-backend/utils/claude_api_integration.py
@@ -250,10 +250,19 @@ class ClaudeAPIBatchManager:
         return response
 
     async def _check_and_apply_rate_limit(self) -> bool:
-        """Return True if request can proceed; False if rate-limited."""
+        """Return True if request can proceed; False if rate-limited.
+
+        ``ConversationRateLimiter.can_make_request()`` returns a Dict; the
+        ``can_proceed`` key governs whether the request may proceed (#10849).
+        """
         if not self.rate_limiter:
             return True
-        if self.rate_limiter.can_make_request():
+        result = self.rate_limiter.can_make_request()
+        if isinstance(result, dict):
+            can_proceed = bool(result.get("can_proceed", True))
+        else:
+            can_proceed = bool(result)
+        if can_proceed:
             return True
         await self._increment_metric("rate_limit_hits")
         async with self._lock:
@@ -658,6 +667,78 @@ class AutoBotClaudeAPIAdapter(AsyncInitializable):
         """Optimize a TodoWrite batch via the manager (folded from suite, #10796)."""
         await self.ensure_initialized()
         return await self.manager.submit_todowrite(todos)
+
+    async def optimize_for_send(
+        self,
+        content: str,
+        context_type: str = "general",
+    ) -> str:
+        """Apply rate-limit check and payload optimization before an outbound send.
+
+        Called by provider implementations (e.g. AnthropicProvider) before
+        dispatching to the upstream API.  Returns the (possibly optimized)
+        content string.  When rate-limited and graceful degradation is not
+        available, logs a warning and returns the original content so the
+        caller's normal send path proceeds (fail-safe, not fail-closed).
+
+        Issue #10849: wires live outbound Claude requests through the adapter's
+        optimization pipeline (rate-limiter, payload optimizer, metric recording).
+        """
+        await self.ensure_initialized()
+        if not self.manager or not self.manager.is_running:
+            return content
+        await self.manager._increment_metric("total_requests")
+        if not await self.manager._check_and_apply_rate_limit():
+            if self.manager.degradation_manager:
+                try:
+                    fallback = await self.manager.degradation_manager.handle_request(content, {"type": context_type})
+                    if fallback.success:
+                        logger.debug(
+                            "Claude adapter: graceful degradation applied for context=%s",
+                            context_type,
+                        )
+                except Exception as _deg_err:
+                    logger.debug("Degradation manager error (ignored): %s", _deg_err)
+            logger.warning(
+                "Claude adapter: rate limit exceeded for context=%s; " "proceeding with original payload (fail-safe)",
+                context_type,
+            )
+            return content
+        optimized = await self.manager._optimize_payload_if_enabled(content)
+        if self.manager.rate_limiter:
+            self.manager.rate_limiter.record_request(len(content))
+        return optimized
+
+    async def record_send_result(
+        self,
+        context_type: str,
+        content_len: int,
+        response_time: float,
+        success: bool,
+        error_message: str = "",
+    ) -> None:
+        """Record post-send metrics and pattern analysis for an outbound call.
+
+        Called by provider implementations after the upstream API responds.
+        Issue #10849: feeds live send results into the adapter's metrics and
+        the tool-pattern analyzer so optimization recommendations reflect real
+        traffic.
+        """
+        if not self.manager or not self.manager.is_running:
+            return
+        if success:
+            await self.manager._increment_metric("individual_requests")
+            await self.manager._update_response_time_metric(response_time)
+        else:
+            await self.manager._increment_metric("failed_requests")
+        if self.manager.pattern_analyzer:
+            self.manager.pattern_analyzer.record_tool_call(
+                tool_name=context_type,
+                parameters={"content_len": content_len},
+                response_time=response_time,
+                success=success,
+                error_message=error_message if not success else "",
+            )
 
     async def shutdown(self):
         """Shutdown the adapter."""


### PR DESCRIPTION
## Thinking Path
Follow-up to #10796: `AutoBotClaudeAPIAdapter` is booted at startup but no live traffic flowed through it, so its rate-limiter/optimizer/pattern-analyzer optimized nothing. This wires the real Anthropic send path to the adapter.

## What Changed
- `utils/claude_api_integration.py`: added `optimize_for_send()` + `record_send_result()` to the adapter (async, lazy singleton access). **Fixed a real bug**: `_check_and_apply_rate_limit` treated `ConversationRateLimiter.can_make_request()`'s **Dict** return as always-truthy → rate-limiting was a silent no-op; now reads the `can_proceed` key.
- `llm_shared/providers/anthropic.py`: `_chat_completion_impl` + `stream_completion` call the adapter pre-send (rate-limit + record) and post-send (metrics), via a lazy `_get_adapter_sync()`. **Three-layer fail-safe**: adapter absent/uninitialized → skipped; any exception → logged at DEBUG and the send proceeds with the original payload. Streaming preserved.

## Honest scope
The adapter operates on a **flattened content string** while the provider sends **structured messages**, so `optimize_for_send`'s optimized-string output is NOT applied back to the structured payload (that would be lossy/unsafe). This PR makes the adapter **observe live traffic** (metrics + tool-pattern analysis now reflect real requests) and fixes the rate-limit no-op. Full payload-mutation + the `submit_request` intelligent-batcher (still a typed-mismatched stub) are deferred to a follow-up.

## Verification
- `py_compile` + `flake8 -F,E501` clean (3 files).
- New `test_claude_adapter_wiring.py` (20 tests) + pre-existing adapter tests: 12 passed, 8 skipped (anthropic SDK absent in minimal env), 9 pre-existing pass.

## Model Used
Opus 4.8

Closes #10849. Follow-up filed for adapter string-vs-structured mismatch + batcher.