### PR TITLE
feat(llm): Claude Code / Claude Agent SDK execution provider — streamed + MCP-governed (#10550)

### DIFF
--- a/autobot-backend/services/execution/__init__.py
+++ b/autobot-backend/services/execution/__init__.py
@@ -36,6 +36,11 @@ from services.execution.base_backend import (
     ExecutionTask,
     ResourceLimits,
 )
+from services.execution.claude_code_backend import (
+    CLAUDE_CODE_BACKEND,
+    ClaudeCodeBackend,
+    build_claude_code_backend,
+)
 from services.execution.docker_backend import DockerBackend
 from services.execution.execution_manager import (
     ExecutionManager,
@@ -58,4 +63,8 @@ __all__ = [
     "ModalBackend",
     "ExecutionManager",
     "get_execution_manager",
+    # Claude Code / Agent SDK execution provider (Issue #10550)
+    "CLAUDE_CODE_BACKEND",
+    "ClaudeCodeBackend",
+    "build_claude_code_backend",
 ]

--- a/autobot-backend/services/execution/claude_code_backend.py
+++ b/autobot-backend/services/execution/claude_code_backend.py
@@ -1,0 +1,627 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Claude Code / Claude Agent SDK execution provider (Issue #10550).
+
+Offers the Claude Code CLI (headless ``--print`` mode) or the ``claude-agent-sdk``
+Python package as a selectable EXECUTION backend that runs INSIDE AutoBot's
+governance: approval gates, budgets, and RBAC are enforced by routing Claude
+Code's tool calls through AutoBot's own MCP server.
+
+Architecture
+------------
+                         ┌──────────────────────┐
+   run_task(prompt)  ──► │ ClaudeCodeBackend     │
+                         │  (ExecutionBackend)    │
+                         └──────┬───────────────-┘
+                                │ streams JSONL / SDK events
+                         ┌──────▼──────────────────────┐
+                         │  AutoBot event stream         │
+                         │  ACTION + OBSERVATION events │
+                         └──────────────────────────────┘
+                                │ MCP tool calls
+                         ┌──────▼──────────────────────┐
+                         │  AutoBot MCP server           │
+                         │  (governed, RBAC-checked)     │
+                         └──────────────────────────────┘
+
+Governance seam
+---------------
+``ClaudeCodeBackend`` is initialised with the URL/token of AutoBot's MCP server
+(``autobot-backend/mcp/autobot_server.py``, HTTP transport on port 8200).
+When invoking the ``claude`` CLI it passes ``--mcp-config`` so every tool call
+Claude Code makes goes through the MCP server, which already enforces
+approval/budget/RBAC.  SDK path: the SDK subprocess inherits the MCP config env.
+
+Guard-import
+------------
+The ``claude-agent-sdk`` package is optional.  Both import paths use the
+``MissingDep`` sentinel so the module loads cleanly when the package is absent;
+``is_available()`` returns False and the backend reports itself unavailable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Dict, Optional
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.missing_dep import MissingDep as _MissingDep
+from autobot_shared.ssot_config import config
+from services.execution.base_backend import (
+    BackendType,
+    ExecutionBackend,
+    ExecutionResult,
+    ExecutionStatus,
+    ExecutionTask,
+)
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Guard-import: claude-agent-sdk (optional)
+# ---------------------------------------------------------------------------
+
+try:
+    import claude_agent_sdk as _sdk  # type: ignore[import-not-found]
+
+    _SDK_AVAILABLE = True
+except ImportError as _sdk_err:
+    _sdk = _MissingDep("claude_agent_sdk", _sdk_err)  # type: ignore[assignment]
+    _SDK_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Feature flag + backend-type extension
+# ---------------------------------------------------------------------------
+
+CLAUDE_CODE_BACKEND = "claude_code"
+
+# Env-flag: set AUTOBOT_FEATURE_CLAUDE_CODE_EXECUTION=true to enable.
+# Absent or falsy → provider reports unavailable (no crash).
+_ENV_FLAG = "AUTOBOT_FEATURE_CLAUDE_CODE_EXECUTION"
+
+# MCP server defaults (matches autobot_mcp_main.py HTTP transport)
+_DEFAULT_MCP_HOST = "127.0.0.1"
+_DEFAULT_MCP_PORT = 8200
+
+
+# ---------------------------------------------------------------------------
+# Step events — mirror the types consumed by the event stream
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StepEvent:
+    """Internal representation of a single Claude Code step before fan-out."""
+
+    kind: str  # "message" | "tool_use" | "tool_result" | "error" | "complete"
+    content: Dict[str, Any] = field(default_factory=dict)
+    tool_name: str = ""
+    tool_id: str = ""
+
+
+# ---------------------------------------------------------------------------
+# JSONL stream parser (CLI path)
+# ---------------------------------------------------------------------------
+
+
+def _parse_cli_line(raw: str) -> Optional[_StepEvent]:
+    """Parse one JSONL line from ``claude --output-format stream-json``.
+
+    Returns None for unrecognised lines so callers can skip silently.
+    The CLI emits events with a ``type`` key; the subset we care about:
+    - ``assistant`` (content blocks: text / tool_use)
+    - ``tool_result``
+    - ``result``
+    - ``error``
+    """
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        obj = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+    ev_type = obj.get("type", "")
+
+    if ev_type == "assistant":
+        blocks = obj.get("message", {}).get("content", [])
+        for block in blocks:
+            btype = block.get("type", "")
+            if btype == "text":
+                return _StepEvent(kind="message", content={"text": block.get("text", "")})
+            if btype == "tool_use":
+                return _StepEvent(
+                    kind="tool_use",
+                    content={"input": block.get("input", {})},
+                    tool_name=block.get("name", ""),
+                    tool_id=block.get("id", ""),
+                )
+        return None
+
+    if ev_type == "tool_result":
+        return _StepEvent(
+            kind="tool_result",
+            content={"output": obj.get("output", ""), "is_error": obj.get("is_error", False)},
+            tool_id=obj.get("tool_use_id", ""),
+        )
+
+    if ev_type == "result":
+        return _StepEvent(
+            kind="complete",
+            content={
+                "subtype": obj.get("subtype", ""),
+                "is_error": obj.get("is_error", False),
+                "result": obj.get("result", ""),
+                "usage": obj.get("usage", {}),
+            },
+        )
+
+    if ev_type == "error":
+        return _StepEvent(kind="error", content={"error": obj.get("error", obj)})
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Event-stream bridge
+# ---------------------------------------------------------------------------
+
+
+async def _publish_action(event_stream: Any, step: _StepEvent, task_id: str) -> None:
+    """Emit an ACTION event for a tool-use step."""
+    try:
+        from events.types import ActionContent, AgentEvent, EventType
+
+        action = ActionContent(
+            tool_name=step.tool_name,
+            arguments=step.content.get("input", {}),
+            tool_id=step.tool_id or str(uuid.uuid4()),
+        )
+        evt = AgentEvent(
+            event_type=EventType.ACTION,
+            content=action.to_dict(),
+            source="claude_code",
+            task_id=task_id,
+        )
+        await event_stream.publish(evt)
+    except Exception as exc:
+        logger.debug("ClaudeCodeBackend: action publish failed (non-critical): %s", exc)
+
+
+async def _publish_observation(
+    event_stream: Any,
+    step: _StepEvent,
+    action_id: str,
+    task_id: str,
+    elapsed_ms: float,
+) -> None:
+    """Emit an OBSERVATION event for a tool-result step."""
+    try:
+        from events.types import AgentEvent, EventType, ObservationContent
+
+        obs = ObservationContent(
+            action_id=action_id,
+            tool_name=step.tool_name or "unknown",
+            success=not step.content.get("is_error", False),
+            result=step.content.get("output"),
+            error=step.content.get("output") if step.content.get("is_error") else None,
+            execution_time_ms=elapsed_ms,
+        )
+        evt = AgentEvent(
+            event_type=EventType.OBSERVATION,
+            content=obs.to_dict(),
+            source="claude_code",
+            task_id=task_id,
+        )
+        await event_stream.publish(evt)
+    except Exception as exc:
+        logger.debug("ClaudeCodeBackend: observation publish failed (non-critical): %s", exc)
+
+
+async def _publish_message(event_stream: Any, text: str, task_id: str) -> None:
+    """Emit a MESSAGE event for an assistant text step."""
+    try:
+        from events.types import AgentEvent, EventType, MessageContent
+
+        msg = MessageContent(role="assistant", text=text)
+        evt = AgentEvent(
+            event_type=EventType.MESSAGE,
+            content=msg.to_dict(),
+            source="claude_code",
+            task_id=task_id,
+        )
+        await event_stream.publish(evt)
+    except Exception as exc:
+        logger.debug("ClaudeCodeBackend: message publish failed (non-critical): %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# MCP config builder
+# ---------------------------------------------------------------------------
+
+
+def _build_mcp_config(mcp_url: str, mcp_token: str) -> Dict[str, Any]:
+    """Build the ``--mcp-config`` JSON structure for the Claude CLI."""
+    return {
+        "mcpServers": {
+            "autobot": {
+                "url": mcp_url,
+                "transport": "http",
+                "headers": {"Authorization": f"Bearer {mcp_token}"},
+            }
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core backend
+# ---------------------------------------------------------------------------
+
+
+class ClaudeCodeBackend(ExecutionBackend):
+    """Execution backend that drives tasks via Claude Code CLI or Agent SDK.
+
+    Streams every step (tool use, tool result, assistant message) into
+    AutoBot's event stream as ACTION / OBSERVATION / MESSAGE events.
+    All tool calls go through AutoBot's MCP server, which enforces
+    approval gates, budgets, and RBAC (Issue #10550).
+
+    Selectable via ``BackendType`` value ``"claude_code"`` (string).
+    Gated on:
+      1. Anthropic API key (``ANTHROPIC_API_KEY`` or provider settings).
+      2. ``AUTOBOT_FEATURE_CLAUDE_CODE_EXECUTION=true`` env flag.
+      3. ``claude`` CLI on PATH (CLI path) OR ``claude-agent-sdk`` installed (SDK path).
+    """
+
+    def __init__(
+        self,
+        event_stream: Any = None,
+        mcp_host: str = _DEFAULT_MCP_HOST,
+        mcp_port: int = _DEFAULT_MCP_PORT,
+        mcp_token: str = "",
+        use_sdk: bool = False,
+    ) -> None:
+        super().__init__(BackendType.LOCAL)  # reuse LOCAL slot; manager keys by instance
+        self._event_stream = event_stream
+        self._mcp_host = mcp_host
+        self._mcp_port = mcp_port
+        self._mcp_token = mcp_token or config.mcp_token
+        self._use_sdk = use_sdk and _SDK_AVAILABLE
+        self._api_key: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Provider availability
+    # ------------------------------------------------------------------
+
+    def _resolve_api_key(self) -> Optional[str]:
+        if self._api_key:
+            return self._api_key
+        self._api_key = config.anthropic_api_key or None
+        return self._api_key
+
+    def _feature_flag_enabled(self) -> bool:
+        return os.environ.get(_ENV_FLAG, "").lower() in ("1", "true", "yes")
+
+    def _cli_available(self) -> bool:
+        return shutil.which("claude") is not None
+
+    # ------------------------------------------------------------------
+    # ExecutionBackend abstract interface
+    # ------------------------------------------------------------------
+
+    async def health_check(self) -> bool:
+        """Return True when all preconditions are satisfied."""
+        if not self._feature_flag_enabled():
+            return False
+        if not self._resolve_api_key():
+            return False
+        if self._use_sdk:
+            return _SDK_AVAILABLE
+        return self._cli_available()
+
+    async def cleanup(self) -> None:
+        """No persistent resources to release."""
+
+    def get_backend_info(self) -> Dict[str, Any]:
+        return {
+            "type": CLAUDE_CODE_BACKEND,
+            "healthy": self._health_status,
+            "sdk_available": _SDK_AVAILABLE,
+            "cli_available": self._cli_available(),
+            "feature_flag": self._feature_flag_enabled(),
+            "mcp_url": f"http://{self._mcp_host}:{self._mcp_port}",
+            "last_health_check": self._last_health_check.isoformat(),
+        }
+
+    async def execute(self, task: ExecutionTask) -> ExecutionResult:
+        """Drive *task* via Claude Code and stream steps to the event stream."""
+        if not await self.is_healthy():
+            return ExecutionResult(
+                task_id=task.task_id,
+                status=ExecutionStatus.FAILED,
+                stderr="ClaudeCodeBackend unavailable: check API key, feature flag, and claude CLI/SDK.",
+                backend_type=CLAUDE_CODE_BACKEND,
+            )
+
+        logger.info("ClaudeCodeBackend: executing task %s", task.task_id)
+        start = time.monotonic()
+
+        if self._use_sdk and _SDK_AVAILABLE:
+            stdout, stderr, ok = await self._run_sdk(task)
+        else:
+            stdout, stderr, ok = await self._run_cli(task)
+
+        elapsed_ms = (time.monotonic() - start) * 1000
+        status = ExecutionStatus.SUCCESS if ok else ExecutionStatus.FAILED
+        return ExecutionResult(
+            task_id=task.task_id,
+            status=status,
+            stdout=stdout,
+            stderr=stderr,
+            return_code=0 if ok else 1,
+            execution_time_ms=elapsed_ms,
+            backend_type=CLAUDE_CODE_BACKEND,
+        )
+
+    # ------------------------------------------------------------------
+    # CLI execution path
+    # ------------------------------------------------------------------
+
+    async def _run_cli(self, task: ExecutionTask) -> tuple[str, str, bool]:
+        """Invoke ``claude --print --output-format stream-json`` and stream events."""
+        cli = shutil.which("claude")
+        if cli is None:
+            return "", "claude CLI not found on PATH", False
+
+        mcp_url = f"http://{self._mcp_host}:{self._mcp_port}"
+        mcp_cfg = _build_mcp_config(mcp_url, self._mcp_token)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".json",
+            delete=False,
+            encoding="utf-8",
+        ) as fh:
+            json.dump(mcp_cfg, fh)
+            mcp_cfg_path = fh.name
+
+        try:
+            return await self._run_cli_with_config(task, cli, mcp_cfg_path)
+        finally:
+            try:
+                os.unlink(mcp_cfg_path)
+            except OSError:
+                pass
+
+    async def _run_cli_with_config(
+        self,
+        task: ExecutionTask,
+        cli: str,
+        mcp_cfg_path: str,
+    ) -> tuple[str, str, bool]:
+        """Spawn and stream from the Claude CLI subprocess."""
+        cmd = [
+            cli,
+            "--output-format",
+            "stream-json",
+            "--print",
+            "--mcp-config",
+            mcp_cfg_path,
+        ]
+        model = task.metadata.get("model")
+        if model:
+            cmd += ["--model", model]
+        max_turns = task.metadata.get("max_turns")
+        if max_turns is not None:
+            cmd += ["--max-turns", str(max_turns)]
+
+        cmd.append(task.code)  # prompt is the task code/description
+
+        env = {**os.environ, "ANTHROPIC_API_KEY": self._resolve_api_key() or ""}
+        env.update(task.env_vars)
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+        except FileNotFoundError as exc:
+            return "", f"Failed to start claude CLI: {exc}", False
+
+        stdout_chunks: list[str] = []
+        stderr_chunks: list[str] = []
+        ok = True
+        timeout = task.timeout_seconds or 600
+
+        try:
+            await asyncio.wait_for(
+                self._stream_cli_output(proc, task.task_id, stdout_chunks),
+                timeout=float(timeout),
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            ok = False
+            stderr_chunks.append(f"Timed out after {timeout}s")
+        except Exception as exc:
+            ok = False
+            stderr_chunks.append(str(exc))
+
+        if proc.stderr:
+            raw_err = await proc.stderr.read()
+            if raw_err:
+                stderr_chunks.append(raw_err.decode("utf-8", errors="replace"))
+
+        await proc.wait()
+        if proc.returncode not in (0, None):
+            ok = False
+
+        return "\n".join(stdout_chunks), "\n".join(stderr_chunks), ok
+
+    async def _stream_cli_output(
+        self,
+        proc: asyncio.subprocess.Process,
+        task_id: str,
+        chunks: list[str],
+    ) -> None:
+        """Read JSONL lines from proc.stdout and fan out to the event stream."""
+        assert proc.stdout is not None
+        pending_actions: Dict[str, tuple[str, float]] = {}  # tool_id → (tool_name, start_ms)
+        stream = self._event_stream
+
+        async for raw_bytes in proc.stdout:
+            line = raw_bytes.decode("utf-8", errors="replace")
+            chunks.append(line.rstrip())
+            step = _parse_cli_line(line)
+            if step is None or stream is None:
+                continue
+            await self._dispatch_step(step, task_id, pending_actions, stream)
+
+    async def _dispatch_step(
+        self,
+        step: _StepEvent,
+        task_id: str,
+        pending_actions: Dict[str, tuple[str, float]],
+        stream: Any,
+    ) -> None:
+        """Route a parsed CLI step to the appropriate event-stream publish call."""
+        if step.kind == "message":
+            await _publish_message(stream, step.content.get("text", ""), task_id)
+
+        elif step.kind == "tool_use":
+            pending_actions[step.tool_id] = (step.tool_name, time.monotonic() * 1000)
+            await _publish_action(stream, step, task_id)
+
+        elif step.kind == "tool_result":
+            tool_name, t0_ms = pending_actions.pop(step.tool_id, ("unknown", time.monotonic() * 1000))
+            step.tool_name = tool_name
+            elapsed = time.monotonic() * 1000 - t0_ms
+            await _publish_observation(stream, step, step.tool_id, task_id, elapsed)
+
+        elif step.kind == "error":
+            logger.warning("ClaudeCodeBackend: CLI error event task=%s: %s", task_id, step.content)
+
+    # ------------------------------------------------------------------
+    # SDK execution path (optional — degrades to CLI when SDK absent)
+    # ------------------------------------------------------------------
+
+    async def _run_sdk(self, task: ExecutionTask) -> tuple[str, str, bool]:
+        """Drive the task via the ``claude-agent-sdk`` Python package.
+
+        Falls back to the CLI path when the SDK is not actually importable
+        at call time (belt-and-suspenders beyond the ``_use_sdk`` flag).
+        """
+        if not _SDK_AVAILABLE:
+            logger.warning("ClaudeCodeBackend: SDK path requested but not installed; falling back to CLI")
+            return await self._run_cli(task)
+
+        mcp_url = f"http://{self._mcp_host}:{self._mcp_port}"
+        mcp_cfg = _build_mcp_config(mcp_url, self._mcp_token)
+
+        chunks: list[str] = []
+        ok = True
+        try:
+            async for event in self._sdk_stream(task, mcp_cfg):
+                chunks.append(json.dumps(event))
+                if self._event_stream:
+                    await self._dispatch_sdk_event(event, task.task_id)
+        except Exception as exc:
+            ok = False
+            return "\n".join(chunks), str(exc), False
+
+        return "\n".join(chunks), "", ok
+
+    async def _sdk_stream(self, task: ExecutionTask, mcp_cfg: Dict[str, Any]) -> AsyncIterator[Dict[str, Any]]:
+        """Yield SDK events from the ``claude-agent-sdk`` package."""
+        # The SDK API surface is provisional; this adapts to the common
+        # `run(prompt, mcp_servers=[...])` shape documented in the SDK README.
+        # Exact kwarg names may differ; callers mock this in tests.
+        api_key = self._resolve_api_key() or ""
+        model = task.metadata.get("model", "claude-sonnet-4-6")
+        max_turns = task.metadata.get("max_turns", 10)
+        mcp_servers = [mcp_cfg["mcpServers"]["autobot"]]
+
+        session = _sdk.run(  # type: ignore[union-attr]
+            prompt=task.code,
+            api_key=api_key,
+            model=model,
+            max_turns=max_turns,
+            mcp_servers=mcp_servers,
+        )
+        # SDK may return an async iterable or a coroutine depending on version.
+        if hasattr(session, "__aiter__"):
+            async for event in session:
+                yield event if isinstance(event, dict) else vars(event)
+        else:
+            result = await session
+            yield result if isinstance(result, dict) else vars(result)
+
+    async def _dispatch_sdk_event(self, event: Dict[str, Any], task_id: str) -> None:
+        """Translate an SDK event dict into an event-stream publish call."""
+        ev_type = event.get("type", "")
+        if ev_type == "tool_use":
+            step = _StepEvent(
+                kind="tool_use",
+                content={"input": event.get("input", {})},
+                tool_name=event.get("name", ""),
+                tool_id=event.get("id", str(uuid.uuid4())),
+            )
+            await _publish_action(self._event_stream, step, task_id)
+        elif ev_type == "tool_result":
+            step = _StepEvent(
+                kind="tool_result",
+                content={"output": event.get("output", ""), "is_error": event.get("is_error", False)},
+                tool_name=event.get("tool_name", ""),
+                tool_id=event.get("tool_use_id", ""),
+            )
+            await _publish_observation(self._event_stream, step, step.tool_id, task_id, 0.0)
+        elif ev_type in ("text", "message"):
+            await _publish_message(self._event_stream, event.get("text", ""), task_id)
+
+
+# ---------------------------------------------------------------------------
+# Provider-registry entry point
+# ---------------------------------------------------------------------------
+
+
+def build_claude_code_backend(
+    event_stream: Any = None,
+    mcp_host: str = _DEFAULT_MCP_HOST,
+    mcp_port: int = _DEFAULT_MCP_PORT,
+    mcp_token: str = "",
+    use_sdk: bool = False,
+) -> ClaudeCodeBackend:
+    """Factory used by the execution-manager registry.
+
+    Returns a ``ClaudeCodeBackend`` wired to *event_stream*.
+    The backend's ``is_available()`` / ``health_check()`` gate activation.
+    """
+    return ClaudeCodeBackend(
+        event_stream=event_stream,
+        mcp_host=mcp_host,
+        mcp_port=mcp_port,
+        mcp_token=mcp_token,
+        use_sdk=use_sdk,
+    )
+
+
+__all__ = [
+    "CLAUDE_CODE_BACKEND",
+    "ClaudeCodeBackend",
+    "build_claude_code_backend",
+    "_build_mcp_config",
+    "_parse_cli_line",
+    "_StepEvent",
+]

--- a/autobot-backend/services/execution/claude_code_backend.py
+++ b/autobot-backend/services/execution/claude_code_backend.py
@@ -89,6 +89,26 @@ CLAUDE_CODE_BACKEND = "claude_code"
 # Absent or falsy → provider reports unavailable (no crash).
 _ENV_FLAG = "AUTOBOT_FEATURE_CLAUDE_CODE_EXECUTION"
 
+# Security: task-supplied env_vars may never set these — credentials (which the
+# task could redirect to an attacker endpoint or override with a stolen key) and
+# process loader / path vars (which could hijack the spawned CLI). Pinned by the
+# backend after the task env is applied.
+_PROTECTED_ENV_KEYS = frozenset(
+    {
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_API_URL",
+        "CLAUDE_CODE_ENTRYPOINT",
+        "PATH",
+        "LD_PRELOAD",
+        "LD_LIBRARY_PATH",
+        "DYLD_INSERT_LIBRARIES",
+        "PYTHONPATH",
+        "PYTHONSTARTUP",
+    }
+)
+
 # MCP server defaults (matches autobot_mcp_main.py HTTP transport)
 _DEFAULT_MCP_HOST = "127.0.0.1"
 _DEFAULT_MCP_PORT = 8200
@@ -420,16 +440,23 @@ class ClaudeCodeBackend(ExecutionBackend):
             mcp_cfg_path,
         ]
         model = task.metadata.get("model")
-        if model:
-            cmd += ["--model", model]
+        if model and not str(model).startswith("-"):  # never let a value inject a flag
+            cmd += ["--model", str(model)]
         max_turns = task.metadata.get("max_turns")
         if max_turns is not None:
-            cmd += ["--max-turns", str(max_turns)]
+            cmd += ["--max-turns", str(int(max_turns))]
 
-        cmd.append(task.code)  # prompt is the task code/description
+        # Security: `--` ends option parsing so a prompt starting with `-`/`--`
+        # (e.g. "--dangerously-skip-permissions") can NOT be parsed as a flag.
+        cmd.append("--")
+        cmd.append(task.code)  # prompt is the task code/description (positional only)
 
-        env = {**os.environ, "ANTHROPIC_API_KEY": self._resolve_api_key() or ""}
-        env.update(task.env_vars)
+        # Security: task-supplied env_vars must NOT override credentials or the
+        # process loader/PATH (env-injection / credential-override). Apply the
+        # task env first (filtered), then pin the protected vars last so they win.
+        env = dict(os.environ)
+        env.update({k: v for k, v in task.env_vars.items() if k not in _PROTECTED_ENV_KEYS})
+        env["ANTHROPIC_API_KEY"] = self._resolve_api_key() or ""
 
         try:
             proc = await asyncio.create_subprocess_exec(

--- a/autobot-backend/services/execution/claude_code_backend.py
+++ b/autobot-backend/services/execution/claude_code_backend.py
@@ -309,7 +309,7 @@ class ClaudeCodeBackend(ExecutionBackend):
         event_stream: Any = None,
         mcp_host: str = _DEFAULT_MCP_HOST,
         mcp_port: int = _DEFAULT_MCP_PORT,
-        mcp_token: str = "",
+        mcp_token: str = "",  # nosec B107 - optional token; resolved from config when empty
         use_sdk: bool = False,
     ) -> None:
         super().__init__(BackendType.LOCAL)  # reuse LOCAL slot; manager keys by instance
@@ -627,7 +627,7 @@ def build_claude_code_backend(
     event_stream: Any = None,
     mcp_host: str = _DEFAULT_MCP_HOST,
     mcp_port: int = _DEFAULT_MCP_PORT,
-    mcp_token: str = "",
+    mcp_token: str = "",  # nosec B107 - optional token; resolved from config when empty
     use_sdk: bool = False,
 ) -> ClaudeCodeBackend:
     """Factory used by the execution-manager registry.

--- a/autobot-backend/tests/test_claude_code_backend.py
+++ b/autobot-backend/tests/test_claude_code_backend.py
@@ -1,0 +1,415 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for the Claude Code / Claude Agent SDK execution provider (Issue #10550).
+
+All tests mock the claude CLI / SDK so they run without the binary installed
+or a live Anthropic key.  The three acceptance criteria tested here:
+  1. Provider is ``unavailable`` when SDK/CLI absent (health_check → False).
+  2. A task run streams ACTION + OBSERVATION + MESSAGE events.
+  3. MCP-server config (URL, token) is passed to the CLI / SDK call.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.execution.base_backend import ExecutionStatus, ExecutionTask
+from services.execution.claude_code_backend import (
+    ClaudeCodeBackend,
+    _build_mcp_config,
+    _parse_cli_line,
+    build_claude_code_backend,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TASK = ExecutionTask(
+    task_id="task-test-01",
+    code="Write a hello-world function",
+    language="natural_language",
+    timeout_seconds=30,
+)
+
+
+def _make_backend(event_stream=None, **kwargs) -> ClaudeCodeBackend:
+    return ClaudeCodeBackend(
+        event_stream=event_stream,
+        mcp_host="127.0.0.1",
+        mcp_port=8200,
+        mcp_token="dev:kb,memory,agents",
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guard-import / unavailability tests
+# ---------------------------------------------------------------------------
+
+
+class TestProviderUnavailableWhenCliAbsent:
+    """Provider degrades to unavailable when claude CLI is not installed."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_false_no_cli(self):
+        """health_check() → False when claude is absent from PATH."""
+        backend = _make_backend()
+        with patch.dict(os.environ, {"AUTOBOT_FEATURE_CLAUDE_CODE_EXECUTION": "true"}):
+            with patch("services.execution.claude_code_backend.shutil.which", return_value=None):
+                with patch.object(backend, "_resolve_api_key", return_value="sk-test"):
+                    healthy = await backend.health_check()
+        assert healthy is False
+
+    @pytest.mark.asyncio
+    async def test_health_check_false_no_flag(self):
+        """health_check() → False when feature flag is off."""
+        backend = _make_backend()
+        with patch.dict(os.environ, {"AUTOBOT_FEATURE_CLAUDE_CODE_EXECUTION": "false"}):
+            with patch("services.execution.claude_code_backend.shutil.which", return_value="/usr/bin/claude"):
+                with patch.object(backend, "_resolve_api_key", return_value="sk-test"):
+                    healthy = await backend.health_check()
+        assert healthy is False
+
+    @pytest.mark.asyncio
+    async def test_health_check_false_no_api_key(self):
+        """health_check() → False when Anthropic API key is not configured."""
+        backend = _make_backend()
+        with patch.dict(os.environ, {"AUTOBOT_FEATURE_CLAUDE_CODE_EXECUTION": "true"}):
+            with patch("services.execution.claude_code_backend.shutil.which", return_value="/usr/bin/claude"):
+                with patch.object(backend, "_resolve_api_key", return_value=None):
+                    healthy = await backend.health_check()
+        assert healthy is False
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_failed_when_unhealthy(self):
+        """execute() returns FAILED status when backend is not healthy."""
+        backend = _make_backend()
+        with patch.object(backend, "is_healthy", new_callable=AsyncMock, return_value=False):
+            result = await backend.execute(_TASK)
+        assert result.status == ExecutionStatus.FAILED
+        assert "unavailable" in result.stderr.lower()
+
+    @pytest.mark.asyncio
+    async def test_health_check_true_when_preconditions_met(self):
+        """health_check() → True when flag + key + CLI are all present."""
+        backend = _make_backend()
+        with patch.dict(os.environ, {"AUTOBOT_FEATURE_CLAUDE_CODE_EXECUTION": "true"}):
+            with patch("services.execution.claude_code_backend.shutil.which", return_value="/usr/bin/claude"):
+                with patch.object(backend, "_resolve_api_key", return_value="sk-test"):
+                    healthy = await backend.health_check()
+        assert healthy is True
+
+
+# ---------------------------------------------------------------------------
+# MCP config tests
+# ---------------------------------------------------------------------------
+
+
+class TestMcpConfig:
+    """MCP server config is built and passed to the CLI/SDK."""
+
+    def test_build_mcp_config_structure(self):
+        """_build_mcp_config produces the expected mcpServers structure."""
+        cfg = _build_mcp_config("http://127.0.0.1:8200", "mytoken")
+        assert "mcpServers" in cfg
+        autobot = cfg["mcpServers"]["autobot"]
+        assert autobot["url"] == "http://127.0.0.1:8200"
+        assert autobot["transport"] == "http"
+        assert autobot["headers"]["Authorization"] == "Bearer mytoken"
+
+    @pytest.mark.asyncio
+    async def test_cli_path_writes_mcp_config_file(self):
+        """CLI invocation writes a temp MCP config file and passes its path."""
+        backend = _make_backend()
+        captured_cmd: list[list[str]] = []
+
+        async def _fake_exec(*cmd, **kwargs):
+            captured_cmd.append(list(cmd))
+            return _make_mock_proc([])
+
+        with patch.dict(os.environ, {"AUTOBOT_FEATURE_CLAUDE_CODE_EXECUTION": "true"}):
+            with patch("services.execution.claude_code_backend.shutil.which", return_value="/usr/bin/claude"):
+                with patch.object(backend, "_resolve_api_key", return_value="sk-test"):
+                    with patch("asyncio.create_subprocess_exec", new=_fake_exec):
+                        await backend._run_cli(_TASK)
+
+        assert len(captured_cmd) == 1
+        cmd = captured_cmd[0]
+        assert "--mcp-config" in cmd
+        mcp_idx = cmd.index("--mcp-config")
+        cfg_path = cmd[mcp_idx + 1]
+        # The file is deleted after _run_cli returns; just check the arg is present.
+        assert cfg_path.endswith(".json")
+
+    @pytest.mark.asyncio
+    async def test_backend_info_includes_mcp_url(self):
+        """get_backend_info() exposes the MCP URL for monitoring."""
+        backend = ClaudeCodeBackend(mcp_host="10.0.0.1", mcp_port=9999)
+        info = backend.get_backend_info()
+        assert info["mcp_url"] == "http://10.0.0.1:9999"
+
+
+# ---------------------------------------------------------------------------
+# Event-streaming tests
+# ---------------------------------------------------------------------------
+
+
+class TestEventStreaming:
+    """Steps (tool calls, results, messages) stream into the event bus."""
+
+    @pytest.mark.asyncio
+    async def test_cli_stream_emits_action_and_observation_events(self):
+        """A tool-use / tool-result pair produces ACTION then OBSERVATION events."""
+        published: list[Any] = []
+
+        stream = MagicMock()
+        stream.publish = AsyncMock(side_effect=lambda evt: published.append(evt))
+
+        # Simulate two JSONL lines: tool_use then tool_result
+        tool_use_line = json.dumps({
+            "type": "assistant",
+            "message": {
+                "content": [{
+                    "type": "tool_use",
+                    "id": "tu-001",
+                    "name": "kb.search",
+                    "input": {"query": "hello"},
+                }]
+            },
+        })
+        tool_result_line = json.dumps({
+            "type": "tool_result",
+            "tool_use_id": "tu-001",
+            "output": "42 results",
+            "is_error": False,
+        })
+        result_line = json.dumps({
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": "Done",
+            "usage": {},
+        })
+
+        backend = _make_backend(event_stream=stream)
+        lines = [tool_use_line, tool_result_line, result_line]
+
+        async def _fake_exec(*a, **kw):
+            return _make_mock_proc(lines)
+
+        with patch.dict(os.environ, {"AUTOBOT_FEATURE_CLAUDE_CODE_EXECUTION": "true"}):
+            with patch("services.execution.claude_code_backend.shutil.which", return_value="/usr/bin/claude"):
+                with patch.object(backend, "_resolve_api_key", return_value="sk-test"):
+                    with patch("asyncio.create_subprocess_exec", new=_fake_exec):
+                        await backend._run_cli(_TASK)
+
+        event_types = [e.event_type.name for e in published]
+        assert "ACTION" in event_types, f"No ACTION event; got {event_types}"
+        assert "OBSERVATION" in event_types, f"No OBSERVATION event; got {event_types}"
+
+    @pytest.mark.asyncio
+    async def test_cli_stream_emits_message_event_for_text(self):
+        """An assistant text block produces a MESSAGE event."""
+        published: list[Any] = []
+        stream = MagicMock()
+        stream.publish = AsyncMock(side_effect=lambda evt: published.append(evt))
+
+        text_line = json.dumps({
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "text", "text": "Hello from Claude"}]
+            },
+        })
+        backend = _make_backend(event_stream=stream)
+
+        async def _fake_exec(*a, **kw):
+            return _make_mock_proc([text_line])
+
+        with patch.dict(os.environ, {"AUTOBOT_FEATURE_CLAUDE_CODE_EXECUTION": "true"}):
+            with patch("services.execution.claude_code_backend.shutil.which", return_value="/usr/bin/claude"):
+                with patch.object(backend, "_resolve_api_key", return_value="sk-test"):
+                    with patch("asyncio.create_subprocess_exec", new=_fake_exec):
+                        await backend._run_cli(_TASK)
+
+        event_types = [e.event_type.name for e in published]
+        assert "MESSAGE" in event_types
+
+
+# ---------------------------------------------------------------------------
+# JSONL parser unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseCLILine:
+    """_parse_cli_line correctly maps JSONL shapes to _StepEvent."""
+
+    def test_parses_tool_use(self):
+        line = json.dumps({
+            "type": "assistant",
+            "message": {
+                "content": [{
+                    "type": "tool_use",
+                    "id": "id-1",
+                    "name": "kb.search",
+                    "input": {"q": "x"},
+                }]
+            },
+        })
+        step = _parse_cli_line(line)
+        assert step is not None
+        assert step.kind == "tool_use"
+        assert step.tool_name == "kb.search"
+        assert step.tool_id == "id-1"
+
+    def test_parses_tool_result(self):
+        line = json.dumps({"type": "tool_result", "tool_use_id": "id-1", "output": "ok", "is_error": False})
+        step = _parse_cli_line(line)
+        assert step is not None
+        assert step.kind == "tool_result"
+        assert step.content["output"] == "ok"
+
+    def test_parses_text_message(self):
+        line = json.dumps({
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "hi"}]},
+        })
+        step = _parse_cli_line(line)
+        assert step is not None
+        assert step.kind == "message"
+        assert step.content["text"] == "hi"
+
+    def test_parses_result_event(self):
+        line = json.dumps({"type": "result", "subtype": "success", "is_error": False, "result": "done", "usage": {}})
+        step = _parse_cli_line(line)
+        assert step is not None
+        assert step.kind == "complete"
+
+    def test_parses_error_event(self):
+        line = json.dumps({"type": "error", "error": {"message": "rate limited"}})
+        step = _parse_cli_line(line)
+        assert step is not None
+        assert step.kind == "error"
+
+    def test_returns_none_for_garbage(self):
+        assert _parse_cli_line("not json at all !!!") is None
+        assert _parse_cli_line("") is None
+        assert _parse_cli_line(json.dumps({"type": "unknown_ev"})) is None
+
+    def test_returns_none_for_empty_assistant_message(self):
+        line = json.dumps({"type": "assistant", "message": {"content": []}})
+        step = _parse_cli_line(line)
+        assert step is None
+
+
+# ---------------------------------------------------------------------------
+# SDK path tests (SDK mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestSDKPath:
+    """SDK execution path — sdk itself is mocked."""
+
+    @pytest.mark.asyncio
+    async def test_sdk_path_streams_events_when_sdk_available(self):
+        """When SDK available + use_sdk=True, events flow through _dispatch_sdk_event."""
+        published: list[Any] = []
+        stream = MagicMock()
+        stream.publish = AsyncMock(side_effect=lambda evt: published.append(evt))
+
+        backend = _make_backend(event_stream=stream, use_sdk=True)
+
+        # Patch _SDK_AVAILABLE so the backend believes SDK is present.
+        sdk_events = [
+            {"type": "tool_use", "id": "s1", "name": "memory.search", "input": {"q": "test"}},
+            {"type": "tool_result", "tool_use_id": "s1", "output": "result", "is_error": False},
+            {"type": "text", "text": "All done."},
+        ]
+
+        async def _fake_sdk_stream(t, cfg):
+            for ev in sdk_events:
+                yield ev
+
+        with patch("services.execution.claude_code_backend._SDK_AVAILABLE", True):
+            with patch.object(backend, "_use_sdk", True):
+                with patch.object(backend, "_sdk_stream", _fake_sdk_stream):
+                    with patch.object(backend, "is_healthy", new_callable=AsyncMock, return_value=True):
+                        result = await backend.execute(_TASK)
+
+        assert result.status == ExecutionStatus.SUCCESS
+        event_types = [e.event_type.name for e in published]
+        assert "ACTION" in event_types
+        assert "OBSERVATION" in event_types
+        assert "MESSAGE" in event_types
+
+    @pytest.mark.asyncio
+    async def test_sdk_path_falls_back_to_cli_when_sdk_absent(self):
+        """use_sdk=True but SDK absent → falls back to CLI path."""
+        backend = _make_backend(use_sdk=True)
+        cli_called = []
+
+        async def _fake_cli(t):
+            cli_called.append(True)
+            return "output", "", True
+
+        with patch("services.execution.claude_code_backend._SDK_AVAILABLE", False):
+            with patch.object(backend, "_run_cli", _fake_cli):
+                await backend._run_sdk(_TASK)
+
+        assert cli_called, "Expected CLI fallback when SDK absent"
+
+
+# ---------------------------------------------------------------------------
+# Factory test
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFactory:
+    def test_factory_returns_claude_code_backend(self):
+        backend = build_claude_code_backend()
+        assert isinstance(backend, ClaudeCodeBackend)
+        assert backend._mcp_port == 8200
+
+    def test_factory_passes_event_stream(self):
+        stream = MagicMock()
+        backend = build_claude_code_backend(event_stream=stream)
+        assert backend._event_stream is stream
+
+
+# ---------------------------------------------------------------------------
+# Async helpers
+# ---------------------------------------------------------------------------
+
+
+def _async_iter_bytes(lines: list[str]):
+    """Return an async generator that yields lines as bytes."""
+
+    async def _gen():
+        for line in lines:
+            yield (line + "\n").encode("utf-8")
+
+    return _gen()
+
+
+def _make_mock_proc(lines: list[str]) -> MagicMock:
+    """Build a mock subprocess object whose stdout yields *lines* as bytes."""
+    proc = MagicMock()
+    proc.stdout = _async_iter_bytes(lines)
+
+    async def _read_stderr() -> bytes:
+        return b""
+
+    proc.stderr = MagicMock()
+    proc.stderr.read = _read_stderr
+    proc.returncode = 0
+    proc.wait = AsyncMock()
+    proc.kill = MagicMock()
+    return proc

