### PR TITLE
fix(reliability): harden FailurePatternDetector smembers key-building against bytes (#10906)

### DIFF
--- a/autobot-backend/services/failure_pattern_detector.py
+++ b/autobot-backend/services/failure_pattern_detector.py
@@ -238,14 +238,23 @@ class FailurePatternDetector(AsyncRedisClientMixin):
         except Exception as exc:
             logger.warning("Failed to store pattern: %s", exc)
 
+    @staticmethod
+    def _decode_members(raw: set) -> set:
+        """Normalise smembers() output to a set of str.
+
+        Redis-py returns ``set[bytes]`` when *decode_responses* is False/unset
+        and ``set[str]`` when it is True.  Normalising at the consumption
+        point makes every caller correct regardless of client configuration.
+        """
+        return {m.decode() if isinstance(m, bytes) else m for m in raw}
+
     async def get_pattern_statistics(self) -> Dict[str, Any]:
         """Get overall statistics about learned patterns."""
         try:
             redis = await self._get_redis()
 
-            pattern_hashes = (
-                await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT) or set()
-            )
+            raw = await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT)
+            pattern_hashes = self._decode_members(raw or set())
 
             if not pattern_hashes:
                 return {
@@ -304,9 +313,8 @@ class FailurePatternDetector(AsyncRedisClientMixin):
         """
         try:
             redis = await self._get_redis()
-            pattern_hashes = (
-                await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT) or set()
-            )
+            raw = await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT)
+            pattern_hashes = self._decode_members(raw or set())
 
             patterns: List[FailurePattern] = []
 
@@ -331,9 +339,8 @@ class FailurePatternDetector(AsyncRedisClientMixin):
         """Clear all learned patterns (for testing or reset)."""
         try:
             redis = await self._get_redis()
-            pattern_hashes = (
-                await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT) or set()
-            )
+            raw = await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT)
+            pattern_hashes = self._decode_members(raw or set())
 
             for pattern_hash in pattern_hashes:
                 pattern_key = f"{PATTERN_KEY_PREFIX}{pattern_hash}"

--- a/autobot-backend/tests/orchestration/test_failure_pattern_detector_async.py
+++ b/autobot-backend/tests/orchestration/test_failure_pattern_detector_async.py
@@ -298,9 +298,7 @@ async def test_clear_patterns_bytes_smembers_uses_str_key() -> None:
     )
     # The bytes-repr variant must NOT appear.
     bad_key = f"{PATTERN_KEY_PREFIX}b'abc123'"
-    assert bad_key not in all_args, (
-        f"delete was called with bytes-repr key {bad_key!r} — bytes were not decoded."
-    )
+    assert bad_key not in all_args, f"delete was called with bytes-repr key {bad_key!r} — bytes were not decoded."
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/tests/orchestration/test_failure_pattern_detector_async.py
+++ b/autobot-backend/tests/orchestration/test_failure_pattern_detector_async.py
@@ -270,6 +270,37 @@ async def test_clear_patterns_awaits_delete_per_pattern_and_set() -> None:
     all_args = [c.args[0] for c in redis.delete.await_args_list]
     # One call must target the known-patterns set key.
     assert any(KNOWN_PATTERNS_KEY in str(a) for a in all_args)
+    # Pattern key must use the decoded string hash — not the bytes repr.
+    expected_pattern_key = f"{PATTERN_KEY_PREFIX}{h.decode()}"
+    assert any(a == expected_pattern_key for a in all_args), (
+        f"Expected delete({expected_pattern_key!r}) but got calls with: {all_args!r}. "
+        "smembers bytes were not decoded before building the Redis key."
+    )
+
+
+@pytest.mark.asyncio
+async def test_clear_patterns_bytes_smembers_uses_str_key() -> None:
+    """Regression (#10906): when smembers returns bytes, clear_patterns must delete
+    'failure:pattern:<hex>' not 'failure:pattern:b\"<hex>\"'."""
+    det = FailurePatternDetector()
+    # Simulate a redis client with decode_responses=False — smembers returns bytes.
+    raw_hash = b"abc123"
+    redis = make_async_redis(smembers_returns={raw_hash})
+
+    with patch(_MIXIN_PATH, new=AsyncMock(return_value=redis)):
+        await det.clear_patterns()
+
+    all_args = [c.args[0] for c in redis.delete.await_args_list]
+    expected_pattern_key = f"{PATTERN_KEY_PREFIX}abc123"
+    assert expected_pattern_key in all_args, (
+        f"Expected delete key {expected_pattern_key!r} but delete was called with: {all_args!r}. "
+        "Bytes from smembers must be decoded before building the Redis key."
+    )
+    # The bytes-repr variant must NOT appear.
+    bad_key = f"{PATTERN_KEY_PREFIX}b'abc123'"
+    assert bad_key not in all_args, (
+        f"delete was called with bytes-repr key {bad_key!r} — bytes were not decoded."
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path
#10906 reported that `clear_patterns` builds delete keys from `smembers()` bytes → `failure:pattern:b'<hex>'` → patterns never deleted.

## Verification of premise (important)
Confirmed the bug is **latent, not active in production**: `RedisConfig.decode_responses` defaults to **True** (autobot_shared/redis_management/config.py:61,153), so `smembers()` returns `set[str]` today and keys already resolve correctly. The hazard is real only if `decode_responses` is ever set False.

## What Changed
Applied a defensive `isinstance`-guarded normalization so the code is correct **either way** (removes the latent footgun):
- New `_decode_members(raw) -> set` staticmethod: `{m.decode() if isinstance(m, bytes) else m for m in raw}`.
- Wired into **all three** `smembers(KNOWN_PATTERNS_KEY)` consumers (not just clear_patterns): `clear_patterns`, `get_pattern_statistics`, `list_known_patterns` — each built a `f"{PATTERN_KEY_PREFIX}{hash}"` key that would break under bytes.

## Verification
- `py_compile` + `flake8 -F` + `black --check` clean.
- 12 tests pass incl. new `test_clear_patterns_bytes_smembers_uses_str_key` (mocks smembers→{b'abc123'}, asserts delete called with `failure:pattern:abc123`, not the bytes-repr key).

## Model Used
Opus 4.8

Closes #10906. (Latent hardening — no active prod impact given decode_responses=True.)