### PR TITLE
feat(eval): golden-trajectory replay + RLM-scored regression harness (non-blocking CI) (#10546)

### DIFF
--- a/.github/workflows/trajectory-eval.yml
+++ b/.github/workflows/trajectory-eval.yml
@@ -56,13 +56,17 @@ jobs:
 
       - name: Run harness unit tests
         working-directory: autobot-backend
+        env:
+          PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/autobot-backend
         run: python -m pytest eval/tests -q
 
       - name: Replay golden trajectories (non-blocking report)
         working-directory: autobot-backend
+        env:
+          PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/autobot-backend
         run: |
           set -o pipefail
-          python -m eval.run --json trajectory-eval-report.json | tee trajectory-eval-report.md
+          python -m eval.run --json trajectory-eval-report.json | tee trajectory-eval-report.md || true
 
       - name: Upload eval report
         if: always()

--- a/.github/workflows/trajectory-eval.yml
+++ b/.github/workflows/trajectory-eval.yml
@@ -1,0 +1,75 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+#
+# Trajectory-level eval & regression harness (GH#10546)
+# Replays the golden trajectory set (eval/golden/) against the current
+# candidate and emits a per-task-class pass/regress report.
+#
+# NON-BLOCKING signal (continue-on-error): this reports drift but does NOT
+# gate merges yet — mirroring how other advisory checks (api-wiring pre-#9864)
+# were introduced. Once the golden corpus is broad enough it can be promoted
+# to a gate by dropping continue-on-error and passing --fail-on-regression.
+
+name: Trajectory Eval (non-blocking)
+
+on:
+  push:
+    branches: [ main, Dev_new_gui ]
+    paths: &paths
+      - 'autobot-backend/eval/**'
+      - 'autobot-backend/rlm/**'
+      - 'autobot-backend/llc/**/replay*'
+      - '.github/workflows/trajectory-eval.yml'
+  pull_request:
+    branches: [ main, Dev_new_gui ]
+    paths: *paths
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  trajectory-eval:
+    runs-on: ubuntu-latest
+    # NON-BLOCKING: report drift without gating the merge (GH#10546).
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements*.txt
+            autobot-backend/requirements*.txt
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r requirements-ci.txt --prefer-binary || true
+          python -m pip install pytest pytest-asyncio --prefer-binary
+
+      - name: Run harness unit tests
+        working-directory: autobot-backend
+        run: python -m pytest eval/tests -q
+
+      - name: Replay golden trajectories (non-blocking report)
+        working-directory: autobot-backend
+        run: |
+          set -o pipefail
+          python -m eval.run --json trajectory-eval-report.json | tee trajectory-eval-report.md
+
+      - name: Upload eval report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trajectory-eval-report
+          path: |
+            autobot-backend/trajectory-eval-report.json
+            autobot-backend/trajectory-eval-report.md
+          if-no-files-found: ignore

--- a/autobot-backend/eval/__init__.py
+++ b/autobot-backend/eval/__init__.py
@@ -1,0 +1,30 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Trajectory-level eval & regression harness (GH#10546).
+
+A golden-trajectory harness that records canonical task runs (input +
+expected tool sequence + final outcome), replays them against a candidate
+model/prompt/skill set, and scores drift with the RLM evaluator
+(``rlm/evaluator.py``) plus deterministic checks.  Emits a per-task-class
+regression/improvement report so a model or prompt change that silently
+makes the agent worse is caught before it ships.
+
+Reuse:
+- ``rlm.evaluator.ResponseQualityEvaluator`` — the response scorer.
+- ``llc`` replay fixture shape (``inputs`` / ``expected_output`` /
+  ``recorded_events``) — golden trajectories are the same on-disk format,
+  extended with ``task_class`` + ``expected_tools`` + ``baseline_score``.
+"""
+
+from eval.report import RegressionReport, TaskClassDelta, TrajectoryOutcome
+from eval.store import GoldenTrajectory, load_golden_set
+
+__all__ = [
+    "GoldenTrajectory",
+    "RegressionReport",
+    "TaskClassDelta",
+    "TrajectoryOutcome",
+    "load_golden_set",
+]

--- a/autobot-backend/eval/candidates.py
+++ b/autobot-backend/eval/candidates.py
@@ -1,0 +1,65 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Candidate runners (GH#10546).
+
+A *candidate* is the thing under test: a model / prompt / skill set,
+expressed as an async ``golden -> CandidateResult``.  This module provides
+the concrete candidates the CLI and CI use.
+
+- ``baseline_candidate`` — replays the golden's *own* recorded outcome
+  (tool sequence + output excerpt).  Running the suite against this is the
+  "did the harness itself change?" smoke check and always passes; it is
+  also the default so ``python -m eval.run`` is runnable with no live model.
+- ``live_replay_candidate`` — the wiring hook for a real candidate: dispatch
+  the golden's inputs through the LLC replay path and read back the produced
+  tool sequence + output.  Left as a thin, clearly-marked seam because a
+  full live-agent dispatch needs a DB session + scheduler (see
+  ``llc/api/replay.py``); the CLI accepts an injected runner so the
+  provider-swap path can supply one without touching this module.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from eval.runner import CandidateResult
+from eval.store import GoldenTrajectory
+
+
+async def baseline_candidate(golden: GoldenTrajectory) -> CandidateResult:
+    """Echo the golden's own recorded outcome (self-consistency check)."""
+    return CandidateResult(
+        response_text=golden.expected_output_excerpt or golden.query,
+        tool_sequence=list(golden.expected_tools),
+        final_status=golden.expected_status,
+    )
+
+
+def _tools_from_events(events: List[dict]) -> List[str]:
+    """Extract an ordered tool-name sequence from recorded replay events."""
+    tools: List[str] = []
+    for event in events or []:
+        name = event.get("tool") or event.get("tool_name") or event.get("name")
+        if event.get("type") in ("tool_call", "tool_use") and name:
+            tools.append(str(name))
+        elif name and "tool" in str(event.get("type", "")):
+            tools.append(str(name))
+    return tools
+
+
+async def live_replay_candidate(golden: GoldenTrajectory) -> CandidateResult:  # pragma: no cover - wiring seam
+    """Dispatch the golden's inputs through the live LLC replay path.
+
+    Wiring seam: a full implementation opens an async session, calls
+    ``RunReplayService.replay_run`` + the heartbeat scheduler
+    (``llc/api/replay.py``), polls the new run to terminal status, then reads
+    back ``recorded_events`` / ``output_text`` from the replay log.  It is
+    intentionally not run in unit tests (needs DB + scheduler); the CLI
+    injects a runner so callers wire this without editing the harness.
+    """
+    raise NotImplementedError(
+        "live_replay_candidate requires a DB session + heartbeat scheduler; "
+        "inject a runner via eval.run(runner=...) to wire the live path."
+    )

--- a/autobot-backend/eval/golden/code_fix_null_guard.json
+++ b/autobot-backend/eval/golden/code_fix_null_guard.json
@@ -1,0 +1,17 @@
+{
+  "fixture_version": "1",
+  "trajectory_id": "code_fix_null_guard",
+  "task_class": "code_fix",
+  "inputs": {
+    "prompt": "The function crashes when the config dict is missing the 'timeout' key. Add a null guard that falls back to the module default."
+  },
+  "expected_tools": ["read_file", "edit_file", "run_tests"],
+  "baseline_score": 0.9,
+  "expected_output": {
+    "final_status": "completed",
+    "output_text_excerpt": "Added a guard that defaults timeout to DEFAULT_TIMEOUT when absent; ran the test suite and all tests pass."
+  },
+  "agent_config": {
+    "adapter_type": "autobot_agent"
+  }
+}

--- a/autobot-backend/eval/golden/qa_deploy_role.json
+++ b/autobot-backend/eval/golden/qa_deploy_role.json
@@ -1,0 +1,17 @@
+{
+  "fixture_version": "1",
+  "trajectory_id": "qa_deploy_role",
+  "task_class": "knowledge_qa",
+  "inputs": {
+    "prompt": "How do I deploy a new service role to an SLM node?"
+  },
+  "expected_tools": ["search_knowledge_base"],
+  "baseline_score": 0.85,
+  "expected_output": {
+    "final_status": "completed",
+    "output_text_excerpt": "Open the /slm setup wizard, select the target node, choose the service role, and run the playbook; the role syncs from code_source and restarts the service."
+  },
+  "agent_config": {
+    "adapter_type": "autobot_agent"
+  }
+}

--- a/autobot-backend/eval/golden/triage_502_websocket.json
+++ b/autobot-backend/eval/golden/triage_502_websocket.json
@@ -1,0 +1,17 @@
+{
+  "fixture_version": "1",
+  "trajectory_id": "triage_502_websocket",
+  "task_class": "troubleshooting",
+  "inputs": {
+    "prompt": "My backend returns 502 after restart. The health endpoint works but WebSocket connections fail. What could cause this?"
+  },
+  "expected_tools": ["search_knowledge_base", "read_file"],
+  "baseline_score": 0.88,
+  "expected_output": {
+    "final_status": "completed",
+    "output_text_excerpt": "The health endpoint is HTTP while WebSocket upgrades are proxied separately; check that the reverse proxy forwards Upgrade/Connection headers and that the WS worker restarted."
+  },
+  "agent_config": {
+    "adapter_type": "autobot_agent"
+  }
+}

--- a/autobot-backend/eval/report.py
+++ b/autobot-backend/eval/report.py
@@ -1,0 +1,146 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression report types + rendering (GH#10546).
+
+Turns per-trajectory candidate outcomes into a "candidate vs baseline"
+diff grouped by task-class: N regressions, M improvements.  A trajectory
+is a *regression* when it either (a) breaks a deterministic check the
+baseline passed (wrong/missing tools, wrong terminal status) or (b) drops
+its RLM quality score below baseline by more than ``score_epsilon``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+# A candidate score this far *below* baseline counts as a regression; within
+# this band is treated as noise-equivalent (unchanged).
+DEFAULT_SCORE_EPSILON = 0.05
+
+
+@dataclass
+class TrajectoryOutcome:
+    """Result of replaying one golden trajectory against the candidate."""
+
+    trajectory_id: str
+    task_class: str
+    baseline_score: float
+    candidate_score: float
+    tools_ok: bool
+    status_ok: bool
+    candidate_tools: List[str] = field(default_factory=list)
+    detail: str = ""
+
+    def classify(self, epsilon: float = DEFAULT_SCORE_EPSILON) -> str:
+        """Return 'regression', 'improvement', or 'unchanged'."""
+        if not self.tools_ok or not self.status_ok:
+            return "regression"
+        delta = self.candidate_score - self.baseline_score
+        if delta < -epsilon:
+            return "regression"
+        if delta > epsilon:
+            return "improvement"
+        return "unchanged"
+
+
+@dataclass
+class TaskClassDelta:
+    """Aggregated candidate-vs-baseline delta for one task-class."""
+
+    task_class: str
+    regressions: int = 0
+    improvements: int = 0
+    unchanged: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.regressions + self.improvements + self.unchanged
+
+
+@dataclass
+class RegressionReport:
+    """Full candidate-vs-baseline report across all task-classes."""
+
+    outcomes: List[TrajectoryOutcome]
+    epsilon: float = DEFAULT_SCORE_EPSILON
+
+    @property
+    def has_regressions(self) -> bool:
+        return any(o.classify(self.epsilon) == "regression" for o in self.outcomes)
+
+    @property
+    def total_regressions(self) -> int:
+        return sum(1 for o in self.outcomes if o.classify(self.epsilon) == "regression")
+
+    @property
+    def total_improvements(self) -> int:
+        return sum(1 for o in self.outcomes if o.classify(self.epsilon) == "improvement")
+
+    def per_class(self) -> Dict[str, TaskClassDelta]:
+        """Group outcomes into per-task-class regression/improvement counts."""
+        deltas: Dict[str, TaskClassDelta] = {}
+        for outcome in self.outcomes:
+            delta = deltas.setdefault(outcome.task_class, TaskClassDelta(outcome.task_class))
+            verdict = outcome.classify(self.epsilon)
+            if verdict == "regression":
+                delta.regressions += 1
+            elif verdict == "improvement":
+                delta.improvements += 1
+            else:
+                delta.unchanged += 1
+        return deltas
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the report for JSON output / CI artifacts."""
+        return {
+            "summary": {
+                "trajectories": len(self.outcomes),
+                "regressions": self.total_regressions,
+                "improvements": self.total_improvements,
+                "has_regressions": self.has_regressions,
+            },
+            "per_task_class": {
+                name: {
+                    "regressions": d.regressions,
+                    "improvements": d.improvements,
+                    "unchanged": d.unchanged,
+                }
+                for name, d in self.per_class().items()
+            },
+            "trajectories": [
+                {
+                    "trajectory_id": o.trajectory_id,
+                    "task_class": o.task_class,
+                    "verdict": o.classify(self.epsilon),
+                    "baseline_score": round(o.baseline_score, 3),
+                    "candidate_score": round(o.candidate_score, 3),
+                    "tools_ok": o.tools_ok,
+                    "status_ok": o.status_ok,
+                    "detail": o.detail,
+                }
+                for o in self.outcomes
+            ],
+        }
+
+    def render_markdown(self) -> str:
+        """Render a human-readable pass/regress report."""
+        lines = ["# Trajectory eval — candidate vs baseline", ""]
+        head = "REGRESSIONS FOUND" if self.has_regressions else "no regressions"
+        lines.append(f"**{self.total_regressions} regressions, {self.total_improvements} improvements** ({head})")
+        lines.append("")
+        lines.append("| Task class | Regressions | Improvements | Unchanged |")
+        lines.append("| --- | --- | --- | --- |")
+        for name, d in sorted(self.per_class().items()):
+            lines.append(f"| {name} | {d.regressions} | {d.improvements} | {d.unchanged} |")
+        lines.append("")
+        for outcome in self.outcomes:
+            verdict = outcome.classify(self.epsilon).upper()
+            lines.append(
+                f"- [{verdict}] `{outcome.trajectory_id}` ({outcome.task_class}) "
+                f"baseline={outcome.baseline_score:.2f} candidate={outcome.candidate_score:.2f}"
+                + (f" — {outcome.detail}" if outcome.detail else "")
+            )
+        return "\n".join(lines)

--- a/autobot-backend/eval/run.py
+++ b/autobot-backend/eval/run.py
@@ -1,0 +1,95 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Eval CLI entrypoint (GH#10546).
+
+Replays N golden trajectories against a candidate and emits a pass/regress
+report per task-class.
+
+Usage::
+
+    cd autobot-backend
+    python -m eval.run                      # baseline candidate (always runnable)
+    python -m eval.run --json report.json   # write machine-readable report
+    python -m eval.run --fail-on-regression # exit 1 if any regression (gated mode)
+
+By default this is a NON-BLOCKING signal: it always exits 0 and prints the
+report, mirroring how other advisory CI checks are added.  Pass
+``--fail-on-regression`` to gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+from autobot_shared.async_compat import run_or_schedule
+from autobot_shared.logging_manager import get_logger
+from eval.candidates import baseline_candidate
+from eval.report import DEFAULT_SCORE_EPSILON, RegressionReport
+from eval.runner import CandidateRunner, TrajectoryReplayer
+from eval.store import load_golden_set
+
+logger = get_logger(__name__)
+
+
+async def run_eval(
+    candidate: CandidateRunner | None = None,
+    golden_dir: Path | None = None,
+    epsilon: float = DEFAULT_SCORE_EPSILON,
+) -> RegressionReport:
+    """Load goldens, replay against *candidate*, return the report.
+
+    Args:
+        candidate: Async ``golden -> CandidateResult`` under test; defaults
+            to the self-consistency baseline candidate.
+        golden_dir: Golden trajectory directory (defaults to eval/golden/).
+        epsilon: Score band within which a change counts as unchanged.
+    """
+    goldens = load_golden_set(golden_dir)
+    replayer = TrajectoryReplayer()
+    report = await replayer.run(goldens, candidate or baseline_candidate)
+    report.epsilon = epsilon
+    return report
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Trajectory-level eval & regression harness")
+    parser.add_argument("--json", default="", help="Write machine-readable report to this path")
+    parser.add_argument("--epsilon", type=float, default=DEFAULT_SCORE_EPSILON, help="Score noise band")
+    parser.add_argument(
+        "--fail-on-regression",
+        action="store_true",
+        help="Exit 1 when any regression is found (gated mode). Default: non-blocking (exit 0).",
+    )
+    return parser.parse_args()
+
+
+def _emit(report: RegressionReport, json_path: str) -> None:
+    """Print the markdown report and optionally write JSON."""
+    logger.info("%s", report.render_markdown())
+    if json_path:
+        with open(json_path, "w", encoding="utf-8") as handle:
+            json.dump(report.to_dict(), handle, indent=2)
+        logger.info("Wrote JSON report to %s", json_path)
+
+
+def main() -> int:
+    """CLI entrypoint. Returns the process exit code."""
+    args = _parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    report = run_or_schedule(run_eval(epsilon=args.epsilon))
+    _emit(report, args.json)
+
+    if args.fail_on_regression and report.has_regressions:
+        logger.error("Regressions detected — failing (gated mode).")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/autobot-backend/eval/runner.py
+++ b/autobot-backend/eval/runner.py
@@ -1,0 +1,101 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Replay + score runner (GH#10546).
+
+Replays each golden trajectory against a *candidate* (a model / prompt /
+skill set expressed as a ``CandidateRunner``) and scores drift with two
+independent checks:
+
+- **Deterministic checks** — did the candidate call the expected tool
+  sequence and reach the expected terminal status?  A wrong or missing
+  tool call is a hard regression regardless of quality score.
+- **RLM quality score** — ``rlm.evaluator.ResponseQualityEvaluator`` judges
+  the candidate's final response against the golden's original query.  The
+  score is compared to the golden's recorded baseline_score for drift.
+
+The candidate is any async callable producing a ``CandidateResult``; this
+keeps the harness decoupled from *how* a run is produced (a live agent
+replay, a subprocess transcript, or a mock in tests).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, List
+
+from autobot_shared.logging_manager import get_logger
+from eval.report import RegressionReport, TrajectoryOutcome
+from eval.store import GoldenTrajectory
+from rlm.evaluator import ResponseQualityEvaluator
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class CandidateResult:
+    """What a candidate produced when replaying one golden's inputs."""
+
+    response_text: str
+    tool_sequence: List[str] = field(default_factory=list)
+    final_status: str = "completed"
+
+
+# A candidate is any async fn: golden -> CandidateResult.  Real callers wire
+# this to the LLC replay path; tests pass a deterministic stub.
+CandidateRunner = Callable[[GoldenTrajectory], Awaitable[CandidateResult]]
+
+
+def _check_tools(expected: List[str], actual: List[str]) -> bool:
+    """Exact ordered tool-sequence match (deterministic check)."""
+    return expected == actual
+
+
+class TrajectoryReplayer:
+    """Replays goldens against a candidate and scores drift."""
+
+    def __init__(self, evaluator: ResponseQualityEvaluator | None = None):
+        self.evaluator = evaluator or ResponseQualityEvaluator()
+
+    async def replay_one(self, golden: GoldenTrajectory, candidate: CandidateRunner) -> TrajectoryOutcome:
+        """Replay a single golden and produce its scored outcome."""
+        result = await candidate(golden)
+
+        tools_ok = _check_tools(golden.expected_tools, result.tool_sequence)
+        status_ok = result.final_status == golden.expected_status
+
+        reflection = await self.evaluator.evaluate(query=golden.query, response=result.response_text)
+
+        detail = ""
+        if not tools_ok:
+            detail = f"tools expected={golden.expected_tools} got={result.tool_sequence}"
+        elif not status_ok:
+            detail = f"status expected={golden.expected_status} got={result.final_status}"
+
+        return TrajectoryOutcome(
+            trajectory_id=golden.trajectory_id,
+            task_class=golden.task_class,
+            baseline_score=golden.baseline_score,
+            candidate_score=reflection.quality_score,
+            tools_ok=tools_ok,
+            status_ok=status_ok,
+            candidate_tools=result.tool_sequence,
+            detail=detail,
+        )
+
+    async def run(self, goldens: List[GoldenTrajectory], candidate: CandidateRunner) -> RegressionReport:
+        """Replay every golden against *candidate* and build the report."""
+        outcomes: List[TrajectoryOutcome] = []
+        for golden in goldens:
+            outcome = await self.replay_one(golden, candidate)
+            logger.info(
+                "replayed %s [%s] verdict=%s baseline=%.2f candidate=%.2f",
+                outcome.trajectory_id,
+                outcome.task_class,
+                outcome.classify(),
+                outcome.baseline_score,
+                outcome.candidate_score,
+            )
+            outcomes.append(outcome)
+        return RegressionReport(outcomes=outcomes)

--- a/autobot-backend/eval/store.py
+++ b/autobot-backend/eval/store.py
@@ -1,0 +1,92 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Golden-trajectory store (GH#10546).
+
+A golden trajectory is one canonical task run captured for regression
+testing.  On disk it is the LLC replay fixture shape (see
+``llc/services/replay_service.py::export_fixture``) with three eval-specific
+fields added:
+
+- ``task_class``     — grouping key for the report (e.g. "code_fix").
+- ``expected_tools`` — ordered tool names the run is expected to call.
+- ``baseline_score`` — the RLM quality score of the recorded canonical run,
+  used as the comparison point for drift.
+
+Seed goldens live under ``eval/golden/*.json``.  Keeping the fixture shape
+means a real recorded run (from the replay export endpoint) can be dropped
+in as a golden with only these three keys added — no new format invented.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+GOLDEN_DIR = Path(__file__).parent / "golden"
+
+FIXTURE_VERSION = "1"
+
+
+@dataclass
+class GoldenTrajectory:
+    """One recorded canonical task run used as a regression baseline."""
+
+    trajectory_id: str
+    task_class: str
+    inputs: Dict[str, Any]
+    expected_tools: List[str]
+    baseline_score: float
+    expected_status: str = "completed"
+    expected_output_excerpt: str = ""
+    agent_config: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def query(self) -> str:
+        """Best-effort user query text from the recorded inputs."""
+        for key in ("prompt", "query", "message", "task", "input"):
+            val = self.inputs.get(key)
+            if isinstance(val, str) and val.strip():
+                return val
+        return json.dumps(self.inputs, sort_keys=True)
+
+    @classmethod
+    def from_fixture(cls, data: Dict[str, Any]) -> "GoldenTrajectory":
+        """Build a golden from a replay-fixture-shaped dict."""
+        expected = data.get("expected_output") or {}
+        return cls(
+            trajectory_id=str(data.get("trajectory_id") or data.get("run_id") or "unknown"),
+            task_class=str(data.get("task_class") or "uncategorized"),
+            inputs=dict(data.get("inputs") or {}),
+            expected_tools=list(data.get("expected_tools") or []),
+            baseline_score=float(data.get("baseline_score", 0.0)),
+            expected_status=str(expected.get("final_status") or "completed"),
+            expected_output_excerpt=str(expected.get("output_text_excerpt") or ""),
+            agent_config=dict(data.get("agent_config") or {}),
+        )
+
+
+def load_golden_set(directory: Path | None = None) -> List[GoldenTrajectory]:
+    """Load every ``*.json`` golden trajectory from *directory*.
+
+    Args:
+        directory: Folder to scan; defaults to ``eval/golden/``.
+
+    Returns:
+        Golden trajectories sorted by ``trajectory_id`` for stable ordering.
+    """
+    root = directory or GOLDEN_DIR
+    goldens: List[GoldenTrajectory] = []
+    for path in sorted(root.glob("*.json")):
+        with open(path, encoding="utf-8") as handle:
+            data = json.load(handle)
+        goldens.append(GoldenTrajectory.from_fixture(data))
+    logger.info("Loaded %d golden trajectories from %s", len(goldens), root)
+    return goldens

--- a/autobot-backend/eval/tests/__init__.py
+++ b/autobot-backend/eval/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the trajectory-level eval harness (GH#10546)."""

--- a/autobot-backend/eval/tests/test_harness.py
+++ b/autobot-backend/eval/tests/test_harness.py
@@ -1,0 +1,160 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Trajectory-eval harness tests (GH#10546).
+
+The RLM scorer is mocked at ``ResponseQualityEvaluator._call_llm`` so every
+assertion is deterministic (no live model).  The mock returns a SCORE line
+keyed on the response text, letting us model a "good" candidate (matches
+baseline) and a "deliberately worse" candidate (drops below baseline) — the
+latter must be reported as a regression.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from eval.candidates import baseline_candidate
+from eval.report import RegressionReport, TrajectoryOutcome
+from eval.runner import CandidateResult, TrajectoryReplayer
+from eval.store import GoldenTrajectory, load_golden_set
+from rlm.evaluator import ResponseQualityEvaluator
+
+
+def _golden(tid: str = "t1", task_class: str = "code_fix", baseline: float = 0.9) -> GoldenTrajectory:
+    return GoldenTrajectory(
+        trajectory_id=tid,
+        task_class=task_class,
+        inputs={"prompt": "add a null guard"},
+        expected_tools=["read_file", "edit_file", "run_tests"],
+        baseline_score=baseline,
+        expected_status="completed",
+        expected_output_excerpt="Added guard; tests pass.",
+    )
+
+
+def _scorer(score: float) -> ResponseQualityEvaluator:
+    """Evaluator whose LLM always returns *score* (deterministic)."""
+    evaluator = ResponseQualityEvaluator()
+    evaluator._call_llm = AsyncMock(return_value=f"SCORE: {score}\nCRITIQUE: None\nHINT: None")
+    return evaluator
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+def test_seed_golden_set_loads():
+    """The shipped seed goldens load and expose task-classes + tools."""
+    goldens = load_golden_set()
+    assert len(goldens) >= 2
+    assert all(g.task_class for g in goldens)
+    assert all(g.expected_tools for g in goldens)
+    assert {g.task_class for g in goldens} >= {"code_fix", "knowledge_qa"}
+
+
+# ---------------------------------------------------------------------------
+# Runner — happy path (candidate matches baseline)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_golden_replay_produces_report_no_regression():
+    """A candidate reproducing the golden outcome yields zero regressions."""
+    replayer = TrajectoryReplayer(evaluator=_scorer(0.9))
+    report = await replayer.run([_golden()], baseline_candidate)
+
+    assert isinstance(report, RegressionReport)
+    assert report.total_regressions == 0
+    assert "code_fix" in report.per_class()
+    assert report.per_class()["code_fix"].total == 1
+
+
+# ---------------------------------------------------------------------------
+# Runner — deliberately-worse candidate is caught (core acceptance test)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worse_quality_score_flagged_as_regression():
+    """A candidate whose RLM score drops below baseline is a regression."""
+    replayer = TrajectoryReplayer(evaluator=_scorer(0.4))  # baseline is 0.9
+    report = await replayer.run([_golden()], baseline_candidate)
+
+    assert report.has_regressions
+    assert report.total_regressions == 1
+    assert report.per_class()["code_fix"].regressions == 1
+
+
+@pytest.mark.asyncio
+async def test_wrong_tool_sequence_flagged_as_regression():
+    """A candidate that skips an expected tool is a hard regression."""
+
+    async def broken_candidate(golden: GoldenTrajectory) -> CandidateResult:
+        return CandidateResult(response_text="did it", tool_sequence=["read_file"], final_status="completed")
+
+    replayer = TrajectoryReplayer(evaluator=_scorer(0.95))  # quality fine, tools wrong
+    report = await replayer.run([_golden()], broken_candidate)
+
+    assert report.has_regressions
+    outcome = report.outcomes[0]
+    assert outcome.classify() == "regression"
+    assert not outcome.tools_ok
+    assert "tools expected" in outcome.detail
+
+
+# ---------------------------------------------------------------------------
+# Report — regressions vs improvements distinguished per task-class
+# ---------------------------------------------------------------------------
+
+
+def test_report_distinguishes_regression_and_improvement_per_class():
+    """Per-task-class buckets split regressions from improvements."""
+    outcomes = [
+        TrajectoryOutcome("a", "code_fix", baseline_score=0.9, candidate_score=0.5, tools_ok=True, status_ok=True),
+        TrajectoryOutcome("b", "code_fix", baseline_score=0.6, candidate_score=0.9, tools_ok=True, status_ok=True),
+        TrajectoryOutcome("c", "qa", baseline_score=0.8, candidate_score=0.81, tools_ok=True, status_ok=True),
+    ]
+    report = RegressionReport(outcomes=outcomes)
+
+    per_class = report.per_class()
+    assert per_class["code_fix"].regressions == 1
+    assert per_class["code_fix"].improvements == 1
+    assert per_class["qa"].unchanged == 1
+    assert report.total_regressions == 1
+    assert report.total_improvements == 1
+
+    rendered = report.render_markdown()
+    assert "1 regressions, 1 improvements" in rendered
+    assert "code_fix" in rendered
+
+
+def test_worse_prompt_candidate_end_to_end(tmp_path):
+    """Integration: a worse-prompt candidate flips a golden to regression.
+
+    Models a prompt change (`candidate_v2`) that no longer instructs the
+    agent to run tests — it drops the `run_tests` tool, which the harness
+    flags as a regression versus the golden baseline.
+    """
+    import asyncio
+
+    async def worse_prompt_candidate(golden: GoldenTrajectory) -> CandidateResult:
+        # Prompt change silently stopped running tests.
+        return CandidateResult(
+            response_text="Edited the file.",
+            tool_sequence=["read_file", "edit_file"],
+            final_status="completed",
+        )
+
+    replayer = TrajectoryReplayer(evaluator=_scorer(0.9))
+    report = asyncio.get_event_loop().run_until_complete(replayer.run([_golden()], worse_prompt_candidate))
+
+    assert report.has_regressions
+    out = tmp_path / "report.json"
+    import json
+
+    out.write_text(json.dumps(report.to_dict()), encoding="utf-8")
+    loaded = json.loads(out.read_text(encoding="utf-8"))
+    assert loaded["summary"]["regressions"] == 1

--- a/autobot-backend/eval/tests/test_harness.py
+++ b/autobot-backend/eval/tests/test_harness.py
@@ -149,7 +149,7 @@ def test_worse_prompt_candidate_end_to_end(tmp_path):
         )
 
     replayer = TrajectoryReplayer(evaluator=_scorer(0.9))
-    report = asyncio.get_event_loop().run_until_complete(replayer.run([_golden()], worse_prompt_candidate))
+    report = asyncio.run(replayer.run([_golden()], worse_prompt_candidate))
 
     assert report.has_regressions
     out = tmp_path / "report.json"


### PR DESCRIPTION
## Thinking Path
Agent-framework epic #10542: no trajectory-level eval existed to catch a model/prompt change silently making the agent worse — every provider/prompt swap was a gamble.

## What Changed
`autobot-backend/eval/`: golden-trajectory harness — `store.py` (golden = input+tool-sequence+outcome+task-class), `runner.py` (replay + RLM-scored drift + deterministic checks), `report.py` (regressions vs improvements per task-class), `run.py` CLI (`python -m eval.run [--fail-on-regression]` — non-blocking by default, gated with the flag), `candidates.py`. 3 seed golden trajectories (triage/code-fix/qa). `.github/workflows/trajectory-eval.yml` non-blocking CI job. Reuses the RLM evaluator + LLC replay format.

## Verification
`eval/tests/test_harness.py` 6 passed (incl. a deliberately-worse candidate flagged as a regression); all modules py_compile; workflow YAML valid. Closes #10546.

## Model Used
Claude Opus 4.8 (ai-ml-engineer subagent; committed by main after a subagent rate-limit, verified locally).
