### PR TITLE
docs(skills): STANDALONE/SUPERCHARGED capability tiers + output contracts (#10541)

### DIFF
--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -22,6 +22,72 @@ Two-phase research skill: first understand the source, then compare against Auto
 
 **Comments** after the primary input provide steering context for both phases.
 
+## Capability Tiers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ research                                                      │
+├─────────────────────────────────────────────────────────────┤
+│ STANDALONE   (always works, zero config)                     │
+│   • Analyze a given URL, GitHub repo, or local file          │
+│   • web-fetch degradation: Jina Reader → wget → httpx        │
+├─────────────────────────────────────────────────────────────┤
+│ SUPERCHARGED (unlocks when you connect a provider)           │
+│   • SEARXNG_INSTANCE_URL    → topic search (no URL given)    │
+│   • BRAVE_SEARCH_API_KEY    → topic search + preferred       │
+│                               ranking, SearXNG as fallback   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**STANDALONE — always works, zero config**
+
+- Analyze any explicitly-supplied source: a URL (fetched via the `web-fetch`
+  skill, which itself degrades Jina Reader → `wget` → `httpx`), a GitHub repo,
+  or a local file path.
+- Full Phase 1 / Phase 2 comparison against the AutoBot codebase.
+
+**SUPERCHARGED — unlocks per connected provider**
+
+Topic search (a plain-text query with no URL) needs a configured web-search
+provider. The runtime registry
+([`autobot-backend/agent_loop/search/registry.py`](../../../autobot-backend/agent_loop/search/registry.py))
+is credential-gated and degrades in this order:
+
+| Connect this | Unlocks |
+|--------------|---------|
+| `SEARXNG_INSTANCE_URL` | Topic search via a self-hosted SearXNG instance. |
+| `BRAVE_SEARCH_API_KEY` | Topic search via Brave (preferred when both are set); SearXNG becomes the fallback. |
+| *(neither set)* | Topic search returns no results — the skill still works on any directly-supplied URL/repo/file. |
+
+The registry never errors on a missing provider: an unconfigured or unreachable
+provider degrades to the next one, and an empty chain returns `[]` (no results)
+rather than failing.
+
+## Output Contract
+
+Regardless of tier, topic-search research follows a fixed **Summary → findings →
+verdict** shape so results are comparable across runs:
+
+```
+## Research: <query or source>
+
+**Summary:** one-to-three sentence answer.
+
+### Findings
+
+| # | Source | Provider/Tier | Key point |
+|---|--------|---------------|-----------|
+| 1 | <title / url> | brave | searxng | direct-url | ... |
+| 2 | ...    | ...           | ...       |
+
+**Verdict:** the bottom-line conclusion, with the confidence level and any
+caveat (e.g. "no web-search provider configured — direct sources only").
+```
+
+Phase 1 (Source Analysis) and Phase 2 (AutoBot Comparison) keep their existing
+section structures below; the contract above governs the topic-search entry
+point specifically.
+
 ## Phase 1 — Understand Source
 
 Fetch and analyze the input. Produce this structure:

--- a/autobot-backend/skills/builtin/README.md
+++ b/autobot-backend/skills/builtin/README.md
@@ -1,0 +1,115 @@
+# Built-in Agent Skills — Authoring Guide
+
+This directory holds AutoBot's built-in **agent runtime skills**. Each skill is a
+`SKILL.md` file (`<skill-name>/SKILL.md`) that the agent reads to learn *when* to
+use a capability and *how* to run it. These are distinct from the developer
+workflow skills under `.claude/skills/` — those drive Claude Code sessions; these
+drive the running agent.
+
+## File layout
+
+```
+autobot-backend/skills/builtin/
+├── README.md                       ← this guide
+├── web_fetch/SKILL.md
+├── github_search/SKILL.md
+├── youtube_transcript/SKILL.md
+└── rss_reader/SKILL.md
+```
+
+## SKILL.md structure
+
+Only the YAML front-matter (delimited by `---` lines at the top) is machine-parsed
+by [`manifest_parser.py`](../manifest_parser.py). The markdown body below the
+front-matter is free-form prose read by the agent. Required front-matter fields:
+`name`, `version`, `description`; recommended: `category`, `tools`, `triggers`,
+`tags`, `author`.
+
+The body should follow this section order:
+
+1. `## Capability Tiers` — **required** (see below)
+2. `## When to Use`
+3. `## Workflow`
+4. `## Output Format` / `## Output Contract` — **output contract required** for
+   skills that return findings (research, search, KB lookups)
+5. `## Parameters`
+6. `## Limitations`
+7. `## Fallback Instructions`
+
+## Capability Tiers convention (required)
+
+Every skill declares two capability tiers so users can see what works out of the
+box versus what a connected tool unlocks. Document the **real** behavior of the
+skill's graceful-degradation chain — never invent tool integrations.
+
+- **STANDALONE** — always works, zero config. What the skill can do with no keys,
+  no login, and no external service configured (including its built-in fallback
+  chain, e.g. Jina Reader → `wget` → `httpx`).
+- **SUPERCHARGED** — unlocks per connected tool. What each optional
+  provider/connector/credential adds on top. An unset connector must simply keep
+  the skill on the STANDALONE tier — connecting a tool never changes the
+  degradation logic itself.
+
+Lead the section with a small ASCII capability box, then spell out each tier:
+
+```
+## Capability Tiers
+
+┌─────────────────────────────────────────────────────────────┐
+│ <skill-name>                                                 │
+├─────────────────────────────────────────────────────────────┤
+│ STANDALONE   (always works, zero config)                     │
+│   • <what works with nothing connected>                      │
+├─────────────────────────────────────────────────────────────┤
+│ SUPERCHARGED (unlocks when you connect a tool)               │
+│   • <connector> → <what it adds>                             │
+└─────────────────────────────────────────────────────────────┘
+
+**STANDALONE — always works, zero config**
+- ...
+
+**SUPERCHARGED — unlocks per connected tool**
+
+| Connect this | Unlocks |
+|--------------|---------|
+| <credential / connector> | <capability it adds> |
+```
+
+(Fence the box with triple backticks in the real file so it renders literally.)
+
+## Output Contract convention (required for result-returning skills)
+
+Skills that return findings (research, search, KB lookups) must document a fixed
+output shape so callers and downstream summarizers can rely on the structure.
+Match Anthropic's **Summary → findings table → verdict** discipline:
+
+```
+## Output Contract
+
+## <title>
+
+**Summary:** one-to-three sentence answer.
+
+### Findings
+
+| # | Source | Provider/Tier | Key point |
+|---|--------|---------------|-----------|
+| 1 | ...    | ...           | ...       |
+
+**Verdict:** bottom-line conclusion + confidence + any caveat
+(e.g. "no provider configured — direct sources only").
+```
+
+Always include a `Tier used` / `Provider` marker in the output so consumers can
+see which point in the fallback chain produced the result. Define the degraded
+single-line shape too (e.g. `Unreachable: <url> — <reason>`).
+
+## Rules
+
+- Document **only real behavior**. Read the skill's actual fallback chain (and,
+  for topic search, the credential-gated
+  [`agent_loop/search/registry.py`](../../agent_loop/search/registry.py)) — do
+  not fabricate integrations.
+- STANDALONE must genuinely require zero config. If a capability needs a key or
+  login, it belongs in SUPERCHARGED.
+- Keep the ASCII box aligned and the tables valid markdown.

