### PR TITLE
fix(frontend): repair 6 pre-existing failing tests + document updateUserSetting placeholder (#11026, #11010, #11024)

### DIFF
--- a/autobot-frontend/src/components/chat/__tests__/ChatSettingsModal.spec.ts
+++ b/autobot-frontend/src/components/chat/__tests__/ChatSettingsModal.spec.ts
@@ -21,6 +21,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref } from 'vue'
 import { mount, type VueWrapper } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
 
 // ── Module-level mocks (hoisted) ─────────────────────────────────────────────
 
@@ -39,7 +40,18 @@ import ChatSettingsModal from '../ChatSettingsModal.vue'
 
 // ── Mock state ───────────────────────────────────────────────────────────────
 
-const stubT = (key: string) => key
+// vue-i18n 11 requires app.use(); ChatSettingsModal uses useI18n() in
+// <script setup>, so a bare $t mock is insufficient. Install a real i18n
+// instance with empty messages + warnings off so t('key') returns the key
+// verbatim (matching the assertions on translation keys below).
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: { en: {} },
+  missingWarn: false,
+  fallbackWarn: false,
+})
 
 // Shared reactive prefs state, mimicking the singleton composable.
 const reasoningEffort = ref<'auto' | 'low' | 'medium' | 'high'>('auto')
@@ -55,7 +67,7 @@ function mountModal(show = true): VueWrapper {
   return mount(ChatSettingsModal, {
     props: { show },
     global: {
-      mocks: { $t: stubT },
+      plugins: [i18n],
     },
   })
 }

--- a/autobot-frontend/src/components/llc/__tests__/HandoffModal.test.ts
+++ b/autobot-frontend/src/components/llc/__tests__/HandoffModal.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
 
 const get = vi.fn()
 const post = vi.fn()
