### PR TITLE
refactor(cognify): fact_extractor → shared batching helper + derive extractor type-lists from Literals (#11017)

### DIFF
--- a/autobot-backend/knowledge/pipeline/cognifiers/causal_relationship_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/causal_relationship_extractor.py
@@ -12,7 +12,7 @@ distinguishing causality from correlation. Uses LLM guidance for high-confidence
 extraction with condition detection and evidence tracking.
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, get_args
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
@@ -21,12 +21,17 @@ from knowledge.pipeline.cognifiers.llm_utils import (
     batched_chunk_extract,
     parse_llm_json_response,
 )
-from knowledge.pipeline.models.causal_edge import CausalEdge
+from knowledge.pipeline.models.causal_edge import CausalEdge, EffectType
 from knowledge.pipeline.models.chunk import ProcessedChunk
 from knowledge.pipeline.registry import TaskRegistry
 from services.llm_service import get_llm_service
 
 logger = get_logger(__name__)
+
+# Allowed effect-type values derived from the EffectType Literal (#11017) so the
+# prompt fragment and the validation set can never drift from the type.
+_EFFECT_TYPES = tuple(get_args(EffectType))
+_EFFECT_TYPES_STR = ", ".join(_EFFECT_TYPES)
 
 CAUSAL_EXTRACTION_PROMPT = """Extract CAUSAL relationships from the following text.
 
@@ -37,7 +42,7 @@ CRITICAL: Distinguish explicit causality from correlation:
 For each causal relationship, provide:
 - source_name: The cause entity (e.g., "cache_ttl", "request_rate")
 - target_name: The effect entity (e.g., "query_latency", "memory_usage")
-- effect_type: One of CAUSES, ENABLES, PREVENTS, AMPLIFIES, REDUCES, INHIBITS, ACCELERATES, DECELERATES
+- effect_type: One of %%EFFECT_TYPES%%
 - condition: When does this causality hold? (e.g., "when cache is full", "under high load",
   or empty string for unconditional)
 - evidence_text: The exact sentence supporting this causality
@@ -57,7 +62,7 @@ Return empty array [] if no clear causal relationships found.
 
 Text:
 {text}
-"""
+""".replace("%%EFFECT_TYPES%%", _EFFECT_TYPES_STR)
 
 CAUSAL_EXTRACTION_BATCH_PROMPT = """Extract CAUSAL relationships from each of the following text chunks.
 
@@ -67,7 +72,7 @@ CRITICAL: Distinguish explicit causality from correlation:
 
 Each chunk is labeled "Chunk N:". For each causal relationship provide:
 - source_name, target_name
-- effect_type: One of CAUSES, ENABLES, PREVENTS, AMPLIFIES, REDUCES, INHIBITS, ACCELERATES, DECELERATES
+- effect_type: One of %%EFFECT_TYPES%%
 - condition (empty string if unconditional)
 - evidence_text: The exact sentence supporting this causality
 - confidence: 0.9-1.0 explicit, 0.7-0.85 strong inference, reject (<0.7)
@@ -83,7 +88,7 @@ no clear causality. Example for two chunks:
 
 Chunks:
 {chunks}
-"""
+""".replace("%%EFFECT_TYPES%%", _EFFECT_TYPES_STR)
 
 
 # NLP patterns for lightweight causal detection (fallback mode)
@@ -386,16 +391,7 @@ class CausalRelationshipExtractor(BaseCognifier):
                     continue
 
                 effect_type = raw.get("effect_type", "CAUSES")
-                if effect_type not in (
-                    "CAUSES",
-                    "ENABLES",
-                    "PREVENTS",
-                    "AMPLIFIES",
-                    "REDUCES",
-                    "INHIBITS",
-                    "ACCELERATES",
-                    "DECELERATES",
-                ):
+                if effect_type not in _EFFECT_TYPES:
                     effect_type = "CAUSES"
 
                 edge = CausalEdge(

--- a/autobot-backend/knowledge/pipeline/cognifiers/event_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/event_extractor.py
@@ -10,7 +10,7 @@ Issue #759: Knowledge Pipeline Foundation - Extract, Cognify, Load (ECL).
 
 import re
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List
+from typing import Any, Dict, List, get_args
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
@@ -28,6 +28,11 @@ from services.llm_service import get_llm_service
 
 logger = get_logger(__name__)
 
+# Prompt fragments derived from the TemporalType/EventType Literals (#11017) so the
+# prompt can never drift from the type (validation already uses ``__args__``).
+_TEMPORAL_TYPES_STR = ", ".join(get_args(TemporalType))
+_EVENT_TYPES_STR = ", ".join(get_args(EventType))
+
 
 EVENT_EXTRACTION_PROMPT = """Extract temporal events from the text.
 
@@ -35,8 +40,8 @@ For each event:
 - name: Event title
 - description: Brief description
 - temporal_expression: Time phrase (e.g., "yesterday", "2024-01-15")
-- temporal_type: point, range, relative, recurring
-- event_type: action, decision, change, milestone, occurrence
+- temporal_type: One of %%TEMPORAL_TYPES%%
+- event_type: One of %%EVENT_TYPES%%
 - participants: Entity names involved
 - location: Where it happened (if mentioned)
 - confidence: 0.0-1.0
@@ -45,7 +50,7 @@ Return JSON: [{{"name": "...", "description": "...", ...}}, ...]
 
 Text:
 {text}
-"""
+""".replace("%%TEMPORAL_TYPES%%", _TEMPORAL_TYPES_STR).replace("%%EVENT_TYPES%%", _EVENT_TYPES_STR)
 
 EVENT_EXTRACTION_BATCH_PROMPT = """Extract temporal events from each of the following text chunks.
 
@@ -53,8 +58,8 @@ Each chunk is labeled "Chunk N:". For each event provide:
 - name: Event title
 - description: Brief description
 - temporal_expression: Time phrase (e.g., "yesterday", "2024-01-15")
-- temporal_type: point, range, relative, recurring
-- event_type: action, decision, change, milestone, occurrence
+- temporal_type: One of %%TEMPORAL_TYPES%%
+- event_type: One of %%EVENT_TYPES%%
 - participants: Entity names involved
 - location: Where it happened (if mentioned)
 - confidence: 0.0-1.0
@@ -70,7 +75,7 @@ Example for two chunks:
 
 Chunks:
 {chunks}
-"""
+""".replace("%%TEMPORAL_TYPES%%", _TEMPORAL_TYPES_STR).replace("%%EVENT_TYPES%%", _EVENT_TYPES_STR)
 
 
 @TaskRegistry.register_cognifier("extract_events")

--- a/autobot-backend/knowledge/pipeline/cognifiers/fact_batching_test.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/fact_batching_test.py
@@ -123,3 +123,67 @@ async def test_single_chunk_skips_batching():
     assert ext.llm.chat.call_count == 1
     assert len(facts) == 1
     assert facts[0].source_chunk_ids == [c0.id]
+
+
+# ---------------------------------------------------------------------------
+# #11017 — fact_extractor routes through the shared helper: honors config flag,
+# derives allowed types from the FactType Literal, inherits partial-response fix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flag_off_uses_legacy_per_chunk(monkeypatch):
+    """cognifier_multichunk_batching=False → one LLM call PER chunk (no batching)."""
+    import knowledge.pipeline.cognifiers.fact_extractor as fx
+
+    monkeypatch.setattr(fx.config, "cognifier_multichunk_batching", False)
+    c0, c1 = _chunk("c0"), _chunk("c1")
+    ext = _extractor()
+    ext.llm = types.SimpleNamespace(
+        chat=AsyncMock(
+            side_effect=[
+                types.SimpleNamespace(content=json.dumps([_fact("A")])),
+                types.SimpleNamespace(content=json.dumps([_fact("B")])),
+            ]
+        )
+    )
+    facts = await ext._process_batch([c0, c1], _ctx())
+    assert ext.llm.chat.call_count == 2  # per-chunk, not batched
+    assert {f.subject for f in facts} == {"A", "B"}
+
+
+@pytest.mark.asyncio
+async def test_partial_batch_recovers_missing_chunk(monkeypatch):
+    """A batch response missing an index recovers that chunk via per-chunk fallback
+    instead of silently dropping it — inherited from the shared helper (#11012/#11017)."""
+    import knowledge.pipeline.cognifiers.fact_extractor as fx
+
+    monkeypatch.setattr(fx.config, "cognifier_multichunk_batching", True)
+    c0, c1 = _chunk("c0"), _chunk("c1")
+    ext = _extractor()
+    # Batch reply omits index "1"; the per-chunk fallback for c1 returns a fact.
+    ext.llm = types.SimpleNamespace(
+        chat=AsyncMock(
+            side_effect=[
+                types.SimpleNamespace(content=json.dumps({"0": [_fact("A")]})),
+                types.SimpleNamespace(content=json.dumps([_fact("recovered")])),
+            ]
+        )
+    )
+    facts = await ext._process_batch([c0, c1], _ctx())
+    subjects = {f.subject for f in facts}
+    assert "A" in subjects and "recovered" in subjects  # c1 not dropped
+
+
+def test_valid_fact_types_derived_from_literal():
+    """VALID_FACT_TYPES and the prompt fragment come from the FactType Literal (#11017)."""
+    from typing import get_args
+
+    from knowledge.pipeline.cognifiers import fact_extractor as fx
+    from knowledge.pipeline.models.fact import FactType
+
+    expected = set(get_args(FactType))
+    assert set(fx.VALID_FACT_TYPES) == expected
+    for value in expected:
+        assert value in fx.FACT_EXTRACTION_PROMPT
+        assert value in fx.FACT_EXTRACTION_BATCH_PROMPT

--- a/autobot-backend/knowledge/pipeline/cognifiers/fact_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/fact_extractor.py
@@ -11,18 +11,25 @@ as discrete retrievable units alongside full chunks.
 """
 
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, get_args
 from uuid import UUID
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config
 from knowledge.pipeline.base import BaseCognifier, PipelineContext
-from knowledge.pipeline.cognifiers.llm_utils import parse_llm_json_response
+from knowledge.pipeline.cognifiers.llm_utils import batched_chunk_extract, parse_llm_json_response
 from knowledge.pipeline.models.chunk import ProcessedChunk
-from knowledge.pipeline.models.fact import AtomicFact
+from knowledge.pipeline.models.fact import AtomicFact, FactType
 from knowledge.pipeline.registry import TaskRegistry
 from services.llm_service import get_llm_service
 
 logger = get_logger(__name__)
+
+# Single source of truth for the allowed fact-type values (#11017): derived from
+# the ``FactType`` Literal so the prompt fragment and the validation set can never
+# drift from the type. Adding a value to FactType updates both at once.
+_FACT_TYPES = tuple(get_args(FactType))
+_FACT_TYPES_STR = ", ".join(f"'{t}'" for t in _FACT_TYPES)
 
 # Max characters of a chunk sent to the LLM (shared by per-chunk and batched paths).
 MAX_CHUNK_CHARS = 2000
@@ -33,7 +40,7 @@ For each fact, provide:
 - subject: Main subject or entity (e.g., "AutoBot", "ChromaDB")
 - predicate: Relationship or property (e.g., "is", "enables", "has")
 - object: Object entity or value (e.g., "AI platform", "knowledge base")
-- fact_type: One of 'statement', 'relationship', 'property', 'definition', 'rule', 'measurement'
+- fact_type: One of %%FACT_TYPES%%
 - description: Natural language description of the fact
 - context: Supporting context from the text (relevant sentence or phrase)
 - confidence: Score 0.0-1.0 indicating extraction confidence
@@ -51,7 +58,7 @@ Return JSON array of facts:
 
 Text:
 {text}
-"""
+""".replace("%%FACT_TYPES%%", _FACT_TYPES_STR)
 
 # Batched variant (#10647): extract facts from multiple labeled chunks in one
 # call, keyed by chunk index, to cut LLM round-trips.
@@ -59,7 +66,7 @@ FACT_EXTRACTION_BATCH_PROMPT = """Extract atomic facts from each of the followin
 
 Each chunk is labeled "Chunk N:". For each fact provide:
 - subject, predicate, object
-- fact_type: One of 'statement', 'relationship', 'property', 'definition', 'rule', 'measurement'
+- fact_type: One of %%FACT_TYPES%%
 - description, context, confidence (0.0-1.0)
 
 Return a JSON object mapping each chunk index (as a string) to its array of facts
@@ -75,7 +82,7 @@ no facts. Example for two chunks:
 
 Chunks:
 {chunks}
-"""
+""".replace("%%FACT_TYPES%%", _FACT_TYPES_STR)
 
 # NLP-based patterns for fact extraction (Issue #3395)
 # Used when sentence-level parsing can identify simple facts
@@ -104,15 +111,9 @@ NLP_PATTERNS = [
     ),
 ]
 
-# Valid fact types
-VALID_FACT_TYPES = {
-    "statement",
-    "relationship",
-    "property",
-    "definition",
-    "rule",
-    "measurement",
-}
+# Valid fact types — derived from the FactType Literal (#11017) so validation
+# can never drift from the type or the prompt fragment above.
+VALID_FACT_TYPES = frozenset(_FACT_TYPES)
 
 
 @TaskRegistry.register_cognifier("extract_facts")
@@ -246,57 +247,29 @@ class FactExtractor(BaseCognifier):
         return all_facts
 
     async def _process_batch(self, chunks: List[ProcessedChunk], context: PipelineContext) -> List[AtomicFact]:
-        """Extract facts from a batch of chunks in one LLM call (#10647).
+        """Extract facts for a batch in ONE LLM call when batching is on (#10647/#11017).
 
-        Falls back to per-chunk extraction on any structural failure (non-object
-        response, keys that don't match the chunk indices, or an exception);
-        structural correctness never regresses. A valid response that merely
-        omits some chunk keys is logged, not retried. Single-chunk batches skip
-        batching.
+        Routes through the shared ``batched_chunk_extract`` helper (index-keyed
+        prompt, per-*missing*-chunk fallback, batch-scaled ``max_tokens``) instead
+        of a fact-local reimplementation — so fact extraction honors the
+        ``cognifier_multichunk_batching`` / ``cognifier_batch_max_chunk_chars``
+        config like the other extractors and inherits the #11012 partial-response
+        fix. Falls back to the legacy per-chunk loop when the flag is disabled.
         """
-        if not chunks:
-            return []
-        if len(chunks) == 1:
-            return await self._extract_from_chunk(chunks[0], context)
-        try:
-            return await self._extract_batched(chunks, context)
-        except Exception as e:
-            logger.warning("Batched fact extraction failed (%s); falling back to per-chunk", e)
+        if not config.cognifier_multichunk_batching:
             facts: List[AtomicFact] = []
             for chunk in chunks:
                 facts.extend(await self._extract_from_chunk(chunk, context))
             return facts
-
-    async def _extract_batched(self, chunks: List[ProcessedChunk], context: PipelineContext) -> List[AtomicFact]:
-        """Extract facts from multiple chunks in a single LLM call (#10647).
-
-        Raises on a non-object response, or one whose keys are disjoint from the
-        chunk indices, so the caller falls back to per-chunk extraction.
-        """
-        blocks = "\n\n".join(f"Chunk {i}:\n{c.content[:MAX_CHUNK_CHARS]}" for i, c in enumerate(chunks))
-        prompt = FACT_EXTRACTION_BATCH_PROMPT.format(chunks=blocks)
-        response = await self.llm.chat(
-            [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
+        return await batched_chunk_extract(
+            chunks,
+            llm=self.llm,
+            batch_prompt_template=FACT_EXTRACTION_BATCH_PROMPT,
+            llm_type="extraction",
+            max_chunk_chars=config.cognifier_batch_max_chunk_chars,
+            convert=lambda raw, chunk: self._convert_to_facts(raw, chunk, context.document_id),
+            extract_one=lambda chunk: self._extract_from_chunk(chunk, context),
         )
-        parsed = parse_llm_json_response(response.content)
-        if not isinstance(parsed, dict):
-            raise ValueError("batched fact response was not a JSON object")
-        if {str(i) for i in range(len(chunks))}.isdisjoint(parsed.keys()):
-            raise ValueError("batched response keys do not match chunk indices")
-        facts: List[AtomicFact] = []
-        matched = 0
-        for i, chunk in enumerate(chunks):
-            raw = parsed.get(str(i))
-            if raw is None:
-                continue
-            matched += 1
-            if isinstance(raw, dict):  # tolerate a single fact object
-                raw = [raw]
-            if isinstance(raw, list):
-                facts.extend(self._convert_to_facts(raw, chunk, context.document_id))
-        if matched < len(chunks):
-            logger.debug("Batched fact extraction matched %d/%d chunks", matched, len(chunks))
-        return facts
 
     async def _extract_from_chunk(self, chunk: ProcessedChunk, context: PipelineContext) -> List[AtomicFact]:
         """Extract facts from a single chunk using LLM.

--- a/autobot-backend/knowledge/pipeline/cognifiers/literal_derivation_test.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/literal_derivation_test.py
@@ -1,0 +1,47 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11017 — extractor prompt fragments + validation are derived from their model
+Literal types, so allowed values can never drift from the type."""
+
+from typing import get_args
+
+
+def test_causal_effect_types_derived_from_literal():
+    from knowledge.pipeline.cognifiers import causal_relationship_extractor as c
+    from knowledge.pipeline.models.causal_edge import EffectType
+
+    expected = set(get_args(EffectType))
+    assert set(c._EFFECT_TYPES) == expected
+    for value in expected:
+        assert value in c.CAUSAL_EXTRACTION_PROMPT
+        assert value in c.CAUSAL_EXTRACTION_BATCH_PROMPT
+
+
+def test_event_types_derived_from_literals():
+    from knowledge.pipeline.cognifiers import event_extractor as e
+    from knowledge.pipeline.models.event import EventType, TemporalType
+
+    for value in get_args(TemporalType):
+        assert value in e.EVENT_EXTRACTION_PROMPT
+        assert value in e.EVENT_EXTRACTION_BATCH_PROMPT
+    for value in get_args(EventType):
+        assert value in e.EVENT_EXTRACTION_PROMPT
+        assert value in e.EVENT_EXTRACTION_BATCH_PROMPT
+
+
+def test_no_sentinel_placeholders_leak_into_prompts():
+    from knowledge.pipeline.cognifiers import causal_relationship_extractor as c
+    from knowledge.pipeline.cognifiers import event_extractor as e
+    from knowledge.pipeline.cognifiers import fact_extractor as f
+
+    for prompt in (
+        f.FACT_EXTRACTION_PROMPT,
+        f.FACT_EXTRACTION_BATCH_PROMPT,
+        c.CAUSAL_EXTRACTION_PROMPT,
+        c.CAUSAL_EXTRACTION_BATCH_PROMPT,
+        e.EVENT_EXTRACTION_PROMPT,
+        e.EVENT_EXTRACTION_BATCH_PROMPT,
+    ):
+        assert "%%" not in prompt


### PR DESCRIPTION
## Thinking Path
Post-merge consolidation audit (#11017). Two cleanups in `knowledge/pipeline/cognifiers/`:

**RANK 1 — fact_extractor forked the shared helper (dedup + latent bug + flag drift).**
`FactExtractor._extract_batched` hand-reimplemented `llm_utils.batched_chunk_extract`, so it (a) duplicated ~30 lines, (b) ignored `cognifier_multichunk_batching`/`cognifier_batch_max_chunk_chars` that entity/event/causal honor, and (c) **still had the silent-data-loss bug** (`if raw is None: continue` drops missing chunks) that #11012 fixed only in the shared helper. Routed `_process_batch` through `batched_chunk_extract` and deleted `_extract_batched` — fact now honors the flags and inherits the per-missing-chunk fallback + batch-scaled `max_tokens`.

**RANK 4 — extractor allowed-value lists duplicated their model `Literal` types (drift risk).**
`fact_type` / `effect_type` / `temporal_type` / `event_type` were authored twice — once as the `Literal` that validates the parsed object, once as free text in the prompt (and, for fact + causal, a third time as a hardcoded validation set). Derived all of them from the Literal via `get_args(...)`: `VALID_FACT_TYPES` and the causal validation tuple now come from the type, and every prompt fragment is interpolated from it. Adding a value to a Literal now updates the type, validation, and prompt together — no silent capability loss.

Kept `Literal` as the SoT (no new Enums), per the repo rule.

## Verification
152 passed / 2 skipped. New tests: fact flag-off legacy path, fact partial-batch recovery (bug now fixed for fact), and Literal-derivation for fact/causal/event prompts + no sentinel leakage. Existing fact/causal/event batching suites pass unchanged (behavior-compatible). Black + flake8 (incl E402/F401) clean.

RANK 2 (batch the entity-conditioned relationship_extractor — needs a helper extension) split to **#11044**.

Closes #11017

## Model Used
Opus 4.8