### PR TITLE
feat(agent): wire ClaimVerifier + self-improvement write-path + subagent reflection into hot paths (#10602)

### DIFF
--- a/autobot-backend/orchestration/execution_strategies/_parallel.py
+++ b/autobot-backend/orchestration/execution_strategies/_parallel.py
@@ -12,11 +12,22 @@ import asyncio
 from typing import Any, Callable, Dict
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import SUBAGENT_REFLECTION_ENABLED
 
 from ..types import WorkflowPlan
 from ._base import BaseExecutionStrategy
 
 logger = get_logger(__name__)
+
+
+def _get_subagent_dispatcher(max_parallel: int):
+    """Lazy import of SubagentDispatcher to avoid circular imports at module load.
+
+    Exposed as a module-level function so tests can patch it.
+    """
+    from orchestration.subagent_dispatcher import SubagentTask, get_subagent_dispatcher  # noqa: PLC0415
+
+    return SubagentTask, get_subagent_dispatcher(max_parallel=max_parallel)
 
 
 class ParallelStrategy(BaseExecutionStrategy):
@@ -33,7 +44,13 @@ class ParallelStrategy(BaseExecutionStrategy):
         self._dependencies_met = dependencies_met
 
     async def execute(self, plan: WorkflowPlan) -> Dict[str, Any]:
-        """Execute independent tasks in parallel"""
+        """Execute independent tasks in parallel.
+
+        When AUTOBOT_SUBAGENT_REFLECTION_ENABLED=true, routes the ready batch
+        through SubagentDispatcher so each task gets a score-and-revise reflection
+        pass after execution (#10602).  The existing asyncio.create_task path is
+        used when the flag is off (default) — zero overhead.
+        """
         results = {}
         pending_tasks = list(plan.tasks)
         running_tasks = []
@@ -47,8 +64,12 @@ class ParallelStrategy(BaseExecutionStrategy):
                     pending_tasks.remove(task)
 
             # Start ready tasks (respecting resource limits)
-            for task in ready_tasks:
-                if len(running_tasks) < self.max_parallel_tasks:
+            startable = ready_tasks[: self.max_parallel_tasks - len(running_tasks)]
+            if startable and SUBAGENT_REFLECTION_ENABLED:
+                batch_results = await self._execute_batch_with_reflection(startable, results)
+                results.update(batch_results)
+            else:
+                for task in startable:
                     logger.info("Starting parallel task %s", task.task_id)
                     task_future = asyncio.create_task(self._safe_execute(task, results))
                     running_tasks.append((task, task_future))
@@ -78,3 +99,32 @@ class ParallelStrategy(BaseExecutionStrategy):
                 break
 
         return results
+
+    async def _execute_batch_with_reflection(self, tasks: list, ctx: Dict[str, Any]) -> Dict[str, Any]:
+        """Run a batch of tasks through SubagentDispatcher with reflection (#10602).
+
+        Wires get_subagent_dispatcher() into the parallel hot path so enable_reflection
+        is actually set.  Falls back to direct _safe_execute on any dispatcher error.
+        """
+        try:
+            SubagentTask, dispatcher = _get_subagent_dispatcher(self.max_parallel_tasks)
+            subtasks = [
+                SubagentTask(
+                    task_id=t.task_id,
+                    func=self._safe_execute,
+                    args=(t, ctx),
+                    timeout=getattr(t, "timeout", 300),
+                    enable_reflection=True,
+                    task_description=getattr(t, "description", t.task_id),
+                )
+                for t in tasks
+            ]
+            batch_results = await dispatcher.spawn_parallel_tasks(subtasks)
+            logger.info("SubagentDispatcher(reflection=True) finished %d tasks", len(tasks))
+            return {t.task_id: batch_results.get(t.task_id, {}) for t in tasks}
+        except Exception as exc:
+            logger.warning("SubagentDispatcher batch failed, falling back to direct execute: %s", exc)
+            fallback: Dict[str, Any] = {}
+            for t in tasks:
+                fallback[t.task_id] = await self._safe_execute(t, ctx)
+            return fallback

--- a/autobot-backend/orchestration/subagent_dispatcher.py
+++ b/autobot-backend/orchestration/subagent_dispatcher.py
@@ -105,7 +105,7 @@ class SubagentDispatcher:
             try:
                 coro = asyncio.wait_for(
                     self._execute_task(task),
-                    timeout=task.timeout_seconds,
+                    timeout=task.timeout,
                 )
                 pending.append((task.task_id, coro))
             except Exception as exc:

--- a/autobot-backend/orchestration/workflow_runner.py
+++ b/autobot-backend/orchestration/workflow_runner.py
@@ -23,7 +23,24 @@ import time
 from typing import Any, Dict, List, Set, Tuple
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import SELF_IMPROVEMENT_ENABLED
 from events.bus import PersistStrategy, publish_event
+
+# Lazy-import helpers — exposed at module level so tests can patch them.
+
+
+def _get_task_outcome_judge():
+    from judges.task_outcome_judge import TaskOutcomeJudge  # noqa: PLC0415
+
+    return TaskOutcomeJudge()
+
+
+def _get_task_pattern_learner():
+    from agents.task_pattern_learner import MIN_OUTCOMES_TO_LEARN, TaskPatternLearner  # noqa: PLC0415
+
+    return MIN_OUTCOMES_TO_LEARN, TaskPatternLearner()
+
+
 from orchestration.agent_router import AgentRouter
 from orchestration.collaboration_coordinator import CollaborationCoordinator
 from orchestration.execution_strategies import ExecutionStrategyHandler
@@ -279,6 +296,13 @@ class WorkflowRunner:
         }
         # GH#7357: capture trajectory for future planner retrieval
         await self._capture_trajectory(plan, response)