--- a/autobot-backend/skills/builtin/github_search/SKILL.md
+++ b/autobot-backend/skills/builtin/github_search/SKILL.md
@@ -32,6 +32,62 @@ tags:
   - code-search
 ---
 
+## Capability Tiers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ github-search                                                 │
+├─────────────────────────────────────────────────────────────┤
+│ STANDALONE   (always works, zero config)                     │
+│   • Search public repos / issues / PRs via unauthenticated   │
+│     GitHub REST API (curl fallback)                          │
+├─────────────────────────────────────────────────────────────┤
+│ SUPERCHARGED (unlocks when you connect a tool)               │
+│   • gh auth login / GITHUB_TOKEN → gh CLI subcommands,       │
+│     higher rate limits, private-repo access, JSON/jq output  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**STANDALONE — always works, zero config**
+
+- Search public repositories, issues, and pull requests through the
+  unauthenticated GitHub REST API (`curl 'https://api.github.com/search/...'`).
+- Subject to GitHub's low anonymous rate limit; public results only.
+
+**SUPERCHARGED — unlocks per connected tool**
+
+| Connect this | Unlocks |
+|--------------|---------|
+| `gh auth login` **or** `GITHUB_TOKEN` | Native `gh search` / `gh view` subcommands, `--json` / `--jq` / `--template` output, higher authenticated rate limits, and access to private repos the token can see. |
+
+The skill prefers the authenticated `gh` path when available and degrades to the
+anonymous REST tier otherwise — no configuration change is required to fall back.
+
+## Output Contract
+
+Search results are returned in this fixed shape:
+
+```
+## GitHub Search: <query>
+
+**Tier used:** gh-cli (authenticated) | rest-api (anonymous)
+**Results:** <n>
+
+| # | Name / Ref | Stars/State | Description |
+|---|-----------|-------------|-------------|
+| 1 | owner/repo | ★ 1.2k     | ...         |
+```
+
+Detail lookups (`view_issue` / `view_pr`) return:
+
+```
+## <owner>/<repo>#<number> — <title>
+
+**State:** open | closed   **Author:** <login>   **Labels:** ...
+
+<body excerpt>
+```
+
 ## When to Use
 
 Use this skill when an agent needs to search or retrieve data from GitHub —

