### PR TITLE
refactor(llm): adopt LLMType enum at call sites + make it a str-Enum + warn on unknown tier (#11019)

### DIFF
--- a/autobot-backend/agents/agent_orchestration/routing.py
+++ b/autobot-backend/agents/agent_orchestration/routing.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from constants.threshold_constants import LLMDefaults
+from llm_shared.types import LLMType
 
 from .topology import AgentTopology, InMemoryTopologyDB
 from .topology_routing import TopologyAwareRouter
@@ -311,7 +312,7 @@ class AgentRouter:
 
             response = await self.llm_interface.chat_completion(
                 messages=messages,
-                llm_type="orchestrator",
+                llm_type=LLMType.ORCHESTRATOR,
                 temperature=0.3,  # Lower temperature for consistent routing
                 max_tokens=LLMDefaults.CHAT_MAX_TOKENS,
                 top_p=0.8,

--- a/autobot-backend/agents/chat_agent.py
+++ b/autobot-backend/agents/chat_agent.py
@@ -19,6 +19,7 @@ from autobot_shared.ssot_config import (
     get_agent_provider_explicit,
 )
 from constants.threshold_constants import LLMDefaults
+from llm_shared.types import LLMType
 from prompt_manager import get_language_instruction, resolve_language
 from services.llm_service import get_llm_service
 
@@ -169,7 +170,7 @@ class ChatAgent(StandardizedAgent):
             # Generate response using optimized settings for chat
             response = await self.llm_interface.chat(
                 messages=messages,
-                llm_type="chat",  # This will use the chat-specific model
+                llm_type=LLMType.CHAT,  # This will use the chat-specific model
                 temperature=LLMDefaults.DEFAULT_TEMPERATURE,
                 max_tokens=LLMDefaults.CHAT_MAX_TOKENS,
                 top_p=LLMDefaults.DEFAULT_TOP_P,

--- a/autobot-backend/agents/llm_failsafe_agent.py
+++ b/autobot-backend/agents/llm_failsafe_agent.py
@@ -25,6 +25,7 @@ from autobot_shared.ssot_config import (
     get_agent_model_explicit,
     get_agent_provider_explicit,
 )
+from llm_shared.types import LLMType
 
 from .base_agent import DeploymentMode
 from .standardized_agent import ActionHandler, StandardizedAgent
@@ -495,7 +496,7 @@ class LLMFailsafeAgent(StandardizedAgent):
                 try:
                     messages = self._create_structured_messages(prompt, context)
                     response_data = await asyncio.wait_for(
-                        llm.chat(messages, llm_type="task"),
+                        llm.chat(messages, llm_type=LLMType.TASK),
                         timeout=self.timeouts[LLMTier.PRIMARY],
                     )
                     response = response_data.content
@@ -526,7 +527,7 @@ class LLMFailsafeAgent(StandardizedAgent):
                 try:
                     messages = [{"role": "user", "content": simplified_prompt}]
                     response_data = await asyncio.wait_for(
-                        llm.chat(messages, llm_type="task"),
+                        llm.chat(messages, llm_type=LLMType.TASK),
                         timeout=self.timeouts[LLMTier.SECONDARY],
                     )
                     response = response_data.content

--- a/autobot-backend/agents/rag_agent.py
+++ b/autobot-backend/agents/rag_agent.py
@@ -20,6 +20,7 @@ from autobot_shared.ssot_config import (
     get_agent_provider_explicit,
 )
 from constants.threshold_constants import LLMDefaults
+from llm_shared.types import LLMType
 from services.llm_service import get_llm_service
 
 from .base_agent import AgentRequest
@@ -186,7 +187,7 @@ class RAGAgent(StandardizedAgent):
 
             response = await self.llm_interface.chat(
                 messages=messages,
-                llm_type="rag",
+                llm_type=LLMType.RAG,
                 temperature=0.5,
                 max_tokens=LLMDefaults.SYNTHESIS_MAX_TOKENS,
                 top_p=LLMDefaults.DEFAULT_TOP_P,
@@ -230,7 +231,7 @@ class RAGAgent(StandardizedAgent):
 
             response = await self.llm_interface.chat(
                 messages=messages,
-                llm_type="rag",
+                llm_type=LLMType.RAG,
                 temperature=0.6,
                 max_tokens=LLMDefaults.CHAT_MAX_TOKENS,
                 top_p=0.85,
@@ -539,7 +540,7 @@ Focus on creating 2-4 reformulated queries that would retrieve different but rel
 
             llm_response = await self.llm_interface.chat(
                 messages=messages,
-                llm_type="rag",
+                llm_type=LLMType.RAG,
                 temperature=kwargs.get("temperature", 0.5),
                 max_tokens=kwargs.get("max_tokens", LLMDefaults.SYNTHESIS_MAX_TOKENS),
                 top_p=kwargs.get("top_p", LLMDefaults.DEFAULT_TOP_P),

--- a/autobot-backend/api/analytics_code_generation.py
+++ b/autobot-backend/api/analytics_code_generation.py
@@ -52,6 +52,7 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_constants import TTL_30_DAYS
+from llm_shared.types import LLMType
 
 # LLM Service for real code generation
 from services.llm_service import get_llm_service
@@ -532,7 +533,7 @@ class CodeGenerationEngine:
             # Call LLM via chat
             response = await llm_client.chat(
                 messages=messages,
-                llm_type="task",  # Use task-optimized model
+                llm_type=LLMType.TASK,  # Use task-optimized model
                 temperature=0.2,  # Lower temperature for code generation
                 max_tokens=4096,
             )

--- a/autobot-backend/api/chat_compare.py
+++ b/autobot-backend/api/chat_compare.py
@@ -28,6 +28,7 @@ from api.schemas_chat import CompareRequest
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from llm_shared.types import LLMType
 
 logger = get_logger(__name__)
 
@@ -85,7 +86,7 @@ async def _stream_single_model(
         registry = get_provider_registry()
         llm_request = LLMRequest(
             messages=messages,
-            llm_type="chat",
+            llm_type=LLMType.CHAT,
             provider=provider_name or None,
             model_name=model_name or None,
             stream=True,

--- a/autobot-backend/api/codebase_analytics/analyzers.py
+++ b/autobot-backend/api/codebase_analytics/analyzers.py
@@ -19,6 +19,7 @@ import aiofiles
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.missing_dep import optional_import
 from constants.network_constants import NetworkConstants
+from llm_shared.types import LLMType
 from services.llm_service import get_llm_service
 from type_defs.common import Metadata
 
@@ -1346,7 +1347,7 @@ async def detect_hardcodes_and_debt_with_llm(
             language=language, file_path=file_path, code_snippet=code_snippet[:800]
         )
         messages = [{"role": "user", "content": prompt}]
-        response = await llm.chat(messages, llm_type="task")
+        response = await llm.chat(messages, llm_type=LLMType.TASK)
         result = _parse_llm_json_response(response.content.strip())
         return result if result else empty_result
     except Exception as e:

--- a/autobot-backend/judges/__init__.py
+++ b/autobot-backend/judges/__init__.py
@@ -23,6 +23,7 @@ from enum import Enum
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from llm_shared.types import LLMType
 
 logger = get_logger(__name__)
 
@@ -184,7 +185,7 @@ class BaseLLMJudge:
                     {"role": "system", "content": self._get_system_prompt()},
                     {"role": "user", "content": prompt},
                 ],
-                llm_type="analysis",
+                llm_type=LLMType.ANALYSIS,
                 temperature=0.1,  # Low temperature for consistent judgments
                 structured_output=True,  # #10672: force valid JSON so judgments aren't dropped
             )

--- a/autobot-backend/knowledge/pipeline/cognifiers/causal_relationship_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/causal_relationship_extractor.py
@@ -24,6 +24,7 @@ from knowledge.pipeline.cognifiers.llm_utils import (
 from knowledge.pipeline.models.causal_edge import CausalEdge, EffectType
 from knowledge.pipeline.models.chunk import ProcessedChunk
 from knowledge.pipeline.registry import TaskRegistry
+from llm_shared.types import LLMType
 from services.llm_service import get_llm_service
 
 logger = get_logger(__name__)
@@ -330,7 +331,7 @@ class CausalRelationshipExtractor(BaseCognifier):
             chunks,
             llm=self.llm,
             batch_prompt_template=CAUSAL_EXTRACTION_BATCH_PROMPT,
-            llm_type="extraction",
+            llm_type=LLMType.EXTRACTION,
             max_chunk_chars=config.cognifier_batch_max_chunk_chars,
             convert=lambda raw, chunk: self._convert_to_causal_edges(raw, chunk, context.document_id),
             extract_one=lambda chunk: self._extract_from_chunk(chunk, context),
@@ -350,7 +351,7 @@ class CausalRelationshipExtractor(BaseCognifier):
         prompt = CAUSAL_EXTRACTION_PROMPT.format(text=chunk.content)
         try:
             response = await self.llm.chat(
-                [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
+                [{"role": "user", "content": prompt}], llm_type=LLMType.EXTRACTION, structured_output=True
             )
             # #10645: parse strictly so malformed JSON surfaces as an error
             # rather than being silently coerced; a bad response for one chunk

--- a/autobot-backend/knowledge/pipeline/cognifiers/context_generator.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/context_generator.py
@@ -17,6 +17,7 @@ from autobot_shared.ssot_config import config
 from autobot_shared.time_utils import now_utc
 from knowledge.pipeline.base import BaseCognifier, PipelineContext
 from knowledge.pipeline.registry import TaskRegistry
+from llm_shared.types import LLMType
 from services.llm_service import get_llm_service
 
 logger = get_logger(__name__)
@@ -86,7 +87,7 @@ class ContextGeneratorCognifier(BaseCognifier):
     async def _call_llm_for_summary(self, doc_text: str) -> str:
         prompt = _SUMMARY_PROMPT.format(doc_text=doc_text[:_DOC_TEXT_LIMIT])
         try:
-            response = await self.llm.chat([{"role": "user", "content": prompt}], llm_type="analysis")
+            response = await self.llm.chat([{"role": "user", "content": prompt}], llm_type=LLMType.ANALYSIS)
             return response.content.strip()
         except Exception as e:  # noqa: BLE001
             logger.error("Context summary LLM call failed: %s", e)
@@ -108,7 +109,7 @@ class ContextGeneratorCognifier(BaseCognifier):
             return ""
         prompt = _CHUNK_PROMPT.format(doc_summary=doc_summary, chunk_text=chunk_text)
         try:
-            response = await self.llm.chat([{"role": "user", "content": prompt}], llm_type="analysis")
+            response = await self.llm.chat([{"role": "user", "content": prompt}], llm_type=LLMType.ANALYSIS)
             return response.content.strip()
         except Exception as e:  # noqa: BLE001
             logger.error("Chunk context LLM call failed: %s", e)

--- a/autobot-backend/knowledge/pipeline/cognifiers/entity_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/entity_extractor.py
@@ -24,6 +24,7 @@ from knowledge.pipeline.cognifiers.llm_utils import (
 from knowledge.pipeline.models.chunk import ProcessedChunk
 from knowledge.pipeline.models.entity import Entity, EntityType
 from knowledge.pipeline.registry import TaskRegistry
+from llm_shared.types import LLMType
 from services.llm_service import get_llm_service
 
 logger = get_logger(__name__)
@@ -301,7 +302,7 @@ class EntityExtractor(BaseCognifier):
             chunks,
             llm=self.llm,
             batch_prompt_template=ENTITY_EXTRACTION_BATCH_PROMPT,
-            llm_type="extraction",
+            llm_type=LLMType.EXTRACTION,
             max_chunk_chars=config.cognifier_batch_max_chunk_chars,
             convert=lambda raw, chunk: self._convert_to_entities(raw, chunk, context.document_id),
             extract_one=lambda chunk: self._extract_from_chunk(chunk, context),
@@ -318,7 +319,7 @@ class EntityExtractor(BaseCognifier):
         prompt = ENTITY_EXTRACTION_PROMPT.format(text=chunk.content)
         try:
             response = await self.llm.chat(
-                [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
+                [{"role": "user", "content": prompt}], llm_type=LLMType.EXTRACTION, structured_output=True
             )
         except Exception as e:
             logger.error("Entity extraction LLM call failed (transient): %s", e)

--- a/autobot-backend/knowledge/pipeline/cognifiers/event_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/event_extractor.py
@@ -24,6 +24,7 @@ from knowledge.pipeline.models.chunk import ProcessedChunk
 from knowledge.pipeline.models.entity import Entity
 from knowledge.pipeline.models.event import EventType, TemporalEvent, TemporalType
 from knowledge.pipeline.registry import TaskRegistry
+from llm_shared.types import LLMType
 from services.llm_service import get_llm_service
 
 logger = get_logger(__name__)
@@ -137,7 +138,7 @@ class EventExtractor(BaseCognifier):
             chunks,
             llm=self.llm,
             batch_prompt_template=EVENT_EXTRACTION_BATCH_PROMPT,
-            llm_type="extraction",
+            llm_type=LLMType.EXTRACTION,
             max_chunk_chars=config.cognifier_batch_max_chunk_chars,
             convert=lambda raw, chunk: self._convert_to_events(raw, chunk, entity_map, context),
             extract_one=lambda chunk: self._extract_from_chunk(chunk, entity_map, context),
@@ -157,7 +158,7 @@ class EventExtractor(BaseCognifier):
         prompt = EVENT_EXTRACTION_PROMPT.format(text=chunk.content)
         try:
             response = await self.llm.chat(
-                [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
+                [{"role": "user", "content": prompt}], llm_type=LLMType.EXTRACTION, structured_output=True
             )
         except Exception as e:
             logger.error("Event extraction LLM call failed (transient): %s", e)

--- a/autobot-backend/knowledge/pipeline/cognifiers/fact_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/fact_extractor.py
@@ -21,6 +21,7 @@ from knowledge.pipeline.cognifiers.llm_utils import batched_chunk_extract, parse
 from knowledge.pipeline.models.chunk import ProcessedChunk
 from knowledge.pipeline.models.fact import AtomicFact, FactType
 from knowledge.pipeline.registry import TaskRegistry
+from llm_shared.types import LLMType
 from services.llm_service import get_llm_service
 
 logger = get_logger(__name__)
@@ -265,7 +266,7 @@ class FactExtractor(BaseCognifier):
             chunks,
             llm=self.llm,
             batch_prompt_template=FACT_EXTRACTION_BATCH_PROMPT,
-            llm_type="extraction",
+            llm_type=LLMType.EXTRACTION,
             max_chunk_chars=config.cognifier_batch_max_chunk_chars,
             convert=lambda raw, chunk: self._convert_to_facts(raw, chunk, context.document_id),
             extract_one=lambda chunk: self._extract_from_chunk(chunk, context),
@@ -280,7 +281,7 @@ class FactExtractor(BaseCognifier):
         prompt = FACT_EXTRACTION_PROMPT.format(text=chunk.content[:MAX_CHUNK_CHARS])
         try:
             response = await self.llm.chat(
-                [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
+                [{"role": "user", "content": prompt}], llm_type=LLMType.EXTRACTION, structured_output=True
             )
         except Exception as e:
             logger.error("Fact extraction LLM call failed (transient) for chunk %s: %s", chunk.id, e)

--- a/autobot-backend/knowledge/pipeline/cognifiers/recursive_summarizer.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/recursive_summarizer.py
@@ -26,6 +26,7 @@ from knowledge.pipeline.models.chunk import ProcessedChunk
 from knowledge.pipeline.models.entity import Entity
 from knowledge.pipeline.models.summary import Summary, SummaryLevel
 from knowledge.pipeline.registry import TaskRegistry
+from llm_shared.types import LLMType
 from rlm.evaluator import ResponseQualityEvaluator
 from rlm.types import RLMConfig
 from services.llm_service import get_llm_service
@@ -253,7 +254,7 @@ class RecursiveSummarizer(BaseCognifier):
 
     async def _generate_and_parse(self, prompt: str) -> dict:
         """Call LLM and parse JSON response (#1383: extracted helper)."""
-        response = await self.llm.chat([{"role": "user", "content": prompt}], llm_type="analysis")
+        response = await self.llm.chat([{"role": "user", "content": prompt}], llm_type=LLMType.ANALYSIS)
         raw = parse_llm_json_response(response.content, fallback_dict=True)
         if isinstance(raw, dict):
             return raw

--- a/autobot-backend/knowledge/pipeline/cognifiers/relationship_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/relationship_extractor.py
@@ -22,6 +22,7 @@ from knowledge.pipeline.models.chunk import ProcessedChunk
 from knowledge.pipeline.models.entity import Entity
 from knowledge.pipeline.models.relationship import Relationship, RelationType
 from knowledge.pipeline.registry import TaskRegistry
+from llm_shared.types import LLMType
 from services.llm_service import get_llm_service
 
 logger = get_logger(__name__)
@@ -249,7 +250,7 @@ class RelationshipExtractor(BaseCognifier):
         prompt = RELATIONSHIP_EXTRACTION_PROMPT.format(entities=entity_list, text=chunk.content)
         try:
             response = await self.llm.chat(
-                [{"role": "user", "content": prompt}], llm_type="extraction", structured_output=True
+                [{"role": "user", "content": prompt}], llm_type=LLMType.EXTRACTION, structured_output=True
             )
         except Exception as e:
             logger.error("Relationship extraction LLM call failed (transient): %s", e)

--- a/autobot-backend/knowledge/pipeline/cognifiers/summarizer.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/summarizer.py
@@ -24,6 +24,7 @@ from knowledge.pipeline.models.chunk import ProcessedChunk
 from knowledge.pipeline.models.entity import Entity
 from knowledge.pipeline.models.summary import Summary, SummaryLevel
 from knowledge.pipeline.registry import TaskRegistry
+from llm_shared.types import LLMType
 from services.llm_service import get_llm_service
 
 logger = get_logger(__name__)
@@ -216,7 +217,7 @@ class HierarchicalSummarizer(BaseCognifier):
         """Summarize text using LLM."""
         try:
             prompt = SUMMARY_PROMPT.format(max_words=max_words, text=text)
-            response = await self.llm.chat([{"role": "user", "content": prompt}], llm_type="analysis")
+            response = await self.llm.chat([{"role": "user", "content": prompt}], llm_type=LLMType.ANALYSIS)
             raw = parse_llm_json_response(response.content, fallback_dict=True)
             parsed = raw if isinstance(raw, dict) else {"summary": "", "key_topics": [], "key_entities": []}
 

--- a/autobot-backend/llc/kb/handoff_brief.py
+++ b/autobot-backend/llc/kb/handoff_brief.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.logging_manager import get_logger
+from llm_shared.types import LLMType
 
 from .rag_assembler import AssemblerProfile, LLCRAGAssembler
 
@@ -83,7 +84,7 @@ class HandoffBriefGenerator:
                         "artifacts (list of created/modified artifacts)",
                     },
                 ],
-                llm_type="extraction",
+                llm_type=LLMType.EXTRACTION,
                 temperature=0.1,
                 max_tokens=1024,
             )
@@ -172,7 +173,7 @@ class HandoffBriefGenerator:
                         "suggested_approach (recommended strategy for this work)",
                     },
                 ],
-                llm_type="extraction",
+                llm_type=LLMType.EXTRACTION,
                 temperature=0.1,
                 max_tokens=1024,
             )

--- a/autobot-backend/llc/kb/sprint_summarizer.py
+++ b/autobot-backend/llc/kb/sprint_summarizer.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.logging_manager import get_logger
+from llm_shared.types import LLMType
 
 from ..kb.collections import KbCollectionManager
 from ..models.sprint import LLCSprint
@@ -242,7 +243,7 @@ class SprintKbSummarizer:
         try:
             response = await llm.chat(
                 [{"role": "user", "content": prompt}],
-                llm_type="summarization",
+                llm_type=LLMType.ANALYSIS,
                 max_tokens=1024,
             )
         except Exception as exc:

--- a/autobot-backend/llm_shared/llm_type_enum_test.py
+++ b/autobot-backend/llm_shared/llm_type_enum_test.py
@@ -1,0 +1,36 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11019 — LLMType is a str-Enum, so a member is interchangeable with its string
+value. This is what makes migrating call sites from raw strings to LLMType.X safe:
+router dict-lookups keyed by the string still resolve and ``== "extraction"``
+comparisons (incl. existing test assertions) keep holding."""
+
+from llm_shared.types import LLMType
+
+
+def test_llmtype_is_str_subclass():
+    assert issubclass(LLMType, str)
+    assert isinstance(LLMType.EXTRACTION, str)
+
+
+def test_llmtype_member_equals_its_value():
+    assert LLMType.EXTRACTION == "extraction"
+    assert LLMType.ANALYSIS == "analysis"
+    assert LLMType.EXTRACTION.value == "extraction"
+
+
+def test_llmtype_resolves_as_dict_key_with_raw_string():
+    # A dict keyed by the raw string still resolves via the enum member and vice
+    # versa — the property the model-tier router relies on.
+    by_string = {"extraction": 1, "analysis": 2}
+    assert by_string[LLMType.EXTRACTION] == 1
+    by_enum = {LLMType.EXTRACTION: 1}
+    assert by_enum["extraction"] == 1
+
+
+def test_all_members_roundtrip():
+    for member in LLMType:
+        assert LLMType(member.value) is member
+        assert member == member.value

--- a/autobot-backend/llm_shared/types.py
+++ b/autobot-backend/llm_shared/types.py
@@ -58,8 +58,14 @@ class ProviderType(Enum):
     BEDROCK = "bedrock"  # GH#9010
 
 
-class LLMType(Enum):
-    """Types of LLM usage contexts."""
+class LLMType(str, Enum):
+    """Types of LLM usage contexts.
+
+    Subclasses ``str`` (#11019) so a member is interchangeable with its string
+    value everywhere — ``LLMType.EXTRACTION == "extraction"``, dict lookups keyed
+    by the raw string still resolve, and legacy call sites passing the string keep
+    working — while call sites can adopt ``LLMType.X`` for author-time typo safety.
+    """
 
     ORCHESTRATOR = "orchestrator"
     TASK = "task"

--- a/autobot-backend/orchestration/subagent_dispatcher.py
+++ b/autobot-backend/orchestration/subagent_dispatcher.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from llm_shared.types import LLMType
 from orchestration.primitives import bounded_gather
 
 logger = get_logger(__name__)
@@ -192,7 +193,7 @@ class SubagentDispatcher:
         try:
             response = await llm.chat(
                 messages=[{"role": "user", "content": prompt}],
-                llm_type="analysis",
+                llm_type=LLMType.ANALYSIS,
                 temperature=0.1,
                 max_tokens=256,
             )
@@ -221,7 +222,7 @@ class SubagentDispatcher:
         try:
             response = await llm.chat(
                 messages=[{"role": "user", "content": prompt}],
-                llm_type="analysis",
+                llm_type=LLMType.ANALYSIS,
                 temperature=0.3,
                 max_tokens=1024,
             )

--- a/autobot-backend/services/context_sufficiency.py
+++ b/autobot-backend/services/context_sufficiency.py
@@ -23,6 +23,7 @@ from enum import Enum
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from llm_shared.types import LLMType
 
 logger = get_logger(__name__)
 
@@ -334,7 +335,7 @@ async def _llm_evaluate(
         response = await asyncio.wait_for(
             llm.chat(
                 messages=messages,
-                llm_type="task",
+                llm_type=LLMType.TASK,
                 max_tokens=5,
                 temperature=0.0,
             ),

--- a/autobot-backend/services/llm_service.py
+++ b/autobot-backend/services/llm_service.py
@@ -88,14 +88,24 @@ _TASK_TYPE_DEFAULTS: Dict[str, Dict[str, Any]] = {
 
 
 def _normalize_llm_type(llm_type: str | LLMType | None) -> LLMType:
-    """Coerce string or None to an LLMType enum value."""
+    """Coerce string or None to an LLMType enum value.
+
+    An unrecognized string (e.g. a typo like ``"anaylsis"`` or a non-existent tier
+    like ``"summarization"``) is logged and mapped to ``GENERAL`` rather than
+    silently misrouting the model tier (#11019). Callers should pass ``LLMType.X``
+    so typos become AttributeErrors at author time.
+    """
     if isinstance(llm_type, LLMType):
         return llm_type
     if isinstance(llm_type, str):
         try:
             return LLMType(llm_type.lower())
         except ValueError:
-            pass
+            logger.warning(
+                "Unknown llm_type %r — routing to GENERAL tier. Use an LLMType member; valid: %s",
+                llm_type,
+                ", ".join(t.value for t in LLMType),
+            )
     return LLMType.GENERAL
 
 

--- a/autobot-backend/services/nl_database_service.py
+++ b/autobot-backend/services/nl_database_service.py
@@ -32,6 +32,7 @@ from autobot_shared.redis_client import RedisDatabase, get_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config
 from autobot_shared.time_utils import utc_timestamp
+from llm_shared.types import LLMType
 
 logger = get_logger(__name__)
 
@@ -523,7 +524,7 @@ class NLDatabaseService:
             if self._llm is None:
                 self._llm = LLMService()
 
-            llm_response = await self._llm.chat([{"role": "user", "content": prompt}], llm_type="task")
+            llm_response = await self._llm.chat([{"role": "user", "content": prompt}], llm_type=LLMType.TASK)
             response = llm_response.content
             return _extract_sql_from_response(response)
         except Exception as exc:


### PR DESCRIPTION
## Thinking Path
Post-merge audit (#11019). `LLMType` existed but ~31 call sites passed raw strings (`llm_type="extraction"`). Worse, `_normalize_llm_type` **silently** mapped an unrecognized string to `GENERAL` — so a typo (or the real bug `llm_type="summarization"`, which is not a valid tier) quietly misrouted the model tier.

## What Changed
- **`LLMType` is now `class LLMType(str, Enum)`** (matching `ArchitectureFamily`), so a member is interchangeable with its string value everywhere: `LLMType.EXTRACTION == "extraction"`, router dict-lookups keyed by the raw string still resolve, and legacy string call sites keep working. This makes the migration a safe drop-in.
- **Adopted `LLMType.X` at 21 call sites** (cognifiers, judges, agents, api, services) for author-time typo safety.
- **Real bug fixed:** `llc/kb/sprint_summarizer.py` passed `llm_type="summarization"` — not a valid `LLMType`, so it silently ran on the GENERAL tier. Now `LLMType.ANALYSIS` (how summarizers are tiered per #10598).
- **`_normalize_llm_type` now logs a warning** on an unknown string before falling back to GENERAL, so future typos are visible even from string callers.

## Verification
Cognifier suite 152 pass (their `llm_type == "extraction"` assertions still hold thanks to the str-Enum). New `llm_type_enum_test.py` (4 tests): str-subclass, member==value, dict-key interchangeability, all-members roundtrip. Black + isort + flake8 (repo config) clean; all 24 files compile. (Pre-existing `judge_integration_test` failures are unrelated — present on base, #10880.)

Closes #11019

## Model Used
Opus 4.8