### PR TITLE
feat(precision): chat inline response judge + grounded-agent structured extraction (#10599)

### DIFF
--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -30,7 +30,7 @@ from typing import Any, Dict, List, Tuple
 from langchain_core.runnables import RunnableConfig
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.ssot_config import config
+from autobot_shared.ssot_config import config as _ssot_config
 
 try:
     from langgraph.checkpoint.redis.aio import AsyncRedisSaver
@@ -118,6 +118,10 @@ class ChatState(TypedDict, total=False):
     reflection_count: int
     reflection_history: List[Dict[str, Any]]
     rlm_refinement_hint: str
+
+    # Inline AgentResponseJudge (#10599, §3.3) — how many times the judge
+    # has already triggered a regeneration for this turn (capped at 1).
+    judge_count: int
 
     # Tool-call loop detection (#3254)
     # Each entry is a frozenset fingerprint of (tool_name, args_hash) for one iteration.
@@ -610,6 +614,87 @@ async def reflect_on_response(state: ChatState, config: RunnableConfig) -> dict:
     }
 
 
+async def inline_judge_response(state: ChatState, config: RunnableConfig) -> dict:
+    """Optional AgentResponseJudge gate on chat replies (#10599, §3.3).
+
+    Controlled by ``AUTOBOT_CHAT_INLINE_JUDGE`` (default OFF).  When enabled
+    the judge scores the latest LLM response.  If the overall_score is below
+    ``AUTOBOT_CHAT_INLINE_JUDGE_THRESHOLD`` and the judge hasn't already
+    triggered a regeneration for this turn (``judge_count == 0``), it injects
+    a refinement hint into state so ``generate_response`` can retry once.
+    The node is a no-op when the flag is off, ensuring zero added latency in
+    the default configuration.
+    """
+    if not _ssot_config.chat_inline_judge_enabled:
+        return {}
+
+    llm_response = state.get("llm_response", "")
+    if not llm_response:
+        return {}
+
+    judge_count = state.get("judge_count", 0)
+    if judge_count > 0:
+        # Already triggered one regeneration this turn — do not loop.
+        return {}
+
+    try:
+        from judges.agent_response_judge import AgentResponseJudge
+
+        judge = AgentResponseJudge()
+        request_ctx = {"message": state.get("user_message", "")}
+        response_ctx = {"content": llm_response}
+        is_good, score, summary = await judge.assess_response_quality(
+            request=request_ctx,
+            response=response_ctx,
+            agent_type="chat",
+            context={"knowledge_used": state.get("used_knowledge", False)},
+        )
+
+        logger.info(
+            "[inline_judge] score=%.2f is_good=%s judge_count=%d summary=%s",
+            score,
+            is_good,
+            judge_count,
+            summary,
+        )
+
+        if is_good:
+            return {"judge_count": judge_count + 1}
+
+        threshold = _ssot_config.chat_inline_judge_threshold
+        if score < threshold:
+            hint = (
+                f"[Judge feedback] Your previous response scored {score:.2f} "
+                f"(threshold {threshold:.2f}).  Please revise for accuracy and "
+                "relevance, grounding your answer in the provided sources."
+            )
+            return {
+                "judge_count": judge_count + 1,
+                "rlm_refinement_hint": hint,
+            }
+
+        return {"judge_count": judge_count + 1}
+
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[inline_judge] judge call failed (non-fatal): %s", exc)
+        return {}
+
+
+def route_after_judge(state: ChatState) -> str:
+    """Route after inline judge (#10599).
+
+    If the judge set a refinement hint and hasn't exhausted its one-shot
+    budget, loop back to generate_response.  Otherwise proceed to persist.
+    """
+    hint = state.get("rlm_refinement_hint", "")
+    judge_count = state.get("judge_count", 0)
+    if hint and judge_count == 1:
+        # judge_count==1 means the hint was just set on this pass; route back
+        # to generate_response for exactly one regeneration.
+        return "generate_response"
+    return "persist_conversation"
+
+
 async def request_approval(state: ChatState, config: RunnableConfig) -> dict:
     """Interrupt execution to request command approval from the user.
 
@@ -1087,13 +1172,14 @@ def route_after_reflection(state: ChatState) -> str:
     """Route after RLM self-reflection (#1373).
 
     If the evaluator returned REFINE and the reflection budget isn't
-    exhausted, loop back to generate_response.  Otherwise persist.
+    exhausted, loop back to generate_response.  Otherwise run the optional
+    inline judge (#10599) before persisting.
     """
     from rlm.types import RLMConfig
 
     history = state.get("reflection_history", [])
     if not history:
-        return "persist_conversation"
+        return "inline_judge_response"
 
     latest = history[-1]
     verdict = latest.get("verdict", "ACCEPT")
@@ -1104,7 +1190,7 @@ def route_after_reflection(state: ChatState) -> str:
 
     if verdict == "REFINE" and reflection_count < max_reflections:
         return "generate_response"
-    return "persist_conversation"
+    return "inline_judge_response"
 
 
 def route_after_execution(state: ChatState) -> str:
@@ -1139,8 +1225,8 @@ def route_after_execution(state: ChatState) -> str:
 def build_chat_graph() -> StateGraph:
     """Build the chat workflow StateGraph.
 
-    Graph topology (#1718 — agentic search node; #1373 — RLM reflection loop;
-    #3254 — content-aware tool-call loop detection):
+    Graph topology (#1718 — agentic search; #1373 — RLM reflection;
+    #3254 — loop detection; #10599 — inline judge):
         START -> initialize_session -> detect_intent
             -> [END if special intent]
             -> prepare_llm -> perform_knowledge_search -> generate_response
@@ -1149,7 +1235,10 @@ def build_chat_graph() -> StateGraph:
                 -> [reflect_on_response if no tools]
             reflect_on_response
                 -> [generate_response if REFINE and budget remains]
-                -> [persist_conversation if ACCEPT or budget exhausted]
+                -> [inline_judge_response otherwise]
+            inline_judge_response  (#10599 — no-op when AUTOBOT_CHAT_INLINE_JUDGE=false)
+                -> [generate_response if score below threshold and first attempt]
+                -> [persist_conversation otherwise]
             execute_tools
                 -> [generate_response if should_continue AND loop_count < threshold]
                 -> [persist_conversation if done or loop aborted (#3254)]
@@ -1164,6 +1253,7 @@ def build_chat_graph() -> StateGraph:
     builder.add_node("perform_knowledge_search", perform_knowledge_search)  # Issue #1718
     builder.add_node("generate_response", generate_response)
     builder.add_node("reflect_on_response", reflect_on_response)
+    builder.add_node("inline_judge_response", inline_judge_response)  # Issue #10599
     builder.add_node("request_approval", request_approval)
     builder.add_node("execute_tools", execute_tools)
     builder.add_node("persist_conversation", persist_conversation)
@@ -1176,6 +1266,7 @@ def build_chat_graph() -> StateGraph:
     builder.add_edge("perform_knowledge_search", "generate_response")  # Issue #1718
     builder.add_conditional_edges("generate_response", route_after_generation)
     builder.add_conditional_edges("reflect_on_response", route_after_reflection)
+    builder.add_conditional_edges("inline_judge_response", route_after_judge)  # Issue #10599
     builder.add_edge("request_approval", "execute_tools")
     builder.add_conditional_edges("execute_tools", route_after_execution)
     builder.add_edge("persist_conversation", END)
@@ -1208,8 +1299,8 @@ async def get_redis_checkpointer() -> "AsyncRedisSaver":  # type: ignore[return]
         _REDIS_URI = f"redis://{redis_host}:{redis_port}"
         ttl_minutes = ssot.redis.checkpoint_ttl_minutes
     except Exception:
-        redis_host = config.redis_host
-        redis_port = config.redis_port
+        redis_host = _ssot_config.redis_host
+        redis_port = _ssot_config.redis_port
         _REDIS_URI = f"redis://{redis_host}:{redis_port}"
         logger.warning(
             "SSOT config unavailable, using fallback Redis URI: %s",

--- a/autobot-backend/services/grounded_agent.py
+++ b/autobot-backend/services/grounded_agent.py
@@ -356,13 +356,18 @@ Format as JSON array of objects with fields: claim_text, subject, predicate, obj
                 llm_type=LLMType.EXTRACTION,
                 temperature=0.1,
                 max_tokens=1024,
+                structured_output=True,  # #10599 §3.4: prevent silent JSON drops
             )
 
-            # Parse JSON response (simplified - production would use robust parsing)
+            # Parse JSON response — structured_output=True asks the provider for
+            # valid JSON; the fence-stripping fallback in _extract_json_object
+            # covers providers that ignore the flag (#10672).
             import json
 
+            from judges import _extract_json_object
+
             try:
-                claims_data = json.loads(response_obj.content)
+                claims_data = _extract_json_object(response_obj.content)
             except json.JSONDecodeError:
                 logger.warning("Failed to parse claim extraction JSON")
                 claims_data = []

--- a/autobot-backend/tests/unit/chat_workflow/test_inline_judge.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_inline_judge.py
@@ -1,0 +1,340 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for the inline AgentResponseJudge gate (#10599, §3.3).
+
+Verified scenarios:
+  (a) Judge flag OFF (default) → inline_judge_response is a no-op; no LLM call.
+  (b) Judge flag ON + score above threshold → judge_count incremented; no hint.
+  (c) Judge flag ON + score below threshold + first attempt → hint set; route
+      returns generate_response for one regeneration.
+  (d) Judge flag ON + judge_count already 1 → no further regeneration (cap).
+  (e) Judge call raises exception → node returns {} (non-fatal).
+  (f) route_after_judge with no hint → returns persist_conversation.
+  (g) Grounding instruction present in prompt when citation flag is enabled.
+  (h) structured_output=True forwarded in grounded_agent._extract_claims.
+"""
+
+import json
+import sys
+import types
+import typing
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub langchain / langgraph so graph.py can be imported without those packages
+# being installed in the test environment.
+# ---------------------------------------------------------------------------
+
+_STUBS = {
+    "langchain_core": types.ModuleType("langchain_core"),
+    "langchain_core.messages": types.ModuleType("langchain_core.messages"),
+    "langchain_core.runnables": types.ModuleType("langchain_core.runnables"),
+    "xxhash": types.ModuleType("xxhash"),
+    "redis": types.ModuleType("redis"),
+    "redis.asyncio": types.ModuleType("redis.asyncio"),
+    "langgraph": types.ModuleType("langgraph"),
+    "langgraph.checkpoint": types.ModuleType("langgraph.checkpoint"),
+    "langgraph.checkpoint.redis": types.ModuleType("langgraph.checkpoint.redis"),
+    "langgraph.checkpoint.redis.aio": types.ModuleType("langgraph.checkpoint.redis.aio"),
+    "langgraph.graph": types.ModuleType("langgraph.graph"),
+    "langgraph.types": types.ModuleType("langgraph.types"),
+    "typing_extensions": types.ModuleType("typing_extensions"),
+}
+
+for _name, _stub in _STUBS.items():
+    sys.modules.setdefault(_name, _stub)
+
+for _attr in ("END", "START", "StateGraph"):
+    if not hasattr(sys.modules["langgraph.graph"], _attr):
+        setattr(sys.modules["langgraph.graph"], _attr, MagicMock())
+
+if not hasattr(sys.modules["langgraph.types"], "interrupt"):
+    sys.modules["langgraph.types"].interrupt = MagicMock()
+
+if not hasattr(sys.modules["typing_extensions"], "TypedDict"):
+    sys.modules["typing_extensions"].TypedDict = typing.TypedDict
+
+for _attr in ("HumanMessage", "SystemMessage", "AIMessage", "BaseMessage"):
+    if not hasattr(sys.modules["langchain_core.messages"], _attr):
+        setattr(sys.modules["langchain_core.messages"], _attr, MagicMock())
+
+if not hasattr(sys.modules["langchain_core.runnables"], "RunnableConfig"):
+    sys.modules["langchain_core.runnables"].RunnableConfig = MagicMock()
+
+# AsyncRedisSaver must exist so the try/except in graph.py sets _REDIS_CHECKPOINTER_AVAILABLE=True
+sys.modules["langgraph.checkpoint.redis.aio"].AsyncRedisSaver = MagicMock()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_state(
+    llm_response: str = "A helpful answer.",
+    judge_count: int = 0,
+    used_knowledge: bool = False,
+    user_message: str = "What is AutoBot?",
+    rlm_refinement_hint: str = "",
+) -> dict:
+    return {
+        "llm_response": llm_response,
+        "judge_count": judge_count,
+        "used_knowledge": used_knowledge,
+        "user_message": user_message,
+        "reflection_history": [],
+        "rlm_refinement_hint": rlm_refinement_hint,
+    }
+
+
+def _make_config() -> dict:
+    return {"configurable": {"manager": MagicMock()}}
+
+
+# ---------------------------------------------------------------------------
+# Import the functions under test (after stubs are in place)
+# ---------------------------------------------------------------------------
+
+
+def _load_graph():
+    """Load graph.py isolated so stubs take effect before module-level imports."""
+    _graph_path = Path(__file__).parent.parent.parent.parent / "chat_workflow" / "graph.py"
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(f"_graph_judge_test_{id(object())}", _graph_path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# inline_judge_response node tests
+# ---------------------------------------------------------------------------
+
+
+class TestInlineJudgeNode:
+    """Tests for the inline_judge_response graph node."""
+
+    @pytest.mark.asyncio
+    async def test_judge_disabled_is_noop(self) -> None:
+        """(a) AUTOBOT_CHAT_INLINE_JUDGE=false → node returns {} without any LLM call."""
+        graph_mod = _load_graph()
+
+        mock_ssot = MagicMock()
+        mock_ssot.chat_inline_judge_enabled = False
+
+        with patch.object(graph_mod, "_ssot_config", mock_ssot):
+            result = await graph_mod.inline_judge_response(_make_state(), _make_config())
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_empty_response_is_noop(self) -> None:
+        """No llm_response in state → node returns {} immediately."""
+        graph_mod = _load_graph()
+
+        mock_ssot = MagicMock()
+        mock_ssot.chat_inline_judge_enabled = True
+
+        with patch.object(graph_mod, "_ssot_config", mock_ssot):
+            result = await graph_mod.inline_judge_response(_make_state(llm_response=""), _make_config())
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_judge_count_cap_prevents_second_regen(self) -> None:
+        """(d) judge_count already 1 → node is a no-op (cap enforcement)."""
+        graph_mod = _load_graph()
+
+        mock_ssot = MagicMock()
+        mock_ssot.chat_inline_judge_enabled = True
+
+        with patch.object(graph_mod, "_ssot_config", mock_ssot):
+            result = await graph_mod.inline_judge_response(_make_state(judge_count=1), _make_config())
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_judge_exception_is_nonfatal(self) -> None:
+        """(e) When the judge raises an exception the node returns {} (non-fatal)."""
+        graph_mod = _load_graph()
+
+        mock_ssot = MagicMock()
+        mock_ssot.chat_inline_judge_enabled = True
+        mock_ssot.chat_inline_judge_threshold = 0.6
+
+        # Pre-register a stub in sys.modules so the lazy import inside the
+        # function body resolves to our mock rather than the real class.
+        failing_judge = MagicMock()
+        failing_judge.assess_response_quality = AsyncMock(side_effect=RuntimeError("LLM down"))
+        judge_stub = types.ModuleType("judges.agent_response_judge")
+        judge_stub.AgentResponseJudge = MagicMock(return_value=failing_judge)
+
+        with (
+            patch.object(graph_mod, "_ssot_config", mock_ssot),
+            patch.dict("sys.modules", {"judges.agent_response_judge": judge_stub}),
+        ):
+            result = await graph_mod.inline_judge_response(_make_state(), _make_config())
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_low_score_sets_refinement_hint(self) -> None:
+        """(c) Low score + first attempt → rlm_refinement_hint set + judge_count=1."""
+        graph_mod = _load_graph()
+
+        mock_ssot = MagicMock()
+        mock_ssot.chat_inline_judge_enabled = True
+        mock_ssot.chat_inline_judge_threshold = 0.6
+
+        low_score_judge = MagicMock()
+        low_score_judge.assess_response_quality = AsyncMock(return_value=(False, 0.3, "Quality: 0.30"))
+        judge_stub = types.ModuleType("judges.agent_response_judge")
+        judge_stub.AgentResponseJudge = MagicMock(return_value=low_score_judge)
+
+        with (
+            patch.object(graph_mod, "_ssot_config", mock_ssot),
+            patch.dict("sys.modules", {"judges.agent_response_judge": judge_stub}),
+        ):
+            result = await graph_mod.inline_judge_response(_make_state(), _make_config())
+
+        assert result.get("judge_count") == 1
+        hint = result.get("rlm_refinement_hint", "")
+        assert "Judge feedback" in hint or "judge" in hint.lower() or "0.3" in hint
+
+    @pytest.mark.asyncio
+    async def test_good_score_increments_count_no_hint(self) -> None:
+        """(b) Score above threshold → judge_count incremented; no refinement hint."""
+        graph_mod = _load_graph()
+
+        mock_ssot = MagicMock()
+        mock_ssot.chat_inline_judge_enabled = True
+        mock_ssot.chat_inline_judge_threshold = 0.6
+
+        high_score_judge = MagicMock()
+        high_score_judge.assess_response_quality = AsyncMock(return_value=(True, 0.85, "Quality: 0.85"))
+        judge_stub = types.ModuleType("judges.agent_response_judge")
+        judge_stub.AgentResponseJudge = MagicMock(return_value=high_score_judge)
+
+        with (
+            patch.object(graph_mod, "_ssot_config", mock_ssot),
+            patch.dict("sys.modules", {"judges.agent_response_judge": judge_stub}),
+        ):
+            result = await graph_mod.inline_judge_response(_make_state(), _make_config())
+
+        assert result.get("judge_count") == 1
+        assert not result.get("rlm_refinement_hint", "")
+
+
+# ---------------------------------------------------------------------------
+# route_after_judge routing function
+# ---------------------------------------------------------------------------
+
+
+class TestRouteAfterJudge:
+    """Tests for the route_after_judge conditional edge function."""
+
+    def test_no_hint_routes_to_persist(self) -> None:
+        """(f) No refinement hint → persist_conversation."""
+        graph_mod = _load_graph()
+        state = _make_state()
+        assert graph_mod.route_after_judge(state) == "persist_conversation"
+
+    def test_hint_and_count_one_routes_to_generate(self) -> None:
+        """(c) Hint present + judge_count==1 → generate_response for one retry."""
+        graph_mod = _load_graph()
+        state = {
+            **_make_state(),
+            "rlm_refinement_hint": "[Judge feedback] Please revise.",
+            "judge_count": 1,
+        }
+        assert graph_mod.route_after_judge(state) == "generate_response"
+
+    def test_hint_and_count_two_routes_to_persist(self) -> None:
+        """(d) hint present but judge_count>=2 → cap respected → persist."""
+        graph_mod = _load_graph()
+        state = {
+            **_make_state(),
+            "rlm_refinement_hint": "[Judge feedback] Please revise.",
+            "judge_count": 2,
+        }
+        assert graph_mod.route_after_judge(state) == "persist_conversation"
+
+    def test_hint_count_zero_routes_to_persist(self) -> None:
+        """hint set but judge_count==0 → hint came from RLM, not the judge → persist."""
+        graph_mod = _load_graph()
+        state = {
+            **_make_state(),
+            "rlm_refinement_hint": "Some RLM hint",
+            "judge_count": 0,
+        }
+        assert graph_mod.route_after_judge(state) == "persist_conversation"
+
+
+# ---------------------------------------------------------------------------
+# Grounding instruction in prompt (§3.1 / §3.2)
+# ---------------------------------------------------------------------------
+
+
+class TestGroundingInPrompt:
+    """(g) Verify the citation instruction appears in KB context when enabled."""
+
+    def test_citation_instruction_present_when_enabled(self, monkeypatch) -> None:
+        """build_grounded_context includes the grounding sentence when flag=True."""
+        from autobot_shared.ssot_config import config
+        from services.knowledge.service import build_grounded_context
+
+        monkeypatch.setattr(config, "chat_citation_instruction_enabled", True, raising=False)
+        ctx = build_grounded_context(["Redis is configured in config/redis.yaml"])
+        assert "[Source 1]" in ctx
+        assert "don't know" in ctx or "you don't know" in ctx
+
+    def test_source_labels_present_when_instruction_disabled(self, monkeypatch) -> None:
+        """[Source N] labels always present even when instruction is off."""
+        from autobot_shared.ssot_config import config
+        from services.knowledge.service import build_grounded_context
+
+        monkeypatch.setattr(config, "chat_citation_instruction_enabled", False, raising=False)
+        ctx = build_grounded_context(["fact one", "fact two"])
+        assert "[Source 1] fact one" in ctx
+        assert "[Source 2] fact two" in ctx
+
+    def test_empty_input_returns_empty_string(self) -> None:
+        """build_grounded_context([]) must return an empty string."""
+        from services.knowledge.service import build_grounded_context
+
+        assert build_grounded_context([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# structured_output forwarded in grounded_agent._extract_claims (§3.4)
+# ---------------------------------------------------------------------------
+
+
+class TestStructuredOutputInExtractClaims:
+    """(h) _extract_claims passes structured_output=True to the LLM call."""
+
+    @pytest.mark.asyncio
+    async def test_structured_output_forwarded(self) -> None:
+        """_extract_claims uses structured_output=True so JSON isn't silently lost."""
+        from services.grounded_agent import GroundedAgent
+
+        fake_response = types.SimpleNamespace(content=json.dumps([]))
+        mock_llm = MagicMock()
+        mock_llm.chat = AsyncMock(return_value=fake_response)
+
+        agent = GroundedAgent.__new__(GroundedAgent)
+        agent.llm_service = mock_llm
+
+        await agent._extract_claims("test query", "test response")
+
+        call_kwargs = mock_llm.chat.call_args[1]
+        assert (
+            call_kwargs.get("structured_output") is True
+        ), "_extract_claims must pass structured_output=True to prevent silent JSON drops"

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -210,6 +210,13 @@ class LLMConfig(BaseSettings):
             "AUTOBOT_CHAT_GROUNDING",
         ),
     )
+    # Inline AgentResponseJudge on chat replies (#10599, §3.3).
+    # OFF by default — each judge call adds one LLM round-trip.
+    # Enable with AUTOBOT_CHAT_INLINE_JUDGE=true.
+    chat_inline_judge_enabled: bool = Field(default=False, alias="AUTOBOT_CHAT_INLINE_JUDGE")
+    # Minimum judge overall_score to accept a response without one regeneration
+    # attempt.  Only used when chat_inline_judge_enabled=True.
+    chat_inline_judge_threshold: float = Field(default=0.6, alias="AUTOBOT_CHAT_INLINE_JUDGE_THRESHOLD")
 
     # Provider-specific endpoints (each provider can have its own URL)
     ollama_endpoint: str = Field(default="http://127.0.0.1:11434", alias="AUTOBOT_OLLAMA_ENDPOINT")


### PR DESCRIPTION
## Thinking Path
Umbrella #10603 §3: grounding/citation context (§3.1/§3.2) is already wired end-to-end (`build_grounded_context`/`format_knowledge_context` → `[Source N]` labels), and judges already use `structured_output`. The remaining gaps were the inline judge node and structured claim extraction.

## What Changed
- **§3.3 inline judge** (`chat_workflow/graph.py`) — new `inline_judge_response` node (config-gated) runs `AgentResponseJudge` after ACCEPT; on a low score sets `rlm_refinement_hint` and allows exactly ONE regeneration (`route_after_judge`, one-shot cap via `judge_count`); all exceptions non-fatal. Flag OFF ⇒ zero extra LLM calls, behavior unchanged.
- **§3.4 structured extraction** (`services/grounded_agent.py`) — `_extract_claims` LLM call gains `structured_output=True` + fence-tolerant `_extract_json_object`.
- Config flags in `ssot_config.py`: `chat_inline_judge_enabled` (env `AUTOBOT_CHAT_INLINE_JUDGE`, default False), `chat_inline_judge_threshold` (default 0.6).

## Verification
14 new tests (`test_inline_judge.py`, scenarios a–h) + 60/60 chat_workflow + 43/43 knowledge-service tests pass. Black clean. §3.5 (route factual queries through GroundedAgent) deferred as higher-blast-radius follow-up.

Closes #10599

## Model Used
Opus 4.8