### PR TITLE
fix(frontend): resolve no-unused-vars in chat/file-browser/knowledge (#9924)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -289,13 +289,10 @@ import { useOverseerAgent } from '@/composables/useOverseerAgent'
 // GH#9062: migrated from useGlobalWebSocket — context events flow through
 // LiveEventManager (global channel), so useEventBus is the correct subscriber
 import { useEventBus } from '@/composables/useEventBus'
-import ApiClient from '@/utils/ApiClient'
 import batchApiService from '@/services/BatchApiService'
 // MIGRATED: Using AppConfig.js for better configuration management
 import appConfig from '@/config/AppConfig.js'
 import { getApiBase } from '@/config/ssot-config'
-// FIXED: Import NetworkConstants for IP fallback values
-import { NetworkConstants } from '@/constants/network'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('ChatInterface')
@@ -380,7 +377,7 @@ const contextWindowProps = computed(() => ({
 }))
 
 // GH#9043: context overflow protection — auto-summarize when approaching limit
-const { isProtectionActive, isSummarizing } = useContextOverflowProtection({
+const { isProtectionActive: _isProtectionActive, isSummarizing } = useContextOverflowProtection({
   sessionId: computed(() => store.currentSessionId),
   messages: computed(() => store.currentSession?.messages ?? []),
   modelName: computed(() => store.settings.model),
@@ -420,7 +417,7 @@ const _stopCountdown = (): void => {
   }
 }
 
-const _startCountdown = (timeoutSeconds: number, deadlineTs?: number): void => {
+const _startCountdown = (timeoutSeconds: number, _deadlineTs?: number): void => {
   _stopCountdown()
   toolApprovalSecondsLeft.value = timeoutSeconds
   _countdownInterval = setInterval(() => {
@@ -481,7 +478,7 @@ const onToolDenied = async (comment?: string): Promise<void> => {
 // Voice output (#928)
 const {
   voiceOutputEnabled, isSpeaking, toggleVoiceOutput,
-  speak, speakStreaming, flushStreaming,
+  speak: _speak, speakStreaming, flushStreaming,
 } = useVoiceOutput()
 
 // Voice conversation (#1029)
@@ -785,7 +782,7 @@ const handleTabChange = (tabKey: string) => {
 }
 
 // Terminal tab handler for explicit new tab opening (not used for tab clicks)
-const openTerminalInNewTab = () => {
+const _openTerminalInNewTab = () => {
   // Open terminal in a new browser tab by navigating to tools/terminal
   window.open('/tools/terminal', '_blank')
 }
@@ -945,7 +942,7 @@ const onCommandCommented = async (commentData: { command: string; comment: strin
         throw new Error(`Server returned ${response.status}`)
       }
 
-      const result = await response.json()
+      await response.json()
 
       logger.debug('Command denied with user feedback/alternative approach')
       notify(t('chat.interface.feedbackSent'), 'success')
@@ -1273,7 +1270,7 @@ watch(
     }
     return null
   },
-  (current, previous) => {
+  (current, _previous) => {
     if (!voiceOutputEnabled.value || voiceConversation.isActive.value) return
     if (!current) return
 

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -668,7 +668,7 @@ const estimatedResponseTime = ref<number | null>(null)
 
 // Issue #249: Citation display state
 const citationExpansion = useExpansion<string>()
-const expandedCitations = citationExpansion.expanded
+const _expandedCitations = citationExpansion.expanded
 
 // CRITICAL FIX: Prevent EmptyState from flashing during polling/reactivity updates
 // Once messages have been loaded, never show EmptyState again (prevents flicker)
@@ -731,7 +731,7 @@ const {
   totalSize,
   measureElement,
   scrollToBottom,
-  isStuckToBottom,
+  isStuckToBottom: _isStuckToBottom,
 } = useVirtualChatScroll({
   messagesContainerRef: messagesContainer,
   filteredMessages,
@@ -927,7 +927,7 @@ const formatMessageContent = (content: string, messageId?: string): string => {
   return result
 }
 
-const getStatusText = (status: string): string => {
+const _getStatusText = (status: string): string => {
   const statusMap: Record<string, string> = {
     sending: t('chat.messages.statusSending'),
     sent: t('chat.messages.statusSent'),
@@ -992,24 +992,24 @@ const hasCodeBlocks = (content: string): boolean => {
 }
 
 // Issue #249: Citation helper functions
-const toggleCitations = (messageId: string) => {
+const _toggleCitations = (messageId: string) => {
   citationExpansion.toggle(messageId)
 }
 
-const truncateCitation = (content: string, maxLength: number = 200): string => {
+const _truncateCitation = (content: string, maxLength: number = 200): string => {
   if (!content) return ''
   if (content.length <= maxLength) return content
   return content.substring(0, maxLength).trim() + '...'
 }
 
-const getScoreClass = (score: number): string => {
+const _getScoreClass = (score: number): string => {
   if (score >= 0.9) return 'score-excellent'
   if (score >= 0.8) return 'score-good'
   if (score >= 0.7) return 'score-acceptable'
   return 'score-low'
 }
 
-const formatSourcePath = (sourcePath: string): string => {
+const _formatSourcePath = (sourcePath: string): string => {
   if (!sourcePath) return 'Unknown'
   // Extract filename from path
   const parts = sourcePath.split('/')
@@ -1042,7 +1042,7 @@ const copyMessage = async (message: ChatMessage) => {
   try {
     await navigator.clipboard.writeText(message.content)
     // Could show a toast notification here
-  } catch (error) {
+  } catch {
     // Fallback for older browsers
     const textArea = document.createElement('textarea')
     textArea.value = message.content
@@ -1095,7 +1095,7 @@ const retryMessage = async (messageId: string) => {
 }
 
 // TOOL_CALL Detection
-const detectToolCalls = (message: ChatMessage) => {
+const _detectToolCalls = (message: ChatMessage) => {
   const toolCallRegex = /<TOOL_CALL\s+name="execute_command"\s+params='({.*?})'>(.*?)<\/TOOL_CALL>/gs
   const matches = [...message.content.matchAll(toolCallRegex)]
 

--- a/autobot-frontend/src/components/file-browser/FileBrowser.vue
+++ b/autobot-frontend/src/components/file-browser/FileBrowser.vue
@@ -143,7 +143,7 @@ const sortField = ref('name')
 const sortOrder = ref<'asc' | 'desc'>('asc')
 const showPreview = ref(false)
 
-const userStore = useUserStore()
+const _userStore = useUserStore()
 
 // Computed properties
 const sortedFiles = computed(() => {
@@ -177,7 +177,7 @@ const sortedFiles = computed(() => {
 })
 
 // Methods
-const { execute: refreshFiles, loading: isRefreshingFiles } = useAsyncHandler(
+const { execute: refreshFiles, loading: _isRefreshingFiles } = useAsyncHandler(
   async () => {
     await fetchFiles(currentPath.value)
 
@@ -191,7 +191,7 @@ const { execute: refreshFiles, loading: isRefreshingFiles } = useAsyncHandler(
   }
 )
 
-const { execute: loadDirectoryTree, loading: isLoadingTree } = useAsyncHandler(
+const { execute: loadDirectoryTree, loading: _isLoadingTree } = useAsyncHandler(
   async () => {
     await fetchTree()
   },
@@ -236,7 +236,7 @@ const triggerFileUpload = () => {
   fileUploadRef.value?.triggerFileSelect()
 }
 
-const { execute: uploadFiles, loading: isUploadingFiles } = useAsyncHandler(
+const { execute: uploadFiles, loading: _isUploadingFiles } = useAsyncHandler(
   async (fileList: FileList) => {
     await composableUploadFiles(fileList, currentPath.value)
     await refreshFiles()
@@ -265,7 +265,7 @@ const handleFileSelected = async (fileList: FileList) => {
   await uploadFiles(fileList)
 }
 
-const { execute: viewFile, loading: isViewingFile } = useAsyncHandler(
+const { execute: viewFile, loading: _isViewingFile } = useAsyncHandler(
   async (file: FileBrowserItem) => {
     await fetchPreview(file, getFileType)
     showPreview.value = true
@@ -285,7 +285,7 @@ const { execute: viewFile, loading: isViewingFile } = useAsyncHandler(
   }
 )
 
-const { execute: performDelete, loading: isDeletingFile } = useAsyncHandler(
+const { execute: performDelete, loading: _isDeletingFile } = useAsyncHandler(
   async (file: FileBrowserItem) => {
     const itemType = file.is_dir ? 'folder' : 'file'
     await deleteFileOrFolder(file.path)
@@ -318,7 +318,7 @@ const deleteFile = async (file: FileBrowserItem) => {
   }
 }
 
-const { execute: performRename, loading: isRenamingFile } = useAsyncHandler(
+const { execute: performRename, loading: _isRenamingFile } = useAsyncHandler(
   async (file: FileBrowserItem, newName: string) => {
     await renameFileOrFolder(file.path, newName)
     await refreshFiles()
@@ -349,7 +349,7 @@ const renameFile = async (file: FileBrowserItem) => {
   }
 }
 
-const { execute: performCreateFolder, loading: isCreatingFolder } = useAsyncHandler(
+const { execute: performCreateFolder, loading: _isCreatingFolder } = useAsyncHandler(
   async (folderName: string) => {
     await createDirectory(currentPath.value, folderName)
     await refreshFiles()

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -205,10 +205,9 @@ import { useKnowledgeIcons } from '@/composables/knowledge/useKnowledgeIcons'
 import { useKnowledgeCategories } from '@/composables/knowledge/useKnowledgeCategories'
 import { useMachineKnowledge } from '@/composables/knowledge/useMachineKnowledge'
 import { useManPages } from '@/composables/knowledge/useManPages'
-import { formatDate, formatFileSize, formatCategoryName } from '@/utils/formatHelpers'
+import { formatCategoryName } from '@/utils/formatHelpers'
 import { useKnowledgeVectorization } from '@/composables/useKnowledgeVectorization'
 import { useLoadingState } from '@/composables/useLoadingState'
-import { usePagination } from '@/composables/usePagination'
 import { useDebounce } from '@/composables/useTimeout'
 import TreeNodeComponent, { type TreeNode } from './TreeNodeComponent.vue'
 import VectorizationProgressModal from './VectorizationProgressModal.vue'
@@ -223,7 +222,7 @@ const logger = createLogger('KnowledgeBrowser')
 
 // Domain composables (migrated from useKnowledgeBase BC shim in #5193)
 const { getCategoryIcon, getFileIcon: getFileIconUtil } = useKnowledgeIcons()
-const { getCategorizedFacts, buildCategoryFilterOptions } = useKnowledgeCategories()
+const { getCategorizedFacts: _getCategorizedFacts, buildCategoryFilterOptions: _buildCategoryFilterOptions } = useKnowledgeCategories()
 const { refreshSystemKnowledge } = useMachineKnowledge()
 const { populateAutoBotDocs } = useManPages()
 
@@ -709,7 +708,7 @@ const loadKnowledgeTreeFn = async () => {
   }
 }
 
-const loadUserKnowledge = async () => {
+const _loadUserKnowledge = async () => {
   // Reset pagination and load first page
   resetPagination()
   await loadMore()
@@ -948,7 +947,7 @@ const handlePopulate = async (categoryId: string) => {
   }
 }
 
-const handleImport = () => {
+const _handleImport = () => {
   router.push('/knowledge/upload')
 }
 
@@ -1077,7 +1076,7 @@ const clearSearch = () => {
 }
 
 // Utility functions (now using composable)
-const getFileIcon = (node: TreeNode): string => {
+const _getFileIcon = (node: TreeNode): string => {
   if (node.type === 'folder') {
     return nodeExpansion.isExpanded(node.id) ? 'folder-open' : 'folder'
   }

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -174,7 +174,7 @@ import { useKnowledgeIcons } from '@/composables/knowledge/useKnowledgeIcons'
 import { useKnowledgeCategories } from '@/composables/knowledge/useKnowledgeCategories'
 import type { MainCategoryItem } from '@/composables/knowledge/useKnowledgeCategories'
 import type { KnowledgeStats } from '@/types/knowledgeBase'
-import { formatDate, formatCategoryName, formatFileSize } from '@/utils/formatHelpers'
+import { formatCategoryName, formatFileSize } from '@/utils/formatHelpers'
 import KnowledgeBrowser from './KnowledgeBrowser.vue'
 import DocumentChangeFeed from './DocumentChangeFeed.vue'
 import CategoryEditModal from './modals/CategoryEditModal.vue'
@@ -192,12 +192,12 @@ import '@/styles/document-feed-wrapper.css'
 
 // Domain composables (migrated from useKnowledgeBase BC shim in #5193)
 const { fetchBasicStats } = useKnowledgeStats()
-const { getCategoryIcon, getTypeIcon } = useKnowledgeIcons()
+const { getCategoryIcon: _getCategoryIcon, getTypeIcon } = useKnowledgeIcons()
 const { fetchMainCategories, fetchCategoryDocuments } = useKnowledgeCategories()
 
 // Router
 const router = useRouter()
-const route = useRoute()
+const _route = useRoute()
 
 // UI state
 const selectedMainCategory = ref<string | null>(null)
@@ -243,7 +243,7 @@ const showCategoryEditModal = ref(false)
 const categoryToEdit = ref<Category | null>(null)
 
 // Computed properties
-const systemCategories = computed(() => {
+const _systemCategories = computed(() => {
   return kbStats.value?.categories || []
 })
 
@@ -260,7 +260,7 @@ const getKBStats = async () => {
   }
 }
 
-const browseCategory = async (category: string) => {
+const _browseCategory = async (category: string) => {
   // Navigate to search with category filter
   router.push({
     path: '/knowledge/search',
@@ -268,7 +268,7 @@ const browseCategory = async (category: string) => {
   })
 }
 
-const viewCategoryDocuments = async (category: MainCategoryItem) => {
+const _viewCategoryDocuments = async (category: MainCategoryItem) => {
   isLoadingCategoryDocs.value = true
   selectedCategoryPath.value = category.path as string
 

--- a/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue
+++ b/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue
@@ -264,12 +264,12 @@ export default {
 
     // Use composables for async operations
     const { isLoading, wrap: fetchStatsOp } = useLoadingState()
-    const { isLoading: isInitializing, wrap: initializeMachineKnowledgeOp } = useLoadingState()
-    const { isLoading: isReindexing, wrap: reindexDocumentsOp } = useLoadingState()
-    const { isLoading: isRefreshing, wrap: refreshSystemKnowledgeOp } = useLoadingState()
-    const { isLoading: isPopulating, wrap: populateManPagesOp } = useLoadingState()
-    const { isLoading: isDocPopulating, wrap: populateAutoBotDocsOp } = useLoadingState()
-    const { isLoading: isVectorizing, wrap: generateVectorEmbeddingsOp } = useLoadingState()
+    const { isLoading: isInitializing } = useLoadingState()
+    const { isLoading: isReindexing } = useLoadingState()
+    const { isLoading: isRefreshing } = useLoadingState()
+    const { isLoading: isPopulating } = useLoadingState()
+    const { isLoading: isDocPopulating } = useLoadingState()
+    const { isLoading: isVectorizing } = useLoadingState()
 
     const addLogEntry = (message, status) => {
       const time = new Date().toLocaleTimeString();


### PR DESCRIPTION
## Thinking Path
Toward green `frontend-tests` (`--max-warnings 0`): fixed all 45 eslint warnings in the 6 highest-warning components. Per the no-delete rule, genuinely dead imports/bindings were removed; purposeful-but-currently-unused code was preserved via `_`-prefix (the config's allowed unused pattern) rather than deleted.

## What Changed (45 warnings → 0)
- Removed genuine unused imports (ChatInterface: `ApiClient`, `NetworkConstants`; KnowledgeBrowser/Categories: unused `formatDate`/`usePagination`).
- Dropped dead destructure aliases (SystemKnowledgeManager: 6 unused `wrap:` from `useLoadingState`; FileBrowser: 7 unused `loading:` aliases → `_`).
- `catch (error)`→`catch {}`, `const result = await x.json()`→`await x.json()` (root-cause).
- `_`-prefixed preserved-not-deleted handlers/computeds.

## Reviewer flags (preserved via `_`, not deleted — judgment calls)
- `ChatMessages._detectToolCalls`: only caller is an intentionally-commented-out watcher ("caused duplicate approval dialogs") — NOT re-wired.
- `KnowledgeCategories._browseCategory/_viewCategoryDocuments/_systemCategories`: older category-browse flow superseded by embedded `<KnowledgeBrowser>` — wiring is a UX decision.
- Citation helpers in ChatMessages superseded by `<CitationsDisplay>`; preserved.

## Verification (independently re-run)
- `eslint` 6 files → **0 warnings, 0 errors**.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0.
- `vitest` (5 related suites) → 78/78.

## Model Used
Opus 4.8

Contributes to #9924 green frontend-tests (357→312 problems).