### PR TITLE
fix(frontend): resolve any + no-unused-vars in d.ts/repositories/views (#9924)

### DIFF
--- a/autobot-frontend/src/config/AppConfig.d.ts
+++ b/autobot-frontend/src/config/AppConfig.d.ts
@@ -117,7 +117,7 @@ export interface FetchOptions extends RequestInit {
 }
 
 export declare class AppConfigService {
-  serviceDiscovery: any;
+  serviceDiscovery: unknown;
   config: AppConfig;
   configLoaded: boolean;
   debugMode: boolean;
@@ -146,7 +146,7 @@ export declare class AppConfigService {
 
   mergeConfig(remoteConfig: Partial<AppConfig>): void;
 
-  get(path: string, defaultValue?: any): any;
+  get(path: string, defaultValue?: unknown): unknown;
 
   isFeatureEnabled(featureName: string): boolean;
 
@@ -160,7 +160,7 @@ export declare class AppConfigService {
 
   invalidateCache(): void;
 
-  log(...args: any[]): void;
+  log(...args: unknown[]): void;
 
   getAllServiceUrls(): Promise<{ [key: string]: string }>;
 

--- a/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
+++ b/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
@@ -282,7 +282,7 @@ export class KnowledgeRepository extends ApiRepository {
 
   // Legacy add text method
   // Issue #552: Fixed path - backend uses /api/knowledge_base/add_text
-  async addKnowledge(content: string, metadata: Record<string, any> = {}): Promise<any> {
+  async addKnowledge(content: string, metadata: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
     const response = await this.post<Record<string, unknown>>(`${getApiBase()}/knowledge_base/add_text`, {
       content,
       metadata
@@ -489,7 +489,7 @@ export class KnowledgeRepository extends ApiRepository {
     const response = await this.get<{ results: BackendSearchResult[] }>(`${getApiBase()}/knowledge_base/documents/${documentId}/similar?limit=${limit}`)
 
     // Transform results to match SearchResult format
-    const results = (response.data as any).results || response.data || []
+    const results = ((response.data as { results?: BackendSearchResult[] }).results || response.data || []) as BackendSearchResult[]
     return results.map((result: BackendSearchResult) => ({
       document: {
         id: result.metadata?.fact_id || result.node_id,
@@ -513,7 +513,7 @@ export class KnowledgeRepository extends ApiRepository {
   async getSearchSuggestions(query: string, limit: number = 8): Promise<string[]> {
     try {
       const response = await this.get<string[]>(`${getApiBase()}/knowledge_base/suggestions?query=${encodeURIComponent(query)}&limit=${limit}`)
-      return (response.data as any) || []
+      return response.data || []
     } catch {
       // Return empty array if suggestions endpoint not available
       return []

--- a/autobot-frontend/src/models/repositories/__tests__/SystemRepository.shape.test.ts
+++ b/autobot-frontend/src/models/repositories/__tests__/SystemRepository.shape.test.ts
@@ -15,6 +15,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { SystemRepository } from '../SystemRepository'
+import type { AutoBotSettings } from '@/types/models'
 
 vi.mock('@/config/ssot-config', () => ({
   getApiBase: () => '/api'
@@ -380,7 +381,7 @@ describe('SystemRepository shape handling (#5207 audit)', () => {
       const response = { ui: partial.ui }
       postSpy.mockResolvedValue({ data: response })
 
-      const result = await repo.updateSettings(partial as any)
+      const result = await repo.updateSettings(partial as Partial<AutoBotSettings>)
 
       expect(postSpy).toHaveBeenCalledWith(
         expect.stringContaining('/api/settings/'),
@@ -404,15 +405,15 @@ describe('SystemRepository shape handling (#5207 audit)', () => {
   // they can't silently reappear.
   describe('config-file methods removed (#5214)', () => {
     it('getConfigFiles is not present on SystemRepository', () => {
-      expect((repo as any).getConfigFiles).toBeUndefined()
+      expect((repo as unknown as Record<string, unknown>).getConfigFiles).toBeUndefined()
     })
 
     it('getConfigFile is not present on SystemRepository', () => {
-      expect((repo as any).getConfigFile).toBeUndefined()
+      expect((repo as unknown as Record<string, unknown>).getConfigFile).toBeUndefined()
     })
 
     it('updateConfigFile is not present on SystemRepository', () => {
-      expect((repo as any).updateConfigFile).toBeUndefined()
+      expect((repo as unknown as Record<string, unknown>).updateConfigFile).toBeUndefined()
     })
   })
 })

--- a/autobot-frontend/src/types/app-config.d.ts
+++ b/autobot-frontend/src/types/app-config.d.ts
@@ -12,6 +12,8 @@
  * Issue #156: Complete type safety for configuration access
  */
 
+import type { ServicesConfig, InfrastructureConfig } from '@/config/AppConfig'
+
 /**
  * Terminal host configuration
  */
@@ -40,18 +42,18 @@ export interface BackendConfig {
    */
   config?: {
     hosts?: HostConfig[]
-    services?: Record<string, any>
+    services?: ServicesConfig | Record<string, unknown>
   }
 
   /**
    * Service configurations
    */
-  services?: Record<string, any>
+  services?: ServicesConfig | Record<string, unknown>
 
   /**
    * Infrastructure settings
    */
-  infrastructure?: Record<string, any>
+  infrastructure?: InfrastructureConfig | Record<string, unknown>
 
   /**
    * Network settings
@@ -60,7 +62,7 @@ export interface BackendConfig {
     backend?: { host: string; port: string; protocol: string }
     frontend?: { host: string; port: string; protocol: string }
     redis?: { host: string; port: string }
-    [key: string]: any
+    [key: string]: unknown
   }
 }
 

--- a/autobot-frontend/src/types/pinia-persist.d.ts
+++ b/autobot-frontend/src/types/pinia-persist.d.ts
@@ -12,7 +12,7 @@
  * Issue #156: Eliminates need for 'as any' type casts in store definitions
  */
 
-import 'pinia'
+import type { StateTree, PiniaPluginContext } from 'pinia'
 
 declare module 'pinia' {
   /**
@@ -71,23 +71,23 @@ declare module 'pinia' {
       /**
        * Serialize state before storing
        */
-      serialize: (value: any) => string
+      serialize: (value: StateTree) => string
 
       /**
        * Deserialize state when loading
        */
-      deserialize: (value: string) => any
+      deserialize: (value: string) => StateTree
     }
 
     /**
      * Hook called before state is persisted
      */
-    beforeRestore?: (context: any) => void
+    beforeRestore?: (context: PiniaPluginContext) => void
 
     /**
      * Hook called after state is restored
      */
-    afterRestore?: (context: any) => void
+    afterRestore?: (context: PiniaPluginContext) => void
 
     /**
      * Enable debug mode for persistence operations

--- a/autobot-frontend/src/utils/RumConsoleHelper.ts
+++ b/autobot-frontend/src/utils/RumConsoleHelper.ts
@@ -6,7 +6,16 @@
  * Issue #156 Fix: Import RumAgent to ensure Window.rum type is available
  */
 
-import type { ApiCall } from './RumAgent'
+import type { ApiCall, CriticalIssue, RumMetadata } from './RumAgent'
+
+/** Per-endpoint aggregation computed in rumApiStats(). */
+interface EndpointStats {
+  count: number
+  totalDuration: number
+  timeouts: number
+  errors: number
+  slowCalls: number
+}
 // Import the module to ensure Window.rum declaration is loaded
 import './RumAgent'
 
@@ -93,7 +102,7 @@ window.rumIssues = () => {
     return
   }
 
-  issues.forEach((issue: any, index: number) => {
+  issues.forEach((issue: CriticalIssue, index: number) => {
     console.group(`${index + 1}. ${issue.type} (${new Date(issue.timestamp).toLocaleTimeString()})`)
     console.groupEnd()
   })
@@ -109,7 +118,7 @@ window.rumApiStats = () => {
   const apiCalls = metrics.apiCalls
 
   // Group by endpoint
-  const endpointStats: Record<string, any> = {}
+  const endpointStats: Record<string, EndpointStats> = {}
   apiCalls.forEach((call: ApiCall) => {
     const endpoint = call.url
     if (!endpointStats[endpoint]) {
@@ -130,7 +139,7 @@ window.rumApiStats = () => {
     if (call.isSlow) stats.slowCalls++
   })
 
-  Object.entries(endpointStats).forEach(([endpoint, stats]: [string, any]) => {
+  Object.entries(endpointStats).forEach(([endpoint, stats]: [string, EndpointStats]) => {
     const avgDuration = Math.round(stats.totalDuration / stats.count)
     const hasIssues = stats.timeouts > 0 || stats.errors > 0 || stats.slowCalls > 0
 
@@ -164,7 +173,7 @@ window.rumDebug = () => {
   }
 
   const originalTrackError = window.rum.trackError.bind(window.rum)
-  window.rum.trackError = function(type: string, data: any) {
+  window.rum.trackError = function(type: string, data: RumMetadata) {
     return originalTrackError(type, data)
   }
 

--- a/autobot-frontend/src/views/AgentRegistryView.vue
+++ b/autobot-frontend/src/views/AgentRegistryView.vue
@@ -11,13 +11,11 @@
  */
 
 import { ref, onMounted, computed } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { useAgentRegistry, type SpecializedAgent, type BackendAgent } from '@/composables/useAgentRegistry'
+import { useAgentRegistry, type SpecializedAgent } from '@/composables/useAgentRegistry'
 import { useAvailableModels } from '@/composables/useAvailableModels'
 import AgentSettingsPanel from '@/components/agents/AgentSettingsPanel.vue'
 import { createLogger } from '@/utils/debugUtils'
 
-const { t } = useI18n()
 const logger = createLogger('AgentRegistryView')
 
 const {
@@ -36,7 +34,6 @@ const {
 const {
   availableModelNames,
   isLoading: isLoadingModels,
-  error: modelsError,
   hasErrors: modelsHaveErrors,
   providersErrored,
   fetchModels,
@@ -70,13 +67,6 @@ function getColorClasses(color: string): string {
   return colorMap[color] || colorMap.gray
 }
 
-const categoryIcons: Record<string, string> = {
-  implementation: 'M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4',
-  analysis: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z',
-  planning: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01',
-  specialized: 'M13 10V3L4 14h7v7l9-11h-7z',
-  general: 'M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4',
-}
 
 async function openAgentDetail(agent: SpecializedAgent) {
   showDetailModal.value = true

--- a/autobot-frontend/src/views/DevSpeedupView.vue
+++ b/autobot-frontend/src/views/DevSpeedupView.vue
@@ -10,13 +10,10 @@
  */
 
 import { ref, computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 import { useDevSpeedup } from '@/composables/useDevSpeedup'
-import type { CodeSnippet, CodeTemplate } from '@/composables/useDevSpeedup'
 import { createLogger } from '@/utils/debugUtils'
 import Icon from '@/components/ui/Icon.vue'
 
-const { t } = useI18n()
 const logger = createLogger('DevSpeedupView')
 
 const {
@@ -32,7 +29,6 @@ const {
   generateSnippet,
   fetchTemplates,
   suggestRefactor,
-  generateBoilerplate,
   generateTests,
   optimizeCode,
   formatCode,


### PR DESCRIPTION
## Thinking Path
Toward green `frontend-tests` — all 32 eslint warnings in 8 files (incl. ambient `.d.ts`).

## What Changed (32 → 0)
- **any→typed**: AppConfig.d.ts / app-config.d.ts (`unknown` + concrete `ServicesConfig`/`InfrastructureConfig` unions), KnowledgeRepository (`Record<string,unknown>`, `BackendSearchResult`), pinia-persist.d.ts (`StateTree`/`PiniaPluginContext`), RumConsoleHelper (`CriticalIssue`/`RumMetadata`), SystemRepository.shape.test (`Partial<AutoBotSettings>`).
- **unused removed**: `useI18n`/`t` (templates use `$t`); dead consts `categoryIcons` (AgentRegistryView) + `generateBoilerplate` binding (DevSpeedupView) — orphaned, no template/script reference.

## Reviewer note
`app-config.d.ts` needed `ServicesConfig | Record<string,unknown>` (not bare `Record`) — plain Record broke `useTerminalStore` assignability (the concrete `AppConfig` from `getBackendConfig()` has no index signature). Caught via vue-tsc.

## Verification (independently re-run)
- `eslint` 8 files → **0 warnings, 0 errors**.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (whole project).
- `vitest` (15 suites) → 157/157.
- No eslint-disable/@ts-ignore; no runtime coercions.

## Model Used
Opus 4.8

Contributes to #9924 green frontend-tests (278→246 problems).