### PR TITLE
fix(frontend): replace no-explicit-any in desktop browser/plugins/BI view (#9924 batch 7)

### DIFF
--- a/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
+++ b/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
@@ -420,7 +420,7 @@
 <script lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import type { Ref } from 'vue'
-import type { AutomationResults, SearchData, TestData, MessageData } from '@/types/browser'
+import type { AutomationResults, SearchData, TestData, TestResult, MessageData, TestStep } from '@/types/browser'
 import appConfig from '@/config/AppConfig.js'
 import { useBrowserSessionData } from '@/composables/desktop/useBrowserSessionData'
 import type { PlaywrightNavigationResponse, PageRegion, SnapshotWithRegionsResult } from '@/composables/desktop/useBrowserSessionData'
@@ -443,6 +443,24 @@ interface ConsoleLogEntry {
   timestamp: string
   level: string
   message: string
+}
+
+interface PopoutBrowserProps {
+  sessionId: string
+  initialUrl: string
+  canResize: boolean
+  autoPopout: boolean
+}
+
+type PopoutBrowserEmit = (event: 'close' | 'navigate' | 'interact' | 'popout' | 'dock', ...args: unknown[]) => void
+
+// Minimal shape of an Electron <webview> element (only the methods this component calls)
+interface WebviewElement {
+  canGoBack(): boolean
+  canGoForward(): boolean
+  goBack(): void
+  goForward(): void
+  reload(): void
 }
 
 export default {
@@ -475,7 +493,7 @@ export default {
     }
   },
   emits: ['close', 'navigate', 'interact', 'popout', 'dock'],
-  setup(props: any, { emit }: any) {
+  setup(props: PopoutBrowserProps, { emit }: { emit: PopoutBrowserEmit }) {
     // Browser session data composable (replaces inline fetchWithAuth/apiClient calls)
     const browserApi = useBrowserSessionData()
 
@@ -525,7 +543,7 @@ export default {
 
     // Refs
     const vncIframe: Ref<HTMLIFrameElement | null> = ref(null)
-    const webview: Ref<any | null> = ref(null)
+    const webview: Ref<WebviewElement | null> = ref(null)
     const remoteIframe: Ref<HTMLIFrameElement | null> = ref(null)
 
     // Region-marking state (#5136 / #6446) — snapshot-with-regions wire-in
@@ -792,7 +810,7 @@ export default {
         onSuccess: (data) => {
           if (data) {
             automationResults.value.lastSearch = data as unknown as SearchData
-            addConsoleLog('info', `Search completed: ${(data as any).results?.length || 0} results found`)
+            addConsoleLog('info', `Search completed: ${(data as SearchData).results?.length || 0} results found`)
           }
         },
         onError: (error) => {
@@ -813,8 +831,8 @@ export default {
       {
         onSuccess: (data) => {
           if (data) {
-            const tests = (data as any).tests
-            const passed = tests?.filter((t: any) => t.status === 'PASS').length || 0
+            const tests = (data as TestData).tests
+            const passed = tests?.filter((t: TestResult) => t.status === 'PASS').length || 0
             const total = tests?.length || 0
 
             automationResults.value.lastTest = { passed, total, data } as TestData
@@ -840,8 +858,8 @@ export default {
         onSuccess: (data) => {
           if (data) {
             automationResults.value.lastMessage = data as unknown as MessageData
-            const steps = (data as any).steps
-            const successSteps = steps?.filter((s: any) => s.status === 'SUCCESS').length || 0
+            const steps = (data as MessageData).steps
+            const successSteps = steps?.filter((s: TestStep) => s.status === 'SUCCESS').length || 0
             addConsoleLog('info', `Test message completed: ${successSteps} steps successful`)
           }
         },
@@ -991,7 +1009,7 @@ export default {
       browserStatus.value = 'connected'
     }
 
-    const handlePlaywrightError = (error: any) => {
+    const handlePlaywrightError = (error: Error) => {
       logger.error('Playwright connection error:', error)
       browserStatus.value = 'error'
       addConsoleLog('error', `Playwright connection failed: ${error.message || error}`)
@@ -1008,7 +1026,7 @@ export default {
       browserStatus.value = 'ready'
     }
 
-    const handleSessionError = (error: any) => {
+    const handleSessionError = (error: Error) => {
       logger.error('Session initialization error:', error)
       loading.value = false
       browserStatus.value = 'error'

--- a/autobot-frontend/src/composables/desktop/useBrowserSessionData.ts
+++ b/autobot-frontend/src/composables/desktop/useBrowserSessionData.ts
@@ -68,9 +68,9 @@ export function useBrowserSessionData() {
       return null
     }
     try {
-      return (await apiClient.get<any>(
+      return await apiClient.get<BrowserSessionResponse>(
         `${getApiBase()}/research-browser/browser/${sessionId}`
-      )) as BrowserSessionResponse
+      )
     } catch (err) {
       logger.warn('Could not get session info, using manual mode', err)
       return null
@@ -101,10 +101,10 @@ export function useBrowserSessionData() {
     sessionId: string
   ): Promise<PlaywrightNavigationResponse | null> {
     try {
-      return (await apiClient.post<any>(`${playwrightApiUrl}/navigate`, {
+      return await apiClient.post<PlaywrightNavigationResponse>(`${playwrightApiUrl}/navigate`, {
         url,
         session_id: sessionId
-      })) as unknown as PlaywrightNavigationResponse
+      })
     } catch (err) {
       logger.warn('Playwright navigation failed, relying on VNC', err)
       return null
@@ -115,34 +115,34 @@ export function useBrowserSessionData() {
    * Playwright back navigation.
    */
   async function navigateBack(): Promise<PlaywrightNavigationResponse> {
-    return (await apiClient.post<any>(
+    return await apiClient.post<PlaywrightNavigationResponse>(
       `${getApiBase()}/playwright/back`
-    )) as unknown as PlaywrightNavigationResponse
+    )
   }
 
   /**
    * Playwright forward navigation.
    */
   async function navigateForward(): Promise<PlaywrightNavigationResponse> {
-    return (await apiClient.post<any>(
+    return await apiClient.post<PlaywrightNavigationResponse>(
       `${getApiBase()}/playwright/forward`
-    )) as unknown as PlaywrightNavigationResponse
+    )
   }
 
   /**
    * Playwright page reload.
    */
   async function reloadPage(): Promise<PlaywrightNavigationResponse> {
-    return (await apiClient.post<any>(
+    return await apiClient.post<PlaywrightNavigationResponse>(
       `${getApiBase()}/playwright/reload`
-    )) as unknown as PlaywrightNavigationResponse
+    )
   }
 
   /**
    * Run a DuckDuckGo web search via Playwright.
    */
   async function webSearch(playwrightApiUrl: string, query: string): Promise<unknown> {
-    return await apiClient.post<any>(`${playwrightApiUrl}/search`, {
+    return await apiClient.post<unknown>(`${playwrightApiUrl}/search`, {
       query,
       search_engine: 'duckduckgo'
     })
@@ -152,7 +152,7 @@ export function useBrowserSessionData() {
    * Run Playwright frontend tests against the current origin.
    */
   async function runFrontendTests(playwrightApiUrl: string): Promise<unknown> {
-    return await apiClient.post<any>(`${playwrightApiUrl}/test-frontend`, {
+    return await apiClient.post<unknown>(`${playwrightApiUrl}/test-frontend`, {
       frontend_url: window.location.origin
     })
   }
@@ -161,7 +161,7 @@ export function useBrowserSessionData() {
    * Send a test automation message via Playwright.
    */
   async function sendTestMessage(playwrightApiUrl: string): Promise<unknown> {
-    return await apiClient.post<any>(`${playwrightApiUrl}/send-test-message`, {
+    return await apiClient.post<unknown>(`${playwrightApiUrl}/send-test-message`, {
       message: 'Test message from browser automation',
       frontend_url: window.location.origin
     })
@@ -182,10 +182,10 @@ export function useBrowserSessionData() {
     sessionId: string,
     goal = ''
   ): Promise<SnapshotWithRegionsResult> {
-    const envelope = await apiClient.post<any>(
+    const envelope = await apiClient.post<{ data: Record<string, unknown> }>(
       `${getApiBase()}/playwright/snapshot-with-regions`,
       { session_id: sessionId, goal }
-    ) as { data: Record<string, unknown> }
+    )
     const payload = envelope?.data ?? (envelope as unknown as Record<string, unknown>)
     const rawRegions = (payload.regions as Array<Record<string, unknown>>) ?? []
     return {
@@ -205,10 +205,10 @@ export function useBrowserSessionData() {
     sessionId: string,
     goal: string
   ): Promise<PageRegion[]> {
-    const envelope = await apiClient.post<any>(
+    const envelope = await apiClient.post<{ data: Record<string, unknown> }>(
       `${getApiBase()}/playwright/ai-propose-regions`,
       { session_id: sessionId, goal }
-    ) as { data: Record<string, unknown> }
+    )
     const payload = envelope?.data ?? (envelope as unknown as Record<string, unknown>)
     const rawRegions = (payload.proposed_regions as Array<Record<string, unknown>>) ?? []
     return rawRegions.map(r => ({

--- a/autobot-frontend/src/composables/usePlugins.ts
+++ b/autobot-frontend/src/composables/usePlugins.ts
@@ -76,7 +76,9 @@ export function usePlugins() {
   async function listPlugins(): Promise<void> {
     error.value = null
     try {
-      const data = await wrap(() => ApiClient.get<any>(`${getApiBase()}/plugins`))
+      const data = await wrap(() =>
+        ApiClient.get<PluginInfo[] | { plugins?: PluginInfo[] }>(`${getApiBase()}/plugins`),
+      )
       // Backend returns {plugins:[...], total:N}. Guard against a bare array
       // response to handle shape divergence between PluginListResponse and actual
       // payload. (#6774)
@@ -91,7 +93,9 @@ export function usePlugins() {
   async function discoverPlugins(): Promise<void> {
     error.value = null
     try {
-      const data = await wrap(() => ApiClient.get<any>(`${getApiBase()}/plugins/discover`))
+      const data = await wrap(() =>
+        ApiClient.get<{ discovered?: PluginManifest[] }>(`${getApiBase()}/plugins/discover`),
+      )
       discovered.value = data.discovered ?? []
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Failed to discover plugins'
@@ -103,7 +107,7 @@ export function usePlugins() {
   async function loadPlugin(name: string, config?: Record<string, unknown>): Promise<boolean> {
     error.value = null
     try {
-      await ApiClient.post<any>(`${getApiBase()}/plugins/${name}/load`, config ? { config } : {})
+      await ApiClient.post<unknown>(`${getApiBase()}/plugins/${name}/load`, config ? { config } : {})
       await listPlugins()
       return true
     } catch (err: unknown) {
@@ -117,7 +121,7 @@ export function usePlugins() {
   async function unloadPlugin(name: string): Promise<boolean> {
     error.value = null
     try {
-      await ApiClient.post<any>(`${getApiBase()}/plugins/${name}/unload`, {})
+      await ApiClient.post<unknown>(`${getApiBase()}/plugins/${name}/unload`, {})
       await listPlugins()
       return true
     } catch (err: unknown) {
@@ -131,7 +135,7 @@ export function usePlugins() {
   async function reloadPlugin(name: string): Promise<boolean> {
     error.value = null
     try {
-      await ApiClient.post<any>(`${getApiBase()}/plugins/${name}/reload`, {})
+      await ApiClient.post<unknown>(`${getApiBase()}/plugins/${name}/reload`, {})
       await listPlugins()
       return true
     } catch (err: unknown) {
@@ -145,7 +149,7 @@ export function usePlugins() {
   async function enablePlugin(name: string): Promise<boolean> {
     error.value = null
     try {
-      await ApiClient.post<any>(`${getApiBase()}/plugins/${name}/enable`, {})
+      await ApiClient.post<unknown>(`${getApiBase()}/plugins/${name}/enable`, {})
       await listPlugins()
       return true
     } catch (err: unknown) {
@@ -159,7 +163,7 @@ export function usePlugins() {
   async function disablePlugin(name: string): Promise<boolean> {
     error.value = null
     try {
-      await ApiClient.post<any>(`${getApiBase()}/plugins/${name}/disable`, {})
+      await ApiClient.post<unknown>(`${getApiBase()}/plugins/${name}/disable`, {})
       await listPlugins()
       return true
     } catch (err: unknown) {
@@ -172,7 +176,7 @@ export function usePlugins() {
 
   async function getPluginInfo(name: string): Promise<PluginInfo | null> {
     try {
-      return await ApiClient.get<any>(`${getApiBase()}/plugins/${name}`)
+      return await ApiClient.get<PluginInfo>(`${getApiBase()}/plugins/${name}`)
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : `Failed to get info for plugin ${name}`
       logger.error('getPluginInfo error: %s', msg)
@@ -182,7 +186,7 @@ export function usePlugins() {
 
   async function getPluginConfig(name: string): Promise<Record<string, unknown> | null> {
     try {
-      return await ApiClient.get<any>(`${getApiBase()}/plugins/${name}/config`)
+      return await ApiClient.get<Record<string, unknown>>(`${getApiBase()}/plugins/${name}/config`)
     } catch {
       logger.warn('getPluginConfig: no config for %s', name)
       return null
@@ -195,7 +199,7 @@ export function usePlugins() {
   ): Promise<boolean> {
     error.value = null
     try {
-      await ApiClient.put<any>(`${getApiBase()}/plugins/${name}/config`, { config })
+      await ApiClient.put<unknown>(`${getApiBase()}/plugins/${name}/config`, { config })
       return true
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : `Failed to update config for plugin ${name}`

--- a/autobot-frontend/src/views/BusinessIntelligenceView.vue
+++ b/autobot-frontend/src/views/BusinessIntelligenceView.vue
@@ -65,7 +65,7 @@
           :class="['tab-btn', { active: activeTab === tab.id }]"
           @click="activeTab = tab.id"
         >
-          <Icon :name="(tab.icon as any)" />
+          <Icon :name="tab.icon" />
           {{ tab.label }}
           <span v-if="tab.badge" class="tab-badge" :class="tab.badgeClass">{{ tab.badge }}</span>
         </button>
@@ -324,14 +324,73 @@ import { createLogger } from '@/utils/debugUtils'
 const logger = createLogger('BusinessIntelligenceView')
 const { t } = useI18n()
 
+// Business Intelligence dashboard data shapes (Issue #744 /advanced/* endpoints)
+interface BiDashboard {
+  health?: { score?: number; grade?: string; status?: string }
+  cost?: { total_usd?: number; trend?: string; growth_rate?: number }
+  agents?: { total_agents?: number; total_tasks?: number; avg_success_rate?: number }
+  engagement?: { total_sessions?: number; page_views?: number }
+}
+
+interface MaintenanceRecommendation {
+  id: string
+  priority: string
+  category: string
+  title: string
+  description: string
+  affected_component: string
+  predicted_issue: string
+  confidence: number
+  recommended_action: string
+}
+
+interface BiMaintenance {
+  by_priority: { critical: number; high: number; medium: number; low: number }
+  recommendations?: MaintenanceRecommendation[]
+}
+
+interface OptimizationRecommendation {
+  id: string
+  resource_type: string
+  implementation_effort: string
+  title: string
+  details: string
+  expected_savings?: { cost_usd?: number; performance_percent?: number }
+  recommended_change: string
+}
+
+interface BiOptimization {
+  total_recommendations?: number
+  potential_savings?: { cost_usd?: number; performance_improvement_percent?: number }
+  recommendations?: OptimizationRecommendation[]
+}
+
+interface BiInsight {
+  priority: string
+  type: string
+  title: string
+  action: string
+  impact: string
+}
+
+interface BiInsights {
+  insights?: BiInsight[]
+}
+
+interface BiReport {
+  report_type?: string
+  generated_at: string
+  [key: string]: unknown
+}
+
 // State
 const loading = ref(false)
 const activeTab = ref('analytics')
-const dashboard = ref<any>(null)
-const maintenance = ref<any>(null)
-const optimization = ref<any>(null)
-const insights = ref<any>(null)
-const generatedReport = ref<any>(null)
+const dashboard = ref<BiDashboard | null>(null)
+const maintenance = ref<BiMaintenance | null>(null)
+const optimization = ref<BiOptimization | null>(null)
+const insights = ref<BiInsights | null>(null)
+const generatedReport = ref<BiReport | null>(null)
 
 // Tab configuration with badges
 const tabs = computed(() => [
@@ -341,7 +400,7 @@ const tabs = computed(() => [
     label: t('analytics.bi.tabs.maintenance'),
     icon: 'tools' as IconName,
     badge: maintenance.value?.by_priority?.critical || 0,
-    badgeClass: maintenance.value?.by_priority?.critical > 0 ? 'critical' : ''
+    badgeClass: (maintenance.value?.by_priority?.critical as number) > 0 ? 'critical' : ''
   },
   {
     id: 'optimization',
@@ -365,13 +424,13 @@ const formatDate = (dateStr: string): string => {
   return new Date(dateStr).toLocaleString()
 }
 
-const getTrendClass = (trend: string): string => {
+const getTrendClass = (trend: string | undefined): string => {
   if (trend === 'increasing') return 'trend-up'
   if (trend === 'decreasing') return 'trend-down'
   return 'trend-stable'
 }
 
-const getTrendIcon = (trend: string): IconName => {
+const getTrendIcon = (trend: string | undefined): IconName => {
   if (trend === 'increasing') return 'arrow-up'
   if (trend === 'decreasing') return 'arrow-down'
   return 'minus'
@@ -380,7 +439,7 @@ const getTrendIcon = (trend: string): IconName => {
 const fetchDashboard = async () => {
   try {
     // Issue #552: Fixed path - backend uses /api/advanced/* not /api/analytics/advanced/*
-    const res = await api.get<{ data: any }>(`${getApiBase()}/advanced/dashboard`)
+    const res = await api.get<{ data: BiDashboard }>(`${getApiBase()}/advanced/dashboard`)
     dashboard.value = res.data
   } catch (error) {
     logger.error('Failed to fetch dashboard:', error)
@@ -390,7 +449,7 @@ const fetchDashboard = async () => {
 const fetchMaintenance = async () => {
   try {
     // Issue #552: Fixed path - backend uses /api/advanced/* not /api/analytics/advanced/*
-    const res = await api.get<{ data: any }>(`${getApiBase()}/advanced/maintenance`)
+    const res = await api.get<{ data: BiMaintenance }>(`${getApiBase()}/advanced/maintenance`)
     maintenance.value = res.data
   } catch (error) {
     logger.error('Failed to fetch maintenance:', error)
@@ -400,7 +459,7 @@ const fetchMaintenance = async () => {
 const fetchOptimization = async () => {
   try {
     // Issue #552: Fixed path - backend uses /api/advanced/* not /api/analytics/advanced/*
-    const res = await api.get<{ data: any }>(`${getApiBase()}/advanced/optimization`)
+    const res = await api.get<{ data: BiOptimization }>(`${getApiBase()}/advanced/optimization`)
     optimization.value = res.data
   } catch (error) {
     logger.error('Failed to fetch optimization:', error)
@@ -410,7 +469,7 @@ const fetchOptimization = async () => {
 const fetchInsights = async () => {
   try {
     // Issue #552: Fixed path - backend uses /api/advanced/* not /api/analytics/advanced/*
-    const res = await api.get<{ data: any }>(`${getApiBase()}/advanced/insights`)
+    const res = await api.get<{ data: BiInsights }>(`${getApiBase()}/advanced/insights`)
     insights.value = res.data
   } catch (error) {
     logger.error('Failed to fetch insights:', error)
@@ -421,7 +480,7 @@ const generateReport = async (reportType: string) => {
   try {
     loading.value = true
     // Issue #552: Fixed path - backend uses /api/advanced/* not /api/analytics/advanced/*
-    const res = await api.post<{ data: any }>(`${getApiBase()}/advanced/report`, {
+    const res = await api.post<{ data: BiReport }>(`${getApiBase()}/advanced/report`, {
       report_type: reportType,
       days: 30
     })


### PR DESCRIPTION
## Thinking Path
#9924 grind — PopoutChromiumBrowser.vue (11), useBrowserSessionData.ts (10), usePlugins.ts (10), BusinessIntelligenceView.vue (10). Strictly type-only.

## What Changed — 41 `any` removed
- **useBrowserSessionData.ts / usePlugins.ts**: `apiClient.get/post<any>` → concrete return types (reused in-file/`@/types` types); discarded-result POSTs → `<unknown>`.
- **PopoutChromiumBrowser.vue**: typed `setup(props/emit)`, minimal `WebviewElement` (5 methods used), `error: Error` on the two (unwired) error handlers, `as` casts for search/test/message data.
- **BusinessIntelligenceView.vue**: 5 minimal BI response interfaces reflecting template-consumed fields; dropped redundant `tab.icon as any`.

## Reviewer notes (independently verified)
- `badgeClass: (maintenance.value?.by_priority?.critical as number) > 0` — faithful cast; `undefined > 0` is `false` at runtime identically to the old `any` path. Behavior preserved.
- Pre-existing asymmetry surfaced (sibling `badge:` uses `|| 0`, `badgeClass` doesn't) — left as-is (type-only scope). Cosmetic, both render correctly.
- Diff-scan confirms NO added `typeof`/`??`/`||`/`if` runtime coercions.

## Verification (independently re-run)
- `eslint` → 0 `no-explicit-any`, exit 0.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0.
- No test/spec files import these 4 (N/A).

## Model Used
Opus 4.8

Contributes to #9924 (727→686 remaining no-explicit-any).