### PR TITLE
feat(llm): preserve reasoning_content from reasoning models (#10582)

### DIFF
--- a/autobot-backend/llm_shared/models.py
+++ b/autobot-backend/llm_shared/models.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -136,6 +136,7 @@ class LLMResponse:
     hidden_params: Dict[str, Any] = field(default_factory=dict)
     tool_calls: List["ToolCall"] | None = None
     lightweight_mode_used: bool = False  # MVA-1993: Set when trivial tier is used
+    reasoning_content: Optional[str] = None  # #10582: captured reasoning/thinking text
 
 
 @dataclass

--- a/autobot-backend/llm_shared/providers/anthropic.py
+++ b/autobot-backend/llm_shared/providers/anthropic.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 import re
 import time
-from typing import Any, AsyncIterator, Dict, List
+from typing import Any, AsyncIterator, Dict, List, Optional
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
@@ -68,6 +68,17 @@ _THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
 def _strip_think_blocks(text: str) -> str:
     """Remove ``<think>…</think>`` wrapper blocks from *text*."""
     return _THINK_BLOCK_RE.sub("", text).strip()
+
+
+def _extract_think_tag_content(text: str) -> Optional[str]:
+    """Return the concatenated inner text of all ``<think>…</think>`` blocks, or None."""
+    matches = _THINK_BLOCK_RE.findall(text)
+    if not matches:
+        return None
+    # findall returns the full match including tags; strip the wrapper.
+    inner_re = re.compile(r"<think>(.*?)</think>", re.DOTALL | re.IGNORECASE)
+    parts = inner_re.findall(text)
+    return "\n".join(p.strip() for p in parts if p.strip()) or None
 
 
 def _build_api_kwargs(
@@ -119,17 +130,47 @@ def _extract_text_content(response_content: list, preserve_reasoning: bool) -> s
     When *preserve_reasoning* is False (default) ``<think>…</think>`` wrapper
     blocks written by the model are stripped before returning.
     """
-    parts: List[str] = []
+    text, _ = _extract_content_pair(response_content, preserve_reasoning)
+    return text
+
+
+def _extract_content_pair(
+    response_content: list, preserve_reasoning: bool
+) -> tuple[str, Optional[str]]:
+    """
+    Extract ``(content, reasoning_content)`` from an Anthropic response block list.
+
+    *content* has thinking blocks removed (or ``<think>`` tags stripped unless
+    *preserve_reasoning* is True).  *reasoning_content* contains the captured
+    reasoning text from native ``thinking`` blocks and ``<think>`` tags, or
+    ``None`` if none were present.
+    """
+    reasoning_parts: List[str] = []
+    text_parts: List[str] = []
+
     for block in response_content:
         block_type = getattr(block, "type", None)
         if block_type == "thinking":
+            thinking_text = getattr(block, "thinking", None) or getattr(block, "text", None)
+            if thinking_text:
+                reasoning_parts.append(thinking_text.strip())
             continue
         text = getattr(block, "text", None)
         if text:
-            parts.append(text)
+            text_parts.append(text)
 
-    joined = "\n".join(parts)
-    return joined if preserve_reasoning else _strip_think_blocks(joined)
+    joined = "\n".join(text_parts)
+    if preserve_reasoning:
+        content = joined
+    else:
+        # Capture any <think> tags from the text blocks before stripping them.
+        tag_reasoning = _extract_think_tag_content(joined)
+        if tag_reasoning:
+            reasoning_parts.append(tag_reasoning)
+        content = _strip_think_blocks(joined)
+
+    reasoning_content: Optional[str] = "\n".join(reasoning_parts) if reasoning_parts else None
+    return content, reasoning_content
 
 
 class AnthropicProvider(BaseProvider):
@@ -250,7 +291,7 @@ class AnthropicProvider(BaseProvider):
             call_kwargs = sorted_for_cache(call_kwargs)
 
             response = await client.messages.create(**call_kwargs)
-            content = _extract_text_content(response.content, preserve_reasoning)
+            content, reasoning_content = _extract_content_pair(response.content, preserve_reasoning)
             total_tokens = response.usage.input_tokens + response.usage.output_tokens
             processing_time = time.time() - start
 
@@ -292,6 +333,7 @@ class AnthropicProvider(BaseProvider):
                     api_kwargs_applied=call_kwargs,
                     total_tokens=total_tokens,
                 ),
+                reasoning_content=reasoning_content,
             )
         except Exception as exc:
             self._total_errors += 1
@@ -351,6 +393,8 @@ __all__ = [
     "AnthropicProvider",
     "_ANTHROPIC_MODELS",
     "_build_api_kwargs",
+    "_extract_content_pair",
     "_extract_text_content",
+    "_extract_think_tag_content",
     "_strip_think_blocks",
 ]

--- a/autobot-backend/llm_shared/providers/anthropic.py
+++ b/autobot-backend/llm_shared/providers/anthropic.py
@@ -134,9 +134,7 @@ def _extract_text_content(response_content: list, preserve_reasoning: bool) -> s
     return text
 
 
-def _extract_content_pair(
-    response_content: list, preserve_reasoning: bool
-) -> tuple[str, Optional[str]]:
+def _extract_content_pair(response_content: list, preserve_reasoning: bool) -> tuple[str, Optional[str]]:
     """
     Extract ``(content, reasoning_content)`` from an Anthropic response block list.
 

--- a/autobot-backend/llm_shared/providers/custom_openai.py
+++ b/autobot-backend/llm_shared/providers/custom_openai.py
@@ -136,6 +136,9 @@ class CustomOpenAIProvider(BaseProvider):
                     except Exception:
                         args = {}
                     tool_calls.append(ToolCall(id=tc.id, name=tc.function.name, arguments=args))
+            # #10582: capture reasoning_content from providers that surface it
+            # (DeepSeek-R1, QwQ, SGLang, and similar OpenAI-compat servers).
+            reasoning_content: str | None = getattr(choice.message, "reasoning_content", None) or None
             return LLMResponse(
                 content=choice.message.content or "",
                 model=api_model,
@@ -154,6 +157,7 @@ class CustomOpenAIProvider(BaseProvider):
                     api_kwargs_applied=params,
                     total_tokens=total_tokens,
                 ),
+                reasoning_content=reasoning_content,
             )
         except Exception as exc:
             self._total_errors += 1

--- a/autobot-backend/llm_shared/providers/openai.py
+++ b/autobot-backend/llm_shared/providers/openai.py
@@ -158,6 +158,9 @@ class OpenAIProvider(BaseProvider):
                     except Exception:
                         args = {}
                     tool_calls.append(ToolCall(id=tc.id, name=tc.function.name, arguments=args))
+            # #10582: capture reasoning_content from o1/o3 or compatible models
+            # that expose it as a separate field on the message object.
+            reasoning_content: str | None = getattr(choice.message, "reasoning_content", None) or None
             return LLMResponse(
                 content=choice.message.content or "",
                 model=response.model,
@@ -176,6 +179,7 @@ class OpenAIProvider(BaseProvider):
                     api_kwargs_applied=params,
                     total_tokens=response.usage.total_tokens,
                 ),
+                reasoning_content=reasoning_content,
             )
         except Exception as exc:
             self._total_errors += 1

