### PR TITLE
perf(cognify): batch the entity-conditioned relationship_extractor (last un-batched cognifier) (#11044)

### DIFF
--- a/autobot-backend/knowledge/pipeline/cognifiers/llm_utils.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/llm_utils.py
@@ -89,20 +89,26 @@ def build_entity_map(
     return entity_map
 
 
-def build_indexed_chunk_blocks(contents: List[str], max_chars: int) -> str:
+def build_indexed_chunk_blocks(contents: List[str], max_chars: int, aux: List[str] | None = None) -> str:
     """Render chunk texts as ``Chunk N:`` blocks for an index-keyed batch prompt.
 
     Args:
         contents: Per-chunk text, in order.
         max_chars: Truncate each chunk to this many characters (0 = no limit).
+        aux: Optional per-chunk auxiliary text (parallel to ``contents``) folded
+            into each block before the text — e.g. a chunk-relevant entity list
+            for entity-conditioned extraction (#11044).
 
     Returns:
-        Newline-separated ``Chunk i:\\n<text>`` blocks.
+        Newline-separated ``Chunk i:\\n[<aux>\\n]<text>`` blocks.
     """
     parts = []
     for i, text in enumerate(contents):
         body = text[:max_chars] if max_chars and max_chars > 0 else text
-        parts.append(f"Chunk {i}:\n{body}")
+        if aux is not None and aux[i]:
+            parts.append(f"Chunk {i}:\n{aux[i]}\n{body}")
+        else:
+            parts.append(f"Chunk {i}:\n{body}")
     return "\n\n".join(parts)
 
 
@@ -149,6 +155,7 @@ async def batched_chunk_extract(
     convert: Callable[[List[Any], Any], List[_R]],
     extract_one: Callable[[Any], Awaitable[List[_R]]],
     content_of: Callable[[Any], str] = lambda c: c.content,
+    aux_of: Callable[[Any], str] | None = None,
 ) -> List[_R]:
     """Extract items from many chunks in ONE structured LLM call (#10598).
 
@@ -167,6 +174,8 @@ async def batched_chunk_extract(
         convert: ``(raw_items, chunk) -> [domain objects]``.
         extract_one: Per-chunk async fallback returning domain objects.
         content_of: Extract the text of a chunk (default ``chunk.content``).
+        aux_of: Optional per-chunk auxiliary text folded into each indexed block —
+            e.g. a chunk-relevant entity list for entity-conditioned extraction (#11044).
 
     Returns:
         Flattened list of extracted items across all chunks, in chunk order.
@@ -176,7 +185,8 @@ async def batched_chunk_extract(
     if len(chunks) == 1:
         return await extract_one(chunks[0])
     try:
-        blocks = build_indexed_chunk_blocks([content_of(c) for c in chunks], max_chunk_chars)
+        aux = [aux_of(c) for c in chunks] if aux_of is not None else None
+        blocks = build_indexed_chunk_blocks([content_of(c) for c in chunks], max_chunk_chars, aux=aux)
         prompt = batch_prompt_template.format(chunks=blocks)
         batch_max_tokens = min(_BATCH_MAX_TOKENS_PER_CHUNK * len(chunks), _BATCH_MAX_TOKENS_CAP)
         response = await llm.chat(

--- a/autobot-backend/knowledge/pipeline/cognifiers/relationship_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/relationship_extractor.py
@@ -13,8 +13,10 @@ from itertools import combinations
 from typing import Any, Dict, List, Set, Tuple
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config
 from knowledge.pipeline.base import BaseCognifier, PipelineContext
 from knowledge.pipeline.cognifiers.llm_utils import (
+    batched_chunk_extract,
     build_entity_map,
     parse_llm_json_response,
 )
@@ -44,6 +46,34 @@ Return JSON array:
 
 Text:
 {text}
+"""
+
+
+# Batched variant (#11044): extract relationships from many entity-conditioned
+# chunks in one call. Each "Chunk N:" block carries its own chunk-relevant entity
+# list (folded in via ``aux_of``), so the model only relates entities present in
+# that chunk — matching the per-chunk conditioning of the single-chunk path.
+RELATIONSHIP_EXTRACTION_BATCH_PROMPT = """Extract relationships between entities from each of the following text chunks.
+
+Each chunk is labeled "Chunk N:" and lists its known entities followed by its text.
+Only relate entities listed for that same chunk.
+
+Relationship types: CAUSES, ENABLES, PREVENTS, TRIGGERS, CONTAINS, PART_OF,
+COMPOSED_OF, RELATES_TO, SIMILAR_TO, CONTRASTS_WITH, PRECEDES, FOLLOWS,
+DURING, IS_A, INSTANCE_OF, SUBTYPE_OF, CREATED_BY, AUTHORED_BY, OWNED_BY,
+IMPLEMENTS, EXTENDS, DEPENDS_ON, USES
+
+Return a JSON object mapping each chunk index (as a string) to its array of
+relationships (fields: source, target, type, description, bidirectional,
+confidence); use an empty array for chunks with no relationships. Example:
+{{
+  "0": [{{"source": "Entity1", "target": "Entity2", "type": "CAUSES",
+    "description": "...", "bidirectional": false, "confidence": 0.9}}],
+  "1": []
+}}
+
+Chunks:
+{chunks}
 """
 
 
@@ -228,12 +258,28 @@ class RelationshipExtractor(BaseCognifier):
         entities: List[Entity],
         entity_map: Dict[str, Entity],
     ) -> List[Relationship]:
-        """Process batch of chunks for relationships."""
-        relationships = []
-        for chunk in chunks:
-            chunk_rels = await self._extract_from_chunk(chunk, entities, entity_map)
-            relationships.extend(chunk_rels)
-        return relationships
+        """Extract relationships for a batch in ONE LLM call when batching is on (#11044).
+
+        Routes through the shared ``batched_chunk_extract`` helper, folding each
+        chunk's relevant entity list into its block via ``aux_of`` so the
+        entity-conditioning of the per-chunk path is preserved. Falls back to the
+        legacy per-chunk loop when the config flag is disabled.
+        """
+        if not config.cognifier_multichunk_batching:
+            relationships = []
+            for chunk in chunks:
+                relationships.extend(await self._extract_from_chunk(chunk, entities, entity_map))
+            return relationships
+        return await batched_chunk_extract(
+            chunks,
+            llm=self.llm,
+            batch_prompt_template=RELATIONSHIP_EXTRACTION_BATCH_PROMPT,
+            llm_type=LLMType.EXTRACTION,
+            max_chunk_chars=config.cognifier_batch_max_chunk_chars,
+            convert=lambda raw, chunk: self._convert_to_relationships(raw, chunk, entity_map),
+            extract_one=lambda chunk: self._extract_from_chunk(chunk, entities, entity_map),
+            aux_of=lambda chunk: "Entities:\n" + self._format_entity_list(entities, chunk),
+        )
 
     async def _extract_from_chunk(
         self,

--- a/autobot-backend/knowledge/pipeline/cognifiers/relationship_extractor_test.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/relationship_extractor_test.py
@@ -285,3 +285,79 @@ class TestDeduplicationByEntityPair:
 
         assert len(rels) == 1
         assert chunk.id in rels[0].source_chunk_ids
+
+
+# ---------------------------------------------------------------------------
+# #11044 — multi-chunk batching (entity-conditioned via aux_of)
+# ---------------------------------------------------------------------------
+
+
+def _rel(src: str, tgt: str) -> dict:
+    return {
+        "source": src,
+        "target": tgt,
+        "type": "USES",
+        "description": "",
+        "bidirectional": False,
+        "confidence": 0.9,
+    }
+
+
+def _llm_extractor():
+    ext = RelationshipExtractor.__new__(RelationshipExtractor)
+    ext.batch_size = 5
+    ext.min_confidence = 0.0
+    return ext
+
+
+@pytest.mark.asyncio
+async def test_batched_relationship_extraction_one_call(monkeypatch):
+    import json
+    import types
+    from unittest.mock import AsyncMock
+
+    import knowledge.pipeline.cognifiers.relationship_extractor as rex
+
+    monkeypatch.setattr(rex.config, "cognifier_multichunk_batching", True)
+    c0, c1 = _chunk("A uses B"), _chunk("C uses D")
+    ents = [_entity("A"), _entity("B"), _entity("C"), _entity("D")]
+    emap = {e.name.lower(): e for e in ents}
+
+    resp = json.dumps({"0": [_rel("A", "B")], "1": [_rel("C", "D")]})
+    ext = _llm_extractor()
+    ext.llm = types.SimpleNamespace(chat=AsyncMock(return_value=types.SimpleNamespace(content=resp)))
+
+    rels = await ext._process_batch([c0, c1], ents, emap)
+
+    assert ext.llm.chat.call_count == 1  # ONE batched call, not one per chunk
+    assert len(rels) == 2
+    # the batched prompt folds each chunk's entity list in via aux_of
+    _, kwargs = ext.llm.chat.call_args
+    sent = ext.llm.chat.call_args[0][0][0]["content"]
+    assert "Entities:" in sent and "Chunk 0:" in sent and "Chunk 1:" in sent
+
+
+@pytest.mark.asyncio
+async def test_flag_off_uses_per_chunk(monkeypatch):
+    import json
+    import types
+    from unittest.mock import AsyncMock
+
+    import knowledge.pipeline.cognifiers.relationship_extractor as rex
+
+    monkeypatch.setattr(rex.config, "cognifier_multichunk_batching", False)
+    c0, c1 = _chunk("A uses B"), _chunk("C uses D")
+    ents = [_entity("A"), _entity("B")]
+    emap = {e.name.lower(): e for e in ents}
+
+    ext = _llm_extractor()
+    ext.llm = types.SimpleNamespace(
+        chat=AsyncMock(
+            side_effect=[
+                types.SimpleNamespace(content=json.dumps([_rel("A", "B")])),
+                types.SimpleNamespace(content=json.dumps([])),
+            ]
+        )
+    )
+    await ext._process_batch([c0, c1], ents, emap)
+    assert ext.llm.chat.call_count == 2  # legacy per-chunk path


### PR DESCRIPTION
## Thinking Path
Split from #11017. relationship_extractor was the only cognifier still doing **one LLM call per chunk**, because its prompt is entity-conditioned — it injects a per-chunk `{entities}` list (`_format_entity_list` filters entities to `chunk.id in e.source_chunk_ids`), which the shared `batched_chunk_extract` couldn't express (it only handled `{chunks}` = content). Per #11044, I extended the helper rather than forking it, so all 5 extractors stay on one code path.

## What Changed
- **`llm_utils`:** `build_indexed_chunk_blocks` + `batched_chunk_extract` gained an optional per-chunk auxiliary payload (`aux_of: Callable[[chunk], str]`) folded into each `Chunk N:` block before the text. Backward compatible (default None → unchanged output).
- **`relationship_extractor._process_batch`** now routes through `batched_chunk_extract` with `aux_of=lambda chunk: "Entities:\n" + self._format_entity_list(entities, chunk)` and a new `RELATIONSHIP_EXTRACTION_BATCH_PROMPT`, so each block carries its own chunk-relevant entity list — preserving the per-chunk conditioning. Falls back to the legacy per-chunk loop when `cognifier_multichunk_batching` is off, and inherits the per-missing-chunk fallback + batch-scaled max_tokens from the shared helper.

Now all five cognifiers (entity/event/fact/causal/relationship) batch — ~K→1 round-trips.

## Verification
154 cognifier tests pass / 2 skipped (all other extractors unchanged — the `aux` extension is backward compatible). New: batched relationship extraction = one call with per-chunk entities folded into the prompt; flag-off = legacy per-chunk. Black + flake8 clean.

Closes #11044

## Model Used
Opus 4.8