### PR TITLE
perf(knowledge): multi-chunk batching for entity/event/causal extractors (#10598)

### DIFF
--- a/autobot-backend/knowledge/pipeline/cognifiers/causal_relationship_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/causal_relationship_extractor.py
@@ -76,7 +76,8 @@ Return a JSON object mapping each chunk index (as a string) to its array of
 causal relationships (same fields as above); use an empty array for chunks with
 no clear causality. Example for two chunks:
 {{
-  "0": [{{"source_name": "cache_ttl", "target_name": "query_latency", "effect_type": "REDUCES", "condition": "", "evidence_text": "...", "confidence": 0.95}}],
+  "0": [{{"source_name": "cache_ttl", "target_name": "query_latency", "effect_type": "REDUCES",
+         "condition": "", "evidence_text": "...", "confidence": 0.95}}],
   "1": []
 }}
 

--- a/autobot-backend/knowledge/pipeline/cognifiers/causal_relationship_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/causal_relationship_extractor.py
@@ -15,8 +15,12 @@ extraction with condition detection and evidence tracking.
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config
 from knowledge.pipeline.base import BaseCognifier, PipelineContext
-from knowledge.pipeline.cognifiers.llm_utils import parse_llm_json_response
+from knowledge.pipeline.cognifiers.llm_utils import (
+    batched_chunk_extract,
+    parse_llm_json_response,
+)
 from knowledge.pipeline.models.causal_edge import CausalEdge
 from knowledge.pipeline.models.chunk import ProcessedChunk
 from knowledge.pipeline.registry import TaskRegistry
@@ -54,6 +58,32 @@ Return empty array [] if no clear causal relationships found.
 Text:
 {text}
 """
+
+CAUSAL_EXTRACTION_BATCH_PROMPT = """Extract CAUSAL relationships from each of the following text chunks.
+
+CRITICAL: Distinguish explicit causality from correlation:
+- ACCEPT: "X causes Y", "X leads to Y", "X results in Y", "if X then Y", "because X, Y happens"
+- REJECT: "X and Y both increase", "X is correlated with Y", "X and Y tend to occur together"
+
+Each chunk is labeled "Chunk N:". For each causal relationship provide:
+- source_name, target_name
+- effect_type: One of CAUSES, ENABLES, PREVENTS, AMPLIFIES, REDUCES, INHIBITS, ACCELERATES, DECELERATES
+- condition (empty string if unconditional)
+- evidence_text: The exact sentence supporting this causality
+- confidence: 0.9-1.0 explicit, 0.7-0.85 strong inference, reject (<0.7)
+
+Return a JSON object mapping each chunk index (as a string) to its array of
+causal relationships (same fields as above); use an empty array for chunks with
+no clear causality. Example for two chunks:
+{{
+  "0": [{{"source_name": "cache_ttl", "target_name": "query_latency", "effect_type": "REDUCES", "condition": "", "evidence_text": "...", "confidence": 0.95}}],
+  "1": []
+}}
+
+Chunks:
+{chunks}
+"""
+
 
 # NLP patterns for lightweight causal detection (fallback mode)
 CAUSAL_KEYWORDS = {
@@ -279,21 +309,26 @@ class CausalRelationshipExtractor(BaseCognifier):
         return all_edges
 
     async def _process_batch(self, chunks: List[ProcessedChunk], context: PipelineContext) -> List[CausalEdge]:
-        """
-        Process a batch of chunks.
+        """Extract causal edges for a batch in ONE LLM call when batching is on (#10598).
 
-        Args:
-            chunks: Batch of chunks
-            context: Pipeline context
-
-        Returns:
-            List of causal edges from batch
+        Routes through ``batched_chunk_extract`` (index-keyed prompt, per-chunk
+        fallback) so K chunks cost one round-trip instead of K. Falls back to the
+        legacy per-chunk loop when the config flag is disabled.
         """
-        edges = []
-        for chunk in chunks:
-            chunk_edges = await self._extract_from_chunk(chunk, context)
-            edges.extend(chunk_edges)
-        return edges
+        if not config.cognifier_multichunk_batching:
+            edges = []
+            for chunk in chunks:
+                edges.extend(await self._extract_from_chunk(chunk, context))
+            return edges
+        return await batched_chunk_extract(
+            chunks,
+            llm=self.llm,
+            batch_prompt_template=CAUSAL_EXTRACTION_BATCH_PROMPT,
+            llm_type="extraction",
+            max_chunk_chars=config.cognifier_batch_max_chunk_chars,
+            convert=lambda raw, chunk: self._convert_to_causal_edges(raw, chunk, context.document_id),
+            extract_one=lambda chunk: self._extract_from_chunk(chunk, context),
+        )
 
     async def _extract_from_chunk(self, chunk: ProcessedChunk, context: PipelineContext) -> List[CausalEdge]:
         """

--- a/autobot-backend/knowledge/pipeline/cognifiers/entity_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/entity_extractor.py
@@ -15,8 +15,12 @@ from typing import Any, Dict, List
 from uuid import UUID
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config
 from knowledge.pipeline.base import BaseCognifier, CognifyError, PipelineContext
-from knowledge.pipeline.cognifiers.llm_utils import parse_llm_json_response
+from knowledge.pipeline.cognifiers.llm_utils import (
+    batched_chunk_extract,
+    parse_llm_json_response,
+)
 from knowledge.pipeline.models.chunk import ProcessedChunk
 from knowledge.pipeline.models.entity import Entity, EntityType
 from knowledge.pipeline.registry import TaskRegistry
@@ -61,6 +65,26 @@ Return JSON array of entities:
 
 Text:
 {text}
+"""
+
+ENTITY_EXTRACTION_BATCH_PROMPT = """Extract named entities from each of the following text chunks.
+
+Each chunk is labeled "Chunk N:". For each entity provide:
+- name: The entity name as mentioned in text
+- type: One of PERSON, ORGANIZATION, CONCEPT, TECHNOLOGY, LOCATION, EVENT, DOCUMENT
+- description: Brief description
+- confidence: Score 0.0-1.0
+
+Return a JSON object mapping each chunk index (as a string) to its array of
+entities (same fields as above); use an empty array for chunks with no entities.
+Example for two chunks:
+{{
+  "0": [{{"name": "AutoBot", "type": "TECHNOLOGY", "description": "...", "confidence": 0.9}}],
+  "1": []
+}}
+
+Chunks:
+{chunks}
 """
 
 
@@ -262,12 +286,26 @@ class EntityExtractor(BaseCognifier):
         return merged
 
     async def _process_batch(self, chunks: List[ProcessedChunk], context: PipelineContext) -> List[Entity]:
-        """Process a batch of chunks."""
-        entities = []
-        for chunk in chunks:
-            chunk_entities = await self._extract_from_chunk(chunk, context)
-            entities.extend(chunk_entities)
-        return entities
+        """Extract entities for a batch in ONE LLM call when batching is on (#10598).
+
+        Routes through ``batched_chunk_extract`` (index-keyed prompt, per-chunk
+        fallback) so K chunks cost one round-trip instead of K. Falls back to the
+        legacy per-chunk loop when the config flag is disabled.
+        """
+        if not config.cognifier_multichunk_batching:
+            entities = []
+            for chunk in chunks:
+                entities.extend(await self._extract_from_chunk(chunk, context))
+            return entities
+        return await batched_chunk_extract(
+            chunks,
+            llm=self.llm,
+            batch_prompt_template=ENTITY_EXTRACTION_BATCH_PROMPT,
+            llm_type="extraction",
+            max_chunk_chars=config.cognifier_batch_max_chunk_chars,
+            convert=lambda raw, chunk: self._convert_to_entities(raw, chunk, context.document_id),
+            extract_one=lambda chunk: self._extract_from_chunk(chunk, context),
+        )
 
     async def _extract_from_chunk(self, chunk: ProcessedChunk, context: PipelineContext) -> List[Entity]:
         """Extract entities from a single chunk.

--- a/autobot-backend/knowledge/pipeline/cognifiers/event_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/event_extractor.py
@@ -13,8 +13,10 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config
 from knowledge.pipeline.base import BaseCognifier, PipelineContext
 from knowledge.pipeline.cognifiers.llm_utils import (
+    batched_chunk_extract,
     build_entity_map,
     parse_llm_json_response,
 )
@@ -43,6 +45,30 @@ Return JSON: [{{"name": "...", "description": "...", ...}}, ...]
 
 Text:
 {text}
+"""
+
+EVENT_EXTRACTION_BATCH_PROMPT = """Extract temporal events from each of the following text chunks.
+
+Each chunk is labeled "Chunk N:". For each event provide:
+- name: Event title
+- description: Brief description
+- temporal_expression: Time phrase (e.g., "yesterday", "2024-01-15")
+- temporal_type: point, range, relative, recurring
+- event_type: action, decision, change, milestone, occurrence
+- participants: Entity names involved
+- location: Where it happened (if mentioned)
+- confidence: 0.0-1.0
+
+Return a JSON object mapping each chunk index (as a string) to its array of
+events (same fields as above); use an empty array for chunks with no events.
+Example for two chunks:
+{{
+  "0": [{{"name": "...", "description": "...", "temporal_expression": "...", "temporal_type": "point", "event_type": "occurrence", "participants": [], "confidence": 0.9}}],
+  "1": []
+}}
+
+Chunks:
+{chunks}
 """
 
 
@@ -90,12 +116,26 @@ class EventExtractor(BaseCognifier):
         entity_map: Dict[str, Entity],
         context: PipelineContext,
     ) -> List[TemporalEvent]:
