### PR TITLE
fix(test): model KEK-rewrap root swap so test_service_rewrap_system_vault decrypts (#10969)

### DIFF
--- a/autobot-backend/tests/migrations/test_secrets_api.py
+++ b/autobot-backend/tests/migrations/test_secrets_api.py
@@ -200,14 +200,22 @@ async def service_client(fresh_db_url):
     async def _service_principal_override():
         return "test-slm"
 
+    # The active root key the coordinator derives KEKs from.  A KEK rewrap migrates
+    # the stored wrapped-DEKs to a *new* root; in production the operator then swaps
+    # AUTOBOT_SECRETS_ROOT_KEY and restarts, so subsequent reads use the new root.
+    # We model that restart by rebuilding the coordinator from this mutable holder,
+    # letting a rewrap test flip the active root before reading back.
+    active_root = {"key": _ROOT}
+
     app.dependency_overrides[envelope_secrets.get_session] = _session_override
     app.dependency_overrides[envelope_secrets.get_coordinator] = lambda: SecretsCoordinator(
-        EnvelopeSecretsService(root_key=_ROOT)
+        EnvelopeSecretsService(root_key=active_root["key"])
     )
     app.dependency_overrides[envelope_secrets.service_principal] = _service_principal_override
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://t", follow_redirects=True) as c:
+        c.set_active_root = lambda raw: active_root.__setitem__("key", raw)  # type: ignore[attr-defined]
         yield c
     await engine.dispose()
 
@@ -250,6 +258,10 @@ async def test_service_rewrap_system_vault(service_client):
     r = await service_client.post(f"{_P}/system/{sid}/rewrap", json={"new_root_key": _ROOT2_B64})
     assert r.status_code == 200, r.text
     assert r.json()["version"] == 1  # KEK-only rotation — sealed value untouched
+    # The DEK is now wrapped under _ROOT2; a read must use the migrated root (as prod
+    # does after swapping AUTOBOT_SECRETS_ROOT_KEY + restart).  The sealed value —
+    # never re-encrypted — still decrypts, proving the rewrap preserved the payload.
+    service_client.set_active_root(base64.urlsafe_b64decode(_ROOT2_B64))
     rr = await service_client.get(f"{_P}/system/{sid}")
     assert rr.status_code == 200 and rr.json()["value"] == "fleet-secret"
 


### PR DESCRIPTION
## Thinking Path
migration-matrix has been red on **every PR** since 2026-06-26 (blame 5435e7793c) on `test_secrets_api.py::test_service_rewrap_system_vault` — `AEAD authentication failed`. Root-caused: this is a **test-assertion bug, NOT a crypto bug**.

## Root Cause (verified with a standalone crypto proof)
The envelope scheme is correct: root(KEK) wraps DEK → DEK AEAD-seals the value. `rotate_kek()` unwraps each DEK with the OLD KEK and re-wraps under the NEW root; the sealed value is untouched (version stays 1). But the test did a GET **after** rewrap and asserted the process (still holding the OLD root via the fixture's hardcoded `root_key=_ROOT`) could decrypt — **cryptographically impossible**: the DEK is now wrapped under `_ROOT2`, so `read()` (which derives the KEK from the init-time `self._root`) hits AESGCM InvalidTag. In production a KEK rewrap is a migration: rewrap all secrets → swap `AUTOBOT_SECRETS_ROOT_KEY` → restart, after which reads use the new root. The test never modeled that swap.

## What Changed (test-only — no production/crypto code)
The `service_client` fixture now derives KEKs from a mutable `active_root` holder + exposes `set_active_root()`; `test_service_rewrap_system_vault` flips the active root to `_ROOT2` before the GET, modelling the prod restart. The GET then decrypts the untouched sealed payload → "fleet-secret", proving rewrap preserved it. All AEAD/AAD/version security properties unchanged.

## Verification
- Standalone crypto proof (mirrors service code vs `secrets_envelope`): baseline OK; read-under-OLD-root after rewrap → DecryptionError (matches CI); read-under-NEW-root → "fleet-secret". 
- py_compile + flake8 -F + black --check clean. No other secrets test affected.
- The migration-matrix job on THIS PR should now pass (the fix's proof).

## Model Used
Opus 4.8

Closes #10969. Discovery: sibling test_rewrap_same_plaintext has a misleading docstring (never GETs) — minor, noted.