### PR TITLE
fix(frontend): replace no-explicit-any in knowledge/mocks/SharedChatView (#9924 batch 15)

### DIFF
--- a/autobot-frontend/src/components/knowledge/ChromaDBExplorer.vue
+++ b/autobot-frontend/src/components/knowledge/ChromaDBExplorer.vue
@@ -249,20 +249,20 @@ const apiClient = useApiClient()
 interface CollectionMetadata {
   name: string
   count: number
-  metadata: Record<string, any> | null
+  metadata: Record<string, unknown> | null
 }
 
 interface DocumentItem {
   id: string
   document: string | null
-  metadata: Record<string, any> | null
+  metadata: Record<string, unknown> | null
   embedding_dim: number | null
 }
 
 interface SearchResultItem {
   id: string
   document: string | null
-  metadata: Record<string, any> | null
+  metadata: Record<string, unknown> | null
   distance: number | null
 }
 
@@ -329,7 +329,7 @@ async function loadDocuments() {
       data: {
         ids: string[]
         documents: (string | null)[]
-        metadatas: (Record<string, any> | null)[]
+        metadatas: (Record<string, unknown> | null)[]
         embedding_dim: number | null
       }
       total: number

--- a/autobot-frontend/src/components/knowledge/KnowledgeSearch.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeSearch.vue
@@ -295,6 +295,13 @@ const ragOptions = ref({
   limit: 10
 })
 
+// Issue #685: documents may carry access-level fields not present on the base
+// KnowledgeDocument type (populated by the backend for hierarchical filtering).
+interface AccessLevelDoc {
+  access_level?: string
+  metadata?: { access_level?: string }
+}
+
 // Issue #4035: Debounce filter changes to avoid excessive re-searches
 const { debouncedFn: debouncedCategoryChange } = useDebouncedFn(
   async () => {
@@ -389,8 +396,8 @@ const handleSearch = async () => {
           // Issue #685: Filter by access level client-side
           if (selectedAccessLevel.value) {
             results = results.filter(r => {
-              const docAccessLevel = (r.document as any)?.access_level
-              const metaAccessLevel = (r.document as any)?.metadata?.access_level
+              const docAccessLevel = (r.document as AccessLevelDoc)?.access_level
+              const metaAccessLevel = (r.document as AccessLevelDoc)?.metadata?.access_level
               return docAccessLevel === selectedAccessLevel.value || metaAccessLevel === selectedAccessLevel.value
             })
           }
@@ -422,8 +429,8 @@ const handleSearch = async () => {
       // Issue #685: Filter by access level client-side
       if (selectedAccessLevel.value) {
         results = results.filter(r => {
-          const docAccessLevel = (r.document as any)?.access_level
-          const metaAccessLevel = (r.document as any)?.metadata?.access_level
+          const docAccessLevel = (r.document as AccessLevelDoc)?.access_level
+          const metaAccessLevel = (r.document as AccessLevelDoc)?.metadata?.access_level
           return docAccessLevel === selectedAccessLevel.value || metaAccessLevel === selectedAccessLevel.value
         })
       }

--- a/autobot-frontend/src/components/knowledge/__tests__/KnowledgeUpload.spec.ts
+++ b/autobot-frontend/src/components/knowledge/__tests__/KnowledgeUpload.spec.ts
@@ -25,7 +25,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
 import { nextTick } from 'vue'
 
@@ -112,10 +112,10 @@ function applyMocks(
   controllerMock: ReturnType<typeof makeControllerMock>,
   progressMock: ReturnType<typeof makeUploadProgressMock>
 ) {
-  vi.mocked(useI18n).mockReturnValue({ t: stubT } as any)
-  vi.mocked(useKnowledgeController).mockReturnValue(controllerMock as any)
-  vi.mocked(useUploadProgress).mockReturnValue(progressMock as any)
-  vi.mocked(useKnowledgeIcons).mockReturnValue(makeKnowledgeBaseMock() as any)
+  vi.mocked(useI18n).mockReturnValue({ t: stubT } as unknown as ReturnType<typeof useI18n>)
+  vi.mocked(useKnowledgeController).mockReturnValue(controllerMock as unknown as ReturnType<typeof useKnowledgeController>)
+  vi.mocked(useUploadProgress).mockReturnValue(progressMock as unknown as ReturnType<typeof useUploadProgress>)
+  vi.mocked(useKnowledgeIcons).mockReturnValue(makeKnowledgeBaseMock() as unknown as ReturnType<typeof useKnowledgeIcons>)
 }
 
 // ── Mount helper ─────────────────────────────────────────────────────────────
@@ -170,7 +170,7 @@ function makeFile(name: string, sizeBytes: number, mimeType = 'text/plain'): Fil
  * element in subsequent calls within the same test (e.g. duplicate-detection
  * test calls selectFiles twice on the same wrapper).
  */
-async function selectFiles(wrapper: any, files: File[]) {
+async function selectFiles(wrapper: VueWrapper, files: File[]) {
   const fileInput = wrapper.find('input[type="file"][accept]')
   Object.defineProperty(fileInput.element, 'files', {
     value: files,

--- a/autobot-frontend/src/test/mocks/api-client-mock.ts
+++ b/autobot-frontend/src/test/mocks/api-client-mock.ts
@@ -21,7 +21,7 @@ export class MockApiClient {
   }
 
   // Helper methods to configure mock responses
-  mockGet(endpoint: string, response: any) {
+  mockGet(endpoint: string, response: unknown) {
     this.get.mockImplementation((url: string) => {
       if (url === endpoint) {
         return Promise.resolve({
@@ -34,7 +34,7 @@ export class MockApiClient {
     })
   }
 
-  mockPost(endpoint: string, response: any) {
+  mockPost(endpoint: string, response: unknown) {
     this.post.mockImplementation((url: string) => {
       if (url === endpoint) {
         return Promise.resolve({
@@ -118,12 +118,12 @@ export const createMockApiService = () => {
       return await response.json()
     },
 
-    async post(endpoint: string, data?: any) {
+    async post(endpoint: string, data?: unknown) {
       const response = await mockClient.post(endpoint, data)
       return await response.json()
     },
 
-    async put(endpoint: string, data?: any) {
+    async put(endpoint: string, data?: unknown) {
       const response = await mockClient.put(endpoint, data)
       return await response.json()
     },
@@ -164,7 +164,7 @@ export const createMockApiService = () => {
       return this.get('/api/settings')
     },
 
-    async saveSettings(settings: any) {
+    async saveSettings(settings: unknown) {
       return this.post('/api/settings', settings)
     },
 

--- a/autobot-frontend/src/test/mocks/websocket-mock.ts
+++ b/autobot-frontend/src/test/mocks/websocket-mock.ts
@@ -39,7 +39,7 @@ export class MockWebSocket {
   }
 
   // Helper methods for testing
-  public simulateMessage(data: any) {
+  public simulateMessage(data: unknown) {
     if (this.readyState === MockWebSocket.OPEN && this.onmessage) {
       const event = new MessageEvent('message', {
         data: typeof data === 'string' ? data : JSON.stringify(data),
@@ -51,7 +51,7 @@ export class MockWebSocket {
   public simulateError(error?: string) {
     if (this.onerror) {
       const event = new Event('error')
-      ;(event as any).error = error || 'Mock WebSocket error'
+      ;(event as Event & { error?: string }).error = error || 'Mock WebSocket error'
       this.onerror(event)
     }
   }
@@ -132,7 +132,7 @@ export const createMockTerminalOutput = (output: string, command?: string) =>
     timestamp: Date.now(),
   })
 
-export const createMockSystemStatus = (status: string, details?: any) =>
+export const createMockSystemStatus = (status: string, details?: unknown) =>
   createMockWebSocketEvent(WebSocketMessageType.SYSTEM_STATUS, {
     status,
     details,
@@ -163,7 +163,7 @@ export class WebSocketTestUtil {
     return this.mockWs || MockWebSocket.getLatestInstance() || null
   }
 
-  simulateMessage(type: string, data: any) {
+  simulateMessage(type: string, data: unknown) {
     const ws = this.getConnection()
     if (ws) {
       ws.simulateMessage(createMockWebSocketEvent(type, data))
@@ -242,7 +242,7 @@ export class WebSocketTestUtil {
     }
   }
 
-  expectMessageSent(expectedData?: any) {
+  expectMessageSent(expectedData?: unknown) {
     const ws = this.getConnection()
     expect(ws?.send).toHaveBeenCalled()
 

--- a/autobot-frontend/src/views/SharedChatView.vue
+++ b/autobot-frontend/src/views/SharedChatView.vue
@@ -100,6 +100,16 @@ interface Message {
   created_at?: string | null
 }
 
+interface SharedChatPayload {
+  has_password?: boolean
+  messages?: Message[]
+}
+
+interface HttpErrorLike {
+  response?: { status?: number }
+  status?: number
+}
+
 const loading = ref(true)
 const error = ref('')
 const needsPassword = ref(false)
@@ -111,7 +121,7 @@ const messages = ref<Message[]>([])
 const token = route.params.token as string
 
 const handleResponse = (data: Record<string, unknown>) => {
-  const payload = (data as any)?.data ?? data
+  const payload = ((data as { data?: SharedChatPayload }).data ?? data) as SharedChatPayload
   if (payload?.has_password && (!payload.messages || payload.messages.length === 0)) {
     needsPassword.value = true
     return
@@ -122,10 +132,11 @@ const handleResponse = (data: Record<string, unknown>) => {
 
 onMounted(async () => {
   try {
-    const result = await ApiClient.get<any>(`${getApiBase()}/chat/shared/${token}`)
+    const result = await ApiClient.get<Record<string, unknown>>(`${getApiBase()}/chat/shared/${token}`)
     handleResponse(result)
-  } catch (err: any) {
-    const status = err?.response?.status ?? err?.status
+  } catch (err) {
+    const e = err as HttpErrorLike
+    const status = e?.response?.status ?? e?.status
     if (status === 404) {
       error.value = t('chat.share.linkNotFound')
     } else if (status === 410) {
@@ -144,12 +155,13 @@ const submitPassword = async () => {
   unlocking.value = true
   passwordError.value = ''
   try {
-    const result = await ApiClient.post<any>(`${getApiBase()}/chat/shared/${token}/access`, {
+    const result = await ApiClient.post<Record<string, unknown>>(`${getApiBase()}/chat/shared/${token}/access`, {
       password: passwordInput.value.trim(),
     })
     handleResponse(result)
-  } catch (err: any) {
-    const status = err?.response?.status ?? err?.status
+  } catch (err) {
+    const e = err as HttpErrorLike
+    const status = e?.response?.status ?? e?.status
     if (status === 401) {
       passwordError.value = t('chat.share.wrongPassword')
     } else {


### PR DESCRIPTION
## Thinking Path
#9924 grind — KnowledgeUpload.spec, api-client-mock, websocket-mock, SharedChatView.vue, ChromaDBExplorer.vue, KnowledgeSearch.vue. Strictly type-only.

## What Changed — 28 `any` removed
- Test mocks → `unknown`; `vi.mocked().mockReturnValue(x as unknown as ReturnType<...>)`.
- SharedChatView: typed cast (pre-existing `?? data` preserved), `catch(err)` + `err as HttpErrorLike`; new `SharedChatPayload`/`HttpErrorLike`.
- Knowledge components: `Record<string,unknown>`, minimal `AccessLevelDoc` cast.

## Verification (independently re-run)
- `eslint` → 0 `no-explicit-any`, exit 0.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0.
- `vitest` → 74/74.
- Diff inspected directly: both `??` are pre-existing; no runtime coercions added.

## Model Used
Opus 4.8

Contributes to #9924 (209→181 remaining no-explicit-any).