### PR TITLE
fix(frontend): replace no-explicit-any in AdvancedAnalytics + composables (#9924 batch 6)

### DIFF
--- a/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
@@ -244,7 +244,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="(feature, idx) in (engagementMetrics.feature_popularity as any[])" :key="feature.feature">
+            <tr v-for="(feature, idx) in engagementMetrics.feature_popularity" :key="feature.feature">
               <td>
                 <span class="rank-badge" :class="'rank-' + ((idx as number) + 1)">{{ (idx as number) + 1 }}</span>
                 {{ feature.feature }}
@@ -271,7 +271,7 @@
         </template>
         <div class="peak-hours-list">
           <div
-            v-for="(peak, idx) in (usageHeatmap.peak_hours as any[])"
+            v-for="(peak, idx) in usageHeatmap.peak_hours"
             :key="peak.hour"
             class="peak-hour-item"
           >
@@ -337,8 +337,105 @@ const logger = createLogger('AdvancedAnalytics')
 
 // Issue #701: Type for API response with data property
 interface ApiDataResponse {
-  data?: any
-  [key: string]: any
+  data?: unknown
+  [key: string]: unknown
+}
+
+// Domain shapes for analytics responses (fields consumed by the template)
+interface CostSummary {
+  total_cost_usd?: number
+  avg_daily_cost?: number
+}
+
+interface CostTrends {
+  trend?: string
+  growth_rate_percent?: number
+}
+
+interface ModelCost {
+  model: string
+  cost_usd?: number
+  input_tokens: number
+  output_tokens: number
+  call_count: number
+}
+
+interface ModelCostsData {
+  models?: ModelCost[]
+}
+
+interface AgentPerformance {
+  agent_id: string
+  agent_type?: string
+  total_tasks?: number
+  success_rate: number
+  error_rate: number
+  avg_duration_ms: number
+}
+
+interface AgentMetrics {
+  total_agents?: number
+  summary?: {
+    total_tasks?: number
+    avg_success_rate?: number
+  }
+  agents?: AgentPerformance[]
+}
+
+interface AgentRecommendationDetail {
+  severity: string
+  message: string
+  suggestion: string
+}
+
+interface AgentRecommendation {
+  agent_id: string
+  agent_type?: string
+  recommendations: AgentRecommendationDetail[]
+}
+
+interface Recommendations {
+  recommendations?: AgentRecommendation[]
+}
+
+interface ExportEndpoint {
+  path: string
+  description: string
+}
+
+interface ExportFormat {
+  format: string
+  description: string
+  icon: IconName
+  endpoints: ExportEndpoint[]
+}
+
+interface ExportFormatsData {
+  formats?: ExportFormat[]
+}
+
+interface EngagementMetricsData {
+  metrics?: {
+    total_sessions?: number
+    total_page_views?: number
+    avg_session_duration_ms?: number
+    pages_per_session?: number
+  }
+  feature_popularity?: FeaturePopularity[]
+}
+
+interface FeaturePopularity {
+  feature: string
+  views: number
+}
+
+interface PeakHour {
+  hour: number
+  total_events: number
+}
+
+interface UsageHeatmap {
+  peak_hours?: PeakHour[]
 }
 
 // State
@@ -347,15 +444,15 @@ const activeTab = ref('cost')
 const showExportModal = ref(false)
 
 // Data
-const costSummary = ref<any>(null)
-const costTrends = ref<any>(null)
-const modelCosts = ref<any[]>([])
-const agentMetrics = ref<any>(null)
-const recommendations = ref<any>(null)
-const exportFormats = ref<any[]>([])
-const behaviorMetrics = ref<any>(null)
-const engagementMetrics = ref<any>(null)
-const usageHeatmap = ref<any>(null)
+const costSummary = ref<CostSummary | null>(null)
+const costTrends = ref<CostTrends | null>(null)
+const modelCosts = ref<ModelCost[]>([])
+const agentMetrics = ref<AgentMetrics | null>(null)
+const recommendations = ref<Recommendations | null>(null)
+const exportFormats = ref<ExportFormat[]>([])
+const behaviorMetrics = ref<unknown>(null)
+const engagementMetrics = ref<EngagementMetricsData | null>(null)
+const usageHeatmap = ref<UsageHeatmap | null>(null)
 
 // Tabs configuration
 const tabs = computed(() => [
@@ -419,9 +516,9 @@ const fetchCostData = async () => {
       api.get<ApiDataResponse>(`${getApiBase()}/analytics/cost/trends`),
       api.get<ApiDataResponse>(`${getApiBase()}/analytics/cost/by-model`)
     ])
-    costSummary.value = (summaryRes as ApiDataResponse).data
-    costTrends.value = (trendsRes as ApiDataResponse).data
-    modelCosts.value = (modelsRes as ApiDataResponse).data?.models || []
+    costSummary.value = (summaryRes as ApiDataResponse).data as CostSummary | null
+    costTrends.value = (trendsRes as ApiDataResponse).data as CostTrends | null
+    modelCosts.value = ((modelsRes as ApiDataResponse).data as ModelCostsData | undefined)?.models || []
   } catch (error) {
     logger.error('Failed to fetch cost data:', error)
   }
@@ -435,8 +532,8 @@ const fetchAgentData = async () => {
       api.get<ApiDataResponse>(`${getApiBase()}/analytics/agents/performance`),
       api.get<ApiDataResponse>(`${getApiBase()}/analytics/agents/recommendations`)
     ])
