### PR TITLE
fix(llm,npu): openrouter LLMResponse fields + deprecated pydantic .json() (#10947, #10952)

### DIFF
--- a/autobot-backend/llm_shared/providers/openrouter.py
+++ b/autobot-backend/llm_shared/providers/openrouter.py
@@ -116,8 +116,8 @@ class OpenRouterProvider(BaseProvider):
 
             return LLMResponse(
                 content=content,
-                model_name=request.model_name or chat_kwargs["model"],
-                provider_name=self.provider_name,
+                model=request.model_name or chat_kwargs["model"],
+                provider=self.provider_name,
                 usage=usage,
                 provider_metadata=self._build_provider_metadata(
                     model_api_name=chat_kwargs["model"],
@@ -132,8 +132,8 @@ class OpenRouterProvider(BaseProvider):
             logger.error(error_msg)
             return LLMResponse(
                 content="",
-                model_name=request.model_name or "openrouter-model",
-                provider_name=self.provider_name,
+                model=request.model_name or "openrouter-model",
+                provider=self.provider_name,
                 error=error_msg,
             )
 

--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -784,7 +784,7 @@ class NPUWorkerManager(AsyncInitializable):
 
         try:
             key = f"npu:worker:{worker_id}:status"
-            value = status.json()
+            value = status.model_dump_json()
 
             # Store with TTL (2x health check interval)
             ttl = self._load_balancing_config.health_check_interval * 2
@@ -857,7 +857,7 @@ class NPUWorkerManager(AsyncInitializable):
         try:
             key = f"npu:worker:{worker_id}:metrics"
             ttl = self._load_balancing_config.health_check_interval * 2
-            await self.redis_client.setex(key, ttl, metrics.json())
+            await self.redis_client.setex(key, ttl, metrics.model_dump_json())
         except Exception as e:
             logger.error("Failed to store worker metrics in Redis: %s", e)
 


### PR DESCRIPTION
## Thinking Path
Two small pre-existing bugs found while implementing #10582/#10951.

## What Changed
- **#10947** `llm_shared/providers/openrouter.py`: both `LLMResponse(...)` calls passed `model_name=`/`provider_name=`, but `LLMResponse` is a `@dataclass` with fields `model`/`provider` — so OpenRouter responses raised `TypeError` at runtime. Renamed to `model=`/`provider=` (the `request.model_name` value source is correct — LLMRequest does have `model_name`).
- **#10952** `services/npu_worker_manager.py`: `status.json()` / `metrics.json()` → `.model_dump_json()` (Pydantic-v2; `.json()` is deprecated, same output).

## Verification
- `py_compile` + `flake8 -F` + `black --check` clean (both files).

## Model Used
Opus 4.8

Closes #10947, #10952.