### PR TITLE
fix(security): timing-safe internal-API-key comparison across auth paths (#11006)

### DIFF
--- a/autobot-backend/api/envelope_secrets.py
+++ b/autobot-backend/api/envelope_secrets.py
@@ -28,7 +28,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth_middleware import get_auth_middleware
+from auth_middleware import get_auth_middleware, verify_internal_api_key
 from autobot_shared.secrets_vault import VaultKind, VaultRef
 from llc.deps import get_session
 from models.secret import Secret
@@ -83,10 +83,7 @@ async def service_principal(request: Request) -> str:
     Either path is scoped STRICTLY to the system vault.  Non-system vault access is
     rejected at the endpoint level so the audit log always sees the attempt.
     """
-    from autobot_shared.ssot_config import config as _ssot
-
-    _internal_key = _ssot.misc.internal_api_key
-    if _internal_key and request.headers.get("X-Internal-API-Key") == _internal_key:
+    if verify_internal_api_key(request.headers.get("X-Internal-API-Key")):
         service_id = "slm-backend"
         logger.info(
             "service principal authenticated via X-Internal-API-Key",

--- a/autobot-backend/api/task_workspace_ws.py
+++ b/autobot-backend/api/task_workspace_ws.py
@@ -43,9 +43,12 @@ import json
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect, status
 from pydantic import BaseModel
 
-from auth_middleware import check_admin_permission, get_auth_middleware
+from auth_middleware import (
+    check_admin_permission,
+    get_auth_middleware,
+    verify_internal_api_key,
+)
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.ssot_config import config as ssot_config
 from services.docker_task_workspace import (
     WorkspaceInfo,
     get_task_workspace_manager,
@@ -385,8 +388,9 @@ def _validate_ws_origin(websocket: WebSocket) -> None:
 
     auth_header = websocket.headers.get("authorization", "")
     if not auth_header:
-        # Allow when running under test or dev environment without auth layer
-        if not os.environ.get("AUTOBOT_REQUIRE_WS_AUTH", "1") == "1":
+        # Allow only when auth is explicitly disabled (test/dev); production
+        # defaults to "1" and therefore fails closed on a missing Authorization.
+        if os.environ.get("AUTOBOT_REQUIRE_WS_AUTH", "1") != "1":
             return
         # Production: block unauthenticated connections
         raise PermissionError("Authorization header required for workspace shell")
@@ -400,8 +404,7 @@ def _authenticate_ws_admin(websocket: WebSocket) -> bool:
     so the standard auth middleware resolves the caller. Any error → deny.
     """
     try:
-        internal_key = ssot_config.misc.internal_api_key
-        if internal_key and websocket.headers.get("X-Internal-API-Key") == internal_key:
+        if verify_internal_api_key(websocket.headers.get("X-Internal-API-Key")):
             return True
         user = get_auth_middleware().get_user_from_request(websocket)  # type: ignore[arg-type]
         if not user:

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -848,8 +848,7 @@ async def get_current_user(request: Request) -> Dict:
     Raises HTTPException if authentication fails.
     """
     # Issue #1779: Allow trusted internal services via API key
-    _internal_key = ssot_config.misc.internal_api_key
-    if _internal_key and request.headers.get("X-Internal-API-Key") == _internal_key:
+    if verify_internal_api_key(request.headers.get("X-Internal-API-Key")):
         return {"username": "service:slm", "role": "admin", "service": True}
 
     middleware = get_auth_middleware()
@@ -904,6 +903,19 @@ async def get_current_user(request: Request) -> Dict:
     raise_auth_error("AUTH_0002", "Authentication required")
 
 
+def verify_internal_api_key(provided: str | None) -> bool:
+    """Constant-time check of the trusted internal-service API key (Issue #1145).
+
+    Returns True only when the internal key is configured AND ``provided`` matches
+    it exactly. Uses :func:`secrets.compare_digest` so a partial match cannot be
+    inferred from response timing; a missing/``None`` header can never match.
+    """
+    expected = ssot_config.misc.internal_api_key
+    if not expected or not provided:
+        return False
+    return secrets.compare_digest(provided, expected)
+
+
 def check_admin_permission(request: Request) -> bool:
     """
     FastAPI dependency to check if user has admin permission.
@@ -921,8 +933,7 @@ def check_admin_permission(request: Request) -> bool:
     """
     # Issue #1145: Allow trusted internal services (e.g. SLM backend) via API key.
     # The key is set via AUTOBOT_INTERNAL_API_KEY env var on both services.
-    _internal_key = ssot_config.misc.internal_api_key
-    if _internal_key and request.headers.get("X-Internal-API-Key") == _internal_key:
+    if verify_internal_api_key(request.headers.get("X-Internal-API-Key")):
         logger.debug("Internal API key auth: granting admin access")
         return True
 


### PR DESCRIPTION
## Thinking Path
Automated security review of the merged #10989 fix flagged two items in `api/task_workspace_ws.py`. On verification against the actual code:

- **Memory-privacy IDOR (flagged HIGH) — false positive.** `check_admin_permission(request)` (`auth_middleware.py`) is self-contained: it resolves the caller via `get_user_from_request(request)` with **no nested `Depends()`**, so the direct call in `_resolve_target_user` correctly enforces admin (a non-admin hits `raise_auth_error(...403)` → denied). No bypass exists.
- **Internal-API-key comparison — real, low-severity hardening.** The `X-Internal-API-Key` path is an intentional, codebase-wide internal-service auth mechanism (Issue #1145), **not** a spoofable-field bypass. But the secret was compared with `==` at **4 sites**, a timing side-channel.
- **`_validate_ws_origin` boolean — correct but confusing.** `not os.environ.get(...) == "1"` is functionally fail-closed but relies on operator precedence.

## What Changed
- New `verify_internal_api_key(provided)` helper in `auth_middleware.py` using `secrets.compare_digest` with `None`/empty guards (a missing header can never match, and an unset expected key rejects everything — fail-closed).
- Routed all **4** internal-key checks through the helper (DRY, consistent, constant-time):
  - `auth_middleware.py` — `get_current_user` + `check_admin_permission`
  - `api/envelope_secrets.py` — service-principal auth
  - `api/task_workspace_ws.py` — `_authenticate_ws_admin`
- Rewrote the WS-origin guard to explicit `!= "1"` for clarity (behaviourally identical, still fail-closed in production).
- Removed now-unused `ssot_config`/`_ssot` imports in the two API modules.

No behavioural change for valid keys or non-admins; only the comparison becomes constant-time.

## Verification
- `python -m py_compile` — clean on all 3 files.
- `black --check` + `isort --check-only` — clean.
- `flake8 --select=F` — 0 (no unused imports / redefinitions after removing the locals).
- A dedicated unit test isn't feasible: the repo-wide `conftest.py` stubs `auth_middleware` as a MagicMock (its real import pulls the full config/Redis chain), so importing the real helper yields a mock in CI too. Behaviour is covered by existing app-level auth/WS smoke tests; the stub gap is tracked under #10691.

## Model Used
Opus 4.8

Closes #11006. Follow-up hardening to #10989.