--- a/autobot-backend/tests/test_claude_code_backend.py
+++ b/autobot-backend/tests/test_claude_code_backend.py
@@ -431,6 +431,7 @@ def _make_mock_proc(lines: list[str]) -> MagicMock:
 
 # --- Security hardening (#10550 security review) ---------------------------------
 
+
 def test_protected_env_keys_block_credential_override():
     """task.env_vars must NOT override ANTHROPIC_API_KEY / loader / PATH vars."""
     from services.execution.claude_code_backend import _PROTECTED_ENV_KEYS

--- a/autobot-backend/tests/test_claude_code_backend.py
+++ b/autobot-backend/tests/test_claude_code_backend.py
@@ -427,3 +427,26 @@ def _make_mock_proc(lines: list[str]) -> MagicMock:
     proc.wait = AsyncMock()
     proc.kill = MagicMock()
     return proc
+
+
+# --- Security hardening (#10550 security review) ---------------------------------
+
+def test_protected_env_keys_block_credential_override():
+    """task.env_vars must NOT override ANTHROPIC_API_KEY / loader / PATH vars."""
+    from services.execution.claude_code_backend import _PROTECTED_ENV_KEYS
+
+    for key in ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "PATH", "LD_PRELOAD", "PYTHONPATH"):
+        assert key in _PROTECTED_ENV_KEYS
+
+
+def test_prompt_cannot_inject_a_flag():
+    """A prompt starting with '--' must be passed positionally (after '--'), not as a flag.
+
+    Guards against '--dangerously-skip-permissions' style argument injection.
+    """
+    import services.execution.claude_code_backend as mod
+
+    src = open(mod.__file__, encoding="utf-8").read()
+    # The end-of-options separator must be appended before the prompt positional.
+    assert 'cmd.append("--")' in src
+    assert src.index('cmd.append("--")') < src.index("cmd.append(task.code)")

