### PR TITLE
fix(frontend): resolve any + no-unused-vars in secrets/terminal/ui/composables (#9924)

### DIFF
--- a/autobot-frontend/src/components/secrets/SecretVault.vue
+++ b/autobot-frontend/src/components/secrets/SecretVault.vue
@@ -12,7 +12,6 @@
 
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useChatStore, type SessionSecret } from '@/stores/useChatStore'
 import { useSessionActivityLogger, type SecretType } from '@/composables/useSessionActivityLogger'
 import { useDebounce } from '@/composables/useDebounce'
 import { useVirtualList } from '@/composables/useVirtualList'
@@ -22,8 +21,7 @@ import { useLoadingState } from '@/composables/useLoadingState'
 
 const logger = createLogger('SecretVault')
 const { t } = useI18n()
-const chatStore = useChatStore()
-const { linkSecretToSession, logSecretUsage } = useSessionActivityLogger()
+const { logSecretUsage } = useSessionActivityLogger()
 
 // Props
 const props = defineProps<{
@@ -67,9 +65,6 @@ const secrets = ref<SecretItem[]>([])
 
 // Debounce search query for performance (Issue #4035)
 const debouncedSearchQuery = useDebounce(searchQuery, 400)
-
-// Get current session secrets
-const currentSession = computed(() => chatStore.currentSession)
 
 // Combine and filter secrets
 const allSecrets = computed<SecretItem[]>(() => {

--- a/autobot-frontend/src/components/services/RedisServiceControl.vue
+++ b/autobot-frontend/src/components/services/RedisServiceControl.vue
@@ -227,7 +227,7 @@
 
 <script setup>
 import Icon from '@/components/ui/Icon.vue'
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useServiceManagement } from '@/composables/useServiceManagement'
 import { NetworkConstants } from '@/constants/network'
@@ -244,7 +244,6 @@ const {
   serviceStatus,
   healthStatus,
   loading,
-  error,
   startService,
   stopService,
   restartService,
@@ -296,8 +295,7 @@ const getHealthCheckVariant = (status) => {
  * Lifecycle: Subscribe to WebSocket updates on mount
  */
 onMounted(() => {
-  subscribeToStatusUpdates((message) => {
-  })
+  subscribeToStatusUpdates()
 })
 
 /**

--- a/autobot-frontend/src/components/terminal/Terminal.vue
+++ b/autobot-frontend/src/components/terminal/Terminal.vue
@@ -117,6 +117,17 @@ const props = withDefaults(defineProps<Props>(), {
   chatSessionId: null
 })
 
+// Incoming terminal WebSocket message shape (backend sends heterogeneous
+// payloads keyed by `type`; fields are optional per message type).
+interface TerminalWsMessage {
+  type: string
+  data?: string
+  message?: string
+  completions?: string[]
+  prefix?: string
+  error?: string
+}
+
 // State
 // CRITICAL: Session ID will be retrieved from backend (for chat) or generated (for system terminal)
 const sessionId = ref<string | null>(null)
@@ -158,8 +169,8 @@ const { isConnected, isConnecting, send: wsSend, connect: wsConnect, disconnect:
     },
     onMessage: (data) => {
       try {
-        handleTerminalMessage(data)
-      } catch (error) {
+        handleTerminalMessage(data as TerminalWsMessage)
+      } catch {
         // Handle plain text messages
         addTerminalLine('', String(data), 'output')
       }
@@ -354,23 +365,25 @@ const sendCommand = (command: string) => {
   }
 }
 
-const handleTerminalMessage = (data: any) => {
+const handleTerminalMessage = (data: TerminalWsMessage) => {
   switch (data.type) {
     case 'output':
-      addTerminalLine('', data.data, 'output')
+      addTerminalLine('', data.data as string, 'output')
       break
     case 'error':
-      addTerminalLine('', data.data, 'error')
+      addTerminalLine('', data.data as string, 'error')
       break
     case 'prompt':
       currentPrompt.value = data.data || '$ '
       break
     case 'status':
-      statusMessage.value = data.message
+      statusMessage.value = data.message as string
       break
     // Issue #756: Handle tab completion response
     case 'tab_completion':
-      handleTabCompletionResponse(data)
+      handleTabCompletionResponse(
+        data as { completions: string[]; prefix: string; error?: string },
+      )
       break
     default:
       addTerminalLine('', JSON.stringify(data), 'info')
@@ -458,7 +471,7 @@ const copyTerminalOutput = async () => {
 
     await navigator.clipboard.writeText(output)
     addTerminalLine('system', t('terminal.terminal.outputCopied'), 'info')
-  } catch (error) {
+  } catch {
     addTerminalLine('system', t('terminal.terminal.copyFailed'), 'error')
   }
 }

--- a/autobot-frontend/src/components/ui/DataTable.vue
+++ b/autobot-frontend/src/components/ui/DataTable.vue
@@ -149,14 +149,14 @@ interface Column {
   key: string
   label: string
   sortable?: boolean
-  format?: (value: any) => string
+  format?: (value: unknown) => string
 }
 
 interface Props {
   /** Table columns configuration */
   columns: Column[]
   /** Table data rows */
-  data: any[]
+  data: Record<string, unknown>[]
   /** Show table header */
   showHeader?: boolean
   /** Table title */
@@ -228,8 +228,8 @@ const sortedData = computed(() => {
   // Apply sorting
   if (sortKey.value) {
     result.sort((a, b) => {
-      const aVal = a[sortKey.value!]
-      const bVal = b[sortKey.value!]
+      const aVal = a[sortKey.value!] as string | number
+      const bVal = b[sortKey.value!] as string | number
       const compare = aVal < bVal ? -1 : aVal > bVal ? 1 : 0
       return sortDirection.value === 'asc' ? compare : -compare
     })
@@ -245,7 +245,7 @@ const sortedData = computed(() => {
   return result
 })
 
-const formatCell = (value: any, column: Column) => {
+const formatCell = (value: unknown, column: Column) => {
   if (column.format) {
     return column.format(value)
   }

--- a/autobot-frontend/src/composables/__tests__/useAvailableLanguages.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useAvailableLanguages.test.ts
@@ -35,8 +35,8 @@ describe('useAvailableLanguages', () => {
     // vi.spyOn on a constructor requires mockImplementation to use a class or
     // a function that works with `new` (returns an object from within the function).
     const spy = vi.spyOn(Intl, 'DisplayNames').mockImplementation(
-      function (_locales: any, _options: any) {
-        return { of: () => undefined, resolvedOptions: () => ({} as any) }
+      function (_locales: Intl.LocalesArgument, _options: Intl.DisplayNamesOptions) {
+        return { of: () => undefined, resolvedOptions: () => ({} as Intl.ResolvedDisplayNamesOptions) }
       } as unknown as typeof Intl.DisplayNames
     )
 

--- a/autobot-frontend/src/composables/__tests__/useClipboard.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useClipboard.test.ts
@@ -19,6 +19,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { Ref } from 'vue'
 import {
   useClipboard,
   useClipboardWithMessage,
@@ -490,7 +491,7 @@ describe('useClipboardElement Helper', () => {
 
     const clipboard = useClipboardElement()
 
-    const result = await clipboard.copyElement(elementRef as any)
+    const result = await clipboard.copyElement(elementRef as Ref<HTMLElement | undefined>)
 
     expect(result).toBe(true)
     expect(mockWriteText).toHaveBeenCalledWith('Code content')
@@ -503,7 +504,7 @@ describe('useClipboardElement Helper', () => {
 
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    const result = await clipboard.copyElement(elementRef as any)
+    const result = await clipboard.copyElement(elementRef as Ref<HTMLElement | undefined>)
 
     expect(result).toBe(false)
     expect(consoleErrorSpy).toHaveBeenCalled()
@@ -600,7 +601,7 @@ describe('useClipboard - Edge Cases', () => {
   it('should handle copy during pending copy', async () => {
     vi.useFakeTimers()
 
-    let resolveFirst: any
+    let resolveFirst!: (value?: void | PromiseLike<void>) => void
     mockWriteText.mockImplementationOnce(() => {
       return new Promise((resolve) => {
         resolveFirst = resolve

--- a/autobot-frontend/src/composables/security/useThreatIntelligence.ts
+++ b/autobot-frontend/src/composables/security/useThreatIntelligence.ts
@@ -43,7 +43,7 @@ export interface CheckUrlResult {
 export function useThreatIntelligence() {
   /** Fetch threat-intelligence service status. */
   async function fetchThreatIntelStatus(): Promise<ThreatIntelStatus> {
-    const response = await apiClient.get<any>(`${getApiBase()}/security/threat-intel/status`)
+    const response = await apiClient.get(`${getApiBase()}/security/threat-intel/status`)
     const data = (response as { data?: Record<string, unknown> }).data
     return {
       any_service_configured: (data?.any_service_configured as boolean) ?? false,
@@ -55,7 +55,7 @@ export function useThreatIntelligence() {
 
   /** Fetch domain-security statistics. */
   async function fetchDomainSecurityStats(): Promise<DomainSecurityStats> {
-    const response = await apiClient.get<any>(`${getApiBase()}/security/domain-security/stats`)
+    const response = await apiClient.get(`${getApiBase()}/security/domain-security/stats`)
     const data = (response as { data?: Record<string, unknown> }).data
     const stats = (data?.success ? (data.stats as Record<string, unknown>) : null) ?? {}
     return {
@@ -69,7 +69,7 @@ export function useThreatIntelligence() {
 
   /** Check a URL against threat-intelligence services. */
   async function checkUrl(url: string): Promise<CheckUrlResult> {
-    const response = await apiClient.post<any>(`${getApiBase()}/security/threat-intel/check-url`, { url })
+    const response = await apiClient.post(`${getApiBase()}/security/threat-intel/check-url`, { url })
     const data = (response as { data?: CheckUrlResult }).data
     if (!data) {
       throw new Error('Empty response from threat-intel check-url')

--- a/autobot-frontend/src/composables/useMarketplaceSources.ts
+++ b/autobot-frontend/src/composables/useMarketplaceSources.ts
@@ -35,7 +35,7 @@ export function useMarketplaceSources() {
     error.value = null
     loading.value = true
     try {
-      const data = await ApiClient.get<any>(`${getApiBase()}/marketplace-sources`) as ListResponse
+      const data = await ApiClient.get(`${getApiBase()}/marketplace-sources`) as ListResponse
       sources.value = data.sources ?? []
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Failed to list marketplace sources'
@@ -49,7 +49,7 @@ export function useMarketplaceSources() {
   async function addSource(payload: { name: string; url: string; description?: string }): Promise<MarketplaceSource | null> {
     error.value = null
     try {
-      const data = await ApiClient.post<any>(
+      const data = await ApiClient.post(
         `${getApiBase()}/marketplace-sources`,
         payload,
       ) as MarketplaceSource
@@ -66,7 +66,7 @@ export function useMarketplaceSources() {
   async function deleteSource(id: string): Promise<boolean> {
     error.value = null
     try {
-      await ApiClient.delete<any>(`${getApiBase()}/marketplace-sources/${id}`)
+      await ApiClient.delete(`${getApiBase()}/marketplace-sources/${id}`)
       await listSources()
       return true
     } catch (err: unknown) {

--- a/autobot-frontend/src/composables/usePreferences.ts
+++ b/autobot-frontend/src/composables/usePreferences.ts
@@ -27,6 +27,14 @@ interface AccountAppearance {
   theme_preset: ThemePreset
 }
 
+/** Backend response for the active personality profile (#753 language sync). */
+interface PersonalityActiveResponse {
+  data?: {
+    id?: string
+    language_code?: string
+  }
+}
+
 // Preference types
 export type FontSize = 'small' | 'medium' | 'large'
 export type AccentColor = 'teal' | 'emerald' | 'blue' | 'purple' | 'orange'
@@ -156,7 +164,7 @@ function applyLayoutDensity(density: LayoutDensity): void {
  * Sync language preference to backend personality profile
  */
 function syncLanguageToBackend(code: string): void {
-  apiClient.get<any>(`${getApiBase()}/personality/active`).then((res: any) => {
+  apiClient.get<PersonalityActiveResponse>(`${getApiBase()}/personality/active`).then((res) => {
     if (res.data && res.data.id) {
       apiClient.put(
         `${getApiBase()}/personality/profiles/${res.data.id}`,
@@ -178,7 +186,7 @@ export function usePreferences() {
    */
   async function loadLanguageFromBackend(): Promise<void> {
     try {
-      const res = await apiClient.get<any>(`${getApiBase()}/personality/active`)
+      const res = await apiClient.get<PersonalityActiveResponse>(`${getApiBase()}/personality/active`)
       const code: string | undefined = res.data?.language_code
       if (code && code !== language.value) {
         await setLanguage(code)

--- a/autobot-frontend/src/models/controllers/__tests__/ChatController.test.ts
+++ b/autobot-frontend/src/models/controllers/__tests__/ChatController.test.ts
@@ -103,15 +103,15 @@ describe('ChatController', () => {
 
   describe('autoSave methods removed', () => {
     it('should not have enableAutoSave method', () => {
-      expect((controller as any).enableAutoSave).toBeUndefined()
+      expect((controller as unknown as Record<string, unknown>).enableAutoSave).toBeUndefined()
     })
 
     it('should not have disableAutoSave method', () => {
-      expect((controller as any).disableAutoSave).toBeUndefined()
+      expect((controller as unknown as Record<string, unknown>).disableAutoSave).toBeUndefined()
     })
 
     it('should not have _autoSaveIntervalId field', () => {
-      expect((controller as any)._autoSaveIntervalId).toBeUndefined()
+      expect((controller as unknown as Record<string, unknown>)._autoSaveIntervalId).toBeUndefined()
     })
   })
 })

--- a/autobot-frontend/src/test/mocks/api-handlers.ts
+++ b/autobot-frontend/src/test/mocks/api-handlers.ts
@@ -20,7 +20,7 @@ export const handlers = [
   ...canvasHandlers,
   // Chat API endpoints
   http.post(`${API_BASE}/api/chat`, async ({ request }) => {
-    const body = await request.json() as any
+    const body = await request.json() as { message?: string; chatId?: string }
     const mockMessage = createMockChatMessage({
       content: `Echo: ${body.message}`,
       sender: 'assistant',
@@ -161,7 +161,7 @@ export const handlers = [
 
   // Terminal API endpoints
   http.post(`${API_BASE}/api/terminal/execute`, async ({ request }) => {
-    const body = await request.json() as any
+    const body = await request.json() as { command?: string }
     return HttpResponse.json(
       createMockApiResponse({
         command: body.command,
@@ -191,7 +191,7 @@ export const handlers = [
 
   // Knowledge Base API endpoints
   http.post(`${API_BASE}/api/knowledge_base/search`, async ({ request }) => {
-    const body = await request.json() as any
+    const body = await request.json() as { query?: string }
     return HttpResponse.json(
       createMockApiResponse({
         query: body.query,

--- a/autobot-frontend/src/utils/chunkTestUtility.ts
+++ b/autobot-frontend/src/utils/chunkTestUtility.ts
@@ -38,7 +38,7 @@ export async function testComponentChunkLoading(components: string[]): Promise<C
       const startTime = Date.now()
 
       // Test based on component type
-      let _module: any
+      let _module: Record<string, unknown>
 
       if (component.includes('View')) {
         // Test view components
@@ -198,7 +198,7 @@ export async function runComprehensiveChunkTests(): Promise<void> {
 
     // Store test results for debugging
     if (typeof window !== 'undefined') {
-      (window as any).__chunkTestResults = report
+      (window as unknown as Record<string, unknown>).__chunkTestResults = report
     }
 
   } catch (error) {
@@ -238,7 +238,7 @@ export async function quickChunkValidation(): Promise<boolean> {
 
 // Export for browser console testing
 if (typeof window !== 'undefined') {
-  (window as any).chunkTest = {
+  (window as unknown as Record<string, unknown>).chunkTest = {
     runComprehensive: runComprehensiveChunkTests,
     quickValidation: quickChunkValidation,
     testComponents: testComponentChunkLoading,


### PR DESCRIPTION
## Thinking Path
Toward green `frontend-tests` — all 36 eslint warnings across 12 files. Subagent verified consumer components per the boundary-type instruction added after warn4.

## What Changed (215 → ~179 problems)
- **any→typed**: DataTable (`unknown`/`Record<string,unknown>[]`), Terminal (`TerminalWsMessage`), useThreatIntelligence/useMarketplaceSources (drop `<any>`→default `unknown`), usePreferences (`PersonalityActiveResponse`), api-handlers (concrete request shapes), test mocks (`Intl.*`, `Ref<...>`, `Record<string,unknown>`).
- **dead code removed** (orphaned, reported): SecretVault post-refactor leftovers (`SessionSecret`/`linkSecretToSession`/`currentSession`/`useChatStore`), RedisServiceControl empty no-op callback.
- Unused params/imports → `_`/removed; `catch(e)`→`catch {}`.

## Consumers verified
DataTable (test+story), usePreferences (ChatSettingsModal.spec, useVoiceOutput.test, usePreferences.rtl.spec) — all typecheck + pass.

## Verification (independently re-run)
- `eslint` 12 files → **0 warnings, 0 errors**.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (whole project).
- `vitest` (8 suites) → 97/97.
- No eslint-disable/@ts-ignore; no runtime coercions.

## Model Used
Opus 4.8

Contributes to #9924 green frontend-tests.