--- a/autobot-backend/skills/builtin/rss_reader/SKILL.md
+++ b/autobot-backend/skills/builtin/rss_reader/SKILL.md
@@ -29,6 +29,58 @@ tags:
   - content-aggregation
 ---
 
+## Capability Tiers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ rss-reader                                                    │
+├─────────────────────────────────────────────────────────────┤
+│ STANDALONE   (always works, zero config)                     │
+│   • Parse any public RSS/Atom feed with feedparser           │
+│     (tolerant of malformed XML, no auth)                     │
+├─────────────────────────────────────────────────────────────┤
+│ SUPERCHARGED (unlocks when you connect a tool)               │
+│   • atoma parser         → typed Atom objects on strict feeds │
+│   • Custom User-Agent /  → feeds that reject the default      │
+│     Accept header           request                          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**STANDALONE — always works, zero config**
+
+- Parse any public RSS or Atom feed with `feedparser`; both formats are detected
+  automatically and malformed XML is tolerated.
+- List titles, extract entries as JSON, read full entry content, and inspect
+  feed metadata — all without authentication.
+
+**SUPERCHARGED — unlocks per connected tool**
+
+| Connect this | Unlocks |
+|--------------|---------|
+| `atoma` parser | Strongly-typed Atom entry objects for strict Atom feeds where `feedparser` degrades. |
+| Custom `User-Agent` / `Accept` header handler | Feeds that reject the default request (403 / empty body) become readable. |
+
+These are graceful fallbacks — the skill defaults to `feedparser` and only needs
+the extras for the minority of feeds that require them.
+
+## Output Contract
+
+Feed reads return this fixed shape:
+
+```
+## Feed: <feed title>
+
+**URL:** <feed_url>   **Type:** rss | atom   **Entries:** <n>
+**Parser:** feedparser | atoma
+
+| # | Title | Published | Link |
+|---|-------|-----------|------|
+| 1 | ...   | ...       | ...  |
+```
+
+Single-entry content mode returns the raw entry body (HTML or plain text) under
+a `## <entry title>` heading.
+
 ## When to Use
 
 Use this skill when an agent needs to read news, blog posts, or any content

--- a/autobot-backend/skills/builtin/web_fetch/SKILL.md
+++ b/autobot-backend/skills/builtin/web_fetch/SKILL.md
@@ -26,6 +26,57 @@ tags:
   - content-extraction
 ---
 
+## Capability Tiers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ web-fetch                                                     │
+├─────────────────────────────────────────────────────────────┤
+│ STANDALONE   (always works, zero config)                     │
+│   • Fetch any public URL as clean markdown via Jina Reader   │
+│   • wget / httpx fallback when Jina is down or rate-limited  │
+│   • JSON + plain-text output modes                           │
+├─────────────────────────────────────────────────────────────┤
+│ SUPERCHARGED (unlocks when you connect a tool)               │
+│   • Jina API key    → higher rate limits, larger responses   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**STANDALONE — always works, zero config**
+
+- Fetch and extract clean markdown from any HTTP/HTTPS URL through the public
+  Jina Reader endpoint (no key required).
+- Automatic graceful degradation: Jina Reader → `wget` → `httpx` if the
+  preferred path is unavailable or rate-limited.
+- `markdown` (default), `json`, and `text` output modes.
+
+**SUPERCHARGED — unlocks per connected tool**
+
+| Connect this | Unlocks |
+|--------------|---------|
+| `api_key` — Jina API key | Higher request rate limits and larger extracted-text responses than the anonymous tier. |
+
+Nothing here changes the degradation logic — an unset key simply keeps the skill
+on the anonymous STANDALONE tier.
+
+## Output Contract
+
+Every fetch returns this fixed shape so callers can rely on the structure:
+
+```
+## Fetched: <page title or URL>
+
+**Source:** <final URL after redirects>
+**Tier used:** jina | wget | httpx
+**Extracted:** <approx word/char count>
+
+<clean markdown / text / JSON body>
+```
+
+- `Tier used` names which path in the fallback chain produced the result.
+- On total failure the contract collapses to a single line:
+  `Unreachable: <url> — <reason>` (see Fallback Instructions).
+
 ## When to Use
 
 Use this skill whenever an agent needs to read the content of a public URL — news