--- a/autobot-backend/tests/test_claude_code_backend.py
+++ b/autobot-backend/tests/test_claude_code_backend.py
@@ -175,30 +175,38 @@ class TestEventStreaming:
         stream.publish = AsyncMock(side_effect=lambda evt: published.append(evt))
 
         # Simulate two JSONL lines: tool_use then tool_result
-        tool_use_line = json.dumps({
-            "type": "assistant",
-            "message": {
-                "content": [{
-                    "type": "tool_use",
-                    "id": "tu-001",
-                    "name": "kb.search",
-                    "input": {"query": "hello"},
-                }]
-            },
-        })
-        tool_result_line = json.dumps({
-            "type": "tool_result",
-            "tool_use_id": "tu-001",
-            "output": "42 results",
-            "is_error": False,
-        })
-        result_line = json.dumps({
-            "type": "result",
-            "subtype": "success",
-            "is_error": False,
-            "result": "Done",
-            "usage": {},
-        })
+        tool_use_line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tu-001",
+                            "name": "kb.search",
+                            "input": {"query": "hello"},
+                        }
+                    ]
+                },
+            }
+        )
+        tool_result_line = json.dumps(
+            {
+                "type": "tool_result",
+                "tool_use_id": "tu-001",
+                "output": "42 results",
+                "is_error": False,
+            }
+        )
+        result_line = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "Done",
+                "usage": {},
+            }
+        )
 
         backend = _make_backend(event_stream=stream)
         lines = [tool_use_line, tool_result_line, result_line]
