### PR TITLE
feat(skills): role-curated skill bundles in SkillHub (#10540)

### DIFF
--- a/autobot-backend/api/schemas_workflows.py
+++ b/autobot-backend/api/schemas_workflows.py
@@ -654,6 +654,36 @@ class SkillTracesResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# skills/bundles.py schemas  (Issue #10540)
+# ---------------------------------------------------------------------------
+
+
+class SkillBundleResponse(BaseModel):
+    """A single role-curated skill bundle returned by GET /skills/bundles."""
+
+    id: str
+    name: str
+    description: str
+    member_skill_ids: List[str]
+
+
+class SkillBundlesListResponse(BaseModel):
+    """Response for GET /skills/bundles (Issue #10540)."""
+
+    bundles: List[SkillBundleResponse]
+    total: int
+
+
+class SkillBundleInstallResponse(BaseModel):
+    """Response for POST /skills/bundles/{bundle_id}/enable (Issue #10540)."""
+
+    bundle_id: str
+    enabled: List[str]
+    skipped: List[str]
+    failed: Dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
 # structured_thinking_mcp.py schemas  (Issue #5912)
 # ---------------------------------------------------------------------------
 

--- a/autobot-backend/api/skills.py
+++ b/autobot-backend/api/skills.py
@@ -32,6 +32,8 @@ from api.schemas_common import DataResponse
 from api.schemas_workflows import (
     MCPSpanResponse,
     SkillActionsResponse,
+    SkillBundleInstallResponse,
+    SkillBundlesListResponse,
     SkillDetailResponse,
     SkillHealthResponse,
     SkillMetricsResponse,
@@ -292,6 +294,67 @@ async def install_catalog_skill(name: str, body: SkillInstallRequest) -> Dict[st
 
     logger.info("Installed catalog skill '%s' (id=%s)", pkg.name, pkg.id)
     return {"success": True, "id": pkg.id, "name": pkg.name, "version": pkg.version, "trust_level": pkg.trust_level}
+
+
+@router.get("/bundles", summary="List curated skill bundles", response_model=SkillBundlesListResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_skill_bundles",
+    error_code_prefix="SKILLS",
+)
+async def list_skill_bundles() -> dict:
+    """Return all role-curated skill bundles (Research / Engineering / Knowledge).
+
+    Bundles are DATA ONLY — they reference existing builtin skill ids and
+    introduce no new skill logic (Issue #10540).
+    """
+    from skills.bundles import list_bundles
+
+    return {
+        "bundles": [
+            {
+                "id": b.id,
+                "name": b.name,
+                "description": b.description,
+                "member_skill_ids": b.member_skill_ids,
+            }
+            for b in list_bundles()
+        ],
+        "total": len(list_bundles()),
+    }
+
+
+@router.post(
+    "/bundles/{bundle_id}/enable",
+    summary="Enable all skills in a curated bundle",
+    response_model=SkillBundleInstallResponse,
+)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="enable_skill_bundle",
+    error_code_prefix="SKILLS",
+)
+async def enable_skill_bundle(bundle_id: str) -> dict:
+    """Enable every member skill of a curated bundle.
+
+    Delegates to the existing ``registry.enable_skill`` +
+    ``manager.persist_skill_enabled`` pair for each member skill — exactly the
+    same path taken by ``POST /skills/{name}/enable`` (Issue #10540).
+
+    Returns which skills were enabled, which were skipped (not registered),
+    and which failed (e.g. dependency errors).
+    """
+    from skills.bundles import enable_bundle, get_bundle
+
+    try:
+        get_bundle(bundle_id)  # validate before doing any work
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    registry = get_skill_registry()
+    manager = _get_manager()
+    result = await enable_bundle(bundle_id, registry=registry, manager=manager)
+    return result
 
 
 @router.get("/{name}", summary="Get skill details", response_model=SkillDetailResponse)

--- a/autobot-backend/skills/bundles.py
+++ b/autobot-backend/skills/bundles.py
@@ -1,0 +1,171 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Role-curated skill bundles for SkillHub (Issue #10540)
+
+A bundle is a named, role-oriented group of existing builtin skill ids.
+No new skill logic is introduced — bundles are pure DATA that reference the
+skill ids registered by ``skills.registry.SkillRegistry``.  Installing a
+bundle delegates one-by-one to the existing
+``SkillRegistry.enable_skill`` / ``SkillManager.persist_skill_enabled``
+pair, exactly as the per-skill ``POST /skills/{name}/enable`` endpoint does.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class SkillBundle:
+    """Immutable description of a role-curated skill bundle."""
+
+    id: str
+    name: str
+    description: str
+    member_skill_ids: List[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Canonical bundle catalogue — DATA ONLY.
+# Member ids must match the ``name`` field in each skill's SkillManifest.
+# ---------------------------------------------------------------------------
+
+_BUNDLES: List[SkillBundle] = [
+    SkillBundle(
+        id="research",
+        name="Research",
+        description=(
+            "Skills for gathering information from the web, feeds, videos, "
+            "code repositories, and discovering new capabilities."
+        ),
+        member_skill_ids=[
+            "web-fetch",
+            "rss-reader",
+            "youtube-transcript",
+            "github-search",
+            "skill-researcher",
+        ],
+    ),
+    SkillBundle(
+        id="engineering",
+        name="Engineering",
+        description=(
+            "Skills that support software development workflows: code review, "
+            "autonomous skill generation, and intelligent skill routing."
+        ),
+        member_skill_ids=[
+            "code-review",
+            "autonomous-skill-development",
+            "skill-router",
+        ],
+    ),
+    SkillBundle(
+        id="knowledge",
+        name="Knowledge",
+        description=(
+            "Skills for capturing, analysing, and organising information: "
+            "document analysis, note taking, and calendar integration."
+        ),
+        member_skill_ids=[
+            "document-analysis",
+            "note-taking",
+            "calendar-integration",
+        ],
+    ),
+]
+
+# Fast lookup by bundle id
+_BUNDLE_BY_ID: Dict[str, SkillBundle] = {b.id: b for b in _BUNDLES}
+
+
+# ---------------------------------------------------------------------------
+# Public API — data access
+# ---------------------------------------------------------------------------
+
+
+def list_bundles() -> List[SkillBundle]:
+    """Return all curated skill bundles (ordered, immutable)."""
+    return list(_BUNDLES)
+
+
+def get_bundle(bundle_id: str) -> SkillBundle:
+    """Return the bundle with the given id.
+
+    Raises:
+        ValueError: when *bundle_id* is not a known bundle.
+    """
+    try:
+        return _BUNDLE_BY_ID[bundle_id]
+    except KeyError:
+        raise ValueError(f"Unknown bundle id '{bundle_id}'") from None
+
+
+# ---------------------------------------------------------------------------
+# Install helper — reuses existing enable API
+# ---------------------------------------------------------------------------
+
+
+async def enable_bundle(
+    bundle_id: str,
+    *,
+    registry,
+    manager,
+) -> Dict[str, object]:
+    """Enable every member skill of a bundle via the existing governance path.
+
+    Delegates to ``registry.enable_skill`` (dependency-checked) and
+    ``manager.persist_skill_enabled`` (Redis persistence) for each member,
+    mirroring ``POST /skills/{name}/enable`` exactly.
+
+    Args:
+        bundle_id: Id of the bundle to install.
+        registry: ``SkillRegistry`` instance (injected to allow testing).
+        manager: ``SkillManager`` instance (injected to allow testing).
+
+    Returns:
+        A dict with keys:
+        - ``bundle_id`` — the requested bundle id
+        - ``enabled`` — skill ids that were successfully enabled
+        - ``skipped`` — skill ids that were not in the registry
+        - ``failed`` — mapping of skill id → error message
+
+    Raises:
+        ValueError: when *bundle_id* is not a known bundle.
+    """
+    bundle = get_bundle(bundle_id)  # raises ValueError on unknown id
+
+    enabled: List[str] = []
+    skipped: List[str] = []
+    failed: Dict[str, str] = {}
+
+    for skill_id in bundle.member_skill_ids:
+        result = registry.enable_skill(skill_id)
+        if not result["success"]:
+            error_msg: str = result.get("error", "enable failed")
+            # Skill not in registry vs other failure
+            if "not found" in error_msg.lower():
+                logger.debug("Bundle '%s': skill '%s' not registered, skipping", bundle_id, skill_id)
+                skipped.append(skill_id)
+            else:
+                logger.warning("Bundle '%s': failed to enable '%s': %s", bundle_id, skill_id, error_msg)
+                failed[skill_id] = error_msg
+            continue
+
+        await manager.persist_skill_enabled(skill_id, True)
+        logger.info("Bundle '%s': enabled skill '%s'", bundle_id, skill_id)
+        enabled.append(skill_id)
+
+    return {
+        "bundle_id": bundle_id,
+        "enabled": enabled,
+        "skipped": skipped,
+        "failed": failed,
+    }

--- a/autobot-backend/skills/bundles_test.py
+++ b/autobot-backend/skills/bundles_test.py
@@ -1,0 +1,186 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for role-curated skill bundles (Issue #10540)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from skills.bundles import SkillBundle, enable_bundle, get_bundle, list_bundles
+
+# ---------------------------------------------------------------------------
+# list_bundles
+# ---------------------------------------------------------------------------
+
+
+def test_list_bundles_returns_three():
+    """Exactly the 3 curated bundles are seeded."""
+    bundles = list_bundles()
+    assert len(bundles) == 3
+
+
+def test_bundle_ids():
+    """Bundle ids are 'research', 'engineering', 'knowledge'."""
+    ids = {b.id for b in list_bundles()}
+    assert ids == {"research", "engineering", "knowledge"}
+
+
+def test_each_bundle_has_members():
+    """Every bundle carries at least one member skill id."""
+    for bundle in list_bundles():
+        assert len(bundle.member_skill_ids) >= 1, f"Bundle '{bundle.id}' has no members"
+
+
+def test_bundle_member_ids_are_kebab_case():
+    """All member ids follow kebab-case (matching SkillManifest.name conventions)."""
+    import re
+
+    pattern = re.compile(r"^[a-z][a-z0-9-]*$")
+    for bundle in list_bundles():
+        for mid in bundle.member_skill_ids:
+            assert pattern.match(mid), f"'{mid}' in bundle '{bundle.id}' is not kebab-case"
+
+
+def test_research_bundle_contains_expected_skills():
+    """Research bundle includes web-fetch, rss-reader, youtube-transcript, github-search, skill-researcher."""
+    bundle = get_bundle("research")
+    expected = {"web-fetch", "rss-reader", "youtube-transcript", "github-search", "skill-researcher"}
+    assert expected.issubset(set(bundle.member_skill_ids))
+
+
+def test_engineering_bundle_contains_expected_skills():
+    """Engineering bundle includes code-review, autonomous-skill-development, skill-router."""
+    bundle = get_bundle("engineering")
+    expected = {"code-review", "autonomous-skill-development", "skill-router"}
+    assert expected.issubset(set(bundle.member_skill_ids))
+
+
+def test_knowledge_bundle_contains_expected_skills():
+    """Knowledge bundle includes document-analysis, note-taking, calendar-integration."""
+    bundle = get_bundle("knowledge")
+    expected = {"document-analysis", "note-taking", "calendar-integration"}
+    assert expected.issubset(set(bundle.member_skill_ids))
+
+
+# ---------------------------------------------------------------------------
+# get_bundle
+# ---------------------------------------------------------------------------
+
+
+def test_get_bundle_returns_correct_bundle():
+    """get_bundle('research') returns the Research bundle."""
+    bundle = get_bundle("research")
+    assert isinstance(bundle, SkillBundle)
+    assert bundle.id == "research"
+    assert bundle.name == "Research"
+
+
+def test_get_bundle_unknown_raises_value_error():
+    """get_bundle raises ValueError for an unknown bundle id."""
+    with pytest.raises(ValueError, match="Unknown bundle id 'nonexistent'"):
+        get_bundle("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# enable_bundle
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def anyio_backend():
+    """Use asyncio backend only (not trio)."""
+    return "asyncio"
+
+
+def _make_registry(skill_ids: list[str], fail_ids: list[str] | None = None) -> MagicMock:
+    """Build a mock registry whose enable_skill succeeds for skill_ids."""
+    fail_ids = fail_ids or []
+    registry = MagicMock()
+
+    def _enable(name: str):
+        if name in fail_ids:
+            return {"success": False, "error": f"dependency missing for {name}"}
+        if name not in skill_ids:
+            return {"success": False, "error": f"Skill '{name}' not found"}
+        return {"success": True}
+
+    registry.enable_skill.side_effect = _enable
+    return registry
+
+
+def _make_manager() -> MagicMock:
+    manager = MagicMock()
+    manager.persist_skill_enabled = AsyncMock(return_value=True)
+    return manager
+
+
+@pytest.mark.anyio
+async def test_enable_bundle_calls_enable_for_each_member():
+    """enable_bundle calls registry.enable_skill once per member skill."""
+    bundle = get_bundle("research")
+    registry = _make_registry(bundle.member_skill_ids)
+    manager = _make_manager()
+
+    result = await enable_bundle("research", registry=registry, manager=manager)
+
+    assert result["bundle_id"] == "research"
+    assert set(result["enabled"]) == set(bundle.member_skill_ids)
+    assert result["skipped"] == []
+    assert result["failed"] == {}
+    assert registry.enable_skill.call_count == len(bundle.member_skill_ids)
+
+
+@pytest.mark.anyio
+async def test_enable_bundle_persists_each_enabled_skill():
+    """enable_bundle calls manager.persist_skill_enabled for every successfully enabled skill."""
+    bundle = get_bundle("engineering")
+    registry = _make_registry(bundle.member_skill_ids)
+    manager = _make_manager()
+
+    await enable_bundle("engineering", registry=registry, manager=manager)
+
+    assert manager.persist_skill_enabled.call_count == len(bundle.member_skill_ids)
+    persisted = {call.args[0] for call in manager.persist_skill_enabled.call_args_list}
+    assert persisted == set(bundle.member_skill_ids)
+
+
+@pytest.mark.anyio
+async def test_enable_bundle_skips_unregistered_skills():
+    """Skills absent from the registry are reported in 'skipped', not 'failed'."""
+    # Only provide 2 of the 3 knowledge skills in the mock registry
+    partial_ids = ["document-analysis", "note-taking"]
+    registry = _make_registry(partial_ids)
+    manager = _make_manager()
+
+    result = await enable_bundle("knowledge", registry=registry, manager=manager)
+
+    assert set(result["enabled"]) == set(partial_ids)
+    assert "calendar-integration" in result["skipped"]
+    assert result["failed"] == {}
+
+
+@pytest.mark.anyio
+async def test_enable_bundle_records_non_notfound_failures():
+    """Dependency failures are reported in 'failed', not 'skipped'."""
+    bundle = get_bundle("engineering")
+    # code-review will fail with a dependency error (not "not found")
+    registry = _make_registry(bundle.member_skill_ids, fail_ids=["code-review"])
+    manager = _make_manager()
+
+    result = await enable_bundle("engineering", registry=registry, manager=manager)
+
+    assert "code-review" in result["failed"]
+    assert "code-review" not in result["enabled"]
+    assert "code-review" not in result["skipped"]
+
+
+@pytest.mark.anyio
+async def test_enable_bundle_unknown_id_raises():
+    """enable_bundle raises ValueError for an unknown bundle id."""
+    registry = _make_registry([])
+    manager = _make_manager()
+
+    with pytest.raises(ValueError, match="Unknown bundle id 'bogus'"):
+        await enable_bundle("bogus", registry=registry, manager=manager)


### PR DESCRIPTION
## Thinking Path
Skills listed flat in SkillHub — no role-oriented grouping. Add curated bundles (Research/Engineering/Knowledge). **Data-only over existing skills; installing a bundle enables members via the existing enable API.**

## What Changed
- New `skills/bundles.py`: frozen `SkillBundle{id,name,description,member_skill_ids}` + `list_bundles()`/`get_bundle()`/`enable_bundle()`. 3 bundles seeded from **real, verified** skills (research: web-fetch/rss-reader/youtube-transcript/github-search/skill-researcher; engineering: code-review/autonomous-skill-development/skill-router; knowledge: document-analysis/note-taking/calendar-integration). No invented skills.
- `enable_bundle()` reuses the EXISTING per-skill `registry.enable_skill` + `manager.persist_skill_enabled` (same as POST /skills/{name}/enable) — no new skill logic; unknown members skipped, unknown bundle → ValueError/404.
- `api/skills.py`: `GET /skills/bundles` + `POST /skills/bundles/{id}/enable`, registered BEFORE the `/{name}` wildcard to avoid route-order conflict. Response schemas in `schemas_workflows.py`.

Frontend SkillHub UI wiring = follow-up (flat listing non-trivial to extend safely).

## Verification
- `py_compile` + `flake8 -F` + **`black --check`** clean (4 files).
- 14/14 tests: 3 bundles, correct members (kebab-case), get_bundle + unknown→ValueError, enable_bundle calls enable+persist per member, skips unregistered, records failures.

## Model Used
Opus 4.8

Closes #10540. Frontend UI = follow-up.