### PR TITLE
Content Reach Tasks 2–6: five content sources + BrowserBackend + bootstrap (#10932)

### DIFF
--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,0 +1,32 @@
+# Content Reach Sources (#10932, Tasks 2-6) — SDD Progress
+Plan: docs/superpowers/plans/2026-07-05-content-reach-sources.md
+BASE (pre-S0): e767cbfc58b07f316cfc18281ee610eeefb7fac7
+Branch: issue-10932-sources → PR to Dev_new_gui (NOT local merge — auto-sync pushes main tree)
+REMINDER: run `black --check` on all files (ruff != Black) before PR.
+
+## Tasks
+- S0 deps + BrowserBackend: complete (96fc088, review clean, 3 minor/polish)
+- S1 web_search: complete (abab3d7, review approved, 4 minor → consolidated cleanup)
+- S1 web_search: pending
+- S2 web_page: pending
+- S3 youtube: pending
+- S4 reddit/HN: pending
+- S5 social: pending
+- S6 bootstrap: pending
+- [Minor][S0] browser.py:64 `pragma: no cover` on _get_manager hides lazy-import from coverage; consider a smoke test in Task 7 wiring.
+- [Minor][S0] test_browser.py match="url" is broad; tighten in a cleanup pass.
+- [Minor][S1→cleanup] web_search.py: logger declared but unused — add logger.warning on ddgs-absent + logger.debug on empty results.
+- [Minor][S1→cleanup] web_search.py:95 fetch() leaks ImportError if ddgs absent & DDGS unpatched — guard lazy import → BackendError.
+- [Minor][S1→cleanup] Jina: Accept:application/json but consumes response.text; add header assertion in test.
+- S2 web_page: complete (f12ec1a, hardening applied)
+- S2 web_page: complete (f12ec1a, approved)
+- [Cleanup][S1/S2/S4] wrap httpx client.get() in try/except httpx.HTTPError -> BackendError across all HTTP backends (registry falls through anyway, but BackendError is the contract type).
+- [Cleanup][S1/S2/S3] use pytest.importorskip for "probe true when importable" tests (optional libs may be absent in CI image).
+- S3 youtube: complete (f7afe54)
+- S3 youtube: complete (f7afe54 + e9ea713 srv1 fix, re-review clean)
+- [Minor][S3→cleanup] _vtt_to_text docstring still mentions SRV1 (stale, cosmetic).
+- S4 reddit/HN: complete (069898e + 19d668b async/https/enum fix, re-review clean)
+- [Minor][S1/S2/S4→cleanup] injected-client vs async-with branching repeats across httpx backends — extract a small `_http_get` helper (DRY).
+- S5 social: complete (50cb48a, approved no issues)
+- S6 bootstrap: complete (a188e34, approved no issues). ALL S0-S6 DONE.
+- S1-S3 cleanup pass: complete. Changes: logger.warning in DdgsBackend.probe() + logger.debug before empty-results BackendError; ImportError guard in DdgsBackend.fetch() → BackendError; httpx.HTTPError wrapping in JinaSearchBackend.fetch(), TrafilaturaBackend.fetch(), JinaReaderBackend.fetch(); _vtt_to_text docstring cleaned (removed stale SRV1 reference); pytest.importorskip added to ddgs and trafilatura "probe true" tests; Accept header assertion added to JinaSearchBackend test; httpx.HTTPError → BackendError tests added for all three backends. Suite: 84 passed (was 80). ruff + black clean.

--- a/autobot-backend/content_reach/backends/__init__.py
+++ b/autobot-backend/content_reach/backends/__init__.py
@@ -1,0 +1,9 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shared content-reach backends (browser, etc.) used by multiple source chains."""
+
+from content_reach.backends.browser import BrowserBackend, BrowserSearchBackend
+
+__all__ = ["BrowserBackend", "BrowserSearchBackend"]

--- a/autobot-backend/content_reach/backends/browser.py
+++ b/autobot-backend/content_reach/backends/browser.py
@@ -1,0 +1,113 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shared browser-backed content backend using research_browser_manager (#10932).
+
+BrowserBackend wraps get_research_browser_manager().research_url() and maps its
+dict return to ContentResult.  Playwright availability is checked lazily (inside
+each method) so importing this module never loads the playwright stack.
+
+BrowserSearchBackend extends BrowserBackend for query→search: it builds a
+DuckDuckGo HTML search URL from the request query, then delegates to the browser
+for navigation and content extraction.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import quote_plus
+
+from autobot_shared.logging_manager import get_logger
+from content_reach.base import BackendError, ContentBackend, ContentRequest, ContentResult
+from source_attribution import SourceReliability, SourceType
+
+logger = get_logger(__name__)
+
+_DDG_SEARCH_URL = "https://duckduckgo.com/html/?q={}"
+
+
+def _get_manager():  # pragma: no cover — replaced by monkeypatch in tests
+    """Lazy accessor for the research browser manager (avoids import at module load)."""
+    from research_browser_manager import get_research_browser_manager
+
+    return get_research_browser_manager()
+
+
+class BrowserBackend(ContentBackend):
+    """Content backend that uses the Playwright-based research browser manager.
+
+    probe() returns PLAYWRIGHT_AVAILABLE — imported lazily to avoid loading the
+    playwright stack at module import time.
+    """
+
+    def __init__(
+        self,
+        source_type: SourceType,
+        name: str = "browser",
+    ) -> None:
+        self.source_type = source_type
+        self.name = name
+
+    async def probe(self) -> bool:
+        """Return True iff Playwright is available in this environment."""
+        import research_browser_manager as rbm
+
+        return rbm.PLAYWRIGHT_AVAILABLE
+
+    async def fetch(self, request: ContentRequest) -> ContentResult:
+        """Navigate to request.url and return extracted content.
+
+        Raises BackendError if request.url is empty or the browser fetch fails.
+        """
+        if not request.url:
+            raise BackendError("BrowserBackend requires a non-empty url on the request")
+
+        manager = _get_manager()
+        result = await manager.research_url(
+            request.conversation_id,
+            request.url,
+            extract_content=True,
+        )
+
+        if not result.get("success"):
+            raise BackendError(f"BrowserBackend: research_url returned success=False for {request.url!r}")
+
+        content = result.get("content") or {}
+        text = content.get("text_content", "")
+        structured = content.get("structured_data") or {}
+
+        return ContentResult(
+            success=True,
+            source_type=self.source_type,
+            backend_used=self.name,
+            text=text,
+            structured=structured,
+            url=request.url,
+            reliability=SourceReliability.MEDIUM,
+            metadata={"title": result.get("title", "")},
+        )
+
+
+class BrowserSearchBackend(BrowserBackend):
+    """Browser backend for query-to-search: builds a DDG HTML search URL then delegates.
+
+    Encodes request.query into a DuckDuckGo HTML search URL and passes it to the
+    parent BrowserBackend.fetch() so the browser navigates to the results page and
+    extracts content.
+    """
+
+    def __init__(self, source_type: SourceType) -> None:
+        super().__init__(source_type=source_type, name="browser_search")
+
+    async def fetch(self, request: ContentRequest) -> ContentResult:
+        """Build a DDG search URL from request.query and fetch via browser."""
+        search_url = _DDG_SEARCH_URL.format(quote_plus(request.query))
+        search_request = ContentRequest(
+            query=request.query,
+            url=search_url,
+            source=request.source,
+            limit=request.limit,
+            conversation_id=request.conversation_id,
+            options=request.options,
+        )
+        return await super().fetch(search_request)

--- a/autobot-backend/content_reach/bootstrap.py
+++ b/autobot-backend/content_reach/bootstrap.py
@@ -1,0 +1,39 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Bootstrap assembler — registers all five default content-source chains (#10932)."""
+
+from __future__ import annotations
+
+from autobot_shared.logging_manager import get_logger
+from content_reach.registry import ContentSourceRegistry
+from content_reach.sources.reddit import build_reddit_chain
+from content_reach.sources.social import build_social_chain
+from content_reach.sources.web_page import build_web_page_chain
+from content_reach.sources.web_search import build_web_search_chain
+from content_reach.sources.youtube import build_youtube_chain
+
+logger = get_logger(__name__)
+
+_DEFAULT_CHAIN_FACTORIES = [
+    build_web_search_chain,
+    build_web_page_chain,
+    build_youtube_chain,
+    build_reddit_chain,
+    build_social_chain,
+]
+
+
+def register_default_sources(registry: ContentSourceRegistry) -> None:
+    """Register all five default content-source chains into *registry*."""
+    for factory in _DEFAULT_CHAIN_FACTORIES:
+        registry.register_chain(factory())
+    logger.info("content_reach: registered %d default sources", len(_DEFAULT_CHAIN_FACTORIES))
+
+
+def build_default_registry() -> ContentSourceRegistry:
+    """Return a fresh ContentSourceRegistry pre-loaded with all default sources."""
+    registry = ContentSourceRegistry()
+    register_default_sources(registry)
+    return registry

--- a/autobot-backend/content_reach/sources/__init__.py
+++ b/autobot-backend/content_reach/sources/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Content source factories for the Content Reach system (#10932)."""

--- a/autobot-backend/content_reach/sources/reddit.py
+++ b/autobot-backend/content_reach/sources/reddit.py
@@ -37,13 +37,15 @@ class RedditJsonBackend(ContentBackend):
     probe() always returns True — liveness validated at fetch-time via circuit breaker.
     fetch() uses request.url (appending .json) when a reddit.com URL is provided,
     otherwise falls back to the Reddit search endpoint using request.query.
+
+    Accepts an optional injected httpx.AsyncClient for testing.
     """
 
     name = "reddit_json"
     source_type = SourceType.REDDIT
 
-    def __init__(self, client: httpx.Client | None = None) -> None:
-        self._client = client or httpx.Client(timeout=_HTTP_TIMEOUT)
+    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+        self._client = client
 
     async def probe(self) -> bool:
         """Always return True — liveness validated at fetch-time via circuit breaker."""
@@ -56,17 +58,29 @@ class RedditJsonBackend(ContentBackend):
         if request.url and "reddit.com" in request.url:
             url = request.url if request.url.endswith(".json") else request.url + ".json"
             try:
-                response = self._client.get(url, headers=headers)
+                if self._client is not None:
+                    response = await self._client.get(url, headers=headers)
+                else:
+                    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+                        response = await client.get(url, headers=headers)
             except httpx.HTTPError as exc:
                 logger.debug("RedditJsonBackend: HTTP error for %r: %s", url, exc)
                 raise BackendError(str(exc)) from exc
         else:
             try:
-                response = self._client.get(
-                    "https://www.reddit.com/search.json",
-                    params={"q": request.query, "limit": request.limit},
-                    headers=headers,
-                )
+                if self._client is not None:
+                    response = await self._client.get(
+                        "https://www.reddit.com/search.json",
+                        params={"q": request.query, "limit": request.limit},
+                        headers=headers,
+                    )
+                else:
+                    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+                        response = await client.get(
+                            "https://www.reddit.com/search.json",
+                            params={"q": request.query, "limit": request.limit},
+                            headers=headers,
+                        )
             except httpx.HTTPError as exc:
                 logger.debug("RedditJsonBackend: HTTP error for query %r: %s", request.query, exc)
                 raise BackendError(str(exc)) from exc
@@ -106,7 +120,7 @@ class RedditJsonBackend(ContentBackend):
             backend_used=self.name,
             text="\n".join(text_lines),
             structured={"posts": posts},
-            reliability=SourceReliability.COMMUNITY,
+            reliability=SourceReliability.MEDIUM,
         )
 
 
@@ -115,13 +129,15 @@ class HnAlgoliaBackend(ContentBackend):
 
     probe() always returns True — pure-HTTP backend, always capable.
     fetch() searches via hn.algolia.com and maps hits to ContentResult.
+
+    Accepts an optional injected httpx.AsyncClient for testing.
     """
 
     name = "hn_algolia"
     source_type = SourceType.REDDIT
 
-    def __init__(self, client: httpx.Client | None = None) -> None:
-        self._client = client or httpx.Client(timeout=_HTTP_TIMEOUT)
+    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+        self._client = client
 
     async def probe(self) -> bool:
         """Always return True — pure-HTTP backend, always capable."""
@@ -130,10 +146,17 @@ class HnAlgoliaBackend(ContentBackend):
     async def fetch(self, request: ContentRequest) -> ContentResult:
         """Fetch HN hits from Algolia; raise BackendError on failure."""
         try:
-            response = self._client.get(
-                "http://hn.algolia.com/api/v1/search",
-                params={"query": request.query},
-            )
+            if self._client is not None:
+                response = await self._client.get(
+                    "https://hn.algolia.com/api/v1/search",
+                    params={"query": request.query, "hitsPerPage": request.limit},
+                )
+            else:
+                async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+                    response = await client.get(
+                        "https://hn.algolia.com/api/v1/search",
+                        params={"query": request.query, "hitsPerPage": request.limit},
+                    )
         except httpx.HTTPError as exc:
             logger.debug("HnAlgoliaBackend: HTTP error for query %r: %s", request.query, exc)
             raise BackendError(str(exc)) from exc
@@ -169,7 +192,7 @@ class HnAlgoliaBackend(ContentBackend):
             backend_used=self.name,
             text="\n".join(text_lines),
             structured={"hits": hits},
-            reliability=SourceReliability.COMMUNITY,
+            reliability=SourceReliability.MEDIUM,
         )
 
 

--- a/autobot-backend/content_reach/sources/reddit.py
+++ b/autobot-backend/content_reach/sources/reddit.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2024 mrveiss. All rights reserved.
+# Unauthorized copying of this file, via any medium is strictly prohibited.
+# Proprietary and confidential.
+# Written by mrveiss.
+"""Reddit/HN content source: RedditJsonBackend → HnAlgoliaBackend → BrowserBackend (#10932).
+
+Chain priority:
+  1. RedditJsonBackend — Reddit public JSON API (no auth required)
+  2. HnAlgoliaBackend  — HN Algolia search API (https://hn.algolia.com/api/v1/search)
+  3. BrowserBackend    — Playwright-backed page fetch (browser required)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import httpx
+
+from content_reach.backends.browser import BrowserBackend
+from content_reach.base import BackendError, ContentBackend, ContentRequest, ContentResult
+from content_reach.chain import ContentSourceChain
+from source_attribution import SourceReliability, SourceType
+
+logger = logging.getLogger(__name__)
+
+# Module-level HTTP timeout constant (seconds).
+_HTTP_TIMEOUT = 15.0
+
+# Reddit API user-agent string.
+_USER_AGENT = "autobot-content-reach/1.0"
+
+
+class RedditJsonBackend(ContentBackend):
+    """Reddit content backend using the public Reddit JSON API.
+
+    probe() always returns True — liveness validated at fetch-time via circuit breaker.
+    fetch() uses request.url (appending .json) when a reddit.com URL is provided,
+    otherwise falls back to the Reddit search endpoint using request.query.
+    """
+
+    name = "reddit_json"
+    source_type = SourceType.REDDIT
+
+    def __init__(self, client: httpx.Client | None = None) -> None:
+        self._client = client or httpx.Client(timeout=_HTTP_TIMEOUT)
+
+    async def probe(self) -> bool:
+        """Always return True — liveness validated at fetch-time via circuit breaker."""
+        return True
+
+    async def fetch(self, request: ContentRequest) -> ContentResult:
+        """Fetch Reddit posts; raise BackendError on network, HTTP, or parse failure."""
+        headers = {"User-Agent": _USER_AGENT}
+
+        if request.url and "reddit.com" in request.url:
+            url = request.url if request.url.endswith(".json") else request.url + ".json"
+            try:
+                response = self._client.get(url, headers=headers)
+            except httpx.HTTPError as exc:
+                logger.debug("RedditJsonBackend: HTTP error for %r: %s", url, exc)
+                raise BackendError(str(exc)) from exc
+        else:
+            try:
+                response = self._client.get(
+                    "https://www.reddit.com/search.json",
+                    params={"q": request.query, "limit": request.limit},
+                    headers=headers,
+                )
+            except httpx.HTTPError as exc:
+                logger.debug("RedditJsonBackend: HTTP error for query %r: %s", request.query, exc)
+                raise BackendError(str(exc)) from exc
+
+        if response.status_code != 200:
+            logger.debug("RedditJsonBackend: HTTP %s", response.status_code)
+            raise BackendError(f"Reddit HTTP {response.status_code}")
+
+        try:
+            data = response.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            logger.debug("RedditJsonBackend: JSON decode error: %s", exc)
+            raise BackendError("Reddit: invalid JSON response") from exc
+
+        children = data.get("data", {}).get("children", [])
+        if not children:
+            raise BackendError("Reddit: no posts returned")
+
+        posts = []
+        text_lines = []
+        for child in children:
+            post_data = child.get("data", {})
+            title = str(post_data.get("title", ""))
+            selftext = str(post_data.get("selftext", ""))
+            permalink = str(post_data.get("permalink", ""))
+            if permalink and not permalink.startswith("http"):
+                permalink = "https://www.reddit.com" + permalink
+            posts.append({"title": title, "selftext": selftext, "permalink": permalink})
+            if selftext:
+                text_lines.append(f"{title}\n{selftext}")
+            else:
+                text_lines.append(title)
+
+        return ContentResult(
+            success=True,
+            source_type=SourceType.REDDIT,
+            backend_used=self.name,
+            text="\n".join(text_lines),
+            structured={"posts": posts},
+            reliability=SourceReliability.COMMUNITY,
+        )
+
+
+class HnAlgoliaBackend(ContentBackend):
+    """HN content backend using the Algolia search API for Hacker News.
+
+    probe() always returns True — pure-HTTP backend, always capable.
+    fetch() searches via hn.algolia.com and maps hits to ContentResult.
+    """
+
+    name = "hn_algolia"
+    source_type = SourceType.REDDIT
+
+    def __init__(self, client: httpx.Client | None = None) -> None:
+        self._client = client or httpx.Client(timeout=_HTTP_TIMEOUT)
+
+    async def probe(self) -> bool:
+        """Always return True — pure-HTTP backend, always capable."""
+        return True
+
+    async def fetch(self, request: ContentRequest) -> ContentResult:
+        """Fetch HN hits from Algolia; raise BackendError on failure."""
+        try:
+            response = self._client.get(
+                "http://hn.algolia.com/api/v1/search",
+                params={"query": request.query},
+            )
+        except httpx.HTTPError as exc:
+            logger.debug("HnAlgoliaBackend: HTTP error for query %r: %s", request.query, exc)
+            raise BackendError(str(exc)) from exc
+
+        if response.status_code != 200:
+            logger.debug("HnAlgoliaBackend: HTTP %s", response.status_code)
+            raise BackendError(f"HN Algolia HTTP {response.status_code}")
+
+        try:
+            data = response.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            logger.debug("HnAlgoliaBackend: JSON decode error: %s", exc)
+            raise BackendError("HN Algolia: invalid JSON response") from exc
+
+        raw_hits = data.get("hits", [])
+        if not raw_hits:
+            raise BackendError("HN Algolia: no hits returned")
+
+        hits = []
+        text_lines = []
+        for hit in raw_hits:
+            title = str(hit.get("story_title") or hit.get("title") or "")
+            object_id = str(hit.get("objectID", ""))
+            hn_url = f"https://news.ycombinator.com/item?id={object_id}"
+            url = hit.get("url") or hn_url
+            points = int(hit.get("points") or 0)
+            hits.append({"title": title, "url": url, "points": points, "hn_url": hn_url})
+            text_lines.append(f"{title} — {url}")
+
+        return ContentResult(
+            success=True,
+            source_type=SourceType.REDDIT,
+            backend_used=self.name,
+            text="\n".join(text_lines),
+            structured={"hits": hits},
+            reliability=SourceReliability.COMMUNITY,
+        )
+
+
+def build_reddit_chain() -> ContentSourceChain:
+    """Build the reddit/HN fallback chain: reddit_json → hn_algolia → browser."""
+    return ContentSourceChain(
+        source="reddit",
+        source_type=SourceType.REDDIT,
+        backends=[RedditJsonBackend(), HnAlgoliaBackend(), BrowserBackend(SourceType.REDDIT)],
+    )

--- a/autobot-backend/content_reach/sources/reddit.py
+++ b/autobot-backend/content_reach/sources/reddit.py
@@ -1,7 +1,7 @@
-# Copyright (c) 2024 mrveiss. All rights reserved.
-# Unauthorized copying of this file, via any medium is strictly prohibited.
-# Proprietary and confidential.
-# Written by mrveiss.
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
 """Reddit/HN content source: RedditJsonBackend → HnAlgoliaBackend → BrowserBackend (#10932).
 
 Chain priority:

--- a/autobot-backend/content_reach/sources/social.py
+++ b/autobot-backend/content_reach/sources/social.py
@@ -1,0 +1,26 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Browser-backed social content source (#10932).
+
+Social content (Twitter/X, Instagram, etc.) is fetched via the shared
+BrowserBackend — local-first, no cookies, Playwright-rendered page.
+No dedicated backend class is needed; BrowserBackend(SourceType.SOCIAL)
+carries the correct source_type through its constructor parameter.
+"""
+
+from __future__ import annotations
+
+from content_reach.backends.browser import BrowserBackend
+from content_reach.chain import ContentSourceChain
+from source_attribution import SourceType
+
+
+def build_social_chain() -> ContentSourceChain:
+    """Return the social content chain: a single BrowserBackend with SOCIAL source_type."""
+    return ContentSourceChain(
+        source="social",
+        source_type=SourceType.SOCIAL,
+        backends=[BrowserBackend(SourceType.SOCIAL)],
+    )

--- a/autobot-backend/content_reach/sources/web_page.py
+++ b/autobot-backend/content_reach/sources/web_page.py
@@ -1,0 +1,174 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Web-page content source: TrafilaturaBackend → JinaReaderBackend → BrowserBackend (#10932).
+
+Chain priority:
+  1. TrafilaturaBackend — HTML fetch via httpx + text extraction via trafilatura (sync, in asyncio.to_thread)
+  2. JinaReaderBackend  — GET https://r.jina.ai/<url> (pure httpx, always available)
+  3. BrowserBackend     — Playwright-backed page fetch (browser required)
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from autobot_shared.logging_manager import get_logger
+from content_reach.backends.browser import BrowserBackend
+from content_reach.base import BackendError, ContentBackend, ContentRequest, ContentResult
+from content_reach.chain import ContentSourceChain
+from source_attribution import SourceReliability, SourceType
+
+logger = get_logger(__name__)
+
+# Module-level HTTP timeout constant (seconds).
+_HTTP_TIMEOUT = 15.0
+
+# Jina Reader base URL.
+_JINA_READER_BASE = "https://r.jina.ai/"
+
+
+def _import_trafilatura():
+    """Lazy import of trafilatura; raises ImportError if not installed."""
+    import trafilatura as _trafilatura
+
+    return _trafilatura
+
+
+# Module-level monkeypatchable sync extractor (wraps trafilatura.extract).
+# Tests can patch this to bypass the real library without asyncio.to_thread.
+def _trafilatura_extract(html: str):
+    """Call trafilatura.extract on html; returns str|None."""
+    tf = _import_trafilatura()
+    return tf.extract(html)
+
+
+class TrafilaturaBackend(ContentBackend):
+    """Web-page backend using httpx to fetch HTML + trafilatura to extract text.
+
+    probe() returns True iff trafilatura is importable.
+    fetch() GETs the URL via httpx.AsyncClient, then calls trafilatura.extract
+    in asyncio.to_thread (trafilatura is sync). None/empty extraction → BackendError.
+
+    Accepts an optional injected httpx.AsyncClient for testing.
+    """
+
+    name = "trafilatura"
+    source_type = SourceType.WEB_PAGE
+
+    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+        self._client = client
+
+    async def probe(self) -> bool:
+        """Return True iff trafilatura is importable."""
+        try:
+            _import_trafilatura()
+            return True
+        except ImportError:
+            logger.warning("TrafilaturaBackend: trafilatura is not installed; backend unavailable")
+            return False
+
+    async def fetch(self, request: ContentRequest) -> ContentResult:
+        """GET request.url, extract text via trafilatura; raise BackendError on failure."""
+        try:
+            _import_trafilatura()
+        except ImportError:
+            raise BackendError("trafilatura not installed")
+
+        if self._client is not None:
+            response = await self._client.get(request.url)
+        else:
+            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+                response = await client.get(request.url)
+
+        html = response.text
+        text = await asyncio.to_thread(_trafilatura_extract, html)
+
+        if not text or not text.strip():
+            logger.debug(
+                "TrafilaturaBackend: empty extraction for %r (status=%s)",
+                request.url,
+                response.status_code,
+            )
+            raise BackendError(f"TrafilaturaBackend: no text extracted from {request.url!r}")
+
+        return ContentResult(
+            success=True,
+            source_type=self.source_type,
+            backend_used=self.name,
+            text=text,
+            structured={},
+            url=request.url,
+            reliability=SourceReliability.MEDIUM,
+        )
+
+
+class JinaReaderBackend(ContentBackend):
+    """Web-page backend via the Jina AI reader endpoint (https://r.jina.ai/).
+
+    probe() returns True — pure-HTTP backend, always capable.
+    fetch() GETs https://r.jina.ai/<url> with Accept: text/plain and returns
+    the response body. Non-200 or empty body → BackendError.
+
+    Accepts an optional injected httpx.AsyncClient for testing.
+    """
+
+    name = "jina_reader"
+    source_type = SourceType.WEB_PAGE
+
+    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+        self._client = client
+
+    async def probe(self) -> bool:
+        """Return True — Jina reader is a plain HTTP endpoint, always available."""
+        return True
+
+    async def fetch(self, request: ContentRequest) -> ContentResult:
+        """GET https://r.jina.ai/<url>; raise BackendError on non-200 or empty body."""
+        url = f"{_JINA_READER_BASE}{request.url}"
+        headers = {"Accept": "text/plain"}
+
+        if self._client is not None:
+            response = await self._client.get(url, headers=headers)
+        else:
+            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+                response = await client.get(url, headers=headers)
+
+        if response.status_code != 200:
+            logger.debug(
+                "JinaReaderBackend: HTTP %s for %r",
+                response.status_code,
+                request.url,
+            )
+            raise BackendError(f"JinaReaderBackend: HTTP {response.status_code} for {request.url!r}")
+
+        text = response.text.strip()
+        if not text:
+            logger.debug("JinaReaderBackend: empty response for %r", request.url)
+            raise BackendError(f"JinaReaderBackend: empty response for {request.url!r}")
+
+        return ContentResult(
+            success=True,
+            source_type=self.source_type,
+            backend_used=self.name,
+            text=text,
+            structured={},
+            url=request.url,
+            reliability=SourceReliability.MEDIUM,
+        )
+
+
+def build_web_page_chain() -> ContentSourceChain:
+    """Build the web-page fallback chain: trafilatura → jina_reader → browser."""
+    return ContentSourceChain(
+        source="web_page",
+        source_type=SourceType.WEB_PAGE,
+        backends=[
+            TrafilaturaBackend(),
+            JinaReaderBackend(),
+            BrowserBackend(SourceType.WEB_PAGE),
+        ],
+    )

--- a/autobot-backend/content_reach/sources/web_page.py
+++ b/autobot-backend/content_reach/sources/web_page.py
@@ -78,11 +78,14 @@ class TrafilaturaBackend(ContentBackend):
         except ImportError:
             raise BackendError("trafilatura not installed")
 
-        if self._client is not None:
-            response = await self._client.get(request.url)
-        else:
-            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-                response = await client.get(request.url)
+        try:
+            if self._client is not None:
+                response = await self._client.get(request.url)
+            else:
+                async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+                    response = await client.get(request.url)
+        except httpx.HTTPError as exc:
+            raise BackendError(f"TrafilaturaBackend: HTTP error fetching {request.url!r}: {exc}") from exc
 
         html = response.text
         text = await asyncio.to_thread(_trafilatura_extract, html)
@@ -131,11 +134,14 @@ class JinaReaderBackend(ContentBackend):
         url = f"{_JINA_READER_BASE}{request.url}"
         headers = {"Accept": "text/plain"}
 
-        if self._client is not None:
-            response = await self._client.get(url, headers=headers)
-        else:
-            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-                response = await client.get(url, headers=headers)
+        try:
+            if self._client is not None:
+                response = await self._client.get(url, headers=headers)
+            else:
+                async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+                    response = await client.get(url, headers=headers)
+        except httpx.HTTPError as exc:
+            raise BackendError(f"JinaReaderBackend: HTTP error fetching {request.url!r}: {exc}") from exc
 
         if response.status_code != 200:
             logger.debug(

--- a/autobot-backend/content_reach/sources/web_search.py
+++ b/autobot-backend/content_reach/sources/web_search.py
@@ -58,11 +58,18 @@ class DdgsBackend(ContentBackend):
             _import_ddgs()
             return True
         except ImportError:
+            logger.warning("ddgs not installed; DdgsBackend unavailable")
             return False
 
     async def fetch(self, request: ContentRequest) -> ContentResult:
         """Fetch web-search results via DDGS.text(); raise BackendError when empty."""
-        ddgs_cls = DDGS if DDGS is not None else _import_ddgs()
+        if DDGS is not None:
+            ddgs_cls = DDGS
+        else:
+            try:
+                ddgs_cls = _import_ddgs()
+            except ImportError:
+                raise BackendError("ddgs not installed")
 
         def _search():
             return ddgs_cls().text(request.query, max_results=request.limit)
@@ -70,6 +77,7 @@ class DdgsBackend(ContentBackend):
         raw_results: list[dict] = await asyncio.to_thread(_search)
 
         if not raw_results:
+            logger.debug("DdgsBackend: no results for %r", request.query)
             raise BackendError(f"DdgsBackend: no results for query {request.query!r}")
 
         text_lines = [f"{r.get('title', '')} — {r.get('href', '')}\n{r.get('body', '')}" for r in raw_results]
@@ -111,11 +119,14 @@ class JinaSearchBackend(ContentBackend):
         url = f"{_JINA_SEARCH_BASE}{encoded_query}"
         headers = {"Accept": "application/json"}
 
-        if self._client is not None:
-            response = await self._client.get(url, headers=headers)
-        else:
-            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-                response = await client.get(url, headers=headers)
+        try:
+            if self._client is not None:
+                response = await self._client.get(url, headers=headers)
+            else:
+                async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+                    response = await client.get(url, headers=headers)
+        except httpx.HTTPError as exc:
+            raise BackendError(f"JinaSearchBackend: HTTP error for query {request.query!r}: {exc}") from exc
 
         if response.status_code != 200:
             raise BackendError(f"JinaSearchBackend: HTTP {response.status_code} for query {request.query!r}")

--- a/autobot-backend/content_reach/sources/web_search.py
+++ b/autobot-backend/content_reach/sources/web_search.py
@@ -1,0 +1,148 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Web-search content source: DdgsBackend → JinaSearchBackend → BrowserSearchBackend (#10932).
+
+Chain priority:
+  1. DdgsBackend   — keyless web search via the ddgs library (sync, wrapped in asyncio.to_thread)
+  2. JinaSearchBackend — GET https://s.jina.ai/<query> (pure httpx, always available)
+  3. BrowserSearchBackend — Playwright-backed DuckDuckGo search (browser required)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from urllib.parse import quote_plus
+
+import httpx
+
+from autobot_shared.logging_manager import get_logger
+from content_reach.backends.browser import BrowserSearchBackend
+from content_reach.base import BackendError, ContentBackend, ContentRequest, ContentResult
+from content_reach.chain import ContentSourceChain
+from source_attribution import SourceReliability, SourceType
+
+logger = get_logger(__name__)
+
+# Module-level HTTP timeout constant (seconds).
+_HTTP_TIMEOUT = 15.0
+
+# Module-level name so tests can monkeypatch: content_reach.sources.web_search.DDGS
+DDGS = None  # populated lazily by _import_ddgs()
+
+_JINA_SEARCH_BASE = "https://s.jina.ai/"
+
+
+def _import_ddgs():
+    """Lazy import of DDGS class; raises ImportError if ddgs is not installed."""
+    from ddgs import DDGS as _DDGS
+
+    return _DDGS
+
+
+class DdgsBackend(ContentBackend):
+    """Web-search backend using the ddgs library (keyless DuckDuckGo search).
+
+    probe() returns True iff ddgs is importable.
+    fetch() runs DDGS().text() in asyncio.to_thread (ddgs is sync).
+    Empty results → BackendError so the chain falls through to JinaSearchBackend.
+    """
+
+    name = "ddgs"
+    source_type = SourceType.WEB_SEARCH
+
+    async def probe(self) -> bool:
+        """Return True iff ddgs is importable."""
+        try:
+            _import_ddgs()
+            return True
+        except ImportError:
+            return False
+
+    async def fetch(self, request: ContentRequest) -> ContentResult:
+        """Fetch web-search results via DDGS.text(); raise BackendError when empty."""
+        ddgs_cls = DDGS if DDGS is not None else _import_ddgs()
+
+        def _search():
+            return ddgs_cls().text(request.query, max_results=request.limit)
+
+        raw_results: list[dict] = await asyncio.to_thread(_search)
+
+        if not raw_results:
+            raise BackendError(f"DdgsBackend: no results for query {request.query!r}")
+
+        text_lines = [f"{r.get('title', '')} — {r.get('href', '')}\n{r.get('body', '')}" for r in raw_results]
+        text = "\n\n".join(text_lines)
+
+        return ContentResult(
+            success=True,
+            source_type=self.source_type,
+            backend_used=self.name,
+            text=text,
+            structured={"results": raw_results},
+            reliability=SourceReliability.MEDIUM,
+        )
+
+
+class JinaSearchBackend(ContentBackend):
+    """Web-search backend via the Jina AI search endpoint (https://s.jina.ai/).
+
+    probe() returns True — pure-HTTP backend, always capable.
+    fetch() GETs https://s.jina.ai/<urlencoded query> and returns the response text.
+    Non-200 or empty body → BackendError.
+
+    Accepts an optional injected httpx.AsyncClient for testing.
+    """
+
+    name = "jina_search"
+    source_type = SourceType.WEB_SEARCH
+
+    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+        self._client = client
+
+    async def probe(self) -> bool:
+        """Return True — Jina search is a plain HTTP endpoint, always available."""
+        return True
+
+    async def fetch(self, request: ContentRequest) -> ContentResult:
+        """GET https://s.jina.ai/<query>; raise BackendError on non-200 or empty body."""
+        encoded_query = quote_plus(request.query)
+        url = f"{_JINA_SEARCH_BASE}{encoded_query}"
+        headers = {"Accept": "application/json"}
+
+        if self._client is not None:
+            response = await self._client.get(url, headers=headers)
+        else:
+            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+                response = await client.get(url, headers=headers)
+
+        if response.status_code != 200:
+            raise BackendError(f"JinaSearchBackend: HTTP {response.status_code} for query {request.query!r}")
+
+        text = response.text.strip()
+        if not text:
+            raise BackendError(f"JinaSearchBackend: empty response for query {request.query!r}")
+
+        return ContentResult(
+            success=True,
+            source_type=self.source_type,
+            backend_used=self.name,
+            text=text,
+            structured={},
+            url=url,
+            reliability=SourceReliability.MEDIUM,
+        )
+
+
+def build_web_search_chain() -> ContentSourceChain:
+    """Build the web-search fallback chain: ddgs → jina_search → browser_search."""
+    return ContentSourceChain(
+        source="web_search",
+        source_type=SourceType.WEB_SEARCH,
+        backends=[
+            DdgsBackend(),
+            JinaSearchBackend(),
+            BrowserSearchBackend(SourceType.WEB_SEARCH),
+        ],
+    )

--- a/autobot-backend/content_reach/sources/youtube.py
+++ b/autobot-backend/content_reach/sources/youtube.py
@@ -63,7 +63,7 @@ def _ytdlp_extract_info(url: str) -> dict:
 
 
 def _vtt_to_text(vtt: str) -> str:
-    """Convert WebVTT/SRV1 caption content to plain text lines."""
+    """Convert WebVTT caption content to plain text lines."""
     # Strip WEBVTT header and timestamps; keep non-empty non-tag lines.
     lines = []
     for line in vtt.splitlines():

--- a/autobot-backend/content_reach/sources/youtube.py
+++ b/autobot-backend/content_reach/sources/youtube.py
@@ -37,7 +37,7 @@ _YDL_OPTS: dict = {
 }
 
 # Caption formats we can parse to plain text, in preference order.
-_PREFERRED_EXTS = ("json3", "srv1", "vtt")
+_PREFERRED_EXTS = ("json3", "vtt", "srv1")
 
 
 def _import_yt_dlp():
@@ -50,9 +50,14 @@ def _import_yt_dlp():
 def _ytdlp_extract_info(url: str) -> dict:
     """Synchronous wrapper around YoutubeDL.extract_info.
 
+    Performs the yt_dlp import and raises BackendError (not ImportError) when
+    yt_dlp is unavailable, so callers do not need to re-check availability.
     Module-level so tests can monkeypatch without hitting the network.
     """
-    yt_dlp = _import_yt_dlp()
+    try:
+        yt_dlp = _import_yt_dlp()
+    except ImportError as exc:
+        raise BackendError("yt-dlp not installed") from exc
     with yt_dlp.YoutubeDL(_YDL_OPTS) as ydl:
         return ydl.extract_info(url, download=False)
 
@@ -97,11 +102,37 @@ def _json3_to_text(raw: str) -> str:
     return "\n".join(parts)
 
 
+def _srv1_to_text(xml: str) -> str:
+    """Convert YouTube SRV1 XML caption format to plain text.
+
+    SRV1 looks like: <transcript><text start="0" dur="3">Hello &amp; world</text>...</transcript>
+    Uses defusedxml (XXE/billion-laughs safe); falls back to regex tag-stripping
+    on parse failure. Never raises.
+    """
+    import html
+
+    import defusedxml.ElementTree as DET
+
+    try:
+        root = DET.fromstring(xml)
+        parts = []
+        for elem in root.iter("text"):
+            raw = (elem.text or "").strip()
+            if raw:
+                parts.append(html.unescape(raw))
+        return "\n".join(parts)
+    except Exception:
+        # Fallback: strip all XML/HTML tags then unescape entities.
+        stripped = re.sub(r"<[^>]+>", " ", xml)
+        return html.unescape(stripped).strip()
+
+
 def _caption_raw_to_text(raw: str, ext: str) -> str:
     """Convert raw caption file content to plain text based on extension."""
     if ext == "json3":
         return _json3_to_text(raw)
-    # vtt and srv1 share the same timestamp-stripping logic.
+    if ext == "srv1":
+        return _srv1_to_text(raw)
     return _vtt_to_text(raw)
 
 
@@ -143,12 +174,11 @@ class YtDlpCaptionBackend(ContentBackend):
             return False
 
     async def fetch(self, request: ContentRequest) -> ContentResult:
-        """Extract captions from request.url via yt-dlp; raise BackendError on failure."""
-        try:
-            _import_yt_dlp()
-        except ImportError:
-            raise BackendError("yt-dlp not installed")
+        """Extract captions from request.url via yt-dlp; raise BackendError on failure.
 
+        _ytdlp_extract_info owns the yt_dlp import check and raises BackendError
+        when yt_dlp is unavailable, so no separate guard is needed here.
+        """
         info: dict = await asyncio.to_thread(_ytdlp_extract_info, request.url)
 
         track = _pick_caption_track(info)

--- a/autobot-backend/content_reach/sources/youtube.py
+++ b/autobot-backend/content_reach/sources/youtube.py
@@ -1,0 +1,204 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""YouTube captions content source via yt-dlp (#10932).
+
+Chain:
+  1. YtDlpCaptionBackend — extracts English captions (subtitles or automatic)
+     via yt-dlp, converts to plain text, returns ContentResult.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+import httpx
+
+from autobot_shared.logging_manager import get_logger
+from content_reach.base import BackendError, ContentBackend, ContentRequest, ContentResult
+from content_reach.chain import ContentSourceChain
+from source_attribution import SourceReliability, SourceType
+
+logger = get_logger(__name__)
+
+# Module-level HTTP timeout constant (seconds).
+_HTTP_TIMEOUT = 15.0
+
+# yt-dlp options used for all caption extractions.
+_YDL_OPTS: dict = {
+    "skip_download": True,
+    "writesubtitles": True,
+    "writeautomaticsub": True,
+    "subtitleslangs": ["en"],
+    "quiet": True,
+    "no_warnings": True,
+}
+
+# Caption formats we can parse to plain text, in preference order.
+_PREFERRED_EXTS = ("json3", "srv1", "vtt")
+
+
+def _import_yt_dlp():
+    """Lazy import of yt_dlp; raises ImportError if not installed."""
+    import yt_dlp as _yt_dlp
+
+    return _yt_dlp
+
+
+def _ytdlp_extract_info(url: str) -> dict:
+    """Synchronous wrapper around YoutubeDL.extract_info.
+
+    Module-level so tests can monkeypatch without hitting the network.
+    """
+    yt_dlp = _import_yt_dlp()
+    with yt_dlp.YoutubeDL(_YDL_OPTS) as ydl:
+        return ydl.extract_info(url, download=False)
+
+
+def _vtt_to_text(vtt: str) -> str:
+    """Convert WebVTT/SRV1 caption content to plain text lines."""
+    # Strip WEBVTT header and timestamps; keep non-empty non-tag lines.
+    lines = []
+    for line in vtt.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("WEBVTT") or line.startswith("NOTE"):
+            continue
+        # Skip timestamp lines like "00:00:00.000 --> 00:00:03.000"
+        if re.match(r"^\d{2}:\d{2}:\d{2}[.,]\d{3}\s+-->\s+", line):
+            continue
+        # Strip inline tags: <c>, </c>, <00:00:00.000>, etc.
+        line = re.sub(r"<[^>]+>", "", line)
+        if line:
+            lines.append(line)
+    return "\n".join(lines)
+
+
+def _json3_to_text(raw: str) -> str:
+    """Convert yt-dlp json3 caption format to plain text."""
+    import json
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+    parts = []
+    for event in data.get("events", []):
+        segs = event.get("segs")
+        if not segs:
+            continue
+        segment_text = "".join(s.get("utf8", "") for s in segs).strip()
+        if segment_text and segment_text != "\n":
+            parts.append(segment_text)
+    return "\n".join(parts)
+
+
+def _caption_raw_to_text(raw: str, ext: str) -> str:
+    """Convert raw caption file content to plain text based on extension."""
+    if ext == "json3":
+        return _json3_to_text(raw)
+    # vtt and srv1 share the same timestamp-stripping logic.
+    return _vtt_to_text(raw)
+
+
+def _pick_caption_track(info: dict) -> tuple[str, str] | None:
+    """Return (url, ext) for the best available English caption track, or None."""
+    for source in ("subtitles", "automatic_captions"):
+        tracks = info.get(source, {}).get("en", [])
+        for ext in _PREFERRED_EXTS:
+            for entry in tracks:
+                if entry.get("ext") == ext and entry.get("url"):
+                    return entry["url"], ext
+    return None
+
+
+class YtDlpCaptionBackend(ContentBackend):
+    """YouTube captions backend using yt-dlp to extract English subtitle tracks.
+
+    probe() returns True iff yt_dlp is importable.
+    fetch() calls yt_dlp.YoutubeDL.extract_info in asyncio.to_thread (yt-dlp
+    is synchronous), picks the best English caption track, GETs its URL via
+    httpx, converts to plain text, and returns a ContentResult.
+
+    Accepts an optional injected httpx.AsyncClient for testing.
+    """
+
+    name = "yt_dlp"
+    source_type = SourceType.YOUTUBE
+
+    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+        self._client = client
+
+    async def probe(self) -> bool:
+        """Return True iff yt_dlp is importable."""
+        try:
+            _import_yt_dlp()
+            return True
+        except ImportError:
+            logger.warning("YtDlpCaptionBackend: yt_dlp is not installed; backend unavailable")
+            return False
+
+    async def fetch(self, request: ContentRequest) -> ContentResult:
+        """Extract captions from request.url via yt-dlp; raise BackendError on failure."""
+        try:
+            _import_yt_dlp()
+        except ImportError:
+            raise BackendError("yt-dlp not installed")
+
+        info: dict = await asyncio.to_thread(_ytdlp_extract_info, request.url)
+
+        track = _pick_caption_track(info)
+        if track is None:
+            logger.debug(
+                "YtDlpCaptionBackend: no English captions found for %r",
+                request.url,
+            )
+            raise BackendError(f"YtDlpCaptionBackend: no English captions for {request.url!r}")
+
+        caption_url, ext = track
+
+        try:
+            if self._client is not None:
+                response = await self._client.get(caption_url)
+            else:
+                async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+                    response = await client.get(caption_url)
+        except httpx.HTTPError as exc:
+            logger.debug(
+                "YtDlpCaptionBackend: HTTP error fetching caption track for %r: %s",
+                request.url,
+                exc,
+            )
+            raise BackendError(f"YtDlpCaptionBackend: HTTP error fetching captions: {exc}") from exc
+
+        text = _caption_raw_to_text(response.text, ext)
+
+        if not text.strip():
+            logger.debug("YtDlpCaptionBackend: empty caption text for %r", request.url)
+            raise BackendError(f"YtDlpCaptionBackend: empty captions for {request.url!r}")
+
+        return ContentResult(
+            success=True,
+            source_type=self.source_type,
+            backend_used=self.name,
+            text=text,
+            structured={
+                "title": info.get("title"),
+                "duration": info.get("duration"),
+            },
+            url=request.url,
+            reliability=SourceReliability.MEDIUM,
+        )
+
+
+def build_youtube_chain() -> ContentSourceChain:
+    """Build the YouTube caption chain: yt_dlp."""
+    return ContentSourceChain(
+        source="youtube",
+        source_type=SourceType.YOUTUBE,
+        backends=[YtDlpCaptionBackend()],
+    )

--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -115,3 +115,8 @@ defusedxml>=0.7.1       # MVA-2039: XML parsing for WebDAV (Nextcloud connector)
 # Optional LLM tracing integrations (GH#9012) — backend starts without them when env vars are absent
 # langfuse>=2.0.0        # Set LANGFUSE_HOST + LANGFUSE_PUBLIC_KEY + LANGFUSE_SECRET_KEY to activate
 # langsmith>=0.1.0       # Set LANGSMITH_API_KEY to activate
+
+# Content Reach optional source backends (#10932) — lazy-imported; backend starts without them
+ddgs>=9.0               # #10932 content-reach: keyless web search (optional, lazy)
+trafilatura>=2.0        # #10932 content-reach: readable article extraction (optional, lazy)
+yt-dlp>=2025.1.1        # #10932 content-reach: YouTube caption extraction (optional, lazy)

--- a/autobot-backend/source_attribution.py
+++ b/autobot-backend/source_attribution.py
@@ -47,6 +47,7 @@ class SourceReliability(Enum):
     MEDIUM = "medium"  # Web search, API responses
     LOW = "low"  # User input, unverified sources
     UNKNOWN = "unknown"  # Cannot determine reliability
+    COMMUNITY = "community"  # Community-sourced content (Reddit, HN) #10932
 
 
 @dataclass

--- a/autobot-backend/source_attribution.py
+++ b/autobot-backend/source_attribution.py
@@ -47,7 +47,6 @@ class SourceReliability(Enum):
     MEDIUM = "medium"  # Web search, API responses
     LOW = "low"  # User input, unverified sources
     UNKNOWN = "unknown"  # Cannot determine reliability
-    COMMUNITY = "community"  # Community-sourced content (Reddit, HN) #10932
 
 
 @dataclass

--- a/autobot-backend/tests/content_reach/backends/__init__.py
+++ b/autobot-backend/tests/content_reach/backends/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss

--- a/autobot-backend/tests/content_reach/backends/test_browser.py
+++ b/autobot-backend/tests/content_reach/backends/test_browser.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import pytest
 
-from content_reach.base import BackendError, ContentRequest
 from content_reach.backends.browser import BrowserBackend, BrowserSearchBackend
+from content_reach.base import BackendError, ContentRequest
 from source_attribution import SourceType
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/tests/content_reach/backends/test_browser.py
+++ b/autobot-backend/tests/content_reach/backends/test_browser.py
@@ -1,0 +1,139 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for content_reach.backends.browser (BrowserBackend, BrowserSearchBackend)."""
+
+from __future__ import annotations
+
+import pytest
+
+from content_reach.base import BackendError, ContentRequest
+from content_reach.backends.browser import BrowserBackend, BrowserSearchBackend
+from source_attribution import SourceType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubManager:
+    """Minimal stub for the research browser manager."""
+
+    def __init__(self, result: dict) -> None:
+        self._result = result
+        self.last_url: str | None = None
+
+    async def research_url(self, conversation_id: str, url: str, extract_content: bool = True) -> dict:
+        self.last_url = url
+        return self._result
+
+
+# ---------------------------------------------------------------------------
+# probe()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_browser_probe_reflects_playwright_available_true(monkeypatch):
+    import research_browser_manager as rbm
+
+    monkeypatch.setattr(rbm, "PLAYWRIGHT_AVAILABLE", True)
+    backend = BrowserBackend(source_type=SourceType.WEB_PAGE)
+    assert await backend.probe() is True
+
+
+@pytest.mark.asyncio
+async def test_browser_probe_reflects_playwright_available_false(monkeypatch):
+    import research_browser_manager as rbm
+
+    monkeypatch.setattr(rbm, "PLAYWRIGHT_AVAILABLE", False)
+    backend = BrowserBackend(source_type=SourceType.WEB_PAGE)
+    assert await backend.probe() is False
+
+
+# ---------------------------------------------------------------------------
+# fetch() — BrowserBackend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_browser_fetch_maps_research_result(monkeypatch):
+    stub_manager = _StubManager(
+        {
+            "success": True,
+            "content": {
+                "text_content": "hello",
+                "structured_data": {"headings": []},
+            },
+            "title": "T",
+        }
+    )
+    import content_reach.backends.browser as browser_mod
+
+    monkeypatch.setattr(browser_mod, "_get_manager", lambda: stub_manager)
+
+    backend = BrowserBackend(source_type=SourceType.WEB_PAGE)
+    request = ContentRequest(url="https://example.com", query="")
+    result = await backend.fetch(request)
+
+    assert result.success is True
+    assert result.text == "hello"
+    assert result.backend_used == "browser"
+    assert result.url == request.url
+    assert result.structured == {"headings": []}
+
+
+@pytest.mark.asyncio
+async def test_browser_fetch_raises_without_url(monkeypatch):
+    import content_reach.backends.browser as browser_mod
+
+    monkeypatch.setattr(browser_mod, "_get_manager", lambda: _StubManager({}))
+
+    backend = BrowserBackend(source_type=SourceType.WEB_PAGE)
+    request = ContentRequest(query="x")  # url defaults to ""
+    with pytest.raises(BackendError, match="url"):
+        await backend.fetch(request)
+
+
+@pytest.mark.asyncio
+async def test_browser_fetch_raises_on_unsuccessful(monkeypatch):
+    stub_manager = _StubManager({"success": False})
+    import content_reach.backends.browser as browser_mod
+
+    monkeypatch.setattr(browser_mod, "_get_manager", lambda: stub_manager)
+
+    backend = BrowserBackend(source_type=SourceType.WEB_PAGE)
+    request = ContentRequest(url="https://example.com")
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+
+# ---------------------------------------------------------------------------
+# fetch() — BrowserSearchBackend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_browser_search_builds_ddg_url(monkeypatch):
+    stub_manager = _StubManager(
+        {
+            "success": True,
+            "content": {"text_content": "results", "structured_data": {}},
+            "title": "DDG",
+        }
+    )
+    import content_reach.backends.browser as browser_mod
+
+    monkeypatch.setattr(browser_mod, "_get_manager", lambda: stub_manager)
+
+    backend = BrowserSearchBackend(source_type=SourceType.WEB_SEARCH)
+    request = ContentRequest(query="cats dogs")
+    await backend.fetch(request)
+
+    # The URL passed to research_url must be the DDG search URL with encoded query
+    assert stub_manager.last_url is not None
+    assert "duckduckgo.com" in stub_manager.last_url
+    # Accept both + and %20 encoding — urllib.parse.quote_plus uses +
+    assert "cats" in stub_manager.last_url
+    assert "dogs" in stub_manager.last_url

--- a/autobot-backend/tests/content_reach/sources/__init__.py
+++ b/autobot-backend/tests/content_reach/sources/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss

--- a/autobot-backend/tests/content_reach/sources/test_reddit.py
+++ b/autobot-backend/tests/content_reach/sources/test_reddit.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2024 mrveiss. All rights reserved.
+# Unauthorized copying of this file, via any medium is strictly prohibited.
+# Proprietary and confidential.
+# Written by mrveiss.
+"""Tests for content_reach.sources.reddit (RedditJsonBackend, HnAlgoliaBackend, build_reddit_chain)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from content_reach.base import BackendError, ContentRequest
+from source_attribution import SourceType
+
+# ---------------------------------------------------------------------------
+# Sample JSON fixtures
+# ---------------------------------------------------------------------------
+
+_REDDIT_SEARCH_JSON = {
+    "data": {
+        "children": [
+            {
+                "data": {
+                    "title": "Post 1",
+                    "selftext": "Content 1",
+                    "permalink": "/r/python/comments/abc/post_1/",
+                }
+            },
+            {
+                "data": {
+                    "title": "Post 2",
+                    "selftext": "",
+                    "permalink": "/r/python/comments/def/post_2/",
+                }
+            },
+        ]
+    }
+}
+
+_HN_ALGOLIA_JSON = {
+    "hits": [
+        {
+            "title": "HN Post 1",
+            "url": "https://example.com/1",
+            "points": 42,
+            "objectID": "12345",
+        },
+        {
+            "story_title": "HN Post 2",
+            "url": None,
+            "points": 10,
+            "objectID": "67890",
+        },
+    ]
+}
+
+
+def _make_sync_mock_client(status_code: int, body: dict | None = None):
+    """Build a MagicMock httpx.Client whose .get() returns a fixed response."""
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_response.json.return_value = body or {}
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_client.get.return_value = mock_response
+    return mock_client, mock_response
+
+
+# ---------------------------------------------------------------------------
+# RedditJsonBackend — search mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reddit_search_maps_posts():
+    """Mock returns 2-post reddit search JSON; result.structured['posts'] has 2 entries."""
+    from content_reach.sources.reddit import RedditJsonBackend
+
+    mock_client, _ = _make_sync_mock_client(200, _REDDIT_SEARCH_JSON)
+    backend = RedditJsonBackend(client=mock_client)
+    request = ContentRequest(query="python tips", limit=2)
+    result = await backend.fetch(request)
+
+    assert result.success is True
+    assert result.source_type is SourceType.REDDIT
+    posts = result.structured["posts"]
+    assert len(posts) == 2
+    assert posts[0]["title"] == "Post 1"
+    assert posts[1]["title"] == "Post 2"
+
+
+@pytest.mark.asyncio
+async def test_reddit_search_sends_user_agent():
+    """fetch() sends the expected User-Agent header."""
+    from content_reach.sources.reddit import RedditJsonBackend, _USER_AGENT
+
+    mock_client, _ = _make_sync_mock_client(200, _REDDIT_SEARCH_JSON)
+    backend = RedditJsonBackend(client=mock_client)
+    request = ContentRequest(query="python tips", limit=2)
+    await backend.fetch(request)
+
+    call_kwargs = mock_client.get.call_args
+    headers = call_kwargs.kwargs.get("headers", {})
+    assert headers.get("User-Agent") == _USER_AGENT
+
+
+# ---------------------------------------------------------------------------
+# RedditJsonBackend — URL mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reddit_url_mode_appends_json():
+    """URL mode with reddit.com URL appends .json suffix."""
+    from content_reach.sources.reddit import RedditJsonBackend
+
+    mock_client, _ = _make_sync_mock_client(200, _REDDIT_SEARCH_JSON)
+    backend = RedditJsonBackend(client=mock_client)
+    request = ContentRequest(url="https://www.reddit.com/r/python")
+    await backend.fetch(request)
+
+    called_url = mock_client.get.call_args.args[0]
+    assert called_url.endswith(".json")
+
+
+@pytest.mark.asyncio
+async def test_reddit_url_mode_no_double_json():
+    """URL already ending in .json does not get a second .json appended."""
+    from content_reach.sources.reddit import RedditJsonBackend
+
+    mock_client, _ = _make_sync_mock_client(200, _REDDIT_SEARCH_JSON)
+    backend = RedditJsonBackend(client=mock_client)
+    request = ContentRequest(url="https://www.reddit.com/r/python.json")
+    await backend.fetch(request)
+
+    called_url = mock_client.get.call_args.args[0]
+    assert not called_url.endswith(".json.json")
+    assert called_url.endswith(".json")
+
+
+# ---------------------------------------------------------------------------
+# RedditJsonBackend — error cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reddit_non200_raises_backend_error():
+    """Non-200 response raises BackendError."""
+    from content_reach.sources.reddit import RedditJsonBackend
+
+    mock_client, _ = _make_sync_mock_client(403)
+    backend = RedditJsonBackend(client=mock_client)
+    request = ContentRequest(query="python")
+    with pytest.raises(BackendError, match="403"):
+        await backend.fetch(request)
+
+
+@pytest.mark.asyncio
+async def test_reddit_empty_children_raises_backend_error():
+    """Reddit JSON with empty data.children raises BackendError."""
+    from content_reach.sources.reddit import RedditJsonBackend
+
+    empty_json = {"data": {"children": []}}
+    mock_client, _ = _make_sync_mock_client(200, empty_json)
+    backend = RedditJsonBackend(client=mock_client)
+    request = ContentRequest(query="python")
+    with pytest.raises(BackendError, match="no posts"):
+        await backend.fetch(request)
+
+
+# ---------------------------------------------------------------------------
+# HnAlgoliaBackend — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hn_maps_hits():
+    """Mock returns 2-hit algolia JSON; result.structured['hits'] has 2 entries with hn_url."""
+    from content_reach.sources.reddit import HnAlgoliaBackend
+
+    mock_client, _ = _make_sync_mock_client(200, _HN_ALGOLIA_JSON)
+    backend = HnAlgoliaBackend(client=mock_client)
+    request = ContentRequest(query="python asyncio")
+    result = await backend.fetch(request)
+
+    assert result.success is True
+    assert result.source_type is SourceType.REDDIT
+    hits = result.structured["hits"]
+    assert len(hits) == 2
+    # First hit: has url field
+    assert hits[0]["hn_url"] == "https://news.ycombinator.com/item?id=12345"
+    # Second hit: url is None → fallback hn_url
+    assert hits[1]["hn_url"] == "https://news.ycombinator.com/item?id=67890"
+    # Second hit: story_title used
+    assert hits[1]["title"] == "HN Post 2"
+
+
+# ---------------------------------------------------------------------------
+# HnAlgoliaBackend — error cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hn_empty_hits_raises_backend_error():
+    """Algolia response with empty hits raises BackendError."""
+    from content_reach.sources.reddit import HnAlgoliaBackend
+
+    mock_client, _ = _make_sync_mock_client(200, {"hits": []})
+    backend = HnAlgoliaBackend(client=mock_client)
+    request = ContentRequest(query="python asyncio")
+    with pytest.raises(BackendError, match="no hits"):
+        await backend.fetch(request)
+
+
+# ---------------------------------------------------------------------------
+# Shared — httpx.HTTPError wrapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_httpx_error_raises_backend_error():
+    """httpx.HTTPError from either backend is wrapped into BackendError."""
+    from content_reach.sources.reddit import HnAlgoliaBackend, RedditJsonBackend
+
+    for BackendCls in (RedditJsonBackend, HnAlgoliaBackend):
+        mock_client = MagicMock(spec=httpx.Client)
+        mock_client.get.side_effect = httpx.HTTPError("connection failed")
+        backend = BackendCls(client=mock_client)
+        request = ContentRequest(query="test")
+        with pytest.raises(BackendError):
+            await backend.fetch(request)
+
+
+# ---------------------------------------------------------------------------
+# build_reddit_chain()
+# ---------------------------------------------------------------------------
+
+
+def test_build_reddit_chain_backend_names():
+    """build_reddit_chain() returns chain with backends: reddit_json, hn_algolia, browser."""
+    from content_reach.sources.reddit import build_reddit_chain
+
+    chain = build_reddit_chain()
+    assert chain.backend_names() == ["reddit_json", "hn_algolia", "browser"]

--- a/autobot-backend/tests/content_reach/sources/test_reddit.py
+++ b/autobot-backend/tests/content_reach/sources/test_reddit.py
@@ -1,7 +1,7 @@
-# Copyright (c) 2024 mrveiss. All rights reserved.
-# Unauthorized copying of this file, via any medium is strictly prohibited.
-# Proprietary and confidential.
-# Written by mrveiss.
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
 """Tests for content_reach.sources.reddit (RedditJsonBackend, HnAlgoliaBackend, build_reddit_chain)."""
 
 from __future__ import annotations

--- a/autobot-backend/tests/content_reach/sources/test_reddit.py
+++ b/autobot-backend/tests/content_reach/sources/test_reddit.py
@@ -93,7 +93,7 @@ async def test_reddit_search_maps_posts():
 @pytest.mark.asyncio
 async def test_reddit_search_sends_user_agent():
     """fetch() sends the expected User-Agent header."""
-    from content_reach.sources.reddit import RedditJsonBackend, _USER_AGENT
+    from content_reach.sources.reddit import _USER_AGENT, RedditJsonBackend
 
     mock_client, _ = _make_async_mock_client(200, _REDDIT_SEARCH_JSON)
     backend = RedditJsonBackend(client=mock_client)

--- a/autobot-backend/tests/content_reach/sources/test_reddit.py
+++ b/autobot-backend/tests/content_reach/sources/test_reddit.py
@@ -6,13 +6,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
 
 from content_reach.base import BackendError, ContentRequest
-from source_attribution import SourceType
+from source_attribution import SourceReliability, SourceType
 
 # ---------------------------------------------------------------------------
 # Sample JSON fixtures
@@ -57,12 +57,12 @@ _HN_ALGOLIA_JSON = {
 }
 
 
-def _make_sync_mock_client(status_code: int, body: dict | None = None):
-    """Build a MagicMock httpx.Client whose .get() returns a fixed response."""
+def _make_async_mock_client(status_code: int, body: dict | None = None):
+    """Build an AsyncMock httpx.AsyncClient whose .get() returns a fixed response."""
     mock_response = MagicMock()
     mock_response.status_code = status_code
     mock_response.json.return_value = body or {}
-    mock_client = MagicMock(spec=httpx.Client)
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
     mock_client.get.return_value = mock_response
     return mock_client, mock_response
 
@@ -77,7 +77,7 @@ async def test_reddit_search_maps_posts():
     """Mock returns 2-post reddit search JSON; result.structured['posts'] has 2 entries."""
     from content_reach.sources.reddit import RedditJsonBackend
 
-    mock_client, _ = _make_sync_mock_client(200, _REDDIT_SEARCH_JSON)
+    mock_client, _ = _make_async_mock_client(200, _REDDIT_SEARCH_JSON)
     backend = RedditJsonBackend(client=mock_client)
     request = ContentRequest(query="python tips", limit=2)
     result = await backend.fetch(request)
@@ -95,7 +95,7 @@ async def test_reddit_search_sends_user_agent():
     """fetch() sends the expected User-Agent header."""
     from content_reach.sources.reddit import RedditJsonBackend, _USER_AGENT
 
-    mock_client, _ = _make_sync_mock_client(200, _REDDIT_SEARCH_JSON)
+    mock_client, _ = _make_async_mock_client(200, _REDDIT_SEARCH_JSON)
     backend = RedditJsonBackend(client=mock_client)
     request = ContentRequest(query="python tips", limit=2)
     await backend.fetch(request)
@@ -115,7 +115,7 @@ async def test_reddit_url_mode_appends_json():
     """URL mode with reddit.com URL appends .json suffix."""
     from content_reach.sources.reddit import RedditJsonBackend
 
-    mock_client, _ = _make_sync_mock_client(200, _REDDIT_SEARCH_JSON)
+    mock_client, _ = _make_async_mock_client(200, _REDDIT_SEARCH_JSON)
     backend = RedditJsonBackend(client=mock_client)
     request = ContentRequest(url="https://www.reddit.com/r/python")
     await backend.fetch(request)
@@ -129,7 +129,7 @@ async def test_reddit_url_mode_no_double_json():
     """URL already ending in .json does not get a second .json appended."""
     from content_reach.sources.reddit import RedditJsonBackend
 
-    mock_client, _ = _make_sync_mock_client(200, _REDDIT_SEARCH_JSON)
+    mock_client, _ = _make_async_mock_client(200, _REDDIT_SEARCH_JSON)
     backend = RedditJsonBackend(client=mock_client)
     request = ContentRequest(url="https://www.reddit.com/r/python.json")
     await backend.fetch(request)
@@ -149,7 +149,7 @@ async def test_reddit_non200_raises_backend_error():
     """Non-200 response raises BackendError."""
     from content_reach.sources.reddit import RedditJsonBackend
 
-    mock_client, _ = _make_sync_mock_client(403)
+    mock_client, _ = _make_async_mock_client(403)
     backend = RedditJsonBackend(client=mock_client)
     request = ContentRequest(query="python")
     with pytest.raises(BackendError, match="403"):
@@ -162,11 +162,29 @@ async def test_reddit_empty_children_raises_backend_error():
     from content_reach.sources.reddit import RedditJsonBackend
 
     empty_json = {"data": {"children": []}}
-    mock_client, _ = _make_sync_mock_client(200, empty_json)
+    mock_client, _ = _make_async_mock_client(200, empty_json)
     backend = RedditJsonBackend(client=mock_client)
     request = ContentRequest(query="python")
     with pytest.raises(BackendError, match="no posts"):
         await backend.fetch(request)
+
+
+# ---------------------------------------------------------------------------
+# RedditJsonBackend — reliability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reddit_result_reliability_medium():
+    """RedditJsonBackend result has reliability MEDIUM."""
+    from content_reach.sources.reddit import RedditJsonBackend
+
+    mock_client, _ = _make_async_mock_client(200, _REDDIT_SEARCH_JSON)
+    backend = RedditJsonBackend(client=mock_client)
+    request = ContentRequest(query="python tips", limit=2)
+    result = await backend.fetch(request)
+
+    assert result.reliability is SourceReliability.MEDIUM
 
 
 # ---------------------------------------------------------------------------
@@ -179,7 +197,7 @@ async def test_hn_maps_hits():
     """Mock returns 2-hit algolia JSON; result.structured['hits'] has 2 entries with hn_url."""
     from content_reach.sources.reddit import HnAlgoliaBackend
 
-    mock_client, _ = _make_sync_mock_client(200, _HN_ALGOLIA_JSON)
+    mock_client, _ = _make_async_mock_client(200, _HN_ALGOLIA_JSON)
     backend = HnAlgoliaBackend(client=mock_client)
     request = ContentRequest(query="python asyncio")
     result = await backend.fetch(request)
@@ -196,6 +214,34 @@ async def test_hn_maps_hits():
     assert hits[1]["title"] == "HN Post 2"
 
 
+@pytest.mark.asyncio
+async def test_hn_forwards_limit():
+    """HnAlgoliaBackend passes request.limit as hitsPerPage query param."""
+    from content_reach.sources.reddit import HnAlgoliaBackend
+
+    mock_client, _ = _make_async_mock_client(200, _HN_ALGOLIA_JSON)
+    backend = HnAlgoliaBackend(client=mock_client)
+    request = ContentRequest(query="python asyncio", limit=5)
+    await backend.fetch(request)
+
+    call_kwargs = mock_client.get.call_args
+    params = call_kwargs.kwargs.get("params", {})
+    assert params.get("hitsPerPage") == 5
+
+
+@pytest.mark.asyncio
+async def test_hn_result_reliability_medium():
+    """HnAlgoliaBackend result has reliability MEDIUM."""
+    from content_reach.sources.reddit import HnAlgoliaBackend
+
+    mock_client, _ = _make_async_mock_client(200, _HN_ALGOLIA_JSON)
+    backend = HnAlgoliaBackend(client=mock_client)
+    request = ContentRequest(query="python asyncio")
+    result = await backend.fetch(request)
+
+    assert result.reliability is SourceReliability.MEDIUM
+
+
 # ---------------------------------------------------------------------------
 # HnAlgoliaBackend — error cases
 # ---------------------------------------------------------------------------
@@ -206,7 +252,7 @@ async def test_hn_empty_hits_raises_backend_error():
     """Algolia response with empty hits raises BackendError."""
     from content_reach.sources.reddit import HnAlgoliaBackend
 
-    mock_client, _ = _make_sync_mock_client(200, {"hits": []})
+    mock_client, _ = _make_async_mock_client(200, {"hits": []})
     backend = HnAlgoliaBackend(client=mock_client)
     request = ContentRequest(query="python asyncio")
     with pytest.raises(BackendError, match="no hits"):
@@ -224,7 +270,7 @@ async def test_httpx_error_raises_backend_error():
     from content_reach.sources.reddit import HnAlgoliaBackend, RedditJsonBackend
 
     for BackendCls in (RedditJsonBackend, HnAlgoliaBackend):
-        mock_client = MagicMock(spec=httpx.Client)
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
         mock_client.get.side_effect = httpx.HTTPError("connection failed")
         backend = BackendCls(client=mock_client)
         request = ContentRequest(query="test")

--- a/autobot-backend/tests/content_reach/sources/test_social.py
+++ b/autobot-backend/tests/content_reach/sources/test_social.py
@@ -1,0 +1,76 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for content_reach.sources.social (build_social_chain)."""
+
+from __future__ import annotations
+
+import pytest
+
+from content_reach.base import ContentRequest
+from source_attribution import SourceType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubManager:
+    """Minimal stub for the research browser manager."""
+
+    def __init__(self, result: dict) -> None:
+        self._result = result
+
+    async def research_url(self, conversation_id: str, url: str, extract_content: bool = True) -> dict:
+        return self._result
+
+
+# ---------------------------------------------------------------------------
+# build_social_chain()
+# ---------------------------------------------------------------------------
+
+
+def test_build_social_chain():
+    """build_social_chain() returns a chain named 'social' with one 'browser' backend."""
+    from content_reach.sources.social import build_social_chain
+
+    chain = build_social_chain()
+    assert chain.backend_names() == ["browser"]
+    assert chain.source_type is SourceType.SOCIAL
+    assert chain.source == "social"
+
+
+# ---------------------------------------------------------------------------
+# fetch() — result carries SourceType.SOCIAL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_social_fetch_carries_social_source_type(monkeypatch):
+    """BrowserBackend(SOCIAL).fetch() maps the stub result and carries source_type=SOCIAL."""
+    stub_manager = _StubManager(
+        {
+            "success": True,
+            "content": {
+                "text_content": "tweet text",
+                "structured_data": {},
+            },
+            "title": "t",
+        }
+    )
+
+    import content_reach.backends.browser as browser_mod
+
+    monkeypatch.setattr(browser_mod, "_get_manager", lambda: stub_manager)
+
+    from content_reach.sources.social import build_social_chain
+
+    chain = build_social_chain()
+    backend = chain.backends[0]
+
+    request = ContentRequest(url="https://twitter.com/x/status/1")
+    result = await backend.fetch(request)
+
+    assert result.success is True
+    assert result.source_type is SourceType.SOCIAL

--- a/autobot-backend/tests/content_reach/sources/test_web_page.py
+++ b/autobot-backend/tests/content_reach/sources/test_web_page.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from content_reach.base import BackendError, ContentRequest
@@ -21,6 +22,7 @@ from source_attribution import SourceType
 @pytest.mark.asyncio
 async def test_trafilatura_probe_true_when_importable():
     """probe() returns True when trafilatura is importable (installed here)."""
+    pytest.importorskip("trafilatura")
     from content_reach.sources.web_page import TrafilaturaBackend
 
     backend = TrafilaturaBackend()
@@ -147,6 +149,26 @@ async def test_trafilatura_fetch_absent_lib_raises_backend_error(monkeypatch):
         await backend.fetch(request)
 
 
+@pytest.mark.asyncio
+async def test_trafilatura_fetch_httpx_error_raises_backend_error(monkeypatch):
+    """httpx.HTTPError raised by client.get() → BackendError (not raw httpx error)."""
+    from content_reach.sources import web_page as wp_mod
+
+    monkeypatch.setattr(wp_mod, "_trafilatura_extract", lambda html: "text")
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=httpx.HTTPError("connection refused"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    from content_reach.sources.web_page import TrafilaturaBackend
+
+    backend = TrafilaturaBackend(client=mock_client)
+    request = ContentRequest(url="https://example.com/article")
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+
 # ---------------------------------------------------------------------------
 # JinaReaderBackend — fetch()
 # ---------------------------------------------------------------------------
@@ -230,6 +252,22 @@ async def test_jina_reader_empty_text_raises():
 
     mock_client = AsyncMock()
     mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    backend = JinaReaderBackend(client=mock_client)
+    request = ContentRequest(url="https://example.com/page")
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+
+@pytest.mark.asyncio
+async def test_jina_reader_httpx_error_raises_backend_error():
+    """httpx.HTTPError raised by client.get() → BackendError (not raw httpx error)."""
+    from content_reach.sources.web_page import JinaReaderBackend
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=httpx.HTTPError("connection refused"))
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 

--- a/autobot-backend/tests/content_reach/sources/test_web_page.py
+++ b/autobot-backend/tests/content_reach/sources/test_web_page.py
@@ -1,0 +1,254 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for content_reach.sources.web_page (TrafilaturaBackend, JinaReaderBackend, build_web_page_chain)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from content_reach.base import BackendError, ContentRequest
+from source_attribution import SourceType
+
+# ---------------------------------------------------------------------------
+# TrafilaturaBackend — probe()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trafilatura_probe_true_when_importable():
+    """probe() returns True when trafilatura is importable (installed here)."""
+    from content_reach.sources.web_page import TrafilaturaBackend
+
+    backend = TrafilaturaBackend()
+    result = await backend.probe()
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_trafilatura_probe_false_when_absent(monkeypatch):
+    """probe() returns False when the lazy import helper raises ImportError."""
+    from content_reach.sources import web_page as wp_mod
+
+    monkeypatch.setattr(
+        wp_mod,
+        "_import_trafilatura",
+        lambda: (_ for _ in ()).throw(ImportError("no trafilatura")),
+    )
+
+    from content_reach.sources.web_page import TrafilaturaBackend
+
+    backend = TrafilaturaBackend()
+    result = await backend.probe()
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# TrafilaturaBackend — fetch()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trafilatura_fetch_maps_extracted_text(monkeypatch):
+    """fetch() maps trafilatura-extracted text into a successful ContentResult."""
+    from content_reach.sources import web_page as wp_mod
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "<html><body>raw html</body></html>"
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    monkeypatch.setattr(wp_mod, "_trafilatura_extract", lambda html: "Extracted article text")
+
+    from content_reach.sources.web_page import TrafilaturaBackend
+
+    backend = TrafilaturaBackend(client=mock_client)
+    request = ContentRequest(url="https://example.com/article")
+    result = await backend.fetch(request)
+
+    assert result.success is True
+    assert result.backend_used == "trafilatura"
+    assert result.source_type is SourceType.WEB_PAGE
+    assert result.text == "Extracted article text"
+    assert result.url == "https://example.com/article"
+
+
+@pytest.mark.asyncio
+async def test_trafilatura_fetch_none_extraction_raises(monkeypatch):
+    """None returned by trafilatura.extract → BackendError."""
+    from content_reach.sources import web_page as wp_mod
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "<html></html>"
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    monkeypatch.setattr(wp_mod, "_trafilatura_extract", lambda html: None)
+
+    from content_reach.sources.web_page import TrafilaturaBackend
+
+    backend = TrafilaturaBackend(client=mock_client)
+    request = ContentRequest(url="https://example.com/empty")
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+
+@pytest.mark.asyncio
+async def test_trafilatura_fetch_empty_extraction_raises(monkeypatch):
+    """Empty string returned by trafilatura.extract → BackendError."""
+    from content_reach.sources import web_page as wp_mod
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "<html></html>"
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    monkeypatch.setattr(wp_mod, "_trafilatura_extract", lambda html: "   ")
+
+    from content_reach.sources.web_page import TrafilaturaBackend
+
+    backend = TrafilaturaBackend(client=mock_client)
+    request = ContentRequest(url="https://example.com/whitespace")
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+
+@pytest.mark.asyncio
+async def test_trafilatura_fetch_absent_lib_raises_backend_error(monkeypatch):
+    """If trafilatura is absent, fetch() raises BackendError (not ImportError)."""
+    from content_reach.sources import web_page as wp_mod
+
+    monkeypatch.setattr(
+        wp_mod,
+        "_import_trafilatura",
+        lambda: (_ for _ in ()).throw(ImportError("no trafilatura")),
+    )
+
+    from content_reach.sources.web_page import TrafilaturaBackend
+
+    backend = TrafilaturaBackend()
+    request = ContentRequest(url="https://example.com/article")
+    with pytest.raises(BackendError, match="trafilatura not installed"):
+        await backend.fetch(request)
+
+
+# ---------------------------------------------------------------------------
+# JinaReaderBackend — fetch()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_jina_reader_fetch_maps_text():
+    """fetch() maps a 200 response body to a successful ContentResult."""
+    from content_reach.sources.web_page import JinaReaderBackend
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "Article text from Jina"
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    backend = JinaReaderBackend(client=mock_client)
+    request = ContentRequest(url="https://example.com/page")
+    result = await backend.fetch(request)
+
+    assert result.success is True
+    assert result.backend_used == "jina_reader"
+    assert result.source_type is SourceType.WEB_PAGE
+    assert result.text == "Article text from Jina"
+
+
+@pytest.mark.asyncio
+async def test_jina_reader_fetch_sends_accept_header():
+    """fetch() sends Accept: text/plain header to the Jina reader endpoint."""
+    from content_reach.sources.web_page import JinaReaderBackend
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "Content here"
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    backend = JinaReaderBackend(client=mock_client)
+    request = ContentRequest(url="https://example.com/page")
+    await backend.fetch(request)
+
+    call_kwargs = mock_client.get.call_args
+    headers = call_kwargs.kwargs.get("headers", {})
+    assert headers.get("Accept") == "text/plain"
+
+
+@pytest.mark.asyncio
+async def test_jina_reader_non_200_raises():
+    """Non-200 response raises BackendError."""
+    from content_reach.sources.web_page import JinaReaderBackend
+
+    mock_response = MagicMock()
+    mock_response.status_code = 429
+    mock_response.text = ""
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    backend = JinaReaderBackend(client=mock_client)
+    request = ContentRequest(url="https://example.com/page")
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+
+@pytest.mark.asyncio
+async def test_jina_reader_empty_text_raises():
+    """200 response with empty text raises BackendError."""
+    from content_reach.sources.web_page import JinaReaderBackend
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "   "
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    backend = JinaReaderBackend(client=mock_client)
+    request = ContentRequest(url="https://example.com/page")
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+
+# ---------------------------------------------------------------------------
+# build_web_page_chain()
+# ---------------------------------------------------------------------------
+
+
+def test_build_web_page_chain_order():
+    """Chain has trafilatura → jina_reader → browser in that order with WEB_PAGE type."""
+    from content_reach.sources.web_page import build_web_page_chain
+
+    chain = build_web_page_chain()
+    assert chain.backend_names() == ["trafilatura", "jina_reader", "browser"]
+    assert chain.source_type is SourceType.WEB_PAGE
+    assert chain.source == "web_page"

--- a/autobot-backend/tests/content_reach/sources/test_web_search.py
+++ b/autobot-backend/tests/content_reach/sources/test_web_search.py
@@ -1,0 +1,183 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for content_reach.sources.web_search (DdgsBackend, JinaSearchBackend, build_web_search_chain)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from content_reach.base import BackendError, ContentRequest
+from source_attribution import SourceType
+
+# ---------------------------------------------------------------------------
+# DdgsBackend — probe()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ddgs_probe_true_when_importable():
+    """probe() returns True when ddgs is importable (ddgs is installed here)."""
+    from content_reach.sources.web_search import DdgsBackend
+
+    backend = DdgsBackend()
+    result = await backend.probe()
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_ddgs_probe_false_when_absent(monkeypatch):
+    """probe() returns False when the lazy import helper raises ImportError."""
+    from content_reach.sources import web_search as ws_mod
+
+    monkeypatch.setattr(ws_mod, "_import_ddgs", lambda: (_ for _ in ()).throw(ImportError("no ddgs")))
+
+    from content_reach.sources.web_search import DdgsBackend
+
+    backend = DdgsBackend()
+    result = await backend.probe()
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# DdgsBackend — fetch()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ddgs_fetch_maps_results(monkeypatch):
+    """fetch() maps two DDGS results into ContentResult correctly."""
+    from content_reach.sources import web_search as ws_mod
+
+    fake_results = [
+        {"title": "Alpha", "href": "https://alpha.com", "body": "Alpha snippet"},
+        {"title": "Beta", "href": "https://beta.com", "body": "Beta snippet"},
+    ]
+
+    mock_ddgs_cls = MagicMock()
+    mock_ddgs_instance = MagicMock()
+    mock_ddgs_instance.text.return_value = fake_results
+    mock_ddgs_cls.return_value = mock_ddgs_instance
+
+    monkeypatch.setattr(ws_mod, "DDGS", mock_ddgs_cls)
+
+    from content_reach.sources.web_search import DdgsBackend
+
+    backend = DdgsBackend()
+    request = ContentRequest(query="test query", limit=2)
+    result = await backend.fetch(request)
+
+    assert result.success is True
+    assert result.backend_used == "ddgs"
+    assert result.source_type is SourceType.WEB_SEARCH
+    assert len(result.structured["results"]) == 2
+    assert result.structured["results"][0]["title"] == "Alpha"
+    assert "Alpha" in result.text
+
+
+@pytest.mark.asyncio
+async def test_ddgs_fetch_empty_raises(monkeypatch):
+    """.text() returning [] causes BackendError so the chain falls through."""
+    from content_reach.sources import web_search as ws_mod
+
+    mock_ddgs_cls = MagicMock()
+    mock_ddgs_instance = MagicMock()
+    mock_ddgs_instance.text.return_value = []
+    mock_ddgs_cls.return_value = mock_ddgs_instance
+
+    monkeypatch.setattr(ws_mod, "DDGS", mock_ddgs_cls)
+
+    from content_reach.sources.web_search import DdgsBackend
+
+    backend = DdgsBackend()
+    request = ContentRequest(query="empty query")
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+
+# ---------------------------------------------------------------------------
+# JinaSearchBackend — fetch()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_jina_search_fetch():
+    """fetch() maps a 200 response into a successful ContentResult."""
+    from content_reach.sources.web_search import JinaSearchBackend
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "Result text from Jina"
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    # Support async context manager usage
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    backend = JinaSearchBackend(client=mock_client)
+    request = ContentRequest(query="jina test query")
+    result = await backend.fetch(request)
+
+    assert result.success is True
+    assert result.backend_used == "jina_search"
+    assert result.source_type is SourceType.WEB_SEARCH
+    assert "Result text from Jina" in result.text
+
+
+@pytest.mark.asyncio
+async def test_jina_search_non_200_raises():
+    """Non-200 response raises BackendError."""
+    from content_reach.sources.web_search import JinaSearchBackend
+
+    mock_response = MagicMock()
+    mock_response.status_code = 503
+    mock_response.text = ""
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    backend = JinaSearchBackend(client=mock_client)
+    request = ContentRequest(query="failing query")
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+
+@pytest.mark.asyncio
+async def test_jina_search_empty_text_raises():
+    """200 response with empty text raises BackendError."""
+    from content_reach.sources.web_search import JinaSearchBackend
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "   "
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    backend = JinaSearchBackend(client=mock_client)
+    request = ContentRequest(query="empty text")
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+
+# ---------------------------------------------------------------------------
+# build_web_search_chain()
+# ---------------------------------------------------------------------------
+
+
+def test_build_web_search_chain_order():
+    """Chain has ddgs → jina_search → browser_search in that order with WEB_SEARCH type."""
+    from content_reach.sources.web_search import build_web_search_chain
+
+    chain = build_web_search_chain()
+    assert chain.backend_names() == ["ddgs", "jina_search", "browser_search"]
+    assert chain.source_type is SourceType.WEB_SEARCH
+    assert chain.source == "web_search"

--- a/autobot-backend/tests/content_reach/sources/test_web_search.py
+++ b/autobot-backend/tests/content_reach/sources/test_web_search.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from content_reach.base import BackendError, ContentRequest
@@ -21,6 +22,7 @@ from source_attribution import SourceType
 @pytest.mark.asyncio
 async def test_ddgs_probe_true_when_importable():
     """probe() returns True when ddgs is importable (ddgs is installed here)."""
+    pytest.importorskip("ddgs")
     from content_reach.sources.web_search import DdgsBackend
 
     backend = DdgsBackend()
@@ -164,6 +166,45 @@ async def test_jina_search_empty_text_raises():
 
     backend = JinaSearchBackend(client=mock_client)
     request = ContentRequest(query="empty text")
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+
+@pytest.mark.asyncio
+async def test_jina_search_sends_accept_header():
+    """fetch() sends Accept: application/json header to the Jina search endpoint."""
+    from content_reach.sources.web_search import JinaSearchBackend
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "Result text from Jina"
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    backend = JinaSearchBackend(client=mock_client)
+    request = ContentRequest(query="accept header check")
+    await backend.fetch(request)
+
+    call_kwargs = mock_client.get.call_args
+    headers = call_kwargs.kwargs.get("headers", {})
+    assert headers.get("Accept") == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_jina_search_httpx_error_raises_backend_error():
+    """fetch() wraps httpx.HTTPError into BackendError."""
+    from content_reach.sources.web_search import JinaSearchBackend
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=httpx.HTTPError("connection failed"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    backend = JinaSearchBackend(client=mock_client)
+    request = ContentRequest(query="http error query")
     with pytest.raises(BackendError):
         await backend.fetch(request)
 

--- a/autobot-backend/tests/content_reach/sources/test_youtube.py
+++ b/autobot-backend/tests/content_reach/sources/test_youtube.py
@@ -28,6 +28,23 @@ Hello world
 This is a test caption.
 """
 
+_FAKE_JSON3 = """\
+{
+  "events": [
+    {"segs": [{"utf8": "Hello world"}]},
+    {"segs": [{"utf8": "This is a test caption."}]}
+  ]
+}
+"""
+
+_FAKE_SRV1 = """\
+<?xml version="1.0" encoding="utf-8" ?>
+<transcript>
+  <text start="0" dur="3">Hello &amp; welcome</text>
+  <text start="3" dur="3">This is SRV1.</text>
+</transcript>
+"""
+
 _FAKE_INFO = {
     "title": "Test Video",
     "duration": 120,
@@ -49,6 +66,17 @@ _FAKE_INFO_AUTO = {
             {"ext": "vtt", "url": "https://fake-caption-host/auto.vtt"},
         ]
     },
+}
+
+_FAKE_INFO_SRV1 = {
+    "title": "SRV1 Video",
+    "duration": 10,
+    "subtitles": {
+        "en": [
+            {"ext": "srv1", "url": "https://fake-caption-host/captions.srv1"},
+        ]
+    },
+    "automatic_captions": {},
 }
 
 _FAKE_INFO_NO_CAPTIONS = {
@@ -128,13 +156,18 @@ async def test_ytdlp_fetch_maps_caption_text(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_ytdlp_fetch_falls_back_to_automatic_captions(monkeypatch):
-    """fetch() falls back to automatic_captions["en"] when subtitles["en"] absent."""
+    """fetch() falls back to automatic_captions["en"] and parses json3 body correctly.
+
+    _FAKE_INFO_AUTO exposes a json3 track first; the mock response body is valid
+    json3 so the real _json3_to_text path is exercised (not the JSONDecodeError
+    fallback that a VTT body would trigger).
+    """
     from content_reach.sources import youtube as yt_mod
 
     monkeypatch.setattr(yt_mod, "_ytdlp_extract_info", lambda url: _FAKE_INFO_AUTO)
 
     mock_response = MagicMock()
-    mock_response.text = _FAKE_VTT
+    mock_response.text = _FAKE_JSON3  # json3 body matches the json3 track selected
 
     mock_client = AsyncMock(spec=httpx.AsyncClient)
     mock_client.get = AsyncMock(return_value=mock_response)
@@ -150,6 +183,8 @@ async def test_ytdlp_fetch_falls_back_to_automatic_captions(monkeypatch):
     assert result.success is True
     assert result.backend_used == "yt_dlp"
     assert result.structured["title"] == "Auto Video"
+    assert "Hello world" in result.text
+    assert "This is a test caption." in result.text
 
 
 # ---------------------------------------------------------------------------
@@ -234,3 +269,45 @@ def test_build_youtube_chain_order():
     assert chain.source == "youtube"
     assert chain.source_type == SourceType.YOUTUBE
     assert chain.backend_names() == ["yt_dlp"]
+
+
+# ---------------------------------------------------------------------------
+# _srv1_to_text unit test
+# ---------------------------------------------------------------------------
+
+
+def test_srv1_track_parsed():
+    """_srv1_to_text extracts plain text from SRV1 XML, unescaping HTML entities."""
+    from content_reach.sources.youtube import _srv1_to_text
+
+    result = _srv1_to_text(_FAKE_SRV1)
+    assert "Hello & welcome" in result
+    assert "This is SRV1." in result
+
+
+@pytest.mark.asyncio
+async def test_ytdlp_fetch_srv1_track(monkeypatch):
+    """fetch() selects an srv1 track and returns correctly decoded plain text."""
+    from content_reach.sources import youtube as yt_mod
+
+    monkeypatch.setattr(yt_mod, "_ytdlp_extract_info", lambda url: _FAKE_INFO_SRV1)
+
+    mock_response = MagicMock()
+    mock_response.text = _FAKE_SRV1
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    from content_reach.sources.youtube import YtDlpCaptionBackend
+
+    backend = YtDlpCaptionBackend(client=mock_client)
+    request = ContentRequest(url="https://www.youtube.com/watch?v=srv1test")
+    result = await backend.fetch(request)
+
+    assert result.success is True
+    assert result.backend_used == "yt_dlp"
+    assert result.structured["title"] == "SRV1 Video"
+    assert "Hello & welcome" in result.text
+    assert "This is SRV1." in result.text

--- a/autobot-backend/tests/content_reach/sources/test_youtube.py
+++ b/autobot-backend/tests/content_reach/sources/test_youtube.py
@@ -1,0 +1,236 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for content_reach.sources.youtube (YtDlpCaptionBackend, build_youtube_chain)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from content_reach.base import BackendError, ContentRequest
+from source_attribution import SourceType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_VTT = """\
+WEBVTT
+
+00:00:00.000 --> 00:00:03.000
+Hello world
+
+00:00:03.000 --> 00:00:06.000
+This is a test caption.
+"""
+
+_FAKE_INFO = {
+    "title": "Test Video",
+    "duration": 120,
+    "subtitles": {
+        "en": [
+            {"ext": "vtt", "url": "https://fake-caption-host/captions.vtt"},
+        ]
+    },
+    "automatic_captions": {},
+}
+
+_FAKE_INFO_AUTO = {
+    "title": "Auto Video",
+    "duration": 60,
+    "subtitles": {},
+    "automatic_captions": {
+        "en": [
+            {"ext": "json3", "url": "https://fake-caption-host/auto.json3"},
+            {"ext": "vtt", "url": "https://fake-caption-host/auto.vtt"},
+        ]
+    },
+}
+
+_FAKE_INFO_NO_CAPTIONS = {
+    "title": "No Captions",
+    "duration": 30,
+    "subtitles": {},
+    "automatic_captions": {},
+}
+
+
+# ---------------------------------------------------------------------------
+# YtDlpCaptionBackend — probe()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ytdlp_probe_true_when_importable():
+    """probe() returns True when yt_dlp is importable (installed in this venv)."""
+    yt_dlp = pytest.importorskip("yt_dlp")  # noqa: F841 — skip if absent
+    from content_reach.sources.youtube import YtDlpCaptionBackend
+
+    backend = YtDlpCaptionBackend()
+    assert await backend.probe() is True
+
+
+@pytest.mark.asyncio
+async def test_ytdlp_probe_false_when_absent(monkeypatch):
+    """probe() returns False when the lazy import helper raises ImportError."""
+    from content_reach.sources import youtube as yt_mod
+
+    monkeypatch.setattr(
+        yt_mod,
+        "_import_yt_dlp",
+        lambda: (_ for _ in ()).throw(ImportError("no yt_dlp")),
+    )
+
+    from content_reach.sources.youtube import YtDlpCaptionBackend
+
+    backend = YtDlpCaptionBackend()
+    assert await backend.probe() is False
+
+
+# ---------------------------------------------------------------------------
+# YtDlpCaptionBackend — fetch(): happy path (subtitles["en"])
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ytdlp_fetch_maps_caption_text(monkeypatch):
+    """fetch() returns ContentResult with captions text when subtitles["en"] present."""
+    from content_reach.sources import youtube as yt_mod
+
+    monkeypatch.setattr(yt_mod, "_ytdlp_extract_info", lambda url: _FAKE_INFO)
+
+    mock_response = MagicMock()
+    mock_response.text = _FAKE_VTT
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    from content_reach.sources.youtube import YtDlpCaptionBackend
+
+    backend = YtDlpCaptionBackend(client=mock_client)
+    request = ContentRequest(url="https://www.youtube.com/watch?v=test123")
+    result = await backend.fetch(request)
+
+    assert result.success is True
+    assert result.backend_used == "yt_dlp"
+    assert result.source_type == SourceType.YOUTUBE
+    assert "Hello world" in result.text
+    assert result.structured["title"] == "Test Video"
+    assert result.structured["duration"] == 120
+    assert result.url == "https://www.youtube.com/watch?v=test123"
+
+
+@pytest.mark.asyncio
+async def test_ytdlp_fetch_falls_back_to_automatic_captions(monkeypatch):
+    """fetch() falls back to automatic_captions["en"] when subtitles["en"] absent."""
+    from content_reach.sources import youtube as yt_mod
+
+    monkeypatch.setattr(yt_mod, "_ytdlp_extract_info", lambda url: _FAKE_INFO_AUTO)
+
+    mock_response = MagicMock()
+    mock_response.text = _FAKE_VTT
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    from content_reach.sources.youtube import YtDlpCaptionBackend
+
+    backend = YtDlpCaptionBackend(client=mock_client)
+    request = ContentRequest(url="https://www.youtube.com/watch?v=auto456")
+    result = await backend.fetch(request)
+
+    assert result.success is True
+    assert result.backend_used == "yt_dlp"
+    assert result.structured["title"] == "Auto Video"
+
+
+# ---------------------------------------------------------------------------
+# YtDlpCaptionBackend — fetch(): no captions → BackendError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ytdlp_fetch_no_captions_raises(monkeypatch):
+    """fetch() raises BackendError when no English captions are available."""
+    from content_reach.sources import youtube as yt_mod
+
+    monkeypatch.setattr(yt_mod, "_ytdlp_extract_info", lambda url: _FAKE_INFO_NO_CAPTIONS)
+
+    from content_reach.sources.youtube import YtDlpCaptionBackend
+
+    backend = YtDlpCaptionBackend()
+    request = ContentRequest(url="https://www.youtube.com/watch?v=nocap789")
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+
+# ---------------------------------------------------------------------------
+# YtDlpCaptionBackend — fetch(): yt_dlp absent → BackendError in fetch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ytdlp_fetch_raises_when_yt_dlp_absent(monkeypatch):
+    """fetch() raises BackendError (not ImportError) when yt_dlp is not installed."""
+    from content_reach.sources import youtube as yt_mod
+
+    monkeypatch.setattr(
+        yt_mod,
+        "_import_yt_dlp",
+        lambda: (_ for _ in ()).throw(ImportError("no yt_dlp")),
+    )
+
+    from content_reach.sources.youtube import YtDlpCaptionBackend
+
+    backend = YtDlpCaptionBackend()
+    request = ContentRequest(url="https://www.youtube.com/watch?v=absent")
+    with pytest.raises(BackendError, match="yt-dlp not installed"):
+        await backend.fetch(request)
+
+
+# ---------------------------------------------------------------------------
+# YtDlpCaptionBackend — fetch(): httpx error → BackendError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ytdlp_fetch_httpx_error_raises_backend_error(monkeypatch):
+    """fetch() wraps httpx.HTTPError into BackendError."""
+    from content_reach.sources import youtube as yt_mod
+
+    monkeypatch.setattr(yt_mod, "_ytdlp_extract_info", lambda url: _FAKE_INFO)
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(side_effect=httpx.HTTPError("connection failed"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    from content_reach.sources.youtube import YtDlpCaptionBackend
+
+    backend = YtDlpCaptionBackend(client=mock_client)
+    request = ContentRequest(url="https://www.youtube.com/watch?v=httperr")
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+
+# ---------------------------------------------------------------------------
+# build_youtube_chain()
+# ---------------------------------------------------------------------------
+
+
+def test_build_youtube_chain_order():
+    """build_youtube_chain() returns chain with source_type YOUTUBE and backend ['yt_dlp']."""
+    from content_reach.sources.youtube import build_youtube_chain
+
+    chain = build_youtube_chain()
+    assert chain.source == "youtube"
+    assert chain.source_type == SourceType.YOUTUBE
+    assert chain.backend_names() == ["yt_dlp"]

--- a/autobot-backend/tests/content_reach/test_bootstrap.py
+++ b/autobot-backend/tests/content_reach/test_bootstrap.py
@@ -1,0 +1,38 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for content_reach.bootstrap — default source registry assembler (#10932)."""
+
+from content_reach.bootstrap import build_default_registry, register_default_sources
+from content_reach.registry import ContentSourceRegistry
+from source_attribution import SourceType
+
+_EXPECTED_SOURCES = {"web_search", "web_page", "youtube", "reddit", "social"}
+
+_SOURCE_TYPE_MAP = {
+    "web_search": SourceType.WEB_SEARCH,
+    "web_page": SourceType.WEB_PAGE,
+    "youtube": SourceType.YOUTUBE,
+    "reddit": SourceType.REDDIT,
+    "social": SourceType.SOCIAL,
+}
+
+
+def test_build_default_registry_has_all_sources():
+    registry = build_default_registry()
+    assert set(registry.list_sources()) == _EXPECTED_SOURCES
+
+
+def test_each_chain_source_type():
+    registry = build_default_registry()
+    for source_name, expected_type in _SOURCE_TYPE_MAP.items():
+        chain = registry.get_chain(source_name)
+        assert chain is not None, f"chain for {source_name!r} is missing"
+        assert chain.source_type == expected_type, f"{source_name}: expected {expected_type}, got {chain.source_type}"
+
+
+def test_register_default_sources_into_existing():
+    registry = ContentSourceRegistry()
+    register_default_sources(registry)
+    assert set(registry.list_sources()) == _EXPECTED_SOURCES

--- a/docs/superpowers/plans/2026-07-05-content-reach-sources.md
+++ b/docs/superpowers/plans/2026-07-05-content-reach-sources.md
@@ -1,0 +1,169 @@
+# Content Reach — Tasks 2–6 (Source Backends) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Implement the five content sources on top of the merged `ContentSourceRegistry` foundation — web-search, web-page, YouTube, Reddit/HN, and browser-backed social — each as a primary→fallback `ContentSourceChain`, plus the shared `BrowserBackend` universal fallback and a `bootstrap` assembler.
+
+**Architecture:** Each source module in `content_reach/sources/` defines one or more `ContentBackend` subclasses and a `build_<source>_chain() -> ContentSourceChain` factory. Optional heavy libs (`ddgs`, `trafilatura`, `yt-dlp`) are **lazy-imported behind an availability probe** (mirrors `research_browser_manager`'s `PLAYWRIGHT_AVAILABLE` pattern) so a missing lib degrades to httpx/browser fallbacks. Plain-HTTP backends (Jina, Reddit `.json`, HN Algolia) use the already-present `httpx`. `BrowserBackend` wraps `get_research_browser_manager().research_url()`.
+
+**Tech Stack:** Python 3.10+, `httpx` (async, present), `ddgs`, `trafilatura`, `yt-dlp` (optional/lazy), existing `content_reach.*`, `research_browser_manager`, `source_attribution`.
+
+**Scope:** ADDITIVE ONLY — like Task 1, this PR changes no runtime behavior. Backends + chains + a `build_default_registry()` assembler + tests. Boot-time registration and agent-tool exposure are the NEXT PR (umbrella Task 7).
+
+## Global Constraints
+
+- 4-line `mrveiss` copyright header verbatim on every new file (`# Copyright 2025-2026 mrveiss` / `# SPDX-License-Identifier: Apache-2.0` / `# AutoBot - AI-Powered Automation Platform` / `# Author: mrveiss`).
+- **Async-first** — all `fetch`/`probe` are `async`. Sync libs (`yt-dlp`, `trafilatura` parsing, `ddgs`) run via `asyncio.to_thread`. HTTP via `httpx.AsyncClient`.
+- Reuse canonical modules — import `content_reach.base`, `research_browser_manager`, `source_attribution`; never reimplement.
+- Optional libs lazy-imported inside methods; `probe()` returns False when the lib is absent (never raise at import).
+- Cache/TTL/timeout literals → module-level constants (per CLAUDE.md); HTTP timeouts as a named constant.
+- Logging via `autobot_shared.logging_manager.get_logger` — no `print()`.
+- No commit trailers (mrveiss sole author). Commit format `feat(content-reach): <desc> (#10932)`.
+- TDD: failing test first. Tests MOCK the network/lib (no real network in unit tests); any real-network test is marked `@pytest.mark.integration` (skipped by default).
+- Interpreter is `python3`. Run tests from repo root or backend dir; root `pytest.ini` sets `pythonpath`.
+- Backends live in `content_reach/backends/`, sources in `content_reach/sources/`; both need `__init__.py`.
+
+## Shared interfaces (given — from merged Task 1)
+
+- `content_reach.base`: `ContentBackend` (attrs `name`, `source_type`; abstract async `probe()`, `fetch(request)`), `ContentRequest(query, url, source, limit, conversation_id, options)`, `ContentResult(success, source_type, backend_used, text, structured, url, reliability, metadata)` + `ContentResult.failure(source_type, detail)`, `BackendError`.
+- `content_reach.chain.ContentSourceChain(source, source_type, backends)`.
+- `source_attribution.SourceType` (incl. `YOUTUBE`/`REDDIT`/`WEB_PAGE`/`SOCIAL`/`WEB_SEARCH`), `SourceReliability`.
+- `research_browser_manager.get_research_browser_manager()` → manager with `async research_url(conversation_id, url, extract_content=True) -> dict` (dict has `success`, `content.text_content`, `content.structured_data`, `title`); module-level `PLAYWRIGHT_AVAILABLE: bool`.
+
+**Common probe semantics for this PR:** `probe()` checks *capability* (optional lib importable, or `PLAYWRIGHT_AVAILABLE` for browser). Pure-HTTP backends (Jina/Reddit/HN) return `True` from `probe()` (a cheap network HEAD every 30s isn't worth it; the circuit breaker + fetch-failure fall-through handle real outages). Document this on each `probe()`.
+
+---
+
+### Task S0: dependencies + shared `BrowserBackend`
+
+**Files:**
+- Modify: `autobot-backend/requirements.txt` (add the three optional libs)
+- Create: `autobot-backend/content_reach/backends/__init__.py`
+- Create: `autobot-backend/content_reach/backends/browser.py`
+- Test: `autobot-backend/tests/content_reach/backends/test_browser.py`
+
+**Interfaces produced:**
+- `BrowserBackend(source_type: SourceType, name: str = "browser")` — `async probe()` returns `PLAYWRIGHT_AVAILABLE`; `async fetch(request)` requires `request.url`, calls `get_research_browser_manager().research_url(request.conversation_id, request.url)`, maps the dict to `ContentResult` (text=`content.text_content`, structured=`content.structured_data`, url=request.url, reliability=MEDIUM). Raises `BackendError` if `request.url` empty or `result["success"]` is false.
+- `BrowserSearchBackend(BrowserBackend)` — for query→search: `fetch` builds `https://duckduckgo.com/html/?q=<urlencoded query>` as the URL then delegates to the browser navigation+extract. `name = "browser_search"`.
+
+**Steps:**
+- [ ] **Add deps** to `autobot-backend/requirements.txt` (append, with comments):
+  ```
+  ddgs>=9.0            # #10932 content-reach: keyless web search (optional, lazy)
+  trafilatura>=2.0     # #10932 content-reach: readable article extraction (optional, lazy)
+  yt-dlp>=2025.1.1     # #10932 content-reach: YouTube caption extraction (optional, lazy)
+  ```
+  (Verify the latest available version strings with `python3 -m pip show <pkg>`; pin `>=` to the installed version's major.)
+- [ ] **Write failing test** `tests/content_reach/backends/test_browser.py` (also create `tests/content_reach/backends/__init__.py` if package-style discovery needs it — check sibling test dirs first):
+  - `test_browser_probe_reflects_playwright_available` — monkeypatch `research_browser_manager.PLAYWRIGHT_AVAILABLE` True/False, assert `probe()` matches.
+  - `test_browser_fetch_maps_research_result` — monkeypatch `get_research_browser_manager` to return a stub whose `research_url` returns `{"success": True, "content": {"text_content": "hello", "structured_data": {"headings": []}}, "title": "T"}`; assert `ContentResult.success`, `text=="hello"`, `backend_used=="browser"`, `url==request.url`.
+  - `test_browser_fetch_raises_without_url` — `ContentRequest(query="x")` (no url) → `BackendError`.
+  - `test_browser_fetch_raises_on_unsuccessful` — stub returns `{"success": False}` → `BackendError`.
+  - `test_browser_search_builds_ddg_url` — `BrowserSearchBackend`, `ContentRequest(query="cats dogs")`; capture the url passed to `research_url`, assert it is `https://duckduckgo.com/html/?q=cats+dogs` (or `%20`-encoded — assert it contains the encoded query).
+- [ ] Run: `python3 -m pytest autobot-backend/tests/content_reach/backends/test_browser.py -v` → FAIL (module missing).
+- [ ] **Implement** `backends/__init__.py` (header + docstring) and `backends/browser.py`. Lazy-import `PLAYWRIGHT_AVAILABLE` and `get_research_browser_manager` inside methods (avoids importing playwright stack at module load). Use `urllib.parse.urlencode`/`quote_plus` for the search URL. `research_url` is async — `await` it directly.
+- [ ] Run the test → PASS. Confirm pristine.
+- [ ] Commit: `git commit -m "feat(content-reach): add optional source deps + shared BrowserBackend (#10932)"`
+
+---
+
+### Task S1: web-search source (`ddgs ▸ s.jina.ai ▸ browser`)
+
+**Files:** Create `content_reach/sources/__init__.py`, `content_reach/sources/web_search.py`; Test `tests/content_reach/sources/test_web_search.py`.
+
+**Interfaces produced:**
+- `DdgsBackend` (name `ddgs`, source_type `WEB_SEARCH`): `probe()` → True iff `import ddgs` succeeds; `fetch(request)` → `await asyncio.to_thread(lambda: DDGS().text(request.query, max_results=request.limit))` → list of `{title, href, body}`; build `text` as a newline list of `title — href` + snippets, `structured={"results": [...]}`. Empty results → raise `BackendError` (so the chain falls through).
+- `JinaSearchBackend` (name `jina_search`): `fetch` GETs `https://s.jina.ai/<urlencoded query>` with header `Accept: application/json` (fallback `text/plain`) via `httpx.AsyncClient(timeout=_HTTP_TIMEOUT)`; parse results. Non-200 or empty → `BackendError`.
+- `build_web_search_chain() -> ContentSourceChain(source="web_search", source_type=WEB_SEARCH, backends=[DdgsBackend(), JinaSearchBackend(), BrowserSearchBackend(WEB_SEARCH)])`.
+
+**Steps:**
+- [ ] **Failing tests** (`tests/content_reach/sources/test_web_search.py`, create `sources/__init__.py` test-dir if needed):
+  - `test_ddgs_probe_true_when_importable` (ddgs is installed in this env) and a `test_ddgs_probe_false_when_absent` that monkeypatches the import to raise (e.g. patch `builtins.__import__` or the module's lazy import helper) → False.
+  - `test_ddgs_fetch_maps_results` — monkeypatch the `DDGS` used by the backend so `.text()` returns two fake dicts; assert `ContentResult.success`, `structured["results"]` length 2, `backend_used=="ddgs"`.
+  - `test_ddgs_fetch_empty_raises` — `.text()` returns `[]` → `BackendError`.
+  - `test_jina_search_fetch` — mock `httpx.AsyncClient.get` (via monkeypatch or an injected client) to return a 200 with a small JSON/text body; assert mapped result.
+  - `test_build_web_search_chain_order` — assert `build_web_search_chain().backend_names() == ["ddgs", "jina_search", "browser_search"]` and `source_type is SourceType.WEB_SEARCH`.
+- [ ] Run → FAIL. Implement. Run → PASS.
+- [ ] Commit: `feat(content-reach): web-search source (ddgs ▸ jina ▸ browser) (#10932)`
+
+*Implementer note:* prefer structuring each HTTP backend to accept an optional `client: httpx.AsyncClient | None` param (default None → create one per fetch) so tests can inject a mock client instead of monkeypatching globally. Keep `DDGS` referenced as a module-level name you can monkeypatch.
+
+---
+
+### Task S2: web-page source (`httpx+trafilatura ▸ r.jina.ai ▸ browser`)
+
+**Files:** Create `content_reach/sources/web_page.py`; Test `tests/content_reach/sources/test_web_page.py`.
+
+**Interfaces produced:**
+- `TrafilaturaBackend` (name `trafilatura`, source_type `WEB_PAGE`): `probe()` → True iff `import trafilatura`; `fetch(request)` requires `request.url`; GET the URL via `httpx.AsyncClient`, then `text = await asyncio.to_thread(trafilatura.extract, html)`. `None`/empty extraction → `BackendError`.
+- `JinaReaderBackend` (name `jina_reader`): GET `https://r.jina.ai/<request.url>` (header `Accept: text/plain`) → readable text; non-200/empty → `BackendError`.
+- `build_web_page_chain() -> ContentSourceChain(source="web_page", source_type=WEB_PAGE, backends=[TrafilaturaBackend(), JinaReaderBackend(), BrowserBackend(WEB_PAGE)])`.
+
+**Steps:** analogous to S1 (mock httpx + monkeypatch `trafilatura.extract`). Tests: trafilatura maps extracted text; empty extraction raises; jina reader maps text; chain order `["trafilatura", "jina_reader", "browser"]`. TDD RED→GREEN. Commit `feat(content-reach): web-page source (trafilatura ▸ jina ▸ browser) (#10932)`.
+
+---
+
+### Task S3: YouTube captions source (`yt-dlp`)
+
+**Files:** Create `content_reach/sources/youtube.py`; Test `tests/content_reach/sources/test_youtube.py`.
+
+**Interfaces produced:**
+- `YtDlpCaptionBackend` (name `yt_dlp`, source_type `YOUTUBE`): `probe()` → True iff `import yt_dlp`; `fetch(request)` requires a YouTube `request.url`; run in `asyncio.to_thread`: `yt_dlp.YoutubeDL({"skip_download": True, "writesubtitles": True, "writeautomaticsub": True, "subtitleslangs": ["en"], "quiet": True, "no_warnings": True}).extract_info(url, download=False)`; pull the English subtitle/automatic-caption track URL from `info["subtitles"]`/`info["automatic_captions"]`, fetch that track via `httpx`, and return its text (strip to plain text). No captions → `BackendError`. `structured={"title": info.get("title"), "duration": info.get("duration")}`.
+- `build_youtube_chain() -> ContentSourceChain(source="youtube", source_type=YOUTUBE, backends=[YtDlpCaptionBackend()])`.
+
+**Steps:** TDD with `extract_info` monkeypatched to return a fake `info` dict (with a fake caption URL) and httpx mocked to return caption text; assert mapped result + `backend_used=="yt_dlp"`. Test `no captions → BackendError`. Test `probe False when yt_dlp absent`. Chain order `["yt_dlp"]`. Commit `feat(content-reach): youtube captions source via yt-dlp (#10932)`.
+
+*Implementer note:* verify the exact shape of `info["automatic_captions"]["en"]` (a list of `{ext,url,...}`) against the installed yt-dlp with a quick `python3 -c`; pick the `ext in ("json3","srv1","vtt")` entry and convert to plain text. Keep the yt-dlp options dict as a module-level constant.
+
+---
+
+### Task S4: Reddit/HN source (`old.reddit .json ▸ HN Algolia ▸ browser`)
+
+**Files:** Create `content_reach/sources/reddit.py`; Test `tests/content_reach/sources/test_reddit.py`.
+
+**Interfaces produced:**
+- `RedditJsonBackend` (name `reddit_json`, source_type `REDDIT`): `fetch(request)` — if `request.url` is a reddit URL, GET `<url>.json`; else GET `https://www.reddit.com/search.json?q=<query>&limit=<limit>`. MUST send a descriptive `User-Agent` header (module constant, e.g. `"autobot-content-reach/1.0"`) — reddit 403s default clients. Parse `data.children[].data` → title/selftext/permalink. Non-200/empty → `BackendError`.
+- `HnAlgoliaBackend` (name `hn_algolia`): GET `http://hn.algolia.com/api/v1/search?query=<query>` → `hits[]` (title, url, points, objectID → `https://news.ycombinator.com/item?id=`). Non-200/empty → `BackendError`.
+- `build_reddit_chain() -> ContentSourceChain(source="reddit", source_type=REDDIT, backends=[RedditJsonBackend(), HnAlgoliaBackend(), BrowserBackend(REDDIT)])`.
+
+**Steps:** TDD with mocked httpx returning sample reddit/HN JSON; assert mapping + UA header present (assert the request carried the UA). Empty → raise. Chain order `["reddit_json", "hn_algolia", "browser"]`. Commit `feat(content-reach): reddit/HN source via public JSON (#10932)`.
+
+---
+
+### Task S5: browser-backed social source
+
+**Files:** Create `content_reach/sources/social.py`; Test `tests/content_reach/sources/test_social.py`.
+
+**Interfaces produced:**
+- `build_social_chain() -> ContentSourceChain(source="social", source_type=SOCIAL, backends=[BrowserBackend(SOCIAL)])` — reuses the shared `BrowserBackend` with `source_type=SOCIAL` (Twitter/IG/etc. via rendered page; local-first, no cookies). No new backend class unless a thin `SocialBrowserBackend` is needed to set `source_type`; prefer passing `SOCIAL` to `BrowserBackend`.
+
+**Steps:** TDD: `test_build_social_chain` asserts `backend_names()==["browser"]`, `source_type is SourceType.SOCIAL`; a `fetch` test reusing the browser stub asserting the result carries `source_type=SOCIAL`. Commit `feat(content-reach): browser-backed social source (#10932)`.
+
+---
+
+### Task S6: `bootstrap` registry assembler
+
+**Files:** Create `content_reach/bootstrap.py`; Test `tests/content_reach/test_bootstrap.py`.
+
+**Interfaces produced:**
+- `build_default_registry() -> ContentSourceRegistry` — constructs a fresh `ContentSourceRegistry`, registers all five chains (`build_web_search_chain`, `build_web_page_chain`, `build_youtube_chain`, `build_reddit_chain`, `build_social_chain`), returns it.
+- `register_default_sources(registry: ContentSourceRegistry) -> None` — registers the five chains into a given registry (used by boot wiring in the next PR).
+
+**Steps:**
+- [ ] **Failing test** `tests/content_reach/test_bootstrap.py`:
+  - `test_build_default_registry_has_all_sources` — `set(build_default_registry().list_sources()) == {"web_search","web_page","youtube","reddit","social"}`.
+  - `test_each_chain_source_type` — assert each registered chain's `source_type` matches (`web_search`→WEB_SEARCH, `youtube`→YOUTUBE, `reddit`→REDDIT, `web_page`→WEB_PAGE, `social`→SOCIAL).
+  - `test_register_default_sources_into_existing` — pass a fresh `ContentSourceRegistry`, call `register_default_sources`, assert 5 sources present.
+- [ ] Run → FAIL. Implement `bootstrap.py`. Run → PASS.
+- [ ] **Full-suite gate:** `python3 -m pytest autobot-backend/tests/content_reach/ -v` (all foundation + new source tests green) and import smoke `cd autobot-backend && python3 -c "import content_reach.bootstrap; print('ok')"`.
+- [ ] Commit: `feat(content-reach): bootstrap assembler for default source registry (#10932)`
+
+---
+
+## Self-Review
+
+**Spec coverage:** S0 BrowserBackend + deps → spec §4.4/§7; S1–S5 → the five `sources/` in spec §3; S6 assembler enables spec §4.5 health probe to report real sources and Task 7 boot wiring. Agent tools + boot registration = deferred to Task 7 (noted, not a gap). ✓
+**Async-first:** every sync lib (`ddgs`, `trafilatura`, `yt-dlp`) wrapped in `asyncio.to_thread`; HTTP via `httpx.AsyncClient`. ✓
+**Lazy-import/optional:** all three heavy libs lazy + probe-guarded; Reddit/HN/Jina need only httpx. ✓
+**Type consistency:** every `build_*_chain()` returns `ContentSourceChain(source, source_type, backends)`; every backend has `name`/`source_type` + async `probe`/`fetch` returning `ContentResult`/raising `BackendError`. ✓
+**Test hygiene:** unit tests mock network/lib (no real calls); real-network tests `@pytest.mark.integration`. ✓


### PR DESCRIPTION
## Thinking Path

Content Reach umbrella #10932 (from researching Agent-Reach). Task 1 (the `ContentSourceRegistry` foundation) already merged. This PR delivers **Tasks 2–6**: the five real content sources on top of that foundation, plus the shared `BrowserBackend` and a `bootstrap` assembler.

Built via subagent-driven TDD (per-task implement → review → fix → re-review, then an opus whole-branch review). **Additive only** — no boot wiring or agent-tool surface yet (that is the next PR, umbrella Task 7), so this changes no runtime behavior until a chain is registered.

## What Changed

New `content_reach/sources/` + `content_reach/backends/` + `content_reach/bootstrap.py`. Each source is a primary→fallback `ContentSourceChain`; optional heavy libs are lazy-imported behind availability probes; Jina/Reddit/HN use `httpx.AsyncClient`; the shared `BrowserBackend` wraps the existing `research_browser_manager` (local-first, no cookies).

| Source | Chain | Notes |
|---|---|---|
| web_search | `ddgs ▸ s.jina.ai ▸ browser_search` | keyless |
| web_page | `trafilatura ▸ r.jina.ai ▸ browser` | readable extraction |
| youtube | `yt_dlp` captions | json3 / vtt / srv1 parsers (srv1 via `defusedxml`, XXE-safe) |
| reddit | `reddit .json ▸ HN Algolia ▸ browser` | public JSON, descriptive UA |
| social | `browser` | Twitter/IG etc. via rendered page |

- `bootstrap.build_default_registry()` / `register_default_sources()` assemble all five chains (the seam Task 7 will wire at boot).
- Deps added to `requirements.txt`: `ddgs`, `trafilatura`, `yt-dlp` (all optional/lazy at runtime).
- All backends: async-first (sync libs via `asyncio.to_thread`), wrap `httpx.HTTPError`/lib failures as `BackendError`, empty results → `BackendError` so the chain falls through, per-backend logging.

## Verification

- **84/84** `content_reach` unit tests pass (network + libs mocked; youtube json3/vtt/srv1 parsers each exercised with representative inputs).
- `black --check` (26.3.1, matches CI) · `isort` · `ruff` all clean.
- Import smoke: all source/backend/bootstrap modules import.
- Opus whole-branch review: async-first clean throughout, `BackendError` contract honored end-to-end, optional-lib-safe, chain factories exactly per spec — "Ready to merge" after the one header fix (now applied).

## Model Used

Claude Opus 4.8 (orchestration + whole-branch review), Sonnet 4.6 (implementers + per-task reviews), Haiku (trivial reviews).

Part of #10932. Design/plan: `docs/superpowers/plans/2026-07-05-content-reach-sources.md`.