@@ -18,7 +19,23 @@ vi.mock('@/stores/useUserStore', () => ({
 
 import HandoffModal from '../HandoffModal.vue'
 
-const mountOpts = { global: { mocks: { $t: (k: string) => k } } }
+// vue-i18n 11 requires app.use(); HandoffModal uses useI18n() in <script setup>,
+// so a bare $t mock is not enough. Install a real i18n instance with empty
+// messages + warnings off so t('key') / $t('key') return the key verbatim (the
+// original assertion contract that mocks: { $t } provided).
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: { en: {} },
+  missingWarn: false,
+  fallbackWarn: false,
+})
+
+// BaseModal (@autobot/ui) wraps its body/actions in <Teleport to="body">;
+// stub Teleport so the slotted <select> + .handoff-confirm render inline where
+// wrapper.find() can reach them.
+const mountOpts = { global: { plugins: [i18n], stubs: { teleport: true } } }
 
 describe('HandoffModal (GH#10531)', () => {
   beforeEach(() => {

--- a/autobot-frontend/src/components/settings/SettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/SettingsPanel.vue
@@ -204,8 +204,14 @@ const updateChatSetting = (key: string, value: unknown) => {
   markAsChanged()
 }
 
-const updateUserSetting = (key: string, value: unknown) => {
-  // Handle user management settings
+// NOTE (#11024): No-op placeholder. There is no user-settings section in
+// SettingsStructure yet and nothing in the app emits a `user.*` setting-changed
+// event, so the `case 'user'` branch in handleSettingChanged is currently
+// unreachable. Kept (not deleted) as the wire-in point for a future User
+// Management settings section — persist into a `settings.value.user` section
+// (mirroring updateChatSetting/updateUISetting) once that section is added and
+// a child view emits `user.*`.
+const updateUserSetting = (_key: string, _value: unknown) => {
   markAsChanged()
 }
 

--- a/autobot-frontend/src/components/ui/__tests__/BaseModal.test.ts
+++ b/autobot-frontend/src/components/ui/__tests__/BaseModal.test.ts
@@ -66,7 +66,7 @@ describe('BaseModal focus trap (#5016)', () => {
     await flushPromises()
     const dialog = wrapper.find('[role="dialog"]')
     expect(dialog.exists()).toBe(true)
-    expect(dialog.find('.close-btn').exists()).toBe(true)
+    expect(dialog.find('.aui-dialog-close').exists()).toBe(true)
     expect(dialog.find('.body-btn').exists()).toBe(true)
     wrapper.unmount()
   })

--- a/autobot-frontend/src/composables/__tests__/useConnectionTester.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useConnectionTester.test.ts
@@ -620,10 +620,9 @@ describe('useConnectionTester composable', () => {
     })
 
     it('should cancel ongoing test', async () => {
-      let _resolveFetch: () => void
-      const fetchPromise = new Promise<Response>((resolve) => {
-        resolveFetch = () => resolve(new Response(null, { status: 200 }))
-      })
+      // Never-resolving fetch: the test cancels the in-flight request rather than
+      // completing it, so no resolver is needed.
+      const fetchPromise = new Promise<Response>(() => {})
       vi.mocked(fetch).mockReturnValue(fetchPromise)
 
       const tester = useConnectionTester({
@@ -743,10 +742,9 @@ describe('useConnectionTester composable', () => {
     })
 
     it('should cancel all ongoing tests', async () => {
-      let _resolveFetch: () => void
-      const fetchPromise = new Promise<Response>((resolve) => {
-        resolveFetch = () => resolve(new Response(null, { status: 200 }))
-      })
+      // Never-resolving fetch: the test cancels the in-flight requests rather than
+      // completing them, so no resolver is needed.
+      const fetchPromise = new Promise<Response>(() => {})
       vi.mocked(fetch).mockReturnValue(fetchPromise)
 
       const { testers, testAll, cancelAll } = useConnectionTesters({

--- a/autobot-frontend/src/views/llc/__tests__/BacklogView.reorder.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/BacklogView.reorder.test.ts
@@ -6,6 +6,8 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
 
 const post = vi.fn()
 const get = vi.fn()
@@ -45,9 +47,15 @@ const ITEMS = [
   { id: 'c', title: 'C', type: 'pbi', status: 'new', priority: 'medium', backlog_position: 2 },
 ]
 
+// vue-i18n 11 requires app.use(); install a real i18n plugin (BacklogView uses
+// useI18n()) so mounting doesn't throw. Real en.json keeps template render valid.
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
 async function mountView() {
   get.mockResolvedValue({ items: ITEMS.map(i => ({ ...i })) })
-  const wrapper = mount(BacklogView, { global: { stubs: { LlcBreadcrumb: true, 'router-link': true } } })
+  const wrapper = mount(BacklogView, {
+    global: { plugins: [i18n], stubs: { LlcBreadcrumb: true, 'router-link': true } },
+  })
   await flushPromises()
   return wrapper
 }

--- a/autobot-frontend/src/views/llc/__tests__/ProjectBrowserView.enrichment.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/ProjectBrowserView.enrichment.test.ts
@@ -5,8 +5,16 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
 
 const get = vi.fn()
+
+// vue-i18n 11 requires the plugin be installed via app.use(); load the real
+// en.json messages so the card text assertions ("7 open", "No active sprint")
+// resolve against the actual translations.
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+const mountOpts = { global: { plugins: [i18n], stubs: { LlcBreadcrumb: true } } }
 
 vi.mock('@/plugins/api', () => ({ useApiClient: () => ({ get }) }))
 vi.mock('@/utils/debugUtils', () => ({
@@ -49,7 +57,7 @@ describe('ProjectBrowserView enrichment (GH#10232)', () => {
       return Promise.resolve([])
     })
 
-    const wrapper = mount(ProjectBrowserView, { global: { stubs: { LlcBreadcrumb: true } } })
+    const wrapper = mount(ProjectBrowserView, mountOpts)
     await flushPromises()
 
     expect(wrapper.text()).toContain('7 open')
@@ -66,7 +74,7 @@ describe('ProjectBrowserView enrichment (GH#10232)', () => {
       return Promise.resolve([])
     })
 
-    const wrapper = mount(ProjectBrowserView, { global: { stubs: { LlcBreadcrumb: true } } })
+    const wrapper = mount(ProjectBrowserView, mountOpts)
     await flushPromises()
 
     expect(wrapper.text()).toContain('No active sprint')


### PR DESCRIPTION
## Thinking Path
Per directive to fix pre-existing problems: repaired the pre-existing FAILING frontend tests (not just filed) plus a dead-code and a placeholder issue.

## What Changed
- **#11026 — vue-i18n test harness (13 tests were failing → now pass)**: 4 files (`ProjectBrowserView.enrichment`, `BacklogView.reorder`, `HandoffModal`, `ChatSettingsModal`) mounted `useI18n()` components with only a `$t` mock → installed the real `createI18n` plugin (reusing the established `DataTable.test.ts`/`HostSelectionDialog.test.ts` pattern); HandoffModal also needed `stubs: { teleport: true }` (BaseModal teleports slots to body).
- **BaseModal.test.ts (pre-existing failing, surfaced here)**: `@autobot/ui` renamed the close button → `.aui-dialog-close`; updated the stale `.close-btn` selector. 5/5 pass.
- **#11010 — dead test code**: `useConnectionTester.test.ts` cancel blocks had orphaned `_resolveFetch`/`resolveFetch`; replaced with a never-resolving promise (correct cancel-test semantics). 44/44 pass.
- **#11024 — updateUserSetting**: investigated — NOTHING emits `user.*`, `SettingsStructure` has no `user` section, and `/settings` route redirects to the SLM admin app (SettingsPanel is unmounted in prod). It's an unreachable placeholder → per project rule NOT deleted; added a `// NOTE (#11024)` with the concrete wire-in plan, and prefixed unused `_key`/`_value` (−2 warnings).

## Verification (independently re-run)
- Target tests: **6 files / 79 tests pass** (13 i18n + 44 useConnectionTester + others).
- Full suite regression: 1902 passed (only the now-fixed BaseModal was failing).
- `eslint` changed files → 0 errors (1 pre-existing `tabs` unused-var, handled in the no-unused-vars sweep).
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0.

Closes #11026, #11010. #11024 documented (placeholder, no live caller).

## Model Used
Opus 4.8