### PR TITLE
fix(frontend): replace no-explicit-any in async/debug utils + CodeQuality/ChatMessages (#9924 batch 11)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -447,12 +447,14 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch, reactive } from 'vue';
+import type { DirectiveBinding } from 'vue';
 import { BaseModal } from '@autobot/ui'
 import { useRoute } from 'vue-router';
 import { createLogger } from '@/utils/debugUtils';
 import { getCssVar } from '@/composables/useCssVars';
 import { useWebSocket } from '@/composables/useWebSocket';
 import { useCodeQualityData } from '@/composables/analytics/useCodeQualityData';
+import type { QualityDrillDown } from '@/composables/analytics/useCodeQualityData';
 import { useUnwiredTrackers } from '@/composables/analytics/useUnwiredTrackers';
 import UnwiredTrackerTile from '@/components/analytics/UnwiredTrackerTile.vue';
 import EmptyState from '@/components/ui/EmptyState.vue';
@@ -548,6 +550,17 @@ interface TrendPoint {
   date: string;
 }
 
+// WebSocket message envelope emitted by /api/quality/ws.
+interface QualityWsMessage {
+  type: string;
+  data: Record<string, unknown>;
+}
+
+// HTMLElement augmented with the click-outside listener stored by v-click-outside.
+interface ClickOutsideElement extends HTMLElement {
+  _clickOutside?: (event: Event) => void;
+}
+
 // State
 const loading = ref(false);
 const wsConnected = ref(false);
@@ -575,7 +588,7 @@ const complexity = ref<Complexity>({
 });
 const trendData = ref<Array<{ date: string; score: number }>>([]);
 const codebaseStats = ref({ files: 0, lines: 0, issues: 0 });
-const drillDownData = ref({ total_files: 0, total_issues: 0, average_score: 0, files: [] as any[] });
+const drillDownData = ref<QualityDrillDown>({ total_files: 0, total_issues: 0, average_score: 0, files: [] });
 
 // WebSocket managed via useWebSocket composable
 const _qualityWsUrl = (() => {
@@ -845,19 +858,19 @@ function connectWebSocket(): void {
   wsConnect();
 }
 
-function handleWebSocketMessage(message: any): void {
+function handleWebSocketMessage(message: QualityWsMessage): void {
   switch (message.type) {
     case 'snapshot':
       // Update all data from snapshot
       if (message.data.health_score) {
-        healthScore.value = message.data.health_score;
+        healthScore.value = message.data.health_score as HealthScore;
       }
       break;
     case 'metric_update':
       // Update specific metric
       const metricIndex = metrics.value.findIndex(m => m.category === message.data.category);
       if (metricIndex >= 0) {
-        metrics.value[metricIndex] = { ...metrics.value[metricIndex], ...message.data };
+        metrics.value[metricIndex] = { ...metrics.value[metricIndex], ...message.data } as Metric;
       }
       break;
     case 'pattern_update':
@@ -960,16 +973,16 @@ function formatShortDate(dateStr: string): string {
 
 // Directive for click outside
 const vClickOutside = {
-  mounted(el: HTMLElement, binding: any) {
-    (el as any)._clickOutside = (event: Event) => {
+  mounted(el: HTMLElement, binding: DirectiveBinding<() => void>) {
+    (el as ClickOutsideElement)._clickOutside = (event: Event) => {
       if (!(el === event.target || el.contains(event.target as Node))) {
         binding.value();
       }
     };
-    document.addEventListener('click', (el as any)._clickOutside);
+    document.addEventListener('click', (el as ClickOutsideElement)._clickOutside as EventListener);
   },
   unmounted(el: HTMLElement) {
-    document.removeEventListener('click', (el as any)._clickOutside);
+    document.removeEventListener('click', (el as ClickOutsideElement)._clickOutside as EventListener);
   },
 };
 

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -565,6 +565,7 @@ import { useDisplaySettings } from '@/composables/useDisplaySettings'
 import { usePermissionStore } from '@/stores/usePermissionStore'
 import { useVirtualChatScroll } from '@/composables/useVirtualChatScroll'
 import type { ChatMessage } from '@/stores/useChatStore'
+import type { FileAttachment } from '@/types/api'
 import MessageStatus from '@/components/ui/MessageStatus.vue'
 import LoadingSpinner from '@/components/ui/LoadingSpinner.vue'
 import SkeletonLoader from '@/components/ui/SkeletonLoader.vue'
@@ -595,7 +596,7 @@ const emit = defineEmits<{
     command: string
     host: string
     purpose: string
-    params: Record<string, any>
+    params: Record<string, unknown>
     terminal_session_id: string | null
   }]
 }>()
@@ -773,7 +774,7 @@ const getMessageWrapperClass = (message: ChatMessage): string => {
 
   // Add message type class for type-specific styling
   // Issue #680: Exclude streaming types from type-class assignment to prevent wrong badges
-  const messageType = message.type || (message.metadata as any)?.display_type
+  const messageType = message.type || (message.metadata?.display_type as string | undefined)
   const noTypeClassTypes = ['response', 'message', 'default', 'llm_response', 'llm_response_chunk']
   if (messageType && !noTypeClassTypes.includes(String(messageType))) {
     classes.push(`type-${messageType}`)
@@ -838,7 +839,7 @@ const getSenderName = (sender: string): string => {
 
 /** Issue #1310: Visible badge for typed messages so they're clearly distinguishable. */
 const getMessageTypeBadge = (message: ChatMessage): { label: string; icon: string; type: string } | null => {
-  const msgType = message.type || (message.metadata as any)?.display_type
+  const msgType = message.type || (message.metadata?.display_type as string | undefined)
   if (!msgType) return null
 
   const badges: Record<string, { label: string; icon: string; type: string }> = {
@@ -1070,7 +1071,7 @@ const getAttachmentIcon = (type: string): IconName => {
 
 // NOTE: formatFileSize removed - now using shared utility from @/utils/formatHelpers
 
-const viewAttachment = (attachment: any) => {
+const viewAttachment = (attachment: FileAttachment) => {
   // Handle attachment viewing
   if (attachment.url) {
     window.open(attachment.url, '_blank')
@@ -1107,7 +1108,7 @@ const detectToolCalls = (message: ChatMessage) => {
 
       // Search for terminal_session_id in recent assistant messages
       // The terminal_session_id might be in metadata of streaming chunks, not necessarily the message with TOOL_CALL
-      let terminal_session_id: string | null = ((message.metadata as any)?.terminal_session_id as string) || null
+      let terminal_session_id: string | null = (message.metadata?.terminal_session_id as string) || null
 
       if (!terminal_session_id) {
         // Search backwards through recent assistant messages for terminal_session_id
@@ -1117,7 +1118,7 @@ const detectToolCalls = (message: ChatMessage) => {
           .slice(0, 10) // Check last 10 assistant messages
 
         for (const msg of recentAssistantMessages) {
-          const metadataSessionId = (msg.metadata as any)?.terminal_session_id as string | null
+          const metadataSessionId = msg.metadata?.terminal_session_id as string | null
           if (metadataSessionId) {
             terminal_session_id = metadataSessionId
             logger.debug('Found terminal_session_id in message metadata:', terminal_session_id)

--- a/autobot-frontend/src/utils/asyncComponentHelpers.ts
+++ b/autobot-frontend/src/utils/asyncComponentHelpers.ts
@@ -1,7 +1,7 @@
 // Copyright 2025-2026 mrveiss
 // SPDX-License-Identifier: Apache-2.0
 import { defineAsyncComponent, defineComponent, h } from 'vue'
-import type { AsyncComponentLoader } from 'vue'
+import type { AsyncComponentLoader, Component } from 'vue'
 import AsyncErrorFallback from '@/components/async/AsyncErrorFallback.vue'
 // Issue #156 Fix: Import RumAgent to get complete Window.rum type
 import '../utils/RumAgent'
@@ -15,7 +15,7 @@ declare global {
   interface Window {
     // Issue #156 Fix: rum is declared in RumAgent.ts with complete type
     __webpack_require__?: {
-      cache: Record<string, any>
+      cache: Record<string, unknown>
     }
   }
 }
@@ -32,7 +32,7 @@ export interface AsyncComponentOptions {
   /** Loading timeout in milliseconds */
   timeout?: number
   /** Props to pass to the component */
-  props?: Record<string, any>
+  props?: Record<string, unknown>
   /** Whether to show detailed loading progress */
   showProgress?: boolean
   /** Custom error handler */
@@ -133,7 +133,7 @@ export function defineRobustAsyncComponent(
       logger.error(`Failed to load ${name}:`, error)
 
       // Issue #156 Fix: Type guard for error message property
-      const errorMessage = (error as any)?.message || String(error)
+      const errorMessage = (error as Error | undefined)?.message || String(error)
 
       // Check if this is a chunk loading error
       const isChunkError = errorMessage.includes('Loading chunk') ||
@@ -233,26 +233,26 @@ export function createRouteComponent(
  * @returns Component with chunk loading error boundaries
  */
 export function createLazyComponent(
-  importFn: () => Promise<any>,
+  importFn: () => Promise<{ default?: Component } | Component>,
   componentName: string
 ) {
   return defineRobustAsyncComponent(
     async () => {
       try {
         const module = await importFn()
-        return module.default || module
-      } catch (error: any) {
+        return (module as { default?: Component }).default || (module as Component)
+      } catch (error) {
         // Handle specific chunk loading errors
-        if (error?.message?.includes('Loading chunk') ||
-            error?.message?.includes('ChunkLoadError') ||
-            error?.message?.includes('Loading CSS chunk')) {
+        if ((error as Error)?.message?.includes('Loading chunk') ||
+            (error as Error)?.message?.includes('ChunkLoadError') ||
+            (error as Error)?.message?.includes('Loading CSS chunk')) {
 
           logger.warn(`Chunk loading failed for ${componentName}, attempting cache bust...`)
 
           // Attempt to clear module cache and retry once
-          if (typeof window !== 'undefined' && (window as any).__webpack_require__) {
+          if (typeof window !== 'undefined' && window.__webpack_require__) {
             // Clear webpack module cache if possible
-            const webpackRequire = (window as any).__webpack_require__
+            const webpackRequire = window.__webpack_require__
             if (webpackRequire.cache) {
               Object.keys(webpackRequire.cache).forEach(key => {
                 if (key.includes(componentName.toLowerCase())) {
@@ -265,7 +265,7 @@ export function createLazyComponent(
           // Use cache management system for chunk errors
           try {
             const { handleChunkLoadingError } = await import('./cacheManagement')
-            await handleChunkLoadingError(error, componentName)
+            await handleChunkLoadingError(error as Error, componentName)
             return // Cache management will handle the reload
           } catch (cacheError) {
             logger.error(`Cache management failed for ${componentName}:`, cacheError)

--- a/autobot-frontend/src/utils/debugUtils.ts
+++ b/autobot-frontend/src/utils/debugUtils.ts
@@ -38,7 +38,7 @@ export interface StorageValidationResult {
   isValid: boolean
   key: string
   error?: string
-  value?: any
+  value?: unknown
 }
 
 /**
@@ -257,7 +257,7 @@ export function clearStorage(type: StorageType = 'localStorage'): boolean {
  * const config = safeJsonParse(response.data, null)
  * ```
  */
-export function safeJsonParse<T = any>(
+export function safeJsonParse<T = unknown>(
   jsonString: string | null,
   fallback: T
 ): T {
@@ -286,7 +286,7 @@ export function safeJsonParse<T = any>(
  * localStorage.setItem('data', safeJsonStringify(data, '{}'))
  * ```
  */
-export function safeJsonStringify(obj: any, fallback: string = '{}'): string {
+export function safeJsonStringify(obj: unknown, fallback: string = '{}'): string {
   try {
     return JSON.stringify(obj)
   } catch (e) {
@@ -309,7 +309,7 @@ export function safeJsonStringify(obj: any, fallback: string = '{}'): string {
  * const session = getStorageJson('session', null, 'sessionStorage')
  * ```
  */
-export function getStorageJson<T = any>(
+export function getStorageJson<T = unknown>(
   key: string,
   fallback: T,
   type: StorageType = 'localStorage'
@@ -334,7 +334,7 @@ export function getStorageJson<T = any>(
  */
 export function setStorageJson(
   key: string,
-  value: any,
+  value: unknown,
   type: StorageType = 'localStorage'
 ): boolean {
   const json = safeJsonStringify(value)
@@ -407,7 +407,7 @@ export function validateStorageJson(
  * ```
  */
 export function checkVueFramework(): VueFrameworkCheck {
-  const w = window as any
+  const w = window as unknown as Record<string, unknown>
 
   return {
     vue_available: typeof w.Vue !== 'undefined',
@@ -458,7 +458,7 @@ export function getPerformanceMetrics(): PerformanceMetrics {
   }
 
   // Memory metrics (if available)
-  const perf = performance as any
+  const perf = performance as Performance & { memory?: { usedJSHeapSize: number; totalJSHeapSize: number; jsHeapSizeLimit: number } }
   if (perf.memory) {
     metrics.memory = {
       usedJSHeapSize: perf.memory.usedJSHeapSize,


### PR DESCRIPTION
## Thinking Path
#9924 grind — asyncComponentHelpers.ts (7), debugUtils.ts (7), CodeQualityDashboard.vue (6), ChatMessages.vue (6 script). Strictly type-only.

## What Changed — 26 `any` removed
- **asyncComponentHelpers.ts**: `Record<string,unknown>`, Vue `Component`, `catch(error)`+use-site cast, declared `window.__webpack_require__`.
- **debugUtils.ts**: `unknown` params, `<T = unknown>` generic defaults, `Performance & { memory? }` minimal shape.
- **CodeQualityDashboard.vue**: reused `QualityDrillDown`; minimal `QualityWsMessage`/`ClickOutsideElement`; Vue `DirectiveBinding`.
- **ChatMessages.vue**: `Record<string,unknown>`, reused `FileAttachment`, `metadata?.x as string` casts.

## Scope note
ChatMessages.vue also has 14 `(message.metadata as any)` casts **inside `<template>`** — eslint's `no-explicit-any` does not lint template expressions, so they are NOT part of the failing check and were left untouched (avoids template-expression risk). All 26 script-block violations fixed.

## Verification (independently re-run)
- `eslint` → 0 `no-explicit-any`, exit 0.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0.
- `vitest` → 257 passed (4 pre-existing #11026 i18n failures, git-stash confirmed).
- Diff-scan for runtime coercions → none.

## Model Used
Opus 4.8

Contributes to #9924 (589→563 remaining no-explicit-any).