### PR TITLE
fix(frontend): sweep no-explicit-any from all Storybook stories (#9924 batch 13)

### DIFF
--- a/autobot-frontend/src/components/admin/NpuWorkerPairConfirmDialog.stories.ts
+++ b/autobot-frontend/src/components/admin/NpuWorkerPairConfirmDialog.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof NpuWorkerPairConfirmDialog>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories
+type Story = StoryObj<Record<string, unknown>>
 
 const inferenceResult: NpuWorkerPairResult = {
   success: true,

--- a/autobot-frontend/src/components/agents/AgentSettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/agents/AgentSettingsPanel.stories.ts
@@ -21,7 +21,7 @@ const meta = {
 } as Meta<typeof AgentSettingsPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
  
 type Story = { render?: () => unknown; decorators?: unknown[]; parameters?: unknown };
 

--- a/autobot-frontend/src/components/agents/HeartbeatPanel.stories.ts
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.stories.ts
@@ -22,7 +22,7 @@ const meta = {
 } as Meta<typeof HeartbeatPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
  
 type Story = { render?: () => unknown; decorators?: unknown[]; parameters?: unknown };
 

--- a/autobot-frontend/src/components/analytics/AddSourceModal.stories.ts
+++ b/autobot-frontend/src/components/analytics/AddSourceModal.stories.ts
@@ -15,8 +15,8 @@ const meta = {
 } as Meta<typeof AddSourceModal>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/AdvancedAnalytics.stories.ts
+++ b/autobot-frontend/src/components/analytics/AdvancedAnalytics.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof AdvancedAnalytics>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/analytics/AgentCostPanel.stories.ts
+++ b/autobot-frontend/src/components/analytics/AgentCostPanel.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof AgentCostPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/analytics/AnalyticsGrid.stories.ts
+++ b/autobot-frontend/src/components/analytics/AnalyticsGrid.stories.ts
@@ -18,8 +18,8 @@ const meta = {
 } as Meta<typeof AnalyticsGrid>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/AnalyticsHeader.stories.ts
+++ b/autobot-frontend/src/components/analytics/AnalyticsHeader.stories.ts
@@ -21,8 +21,8 @@ const meta = {
 } as Meta<typeof AnalyticsHeader>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/AnalyticsHeaderControls.stories.ts
+++ b/autobot-frontend/src/components/analytics/AnalyticsHeaderControls.stories.ts
@@ -21,8 +21,8 @@ const meta = {
 } as Meta<typeof AnalyticsHeaderControls>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/AnalyticsProgressSection.stories.ts
+++ b/autobot-frontend/src/components/analytics/AnalyticsProgressSection.stories.ts
@@ -40,8 +40,8 @@ const meta = {
 } as Meta<typeof AnalyticsProgressSection>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof CodeEvolutionTimeline>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/analytics/CodeGenerationDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodeGenerationDashboard.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof CodeGenerationDashboard>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof CodeQualityDashboard>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof CodeReviewDashboard>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/analytics/CodeSmellsSection.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodeSmellsSection.stories.ts
@@ -42,8 +42,8 @@ const meta = {
 } as Meta<typeof CodeSmellsSection>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof CodebaseAnalytics>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof CodebaseAnalyticsLanding>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.stories.ts
@@ -37,8 +37,8 @@ const meta = {
 } as Meta<typeof CodebaseDependenciesPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.stories.ts
@@ -18,8 +18,8 @@ const meta = {
 } as Meta<typeof CodebaseOverviewPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/CodebaseSecurityPanel.stories.ts
+++ b/autobot-frontend/src/components/analytics/CodebaseSecurityPanel.stories.ts
@@ -19,8 +19,8 @@ const meta = {
 } as Meta<typeof CodebaseSecurityPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/ConversationFlowDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/ConversationFlowDashboard.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof ConversationFlowDashboard>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/analytics/DeclarationsSection.stories.ts
+++ b/autobot-frontend/src/components/analytics/DeclarationsSection.stories.ts
@@ -46,8 +46,8 @@ const meta = {
 } as Meta<typeof DeclarationsSection>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/DuplicatesSection.stories.ts
+++ b/autobot-frontend/src/components/analytics/DuplicatesSection.stories.ts
@@ -36,8 +36,8 @@ const meta = {
 } as Meta<typeof DuplicatesSection>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/HardcodesSection.stories.ts
+++ b/autobot-frontend/src/components/analytics/HardcodesSection.stories.ts
@@ -45,8 +45,8 @@ const meta = {
 } as Meta<typeof HardcodesSection>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/HealthScoreGauge.stories.ts
+++ b/autobot-frontend/src/components/analytics/HealthScoreGauge.stories.ts
@@ -17,8 +17,8 @@ const meta = {
 } as Meta<typeof HealthScoreGauge>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/IndexingProgress.stories.ts
+++ b/autobot-frontend/src/components/analytics/IndexingProgress.stories.ts
@@ -19,8 +19,8 @@ const meta = {
 } as Meta<typeof IndexingProgress>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/LLMPatternDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/LLMPatternDashboard.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof LLMPatternDashboard>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/analytics/LogPatternDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/LogPatternDashboard.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof LogPatternDashboard>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/analytics/PatternAnalysis.stories.ts
+++ b/autobot-frontend/src/components/analytics/PatternAnalysis.stories.ts
@@ -15,8 +15,8 @@ const meta = {
 } as Meta<typeof PatternAnalysis>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof PerformanceAnalysisDashboard>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/analytics/PrecommitHookDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/PrecommitHookDashboard.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof PrecommitHookDashboard>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/analytics/ProblemsReportSection.stories.ts
+++ b/autobot-frontend/src/components/analytics/ProblemsReportSection.stories.ts
@@ -49,8 +49,8 @@ const meta = {
 } as Meta<typeof ProblemsReportSection>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/ShareSourceModal.stories.ts
+++ b/autobot-frontend/src/components/analytics/ShareSourceModal.stories.ts
@@ -25,8 +25,8 @@ const meta = {
 } as Meta<typeof ShareSourceModal>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/SourceManager.stories.ts
+++ b/autobot-frontend/src/components/analytics/SourceManager.stories.ts
@@ -15,8 +15,8 @@ const meta = {
 } as Meta<typeof SourceManager>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.stories.ts
+++ b/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof TechnicalDebtDashboard>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/artifact-cells/ChartCell.stories.ts
+++ b/autobot-frontend/src/components/artifact-cells/ChartCell.stories.ts
@@ -136,7 +136,7 @@ export const Empty: Story = {
 
 export const WithError: Story = {
   args: {
-    richPayload: invalidSpec as any,
+    richPayload: invalidSpec,
     title: 'Error State Chart'
   }
 }

--- a/autobot-frontend/src/components/async/AsyncComponentWrapper.stories.ts
+++ b/autobot-frontend/src/components/async/AsyncComponentWrapper.stories.ts
@@ -50,8 +50,8 @@ const meta = {
 } as Meta<typeof AsyncComponentWrapper>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 // Loader that resolves immediately
 const fastLoader = () => Promise.resolve({ default: SimpleLoaded });

--- a/autobot-frontend/src/components/async/AsyncErrorFallback.stories.ts
+++ b/autobot-frontend/src/components/async/AsyncErrorFallback.stories.ts
@@ -28,8 +28,8 @@ const meta = {
 } as Meta<typeof AsyncErrorFallback>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/audit/AuditFilters.stories.ts
+++ b/autobot-frontend/src/components/audit/AuditFilters.stories.ts
@@ -42,8 +42,8 @@ const meta = {
 } as Meta<typeof AuditFilters>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/audit/AuditLogTable.stories.ts
+++ b/autobot-frontend/src/components/audit/AuditLogTable.stories.ts
@@ -64,8 +64,8 @@ const meta = {
 } as Meta<typeof AuditLogTable>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/audit/AuditStatistics.stories.ts
+++ b/autobot-frontend/src/components/audit/AuditStatistics.stories.ts
@@ -48,8 +48,8 @@ const meta = {
 } as Meta<typeof AuditStatistics>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/audit/AuditTimeline.stories.ts
+++ b/autobot-frontend/src/components/audit/AuditTimeline.stories.ts
@@ -73,8 +73,8 @@ const meta = {
 } as Meta<typeof AuditTimeline>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const SessionTimeline: Story = {
   args: {

--- a/autobot-frontend/src/components/auth/LoginForm.stories.ts
+++ b/autobot-frontend/src/components/auth/LoginForm.stories.ts
@@ -9,8 +9,8 @@ const meta = {
 } as Meta<typeof LoginForm>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/autoresearch/ApprovalCard.stories.ts
+++ b/autobot-frontend/src/components/autoresearch/ApprovalCard.stories.ts
@@ -18,8 +18,8 @@ const meta = {
 } as Meta<typeof ApprovalCard>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const WithMetrics: Story = {
   args: {

--- a/autobot-frontend/src/components/autoresearch/ExperimentTimeline.stories.ts
+++ b/autobot-frontend/src/components/autoresearch/ExperimentTimeline.stories.ts
@@ -24,8 +24,8 @@ const meta = {
 } as Meta<typeof ExperimentTimeline>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Empty: Story = {
   args: {

--- a/autobot-frontend/src/components/autoresearch/InsightsPanel.stories.ts
+++ b/autobot-frontend/src/components/autoresearch/InsightsPanel.stories.ts
@@ -20,8 +20,8 @@ const meta = {
 } as Meta<typeof InsightsPanel>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Empty: Story = {
   args: {

--- a/autobot-frontend/src/components/autoresearch/PromptOptimizerPanel.stories.ts
+++ b/autobot-frontend/src/components/autoresearch/PromptOptimizerPanel.stories.ts
@@ -34,8 +34,8 @@ const meta = {
 } as Meta<typeof PromptOptimizerPanel>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const NoSession: Story = {
   args: {

--- a/autobot-frontend/src/components/base/BaseBadge.stories.ts
+++ b/autobot-frontend/src/components/base/BaseBadge.stories.ts
@@ -33,8 +33,8 @@ const meta = {
 } as Meta<typeof BaseBadge>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Primary: Story = {
   args: {

--- a/autobot-frontend/src/components/base/BaseButton.stories.ts
+++ b/autobot-frontend/src/components/base/BaseButton.stories.ts
@@ -46,8 +46,8 @@ const meta = {
 } as Meta<typeof BaseButton>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Primary: Story = {
   args: {

--- a/autobot-frontend/src/components/base/BaseCard.stories.ts
+++ b/autobot-frontend/src/components/base/BaseCard.stories.ts
@@ -25,15 +25,15 @@ const meta = {
 } as Meta<typeof BaseCard>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {
     variant: 'default',
     padding: 'md',
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { BaseCard },
     setup() {
       return { args };
@@ -52,7 +52,7 @@ export const Elevated: Story = {
     variant: 'elevated',
     padding: 'md',
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { BaseCard },
     setup() {
       return { args };
@@ -71,7 +71,7 @@ export const Outline: Story = {
     variant: 'outline',
     padding: 'md',
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { BaseCard },
     setup() {
       return { args };
@@ -91,7 +91,7 @@ export const Hoverable: Story = {
     padding: 'md',
     hoverable: true,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { BaseCard },
     setup() {
       return { args };
@@ -110,7 +110,7 @@ export const NoPadding: Story = {
     variant: 'default',
     padding: 'none',
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { BaseCard },
     setup() {
       return { args };

--- a/autobot-frontend/src/components/base/BaseInput.stories.ts
+++ b/autobot-frontend/src/components/base/BaseInput.stories.ts
@@ -52,8 +52,8 @@ const meta = {
 } as Meta<typeof BaseInput>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/base/BasePanel.stories.ts
+++ b/autobot-frontend/src/components/base/BasePanel.stories.ts
@@ -23,14 +23,14 @@ const meta = {
 } as Meta<typeof BasePanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {
     title: 'Panel Title',
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { BasePanel },
     setup() {
       return { args };
@@ -48,7 +48,7 @@ export const Collapsible: Story = {
     title: 'Collapsible Panel',
     collapsible: true,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { BasePanel },
     setup() {
       return { args };
@@ -68,7 +68,7 @@ export const StartCollapsed: Story = {
     collapsible: true,
     collapsed: true,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { BasePanel },
     setup() {
       return { args };
@@ -86,7 +86,7 @@ export const WithComplexContent: Story = {
     title: 'Settings Panel',
     collapsible: true,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { BasePanel },
     setup() {
       return { args };

--- a/autobot-frontend/src/components/base/BaseTable.stories.ts
+++ b/autobot-frontend/src/components/base/BaseTable.stories.ts
@@ -33,8 +33,8 @@ const meta = {
 } as Meta<typeof BaseTable>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/browser/BrowserSessionManager.stories.ts
+++ b/autobot-frontend/src/components/browser/BrowserSessionManager.stories.ts
@@ -16,8 +16,8 @@ const meta = {
 } as Meta<typeof BrowserSessionManager>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 /**
  * BrowserSessionManager is a self-contained component that fetches live

--- a/autobot-frontend/src/components/browser/InteractiveScreenshot.stories.ts
+++ b/autobot-frontend/src/components/browser/InteractiveScreenshot.stories.ts
@@ -60,8 +60,8 @@ const meta = {
 } as Meta<typeof InteractiveScreenshot>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 /** No screenshot loaded — shows placeholder message */
 export const Empty: Story = {

--- a/autobot-frontend/src/components/charts/BaseChart.stories.ts
+++ b/autobot-frontend/src/components/charts/BaseChart.stories.ts
@@ -41,9 +41,9 @@ const meta = {
 } as Meta<typeof BaseChart>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const BarChart: Story = {
   args: {

--- a/autobot-frontend/src/components/charts/DependencyTreemap.stories.ts
+++ b/autobot-frontend/src/components/charts/DependencyTreemap.stories.ts
@@ -32,9 +32,9 @@ const meta = {
 } as Meta<typeof DependencyTreemap>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 const sampleData = [
   { package: 'fastapi', usage_count: 87 },

--- a/autobot-frontend/src/components/charts/EvolutionTimelineChart.stories.ts
+++ b/autobot-frontend/src/components/charts/EvolutionTimelineChart.stories.ts
@@ -36,9 +36,9 @@ const meta = {
 } as Meta<typeof EvolutionTimelineChart>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 function makeDays(count: number) {
   const now = Date.now();

--- a/autobot-frontend/src/components/charts/FunctionCallGraph.stories.ts
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.stories.ts
@@ -32,9 +32,9 @@ const meta = {
 } as Meta<typeof FunctionCallGraph>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 const sampleData = {
   nodes: [

--- a/autobot-frontend/src/components/charts/ImportTreeChart.stories.ts
+++ b/autobot-frontend/src/components/charts/ImportTreeChart.stories.ts
@@ -32,9 +32,9 @@ const meta = {
 } as Meta<typeof ImportTreeChart>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 const sampleData = [
   {

--- a/autobot-frontend/src/components/charts/ModuleImportsChart.stories.ts
+++ b/autobot-frontend/src/components/charts/ModuleImportsChart.stories.ts
@@ -36,9 +36,9 @@ const meta = {
 } as Meta<typeof ModuleImportsChart>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 const sampleData = [
   { path: 'src/services/auth.py', name: 'auth', package: 'services', import_count: 42, functions: 12, classes: 3 },

--- a/autobot-frontend/src/components/charts/PatternEvolutionChart.stories.ts
+++ b/autobot-frontend/src/components/charts/PatternEvolutionChart.stories.ts
@@ -32,9 +32,9 @@ const meta = {
 } as Meta<typeof PatternEvolutionChart>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 function makeDays(count: number) {
   const now = Date.now();

--- a/autobot-frontend/src/components/charts/ProblemTypesChart.stories.ts
+++ b/autobot-frontend/src/components/charts/ProblemTypesChart.stories.ts
@@ -32,9 +32,9 @@ const meta = {
 } as Meta<typeof ProblemTypesChart>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 const sampleData = [
   { type: 'security', count: 23 },

--- a/autobot-frontend/src/components/charts/RaceConditionsDonut.stories.ts
+++ b/autobot-frontend/src/components/charts/RaceConditionsDonut.stories.ts
@@ -32,9 +32,9 @@ const meta = {
 } as Meta<typeof RaceConditionsDonut>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 const sampleData = [
   { category: 'thread_unsafe_singleton', count: 7 },

--- a/autobot-frontend/src/components/charts/SeverityBarChart.stories.ts
+++ b/autobot-frontend/src/components/charts/SeverityBarChart.stories.ts
@@ -32,9 +32,9 @@ const meta = {
 } as Meta<typeof SeverityBarChart>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 const sampleData = [
   { severity: 'critical', count: 5 },

--- a/autobot-frontend/src/components/charts/TopFilesChart.stories.ts
+++ b/autobot-frontend/src/components/charts/TopFilesChart.stories.ts
@@ -36,9 +36,9 @@ const meta = {
 } as Meta<typeof TopFilesChart>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 const sampleData = [
   { file: 'src/services/auth_service.py', count: 47 },

--- a/autobot-frontend/src/components/chat/ApprovalRequestCard.stories.ts
+++ b/autobot-frontend/src/components/chat/ApprovalRequestCard.stories.ts
@@ -38,9 +38,9 @@ const meta = {
 } as Meta<typeof ApprovalRequestCard>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Pending: Story = {
   args: {

--- a/autobot-frontend/src/components/chat/ChatBrowser.stories.ts
+++ b/autobot-frontend/src/components/chat/ChatBrowser.stories.ts
@@ -20,9 +20,9 @@ const meta = {
 } as Meta<typeof ChatBrowser>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const WithSession: Story = {
   args: {

--- a/autobot-frontend/src/components/chat/ChatFilePanel.stories.ts
+++ b/autobot-frontend/src/components/chat/ChatFilePanel.stories.ts
@@ -16,15 +16,15 @@ const meta = {
 } as Meta<typeof ChatFilePanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {
     sessionId: 'session-file-001',
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { ChatFilePanel },
     setup() { return { args }; },
     template: `<div style="height:600px; width:320px;"><ChatFilePanel v-bind="args" /></div>`,
@@ -35,7 +35,7 @@ export const DifferentSession: Story = {
   args: {
     sessionId: 'session-file-002',
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { ChatFilePanel },
     setup() { return { args }; },
     template: `<div style="height:600px; width:320px;"><ChatFilePanel v-bind="args" /></div>`,

--- a/autobot-frontend/src/components/chat/ChatHeader.stories.ts
+++ b/autobot-frontend/src/components/chat/ChatHeader.stories.ts
@@ -28,8 +28,8 @@ const meta = {
 } as Meta<typeof ChatHeader>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/chat/ChatInput.stories.ts
+++ b/autobot-frontend/src/components/chat/ChatInput.stories.ts
@@ -10,9 +10,9 @@ const meta = {
 } as Meta<typeof ChatInput>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/chat/ChatInterface.stories.ts
+++ b/autobot-frontend/src/components/chat/ChatInterface.stories.ts
@@ -13,9 +13,9 @@ const meta = {
 } as Meta<typeof ChatInterface>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/chat/ChatMessages.stories.ts
+++ b/autobot-frontend/src/components/chat/ChatMessages.stories.ts
@@ -13,9 +13,9 @@ const meta = {
 } as Meta<typeof ChatMessages>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/chat/ChatSidebar.stories.ts
+++ b/autobot-frontend/src/components/chat/ChatSidebar.stories.ts
@@ -13,9 +13,9 @@ const meta = {
 } as Meta<typeof ChatSidebar>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/chat/ChatTabContent.stories.ts
+++ b/autobot-frontend/src/components/chat/ChatTabContent.stories.ts
@@ -25,9 +25,9 @@ const meta = {
 } as Meta<typeof ChatTabContent>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const ChatTab: Story = {
   args: {
@@ -35,7 +35,7 @@ export const ChatTab: Story = {
     currentSessionId: 'session-001',
     novncUrl: '',
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { ChatTabContent },
     setup() { return { args }; },
     template: `<div style="height:600px; overflow:hidden;"><ChatTabContent v-bind="args" /></div>`,
@@ -48,7 +48,7 @@ export const FilesTab: Story = {
     currentSessionId: 'session-001',
     novncUrl: '',
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { ChatTabContent },
     setup() { return { args }; },
     template: `<div style="height:600px; overflow:hidden;"><ChatTabContent v-bind="args" /></div>`,
@@ -61,7 +61,7 @@ export const TerminalTab: Story = {
     currentSessionId: 'session-001',
     novncUrl: '',
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { ChatTabContent },
     setup() { return { args }; },
     template: `<div style="height:600px; overflow:hidden;"><ChatTabContent v-bind="args" /></div>`,

--- a/autobot-frontend/src/components/chat/ChatTabs.stories.ts
+++ b/autobot-frontend/src/components/chat/ChatTabs.stories.ts
@@ -17,9 +17,9 @@ const meta = {
 } as Meta<typeof ChatTabs>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const ChatActive: Story = {
   args: {

--- a/autobot-frontend/src/components/chat/CitationsDisplay.stories.ts
+++ b/autobot-frontend/src/components/chat/CitationsDisplay.stories.ts
@@ -44,9 +44,9 @@ const meta = {
 } as Meta<typeof CitationsDisplay>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Collapsed: Story = {
   args: {

--- a/autobot-frontend/src/components/chat/DeleteConversationDialog.stories.ts
+++ b/autobot-frontend/src/components/chat/DeleteConversationDialog.stories.ts
@@ -28,9 +28,9 @@ const meta = {
 } as Meta<typeof DeleteConversationDialog>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Visible: Story = {
   args: {

--- a/autobot-frontend/src/components/chat/DocumentationCategoryFilter.stories.ts
+++ b/autobot-frontend/src/components/chat/DocumentationCategoryFilter.stories.ts
@@ -32,9 +32,9 @@ const meta = {
 } as Meta<typeof DocumentationCategoryFilter>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/chat/DocumentationResultCard.stories.ts
+++ b/autobot-frontend/src/components/chat/DocumentationResultCard.stories.ts
@@ -37,9 +37,9 @@ const meta = {
 } as Meta<typeof DocumentationResultCard>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/chat/DocumentationSearchSidebar.stories.ts
+++ b/autobot-frontend/src/components/chat/DocumentationSearchSidebar.stories.ts
@@ -16,15 +16,15 @@ const meta = {
 } as Meta<typeof DocumentationSearchSidebar>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Open: Story = {
   args: {
     initiallyOpen: true,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { DocumentationSearchSidebar },
     setup() { return { args }; },
     template: `<div style="height:700px; width:360px; overflow:hidden;"><DocumentationSearchSidebar v-bind="args" /></div>`,
@@ -35,7 +35,7 @@ export const Collapsed: Story = {
   args: {
     initiallyOpen: false,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { DocumentationSearchSidebar },
     setup() { return { args }; },
     template: `<div style="height:700px; width:360px; overflow:hidden;"><DocumentationSearchSidebar v-bind="args" /></div>`,

--- a/autobot-frontend/src/components/chat/DocumentationSuggestionChip.stories.ts
+++ b/autobot-frontend/src/components/chat/DocumentationSuggestionChip.stories.ts
@@ -45,9 +45,9 @@ const meta = {
 } as Meta<typeof DocumentationSuggestionChip>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/chat/MessageAttachments.stories.ts
+++ b/autobot-frontend/src/components/chat/MessageAttachments.stories.ts
@@ -17,8 +17,8 @@ const meta = {
 } as Meta<typeof MessageAttachments>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/chat/MessageItem.stories.ts
+++ b/autobot-frontend/src/components/chat/MessageItem.stories.ts
@@ -37,8 +37,8 @@ const meta = {
 } as Meta<typeof MessageItem>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const baseUserMessage = {
   id: 'msg-1',

--- a/autobot-frontend/src/components/chat/MultiModelChat.stories.ts
+++ b/autobot-frontend/src/components/chat/MultiModelChat.stories.ts
@@ -12,8 +12,8 @@ const meta = {
 } as Meta<typeof MultiModelChat>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/chat/OverseerPlanMessage.stories.ts
+++ b/autobot-frontend/src/components/chat/OverseerPlanMessage.stories.ts
@@ -21,8 +21,8 @@ const meta = {
 } as Meta<typeof OverseerPlanMessage>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const basePlan = {
   analysis: 'The user wants to check system health and restart the web service if it is down.',

--- a/autobot-frontend/src/components/chat/OverseerStepMessage.stories.ts
+++ b/autobot-frontend/src/components/chat/OverseerStepMessage.stories.ts
@@ -17,8 +17,8 @@ const meta = {
 } as Meta<typeof OverseerStepMessage>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Pending: Story = {
   args: {

--- a/autobot-frontend/src/components/chat/PresetManagementModal.stories.ts
+++ b/autobot-frontend/src/components/chat/PresetManagementModal.stories.ts
@@ -14,8 +14,8 @@ const meta = {
 } as Meta<typeof PresetManagementModal>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/chat/ReasoningTrace.stories.ts
+++ b/autobot-frontend/src/components/chat/ReasoningTrace.stories.ts
@@ -21,8 +21,8 @@ const meta = {
 } as Meta<typeof ReasoningTrace>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const sampleEntries = [
   { id: '1', kind: 'step_start', label: 'Starting task: analyze user request', durationMs: null },

--- a/autobot-frontend/src/components/chat/ShareConversationDialog.stories.ts
+++ b/autobot-frontend/src/components/chat/ShareConversationDialog.stories.ts
@@ -21,8 +21,8 @@ const meta = {
 } as Meta<typeof ShareConversationDialog>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/chat/SlashCommandDropdown.stories.ts
+++ b/autobot-frontend/src/components/chat/SlashCommandDropdown.stories.ts
@@ -18,8 +18,8 @@ const meta = {
 } as Meta<typeof SlashCommandDropdown>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 const samplePresets = [
   { id: '1', name: 'standup', description: 'Daily standup summary', content: 'Give me a standup summary...', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },

--- a/autobot-frontend/src/components/chat/TranslationShortcutPanel.stories.ts
+++ b/autobot-frontend/src/components/chat/TranslationShortcutPanel.stories.ts
@@ -17,8 +17,8 @@ const meta = {
 } as Meta<typeof TranslationShortcutPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/chat/TypingIndicator.stories.ts
+++ b/autobot-frontend/src/components/chat/TypingIndicator.stories.ts
@@ -25,8 +25,8 @@ const meta = {
 } as Meta<typeof TypingIndicator>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/chat/VisionAnalysisModal.stories.ts
+++ b/autobot-frontend/src/components/chat/VisionAnalysisModal.stories.ts
@@ -12,8 +12,8 @@ const meta = {
 } as Meta<typeof VisionAnalysisModal>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 // VisionAnalysisModal has no props — all state is internal.
 // Stories demonstrate the visual shell only; actual file upload and API

--- a/autobot-frontend/src/components/chat/VisualBrowserPanel.stories.ts
+++ b/autobot-frontend/src/components/chat/VisualBrowserPanel.stories.ts
@@ -12,8 +12,8 @@ const meta = {
 } as Meta<typeof VisualBrowserPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 // VisualBrowserPanel manages all state internally (URL bar, screenshot,
 // connection status). Stories show the visual shell; API and Playwright

--- a/autobot-frontend/src/components/chat/VoiceConversationOverlay.stories.ts
+++ b/autobot-frontend/src/components/chat/VoiceConversationOverlay.stories.ts
@@ -12,8 +12,8 @@ const meta = {
 } as Meta<typeof VoiceConversationOverlay>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 // VoiceConversationOverlay relies entirely on the useVoiceConversation composable
 // for its state (isActive, bubbles, mode, etc.).  The overlay only renders when

--- a/autobot-frontend/src/components/chat/VoiceConversationPanel.stories.ts
+++ b/autobot-frontend/src/components/chat/VoiceConversationPanel.stories.ts
@@ -12,8 +12,8 @@ const meta = {
 } as Meta<typeof VoiceConversationPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 // VoiceConversationPanel derives all state from the useVoiceConversation
 // composable (state, mode, bubbles, audioLevel, etc.).  Stories document the

--- a/autobot-frontend/src/components/collaboration/ActivityFeed.stories.ts
+++ b/autobot-frontend/src/components/collaboration/ActivityFeed.stories.ts
@@ -11,9 +11,9 @@ const meta = {
 } as Meta<typeof ActivityFeed>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/collaboration/ActivityTimeline.stories.ts
+++ b/autobot-frontend/src/components/collaboration/ActivityTimeline.stories.ts
@@ -11,9 +11,9 @@ const meta = {
 } as Meta<typeof ActivityTimeline>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/collaboration/InviteUserDialog.stories.ts
+++ b/autobot-frontend/src/components/collaboration/InviteUserDialog.stories.ts
@@ -16,9 +16,9 @@ const meta = {
 } as Meta<typeof InviteUserDialog>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Open: Story = {
   name: 'Dialog open',

--- a/autobot-frontend/src/components/collaboration/ParticipantList.stories.ts
+++ b/autobot-frontend/src/components/collaboration/ParticipantList.stories.ts
@@ -20,9 +20,9 @@ const meta = {
 } as Meta<typeof ParticipantList>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/collaboration/PresenceIndicator.stories.ts
+++ b/autobot-frontend/src/components/collaboration/PresenceIndicator.stories.ts
@@ -16,9 +16,9 @@ const meta = {
 } as Meta<typeof PresenceIndicator>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Compact: Story = {
   name: 'Compact (default)',

--- a/autobot-frontend/src/components/collaboration/SecretNotifications.stories.ts
+++ b/autobot-frontend/src/components/collaboration/SecretNotifications.stories.ts
@@ -11,9 +11,9 @@ const meta = {
 } as Meta<typeof SecretNotifications>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/common/ErrorBoundary.stories.ts
+++ b/autobot-frontend/src/components/common/ErrorBoundary.stories.ts
@@ -23,15 +23,15 @@ const meta = {
 } as Meta<typeof ErrorBoundary>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {
     title: 'Something went wrong',
     message: 'An unexpected error occurred. Please try again.',
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { ErrorBoundary },
     setup() {
       return { args };
@@ -52,7 +52,7 @@ export const Retryable: Story = {
     message: 'The data could not be loaded. Click retry to try again.',
     retryable: true,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { ErrorBoundary },
     setup() {
       return { args };

--- a/autobot-frontend/src/components/common/PermissionDenied.stories.ts
+++ b/autobot-frontend/src/components/common/PermissionDenied.stories.ts
@@ -9,8 +9,8 @@ const meta = {
 } as Meta<typeof PermissionDenied>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/desktop/ConnectionSettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/desktop/ConnectionSettingsPanel.stories.ts
@@ -24,8 +24,8 @@ const meta = {
 } as Meta<typeof ConnectionSettingsPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = import('@storybook/vue3').StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = import('@storybook/vue3').StoryObj<Record<string, unknown>>;
 
 /**
  * Default state: the component mounts, loads settings and begins metrics polling.

--- a/autobot-frontend/src/components/desktop/DesktopContextPanel.stories.ts
+++ b/autobot-frontend/src/components/desktop/DesktopContextPanel.stories.ts
@@ -24,8 +24,8 @@ const meta = {
 } as Meta<typeof DesktopContextPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = import('@storybook/vue3').StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = import('@storybook/vue3').StoryObj<Record<string, unknown>>;
 
 /**
  * Default render — composable starts with context = null so the loading skeleton is shown.

--- a/autobot-frontend/src/components/desktop/DesktopInterface.stories.ts
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.stories.ts
@@ -34,8 +34,8 @@ const meta = {
 } as Meta<typeof DesktopInterface>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = import('@storybook/vue3').StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = import('@storybook/vue3').StoryObj<Record<string, unknown>>;
 
 /**
  * Default — no host prop; the component attempts to load the VNC URL from AppConfig.
@@ -46,7 +46,7 @@ export const Default: Story = {
   args: {
     host: null,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { DesktopInterface },
     setup() { return { args } },
     template: `<div style="height:600px"><DesktopInterface v-bind="args" /></div>`,
@@ -66,7 +66,7 @@ export const WithHostProp: Story = {
       name: 'Frontend VM',
     } satisfies Partial<SelectorHost>,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { DesktopInterface },
     setup() { return { args } },
     template: `<div style="height:600px"><DesktopInterface v-bind="args" /></div>`,
@@ -78,7 +78,7 @@ export const WithHostProp: Story = {
  */
 export const CompactHeight: Story = {
   args: { host: null },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { DesktopInterface },
     setup() { return { args } },
     template: `<div style="height:360px"><DesktopInterface v-bind="args" /></div>`,
@@ -90,7 +90,7 @@ export const CompactHeight: Story = {
  */
 export const TallLayout: Story = {
   args: { host: null },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { DesktopInterface },
     setup() { return { args } },
     template: `<div style="height:900px"><DesktopInterface v-bind="args" /></div>`,
@@ -109,7 +109,7 @@ export const CustomVmHost: Story = {
       name: 'Worker VM',
     } satisfies Partial<SelectorHost>,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { DesktopInterface },
     setup() { return { args } },
     template: `<div style="height:600px"><DesktopInterface v-bind="args" /></div>`,

--- a/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.stories.ts
+++ b/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.stories.ts
@@ -45,8 +45,8 @@ const meta = {
 } as Meta<typeof PopoutChromiumBrowser>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = import('@storybook/vue3').StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = import('@storybook/vue3').StoryObj<Record<string, unknown>>;
 
 /**
  * Manual browser mode — sessionId = "manual-browser" shows the empty state with a
@@ -59,7 +59,7 @@ export const ManualBrowserMode: Story = {
     canResize: true,
     autoPopout: false,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { PopoutChromiumBrowser },
     setup() { return { args } },
     template: `<div style="height:600px"><PopoutChromiumBrowser v-bind="args" @close="() => {}" /></div>`,
@@ -77,7 +77,7 @@ export const ActiveSession: Story = {
     canResize: true,
     autoPopout: false,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { PopoutChromiumBrowser },
     setup() { return { args } },
     template: `<div style="height:600px"><PopoutChromiumBrowser v-bind="args" @close="() => {}" /></div>`,
@@ -94,7 +94,7 @@ export const SecureUrl: Story = {
     canResize: true,
     autoPopout: false,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { PopoutChromiumBrowser },
     setup() { return { args } },
     template: `<div style="height:600px"><PopoutChromiumBrowser v-bind="args" @close="() => {}" /></div>`,
@@ -111,7 +111,7 @@ export const NonResizable: Story = {
     canResize: false,
     autoPopout: false,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { PopoutChromiumBrowser },
     setup() { return { args } },
     template: `<div style="height:500px;width:800px"><PopoutChromiumBrowser v-bind="args" @close="() => {}" /></div>`,
@@ -129,7 +129,7 @@ export const CompactEmbedded: Story = {
     canResize: false,
     autoPopout: false,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { PopoutChromiumBrowser },
     setup() { return { args } },
     template: `<div style="height:400px;width:640px"><PopoutChromiumBrowser v-bind="args" @close="() => {}" /></div>`,

--- a/autobot-frontend/src/components/feature-flags/AccessMetrics.stories.ts
+++ b/autobot-frontend/src/components/feature-flags/AccessMetrics.stories.ts
@@ -24,8 +24,8 @@ const meta = {
 } as Meta<typeof AccessMetrics>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const sampleMetrics = {
   total_violations: 47,

--- a/autobot-frontend/src/components/feature-flags/EndpointEnforcement.stories.ts
+++ b/autobot-frontend/src/components/feature-flags/EndpointEnforcement.stories.ts
@@ -25,8 +25,8 @@ const meta = {
 } as Meta<typeof EndpointEnforcement>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const WithOverrides: Story = {
   args: {

--- a/autobot-frontend/src/components/feature-flags/EnforcementModeSelector.stories.ts
+++ b/autobot-frontend/src/components/feature-flags/EnforcementModeSelector.stories.ts
@@ -22,8 +22,8 @@ const meta = {
 } as Meta<typeof EnforcementModeSelector>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Disabled: Story = {
   args: {

--- a/autobot-frontend/src/components/feature-flags/FlagChangeHistory.stories.ts
+++ b/autobot-frontend/src/components/feature-flags/FlagChangeHistory.stories.ts
@@ -20,8 +20,8 @@ const meta = {
 } as Meta<typeof FlagChangeHistory>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const now = new Date();
 const hoursAgo = (h: number) => new Date(now.getTime() - h * 3600 * 1000).toISOString();

--- a/autobot-frontend/src/components/file-browser/FileBrowser.stories.ts
+++ b/autobot-frontend/src/components/file-browser/FileBrowser.stories.ts
@@ -16,8 +16,8 @@ const meta = {
 } as Meta<typeof FileBrowser>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/file-browser/FileBrowserHeader.stories.ts
+++ b/autobot-frontend/src/components/file-browser/FileBrowserHeader.stories.ts
@@ -28,8 +28,8 @@ const meta = {
 } as Meta<typeof FileBrowserHeader>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/file-browser/FileListTable.stories.ts
+++ b/autobot-frontend/src/components/file-browser/FileListTable.stories.ts
@@ -43,8 +43,8 @@ const meta = {
 } as Meta<typeof FileListTable>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/file-browser/FilePathNavigation.stories.ts
+++ b/autobot-frontend/src/components/file-browser/FilePathNavigation.stories.ts
@@ -17,8 +17,8 @@ const meta = {
 } as Meta<typeof FilePathNavigation>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Root: Story = {
   args: {

--- a/autobot-frontend/src/components/file-browser/FilePreview.stories.ts
+++ b/autobot-frontend/src/components/file-browser/FilePreview.stories.ts
@@ -22,8 +22,8 @@ const meta = {
 } as Meta<typeof FilePreview>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Hidden: Story = {
   args: {

--- a/autobot-frontend/src/components/file-browser/FileTreeView.stories.ts
+++ b/autobot-frontend/src/components/file-browser/FileTreeView.stories.ts
@@ -32,8 +32,8 @@ const meta = {
 } as Meta<typeof FileTreeView>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/file-browser/FileUpload.stories.ts
+++ b/autobot-frontend/src/components/file-browser/FileUpload.stories.ts
@@ -16,8 +16,8 @@ const meta = {
 } as Meta<typeof FileUpload>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {};
 

--- a/autobot-frontend/src/components/knowledge/BackupManager.stories.ts
+++ b/autobot-frontend/src/components/knowledge/BackupManager.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof BackupManager>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/BatchSelectionToolbar.stories.ts
+++ b/autobot-frontend/src/components/knowledge/BatchSelectionToolbar.stories.ts
@@ -15,8 +15,8 @@ const meta = {
 } as Meta<typeof BatchSelectionToolbar>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/knowledge/BulkActionsToolbar.stories.ts
+++ b/autobot-frontend/src/components/knowledge/BulkActionsToolbar.stories.ts
@@ -18,8 +18,8 @@ const meta = {
 } as Meta<typeof BulkActionsToolbar>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/knowledge/CleanupStatistics.stories.ts
+++ b/autobot-frontend/src/components/knowledge/CleanupStatistics.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof CleanupStatistics>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/DeduplicationManager.stories.ts
+++ b/autobot-frontend/src/components/knowledge/DeduplicationManager.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof DeduplicationManager>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/DocumentChangeFeed.stories.ts
+++ b/autobot-frontend/src/components/knowledge/DocumentChangeFeed.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof DocumentChangeFeed>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/EntityExtractor.stories.ts
+++ b/autobot-frontend/src/components/knowledge/EntityExtractor.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof EntityExtractor>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/EntityGraphManager.stories.ts
+++ b/autobot-frontend/src/components/knowledge/EntityGraphManager.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof EntityGraphManager>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/FailedVectorizationsManager.stories.ts
+++ b/autobot-frontend/src/components/knowledge/FailedVectorizationsManager.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof FailedVectorizationsManager>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/GraphRAGQuery.stories.ts
+++ b/autobot-frontend/src/components/knowledge/GraphRAGQuery.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof GraphRAGQuery>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KBSearchResultPanel.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KBSearchResultPanel.stories.ts
@@ -17,8 +17,8 @@ const meta = {
 } as Meta<typeof KBSearchResultPanel>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Loading: Story = {
   args: {

--- a/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgeAdvanced>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KnowledgeBatchToolbar.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBatchToolbar.stories.ts
@@ -17,8 +17,8 @@ const meta = {
 } as Meta<typeof KnowledgeBatchToolbar>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgeBrowser>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowserHeader.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowserHeader.stories.ts
@@ -16,8 +16,8 @@ const meta = {
 } as Meta<typeof KnowledgeBrowserHeader>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgeCategories>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KnowledgeContentViewer.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeContentViewer.stories.ts
@@ -17,8 +17,8 @@ const meta = {
 } as Meta<typeof KnowledgeContentViewer>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const NoFileSelected: Story = {
   args: {

--- a/autobot-frontend/src/components/knowledge/KnowledgeEntries.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeEntries.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgeEntries>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgeGraph>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph3D.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph3D.stories.ts
@@ -15,8 +15,8 @@ const meta = {
 } as Meta<typeof KnowledgeGraph3D>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Empty: Story = {
   args: {

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraphView.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraphView.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgeGraphView>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KnowledgeMainCategories.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeMainCategories.stories.ts
@@ -17,8 +17,8 @@ const meta = {
 } as Meta<typeof KnowledgeMainCategories>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 const sampleCategories = [
   { id: 'system', name: 'System Knowledge', description: 'System commands and configurations', icon: 'fas fa-cogs', color: '#3b82f6', count: 150 },

--- a/autobot-frontend/src/components/knowledge/KnowledgeMaintenance.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeMaintenance.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgeMaintenance>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KnowledgeManager.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeManager.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgeManager>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgePersistenceDialog>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgePromptEditor>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgeResearchPanel>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KnowledgeScopeSelector.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeScopeSelector.stories.ts
@@ -26,8 +26,8 @@ const meta = {
 } as Meta<typeof KnowledgeScopeSelector>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Private: Story = {
   args: {

--- a/autobot-frontend/src/components/knowledge/KnowledgeSearch.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeSearch.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgeSearch>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KnowledgeStats.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeStats.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgeStats>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgeSystemDocs>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KnowledgeUpload.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeUpload.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgeUpload>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.stories.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof KnowledgeVerificationQueue>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/MemoryOrphanManager.stories.ts
+++ b/autobot-frontend/src/components/knowledge/MemoryOrphanManager.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof MemoryOrphanManager>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/QualityScoreBadge.stories.ts
+++ b/autobot-frontend/src/components/knowledge/QualityScoreBadge.stories.ts
@@ -14,8 +14,8 @@ const meta = {
 } as Meta<typeof QualityScoreBadge>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const High: Story = {
   args: {

--- a/autobot-frontend/src/components/knowledge/SessionOrphanManager.stories.ts
+++ b/autobot-frontend/src/components/knowledge/SessionOrphanManager.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof SessionOrphanManager>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.stories.ts
+++ b/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.stories.ts
@@ -18,8 +18,8 @@ const meta = {
 } as Meta<typeof ShareKnowledgeDialog>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Open: Story = {
   args: {

--- a/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.stories.ts
+++ b/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof SystemKnowledgeManager>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/knowledge/TreeNodeComponent.stories.ts
+++ b/autobot-frontend/src/components/knowledge/TreeNodeComponent.stories.ts
@@ -18,8 +18,8 @@ const meta = {
 } as Meta<typeof TreeNodeComponent>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 const fileNode = {
   id: 'file-1',

--- a/autobot-frontend/src/components/knowledge/VectorizationActionButton.stories.ts
+++ b/autobot-frontend/src/components/knowledge/VectorizationActionButton.stories.ts
@@ -20,8 +20,8 @@ const meta = {
 } as Meta<typeof VectorizationActionButton>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Vectorize: Story = {
   args: {

--- a/autobot-frontend/src/components/knowledge/VectorizationProgressModal.stories.ts
+++ b/autobot-frontend/src/components/knowledge/VectorizationProgressModal.stories.ts
@@ -15,8 +15,8 @@ const meta = {
 } as Meta<typeof VectorizationProgressModal>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Open: Story = {
   args: {

--- a/autobot-frontend/src/components/knowledge/VectorizationStatusBadge.stories.ts
+++ b/autobot-frontend/src/components/knowledge/VectorizationStatusBadge.stories.ts
@@ -19,8 +19,8 @@ const meta = {
 } as Meta<typeof VectorizationStatusBadge>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Vectorized: Story = {
   args: {

--- a/autobot-frontend/src/components/knowledge/WebResearchPanel.stories.ts
+++ b/autobot-frontend/src/components/knowledge/WebResearchPanel.stories.ts
@@ -22,9 +22,9 @@ const meta = {
 
 export default meta
 
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Story = import('@storybook/vue3').StoryObj<any>
+type Story = import('@storybook/vue3').StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/knowledge/WebResearchSettings.stories.ts
+++ b/autobot-frontend/src/components/knowledge/WebResearchSettings.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof WebResearchSettings>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {},

--- a/autobot-frontend/src/components/layout/LanguageSwitcher.stories.ts
+++ b/autobot-frontend/src/components/layout/LanguageSwitcher.stories.ts
@@ -25,8 +25,8 @@ const meta = {
 } as Meta<typeof LanguageSwitcher>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Desktop: Story = {
   args: {
@@ -40,7 +40,7 @@ export const Desktop: Story = {
       },
     },
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { LanguageSwitcher },
     setup() {
       return { args };
@@ -65,7 +65,7 @@ export const Mobile: Story = {
       },
     },
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { LanguageSwitcher },
     setup() {
       return { args };

--- a/autobot-frontend/src/components/layout/NavOverflowMenu.stories.ts
+++ b/autobot-frontend/src/components/layout/NavOverflowMenu.stories.ts
@@ -63,14 +63,14 @@ const meta = {
 } as Meta<typeof NavOverflowMenu>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {
     items: sampleItems,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { NavOverflowMenu },
     setup() {
       return { args };
@@ -98,7 +98,7 @@ export const SingleItem: Story = {
       },
     },
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { NavOverflowMenu },
     setup() {
       return { args };
@@ -128,7 +128,7 @@ export const ManyItems: Story = {
       },
     },
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { NavOverflowMenu },
     setup() {
       return { args };
@@ -153,7 +153,7 @@ export const Empty: Story = {
       },
     },
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { NavOverflowMenu },
     setup() {
       return { args };

--- a/autobot-frontend/src/components/manpage/IntegrationActionsPanel.stories.ts
+++ b/autobot-frontend/src/components/manpage/IntegrationActionsPanel.stories.ts
@@ -30,8 +30,8 @@ const meta = {
 } as Meta<typeof IntegrationActionsPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/manpage/IntegrationStatusPanel.stories.ts
+++ b/autobot-frontend/src/components/manpage/IntegrationStatusPanel.stories.ts
@@ -22,8 +22,8 @@ const meta = {
 } as Meta<typeof IntegrationStatusPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const NotIntegrated: Story = {
   args: {

--- a/autobot-frontend/src/components/manpage/MachineProfilePanel.stories.ts
+++ b/autobot-frontend/src/components/manpage/MachineProfilePanel.stories.ts
@@ -22,8 +22,8 @@ const meta = {
 } as Meta<typeof MachineProfilePanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const LinuxProfile: Story = {
   args: {

--- a/autobot-frontend/src/components/manpage/ManPageManager.stories.ts
+++ b/autobot-frontend/src/components/manpage/ManPageManager.stories.ts
@@ -13,8 +13,8 @@ const meta = {
 } as Meta<typeof ManPageManager>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 // ManPageManager is self-contained: it fetches its own data via composables on mount.
 // Stories render the shell; real data requires a live backend.

--- a/autobot-frontend/src/components/manpage/ManPageSearchPanel.stories.ts
+++ b/autobot-frontend/src/components/manpage/ManPageSearchPanel.stories.ts
@@ -34,8 +34,8 @@ const meta = {
 } as Meta<typeof ManPageSearchPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Hidden: Story = {
   args: {

--- a/autobot-frontend/src/components/manpage/ProgressTrackingPanel.stories.ts
+++ b/autobot-frontend/src/components/manpage/ProgressTrackingPanel.stories.ts
@@ -26,8 +26,8 @@ const meta = {
 } as Meta<typeof ProgressTrackingPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Hidden: Story = {
   args: {

--- a/autobot-frontend/src/components/operations/OperationDetail.stories.ts
+++ b/autobot-frontend/src/components/operations/OperationDetail.stories.ts
@@ -16,8 +16,8 @@ const meta = {
 } as Meta<typeof OperationDetail>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = import('@storybook/vue3').StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = import('@storybook/vue3').StoryObj<Record<string, unknown>>;
 
 const baseOperation = {
   operation_id: 'op-abc123',

--- a/autobot-frontend/src/components/operations/OperationFilters.stories.ts
+++ b/autobot-frontend/src/components/operations/OperationFilters.stories.ts
@@ -16,8 +16,8 @@ const meta = {
 } as Meta<typeof OperationFilters>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = import('@storybook/vue3').StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = import('@storybook/vue3').StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/operations/OperationProgress.stories.ts
+++ b/autobot-frontend/src/components/operations/OperationProgress.stories.ts
@@ -50,8 +50,8 @@ const meta = {
 } as Meta<typeof OperationProgress>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = import('@storybook/vue3').StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = import('@storybook/vue3').StoryObj<Record<string, unknown>>;
 
 export const Running: Story = {
   args: {

--- a/autobot-frontend/src/components/operations/OperationsList.stories.ts
+++ b/autobot-frontend/src/components/operations/OperationsList.stories.ts
@@ -36,8 +36,8 @@ const meta = {
 } as Meta<typeof OperationsList>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = import('@storybook/vue3').StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = import('@storybook/vue3').StoryObj<Record<string, unknown>>;
 
 const sampleOperations = [
   {

--- a/autobot-frontend/src/components/operations/OperationsPanel.stories.ts
+++ b/autobot-frontend/src/components/operations/OperationsPanel.stories.ts
@@ -32,8 +32,8 @@ const meta = {
 } as Meta<typeof OperationsPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = import('@storybook/vue3').StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = import('@storybook/vue3').StoryObj<Record<string, unknown>>;
 
 const sampleOperations = [
   {

--- a/autobot-frontend/src/components/plugins/MarketplaceSourcesModal.stories.ts
+++ b/autobot-frontend/src/components/plugins/MarketplaceSourcesModal.stories.ts
@@ -15,14 +15,14 @@ const meta = {
 } as Meta<typeof MarketplaceSourcesModal>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Open: Story = {
   args: {
     open: true,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { MarketplaceSourcesModal },
     setup() {
       return { args };
@@ -44,7 +44,7 @@ export const Closed: Story = {
   args: {
     open: false,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { MarketplaceSourcesModal },
     setup() {
       return { args };

--- a/autobot-frontend/src/components/plugins/PluginInstallModal.stories.ts
+++ b/autobot-frontend/src/components/plugins/PluginInstallModal.stories.ts
@@ -15,15 +15,15 @@ const meta = {
 } as Meta<typeof PluginInstallModal>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const OpenZipTab: Story = {
   name: 'Open — ZIP tab',
   args: {
     open: true,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { PluginInstallModal },
     setup() {
       return { args };
@@ -45,7 +45,7 @@ export const OpenGitTab: Story = {
   args: {
     open: true,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { PluginInstallModal },
     setup() {
       return { args };
@@ -70,7 +70,7 @@ export const Closed: Story = {
   args: {
     open: false,
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { PluginInstallModal },
     setup() {
       return { args };

--- a/autobot-frontend/src/components/profile/ProfileModal.stories.ts
+++ b/autobot-frontend/src/components/profile/ProfileModal.stories.ts
@@ -15,14 +15,14 @@ const meta = {
 } as Meta<typeof ProfileModal>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {
     isOpen: true
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { ProfileModal },
     setup() {
       return { args };
@@ -43,7 +43,7 @@ export const Closed: Story = {
   args: {
     isOpen: false
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { ProfileModal },
     setup() {
       return { args };
@@ -64,7 +64,7 @@ export const WithBackdrop: Story = {
   args: {
     isOpen: true
   },
-  render: (args: any) => ({
+  render: (args: Record<string, unknown>) => ({
     components: { ProfileModal },
     setup() {
       return { args };

--- a/autobot-frontend/src/components/research/CaptchaNotification.stories.ts
+++ b/autobot-frontend/src/components/research/CaptchaNotification.stories.ts
@@ -10,8 +10,8 @@ const meta = {
 } as Meta<typeof CaptchaNotification>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/secrets/SecretAuditLog.stories.ts
+++ b/autobot-frontend/src/components/secrets/SecretAuditLog.stories.ts
@@ -16,8 +16,8 @@ const meta = {
 } as Meta<typeof SecretAuditLog>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/secrets/SecretVault.stories.ts
+++ b/autobot-frontend/src/components/secrets/SecretVault.stories.ts
@@ -17,8 +17,8 @@ const meta = {
 } as Meta<typeof SecretVault>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const AllSecrets: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/secrets/ShareSecretDialog.stories.ts
+++ b/autobot-frontend/src/components/secrets/ShareSecretDialog.stories.ts
@@ -29,8 +29,8 @@ const meta = {
 } as Meta<typeof ShareSecretDialog>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Open: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/security/SecretsManager.stories.ts
+++ b/autobot-frontend/src/components/security/SecretsManager.stories.ts
@@ -10,8 +10,8 @@ const meta = {
 } as Meta<typeof SecretsManager>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/security/ThreatIntelligenceDashboard.stories.ts
+++ b/autobot-frontend/src/components/security/ThreatIntelligenceDashboard.stories.ts
@@ -10,8 +10,8 @@ const meta = {
 } as Meta<typeof ThreatIntelligenceDashboard>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/security/ThreatIntelligenceSettings.stories.ts
+++ b/autobot-frontend/src/components/security/ThreatIntelligenceSettings.stories.ts
@@ -10,8 +10,8 @@ const meta = {
 } as Meta<typeof ThreatIntelligenceSettings>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/settings/ApiKeySetupWizard.stories.ts
+++ b/autobot-frontend/src/components/settings/ApiKeySetupWizard.stories.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Meta } from '@storybook/vue3';
 import ApiKeySetupWizard from './ApiKeySetupWizard.vue';
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 const meta = {
   title: 'Components/Settings/ApiKeySetupWizard',

--- a/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.stories.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Meta } from '@storybook/vue3';
 import FeatureFlagsSettingsPanel from './FeatureFlagsSettingsPanel.vue';
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 const meta = {
   title: 'Components/Settings/FeatureFlagsSettingsPanel',

--- a/autobot-frontend/src/components/settings/LanguageSettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/settings/LanguageSettingsPanel.stories.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Meta } from '@storybook/vue3';
 import LanguageSettingsPanel from './LanguageSettingsPanel.vue';
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 const meta = {
   title: 'Components/Settings/LanguageSettingsPanel',

--- a/autobot-frontend/src/components/settings/PresetsSettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/settings/PresetsSettingsPanel.stories.ts
@@ -14,7 +14,7 @@ const meta = {
 } as Meta<typeof PresetsSettingsPanel>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {}

--- a/autobot-frontend/src/components/settings/PushNotificationSettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/settings/PushNotificationSettingsPanel.stories.ts
@@ -1,11 +1,11 @@
 // Copyright 2025-2026 mrveiss
 // SPDX-License-Identifier: Apache-2.0
 import type { Meta } from '@storybook/vue3'
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3'
 import PushNotificationSettingsPanel from './PushNotificationSettingsPanel.vue'
 
-type Story = StoryObj<any>
+type Story = StoryObj<Record<string, unknown>>
 
 const meta = {
   title: 'Components/Settings/PushNotificationSettingsPanel',

--- a/autobot-frontend/src/components/settings/SettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/settings/SettingsPanel.stories.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Meta } from '@storybook/vue3';
 import SettingsPanel from './SettingsPanel.vue';
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 const meta = {
   title: 'Components/Settings/SettingsPanel',

--- a/autobot-frontend/src/components/settings/VoiceSettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/settings/VoiceSettingsPanel.stories.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Meta } from '@storybook/vue3';
 import VoiceSettingsPanel from './VoiceSettingsPanel.vue';
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 const meta = {
   title: 'Components/Settings/VoiceSettingsPanel',

--- a/autobot-frontend/src/components/settings/WebResearchSettingsPanel.stories.ts
+++ b/autobot-frontend/src/components/settings/WebResearchSettingsPanel.stories.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { Meta } from '@storybook/vue3';
 import WebResearchSettingsPanel from './WebResearchSettingsPanel.vue';
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
 import type { StoryObj } from '@storybook/vue3';
-type Story = StoryObj<any>;
+type Story = StoryObj<Record<string, unknown>>;
 
 const meta = {
   title: 'Components/Settings/WebResearchSettingsPanel',

--- a/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.stories.ts
+++ b/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.stories.ts
@@ -50,8 +50,8 @@ const meta = {
 } as Meta<typeof AdvancedStepConfirmationModal>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/terminal/BaseXTerminal.stories.ts
+++ b/autobot-frontend/src/components/terminal/BaseXTerminal.stories.ts
@@ -38,8 +38,8 @@ const meta = {
 } as Meta<typeof BaseXTerminal>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 // NOTE: BaseXTerminal initialises an xterm.js Terminal instance on mount and
 // requires a real browser DOM.  In Storybook Canvas mode all stories render

--- a/autobot-frontend/src/components/terminal/CompletionSuggestions.stories.ts
+++ b/autobot-frontend/src/components/terminal/CompletionSuggestions.stories.ts
@@ -45,8 +45,8 @@ const meta = {
 } as Meta<typeof CompletionSuggestions>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const CommandSuggestions: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/terminal/HostSelector.stories.ts
+++ b/autobot-frontend/src/components/terminal/HostSelector.stories.ts
@@ -37,8 +37,8 @@ const meta = {
 } as Meta<typeof HostSelector>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/terminal/SSHTerminal.stories.ts
+++ b/autobot-frontend/src/components/terminal/SSHTerminal.stories.ts
@@ -21,8 +21,8 @@ const meta = {
 } as Meta<typeof SSHTerminal>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 // NOTE: SSHTerminal establishes a WebSocket connection on mount.  In Storybook
 // the WebSocket will fail gracefully — the component renders in the

--- a/autobot-frontend/src/components/terminal/Terminal.stories.ts
+++ b/autobot-frontend/src/components/terminal/Terminal.stories.ts
@@ -26,8 +26,8 @@ const meta = {
 } as Meta<typeof Terminal>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 // NOTE: Terminal uses WebSocket for real-time connection.  In Storybook it will
 // render in a disconnected state since there is no backend available.  All

--- a/autobot-frontend/src/components/terminal/TerminalHeader.stories.ts
+++ b/autobot-frontend/src/components/terminal/TerminalHeader.stories.ts
@@ -37,8 +37,8 @@ const meta = {
 } as Meta<typeof TerminalHeader>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Idle: Story = {
   args: {

--- a/autobot-frontend/src/components/terminal/TerminalInput.stories.ts
+++ b/autobot-frontend/src/components/terminal/TerminalInput.stories.ts
@@ -37,8 +37,8 @@ const meta = {
 } as Meta<typeof TerminalInput>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const ReadyForInput: Story = {
   args: {

--- a/autobot-frontend/src/components/terminal/TerminalModals.stories.ts
+++ b/autobot-frontend/src/components/terminal/TerminalModals.stories.ts
@@ -63,8 +63,8 @@ const meta = {
 } as Meta<typeof TerminalModals>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const AllHidden: Story = {
   args: {

--- a/autobot-frontend/src/components/terminal/TerminalOutput.stories.ts
+++ b/autobot-frontend/src/components/terminal/TerminalOutput.stories.ts
@@ -51,8 +51,8 @@ const meta = {
 } as Meta<typeof TerminalOutput>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const CommandOutput: Story = {
   args: {

--- a/autobot-frontend/src/components/terminal/TerminalSettings.stories.ts
+++ b/autobot-frontend/src/components/terminal/TerminalSettings.stories.ts
@@ -13,8 +13,8 @@ const meta = {
 } as Meta<typeof TerminalSettings>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/terminal/TerminalStatusBar.stories.ts
+++ b/autobot-frontend/src/components/terminal/TerminalStatusBar.stories.ts
@@ -34,8 +34,8 @@ const meta = {
 } as Meta<typeof TerminalStatusBar>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Connected: Story = {
   args: {

--- a/autobot-frontend/src/components/terminal/TerminalWindow.stories.ts
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.stories.ts
@@ -16,8 +16,8 @@ const meta = {
 } as Meta<typeof TerminalWindow>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 // NOTE: TerminalWindow uses WebSocket, Vue Router, and i18n.  In Storybook
 // these are provided by the global decorators configured in .storybook/preview.ts.

--- a/autobot-frontend/src/components/terminal/WorkflowAutomation.stories.ts
+++ b/autobot-frontend/src/components/terminal/WorkflowAutomation.stories.ts
@@ -48,8 +48,8 @@ const meta = {
 } as Meta<typeof WorkflowAutomation>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 // NOTE: WorkflowAutomation is a renderless orchestration component — its
 // template contains only a placeholder comment.  All state is managed via

--- a/autobot-frontend/src/components/ui/BaseAlert.stories.ts
+++ b/autobot-frontend/src/components/ui/BaseAlert.stories.ts
@@ -37,8 +37,8 @@ const meta = {
 } as Meta<typeof BaseAlert>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Success: Story = {
   args: {

--- a/autobot-frontend/src/components/ui/BaseModal.stories.ts
+++ b/autobot-frontend/src/components/ui/BaseModal.stories.ts
@@ -36,8 +36,8 @@ const meta = {
 } as Meta<typeof BaseModal>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/ui/CommandPermissionDialog.stories.ts
+++ b/autobot-frontend/src/components/ui/CommandPermissionDialog.stories.ts
@@ -40,8 +40,8 @@ const meta = {
 } as Meta<typeof CommandPermissionDialog>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/ui/ConfirmDialog.stories.ts
+++ b/autobot-frontend/src/components/ui/ConfirmDialog.stories.ts
@@ -10,8 +10,8 @@ const meta = {
 } as Meta<typeof ConfirmDialog>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/ui/DarkModeToggle.stories.ts
+++ b/autobot-frontend/src/components/ui/DarkModeToggle.stories.ts
@@ -10,8 +10,8 @@ const meta = {
 } as Meta<typeof DarkModeToggle>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/ui/DataTable.stories.ts
+++ b/autobot-frontend/src/components/ui/DataTable.stories.ts
@@ -51,8 +51,8 @@ const meta = {
 } as Meta<typeof DataTable>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const sampleColumns = [
   { key: 'name', label: 'Name', sortable: true },

--- a/autobot-frontend/src/components/ui/EmptyState.stories.ts
+++ b/autobot-frontend/src/components/ui/EmptyState.stories.ts
@@ -31,8 +31,8 @@ const meta = {
 } as Meta<typeof EmptyState>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/ui/HostSelectionDialog.stories.ts
+++ b/autobot-frontend/src/components/ui/HostSelectionDialog.stories.ts
@@ -31,8 +31,8 @@ const meta = {
 } as Meta<typeof HostSelectionDialog>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/ui/HostSelector.stories.ts
+++ b/autobot-frontend/src/components/ui/HostSelector.stories.ts
@@ -24,8 +24,8 @@ const meta = {
 } as Meta<typeof HostSelector>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/ui/Icon.stories.ts
+++ b/autobot-frontend/src/components/ui/Icon.stories.ts
@@ -62,8 +62,8 @@ const meta = {
 } as Meta<typeof Icon>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/ui/LoadingBoundary.stories.ts
+++ b/autobot-frontend/src/components/ui/LoadingBoundary.stories.ts
@@ -27,7 +27,7 @@ const meta = {
 } as Meta<typeof LoadingBoundary>
 
 export default meta
-type Story = StoryObj<any>
+type Story = StoryObj<Record<string, unknown>>
 
 export const Loading: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/ui/LoadingOverlay.stories.ts
+++ b/autobot-frontend/src/components/ui/LoadingOverlay.stories.ts
@@ -15,7 +15,7 @@ const meta = {
 } as Meta<typeof LoadingOverlay>
 
 export default meta
-type Story = StoryObj<any>
+type Story = StoryObj<Record<string, unknown>>
 
 export const Idle: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/ui/LoadingSpinner.stories.ts
+++ b/autobot-frontend/src/components/ui/LoadingSpinner.stories.ts
@@ -24,8 +24,8 @@ const meta = {
 } as Meta<typeof LoadingSpinner>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/ui/MessageStatus.stories.ts
+++ b/autobot-frontend/src/components/ui/MessageStatus.stories.ts
@@ -32,8 +32,8 @@ const meta = {
 } as Meta<typeof MessageStatus>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Sending: Story = {
   args: {

--- a/autobot-frontend/src/components/ui/OfflineBanner.stories.ts
+++ b/autobot-frontend/src/components/ui/OfflineBanner.stories.ts
@@ -10,8 +10,8 @@ const meta = {
 } as Meta<typeof OfflineBanner>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/ui/PreferencesPanel.stories.ts
+++ b/autobot-frontend/src/components/ui/PreferencesPanel.stories.ts
@@ -10,8 +10,8 @@ const meta = {
 } as Meta<typeof PreferencesPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/ui/ProgressBar.stories.ts
+++ b/autobot-frontend/src/components/ui/ProgressBar.stories.ts
@@ -65,8 +65,8 @@ const meta = {
 } as Meta<typeof ProgressBar>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/ui/SkeletonLoader.stories.ts
+++ b/autobot-frontend/src/components/ui/SkeletonLoader.stories.ts
@@ -42,8 +42,8 @@ const meta = {
 } as Meta<typeof SkeletonLoader>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/ui/StableLoadingState.stories.ts
+++ b/autobot-frontend/src/components/ui/StableLoadingState.stories.ts
@@ -32,8 +32,8 @@ const meta = {
 } as Meta<typeof StableLoadingState>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Loading: Story = {
   args: {

--- a/autobot-frontend/src/components/ui/StatusBadge.stories.ts
+++ b/autobot-frontend/src/components/ui/StatusBadge.stories.ts
@@ -26,8 +26,8 @@ const meta = {
 } as Meta<typeof StatusBadge>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Success: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/ui/SystemStatusNotification.stories.ts
+++ b/autobot-frontend/src/components/ui/SystemStatusNotification.stories.ts
@@ -44,8 +44,8 @@ const meta = {
 } as Meta<typeof SystemStatusNotification>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const InfoToast: Story = {
   args: {

--- a/autobot-frontend/src/components/ui/ThemeToggle.stories.ts
+++ b/autobot-frontend/src/components/ui/ThemeToggle.stories.ts
@@ -24,8 +24,8 @@ const meta = {
 } as Meta<typeof ThemeToggle>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Dropdown: Story = {
   args: {

--- a/autobot-frontend/src/components/ui/ToastContainer.stories.ts
+++ b/autobot-frontend/src/components/ui/ToastContainer.stories.ts
@@ -10,8 +10,8 @@ const meta = {
 } as Meta<typeof ToastContainer>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/ui/TouchFriendlyButton.stories.ts
+++ b/autobot-frontend/src/components/ui/TouchFriendlyButton.stories.ts
@@ -47,8 +47,8 @@ const meta = {
 } as Meta<typeof TouchFriendlyButton>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Primary: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/vision/GUIAutomationControls.stories.ts
+++ b/autobot-frontend/src/components/vision/GUIAutomationControls.stories.ts
@@ -20,8 +20,8 @@ const meta = {
 } as Meta<typeof GUIAutomationControls>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const sampleOpportunities = [
   {

--- a/autobot-frontend/src/components/vision/MediaGallery.stories.ts
+++ b/autobot-frontend/src/components/vision/MediaGallery.stories.ts
@@ -16,8 +16,8 @@ const meta = {
 } as Meta<typeof MediaGallery>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const now = Date.now();
 

--- a/autobot-frontend/src/components/vision/ScreenCaptureViewer.stories.ts
+++ b/autobot-frontend/src/components/vision/ScreenCaptureViewer.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof ScreenCaptureViewer>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const sampleAnalysisResult = {
   confidence_score: 0.87,

--- a/autobot-frontend/src/components/vision/VideoProcessor.stories.ts
+++ b/autobot-frontend/src/components/vision/VideoProcessor.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof VideoProcessor>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Default: Story = {
   render: () => ({

--- a/autobot-frontend/src/components/visualizations/AgentActivityVisualization.stories.ts
+++ b/autobot-frontend/src/components/visualizations/AgentActivityVisualization.stories.ts
@@ -23,8 +23,8 @@ const meta = {
 } as Meta<typeof AgentActivityVisualization>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/visualizations/ResourceHeatmap.stories.ts
+++ b/autobot-frontend/src/components/visualizations/ResourceHeatmap.stories.ts
@@ -32,8 +32,8 @@ const meta = {
 } as Meta<typeof ResourceHeatmap>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/visualizations/ServiceMessageTimeline.stories.ts
+++ b/autobot-frontend/src/components/visualizations/ServiceMessageTimeline.stories.ts
@@ -14,8 +14,8 @@ const meta = {
 } as Meta<typeof ServiceMessageTimeline>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   name: 'Default (All Messages)',

--- a/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.stories.ts
+++ b/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.stories.ts
@@ -31,8 +31,8 @@ const meta = {
 } as Meta<typeof SystemArchitectureDiagram>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const Default: Story = {
   args: {

--- a/autobot-frontend/src/components/visualizations/WorkflowVisualization.stories.ts
+++ b/autobot-frontend/src/components/visualizations/WorkflowVisualization.stories.ts
@@ -24,8 +24,8 @@ const meta = {
 } as Meta<typeof WorkflowVisualization>
 
 export default meta
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 export const SampleData: Story = {
   name: 'Sample Data (No Props)',

--- a/autobot-frontend/src/components/workflow/AgentObservabilityPanel.stories.ts
+++ b/autobot-frontend/src/components/workflow/AgentObservabilityPanel.stories.ts
@@ -24,8 +24,8 @@ const meta = {
 } as Meta<typeof AgentObservabilityPanel>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const samplePerformance = {
   coordinator: {

--- a/autobot-frontend/src/components/workflow/NotificationConfigModal.stories.ts
+++ b/autobot-frontend/src/components/workflow/NotificationConfigModal.stories.ts
@@ -20,8 +20,8 @@ const meta = {
 } as Meta<typeof NotificationConfigModal>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Visible: Story = {
   args: {

--- a/autobot-frontend/src/components/workflow/OrchestrationVisualizer.stories.ts
+++ b/autobot-frontend/src/components/workflow/OrchestrationVisualizer.stories.ts
@@ -28,8 +28,8 @@ const meta = {
 } as Meta<typeof OrchestrationVisualizer>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const sampleStatus = {
   status: 'operational',

--- a/autobot-frontend/src/components/workflow/PhaseProgressionIndicator.stories.ts
+++ b/autobot-frontend/src/components/workflow/PhaseProgressionIndicator.stories.ts
@@ -11,8 +11,8 @@ const meta = {
 } as Meta<typeof PhaseProgressionIndicator>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 // PhaseProgressionIndicator fetches its own data on demand via the
 // /api/validation-dashboard/report endpoint. Stories render the idle

--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.stories.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.stories.ts
@@ -20,8 +20,8 @@ const meta = {
 } as Meta<typeof WorkflowCanvas>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Empty: Story = {
   args: {

--- a/autobot-frontend/src/components/workflow/WorkflowHistory.stories.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowHistory.stories.ts
@@ -20,8 +20,8 @@ const meta = {
 } as Meta<typeof WorkflowHistory>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const makeSteps = (statuses: string[]) =>
   statuses.map((status, i) => ({

--- a/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.stories.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.stories.ts
@@ -32,8 +32,8 @@ const meta = {
 } as Meta<typeof WorkflowLiveDashboard>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const makeSteps = (statuses: string[]) =>
   statuses.map((status, i) => ({

--- a/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.stories.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.stories.ts
@@ -16,8 +16,8 @@ const meta = {
 } as Meta<typeof WorkflowNotificationConfig>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const sampleWorkflows = [
   { workflow_id: 'wf-aaa111', name: 'Backend Deployment' },

--- a/autobot-frontend/src/components/workflow/WorkflowProgressWidget.stories.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowProgressWidget.stories.ts
@@ -16,8 +16,8 @@ const meta = {
 } as Meta<typeof WorkflowProgressWidget>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 // WorkflowProgressWidget fetches its own data via the API using the workflowId prop.
 // Stories show the idle state (no workflowId) and the loading state (workflowId set).

--- a/autobot-frontend/src/components/workflow/WorkflowRunner.stories.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowRunner.stories.ts
@@ -24,8 +24,8 @@ const meta = {
 } as Meta<typeof WorkflowRunner>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const makeSteps = (statuses: string[]) =>
   statuses.map((status, i) => ({

--- a/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.stories.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.stories.ts
@@ -24,8 +24,8 @@ const meta = {
 } as Meta<typeof WorkflowTemplateGallery>;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 const makeTemplate = (
   id: string,

--- a/autobot-frontend/src/stories/DesignTokens.stories.ts
+++ b/autobot-frontend/src/stories/DesignTokens.stories.ts
@@ -30,8 +30,8 @@ const meta = {
 } satisfies Meta;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Tokens: Story = {
   render: () => ({

--- a/autobot-frontend/src/stories/IconLibrary.stories.ts
+++ b/autobot-frontend/src/stories/IconLibrary.stories.ts
@@ -192,8 +192,8 @@ const meta = {
 } satisfies Meta;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 export const Catalog: Story = {
   parameters: {

--- a/autobot-frontend/src/stories/Welcome.stories.ts
+++ b/autobot-frontend/src/stories/Welcome.stories.ts
@@ -10,8 +10,8 @@ const meta = {
 } satisfies Meta;
 
 export default meta;
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>;
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>;
 
 interface Card {
   name: string;

--- a/autobot-frontend/src/views/voice/VoiceBundleInfo.stories.ts
+++ b/autobot-frontend/src/views/voice/VoiceBundleInfo.stories.ts
@@ -18,8 +18,8 @@ import { VOICE_BUNDLE_STATE_KEY } from '@/composables/useVoiceBundle'
 import type { UserBundleInfo, VoiceBundleInjectedState } from '@/composables/useVoiceBundle'
 import { ref, provide } from 'vue'
 
-// #7273: relaxed to StoryObj<any> for render-only stories that don't match component props
-type Story = StoryObj<any>
+// #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
+type Story = StoryObj<Record<string, unknown>>
 
 const meta: Meta = {
   title: 'Views/Voice/VoiceBundleInfo',


### PR DESCRIPTION
## Thinking Path
#9924 grind — 296 of the remaining `no-explicit-any` (53%) lived in `.stories.ts` files, all following the same #7273-relaxed pattern (`type Story = StoryObj<any>` + `render: (args: any)`). One mechanical, vue-tsc-verified sweep instead of dozens of small batches.

## What Changed — 296 `any` removed across 257 story files (purely mechanical)
- `StoryObj<any>` → `StoryObj<Record<string, unknown>>` (508×)
- `render: (args: any)` → `render: (args: Record<string, unknown>)` (42×)
- 1 now-redundant `richPayload: invalidSpec as any` → `invalidSpec` (arg is `unknown` under the new Story type).

`Record<string, unknown>` preserves the render-only "relaxed" intent (#7273 — story args intentionally don't match component props) while removing `any`. Stories are Storybook config only — zero app-runtime impact.

## Verification (independently re-run)
- Full-project `eslint` `no-explicit-any`: **535 → 239** (exactly 296 cleared).
- `vue-tsc --noEmit -p tsconfig.app.json` → **exit 0** (stories ARE in tsconfig.app.json; no type errors across all 257 files).
- Diff audit: every added line is one of the 3 transforms above — **zero** unexpected changes.

## Model Used
Opus 4.8

Contributes to #9924 (563→239 remaining no-explicit-any — over halfway in one sweep).