### PR TITLE
fix(frontend): vitest error + 39 non-any eslint warnings at root cause (#9924)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
+++ b/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
@@ -212,7 +212,6 @@ import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-// @ts-ignore - Component may not have type declarations
 import BaseButton from '@/components/base/BaseButton.vue'
 import { useNotificationBus } from '@/composables/useNotificationBus'
 import { useCodeEvolutionData } from '@/composables/analytics/useCodeEvolutionData'

--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue.d.ts
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue.d.ts
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { DefineComponent } from 'vue'
 
-declare const DesktopInterface: DefineComponent<{}, {}, unknown>
+declare const DesktopInterface: DefineComponent<Record<string, never>, Record<string, never>, unknown>
 
 export default DesktopInterface

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -82,7 +82,7 @@
         </BaseButton>
         <h3>{{ getSelectedCategoryName() }}</h3>
       </div>
-      <KnowledgeBrowser :mode="selectedMainCategory! as 'user' | 'autobot' | 'autobot-documentation' | 'system-knowledge' | 'user-knowledge'" :preselected-category="selectedMainCategory!" />
+      <KnowledgeBrowser :mode="selectedBrowserMode" :preselected-category="selectedMainCategory!" />
     </div>
 
     <!-- System Category Documents Panel -->
@@ -201,6 +201,16 @@ const route = useRoute()
 
 // UI state
 const selectedMainCategory = ref<string | null>(null)
+
+type KnowledgeBrowserMode =
+  | 'user'
+  | 'autobot'
+  | 'autobot-documentation'
+  | 'system-knowledge'
+  | 'user-knowledge'
+const selectedBrowserMode = computed(
+  () => selectedMainCategory.value as KnowledgeBrowserMode,
+)
 
 // Shape of a category document as read by this view (Record<string, unknown>
 // on the wire; these are the fields the template/handlers access).

--- a/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
@@ -441,9 +441,7 @@ import { useKnowledgeStore } from '@/stores/useKnowledgeStore'
 import { useKnowledgeController } from '@/models/controllers'
 import type { KnowledgeDocument } from '@/stores/useKnowledgeStore'
 import KnowledgeUpload from './KnowledgeUpload.vue'
-// @ts-ignore - Component lacks TypeScript declaration file
 import SystemKnowledgeManager from '@/components/knowledge/SystemKnowledgeManager.vue'
-// @ts-ignore - Component lacks TypeScript declaration file
 import ManPageManager from '@/components/manpage/ManPageManager.vue'
 import FailedVectorizationsManager from '@/components/knowledge/FailedVectorizationsManager.vue'
 import DeduplicationManager from '@/components/knowledge/DeduplicationManager.vue'

--- a/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue.d.ts
+++ b/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue.d.ts
@@ -14,7 +14,7 @@ declare const KnowledgePersistenceDialog: DefineComponent<
     chatId?: string | null
     chatContext?: KnowledgeChatContext | null
   },
-  {},
+  Record<string, never>,
   unknown
 >
 

--- a/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue.d.ts
+++ b/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue.d.ts
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { DefineComponent } from 'vue'
 
-declare const SystemKnowledgeManager: DefineComponent<{}, {}, unknown>
+declare const SystemKnowledgeManager: DefineComponent<Record<string, never>, Record<string, never>, unknown>
 
 export default SystemKnowledgeManager