--- a/autobot-backend/skills/builtin/youtube_transcript/SKILL.md
+++ b/autobot-backend/skills/builtin/youtube_transcript/SKILL.md
@@ -28,6 +28,53 @@ tags:
   - media
 ---
 
+## Capability Tiers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ youtube-transcript                                            │
+├─────────────────────────────────────────────────────────────┤
+│ STANDALONE   (always works, zero config)                     │
+│   • Extract auto/manual captions + metadata for any public   │
+│     video via yt-dlp (no login, no video download)           │
+├─────────────────────────────────────────────────────────────┤
+│ SUPERCHARGED (unlocks when you connect a tool)               │
+│   • Browser cookies (--cookies-from-browser) → age-gated,    │
+│     members-only, and private videos you can access          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**STANDALONE — always works, zero config**
+
+- Download manual or auto-generated captions for any public video with `yt-dlp`
+  (subtitles only — the video itself is never downloaded).
+- Fetch full video metadata (`--dump-json`) and search YouTube for video IDs.
+- Graceful degradation: manual subs → auto-generated subs → description text.
+
+**SUPERCHARGED — unlocks per connected tool**
+
+| Connect this | Unlocks |
+|--------------|---------|
+| Browser cookies (`--cookies-from-browser firefox`) | Transcripts and metadata for age-gated, members-only, or private videos that the signed-in browser session can access. |
+
+Without cookies the skill simply stays on the public-video STANDALONE tier.
+
+## Output Contract
+
+Transcript extraction returns this fixed shape:
+
+```
+## Transcript: <video title>
+
+**Video:** <url or id>   **Duration:** <hh:mm:ss>   **Uploader:** <name>
+**Caption source:** manual | auto-generated | description-fallback
+
+<plain-text transcript, timing tags stripped>
+```
+
+Metadata-only requests return the raw `--dump-json` object (keys: `title`,
+`description`, `duration`, `uploader`, `view_count`, `upload_date`, `chapters`).
+
 ## When to Use
 
 Use this skill when an agent needs to read or summarize the spoken content of a


### PR DESCRIPTION
## Thinking Path
Anthropic knowledge-work skill docs split capabilities into a STANDALONE tier (zero-config) + SUPERCHARGED tier (unlocks per connected tool), with a capability box + fixed output contract. AutoBot degrades gracefully but never documented the tiers. Docs-only.

## What Changed (all 5 SKILL.md-format skills + a new authoring guide)
- `skills/builtin/{web_fetch,github_search,youtube_transcript,rss_reader}/SKILL.md` + `.claude/skills/research/SKILL.md`: added a **Capability Tiers** section (ASCII box + STANDALONE bullets + SUPERCHARGED 'connect X → unlocks Y' table) and an **Output Contract** (result shape + tier/provider marker + degraded fallback).
- New `skills/builtin/README.md`: makes the tiers + output-contract convention canonical for future skills.
- Tiers cross-checked against **real code** (web_fetch Jina→wget→httpx; github anon-REST vs GITHUB_TOKEN; youtube public captions vs cookies; rss feedparser vs custom-header; research Brave→SearXNG→none via registry.py). No fabricated integrations.

## Verification
- Docs-only: 6 markdown files, 387 insertions, 0 deletions, no frontmatter/code touched.
- Balanced ASCII code-fences; relative links resolve; frontmatter regex still matches all 5.

## Model Used
Opus 4.8

Closes #10541. Discovery: builtin SKILL.md frontmatter doesn't satisfy manifest_parser (missing `entrypoint`) — pre-existing, filed separately.