### PR TITLE
fix(frontend): replace no-explicit-any in terminal-spec/formHelpers/setup/review-dashboards (#9924 batch 12)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
@@ -368,14 +368,21 @@ function withSourceIdParams(params: Record<string, unknown> = {}): Record<string
   return { ...params, source_id: id }
 }
 
+// Issue #638: /patterns/preferences returns a map keyed by pattern id,
+// distinct from the Pattern[] list returned by /patterns.
+interface PatternPreferencesResponse {
+  data?: PatternPreferencesResponse
+  patterns?: Record<string, { enabled: boolean }>
+}
+
 // Issue #701: Type for API response with data property
 interface ApiDataResponse {
-  data?: any
+  data?: ApiDataResponse
   issues?: ReviewIssue[]
   reviews?: ReviewHistory[]
   patterns?: Pattern[]
   path?: string
-  [key: string]: any
+  [key: string]: unknown
 }
 
 // Types
@@ -697,8 +704,8 @@ function savePatternPrefs(): void {
 async function applyPatternPrefs(): Promise<void> {
   // Issue #638: Load preferences from backend first, fallback to localStorage
   try {
-    const response = await api.get<ApiDataResponse>(`${getApiBase()}/code-review/patterns/preferences`);
-    const prefs = (response as ApiDataResponse).patterns || (response as ApiDataResponse).data?.patterns;
+    const response = await api.get<PatternPreferencesResponse>(`${getApiBase()}/code-review/patterns/preferences`);
+    const prefs = (response as PatternPreferencesResponse).patterns || (response as PatternPreferencesResponse).data?.patterns;
 
     if (prefs) {
       // Apply backend preferences
@@ -733,7 +740,7 @@ async function togglePattern(pattern: Pattern): Promise<void> {
   const newState = !pattern.enabled;
 
   try {
-    await api.post<any>(`${getApiBase()}/code-review/patterns/toggle`, {
+    await api.post<unknown>(`${getApiBase()}/code-review/patterns/toggle`, {
       pattern_id: pattern.id,
       enabled: newState
     });
@@ -751,7 +758,7 @@ async function togglePattern(pattern: Pattern): Promise<void> {
 
 async function markResolved(issue: ReviewIssue) {
   try {
-    await api.post<any>(`${getApiBase()}/code-review/feedback`, {
+    await api.post<unknown>(`${getApiBase()}/code-review/feedback`, {
       issue_id: issue.id,
       feedback: 'resolved'
     })
@@ -766,7 +773,7 @@ async function markResolved(issue: ReviewIssue) {
 
 async function markFalsePositive(issue: ReviewIssue) {
   try {
-    await api.post<any>(`${getApiBase()}/code-review/feedback`, {
+    await api.post<unknown>(`${getApiBase()}/code-review/feedback`, {
       issue_id: issue.id,
       feedback: 'false_positive'
     })

--- a/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
@@ -306,8 +306,8 @@ const logger = createLogger('PrecommitHookDashboard')
 
 // Issue #701: Type for API response with data property
 interface ApiDataResponse {
-  data?: any
-  [key: string]: any
+  data?: unknown
+  [key: string]: unknown
 }
 
 // Types
@@ -487,7 +487,7 @@ async function loadStatus() {
     // Issue #701: Added type assertion for response
     const response = await api.get<HookStatus | ApiDataResponse>(`${getApiBase()}/precommit/status`)
     // Issue #701: Response could be data directly or wrapped
-    hookStatus.value = (response as ApiDataResponse).data || response as HookStatus
+    hookStatus.value = (response as ApiDataResponse).data as HookStatus | undefined || response as HookStatus
   } catch (error) {
     logger.warn('Failed to load status:', error)
     hookStatus.value = { installed: false }
@@ -499,7 +499,7 @@ async function loadChecks() {
     // Issue #701: Added type assertion for response
     const response = await api.get<Check[] | ApiDataResponse>(`${getApiBase()}/precommit/checks`)
     // Issue #701: Response could be array directly or wrapped in data
-    checks.value = Array.isArray(response) ? response : ((response as ApiDataResponse).data || [])
+    checks.value = Array.isArray(response) ? response : ((response as ApiDataResponse).data as Check[] | undefined || [])
   } catch (error) {
     logger.warn('Failed to load checks:', error)
     checks.value = []
@@ -511,7 +511,7 @@ async function loadHistory() {
     // Issue #701: Added type assertion for response
     const response = await api.get<CommitCheckResult[] | ApiDataResponse>(`${getApiBase()}/precommit/history`)
     // Issue #701: Response could be array directly or wrapped in data
-    checkHistory.value = Array.isArray(response) ? response : ((response as ApiDataResponse).data || [])
+    checkHistory.value = Array.isArray(response) ? response : ((response as ApiDataResponse).data as CommitCheckResult[] | undefined || [])
   } catch (error) {
     logger.warn('Failed to load history:', error)
     checkHistory.value = []
@@ -523,7 +523,7 @@ async function loadSummary() {
     // Issue #701: Added type assertion for response
     const response = await api.get<Summary | ApiDataResponse>(`${getApiBase()}/precommit/summary`)
     // Issue #701: Response could be data directly or wrapped
-    summary.value = (response as ApiDataResponse).data || response as Summary
+    summary.value = (response as ApiDataResponse).data as Summary | undefined || response as Summary
   } catch (error) {
     logger.warn('Failed to load summary:', error)
     // Keep default empty summary state
@@ -534,7 +534,7 @@ async function installHooks() {
   installing.value = true
   try {
     // Issue #701: api.post requires data argument
-    await api.post<any>(`${getApiBase()}/precommit/install`, {})
+    await api.post<unknown>(`${getApiBase()}/precommit/install`, {})
     await loadStatus()
     showToast(t('analytics.precommit.installSuccess'), 'success')
   } catch (error) {
@@ -549,7 +549,7 @@ async function uninstallHooks() {
   installing.value = true
   try {
     // Issue #701: api.post requires data argument
-    await api.post<any>(`${getApiBase()}/precommit/uninstall`, {})
+    await api.post<unknown>(`${getApiBase()}/precommit/uninstall`, {})
     await loadStatus()
     showToast(t('analytics.precommit.uninstallSuccess'), 'info')
   } catch (error) {
@@ -566,7 +566,7 @@ async function runCheck() {
     // Issue #701: Added type assertion for response
     const response = await api.get<CommitCheckResult | ApiDataResponse>(`${getApiBase()}/precommit/check`)
     // Issue #701: Response could be data directly or wrapped
-    lastResult.value = (response as ApiDataResponse).data || response as CommitCheckResult
+    lastResult.value = (response as ApiDataResponse).data as CommitCheckResult | undefined || response as CommitCheckResult
     await loadHistory()
     await loadSummary()
 
@@ -588,7 +588,7 @@ async function toggleCheck(check: Check) {
   const newState = !check.enabled
   try {
     // Issue #701: Fixed api.post call - data should be second arg
-    await api.post<any>(`${getApiBase()}/precommit/checks/${check.id}/toggle`, { enabled: newState })
+    await api.post<unknown>(`${getApiBase()}/precommit/checks/${check.id}/toggle`, { enabled: newState })
     check.enabled = newState
   } catch (error) {
     logger.warn('Failed to toggle check:', error)

--- a/autobot-frontend/src/components/terminal/__tests__/BaseXTerminal.spec.ts
+++ b/autobot-frontend/src/components/terminal/__tests__/BaseXTerminal.spec.ts
@@ -1,18 +1,39 @@
 // Copyright 2025-2026 mrveiss
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
 import { nextTick } from 'vue'
+import type { Mock } from 'vitest'
 import BaseXTerminal from '../BaseXTerminal.vue'
 
+// Shape of the hand-built xterm Terminal stand-in used by these tests: the
+// vi.fn() methods the component invokes plus the fields the component's watchers
+// mutate (options) and the tests assert on.
+interface TerminalMock {
+  loadAddon: Mock
+  open: Mock
+  onData: Mock
+  onResize: Mock
+  dispose: Mock
+  write: Mock
+  writeln: Mock
+  clear: Mock
+  reset: Mock
+  focus: Mock
+  blur: Mock
+  cols: number
+  rows: number
+  options: Record<string, unknown>
+}
+
 // Track the most recently created Terminal mock instance so tests can inspect it
-let lastTerminalInstance: Record<string, any> | null = null
+let lastTerminalInstance: TerminalMock | null = null
 
 // Factory that creates a fresh Terminal mock instance.
 // Returning an object from the constructor makes `new` yield it directly,
 // so no `this` mutation/aliasing is needed.
-function createTerminalMock(): Record<string, any> {
-  const instance: Record<string, any> = {
+function createTerminalMock(): TerminalMock {
+  const instance: TerminalMock = {
     loadAddon: vi.fn(),
     open: vi.fn(),
     onData: vi.fn(),
@@ -44,7 +65,7 @@ vi.mock('@xterm/xterm', () => ({
 }))
 
 vi.mock('@xterm/addon-fit', () => ({
-  FitAddon: vi.fn(function (this: Record<string, any>) {
+  FitAddon: vi.fn(function (this: { fit: Mock }) {
     this.fit = vi.fn()
   })
 }))
@@ -54,7 +75,7 @@ vi.mock('@xterm/addon-web-links', () => ({
 }))
 
 describe('BaseXTerminal', () => {
-  let wrapper: any
+  let wrapper: VueWrapper | null
 
   beforeEach(() => {
     wrapper = null
@@ -62,7 +83,7 @@ describe('BaseXTerminal', () => {
     // vitest.config has mockReset: true which clears mockImplementation between
     // tests. Re-apply the Terminal constructor implementation so every test gets
     // a proper mock instance when the component calls `new Terminal(...)`.
-    vi.mocked(Terminal).mockImplementation(createTerminalMock as any)
+    vi.mocked(Terminal).mockImplementation(createTerminalMock as unknown as () => Terminal)
   })
 
   afterEach(() => {

--- a/autobot-frontend/src/utils/formHelpers.ts
+++ b/autobot-frontend/src/utils/formHelpers.ts
@@ -25,7 +25,7 @@ const _UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
  * resetFormFields(formData, { category: 'General' })
  * // Result: { name: '', category: 'General', tags: '' }
  */
-export function resetFormFields<T extends Record<string, any>>(
+export function resetFormFields<T extends Record<string, unknown>>(
   form: T,
   defaults: Partial<T> = {}
 ): void {
@@ -68,7 +68,7 @@ export function resetFormFields<T extends Record<string, any>>(
  * hasRequiredFields(formData, ['name', 'email'])
  * // Returns: false (email is empty)
  */
-export function hasRequiredFields<T extends Record<string, any>>(
+export function hasRequiredFields<T extends Record<string, unknown>>(
   form: T,
   requiredFields: (keyof T)[]
 ): boolean {
@@ -103,7 +103,7 @@ export function hasRequiredFields<T extends Record<string, any>>(
  * getEmptyFields(formData, ['name', 'email', 'age'])
  * // Returns: ['email', 'age']
  */
-export function getEmptyFields<T extends Record<string, any>>(
+export function getEmptyFields<T extends Record<string, unknown>>(
   form: T,
   requiredFields: (keyof T)[]
 ): (keyof T)[] {
@@ -142,7 +142,7 @@ export function getEmptyFields<T extends Record<string, any>>(
  * copy.tags.push('js')
  * // original.tags remains ['vue', 'ts']
  */
-export function cloneFormData<T extends Record<string, any>>(form: T): T {
+export function cloneFormData<T extends Record<string, unknown>>(form: T): T {
   return JSON.parse(JSON.stringify(form))
 }
 
@@ -159,7 +159,7 @@ export function cloneFormData<T extends Record<string, any>>(form: T): T {
  * isFormModified(current, initial)
  * // Returns: true
  */
-export function isFormModified<T extends Record<string, any>>(
+export function isFormModified<T extends Record<string, unknown>>(
   currentForm: T,
   initialForm: T
 ): boolean {
@@ -176,7 +176,7 @@ export function isFormModified<T extends Record<string, any>>(
  * trimFormFields(formData)
  * // Result: { name: 'John', email: 'john@example.com' }
  */
-export function trimFormFields<T extends Record<string, any>>(form: T): void {
+export function trimFormFields<T extends Record<string, unknown>>(form: T): void {
   ;(Object.keys(form) as Array<keyof T>).forEach((key) => {
     if (_UNSAFE_KEYS.has(key as string)) return
     if (typeof form[key] === 'string') {

--- a/autobot-frontend/tests/setup.ts
+++ b/autobot-frontend/tests/setup.ts
@@ -7,7 +7,7 @@
  * the AutoBot application with the KB Librarian Agent integration.
  */
 
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
 // Custom matchers for AutoBot-specific assertions
 expect.extend({
@@ -57,7 +57,7 @@ export class AutoBotTestHelpers {
   /**
    * Send a chat message and wait for response
    */
-  static async sendChatMessage(page: any, message: string) {
+  static async sendChatMessage(page: Page, message: string) {
     const input = page.locator('[data-testid="message-input"]');
     const sendButton = page.locator('[data-testid="send-button"]');
 
@@ -76,7 +76,7 @@ export class AutoBotTestHelpers {
   /**
    * Check if KB Librarian is enabled via API
    */
-  static async isKBLibrarianEnabled(page: any) {
+  static async isKBLibrarianEnabled(page: Page) {
     const response = await page.request.get('http://127.0.0.1:8001/api/kb-librarian/status');
     if (!response.ok()) return false;
 
@@ -87,7 +87,7 @@ export class AutoBotTestHelpers {
   /**
    * Wait for backend to be ready
    */
-  static async waitForBackend(page: any, timeout: number = 30000) {
+  static async waitForBackend(page: Page, timeout: number = 30000) {
     let attempts = 0;
     const maxAttempts = timeout / 1000;
 
@@ -111,7 +111,7 @@ export class AutoBotTestHelpers {
   /**
    * Add some test data to knowledge base (if needed)
    */
-  static async seedKnowledgeBase(page: any) {
+  static async seedKnowledgeBase(page: Page) {
     // This would typically add some test documents to the knowledge base
     // For now, we'll just verify the KB is accessible
     try {
@@ -125,7 +125,7 @@ export class AutoBotTestHelpers {
   /**
    * Clean up test data
    */
-  static async cleanupTestData(page: any) {
+  static async cleanupTestData(page: Page) {
     // Clean up any test-specific data if needed
     // This could include clearing test chats, resetting configurations, etc.
     try {
@@ -149,7 +149,7 @@ export class AutoBotTestHelpers {
   /**
    * Take screenshot with timestamp for debugging
    */
-  static async takeDebugScreenshot(page: any, name: string) {
+  static async takeDebugScreenshot(page: Page, name: string) {
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
     await page.screenshot({
       path: `test-results/screenshots/${name}-${timestamp}.png`,


### PR DESCRIPTION
## Thinking Path
#9924 grind — BaseXTerminal.spec.ts (6), formHelpers.ts (6), tests/setup.ts (6), CodeReviewDashboard.vue (5), PrecommitHookDashboard.vue (5). Strictly type-only.

## What Changed — 28 `any` removed
- **BaseXTerminal.spec.ts**: reused `VueWrapper`/`Mock`; minimal `TerminalMock` for the xterm stand-in.
- **formHelpers.ts**: generic constraints `<T extends Record<string, unknown>>`.
- **tests/setup.ts**: reused Playwright `Page` for all helper methods.
- **CodeReviewDashboard.vue / PrecommitHookDashboard.vue**: self-referential `ApiDataResponse`, `unknown` index sigs, `api.post<unknown>`, faithful `.data as X | undefined` casts.

## Discovery (filed)
- Typing `/patterns/preferences` exposed a latent contract mismatch: `applyPatternPrefs` reads it as a keyed map but it was typed `Pattern[]`. Added `PatternPreferencesResponse` matching the code's access (type-only). Filed for backend-contract confirmation.

## Verification (independently re-run)
- `eslint` → 0 `no-explicit-any`, exit 0.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0.
- `vitest BaseXTerminal.spec.ts` → 7/7.
- Diff-scan for runtime coercions → none.

## Model Used
Opus 4.8

Contributes to #9924 (563→535 remaining no-explicit-any).