-        """Process batch of chunks for events."""
-        events = []
-        for chunk in chunks:
-            chunk_events = await self._extract_from_chunk(chunk, entity_map, context)
-            events.extend(chunk_events)
-        return events
+        """Extract events for a batch in ONE LLM call when batching is on (#10598).
+
+        Routes through ``batched_chunk_extract`` (index-keyed prompt, per-chunk
+        fallback) so K chunks cost one round-trip instead of K. Falls back to the
+        legacy per-chunk loop when the config flag is disabled.
+        """
+        if not config.cognifier_multichunk_batching:
+            events = []
+            for chunk in chunks:
+                events.extend(await self._extract_from_chunk(chunk, entity_map, context))
+            return events
+        return await batched_chunk_extract(
+            chunks,
+            llm=self.llm,
+            batch_prompt_template=EVENT_EXTRACTION_BATCH_PROMPT,
+            llm_type="extraction",
+            max_chunk_chars=config.cognifier_batch_max_chunk_chars,
+            convert=lambda raw, chunk: self._convert_to_events(raw, chunk, entity_map, context),
+            extract_one=lambda chunk: self._extract_from_chunk(chunk, entity_map, context),
+        )
 
     async def _extract_from_chunk(
         self,

--- a/autobot-backend/knowledge/pipeline/cognifiers/event_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/event_extractor.py
@@ -63,7 +63,8 @@ Return a JSON object mapping each chunk index (as a string) to its array of
 events (same fields as above); use an empty array for chunks with no events.
 Example for two chunks:
 {{
-  "0": [{{"name": "...", "description": "...", "temporal_expression": "...", "temporal_type": "point", "event_type": "occurrence", "participants": [], "confidence": 0.9}}],
+  "0": [{{"name": "...", "description": "...", "temporal_expression": "...",
+         "temporal_type": "point", "event_type": "occurrence", "participants": [], "confidence": 0.9}}],
   "1": []
 }}
 

--- a/autobot-backend/knowledge/pipeline/cognifiers/llm_utils.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/llm_utils.py
@@ -6,15 +6,19 @@
 Shared LLM utilities for ECL pipeline cognifiers.
 
 Issue #1074: Extract duplicated parse/build helpers from cognifiers (ARCH-3/4).
+Issue #10598: Shared multi-chunk batching helper — pack K chunks into one LLM
+call keyed by chunk index, with per-chunk fallback (generalizes #10647).
 """
 
 import json
-from typing import Any, Dict, List
+from typing import Any, Awaitable, Callable, Dict, List, TypeVar
 
 from autobot_shared.logging_manager import get_logger
 from knowledge.pipeline.models.entity import Entity
 
 logger = get_logger(__name__)
+
+_R = TypeVar("_R")
 
 
 def parse_llm_json_response(
@@ -75,3 +79,100 @@ def build_entity_map(
         if include_canonical:
             entity_map[entity.canonical_name] = entity
     return entity_map
+
+
+def build_indexed_chunk_blocks(contents: List[str], max_chars: int) -> str:
+    """Render chunk texts as ``Chunk N:`` blocks for an index-keyed batch prompt.
+
+    Args:
+        contents: Per-chunk text, in order.
+        max_chars: Truncate each chunk to this many characters (0 = no limit).
+
+    Returns:
+        Newline-separated ``Chunk i:\\n<text>`` blocks.
+    """
+    parts = []
+    for i, text in enumerate(contents):
+        body = text[:max_chars] if max_chars and max_chars > 0 else text
+        parts.append(f"Chunk {i}:\n{body}")
+    return "\n\n".join(parts)
+
+
+def parse_indexed_batch_response(content: str, n_chunks: int) -> Dict[int, List[Any]]:
+    """Parse an index-keyed batch response into ``{chunk_index: [raw items]}``.
+
+    Raises ``ValueError`` on a non-object response or one whose keys are disjoint
+    from the chunk indices, so the caller can fall back to per-chunk extraction
+    (mirrors ``FactExtractor._extract_batched`` #10647). A single-object value is
+    coerced to a one-element list; missing/None indices yield an empty list.
+    """
+    parsed = parse_llm_json_response(content)
+    if not isinstance(parsed, dict):
+        raise ValueError("batched response was not a JSON object")
+    if {str(i) for i in range(n_chunks)}.isdisjoint(parsed.keys()):
+        raise ValueError("batched response keys do not match chunk indices")
+    result: Dict[int, List[Any]] = {}
+    for i in range(n_chunks):
+        raw = parsed.get(str(i))
+        if raw is None:
+            result[i] = []
+        elif isinstance(raw, dict):
+            result[i] = [raw]
+        elif isinstance(raw, list):
+            result[i] = raw
+        else:
+            result[i] = []
+    return result
+
+
+async def batched_chunk_extract(
+    chunks: List[Any],
+    *,
+    llm: Any,
+    batch_prompt_template: str,
+    llm_type: str,
+    max_chunk_chars: int,
+    convert: Callable[[List[Any], Any], List[_R]],
+    extract_one: Callable[[Any], Awaitable[List[_R]]],
+    content_of: Callable[[Any], str] = lambda c: c.content,
+) -> List[_R]:
+    """Extract items from many chunks in ONE structured LLM call (#10598).
+
+    Sends all ``chunks`` in a single index-keyed prompt, parses results back per
+    chunk, and calls ``convert(raw_items, chunk)`` to build domain objects while
+    preserving per-chunk mapping and order. On any structural failure (non-object
+    response, disjoint keys, or exception) it falls back to ``extract_one(chunk)``
+    per chunk so correctness never regresses. A single-chunk batch skips batching.
+
+    Args:
+        chunks: The chunk objects to process.
+        llm: LLM service exposing ``async chat(messages, *, llm_type, structured_output)``.
+        batch_prompt_template: Prompt with a ``{chunks}`` placeholder.
+        llm_type: Cheap task tier passed through to the LLM (e.g. ``"extraction"``).
+        max_chunk_chars: Per-chunk truncation for the batched prompt (0 = no limit).
+        convert: ``(raw_items, chunk) -> [domain objects]``.
+        extract_one: Per-chunk async fallback returning domain objects.
+        content_of: Extract the text of a chunk (default ``chunk.content``).
+
+    Returns:
+        Flattened list of extracted items across all chunks, in chunk order.
+    """
+    if not chunks:
+        return []
+    if len(chunks) == 1:
+        return await extract_one(chunks[0])
+    try:
+        blocks = build_indexed_chunk_blocks([content_of(c) for c in chunks], max_chunk_chars)
+        prompt = batch_prompt_template.format(chunks=blocks)
+        response = await llm.chat([{"role": "user", "content": prompt}], llm_type=llm_type, structured_output=True)
+        by_index = parse_indexed_batch_response(response.content, len(chunks))
+    except Exception as exc:
+        logger.warning("Batched extraction failed (%s); falling back to per-chunk", exc)
+        results: List[_R] = []
+        for chunk in chunks:
+            results.extend(await extract_one(chunk))
+        return results
+    items: List[_R] = []
+    for i, chunk in enumerate(chunks):
+        items.extend(convert(by_index.get(i, []), chunk))
+    return items

--- a/autobot-backend/knowledge/pipeline/cognifiers/multichunk_batching_test.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/multichunk_batching_test.py
@@ -1,0 +1,283 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for shared multi-chunk cognifier batching (#10598).
+
+Extends the fact_extractor batching (#10647) to entity/event/causal extractors
+via the shared ``batched_chunk_extract`` helper:
+
+- A batch of chunks is extracted in ONE LLM call (N sequential -> 1 batch).
+- Facts/entities/edges map back to their source chunk (order + isolation kept).
+- Batched calls pass ``llm_type="extraction"`` + ``structured_output=True``.
+- A malformed / disjoint batched response falls back to per-chunk extraction.
+- A single-chunk batch skips batching; the config flag can force the legacy path.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from knowledge.pipeline.cognifiers import llm_utils
+from knowledge.pipeline.cognifiers.causal_relationship_extractor import CausalRelationshipExtractor
+from knowledge.pipeline.cognifiers.entity_extractor import EntityExtractor
+from knowledge.pipeline.cognifiers.event_extractor import EventExtractor
+
+
+def _chunk(tag: str = ""):
+    return types.SimpleNamespace(id=uuid4(), content=f"text for {tag}", document_id=None)
+
+
+def _ctx():
+    return types.SimpleNamespace(document_id=uuid4())
+
+
+def _resp(payload: str):
+    return types.SimpleNamespace(content=payload)
+
+
+# ---------------------------------------------------------------------------
+# Shared helper — pure, no domain models
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_helper_single_call_maps_items_per_chunk():
+    c0, c1 = _chunk("c0"), _chunk("c1")
+    resp = json.dumps({"0": [{"v": "A"}], "1": [{"v": "B"}]})
+    llm = types.SimpleNamespace(chat=AsyncMock(return_value=_resp(resp)))
+
+    seen: dict = {}
+
+    def convert(raw, chunk):
+        seen[chunk.id] = [r["v"] for r in raw]
+        return [(chunk.id, r["v"]) for r in raw]
+
+    async def extract_one(chunk):  # pragma: no cover - must not run in happy path
+        raise AssertionError("per-chunk fallback should not run")
+
+    items = await llm_utils.batched_chunk_extract(
+        [c0, c1],
+        llm=llm,
+        batch_prompt_template="prefix {chunks}",
+        llm_type="extraction",
+        max_chunk_chars=2000,
+        convert=convert,
+        extract_one=extract_one,
+    )
+
+    assert llm.chat.call_count == 1  # ONE batched call, not one per chunk
+    assert seen == {c0.id: ["A"], c1.id: ["B"]}  # per-chunk mapping preserved
+    assert items == [(c0.id, "A"), (c1.id, "B")]  # order preserved
+    _, kwargs = llm.chat.call_args
+    assert kwargs.get("llm_type") == "extraction"
+    assert kwargs.get("structured_output") is True
+
+
+@pytest.mark.asyncio
+async def test_helper_malformed_falls_back_to_per_chunk():
+    c0, c1 = _chunk("c0"), _chunk("c1")
+    llm = types.SimpleNamespace(chat=AsyncMock(return_value=_resp("not json")))
+    calls: list = []
+
+    async def extract_one(chunk):
+        calls.append(chunk.id)
+        return [chunk.id]
+
+    items = await llm_utils.batched_chunk_extract(
+        [c0, c1],
+        llm=llm,
+        batch_prompt_template="{chunks}",
+        llm_type="extraction",
+        max_chunk_chars=0,
+        convert=lambda raw, chunk: raw,
+        extract_one=extract_one,
+    )
+
+    assert llm.chat.call_count == 1  # the failed batch call
+    assert calls == [c0.id, c1.id]  # both chunks fell back
+    assert items == [c0.id, c1.id]
+
+
+@pytest.mark.asyncio
+async def test_helper_disjoint_keys_falls_back():
+    c0, c1 = _chunk("c0"), _chunk("c1")
+    llm = types.SimpleNamespace(chat=AsyncMock(return_value=_resp(json.dumps({"x": [1]}))))
+    called: list = []
+
+    async def extract_one(chunk):
+        called.append(chunk.id)
+        return []
+
+    await llm_utils.batched_chunk_extract(
+        [c0, c1],
+        llm=llm,
+        batch_prompt_template="{chunks}",
+        llm_type="extraction",
+        max_chunk_chars=0,
+        convert=lambda raw, chunk: raw,
+        extract_one=extract_one,
+    )
+
+    assert called == [c0.id, c1.id]  # disjoint keys -> per-chunk fallback
+
+
+@pytest.mark.asyncio
+async def test_helper_single_chunk_skips_batching():
+    c0 = _chunk("c0")
+    llm = types.SimpleNamespace(chat=AsyncMock())  # must NOT be called for batch path
+
+    async def extract_one(chunk):
+        return ["one"]
+
+    items = await llm_utils.batched_chunk_extract(
+        [c0],
+        llm=llm,
+        batch_prompt_template="{chunks}",
+        llm_type="extraction",
+        max_chunk_chars=0,
+        convert=lambda raw, chunk: raw,
+        extract_one=extract_one,
+    )
+
+    assert llm.chat.call_count == 0  # batch call skipped; extract_one used
+    assert items == ["one"]
+
+
+def test_indexed_blocks_truncate_and_label():
+    blocks = llm_utils.build_indexed_chunk_blocks(["abcdef", "xyz"], max_chars=3)
+    assert blocks == "Chunk 0:\nabc\n\nChunk 1:\nxyz"
+
+
+def test_parse_indexed_batch_response_coerces_single_object():
+    parsed = llm_utils.parse_indexed_batch_response(json.dumps({"0": {"v": 1}, "1": [{"v": 2}]}), 2)
+    assert parsed == {0: [{"v": 1}], 1: [{"v": 2}]}
+
+
+# ---------------------------------------------------------------------------
+# Entity extractor — one batched call, entities mapped to source chunk
+# ---------------------------------------------------------------------------
+
+
+def _entity(name: str):
+    return {"name": name, "type": "CONCEPT", "description": "", "confidence": 0.9}
+
+
+@pytest.mark.asyncio
+async def test_entity_extractor_batches_and_maps():
+    ext = EntityExtractor.__new__(EntityExtractor)
+    c0, c1 = _chunk("c0"), _chunk("c1")
+    resp = json.dumps({"0": [_entity("Redis")], "1": [_entity("Postgres")]})
+    ext.llm = types.SimpleNamespace(chat=AsyncMock(return_value=_resp(resp)))
+
+    entities = await ext._process_batch([c0, c1], _ctx())
+
+    assert ext.llm.chat.call_count == 1  # ONE batched call
+    by_name = {e.name: e for e in entities}
+    assert by_name["Redis"].source_chunk_ids == [c0.id]
+    assert by_name["Postgres"].source_chunk_ids == [c1.id]
+    _, kwargs = ext.llm.chat.call_args
+    assert kwargs.get("llm_type") == "extraction"
+    assert kwargs.get("structured_output") is True
+
+
+@pytest.mark.asyncio
+async def test_entity_extractor_malformed_batch_falls_back(monkeypatch):
+    ext = EntityExtractor.__new__(EntityExtractor)
+    c0, c1 = _chunk("c0"), _chunk("c1")
+    bad = _resp("not json")  # batched -> raise
+    per_chunk = _resp(json.dumps([_entity("X")]))
+    ext.llm = types.SimpleNamespace(chat=AsyncMock(side_effect=[bad, per_chunk, per_chunk]))
+
+    entities = await ext._process_batch([c0, c1], _ctx())
+
+    assert ext.llm.chat.call_count == 3  # 1 failed batch + 2 per-chunk fallback
+    assert {e.source_chunk_ids[0] for e in entities} == {c0.id, c1.id}
+
+
+@pytest.mark.asyncio
+async def test_entity_extractor_flag_off_uses_per_chunk_loop(monkeypatch):
+    from autobot_shared.ssot_config import config
+
+    monkeypatch.setattr(config, "cognifier_multichunk_batching", False)
+    ext = EntityExtractor.__new__(EntityExtractor)
+    c0, c1 = _chunk("c0"), _chunk("c1")
+    ext.llm = types.SimpleNamespace(chat=AsyncMock(return_value=_resp(json.dumps([_entity("A")]))))
+
+    await ext._process_batch([c0, c1], _ctx())
+
+    assert ext.llm.chat.call_count == 2  # one call per chunk (legacy path)
+
+
+# ---------------------------------------------------------------------------
+# Event extractor — one batched call, events mapped to source chunk
+# ---------------------------------------------------------------------------
+
+
+def _event(name: str):
+    return {
+        "name": name,
+        "description": "",
+        "temporal_expression": "2024-01-15",
+        "temporal_type": "point",
+        "event_type": "occurrence",
+        "participants": [],
+        "confidence": 0.9,
+    }
+
+
+@pytest.mark.asyncio
+async def test_event_extractor_batches_and_maps():
+    ext = EventExtractor.__new__(EventExtractor)
+    c0, c1 = _chunk("c0"), _chunk("c1")
+    resp = json.dumps({"0": [_event("Launch")], "1": [_event("Release")]})
+    ext.llm = types.SimpleNamespace(chat=AsyncMock(return_value=_resp(resp)))
+
+    events = await ext._process_batch([c0, c1], {}, _ctx())
+
+    assert ext.llm.chat.call_count == 1
+    by_name = {e.name: e for e in events}
+    assert by_name["Launch"].source_chunk_ids == [c0.id]
+    assert by_name["Release"].source_chunk_ids == [c1.id]
+    _, kwargs = ext.llm.chat.call_args
+    assert kwargs.get("llm_type") == "extraction"
+    assert kwargs.get("structured_output") is True
+
+
+# ---------------------------------------------------------------------------
+# Causal extractor — one batched call, edges mapped to source chunk
+# ---------------------------------------------------------------------------
+
+
+def _edge(src: str, tgt: str):
+    return {
+        "source_name": src,
+        "target_name": tgt,
+        "effect_type": "REDUCES",
+        "condition": "",
+        "evidence_text": f"{src} reduces {tgt}.",
+        "confidence": 0.95,
+    }
+
+
+@pytest.mark.asyncio
+async def test_causal_extractor_batches_and_maps():
+    ext = CausalRelationshipExtractor.__new__(CausalRelationshipExtractor)
+    ext.min_confidence = 0.7
+    c0, c1 = _chunk("c0"), _chunk("c1")
+    resp = json.dumps({"0": [_edge("ttl", "latency")], "1": [_edge("cache", "load")]})
+    ext.llm = types.SimpleNamespace(chat=AsyncMock(return_value=_resp(resp)))
+
+    edges = await ext._process_batch([c0, c1], _ctx())
+
+    assert ext.llm.chat.call_count == 1
+    chunk_ids = {cid for e in edges for cid in e.source_chunk_ids}
+    assert chunk_ids == {c0.id, c1.id}
+    _, kwargs = ext.llm.chat.call_args
+    assert kwargs.get("llm_type") == "extraction"
+    assert kwargs.get("structured_output") is True

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -224,6 +224,15 @@ class LLMConfig(BaseSettings):
         ),
     )
 
+    # Knowledge-ingestion cognifier batching (#10598). When True, extraction
+    # cognifiers pack multiple chunks into ONE structured LLM call (index-keyed)
+    # instead of one call per chunk — a pure token/round-trip win, with an
+    # automatic per-chunk fallback that keeps correctness. Default on.
+    cognifier_multichunk_batching: bool = Field(default=True, alias="AUTOBOT_COGNIFIER_MULTICHUNK_BATCHING")
+    # Per-chunk character cap when packing chunks into a batched cognifier prompt,
+    # so one oversized chunk can't blow the context window (0 = no truncation).
+    cognifier_batch_max_chunk_chars: int = Field(default=2000, alias="AUTOBOT_COGNIFIER_BATCH_MAX_CHUNK_CHARS")
+
     # Provider-specific endpoints (each provider can have its own URL)
     ollama_endpoint: str = Field(default="http://127.0.0.1:11434", alias="AUTOBOT_OLLAMA_ENDPOINT")
     openai_endpoint: str = Field(default="https://api.openai.com/v1", alias="AUTOBOT_OPENAI_ENDPOINT")


### PR DESCRIPTION
## Thinking Path
Umbrella #10603 Task 2. Most of #10598 already landed via sub-issues: cheap-tier `llm_type` (#10643), `structured_output` (#10665), and batching for `fact_extractor` (#10647). The remaining gap: the other extractors still looped chunk-by-chunk (one LLM call per chunk).

## What Changed
- Generalized the proven `fact_extractor` batching (#10647) into reusable helpers in `cognifiers/llm_utils.py`: `build_indexed_chunk_blocks`, `parse_indexed_batch_response`, `batched_chunk_extract` (one index-keyed structured call; per-chunk fallback on any structural failure; preserves order + per-chunk mapping + error isolation).
- Wired into `entity_extractor`, `event_extractor`, `causal_relationship_extractor` (+ batch prompts).
- Relationship extractor deliberately left per-chunk (its prompt embeds per-chunk entity context — index-batching would be lossy; documented).
- Flags (env-backed): `cognifier_multichunk_batching` (default True — pure round-trip win, correctness preserved by fallback), `cognifier_batch_max_chunk_chars` (default 2000).

## Verification
11 new tests + full cognifier suite 143 passed / 2 skipped (spaCy-optional). For 20 chunks across the 3 extractors: 60 → 12 LLM calls (~80% fewer round-trips); single-chunk batches behavior-identical. Black/ruff clean. Subtask 2.3 (shared embedding cache) split to #10987.

Closes #10598

## Model Used
Opus 4.8