--- a/autobot-backend/tests/llm_interface_pkg/test_anthropic_provider.py
+++ b/autobot-backend/tests/llm_interface_pkg/test_anthropic_provider.py
@@ -46,7 +46,9 @@ from llm_shared.models import LLMRequest  # noqa: E402
 from llm_shared.providers.anthropic import (  # noqa: E402  (import after stub)
     AnthropicProvider,
     _build_api_kwargs,
+    _extract_content_pair,
     _extract_text_content,
+    _extract_think_tag_content,
     _strip_think_blocks,
 )
 
@@ -401,3 +403,140 @@ class TestChatCompletionWithThinking:
 
         assert "<think>" in response.content
         assert "visible reasoning" in response.content
+
+
+# ---------------------------------------------------------------------------
+# _extract_think_tag_content  (#10582)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractThinkTagContent:
+    def test_single_block_extracted(self):
+        result = _extract_think_tag_content("<think>reasoning</think>answer")
+        assert result == "reasoning"
+
+    def test_no_block_returns_none(self):
+        assert _extract_think_tag_content("plain text") is None
+
+    def test_multiple_blocks_joined(self):
+        result = _extract_think_tag_content("<think>step1</think>mid<think>step2</think>")
+        assert result is not None
+        assert "step1" in result
+        assert "step2" in result
+
+    def test_empty_tag_returns_none(self):
+        assert _extract_think_tag_content("<think></think>text") is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_content_pair  (#10582)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractContentPair:
+    def _make_block(self, block_type: str, text: str = "", thinking: str = "") -> Any:
+        block = MagicMock()
+        block.type = block_type
+        block.text = text or None
+        block.thinking = thinking or None
+        return block
+
+    def test_think_tag_in_text_block_captured(self):
+        blocks = [self._make_block("text", "<think>reasoning</think>answer")]
+        content, reasoning = _extract_content_pair(blocks, preserve_reasoning=False)
+        assert content == "answer"
+        assert reasoning == "reasoning"
+
+    def test_native_thinking_block_captured(self):
+        thinking_block = self._make_block("thinking", thinking="native reasoning")
+        text_block = self._make_block("text", "answer")
+        content, reasoning = _extract_content_pair([thinking_block, text_block], preserve_reasoning=False)
+        assert content == "answer"
+        assert reasoning == "native reasoning"
+
+    def test_no_reasoning_returns_none(self):
+        blocks = [self._make_block("text", "plain response")]
+        content, reasoning = _extract_content_pair(blocks, preserve_reasoning=False)
+        assert content == "plain response"
+        assert reasoning is None
+
+    def test_preserve_reasoning_keeps_tags_no_reasoning_field(self):
+        blocks = [self._make_block("text", "<think>visible</think>shown")]
+        content, reasoning = _extract_content_pair(blocks, preserve_reasoning=True)
+        assert "<think>" in content
+        # When preserve_reasoning=True, think tags are NOT stripped — reasoning captured separately only on strip path
+        assert reasoning is None
+
+
+# ---------------------------------------------------------------------------
+# reasoning_content wired into LLMResponse  (#10582)
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningContentInResponse:
+    def _make_block(self, block_type: str, text: str = "", thinking: str = "") -> Any:
+        block = MagicMock()
+        block.type = block_type
+        block.text = text or None
+        block.thinking = thinking or None
+        return block
+
+    def _make_sdk_response(self, content_blocks):
+        resp = MagicMock()
+        resp.content = content_blocks
+        resp.model = "claude-sonnet-4-6"
+        resp.stop_reason = "end_turn"
+        resp.usage = MagicMock(input_tokens=100, output_tokens=200)
+        resp.usage.output_tokens_details = None
+        return resp
+
+    @pytest.mark.asyncio
+    async def test_think_tag_response_content_and_reasoning_split(self):
+        """A response with <think>reasoning</think>answer yields content=='answer'
+        and reasoning_content=='reasoning' (#10582 acceptance criterion)."""
+        text_block = self._make_block("text", "<think>reasoning</think>answer")
+        sdk_response = self._make_sdk_response([text_block])
+
+        provider = AnthropicProvider(settings={"api_key": "test-key"})
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=sdk_response)
+        provider._client = mock_client
+
+        request = LLMRequest(messages=[{"role": "user", "content": "think"}])
+        response = await provider.chat_completion(request)
+
+        assert response.content == "answer"
+        assert response.reasoning_content == "reasoning"
+
+    @pytest.mark.asyncio
+    async def test_native_thinking_block_in_reasoning_content(self):
+        thinking_block = self._make_block("thinking", thinking="chain of thought")
+        text_block = self._make_block("text", "Final answer")
+        sdk_response = self._make_sdk_response([thinking_block, text_block])
+
+        provider = AnthropicProvider(settings={"api_key": "test-key"})
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=sdk_response)
+        provider._client = mock_client
+
+        request = LLMRequest(messages=[{"role": "user", "content": "hello"}])
+        response = await provider.chat_completion(request)
+
+        assert response.content == "Final answer"
+        assert response.reasoning_content == "chain of thought"
+
+    @pytest.mark.asyncio
+    async def test_no_reasoning_content_is_none(self):
+        text_block = self._make_block("text", "Hello!")
+        sdk_response = self._make_sdk_response([text_block])
+
+        provider = AnthropicProvider(settings={"api_key": "test-key"})
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=sdk_response)
+        provider._client = mock_client
+
+        request = LLMRequest(messages=[{"role": "user", "content": "hi"}])
+        response = await provider.chat_completion(request)
+
+        assert response.content == "Hello!"
+        assert response.reasoning_content is None


