### PR TITLE
fix(frontend): replace no-explicit-any in test-utils/VisualBrowser/knowledge/audit (#9924 batch 10)

### DIFF
--- a/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
+++ b/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
@@ -67,7 +67,7 @@ function toggleAutomation(): void {
 
 async function checkStatus(): Promise<void> {
   try {
-    const data = await ApiClient.get<any>(`${getApiBase()}/playwright/worker-status`) as Record<string, unknown>
+    const data = await ApiClient.get<Record<string, unknown>>(`${getApiBase()}/playwright/worker-status`)
     isConnected.value = data.status === 'connected' || data.browser_connected === true
   } catch (e) {
     logger.warn('Browser status check failed:', e)
@@ -87,7 +87,7 @@ async function navigate(): Promise<void> {
   url.value = targetUrl
 
   try {
-    const nav = await ApiClient.post<any>(`${getApiBase()}/playwright/navigate`, { url: targetUrl }) as Record<string, unknown>
+    const nav = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/navigate`, { url: targetUrl })
     currentUrl.value = (nav.url as string) || targetUrl
     pageTitle.value = (nav.title as string) || null
     isConnected.value = true
@@ -105,7 +105,7 @@ async function navigate(): Promise<void> {
 
 async function captureScreenshot(): Promise<void> {
   try {
-    const data = await ApiClient.post<any>(`${getApiBase()}/playwright/worker-screenshot`, {}) as Record<string, unknown>
+    const data = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/worker-screenshot`, {})
     screenshot.value = (data.screenshot as string) || null
   } catch (e) {
     logger.warn('Screenshot failed:', e)
@@ -117,7 +117,7 @@ async function goBack(): Promise<void> {
   loading.value = true
   error.value = null
   try {
-    const nav = await ApiClient.post<any>(`${getApiBase()}/playwright/back`, {}) as Record<string, unknown>
+    const nav = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/back`, {})
     if (nav.url) { currentUrl.value = nav.url as string; url.value = nav.url as string }
     if (nav.title) pageTitle.value = nav.title as string
     if (nav.screenshot) screenshot.value = nav.screenshot as string
@@ -133,7 +133,7 @@ async function goForward(): Promise<void> {
   loading.value = true
   error.value = null
   try {
-    const nav = await ApiClient.post<any>(`${getApiBase()}/playwright/forward`, {}) as Record<string, unknown>
+    const nav = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/forward`, {})
     if (nav.url) { currentUrl.value = nav.url as string; url.value = nav.url as string }
     if (nav.title) pageTitle.value = nav.title as string
     if (nav.screenshot) screenshot.value = nav.screenshot as string
@@ -149,7 +149,7 @@ async function reload(): Promise<void> {
   loading.value = true
   error.value = null
   try {
-    const nav = await ApiClient.post<any>(`${getApiBase()}/playwright/reload`, {}) as Record<string, unknown>
+    const nav = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/reload`, {})
     if (nav.screenshot) screenshot.value = nav.screenshot as string
   } catch (e) {
     error.value = e instanceof Error ? e.message : t('chat.visualBrowser.reloadFailed')
@@ -162,10 +162,10 @@ async function handleInteract(payload: { action: string; params: Record<string, 
   if (!isConnected.value || loading.value) return
   loading.value = true
   try {
-    const result = await ApiClient.post<any>(`${getApiBase()}/playwright/interact`, {
+    const result = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/interact`, {
       action: payload.action,
       ...payload.params,
-    }) as Record<string, unknown>
+    })
     if (result.screenshot) screenshot.value = result.screenshot as string
     if (result.url) { currentUrl.value = result.url as string; url.value = result.url as string }
     if (result.title) pageTitle.value = result.title as string

--- a/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
@@ -109,7 +109,7 @@ const sources = ref<SourceCard[]>([])
 
 async function checkBrowserStatus(): Promise<void> {
   try {
-    const data = await ApiClient.get<any>(`${getApiBase()}/playwright/worker-status`) as Record<string, unknown>
+    const data = await ApiClient.get<Record<string, unknown>>(`${getApiBase()}/playwright/worker-status`)
     browserConnected.value = data.status === 'connected' || data.browser_connected === true
   } catch (e) {
     logger.warn('Browser status check failed:', e)
@@ -122,7 +122,7 @@ const { start: _startScreenshotPolling, stop: stopScreenshotPolling } = usePolli
     if (screenshotLoading.value) return
     screenshotLoading.value = true
     try {
-      const data = await ApiClient.post<any>(`${getApiBase()}/playwright/worker-screenshot`, {}) as Record<string, unknown>
+      const data = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/worker-screenshot`, {})
       if (data.screenshot) {
         screenshot.value = data.screenshot as string
         browserConnected.value = true
@@ -142,7 +142,7 @@ async function fetchScreenshot(): Promise<void> {
   if (screenshotLoading.value) return
   screenshotLoading.value = true
   try {
-    const data = await ApiClient.post<any>(`${getApiBase()}/playwright/worker-screenshot`, {}) as Record<string, unknown>
+    const data = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/worker-screenshot`, {})
     if (data.screenshot) {
       screenshot.value = data.screenshot as string
       browserConnected.value = true
@@ -282,7 +282,7 @@ async function _emitAnnotationFeedback(
 ): Promise<void> {
   const userId = userStore.currentUser?.id ?? null
   try {
-    await ApiClient.post<any>(`${getApiBase()}/knowledge_base/rag-feedback`, {
+    await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/knowledge_base/rag-feedback`, {
       source_url: card.url,
       title: card.title,
       query: query.value,
@@ -297,7 +297,7 @@ async function _emitAnnotationFeedback(
 async function acceptSource(card: SourceCard): Promise<void> {
   card.decision = 'accepted'
   try {
-    await ApiClient.post<any>(`${getApiBase()}/knowledge/verification/approve`, {
+    await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/knowledge/verification/approve`, {
       source_url: card.url,
       title: card.title,
     })
@@ -318,10 +318,10 @@ async function handleInteract(payload: { action: string; params: Record<string, 
   if (screenshotLoading.value) return
   screenshotLoading.value = true
   try {
-    const result = await ApiClient.post<any>(`${getApiBase()}/playwright/interact`, {
+    const result = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/playwright/interact`, {
       action: payload.action,
       ...payload.params,
-    }) as Record<string, unknown>
+    })
     if (result.screenshot) screenshot.value = result.screenshot as string
   } catch (e) {
     logger.warn('Interaction failed:', e)
@@ -334,7 +334,7 @@ async function handleInteract(payload: { action: string; params: Record<string, 
 
 async function fetchBoards(retry = true): Promise<void> {
   try {
-    const data = await ApiClient.get<any>(`${getApiBase()}/knowledge_base/boards`) as { boards?: Board[] }
+    const data = await ApiClient.get<{ boards?: Board[] }>(`${getApiBase()}/knowledge_base/boards`)
     if (Array.isArray(data.boards)) {
       boards.value = data.boards
     }

--- a/autobot-frontend/src/composables/useAuditApi.ts
+++ b/autobot-frontend/src/composables/useAuditApi.ts
@@ -49,7 +49,7 @@ export function useAuditApi() {
         if (params?.offset) searchParams.append('offset', params.offset.toString())
         const queryString = searchParams.toString()
         const url = `${getApiBase()}/audit/logs${queryString ? `?${queryString}` : ''}`
-        return await api.get<any>(url)
+        return await api.get<AuditQueryResponse>(url)
       } catch (error: unknown) {
         logger.error('Failed to load audit logs', error)
         showSubtleErrorNotification('Error', 'Failed to load audit logs', 'error')
@@ -59,7 +59,7 @@ export function useAuditApi() {
 
     async getStatistics(): Promise<AuditStatisticsResponse | null> {
       try {
-        return await api.get<any>(`${getApiBase()}/audit/statistics`)
+        return await api.get<AuditStatisticsResponse>(`${getApiBase()}/audit/statistics`)
       } catch (error: unknown) {
         logger.error('Failed to load audit statistics', error)
         showSubtleErrorNotification('Error', 'Failed to load audit statistics', 'error')
@@ -69,7 +69,7 @@ export function useAuditApi() {
 
     async getSessionAuditTrail(sessionId: string): Promise<AuditQueryResponse | null> {
       try {
-        return await api.get<any>(`${getApiBase()}/audit/session/${sessionId}`)
+        return await api.get<AuditQueryResponse>(`${getApiBase()}/audit/session/${sessionId}`)
       } catch (error: unknown) {
         logger.error('Failed to load session audit trail', error)
         showSubtleErrorNotification('Error', 'Failed to load session audit trail', 'error')
@@ -79,7 +79,7 @@ export function useAuditApi() {
 
     async getUserAuditTrail(userId: string, days: number = 7): Promise<AuditQueryResponse | null> {
       try {
-        return await api.get<any>(`${getApiBase()}/audit/user/${userId}?days=${days}`)
+        return await api.get<AuditQueryResponse>(`${getApiBase()}/audit/user/${userId}?days=${days}`)
       } catch (error: unknown) {
         logger.error('Failed to load user audit trail', error)
         showSubtleErrorNotification('Error', 'Failed to load user audit trail', 'error')
@@ -89,7 +89,7 @@ export function useAuditApi() {
 
     async getFailedOperations(hours: number = 24, resultFilter: AuditResult = 'denied'): Promise<AuditQueryResponse | null> {
       try {
-        return await api.get<any>(
+        return await api.get<AuditQueryResponse>(
           `${getApiBase()}/audit/failures?hours=${hours}&result_filter=${resultFilter}`
         )
       } catch (error: unknown) {
@@ -101,7 +101,7 @@ export function useAuditApi() {
 
     async cleanupLogs(request: AuditCleanupRequest): Promise<AuditCleanupResponse | null> {
       try {
-        return await api.post<any>(`${getApiBase()}/audit/cleanup`, request)
+        return await api.post<AuditCleanupResponse>(`${getApiBase()}/audit/cleanup`, request)
       } catch (error: unknown) {
         logger.error('Failed to cleanup audit logs', error)
         showSubtleErrorNotification('Error', 'Failed to cleanup audit logs', 'error')
@@ -111,7 +111,7 @@ export function useAuditApi() {
 
     async getOperationTypes(): Promise<AuditOperationsResponse | null> {
       try {
-        return await api.get<any>(`${getApiBase()}/audit/operations`)
+        return await api.get<AuditOperationsResponse>(`${getApiBase()}/audit/operations`)
       } catch (error: unknown) {
         logger.error('Failed to load operation types', error)
         showSubtleErrorNotification('Error', 'Failed to load operation types', 'error')

--- a/autobot-frontend/src/test/utils/test-utils.ts
+++ b/autobot-frontend/src/test/utils/test-utils.ts
@@ -44,10 +44,10 @@ export const createTestRouter = (routes = testRoutes, initialEntries = ['/']) =>
 
 // Enhanced render function with common setup
 // Issue #156 Fix: RenderOptions<C> requires 1 type argument
-export interface CustomRenderOptions extends Omit<RenderOptions<any>, 'global'> {
+export interface CustomRenderOptions extends Omit<RenderOptions<Component>, 'global'> {
   router?: boolean
   pinia?: boolean
-  global?: RenderOptions<any>['global']
+  global?: RenderOptions<Component>['global']
 }
 
 export const renderComponent = (
@@ -57,7 +57,7 @@ export const renderComponent = (
   const { router = false, pinia = false, global = {}, ...renderOptions } = options
 
   // Issue #156 Fix: RenderOptions<C> requires 1 type argument
-  const globalConfig: RenderOptions<any>['global'] = {
+  const globalConfig: RenderOptions<Component>['global'] = {
     ...global,
     plugins: [
       ...(global.plugins || []),
@@ -87,7 +87,7 @@ export const createMockApiResponse = <T>(data: T, success = true) => ({
 })
 
 // Mock factory for WebSocket events
-export const createMockWebSocketEvent = (type: string, data: any) => ({
+export const createMockWebSocketEvent = (type: string, data: unknown) => ({
   type,
   data: JSON.stringify(data),
   timestamp: Date.now(),
@@ -156,7 +156,7 @@ export const createMockSettings = (overrides = {}) => ({
 
 // Helper to create mock functions with return values
 // Issue #156 Fix: Vitest Mock<T> requires 0-1 type arguments, not 2
-export const createMockFn = <T extends (...args: any[]) => any>(
+export const createMockFn = <T extends (...args: never[]) => unknown>(
   returnValue?: ReturnType<T>
 ): Mock<T> => {
   const mockFn = vi.fn() as Mock<T>
@@ -168,7 +168,7 @@ export const createMockFn = <T extends (...args: any[]) => any>(
 
 // Helper to create mock functions that resolve with values
 // Issue #156 Fix: Vitest Mock<T> requires 0-1 type arguments, not 2
-export const createMockAsyncFn = <T extends (...args: any[]) => Promise<any>>(
+export const createMockAsyncFn = <T extends (...args: never[]) => Promise<unknown>>(
   resolveValue?: Awaited<ReturnType<T>>
 ): Mock<T> => {
   const mockFn = vi.fn() as Mock<T>


### PR DESCRIPTION
## Thinking Path
#9924 grind — test-utils.ts (8), VisualBrowserPanel.vue (7), KnowledgeResearchPanel.vue (7), useAuditApi.ts (7). Strictly type-only.

## What Changed — 29 `any` removed
- **test-utils.ts**: `RenderOptions<Component>`, `data: unknown`, mock-fn constraints `(...args: never[]) => unknown`.
- **VisualBrowserPanel.vue / KnowledgeResearchPanel.vue**: `ApiClient.get/post<any> ... as Record<string,unknown>` → `<Record<string,unknown>>` generic (dropped redundant identity casts); reused file-local `Board`.
- **useAuditApi.ts**: `api.*<any>` → the functions' declared `@/types/audit` response types (all reused).

## Verification (independently re-run)
- `eslint` → 0 `no-explicit-any`, exit 0.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0.
- `vitest useAuditApi.test.ts` → 5/5; 587 passed across test-utils importers. 14 failures are pre-existing vue-i18n harness bug (#11026), verified via git-stash.
- Diff-scan for runtime coercions → none (generics/casts only).

## Model Used
Opus 4.8

Contributes to #9924 (618→589 remaining no-explicit-any).