### PR TITLE
perf(reliability): fast-fail Redis guard in RetrievalLearner to avoid hot-path hang (#10980)

### DIFF
--- a/autobot-backend/knowledge/search_components/retrieval_learner.py
+++ b/autobot-backend/knowledge/search_components/retrieval_learner.py
@@ -19,9 +19,11 @@ rag:retrieval_patterns:__global__:{pattern_hash} HASH   — global fallback patt
 rag:rl:cursors                                   HASH   — last processed stream ID per key
 """
 
+import asyncio
 import hashlib
 import json
 import math
+import os
 import threading
 import time
 from dataclasses import dataclass, field
@@ -29,6 +31,7 @@ from datetime import datetime, timezone
 from typing import Dict, List, Tuple
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
 from constants.ttl_constants import TTL_30_DAYS
 
@@ -54,6 +57,12 @@ _CURSOR_HASH_KEY = "rag:rl:cursors"
 _PATTERN_KEY_PREFIX = "rag:retrieval_patterns:"
 # Sentinel used when no authenticated user is available (global/system scope).
 GLOBAL_USER = "__global__"
+
+# Maximum seconds to wait when acquiring an async Redis client.  Bounds the
+# tenacity retry loop inside get_redis_client so a Redis outage cannot hang the
+# hot routing/planning path.  Override via env var for staging environments that
+# tolerate a slower Redis start-up.
+_REDIS_ACQUIRE_TIMEOUT = float(os.getenv("AUTOBOT_RETRIEVAL_REDIS_TIMEOUT", "1.5"))
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +138,7 @@ class RetrievalLearner:
 
     def __init__(self, redis=None) -> None:
         self._redis = redis
+        self._redis_unavailable = False
         self._redis_lock = threading.Lock()
         self._cursors: Dict[str, str] = {}
         self._cursors_loaded = False
@@ -138,11 +148,35 @@ class RetrievalLearner:
     # ------------------------------------------------------------------
 
     async def _get_redis(self):
-        """Lazily obtain an async Redis client from the canonical factory."""
-        if self._redis is None:
-            from autobot_shared.redis_client import get_redis_client
+        """Lazily obtain an async Redis client with a bounded fast-fail guard.
 
-            self._redis = await get_redis_client(async_client=True, database="analytics")
+        If Redis was previously found to be unavailable (_redis_unavailable is
+        True) the method returns None immediately without retrying, so callers
+        on the hot routing/planning path are never blocked by a Redis outage.
+
+        When the client has not yet been acquired, the call to
+        get_redis_client() — which runs a tenacity retry loop — is wrapped in
+        asyncio.wait_for with a short timeout (_REDIS_ACQUIRE_TIMEOUT seconds).
+        On timeout or connection error the _redis_unavailable flag is set and
+        None is returned; the WARNING is logged only once per instance lifetime.
+        """
+        if self._redis_unavailable:
+            return None
+        if self._redis is not None:
+            return self._redis
+        try:
+            self._redis = await asyncio.wait_for(
+                get_redis_client(async_client=True, database="analytics"),
+                timeout=_REDIS_ACQUIRE_TIMEOUT,
+            )
+        except (asyncio.TimeoutError, Exception) as exc:
+            self._redis_unavailable = True
+            logger.warning(
+                "RetrievalLearner: Redis unavailable (%.1fs timeout) — degrading to no-op: %s",
+                _REDIS_ACQUIRE_TIMEOUT,
+                exc,
+            )
+            return None
         return self._redis
 
     # ------------------------------------------------------------------
@@ -155,6 +189,9 @@ class RetrievalLearner:
             return
         try:
             redis = await self._get_redis()
+            if redis is None:
+                self._cursors_loaded = True
+                return
             stored = await redis.hgetall(_CURSOR_HASH_KEY)
             if stored:
                 self._cursors.update(
@@ -175,6 +212,8 @@ class RetrievalLearner:
         """Persist a single cursor entry to Redis."""
         try:
             redis = await self._get_redis()
+            if redis is None:
+                return
             await redis.hset(_CURSOR_HASH_KEY, stream_key, cursor)
         except Exception as exc:
             logger.warning("RetrievalLearner: could not save cursor for %s: %s", stream_key, exc)
@@ -331,6 +370,8 @@ class RetrievalLearner:
 
         try:
             redis = await self._get_redis()
+            if redis is None:
+                return
             existing_raw = await redis.hgetall(redis_key)
 
             if existing_raw:
@@ -420,6 +461,8 @@ class RetrievalLearner:
 
         try:
             redis = await self._get_redis()
+            if redis is None:
+                return None
             qualifying: List[RetrievalPattern] = []
             for redis_key in candidates:
                 raw = await redis.hgetall(redis_key)
@@ -474,6 +517,8 @@ class RetrievalLearner:
         redis_key = f"{_PATTERN_KEY_PREFIX}{uid}:{pattern_hash}"
         try:
             redis = await self._get_redis()
+            if redis is None:
+                return
             raw = await redis.hgetall(redis_key)
             if not raw:
                 logger.debug("RetrievalLearner: no pattern found for %s", redis_key)
@@ -518,6 +563,9 @@ class RetrievalLearner:
             redis = await self._get_redis()
         except Exception as exc:
             logger.warning("RetrievalLearner: consolidate — redis unavailable: %s", exc)
+            return 0, 0
+
+        if redis is None:
             return 0, 0
 
         all_keys = await _scan_pattern_keys(redis, _PATTERN_KEY_PREFIX)

--- a/autobot-backend/tests/knowledge/search_components/retrieval_learner_fastfail_test.py
+++ b/autobot-backend/tests/knowledge/search_components/retrieval_learner_fastfail_test.py
@@ -21,8 +21,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from knowledge.search_components.retrieval_learner import (
-    RetrievalLearner,
     _REDIS_ACQUIRE_TIMEOUT,
+    RetrievalLearner,
 )
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/tests/knowledge/search_components/retrieval_learner_fastfail_test.py
+++ b/autobot-backend/tests/knowledge/search_components/retrieval_learner_fastfail_test.py
@@ -1,0 +1,244 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Fast-fail Redis guard tests for RetrievalLearner (#10980).
+
+Verifies three guarantees:
+(a) _get_redis() returns None quickly (within the timeout) when get_redis_client
+    hangs or raises, and sets _redis_unavailable.
+(b) Hot-path methods (consume_feedback_stream, get_matching_pattern,
+    record_pattern_outcome, consolidate) degrade to no-op / default return
+    values when Redis is unavailable — they never raise.
+(c) Once _redis_unavailable is cached, _get_redis() returns None WITHOUT
+    calling get_redis_client again (no retry on the second call).
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from knowledge.search_components.retrieval_learner import (
+    RetrievalLearner,
+    _REDIS_ACQUIRE_TIMEOUT,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_learner_no_redis() -> RetrievalLearner:
+    """Return a fresh learner with no pre-injected Redis client."""
+    learner = RetrievalLearner()
+    learner._cursors_loaded = True  # skip cursor-load I/O in tests
+    return learner
+
+
+# ---------------------------------------------------------------------------
+# (a) _get_redis() fast-fail: returns None quickly on hang / error
+# ---------------------------------------------------------------------------
+
+
+class TestGetRedisFastFail:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_get_redis_client_hangs(self):
+        """_get_redis() must complete within the timeout even if the factory hangs.
+
+        We mock get_redis_client to sleep for 10 s (far exceeding the 1.5 s
+        default), wrap the call itself in a tight outer asyncio.wait_for so the
+        test cannot block CI, and assert the result is None.
+        """
+        learner = _make_learner_no_redis()
+
+        async def _hang(*args, **kwargs):
+            await asyncio.sleep(10)
+
+        with patch(
+            "knowledge.search_components.retrieval_learner.get_redis_client",
+            new=_hang,
+        ):
+            # Allow up to (timeout + 0.5 s) for the call to complete.
+            result = await asyncio.wait_for(
+                learner._get_redis(),
+                timeout=_REDIS_ACQUIRE_TIMEOUT + 0.5,
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_sets_redis_unavailable_on_hang(self):
+        """After a hang, _redis_unavailable must be True."""
+        learner = _make_learner_no_redis()
+
+        async def _hang(*args, **kwargs):
+            await asyncio.sleep(10)
+
+        with patch(
+            "knowledge.search_components.retrieval_learner.get_redis_client",
+            new=_hang,
+        ):
+            await asyncio.wait_for(
+                learner._get_redis(),
+                timeout=_REDIS_ACQUIRE_TIMEOUT + 0.5,
+            )
+
+        assert learner._redis_unavailable is True
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_get_redis_client_raises(self):
+        """_get_redis() returns None (does not raise) when the factory raises."""
+        learner = _make_learner_no_redis()
+
+        async def _raise(*args, **kwargs):
+            raise ConnectionRefusedError("Redis is down")
+
+        with patch(
+            "knowledge.search_components.retrieval_learner.get_redis_client",
+            new=_raise,
+        ):
+            result = await learner._get_redis()
+
+        assert result is None
+        assert learner._redis_unavailable is True
+
+    @pytest.mark.asyncio
+    async def test_returns_injected_redis_immediately(self):
+        """When a Redis client was injected at construction, _get_redis() returns it
+        without ever calling get_redis_client (no I/O on the hot path)."""
+        mock_redis = MagicMock()
+        learner = RetrievalLearner(redis=mock_redis)
+
+        with patch(
+            "knowledge.search_components.retrieval_learner.get_redis_client",
+            side_effect=AssertionError("should not be called"),
+        ):
+            result = await learner._get_redis()
+
+        assert result is mock_redis
+
+
+# ---------------------------------------------------------------------------
+# (b) Hot-path methods degrade to no-op when Redis is unavailable
+# ---------------------------------------------------------------------------
+
+
+class TestNoOpDegradationWhenUnavailable:
+    def _make_unavailable_learner(self) -> RetrievalLearner:
+        """Return a learner whose Redis is pre-marked unavailable."""
+        learner = _make_learner_no_redis()
+        learner._redis_unavailable = True
+        return learner
+
+    @pytest.mark.asyncio
+    async def test_consume_feedback_stream_returns_zero(self):
+        """consume_feedback_stream() returns 0 without raising when Redis is out."""
+        learner = self._make_unavailable_learner()
+        result = await learner.consume_feedback_stream("2026-01-01")
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_get_matching_pattern_returns_none(self):
+        """get_matching_pattern() returns None without raising when Redis is out."""
+        learner = self._make_unavailable_learner()
+        result = await learner.get_matching_pattern("any query", complexity="simple")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_record_pattern_outcome_noop(self):
+        """record_pattern_outcome() returns None without raising when Redis is out."""
+        learner = self._make_unavailable_learner()
+        # Must not raise — return value is None (no explicit return).
+        result = await learner.record_pattern_outcome("somehash", success=True)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_consolidate_returns_zero_counts(self):
+        """consolidate() returns (0, 0) without raising when Redis is out."""
+        learner = self._make_unavailable_learner()
+        deduped, pruned = await learner.consolidate()
+        assert deduped == 0
+        assert pruned == 0
+
+    @pytest.mark.asyncio
+    async def test_distil_pattern_noop(self):
+        """_distil_pattern() returns without raising when Redis is out."""
+        learner = self._make_unavailable_learner()
+        result = await learner._distil_pattern("simple", [], {})
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_load_cursors_marks_loaded_and_noop(self):
+        """_load_cursors() marks _cursors_loaded=True and returns without raising."""
+        learner = self._make_unavailable_learner()
+        learner._cursors_loaded = False
+        await learner._load_cursors()
+        assert learner._cursors_loaded is True
+
+    @pytest.mark.asyncio
+    async def test_save_cursor_noop(self):
+        """_save_cursor() returns without raising when Redis is out."""
+        learner = self._make_unavailable_learner()
+        result = await learner._save_cursor("rag:feedback:__global__:2026-01-01", "100-0")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# (c) Once cached, _redis_unavailable short-circuits without re-calling factory
+# ---------------------------------------------------------------------------
+
+
+class TestUnavailableCaching:
+    @pytest.mark.asyncio
+    async def test_get_redis_does_not_retry_after_unavailable_set(self):
+        """_get_redis() must not call get_redis_client a second time after the
+        flag is set — the cached None is returned immediately."""
+        learner = _make_learner_no_redis()
+        call_count = 0
+
+        async def _raise(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise ConnectionRefusedError("Redis is down")
+
+        with patch(
+            "knowledge.search_components.retrieval_learner.get_redis_client",
+            new=_raise,
+        ):
+            # First call: triggers the factory, sets flag, returns None.
+            r1 = await learner._get_redis()
+            # Second call: flag is set, must return None without touching factory.
+            r2 = await learner._get_redis()
+
+        assert r1 is None
+        assert r2 is None
+        # Factory must have been called exactly once.
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_unavailable_flag_set_before_first_call_prevents_factory(self):
+        """When _redis_unavailable is pre-set, get_redis_client is never called."""
+        learner = _make_learner_no_redis()
+        learner._redis_unavailable = True
+
+        with patch(
+            "knowledge.search_components.retrieval_learner.get_redis_client",
+            side_effect=AssertionError("should not be called"),
+        ):
+            result = await learner._get_redis()
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Env-var timeout constant is present and positive
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutConstant:
+    def test_redis_acquire_timeout_is_positive(self):
+        """_REDIS_ACQUIRE_TIMEOUT must be a positive float (env-backed constant)."""
+        assert isinstance(_REDIS_ACQUIRE_TIMEOUT, float)
+        assert _REDIS_ACQUIRE_TIMEOUT > 0


### PR DESCRIPTION
## Thinking Path
`RetrievalLearner._get_redis()` called `get_redis_client(async_client=True)` which runs tenacity retry (5 attempts + backoff) → **hangs when Redis is unavailable**. RetrievalLearner fires on the routing/planning hot path (#10545 feedback hooks), so a Redis outage would stall it. Masked in tests (mock redis injected).

## What Changed (retrieval_learner.py — resilience only, learning logic untouched)
- `_REDIS_ACQUIRE_TIMEOUT = float(os.getenv("AUTOBOT_RETRIEVAL_REDIS_TIMEOUT", "1.5"))` (env-backed, no magic number).
- `_get_redis()`: returns None immediately if `_redis_unavailable` is cached; else wraps `get_redis_client(...)` in `asyncio.wait_for(timeout=...)`; on timeout/error sets `_redis_unavailable`, logs WARNING once, returns None (no re-raise).
- **All 7 callers degrade to no-op** per their return contract when redis is None (cursor load/save → void; consume_feedback_stream → 0; _distil_pattern/record_pattern_outcome → void; get_matching_pattern → None; consolidate → (0,0)).
- Moved `get_redis_client` import to module top-level (patchability + codebase consistency).

## Verification
- **Verified locally**: 14 new fast-fail tests (hang→None within timeout; exception→None+flag; caching = factory called once; each of 7 callers no-ops; env constant) + 60 existing retrieval_learner tests all pass. py_compile + flake8 -F + black clean.

## Model Used
Opus 4.8

Closes #10980. Mirrors the #10545 fast-fail pattern.