### PR TITLE
fix(frontend): replace no-explicit-any in useApi/RumAgent/rum plugin (#9924 batch 5)

### DIFF
--- a/autobot-frontend/src/composables/useApi.ts
+++ b/autobot-frontend/src/composables/useApi.ts
@@ -234,7 +234,7 @@ export function useChatApi() {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have resetChat(), use direct HTTP call
         async () => {
-          return await api.post<any>(`${getApiBase()}/chat/reset`)
+          return await api.post<unknown>(`${getApiBase()}/chat/reset`)
         },
         { errorMessage: 'Failed to reset chat' }
       )
@@ -279,7 +279,7 @@ export function useSettingsApi() {
     /**
      * Update settings
      */
-    async updateSettings(settings: Record<string, any>) {
+    async updateSettings(settings: Record<string, unknown>) {
       return withErrorHandling(
         () => api.saveSettings(settings),
         { errorMessage: 'Failed to update settings' }
@@ -293,7 +293,7 @@ export function useSettingsApi() {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have getBackendSettings(), use direct HTTP call
         async () => {
-          return await api.get<any>(`${getApiBase()}/settings/backend`)
+          return await api.get<unknown>(`${getApiBase()}/settings/backend`)
         },
         {
           errorMessage: 'Failed to load backend settings',
@@ -305,11 +305,11 @@ export function useSettingsApi() {
     /**
      * Update backend settings
      */
-    async updateBackendSettings(settings: Record<string, any>) {
+    async updateBackendSettings(settings: Record<string, unknown>) {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have saveBackendSettings(), use direct HTTP call
         async () => {
-          return await api.post<any>(`${getApiBase()}/settings/backend`, settings)
+          return await api.post<unknown>(`${getApiBase()}/settings/backend`, settings)
         },
         { errorMessage: 'Failed to update backend settings' }
       )
@@ -333,7 +333,7 @@ export function useKnowledgeApi() {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have searchKnowledge(), use direct HTTP call
         async () => {
-          return await api.get<any>(`${getApiBase()}/knowledge/search?query=${encodeURIComponent(query)}&limit=${limit}`)
+          return await api.get<unknown>(`${getApiBase()}/knowledge/search?query=${encodeURIComponent(query)}&limit=${limit}`)
         },
         {
           errorMessage: 'Failed to search knowledge base',
@@ -349,7 +349,7 @@ export function useKnowledgeApi() {
       return withErrorHandling(
         // Issue #549 Fix: Use correct path /api/knowledge_base/facts
         async () => {
-          return await api.post<any>(`${getApiBase()}/knowledge_base/facts`, { content: text, title, source })
+          return await api.post<unknown>(`${getApiBase()}/knowledge_base/facts`, { content: text, title, source })
         },
         { errorMessage: 'Failed to add text to knowledge base' }
       )
@@ -362,7 +362,7 @@ export function useKnowledgeApi() {
       return withErrorHandling(
         // Issue #549 Fix: Use correct path /api/knowledge_base/url
         async () => {
-          return await api.post<any>(`${getApiBase()}/knowledge_base/url`, { url, method })
+          return await api.post<unknown>(`${getApiBase()}/knowledge_base/url`, { url, method })
         },
         { errorMessage: 'Failed to add URL to knowledge base' }
       )
@@ -377,7 +377,7 @@ export function useKnowledgeApi() {
         async () => {
           const formData = new FormData()
           formData.append('file', file)
-          return await api.post<any>(`${getApiBase()}/knowledge_base/upload`, formData)
+          return await api.post<unknown>(`${getApiBase()}/knowledge_base/upload`, formData)
         },
         { errorMessage: 'Failed to add file to knowledge base' }
       )
@@ -455,7 +455,7 @@ export function useFileApi() {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have listFiles(), use direct HTTP call
         async () => {
-          return await api.get<any>(`${getApiBase()}/files/list?path=${encodeURIComponent(path)}`)
+          return await api.get<unknown>(`${getApiBase()}/files/list?path=${encodeURIComponent(path)}`)
         },
         {
           errorMessage: 'Failed to list files',
@@ -481,7 +481,7 @@ export function useFileApi() {
           formData.append('file', file)
           formData.append('path', path)
           formData.append('overwrite', String(overwrite))
-          return await api.post<any>(`${getApiBase()}/files/upload`, formData)
+          return await api.post<unknown>(`${getApiBase()}/files/upload`, formData)
         },
         { errorMessage: 'Failed to upload file' }
       )
@@ -494,7 +494,7 @@ export function useFileApi() {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have viewFile(), use direct HTTP call
         async () => {
-          return await api.get<any>(`${getApiBase()}/files/view?path=${encodeURIComponent(path)}`)
+          return await api.get<unknown>(`${getApiBase()}/files/view?path=${encodeURIComponent(path)}`)
         },
         { errorMessage: 'Failed to view file' }
       )
@@ -507,7 +507,7 @@ export function useFileApi() {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have deleteFile(), use direct HTTP call
         async () => {
-          return await api.delete<any>(`${getApiBase()}/files?path=${encodeURIComponent(path)}`)
+          return await api.delete<unknown>(`${getApiBase()}/files?path=${encodeURIComponent(path)}`)
         },
         { errorMessage: 'Failed to delete file' }
       )
@@ -538,7 +538,7 @@ export function useFileApi() {
           const formData = new FormData()
           formData.append('path', path)
           formData.append('name', name)
-          return await api.post<any>(`${getApiBase()}/files/create_directory`, formData)
+          return await api.post<unknown>(`${getApiBase()}/files/create_directory`, formData)
         },
         { errorMessage: 'Failed to create directory' }
       )
@@ -551,7 +551,7 @@ export function useFileApi() {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have getFileStats(), use direct HTTP call
         async () => {
-          return await api.get<any>(`${getApiBase()}/files/stats`)
+          return await api.get<unknown>(`${getApiBase()}/files/stats`)
         },
         {
           errorMessage: 'Failed to get file statistics',

--- a/autobot-frontend/src/plugins/rum.ts
+++ b/autobot-frontend/src/plugins/rum.ts
@@ -4,7 +4,7 @@
  * Vue RUM Plugin - Integrates RUM agent with Vue application
  */
 
-import type { App } from 'vue'
+import type { App, ComponentPublicInstance } from 'vue'
 import type { Router } from 'vue-router'
 import rumAgent from '../utils/RumAgent'
 import { createLogger } from '@/utils/debugUtils'
@@ -15,17 +15,27 @@ interface RumPluginOptions {
   router?: Router
 }
 
+// Minimal structural view of a component instance as this plugin uses it:
+// the merged options carry an optional `name`, and the performance-tracking
+// mixin stashes mount/update start timestamps directly on the instance.
+type RumComponentInstance = ComponentPublicInstance & {
+  $options: { name?: string }
+  _rumMountStart?: number
+  _rumUpdateStart?: number
+}
+
 export default {
   install(app: App, options: RumPluginOptions = {}) {
     // Configure Vue error handler
     app.config.errorHandler = (error, instance, info) => {
       // Track Vue errors with RUM
       const err = error as Error
+      const vm = instance as RumComponentInstance | null
       rumAgent.trackError('vue_error', {
         message: err.message,
         stack: err.stack,
         componentInfo: info,
-        component: (instance as any)?.$options?.name || 'unknown'
+        component: vm?.$options?.name || 'unknown'
       })
 
       // Also log for development
@@ -40,33 +50,33 @@ export default {
 
     // Add performance tracking mixin
     app.mixin({
-      beforeMount() {
-        if ((this as any).$options.name) {
-          (this as any)._rumMountStart = performance.now()
+      beforeMount(this: RumComponentInstance) {
+        if (this.$options.name) {
+          this._rumMountStart = performance.now()
         }
       },
-      mounted() {
-        if ((this as any).$options.name && (this as any)._rumMountStart) {
-          const mountTime = performance.now() - (this as any)._rumMountStart
+      mounted(this: RumComponentInstance) {
+        if (this.$options.name && this._rumMountStart) {
+          const mountTime = performance.now() - this._rumMountStart
           if (mountTime > 100) { // Only track slow mounts
             rumAgent.logMetric('component_mount', {
-              component: (this as any).$options.name,
+              component: this.$options.name,
               duration: mountTime
             })
           }
         }
       },
-      beforeUpdate() {
-        if ((this as any).$options.name) {
-          (this as any)._rumUpdateStart = performance.now()
+      beforeUpdate(this: RumComponentInstance) {
+        if (this.$options.name) {
+          this._rumUpdateStart = performance.now()
         }
       },
-      updated() {
-        if ((this as any).$options.name && (this as any)._rumUpdateStart) {
-          const updateTime = performance.now() - (this as any)._rumUpdateStart
+      updated(this: RumComponentInstance) {
+        if (this.$options.name && this._rumUpdateStart) {
+          const updateTime = performance.now() - this._rumUpdateStart
           if (updateTime > 50) { // Only track slow updates
             rumAgent.logMetric('component_update', {
-              component: (this as any).$options.name,
+              component: this.$options.name,
               duration: updateTime
             })
           }

--- a/autobot-frontend/src/utils/RumAgent.ts
+++ b/autobot-frontend/src/utils/RumAgent.ts
@@ -73,6 +73,11 @@ interface PrometheusRumMetrics {
   critical_issues?: PrometheusCriticalIssueMetric[]
 }
 
+// Free-form metadata bag attached to RUM records (error data, interaction
+// context, arbitrary metric payloads). Values are opaque — consumers narrow
+// at the use site.
+type RumMetadata = Record<string, unknown>
+
 interface ApiCall {
   timestamp: string
   method: string
@@ -86,10 +91,36 @@ interface ApiCall {
   sessionId: string
 }
 
+// WebSocket event payload. The Prometheus reporter reads `direction` and
+// `type`/`event_type`; any other fields are opaque.
+interface WebSocketEventData {
+  direction?: string
+  type?: string
+  event_type?: string
+  [key: string]: unknown
+}
+
+// Page-level performance metrics captured on window `load`.
+interface PageMetrics {
+  domContentLoaded: number
+  loadComplete: number
+  domInteractive: number
+  firstPaint: number | null
+  timestamp: string
+}
+
+// Slow-resource timing sample captured by the PerformanceObserver.
+interface ResourceTiming {
+  name: string
+  duration: number
+  size?: number
+  timestamp: string
+}
+
 interface WebSocketEvent {
   timestamp: string
   event: string
-  data: Record<string, any>
+  data: WebSocketEventData
   sessionId: string
 }
 
@@ -99,7 +130,7 @@ interface UserInteraction {
   element: string
   elementId?: string | null
   elementClass?: string | null
-  context: Record<string, any>
+  context: RumMetadata
   sessionId: string
 }
 
@@ -111,7 +142,7 @@ interface ErrorInfo {
   sessionId: string
   url: string
   userAgent: string
-  [key: string]: any
+  [key: string]: unknown
 }
 
 interface RumMetrics {
@@ -119,17 +150,37 @@ interface RumMetrics {
   errors: ErrorInfo[]
   userInteractions: UserInteraction[]
   webSocketEvents: WebSocketEvent[]
-  pageMetrics: Record<string, any>
-  resourceTimings: any[]
+  pageMetrics: PageMetrics | Record<string, never>
+  resourceTimings: ResourceTiming[]
   sessionDuration: number
 }
+
+// Payload attached to a critical issue: either a free-form metadata bag or a
+// concrete captured record (an API call or a tracked error).
+type RumIssueData = RumMetadata | ApiCall | ErrorInfo
 
 interface CriticalIssue {
   type: string
   severity: 'critical'
   timestamp: string
   sessionId: string
-  data: Record<string, any>
+  data: RumIssueData
+}
+
+// Snapshot produced by generateReport() and persisted to localStorage.
+interface RumReport {
+  sessionId: string
+  sessionDuration: number
+  timestamp: string
+  summary: {
+    totalApiCalls: number
+    slowApiCalls: number
+    timeoutApiCalls: number
+    totalErrors: number
+    userInteractions: number
+    webSocketEvents: number
+  }
+  recentIssues: Array<ApiCall | ErrorInfo>
 }
 
 class RumAgent {
@@ -298,7 +349,7 @@ class RumAgent {
   }
 
   // WebSocket Monitoring
-  trackWebSocketEvent(event: string, data: Record<string, any> = {}): void {
+  trackWebSocketEvent(event: string, data: WebSocketEventData = {}): void {
     const wsEvent: WebSocketEvent = {
       timestamp: new Date().toISOString(),
       event,
@@ -324,7 +375,7 @@ class RumAgent {
   }
 
   // User Interaction Tracking
-  trackUserInteraction(action: string, element?: Element | null, context: Record<string, any> = {}): void {
+  trackUserInteraction(action: string, element?: Element | null, context: RumMetadata = {}): void {
     const interaction: UserInteraction = {
       timestamp: new Date().toISOString(),
       action,
@@ -377,7 +428,7 @@ class RumAgent {
     })
   }
 
-  trackError(type: string, errorData: Record<string, any>): void {
+  trackError(type: string, errorData: RumMetadata): void {
     const error: ErrorInfo = {
       timestamp: new Date().toISOString(),
       type,
@@ -401,7 +452,7 @@ class RumAgent {
         error_type: type,
         page,
         is_rejection: isRejection,
-        component: errorData.component
+        component: errorData.component as string | undefined
       })
     }
 
@@ -526,7 +577,7 @@ class RumAgent {
   }
 
   // Generic metric logging
-  logMetric(type: string, data: Record<string, any>): Record<string, any> {
+  logMetric(type: string, data: RumMetadata): RumMetadata {
     const metric = {
       type,
       timestamp: new Date().toISOString(),
@@ -538,7 +589,7 @@ class RumAgent {
   }
 
   // Critical issue reporting
-  reportCriticalIssue(type: string, data: Record<string, any>): void {
+  reportCriticalIssue(type: string, data: RumIssueData): void {
     const issue: CriticalIssue = {
       type,
       severity: 'critical',
@@ -562,7 +613,7 @@ class RumAgent {
     // Reduce excessive logging for known network issues
     // Issue #981: Format message as string to prevent [object Object] in log output
     if (issue.type !== 'network_error' && issue.type !== 'http_error') {
-      const dataMsg = issue.data?.message || JSON.stringify(issue.data)
+      const dataMsg = (issue.data as RumMetadata)?.message || JSON.stringify(issue.data)
       logger.error(`🚨🚨🚨 CRITICAL ISSUE: ${issue.type} — ${dataMsg}`)
     }
   }
@@ -665,7 +716,7 @@ class RumAgent {
 
   // #10938: Post a structured RumEvent to /api/rum/event so rum.log captures it.
   // errorData fields go into the nested `data` field the backend formatter expects.
-  private sendRumEvent(type: string, errorData: Record<string, any>): void {
+  private sendRumEvent(type: string, errorData: RumMetadata): void {
     // #10956: if the endpoint has failed repeatedly (e.g. backend restarting →
     // 502), stop sending for a cooldown so telemetry can't flood the console.
     if (Date.now() < this.rumEventCircuitOpenUntil) return
@@ -718,11 +769,11 @@ class RumAgent {
     localStorage.setItem('rum_prometheus_enabled', 'false')
   }
 
-  generateReport(): Record<string, any> {
+  generateReport(): RumReport {
     const now = performance.now()
     const sessionDuration = now - this.startTime
 
-    const report = {
+    const report: RumReport = {
       sessionId: this.sessionId,
       sessionDuration,
       timestamp: new Date().toISOString(),
@@ -815,4 +866,4 @@ declare global {
 window.rum = rumAgent
 
 export default rumAgent
-export type { ApiCall, WebSocketEvent, UserInteraction, ErrorInfo, RumMetrics, CriticalIssue }
+export type { ApiCall, WebSocketEvent, WebSocketEventData, UserInteraction, ErrorInfo, RumMetrics, CriticalIssue, RumMetadata, PageMetrics, ResourceTiming, RumReport }


### PR DESCRIPTION
## Thinking Path
#9924 grind — 3 TS files (useApi.ts 15, RumAgent.ts 13, rum.ts 11). Strictly type-only.

## What Changed — 39 `any` removed
- **useApi.ts**: `api.get/post/delete<any>`→`<unknown>` (matches `ApiClient`'s `<T = unknown>` contract); `Record<string, any>`→`Record<string, unknown>`.
- **RumAgent.ts**: new named types (`RumMetadata`, `WebSocketEventData`, `PageMetrics`, `ResourceTiming`, `RumIssueData` union, `RumReport`) applied to event/metric payloads.
- **rum.ts**: single `RumComponentInstance = ComponentPublicInstance & {...}` replaces 11 `(this as any)`/`(instance as any)` in the perf mixin.

## Reviewer note (independently corrected)
The subagent had written `component: typeof errorData.component === 'string' ? errorData.component : undefined` — a runtime coercion (non-strings→undefined). I changed it to a faithful type-only cast `errorData.component as string | undefined` (value passes through unchanged) to keep this strictly type-only. Re-verified eslint 0 / vue-tsc 0 after.

## Verification (independently re-run)
- `eslint` → exit 0, 0 residual `any`.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (useApi has many consumers — none broke).
- `vitest` (8 files importing these) → 100/100 passed.

## Discoveries (out of scope, pre-existing)
- 3 test files fail on a vue-i18n harness bug (`SyntaxError: Need to install with 'app.use'`): `ProjectBrowserView.enrichment.test.ts`, `BacklogView.reorder.test.ts`, `HandoffModal.test.ts`. Verified via git-stash they fail identically on the pristine tree (NOT caused here). Filing follow-up.

## Model Used
Opus 4.8

Contributes to #9924 (806→767 remaining no-explicit-any).