### PR TITLE
fix(frontend): replace no-explicit-any lint violations with proper types (#9924)

### DIFF
--- a/autobot-frontend/public/service-worker.ts
+++ b/autobot-frontend/public/service-worker.ts
@@ -89,7 +89,17 @@ function _getCacheName(url: string): string {
 /**
  * Get cache entry metadata
  */
-function getCacheMetadata(response: Response): any {
+interface CacheMetadata {
+  timestamp: number
+  url: string
+  status: number
+  headers: {
+    contentType: string | null
+    cacheControl: string | null
+  }
+}
+
+function getCacheMetadata(response: Response): CacheMetadata {
   return {
     timestamp: Date.now(),
     url: response.url,
@@ -158,7 +168,7 @@ self.addEventListener('install', (event: ExtendableEvent) => {
     })
   )
   // Force activation immediately
-  ;(self as any).skipWaiting()
+  ;(self as unknown as ServiceWorkerGlobalScope).skipWaiting()
 })
 
 /**
@@ -191,7 +201,7 @@ self.addEventListener('activate', (event: ExtendableEvent) => {
     })()
   )
   // Claim clients immediately
-  ;(self as any).clients.claim()
+  ;(self as unknown as ServiceWorkerGlobalScope).clients.claim()
 })
 
 /**
@@ -304,7 +314,7 @@ self.addEventListener('fetch', (event: FetchEvent) => {
  */
 self.addEventListener('message', (event: ExtendableMessageEvent) => {
   if (event.data && event.data.type === 'SKIP_WAITING') {
-    ;(self as any).skipWaiting()
+    ;(self as unknown as ServiceWorkerGlobalScope).skipWaiting()
   }
 
   if (event.data && event.data.type === 'CLEAR_CACHES') {

--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -568,7 +568,7 @@ import { useChatStore } from '@/stores/useChatStore'
 import { useKnowledgeStore } from '@/stores/useKnowledgeStore'
 import { useRuntimeFeaturesStore } from '@/stores/useRuntimeFeaturesStore'
 import { useSystemStatus } from '@/composables/useSystemStatus'
-import { useHostSelection } from '@/composables/useHostSelection';
+import { useHostSelection, type InfrastructureHost } from '@/composables/useHostSelection';
 import { useNavOverflow } from '@/composables/useNavOverflow'
 import { useGlobalShortcuts } from '@/composables/useGlobalShortcuts'
 import NavOverflowMenu from '@/components/layout/NavOverflowMenu.vue'
@@ -678,7 +678,7 @@ export default {
     }))
 
     // Host selection event handlers
-    const onHostSelected = (result: { host: any; rememberChoice: boolean }) => {
+    const onHostSelected = (result: { host: InfrastructureHost; rememberChoice: boolean }) => {
       handleHostSelected(result)
     }
 

--- a/autobot-frontend/src/__tests__/transcriber/useSseProgress.test.ts
+++ b/autobot-frontend/src/__tests__/transcriber/useSseProgress.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { useSseProgress } from '@/composables/transcriber/useSseProgress'
 
 describe('useSseProgress', () => {
-  let mockEventSource: any
+  let mockEventSource: Record<string, unknown>
   let onmessageHandler: ((event: MessageEvent) => void) | null = null
   let onerrorHandler: (() => void) | null = null
 
@@ -19,7 +19,7 @@ describe('useSseProgress', () => {
     }
 
     // Mock the EventSource constructor
-    vi.stubGlobal('EventSource', vi.fn(function EventSource(this: any, _url: string) {
+    vi.stubGlobal('EventSource', vi.fn(function EventSource(this: unknown, _url: string) {
       Object.defineProperty(mockEventSource, 'onmessage', {
         set: (handler) => { onmessageHandler = handler },
         get: () => onmessageHandler,

--- a/autobot-frontend/src/__tests__/transcriber/useTranscriberApi.test.ts
+++ b/autobot-frontend/src/__tests__/transcriber/useTranscriberApi.test.ts
@@ -195,7 +195,7 @@ describe('useTranscriberApi', () => {
   })
 
   describe('AI', () => {
-    let mockEventSource: any
+    let mockEventSource: Record<string, unknown>
 
     beforeEach(() => {
       mockEventSource = {

--- a/autobot-frontend/src/components/__tests__/ChatInterface.test.ts
+++ b/autobot-frontend/src/components/__tests__/ChatInterface.test.ts
@@ -20,8 +20,8 @@ const mockInitializeChatInterface = vi.fn()
 const mockLoadChatInitData = vi.fn()
 vi.mock('@/services/BatchApiService', () => ({
   default: {
-    initializeChatInterface: (...args: any[]) => mockInitializeChatInterface(...args),
-    loadChatInitData: (...args: any[]) => mockLoadChatInitData(...args),
+    initializeChatInterface: (...args: unknown[]) => mockInitializeChatInterface(...args),
+    loadChatInitData: (...args: unknown[]) => mockLoadChatInitData(...args),
   },
   BatchApiService: vi.fn(),
 }))


### PR DESCRIPTION
## Thinking Path
The `frontend-tests` CI check (`npm run lint`) has been failing on the Dev_new_gui base (confirmed pre-existing on `49fadeaeb`, before this session's merges — not a regression). All 10 failures are `@typescript-eslint/no-explicit-any` violations across 5 files. These are the "green CI baseline" gaps tracked under umbrella #9924.

## What Changed
Replaced each `any` with a correct, narrower type (no `eslint-disable` suppressions):
- `src/App.vue` — `onHostSelected` param `host: any` → `host: InfrastructureHost` (the exact type `handleHostSelected` already expects); added `type InfrastructureHost` import.
- `public/service-worker.ts` — `getCacheMetadata(): any` → new `CacheMetadata` interface; 3× `(self as any)` → `(self as unknown as ServiceWorkerGlobalScope)` (webworker lib already in use via `ExtendableMessageEvent`).
- `src/**/__tests__` (3 files) — mock `any` → `unknown[]` / `Record<string, unknown>` / `this: unknown`.

## Verification
- `eslint` on all 5 changed files — **exit 0** (0 violations, no new errors).
- `vue-tsc --noEmit -p tsconfig.app.json` — **exit 0** (no type regressions; `any`→concrete only narrows).

## Model Used
Opus 4.8

Contributes to #9924 (test-infra green CI baseline). Turns the `frontend-tests` lint job green.