### PR TITLE
fix(experiments): insights 500 no longer crashes the dashboard (#11081)

### DIFF
--- a/autobot-backend/services/autoresearch/routes.py
+++ b/autobot-backend/services/autoresearch/routes.py
@@ -680,9 +680,19 @@ async def list_insights(
     min_confidence: float = Query(default=0.0, ge=0.0, le=1.0),
     _admin: bool = Depends(check_admin_permission),
 ):
-    """List distilled experiment insights."""
+    """List distilled experiment insights.
+
+    Resilient by design (#11081): on a fresh/empty deployment the insights
+    collection may not exist yet (or the vector store is unavailable), which
+    would otherwise 500 and crash the whole Experiments dashboard. Absence of
+    data is not an error — return an empty list instead.
+    """
     synthesizer = _get_synthesizer(request)
-    insights = await synthesizer.query_insights("*", limit=limit)
+    try:
+        insights = await synthesizer.query_insights("*", limit=limit)
+    except Exception as exc:  # noqa: BLE001 — dashboard list must degrade, not 500
+        logger.warning("autoresearch insights unavailable (returning empty): %s", exc)
+        return {"insights": [], "count": 0}
     filtered = [i for i in insights if i.confidence >= min_confidence]
     return {"insights": [i.to_dict() for i in filtered], "count": len(filtered)}
 

--- a/autobot-frontend/src/views/ExperimentDashboard.vue
+++ b/autobot-frontend/src/views/ExperimentDashboard.vue
@@ -31,7 +31,9 @@ const {
 } = useAutoResearch()
 
 onMounted(async () => {
-  await Promise.all([
+  // #11081: allSettled so one failing widget (e.g. insights on a fresh deployment)
+  // degrades gracefully instead of crashing the whole dashboard via Promise.all.
+  await Promise.allSettled([
     fetchExperiments(),
     fetchStats(),
     fetchPendingApprovals(),


### PR DESCRIPTION
## Thinking Path
Operator hit 'Something went wrong / HTTP 500' on /experiments. The dashboard `Promise.all`s 4 calls; `GET /api/autoresearch/insights` 500s (its `list_insights` runs a semantic query `query_insights("*")` against an insights collection that doesn't exist yet on a fresh deployment), rejecting the whole Promise.all → full-page crash.

## What Changed
- **Backend** `services/autoresearch/routes.py`: `list_insights` now returns `{insights: [], count: 0}` on any synthesizer/collection error (a dashboard list endpoint must not 500 when there's simply no data yet).
- **Frontend** `ExperimentDashboard.vue`: `Promise.all` → `Promise.allSettled` so an individual widget failure degrades gracefully.

## Verification
- Backend: `py_compile` OK. Frontend: eslint clean.

## Model Used
Opus 4.8

Closes #11081