### PR TITLE
fix(auth): eliminate residual single_user gating across frontend + Ansible (#10861)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -623,7 +623,8 @@ export default {
     const chatStore = useChatStore();
     const knowledgeStore = useKnowledgeStore();
     // #10502: runtime (deployment) feature flags from /api/frontend-config,
-    // used to gate the Company OS nav item in single_user deployments.
+    // used to gate the Company OS nav item when the deployment lacks the
+    // PostgreSQL company mode.
     const runtimeFeaturesStore = useRuntimeFeaturesStore();
     const router = useRouter();
     const route = useRoute();
@@ -1010,8 +1011,8 @@ export default {
     const navContainerRef = ref<HTMLElement | null>(null)
 
     // #10502: hide the Company OS entry when the deployment has no PostgreSQL
-    // company mode (single_user) — its endpoints return 503 there. The runtime
-    // flag defaults fail-closed until /frontend-config resolves.
+    // company mode — its endpoints return 503 there. The runtime flag defaults
+    // fail-closed until /frontend-config resolves.
     const filteredNavItems = computed(() =>
       filterByFeatureFlag(navItems).filter(
         (item) =>

--- a/autobot-frontend/src/composables/useServiceDiscovery.ts
+++ b/autobot-frontend/src/composables/useServiceDiscovery.ts
@@ -15,6 +15,7 @@
 import { ref, computed } from 'vue'
 import { discoverService, clearDiscoveryCache } from '@/config/ssot-config'
 import { useUserStore } from '@/stores/useUserStore'
+import { isRealAuthToken } from '@/utils/authToken'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useServiceDiscovery')
@@ -44,7 +45,7 @@ export function useServiceDiscovery() {
   function getAuthToken(): string | null {
     // Access token from user store's authState
     const authState = userStore.authState
-    if (authState && authState.token && authState.token !== 'single_user_mode') {
+    if (authState && isRealAuthToken(authState.token)) {
       return authState.token
     }
     // Return null when no real token - callers must handle this (#820)

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -7614,7 +7614,7 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment runs in single_user mode, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
   },
   "llcMembers": {
     "title": "الأعضاء",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -7614,7 +7614,7 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment runs in single_user mode, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
   },
   "llcMembers": {
     "title": "Mitglieder",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -7663,7 +7663,7 @@
     "adminPanel": "Admin Panel",
     "documents": "AI Documents",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment runs in single_user mode, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
   },
   "llcMembers": {
     "title": "Members",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -7614,7 +7614,7 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment runs in single_user mode, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
   },
   "llcMembers": {
     "title": "Miembros",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -189,7 +189,7 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment runs in single_user mode, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
   },
   "llcMembers": {
     "title": "اعضا",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -7614,7 +7614,7 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment runs in single_user mode, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
   },
   "llcMembers": {
     "title": "Membres",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -189,7 +189,7 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment runs in single_user mode, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
   },
   "llcMembers": {
     "title": "חברים",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -7614,7 +7614,7 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment runs in single_user mode, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
   },
   "llcMembers": {
     "title": "Dalibnieki",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -7614,7 +7614,7 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment runs in single_user mode, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
   },
   "llcMembers": {
     "title": "Czlonkowie",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -7614,7 +7614,7 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment runs in single_user mode, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
   },
   "llcMembers": {
     "title": "Membros",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -189,7 +189,7 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment runs in single_user mode, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
   },
   "llcMembers": {
     "title": "اراکین",

--- a/autobot-frontend/src/models/repositories/ChatRepository.ts
+++ b/autobot-frontend/src/models/repositories/ChatRepository.ts
@@ -5,6 +5,7 @@ import type { AxiosInstance, AxiosResponse, AxiosRequestConfig } from 'axios'
 import { getBackendUrl, getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { readStoredAuthToken } from '@/utils/authToken'
 import type { ChatMessage } from '@/types/api'
 
 // Create scoped logger for ChatRepository
@@ -182,18 +183,7 @@ export class ChatRepository {
   }
 
   private _getAuthToken(): string | null {
-    try {
-      const stored = localStorage.getItem('autobot_auth')
-      if (stored) {
-        const auth = JSON.parse(stored)
-        if (auth.token && auth.token !== 'single_user_mode') {
-          return auth.token
-        }
-      }
-    } catch {
-      // ignore parse errors
-    }
-    return null
+    return readStoredAuthToken()
   }
 
   /**

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -1328,13 +1328,15 @@ router.beforeEach(async (to, from) => {
     // Check authentication requirements
     const requiresAuth = to.matched.some(record => record.meta.requiresAuth === true)
 
-    // If route requires auth and user not authenticated, try backend check first
-    // This handles single_user mode where backend auto-authenticates
+    // If route requires auth and the store has no session yet, verify a
+    // bearer-authenticated session against the backend before redirecting. Auth
+    // is always enabled (#10713); this restores a valid JWT session, it does not
+    // auto-authenticate.
     if (requiresAuth && !userStore.isAuthenticated) {
-      logger.debug('Route requires auth, checking backend for auto-auth (single_user mode)')
+      logger.debug('Route requires auth, verifying session against backend')
       const backendAuthenticated = await userStore.checkAuthFromBackend()
       if (backendAuthenticated) {
-        logger.debug('Backend auto-authenticated user (single_user mode)')
+        logger.debug('Backend confirmed authenticated session')
         // Continue to route - user is now authenticated
         return
       }

--- a/autobot-frontend/src/stores/useLlcCompanyStore.ts
+++ b/autobot-frontend/src/stores/useLlcCompanyStore.ts
@@ -32,8 +32,8 @@ export const useLlcCompanyStore = defineStore('llcCompany', () => {
   const isLoading = ref(false)
   const error = ref<string | null>(null)
   // True when the backend reports LLC is not enabled for this deployment
-  // (single_user mode → HTTP 503). This is an expected state, NOT an error to
-  // surface to end users.
+  // (no PostgreSQL company mode → HTTP 503). This is an expected state, NOT an
+  // error to surface to end users.
   const unavailable = ref(false)
 
   const selectedCompany = computed(
@@ -60,7 +60,7 @@ export const useLlcCompanyStore = defineStore('llcCompany', () => {
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : ''
-      // HTTP 503 = LLC data layer disabled in this deployment mode (single_user).
+      // HTTP 503 = LLC data layer disabled in this deployment (no company mode).
       // Treat as "unavailable", not a user-facing error.
       if (message.startsWith('HTTP 503')) {
         unavailable.value = true

--- a/autobot-frontend/src/stores/useRuntimeFeaturesStore.ts
+++ b/autobot-frontend/src/stores/useRuntimeFeaturesStore.ts
@@ -27,7 +27,7 @@ interface FrontendConfigResponse {
 
 export const useRuntimeFeaturesStore = defineStore('runtimeFeatures', () => {
   // Default fail-closed for deployment-gated modules: hidden until the backend
-  // confirms availability, so single_user deployments never surface a 503 view.
+  // confirms availability, so deployments without company mode never surface a 503 view.
   const features = ref<RuntimeFeatures>({ company_os_enabled: false })
   const isLoaded = ref(false)
   const isLoading = ref(false)

--- a/autobot-frontend/src/stores/useUserStore.ts
+++ b/autobot-frontend/src/stores/useUserStore.ts
@@ -5,6 +5,7 @@ import { defineStore } from 'pinia'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { isRealAuthToken } from '@/utils/authToken'
 
 const logger = createLogger('useUserStore')
 
@@ -283,8 +284,9 @@ export const useUserStore = defineStore('user', () => {
         const auth = JSON.parse(storedAuth)
         const user = JSON.parse(storedUser)
 
-        // Only restore if there's a real JWT token (not fake single_user_mode token) (#972)
-        const hasRealToken = auth.token && auth.token !== 'single_user_mode'
+        // Only restore when a real JWT token is present. Any legacy
+        // `single_user_mode` marker from a retired deployment is rejected (#972, #10861).
+        const hasRealToken = isRealAuthToken(auth.token)
         // Check if token is not expired
         if (hasRealToken && (!auth.expiresAt || new Date(auth.expiresAt) > new Date())) {
           authState.value = {
@@ -326,7 +328,9 @@ export const useUserStore = defineStore('user', () => {
     }
   }
 
-  // Check auth status from backend (handles single_user mode auto-auth)
+  // Verify a bearer-authenticated session against the backend and restore the
+  // user profile. Auth is always enabled (#10713), so this only succeeds when a
+  // valid JWT is already attached by fetchWithAuth; there is no auto-auth mode.
   async function checkAuthFromBackend(): Promise<boolean> {
     try {
       // Issue #916: Use relative URL — nginx at .21 proxies /api/* to backend
@@ -344,9 +348,9 @@ export const useUserStore = defineStore('user', () => {
       if (response.ok) {
         const data = await response.json()
         if (data.authenticated) {
-          // Auto-login with data from backend
+          // Restore the profile for the JWT-authenticated session.
           const user: UserProfile = {
-            id: data.username,  // Use username as ID for single_user mode
+            id: data.username,
             username: data.username,
             email: data.email || '',
             displayName: data.username.charAt(0).toUpperCase() + data.username.slice(1),
@@ -356,17 +360,13 @@ export const useUserStore = defineStore('user', () => {
             lastLoginAt: new Date()
           }
           currentUser.value = user
+          // Preserve the existing JWT (from the login flow / storage). The token
+          // is never invented here — overwriting it would drop a valid JWT (#979).
           authState.value = {
-            isAuthenticated: true,
-            token: data.deployment_mode === 'single_user' ? 'single_user_mode' : undefined
+            ...authState.value,
+            isAuthenticated: true
           }
-          // Only persist when we have a real token marker (single_user mode).
-          // For JWT deployments the token comes from the login flow; persisting
-          // token:undefined here would overwrite a valid JWT in storage (#979).
-          if (data.deployment_mode === 'single_user') {
-            persistToStorage()
-          }
-          logger.info('Auto-authenticated from backend:', data.deployment_mode)
+          logger.info('Restored authenticated session from backend')
           return true
         }
       }

--- a/autobot-frontend/src/utils/ApiClient.ts
+++ b/autobot-frontend/src/utils/ApiClient.ts
@@ -4,6 +4,7 @@ import appConfig from '@/config/AppConfig.js';
 import { createLogger } from '@/utils/debugUtils';
 import { getApiBase } from '@/config/ssot-config';
 import { getSelectedCompanyId } from '@/utils/orgContext';
+import { isRealAuthToken } from '@/utils/authToken';
 
 // Create scoped logger for ApiClient
 const logger = createLogger('ApiClient');
@@ -218,7 +219,7 @@ export class ApiClient {
       const stored = localStorage.getItem('autobot_auth');
       if (!stored) return null;
       const auth = JSON.parse(stored);
-      if (auth.token && auth.token !== 'single_user_mode') {
+      if (isRealAuthToken(auth.token)) {
         // Check expiry before returning — expired tokens cause widespread 401s (#979)
         if (auth.expiresAt && new Date(auth.expiresAt) <= new Date()) {
           logger.warn('Auth token expired, clearing stale localStorage');

--- a/autobot-frontend/src/utils/authToken.ts
+++ b/autobot-frontend/src/utils/authToken.ts
@@ -1,0 +1,46 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Canonical reader for the persisted JWT auth token (#10861).
+ *
+ * AutoBot always runs full user management with backend auth enabled (#10713);
+ * there is no `single_user` deployment mode. Older deployments could persist a
+ * synthetic `single_user_mode` marker in place of a real JWT. That marker is no
+ * longer produced, but it may still linger in a browser's localStorage — sending
+ * it as a Bearer to an auth-enabled backend yields 401s. This helper is the one
+ * place that reads the stored token, rejecting the legacy marker so stale
+ * storage cannot leak a fake token into requests.
+ */
+
+/** localStorage key holding the serialized auth state. */
+const AUTH_STORAGE_KEY = 'autobot_auth'
+
+/**
+ * Legacy synthetic token used by the retired `single_user` deployment mode.
+ * Never emitted anymore; still rejected on read to purge stale storage.
+ */
+const LEGACY_SINGLE_USER_TOKEN = 'single_user_mode'
+
+/** True when the value is a usable JWT (present and not the legacy marker). */
+export function isRealAuthToken(token: unknown): token is string {
+  return typeof token === 'string' && token.length > 0 && token !== LEGACY_SINGLE_USER_TOKEN
+}
+
+/**
+ * Read the persisted JWT from localStorage. Returns null when absent, malformed,
+ * or when only the legacy `single_user_mode` marker is stored. Callers must
+ * handle the null case (defer the request / omit the Authorization header).
+ */
+export function readStoredAuthToken(): string | null {
+  try {
+    const stored = localStorage.getItem(AUTH_STORAGE_KEY)
+    if (!stored) return null
+    const auth: { token?: unknown } = JSON.parse(stored)
+    return isRealAuthToken(auth.token) ? auth.token : null
+  } catch {
+    return null
+  }
+}

--- a/autobot-frontend/src/utils/fetchWithAuth.ts
+++ b/autobot-frontend/src/utils/fetchWithAuth.ts
@@ -15,19 +15,10 @@
  */
 
 import { applyOrgHeader } from '@/utils/orgContext'
+import { readStoredAuthToken } from '@/utils/authToken'
 
 export function getAuthToken(): string | null {
-  try {
-    const stored = localStorage.getItem('autobot_auth')
-    if (!stored) return null
-    const auth: { token?: string } = JSON.parse(stored)
-    if (auth.token && auth.token !== 'single_user_mode') {
-      return auth.token
-    }
-    return null
-  } catch {
-    return null
-  }
+  return readStoredAuthToken()
 }
 
 /**

--- a/autobot-frontend/src/views/llc/CompanySelectorView.vue
+++ b/autobot-frontend/src/views/llc/CompanySelectorView.vue
@@ -20,9 +20,9 @@ const companyStore = useLlcCompanyStore()
 const runtimeFeaturesStore = useRuntimeFeaturesStore()
 
 // #10502: Company OS (LLC) requires a PostgreSQL company/multi-company
-// deployment; in single_user mode the company endpoints return 503. Gate the
-// view on the runtime flag and show an informational empty-state instead of
-// surfacing the raw 503 error + Retry button.
+// deployment; without it the company endpoints return 503. Gate the view on the
+// runtime flag and show an informational empty-state instead of surfacing the
+// raw 503 error + Retry button.
 const companyOsEnabled = computed(() => runtimeFeaturesStore.companyOsEnabled)
 
 async function selectCompany(company: LlcCompany): Promise<void> {
@@ -54,8 +54,8 @@ onMounted(async () => {
       <p class="selector-subtitle">{{ $t('nav.llcSelectCompanyPrompt') }}</p>
     </header>
 
-    <!-- #10502: company mode off (single_user) OR a 503 from the company
-         endpoint — informational empty-state, never a raw error. -->
+    <!-- #10502: company mode off OR a 503 from the company endpoint —
+         informational empty-state, never a raw error. -->
     <div v-if="!companyOsEnabled || companyStore.unavailable" class="selector-unavailable">
       <span class="selector-unavailable-icon" aria-hidden="true">🏢</span>
       <h2 class="selector-unavailable-title">
@@ -141,7 +141,7 @@ onMounted(async () => {
   color: var(--text-secondary, #6b7280);
 }
 
-/* #10502: unavailable (single_user deployment) empty-state */
+/* #10502: unavailable (no company-mode deployment) empty-state */
 .selector-unavailable {
   padding: 3rem 1.5rem;
   text-align: center;

--- a/autobot-slm-backend/ansible/inventory/group_vars/backend.yml
+++ b/autobot-slm-backend/ansible/inventory/group_vars/backend.yml
@@ -7,17 +7,15 @@
 # ==========================================
 # USER-MANAGEMENT MODE
 # ==========================================
-# single_company enables the full PostgreSQL-backed userbase + RBAC and the
-# Company OS (LLC) module. Flipping off single_user (the role default):
-#   * auto-provisions a local PostgreSQL instance (backend role includes the
-#     postgresql role when this is not single_user) and runs `alembic upgrade
-#     head` on first start (#9759);
-#   * activates RBAC — the FIRST user to register becomes the admin, and the
-#     single_user synthetic-admin auth bypass (#6838) no longer applies, so
-#     real authentication is required;
+# AutoBot always runs full, PostgreSQL-backed user management (#10713); there is
+# no single_user mode. single_company (the default) or multi_company:
+#   * auto-provisions a local PostgreSQL instance (the backend role always
+#     includes the postgresql role) and runs `alembic upgrade head` on first
+#     start (#9759);
+#   * activates RBAC — the FIRST user to register becomes the admin, and real
+#     authentication is always required;
 #   * makes the "Company OS" nav item visible (gated on company mode via
 #     /api/frontend-config → company_os_enabled, #10502).
-# Apply with an Ansible sync once PostgreSQL is acceptable on the backend node.
 backend_user_mode: "single_company"
 
 # ==========================================
@@ -133,7 +131,7 @@ backend:
 
     # Deployment settings
     AUTOBOT_DEPLOYMENT_MODE: "production"  # Infrastructure mode: local/hybrid/distributed/production
-    AUTOBOT_USER_MODE: "single_company"    # User management: single_user/single_company/multi_company/provider
+    AUTOBOT_USER_MODE: "single_company"    # User management: single_company/multi_company/provider
     AUTOBOT_BACKEND_HOST: "0.0.0.0"
     AUTOBOT_BACKEND_PORT: 8001
 

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -651,7 +651,7 @@
         # #10400: prefer SLM_SECRET_KEY when present, else keep the role default.
         backend_jwt_secret: "{{ (existing_slm_secret_key.stdout | default('') | trim) if (existing_slm_secret_key.stdout | default('') | trim) | length > 0 else (existing_secret_key.stdout | default('') | trim) }}"
         # #10636: internal service API key + full-user-management DB password,
-        # read from /etc/autobot above (no longer undefined / single_user).
+        # read from /etc/autobot above.
         autobot_internal_api_key: "{{ existing_internal_api_key.stdout | default('') | trim }}"
         backend_postgres_password: "{{ existing_autobot_db_password.stdout | default('') | trim }}"
         # #10636: seed the default platform admin on first boot (full user mgmt).
@@ -663,14 +663,14 @@
       become: true
       register: backend_user_mode_probe
       changed_when: false
-      failed_when: false  # absent .env/var means single_user (no Postgres)
+      failed_when: false  # absent .env/var = not yet configured; skip until set
       when: "'backend' in group_names"
       tags: [backend, migrate]
 
     - name: "[PLAY 2] Backend | Database migration sequence (#10001)"
       when:
         - "'backend' in group_names"
-        - backend_user_mode_probe.stdout | default('') | trim not in ['', 'single_user']
+        - backend_user_mode_probe.stdout | default('') | trim != ''
       tags: [backend, migrate]
       block:
         # Strict migration sequence consolidated into one shared include

--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -41,7 +41,7 @@ backend_redis_password: ""
 # There is no single_user mode; do not reintroduce it as a fallback.
 backend_user_mode: "single_company"
 
-# PostgreSQL for non-single_user modes (Issue #2953)
+# PostgreSQL for user management — always enabled (Issue #2953)
 backend_postgres_host: "127.0.0.1"
 backend_postgres_port: 5432
 backend_postgres_db: "autobot_users"

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -654,7 +654,8 @@
 
 # ==========================================================
 # PostgreSQL for User Management (Issue #2953)
-# Included only when backend_user_mode is not single_user.
+# AutoBot always runs full user management (#10713); every supported user mode
+# is Postgres-backed, so this always runs.
 # Re-uses the shared postgresql role with autobot_users DB.
 # ==========================================================
 - name: "Backend | Configure PostgreSQL for user management (#2953)"
@@ -680,7 +681,6 @@
     # slm_app's rules survive), and this second run must ONLY reload, never
     # restart, the shared instance. postgresql.conf renders identically on both
     # runs (both pass listen_addresses=localhost), so no restart is triggered.
-  when: (backend_user_mode | default('single_company')) != 'single_user'
   tags: ['backend', 'postgresql']
 
 # ==========================================================

--- a/autobot-slm-backend/ansible/setup-user-backend.yml
+++ b/autobot-slm-backend/ansible/setup-user-backend.yml
@@ -86,11 +86,11 @@
       ansible.builtin.shell: "grep -oP '^AUTOBOT_USER_MODE=\\K.*' {{ backend_code_dir }}/.env"
       register: backend_user_mode_probe
       changed_when: false
-      failed_when: false  # absent .env/var means single_user (no Postgres)
+      failed_when: false  # absent .env/var = not yet configured; skip until set
       tags: [migrations]
 
     - name: Database migration sequence (Postgres-backed modes) (#10001)
-      when: backend_user_mode_probe.stdout | default('') | trim not in ['', 'single_user']
+      when: backend_user_mode_probe.stdout | default('') | trim != ''
       tags: [migrations]
       block:
         # Strict migration sequence consolidated into one shared include


### PR DESCRIPTION
## Thinking Path
#10713 retired the backend single_user auth-disable branch (auth always on), but frontend + Ansible still treated single_user as a live mode → auth forced on in backend while frontend/Ansible believe it's off → 401s / mismatched UX. Completes the elimination per the 'always full user management' rule.

## What Changed
**Frontend:** new `utils/authToken.ts` (`isRealAuthToken`/`readStoredAuthToken`) consolidating scattered token reads + purging the legacy `single_user_mode` marker from stale localStorage; wired into ApiClient/fetchWithAuth/ChatRepository/useServiceDiscovery/useUserStore. Removed the **provably-dead** `deployment_mode === 'single_user'` branch in useUserStore (backend DeploymentMode enum has no single_user value — only single_company/multi_company/provider). Reworded stale single_user comments in App.vue/stores/router. i18n `companyOsUnavailableDesc` updated in ALL 11 locales.
**Ansible:** dropped `when != 'single_user'` gates (postgres user-mgmt role always runs); migration gates no longer exclude single_user; comments updated; kept anti-reintroduction guardrail comments.

## Verification
- `vue-tsc`: 0 new errors in touched files (53 pre-existing @autobot/ui workspace-link errors, unrelated).
- Ansible YAML valid. No live single_user gating remains (only intentional guardrail comments + legacy-marker purge).
- Discovery confirmed: backend DeploymentMode has NO single_user value → validated full removal over consolidation.

## Model Used
Opus 4.8

Closes #10861. Relates #10713/#10199/#10636.