### PR TITLE
fix(frontend): replace no-explicit-any in ChatInterface/knowledge/test-config (#9924 batch 9)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -326,6 +326,25 @@ import { useContextWindow } from '@/composables/chat/useContextWindow'
 // GH#9043: context overflow protection — auto-summarize on overflow
 import { useContextOverflowProtection } from '@/composables/chat/useContextOverflowProtection'
 
+// Chat context passed to KnowledgePersistenceDialog (mirrors its chatContext prop).
+interface KnowledgeChatContext {
+  topic?: string
+  keywords?: string[]
+  file_count?: number
+}
+
+// Payload of context_warning / context_compressed live events (GH#8990/#9043).
+interface ContextWindowEventPayload {
+  usage_percent?: number
+}
+
+// TOOL_CALL detected from chat messages and forwarded from ChatTabContent.
+interface DetectedToolCall {
+  command: string
+  purpose: string
+  terminal_session_id?: string | null
+}
+
 // i18n
 const { t } = useI18n()
 
@@ -499,7 +518,7 @@ const contextWarningShown = ref(false)
 // Listen for context_warning events (80% threshold)
 subscribe('global', (event) => {
   if (event.event_type === 'context_warning') {
-    const data = event.payload as any
+    const data = event.payload as ContextWindowEventPayload
     logger.debug('[ContextWindow] Warning event received:', data)
 
     // Only show toast if mode is 'auto' or 'warn', and not already shown
@@ -512,7 +531,7 @@ subscribe('global', (event) => {
       contextWarningShown.value = true
     }
   } else if (event.event_type === 'context_compressed') {
-    const data = event.payload as any
+    const data = event.payload as ContextWindowEventPayload
     logger.info('[ContextWindow] Context compressed:', data)
 
     // Reset warning flag so next session can show it again
@@ -544,7 +563,7 @@ const showMobileSidebar = ref(false)
 const showChatSettings = ref(false)
 
 // Dialog data
-const currentChatContext = ref<any>(null)
+const currentChatContext = ref<KnowledgeChatContext | null>(null)
 const pendingCommand = ref({
   command: '',
   purpose: '',
@@ -772,18 +791,18 @@ const openTerminalInNewTab = () => {
 }
 
 // Dialog handlers
-const onKnowledgeDecisionsApplied = (decisions: any) => {
+const onKnowledgeDecisionsApplied = (decisions: unknown) => {
   logger.debug('Knowledge decisions applied:', decisions)
   // Handle knowledge persistence decisions
 }
 
-const onChatCompiled = (compiledData: any) => {
+const onChatCompiled = (compiledData: unknown) => {
   logger.debug('Chat compiled:', compiledData)
   // Handle compiled chat data
 }
 
 // Handle TOOL_CALL detection from chat messages
-const handleToolCallDetected = async (toolCall: any) => {
+const handleToolCallDetected = async (toolCall: DetectedToolCall) => {
   logger.debug('TOOL_CALL detected, showing approval dialog:', toolCall)
 
   // Assess risk level (simple heuristics for now)
@@ -878,7 +897,7 @@ const handleVisionSendToChat = (payload: {
   })
 }
 
-const onCommandApproved = async (commandData: any) => {
+const onCommandApproved = async (commandData: { command: string; result: unknown; rememberChoice: boolean }) => {
   logger.debug('Command approved:', commandData)
 
   // IMPORTANT: The backend is already waiting for approval and will execute automatically.
@@ -901,7 +920,7 @@ const onCommandDenied = ({ reason }: { command: string; reason: string }) => {
   // Handle command denial
 }
 
-const onCommandCommented = async (commentData: any) => {
+const onCommandCommented = async (commentData: { command: string; comment: string; response: unknown }) => {
   logger.debug('Command commented:', commentData)
 
   try {

--- a/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
@@ -186,6 +186,14 @@ const { t } = useI18n()
 
 const store = useKnowledgeStore()
 
+// Shape of the knowledge_base population/clear endpoint responses.
+interface KnowledgeBaseOpResponse {
+  status?: string
+  message?: string
+  items_added?: number
+  items_removed?: number
+}
+
 // State
 const isPopulating = ref(false)
 const isClearing = ref(false)
@@ -324,7 +332,7 @@ const populateSystemCommands = async () => {
     startProgress(t('knowledge.advanced.progressPopulatingSystemCommands'), 150)
     progressDetails.value = t('knowledge.advanced.progressAddingCommands')
 
-    const response = await ApiClient.post<Record<string, any>>(`${getApiBase()}/knowledge_base/populate_system_commands`, {})
+    const response = await ApiClient.post<KnowledgeBaseOpResponse>(`${getApiBase()}/knowledge_base/populate_system_commands`, {})
 
     if (response.status === 'success') {
       populateStatus.value.systemCommands = 'success'
@@ -336,11 +344,11 @@ const populateSystemCommands = async () => {
     } else {
       throw new Error(response.message || 'Failed to populate system commands')
     }
-  } catch (error: any) {
+  } catch (error) {
     logger.error('Failed to populate system commands:', error)
     populateStatus.value.systemCommands = 'error'
     addStatusMessage('error', t('knowledge.advanced.systemCommandsFailed'),
-      error.message || 'An error occurred while populating system commands')
+      (error as { message?: string }).message || 'An error occurred while populating system commands')
   } finally {
     isPopulating.value = false
     stopProgress()
@@ -362,7 +370,7 @@ const populateManPages = async () => {
     startProgress(t('knowledge.advanced.progressPopulatingManPages'), 50)
     progressDetails.value = t('knowledge.advanced.progressAddingManPages')
 
-    const response = await ApiClient.post<Record<string, any>>(`${getApiBase()}/knowledge_base/populate_man_pages`, {})
+    const response = await ApiClient.post<KnowledgeBaseOpResponse>(`${getApiBase()}/knowledge_base/populate_man_pages`, {})
 
     if (response.status === 'success') {
       populateStatus.value.manPages = 'success'
@@ -374,11 +382,11 @@ const populateManPages = async () => {
     } else {
       throw new Error(response.message || 'Failed to populate manual pages')
     }
-  } catch (error: any) {
+  } catch (error) {
     logger.error('Failed to populate manual pages:', error)
     populateStatus.value.manPages = 'error'
     addStatusMessage('error', t('knowledge.advanced.manualPagesFailed'),
-      error.message || 'An error occurred while populating manual pages')
+      (error as { message?: string }).message || 'An error occurred while populating manual pages')
   } finally {
     isPopulating.value = false
     stopProgress()
@@ -400,7 +408,7 @@ const populateAutoBotDocs = async () => {
     startProgress(t('knowledge.advanced.progressPopulatingAutobotDocs'), 30)
     progressDetails.value = t('knowledge.advanced.progressAddingAutobotDocs')
 
-    const response = await ApiClient.post<Record<string, any>>(`${getApiBase()}/knowledge_base/populate_autobot_docs`, {})
+    const response = await ApiClient.post<KnowledgeBaseOpResponse>(`${getApiBase()}/knowledge_base/populate_autobot_docs`, {})
 
     if (response.status === 'success') {
       populateStatus.value.autobotDocs = 'success'
@@ -412,11 +420,11 @@ const populateAutoBotDocs = async () => {
     } else {
       throw new Error(response.message || 'Failed to populate AutoBot documentation')
     }
-  } catch (error: any) {
+  } catch (error) {
     logger.error('Failed to populate AutoBot docs:', error)
     populateStatus.value.autobotDocs = 'error'
     addStatusMessage('error', t('knowledge.advanced.autobotDocsFailed'),
-      error.message || 'An error occurred while populating AutoBot documentation')
+      (error as { message?: string }).message || 'An error occurred while populating AutoBot documentation')
   } finally {
     isPopulating.value = false
     stopProgress()
@@ -453,7 +461,7 @@ const clearAllKnowledge = async () => {
     startProgress(t('knowledge.advanced.progressClearingKB'), 1)
     progressDetails.value = t('knowledge.advanced.progressRemovingEntries')
 
-    const response = await ApiClient.post<Record<string, any>>(`${getApiBase()}/knowledge_base/clear_all`, {})
+    const response = await ApiClient.post<KnowledgeBaseOpResponse>(`${getApiBase()}/knowledge_base/clear_all`, {})
 
     if (response.status === 'success') {
       addStatusMessage('success', t('knowledge.advanced.clearSuccess'),
@@ -471,10 +479,10 @@ const clearAllKnowledge = async () => {
     } else {
       throw new Error(response.message || 'Failed to clear knowledge base')
     }
-  } catch (error: any) {
+  } catch (error) {
     logger.error('Failed to clear knowledge base:', error)
     addStatusMessage('error', t('knowledge.advanced.clearFailed'),
-      error.message || 'An error occurred while clearing the knowledge base')
+      (error as { message?: string }).message || 'An error occurred while clearing the knowledge base')
   } finally{
     isClearing.value = false
     stopProgress()

--- a/autobot-frontend/src/composables/useKnowledgeGraph.ts
+++ b/autobot-frontend/src/composables/useKnowledgeGraph.ts
@@ -187,11 +187,11 @@ export function useKnowledgeGraph() {
     clearError()
     return wrap(async () => {
       try {
-        const data = await apiClient.post<any>(
+        const data = await apiClient.post<Record<string, unknown>>(
           `${API_BASE}/pipeline/run`, config
         )
         logger.info('Pipeline completed:', data?.pipeline_id)
-        return data as PipelineResult
+        return data as unknown as PipelineResult
       } catch (err) {
         setError(err)
         return null
@@ -214,7 +214,7 @@ export function useKnowledgeGraph() {
           entity_types: params.entity_types,
           limit: params.limit ?? 50,
         })
-        const data = await apiClient.get<any>(`${API_BASE}/entities${qs}`)
+        const data = await apiClient.get<Record<string, unknown>>(`${API_BASE}/entities${qs}`)
         entities.value = (
           data?.entities ?? data ?? []
         ) as Entity[]
@@ -230,7 +230,7 @@ export function useKnowledgeGraph() {
     clearError()
     await wrap(async () => {
       try {
-        const data = await apiClient.get<any>(
+        const data = await apiClient.get<Record<string, unknown>>(
           `${API_BASE}/entities/` +
           `${encodeURIComponent(entityId)}/relationships`
         )
@@ -260,7 +260,7 @@ export function useKnowledgeGraph() {
           event_types: params.event_types,
           entity_name: params.entity_name,
         })
-        const data = await apiClient.get<any>(`${API_BASE}/events${qs}`)
+        const data = await apiClient.get<Record<string, unknown>>(`${API_BASE}/events${qs}`)
         events.value = (
           data?.events ?? data ?? []
         ) as TemporalEvent[]
@@ -278,7 +278,7 @@ export function useKnowledgeGraph() {
     clearError()
     return wrap(async () => {
       try {
-        const data = await apiClient.get<any>(
+        const data = await apiClient.get<Record<string, unknown>>(
           `${API_BASE}/events/` +
           `${encodeURIComponent(entityName)}/timeline`
         )
@@ -308,7 +308,7 @@ export function useKnowledgeGraph() {
           level: params.level,
           top_k: params.top_k ?? 10,
         })
-        const data = await apiClient.get<any>(
+        const data = await apiClient.get<Record<string, unknown>>(
           `${API_BASE}/summaries/search${qs}`
         )
         summaries.value = (
@@ -328,11 +328,11 @@ export function useKnowledgeGraph() {
     clearError()
     return wrap(async () => {
       try {
-        const data = await apiClient.get<any>(
+        const data = await apiClient.get<Record<string, unknown>>(
           `${API_BASE}/documents/` +
           `${encodeURIComponent(documentId)}/overview`
         )
-        return data as DocumentOverview
+        return data as unknown as DocumentOverview
       } catch (err) {
         setError(err)
         return null
@@ -346,11 +346,11 @@ export function useKnowledgeGraph() {
     clearError()
     return wrap(async () => {
       try {
-        const data = await apiClient.get<any>(
+        const data = await apiClient.get<Record<string, unknown>>(
           `${API_BASE}/summaries/` +
           `${encodeURIComponent(summaryId)}/drill-down`
         )
-        return data as DrillDownResult
+        return data as unknown as DrillDownResult
       } catch (err) {
         setError(err)
         return null

--- a/autobot-frontend/src/test/config/test-config.ts
+++ b/autobot-frontend/src/test/config/test-config.ts
@@ -293,10 +293,10 @@ export const initializeTestScenario = (scenario: keyof typeof TEST_SCENARIOS) =>
   TEST_SCENARIOS[scenario]()
 
   // Setup global fetch mock based on current scenario
-  global.fetch = vi.fn().mockImplementation((url: string, options: any = {}) => {
+  global.fetch = vi.fn().mockImplementation((url: string, options: RequestInit = {}) => {
     const method = options.method || 'GET'
     return createMockApiResponse(url.toString(), method)
-  }) as any
+  }) as unknown as typeof global.fetch
 }
 
 // Reset test configuration to defaults
@@ -324,15 +324,15 @@ export const createTestId = (component: string, element: string) => {
 
 // Common test assertions for API calls
 export const expectApiCall = {
-  toTimeout: (promise: Promise<any>) => {
+  toTimeout: (promise: Promise<unknown>) => {
     return expect(promise).rejects.toThrow(/timeout|30000ms/)
   },
 
-  toFail: (promise: Promise<any>) => {
+  toFail: (promise: Promise<unknown>) => {
     return expect(promise).rejects.toThrow(/Failed to fetch|TypeError/)
   },
 
-  toSucceed: (promise: Promise<any>) => {
+  toSucceed: (promise: Promise<unknown>) => {
     return expect(promise).resolves.toEqual(
       expect.objectContaining({
         success: true,
@@ -347,7 +347,7 @@ export const mockWebSocketBehavior = {
   connectionRefused: () => {
     global.WebSocket = vi.fn().mockImplementation(() => {
       throw new Error('Error in connection establishment: net::ERR_CONNECTION_REFUSED')
-    }) as any
+    }) as unknown as typeof global.WebSocket
   },
 
   connectionTimeout: () => {
@@ -359,7 +359,7 @@ export const mockWebSocketBehavior = {
         close: vi.fn(),
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
-        onerror: null as any,
+        onerror: null as WebSocket['onerror'],
       }
 
       // Simulate connection timeout after 30 seconds
@@ -370,7 +370,7 @@ export const mockWebSocketBehavior = {
       }, 30000)
 
       return ws
-    }) as any
+    }) as unknown as typeof global.WebSocket
   },
 
   normalConnection: () => {
@@ -385,7 +385,7 @@ export const mockWebSocketBehavior = {
       onclose: null,
       onmessage: null,
       onerror: null,
-    })) as any
+    })) as unknown as typeof global.WebSocket
   },
 }
 


### PR DESCRIPTION
## Thinking Path
#9924 grind — test-config.ts (9), ChatInterface.vue (8), KnowledgeAdvanced.vue (8), useKnowledgeGraph.ts (8). Strictly type-only.

## What Changed — 33 `any` removed
- **useKnowledgeGraph.ts**: `apiClient.get/post<any>`→`<Record<string,unknown>>`; reused in-file `PipelineResult`/`DocumentOverview`/`DrillDownResult`.
- **KnowledgeAdvanced.vue**: `post<Record<string,any>>`→minimal `KnowledgeBaseOpResponse`; `catch(error: any)`→`catch(error)` + use-site cast.
- **ChatInterface.vue**: minimal event-payload/context interfaces; emit-handler params typed to match emitting dialogs; log-only params → `unknown`.
- **test-config.ts**: `RequestInit`, `Promise<unknown>`, `as unknown as typeof global.fetch/WebSocket`, `null as WebSocket['onerror']`.

## Verification (independently re-run)
- `eslint` → 0 `no-explicit-any`, exit 0.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0.
- `vitest ChatInterface.test.ts` → 23/23.
- Diff-scan for runtime coercions/guards → none (casts only).

## Model Used
Opus 4.8

Contributes to #9924 (651→618 remaining no-explicit-any).