-    agentMetrics.value = (metricsRes as ApiDataResponse).data
-    recommendations.value = (recsRes as ApiDataResponse).data
+    agentMetrics.value = (metricsRes as ApiDataResponse).data as AgentMetrics | null
+    recommendations.value = (recsRes as ApiDataResponse).data as Recommendations | null
   } catch (error) {
     logger.error('Failed to fetch agent data:', error)
   }
@@ -447,9 +544,9 @@ const fetchExportFormats = async () => {
     // Issue #552: Fixed missing /api prefix in analytics endpoints
     // Issue #701: Added type assertion for response
     const res = await api.get<ApiDataResponse>(`${getApiBase()}/analytics/export/formats`)
-    exportFormats.value = (res as ApiDataResponse).data?.formats || []
+    exportFormats.value = ((res as ApiDataResponse).data as ExportFormatsData | undefined)?.formats || []
     // Add icons
-    exportFormats.value.forEach((f: any) => {
+    exportFormats.value.forEach((f: ExportFormat) => {
       if (f.format === 'CSV') f.icon = 'file-csv'
       else if (f.format === 'JSON') f.icon = 'file-code'
       else if (f.format === 'Prometheus') f.icon = 'chart-area'
@@ -470,9 +567,9 @@ const fetchBehaviorData = async () => {
       api.get<ApiDataResponse>(`${getApiBase()}/analytics/behavior/features`),
       api.get<ApiDataResponse>(`${getApiBase()}/analytics/behavior/stats/heatmap`)
     ])
-    engagementMetrics.value = (engagementRes as ApiDataResponse).data
+    engagementMetrics.value = (engagementRes as ApiDataResponse).data as EngagementMetricsData | null
     behaviorMetrics.value = (featuresRes as ApiDataResponse).data
-    usageHeatmap.value = (heatmapRes as ApiDataResponse).data
+    usageHeatmap.value = (heatmapRes as ApiDataResponse).data as UsageHeatmap | null
   } catch (error) {
     logger.error('Failed to fetch behavior data:', error)
   }
@@ -480,7 +577,7 @@ const fetchBehaviorData = async () => {
 
 const maxFeatureViews = computed((): number => {
   if (!engagementMetrics.value?.feature_popularity?.length) return 0
-  return Math.max(...engagementMetrics.value.feature_popularity.map((f: any) => f.views || 0))
+  return Math.max(...engagementMetrics.value.feature_popularity.map((f: FeaturePopularity) => f.views || 0))
 })
 
 const getPopularityWidth = (views: number): string => {

--- a/autobot-frontend/src/composables/useAutoResearch.ts
+++ b/autobot-frontend/src/composables/useAutoResearch.ts
@@ -91,6 +91,26 @@ export interface ExperimentInsight {
   session_id: string | null
 }
 
+interface ExperimentsResponse {
+  experiments?: Experiment[]
+}
+
+interface OptimizerStatusResponse {
+  session?: OptimizationSession | null
+}
+
+interface VariantsResponse {
+  variants?: PromptVariant[]
+}
+
+interface ApprovalsResponse {
+  approvals?: ApprovalRequest[]
+}
+
+interface InsightsResponse {
+  insights?: ExperimentInsight[]
+}
+
 // --- Composable ---
 
 export function useAutoResearch() {
@@ -122,7 +142,7 @@ export function useAutoResearch() {
         if (params?.limit != null) query.set('limit', String(params.limit))
         if (params?.offset != null) query.set('offset', String(params.offset))
         if (params?.state) query.set('state', params.state)
-        const response = await api.get<any>(`${getApiBase()}/autoresearch/experiments?${query}`)
+        const response = await api.get<ExperimentsResponse>(`${getApiBase()}/autoresearch/experiments?${query}`)
         experiments.value = response.experiments ?? []
       } catch (err) {
         const msg = extractApiErrorMessage(err, 'Failed to fetch experiments')
@@ -135,7 +155,7 @@ export function useAutoResearch() {
 
   async function fetchStats(): Promise<void> {
     try {
-      const response = await api.get<any>(`${getApiBase()}/autoresearch/experiments/stats`)
+      const response = await api.get<ExperimentStats>(`${getApiBase()}/autoresearch/experiments/stats`)
       stats.value = response
     } catch (err) {
       const msg = extractApiErrorMessage(err, 'Failed to fetch experiment stats')
@@ -149,7 +169,7 @@ export function useAutoResearch() {
 
   async function fetchOptimizerStatus(): Promise<void> {
     try {
-      const response = await api.get<any>(`${getApiBase()}/autoresearch/prompt-optimizer/status`)
+      const response = await api.get<OptimizerStatusResponse>(`${getApiBase()}/autoresearch/prompt-optimizer/status`)
       optimizerStatus.value = response.session ?? null
     } catch (err) {
       const msg = extractApiErrorMessage(err, 'Failed to fetch optimizer status')
@@ -163,7 +183,7 @@ export function useAutoResearch() {
     agentName: string,
     maxRounds: number = 3,
   ): Promise<void> {
-    await api.post<any>(`${getApiBase()}/autoresearch/prompt-optimizer/start`, {
+    await api.post<unknown>(`${getApiBase()}/autoresearch/prompt-optimizer/start`, {
       agent_name: agentName,
       max_rounds: maxRounds,
     })
@@ -171,12 +191,12 @@ export function useAutoResearch() {
   }
 
   async function cancelOptimization(): Promise<void> {
-    await api.post<any>(`${getApiBase()}/autoresearch/prompt-optimizer/cancel`)
+    await api.post<unknown>(`${getApiBase()}/autoresearch/prompt-optimizer/cancel`)
     await fetchOptimizerStatus()
   }
 
   async function fetchVariants(sessionId: string): Promise<void> {
-    const response = await api.get<any>(
+    const response = await api.get<VariantsResponse>(
       `${getApiBase()}/autoresearch/prompt-optimizer/variants/${sessionId}`,
     )
     variants.value = response.variants ?? []
@@ -188,7 +208,7 @@ export function useAutoResearch() {
     score: number,
     comment: string = '',
   ): Promise<void> {
-    await api.post<any>(
+    await api.post<unknown>(
       `${getApiBase()}/autoresearch/prompt-optimizer/variants/${variantId}/score?session_id=${sessionId}`,
       { score, comment },
     )
@@ -197,7 +217,7 @@ export function useAutoResearch() {
   // --- Approvals ---
 
   async function fetchPendingApprovals(): Promise<void> {
-    const response = await api.get<any>(`${getApiBase()}/autoresearch/approvals/pending`)
+    const response = await api.get<ApprovalsResponse>(`${getApiBase()}/autoresearch/approvals/pending`)
     pendingApprovals.value = response.approvals ?? []
   }
 
@@ -205,7 +225,7 @@ export function useAutoResearch() {
     sessionId: string,
     experimentId: string,
   ): Promise<void> {
-    await api.post<any>(
+    await api.post<unknown>(
       `${getApiBase()}/autoresearch/approvals/${sessionId}/${experimentId}`,
       { decision: 'approved' },
     )
@@ -216,7 +236,7 @@ export function useAutoResearch() {
     sessionId: string,
     experimentId: string,
   ): Promise<void> {
-    await api.post<any>(
+    await api.post<unknown>(
       `${getApiBase()}/autoresearch/approvals/${sessionId}/${experimentId}`,
       { decision: 'rejected' },
     )
@@ -226,14 +246,14 @@ export function useAutoResearch() {
   // --- Insights ---
 
   async function fetchInsights(minConfidence: number = 0): Promise<void> {
-    const response = await api.get<any>(
+    const response = await api.get<InsightsResponse>(
       `${getApiBase()}/autoresearch/insights?min_confidence=${minConfidence}`,
     )
     insights.value = response.insights ?? []
   }
 
   async function searchInsights(query: string): Promise<void> {
-    const response = await api.get<any>(
+    const response = await api.get<InsightsResponse>(
       `${getApiBase()}/autoresearch/insights/search?q=${encodeURIComponent(query)}`,
     )
     insights.value = response.insights ?? []

--- a/autobot-frontend/src/composables/useBatchProcessing.ts
+++ b/autobot-frontend/src/composables/useBatchProcessing.ts
@@ -49,7 +49,7 @@ export function useBatchProcessingApi() {
         if (filter?.limit) params.append('limit', filter.limit.toString())
         const queryString = params.toString()
         const url = `${getApiBase()}/batch-jobs${queryString ? `?${queryString}` : ''}`
-        return await api.get<any>(url)
+        return await api.get<BatchJobsListResponse>(url)
       } catch (error: unknown) {
         logger.error('Failed to load batch jobs', error)
         showSubtleErrorNotification('Error', 'Failed to load batch jobs', 'error')
@@ -59,7 +59,7 @@ export function useBatchProcessingApi() {
 
     async getJob(jobId: string): Promise<BatchJob | null> {
       try {
-        return await api.get<any>(`${getApiBase()}/batch-jobs/${jobId}`)
+        return await api.get<BatchJob>(`${getApiBase()}/batch-jobs/${jobId}`)
       } catch (error: unknown) {
         logger.error('Failed to get batch job', error)
         showSubtleErrorNotification('Error', 'Failed to get batch job', 'error')
@@ -69,7 +69,7 @@ export function useBatchProcessingApi() {
 
     async createJob(request: CreateBatchJobRequest): Promise<CreateBatchJobResponse | null> {
       try {
-        return await api.post<any>(`${getApiBase()}/batch-jobs`, request)
+        return await api.post<CreateBatchJobResponse>(`${getApiBase()}/batch-jobs`, request)
       } catch (error: unknown) {
         logger.error('Failed to create batch job', error)
         showSubtleErrorNotification('Error', 'Failed to create batch job', 'error')
@@ -79,7 +79,7 @@ export function useBatchProcessingApi() {
 
     async deleteJob(jobId: string): Promise<{ status: string } | null> {
       try {
-        return await api.delete<any>(`${getApiBase()}/batch-jobs/${jobId}`)
+        return await api.delete<{ status: string }>(`${getApiBase()}/batch-jobs/${jobId}`)
       } catch (error: unknown) {
         logger.error('Failed to delete batch job', error)
         showSubtleErrorNotification('Error', 'Failed to delete batch job', 'error')
@@ -89,7 +89,7 @@ export function useBatchProcessingApi() {
 
     async cancelJob(jobId: string): Promise<{ status: string } | null> {
       try {
-        return await api.post<any>(`${getApiBase()}/batch-jobs/${jobId}/cancel`)
+        return await api.post<{ status: string }>(`${getApiBase()}/batch-jobs/${jobId}/cancel`)
       } catch (error: unknown) {
         logger.error('Failed to cancel batch job', error)
         showSubtleErrorNotification('Error', 'Failed to cancel batch job', 'error')
@@ -99,7 +99,7 @@ export function useBatchProcessingApi() {
 
     async getJobLogs(jobId: string): Promise<BatchJobLogsResponse | null> {
       try {
-        return await api.get<any>(`${getApiBase()}/batch-jobs/${jobId}/logs`)
+        return await api.get<BatchJobLogsResponse>(`${getApiBase()}/batch-jobs/${jobId}/logs`)
       } catch (error: unknown) {
         logger.error('Failed to get batch job logs', error)
         showSubtleErrorNotification('Error', 'Failed to get batch job logs', 'error')
@@ -109,7 +109,7 @@ export function useBatchProcessingApi() {
 
     async listTemplates(): Promise<BatchTemplatesListResponse | null> {
       try {
-        return await api.get<any>(`${getApiBase()}/batch-templates`)
+        return await api.get<BatchTemplatesListResponse>(`${getApiBase()}/batch-templates`)
       } catch (error: unknown) {
         logger.error('Failed to load batch templates', error)
         showSubtleErrorNotification('Error', 'Failed to load batch templates', 'error')
@@ -119,7 +119,7 @@ export function useBatchProcessingApi() {
 
     async createTemplate(request: CreateBatchTemplateRequest): Promise<BatchTemplate | null> {
       try {
-        return await api.post<any>(`${getApiBase()}/batch-templates`, request)
+        return await api.post<BatchTemplate>(`${getApiBase()}/batch-templates`, request)
       } catch (error: unknown) {
         logger.error('Failed to create batch template', error)
         showSubtleErrorNotification('Error', 'Failed to create batch template', 'error')
@@ -129,7 +129,7 @@ export function useBatchProcessingApi() {
 
     async deleteTemplate(templateId: string): Promise<{ status: string } | null> {
       try {
-        return await api.delete<any>(`${getApiBase()}/batch-templates/${templateId}`)
+        return await api.delete<{ status: string }>(`${getApiBase()}/batch-templates/${templateId}`)
       } catch (error: unknown) {
         logger.error('Failed to delete batch template', error)
         showSubtleErrorNotification('Error', 'Failed to delete batch template', 'error')
@@ -139,7 +139,7 @@ export function useBatchProcessingApi() {
 
     async listSchedules(): Promise<BatchSchedulesListResponse | null> {
       try {
-        return await api.get<any>(`${getApiBase()}/batch-schedules`)
+        return await api.get<BatchSchedulesListResponse>(`${getApiBase()}/batch-schedules`)
       } catch (error: unknown) {
         logger.error('Failed to load batch schedules', error)
         showSubtleErrorNotification('Error', 'Failed to load batch schedules', 'error')
@@ -149,7 +149,7 @@ export function useBatchProcessingApi() {
 
     async createSchedule(request: CreateBatchScheduleRequest): Promise<BatchSchedule | null> {
       try {
-        return await api.post<any>(`${getApiBase()}/batch-schedules`, request)
+        return await api.post<BatchSchedule>(`${getApiBase()}/batch-schedules`, request)
       } catch (error: unknown) {
         logger.error('Failed to create batch schedule', error)
         showSubtleErrorNotification('Error', 'Failed to create batch schedule', 'error')
@@ -169,7 +169,7 @@ export function useBatchProcessingApi() {
 
     async deleteSchedule(scheduleId: string): Promise<{ status: string } | null> {
       try {
-        return await api.delete<any>(`${getApiBase()}/batch-schedules/${scheduleId}`)
+        return await api.delete<{ status: string }>(`${getApiBase()}/batch-schedules/${scheduleId}`)
       } catch (error: unknown) {
         logger.error('Failed to delete batch schedule', error)
         showSubtleErrorNotification('Error', 'Failed to delete batch schedule', 'error')


### PR DESCRIPTION
## Thinking Path
#9924 grind — AdvancedAnalytics.vue (15), useAutoResearch.ts (12), useBatchProcessing.ts (12). Strictly type-only, casts only (no runtime coercions).

## What Changed — 39 `any` removed
- **AdvancedAnalytics.vue**: 16 minimal analytics response interfaces (CostSummary, ModelCost, AgentMetrics, ExportFormat, UsageHeatmap, …); reused `IconName`; dropped 2 template `as any[]` casts.
- **useAutoResearch.ts**: `api.get<any>`→concrete response envelopes (reused in-file `Experiment`/`ExperimentStats`/…); fire-and-forget `api.post<any>`→`<unknown>`.
- **useBatchProcessing.ts**: all 12 `api.*<any>`→the enclosing methods' already-declared return types from `@/types/batch-processing` (all reused, nothing new).

## Verification (independently re-run)
- `eslint` → exit 0, 0 residual `any`.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0.
- `vitest useAutoResearch.spec.ts` → 7/7 (other 2 files have no tests).
- Independent diff scan for runtime coercions/guards → **none** (verified genuinely type-only).

## Model Used
Opus 4.8

Contributes to #9924 (767→728 remaining no-explicit-any).