### PR TITLE
fix(settings): SettingsPanel.updateUserSetting persists key/value (#11024)

### DIFF
--- a/autobot-frontend/src/components/settings/SettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/SettingsPanel.vue
@@ -204,14 +204,21 @@ const updateChatSetting = (key: string, value: unknown) => {
   markAsChanged()
 }
 
-// NOTE (#11024): No-op placeholder. There is no user-settings section in
-// SettingsStructure yet and nothing in the app emits a `user.*` setting-changed
-// event, so the `case 'user'` branch in handleSettingChanged is currently
-// unreachable. Kept (not deleted) as the wire-in point for a future User
-// Management settings section — persist into a `settings.value.user` section
-// (mirroring updateChatSetting/updateUISetting) once that section is added and
-// a child view emits `user.*`.
-const updateUserSetting = (_key: string, _value: unknown) => {
+// #11024: persist user-management settings into a `settings.value.user` section,
+// mirroring updateBackendSetting (nested-key safe-set + prototype-pollution guard)
+// so the `case 'user'` dispatch in handleSettingChanged round-trips key/value
+// instead of silently dropping both parameters.
+const updateUserSetting = (key: string, value: unknown) => {
+  const root = settings.value as Record<string, unknown>
+  if (!root.user || typeof root.user !== 'object') {
+    root.user = {}
+  }
+  const userSettings = root.user as Record<string, unknown>
+  if (key.includes('.')) {
+    safeNestedSet(userSettings, key, value)
+  } else if (!_UNSAFE_KEYS.has(key)) {
+    userSettings[key] = value
+  }
   markAsChanged()
 }
 


### PR DESCRIPTION
## Thinking Path
`handleSettingChanged` dispatches `case 'user'` → `updateUserSetting(subKey, value)`, but that function was a no-op stub (`_key`/`_value` ignored) — a latent footgun that silently drops any user-management setting change. All 8 sibling `updateXSetting` functions persist into `settings.value.X`; this one didn't.

## What Changed
`autobot-frontend/src/components/settings/SettingsPanel.vue` — implement `updateUserSetting` to mirror `updateBackendSetting`: ensure a `settings.value.user` object, then `safeNestedSet` for dotted keys (prototype-pollution guarded) or a guarded flat set, then `markAsChanged()`.

## Verification
- `eslint` clean (no use-before-define; only a pre-existing unrelated warning).
- `vue-tsc --noEmit -p tsconfig.app.json`: no type errors in the file.

## Model Used
Opus 4.8 (1M context)

Closes #11024