### PR TITLE
hardening: config-crash guard + template IndexError + reranking log-flood + SSRF port-pinning (#11022)

### DIFF
--- a/autobot-backend/api/provider_auth.py
+++ b/autobot-backend/api/provider_auth.py
@@ -12,8 +12,7 @@ vault (``services.envelope_secrets_service``).
 
 Routes
 ------
-POST /api/llm-auth/oauth/initiate          — begin authorization-code flow
-POST /api/llm-auth/oauth/callback          — exchange code + persist tokens
+POST /api/llm-auth/oauth/callback          — exchange authorization code + persist tokens
 POST /api/llm-auth/device/initiate         — begin device-code flow
 POST /api/llm-auth/device/poll             — poll for device-code approval + persist
 GET  /api/llm-auth/status/{provider_name}  — check whether a provider has a stored token
@@ -102,6 +101,15 @@ def _validate_outbound_url(url: str) -> None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Host '{host}' is not in the provider OAuth allowlist",
+        )
+
+    # Port pinning (#11022): only the standard https port is allowed, so an
+    # allowlisted host can't be used to reach a non-HTTPS service on another port
+    # (e.g. https://api.github.com:22/...).
+    if parsed.port not in (None, 443):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only the standard https port (443) is permitted",
         )
 
 

--- a/autobot-backend/knowledge/search_components/reranking.py
+++ b/autobot-backend/knowledge/search_components/reranking.py
@@ -573,14 +573,15 @@ _reranking_active: bool = True
 
 
 def set_reranking_active(active: bool) -> None:
-    """Record whether cross-encoder reranking is currently active (#10600)."""
+    """Record whether cross-encoder reranking is currently active (#10600).
+
+    Logs the transition at DEBUG, not WARNING (#11022): a cross-encoder that loads
+    lazily/intermittently under concurrent load flaps this flag every query, and
+    WARNING-level flapping floods production logs.
+    """
     global _reranking_active
     if _reranking_active != active:
-        logger.warning(
-            "Reranking active state changed: %s -> %s",
-            _reranking_active,
-            active,
-        )
+        logger.debug("Reranking active state changed: %s -> %s", _reranking_active, active)
     _reranking_active = active
 
 

--- a/autobot-backend/llm_shared/tests/test_provider_auth.py
+++ b/autobot-backend/llm_shared/tests/test_provider_auth.py
@@ -507,6 +507,22 @@ class TestProviderAuthSecurity:
         _validate_outbound_url("https://github.com/login/oauth/access_token")
         _validate_outbound_url("https://api.anthropic.com/oauth/token")
 
+    def test_allowlisted_host_nonstandard_port_rejected(self):
+        """#11022: an allowlisted host on a non-443 port is rejected (port pinning)."""
+        from fastapi import HTTPException
+
+        from api.provider_auth import _validate_outbound_url
+
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_outbound_url("https://accounts.google.com:22/token")
+        assert exc_info.value.status_code == 400
+        assert "port" in exc_info.value.detail.lower()
+
+    def test_allowlisted_host_explicit_443_passes(self):
+        from api.provider_auth import _validate_outbound_url
+
+        _validate_outbound_url("https://accounts.google.com:443/o/oauth2/token")  # no raise
+
     def test_microsoftonline_passes(self):
         from api.provider_auth import _validate_outbound_url
 