@@ -223,12 +231,12 @@ class TestEventStreaming:
         stream = MagicMock()
         stream.publish = AsyncMock(side_effect=lambda evt: published.append(evt))
 
-        text_line = json.dumps({
-            "type": "assistant",
-            "message": {
-                "content": [{"type": "text", "text": "Hello from Claude"}]
-            },
-        })
+        text_line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "Hello from Claude"}]},
+            }
+        )
         backend = _make_backend(event_stream=stream)
 
         async def _fake_exec(*a, **kw):
@@ -253,17 +261,21 @@ class TestParseCLILine:
     """_parse_cli_line correctly maps JSONL shapes to _StepEvent."""
 
     def test_parses_tool_use(self):
-        line = json.dumps({
-            "type": "assistant",
-            "message": {
-                "content": [{
-                    "type": "tool_use",
-                    "id": "id-1",
-                    "name": "kb.search",
-                    "input": {"q": "x"},
-                }]
-            },
-        })
+        line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "id-1",
+                            "name": "kb.search",
+                            "input": {"q": "x"},
+                        }
+                    ]
+                },
+            }
+        )
         step = _parse_cli_line(line)
         assert step is not None
         assert step.kind == "tool_use"
@@ -278,10 +290,12 @@ class TestParseCLILine:
         assert step.content["output"] == "ok"
 
     def test_parses_text_message(self):
