### PR TITLE
fix(frontend): replace no-explicit-any in 4 test files (#9924 batch 2)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useConnectionTester.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useConnectionTester.test.ts
@@ -150,11 +150,11 @@ describe('useConnectionTester composable', () => {
     })
 
     it('should track isTesting during test', async () => {
-      let resolveFetch: any
-      const fetchPromise = new Promise((resolve) => {
+      let resolveFetch: () => void
+      const fetchPromise = new Promise<Response>((resolve) => {
         resolveFetch = () => resolve(new Response(null, { status: 200 }))
       })
-      vi.mocked(fetch).mockReturnValue(fetchPromise as any)
+      vi.mocked(fetch).mockReturnValue(fetchPromise)
 
       const tester = useConnectionTester({
         endpoint: 'http://example.com/health'
@@ -620,11 +620,11 @@ describe('useConnectionTester composable', () => {
     })
 
     it('should cancel ongoing test', async () => {
-      let _resolveFetch: any
-      const fetchPromise = new Promise((resolve) => {
+      let _resolveFetch: () => void
+      const fetchPromise = new Promise<Response>((resolve) => {
         resolveFetch = () => resolve(new Response(null, { status: 200 }))
       })
-      vi.mocked(fetch).mockReturnValue(fetchPromise as any)
+      vi.mocked(fetch).mockReturnValue(fetchPromise)
 
       const tester = useConnectionTester({
         endpoint: 'http://example.com/health'
@@ -654,11 +654,11 @@ describe('useConnectionTester composable', () => {
     })
 
     it('should prevent concurrent tests', async () => {
-      let resolveFetch: any
-      const fetchPromise = new Promise((resolve) => {
+      let resolveFetch: () => void
+      const fetchPromise = new Promise<Response>((resolve) => {
         resolveFetch = () => resolve(new Response(null, { status: 200 }))
       })
-      vi.mocked(fetch).mockReturnValue(fetchPromise as any)
+      vi.mocked(fetch).mockReturnValue(fetchPromise)
 
       const tester = useConnectionTester({
         endpoint: 'http://example.com/health'
@@ -743,11 +743,11 @@ describe('useConnectionTester composable', () => {
     })
 
     it('should cancel all ongoing tests', async () => {
-      let _resolveFetch: any
-      const fetchPromise = new Promise((resolve) => {
+      let _resolveFetch: () => void
+      const fetchPromise = new Promise<Response>((resolve) => {
         resolveFetch = () => resolve(new Response(null, { status: 200 }))
       })
-      vi.mocked(fetch).mockReturnValue(fetchPromise as any)
+      vi.mocked(fetch).mockReturnValue(fetchPromise)
 
       const { testers, testAll, cancelAll } = useConnectionTesters({
         backend: { endpoint: 'http://backend.com/health' },
@@ -786,11 +786,11 @@ describe('useConnectionTester composable', () => {
     })
 
     it('should compute anyTesting', async () => {
-      let resolveFetch: any
-      const fetchPromise = new Promise((resolve) => {
+      let resolveFetch: () => void
+      const fetchPromise = new Promise<Response>((resolve) => {
         resolveFetch = () => resolve(new Response(null, { status: 200 }))
       })
-      vi.mocked(fetch).mockReturnValue(fetchPromise as any)
+      vi.mocked(fetch).mockReturnValue(fetchPromise)
 
       const { testers, anyTesting } = useConnectionTesters({
         backend: { endpoint: 'http://backend.com/health' },

--- a/autobot-frontend/src/composables/__tests__/useLocalStorage.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useLocalStorage.test.ts
@@ -61,7 +61,7 @@ describe('useLocalStorage Composable', () => {
 
     // Create a proxy to make localStorage behave like the real thing
     // This ensures Object.keys() and for...in loops work correctly
-    const storageProxy: any = new Proxy(
+    const storageProxy: Storage = new Proxy(
       {
         getItem: getItemSpy,
         setItem: setItemSpy,
@@ -88,7 +88,7 @@ describe('useLocalStorage Composable', () => {
         },
         set(target, prop, value) {
           if (typeof prop === 'string' && !(prop in target)) {
-            localStorageMock[prop] = value
+            localStorageMock[prop] = value as string
             return true
           }
           return false
@@ -121,7 +121,7 @@ describe('useLocalStorage Composable', () => {
           return undefined
         }
       }
-    )
+    ) as unknown as Storage
 
     // Mock localStorage
     Object.defineProperty(global, 'localStorage', {
@@ -134,7 +134,7 @@ describe('useLocalStorage Composable', () => {
     global.window = {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn()
-    } as any
+    } as unknown as Window & typeof globalThis
   })
 
   afterEach(() => {
@@ -155,7 +155,7 @@ describe('useLocalStorage Composable', () => {
       data.value = { name: 'Jane', age: 25 }
       await nextTick()
 
-      const calls = setItemSpy.mock.calls.filter((call: any) => call[0] === 'test-key')
+      const calls = setItemSpy.mock.calls.filter((call: unknown[]) => call[0] === 'test-key')
       expect(calls.length).toBeGreaterThan(0)
       expect(calls[calls.length - 1][1]).toBe(JSON.stringify({ name: 'Jane', age: 25 }))
     })
@@ -169,7 +169,7 @@ describe('useLocalStorage Composable', () => {
       data.value = 'new-value'
       await nextTick()
 
-      const calls = setItemSpy.mock.calls.filter((call: any) => call[0] === 'test-key')
+      const calls = setItemSpy.mock.calls.filter((call: unknown[]) => call[0] === 'test-key')
       expect(calls.length).toBeGreaterThan(0)
       expect(calls[calls.length - 1][1]).toBe('new-value')
     })
@@ -183,7 +183,7 @@ describe('useLocalStorage Composable', () => {
       data.value = 99
       await nextTick()
 
-      const calls = setItemSpy.mock.calls.filter((call: any) => call[0] === 'test-number')
+      const calls = setItemSpy.mock.calls.filter((call: unknown[]) => call[0] === 'test-number')
       expect(calls.length).toBeGreaterThan(0)
       expect(calls[calls.length - 1][1]).toBe(JSON.stringify(99))
     })
@@ -203,7 +203,7 @@ describe('useLocalStorage Composable', () => {
       data.value = [4, 5, 6]
       await nextTick()
 
-      const calls = setItemSpy.mock.calls.filter((call: any) => call[0] === 'test-array')
+      const calls = setItemSpy.mock.calls.filter((call: unknown[]) => call[0] === 'test-array')
       expect(calls.length).toBeGreaterThan(0)
       expect(calls[calls.length - 1][1]).toBe(JSON.stringify([4, 5, 6]))
     })
@@ -217,7 +217,7 @@ describe('useLocalStorage Composable', () => {
       data.value = { count: 1 }
       await nextTick()
 
-      const calls = setItemSpy.mock.calls.filter((call: any) => call[0] === 'test-key')
+      const calls = setItemSpy.mock.calls.filter((call: unknown[]) => call[0] === 'test-key')
       expect(calls.length).toBeGreaterThan(0)
       expect(calls[0][1]).toBe(JSON.stringify({ count: 1 }))
     })
@@ -286,7 +286,7 @@ describe('useLocalStorage Composable', () => {
       data.value = { ...complexObject, number: 100 }
       await nextTick()
 
-      const calls = setItemSpy.mock.calls.filter((call: any) => call[0] === 'complex-key')
+      const calls = setItemSpy.mock.calls.filter((call: unknown[]) => call[0] === 'complex-key')
       expect(calls.length).toBeGreaterThan(0)
     })
 
@@ -307,7 +307,7 @@ describe('useLocalStorage Composable', () => {
 
       expect(customSerializer).toHaveBeenCalledWith(newDate)
 
-      const calls = setItemSpy.mock.calls.filter((call: any) => call[0] === 'date-key')
+      const calls = setItemSpy.mock.calls.filter((call: unknown[]) => call[0] === 'date-key')
       expect(calls.length).toBeGreaterThan(0)
     })
 
@@ -340,7 +340,7 @@ describe('useLocalStorage Composable', () => {
       data.value = 'updated-value'
       await nextTick()
 
-      const calls = setItemSpy.mock.calls.filter((call: any) => call[0] === 'raw-key')
+      const calls = setItemSpy.mock.calls.filter((call: unknown[]) => call[0] === 'raw-key')
       expect(calls.length).toBeGreaterThan(0)
       expect(calls[calls.length - 1][1]).toBe('updated-value')
     })
@@ -361,7 +361,7 @@ describe('useLocalStorage Composable', () => {
       data.value = 'updated'
       await nextTick()
 
-      const calls = setItemSpy.mock.calls.filter((call: any) => call[0] === 'raw-key')
+      const calls = setItemSpy.mock.calls.filter((call: unknown[]) => call[0] === 'raw-key')
       expect(calls.length).toBeGreaterThan(0)
       expect(calls[0][1]).toBe('updated')
     })
@@ -404,7 +404,7 @@ describe('useLocalStorage Composable', () => {
     })
 
     it('should handle serialization errors', async () => {
-      const circularRef: any = { self: null }
+      const circularRef: { self: unknown } = { self: null }
       circularRef.self = circularRef
 
       const customSerializer = vi.fn(() => {
@@ -417,7 +417,7 @@ describe('useLocalStorage Composable', () => {
         onError
       })
 
-      data.value = circularRef
+      data.value = circularRef as unknown as { test: boolean }
       await nextTick()
 
       expect(onError).toHaveBeenCalled()
@@ -481,8 +481,8 @@ describe('useLocalStorage Composable', () => {
       const data = useLocalStorage('sync-key', 'initial')
 
       // Get the storage event handler
-      const storageHandler = (window.addEventListener as any).mock.calls.find(
-        (call: any) => call[0] === 'storage'
+      const storageHandler = vi.mocked(window.addEventListener).mock.calls.find(
+        (call: unknown[]) => call[0] === 'storage'
       )?.[1]
 
       expect(storageHandler).toBeDefined()
@@ -503,8 +503,8 @@ describe('useLocalStorage Composable', () => {
     it('should set value to null when storage event indicates removal', async () => {
       const data = useLocalStorage('remove-key', 'initial')
 
-      const storageHandler = (window.addEventListener as any).mock.calls.find(
-        (call: any) => call[0] === 'storage'
+      const storageHandler = vi.mocked(window.addEventListener).mock.calls.find(
+        (call: unknown[]) => call[0] === 'storage'
       )?.[1]
 
       // Simulate removal in another tab
@@ -524,8 +524,8 @@ describe('useLocalStorage Composable', () => {
       const data = useLocalStorage('my-key', 'initial')
       const initialValue = data.value
 
-      const storageHandler = (window.addEventListener as any).mock.calls.find(
-        (call: any) => call[0] === 'storage'
+      const storageHandler = vi.mocked(window.addEventListener).mock.calls.find(
+        (call: unknown[]) => call[0] === 'storage'
       )?.[1]
 
       // Simulate storage event for different key
@@ -544,8 +544,8 @@ describe('useLocalStorage Composable', () => {
     it('should handle storage events with raw mode', async () => {
       const data = useLocalStorage('raw-sync', 'initial', { raw: true })
 
-      const storageHandler = (window.addEventListener as any).mock.calls.find(
-        (call: any) => call[0] === 'storage'
+      const storageHandler = vi.mocked(window.addEventListener).mock.calls.find(
+        (call: unknown[]) => call[0] === 'storage'
       )?.[1]
 
       const storageEvent = {
@@ -565,8 +565,8 @@ describe('useLocalStorage Composable', () => {
         mergeStrategy: 'ignore'
       })
 
-      const storageHandler = (window.addEventListener as any).mock.calls.find(
-        (call: any) => call[0] === 'storage'
+      const storageHandler = vi.mocked(window.addEventListener).mock.calls.find(
+        (call: unknown[]) => call[0] === 'storage'
       )?.[1]
 
       const storageEvent = {
@@ -587,8 +587,8 @@ describe('useLocalStorage Composable', () => {
         mergeStrategy: 'overwrite'
       })
 
-      const storageHandler = (window.addEventListener as any).mock.calls.find(
-        (call: any) => call[0] === 'storage'
+      const storageHandler = vi.mocked(window.addEventListener).mock.calls.find(
+        (call: unknown[]) => call[0] === 'storage'
       )?.[1]
 
       const storageEvent = {
@@ -608,8 +608,8 @@ describe('useLocalStorage Composable', () => {
       const onError = vi.fn()
       const _data = useLocalStorage('parse-error-key', 'initial', { onError })
 
-      const storageHandler = (window.addEventListener as any).mock.calls.find(
-        (call: any) => call[0] === 'storage'
+      const storageHandler = vi.mocked(window.addEventListener).mock.calls.find(
+        (call: unknown[]) => call[0] === 'storage'
       )?.[1]
 
       const storageEvent = {
@@ -638,13 +638,13 @@ describe('useLocalStorage Composable', () => {
 
       // Mutate nested object
       if (data.value && typeof data.value === 'object' && 'nested' in data.value) {
-        const nested = (data.value as any).nested
+        const nested = (data.value as { nested: { value: string } }).nested
         nested.value = 'mutated'
       }
 
       // Re-read should not be mutated
       const data2 = useLocalStorage('deep-key', {}, { deep: true })
-      expect((data2.value as any).nested.value).toBe('test')
+      expect((data2.value as { nested: { value: string } }).nested.value).toBe('test')
     })
 
     it('should watch with deep option when enabled', async () => {
@@ -654,13 +654,13 @@ describe('useLocalStorage Composable', () => {
 
       // Mutate nested property
       if (data.value && typeof data.value === 'object' && 'nested' in data.value) {
-        (data.value as any).nested.count = 1
+        (data.value as { nested: { count: number } }).nested.count = 1
       }
 
       await nextTick()
 
       // Should have triggered write
-      const calls = setItemSpy.mock.calls.filter((call: any) => call[0] === 'deep-watch')
+      const calls = setItemSpy.mock.calls.filter((call: unknown[]) => call[0] === 'deep-watch')
       expect(calls.length).toBeGreaterThan(0)
     })
   })
@@ -672,7 +672,7 @@ describe('useLocalStorage Composable', () => {
   describe('SSR Safety', () => {
     it('should handle missing window object', () => {
       const originalWindow = global.window
-      delete (global as any).window
+      delete (global as unknown as Record<string, unknown>).window
 
       const data = useLocalStorage('ssr-key', 'default')
 
@@ -683,7 +683,7 @@ describe('useLocalStorage Composable', () => {
 
     it('should handle missing localStorage', () => {
       const originalLocalStorage = global.localStorage
-      delete (global as any).localStorage
+      delete (global as unknown as Record<string, unknown>).localStorage
 
       const data = useLocalStorage('ssr-key', 'default')
 
@@ -722,13 +722,13 @@ describe('useLocalStorage Composable', () => {
 
     it('should throw error for invalid key (non-string)', () => {
       expect(() => {
-        useLocalStorage(null as any, 'value')
+        useLocalStorage(null as unknown as string, 'value')
       }).toThrow('[useLocalStorage] Invalid key')
     })
 
     it('should throw error for invalid key (undefined)', () => {
       expect(() => {
-        useLocalStorage(undefined as any, 'value')
+        useLocalStorage(undefined as unknown as string, 'value')
       }).toThrow('[useLocalStorage] Invalid key')
     })
   })
@@ -771,7 +771,7 @@ describe('useLocalStorage Composable', () => {
 
     it('should handle SSR safely', () => {
       const originalLocalStorage = global.localStorage
-      delete (global as any).localStorage
+      delete (global as unknown as Record<string, unknown>).localStorage
 
       expect(() => {
         clearLocalStorage()
@@ -829,7 +829,7 @@ describe('useLocalStorage Composable', () => {
 
     it('should handle SSR safely', () => {
       const originalLocalStorage = global.localStorage
-      delete (global as any).localStorage
+      delete (global as unknown as Record<string, unknown>).localStorage
 
       const keys = getLocalStorageKeys()
 
@@ -892,7 +892,7 @@ describe('useLocalStorage Composable', () => {
 
     it('should handle SSR safely', () => {
       const originalLocalStorage = global.localStorage
-      delete (global as any).localStorage
+      delete (global as unknown as Record<string, unknown>).localStorage
 
       const size = getLocalStorageSize()
 
@@ -935,7 +935,7 @@ describe('useLocalStorage Composable', () => {
     it('should handle undefined values by converting to null', async () => {
       const data = useLocalStorage('undefined-key', { value: 'test' })
 
-      data.value = undefined as any
+      data.value = undefined as unknown as { value: string }
       await nextTick()
 
       // undefined should not remove, but setting to null removes
@@ -950,7 +950,7 @@ describe('useLocalStorage Composable', () => {
       data.value = ''
       await nextTick()
 
-      const calls = setItemSpy.mock.calls.filter((call: any) => call[0] === 'empty-key')
+      const calls = setItemSpy.mock.calls.filter((call: unknown[]) => call[0] === 'empty-key')
       expect(calls.length).toBeGreaterThan(0)
       expect(calls[0][1]).toBe('')
       expect(data.value).toBe('')

--- a/autobot-frontend/src/test/utils/test-setup-helpers.ts
+++ b/autobot-frontend/src/test/utils/test-setup-helpers.ts
@@ -3,7 +3,8 @@
 import { vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { createRouter, createWebHistory } from 'vue-router'
-import type { Router } from 'vue-router'
+import type { Router, RouteRecordRaw } from 'vue-router'
+import type { Pinia } from 'pinia'
 // Issue #172: Import from consolidated network.ts (TypeScript + .env support)
 import { NetworkConstants, ServiceURLs } from '@/constants/network'
 
@@ -22,8 +23,8 @@ export const setupTestEnv = () => {
 export const setupWindowMocks = () => {
   // Mock window.location
   // Issue #156 Fix: Type assertion for window.location mock
-  delete (window as any).location
-  ;(window as any).location = {
+  delete (window as unknown as Record<string, unknown>).location
+  ;(window as unknown as Record<string, unknown>).location = {
     ...window.location,
     href: 'http://localhost:3000/',
     origin: 'http://localhost:3000',
@@ -66,9 +67,9 @@ export const setupWindowMocks = () => {
 
   // Mock notification API
   // Issue #156 Fix: Type assertions for Notification mock
-  global.Notification = vi.fn() as any
-  ;(global.Notification as any).permission = 'granted'
-  ;(global.Notification as any).requestPermission = vi.fn(() => Promise.resolve('granted'))
+  global.Notification = vi.fn() as unknown as typeof Notification
+  ;(global.Notification as unknown as Record<string, unknown>).permission = 'granted'
+  ;(global.Notification as unknown as Record<string, unknown>).requestPermission = vi.fn(() => Promise.resolve('granted'))
 }
 
 // Setup Pinia store for testing
@@ -79,7 +80,7 @@ export const setupPiniaStore = () => {
 }
 
 // Setup Vue Router for testing
-export const setupTestRouter = (routes: any[] = []) => {
+export const setupTestRouter = (routes: RouteRecordRaw[] = []) => {
   const defaultRoutes = [
     { path: '/', name: 'home', component: { template: '<div>Home</div>' } },
     { path: '/chat', name: 'chat', component: { template: '<div>Chat</div>' } },
@@ -97,9 +98,9 @@ export const setupTestRouter = (routes: any[] = []) => {
 }
 
 // Mock fetch API with custom responses
-export const setupFetchMock = (responses: Record<string, any> = {}) => {
+export const setupFetchMock = (responses: Record<string, unknown> = {}) => {
   // Issue #156 Fix: Type url parameter as string | URL
-  global.fetch = vi.fn((url: string | URL, options?: any) => {
+  global.fetch = vi.fn((url: string | URL, options?: RequestInit) => {
     const urlString = typeof url === 'string' ? url : url.toString()
     const method = options?.method || 'GET'
     const key = `${method} ${urlString}`
@@ -128,7 +129,7 @@ export const setupFetchMock = (responses: Record<string, any> = {}) => {
     }
 
     return Promise.resolve(defaultResponse)
-  }) as any
+  }) as unknown as typeof fetch
 }
 
 // Setup WebSocket mocks
@@ -145,14 +146,14 @@ export const setupWebSocketMocks = () => {
     onclose: null,
     onmessage: null,
     onerror: null,
-  })) as any
+  })) as unknown as typeof WebSocket
 
   // WebSocket constants
   // Issue #156 Fix: Type assertions for read-only WebSocket constants
-  ;(global.WebSocket as any).CONNECTING = 0
-  ;(global.WebSocket as any).OPEN = 1
-  ;(global.WebSocket as any).CLOSING = 2
-  ;(global.WebSocket as any).CLOSED = 3
+  ;(global.WebSocket as unknown as Record<string, number>).CONNECTING = 0
+  ;(global.WebSocket as unknown as Record<string, number>).OPEN = 1
+  ;(global.WebSocket as unknown as Record<string, number>).CLOSING = 2
+  ;(global.WebSocket as unknown as Record<string, number>).CLOSED = 3
 }
 
 // Setup console mocks to reduce test noise
@@ -233,7 +234,7 @@ export const setupFileAPIMocks = () => {
     slice: vi.fn(),
     stream: vi.fn(),
     text: () => Promise.resolve(parts.join('')),
-  })) as any
+  })) as unknown as typeof File
 
   global.FileReader = vi.fn().mockImplementation(() => ({
     readAsDataURL: vi.fn(),
@@ -252,7 +253,7 @@ export const setupFileAPIMocks = () => {
     LOADING: 1,
     DONE: 2,
     readyState: 0,
-  })) as any
+  })) as unknown as typeof FileReader
 }
 
 // Comprehensive test environment setup
@@ -262,7 +263,7 @@ export const setupTestEnvironment = (options: {
   mockFetch?: boolean
   mockWebSocket?: boolean
   mockTimers?: boolean
-  fetchResponses?: Record<string, any>
+  fetchResponses?: Record<string, unknown>
 } = {}) => {
   const {
     includeRouter = true,
@@ -284,8 +285,8 @@ export const setupTestEnvironment = (options: {
 
   const setup: {
     router?: Router
-    pinia?: any
-    timers?: any
+    pinia?: Pinia
+    timers?: ReturnType<typeof setupTimerMocks>
   } = {}
 
   // Optional setups
@@ -341,7 +342,7 @@ export const generateTestData = {
     ...overrides,
   }),
 
-  apiResponse: (data: any, success = true) => ({
+  apiResponse: (data: unknown, success = true) => ({
     success,
     data,
     message: success ? 'Success' : 'Error occurred',

--- a/autobot-frontend/tests/canvas/canvas.spec.ts
+++ b/autobot-frontend/tests/canvas/canvas.spec.ts
@@ -4,6 +4,17 @@
 // Author: mrveiss
 import { test, expect } from '@playwright/test'
 
+// Minimal shape of the canvas store exposed on window for E2E hooks.
+interface CanvasStoreHandle {
+  cells: Array<{ id: string }>
+  isDirty: boolean
+  addCell: (owner: string) => void
+  updateCellContent: (id: string, content: string) => void
+  upsertStreamCell: (cell: { cellId: string; seq: number; delta: string; state: string }) => void
+}
+
+type CanvasWindow = Window & { __canvasStore?: CanvasStoreHandle }
+
 test.describe('Canvas (MVA-360 Phase 1)', () => {
   test.beforeEach(async ({ page }) => {
     // Set feature flag and navigate to canvas
@@ -49,7 +60,7 @@ test.describe('Canvas (MVA-360 Phase 1)', () => {
   test('agent cell displays ownership signals: color border + background tint + 🤖 badge', async ({ page }) => {
     // Create an agent cell (simulated via store)
     await page.evaluate(() => {
-      const store = (window as any).__canvasStore
+      const store = (window as unknown as CanvasWindow).__canvasStore
       if (store) {
         store.upsertStreamCell({
           cellId: 'agent-cell-1',
@@ -80,7 +91,7 @@ test.describe('Canvas (MVA-360 Phase 1)', () => {
   test('user cell displays without agent styling (color independence verified)', async ({ page }) => {
     // Create a user cell
     await page.evaluate(() => {
-      const store = (window as any).__canvasStore
+      const store = (window as unknown as CanvasWindow).__canvasStore
       if (store) {
         store.addCell('user')
       }
@@ -106,7 +117,7 @@ test.describe('Canvas (MVA-360 Phase 1)', () => {
   test('streaming state machine: skeleton → partial → complete transitions', async ({ page }) => {
     // Start with skeleton (placeholder)
     await page.evaluate(() => {
-      const store = (window as any).__canvasStore
+      const store = (window as unknown as CanvasWindow).__canvasStore
       if (store) {
         store.upsertStreamCell({
           cellId: 'stream-cell-1',
@@ -126,7 +137,7 @@ test.describe('Canvas (MVA-360 Phase 1)', () => {
 
     // Transition to partial (streaming)
     await page.evaluate(() => {
-      const store = (window as any).__canvasStore
+      const store = (window as unknown as CanvasWindow).__canvasStore
       if (store) {
         store.upsertStreamCell({
           cellId: 'stream-cell-1',
@@ -145,7 +156,7 @@ test.describe('Canvas (MVA-360 Phase 1)', () => {
 
     // Transition to complete
     await page.evaluate(() => {
-      const store = (window as any).__canvasStore
+      const store = (window as unknown as CanvasWindow).__canvasStore
       if (store) {
         store.upsertStreamCell({
           cellId: 'stream-cell-1',
@@ -186,27 +197,27 @@ test.describe('Canvas (MVA-360 Phase 1)', () => {
   test('keyboard shortcuts work: ⌘Z undo, ⌘⇧Z redo, ⌘⇧E export, ⌘L add cell', async ({ page }) => {
     // Add a cell, edit it, then undo
     await page.evaluate(() => {
-      const store = (window as any).__canvasStore
+      const store = (window as unknown as CanvasWindow).__canvasStore
       if (store) {
         store.addCell('user')
         store.updateCellContent(store.cells[store.cells.length - 1].id, 'test content')
       }
     })
 
-    const initialCount = await page.evaluate(() => (window as any).__canvasStore?.cells.length)
+    const initialCount = await page.evaluate(() => (window as unknown as CanvasWindow).__canvasStore?.cells.length)
 
     // Press ⌘Z (meta+z)
     await page.keyboard.press('Meta+z')
     await page.waitForTimeout(100)
 
-    const afterUndoCount = await page.evaluate(() => (window as any).__canvasStore?.cells.length)
+    const afterUndoCount = await page.evaluate(() => (window as unknown as CanvasWindow).__canvasStore?.cells.length)
     expect(afterUndoCount).toBe((initialCount || 0) - 1)
 
     // Press ⌘⇧Z (meta+shift+z)
     await page.keyboard.press('Meta+Shift+z')
     await page.waitForTimeout(100)
 
-    const afterRedoCount = await page.evaluate(() => (window as any).__canvasStore?.cells.length)
+    const afterRedoCount = await page.evaluate(() => (window as unknown as CanvasWindow).__canvasStore?.cells.length)
     expect(afterRedoCount).toBe(initialCount)
 
     // Verify export sheet opens on ⌘⇧E
@@ -235,7 +246,7 @@ test.describe('Canvas (MVA-360 Phase 1)', () => {
 
     // Add a cell to trigger dirty state
     await page.evaluate(() => {
-      const store = (window as any).__canvasStore
+      const store = (window as unknown as CanvasWindow).__canvasStore
       if (store) {
         store.addCell('user')
         store.isDirty = true
@@ -253,7 +264,7 @@ test.describe('Canvas (MVA-360 Phase 1)', () => {
   test('edge state: empty canvas shows "+ Add your first cell" CTA', async ({ page }) => {
     // Ensure canvas is empty
     await page.evaluate(() => {
-      const store = (window as any).__canvasStore
+      const store = (window as unknown as CanvasWindow).__canvasStore
       if (store) {
         store.cells = []
       }
@@ -281,7 +292,7 @@ test.describe('Canvas (MVA-360 Phase 1)', () => {
 
     // Trigger stream to skeleton state
     await page.evaluate(() => {
-      const store = (window as any).__canvasStore
+      const store = (window as unknown as CanvasWindow).__canvasStore
       if (store) {
         store.upsertStreamCell({
           cellId: 'motion-cell',
@@ -303,7 +314,7 @@ test.describe('Canvas (MVA-360 Phase 1)', () => {
   test('color independence: agent cell signals visible without relying on color alone (border + icon + badge)', async ({ page }) => {
     // Create agent cell
     await page.evaluate(() => {
-      const store = (window as any).__canvasStore
+      const store = (window as unknown as CanvasWindow).__canvasStore
       if (store) {
         store.upsertStreamCell({
           cellId: 'color-test-cell',
@@ -332,7 +343,7 @@ test.describe('Canvas (MVA-360 Phase 1)', () => {
   test('visual snapshot: default split layout (desktop)', async ({ page }) => {
     // Add some cells for visual interest
     await page.evaluate(() => {
-      const store = (window as any).__canvasStore
+      const store = (window as unknown as CanvasWindow).__canvasStore
       if (store) {
         store.addCell('user')
         store.updateCellContent(store.cells[0].id, '# User Cell\nSome content here')
@@ -358,7 +369,7 @@ test.describe('Canvas (MVA-360 Phase 1)', () => {
 
     // Add cells
     await page.evaluate(() => {
-      const store = (window as any).__canvasStore
+      const store = (window as unknown as CanvasWindow).__canvasStore
       if (store) {
         store.addCell('user')
         store.updateCellContent(store.cells[0].id, 'Mobile content')
@@ -373,7 +384,7 @@ test.describe('Canvas (MVA-360 Phase 1)', () => {
     await page.emulateMedia({ reducedMotion: 'reduce' })
 
     await page.evaluate(() => {
-      const store = (window as any).__canvasStore
+      const store = (window as unknown as CanvasWindow).__canvasStore
       if (store) {
         store.upsertStreamCell({
           cellId: 'no-motion-cell',


### PR DESCRIPTION
## Thinking Path
Incremental grind of the 984 `no-explicit-any` eslint warnings blocking the `frontend-tests` job (`--max-warnings 0`), per #9924. Batch of the 4 highest-count **test/util** files (lowest regression risk).

## What Changed — 85 `any` removed (type-only, no test-logic changes)
- `useLocalStorage.test.ts` (39): `(call: any)`→`(call: unknown[])`, spy casts→`vi.mocked(...)`, global patch→`(global as unknown as Record<string, unknown>)`, `storageProxy: Storage`, dynamic property access→minimal shapes.
- `test-setup-helpers.ts` (20): `setupTestRouter(routes: RouteRecordRaw[])`, `pinia?: Pinia`, `options?: RequestInit`, global mocks→`unknown as typeof X`.
- `canvas.spec.ts` (16): local `CanvasWindow`/`CanvasStoreHandle` types.
- `useConnectionTester.test.ts` (10): fetch promises→`new Promise<Response>` + `resolveFetch: () => void` (dropped `as any` casts).

`expect.any(Number|Function)` retained — those are Vitest matcher APIs, not the TS `any` type.

## Verification (independently re-run, not just the subagent's report)
- `eslint` on all 4 files → **exit 0**, zero output.
- `vitest run` (2 unit files) → **104/104 passed**.
- `vue-tsc` clean; `grep` confirms 0 residual TS `any`.

## Discoveries
- #11010 — pre-existing dead code in `useConnectionTester.test.ts` cancel blocks (`_resolveFetch` declared, `resolveFetch` assigned/unused). Confirmed on base, left untouched (out of type-only scope).

## Model Used
Opus 4.8

Contributes to #9924 (984→899 remaining).