### PR TITLE
fix(frontend): stop browser console error storm — RUM feedback loop + unthrottled network errors + router throw (#10956)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -754,7 +754,14 @@ const handleTabChange = (tabKey: string) => {
   logger.debug('Tab change requested:', tabKey)
   activeTab.value = tabKey
   const routeName = tabKey === 'chat' ? 'chat-default' : `chat-${tabKey}`
-  router.push({ name: routeName }).catch(() => {})
+  // Vue Router throws synchronously (not via the returned promise) when the
+  // named route isn't registered, so `.catch()` can't swallow it — guard with
+  // hasRoute() before navigating so an unmapped tab can't raise a console error.
+  if (router.hasRoute(routeName)) {
+    router.push({ name: routeName }).catch(() => {})
+  } else {
+    logger.debug(`No route registered for tab "${tabKey}" (${routeName}); skipping URL sync`)
+  }
   logger.debug('Active tab changed to:', activeTab.value)
 }
 

--- a/autobot-frontend/src/plugins/errorHandler.ts
+++ b/autobot-frontend/src/plugins/errorHandler.ts
@@ -12,6 +12,18 @@ import { createLogger } from '@/utils/debugUtils'
 // Create scoped logger for errorHandler
 const logger = createLogger('errorHandler')
 
+// Telemetry endpoints (RUM) must be excluded from error tracking/notification.
+// Otherwise a failing telemetry POST is itself tracked as an error, which POSTs
+// again — an infinite feedback loop that floods the console with thousands of
+// "/api/rum/event 502" errors (#10956).
+const isTelemetryUrl = (url: unknown): boolean =>
+  typeof url === 'string' && url.includes('/rum/')
+
+// Connectivity failures (backend restart, brief network drop) reject one fetch
+// per in-flight request. Collapse the console error / RUM event / toast to at
+// most one per this window so a transient outage can't spam the console.
+const NETWORK_ERROR_THROTTLE_MS = 10000
+
 interface ErrorNotification {
   id: string
   message: string
@@ -25,6 +37,8 @@ class GlobalErrorHandler {
   private notifications: ErrorNotification[] = []
   private listeners: Set<(notifications: ErrorNotification[]) => void> = new Set()
   private maxNotifications = 5
+  // Timestamp of the last surfaced connectivity failure — see NETWORK_ERROR_THROTTLE_MS.
+  private lastNetworkErrorAt = 0
 
   constructor() {
     this.setupGlobalHandlers()
@@ -103,6 +117,12 @@ class GlobalErrorHandler {
               ? args[0].href
               : (args[0] as Request)?.url
 
+          // Never track/log/notify failures of the telemetry endpoint itself —
+          // doing so re-POSTs telemetry and forms an infinite loop (#10956).
+          if (isTelemetryUrl(requestUrl)) {
+            return response
+          }
+
           // Track HTTP errors
           rumAgent.trackError('http_error', {
             status: response.status,
@@ -149,38 +169,52 @@ class GlobalErrorHandler {
 
         return response
       } catch (error) {
-        // Don't log expected health check failures or AbortError
-        // (AbortError fires legitimately when components abort in-flight
-        // requests on unmount or rapid navigation — not a real failure).
-        const isHealthCheck = typeof args[0] === 'string' && args[0].includes('/health')
-        const isAbortError =
-          (error instanceof DOMException && error.name === 'AbortError') ||
-          (error as Error)?.name === 'AbortError'
-        if (!isHealthCheck && !isAbortError) {
-          logger.error('Fetch error:', error)
-        }
-
-        // Track network errors
+        const err = error as Error
         const requestUrl = typeof args[0] === 'string'
           ? args[0]
           : args[0] instanceof URL
             ? args[0].href
             : (args[0] as Request)?.url
 
-        rumAgent.trackError('network_error', {
-          message: (error as Error).message,
-          stack: (error as Error).stack,
-          url: requestUrl,
-          source: 'fetch_interceptor'
-        })
+        // AbortError fires legitimately when components abort in-flight requests
+        // on unmount / rapid navigation. Fully benign: never log, track, or
+        // notify — just re-throw so the caller's own handling runs.
+        const isAbortError =
+          (error instanceof DOMException && error.name === 'AbortError') ||
+          err?.name === 'AbortError'
+        // Telemetry failures must not generate more telemetry (#10956 loop).
+        if (isAbortError || isTelemetryUrl(requestUrl)) {
+          throw error
+        }
 
-        // Only show notification for non-health check failures
-        if (!isHealthCheck) {
+        const isHealthCheck = typeof requestUrl === 'string' && requestUrl.includes('/health')
+        // Collapse repeated connectivity failures (backend restart, network
+        // drop) so a transient outage can't spam thousands of console
+        // errors / RUM events / toasts (#10956).
+        const now = Date.now()
+        const throttled = now - this.lastNetworkErrorAt < NETWORK_ERROR_THROTTLE_MS
+        this.lastNetworkErrorAt = now
+
+        if (!isHealthCheck && !throttled) {
+          logger.error('Fetch error:', error)
+        }
+
+        if (!throttled) {
+          rumAgent.trackError('network_error', {
+            message: err.message,
+            stack: err.stack,
+            url: requestUrl,
+            source: 'fetch_interceptor'
+          })
+        }
+
+        // Only show notification for non-health-check, non-throttled failures
+        if (!isHealthCheck && !throttled) {
           this.addNotification({
             message: 'Network connection failed. Please check your internet connection.',
             type: 'error',
             dismissible: true,
-            stack: (error as Error).stack
+            stack: err.stack
           })
         }
 

--- a/autobot-frontend/src/utils/RumAgent.ts
+++ b/autobot-frontend/src/utils/RumAgent.ts
@@ -143,6 +143,12 @@ class RumAgent {
     timeoutThreshold: number
   }
   private rumEventEndpoint: string
+  // #10956: circuit breaker so a failing telemetry endpoint can't be retried
+  // in a tight loop (backend restart → 502 per event → console flood).
+  private rumEventFailures = 0
+  private rumEventCircuitOpenUntil = 0
+  private static readonly RUM_EVENT_FAILURE_THRESHOLD = 5
+  private static readonly RUM_EVENT_CIRCUIT_COOLDOWN_MS = 60000
   // Issue #476: Prometheus metrics export configuration
   private prometheusEnabled: boolean
   private prometheusEndpoint: string
@@ -660,6 +666,10 @@ class RumAgent {
   // #10938: Post a structured RumEvent to /api/rum/event so rum.log captures it.
   // errorData fields go into the nested `data` field the backend formatter expects.
   private sendRumEvent(type: string, errorData: Record<string, any>): void {
+    // #10956: if the endpoint has failed repeatedly (e.g. backend restarting →
+    // 502), stop sending for a cooldown so telemetry can't flood the console.
+    if (Date.now() < this.rumEventCircuitOpenUntil) return
+
     const payload = {
       type,
       timestamp: new Date().toISOString(),
@@ -673,9 +683,28 @@ class RumAgent {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
       keepalive: true
-    }).catch(() => {
-      // Silently ignore — never disrupt the user experience for telemetry
     })
+      .then((res) => {
+        // A 502/5xx is a resolved response, not a rejection — count it so the
+        // breaker opens during backend outages.
+        if (res.ok) {
+          this.rumEventFailures = 0
+        } else {
+          this.recordRumEventFailure()
+        }
+      })
+      .catch(() => {
+        // Network-layer rejection (backend unreachable) — also a failure.
+        this.recordRumEventFailure()
+      })
+  }
+
+  private recordRumEventFailure(): void {
+    this.rumEventFailures += 1
+    if (this.rumEventFailures >= RumAgent.RUM_EVENT_FAILURE_THRESHOLD) {
+      this.rumEventCircuitOpenUntil = Date.now() + RumAgent.RUM_EVENT_CIRCUIT_COOLDOWN_MS
+      this.rumEventFailures = 0
+    }
   }
 
   // Issue #476: Enable/disable Prometheus reporting


### PR DESCRIPTION
## Thinking Path
User's browser console showed **21941 errors**, then a live flood of `/api/rum/event:1 Failed to load resource: 502`. A fresh headless session is clean (0 errors on most views), so this is amplification, not a render loop. Traced three compounding defects.

## What Changed
### 1. RUM telemetry feedback loop (dominant cause)
`RumAgent.sendRumEvent()` POSTs to `/api/rum/event` through the **intercepted** `window.fetch`. When that POST fails (backend restarting → 502), `errorHandler`'s `!response.ok` (line 107) and `catch` (line 170) branches called `rumAgent.trackError('http_error'/'network_error')` **again** → another POST → 502 → infinite loop. That is the `/api/rum/event 502` flood and the bulk of the 21941.
- `errorHandler.ts`: excludes telemetry URLs (`/rum/`) from tracking / logging / notification.
- `RumAgent.ts`: circuit breaker in `sendRumEvent` — opens after 5 consecutive failures for 60s. Now inspects `res.ok` (a 502 is a *resolved* response; the old `.catch()`-only code never detected it).

### 2. Unthrottled connectivity errors
Navigation/backend-blip fetches reject as `TypeError: Failed to fetch` (not `AbortError`), so each logged an error + RUM event + a "Network connection failed" toast, with no dedupe.
- Fully ignore `AbortError` (no toast either — it's a deliberate cancel).
- Throttle connectivity failures to one surfaced error / RUM / toast per 10s.

### 3. ChatInterface tab-change router throw
`ChatInterface.vue:757` — `router.push({ name: 'chat-'+tabKey })` throws **synchronously** for unregistered routes (only `chat-default/terminal/novnc/session` exist); `.catch()` can't catch a sync throw. Guarded with `router.hasRoute()`.

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json`: no type errors in the three edited files.
- Headless Playwright: fresh `/chat` session 0 errors; backend-restart 502s no longer re-amplify (telemetry excluded + breaker).

## Model Used
Opus 4.8 (1M context)

Closes #10956