--- a/autobot-backend/orchestration/orchestrator_prompts.py
+++ b/autobot-backend/orchestration/orchestrator_prompts.py
@@ -60,7 +60,9 @@ def _render_learned_template_section(learned_prompt_template: str | None, goal: 
         return ""
     try:
         rendered = learned_prompt_template.format(goal=goal)
-    except (KeyError, ValueError):
+    except (KeyError, ValueError, IndexError):
+        # IndexError guards a stored template containing a positional field like
+        # ``{0}`` — ``.format(goal=...)`` raises IndexError, not KeyError/ValueError (#11022).
         rendered = learned_prompt_template
     return f"\n        Learned approach for this task type:\n        {rendered}\n"
 

--- a/autobot-backend/tests/agents/test_learned_prompt_template_wiring.py
+++ b/autobot-backend/tests/agents/test_learned_prompt_template_wiring.py
@@ -194,3 +194,14 @@ def test_build_planning_prompt_no_template_unchanged():
 
     prompt = build_planning_prompt("deploy service X", "{}")
     assert "Learned approach" not in prompt
+
+
+def test_learned_template_with_positional_field_does_not_crash():
+    """#11022: a stored template containing a positional field like {0} must not
+    raise IndexError from .format(goal=...); it falls back to the raw template."""
+    from orchestration.orchestrator_prompts import _render_learned_template_section
+
+    # {0} is a positional field — .format(goal=...) raises IndexError, previously uncaught.
+    out = _render_learned_template_section("Do {0} then {goal}", "deploy")
+    assert "Learned approach" in out
+    assert "{0}" in out  # rendered raw (fallback), not crashed

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -89,10 +89,27 @@ PLAN_BEST_OF_N_ENABLED: bool = os.environ.get("AUTOBOT_PLAN_BEST_OF_N_ENABLED", 
     "true",
     "yes",
 }
-PLAN_BEST_OF_N_COUNT: int = min(
-    5,
-    max(2, int(os.environ.get("AUTOBOT_PLAN_BEST_OF_N_COUNT", "3"))),
-)
+
+
+def _env_int(name: str, default: int, *, lo: int | None = None, hi: int | None = None) -> int:
+    """Parse an int env var, falling back to *default* on missing/invalid input.
+
+    Never crash at import (#11022): a non-numeric ``AUTOBOT_PLAN_BEST_OF_N_COUNT``
+    used to raise ``ValueError`` at module import, taking down backend startup.
+    Optionally clamps to ``[lo, hi]``.
+    """
+    try:
+        val = int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        val = default
+    if lo is not None:
+        val = max(lo, val)
+    if hi is not None:
+        val = min(hi, val)
+    return val
+
+
+PLAN_BEST_OF_N_COUNT: int = _env_int("AUTOBOT_PLAN_BEST_OF_N_COUNT", 3, lo=2, hi=5)
 
 # #10602: ClaimVerifier wiring — adds KB RAG + optional research-agent LLM call per claim.
 # Default OFF because it adds latency/cost; set AUTOBOT_CLAIM_VERIFICATION_ENABLED=true to opt in.

--- a/autobot_shared/ssot_config_test.py
+++ b/autobot_shared/ssot_config_test.py
@@ -437,3 +437,28 @@ class TestChatCitationInstructionAliasChoices:
         monkeypatch.delenv("AUTOBOT_CHAT_GROUNDING", raising=False)
         cfg = _IsolatedLLMConfig()
         assert cfg.chat_citation_instruction_enabled is True
+
+
+class TestEnvIntSafeParse:
+    """#11022: _env_int must never crash the module at import on bad env input."""
+
+    def test_invalid_falls_back_to_default(self):
+        import importlib
+
+        with patch.dict(os.environ, {"AUTOBOT_PLAN_BEST_OF_N_COUNT": "not-a-number"}):
+            import autobot_shared.ssot_config as c
+
+            importlib.reload(c)
+            assert c.PLAN_BEST_OF_N_COUNT == 3
+            assert c._env_int("X_MISSING_VAR", 7) == 7
+            assert c._env_int("AUTOBOT_PLAN_BEST_OF_N_COUNT", 3) == 3  # invalid → default
+
+    def test_clamps_to_bounds(self):
+        import autobot_shared.ssot_config as c
+
+        with patch.dict(os.environ, {"X_CLAMP": "99"}):
+            assert c._env_int("X_CLAMP", 3, lo=2, hi=5) == 5
+        with patch.dict(os.environ, {"X_CLAMP": "1"}):
+            assert c._env_int("X_CLAMP", 3, lo=2, hi=5) == 2
+        with patch.dict(os.environ, {"X_CLAMP": "4"}):
+            assert c._env_int("X_CLAMP", 3, lo=2, hi=5) == 4


### PR DESCRIPTION
## Thinking Path
Post-merge audit minor-hardening bundle (#11022). Four small, independent real fixes:

## What Changed
1. **Import-time crash (`autobot_shared/ssot_config.py`):** a non-numeric `AUTOBOT_PLAN_BEST_OF_N_COUNT` raised `ValueError` at module import → backend wouldn't start. New `_env_int(name, default, lo, hi)` safe-parses (falls back to default, clamps) — never crashes at import.
2. **Uncaught IndexError (`orchestration/orchestrator_prompts.py`):** a learned template containing a positional field like `{0}` made `.format(goal=...)` raise `IndexError`, which the `except (KeyError, ValueError)` missed → planning crash. Added `IndexError` to the guard (falls back to the raw template).
3. **Reranking log-flood (`knowledge/search_components/reranking.py`):** `set_reranking_active` logged the state transition at WARNING; a lazily/intermittently-loading cross-encoder flaps it every query under concurrent load → WARNING flood. Dropped to DEBUG.
4. **SSRF hardening (`api/provider_auth.py`):** `_validate_outbound_url` allowlisted the host but not the port, so `https://api.github.com:22/...` passed. Added port pinning (only 443/default). Also removed a stale `POST /oauth/initiate` line from the module docstring (no such route).

## Verification
88 tests pass. New: `_env_int` invalid→default + clamp; positional-field template no-crash; non-443 port rejected + explicit-443 passes. Black + flake8 (repo config) clean.

Two bundle items **split to follow-ups** (out of 'minor hardening' scope): #11064 (BM25 corpus stats — flag-OFF algorithmic change) and #11065 (admin-erase for legacy unowned memory — needs a product decision).

Closes #11022

## Model Used
Opus 4.8