### PR TITLE
fix(ci): retry torch install — pytorch.org TLS flake breaks smoke-test (#11039)

### DIFF
--- a/autobot-backend/services/autoresearch/Dockerfile
+++ b/autobot-backend/services/autoresearch/Dockerfile
@@ -11,7 +11,16 @@ WORKDIR /experiment
 
 # Install minimal runtime dependencies for experiment scripts.
 # numpy and torch-cpu cover the typical nanoGPT training baseline.
-RUN pip install --no-cache-dir numpy torch --extra-index-url https://download.pytorch.org/whl/cpu
+# #11039: retry torch install — download.pytorch.org intermittently drops the
+# TLS handshake; assert the import so an exhausted retry loop still fails the build.
+RUN for i in 1 2 3 4 5; do \
+        pip install --no-cache-dir --retries 5 --timeout 120 \
+            numpy torch --extra-index-url https://download.pytorch.org/whl/cpu \
+        && break; \
+        echo "torch install attempt $i failed (network/TLS); retrying in $((i*10))s..."; \
+        sleep $((i*10)); \
+    done \
+    && python3 -c "import torch, numpy"
 
 # Copy the experiment entrypoint.  The train script itself is provided at
 # runtime via a read-only volume mount at /experiment.

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -40,9 +40,19 @@ COPY autobot-backend/requirements.txt /tmp/requirements.txt
 RUN grep -v -E "(autobot.shared|^-r |^-c |^torch==|^torchvision==)" /tmp/requirements.txt \
         > /app/requirements-filtered.txt \
     && python3 -m pip install --no-cache-dir -c /app/constraints/shared.txt -r /app/requirements-root.txt \
-    && python3 -m pip install --no-cache-dir \
-        torch==2.12.1 torchvision==0.27.1 \
-        --index-url https://download.pytorch.org/whl/cpu \
+    # #11039: download.pytorch.org intermittently drops the TLS handshake
+    # (SSLV3_ALERT_HANDSHAKE_FAILURE), failing the whole build on a transient
+    # network blip. Retry with backoff, then assert the import so an exhausted
+    # loop still fails the build (a bare for-loop exits 0 even if every try failed).
+    && for i in 1 2 3 4 5; do \
+           python3 -m pip install --no-cache-dir --retries 5 --timeout 120 \
+               torch==2.12.1 torchvision==0.27.1 \
+               --index-url https://download.pytorch.org/whl/cpu \
+           && break; \
+           echo "torch install attempt $i failed (network/TLS); retrying in $((i*10))s..."; \
+           sleep $((i*10)); \
+       done \
+    && python3 -c "import torch, torchvision" \
     && python3 -m pip install --no-cache-dir -c /app/constraints/shared.txt -r /app/requirements-filtered.txt
 
 


### PR DESCRIPTION
## Thinking Path
`smoke-test` (and every PR gated on it) fails intermittently during the Docker build: `ERROR: ... SSLV3_ALERT_HANDSHAKE_FAILURE` while pip fetches `torch`/`torchvision` from `download.pytorch.org`. It's a transient network/TLS blip but it aborts the whole build with no retry — it blocked real merges (#11047, #11029).

## What Changed
Wrapped both torch installs in a retry loop (5 attempts, linear backoff, `--retries 5 --timeout 120`), then assert `import torch` so an exhausted loop still fails the build (a bare `for` loop exits 0):
- `docker/backend/Dockerfile` (CPU torch from the pytorch index)
- `autobot-backend/services/autoresearch/Dockerfile`

## Verification
- `sh -n` validates both retry-loop shell bodies.
- The build's success path is unchanged; only transient-failure resilience is added.

## Model Used
Opus 4.8 (1M context)

Closes #11039