+        # #10602: self-improvement write path — persist outcome then trigger learning.
+        # Fire-and-forget; never breaks workflow return.
+        if SELF_IMPROVEMENT_ENABLED:
+            asyncio.create_task(
+                self._record_outcome_for_learning(plan, response),
+                name=f"self-improve-{plan.plan_id}",
+            )
         return response
 
     async def _capture_trajectory(self, plan: WorkflowPlan, result: Dict[str, Any]) -> None:
@@ -317,6 +341,42 @@ class WorkflowRunner:
             )
         except Exception as exc:
             logger.warning("TrajectoryStore.capture failed (non-fatal): %s", exc)
+
+    async def _record_outcome_for_learning(self, plan: WorkflowPlan, result: Dict[str, Any]) -> None:
+        """Persist a task outcome via TaskOutcomeJudge then trigger TaskPatternLearner (#10602).
+
+        Connects the self-improvement write path: previously TaskOutcomeJudge.evaluate_task_outcome
+        was only called from _score_plan (planning phase) and nothing fed the Redis outcomes list
+        that TaskPatternLearner.learn_from_outcomes reads.  This method closes the loop:
+        1. Evaluate the completed workflow output with TaskOutcomeJudge (persists to Redis).
+        2. When MIN_OUTCOMES_TO_LEARN is reached, TaskPatternLearner extracts and stores the
+           best strategy so AgentRouter._check_learned_strategy can use it on the next request.
+
+        Fire-and-forget — all errors logged but never propagated.
+        """
+        try:
+            task_type = getattr(plan, "task_type", None) or plan.strategy.value
+            output_summary = str(result.get("results", ""))[:500]
+            judge = _get_task_outcome_judge()
+            await judge.evaluate_task_outcome(
+                task_type=task_type,
+                goal=plan.goal,
+                output=output_summary,
+                strategy_used=plan.strategy.value,
+            )
+
+            # Trigger learning when enough outcomes have accumulated.
+            min_outcomes, learner = _get_task_pattern_learner()
+            outcomes = await judge.get_outcomes(task_type, limit=min_outcomes + 1)
+            if len(outcomes) >= min_outcomes:
+                await learner.learn_from_outcomes(task_type, [o.__dict__ for o in outcomes])
+                logger.info(
+                    "Self-improvement: learned from %d outcomes for task_type='%s'",
+                    len(outcomes),
+                    task_type,
+                )
+        except Exception as exc:
+            logger.debug("Self-improvement recording skipped (non-fatal): %s", exc)
 
     async def _record_failure_pattern(self, plan: WorkflowPlan, error: Exception) -> Dict[str, Any] | None:
         """Learn this workflow failure and flag it when it is a known recurring pattern (#10628).

--- a/autobot-backend/services/grounded_agent.py
+++ b/autobot-backend/services/grounded_agent.py
@@ -37,12 +37,23 @@ from uuid import uuid4
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.ssot_config import CLAIM_VERIFICATION_ENABLED
 from knowledge_factory import get_or_create_knowledge_base
 from llm_shared.types import LLMType
 from services.ai_stack_client import get_ai_stack_client
 from services.causal_inference_engine import CausalInferenceEngine
 
 logger = get_logger(__name__)
+
+
+def _make_claim_verifier(knowledge_base):
+    """Lazy import of ClaimVerifier to avoid circular imports at module load.
+
+    Exposed as a module-level function so tests can patch it.
+    """
+    from services.claim_verifier import ClaimVerifier  # noqa: PLC0415
+
+    return ClaimVerifier(knowledge_base=knowledge_base)
 
 
 class ClaimStatus(str, Enum):
@@ -387,31 +398,15 @@ Format as JSON array of objects with fields: claim_text, subject, predicate, obj
             return []
 
     async def _classify_and_verify_claim(self, claim: Claim) -> VerifiedClaim:
-        """
-        Classify claim against KB and verify if needed.
+        """Classify claim against KB and verify if needed.
 
-        Classification:
-        - IN_KB: Found in knowledge base
-        - UNKNOWN: Not in KB, needs research
-        - CONTRADICTS: Contradicts KB fact
-        - VERIFIED: Verified through external research
-        - UNVERIFIABLE: Cannot be verified
-
-        Args:
-            claim: Claim to classify
-
-        Returns:
-            VerifiedClaim with status and evidence
+        When AUTOBOT_CLAIM_VERIFICATION_ENABLED=true, UNKNOWN claims are escalated
+        to ClaimVerifier for a second RAG pass with research-agent fallback (#10602).
         """
         if not self.kb:
