### PR TITLE
fix(security): allowlist task env vars to prevent subprocess env-injection across execution backends (#11001)

### DIFF
--- a/autobot-backend/services/execution/claude_code_backend.py
+++ b/autobot-backend/services/execution/claude_code_backend.py
@@ -64,6 +64,7 @@ from services.execution.base_backend import (
     ExecutionStatus,
     ExecutionTask,
 )
+from services.execution.env_sanitizer import safe_task_env
 
 logger = get_logger(__name__)
 
@@ -89,25 +90,10 @@ CLAUDE_CODE_BACKEND = "claude_code"
 # Absent or falsy → provider reports unavailable (no crash).
 _ENV_FLAG = "AUTOBOT_FEATURE_CLAUDE_CODE_EXECUTION"
 
-# Security: task-supplied env_vars may never set these — credentials (which the
-# task could redirect to an attacker endpoint or override with a stolen key) and
-# process loader / path vars (which could hijack the spawned CLI). Pinned by the
-# backend after the task env is applied.
-_PROTECTED_ENV_KEYS = frozenset(
-    {
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_AUTH_TOKEN",
-        "ANTHROPIC_BASE_URL",
-        "ANTHROPIC_API_URL",
-        "CLAUDE_CODE_ENTRYPOINT",
-        "PATH",
-        "LD_PRELOAD",
-        "LD_LIBRARY_PATH",
-        "DYLD_INSERT_LIBRARIES",
-        "PYTHONPATH",
-        "PYTHONSTARTUP",
-    }
-)
+# Security: task-supplied env_vars are semi-untrusted. They are sanitized via
+# ``safe_task_env`` (AUTOBOT_* allowlist + credential/loader/shell denylist) —
+# see services/execution/env_sanitizer.py — the AUTOBOT_* allowlist plus the
+# PROTECTED_ENV_KEYS / LD_*/DYLD_* denylist live there as the single source.
 
 # MCP server defaults (matches autobot_mcp_main.py HTTP transport)
 _DEFAULT_MCP_HOST = "127.0.0.1"
@@ -451,11 +437,11 @@ class ClaudeCodeBackend(ExecutionBackend):
         cmd.append("--")
         cmd.append(task.code)  # prompt is the task code/description (positional only)
 
-        # Security: task-supplied env_vars must NOT override credentials or the
-        # process loader/PATH (env-injection / credential-override). Apply the
-        # task env first (filtered), then pin the protected vars last so they win.
-        env = dict(os.environ)
-        env.update({k: v for k, v in task.env_vars.items() if k not in _PROTECTED_ENV_KEYS})
+        # Security: task-supplied env_vars are semi-untrusted. Start from the
+        # trusted parent env, then contribute ONLY allowlisted AUTOBOT_* task
+        # vars (hijack/credential vars rejected). Pin the credential last so it
+        # always wins over anything a task could set.
+        env = safe_task_env(os.environ, task.env_vars)
         env["ANTHROPIC_API_KEY"] = self._resolve_api_key() or ""
 
         try:

--- a/autobot-backend/services/execution/docker_backend.py
+++ b/autobot-backend/services/execution/docker_backend.py
@@ -42,6 +42,7 @@ from services.execution.base_backend import (
     ExecutionTask,
 )
 from services.execution.container_pool import ContainerPoolRegistry
+from services.execution.env_sanitizer import safe_task_env
 from services.execution.snapshot_index import (
     SnapshotIndex,
     SnapshotRecord,
@@ -208,7 +209,10 @@ class DockerBackend(ExecutionBackend):
             self._container_map[task.task_id] = container.id
 
             cmd = self._prepare_command(task)
-            env = {k: str(v) for k, v in (task.env_vars or {}).items()}
+            # Security: only allowlisted AUTOBOT_* task vars reach the
+            # container; hijack/credential vars are dropped. Container env is
+            # image-provided (empty base) so the task contributes nothing else.
+            env = {k: str(v) for k, v in safe_task_env({}, task.env_vars).items()}
 
             exec_result = await asyncio.to_thread(
                 container.exec_run,
@@ -271,7 +275,7 @@ class DockerBackend(ExecutionBackend):
                     detach=True,
                     mem_limit=f"{task.resource_limits.memory_mb}m",
                     cpus=task.resource_limits.cpu_cores,
-                    environment=task.env_vars,
+                    environment=safe_task_env({}, task.env_vars),
                     stdout=True,
                     stderr=True,
                     remove=False,

--- a/autobot-backend/services/execution/env_sanitizer.py
+++ b/autobot-backend/services/execution/env_sanitizer.py
@@ -1,0 +1,122 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Task environment-variable sanitizer for execution backends (security).
+
+Automated security review flagged ``claude_code_backend`` merging semi-untrusted
+``task.env_vars`` into the subprocess environment behind an *incomplete denylist*.
+An incomplete denylist lets a task inject language-runtime / loader / shell-startup
+hijack variables (``NODE_OPTIONS``, ``BASH_ENV``, ``LD_PRELOAD``, ``GIT_SSH_COMMAND``,
+``PERL5OPT`` ...) into the spawned process, yielding arbitrary code execution.
+
+Trust model
+-----------
+* ``base_env`` is the backend's OWN, TRUSTED environment (``os.environ``): PATH,
+  HOME, LANG, ANTHROPIC_* credentials, the language runtime. The subprocess
+  legitimately needs it, so it is passed through untouched.
+* ``task_env_vars`` is SEMI-UNTRUSTED (agent/task-generated). It is filtered with
+  an *allowlist* — only the application's own ``AUTOBOT_*`` task vars may be
+  contributed — plus a comprehensive *denylist* as defense-in-depth.
+
+This is the single shared implementation used by every execution backend so the
+policy can never drift between them.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Mapping
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+# Allowlist: only the application's own task variables may be contributed by a
+# task. Verified against the codebase — no production caller sets non-``AUTOBOT_``
+# execution-task env vars, so this does not over-restrict real usage.
+_ALLOWED_TASK_ENV_RE = re.compile(r"^AUTOBOT_[A-Z0-9_]+$")
+
+# Denylist (defense-in-depth): never contributable even if somehow allowlisted.
+# Credentials + process loader / interpreter / shell-startup hijack vectors.
+# Kept in sync with ``secure_command_executor._DANGEROUS_ENV_VARS``.
+PROTECTED_ENV_KEYS = frozenset(
+    {
+        # Anthropic / Claude Code credentials and endpoints
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_API_URL",
+        "CLAUDE_CODE_ENTRYPOINT",
+        # Path / executable resolution
+        "PATH",
+        # Python interpreter hijack
+        "PYTHONPATH",
+        "PYTHONSTARTUP",
+        # Node.js runtime hijack
+        "NODE_OPTIONS",
+        "NODE_PATH",
+        # Perl runtime hijack
+        "PERL5OPT",
+        "PERL5LIB",
+        # Ruby runtime hijack
+        "RUBYOPT",
+        "RUBYLIB",
+        # Git subprocess hijack
+        "GIT_SSH_COMMAND",
+        "GIT_EXEC_PATH",
+        # glibc / iconv loader hijack
+        "GCONV_PATH",
+        # Shell parsing / startup
+        "IFS",
+        "BASH_ENV",
+        "ENV",
+        "PROMPT_COMMAND",
+    }
+)
+
+# Any variable whose name starts with one of these prefixes is a dynamic-loader
+# hijack vector (there are many ``LD_*`` / ``DYLD_*`` variants beyond the common
+# three) and is always protected.
+_PROTECTED_ENV_PREFIXES = ("LD_", "DYLD_")
+
+
+def is_protected_env_key(key: str) -> bool:
+    """Return True if ``key`` is a credential / loader / shell-startup hijack var.
+
+    Covers the explicit :data:`PROTECTED_ENV_KEYS` denylist and the ``LD_*`` /
+    ``DYLD_*`` dynamic-loader prefix families.
+    """
+    return key in PROTECTED_ENV_KEYS or key.startswith(_PROTECTED_ENV_PREFIXES)
+
+
+def safe_task_env(
+    base_env: Mapping[str, str],
+    task_env_vars: Mapping[str, str] | None,
+) -> Dict[str, str]:
+    """Merge trusted ``base_env`` with allowlisted, denylist-filtered task vars.
+
+    Args:
+        base_env: The backend's own trusted environment (``os.environ``). Passed
+            through untouched — the subprocess needs PATH/HOME/credentials/runtime.
+        task_env_vars: Semi-untrusted task-supplied variables.
+
+    Returns:
+        A new dict: ``base_env`` plus only those task vars that match the
+        ``AUTOBOT_*`` allowlist AND are not on the protected denylist.
+    """
+    env: Dict[str, str] = dict(base_env)
+    dropped: list[str] = []
+    for key, value in (task_env_vars or {}).items():
+        if is_protected_env_key(key) or not _ALLOWED_TASK_ENV_RE.match(key):
+            dropped.append(key)
+            continue
+        env[key] = value
+    if dropped:
+        # Log dropped KEY names only — never their values.
+        logger.warning(
+            "Dropped %d task env var(s) not on the AUTOBOT_* allowlist: %s",
+            len(dropped),
+            ", ".join(sorted(dropped)),
+        )
+    return env

--- a/autobot-backend/services/execution/local_backend.py
+++ b/autobot-backend/services/execution/local_backend.py
@@ -23,6 +23,7 @@ from services.execution.base_backend import (
     ExecutionStatus,
     ExecutionTask,
 )
+from services.execution.env_sanitizer import safe_task_env
 
 logger = get_logger(__name__)
 
@@ -58,9 +59,9 @@ class LocalBackend(ExecutionBackend):
         )
 
         try:
-            # Prepare environment
-            env = os.environ.copy()
-            env.update(task.env_vars)
+            # Security: sanitize semi-untrusted task env vars (AUTOBOT_*
+            # allowlist + hijack/credential denylist) over the trusted parent env.
+            env = safe_task_env(os.environ, task.env_vars)
 
             # Prepare command based on language
             cmd = self._prepare_command(task, env)

--- a/autobot-backend/services/execution/modal_backend.py
+++ b/autobot-backend/services/execution/modal_backend.py
@@ -26,6 +26,7 @@ from services.execution.base_backend import (
     ExecutionStatus,
     ExecutionTask,
 )
+from services.execution.env_sanitizer import safe_task_env
 
 logger = get_logger(__name__)
 
@@ -198,9 +199,11 @@ class ModalBackend(ExecutionBackend):
 
             try:
                 with redirect_stdout(stdout_capture), redirect_stderr(stderr_capture):
-                    # Execute code in isolated namespace
-                    namespace = {"__name__": "__modal__"}
-                    namespace.update(task.env_vars)
+                    # Execute code in isolated namespace. Security: task env
+                    # vars become exec() globals, so filter them through the
+                    # same AUTOBOT_* allowlist to block runtime/loader hijack
+                    # names leaking into the executed code namespace.
+                    namespace = safe_task_env({"__name__": "__modal__"}, task.env_vars)
 
                     exec(task.code, namespace)  # nosec B102
 

--- a/autobot-backend/tests/test_claude_code_backend.py
+++ b/autobot-backend/tests/test_claude_code_backend.py
@@ -434,10 +434,20 @@ def _make_mock_proc(lines: list[str]) -> MagicMock:
 
 def test_protected_env_keys_block_credential_override():
     """task.env_vars must NOT override ANTHROPIC_API_KEY / loader / PATH vars."""
-    from services.execution.claude_code_backend import _PROTECTED_ENV_KEYS
+    from services.execution.env_sanitizer import is_protected_env_key
 
-    for key in ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "PATH", "LD_PRELOAD", "PYTHONPATH"):
-        assert key in _PROTECTED_ENV_KEYS
+    for key in (
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_BASE_URL",
+        "PATH",
+        "LD_PRELOAD",
+        "PYTHONPATH",
+        "NODE_OPTIONS",
+        "BASH_ENV",
+        "GIT_SSH_COMMAND",
+        "DYLD_INSERT_LIBRARIES",
+    ):
+        assert is_protected_env_key(key)
 
 
 def test_prompt_cannot_inject_a_flag():

--- a/autobot-backend/tests/test_env_sanitizer.py
+++ b/autobot-backend/tests/test_env_sanitizer.py
@@ -1,0 +1,99 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the execution env-var sanitizer (subprocess env-injection fix).
+
+Verifies the AUTOBOT_* allowlist + credential/loader/shell denylist and that every
+execution backend routes task env vars through the shared ``safe_task_env`` helper.
+"""
+
+from services.execution.env_sanitizer import (
+    PROTECTED_ENV_KEYS,
+    is_protected_env_key,
+    safe_task_env,
+)
+
+
+def test_preserves_base_env():
+    base = {"PATH": "/usr/bin", "HOME": "/home/x", "ANTHROPIC_API_KEY": "secret"}
+    result = safe_task_env(base, {})
+    assert result == base
+    # A new dict is returned; the base is not mutated.
+    result["AUTOBOT_X"] = "1"
+    assert "AUTOBOT_X" not in base
+
+
+def test_keeps_allowlisted_autobot_var():
+    result = safe_task_env({"PATH": "/usr/bin"}, {"AUTOBOT_TASK_ID": "t-42"})
+    assert result["AUTOBOT_TASK_ID"] == "t-42"
+    assert result["PATH"] == "/usr/bin"
+
+
+def test_drops_runtime_hijack_vars():
+    hijack = {
+        "NODE_OPTIONS": "--require /tmp/evil.js",
+        "BASH_ENV": "/tmp/evil.sh",
+        "GIT_SSH_COMMAND": "sh -c evil",
+        "PERL5OPT": "-Mevil",
+        "RUBYOPT": "-revil",
+        "GCONV_PATH": "/tmp/evil",
+        "IFS": " ",
+    }
+    result = safe_task_env({"PATH": "/usr/bin"}, hijack)
+    for key in hijack:
+        assert key not in result
+    assert result == {"PATH": "/usr/bin"}
+
+
+def test_drops_ld_and_dyld_prefix_variants():
+    # Not just LD_PRELOAD — ANY LD_*/DYLD_* variant must be rejected.
+    for key in ("LD_PRELOAD", "LD_AUDIT", "LD_LIBRARY_PATH", "DYLD_INSERT_LIBRARIES", "DYLD_FRAMEWORK_PATH"):
+        assert is_protected_env_key(key)
+        result = safe_task_env({}, {key: "/tmp/evil"})
+        assert key not in result
+
+
+def test_drops_random_non_allowlisted_key():
+    result = safe_task_env({}, {"TEST_VAR": "x", "FOO": "y", "MY_SECRET": "z"})
+    assert result == {}
+
+
+def test_denylist_covers_all_expected_hijack_vars():
+    for key in (
+        "NODE_OPTIONS",
+        "NODE_PATH",
+        "BASH_ENV",
+        "ENV",
+        "PERL5OPT",
+        "PERL5LIB",
+        "RUBYOPT",
+        "RUBYLIB",
+        "GIT_SSH_COMMAND",
+        "GIT_EXEC_PATH",
+        "GCONV_PATH",
+        "IFS",
+        "ANTHROPIC_API_KEY",
+        "PATH",
+        "PYTHONPATH",
+    ):
+        assert key in PROTECTED_ENV_KEYS
+
+
+def test_protected_autobot_named_hijack_still_dropped():
+    # Defense-in-depth: even if a hijack var were AUTOBOT_-shaped it stays blocked
+    # via the denylist. (LD_ prefix beats the allowlist regardless.)
+    assert is_protected_env_key("LD_PRELOAD")
+    assert not is_protected_env_key("AUTOBOT_MODEL")
+
+
+def test_backends_use_safe_task_env():
+    """Each backend's env-building path must reference the shared sanitizer."""
+    import services.execution.claude_code_backend as ccb
+    import services.execution.docker_backend as db
+    import services.execution.local_backend as lb
+    import services.execution.modal_backend as mb
+
+    for mod in (ccb, db, lb, mb):
+        src = open(mod.__file__, encoding="utf-8").read()
+        assert "safe_task_env" in src, f"{mod.__name__} does not use safe_task_env"

--- a/autobot-backend/tests/test_execution_backends.py
+++ b/autobot-backend/tests/test_execution_backends.py
@@ -176,14 +176,14 @@ class TestLocalBackend:
         assert "timeout" in result.stderr.lower()
 
     async def test_execute_with_env_vars(self):
-        """Test environment variable injection."""
+        """Allowlisted AUTOBOT_* task env vars reach the subprocess."""
         backend = LocalBackend()
 
         task = ExecutionTask(
             task_id="local-5",
-            code="echo $TEST_VAR",
+            code="echo $AUTOBOT_TEST_VAR",
             language="bash",
-            env_vars={"TEST_VAR": "test-value"},
+            env_vars={"AUTOBOT_TEST_VAR": "test-value"},
             timeout_seconds=10,
         )
 
@@ -191,6 +191,23 @@ class TestLocalBackend:
 
         assert result.status == ExecutionStatus.SUCCESS
         assert "test-value" in result.stdout
+
+    async def test_execute_drops_non_allowlisted_env_var(self):
+        """A non-AUTOBOT_ task env var is dropped and never reaches the subprocess."""
+        backend = LocalBackend()
+
+        task = ExecutionTask(
+            task_id="local-5b",
+            code="echo [$TEST_VAR]",
+            language="bash",
+            env_vars={"TEST_VAR": "leak"},
+            timeout_seconds=10,
+        )
+
+        result = await backend.execute(task)
+
+        assert result.status == ExecutionStatus.SUCCESS
+        assert "leak" not in result.stdout
 
     async def test_health_check(self):
         """Test backend health check."""


### PR DESCRIPTION
## Thinking Path
Automated security review flagged MEDIUM env-var injection in `claude_code_backend.py` (incomplete denylist). Audit found the same class in local/modal/docker backends — they merged `task.env_vars` with **no filtering at all**. `task.env_vars` is semi-untrusted (agent/task-generated); the parent `os.environ` is the backend's trusted env.

## What Changed
New shared `services/execution/env_sanitizer.py` `safe_task_env(base_env, task_env_vars)`:
- **Allowlist**: task vars accepted only if key matches `^AUTOBOT_[A-Z0-9_]+$` (the app's own namespace). Verified repo-wide: **zero** production callers set non-AUTOBOT task env vars, so nothing legit is over-restricted. Base (trusted) env untouched.
- **Defense-in-depth denylist** (`PROTECTED_ENV_KEYS` + `is_protected_env_key`): NODE_OPTIONS/NODE_PATH/BASH_ENV/ENV/PERL5OPT/PERL5LIB/RUBYOPT/RUBYLIB/GIT_SSH_COMMAND/GIT_EXEC_PATH/GCONV_PATH/IFS/PROMPT_COMMAND + any `LD_*`/`DYLD_*` prefix + ANTHROPIC_*/PATH/PYTHON*.
- Applied to **all 4 backends**: claude_code (ANTHROPIC_API_KEY still pinned last), local, modal (exec-globals namespace), docker (2 sites; base `{}` for the container boundary). ssh doesn't use env_vars. Dropped keys logged at WARNING (never values).

## Verification
- **Verified locally**: test_env_sanitizer.py 8/8; full suite test_execution_backends + test_claude_code_backend + sanitizer = 87 passed, 2 skipped. Real-subprocess test confirms allowlisted var passes + parent PATH/HOME preserved. py_compile + flake8 + black clean.

## Model Used
Opus 4.8

Closes #11001. Discoveries: modal exec()-globals injection surface (deeper #nosec-B102 concern) + secure_command_executor has a parallel denylist (consolidation opportunity) — follow-ups.