### PR TITLE
fix(frontend): resolve any + no-unused-vars in terminal/chat/composables (#9924)

### DIFF
--- a/autobot-frontend/src/components/chat/DocumentationSearchSidebar.vue
+++ b/autobot-frontend/src/components/chat/DocumentationSearchSidebar.vue
@@ -171,7 +171,6 @@
 import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
 import { ref, onMounted, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
 import DocumentationResultCard from './DocumentationResultCard.vue'
 import DocumentationSuggestionChip from './DocumentationSuggestionChip.vue'
 import DocumentationCategoryFilter from './DocumentationCategoryFilter.vue'
@@ -179,7 +178,6 @@ import { useDocumentationSearch } from '@/composables/chat/useDocumentationSearc
 import type { DocResult, DocCategory } from '@/composables/chat/useDocumentationSearch'
 import { createLogger } from '@/utils/debugUtils'
 
-const { t } = useI18n()
 const logger = createLogger('DocumentationSearchSidebar')
 
 type Category = DocCategory
@@ -312,7 +310,7 @@ const handleSortChange = () => {
     relevance: (a, b) => (b.score || 0) - (a.score || 0),
     title: (a, b) => a.title.localeCompare(b.title),
     category: (a, b) => a.category.localeCompare(b.category),
-    date: (a, b) => 0 // Would need indexed_at field
+    date: (_a, _b) => 0 // Would need indexed_at field
   }
   results.value.sort(sortFns[sortBy.value] || sortFns.relevance)
 }
@@ -373,7 +371,7 @@ const addToRecent = (doc: DocResult) => {
   // Persist to localStorage
   try {
     localStorage.setItem('autobot_recent_docs', JSON.stringify(recentDocs.value))
-  } catch (e) {
+  } catch {
     // Ignore storage errors
   }
 }
@@ -405,7 +403,7 @@ const loadRecentDocs = () => {
     if (stored) {
       recentDocs.value = JSON.parse(stored)
     }
-  } catch (e) {
+  } catch {
     // Ignore parse errors
   }
 }

--- a/autobot-frontend/src/components/chat/ShareConversationDialog.vue
+++ b/autobot-frontend/src/components/chat/ShareConversationDialog.vue
@@ -220,7 +220,6 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
 import { BaseModal } from '@autobot/ui'
 import BaseButton from '@/components/base/BaseButton.vue'
 import ApiClient from '@/utils/ApiClient'
@@ -229,7 +228,6 @@ import { createLogger } from '@/utils/debugUtils'
 import { useBatchSelection } from '@/composables/useBatchSelection'
 import Icon from '@/components/ui/Icon.vue'
 
