### PR TITLE
fix(frontend): replace no-explicit-any in BaseTable/FileBrowser/knowledge (#9924 batch 8)

### DIFF
--- a/autobot-frontend/src/components/base/BaseTable.vue
+++ b/autobot-frontend/src/components/base/BaseTable.vue
@@ -77,10 +77,10 @@
           <!-- Data Rows -->
           <tr
             v-for="(row, index) in data"
-            :key="row[rowKey] || index"
+            :key="(row[rowKey] as RowKeyValue) || index"
             class="table-row"
             :class="{
-              'row-selected': selectedRows.has(row[rowKey]),
+              'row-selected': selectedRows.has(row[rowKey] as RowKeyValue),
               'row-zebra': zebra && index % 2 === 1,
               'row-clickable': rowClickable
             }"
@@ -90,8 +90,8 @@
             <td v-if="selectable" class="select-cell">
               <input
                 type="checkbox"
-                :checked="selectedRows.has(row[rowKey])"
-                @change="toggleRowSelection(row[rowKey])"
+                :checked="selectedRows.has(row[rowKey] as RowKeyValue)"
+                @change="toggleRowSelection(row[rowKey] as RowKeyValue)"
                 @click.stop
                 class="checkbox-input"
                 :aria-label="t('base.table.selectRow', { row: index + 1 })"
@@ -143,6 +143,12 @@ const TABLE_VARIANTS = ['default', 'bordered', 'striped'] as const
 
 const logger = createLogger('BaseTable')
 