--- a/autobot-frontend/src/components/knowledge/WebResearchPanel.stories.ts
+++ b/autobot-frontend/src/components/knowledge/WebResearchPanel.stories.ts
@@ -23,7 +23,6 @@ const meta = {
 export default meta
 
 // #7273: relaxed to StoryObj<Record<string, unknown>> for render-only stories that don't match component props
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Story = import('@storybook/vue3').StoryObj<Record<string, unknown>>
 
 export const Default: Story = {

--- a/autobot-frontend/src/components/manpage/ManPageManager.vue.d.ts
+++ b/autobot-frontend/src/components/manpage/ManPageManager.vue.d.ts
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { DefineComponent } from 'vue'
 
-declare const ManPageManager: DefineComponent<{}, {}, unknown>
+declare const ManPageManager: DefineComponent<Record<string, never>, Record<string, never>, unknown>
 
 export default ManPageManager

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -787,7 +787,6 @@ import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
 import { ref, reactive, computed, onMounted, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-// @ts-ignore - JavaScript API client without type declarations
 import { secretsApiClient } from '@/utils/SecretsApiClient';
 import { useChatStore } from '@/stores/useChatStore';
 import { createLogger } from '@/utils/debugUtils';

--- a/autobot-frontend/src/components/terminal/TerminalWindow.vue.d.ts
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.vue.d.ts
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { DefineComponent } from 'vue'
 
-declare const TerminalWindow: DefineComponent<{}, {}, unknown>
+declare const TerminalWindow: DefineComponent<Record<string, never>, Record<string, never>, unknown>
 
 export default TerminalWindow

--- a/autobot-frontend/src/components/workflow/WorkflowProgressWidget.vue.d.ts
+++ b/autobot-frontend/src/components/workflow/WorkflowProgressWidget.vue.d.ts
@@ -6,7 +6,7 @@ declare const WorkflowProgressWidget: DefineComponent<
   {
     workflowId?: string
   },
-  {},
+  Record<string, never>,
   unknown
 >
 

--- a/autobot-frontend/src/composables/__tests__/useActionQueue.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useActionQueue.test.ts
@@ -6,12 +6,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { nextTick } from 'vue'
+import { nextTick, ref } from 'vue'
 
 
 // Mock useNetworkStatus so queue tests are isolated from real network probes
 vi.mock('../useNetworkStatus', () => {
-  const { ref } = require('vue')
   const isOnline = ref(true)
   return {
     useNetworkStatus: vi.fn(() => ({

--- a/autobot-frontend/src/composables/__tests__/useInlineEdit.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useInlineEdit.test.ts
@@ -68,8 +68,7 @@ describe('useInlineEdit', () => {
     startEdit(item)
     editText.value = 'new'
     await saveEdit(item)
-    expect(save).toHaveBeenCalledOnce()
-    expect(save).toHaveBeenCalledWith(item, 'new')
+    expect(save).toHaveBeenCalledExactlyOnceWith(item, 'new')
     expect(editingId.value).toBeNull()
   })
 

--- a/autobot-frontend/src/composables/useSettingsHandlers.ts
+++ b/autobot-frontend/src/composables/useSettingsHandlers.ts
@@ -30,6 +30,11 @@ export interface ValidationState {
 }
 
 /**
+ * Emit signature used by the settings handlers: (eventName, key, value).
+ */
+type SettingsEmit = (eventName: string, key: string, value: unknown) => void
+
+/**
  * Creates reusable typed event handlers for settings forms
  *
  * @param emit - Vue emit function for the component
@@ -45,7 +50,7 @@ export function useSettingsHandlers<T extends (...args: unknown[]) => void>(
    */
   const handleInputChange = (key: string) => (event: Event) => {
     const target = event.target as HTMLInputElement
-    ;(emit as Function)(eventName, key, target.value)
+    ;(emit as SettingsEmit)(eventName, key, target.value)
   }
 
   /**
@@ -53,7 +58,7 @@ export function useSettingsHandlers<T extends (...args: unknown[]) => void>(
    */
   const handleNumberInputChange = (key: string) => (event: Event) => {
     const target = event.target as HTMLInputElement
-    ;(emit as Function)(eventName, key, parseInt(target.value, 10))
+    ;(emit as SettingsEmit)(eventName, key, parseInt(target.value, 10))
   }
 
   /**
@@ -61,7 +66,7 @@ export function useSettingsHandlers<T extends (...args: unknown[]) => void>(
    */
   const handleFloatInputChange = (key: string) => (event: Event) => {
     const target = event.target as HTMLInputElement
-    ;(emit as Function)(eventName, key, parseFloat(target.value))
+    ;(emit as SettingsEmit)(eventName, key, parseFloat(target.value))
   }
 
   /**
@@ -69,7 +74,7 @@ export function useSettingsHandlers<T extends (...args: unknown[]) => void>(
    */
   const handleCheckboxChange = (key: string) => (event: Event) => {
     const target = event.target as HTMLInputElement
-    ;(emit as Function)(eventName, key, target.checked)
+    ;(emit as SettingsEmit)(eventName, key, target.checked)
   }
 
   /**
@@ -77,7 +82,7 @@ export function useSettingsHandlers<T extends (...args: unknown[]) => void>(
    */
   const handleSelectChange = (key: string) => (event: Event) => {
     const target = event.target as HTMLSelectElement
-    ;(emit as Function)(eventName, key, target.value)
+    ;(emit as SettingsEmit)(eventName, key, target.value)
   }
 
   return {

--- a/autobot-frontend/src/models/controllers/ChatController.ts
+++ b/autobot-frontend/src/models/controllers/ChatController.ts
@@ -1106,15 +1106,9 @@ export class ChatController {
   ): Promise<boolean> {
     try {
       // Lazy import to avoid circular dependency at module load time
-       
-      // @ts-ignore
-      const { fetchWithAuth } = require('@/utils/fetchWithAuth') as { fetchWithAuth: typeof import('@/utils/fetchWithAuth').fetchWithAuth }
-       
-      // @ts-ignore
-      const appConfig = (require('@/config/AppConfig.js') as { default: { getApiUrl: (p: string) => Promise<string> } }).default
-       
-      // @ts-ignore
-      const { getApiBase } = require('@/config/ssot-config') as { getApiBase: () => string }
+      const { fetchWithAuth } = await import('@/utils/fetchWithAuth')
+      const appConfig = (await import('@/config/AppConfig.js')).default
+      const { getApiBase } = await import('@/config/ssot-config')
 
       const resolvedTaskId = taskId ?? this.chatStore.currentSessionId ?? null
       const url = await appConfig.getApiUrl(

--- a/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.connectors.test.ts
+++ b/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.connectors.test.ts
@@ -58,9 +58,9 @@ describe('KnowledgeRepository connector endpoints (#5200)', () => {
     putSpy = vi.fn()
     // @ts-expect-error - override inherited methods for unit test isolation
     repo.get = getSpy
-    // @ts-expect-error
+    // @ts-expect-error - override inherited methods for unit test isolation
     repo.post = postSpy
-    // @ts-expect-error
+    // @ts-expect-error - override inherited methods for unit test isolation
     repo.put = putSpy
   })
 

--- a/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.verification.test.ts
+++ b/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.verification.test.ts
@@ -28,7 +28,7 @@ describe('KnowledgeRepository verification endpoints (#5207 audit)', () => {
     postSpy = vi.fn()
     // @ts-expect-error - override inherited methods for unit test isolation
     repo.get = getSpy
-    // @ts-expect-error
+    // @ts-expect-error - override inherited methods for unit test isolation
     repo.post = postSpy
   })
 

--- a/autobot-frontend/src/shims-vue.d.ts
+++ b/autobot-frontend/src/shims-vue.d.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 declare module '*.vue' {
   import { DefineComponent } from 'vue';
-  const component: DefineComponent<{}, {}, any>;
+  const component: DefineComponent<Record<string, never>, Record<string, never>, unknown>;
   export default component;
 }
 

--- a/autobot-frontend/src/test/mocks/websocket-mock.ts
+++ b/autobot-frontend/src/test/mocks/websocket-mock.ts
@@ -78,15 +78,13 @@ export class MockWebSocket {
   }
 
   static mockImplementation() {
-    // @ts-ignore
-    global.WebSocket = MockWebSocket
+    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket
   }
 
   static restoreImplementation() {
     // Restore original WebSocket if available
     if ('WebSocket' in globalThis) {
-      // @ts-ignore
-      delete global.WebSocket
+      delete (globalThis as { WebSocket?: typeof WebSocket }).WebSocket
     }
   }
 }

--- a/autobot-frontend/src/utils/SecretsApiClient.d.ts
+++ b/autobot-frontend/src/utils/SecretsApiClient.d.ts
@@ -11,7 +11,7 @@ export interface SecretData {
   expires_at?: string | null;
 }
 
-export interface SecretUpdateData extends Partial<SecretData> {}
+export type SecretUpdateData = Partial<SecretData>
 
 export interface TransferData {
   secret_ids: string[];

--- a/autobot-frontend/tests/setup.ts
+++ b/autobot-frontend/tests/setup.ts
@@ -41,13 +41,11 @@ expect.extend({
   }
 });
 
-// Declare the extended matchers
-declare global {
-  namespace PlaywrightTest {
-    interface Matchers<R> {
-      toHaveKBLibrarianResponse(message: string): R;
-      toBeValidApiResponse(): R;
-    }
+// Declare the extended matchers via module augmentation (no namespace)
+declare module '@playwright/test' {
+  interface Matchers<R> {
+    toHaveKBLibrarianResponse(message: string): R;
+    toBeValidApiResponse(): R;
   }
 }
 


### PR DESCRIPTION
## Thinking Path
Per directive to fix ALL pre-existing problems: `frontend-tests` enforces `--max-warnings 0`, so every eslint warning (not just `no-explicit-any`) must reach 0. This clears the 1 hard error + the finite non-any/non-unused-vars rule set, all at ROOT CAUSE (no new suppressions).

## What Changed (398 → 359 problems; 1 error → 0)
- **vitest/prefer-called-exactly-once-with** (error): `toHaveBeenCalledOnce`+`toHaveBeenCalledWith` → `toHaveBeenCalledExactlyOnceWith`.
- **unused eslint-disable**: removed dangling directive from WebResearchPanel.stories.ts (stories-sweep byproduct).
- **no-unsafe-function-type** (5): `Function` → `SettingsEmit` signature.
- **ban-ts-comment** (12): deleted stale `@ts-ignore` (underlying types now resolve); added descriptions to bare `@ts-expect-error`.
- **no-require-imports** (4): `require()` → `await import()` (ChatController, already async) / top-level `import` (test).
- **no-empty-object-type** (13): `{}` → `Record<string, never>` in `.vue.d.ts`/shims; empty interface → type alias.
- **vue/no-deprecated-filter** (1): extracted `KnowledgeBrowserMode` computed (rule mis-read a TS union `|` as a Vue2 filter).
- **no-namespace** (1): `declare global { namespace }` → module augmentation.

## Runtime-adjacent (behaviorally equivalent, verified)
`require`→`await import` (lazy+async preserved), `global`→`globalThis` in a test mock, a `mode` computed. 

## Verification (independently re-run)
- `eslint`: 0 errors; all 7 target rules + error + unused-disable = **0**.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0.
- `vitest` on all changed-file consumers (ChatController, KnowledgeCategories, WS-mock, settings, +test files) → **81/81 + 34/34 pass**.

## Model Used
Opus 4.8

Contributes to #9924 (greening frontend-tests: 398→359 problems; remaining = 181 no-explicit-any + 178 no-unused-vars).