### PR DESCRIPTION
## Thinking Path
Part of #10542 (provider quality). Reasoning models (Qwen3, DeepSeek-R1, o1/o3, vLLM/SGLang `--reasoning-parser`) emit chain-of-thought as `<think>…</think>` / a separate `reasoning_content` field. AutoBot discarded the reasoning *text* (kept only token counts).

## What Changed
- `llm_shared/models.py`: added `LLMResponse.reasoning_content: Optional[str] = None` (optional, last field — all 50+ keyword call sites unaffected).
- **Anthropic** (`providers/anthropic.py`): new `_extract_content_pair()` returns `(content, reasoning_content)` — captures native SDK `thinking` blocks + inner `<think>` tag text; keeps `content` clean (reasoning stripped out as before) but PRESERVES the text in the new field. `_extract_text_content()` delegates for full back-compat.
- **CustomOpenAI / OpenAI** (`providers/*.py`): `getattr(choice.message, "reasoning_content", None)` — captures DeepSeek-R1/QwQ/SGLang/o1 reasoning; None on vanilla responses.

## Honest scope
Streaming deferred (streaming yields raw text chunks, doesn't build an LLMResponse — accumulating a parallel reasoning buffer is a separate follow-up).

## Verification
- `py_compile` + `flake8 -F` clean (5 files).
- Acceptance: `<think>reasoning</think>answer` → `content=="answer"`, `reasoning_content=="reasoning"`. Native thinking-block path + no-reasoning path tested; `LLMResponse(` caller audit confirms keyword-safe.

## Model Used
Opus 4.8

Closes #10582. Discovery #10947 (openrouter invalid LLMResponse fields) filed separately. Streaming reasoning = follow-up.