### PR TITLE
feat(knowledge): OKF export/import adapter for the Knowledge Base (#10617)

### DIFF
--- a/autobot-backend/knowledge/adapters/__init__.py
+++ b/autobot-backend/knowledge/adapters/__init__.py
@@ -1,0 +1,9 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Knowledge-base adapter modules."""
+
+from knowledge.adapters.okf_adapter import OKFAdapter, export_to_okf, import_from_okf
+
+__all__ = ["OKFAdapter", "export_to_okf", "import_from_okf"]

--- a/autobot-backend/knowledge/adapters/okf_adapter.py
+++ b/autobot-backend/knowledge/adapters/okf_adapter.py
@@ -1,0 +1,776 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Open Knowledge Format (OKF) v0.1 Export/Import Adapter
+
+Issue #10617: Adds a lossless round-trip adapter between the AutoBot Knowledge
+Base and OKF bundles — directories of Markdown "concept" files with YAML
+frontmatter.
+
+OKF v0.1 spec
+-------------
+* One file per KB fact/concept: ``<slug>.md``
+* YAML frontmatter block delimited by ``---`` fences (required)
+* Required frontmatter field: ``type`` (maps to KB metadata ``type`` or
+  ``source_type``; defaults to ``"concept"`` when absent in KB metadata)
+* Optional frontmatter fields: ``id``, ``title``, ``category``, ``tags``,
+  ``created_at``, ``updated_at``, and any other KB metadata keys
+* Body: the raw fact ``content`` string
+* Cross-links: ``[[target-slug]]`` in the body are rewritten to standard
+  Markdown links ``[target-slug](target-slug.md)`` on export and resolved back
+  to fact IDs on import
+
+Round-trip guarantee
+--------------------
+``export_to_okf`` -> ``import_from_okf`` -> ``export_to_okf`` produces a
+byte-identical bundle (same file names, same content, same ordering) for any
+KB state — enabling git-versionable snapshots of the knowledge base.
+
+Slugging rules
+--------------
+* Title (from metadata ``title`` key) -> lowercase, alphanumeric + hyphens
+* Fallback: fact_id shortened to 8 chars when no title present
+* Duplicates get a numeric suffix: ``concept``, ``concept-2``, ``concept-3``
+* Slug alphabet: ``[a-z0-9-]``; max 80 chars before suffix
+
+Usage (standalone — no live KB required)
+-----------------------------------------
+::
+
+    from knowledge.adapters.okf_adapter import OKFAdapter
+
+    adapter = OKFAdapter(kb=None)  # or a real KnowledgeBase instance
+    result = await adapter.export_to_okf(facts, "/tmp/my-okf-bundle")
+    facts  = await adapter.import_from_okf("/tmp/my-okf-bundle")
+
+Usage (via KB service method)
+------------------------------
+::
+
+    from knowledge import get_knowledge_base
+    from knowledge.adapters.okf_adapter import export_to_okf, import_from_okf
+
+    kb   = await get_knowledge_base()
+    info = await export_to_okf(kb, "/tmp/bundle")
+    info = await import_from_okf(kb, "/tmp/bundle")
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import unicodedata
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: YAML frontmatter fence marker.
+_FENCE = "---"
+
+#: Default ``type`` value injected when KB metadata has no ``type`` field.
+_DEFAULT_TYPE = "concept"
+
+#: Maximum slug length before a disambiguation suffix is appended.
+_SLUG_MAX_LEN = 80
+
+#: Wiki-link pattern: ``[[some-slug]]`` — used inside fact content.
+_WIKILINK_RE = re.compile(r"\[\[([^\]]+)]]")
+
+#: Markdown link pattern written by export: ``[slug](slug.md)``.
+_MDLINK_RE = re.compile(r"\[([^\]]+)]\(([^\)]+)\.md\)")
+
+#: Metadata keys that live in frontmatter (not buried inside ``metadata:``).
+_FRONTMATTER_KEYS = frozenset(
+    {
+        "id",
+        "type",
+        "title",
+        "category",
+        "tags",
+        "created_at",
+        "updated_at",
+        "source_type",
+        "verification_status",
+        "quality_score",
+        "collection",
+        "embedding_model",
+    }
+)
+
+#: Keys that should never be round-tripped via frontmatter (internal/runtime).
+_SKIP_KEYS = frozenset(
+    {
+        "fact_id",  # stored as ``id`` in frontmatter
+        "timestamp",  # stored as ``created_at``
+        "source_type",  # unified with ``type`` in OKF frontmatter
+        "content_fingerprint",
+        "embedding",
+        "provenance_chain",
+        "source_connector_id",
+        "verification_method",
+        "verified_by",
+        "verified_at",
+        "source_session_id",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Slug helpers
+# ---------------------------------------------------------------------------
+
+
+def _slugify(text: str) -> str:
+    """Convert *text* to an OKF-safe slug.
+
+    Rules: lowercase Unicode -> ASCII transliteration -> keep ``[a-z0-9]`` and
+    spaces -> replace spaces/hyphens with single hyphens -> strip leading/trailing
+    hyphens -> truncate to ``_SLUG_MAX_LEN``.
+
+    Args:
+        text: Source text (title or fact_id).
+
+    Returns:
+        Slug string matching ``[a-z0-9][a-z0-9-]*``.
+    """
+    # Normalise Unicode and transliterate to ASCII
+    nfkd = unicodedata.normalize("NFKD", text)
+    ascii_text = nfkd.encode("ascii", "ignore").decode("ascii")
+    lowered = ascii_text.lower()
+    # Replace any non-alphanumeric character with a hyphen
+    slugged = re.sub(r"[^a-z0-9]+", "-", lowered)
+    slugged = slugged.strip("-")
+    return slugged[:_SLUG_MAX_LEN] or "concept"
+
+
+def _unique_slug(base_slug: str, taken: set, *, counter_start: int = 2) -> str:
+    """Return *base_slug* or a disambiguated variant not present in *taken*.
+
+    Args:
+        base_slug: Preferred slug.
+        taken: Set of already-assigned slugs (mutated by caller after return).
+        counter_start: First numeric suffix to try.
+
+    Returns:
+        Unique slug string.
+    """
+    if base_slug not in taken:
+        return base_slug
+    counter = counter_start
+    while True:
+        candidate = "%s-%d" % (base_slug, counter)
+        if candidate not in taken:
+            return candidate
+        counter += 1
+
+
+# ---------------------------------------------------------------------------
+# OKF file serialisation helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_frontmatter(fact: Dict[str, Any], slug: str) -> Dict[str, Any]:
+    """Assemble the YAML frontmatter dict for a single fact.
+
+    The ``type`` key is guaranteed to be present (OKF required field).
+
+    Args:
+        fact: KB fact dict with keys ``fact_id``, ``content``, ``metadata``,
+              ``timestamp`` (optional).
+        slug: The slug assigned to this fact (used as the concept identifier).
+
+    Returns:
+        Ordered dict for yaml.dump (type is always first).
+    """
+    meta = fact.get("metadata") or {}
+
+    fm: Dict[str, Any] = {}
+
+    # Required OKF field — must be first for human readability
+    raw_type = meta.get("type") or meta.get("source_type") or _DEFAULT_TYPE
+    fm["type"] = str(raw_type)
+
+    # Stable identity
+    fm["id"] = fact.get("fact_id", slug)
+
+    # Optional well-known fields — preserve originals when present
+    if meta.get("title"):
+        fm["title"] = str(meta["title"])
+    if meta.get("category"):
+        fm["category"] = str(meta["category"])
+    if meta.get("tags"):
+        tags = meta["tags"]
+        if isinstance(tags, str):
+            tags = [t.strip() for t in tags.split(",") if t.strip()]
+        fm["tags"] = sorted(str(t) for t in tags) if tags else []
+    if meta.get("collection"):
+        fm["collection"] = str(meta["collection"])
+
+    # Timestamps
+    created = fact.get("timestamp") or meta.get("created_at") or meta.get("timestamp")
+    if created:
+        fm["created_at"] = str(created)
+    if meta.get("updated_at"):
+        fm["updated_at"] = str(meta["updated_at"])
+
+    # Provenance
+    if meta.get("verification_status"):
+        fm["verification_status"] = str(meta["verification_status"])
+    if meta.get("quality_score") is not None and meta["quality_score"] != 0.0:
+        fm["quality_score"] = float(meta["quality_score"])
+    if meta.get("embedding_model"):
+        fm["embedding_model"] = str(meta["embedding_model"])
+
+    # Remaining metadata keys that are not in _SKIP_KEYS and not already emitted
+    emitted = set(fm.keys()) | {"type", "id"}
+    for key, value in sorted(meta.items()):
+        if key in _SKIP_KEYS:
+            continue
+        if key in emitted:
+            continue
+        # Serialise dicts/lists as YAML-native structures
+        fm[key] = value
+
+    return fm
+
+
+def _render_okf_file(frontmatter: Dict[str, Any], body: str) -> str:
+    """Render a complete OKF ``.md`` file as a string.
+
+    Args:
+        frontmatter: Dict to serialise as YAML between ``---`` fences.
+        body: Raw concept content (may contain markdown links).
+
+    Returns:
+        Complete file content string ending with a newline.
+    """
+    yaml_block = yaml.dump(
+        frontmatter,
+        default_flow_style=False,
+        allow_unicode=True,
+        sort_keys=False,
+    )
+    return "%s\n%s%s\n\n%s\n" % (_FENCE, yaml_block, _FENCE, body.rstrip())
+
+
+def _rewrite_wikilinks_to_md(content: str, slug_map: Dict[str, str]) -> str:
+    """Replace ``[[target-slug]]`` cross-links with Markdown links on export.
+
+    Args:
+        content: Raw fact content possibly containing wiki-links.
+        slug_map: Mapping of fact_id -> slug for resolving link targets.
+
+    Returns:
+        Content with wiki-links rewritten to ``[slug](slug.md)`` format.
+    """
+
+    def _replace(match: re.Match) -> str:
+        target = match.group(1).strip()
+        # target may be a fact_id or already a slug
+        resolved = slug_map.get(target, target)
+        return "[%s](%s.md)" % (resolved, resolved)
+
+    return _WIKILINK_RE.sub(_replace, content)
+
+
+def _rewrite_md_links_to_ids(content: str, slug_to_id: Dict[str, str]) -> str:
+    """Replace ``[slug](slug.md)`` links back to ``[[fact_id]]`` on import.
+
+    Args:
+        content: OKF file body possibly containing Markdown links.
+        slug_to_id: Mapping of slug -> fact_id for resolving link targets.
+
+    Returns:
+        Content with Markdown links rewritten to ``[[fact_id]]`` format.
+    """
+
+    def _replace(match: re.Match) -> str:
+        slug = match.group(2).strip()  # group 2 is the href without .md
+        fact_id = slug_to_id.get(slug, slug)
+        return "[[%s]]" % fact_id
+
+    return _MDLINK_RE.sub(_replace, content)
+
+
+# ---------------------------------------------------------------------------
+# OKF file parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_okf_file(path: Path) -> Tuple[Dict[str, Any], str]:
+    """Parse an OKF ``.md`` file into frontmatter dict and body string.
+
+    Args:
+        path: Path to the ``.md`` file.
+
+    Returns:
+        ``(frontmatter, body)`` tuple.
+
+    Raises:
+        ValueError: If the file lacks a valid frontmatter block or the
+                    required ``type`` field is absent.
+    """
+    raw = path.read_text(encoding="utf-8")
+    lines = raw.split("\n")
+
+    if not lines or lines[0].rstrip() != _FENCE:
+        raise ValueError("OKF file %s does not start with '---' frontmatter fence" % path)
+
+    end_fence = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.rstrip() == _FENCE:
+            end_fence = i
+            break
+
+    if end_fence is None:
+        raise ValueError("OKF file %s has no closing '---' frontmatter fence" % path)
+
+    yaml_text = "\n".join(lines[1:end_fence])
+    frontmatter = yaml.safe_load(yaml_text) or {}
+
+    if "type" not in frontmatter:
+        raise ValueError("OKF file %s is missing required 'type' frontmatter field" % path)
+
+    # Body starts after the blank line that follows the closing fence
+    body_lines = lines[end_fence + 1 :]
+    # Strip one leading blank line if present (written by _render_okf_file)
+    if body_lines and not body_lines[0].strip():
+        body_lines = body_lines[1:]
+    body = "\n".join(body_lines).rstrip()
+
+    return frontmatter, body
+
+
+def _frontmatter_to_metadata(frontmatter: Dict[str, Any], fact_id: str) -> Dict[str, Any]:
+    """Reconstruct KB metadata from OKF frontmatter.
+
+    Args:
+        frontmatter: Parsed YAML frontmatter dict.
+        fact_id: The canonical fact_id (from ``id`` field or derived from slug).
+
+    Returns:
+        KB-compatible metadata dict.
+    """
+    meta: Dict[str, Any] = {}
+
+    meta["fact_id"] = fact_id
+
+    # Required OKF field
+    raw_type = frontmatter.get("type", _DEFAULT_TYPE)
+    meta["type"] = str(raw_type)
+    # Preserve source_type for KB provenance
+    meta["source_type"] = str(raw_type)
+
+    # Map well-known fields back
+    for key in (
+        "title",
+        "category",
+        "collection",
+        "verification_status",
+        "quality_score",
+        "embedding_model",
+    ):
+        if key in frontmatter:
+            meta[key] = frontmatter[key]
+
+    if "tags" in frontmatter:
+        tags = frontmatter["tags"]
+        if isinstance(tags, list):
+            meta["tags"] = tags
+        elif isinstance(tags, str):
+            meta["tags"] = [t.strip() for t in tags.split(",") if t.strip()]
+
+    if "created_at" in frontmatter:
+        meta["created_at"] = str(frontmatter["created_at"])
+        meta["timestamp"] = str(frontmatter["created_at"])
+    if "updated_at" in frontmatter:
+        meta["updated_at"] = str(frontmatter["updated_at"])
+
+    # Pass through any extra keys not already handled
+    handled = frozenset(
+        {
+            "type",
+            "id",
+            "title",
+            "category",
+            "tags",
+            "collection",
+            "created_at",
+            "updated_at",
+            "verification_status",
+            "quality_score",
+            "embedding_model",
+        }
+    )
+    for key, value in frontmatter.items():
+        if key not in handled and key not in meta:
+            meta[key] = value
+
+    return meta
+
+
+# ---------------------------------------------------------------------------
+# Main adapter class
+# ---------------------------------------------------------------------------
+
+
+class OKFAdapter:
+    """Lossless OKF v0.1 export/import adapter for the AutoBot Knowledge Base.
+
+    Can operate standalone (``kb=None``) against a pre-loaded list of fact
+    dicts, or against a live ``KnowledgeBase`` instance for full round-trips.
+
+    Deterministic output
+    --------------------
+    Facts are sorted by ``fact_id`` before export so that the resulting file
+    set is stable across runs and git-versionable.
+    """
+
+    def __init__(self, kb: Optional[Any] = None) -> None:
+        """Initialise the adapter.
+
+        Args:
+            kb: Optional live ``KnowledgeBase`` instance.  Required only for
+                the ``export_from_kb`` and ``import_into_kb`` convenience
+                helpers; ``export_to_okf`` and ``import_from_okf`` accept
+                caller-supplied fact dicts directly.
+        """
+        self._kb = kb
+
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+
+    def _assign_slugs(self, facts: List[Dict[str, Any]]) -> Dict[str, str]:
+        """Build a stable fact_id -> slug mapping for all facts.
+
+        Facts are sorted by ``fact_id`` before slug assignment to ensure
+        deterministic output.
+
+        Args:
+            facts: List of KB fact dicts.
+
+        Returns:
+            Mapping of ``fact_id -> slug``.
+        """
+        slug_map: Dict[str, str] = {}
+        taken: set = set()
+        for fact in sorted(facts, key=lambda f: f.get("fact_id", "")):
+            fact_id = fact.get("fact_id", "")
+            meta = fact.get("metadata") or {}
+            title = meta.get("title") or fact_id[:8]
+            base = _slugify(title)
+            slug = _unique_slug(base, taken)
+            taken.add(slug)
+            slug_map[fact_id] = slug
+        return slug_map
+
+    async def export_to_okf(
+        self,
+        facts: List[Dict[str, Any]],
+        output_dir: str,
+    ) -> Dict[str, Any]:
+        """Serialise a list of KB facts to an OKF bundle directory.
+
+        Each fact becomes one ``<slug>.md`` file containing YAML frontmatter
+        (with required ``type`` field) and the fact ``content`` as the body.
+        Wiki-link cross-references (``[[fact_id]]``) in content are rewritten
+        to Markdown links (``[slug](slug.md)``).
+
+        Args:
+            facts: List of KB fact dicts (from ``kb.get_all_facts()`` or
+                   similar).  Each dict must contain at minimum ``fact_id``
+                   and ``content``.
+            output_dir: Directory path to write ``*.md`` files into.  Created
+                        if it does not exist.
+
+        Returns:
+            Dict with keys ``status``, ``exported_count``, ``output_dir``,
+            ``files``.
+        """
+        try:
+            out_path = Path(output_dir)
+            await asyncio.to_thread(out_path.mkdir, parents=True, exist_ok=True)
+
+            slug_map = self._assign_slugs(facts)
+
+            files_written: List[str] = []
+            # Process in deterministic order (sort by fact_id)
+            for fact in sorted(facts, key=lambda f: f.get("fact_id", "")):
+                fact_id = fact.get("fact_id", "")
+                slug = slug_map.get(fact_id, _slugify(fact_id[:8]))
+
+                content = fact.get("content", "")
+                body = _rewrite_wikilinks_to_md(content, slug_map)
+
+                frontmatter = _build_frontmatter(fact, slug)
+                file_content = _render_okf_file(frontmatter, body)
+
+                file_path = out_path / ("%s.md" % slug)
+                await asyncio.to_thread(file_path.write_text, file_content, encoding="utf-8")
+                files_written.append(str(file_path))
+                logger.debug("OKF export: wrote %s (fact_id=%s)", file_path.name, fact_id)
+
+            logger.info("OKF export complete: %d facts -> %s", len(files_written), out_path)
+            return {
+                "status": "success",
+                "exported_count": len(files_written),
+                "output_dir": str(out_path),
+                "files": sorted(files_written),
+            }
+
+        except Exception as exc:
+            logger.error("OKF export failed: %s", exc)
+            return {"status": "error", "message": "OKF export failed: %s" % exc}
+
+    # ------------------------------------------------------------------
+    # Import
+    # ------------------------------------------------------------------
+
+    async def import_from_okf(self, bundle_dir: str) -> Dict[str, Any]:
+        """Parse an OKF bundle directory back into a list of KB fact dicts.
+
+        All ``*.md`` files are parsed in alphabetical (slug) order.  Markdown
+        cross-links (``[slug](slug.md)``) are resolved back to ``[[fact_id]]``
+        wiki-links using the ``id`` field in each file's frontmatter.
+
+        Args:
+            bundle_dir: Path to the OKF bundle directory (must exist).
+
+        Returns:
+            Dict with keys ``status``, ``imported_count``, ``facts``,
+            ``errors`` (list of per-file error strings).
+
+        Notes:
+            The returned facts are **not** automatically stored in the KB.
+            Pass them to ``kb.store_fact()`` or use ``import_into_kb()``.
+        """
+        bundle_path = Path(bundle_dir)
+        if not await asyncio.to_thread(bundle_path.is_dir):
+            return {
+                "status": "error",
+                "message": "Bundle directory not found: %s" % bundle_dir,
+            }
+
+        md_files = sorted(await asyncio.to_thread(lambda: list(bundle_path.glob("*.md"))))
+
+        # First pass: collect slug -> fact_id mapping for cross-link resolution
+        slug_to_id: Dict[str, str] = {}
+        raw_parsed: List[Tuple[str, Dict[str, Any], str]] = []
+        errors: List[str] = []
+
+        for md_file in md_files:
+            try:
+                frontmatter, body = await asyncio.to_thread(_parse_okf_file, md_file)
+                slug = md_file.stem
+                fact_id = str(frontmatter.get("id") or slug)
+                slug_to_id[slug] = fact_id
+                raw_parsed.append((slug, frontmatter, body))
+            except Exception as exc:
+                errors.append("%s: %s" % (md_file.name, exc))
+                logger.warning("OKF import: skipped %s — %s", md_file.name, exc)
+
+        # Second pass: resolve cross-links and build fact dicts
+        facts: List[Dict[str, Any]] = []
+        for slug, frontmatter, body in raw_parsed:
+            fact_id = slug_to_id[slug]
+            content = _rewrite_md_links_to_ids(body, slug_to_id)
+            metadata = _frontmatter_to_metadata(frontmatter, fact_id)
+            facts.append(
+                {
+                    "fact_id": fact_id,
+                    "content": content,
+                    "metadata": metadata,
+                    "timestamp": metadata.get("created_at", ""),
+                }
+            )
+
+        logger.info(
+            "OKF import complete: %d facts parsed, %d errors",
+            len(facts),
+            len(errors),
+        )
+        result: Dict[str, Any] = {
+            "status": "success" if not errors else "partial",
+            "imported_count": len(facts),
+            "facts": facts,
+        }
+        if errors:
+            result["errors"] = errors
+        return result
+
+    # ------------------------------------------------------------------
+    # KB service integration helpers
+    # ------------------------------------------------------------------
+
+    async def export_from_kb(
+        self,
+        output_dir: str,
+        *,
+        collection: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> Dict[str, Any]:
+        """Export facts from a live KB to an OKF bundle.
+
+        Requires ``self._kb`` to be a fully initialised ``KnowledgeBase``
+        instance.
+
+        Args:
+            output_dir: Target directory for ``.md`` files.
+            collection: Optional collection filter (passed to ``get_all_facts``).
+            limit: Maximum number of facts to export.
+            offset: Fact scan offset.
+
+        Returns:
+            Same dict shape as ``export_to_okf``.
+        """
+        if self._kb is None:
+            return {"status": "error", "message": "No KnowledgeBase instance provided"}
+
+        facts = await self._kb.get_all_facts(limit=limit, offset=offset, collection=collection)
+        return await self.export_to_okf(facts, output_dir)
+
+    async def import_into_kb(
+        self,
+        bundle_dir: str,
+        *,
+        overwrite: bool = False,
+    ) -> Dict[str, Any]:
+        """Import an OKF bundle into a live KB.
+
+        Requires ``self._kb`` to be a fully initialised ``KnowledgeBase``
+        instance.  Each parsed fact is stored via ``kb.store_fact()``.  When a
+        fact already exists (duplicate detection in ``store_fact``) the result is
+        counted as ``skipped`` unless *overwrite* is True (in which case
+        ``update_fact`` is called instead).
+
+        Args:
+            bundle_dir: Path to the OKF bundle directory.
+            overwrite: If True, update existing facts with ``update_fact()``
+                       rather than skipping duplicates.
+
+        Returns:
+            Dict with ``status``, ``stored_count``, ``skipped_count``,
+            ``error_count``, ``errors``.
+        """
+        if self._kb is None:
+            return {"status": "error", "message": "No KnowledgeBase instance provided"}
+
+        parse_result = await self.import_from_okf(bundle_dir)
+        if parse_result.get("status") == "error":
+            return parse_result
+
+        facts = parse_result.get("facts", [])
+        errors: List[str] = list(parse_result.get("errors", []))
+        stored = 0
+        skipped = 0
+        error_count = 0
+
+        for fact in facts:
+            fact_id = fact["fact_id"]
+            content = fact["content"]
+            metadata = fact["metadata"]
+            try:
+                result = await self._kb.store_fact(content, metadata, fact_id)
+                status = result.get("status")
+                if status == "success":
+                    stored += 1
+                elif status == "duplicate":
+                    if overwrite:
+                        upd = await self._kb.update_fact(fact_id, content=content, metadata=metadata)
+                        if upd.get("status") == "success":
+                            stored += 1
+                        else:
+                            error_count += 1
+                            errors.append("update %s: %s" % (fact_id, upd.get("message")))
+                    else:
+                        skipped += 1
+                else:
+                    error_count += 1
+                    errors.append("store %s: %s" % (fact_id, result.get("message")))
+            except Exception as exc:
+                error_count += 1
+                errors.append("store %s: %s" % (fact_id, exc))
+                logger.error("OKF import_into_kb: failed to store fact %s: %s", fact_id, exc)
+
+        logger.info(
+            "OKF import_into_kb: stored=%d skipped=%d errors=%d",
+            stored,
+            skipped,
+            error_count,
+        )
+        result_dict: Dict[str, Any] = {
+            "status": "success" if error_count == 0 else "partial",
+            "stored_count": stored,
+            "skipped_count": skipped,
+            "error_count": error_count,
+        }
+        if errors:
+            result_dict["errors"] = errors
+        return result_dict
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience functions (KB service API surface)
+# ---------------------------------------------------------------------------
+
+
+async def export_to_okf(
+    kb: Any,
+    output_dir: str,
+    *,
+    collection: Optional[str] = None,
+    limit: Optional[int] = None,
+    offset: int = 0,
+) -> Dict[str, Any]:
+    """Export KB facts to an OKF bundle directory.
+
+    Convenience wrapper around ``OKFAdapter.export_from_kb``.
+
+    Args:
+        kb: Initialised ``KnowledgeBase`` instance.
+        output_dir: Target directory path (created if absent).
+        collection: Optional collection filter.
+        limit: Maximum facts to export (None = all).
+        offset: Scan offset.
+
+    Returns:
+        Dict with export result metadata.
+    """
+    adapter = OKFAdapter(kb=kb)
+    return await adapter.export_from_kb(output_dir, collection=collection, limit=limit, offset=offset)
+
+
+async def import_from_okf(
+    kb: Any,
+    bundle_dir: str,
+    *,
+    overwrite: bool = False,
+) -> Dict[str, Any]:
+    """Import an OKF bundle into the KB.
+
+    Convenience wrapper around ``OKFAdapter.import_into_kb``.
+
+    Args:
+        kb: Initialised ``KnowledgeBase`` instance.
+        bundle_dir: Path to the OKF bundle directory.
+        overwrite: If True, update existing facts instead of skipping
+                   duplicates.
+
+    Returns:
+        Dict with import result metadata.
+    """
+    adapter = OKFAdapter(kb=kb)
+    return await adapter.import_into_kb(bundle_dir, overwrite=overwrite)

--- a/autobot-backend/knowledge/adapters/test_okf_adapter.py
+++ b/autobot-backend/knowledge/adapters/test_okf_adapter.py
@@ -1,0 +1,426 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Round-trip and unit tests for the OKF v0.1 adapter.
+
+Issue #10617: Verifies that export_to_okf -> import_from_okf -> export_to_okf
+produces an identical bundle (byte-for-byte at the file level), that every
+exported file has the required ``type`` frontmatter field, and that cross-links
+round-trip correctly.
+
+All tests are fully self-contained — no live Redis, ChromaDB, or Ollama
+connection required.  The adapter's standalone path (OKFAdapter(kb=None))
+is used throughout.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from knowledge.adapters.okf_adapter import (
+    OKFAdapter,
+    _parse_okf_file,
+    _render_okf_file,
+    _slugify,
+    _unique_slug,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+FACT_A = {
+    "fact_id": "aaa-111",
+    "content": "Alpha concept with a link to [[bbb-222]].",
+    "metadata": {
+        "title": "Alpha Concept",
+        "category": "theory",
+        "type": "concept",
+        "tags": ["alpha", "theory"],
+        "verification_status": "verified",
+    },
+    "timestamp": "2026-01-01T00:00:00+00:00",
+}
+
+FACT_B = {
+    "fact_id": "bbb-222",
+    "content": "Beta concept references [[aaa-111]] and self-links to [[bbb-222]].",
+    "metadata": {
+        "title": "Beta Concept",
+        "category": "implementation",
+        "source_type": "manual_upload",
+        # no explicit 'type' — adapter defaults to 'concept' from source_type path
+        "tags": ["beta"],
+    },
+    "timestamp": "2026-01-02T00:00:00+00:00",
+}
+
+FACT_MINIMAL = {
+    "fact_id": "ccc-333",
+    "content": "Minimal fact with no metadata.",
+    "metadata": {},
+    "timestamp": "",
+}
+
+ALL_FACTS: List[Dict[str, Any]] = [FACT_A, FACT_B, FACT_MINIMAL]
+
+
+# ---------------------------------------------------------------------------
+# Slug helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSlugify:
+    def test_basic(self):
+        assert _slugify("Hello World") == "hello-world"
+
+    def test_unicode_transliteration(self):
+        slug = _slugify("Ālpha Bēta")
+        assert slug == "lpha-b-ta" or all(c in "abcdefghijklmnopqrstuvwxyz0123456789-" for c in slug)
+
+    def test_max_length(self):
+        long_text = "a" * 200
+        assert len(_slugify(long_text)) <= 80
+
+    def test_empty_fallback(self):
+        assert _slugify("") == "concept"
+        assert _slugify("---") == "concept"
+
+    def test_only_allowed_chars(self):
+        slug = _slugify("Python 3.11: Async/Await & Patterns!")
+        assert all(c in "abcdefghijklmnopqrstuvwxyz0123456789-" for c in slug)
+
+
+class TestUniqueSlug:
+    def test_no_conflict(self):
+        taken: set = set()
+        result = _unique_slug("alpha", taken)
+        assert result == "alpha"
+
+    def test_single_conflict(self):
+        taken = {"alpha"}
+        result = _unique_slug("alpha", taken)
+        assert result == "alpha-2"
+
+    def test_multiple_conflicts(self):
+        taken = {"alpha", "alpha-2", "alpha-3"}
+        result = _unique_slug("alpha", taken)
+        assert result == "alpha-4"
+
+
+# ---------------------------------------------------------------------------
+# OKF file round-trip helpers
+# ---------------------------------------------------------------------------
+
+
+class TestRenderAndParse:
+    def test_round_trip_frontmatter(self):
+        fm = {"type": "concept", "id": "x-1", "title": "X One"}
+        body = "Some content here."
+        rendered = _render_okf_file(fm, body)
+        parsed_fm, parsed_body = _parse_file_from_string(rendered)
+        assert parsed_fm["type"] == "concept"
+        assert parsed_body.strip() == body.strip()
+
+    def test_required_type_field_present(self):
+        fm = {"type": "guide", "id": "g-1"}
+        body = "Guide body."
+        rendered = _render_okf_file(fm, body)
+        assert "type: guide" in rendered
+
+    def test_missing_type_raises(self, tmp_path):
+        bad_file = tmp_path / "bad.md"
+        bad_file.write_text("---\nid: x\n---\n\nBody.\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="missing required 'type'"):
+            _parse_okf_file(bad_file)
+
+    def test_no_fence_raises(self, tmp_path):
+        bad_file = tmp_path / "bad2.md"
+        bad_file.write_text("No frontmatter at all.\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="does not start with"):
+            _parse_okf_file(bad_file)
+
+
+def _parse_file_from_string(content: str):
+    """Parse an OKF file from a string (test helper)."""
+    tmp = Path("/tmp/_okf_test_parse.md")
+    tmp.write_text(content, encoding="utf-8")
+    return _parse_okf_file(tmp)
+
+
+# ---------------------------------------------------------------------------
+# Export tests
+# ---------------------------------------------------------------------------
+
+
+class TestExportToOKF:
+    @pytest.mark.asyncio
+    async def test_creates_md_files(self, tmp_path):
+        adapter = OKFAdapter(kb=None)
+        result = await adapter.export_to_okf(ALL_FACTS, str(tmp_path / "bundle"))
+        assert result["status"] == "success"
+        assert result["exported_count"] == 3
+        md_files = list((tmp_path / "bundle").glob("*.md"))
+        assert len(md_files) == 3
+
+    @pytest.mark.asyncio
+    async def test_type_field_in_all_files(self, tmp_path):
+        adapter = OKFAdapter(kb=None)
+        bundle = tmp_path / "bundle"
+        await adapter.export_to_okf(ALL_FACTS, str(bundle))
+        for md_file in bundle.glob("*.md"):
+            fm, _ = _parse_okf_file(md_file)
+            assert "type" in fm, "type missing in %s" % md_file.name
+
+    @pytest.mark.asyncio
+    async def test_cross_links_rewritten(self, tmp_path):
+        adapter = OKFAdapter(kb=None)
+        bundle = tmp_path / "bundle"
+        await adapter.export_to_okf([FACT_A, FACT_B], str(bundle))
+        alpha_file = bundle / "alpha-concept.md"
+        assert alpha_file.exists()
+        content = alpha_file.read_text(encoding="utf-8")
+        # The [[bbb-222]] link should be rewritten to [beta-concept](beta-concept.md)
+        assert "(beta-concept.md)" in content
+        assert "[[bbb-222]]" not in content
+
+    @pytest.mark.asyncio
+    async def test_deterministic_output(self, tmp_path):
+        adapter = OKFAdapter(kb=None)
+        bundle1 = tmp_path / "b1"
+        bundle2 = tmp_path / "b2"
+        await adapter.export_to_okf(ALL_FACTS, str(bundle1))
+        # Reverse fact order — output should still be identical
+        await adapter.export_to_okf(list(reversed(ALL_FACTS)), str(bundle2))
+
+        files1 = sorted(f.name for f in bundle1.glob("*.md"))
+        files2 = sorted(f.name for f in bundle2.glob("*.md"))
+        assert files1 == files2
+
+        for fname in files1:
+            c1 = (bundle1 / fname).read_text(encoding="utf-8")
+            c2 = (bundle2 / fname).read_text(encoding="utf-8")
+            assert c1 == c2, "Non-deterministic output for %s" % fname
+
+    @pytest.mark.asyncio
+    async def test_minimal_fact_gets_default_type(self, tmp_path):
+        adapter = OKFAdapter(kb=None)
+        bundle = tmp_path / "bundle"
+        await adapter.export_to_okf([FACT_MINIMAL], str(bundle))
+        md_files = list(bundle.glob("*.md"))
+        assert len(md_files) == 1
+        fm, _ = _parse_okf_file(md_files[0])
+        assert fm["type"] == "concept"
+
+    @pytest.mark.asyncio
+    async def test_empty_facts_list(self, tmp_path):
+        adapter = OKFAdapter(kb=None)
+        result = await adapter.export_to_okf([], str(tmp_path / "empty"))
+        assert result["status"] == "success"
+        assert result["exported_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_slug_title_based(self, tmp_path):
+        adapter = OKFAdapter(kb=None)
+        bundle = tmp_path / "bundle"
+        await adapter.export_to_okf([FACT_A], str(bundle))
+        assert (bundle / "alpha-concept.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_slug_fallback_to_fact_id(self, tmp_path):
+        fact_no_title = {
+            "fact_id": "xyz-9999",
+            "content": "No title here.",
+            "metadata": {"type": "note"},
+            "timestamp": "",
+        }
+        adapter = OKFAdapter(kb=None)
+        bundle = tmp_path / "bundle"
+        await adapter.export_to_okf([fact_no_title], str(bundle))
+        # slug based on first 8 chars of fact_id "xyz-9999" -> "xyz-9999"
+        assert (bundle / "xyz-9999.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_tags_sorted_in_output(self, tmp_path):
+        fact = {
+            "fact_id": "t-001",
+            "content": "Tagged.",
+            "metadata": {"type": "note", "tags": ["zebra", "alpha", "mango"]},
+            "timestamp": "",
+        }
+        adapter = OKFAdapter(kb=None)
+        bundle = tmp_path / "bundle"
+        await adapter.export_to_okf([fact], str(bundle))
+        md_files = list(bundle.glob("*.md"))
+        fm, _ = _parse_okf_file(md_files[0])
+        assert fm["tags"] == ["alpha", "mango", "zebra"]
+
+
+# ---------------------------------------------------------------------------
+# Import tests
+# ---------------------------------------------------------------------------
+
+
+class TestImportFromOKF:
+    @pytest.mark.asyncio
+    async def test_basic_import(self, tmp_path):
+        adapter = OKFAdapter(kb=None)
+        bundle = tmp_path / "bundle"
+        await adapter.export_to_okf([FACT_A, FACT_B], str(bundle))
+
+        result = await adapter.import_from_okf(str(bundle))
+        assert result["status"] == "success"
+        assert result["imported_count"] == 2
+        assert "facts" in result
+
+    @pytest.mark.asyncio
+    async def test_type_field_preserved(self, tmp_path):
+        adapter = OKFAdapter(kb=None)
+        bundle = tmp_path / "bundle"
+        await adapter.export_to_okf([FACT_A], str(bundle))
+        result = await adapter.import_from_okf(str(bundle))
+        fact = result["facts"][0]
+        assert fact["metadata"]["type"] == "concept"
+
+    @pytest.mark.asyncio
+    async def test_cross_links_resolved(self, tmp_path):
+        adapter = OKFAdapter(kb=None)
+        bundle = tmp_path / "bundle"
+        await adapter.export_to_okf([FACT_A, FACT_B], str(bundle))
+        result = await adapter.import_from_okf(str(bundle))
+        facts_by_id = {f["fact_id"]: f for f in result["facts"]}
+        # The alpha content should have [[bbb-222]] restored
+        alpha = facts_by_id.get("aaa-111")
+        assert alpha is not None
+        assert "[[bbb-222]]" in alpha["content"]
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_dir(self, tmp_path):
+        adapter = OKFAdapter(kb=None)
+        result = await adapter.import_from_okf(str(tmp_path / "nonexistent"))
+        assert result["status"] == "error"
+        assert "not found" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_bad_file_reported_in_errors(self, tmp_path):
+        adapter = OKFAdapter(kb=None)
+        bundle = tmp_path / "bundle"
+        bundle.mkdir()
+        (bundle / "bad.md").write_text("No frontmatter\n", encoding="utf-8")
+        result = await adapter.import_from_okf(str(bundle))
+        # Should report error but not crash
+        assert result.get("errors") or result["imported_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    @pytest.mark.asyncio
+    async def test_export_import_export_identical(self, tmp_path):
+        """Core round-trip guarantee: export -> import -> export == first export."""
+        adapter = OKFAdapter(kb=None)
+        bundle1 = tmp_path / "b1"
+        bundle2 = tmp_path / "b2"
+
+        # First export
+        export1 = await adapter.export_to_okf(ALL_FACTS, str(bundle1))
+        assert export1["status"] == "success"
+
+        # Import
+        import_result = await adapter.import_from_okf(str(bundle1))
+        assert import_result["status"] == "success"
+
+        # Second export from imported facts
+        export2 = await adapter.export_to_okf(import_result["facts"], str(bundle2))
+        assert export2["status"] == "success"
+
+        # Compare file sets
+        files1 = sorted(f.name for f in bundle1.glob("*.md"))
+        files2 = sorted(f.name for f in bundle2.glob("*.md"))
+        assert files1 == files2, "File sets differ after round-trip"
+
+        # Compare file contents
+        for fname in files1:
+            c1 = (bundle1 / fname).read_text(encoding="utf-8")
+            c2 = (bundle2 / fname).read_text(encoding="utf-8")
+            assert c1 == c2, "Content differs for %s after round-trip" % fname
+
+    @pytest.mark.asyncio
+    async def test_fact_id_preserved_through_round_trip(self, tmp_path):
+        adapter = OKFAdapter(kb=None)
+        bundle = tmp_path / "bundle"
+        await adapter.export_to_okf([FACT_A, FACT_B], str(bundle))
+        result = await adapter.import_from_okf(str(bundle))
+        imported_ids = {f["fact_id"] for f in result["facts"]}
+        assert "aaa-111" in imported_ids
+        assert "bbb-222" in imported_ids
+
+    @pytest.mark.asyncio
+    async def test_category_preserved_through_round_trip(self, tmp_path):
+        adapter = OKFAdapter(kb=None)
+        bundle = tmp_path / "bundle"
+        await adapter.export_to_okf([FACT_A], str(bundle))
+        result = await adapter.import_from_okf(str(bundle))
+        alpha = result["facts"][0]
+        assert alpha["metadata"].get("category") == "theory"
+
+    @pytest.mark.asyncio
+    async def test_tags_preserved_through_round_trip(self, tmp_path):
+        adapter = OKFAdapter(kb=None)
+        bundle = tmp_path / "bundle"
+        await adapter.export_to_okf([FACT_A], str(bundle))
+        result = await adapter.import_from_okf(str(bundle))
+        alpha = result["facts"][0]
+        tags = alpha["metadata"].get("tags", [])
+        assert "alpha" in tags
+        assert "theory" in tags
+
+    @pytest.mark.asyncio
+    async def test_content_body_preserved_through_round_trip(self, tmp_path):
+        """Content (excluding link syntax transform) is preserved losslessly."""
+        fact_plain = {
+            "fact_id": "plain-001",
+            "content": "This is plain content with no links.",
+            "metadata": {"type": "note"},
+            "timestamp": "",
+        }
+        adapter = OKFAdapter(kb=None)
+        bundle = tmp_path / "bundle"
+        await adapter.export_to_okf([fact_plain], str(bundle))
+        result = await adapter.import_from_okf(str(bundle))
+        assert result["facts"][0]["content"].strip() == fact_plain["content"].strip()
+
+    @pytest.mark.asyncio
+    async def test_slug_collision_resolution_stable(self, tmp_path):
+        """Two facts with identical titles get distinct slugs, stable across runs."""
+        fact1 = {
+            "fact_id": "dup-001",
+            "content": "First dup.",
+            "metadata": {"type": "note", "title": "Duplicate Title"},
+            "timestamp": "",
+        }
+        fact2 = {
+            "fact_id": "dup-002",
+            "content": "Second dup.",
+            "metadata": {"type": "note", "title": "Duplicate Title"},
+            "timestamp": "",
+        }
+        adapter = OKFAdapter(kb=None)
+        bundle1 = tmp_path / "b1"
+        bundle2 = tmp_path / "b2"
+        await adapter.export_to_okf([fact1, fact2], str(bundle1))
+        await adapter.export_to_okf([fact1, fact2], str(bundle2))
+
+        files1 = sorted(f.name for f in bundle1.glob("*.md"))
+        files2 = sorted(f.name for f in bundle2.glob("*.md"))
+        assert files1 == files2
+        assert len(files1) == 2
+        assert files1[0] != files1[1]


### PR DESCRIPTION
## Thinking Path
Add an OKF (Open Knowledge Format, Google Cloud v0.1) adapter so a KB can be serialized as a portable, git-versionable bundle of markdown+YAML-frontmatter files and re-imported losslessly.

## What Changed
New `knowledge/adapters/okf_adapter.py` (built on the canonical FactsMixin API — `get_all_facts`/`store_fact`/`update_fact`, no hand-rolled storage):
- `export_to_okf(facts, dir)` → one `<slug>.md` per fact; YAML frontmatter (`type` first, id/title/category/tags/timestamps/provenance); `[[fact_id]]` wiki-links rewritten to `[slug](slug.md)`. Deterministic (facts sorted by id → stable slugs).
- `import_from_okf(dir)` → two-pass parse (build slug→id map, then resolve links back to `[[fact_id]]`).
- `export_from_kb` / `import_into_kb(overwrite=False)` service methods + module-level convenience wrappers.
- Round-trip guarantee: export→import→export is **byte-identical** (`source_type` unified with `type` so no spurious frontmatter key accumulates).

Route wiring (e.g. `POST /api/knowledge_base/export/okf`) left as a follow-up; the adapter + service surface are complete and standalone-usable.

## Verification
- `py_compile` + `flake8 -F` + **`black --check`** all clean (3 files).
- 32/32 round-trip tests: byte-identical bundle, required `type` field, cross-link rewrite/resolve, id preservation, deterministic output, slug-collision stability.

## Model Used
Opus 4.8

Closes #10617. Route exposure = follow-up.