+// A table row is an object keyed by column keys; cell values are opaque and
+// narrowed by the consumer's `formatter`/cell slot at use-site.
+type RowData = Record<string, unknown>
+// Row-key values are whatever `row[rowKey]` yields — typically string/number.
+type RowKeyValue = string | number
+
 interface TableColumn {
   key: string
   label: string
@@ -151,12 +157,12 @@ interface TableColumn {
   align?: 'left' | 'center' | 'right'
   numeric?: boolean
   monospace?: boolean
-  formatter?: (value: any) => string
+  formatter?: (value: unknown) => string
 }
 
 interface Props {
   columns: TableColumn[]
-  data: any[]
+  data: RowData[]
   rowKey?: string
   size?: 'compact' | 'comfortable' | 'spacious'
   variant?: 'default' | 'bordered' | 'striped'
@@ -181,8 +187,8 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const emit = defineEmits<{
-  'row-click': [row: any]
-  'selection-change': [selectedKeys: any[]]
+  'row-click': [row: RowData]
+  'selection-change': [selectedKeys: RowKeyValue[]]
   sort: [key: string, order: 'asc' | 'desc']
 }>()
 
@@ -192,9 +198,9 @@ const sortOrder = ref<'asc' | 'desc'>('asc')
 
 // Row selection backed by useBatchSelection. Items source is props.data;
 // the Key is whatever `row[props.rowKey]` yields (typically string/number).
-const rowSelection = useBatchSelection<any, any>(
+const rowSelection = useBatchSelection<RowData, RowKeyValue>(
   () => props.data ?? [],
-  (row) => row[props.rowKey]
+  (row) => row[props.rowKey] as RowKeyValue
 )
 const selectedRows = rowSelection.selected
 const allSelected = rowSelection.allSelected
@@ -234,17 +240,17 @@ const toggleSelectAll = () => {
   }
 }
 
-const toggleRowSelection = (key: any) => {
+const toggleRowSelection = (key: RowKeyValue) => {
   rowSelection.toggleByKey(key)
 }
 
-const handleRowClick = (row: any) => {
+const handleRowClick = (row: RowData) => {
   if (props.rowClickable) {
     emit('row-click', row)
   }
 }
 
-const formatCellValue = (value: any, column: TableColumn) => {
+const formatCellValue = (value: unknown, column: TableColumn) => {
   if (column.formatter) {
     return column.formatter(value)
   }

--- a/autobot-frontend/src/components/file-browser/FileBrowser.vue
+++ b/autobot-frontend/src/components/file-browser/FileBrowser.vue
@@ -89,6 +89,11 @@ import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useUserStore } from '@/stores/useUserStore'
 import { useFileBrowser } from '@/composables/file-browser/useFileBrowser'
+import type { FileBrowserItem, FileBrowserTreeNode, FilePreviewData } from '@/composables/file-browser/useFileBrowser'
+
+// The FilePreview @download payload carries an optional `fileType`, so we only
+// rely on the fields actually read here (name/url) via Pick to stay compatible.
+type PreviewDownloadFile = Pick<FilePreviewData, 'name' | 'url'>
 import { useAsyncHandler } from '@/composables/useErrorHandler'
 import { useSessionActivityLogger } from '@/composables/useSessionActivityLogger'
 
@@ -261,7 +266,7 @@ const handleFileSelected = async (fileList: FileList) => {
 }
 
 const { execute: viewFile, loading: isViewingFile } = useAsyncHandler(
-  async (file: any) => {
+  async (file: FileBrowserItem) => {
     await fetchPreview(file, getFileType)
     showPreview.value = true
 
@@ -281,7 +286,7 @@ const { execute: viewFile, loading: isViewingFile } = useAsyncHandler(
 )
 
 const { execute: performDelete, loading: isDeletingFile } = useAsyncHandler(
-  async (file: any) => {
+  async (file: FileBrowserItem) => {
     const itemType = file.is_dir ? 'folder' : 'file'
     await deleteFileOrFolder(file.path)
     await refreshFiles()
@@ -305,7 +310,7 @@ const { execute: performDelete, loading: isDeletingFile } = useAsyncHandler(
   }
 )
 
-const deleteFile = async (file: any) => {
+const deleteFile = async (file: FileBrowserItem) => {
   const message = t('fileBrowser.browser.deleteConfirm', { name: file.name })
 
   if (confirm(message)) {
@@ -314,7 +319,7 @@ const deleteFile = async (file: any) => {
 }
 
 const { execute: performRename, loading: isRenamingFile } = useAsyncHandler(
-  async (file: any, newName: string) => {
+  async (file: FileBrowserItem, newName: string) => {
     await renameFileOrFolder(file.path, newName)
     await refreshFiles()
 
@@ -336,7 +341,7 @@ const { execute: performRename, loading: isRenamingFile } = useAsyncHandler(
   }
 )
 
-const renameFile = async (file: any) => {
+const renameFile = async (file: FileBrowserItem) => {
   const newName = prompt(t('fileBrowser.browser.renamePrompt'), file.name)
 
   if (newName && newName !== file.name) {
@@ -379,7 +384,7 @@ const closePreview = () => {
   previewFile.value = null
 }
 
-const downloadPreviewFile = (file: any) => {
+const downloadPreviewFile = (file: PreviewDownloadFile) => {
   if (file.url) {
     const a = document.createElement('a')
     a.href = file.url
@@ -388,7 +393,7 @@ const downloadPreviewFile = (file: any) => {
   }
 }
 
-const toggleNode = (item: any) => {
+const toggleNode = (item: FileBrowserTreeNode) => {
   if (item.is_dir) {
     item.expanded = !item.expanded
     selectedPath.value = item.path
@@ -397,7 +402,7 @@ const toggleNode = (item: any) => {
 }
 
 const expandAll = () => {
-  const expandNodeRecursively = (nodes: any[]) => {
+  const expandNodeRecursively = (nodes: FileBrowserTreeNode[]) => {
     nodes.forEach(node => {
       if (node.is_dir) {
         node.expanded = true
@@ -411,7 +416,7 @@ const expandAll = () => {
 }
 
 const collapseAll = () => {
-  const collapseNodeRecursively = (nodes: any[]) => {
+  const collapseNodeRecursively = (nodes: FileBrowserTreeNode[]) => {
     nodes.forEach(node => {
       if (node.is_dir) {
         node.expanded = false

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -266,6 +266,27 @@ interface CategoryOption {
   count: number
 }
 
+// Loose shape of a knowledge fact/entry as returned by the KB endpoints
+// (Record<string, unknown> at the wire; these are the fields we read).
+interface KnowledgeFactLike {
+  key?: string
+  title?: string
+  source?: string
+  content?: string
+  full_content?: string
+  timestamp?: string
+  created_at?: string
+  category?: string
+  metadata?: Record<string, unknown>
+}
+
+// Nested folder scaffold built while grouping facts by path segment. Each key
+// is either a nested directory or the special `_files` bucket of leaf nodes.
+interface NestedDir {
+  _files?: TreeNode[]
+  [segment: string]: NestedDir | TreeNode[] | undefined
+}
+
 // State
 const treeData = ref<TreeNode[]>([])
 const nodeExpansion = useExpansion<string>()
@@ -306,7 +327,7 @@ const { isLoading: isLoadingContent, wrap: loadFileContentOp } = useLoadingState
 const contentError = ref<Error | null>(null)
 
 // Cursor-based pagination for user knowledge entries
-const allLoadedEntries = ref<any[]>([])
+const allLoadedEntries = ref<Record<string, unknown>[]>([])
 const entriesCursor = ref<string>('0')
 const hasMoreEntries = ref<boolean>(true)
 const isLoadingMore = ref<boolean>(false)
@@ -454,12 +475,12 @@ const filteredTree = computed(() => {
 })
 
 // Helper function to build nested folder structure from file paths
-const buildNestedTree = (facts: any[], category: string): TreeNode[] => {
-  const root: Record<string, any> = {}
+const buildNestedTree = (facts: Record<string, unknown>[], category: string): TreeNode[] => {
+  const root: NestedDir = {};
 
-  facts.forEach((fact: any, factIdx: number) => {
+  (facts as KnowledgeFactLike[]).forEach((fact, factIdx: number) => {
     // Extract filename from metadata
-    const filename = fact.metadata?.filename || fact.title || `Fact ${factIdx + 1}`
+    const filename = (fact.metadata?.filename || fact.title || `Fact ${factIdx + 1}`) as string
 
     // Parse the path (e.g., "docs/api/endpoints.md" -> ["docs", "api", "endpoints.md"])
     const pathParts = filename.split('/').filter((p: string) => p)
@@ -475,7 +496,7 @@ const buildNestedTree = (facts: any[], category: string): TreeNode[] => {
         if (!current._files) current._files = []
         // Extract the actual fact ID from the Redis key (e.g., "fact:UUID" -> "UUID")
         const factId = fact.key ? fact.key.replace('fact:', '') : `fact-${category}-${factIdx}`
-        const fileContent = fact.full_content || fact.content || ''
+        const fileContent = (fact.full_content || fact.content || '') as string
         current._files.push({
           id: factId, // Use actual fact ID from Redis, not synthetic ID
           name: part,
@@ -495,13 +516,13 @@ const buildNestedTree = (facts: any[], category: string): TreeNode[] => {
         if (!current[part]) {
           current[part] = {}
         }
-        current = current[part]
+        current = current[part] as NestedDir
       }
     }
   })
 
   // Convert nested object to TreeNode array
-  const convertToTreeNodes = (obj: Record<string, any>, prefix = ''): TreeNode[] => {
+  const convertToTreeNodes = (obj: NestedDir, prefix = ''): TreeNode[] => {
     const nodes: TreeNode[] = []
 
     // Add folders
@@ -509,11 +530,12 @@ const buildNestedTree = (facts: any[], category: string): TreeNode[] => {
       if (key === '_files') return
 
       const folderPath = prefix ? `${prefix}/${key}` : key
-      const children = convertToTreeNodes(obj[key], folderPath)
+      const children = convertToTreeNodes(obj[key] as NestedDir, folderPath)
 
       // Add files from this level
-      if (obj[key]._files) {
-        children.push(...obj[key]._files)
+      const childFiles = (obj[key] as NestedDir)._files
+      if (childFiles) {
+        children.push(...childFiles)
       }
 
       nodes.push({
@@ -707,12 +729,12 @@ const loadMoreEntries = async () => {
   restoreExpandedState(treeData.value, expandedPaths)
 }
 
-const buildTreeFromEntries = (entries: any[]) => {
+const buildTreeFromEntries = (entries: Record<string, unknown>[]) => {
   // Build tree from entries (group by category)
   const categoryMap = new Map<string, TreeNode[]>()
 
   if (Array.isArray(entries)) {
-    entries.forEach((entry: any, idx: number) => {
+    (entries as KnowledgeFactLike[]).forEach((entry, idx: number) => {
       const category = entry.category || 'Uncategorized'
 
       if (!categoryMap.has(category)) {
@@ -935,18 +957,18 @@ const loadFolderContents = async (folder: TreeNode) => {
     const data = await fetchFolderContents(folder.category || '')
 
     if (data.results && Array.isArray(data.results)) {
-      folder.children = data.results.map((item: any, idx: number) => ({
+      folder.children = (data.results as KnowledgeFactLike[]).map((item, idx: number) => ({
         id: `file-${folder.id}-${idx}`,
-        name: item.metadata?.title || item.metadata?.source || `Document ${idx + 1}`,
+        name: (item.metadata?.title || item.metadata?.source || `Document ${idx + 1}`) as string,
         type: 'file' as const,
         path: `${folder.path}/${item.metadata?.title || item.metadata?.source}`,
-        size: item.content?.length || 0,
-        date: item.metadata?.timestamp,
+        size: (item.content?.length as number | undefined) || 0,
+        date: item.metadata?.timestamp as string | undefined,
         category: folder.category,
         metadata: item
       }))
     }
-  } catch (err: any) {
+  } catch (err: unknown) {
     logger.error('Failed to load folder contents:', err)
   }
 }

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -49,7 +49,7 @@
             <Icon name="pencil-alt" />
           </button>
           <div class="category-icon-large" :style="{ backgroundColor: category.color }">
-            <Icon :name="category.icon" />
+            <Icon :name="category.icon as IconName" />
           </div>
           <div class="category-content">
             <h3>{{ category.name }}</h3>
@@ -165,16 +165,20 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
+import type { IconName } from '@/components/ui/Icon.vue'
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter, useRoute } from 'vue-router'
 import { useKnowledgeStats } from '@/composables/knowledge/useKnowledgeStats'
 import { useKnowledgeIcons } from '@/composables/knowledge/useKnowledgeIcons'
 import { useKnowledgeCategories } from '@/composables/knowledge/useKnowledgeCategories'
+import type { MainCategoryItem } from '@/composables/knowledge/useKnowledgeCategories'
+import type { KnowledgeStats } from '@/types/knowledgeBase'
 import { formatDate, formatCategoryName, formatFileSize } from '@/utils/formatHelpers'
 import KnowledgeBrowser from './KnowledgeBrowser.vue'
 import DocumentChangeFeed from './DocumentChangeFeed.vue'
 import CategoryEditModal from './modals/CategoryEditModal.vue'
+import type { Category } from './modals/CategoryEditModal.vue'
 import { BaseModal } from '@autobot/ui'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
@@ -198,24 +202,35 @@ const route = useRoute()
 // UI state
 const selectedMainCategory = ref<string | null>(null)
 
+// Shape of a category document as read by this view (Record<string, unknown>
+// on the wire; these are the fields the template/handlers access).
+interface CategoryDocument {
+  path?: string
+  title?: string
+  filename?: string
+  type?: string
+  size?: number
+  content?: string
+}
+
 // Shared state
 const isLoadingKBStats = ref(false)
-const kbStats = ref<any>(null)
-const mainCategories = ref<any[]>([])
+const kbStats = ref<KnowledgeStats | null>(null)
+const mainCategories = ref<MainCategoryItem[]>([])
 const isLoadingCategories = ref(false)
 const categoriesError = ref<string | null>(null)
 
 // Category documents state
 const isLoadingCategoryDocs = ref(false)
-const categoryDocuments = ref<any[]>([])
+const categoryDocuments = ref<CategoryDocument[]>([])
 const showCategoryDocuments = ref(false)
 const selectedCategoryPath = ref('')
 const showDocumentModal = ref(false)
-const currentDocument = ref<any>(null)
+const currentDocument = ref<CategoryDocument | null>(null)
 
 // Issue #747: Category edit modal state
 const showCategoryEditModal = ref(false)
-const categoryToEdit = ref<any>(null)
+const categoryToEdit = ref<Category | null>(null)
 
 // Computed properties
 const systemCategories = computed(() => {
@@ -243,12 +258,12 @@ const browseCategory = async (category: string) => {
   })
 }
 
-const viewCategoryDocuments = async (category: any) => {
+const viewCategoryDocuments = async (category: MainCategoryItem) => {
   isLoadingCategoryDocs.value = true
-  selectedCategoryPath.value = category.path
+  selectedCategoryPath.value = category.path as string
 
   try {
-    categoryDocuments.value = await fetchCategoryDocuments(category.path)
+    categoryDocuments.value = (await fetchCategoryDocuments(category.path as string)) as CategoryDocument[]
     showCategoryDocuments.value = true
   } catch (error) {
     logger.error('Error loading category documents:', error)
@@ -264,7 +279,7 @@ const closeCategoryDocuments = () => {
   selectedCategoryPath.value = ''
 }
 
-const viewDocumentDetails = (doc: any) => {
+const viewDocumentDetails = (doc: CategoryDocument) => {
   currentDocument.value = doc
   showDocumentModal.value = true
 }
@@ -313,17 +328,17 @@ const getSelectedCategoryName = () => {
 }
 
 // Issue #747: Category edit/delete handlers
-const openCategoryEdit = (category: any, event: Event) => {
+const openCategoryEdit = (category: MainCategoryItem, event: Event) => {
   event.stopPropagation() // Prevent card click from triggering
-  categoryToEdit.value = category
+  categoryToEdit.value = category as Category
   showCategoryEditModal.value = true
 }
 
-const handleCategoryUpdated = (updatedCategory: any) => {
+const handleCategoryUpdated = (updatedCategory: Category) => {
   // Update the category in the list
   const index = mainCategories.value.findIndex(c => c.id === updatedCategory.id)
   if (index !== -1) {
-    mainCategories.value[index] = { ...mainCategories.value[index], ...updatedCategory }
+    mainCategories.value[index] = { ...mainCategories.value[index], ...updatedCategory } as MainCategoryItem
   }
   showCategoryEditModal.value = false
   categoryToEdit.value = null


### PR DESCRIPTION
## Thinking Path
#9924 grind — BaseTable.vue (7, base component), FileBrowser.vue (9), KnowledgeBrowser.vue (9), KnowledgeCategories.vue (9). Strictly type-only.

## What Changed — 34 `any` removed
- **BaseTable.vue**: `RowData = Record<string, unknown>`, `RowKeyValue = string|number` generics for data/emits/`useBatchSelection`; 4 template `as RowKeyValue` casts on key access.
- **FileBrowser.vue**: reused `FileBrowserItem`/`FileBrowserTreeNode`/`FilePreviewData`; `PreviewDownloadFile = Pick<FilePreviewData,'name'|'url'>` for the emitted download payload.
- **KnowledgeBrowser.vue**: `Record<string,unknown>[]` for loaded entries; minimal `KnowledgeFactLike`/`NestedDir` scaffolds; `catch(err: unknown)`.
- **KnowledgeCategories.vue**: reused `MainCategoryItem`/`KnowledgeStats`/`Category`/`IconName`; minimal `CategoryDocument`.

## Verification (independently re-run)
- `eslint` → 0 `no-explicit-any`, exit 0.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (no BaseTable-consumer breakage).
- `vitest` (useKnowledgeBase + useKnowledgeCategories) → 21/21.
- Diff-scan for runtime coercions/guards → none. Only pre-existing `||` (parenthesized+cast); one benign ASI semicolon.

## Model Used
Opus 4.8

Contributes to #9924 (686→652 remaining no-explicit-any).