### PR TITLE
ci: stop auto-fix-formatting injecting the Paperclip commit trailer (#10948)

### DIFF
--- a/.github/workflows/auto-fix-formatting.yml
+++ b/.github/workflows/auto-fix-formatting.yml
@@ -72,8 +72,6 @@ jobs:
 
           Applied Black, isort, and autoflake to match code-quality checks.
           Triggered by workflow auto-fix-formatting.yml.
-
-          Co-Authored-By: Paperclip <noreply@paperclip.ing>
           EOF
           )"
             git push


### PR DESCRIPTION
## Thinking Path
The recurring `No commit trailers` guard failures on auto-formatted PRs (e.g. #10940 RUM) trace to `auto-fix-formatting.yml`, which hardcodes `Co-Authored-By: Paperclip <noreply@paperclip.ing>` in its commit message — so every autofix commit re-injects the cross-project trailer the guard (correctly) blocks.

## What Changed
- `.github/workflows/auto-fix-formatting.yml`: removed the `Co-Authored-By: Paperclip` line (and its blank line) from the autofix commit message. mrveiss is sole author.

## Verification
- YAML validates. No `paperclip` refs remain in the workflow. Own commit is trailer-free (passes the guard).

## Model Used
Opus 4.8 (1M context)

Closes #10948. Removes the CI-level source of the Paperclip contamination that keeps blocking auto-formatted PRs.