### PR TITLE
fix(codegen): parenthesize union members inside arrays (List[X|None]) + render bare containers (#11020)

### DIFF
--- a/autobot-infrastructure/shared/scripts/gen_frontend_types.py
+++ b/autobot-infrastructure/shared/scripts/gen_frontend_types.py
@@ -47,7 +47,7 @@ import types
 import typing
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple, Union, get_args, get_origin
+from typing import Any, Dict, List, Set, Tuple, Union, get_args, get_origin
 
 # PEP 604 `X | Y` unions have origin ``types.UnionType`` (py3.10+), which is a
 # distinct object from ``typing.Union``. ``get_type_hints`` may return either
@@ -56,9 +56,16 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union, get_args, get_o
 _UNION_ORIGINS = (Union, getattr(types, "UnionType", Union))
 
 
+def _ts_array(inner: str) -> str:
+    """Render ``inner[]`` but parenthesize a union member so ``X | null`` becomes
+    ``(X | null)[]`` — otherwise TS parses ``X | null[]`` as ``X | (null[])`` (#11020)."""
+    return f"({inner})[]" if "|" in inner else f"{inner}[]"
+
+
 def _is_optional(annotation: object) -> bool:
     """True when *annotation* is a union that admits ``None`` (Optional[...])."""
     return get_origin(annotation) in _UNION_ORIGINS and type(None) in get_args(annotation)
+
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 OUTPUT_PATH = REPO_ROOT / "autobot-frontend" / "src" / "types" / "_generated" / "workflow.ts"
@@ -203,7 +210,7 @@ def _ts_type(py_type: Any, known_names: Set[str]) -> str:
 
     if origin in (list, List):
         inner = _ts_type(args[0], known_names) if args else "unknown"
-        return f"{inner}[]"
+        return _ts_array(inner)
 
     if origin in (dict, Dict):
         if not args:
@@ -215,7 +222,7 @@ def _ts_type(py_type: Any, known_names: Set[str]) -> str:
 
     if origin in (set, Set, frozenset):
         inner = _ts_type(args[0], known_names) if args else "unknown"
-        return f"{inner}[]"
+        return _ts_array(inner)
 
     if origin is tuple:
         inner = ", ".join(_ts_type(a, known_names) for a in args) if args else "unknown"
@@ -223,6 +230,16 @@ def _ts_type(py_type: Any, known_names: Set[str]) -> str:
 
     if py_type is Any:
         return "unknown"
+
+    # Bare (unsubscripted) containers — no origin/args but a real type. Render the
+    # collection shape rather than falling through to "unknown" (#11020), so
+    # ``Optional[dict]`` becomes ``Record<string, unknown> | null`` etc.
+    if py_type is dict:
+        return "Record<string, unknown>"
+    if py_type in (list, set, frozenset):
+        return "unknown[]"
+    if py_type is tuple:
+        return "unknown[]"
 
     # Last resort — emit the type name and let TypeScript flag it
     name = getattr(py_type, "__name__", None) or repr(py_type)

--- a/repo_tests/gen_frontend_types_test.py
+++ b/repo_tests/gen_frontend_types_test.py
@@ -1,0 +1,46 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11020 — gen_frontend_types._ts_type must parenthesize union members inside an
+array (`List[X | None]` → `(X | null)[]`, not `X | null[]`) and render bare
+containers instead of `unknown`."""
+
+import importlib.util
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+import pytest
+
+_GEN = Path(__file__).resolve().parents[1] / "autobot-infrastructure" / "shared" / "scripts" / "gen_frontend_types.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("gen_frontend_types", _GEN)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.parametrize(
+    "annotation,expected",
+    [
+        (List[Optional[int]], "(number | null)[]"),
+        (List[str | None], "(string | null)[]"),
+        (Set[str | None], "(string | null)[]"),
+        (List[str], "string[]"),  # non-union inner stays unparenthesized
+        (Optional[List[str]], "string[] | null"),
+        (Optional[dict], "Record<string, unknown> | null"),
+        (Optional[list], "unknown[] | null"),
+        (Dict[str, int], "Record<string, number>"),
+    ],
+)
+def test_ts_type_array_and_bare_container_rendering(annotation, expected):
+    mod = _load()
+    assert mod._ts_type(annotation, set()) == expected
+
+
+def test_ts_array_parenthesizes_only_unions():
+    mod = _load()
+    assert mod._ts_array("string") == "string[]"
+    assert mod._ts_array("string | null") == "(string | null)[]"


### PR DESCRIPTION
## Thinking Path
Post-merge audit landmine (found during #10981). `gen_frontend_types._ts_type` rendered `List[X | None]` as `X | null[]`, which TypeScript parses as `X | (null[])` instead of `(X | null)[]`. No current source dataclass has a `List[X | None]` field (so `workflow.ts` is unchanged), but it's a silent correctness trap for any future one.

## What Changed
- New `_ts_array(inner)` helper parenthesizes a union member before `[]`: `(X | null)[]`. Used by the `list`/`set`/`frozenset` branches. Non-union inners (`string[]`) are untouched.
- Bare (unsubscripted) containers now render their shape instead of falling through to `unknown`: `Optional[dict]` → `Record<string, unknown> | null`, `Optional[list]` → `unknown[] | null` (the separate pre-existing gap the audit noted).

## Verification
9 new tests in `repo_tests/gen_frontend_types_test.py` (a testpath dir, so CI runs it): union-in-array parenthesization for List/Set, non-union stays bare, bare dict/list, nested optional. `workflow.ts` regenerates with **zero diff** — purely defensive, drift check stays green. Black + flake8 clean.

Closes #11020

## Model Used
Opus 4.8