### PR TITLE
fix(config): default ollama_host to 127.0.0.1 — fixes empty-host embedding URL (#10944)

### DIFF
--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1577,7 +1577,7 @@ class MiscConfig(BaseSettings):
     nous_api_base_url: str = Field(default="", alias="NOUS_API_BASE_URL")
     nous_api_key: str = Field(default="", alias="NOUS_API_KEY")
     nous_default_model: str = Field(default="", alias="NOUS_DEFAULT_MODEL")
-    ollama_host: str = Field(default="", alias="OLLAMA_HOST")
+    ollama_host: str = Field(default="127.0.0.1", alias="OLLAMA_HOST")
     ollama_url: str = Field(default="", alias="OLLAMA_URL")  # type: ignore[no-redef]  # GH#7105
     openai_api_base_url: str = Field(default="", alias="OPENAI_API_BASE_URL")
     openrouter_api_base_url: str = Field(default="", alias="OPENROUTER_API_BASE_URL")


### PR DESCRIPTION
## Thinking Path
The VectorWriteBuffer vector loss (#10941) was caused by empty embeddings. Root cause: `config.ollama_host` defaults to `""` (alias OLLAMA_HOST, unset), so `npu_client._generate_embedding` built `http://{ollama_host}:11434/api/embeddings` = **`http://:11434/api/embeddings`** (empty host). Every Ollama embedding fallback failed (log: `Ollama embedding generation failed: http://:11434/api/embeddings`), NPU is degraded/unavailable on this box, so embeddings came back `[]`.

## What Changed
- `ssot_config.py`: `ollama_host` default `""` → `"127.0.0.1"` (matches the existing `ollama_endpoint=http://127.0.0.1:11434`). Other callers already fall back to localhost when empty; `npu_client` didn't — this fixes it at the source for all callers.

## Verification
- Live: `config.ollama_host` was `''`; Ollama `/api/embeddings` with `nomic-embed-text` returns 768-dim directly (backend is healthy), so only the empty host was wrong. URL now `http://127.0.0.1:11434/api/embeddings`.
- No caller depends on the empty default (grep: they use it directly or fall back to localhost).

## Model Used
Opus 4.8 (1M context)

Refs #10944, #10941. Restores knowledge-vector embedding on boxes without OLLAMA_HOST set.