### PR TITLE
feat(knowledge): tool-agnostic connector category resolution (#10539)

### DIFF
--- a/autobot-backend/knowledge/connectors/CONNECTORS.md
+++ b/autobot-backend/knowledge/connectors/CONNECTORS.md
@@ -1,0 +1,65 @@
+# Connector Category Reference
+
+Issue #10539 — tool-agnostic connector category abstraction.
+
+Skills and workflow steps can resolve connectors by **category** instead of by
+a hard-coded vendor type.  `ConnectorRegistry.resolve_by_category(category)`
+returns every **live** (configured + started) instance whose `connector_type`
+belongs to that category.  The lookup is case-insensitive.
+
+## Category Map
+
+| Category | Connector types |
+|---|---|
+| `cloud storage` | `gdrive`, `onedrive`, `nextcloud` |
+| `source control` | `gitlab`, `gitea` |
+| `wiki` | `notion` |
+| `knowledge base` | `notion`, `file_server`, `web_crawler` |
+| `file system` | `file_server` |
+| `database` | `database` |
+| `web` | `web_crawler` |
+| `audio` | `audio` |
+| `external` | `external_adapter` |
+
+## Connector Types
+
+| Type | File | Description |
+|---|---|---|
+| `gdrive` | `gdrive.py` | Google Drive API v3 |
+| `onedrive` | `onedrive.py` | Microsoft OneDrive / SharePoint |
+| `nextcloud` | `nextcloud.py` | Nextcloud WebDAV |
+| `gitlab` | `gitlab.py` | GitLab REST API v4 |
+| `gitea` | `gitlab.py` | Gitea / Forgejo REST API v1 |
+| `notion` | `notion.py` | Notion databases and pages |
+| `file_server` | `file_server.py` | Local / NFS / SMB mounts |
+| `web_crawler` | `web_crawler.py` | Playwright-based web crawler |
+| `database` | `database.py` | SQLAlchemy-backed databases |
+| `audio` | `audio_connector.py` | Audio file ingestion |
+| `external_adapter` | `external_adapter.py` | Subprocess / stdout-JSON adapters |
+
+## Usage
+
+```python
+from knowledge.connectors import ConnectorRegistry, CATEGORY_MAP
+
+# Resolve all configured "cloud storage" connectors:
+instances = ConnectorRegistry.resolve_by_category("cloud storage")
+
+# Inspect the full map:
+print(CATEGORY_MAP)
+```
+
+Workflow steps carry the intended category in their `inputs` dict:
+
+```python
+WorkflowStep(
+    task_id="kb_search",
+    agent_type="librarian",
+    action="Search existing knowledge base for relevant information",
+    inputs={"connector_category": "knowledge base"},
+)
+```
+
+The agent reads `inputs["connector_category"]` and calls
+`ConnectorRegistry.resolve_by_category(...)` to obtain live connectors without
+knowing which vendor is deployed.

--- a/autobot-backend/knowledge/connectors/__init__.py
+++ b/autobot-backend/knowledge/connectors/__init__.py
@@ -59,10 +59,11 @@ from knowledge.connectors.models import (
     SourceInfo,
     SyncResult,
 )
-from knowledge.connectors.registry import ConnectorRegistry
+from knowledge.connectors.registry import CATEGORY_MAP, ConnectorRegistry
 
 __all__ = [
     "AbstractConnector",
+    "CATEGORY_MAP",
     "ChangeInfo",
     "ConnectorConfig",
     "ConnectorRegistry",

--- a/autobot-backend/knowledge/connectors/registry.py
+++ b/autobot-backend/knowledge/connectors/registry.py
@@ -37,6 +37,22 @@ from knowledge.connectors.models import ConnectorConfig
 
 logger = get_logger(__name__)
 
+# Issue #10539: Category → connector type list.
+# Maps a logical capability category (lowercase, normalised) to the list of
+# registered connector type strings that satisfy it.  Only connector types
+# that are actually implemented in this codebase are listed here.
+CATEGORY_MAP: Dict[str, List[str]] = {
+    "cloud storage": ["gdrive", "onedrive", "nextcloud"],
+    "source control": ["gitlab", "gitea"],
+    "wiki": ["notion"],
+    "knowledge base": ["notion", "file_server", "web_crawler"],
+    "file system": ["file_server"],
+    "database": ["database"],
+    "web": ["web_crawler"],
+    "audio": ["audio"],
+    "external": ["external_adapter"],
+}
+
 
 class ConnectorRegistry:
     """Class-level registry for connector types and running instances."""
@@ -162,6 +178,44 @@ class ConnectorRegistry:
     def list_types(cls) -> List[str]:
         """Return all registered connector type strings."""
         return list(cls._connectors.keys())
+
+    @classmethod
+    def resolve_by_category(cls, category: str) -> List[object]:
+        """Return live instances whose connector type belongs to *category*.
+
+        Issue #10539: Category resolution lets skills/workflows request a
+        capability (e.g. "cloud storage", "source control") rather than naming
+        a specific vendor connector.  Only instances that are already
+        registered (i.e. configured and started via ``add_instance``) are
+        returned — unconfigured connector types are silently excluded.
+
+        The lookup is case-insensitive and strips surrounding whitespace so
+        callers may pass ``"Cloud Storage"`` or ``"cloud storage"`` equally.
+
+        Args:
+            category: A category label from ``CATEGORY_MAP`` (case-insensitive).
+
+        Returns:
+            List of live connector instances matching the category; empty list
+            if the category is unknown or no matching instance is configured.
+        """
+        key = category.strip().lower()
+        type_ids = CATEGORY_MAP.get(key, [])
+        if not type_ids:
+            logger.debug("resolve_by_category: unknown category %r", category)
+            return []
+        matched = [
+            instance
+            for instance in cls._instances.values()
+            if getattr(getattr(instance, "config", None), "connector_type", None) in type_ids
+        ]
+        logger.debug(
+            "resolve_by_category(%r): types=%r matched=%d instance(s)",
+            category,
+            type_ids,
+            len(matched),
+        )
+        return matched
 
     @classmethod
     def registered_types(cls) -> Mapping[str, Type["AbstractConnector"]]:

--- a/autobot-backend/knowledge/connectors/tests/test_category_resolution.py
+++ b/autobot-backend/knowledge/connectors/tests/test_category_resolution.py
@@ -1,0 +1,209 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for ConnectorRegistry.resolve_by_category — Issue #10539.
+
+Verifies:
+  - resolve_by_category returns configured (live) instances for a category.
+  - resolve_by_category returns empty list for an unconfigured category.
+  - resolve_by_category is case-insensitive and strips surrounding whitespace.
+  - resolve_by_category returns empty list for an unknown category.
+  - CATEGORY_MAP is exported from the package.
+  - Existing exact-type resolution (get / list_types) is unaffected.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from knowledge.connectors.registry import CATEGORY_MAP, ConnectorRegistry  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_instance(connector_type: str, connector_id: str) -> MagicMock:
+    """Build a minimal mock connector instance."""
+    cfg = MagicMock()
+    cfg.connector_type = connector_type
+    cfg.connector_id = connector_id
+    instance = MagicMock()
+    instance.config = cfg
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_instances():
+    """Isolate each test by clearing the live-instance registry."""
+    original = dict(ConnectorRegistry._instances)
+    ConnectorRegistry._instances.clear()
+    yield
+    ConnectorRegistry._instances.clear()
+    ConnectorRegistry._instances.update(original)
+
+
+# ---------------------------------------------------------------------------
+# CATEGORY_MAP contract
+# ---------------------------------------------------------------------------
+
+
+class TestCategoryMap:
+    def test_exported_from_registry(self):
+        assert isinstance(CATEGORY_MAP, dict)
+
+    def test_exported_from_package(self):
+        from knowledge.connectors import CATEGORY_MAP as pkg_map
+
+        assert pkg_map is CATEGORY_MAP
+
+    def test_known_categories_present(self):
+        for category in ("cloud storage", "source control", "wiki", "knowledge base"):
+            assert category in CATEGORY_MAP, "CATEGORY_MAP missing %r" % category
+
+    def test_cloud_storage_members(self):
+        assert set(CATEGORY_MAP["cloud storage"]) == {"gdrive", "onedrive", "nextcloud"}
+
+    def test_source_control_members(self):
+        assert set(CATEGORY_MAP["source control"]) == {"gitlab", "gitea"}
+
+    def test_wiki_members(self):
+        assert "notion" in CATEGORY_MAP["wiki"]
+
+    def test_knowledge_base_members(self):
+        kb = CATEGORY_MAP["knowledge base"]
+        assert "notion" in kb
+        assert "file_server" in kb
+        assert "web_crawler" in kb
+
+    def test_all_types_are_real(self):
+        """Every type listed in CATEGORY_MAP must be a real connector type."""
+        # We cannot import all connectors in the bare test context (they need
+        # Redis/other infra), so we just verify the strings are non-empty
+        # and match the known canonical list.
+        known_types = {
+            "gdrive",
+            "onedrive",
+            "nextcloud",
+            "gitlab",
+            "gitea",
+            "notion",
+            "file_server",
+            "web_crawler",
+            "database",
+            "audio",
+            "external_adapter",
+        }
+        for category, types in CATEGORY_MAP.items():
+            for t in types:
+                assert t in known_types, "CATEGORY_MAP[%r] contains unknown type %r" % (category, t)
+
+
+# ---------------------------------------------------------------------------
+# resolve_by_category — live-instance filtering
+# ---------------------------------------------------------------------------
+
+
+class TestResolveByCategory:
+    def test_returns_empty_for_unconfigured_category(self):
+        result = ConnectorRegistry.resolve_by_category("cloud storage")
+        assert result == []
+
+    def test_returns_matching_instance(self):
+        instance = _make_instance("gdrive", "gdrive-1")
+        ConnectorRegistry._instances["gdrive-1"] = instance
+
+        result = ConnectorRegistry.resolve_by_category("cloud storage")
+        assert instance in result
+
+    def test_returns_multiple_matching_instances(self):
+        gdrive = _make_instance("gdrive", "gdrive-1")
+        onedrive = _make_instance("onedrive", "onedrive-1")
+        ConnectorRegistry._instances["gdrive-1"] = gdrive
+        ConnectorRegistry._instances["onedrive-1"] = onedrive
+
+        result = ConnectorRegistry.resolve_by_category("cloud storage")
+        assert set(result) == {gdrive, onedrive}
+
+    def test_excludes_instances_from_other_categories(self):
+        gitlab = _make_instance("gitlab", "gl-1")
+        gdrive = _make_instance("gdrive", "gd-1")
+        ConnectorRegistry._instances["gl-1"] = gitlab
+        ConnectorRegistry._instances["gd-1"] = gdrive
+
+        result = ConnectorRegistry.resolve_by_category("cloud storage")
+        assert gdrive in result
+        assert gitlab not in result
+
+    def test_unknown_category_returns_empty(self):
+        instance = _make_instance("gdrive", "gdrive-1")
+        ConnectorRegistry._instances["gdrive-1"] = instance
+
+        result = ConnectorRegistry.resolve_by_category("nonexistent category")
+        assert result == []
+
+    def test_case_insensitive_lookup(self):
+        instance = _make_instance("gdrive", "gdrive-1")
+        ConnectorRegistry._instances["gdrive-1"] = instance
+
+        for variant in ("Cloud Storage", "CLOUD STORAGE", "cloud storage", "Cloud storage"):
+            assert instance in ConnectorRegistry.resolve_by_category(variant), (
+                "Expected instance for category variant %r" % variant
+            )
+
+    def test_strips_surrounding_whitespace(self):
+        instance = _make_instance("gdrive", "gdrive-1")
+        ConnectorRegistry._instances["gdrive-1"] = instance
+
+        assert instance in ConnectorRegistry.resolve_by_category("  cloud storage  ")
+
+    def test_knowledge_base_multiple_types(self):
+        notion = _make_instance("notion", "notion-1")
+        fs = _make_instance("file_server", "fs-1")
+        ConnectorRegistry._instances["notion-1"] = notion
+        ConnectorRegistry._instances["fs-1"] = fs
+
+        result = ConnectorRegistry.resolve_by_category("knowledge base")
+        assert notion in result
+        assert fs in result
+
+    def test_source_control_gitlab_and_gitea(self):
+        gl = _make_instance("gitlab", "gl-1")
+        gt = _make_instance("gitea", "gt-1")
+        ConnectorRegistry._instances["gl-1"] = gl
+        ConnectorRegistry._instances["gt-1"] = gt
+
+        result = ConnectorRegistry.resolve_by_category("source control")
+        assert set(result) == {gl, gt}
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat: existing exact-type resolution unaffected
+# ---------------------------------------------------------------------------
+
+
+class TestExistingResolutionUnaffected:
+    def test_get_still_works_by_id(self):
+        instance = _make_instance("gdrive", "gdrive-1")
+        ConnectorRegistry._instances["gdrive-1"] = instance
+
+        assert ConnectorRegistry.get("gdrive-1") is instance
+
+    def test_list_instances_unaffected(self):
+        instance = _make_instance("notion", "notion-1")
+        ConnectorRegistry._instances["notion-1"] = instance
+
+        assert "notion-1" in ConnectorRegistry.list_instances()

--- a/autobot-backend/workflow_templates/research.py
+++ b/autobot-backend/workflow_templates/research.py
@@ -7,6 +7,11 @@ Research Workflow Templates
 
 Issue #381: Extracted from workflow_templates.py god class refactoring.
 Contains research-related workflow template definitions.
+
+Issue #10539: kb_search and store_research steps carry connector_category in
+their inputs dict so agents can resolve the right connector via
+ConnectorRegistry.resolve_by_category("knowledge base") instead of naming a
+specific vendor connector.
 """
 
 from typing import List
@@ -22,6 +27,9 @@ def _create_comprehensive_research_steps() -> List[WorkflowStep]:
 
     Returns list of WorkflowStep objects for knowledge base search, web research,
     source verification, synthesis, and storing results. Issue #620.
+
+    Issue #10539: kb_search and store_research carry connector_category so
+    agents resolve the connector by category rather than by hard-coded type.
     """
     return [
         WorkflowStep(
@@ -30,6 +38,7 @@ def _create_comprehensive_research_steps() -> List[WorkflowStep]:
             action="Search existing knowledge base for relevant information",
             description="Librarian: Knowledge Base Search",
             estimated_duration_seconds=5.0,
+            inputs={"connector_category": "knowledge base"},
         ),
         WorkflowStep(
             task_id="web_research",
@@ -38,6 +47,7 @@ def _create_comprehensive_research_steps() -> List[WorkflowStep]:
             description="Research: Web Research",
             dependencies=["kb_search"],
             estimated_duration_seconds=60.0,
+            inputs={"connector_category": "web"},
         ),
         WorkflowStep(
             task_id="source_verification",
@@ -62,6 +72,7 @@ def _create_comprehensive_research_steps() -> List[WorkflowStep]:
             description="Knowledge_Manager: Store Research",
             dependencies=["synthesis"],
             estimated_duration_seconds=5.0,
+            inputs={"connector_category": "knowledge base"},
         ),
     ]
 
@@ -191,6 +202,7 @@ def _create_tech_research_initial_steps() -> List[WorkflowStep]:
     Create initial steps for technology research: knowledge search and overview.
 
     Issue #620.
+    Issue #10539: existing_knowledge carries connector_category for category-based resolution.
     """
     return [
         WorkflowStep(
@@ -199,6 +211,7 @@ def _create_tech_research_initial_steps() -> List[WorkflowStep]:
             action="Search knowledge base for existing technology information",
             description="Librarian: Technology Knowledge Search",
             estimated_duration_seconds=5.0,
+            inputs={"connector_category": "knowledge base"},
         ),
         WorkflowStep(
             task_id="technology_overview",
@@ -242,6 +255,7 @@ def _create_tech_research_final_steps() -> List[WorkflowStep]:
     Create final steps for technology research: recommendation and storage.
 
     Issue #620.
+    Issue #10539: store_research carries connector_category for category-based resolution.
     """
     return [
         WorkflowStep(
@@ -260,6 +274,7 @@ def _create_tech_research_final_steps() -> List[WorkflowStep]:
             description="Knowledge_Manager: Store Technology Research",
             dependencies=["recommendation"],
             estimated_duration_seconds=5.0,
+            inputs={"connector_category": "knowledge base"},
         ),
     ]
 


### PR DESCRIPTION
## Thinking Path
Connectors resolved only by exact vendor type — skills/workflows had to name a specific connector, so adding a vendor meant editing every consumer. Add a category abstraction (Anthropic's `~~category` pattern).

## What Changed (`knowledge/connectors/registry.py`)
- `CATEGORY_MAP`: real categories → real registered connectors (cloud storage → gdrive/onedrive/nextcloud; source control → gitlab/gitea; wiki → notion; knowledge base → notion/file_server/web_crawler; file system/database/web/audio/external). Only maps connectors that actually exist.
- `resolve_by_category(category)`: case-insensitive; returns the **live/configured** instances whose `connector_type` is in that category (filters `_instances`); `[]` for unknown/none. Additive — exact-type resolution untouched.
- `CONNECTORS.md`: category↔connector table + usage.
- `workflow_templates/research.py`: kb_search/web_research/store steps now carry `inputs={"connector_category": ...}` so agents resolve by category instead of naming a vendor (free-form `inputs` field — no schema change).

## Verification
- `py_compile` + `flake8 -F` + **`black --check`** clean (all files).
- 19/19 tests: category resolution, unknown→[], case-insensitivity, live-instance filtering.

## Model Used
Opus 4.8

Closes #10539.