### PR TITLE
fix(skills): register SKILL.md-only builtin skills via a declarative loader (#10959)

### DIFF
--- a/autobot-backend/skills/base_skill.py
+++ b/autobot-backend/skills/base_skill.py
@@ -185,3 +185,37 @@ class BaseSkill(ABC):
     def get_available_actions(self) -> List[str]:
         """Return list of tool names this skill provides."""
         return self.get_manifest().tools
+
+
+class DeclarativeSkill(BaseSkill):
+    """Concrete BaseSkill for SKILL.md-only builtin skills.
+
+    These skills are capability descriptors — their tools are invoked by the
+    agent via shell commands or delegated libraries documented in the SKILL.md
+    body.  There is no Python execution path; ``execute`` returns a sentinel so
+    the registry can register them (enabling bundle membership, routing-index
+    inclusion, and ``list_skills`` visibility) without fabricating behaviour.
+    """
+
+    def __init__(self, manifest: SkillManifest) -> None:
+        super().__init__()
+        self._manifest = manifest
+
+    def get_manifest(self) -> SkillManifest:  # type: ignore[override]
+        """Return the manifest supplied at construction."""
+        return self._manifest
+
+    async def execute(self, action: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Declarative skills have no Python execution path.
+
+        The agent invokes these capabilities via the tool commands documented
+        in the SKILL.md body (e.g. yt-dlp, feedparser, gh CLI, Jina Reader).
+        """
+        return {
+            "success": False,
+            "error": (
+                f"Skill '{self._manifest.name}' is a declarative skill. "
+                "Invoke its tools via the agent's tool-dispatch layer, "
+                "not through execute()."
+            ),
+        }

--- a/autobot-backend/skills/registry.py
+++ b/autobot-backend/skills/registry.py
@@ -10,14 +10,18 @@ Handles skill lifecycle (load, enable, disable) and dependency validation.
 """
 
 import importlib
+import importlib.util
+import os
 import pkgutil
 import threading
 from typing import Any, Dict, List, Set, Type
 
+import yaml
+
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 from prepared_facts import SkillRoutingIndex
-from skills.base_skill import BaseSkill, SkillHealth, SkillManifest, SkillStatus
+from skills.base_skill import BaseSkill, DeclarativeSkill, SkillHealth, SkillManifest, SkillStatus
 from skills.dependency_resolver import check_missing_dependencies, resolve_dependencies
 
 logger = get_logger(__name__)
@@ -253,6 +257,18 @@ class SkillRegistry:
     def discover_builtin_skills(self) -> int:
         """Auto-discover and register all skills in skills.builtin package.
 
+        Handles two kinds of builtin skills:
+
+        1. Python modules — files ending in ``.py`` (or packages with
+           ``__init__.py``) that contain a ``BaseSkill`` subclass.  Discovered
+           via ``pkgutil.iter_modules`` as before.
+
+        2. Declarative SKILL.md-only subdirectories — subdirectories that
+           contain a ``SKILL.md`` but no Python entry-point.  The YAML
+           front-matter is parsed into a ``SkillManifest`` and the subdir is
+           registered as a ``DeclarativeSkill`` so it appears in the registry,
+           the routing index, and can be enabled/disabled by bundles.
+
         Returns the number of newly registered skills.
         """
         count = 0
@@ -262,6 +278,7 @@ class SkillRegistry:
             logger.warning("skills.builtin package not found")
             return 0
 
+        # --- pass 1: Python BaseSkill subclasses ---
         for importer, modname, _ispkg in pkgutil.iter_modules(builtin_pkg.__path__):
             try:
                 module = importlib.import_module(f"skills.builtin.{modname}")
@@ -272,6 +289,40 @@ class SkillRegistry:
                         count += 1
             except Exception:
                 logger.exception("Failed to load skill module: %s", modname)
+
+        # --- pass 2: SKILL.md-only declarative subdirectories ---
+        for pkg_path in builtin_pkg.__path__:
+            for entry in os.scandir(pkg_path):
+                if not entry.is_dir():
+                    continue
+                skill_md = os.path.join(entry.path, "SKILL.md")
+                py_init = os.path.join(entry.path, "__init__.py")
+                # Only handle dirs that have SKILL.md but no Python package
+                # entry-point (those are already covered by pass 1 above).
+                if not os.path.isfile(skill_md) or os.path.isfile(py_init):
+                    continue
+                # Also skip if any .py file exists — pass 1 handles those.
+                has_py = any(f.endswith(".py") for f in os.listdir(entry.path))
+                if has_py:
+                    continue
+                manifest = _parse_skill_md(skill_md)
+                if manifest is None:
+                    continue
+                # Skip if already registered (e.g. by a Python module of the same name)
+                if self._skills.get(manifest.name):
+                    continue
+                instance = DeclarativeSkill(manifest)
+                with self._lock:
+                    self._skills[manifest.name] = instance
+                logger.info(
+                    "Registered declarative skill: %s v%s (SKILL.md-only)",
+                    manifest.name,
+                    manifest.version,
+                )
+                self._publish_skill_promoted(manifest.name, manifest.tools)
+                count += 1
+
+        self._rebuild_routing_index()
         logger.info("Discovered %d builtin skills", count)
         return count
 
@@ -314,6 +365,66 @@ def _find_enabled_dependents(skills: Dict[str, BaseSkill], name: str) -> List[st
         if skill.enabled and name in skill.get_manifest().dependencies:
             dependents.append(skill_name)
     return dependents
+
+
+def _parse_skill_md(skill_md_path: str) -> SkillManifest | None:
+    """Parse the YAML front-matter of a SKILL.md file into a SkillManifest.
+
+    Returns None and logs a warning on any parse/validation error so that a
+    single malformed SKILL.md cannot abort the entire discovery pass.
+    """
+    try:
+        with open(skill_md_path, encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError as exc:
+        logger.warning("Cannot read %s: %s", skill_md_path, exc)
+        return None
+
+    # Extract the YAML front-matter block delimited by --- lines.
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        logger.warning("SKILL.md has no front-matter block: %s", skill_md_path)
+        return None
+    end = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end = i
+            break
+    if end is None:
+        logger.warning("SKILL.md front-matter not closed: %s", skill_md_path)
+        return None
+
+    raw_yaml = "\n".join(lines[1:end])
+    try:
+        data = yaml.safe_load(raw_yaml)
+    except yaml.YAMLError as exc:
+        logger.warning("Invalid YAML in %s: %s", skill_md_path, exc)
+        return None
+
+    if not isinstance(data, dict):
+        logger.warning("SKILL.md front-matter is not a mapping: %s", skill_md_path)
+        return None
+
+    name = data.get("name")
+    if not name:
+        logger.warning("SKILL.md missing 'name' field: %s", skill_md_path)
+        return None
+
+    try:
+        return SkillManifest(
+            name=str(name),
+            version=str(data.get("version", "1.0.0")),
+            description=str(data.get("description", "")),
+            author=str(data.get("author", "mrveiss")),
+            category=str(data.get("category", "general")),
+            dependencies=[str(d) for d in (data.get("dependencies") or [])],
+            tools=[str(t) for t in (data.get("tools") or [])],
+            triggers=[str(tr) for tr in (data.get("triggers") or [])],
+            tags=[str(tg) for tg in (data.get("tags") or [])],
+        )
+    except Exception as exc:
+        logger.warning("Cannot build SkillManifest from %s: %s", skill_md_path, exc)
+        return None
 
 
 get_skill_registry = lazy_singleton(SkillRegistry)

--- a/autobot-backend/skills/registry_skillmd_test.py
+++ b/autobot-backend/skills/registry_skillmd_test.py
@@ -1,0 +1,236 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for SKILL.md-only builtin skill discovery (Issue #10959).
+
+Verifies that discover_builtin_skills registers the 4 declarative builtins
+(web-fetch, github-search, youtube-transcript, rss-reader) that have only a
+SKILL.md and no Python BaseSkill subclass.
+"""
+
+import textwrap
+from unittest.mock import patch
+
+import pytest
+
+from skills.base_skill import BaseSkill, DeclarativeSkill, SkillManifest
+from skills.registry import SkillRegistry, _parse_skill_md
+
+# ---------------------------------------------------------------------------
+# _parse_skill_md
+# ---------------------------------------------------------------------------
+
+
+def test_parse_skill_md_returns_manifest(tmp_path):
+    """_parse_skill_md parses a minimal front-matter into a SkillManifest."""
+    skill_md = tmp_path / "SKILL.md"
+    skill_md.write_text(
+        textwrap.dedent("""\
+        ---
+        name: test-skill
+        version: 2.0.0
+        description: A test declarative skill
+        author: mrveiss
+        category: internet
+        tools:
+          - fetch_url
+        triggers:
+          - fetch URL
+        tags:
+          - web
+        ---
+
+        ## Body content here
+        """),
+        encoding="utf-8",
+    )
+
+    manifest = _parse_skill_md(str(skill_md))
+
+    assert manifest is not None
+    assert manifest.name == "test-skill"
+    assert manifest.version == "2.0.0"
+    assert manifest.description == "A test declarative skill"
+    assert manifest.category == "internet"
+    assert "fetch_url" in manifest.tools
+    assert "fetch URL" in manifest.triggers
+    assert "web" in manifest.tags
+
+
+def test_parse_skill_md_missing_name_returns_none(tmp_path):
+    """_parse_skill_md returns None when the 'name' field is absent."""
+    skill_md = tmp_path / "SKILL.md"
+    skill_md.write_text(
+        textwrap.dedent("""\
+        ---
+        version: 1.0.0
+        description: No name field
+        ---
+        """),
+        encoding="utf-8",
+    )
+
+    assert _parse_skill_md(str(skill_md)) is None
+
+
+def test_parse_skill_md_no_frontmatter_returns_none(tmp_path):
+    """_parse_skill_md returns None when there is no --- block."""
+    skill_md = tmp_path / "SKILL.md"
+    skill_md.write_text("Just prose, no front-matter.\n", encoding="utf-8")
+
+    assert _parse_skill_md(str(skill_md)) is None
+
+
+def test_parse_skill_md_invalid_yaml_returns_none(tmp_path):
+    """_parse_skill_md returns None on broken YAML."""
+    skill_md = tmp_path / "SKILL.md"
+    skill_md.write_text("---\nname: [broken yaml\n---\n", encoding="utf-8")
+
+    assert _parse_skill_md(str(skill_md)) is None
+
+
+def test_parse_skill_md_uses_defaults_for_optional_fields(tmp_path):
+    """Optional fields default gracefully when absent from front-matter."""
+    skill_md = tmp_path / "SKILL.md"
+    skill_md.write_text(
+        textwrap.dedent("""\
+        ---
+        name: minimal-skill
+        description: Minimal
+        ---
+        """),
+        encoding="utf-8",
+    )
+
+    manifest = _parse_skill_md(str(skill_md))
+
+    assert manifest is not None
+    assert manifest.version == "1.0.0"
+    assert manifest.author == "mrveiss"
+    assert manifest.category == "general"
+    assert manifest.tools == []
+    assert manifest.triggers == []
+    assert manifest.tags == []
+
+
+# ---------------------------------------------------------------------------
+# DeclarativeSkill
+# ---------------------------------------------------------------------------
+
+
+def test_declarative_skill_get_manifest_returns_supplied_manifest():
+    """DeclarativeSkill.get_manifest() returns the manifest given at construction."""
+    manifest = SkillManifest(
+        name="web-fetch",
+        version="1.0.0",
+        description="Fetch URLs",
+        tools=["fetch_url"],
+    )
+    skill = DeclarativeSkill(manifest)
+
+    assert skill.get_manifest() is manifest
+
+
+@pytest.mark.asyncio
+async def test_declarative_skill_execute_returns_clear_error():
+    """execute() on a declarative skill returns success=False with a clear message."""
+    manifest = SkillManifest(name="web-fetch", version="1.0.0", description="Fetch URLs")
+    skill = DeclarativeSkill(manifest)
+
+    result = await skill.execute("fetch_url", {"url": "https://example.com"})
+
+    assert result["success"] is False
+    assert "declarative" in result["error"].lower()
+    assert "web-fetch" in result["error"]
+
+
+def test_declarative_skill_is_baseskill_subclass():
+    """DeclarativeSkill must be a concrete subclass of BaseSkill."""
+    manifest = SkillManifest(name="rss-reader", version="1.0.0", description="RSS")
+    skill = DeclarativeSkill(manifest)
+
+    assert isinstance(skill, BaseSkill)
+
+
+# ---------------------------------------------------------------------------
+# discover_builtin_skills — integration with real builtin package
+# ---------------------------------------------------------------------------
+
+
+_DECLARATIVE_SKILL_IDS = {"web-fetch", "github-search", "youtube-transcript", "rss-reader"}
+
+
+def test_discover_builtin_skills_registers_declarative_skills():
+    """All 4 SKILL.md-only builtins appear in the registry after discovery."""
+    registry = SkillRegistry()
+
+    # Suppress Redis publish side-effects (no Redis in unit tests)
+    with patch.object(registry, "_publish_skill_promoted"):
+        registry.discover_builtin_skills()
+
+    registered_names = {info["name"] for info in registry.list_skills()}
+    missing = _DECLARATIVE_SKILL_IDS - registered_names
+    assert not missing, f"Declarative skills not registered: {missing}"
+
+
+def test_discover_builtin_skills_declarative_manifest_fields():
+    """Registered declarative skills carry the correct manifest fields from SKILL.md."""
+    registry = SkillRegistry()
+
+    with patch.object(registry, "_publish_skill_promoted"):
+        registry.discover_builtin_skills()
+
+    web_fetch = registry.get("web-fetch")
+    assert web_fetch is not None
+    manifest = web_fetch.get_manifest()
+    assert manifest.category == "internet"
+    assert "fetch_url" in manifest.tools
+
+    rss = registry.get("rss-reader")
+    assert rss is not None
+    rss_manifest = rss.get_manifest()
+    assert "parse_feed" in rss_manifest.tools
+
+
+def test_discover_builtin_skills_declarative_are_declarativeskill_instances():
+    """SKILL.md-only builtins are registered as DeclarativeSkill instances."""
+    registry = SkillRegistry()
+
+    with patch.object(registry, "_publish_skill_promoted"):
+        registry.discover_builtin_skills()
+
+    for skill_id in _DECLARATIVE_SKILL_IDS:
+        skill = registry.get(skill_id)
+        assert skill is not None, f"Expected skill '{skill_id}' to be registered"
+        assert isinstance(
+            skill, DeclarativeSkill
+        ), f"Expected '{skill_id}' to be a DeclarativeSkill, got {type(skill).__name__}"
+
+
+def test_discover_builtin_skills_python_skills_still_registered():
+    """Python-based builtins (e.g. code-review) are still registered alongside declarative ones."""
+    registry = SkillRegistry()
+
+    with patch.object(registry, "_publish_skill_promoted"):
+        registry.discover_builtin_skills()
+
+    registered_names = {info["name"] for info in registry.list_skills()}
+    assert "code-review" in registered_names
+    assert "skill-researcher" in registered_names
+
+
+def test_discover_builtin_skills_research_bundle_all_registered():
+    """All skills referenced by the research bundle are now in the registry."""
+    from skills.bundles import get_bundle
+
+    registry = SkillRegistry()
+
+    with patch.object(registry, "_publish_skill_promoted"):
+        registry.discover_builtin_skills()
+
+    bundle = get_bundle("research")
+    registered_names = {info["name"] for info in registry.list_skills()}
+    missing = set(bundle.member_skill_ids) - registered_names
+    assert not missing, f"Research bundle skills not registered: {missing}"


### PR DESCRIPTION
## Thinking Path
The 4 SKILL.md-only builtins (web_fetch/github_search/youtube_transcript/rss_reader) are subdirs with no `__init__.py`/`.py`, so `discover_builtin_skills` (`pkgutil.iter_modules`) **silently skipped them** — they were never registered. Real impact: `bundles.py`'s 'research' bundle references all 4 by name, so `enable_bundle('research')` dropped them into `skipped` every time.

## Investigation
Confirmed genuinely orphaned: zero `agent_loop/` references; the real `autobot-backend/web_fetch/` package is a SEPARATE foundation library (not the builtin descriptor); README documents these as agent-read declarative descriptors.

## What Changed
A **declarative SKILL.md loader** — chose this over Python wrappers because the 4 delegate to *system tools* (Jina Reader, gh CLI, yt-dlp, feedparser) via shell; wrapping them in Python would be a separate feature decision, not a loader fix.
- `registry.py`: second discovery pass scans subdirs with SKILL.md + no Python entry-point; `_parse_skill_md()` parses YAML frontmatter → `SkillManifest` (reads only SkillManifest-understood fields, sidestepping the external-importer's mandatory `entrypoint`); wraps in `DeclarativeSkill` and registers normally.
- `base_skill.py`: new `DeclarativeSkill(BaseSkill)` — `execute()` returns an honest sentinel (`success=False`, 'invoke via agent tool-dispatch'); NO fabricated behavior.

Resolves the earlier frontmatter concern too: these are declarative builtins loaded by `_parse_skill_md`, NOT the external manifest_parser (which requires `entrypoint`) — by design.

## Verification
- **Verified locally**: `skills/registry_skillmd_test.py` 13/13 passed (parse unit tests + DeclarativeSkill + integration proving all 4 register, carry correct manifests, don't displace Python skills, and all research-bundle members are now in the registry). flake8 -F + black clean.

## Model Used
Opus 4.8

Closes #10959.