### PR TITLE
fix(frontend): replace no-explicit-any in chat/knowledge/host-dialog/browser (#9924 batch 14)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatInput.vue
+++ b/autobot-frontend/src/components/chat/ChatInput.vue
@@ -466,6 +466,30 @@ import { useImageGeneration } from '@/composables/useImageGeneration'
 import { useThinkingMode, BUDGET_STEPS, BUDGET_STEP_LABELS } from '@/composables/useThinkingMode'
 import { usePreferences } from '@/composables/usePreferences'
 
+// Minimal Web Speech API event shapes (not in TS lib.dom): only the fields this
+// component reads. SpeechRecognitionResult / *Alternative come from lib.dom.
+interface SpeechRecognitionResultEvent {
+  results: SpeechRecognitionResultList
+}
+interface SpeechRecognitionErrorEventLike {
+  error: string
+}
+
+// Upload tracking item shared by handleFileSelect / retryUpload / uploadFile.
+interface UploadItem {
+  id: string
+  filename: string
+  progress: number
+  status: string
+  current: number
+  total: number
+  eta?: number
+  error?: string
+  file?: File
+  fileId?: string
+  uploadId?: string
+}
+
 const { t } = useI18n()
 const logger = createLogger('ChatInput')
 // Issue #1146: unlock AudioContext on first user gesture so TTS can play even
@@ -882,9 +906,9 @@ const startVoiceRecording = async () => {
     logger.debug('Voice recognition started')
   }
 
-  _recognition.onresult = (event: any) => {
-    const transcript = Array.from(event.results as any[])
-      .map((r: any) => r[0].transcript as string)
+  _recognition.onresult = (event: SpeechRecognitionResultEvent) => {
+    const transcript = Array.from(event.results as unknown as SpeechRecognitionResult[])
+      .map((r: SpeechRecognitionResult) => r[0].transcript as string)
       .join('')
     messageText.value = transcript
   }
@@ -895,7 +919,7 @@ const startVoiceRecording = async () => {
     logger.debug('Voice recognition ended')
   }
 
-  _recognition.onerror = (event: any) => {
+  _recognition.onerror = (event: SpeechRecognitionErrorEventLike) => {
     logger.error('Voice recognition error:', event.error)
     isVoiceRecording.value = false
     _recognition = null
@@ -1028,7 +1052,7 @@ const generateId = (): string => {
 }
 
 // Real file upload implementation
-const uploadFile = async (upload: any, file: File): Promise<void> => {
+const uploadFile = async (upload: UploadItem, file: File): Promise<void> => {
   const formData = new FormData()
   formData.append('file', file)
 

--- a/autobot-frontend/src/components/chat/ChatSidebar.vue
+++ b/autobot-frontend/src/components/chat/ChatSidebar.vue
@@ -600,7 +600,7 @@ const deleteSession = async (sessionId: string) => {
   const [fileStatsResult, kbFactsResult] = await Promise.allSettled([
     // Fetch file stats
     (async () => {
-      const data = await ApiClient.get<any>(`${getApiBase()}/conversation-files/conversation/${sessionId}/list`)
+      const data = await ApiClient.get<{ stats?: FileStats }>(`${getApiBase()}/conversation-files/conversation/${sessionId}/list`)
       return data?.stats || null
     })(),
     // Fetch KB facts (Issue #547)
@@ -636,7 +636,7 @@ const deleteCurrentSession = () => {
   }
 }
 
-const handleDeleteConfirm = async (fileAction: string, fileOptions: any, selectedFactIds: string[] = []) => {
+const handleDeleteConfirm = async (fileAction: string, fileOptions: Record<string, unknown>, selectedFactIds: string[] = []) => {
   if (!deleteTargetSessionId.value) return
   const sessionId = deleteTargetSessionId.value
 
@@ -658,7 +658,7 @@ const handleDeleteConfirm = async (fileAction: string, fileOptions: any, selecte
     }
 
     // Delete the session
-    await controller.deleteChatSession(sessionId, fileAction as any, fileOptions)
+    await controller.deleteChatSession(sessionId, fileAction as 'delete' | 'transfer_kb' | 'transfer_shared', fileOptions)
 
     // Issue #547: Show toast with KB cleanup results
     const totalFacts = deleteKBFacts.value?.length || 0
@@ -713,8 +713,8 @@ const reloadSystem = async () => {
 
   try {
     // Call real system reload API
-    const response = await ApiClient.post<any>(`${getApiBase()}/system/reload_config`)
-    const data = await (response as any).json()
+    const response = await ApiClient.post<unknown>(`${getApiBase()}/system/reload_config`)
+    const data = await (response as { json: () => Promise<Record<string, unknown>> }).json()
 
     if (data && data.success) {
       systemStatus.value = t('status.ready')

--- a/autobot-frontend/src/components/knowledge/KnowledgeStats.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeStats.vue
@@ -385,6 +385,7 @@ import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useKnowledgeStore } from '@/stores/useKnowledgeStore'
+import type { KnowledgeDocument } from '@/stores/useKnowledgeStore'
 import { useKnowledgeController } from '@/models/controllers/index'
 // ManPageManager removed - consolidated to Manage → Advanced (Issue #678)
 import DocumentChangeFeed from '@/components/knowledge/DocumentChangeFeed.vue'
@@ -438,7 +439,7 @@ interface Activity {
 
 interface KnowledgeController {
   refreshStats: () => Promise<void>
-  getDetailedStats: () => Promise<Record<string, any>>
+  getDetailedStats: () => Promise<DetailedStats>
   cleanupKnowledgeBase: () => Promise<void>
   reindexKnowledgeBase: () => Promise<void>
 }
@@ -452,7 +453,7 @@ const store = useKnowledgeStore()
 // Defensive controller initialization
 let controller: KnowledgeController | null = null
 try {
-  controller = useKnowledgeController() as any
+  controller = useKnowledgeController() as unknown as KnowledgeController
   logger.info('Knowledge controller initialized:', controller)
 } catch (error) {
   logger.error('Failed to initialize knowledge controller:', error)
@@ -527,7 +528,7 @@ const maxCategoryCount = computed(() => {
 const documentsByType = computed(() => {
   const types: Record<string, number> = {}
   const documents = store.documents || []
-  documents.forEach((doc: any) => {
+  documents.forEach((doc: KnowledgeDocument) => {
     types[doc.type] = (types[doc.type] || 0) + 1
   })
   return types
@@ -537,7 +538,7 @@ const popularTags = computed(() => {
   const tagCounts: Record<string, number> = {}
 
   const documents = store.documents || []
-  documents.forEach((doc: any) => {
+  documents.forEach((doc: KnowledgeDocument) => {
     const tags = doc.tags || []
     tags.forEach((tag: string) => {
       tagCounts[tag] = (tagCounts[tag] || 0) + 1
@@ -780,7 +781,7 @@ const refreshVectorStats = async () => {
       index_name: storeStats.index_name || 'unknown',
       last_updated: storeStats.last_updated || undefined,
       categories: Array.isArray(storeStats.categories)
-        ? storeStats.categories.map((c: any) => c.name || c)
+        ? (storeStats.categories as unknown as { name?: string }[]).map((c) => c.name || c) as string[]
         : [],
       embedding_model: 'nomic-embed-text',  // From detailed stats
       embedding_dimensions: 768  // From detailed stats

--- a/autobot-frontend/src/components/knowledge/WebResearchSettings.vue
+++ b/autobot-frontend/src/components/knowledge/WebResearchSettings.vue
@@ -464,7 +464,7 @@ async function fetchStatus(): Promise<void> {
   store.setLoading(true)
   store.clearError()
   try {
-    const data = await ApiClient.get<any>(`${getApiBase()}/web-research-settings/web-research/status`) as Record<string, unknown>
+    const data = await ApiClient.get<Record<string, unknown>>(`${getApiBase()}/web-research-settings/web-research/status`) as Record<string, unknown>
     store.updateStatus({
       enabled: Boolean(data.enabled),
       preferred_method: String(data.preferred_method ?? store.status.preferred_method),
@@ -486,7 +486,7 @@ async function handleToggle(): Promise<void> {
   store.clearError()
   const endpoint = store.settings.enabled ? '/web-research-settings/web-research/disable' : '/web-research-settings/web-research/enable'
   try {
-    await ApiClient.post<any>(`${getApiBase()}${endpoint}`, {})
+    await ApiClient.post<unknown>(`${getApiBase()}${endpoint}`, {})
     store.toggleWebResearch()
     store.updateStatus({ enabled: store.settings.enabled })
     logger.info('Web research toggled:', store.settings.enabled ? 'enabled' : 'disabled')
@@ -504,7 +504,7 @@ async function saveSettings(): Promise<void> {
   saveSuccess.value = false
   store.clearError()
   try {
-    await ApiClient.put<any>(`${getApiBase()}/web-research-settings/web-research/settings`, {
+    await ApiClient.put<unknown>(`${getApiBase()}/web-research-settings/web-research/settings`, {
       enabled: store.settings.enabled,
       require_user_confirmation: store.settings.require_user_confirmation,
       preferred_method: store.settings.preferred_method,
@@ -533,7 +533,7 @@ async function clearCache(): Promise<void> {
   isClearingCache.value = true
   store.clearError()
   try {
-    await ApiClient.post<any>(`${getApiBase()}/web-research-settings/web-research/clear-cache`, {})
+    await ApiClient.post<unknown>(`${getApiBase()}/web-research-settings/web-research/clear-cache`, {})
     store.updateStatus({ cache_stats: { cache_size: 0, rate_limiter: store.status.cache_stats?.rate_limiter } })
     logger.info('Web research cache cleared')
   } catch (err: unknown) {
@@ -549,7 +549,7 @@ async function resetCircuitBreakers(): Promise<void> {
   isResettingBreakers.value = true
   store.clearError()
   try {
-    await ApiClient.post<any>(`${getApiBase()}/web-research-settings/web-research/reset-circuit-breakers`, {})
+    await ApiClient.post<unknown>(`${getApiBase()}/web-research-settings/web-research/reset-circuit-breakers`, {})
     store.updateStatus({ circuit_breakers: null })
     logger.info('Web research circuit breakers reset')
   } catch (err: unknown) {

--- a/autobot-frontend/src/components/ui/HostSelectionDialog.vue
+++ b/autobot-frontend/src/components/ui/HostSelectionDialog.vue
@@ -208,8 +208,41 @@ interface InfrastructureHost {
   capabilities?: string[];
   purpose?: string;
   os?: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
   _isLegacyHost?: boolean;
+}
+
+// Minimal shapes for raw secrets / legacy hosts returned by the backend APIs,
+// mapped into InfrastructureHost in loadHosts().
+interface RawSecretMetadata {
+  host?: string;
+  ssh_port?: number;
+  username?: string;
+  auth_type?: 'ssh_key' | 'password';
+  capabilities?: string[];
+  purpose?: string;
+  os?: string;
+}
+
+interface RawSecret {
+  id: string;
+  name: string;
+  type?: string;
+  description?: string;
+  metadata?: RawSecretMetadata;
+}
+
+interface RawLegacyHost {
+  id: string;
+  name: string;
+  host: string;
+  ssh_port?: number;
+  username?: string;
+  auth_type?: 'ssh_key' | 'password';
+  capabilities?: string[];
+  purpose?: string;
+  description?: string;
+  os?: string;
 }
 
 // Props
@@ -272,7 +305,7 @@ const loadHosts = async () => {
 
     // Fetch both secrets (infrastructure_host type) and legacy hosts
     const [secretsResponse, legacyHostsResponse] = await Promise.all([
-      secretsApiClient.getSecrets({}) as Promise<Record<string, any>>,
+      secretsApiClient.getSecrets({}) as Promise<{ secrets?: RawSecret[] }>,
       fetchWithAuth(`${backendUrl}/api/infrastructure/hosts`)
         .then(r => r.ok ? r.json() : { hosts: [] })
         .catch(() => ({ hosts: [] }))
@@ -280,8 +313,8 @@ const loadHosts = async () => {
 
     // Filter to infrastructure_host type secrets
     const infraSecrets = (secretsResponse.secrets || [])
-      .filter((s: any) => s.type === 'infrastructure_host')
-      .map((s: any) => ({
+      .filter((s: RawSecret) => s.type === 'infrastructure_host')
+      .map((s: RawSecret) => ({
         id: s.id,
         name: s.name,
         host: s.metadata?.host || '',
@@ -296,7 +329,7 @@ const loadHosts = async () => {
       }));
 
     // Convert legacy hosts
-    const legacyHosts = (legacyHostsResponse.hosts || []).map((h: any) => ({
+    const legacyHosts = (legacyHostsResponse.hosts || []).map((h: RawLegacyHost) => ({
       id: h.id,
       name: h.name,
       host: h.host,

--- a/autobot-frontend/src/composables/useBrowserAutomation.ts
+++ b/autobot-frontend/src/composables/useBrowserAutomation.ts
@@ -115,7 +115,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
   async function closeSession(sessionId: string): Promise<boolean> {
     error.value = null
     return wrap(async () => {
-      await ApiClient.post<any>(`${getApiBase()}/browser/close`, { session_id: sessionId })
+      await ApiClient.post<unknown>(`${getApiBase()}/browser/close`, { session_id: sessionId })
       sessions.value = sessions.value.filter(s => s.id !== sessionId)
       if (currentSession.value?.id === sessionId) {
         currentSession.value = null
@@ -159,7 +159,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
   async function navigate(sessionId: string, url: string): Promise<boolean> {
     error.value = null
     return wrap(async () => {
-      await ApiClient.post<any>(`${getApiBase()}/browser/navigate`, { session_id: sessionId, url })
+      await ApiClient.post<unknown>(`${getApiBase()}/browser/navigate`, { session_id: sessionId, url })
       logger.debug('Navigated to:', url)
       await fetchSessions()
       return true
@@ -174,7 +174,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
   async function click(sessionId: string, selector: string): Promise<boolean> {
     error.value = null
     return wrap(async () => {
-      await ApiClient.post<any>(`${getApiBase()}/browser/click`, { session_id: sessionId, selector })
+      await ApiClient.post<unknown>(`${getApiBase()}/browser/click`, { session_id: sessionId, selector })
       logger.debug('Clicked element:', selector)
       return true
     }).catch((err) => {
@@ -188,7 +188,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
   async function type(sessionId: string, selector: string, text: string): Promise<boolean> {
     error.value = null
     return wrap(async () => {
-      await ApiClient.post<any>(`${getApiBase()}/browser/type`, { session_id: sessionId, selector, text })
+      await ApiClient.post<unknown>(`${getApiBase()}/browser/type`, { session_id: sessionId, selector, text })
       logger.debug('Typed text into:', selector)
       return true
     }).catch((err) => {
@@ -245,7 +245,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
   async function deleteSession(sessionId: string): Promise<boolean> {
     error.value = null
     return wrap(async () => {
-      await ApiClient.delete<any>(`${getApiBase()}/browser/session/${sessionId}`)
+      await ApiClient.delete<unknown>(`${getApiBase()}/browser/session/${sessionId}`)
       sessions.value = sessions.value.filter(s => s.id !== sessionId)
       logger.debug('Deleted session:', sessionId)
       return true


### PR DESCRIPTION
## Thinking Path
#9924 grind — ChatInput.vue, ChatSidebar.vue, KnowledgeStats.vue, WebResearchSettings.vue, HostSelectionDialog.vue, useBrowserAutomation.ts (5 each). Strictly type-only.

## What Changed — 30 `any` removed
- Reused domain types (`FileStats`, `KnowledgeDocument`, literal unions); minimal new types where none existed (`UploadItem`, Web-Speech `SpeechRecognitionResultEvent`/`ErrorEventLike`, `RawSecret`/`RawLegacyHost`).
- `ApiClient.*<any>` → concrete or `<unknown>` (discarded results); `catch`/cast faithful pass-throughs.

## Scope note
2 pre-existing `eslint-disable`d anys in ChatInput.vue (879/883, Web Speech constructor not in lib.dom) left untouched — already suppressed, not flagged.

## Verification (independently re-run)
- `eslint` → 0 `no-explicit-any`, exit 0.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0.
- `vitest` → 46/46 (5 suites).
- Diff-scan for runtime coercions → none.

## Model Used
Opus 4.8

Contributes to #9924 (239→209 remaining no-explicit-any).