-            return VerifiedClaim(
-                claim=claim,
-                kb_status=ClaimStatus.UNKNOWN,
-                confidence=0.0,
-            )
+            return VerifiedClaim(claim=claim, kb_status=ClaimStatus.UNKNOWN, confidence=0.0)
 
         try:
-            # Search KB for related facts
             search_results = await self.kb.search(
                 query=claim.claim_text,
                 limit=5,
@@ -419,33 +414,18 @@ Format as JSON array of objects with fields: claim_text, subject, predicate, obj
             )
 
             if not search_results:
-                return VerifiedClaim(
-                    claim=claim,
-                    kb_status=ClaimStatus.UNKNOWN,
-                    confidence=0.0,
-                    evidence=["No matching KB facts found"],
-                )
+                return await self._escalate_to_claim_verifier(claim, "No matching KB facts found")
 
-            # Find best match
-            best_match = search_results[0] if search_results else None
-
-            if not best_match:
-                return VerifiedClaim(
-                    claim=claim,
-                    kb_status=ClaimStatus.UNKNOWN,
-                    confidence=0.0,
-                )
-
+            best_match = search_results[0]
             match_confidence = best_match.get("similarity_score", 0.0)
             fact_id = best_match.get("fact_id", "")
 
-            # Determine status based on confidence
             if match_confidence > 0.85:
                 status = ClaimStatus.IN_KB
             elif match_confidence > 0.5:
                 status = ClaimStatus.VERIFIED
             else:
-                status = ClaimStatus.UNKNOWN
+                return await self._escalate_to_claim_verifier(claim, best_match.get("content", "")[:200])
 
             return VerifiedClaim(
                 claim=claim,
@@ -464,6 +444,52 @@ Format as JSON array of objects with fields: claim_text, subject, predicate, obj
                 confidence=0.0,
                 evidence=[f"Classification error: {str(e)[:100]}"],
             )