-        line = json.dumps({
-            "type": "assistant",
-            "message": {"content": [{"type": "text", "text": "hi"}]},
-        })
+        line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "hi"}]},
+            }
+        )
         step = _parse_cli_line(line)
         assert step is not None
         assert step.kind == "message"


### PR DESCRIPTION
## Thinking Path
Agent-framework epic #10542 (model-choice freedom): offer Claude Code / the Claude Agent SDK as a selectable EXECUTION backend (agentic — plans/edits/runs) inside AutoBot governance, distinct from the Anthropic completion provider.

## What Changed
`services/execution/claude_code_backend.py`: `ClaudeCodeBackend(ExecutionBackend)` runs `claude --output-format stream-json --print --mcp-config …` (CLI) or the SDK; streams each step into AutoBot's event stream as ACTION/OBSERVATION/MESSAGE. Governance seam: `--mcp-config` points Claude Code at AutoBot's MCP server (127.0.0.1:8200) so every tool call goes through token-scoped RBAC + approval/budget. Gated on `AUTOBOT_FEATURE_CLAUDE_CODE_EXECUTION` + `ANTHROPIC_API_KEY` + CLI/SDK presence; guard-imports the SDK (`MissingDep`) so the module loads without it.

## Verification
21 tests pass (unavailable when CLI/flag/key absent; event streaming for tool-use/result/message; MCP config; SDK↔CLI fallback). Closes #10550. Live CLI/SDK schema drift noted as the only unverifiable-without-SDK part.

## Model Used
Claude Opus 4.8 (senior-backend-engineer subagent).
