### PR TITLE
fix(migrations): mark 063/064 observable so migration-matrix observability gate passes (#10974)

### DIFF
--- a/autobot-backend/migrations/baseline.py
+++ b/autobot-backend/migrations/baseline.py
@@ -68,13 +68,44 @@ MIGRATIONS_DIR = Path(__file__).resolve().parent
 # chain repair has a designated place to record stamp translations.
 KNOWN_FOREIGN_REVISIONS: dict[str, str] = {}
 
-# Structural markers for revisions whose only effect is a column TYPE change
-# and which are therefore invisible to the created-tables/added-columns
-# probes. Checked only when the table exists: True ⇔ TIMESTAMPTZ.
+# Structural markers for revisions whose TIMESTAMPTZ effect is invisible to the
+# created-tables/added-columns probes — either a column TYPE change, or a
+# TIMESTAMPTZ column added via raw ``op.execute("ALTER TABLE ...")`` (which the
+# literal-arg AST extractor in ``extract_artifacts`` cannot see). Each
+# ``(table, column)`` is verified only when the table exists: the schema looks
+# applied ⇔ that column is TIMESTAMPTZ.
 TIMESTAMPTZ_MARKERS: dict[str, tuple[tuple[str, str], ...]] = {
     "20260422_018": (
         ("process_runs", "started_at"),
         ("agent_sessions", "expires_at"),
+    ),
+    # 20260629_063 adds ``updated_at TIMESTAMPTZ`` to Base-drifted tables via
+    # ``op.execute("ALTER TABLE ... ADD COLUMN IF NOT EXISTS updated_at ...")``,
+    # so the AST probe sees nothing. These markers make it observable and give
+    # adoption a real per-table TIMESTAMPTZ check (the migration's ``has_table``
+    # guard is mirrored by the ``table in facts.tables`` guard in applied_status).
+    "20260629_063": (
+        ("agent_connections", "updated_at"),
+        ("agent_task_history", "updated_at"),
+        ("audit_logs", "updated_at"),
+        ("chat_shared_links", "updated_at"),
+        ("completion_feedback", "updated_at"),
+        ("desktop_mobile_devices", "updated_at"),
+        ("heartbeat_run_events", "updated_at"),
+        ("llc_activity_log", "updated_at"),
+        ("llc_agent_api_keys", "updated_at"),
+        ("llc_heartbeat_runs", "updated_at"),
+        ("llc_routine_runs", "updated_at"),
+        ("llc_run_replay_logs", "updated_at"),
+        ("mesh_edges", "updated_at"),
+        ("mesh_evolution_log", "updated_at"),
+        ("mesh_nodes", "updated_at"),
+        ("mesh_nodes_archive", "updated_at"),
+        ("push_subscriptions", "updated_at"),
+        ("role_permissions", "updated_at"),
+        ("task_approval_links", "updated_at"),
+        ("user_voice_bundle", "updated_at"),
+        ("workflow_audit_log", "updated_at"),
     ),
 }
 

--- a/autobot-backend/tests/migrations/test_probe_ladder_selfcheck.py
+++ b/autobot-backend/tests/migrations/test_probe_ladder_selfcheck.py
@@ -114,6 +114,9 @@ def test_observability_coverage():
         "20260608_052",  # merge revision — no-op
         "20260623_062",  # RBAC colon->dot reconcile (#10458) — data-only head;
         # absorbed by the data-only tail advance, idempotent if re-run
+        "20260630_064",  # llc reviewer cols (UUID) + kb_summary (TEXT) drift fix
+        # (#10750) — non-TIMESTAMPTZ cols added via raw ADD COLUMN IF NOT EXISTS,
+        # so unparseable; fully idempotent (IF NOT EXISTS + has_table) if re-run
     }
     assert unobservable <= allowed, (
         f"new unobservable revisions: {sorted(unobservable - allowed)} — "


### PR DESCRIPTION
## Thinking Path
migration-matrix's static gate `test_probe_ladder_selfcheck::test_observability_coverage` reds every PR — migrations `20260629_063` and `20260630_064` are flagged 'unobservable'. Root cause: `extract_artifacts` only detects `op.create_table`/`op.add_column` with string-literal args, but both migrations add columns via raw `op.execute("ALTER TABLE ... ADD COLUMN IF NOT EXISTS ...")` (for idempotency) → the parser sees zero artifacts.

## What Changed (`migrations/baseline.py` — markers only, no DDL)
- **063 → TIMESTAMPTZ_MARKERS**: it adds `updated_at TIMESTAMPTZ` to 21 tables. Added the 21 `(table, "updated_at")` pairs — makes it statically observable AND gives adoption a real runtime type-check (applied_status verifies each col is `timestamp with time zone`).
- **064 → allowlist**: it adds `reviewer_user_id`/`reviewer_agent_id` UUID + `kb_summary` TEXT (NOT timestamptz — TIMESTAMPTZ_MARKERS would wrongly assert timestamptz type). It's an idempotent intermediate revision (ADD ... IF NOT EXISTS + has_table guards, revised by 065), matching the allowlist's 'safe to re-run' contract. Added with justification.

No test assertion weakened; the gate passes because 063 is genuinely observable and 064 genuinely idempotent-if-re-run. No migration DDL edited.

## Verification
- **Verified locally** (static gate, no DB): `test_observability_coverage` + full `test_probe_ladder_selfcheck.py` → **5 passed**. py_compile + flake8 -F + black --check clean.

## Model Used
Opus 4.8

Closes #10974. Discovery: the marker system only supports timestamptz cols — non-timestamptz raw-execute migrations must use the allowlist (known design limitation).