-const { t } = useI18n()
 const logger = createLogger('ShareConversationDialog')
 
 interface ShareFact {
@@ -303,7 +301,7 @@ const loadFacts = async () => {
   if (!props.sessionId) return
   factsLoading.value = true
   try {
-    const data = await ApiClient.get<any>(`${getApiBase()}/chat/sessions/${props.sessionId}/share/preview`)
+    const data = await ApiClient.get<{ data?: { facts?: ShareFact[] } }>(`${getApiBase()}/chat/sessions/${props.sessionId}/share/preview`)
     facts.value = data?.data?.facts || []
     factSelection.selectAll()
   } catch (err) {
@@ -325,7 +323,7 @@ const handleShare = async () => {
     if (includeKnowledge.value && factSelection.selectedCount.value > 0) {
       body.knowledge_facts = Array.from(factSelection.selected.value)
     }
-    const result = await ApiClient.post<any>(`${getApiBase()}/chat/sessions/${props.sessionId}/share`, body)
+    const result = await ApiClient.post<{ data?: Record<string, unknown> }>(`${getApiBase()}/chat/sessions/${props.sessionId}/share`, body)
     emit('shared', result?.data || {})
     emit('update:visible', false)
   } catch (err) {
@@ -343,7 +341,7 @@ const handleCreateLink = async () => {
     if (linkPassword.value.trim()) body.password = linkPassword.value.trim()
     if (expirySeconds.value) body.expires_in_seconds = expirySeconds.value
 
-    const result = await ApiClient.post<any>(
+    const result = await ApiClient.post<SharedLinkData & { data?: SharedLinkData }>(
       `${getApiBase()}/chat/sessions/${props.sessionId}/share-link`,
       body
     )

--- a/autobot-frontend/src/components/terminal/TerminalWindow.vue
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.vue
@@ -284,7 +284,7 @@
 import { ref, computed, onMounted, onUnmounted, nextTick, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useTerminalService } from '@/services/TerminalService';
-import { useRoute, useRouter } from 'vue-router';
+import { useRoute } from 'vue-router';
 import AdvancedStepConfirmationModal from './AdvancedStepConfirmationModal.vue';
 import CompletionSuggestions from './CompletionSuggestions.vue';
 import TerminalHeader from './TerminalHeader.vue';
@@ -304,7 +304,6 @@ export default {
   setup() {
     const { t } = useI18n();
     const route = useRoute();
-    const router = useRouter();
 
     // Get the terminal service with all its methods
     const {
@@ -314,9 +313,7 @@ export default {
       isConnected,
       resize,
       connect: connectToService,
-      disconnect,
-      createSession,
-      closeSession
+      disconnect
     } = useTerminalService();
 
     // Get current chat ID from parent or route params
@@ -1099,7 +1096,7 @@ export default {
         try {
           await navigator.clipboard.writeText(url);
           alert('Terminal URL copied to clipboard!');
-        } catch (error) {
+        } catch {
           prompt('Copy this URL:', url);
         }
       }

--- a/autobot-frontend/src/components/terminal/WorkflowAutomation.vue
+++ b/autobot-frontend/src/components/terminal/WorkflowAutomation.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('WorkflowAutomation')
@@ -30,10 +30,10 @@ interface WorkflowData {
   }>
 }
 
-interface ProcessInfo {
-  pid: number
-  command: string
-  startTime: Date
+interface TerminalOutputLine {
+  content: string
+  type: string
+  timestamp: Date
 }
 
 interface Props {
@@ -56,7 +56,7 @@ interface Emits {
   (e: 'update:waiting-for-user-confirmation', value: boolean): void
   (e: 'send-automation-control', action: string): void
   (e: 'execute-automated-command', command: string): void
-  (e: 'add-output-line', line: any): void
+  (e: 'add-output-line', line: TerminalOutputLine): void
   (e: 'add-running-process', command: string): void
   (e: 'request-manual-step-confirmation', stepInfo: WorkflowStep): void
 }
@@ -352,7 +352,7 @@ const handleWorkflowMessage = (message: string) => {
 }
 
 // Advanced Modal Methods for parent component
-const executeConfirmedStep = (stepData: any) => {
+const executeConfirmedStep = (stepData: WorkflowStep) => {
   emit('add-output-line', {
     content: `🤖 EXECUTING: ${stepData.command}`,
     type: 'system_message',
@@ -377,7 +377,7 @@ const executeAllRemainingSteps = () => {
   processNextAutomationStep()
 }
 
-const saveCustomWorkflow = (workflowData: any) => {
+const saveCustomWorkflow = (workflowData: WorkflowData) => {
   emit('add-output-line', {
     content: `💾 WORKFLOW SAVED: ${workflowData.name}`,
     type: 'system_message',

--- a/autobot-frontend/src/composables/__tests__/useNavOverflow.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useNavOverflow.test.ts
@@ -4,12 +4,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref, nextTick, createApp, defineComponent, effectScope } from 'vue'
 import { useNavOverflow } from '../useNavOverflow'
 
-let observeCallback: ((entries: any[]) => void) | null = null
+let observeCallback: ((entries: ResizeObserverEntry[]) => void) | null = null
 
 beforeEach(() => {
   observeCallback = null
   vi.stubGlobal('ResizeObserver', class {
-    constructor(cb: (entries: any[]) => void) {
+    constructor(cb: (entries: ResizeObserverEntry[]) => void) {
       observeCallback = cb
     }
     observe() { }
@@ -30,7 +30,7 @@ function makeContainer(width: number, itemWidths: number[]): HTMLElement {
 }
 
 function useComposableInComponent(container: HTMLElement, itemCount: number) {
-  let result: any
+  let result: ReturnType<typeof useNavOverflow>
   const Comp = defineComponent({
     setup() {
       result = useNavOverflow(ref(container), ref(itemCount))
@@ -104,7 +104,7 @@ describe('useNavOverflow', () => {
   it('re-measures when itemCount changes', async () => {
     const container = makeContainer(800, [80, 80])
     const itemCountRef = ref(2)
-    let result: any
+    let result: ReturnType<typeof useNavOverflow>
     const Comp = defineComponent({
       setup() {
         result = useNavOverflow(ref(container), itemCountRef)

--- a/autobot-frontend/src/composables/useDevices.ts
+++ b/autobot-frontend/src/composables/useDevices.ts
@@ -50,8 +50,8 @@ export function useDevices() {
         const response = await api.get<DeviceListResponse>('/devices')
         devices.value = response.devices || []
         logger.debug('Fetched devices:', devices.value.length)
-      } catch (err: any) {
-        const msg = err?.message || 'Failed to load devices'
+      } catch (err) {
+        const msg = (err as Error)?.message || 'Failed to load devices'
         error.value = msg
         logger.error('Failed to fetch devices:', err)
         throw err
@@ -66,8 +66,8 @@ export function useDevices() {
         await api.delete(`/devices/${deviceId}`)
         devices.value = devices.value.filter(d => d.id !== deviceId)
         logger.info('Device deleted:', deviceId)
-      } catch (err: any) {
-        const msg = err?.message || 'Failed to delete device'
+      } catch (err) {
+        const msg = (err as Error)?.message || 'Failed to delete device'
         error.value = msg
         logger.error('Failed to delete device:', err)
         throw err
@@ -82,8 +82,8 @@ export function useDevices() {
         const response = await api.get('/devices/pair-qr')
         logger.debug('Got QR challenge')
         return response
-      } catch (err: any) {
-        const msg = err?.message || 'Failed to get pairing QR code'
+      } catch (err) {
+        const msg = (err as Error)?.message || 'Failed to get pairing QR code'
         error.value = msg
         logger.error('Failed to get QR challenge:', err)
         throw err
@@ -105,8 +105,8 @@ export function useDevices() {
         await fetchDevices()
         logger.info('Device paired:', response.device_id)
         return response
-      } catch (err: any) {
-        const msg = err?.message || 'Failed to pair device'
+      } catch (err) {
+        const msg = (err as Error)?.message || 'Failed to pair device'
         error.value = msg
         logger.error('Failed to pair device:', err)
         throw err

--- a/autobot-frontend/src/composables/useOperationsApi.ts
+++ b/autobot-frontend/src/composables/useOperationsApi.ts
@@ -41,7 +41,7 @@ export function useOperationsApi() {
         if (filter?.limit) params.append('limit', filter.limit.toString())
         const queryString = params.toString()
         const url = `${getApiBase()}/long-running/${queryString ? `?${queryString}` : ''}`
-        return await api.get<any>(url)
+        return await api.get<OperationsListResponse>(url)
       } catch (error: unknown) {
         logger.error('Failed to load operations', error)
         showSubtleErrorNotification('Error', 'Failed to load operations', 'error')
@@ -51,7 +51,7 @@ export function useOperationsApi() {
 
     async getOperation(operationId: string): Promise<Operation | null> {
       try {
-        return await api.get<any>(`${getApiBase()}/long-running/${operationId}`)
+        return await api.get<Operation>(`${getApiBase()}/long-running/${operationId}`)
       } catch (error: unknown) {
         logger.error('Failed to get operation status', error)
         showSubtleErrorNotification('Error', 'Failed to get operation status', 'error')
@@ -61,7 +61,7 @@ export function useOperationsApi() {
 
     async cancelOperation(operationId: string): Promise<CancelOperationResponse | null> {
       try {
-        return await api.post<any>(`${getApiBase()}/long-running/${operationId}/cancel`)
+        return await api.post<CancelOperationResponse>(`${getApiBase()}/long-running/${operationId}/cancel`)
       } catch (error: unknown) {
         logger.error('Failed to cancel operation', error)
         showSubtleErrorNotification('Error', 'Failed to cancel operation', 'error')
@@ -71,7 +71,7 @@ export function useOperationsApi() {
 
     async resumeOperation(operationId: string): Promise<ResumeOperationResponse | null> {
       try {
-        return await api.post<any>(`${getApiBase()}/long-running/${operationId}/resume`)
+        return await api.post<ResumeOperationResponse>(`${getApiBase()}/long-running/${operationId}/resume`)
       } catch (error: unknown) {
         logger.error('Failed to resume operation', error)
         showSubtleErrorNotification('Error', 'Failed to resume operation', 'error')

--- a/autobot-frontend/src/composables/useOverseerAgent.ts
+++ b/autobot-frontend/src/composables/useOverseerAgent.ts
@@ -86,6 +86,17 @@ export interface OverseerUpdate {
   timestamp?: string
 }
 
+export interface OverseerStepContent {
+  status?: string
+  command?: string | null
+  command_explanation?: CommandExplanation | null
+  output?: string
+  output_explanation?: OutputExplanation | null
+  return_code?: number | null
+  execution_time?: number
+  error?: string | null
+}
+
 export interface StreamChunk {
   task_id: string
   step_number: number
@@ -243,7 +254,7 @@ export function useOverseerAgent(options: UseOverseerAgentOptions) {
     // #7275: content is `string | OverseerPlanContent | StreamChunk`; for step-start
     // events it carries StreamChunk-like fields. Cast at boundary; type-narrow guards
     // would be cleaner but add 4x lines for the same runtime behavior.
-    const content = update.content as Record<string, any> | undefined
+    const content = update.content as OverseerStepContent | undefined
 
     // Update step status
     const step = steps.value.find(s => s.step_number === stepNumber)
@@ -285,7 +296,7 @@ export function useOverseerAgent(options: UseOverseerAgentOptions) {
   const handleStepComplete = (update: OverseerUpdate): void => {
     const stepNumber = update.step_number || 0
     // #7275: same boundary cast as handleStepStart (see note above)
-    const content = update.content as Record<string, any> | undefined
+    const content = update.content as OverseerStepContent | undefined
 
     // Update step with final results
     const step = steps.value.find(s => s.step_number === stepNumber)
@@ -323,7 +334,7 @@ export function useOverseerAgent(options: UseOverseerAgentOptions) {
    */
   const handleError = (update: OverseerUpdate): void => {
     // #7275: content union narrowed at boundary (same pattern as other handlers)
-    const content = update.content as Record<string, any> | undefined
+    const content = update.content as OverseerStepContent | undefined
     const errorMsg = content?.error || 'Unknown error'
     error.value = errorMsg
     status.value = 'error'
@@ -348,7 +359,7 @@ export function useOverseerAgent(options: UseOverseerAgentOptions) {
   /**
    * Submit a query to the overseer
    */
-  const submitQuery = (query: string, context?: Record<string, any>): void => {
+  const submitQuery = (query: string, context?: Record<string, unknown>): void => {
     if (!isConnected.value) {
       error.value = 'Not connected to overseer'
       onError?.('Not connected to overseer')


### PR DESCRIPTION
## Thinking Path
Toward green `frontend-tests` — all 34 eslint warnings in 8 files (mix of `no-explicit-any` + `no-unused-vars`).

## What Changed (34 → 0)
- **any→typed**: ShareConversationDialog (`ShareFact`/`SharedLinkData`), useOperationsApi (declared return types), useOverseerAgent (new `OverseerStepContent`), useNavOverflow.test (`ResizeObserverEntry`), useDevices (`catch(err)`+cast).
- **unused removed** (orphaned, no partial wiring): dead `ProcessInfo` interface (WorkflowAutomation); unused `router`/`createSession`/`closeSession` (TerminalWindow); unused `useI18n`/`t` where template uses `$t`.
- Unused params → `_`; `catch(e)`→`catch {}`.

## Reviewer flag
TerminalWindow: `router`/`createSession`/`closeSession` were destructured/assigned but never read (no partial wiring) → removed as orphaned. If intended for future nav/session lifecycle, that's separate follow-up.

## Verification (independently re-run)
- `eslint` 8 files → **0 warnings, 0 errors**.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0.
- `vitest` (3 suites) → 61/61.
- No eslint-disable/@ts-ignore; no runtime coercions.

## Model Used
Opus 4.8

Contributes to #9924 green frontend-tests (312→278 problems).