### PR TITLE
fix(deps): cap websockets<16 — base build broken by #10997 (langgraph-sdk conflict) (#11031)

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -6,7 +6,7 @@ apscheduler>=3.11.3             # Issue #6590: hourly LLM key rotation job
 croniter>=6.2.3                 # GH#9027: required by LLC RoutineScheduler and routines API
 fastapi>=0.139.0                # SECURITY UPDATE - requires starlette >=0.52.1
 uvicorn>=0.50.2
-websockets>=16.0,<17       # Issue #3098: desktop_streaming_manager + slm_client; relaxed from >=16.0 (#10386): both files use only legacy-compat API (WebSocketServerProtocol type annotation, ConnectionClosed/WebSocketException, connect(subprotocols=)) present in 15.x. CI already pins 15.0.1. websockets<16 satisfies langgraph-sdk 0.4.2 (>=14,<16), unblocking langchain >=1.3.10.
+websockets>=15.0,<16       # Issue #3098: desktop_streaming_manager + slm_client; relaxed from >=16.0 (#10386): both files use only legacy-compat API (WebSocketServerProtocol type annotation, ConnectionClosed/WebSocketException, connect(subprotocols=)) present in 15.x. CI already pins 15.0.1. websockets<16 satisfies langgraph-sdk 0.4.2 (>=14,<16), unblocking langchain >=1.3.10.
 python-dotenv>=1.2.2
 aiofiles>=25.1.0
 pydantic>=2.13.4

--- a/autobot-slm-backend/requirements.txt
+++ b/autobot-slm-backend/requirements.txt
@@ -34,7 +34,7 @@ redis[asyncio]>=8.0.1
 
 # Async utilities
 aiofiles>=25.1.0
-websockets>=16.0,<17       # Issue #3098: relaxed from >=16.0 (#10386): slm_client uses only API present in 15.x; <16 satisfies langgraph-sdk 0.4.2 on backend side
+websockets>=15.0,<16       # Issue #3098: relaxed from >=16.0 (#10386): slm_client uses only API present in 15.x; <16 satisfies langgraph-sdk 0.4.2 on backend side
 
 # Ansible integration
 ansible-runner>=2.4.3


### PR DESCRIPTION
## Thinking Path
`smoke-test` is red on Dev_new_gui and every open PR — Docker build fails `ResolutionImpossible: Cannot install langgraph and websockets<17 and >=16.0`. Traced to Dependabot #10997 bumping `websockets>=15.0,<16` → `>=16.0,<17`, contradicting the line's own comment (`langgraph-sdk 0.4.2` needs `>=14,<16`).

## What Changed
Reverted `websockets` spec to `>=15.0,<16` in `autobot-backend/requirements.txt` and `autobot-slm-backend/requirements.txt` (matches CI pin `websockets==15.0.1` and langgraph-sdk). `dependabot.yml` already caps `websockets<16`; #10997 predated the ignore.

## Verification
smoke-test Docker dependency resolution succeeds (previously ResolutionImpossible).

## Model Used
Opus 4.8 (1M context)

Closes #11031