### PR TITLE
fix(execution): replace in-process exec with real Modal Sandbox dispatch (#11003)

### DIFF
--- a/autobot-backend/services/execution/modal_backend.py
+++ b/autobot-backend/services/execution/modal_backend.py
@@ -5,14 +5,16 @@
 """
 Modal Serverless Execution Backend (Issue #4343)
 
-Executes tasks on Modal serverless platform.
+Executes tasks inside real Modal Sandbox isolated containers.
 Supports cost tracking and automatic scaling.
 """
 
+import asyncio
+import os
 from typing import Any, Dict, Tuple
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.time_utils import now_utc, utc_timestamp
+from autobot_shared.time_utils import now_utc
 
 try:
     import modal
@@ -32,37 +34,51 @@ logger = get_logger(__name__)
 
 
 class ModalBackend(ExecutionBackend):
-    """Execute tasks on Modal serverless platform (Issue #4343)."""
+    """Execute tasks inside Modal Sandbox isolated containers (Issue #4343).
+
+    Each call to ``execute()`` spins up a fresh ``modal.Sandbox``, runs the
+    task code with ``sandbox.exec("python", "-c", task.code)``, captures
+    stdout/stderr, and terminates the sandbox in a ``finally`` block.
+
+    Modal SDK calls are blocking; they are offloaded to a thread via
+    ``asyncio.to_thread`` so the event loop is never blocked.
+    """
+
+    _APP_NAME = "autobot-code-execution"
 
     def __init__(self, api_token: str | None = None) -> None:
         """Initialize Modal backend.
 
         Args:
-            api_token: Modal API token (default: from MODAL_TOKEN_ID env var)
+            api_token: Modal API token (default: read from MODAL_TOKEN_ID env var).
 
         Raises:
-            RuntimeError: If Modal SDK is not available
+            RuntimeError: If the Modal SDK is not installed.
         """
         super().__init__(BackendType.MODAL)
 
         if modal is None:
-            raise RuntimeError("modal package not installed. " "Install with: pip install modal")
+            raise RuntimeError("modal package not installed. Install with: pip install modal")
 
         self.api_token = api_token
         self._function_cache: Dict[str, Any] = {}
         self._cost_estimate = 0.0
 
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
     async def execute(self, task: ExecutionTask) -> ExecutionResult:
-        """Execute task on Modal serverless.
+        """Execute task inside a Modal Sandbox isolated container.
 
         Args:
-            task: ExecutionTask with code
+            task: ExecutionTask with code and parameters.
 
         Returns:
-            ExecutionResult with execution details
+            ExecutionResult with execution details.
 
         Raises:
-            RuntimeError: If Modal execution fails
+            RuntimeError: If Modal backend is unhealthy or execution fails.
         """
         if not await self.is_healthy():
             raise RuntimeError("Modal backend is not healthy")
@@ -77,33 +93,20 @@ class ModalBackend(ExecutionBackend):
             result.started_at = now_utc()
             result.status = ExecutionStatus.RUNNING
 
-            # For this implementation, we simulate Modal execution
-            # In production, you would:
-            # 1. Create a Modal function dynamically
-            # 2. Call modal.client.run() with the function
-            # 3. Track execution cost
+            output = await self._call_modal_function(task)
 
-            # Simulated Modal execution
-            try:
-                # Get or create Modal function
-                func = self._get_or_create_function(task)
+            result.stdout = output.get("stdout", "")
+            result.stderr = output.get("stderr", "")
+            result.return_code = output.get("return_code", 0)
+            result.metadata["modal_run_id"] = output.get("run_id", "")
+            result.metadata["cost_estimate"] = output.get("cost", 0.0)
+            result.status = ExecutionStatus.SUCCESS if result.return_code == 0 else ExecutionStatus.FAILED
 
-                # Execute (simulated)
-                output = await self._call_modal_function(func, task)
-
-                result.stdout = output.get("stdout", "")
-                result.stderr = output.get("stderr", "")
-                result.return_code = output.get("return_code", 0)
-                result.metadata["modal_run_id"] = output.get("run_id", "")
-                result.metadata["cost_estimate"] = output.get("cost", 0.0)
-
-                result.status = ExecutionStatus.SUCCESS if result.return_code == 0 else ExecutionStatus.FAILED
-
-            except Exception as e:
-                result.status = ExecutionStatus.FAILED
-                result.stderr = f"Modal execution failed: {str(e)}"
-                result.return_code = -1
-                logger.exception(f"Error executing task {task.task_id} on Modal: {e}")
+        except Exception as e:
+            result.status = ExecutionStatus.FAILED
+            result.stderr = f"Modal execution failed: {str(e)}"
+            result.return_code = -1
+            logger.exception("Error executing task %s on Modal: %s", task.task_id, e)
 
         finally:
             result.completed_at = now_utc()
@@ -113,121 +116,107 @@ class ModalBackend(ExecutionBackend):
         return result
 
     async def health_check(self) -> bool:
-        """Check if Modal service is accessible.
+        """Return True when Modal is installed and credentials appear configured.
+
+        Does NOT make a network call — checks only that the SDK is present and
+        that at least one of the known token env vars is set (or ``api_token``
+        was supplied at construction).  A real connectivity check happens lazily
+        when ``execute()`` is first called.
 
         Returns:
-            True if Modal is accessible
+            True if Modal can plausibly be reached.
         """
-        try:
-            # In production, make an actual Modal health check
-            # For now, just verify we can import
-            if modal is None:
-                return False
-            return True
-        except Exception as e:
-            logger.warning(f"Modal health check failed: {e}")
+        if modal is None:
             return False
+        if self.api_token:
+            return True
+        return bool(os.environ.get("MODAL_TOKEN_ID") or os.environ.get("MODAL_TOKEN_SECRET"))
 
     async def cleanup(self) -> None:
-        """Clean up Modal resources."""
-        # In production, cancel any pending Modal tasks
+        """Clean up cached Modal resources."""
         self._function_cache.clear()
 
     async def verify_task_compatibility(self, task: ExecutionTask) -> Tuple[bool, str]:
-        """Verify task can run on Modal.
+        """Verify task can run on Modal (Python only).
 
         Args:
-            task: Task to check
+            task: Task to check.
 
         Returns:
-            Tuple of (is_compatible, reason)
+            Tuple of (is_compatible, reason_if_not).
         """
-        supported_languages = ["python"]
-        if task.language.lower() not in supported_languages:
-            return (
-                False,
-                f"Modal only supports Python. Got: {task.language}",
-            )
-
+        if task.language.lower() != "python":
+            return False, f"Modal only supports Python. Got: {task.language}"
         return True, ""
 
-    def _get_or_create_function(self, task: ExecutionTask) -> Any:
-        """Get or create Modal function for task.
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
 
-        Args:
-            task: ExecutionTask
-
-        Returns:
-            Modal function (or stub in simulation)
-        """
-        language = task.language.lower()
-
-        if language not in self._function_cache:
-            # In production, create actual Modal function
-            self._function_cache[language] = {
-                "language": language,
-                "created_at": utc_timestamp(),
-            }
-
-        return self._function_cache[language]
-
-    async def _call_modal_function(self, func: Any, task: ExecutionTask) -> Dict[str, Any]:
-        """Call Modal function with task code (simulated).
-
-        Args:
-            func: Modal function
-            task: ExecutionTask with code
+    def _get_or_create_app(self) -> Any:
+        """Return a cached ``modal.App``, looking it up (or creating) on first call.
 
         Returns:
-            Dictionary with execution results
-
-        Note:
-            In production, this would call modal.client.run(func, ...)
+            A ``modal.App`` instance for ``_APP_NAME``.
         """
-        # Simulate Modal execution
+        if "app" not in self._function_cache:
+            self._function_cache["app"] = modal.App.lookup(self._APP_NAME, create_if_missing=True)
+        return self._function_cache["app"]
+
+    def _run_in_sandbox(self, task: ExecutionTask) -> Dict[str, Any]:
+        """Run ``task.code`` inside a real Modal Sandbox (blocking).
+
+        This method is intentionally synchronous so it can be offloaded to a
+        thread by ``_call_modal_function``.  It NEVER falls back to in-process
+        ``exec``; if Modal is unavailable a ``RuntimeError`` propagates.
+
+        Args:
+            task: ExecutionTask with code, env_vars, and timeout.
+
+        Returns:
+            Dictionary with ``stdout``, ``stderr``, ``return_code``, ``run_id``,
+            and ``cost`` keys.
+        """
+        if modal is None:
+            raise RuntimeError("Modal SDK is not available; cannot execute task")
+
+        sanitized_env = {k: v for k, v in safe_task_env({}, task.env_vars).items() if isinstance(v, str)}
+        app = self._get_or_create_app()
+        image = modal.Image.debian_slim(python_version="3.12")
+        secrets = [modal.Secret.from_dict(sanitized_env)] if sanitized_env else []
+        sandbox = modal.Sandbox.create(
+            app=app,
+            image=image,
+            timeout=task.timeout_seconds or 300,
+            secrets=secrets,
+        )
         try:
-            import io
-            from contextlib import redirect_stderr, redirect_stdout
-
-            # Capture stdout/stderr
-            stdout_capture = io.StringIO()
-            stderr_capture = io.StringIO()
-
-            return_code = 0
-            stdout_output = ""
-            stderr_output = ""
-
+            proc = sandbox.exec("python", "-c", task.code)
+            stdout = proc.stdout.read()
+            stderr = proc.stderr.read()
+            proc.wait()
+            rc = proc.returncode if proc.returncode is not None else 0
+            run_id = getattr(sandbox, "object_id", "") or f"modal-{task.task_id}"
+            return {"stdout": stdout, "stderr": stderr, "return_code": rc, "run_id": run_id, "cost": 0.0}
+        finally:
             try:
-                with redirect_stdout(stdout_capture), redirect_stderr(stderr_capture):
-                    # Execute code in isolated namespace. Security: task env
-                    # vars become exec() globals, so filter them through the
-                    # same AUTOBOT_* allowlist to block runtime/loader hijack
-                    # names leaking into the executed code namespace.
-                    namespace = safe_task_env({"__name__": "__modal__"}, task.env_vars)
+                sandbox.terminate()
+            except Exception:
+                pass
 
-                    exec(task.code, namespace)  # nosec B102
+    async def _call_modal_function(self, task: ExecutionTask) -> Dict[str, Any]:
+        """Offload the blocking Modal Sandbox call to a thread.
 
-                stdout_output = stdout_capture.getvalue()
-                stderr_output = stderr_capture.getvalue()
+        Args:
+            task: ExecutionTask.
 
-            except Exception as e:
-                return_code = 1
-                stderr_output = str(e)
+        Returns:
+            Dictionary with ``stdout``, ``stderr``, ``return_code``, ``run_id``,
+            and ``cost`` keys.
 
-            return {
-                "stdout": stdout_output,
-                "stderr": stderr_output,
-                "return_code": return_code,
-                "run_id": f"modal-{task.task_id}",
-                "cost": 0.001,
-            }
-
-        except Exception as e:
-            logger.exception(f"Error calling Modal function: {e}")
-            return {
-                "stdout": "",
-                "stderr": f"Error: {str(e)}",
-                "return_code": -1,
-                "run_id": "",
-                "cost": 0.0,
-            }
+        Raises:
+            RuntimeError: If Modal SDK is not available.
+        """
+        if modal is None:
+            raise RuntimeError("Modal SDK is not available; cannot execute task")
+        return await asyncio.to_thread(self._run_in_sandbox, task)

--- a/autobot-backend/tests/test_execution_backends.py
+++ b/autobot-backend/tests/test_execution_backends.py
@@ -314,6 +314,36 @@ class TestSSHBackend:
             pytest.skip("paramiko not installed")
 
 
+def _make_modal_mock() -> MagicMock:
+    """Build a minimal modal module mock that satisfies ModalBackend init checks."""
+    mock_modal = MagicMock()
+
+    # App lookup
+    mock_app = MagicMock()
+    mock_modal.App.lookup.return_value = mock_app
+
+    # Image
+    mock_image = MagicMock()
+    mock_modal.Image.debian_slim.return_value = mock_image
+
+    # Secret
+    mock_modal.Secret.from_dict.return_value = MagicMock()
+
+    # Sandbox + proc
+    mock_proc = MagicMock()
+    mock_proc.stdout.read.return_value = "hello from sandbox\n"
+    mock_proc.stderr.read.return_value = ""
+    mock_proc.wait.return_value = None
+    mock_proc.returncode = 0
+
+    mock_sandbox = MagicMock()
+    mock_sandbox.exec.return_value = mock_proc
+    mock_sandbox.object_id = "sandbox-abc123"
+    mock_modal.Sandbox.create.return_value = mock_sandbox
+
+    return mock_modal
+
+
 class TestModalBackend:
     """Test Modal execution backend."""
 
@@ -352,6 +382,208 @@ class TestModalBackend:
             assert "python" in reason.lower()
         except RuntimeError:
             pytest.skip("modal not installed")
+
+
+# ---------------------------------------------------------------------------
+# Modal Sandbox dispatch tests (Issue #11003)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestModalSandboxDispatch:
+    """Unit tests for real Modal Sandbox dispatch (Issue #11003).
+
+    All tests monkeypatch ``services.execution.modal_backend.modal`` with a
+    MagicMock so no real Modal SDK or network is required.
+    """
+
+    def _make_backend(self, monkeypatch) -> "ModalBackend":
+        mock_modal = _make_modal_mock()
+        monkeypatch.setattr("services.execution.modal_backend.modal", mock_modal)
+        # Supply a fake token so health_check passes
+        return ModalBackend(api_token="test-token"), mock_modal
+
+    # (a) Successful run returns stdout / return_code 0 / status SUCCESS
+    async def test_successful_run(self, monkeypatch):
+        """Sandbox exec with rc=0 produces SUCCESS result with correct stdout."""
+        backend, mock_modal = self._make_backend(monkeypatch)
+        task = ExecutionTask(task_id="sb-1", code="print('hi')", language="python", timeout_seconds=30)
+
+        result = await backend.execute(task)
+
+        assert result.status == ExecutionStatus.SUCCESS
+        assert result.return_code == 0
+        assert "hello from sandbox" in result.stdout
+        assert result.metadata["modal_run_id"] == "sandbox-abc123"
+
+    # (b) Non-zero returncode → FAILED
+    async def test_nonzero_returncode_gives_failed(self, monkeypatch):
+        """Sandbox proc returning rc=1 maps to ExecutionStatus.FAILED."""
+        backend, mock_modal = self._make_backend(monkeypatch)
+        mock_modal.Sandbox.create.return_value.exec.return_value.returncode = 1
+        mock_modal.Sandbox.create.return_value.exec.return_value.stderr.read.return_value = "oops"
+
+        task = ExecutionTask(task_id="sb-2", code="raise SystemExit(1)", language="python")
+
+        result = await backend.execute(task)
+
+        assert result.status == ExecutionStatus.FAILED
+        assert result.return_code == 1
+
+    # (c) modal is None → RuntimeError / health_check False / no code execution
+    async def test_modal_none_raises_runtime_error(self, monkeypatch):
+        """When modal is None, _call_modal_function raises RuntimeError immediately."""
+        monkeypatch.setattr("services.execution.modal_backend.modal", None)
+
+        # health_check must return False
+        # We cannot instantiate ModalBackend with modal=None — verify that too
+        with pytest.raises(RuntimeError, match="modal"):
+            ModalBackend()
+
+    async def test_health_check_false_when_modal_none(self, monkeypatch):
+        """health_check returns False when modal module is absent."""
+        backend, mock_modal = self._make_backend(monkeypatch)
+        # Patch modal away after construction
+        monkeypatch.setattr("services.execution.modal_backend.modal", None)
+        result = await backend.health_check()
+        assert result is False
+
+    async def test_health_check_false_when_no_credentials(self, monkeypatch):
+        """health_check returns False when no api_token and no env vars."""
+        mock_modal = _make_modal_mock()
+        monkeypatch.setattr("services.execution.modal_backend.modal", mock_modal)
+        monkeypatch.delenv("MODAL_TOKEN_ID", raising=False)
+        monkeypatch.delenv("MODAL_TOKEN_SECRET", raising=False)
+
+        backend = ModalBackend(api_token=None)
+        assert await backend.health_check() is False
+
+    async def test_health_check_true_with_api_token(self, monkeypatch):
+        """health_check returns True when api_token is set at construction."""
+        backend, _ = self._make_backend(monkeypatch)
+        assert await backend.health_check() is True
+
+    async def test_health_check_true_with_env_token_id(self, monkeypatch):
+        """health_check returns True when MODAL_TOKEN_ID env var is present."""
+        mock_modal = _make_modal_mock()
+        monkeypatch.setattr("services.execution.modal_backend.modal", mock_modal)
+        monkeypatch.setenv("MODAL_TOKEN_ID", "tid-123")
+        monkeypatch.delenv("MODAL_TOKEN_SECRET", raising=False)
+
+        backend = ModalBackend(api_token=None)
+        assert await backend.health_check() is True
+
+    # (d) Env vars passed via modal.Secret.from_dict; AUTOBOT_*/hijack names stripped
+    async def test_env_vars_passed_via_secret(self, monkeypatch):
+        """Allowed AUTOBOT_* env vars reach modal.Secret.from_dict."""
+        backend, mock_modal = self._make_backend(monkeypatch)
+        task = ExecutionTask(
+            task_id="sb-3",
+            code="print('env')",
+            language="python",
+            env_vars={"AUTOBOT_MY_VAR": "value123", "SECRET_SAUCE": "should-be-dropped"},
+        )
+
+        await backend.execute(task)
+
+        mock_modal.Secret.from_dict.assert_called_once()
+        passed_dict = mock_modal.Secret.from_dict.call_args[0][0]
+        assert "AUTOBOT_MY_VAR" in passed_dict
+        assert passed_dict["AUTOBOT_MY_VAR"] == "value123"
+        assert "SECRET_SAUCE" not in passed_dict
+
+    async def test_hijack_env_vars_stripped(self, monkeypatch):
+        """PYTHONPATH, LD_PRELOAD and other hijack names are stripped."""
+        backend, mock_modal = self._make_backend(monkeypatch)
+        task = ExecutionTask(
+            task_id="sb-4",
+            code="print('safe')",
+            language="python",
+            env_vars={
+                "PYTHONPATH": "/evil",
+                "LD_PRELOAD": "/evil.so",
+                "NODE_OPTIONS": "--require /evil",
+                "AUTOBOT_SAFE": "ok",
+            },
+        )
+
+        await backend.execute(task)
+
+        mock_modal.Secret.from_dict.assert_called_once()
+        passed_dict = mock_modal.Secret.from_dict.call_args[0][0]
+        for bad_key in ("PYTHONPATH", "LD_PRELOAD", "NODE_OPTIONS"):
+            assert bad_key not in passed_dict
+        assert "AUTOBOT_SAFE" in passed_dict
+
+    async def test_no_secret_when_env_vars_empty(self, monkeypatch):
+        """modal.Secret.from_dict is NOT called when env_vars is empty."""
+        backend, mock_modal = self._make_backend(monkeypatch)
+        task = ExecutionTask(task_id="sb-5", code="print('no env')", language="python", env_vars={})
+
+        await backend.execute(task)
+
+        mock_modal.Secret.from_dict.assert_not_called()
+        # Sandbox.create should have been called with secrets=[]
+        call_kwargs = mock_modal.Sandbox.create.call_args[1]
+        assert call_kwargs.get("secrets") == []
+
+    # (e) sandbox.terminate() is always called (finally)
+    async def test_sandbox_terminate_always_called(self, monkeypatch):
+        """sandbox.terminate() is called even when sandbox.exec raises."""
+        backend, mock_modal = self._make_backend(monkeypatch)
+        mock_sandbox = mock_modal.Sandbox.create.return_value
+        mock_sandbox.exec.side_effect = RuntimeError("sandbox exploded")
+
+        task = ExecutionTask(task_id="sb-6", code="bad code", language="python")
+
+        result = await backend.execute(task)
+
+        mock_sandbox.terminate.assert_called_once()
+        assert result.status == ExecutionStatus.FAILED
+
+    async def test_sandbox_terminate_called_on_success(self, monkeypatch):
+        """sandbox.terminate() is called on the happy path too."""
+        backend, mock_modal = self._make_backend(monkeypatch)
+        mock_sandbox = mock_modal.Sandbox.create.return_value
+
+        task = ExecutionTask(task_id="sb-7", code="print('done')", language="python")
+        await backend.execute(task)
+
+        mock_sandbox.terminate.assert_called_once()
+
+    # Assert exec() is NEVER used to run task code in-process
+    async def test_builtin_exec_never_called(self, monkeypatch):
+        """The built-in exec() must not be used to run task code."""
+        backend, _ = self._make_backend(monkeypatch)
+        task = ExecutionTask(task_id="sb-8", code="x = 1 + 1", language="python")
+
+        # Patch builtins.exec to fail hard if called
+        import builtins
+
+        original_exec = builtins.exec
+
+        def _no_exec(code, *args, **kwargs):
+            raise AssertionError("exec() was called with task code — this is the RCE bug!")
+
+        monkeypatch.setattr(builtins, "exec", _no_exec)
+        try:
+            result = await backend.execute(task)
+        finally:
+            monkeypatch.setattr(builtins, "exec", original_exec)
+
+        # If we reach here, exec() was not called in-process
+        assert result.status == ExecutionStatus.SUCCESS
+
+    # App caching
+    async def test_app_lookup_called_only_once(self, monkeypatch):
+        """modal.App.lookup is called once and the result is cached."""
+        backend, mock_modal = self._make_backend(monkeypatch)
+        task = ExecutionTask(task_id="sb-9", code="pass", language="python")
+
+        await backend.execute(task)
+        await backend.execute(task)
+
+        mock_modal.App.lookup.assert_called_once_with(ModalBackend._APP_NAME, create_if_missing=True)
 
 
 class TestExecutionManager:


### PR DESCRIPTION
## Thinking Path

The existing `_call_modal_function` ran `exec(task.code, namespace)` inside the backend process — an RCE. The fix has one clear requirement: wire real `modal.Sandbox` dispatch. No in-process fallback is acceptable.

Steps taken:
1. Understood `ExecutionTask` fields and `safe_task_env` allowlist behaviour.
2. Designed `_run_in_sandbox()` as a sync function (blocking SDK calls offloaded via `asyncio.to_thread`).
3. Verified the Modal Sandbox API surface against the documented pattern in the issue.
4. Removed `exec()`, `redirect_stdout/stderr`, and the `_get_or_create_function` stub entirely.
5. Wired `health_check` to inspect token presence without a network call.
6. Added 14 unit tests covering every required scenario with a `MagicMock` modal module.

## What Changed

**`autobot-backend/services/execution/modal_backend.py`**
- Removed `exec(task.code, namespace)`, `io.StringIO`, `redirect_stdout/stderr`
- Removed `_get_or_create_function()` (language-keyed stub dict)
- Added `_APP_NAME = "autobot-code-execution"` class attribute
- Added `_get_or_create_app()` — caches `modal.App.lookup(_APP_NAME, create_if_missing=True)` in `self._function_cache["app"]`
- Added `_run_in_sandbox(task)` — synchronous; creates `modal.Sandbox`, calls `sandbox.exec("python", "-c", task.code)`, reads stdout/stderr, calls `proc.wait()`, terminates sandbox in `finally`; env vars pass via `modal.Secret.from_dict(sanitized_env)`
- `_call_modal_function(task)` becomes `async`; signature drops the unused `func` arg; delegates to `asyncio.to_thread(self._run_in_sandbox, task)`
- `execute()` simplified: no inner try/except wrapping a stub; calls `await self._call_modal_function(task)` directly
- `health_check()` returns `True` only when SDK present AND (`self.api_token` set OR `MODAL_TOKEN_ID`/`MODAL_TOKEN_SECRET` env var present) — no network call
- Updated all stale "simulated"/"In production, this would…" docstrings/comments

**`autobot-backend/tests/test_execution_backends.py`**
- Added helper `_make_modal_mock()` that builds a complete `MagicMock` modal module
- Added class `TestModalSandboxDispatch` (14 tests):
  - (a) successful run → `SUCCESS`, correct stdout, `modal_run_id` populated
  - (b) non-zero returncode → `FAILED`
  - (c) `modal=None` → `RuntimeError` at construction; `health_check` returns `False`; no code executed
  - (c) `health_check` False when no credentials
  - (c/d) `health_check` True with `api_token` or env vars
  - (d) `AUTOBOT_*` vars reach `modal.Secret.from_dict`; non-`AUTOBOT_*` vars dropped
  - (d) `PYTHONPATH`, `LD_PRELOAD`, `NODE_OPTIONS` stripped
  - (d) no `Secret.from_dict` call when env vars empty, `secrets=[]` passed to `Sandbox.create`
  - (e) `sandbox.terminate()` called even when `sandbox.exec` raises
  - (e) `sandbox.terminate()` called on the happy path
  - Builtins `exec()` patched to raise `AssertionError` — confirms in-process exec is never invoked
  - App lookup cached: `modal.App.lookup` called exactly once across two executions

## Verification

```
pytest tests/test_execution_backends.py -x -q
```

```
platform linux -- Python 3.10.12, pytest-9.0.2, pluggy-1.6.0
asyncio: mode=auto
collected 72 items

tests/test_execution_backends.py ........................ss............. [ 54%]
.................................                                        [100%]

70 passed, 2 skipped, 2 warnings in 2.22s
```

(2 skips = pre-existing SSH + vanilla Modal tests that skip when paramiko/modal are not installed.)

Black (`--line-length=120`) and ruff report no changes / no issues on both files.

> **Staging note:** This implementation is mock-tested only. It must be validated against a real Modal account before production use. See "Modal SDK assumptions" in the PR description for what a reviewer with a Modal token should verify.

### Modal SDK Assumptions (needs staging verification)

A reviewer with a valid Modal account should confirm:

1. `modal.App.lookup(name, create_if_missing=True)` is the correct call to obtain/create an app by name — the public Sandbox API docs show this pattern but the `create_if_missing` kwarg was introduced in Modal SDK 0.64+; confirm the pinned version supports it.
2. `modal.Sandbox.create(app=app, image=image, timeout=N, secrets=[...])` accepts exactly these keyword names (not `app_id`, not `environment`).
3. `sandbox.exec("python", "-c", code)` returns an object with `.stdout`, `.stderr` stream attributes that support `.read()` and a `.returncode` attribute after `.wait()`.
4. `sandbox.object_id` is the correct attribute for the stable sandbox identifier (vs `sandbox_id` or `id`).
5. `modal.Image.debian_slim(python_version="3.12")` is available and produces a Python 3.12 image.
6. `modal.Secret.from_dict(dict)` is the correct constructor for injecting env vars into a sandbox.

## Model Used

claude-sonnet-4-6

Closes #11003