+
+    async def _escalate_to_claim_verifier(self, claim: Claim, kb_evidence: str) -> VerifiedClaim:
+        """Escalate a low-confidence claim to ClaimVerifier when enabled (#10602).
+
+        Returns UNKNOWN VerifiedClaim when CLAIM_VERIFICATION_ENABLED=false (default).
+        When enabled, runs ClaimVerifier.kb_rag_search + research-agent escalation
+        and maps the result back into GroundedAgent's VerifiedClaim type.
+        """
+        if not CLAIM_VERIFICATION_ENABLED:
+            return VerifiedClaim(
+                claim=claim,
+                kb_status=ClaimStatus.UNKNOWN,
+                confidence=0.0,
+                evidence=[kb_evidence] if kb_evidence else ["No matching KB facts found"],
+                verification_method="kb_lookup",
+            )
+
+        try:
+            verifier = _make_claim_verifier(self.kb)
+            rag_result = await verifier.kb_rag_search(claim.claim_text)
+
+            if rag_result and rag_result.confidence >= 0.7:
+                logger.info(
+                    "ClaimVerifier RAG confidence %.2f for claim: %s...",
+                    rag_result.confidence,
+                    claim.claim_text[:60],
+                )
+                status = ClaimStatus.VERIFIED if rag_result.confidence >= 0.8 else ClaimStatus.UNKNOWN
+                evidence = [m.text[:200] for m in rag_result.matches[:2]] if rag_result.matches else []
+                return VerifiedClaim(
+                    claim=claim,
+                    kb_status=status,
+                    confidence=rag_result.confidence,
+                    evidence=evidence,
+                    verification_method="claim_verifier_rag",
+                )
+        except Exception as exc:
+            logger.warning("ClaimVerifier escalation failed (non-fatal): %s", exc)
+
+        return VerifiedClaim(
+            claim=claim,
+            kb_status=ClaimStatus.UNKNOWN,
+            confidence=0.0,
+            evidence=[kb_evidence] if kb_evidence else [],
+            verification_method="kb_lookup",
+        )
 
     async def _reconstruct_response(
         self,

--- a/autobot-backend/tests/orchestration/test_claim_verifier_wiring.py
+++ b/autobot-backend/tests/orchestration/test_claim_verifier_wiring.py
@@ -1,0 +1,147 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for ClaimVerifier wiring into GroundedAgent (#10602).
+
+Verifies that:
+- CLAIM_VERIFICATION_ENABLED=false (default): _escalate_to_claim_verifier returns UNKNOWN
+  without touching ClaimVerifier.
+- CLAIM_VERIFICATION_ENABLED=true: ClaimVerifier.kb_rag_search is called for low-confidence
+  claims and the result is mapped back into GroundedAgent's VerifiedClaim type.
+- Errors in ClaimVerifier are swallowed; UNKNOWN VerifiedClaim is returned.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.grounded_agent import Claim, ClaimStatus, GroundedAgent
+
+
+def _make_claim(text: str = "test claim") -> Claim:
+    return Claim(claim_text=text, confidence=0.3)
+
+
+def _make_rag_result(confidence: float, match_text: str = "kb evidence") -> types.SimpleNamespace:
+    match = types.SimpleNamespace(text=match_text, url=None)
+    return types.SimpleNamespace(
+        confidence=confidence,
+        matches=[match] if confidence > 0.0 else [],
+    )
+
+
+class TestEscalateToClaimVerifier:
+    @pytest.mark.asyncio
+    async def test_flag_off_returns_unknown_without_claim_verifier(self, monkeypatch):
+        """When CLAIM_VERIFICATION_ENABLED=false, ClaimVerifier is never imported."""
+        monkeypatch.setattr("services.grounded_agent.CLAIM_VERIFICATION_ENABLED", False)
+        agent = GroundedAgent()
+        claim = _make_claim()
+
+        # ClaimVerifier should not be called at all
+        with patch("services.claim_verifier.ClaimVerifier") as mock_cv:
+            result = await agent._escalate_to_claim_verifier(claim, "no evidence")
+
+        mock_cv.assert_not_called()
+        assert result.kb_status == ClaimStatus.UNKNOWN
+        assert result.confidence == 0.0
+
+    @pytest.mark.asyncio
+    async def test_flag_on_calls_claim_verifier_rag(self, monkeypatch):
+        """When CLAIM_VERIFICATION_ENABLED=true, ClaimVerifier.kb_rag_search is called."""
+        monkeypatch.setattr("services.grounded_agent.CLAIM_VERIFICATION_ENABLED", True)
+        agent = GroundedAgent()
+        agent.kb = object()  # non-None KB so verifier is constructed
+        claim = _make_claim("Redis latency is 500ms")
+
+        mock_verifier = AsyncMock()
+        mock_verifier.kb_rag_search = AsyncMock(return_value=_make_rag_result(0.85))
+
+        # _make_claim_verifier is a module-level helper; patch it directly.
+        with patch("services.grounded_agent._make_claim_verifier", return_value=mock_verifier):
+            result = await agent._escalate_to_claim_verifier(claim, "")
+
+        mock_verifier.kb_rag_search.assert_called_once_with(claim.claim_text)
+        # confidence >= 0.8 → VERIFIED
+        assert result.kb_status == ClaimStatus.VERIFIED
+        assert result.confidence == pytest.approx(0.85)
+        assert result.verification_method == "claim_verifier_rag"
+
+    @pytest.mark.asyncio
+    async def test_flag_on_medium_confidence_returns_unknown(self, monkeypatch):
+        """Confidence 0.7-0.8 → UNKNOWN (below VERIFIED threshold)."""
+        monkeypatch.setattr("services.grounded_agent.CLAIM_VERIFICATION_ENABLED", True)
+        agent = GroundedAgent()
+        agent.kb = object()
+        claim = _make_claim("some fact")
+
+        mock_verifier = AsyncMock()
+        mock_verifier.kb_rag_search = AsyncMock(return_value=_make_rag_result(0.75))
+
+        with patch("services.grounded_agent._make_claim_verifier", return_value=mock_verifier):
+            result = await agent._escalate_to_claim_verifier(claim, "")
+
+        # confidence 0.7-0.8 → status is UNKNOWN (threshold for VERIFIED is 0.8)
+        assert result.kb_status == ClaimStatus.UNKNOWN
+        assert result.confidence == pytest.approx(0.75)
+
+    @pytest.mark.asyncio
+    async def test_flag_on_below_threshold_returns_unknown(self, monkeypatch):
+        """ClaimVerifier RAG confidence < 0.7 → UNKNOWN returned."""
+        monkeypatch.setattr("services.grounded_agent.CLAIM_VERIFICATION_ENABLED", True)
+        agent = GroundedAgent()
+        agent.kb = object()
+        claim = _make_claim("obscure fact")
+
+        mock_verifier = AsyncMock()
+        mock_verifier.kb_rag_search = AsyncMock(return_value=_make_rag_result(0.4))
+
+        with patch("services.grounded_agent._make_claim_verifier", return_value=mock_verifier):
+            result = await agent._escalate_to_claim_verifier(claim, "")
+
+        # Below 0.7 threshold → falls through to UNKNOWN
+        assert result.kb_status == ClaimStatus.UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_claim_verifier_error_swallowed_returns_unknown(self, monkeypatch):
+        """ClaimVerifier raising must not propagate; UNKNOWN is returned."""
+        monkeypatch.setattr("services.grounded_agent.CLAIM_VERIFICATION_ENABLED", True)
+        agent = GroundedAgent()
+        agent.kb = object()
+        claim = _make_claim()
+
+        with patch(
+            "services.grounded_agent._make_claim_verifier",
+            side_effect=RuntimeError("redis down"),
+        ):
+            result = await agent._escalate_to_claim_verifier(claim, "evidence")
+
+        assert result.kb_status == ClaimStatus.UNKNOWN
+
+
+class TestClassifyAndVerifyClaimDelegation:
+    @pytest.mark.asyncio
+    async def test_no_kb_returns_unknown(self):
+        """When kb is None, _classify_and_verify_claim returns UNKNOWN immediately."""
+        agent = GroundedAgent()
+        agent.kb = None
+        claim = _make_claim()
+        result = await agent._classify_and_verify_claim(claim)
+        assert result.kb_status == ClaimStatus.UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_delegates_to_escalate(self, monkeypatch):
+        """A <0.5 similarity_score delegates to _escalate_to_claim_verifier."""
+        monkeypatch.setattr("services.grounded_agent.CLAIM_VERIFICATION_ENABLED", False)
+        agent = GroundedAgent()
+        agent.kb = AsyncMock()
+        agent.kb.search = AsyncMock(return_value=[{"similarity_score": 0.3, "fact_id": "f1", "content": "x"}])
+        claim = _make_claim()
+
+        result = await agent._classify_and_verify_claim(claim)
+        # With flag off, escalation returns UNKNOWN
+        assert result.kb_status == ClaimStatus.UNKNOWN

--- a/autobot-backend/tests/orchestration/test_self_improvement_wiring.py
+++ b/autobot-backend/tests/orchestration/test_self_improvement_wiring.py
@@ -1,0 +1,183 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for self-improvement write path wiring (#10602).
+
+Verifies that _record_outcome_for_learning:
+- Calls TaskOutcomeJudge.evaluate_task_outcome (persists outcome to Redis write path).
+- Calls TaskPatternLearner.learn_from_outcomes when MIN_OUTCOMES_TO_LEARN is reached.
+- Errors are swallowed — never break workflow execution.
+- SELF_IMPROVEMENT_ENABLED=false → task is never scheduled (no-op).
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from orchestration.workflow_runner import WorkflowRunner
+
+
+def _make_plan(goal: str = "test goal", strategy: str = "sequential") -> types.SimpleNamespace:
+    return types.SimpleNamespace(
+        plan_id="plan-1",
+        goal=goal,
+        strategy=types.SimpleNamespace(value=strategy),
+        tasks=[],
+        task_type=None,
+    )
+
+
+def _make_result(success: bool = True) -> dict:
+    return {"success": success, "results": {"out": "value"}, "execution_time": 1.0}
+
+
+class TestRecordOutcomeForLearning:
+    @pytest.mark.asyncio
+    async def test_evaluate_task_outcome_called(self):
+        """evaluate_task_outcome is called with plan data — write path fires."""
+        plan = _make_plan("analyse logs")
+
+        fake_judgment = MagicMock(overall_score=0.8)
+        mock_judge = AsyncMock()
+        mock_judge.evaluate_task_outcome = AsyncMock(return_value=fake_judgment)
+        mock_judge.get_outcomes = AsyncMock(return_value=[])  # not enough to learn
+
+        mock_learner = AsyncMock()
+        mock_learner.learn_from_outcomes = AsyncMock()
+
+        with (
+            patch("orchestration.workflow_runner._get_task_outcome_judge", return_value=mock_judge),
+            patch(
+                "orchestration.workflow_runner._get_task_pattern_learner",
+                return_value=(0, mock_learner),
+            ),
+        ):
+            await WorkflowRunner._record_outcome_for_learning(object(), plan, _make_result())
+
+        mock_judge.evaluate_task_outcome.assert_called_once()
+        call_kwargs = mock_judge.evaluate_task_outcome.call_args
+        assert call_kwargs.kwargs["goal"] == "analyse logs"
+        assert call_kwargs.kwargs["strategy_used"] == "sequential"
+
+    @pytest.mark.asyncio
+    async def test_learn_from_outcomes_called_when_threshold_met(self):
+        """learn_from_outcomes is called when MIN_OUTCOMES_TO_LEARN outcomes exist."""
+        from agents.task_pattern_learner import MIN_OUTCOMES_TO_LEARN
+
+        plan = _make_plan()
+
+        fake_judgment = MagicMock(overall_score=0.9)
+        fake_outcomes = [
+            types.SimpleNamespace(
+                score=0.8, task_type="t", goal="g", output_summary="o", strategy_used="s", rationale="r", timestamp="ts"
+            )
+            for _ in range(MIN_OUTCOMES_TO_LEARN)
+        ]
+
+        mock_judge_inst = AsyncMock()
+        mock_judge_inst.evaluate_task_outcome = AsyncMock(return_value=fake_judgment)
+        mock_judge_inst.get_outcomes = AsyncMock(return_value=fake_outcomes)
+
+        mock_learner_inst = AsyncMock()
+        mock_learner_inst.learn_from_outcomes = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "orchestration.workflow_runner._get_task_outcome_judge",
+                return_value=mock_judge_inst,
+            ),
+            patch(
+                "orchestration.workflow_runner._get_task_pattern_learner",
+                return_value=(MIN_OUTCOMES_TO_LEARN, mock_learner_inst),
+            ),
+        ):
+            await WorkflowRunner._record_outcome_for_learning(object(), plan, _make_result())
+
+        mock_learner_inst.learn_from_outcomes.assert_called_once()
+        _, outcomes_arg = mock_learner_inst.learn_from_outcomes.call_args.args
+        assert len(outcomes_arg) == MIN_OUTCOMES_TO_LEARN
+
+    @pytest.mark.asyncio
+    async def test_learn_not_called_when_below_threshold(self):
+        """learn_from_outcomes is NOT called when outcomes < MIN_OUTCOMES_TO_LEARN."""
+        from agents.task_pattern_learner import MIN_OUTCOMES_TO_LEARN
+
+        plan = _make_plan()
+        fake_judgment = MagicMock(overall_score=0.5)
+        # Return one fewer than the minimum
+        fake_outcomes = [
+            types.SimpleNamespace(
+                score=0.5, task_type="t", goal="g", output_summary="o", strategy_used="s", rationale="r", timestamp="ts"
+            )
+            for _ in range(MIN_OUTCOMES_TO_LEARN - 1)
+        ]
+
+        mock_judge_inst = AsyncMock()
+        mock_judge_inst.evaluate_task_outcome = AsyncMock(return_value=fake_judgment)
+        mock_judge_inst.get_outcomes = AsyncMock(return_value=fake_outcomes)
+
+        mock_learner_inst = AsyncMock()
+        mock_learner_inst.learn_from_outcomes = AsyncMock()
+
+        with (
+            patch(
+                "orchestration.workflow_runner._get_task_outcome_judge",
+                return_value=mock_judge_inst,
+            ),
+            patch(
+                "orchestration.workflow_runner._get_task_pattern_learner",
+                return_value=(MIN_OUTCOMES_TO_LEARN, mock_learner_inst),
+            ),
+        ):
+            await WorkflowRunner._record_outcome_for_learning(object(), plan, _make_result())
+
+        mock_learner_inst.learn_from_outcomes.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_errors_swallowed(self):
+        """Any exception in outcome recording must not propagate."""
+        plan = _make_plan()
+
+        with patch(
+            "orchestration.workflow_runner._get_task_outcome_judge",
+            side_effect=RuntimeError("redis down"),
+        ):
+            # Must not raise
+            await WorkflowRunner._record_outcome_for_learning(object(), plan, _make_result())
+
+    @pytest.mark.asyncio
+    async def test_flag_off_skips_task_creation(self, monkeypatch):
+        """SELF_IMPROVEMENT_ENABLED=false → asyncio.create_task never called."""
+        monkeypatch.setattr("orchestration.workflow_runner.SELF_IMPROVEMENT_ENABLED", False)
+
+        created_tasks = []
+
+        def _fake_create_task(coro, **kwargs):
+            created_tasks.append(coro)
+            # Close coro to avoid warnings
+            coro.close()
+            return MagicMock()
+
+        # We need a minimal runner with enough attrs to call the method.
+        plan = _make_plan()
+
+        with patch("orchestration.workflow_runner.asyncio.create_task", side_effect=_fake_create_task):
+            # Import and monkey-patch the success handler.
+            runner = MagicMock()
+            runner._evaluate_workflow_criteria = AsyncMock(return_value={"overall": "full", "score": 1.0})
+            runner._perf = MagicMock()
+            runner._perf.update_from_plan = MagicMock()
+            runner._publish_workflow_event = AsyncMock()
+            runner._strategy_planner = MagicMock()
+            runner._strategy_planner.summarize_results = MagicMock(return_value="ok")
+            runner._capture_trajectory = AsyncMock()
+
+            import time
+
+            await WorkflowRunner._handle_workflow_execution_success(runner, plan, {}, time.time())
+
+        assert created_tasks == [], "create_task should not be called when flag is off"

--- a/autobot-backend/tests/orchestration/test_subagent_reflection_wiring.py
+++ b/autobot-backend/tests/orchestration/test_subagent_reflection_wiring.py
@@ -22,8 +22,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from orchestration.subagent_dispatcher import SubagentTask, get_subagent_dispatcher
 from orchestration.execution_strategies._parallel import ParallelStrategy
+from orchestration.subagent_dispatcher import SubagentTask, get_subagent_dispatcher
 
 
 def _make_agent_task(task_id: str = "t1", description: str = "do work") -> types.SimpleNamespace:

--- a/autobot-backend/tests/orchestration/test_subagent_reflection_wiring.py
+++ b/autobot-backend/tests/orchestration/test_subagent_reflection_wiring.py
@@ -1,0 +1,197 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for SubagentDispatcher wiring into ParallelStrategy (#10602).
+
+Verifies that:
+- SUBAGENT_REFLECTION_ENABLED=false (default): direct asyncio.create_task path,
+  SubagentDispatcher.spawn_parallel_tasks never called.
+- SUBAGENT_REFLECTION_ENABLED=true: _execute_batch_with_reflection is called
+  and routes tasks through get_subagent_dispatcher().
+- Dispatcher errors fall back to direct _safe_execute (no tasks dropped).
+- SubagentTask.timeout field fix: spawn_parallel_tasks no longer AttributeErrors
+  on task.timeout_seconds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from orchestration.subagent_dispatcher import SubagentTask, get_subagent_dispatcher
+from orchestration.execution_strategies._parallel import ParallelStrategy
+
+
+def _make_agent_task(task_id: str = "t1", description: str = "do work") -> types.SimpleNamespace:
+    return types.SimpleNamespace(
+        task_id=task_id,
+        description=description,
+        timeout=60,
+        metadata={},
+        to_failed_result=lambda msg: {"status": "failed", "error": msg},
+    )
+
+
+class TestSubagentTaskTimeoutField:
+    """Guard the pre-existing timeout_seconds → timeout attribute fix."""
+
+    @pytest.mark.asyncio
+    async def test_spawn_parallel_tasks_uses_timeout_not_timeout_seconds(self):
+        """spawn_parallel_tasks must not raise AttributeError for timeout_seconds."""
+
+        async def noop():
+            return "done"
+
+        task = SubagentTask(task_id="t1", func=noop, timeout=10, enable_reflection=False)
+        dispatcher = get_subagent_dispatcher.__wrapped__() if hasattr(get_subagent_dispatcher, "__wrapped__") else None
+        dispatcher = MagicMock()
+        dispatcher.max_parallel = 5
+        dispatcher.spawn_parallel_tasks = AsyncMock(return_value={"t1": "done"})
+
+        # Directly test the field is 'timeout', not 'timeout_seconds'
+        assert hasattr(task, "timeout"), "SubagentTask must have 'timeout' field"
+        assert not hasattr(task, "timeout_seconds"), "Field must be 'timeout', not 'timeout_seconds'"
+        assert task.timeout == 10
+
+
+class TestParallelStrategyReflectionOff:
+    @pytest.mark.asyncio
+    async def test_flag_off_does_not_call_batch_reflection(self, monkeypatch):
+        """SUBAGENT_REFLECTION_ENABLED=false → _execute_batch_with_reflection never called."""
+        monkeypatch.setattr(
+            "orchestration.execution_strategies._parallel.SUBAGENT_REFLECTION_ENABLED",
+            False,
+        )
+
+        execute_calls = []
+
+        async def fake_execute(task, ctx):
+            execute_calls.append(task.task_id)
+            return {"status": "ok", "task_id": task.task_id}
+
+        strategy = ParallelStrategy(
+            execute_single_task=fake_execute,
+            max_parallel_tasks=5,
+            resource_semaphore=asyncio.Semaphore(5),
+            dependencies_met=lambda task, results: True,
+        )
+
+        tasks = [_make_agent_task(f"t{i}") for i in range(3)]
+        plan = types.SimpleNamespace(tasks=tasks)
+
+        with patch.object(strategy, "_execute_batch_with_reflection", new_callable=AsyncMock) as mock_batch:
+            results = await strategy.execute(plan)
+
+        mock_batch.assert_not_called()
+        assert len(results) == 3
+
+
+class TestParallelStrategyReflectionOn:
+    @pytest.mark.asyncio
+    async def test_flag_on_calls_batch_reflection(self, monkeypatch):
+        """SUBAGENT_REFLECTION_ENABLED=true → _execute_batch_with_reflection is called."""
+        monkeypatch.setattr(
+            "orchestration.execution_strategies._parallel.SUBAGENT_REFLECTION_ENABLED",
+            True,
+        )
+
+        async def fake_execute(task, ctx):
+            return {"status": "ok", "task_id": task.task_id}
+
+        strategy = ParallelStrategy(
+            execute_single_task=fake_execute,
+            max_parallel_tasks=5,
+            resource_semaphore=asyncio.Semaphore(5),
+            dependencies_met=lambda task, results: True,
+        )
+
+        tasks = [_make_agent_task("t1")]
+        plan = types.SimpleNamespace(tasks=tasks)
+
+        batch_results = {"t1": {"status": "ok"}}
+        with patch.object(
+            strategy,
+            "_execute_batch_with_reflection",
+            new_callable=AsyncMock,
+            return_value=batch_results,
+        ) as mock_batch:
+            results = await strategy.execute(plan)
+
+        mock_batch.assert_called_once()
+        assert results["t1"]["status"] == "ok"
+
+
+class TestExecuteBatchWithReflection:
+    @pytest.mark.asyncio
+    async def test_routes_through_dispatcher(self, monkeypatch):
+        """_execute_batch_with_reflection uses get_subagent_dispatcher."""
+        monkeypatch.setattr(
+            "orchestration.execution_strategies._parallel.SUBAGENT_REFLECTION_ENABLED",
+            True,
+        )
+
+        async def fake_execute(task, ctx):
+            return {"task_id": task.task_id, "done": True}
+
+        strategy = ParallelStrategy(
+            execute_single_task=fake_execute,
+            max_parallel_tasks=5,
+            resource_semaphore=asyncio.Semaphore(5),
+            dependencies_met=lambda task, results: True,
+        )
+
+        tasks = [_make_agent_task("t1"), _make_agent_task("t2")]
+        expected = {"t1": {"done": True}, "t2": {"done": True}}
+
+        mock_dispatcher = MagicMock()
+        mock_dispatcher.spawn_parallel_tasks = AsyncMock(return_value=expected)
+
+        # _get_subagent_dispatcher is a module-level function; patch it directly.
+        with patch(
+            "orchestration.execution_strategies._parallel._get_subagent_dispatcher",
+            return_value=(SubagentTask, mock_dispatcher),
+        ):
+            result = await strategy._execute_batch_with_reflection(tasks, {})
+
+        mock_dispatcher.spawn_parallel_tasks.assert_called_once()
+        # Verify enable_reflection=True was passed to each SubagentTask
+        dispatched: list[SubagentTask] = mock_dispatcher.spawn_parallel_tasks.call_args.args[0]
+        assert all(t.enable_reflection for t in dispatched)
+        assert set(result.keys()) == {"t1", "t2"}
+
+    @pytest.mark.asyncio
+    async def test_dispatcher_error_falls_back_to_direct_execute(self, monkeypatch):
+        """Dispatcher failure → falls back to _safe_execute, no tasks dropped."""
+        monkeypatch.setattr(
+            "orchestration.execution_strategies._parallel.SUBAGENT_REFLECTION_ENABLED",
+            True,
+        )
+
+        completed = []
+
+        async def fake_execute(task, ctx):
+            completed.append(task.task_id)
+            return {"task_id": task.task_id}
+
+        strategy = ParallelStrategy(
+            execute_single_task=fake_execute,
+            max_parallel_tasks=5,
+            resource_semaphore=asyncio.Semaphore(5),
+            dependencies_met=lambda task, results: True,
+        )
+
+        tasks = [_make_agent_task("t1"), _make_agent_task("t2")]
+
+        with patch(
+            "orchestration.execution_strategies._parallel._get_subagent_dispatcher",
+            side_effect=RuntimeError("dispatcher unavailable"),
+        ):
+            result = await strategy._execute_batch_with_reflection(tasks, {})
+
+        # Fallback executed both tasks
+        assert set(completed) == {"t1", "t2"}
+        assert set(result.keys()) == {"t1", "t2"}

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -94,6 +94,21 @@ PLAN_BEST_OF_N_COUNT: int = min(
     max(2, int(os.environ.get("AUTOBOT_PLAN_BEST_OF_N_COUNT", "3"))),
 )
 
+# #10602: ClaimVerifier wiring — adds KB RAG + optional research-agent LLM call per claim.
+# Default OFF because it adds latency/cost; set AUTOBOT_CLAIM_VERIFICATION_ENABLED=true to opt in.
+_TRUE_VALUES = {"1", "true", "yes"}
+CLAIM_VERIFICATION_ENABLED: bool = os.environ.get("AUTOBOT_CLAIM_VERIFICATION_ENABLED", "false").lower() in _TRUE_VALUES
+
+# #10602: Self-improvement write path — pure plumbing, no extra LLM calls until outcomes exist.
+# Default ON.  Set AUTOBOT_SELF_IMPROVEMENT_ENABLED=false to disable.
+SELF_IMPROVEMENT_ENABLED: bool = os.environ.get("AUTOBOT_SELF_IMPROVEMENT_ENABLED", "true").lower() in _TRUE_VALUES
+
+# #10602: Subagent reflection pass — adds LLM score + optional revision per task.
+# Default OFF; set AUTOBOT_SUBAGENT_REFLECTION_ENABLED=true to opt in.
+SUBAGENT_REFLECTION_ENABLED: bool = (
+    os.environ.get("AUTOBOT_SUBAGENT_REFLECTION_ENABLED", "false").lower() in _TRUE_VALUES
+)
+
 
 class VMConfig(BaseSettings):
     """


### PR DESCRIPTION
## Thinking Path
Umbrella #10603 Task 6: mature components built with zero callers — wire each into its hot path (never delete), config-gated.

## What Changed
- **ClaimVerifier** (`services/grounded_agent.py`) — `_escalate_to_claim_verifier` called from `_classify_and_verify_claim` for low-confidence/no-match claims; maps result into `VerifiedClaim`. Flag `AUTOBOT_CLAIM_VERIFICATION_ENABLED` (default False; OFF ⇒ UNKNOWN, zero overhead).
- **Self-improvement write-path** (`orchestration/workflow_runner.py`) — `_record_outcome_for_learning` fires on workflow success (`asyncio.create_task`, fire-and-forget): `TaskOutcomeJudge.evaluate_task_outcome` → persists, then `learn_from_outcomes` at threshold. Flag `AUTOBOT_SELF_IMPROVEMENT_ENABLED` (default True — pure plumbing). Closes the loop: orchestrator reads learned strategies at plan time, now writes them post-execution.
- **Subagent reflection** (`execution_strategies/_parallel.py`) — `_execute_batch_with_reflection` routes ready batches through `get_subagent_dispatcher().spawn_parallel_tasks()` with `enable_reflection=True`; falls back to direct exec on error. Flag `AUTOBOT_SUBAGENT_REFLECTION_ENABLED` (default False). Also fixed pre-existing `task.timeout_seconds`→`task.timeout` bug in `subagent_dispatcher.py`.
- FailurePatternDetector (6.2), NPU events (6.4), agent recommendation scores (6.6), lightweight short-circuit (6.7) confirmed already wired.

## Verification
17 new tests pass (claim-verifier / self-improvement / subagent-reflection wiring); gated OFF ⇒ unchanged. Black clean. Merged latest `Dev_new_gui` (incl. #10986) cleanly.

Closes #10602

## Model Used
Opus 4.8