### PR TITLE
fix(frontend): resolve any + no-unused-vars in analytics/chat/connectors (#9924)

### DIFF
--- a/autobot-frontend/src/components/__tests__/CommandPalette.test.ts
+++ b/autobot-frontend/src/components/__tests__/CommandPalette.test.ts
@@ -61,7 +61,7 @@ describe('CommandPalette.vue', () => {
       attachTo: document.body
     })
 
-    const palette = wrapper.vm as any
+    const palette = wrapper.vm as unknown as { open: () => void; closeModal: () => void }
     palette.open()
     await flushPromises()
     await wrapper.vm.$nextTick()
@@ -80,7 +80,7 @@ describe('CommandPalette.vue', () => {
       attachTo: document.body
     })
 
-    const palette = wrapper.vm as any
+    const palette = wrapper.vm as unknown as { open: () => void; closeModal: () => void }
     palette.open()
     await wrapper.vm.$nextTick()
 
@@ -100,7 +100,7 @@ describe('CommandPalette.vue', () => {
 
     const filtered = wrapper.vm.filteredCommands
     expect(filtered.length).toBeGreaterThan(0)
-    expect(filtered.every((cmd: any) =>
+    expect(filtered.every((cmd: { label: string; description: string }) =>
       cmd.label.toLowerCase().includes('task') ||
       cmd.description.toLowerCase().includes('task')
     )).toBe(true)

--- a/autobot-frontend/src/components/analytics/PatternAnalysis.vue
+++ b/autobot-frontend/src/components/analytics/PatternAnalysis.vue
@@ -260,7 +260,7 @@
 import Icon from '@/components/ui/Icon.vue'
 import { watch, onMounted, reactive } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { usePatternAnalysis } from '@/composables/usePatternAnalysis'
+import { usePatternAnalysis, type PatternAnalysisReport, type CodeLocation } from '@/composables/usePatternAnalysis'
 
 const { t } = useI18n()
 
@@ -272,7 +272,7 @@ const props = defineProps<{
 
 // Emits
 const emit = defineEmits<{
-  (e: 'analysis-complete', report: any): void
+  (e: 'analysis-complete', report: PatternAnalysisReport): void
   (e: 'error', message: string): void
 }>()
 
@@ -296,7 +296,6 @@ const {
   hasResults,
   analyzePatterns,
   getSummary,
-  getCachedSummary,
   getDuplicates,
   getRegexOpportunities,
   getComplexityHotspots,
@@ -345,7 +344,7 @@ const truncateCode = (code: string, maxLength: number = 100): string => {
   return code.length > maxLength ? code.substring(0, maxLength) + '...' : code
 }
 
-const formatLocation = (loc: any): string => {
+const formatLocation = (loc: CodeLocation | null | undefined): string => {
   if (!loc) return 'N/A'
   let result = `${loc.file_path}:${loc.start_line}`
   if (loc.function_name) result += ` (${loc.function_name})`

--- a/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
@@ -362,10 +362,10 @@ const logger = createLogger('PerformanceAnalysisDashboard')
 
 // Issue #701: Type for API response with data property
 interface ApiDataResponse {
-  data?: any
+  data?: unknown
   total_issues?: number
   issues?: PerformanceIssue[]
-  [key: string]: any
+  [key: string]: unknown
 }
 
 // Types
@@ -536,9 +536,9 @@ async function runAnalysis() {
       params: { path: selectedPath.value }
     })
     // Issue #701: Response is returned directly, handle both response structures
-    lastResult.value = (response as ApiDataResponse).data || response as unknown as AnalysisResult
+    lastResult.value = ((response as ApiDataResponse).data as AnalysisResult | undefined) || response as unknown as AnalysisResult
 
-    const totalIssues = (response as ApiDataResponse).total_issues ?? (response as ApiDataResponse).data?.total_issues ?? 0
+    const totalIssues = (response as ApiDataResponse).total_issues ?? ((response as ApiDataResponse).data as AnalysisResult | undefined)?.total_issues ?? 0
     if (totalIssues === 0) {
       showToast(t('analytics.performanceAnalysis.noIssuesFound'), 'success')
     } else {
@@ -559,7 +559,7 @@ async function loadPatterns() {
     // Issue #701: Added type assertion for response
     const response = await api.get<Pattern[] | ApiDataResponse>(`${getApiBase()}/performance/patterns`)
     // Issue #701: Response could be array directly or wrapped in data
-    patterns.value = Array.isArray(response) ? response : ((response as ApiDataResponse).data || [])
+    patterns.value = Array.isArray(response) ? response : (((response as ApiDataResponse).data as Pattern[] | undefined) || [])
   } catch (error) {
     logger.warn('Failed to load patterns:', error)
     patterns.value = []
@@ -571,7 +571,7 @@ async function loadHotspots() {
     // Issue #701: Added type assertion for response
     const response = await api.get<Hotspot[] | ApiDataResponse>(`${getApiBase()}/performance/hotspots`)
     // Issue #701: Response could be array directly or wrapped in data
-    hotspots.value = Array.isArray(response) ? response : ((response as ApiDataResponse).data || [])
+    hotspots.value = Array.isArray(response) ? response : (((response as ApiDataResponse).data as Hotspot[] | undefined) || [])
   } catch (error) {
     logger.warn('Failed to load hotspots:', error)
     hotspots.value = []
@@ -582,7 +582,7 @@ async function togglePattern(pattern: Pattern) {
   const newState = !pattern.enabled
   try {
     // Issue #701: Fixed api.post call - data should be second arg, options third
-    await api.post<any>(`${getApiBase()}/performance/patterns/${pattern.id}/toggle`, { enabled: newState })
+    await api.post<unknown>(`${getApiBase()}/performance/patterns/${pattern.id}/toggle`, { enabled: newState })
     pattern.enabled = newState
   } catch (error) {
     logger.warn('Failed to toggle pattern:', error)

--- a/autobot-frontend/src/components/artifact-cells/CodeCell.vue
+++ b/autobot-frontend/src/components/artifact-cells/CodeCell.vue
@@ -54,6 +54,7 @@ import Icon from '@/components/ui/Icon.vue'
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import DOMPurify from 'dompurify'
+import type { HLJSApi } from 'highlight.js'
 
 const { t } = useI18n()
 
@@ -84,7 +85,7 @@ const cellId = ref<string>(`code-${crypto.randomUUID()}`)
 const highlightedCode = ref<string>('')
 const copyStatus = ref<string>('')
 const copyTimeout = ref<ReturnType<typeof setTimeout> | null>(null)
-let hljs: any = null
+let hljs: HLJSApi | null = null
 
 // Computed
 const rawCode = computed(() => {
@@ -136,7 +137,7 @@ const language = computed(() => {
 // Methods
 const loadHighlightJs = async () => {
   if (!hljs) {
-    hljs = await import('highlight.js')
+    hljs = (await import('highlight.js')).default
   }
   return hljs
 }
@@ -169,7 +170,7 @@ const highlightCode = async () => {
       ALLOWED_TAGS: ['span', 'br'],
       ALLOWED_ATTR: ['class']
     })
-  } catch (error) {
+  } catch {
     // Fallback to plain text if highlighting fails
     highlightedCode.value = DOMPurify.sanitize(rawCode.value, {
       ALLOWED_TAGS: [],
@@ -203,7 +204,7 @@ const copyCode = async () => {
     copyTimeout.value = setTimeout(() => {
       copyStatus.value = ''
     }, 2000)
-  } catch (error) {
+  } catch {
     copyStatus.value = t('code.copyFailed', 'Failed to copy')
     copyTimeout.value = setTimeout(() => {
       copyStatus.value = ''

--- a/autobot-frontend/src/components/chat/ChatBrowser.vue
+++ b/autobot-frontend/src/components/chat/ChatBrowser.vue
@@ -139,11 +139,6 @@ const sessionIcon = computed(() => {
   return 'times-circle'
 })
 
-const iconClass = computed(() => ({
-  'text-green-600': browserStatus.value === 'connected',
-  'text-yellow-600': browserStatus.value === 'connecting',
-  'text-red-600': browserStatus.value === 'disconnected' || browserStatus.value === 'error'
-}))
 
 // Retry configuration
 const MAX_RETRIES = 3
@@ -170,10 +165,10 @@ const connectBrowserSession = async (retry = false) => {
 
     // Get or create browser session for this conversation
     // Use type assertion for the API call since ApiClient is JavaScript
-    const response = await (apiClient as any).getOrCreateChatBrowserSession({
+    const response = await apiClient.getOrCreateChatBrowserSession({
       conversation_id: props.chatSessionId,
       headless: false
-    }) as BrowserSessionResponse
+    }) as unknown as BrowserSessionResponse
 
     if (response && response.session_id) {
       browserSessionId.value = response.session_id
@@ -239,7 +234,7 @@ const disconnectBrowserSession = async () => {
 
   try {
     // Use type assertion for the API call since ApiClient is JavaScript
-    await (apiClient as any).deleteChatBrowserSession(props.chatSessionId)
+    await apiClient.deleteChatBrowserSession(props.chatSessionId)
     logger.info('Browser session disconnected for chat:', props.chatSessionId)
   } catch (error) {
     logger.warn('Failed to disconnect browser session:', error)

--- a/autobot-frontend/src/components/chat/ChatSidebar.vue
+++ b/autobot-frontend/src/components/chat/ChatSidebar.vue
@@ -636,7 +636,7 @@ const deleteCurrentSession = () => {
   }
 }
 
-const handleDeleteConfirm = async (fileAction: string, fileOptions: Record<string, unknown>, selectedFactIds: string[] = []) => {
+const handleDeleteConfirm = async (fileAction: string, fileOptions: Record<string, unknown> | undefined, selectedFactIds: string[] = []) => {
   if (!deleteTargetSessionId.value) return
   const sessionId = deleteTargetSessionId.value
 
@@ -748,7 +748,7 @@ const cancelSelection = () => {
   sessionSelection.clear()
 }
 
-const toggleSelection = (sessionId: string) => {
+const _toggleSelection = (sessionId: string) => {
   sessionSelection.toggleByKey(sessionId)
 }
 

--- a/autobot-frontend/src/components/chat/DeleteConversationDialog.vue
+++ b/autobot-frontend/src/components/chat/DeleteConversationDialog.vue
@@ -260,7 +260,7 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
-import { ref, computed, watch } from 'vue'
+import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { FileStats } from '@/composables/useConversationFiles'
 import type { SessionFact } from '@/models/repositories/ChatRepository'
@@ -279,9 +279,14 @@ const props = defineProps<{
   kbFactsLoading?: boolean
 }>()
 
+type FileTransferOptions =
+  | { categories: string[]; extract_text: boolean }
+  | { target_path: string }
+  | undefined
+
 const emit = defineEmits<{
   'update:visible': [value: boolean]
-  confirm: [fileAction: string, fileOptions: any, selectedFactIds: string[]]
+  confirm: [fileAction: string, fileOptions: FileTransferOptions, selectedFactIds: string[]]
   cancel: []
 }>()
 
@@ -298,8 +303,6 @@ const factSelection = useBatchSelection<SessionFact, string>(
   (f) => f.id
 )
 
-// Computed
-const hasFiles = computed(() => props.fileStats && props.fileStats.total_files > 0)
 
 // Watch for facts changes to seed selection with already-important/preserve facts.
 watch(() => props.kbFacts, (newFacts) => {
@@ -349,7 +352,7 @@ const getFileActionSummary = (): string => {
   }
 }
 
-const buildFileOptions = (): any => {
+const buildFileOptions = (): FileTransferOptions => {
   if (fileAction.value === 'transfer_kb') {
     return {
       categories: kbCategories.value.split(',').map(c => c.trim()).filter(c => c),
@@ -361,7 +364,7 @@ const buildFileOptions = (): any => {
     }
   }
 
-  return null
+  return undefined
 }
 
 const handleConfirm = () => {

--- a/autobot-frontend/src/components/chat/MessageItem.vue
+++ b/autobot-frontend/src/components/chat/MessageItem.vue
@@ -189,6 +189,7 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import type { ChatMessage } from '@/stores/useChatStore'
+import type { Citation } from '@/types/api'
 import { formatTime } from '@/utils/formatHelpers'
 
 const { t } = useI18n()
@@ -314,9 +315,9 @@ const showMetadata = computed(() => {
 
 // Issue #10548: citations sourced from top-level field (new path) or metadata (legacy).
 const resolvedCitations = computed(() => {
-  const topLevel = (props.message as any).citations
+  const topLevel = (props.message as { citations?: Citation[] }).citations
   if (Array.isArray(topLevel) && topLevel.length > 0) return topLevel
-  return (props.message.metadata as any)?.citations || []
+  return (props.message.metadata as { citations?: Citation[] } | undefined)?.citations || []
 })
 
 const hasCitations = computed(() => {
@@ -325,7 +326,7 @@ const hasCitations = computed(() => {
 
 // Issue #10548: show "no grounded source" badge when grounding is explicitly false.
 const isModelOnlyClaim = computed(() => {
-  const grounding = (props.message as any).grounding
+  const grounding = (props.message as { grounding?: { grounded?: boolean } }).grounding
   return props.message.sender === 'assistant' && grounding != null && grounding.grounded === false
 })
 

--- a/autobot-frontend/src/components/common/ErrorBoundary.vue
+++ b/autobot-frontend/src/components/common/ErrorBoundary.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onErrorCaptured, inject } from 'vue'
+import { ref, computed, onErrorCaptured, inject, type ComponentPublicInstance } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
 import BaseButton from '@/components/base/BaseButton.vue'
@@ -61,7 +61,7 @@ const logger = createLogger('ErrorBoundary')
 
 interface Props {
   fallback?: string
-  onError?: (error: Error, instance: any, info: string) => void
+  onError?: (error: Error, instance: ComponentPublicInstance | null, info: string) => void
   showRetry?: boolean
   showReload?: boolean
 }
@@ -83,7 +83,10 @@ const showDetails = ref(false)
 const retrying = ref(false)
 
 // Inject RUM agent if available
-const rum = inject('rum', null) as any
+const rum = inject('rum', null) as {
+  trackError: (type: string, data: Record<string, unknown>) => void
+  trackUserInteraction: (name: string, target: unknown, data: Record<string, unknown>) => void
+} | null
 
 // Compute user-friendly error message
 const userFriendlyMessage = computed(() => {
@@ -110,7 +113,7 @@ const userFriendlyMessage = computed(() => {
 })
 
 // Capture errors from child components
-onErrorCaptured((error: Error, instance: any, info: string) => {
+onErrorCaptured((error: Error, instance: ComponentPublicInstance | null, info: string) => {
   // Combine error and info into a single data object for the logger
   logger.error('Error captured by ErrorBoundary:', { error, info })
 

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
@@ -20,7 +20,6 @@ import ConnectorHistoryPanel from './ConnectorHistoryPanel.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { BaseModal } from '@autobot/ui'
 import EmptyState from '@/components/ui/EmptyState.vue'
-import { formatTimeAgo } from '@/utils/formatHelpers'
 import { createLogger } from '@/utils/debugUtils'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/ui/Icon.vue'
@@ -136,7 +135,7 @@ async function handleViewHistory(id: string) {
   }
 }
 
-function onConnectorSaved(config: ConnectorConfig) {
+function onConnectorSaved(_config: ConnectorConfig) {
   // Reload all connectors to get fresh statuses
   loadConnectors()
 }
@@ -163,7 +162,7 @@ function getStatus(id: string): ConnectorStatus {
   )
 }
 
-function setCardRef(id: string, el: any) {
+function setCardRef(id: string, el: InstanceType<typeof ConnectorStatusCard> | null) {
   if (el) {
     cardRefs.value[id] = el
   }

--- a/autobot-frontend/src/components/knowledge/connectors/__tests__/ConnectorConfigModal.gitlab.spec.ts
+++ b/autobot-frontend/src/components/knowledge/connectors/__tests__/ConnectorConfigModal.gitlab.spec.ts
@@ -13,6 +13,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 
+import type { App } from 'vue'
 import ConnectorConfigModal from '../ConnectorConfigModal.vue'
 import { knowledgeRepository } from '@/models/repositories/KnowledgeRepository'
 
@@ -38,7 +39,7 @@ function mountModal() {
       },
       plugins: [
         {
-          install(app: any) {
+          install(app: App) {
             app.config.globalProperties.$t = (k: string) => k
           }
         }
@@ -89,7 +90,7 @@ describe('ConnectorConfigModal — GitLab / Gitea / Forgejo (#9011)', () => {
     await wrapper.find('#gl-token').setValue('glpat-secrettoken')
     await wrapper.find('#gl-projects').setValue('42, group/proj')
 
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm as unknown as { connectorName: string; handleSave: () => Promise<void> }
     vm.connectorName = 'My GitLab'
     await vm.handleSave()
     await flushPromises()
@@ -115,7 +116,7 @@ describe('ConnectorConfigModal — GitLab / Gitea / Forgejo (#9011)', () => {
     await wrapper.find('#gt-token').setValue('gitea-token')
     await wrapper.find('#gt-repos').setValue('owner/repo')
 
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm as unknown as { connectorName: string; handleSave: () => Promise<void> }
     vm.connectorName = 'My Gitea'
     await vm.handleSave()
     await flushPromises()


### PR DESCRIPTION
## Thinking Path
Toward green `frontend-tests` — all eslint warnings across 10 target files + a cross-component type fix. (The batch subagent hit an API rate limit mid-work; I finished the remaining 12 warnings and fixed a type error it left.)

## What Changed (246 → 215 problems)
- **any→typed**: MessageItem (`Citation[]`, `{grounding}`), ErrorBoundary (`ComponentPublicInstance`, minimal RUM tracker type), ConnectorManager (`InstanceType<typeof ConnectorStatusCard>`), ConnectorConfigModal.gitlab.spec (`App`, `vm as unknown as {...}`), + subagent's PatternAnalysis/PerformanceAnalysisDashboard/CodeCell/ChatBrowser/CommandPalette.test/DeleteConversationDialog.
- **unused removed/`_`-prefixed**: `formatTimeAgo` import, `_config` param, `_toggleSelection` (orphaned wrapper).
- **Cross-component fix**: the subagent typed DeleteConversationDialog's `confirm` emit as `FileTransferOptions` (`{categories}|{target_path}|null`) but left ChatSidebar's handler as `Record<string,unknown>` → vue-tsc mismatch. Aligned the whole chain on `undefined` (matching `deleteChatSession(fileOptions?)`): `| null`→`| undefined`, `return null`→`return undefined`. Behavior-preserving (delete action passes no options either way).

## Verification (independently re-run)
- `eslint` all 11 changed files → **0 warnings, 0 errors**.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (whole project).
- `vitest` (affected suites) → 124/124.

## Model Used
Opus 4.8

Contributes to #9924 green frontend-tests (246→215 problems).