### PR TITLE
fix(frontend): resolve any + no-unused-vars across 14 components (#9924)

### DIFF
--- a/autobot-frontend/src/components/analytics/AgentCostPanel.vue
+++ b/autobot-frontend/src/components/analytics/AgentCostPanel.vue
@@ -146,7 +146,6 @@
 
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, onMounted } from 'vue'
-import { useI18n } from 'vue-i18n'
 import BaseButton from '@/components/base/BaseButton.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import api from '@/services/api'
@@ -154,7 +153,6 @@ import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('AgentCostPanel')
-const { t } = useI18n()
 
 interface AgentCost {
   agent_id: string
@@ -220,7 +218,7 @@ const closeBudgetDialog = () => {
 const saveBudget = async () => {
   budgetDialog.value.saving = true
   try {
-    await api.put<any>(
+    await api.put<unknown>(
       `${getApiBase()}/cost/by-agent/${budgetDialog.value.agentId}/budget`,
       { budget_monthly_usd: budgetDialog.value.amount }
     )

--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -448,9 +448,9 @@ import { useI18n } from 'vue-i18n'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import PatternAnalysis from '@/components/analytics/PatternAnalysis.vue'
 import { useNotificationBus } from '@/composables/useNotificationBus'
-import { getCssVar } from '@/composables/useCssVars'
 import { useCodebaseExport, type SectionType } from '@/composables/analytics/useCodebaseExport'
 import type { ScanDefinition } from '@/composables/useAnalyticsScanRunner'
+import type { PatternAnalysisReport } from '@/composables/usePatternAnalysis'
 import { useIndexingJob } from '@/composables/analytics/useIndexingJob'
 import { useDashboardLoaders } from '@/composables/analytics/useDashboardLoaders'
 import { useSourceRegistry } from '@/composables/analytics/useSourceRegistry'
@@ -904,7 +904,7 @@ const runFullAnalysis = async () => {
 }
 
 // Pattern analysis event handlers
-const onPatternAnalysisComplete = (report: any) => {
+const onPatternAnalysisComplete = (report: PatternAnalysisReport) => {
   logger.info('Pattern analysis complete:', report?.analysis_summary)
   notify(t('analytics.codebase.notify.patternAnalysisComplete', { count: report?.analysis_summary?.total_patterns_found || 0 }), 'success')
 }

--- a/autobot-frontend/src/components/analytics/code-intelligence/FindingsTable.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/FindingsTable.vue
@@ -39,7 +39,7 @@
     </div>
 
     <!-- Table with virtual scrolling -->
-    <div v-else class="table-container">
+    <div v-else ref="containerRef" class="table-container">
       <table>
         <thead class="sticky top-0 z-10">
           <tr>
@@ -112,7 +112,7 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
-import { ref, computed, watch } from 'vue'
+import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useVirtualList } from '@/composables/useVirtualList'
 import { useDebounce } from '@/composables/useDebounce'

--- a/autobot-frontend/src/components/auth/LoginForm.vue
+++ b/autobot-frontend/src/components/auth/LoginForm.vue
@@ -99,6 +99,20 @@ import { getApiBase } from '@/config/ssot-config'
 import BaseAlert from '@/components/ui/BaseAlert.vue'
 import { useLoadingState } from '@/composables/useLoadingState'
 
+interface LoginUser {
+  user_id?: string
+  username: string
+  email?: string
+  role?: string
+}
+
+interface LoginResponse {
+  success: boolean
+  message?: string
+  token?: string
+  user?: LoginUser
+}
+
 const router = useRouter()
 const userStore = useUserStore()
 
@@ -187,7 +201,7 @@ async function handleLogin() {
   await wrap(async () => {
   try {
     // ApiClient.post() returns parsed JSON directly (#810)
-    const response = await ApiClient.post<any>(`${getApiBase()}/auth/login`, {
+    const response = await ApiClient.post<LoginResponse>(`${getApiBase()}/auth/login`, {
       username: credentials.username,
       password: credentials.password
     })
@@ -235,11 +249,11 @@ async function handleLogin() {
       loginError.value = response.message || t('auth.login.loginFailed')
     }
 
-  } catch (error: any) {
+  } catch (error) {
     logger.error('Login error:', error)
 
     // ApiClient throws Error with message like "HTTP 401: Invalid username or password"
-    const statusMatch = error.message?.match(/HTTP (\d+)/)
+    const statusMatch = (error as Error).message?.match(/HTTP (\d+)/)
     const status = statusMatch ? parseInt(statusMatch[1]) : 0
     if (status === 401) {
       loginError.value = t('auth.login.invalidCredentials')
@@ -250,7 +264,7 @@ async function handleLogin() {
     } else if (status >= 500) {
       loginError.value = t('auth.login.serverError')
     } else {
-      loginError.value = error.message || t('auth.login.unexpectedError')
+      loginError.value = (error as Error).message || t('auth.login.unexpectedError')
     }
   }
   })

--- a/autobot-frontend/src/components/charts/FunctionCallGraph.vue
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.vue
@@ -350,7 +350,6 @@
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { useExpansion } from '@/composables/useExpansion'
-import { useI18n } from 'vue-i18n'
 // Type imports only — runtime load handled by the shared composable (#5206).
 // The default namespace import below gives type-only access to helpers
 // like `cytoscape.StylesheetStyle` / `cytoscape.LayoutOptions` used in
@@ -362,8 +361,6 @@ import { useCytoscapeLibrary } from '@/composables/charts/useCytoscapeLibrary'
 import { useVirtualScrollSimple } from '@/composables/useVirtualScroll'
 import { getCssVar } from '@/composables/useCssVars'
 import { useDebounce } from '@/composables/useTimeout'
-
-const { t } = useI18n()
 
 // Flexible interface to support multiple data formats
 interface GraphNode {
@@ -1265,12 +1262,6 @@ function truncateFile(filePath: string): string {
   const parts = filePath.split('/')
   if (parts.length <= 2) return filePath
   return '...' + parts.slice(-2).join('/')
-}
-
-function truncateFunc(funcId: string): string {
-  const parts = funcId.split('.')
-  if (parts.length <= 2) return funcId
-  return parts.slice(-2).join('.')
 }
 
 

--- a/autobot-frontend/src/components/charts/ImportTreeChart.vue
+++ b/autobot-frontend/src/components/charts/ImportTreeChart.vue
@@ -229,7 +229,7 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
-import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, computed, watch, onUnmounted, nextTick } from 'vue'
 import { useExpansion } from '@/composables/useExpansion'
 import { useI18n } from 'vue-i18n'
 import { getCssVar } from '@/composables/useCssVars'
@@ -587,7 +587,7 @@ function getCytoscapeStyles(): Array<{ selector: string; style: Record<string, s
 function updateCytoscapeElements() {
   if (!cy) return
 
-  const elements: Array<{ data: Record<string, any>; position?: { x: number; y: number } }> = []
+  const elements: Array<{ data: Record<string, unknown>; position?: { x: number; y: number } }> = []
   const nodeIds = new Set<string>()
 
   // Build map of imports and importers for quick lookup

--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue
@@ -214,8 +214,8 @@ const { t } = useI18n()
 const logger = createLogger('DesktopInterface')
 
 // Async operation composables
-const { isLoading: loadingVnc, wrap: wrapLoadVnc } = useLoadingState()
-const { isLoading: loadingCheck, wrap: wrapCheckConnection } = useLoadingState()
+const { wrap: wrapLoadVnc } = useLoadingState()
+const { wrap: wrapCheckConnection } = useLoadingState()
 const errorVnc = ref<Error | null>(null)
 const errorCheck = ref<Error | null>(null)
 

--- a/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
+++ b/autobot-frontend/src/components/desktop/PopoutChromiumBrowser.vue
@@ -418,7 +418,7 @@
 </template>
 
 <script lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import type { Ref } from 'vue'
 import type { AutomationResults, SearchData, TestData, TestResult, MessageData, TestStep } from '@/types/browser'
 import appConfig from '@/config/AppConfig.js'
@@ -431,7 +431,6 @@ import EmptyState from '@/components/ui/EmptyState.vue'
 import StatusBadge from '@/components/ui/StatusBadge.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import Icon from '@/components/ui/Icon.vue'
-import { NetworkConstants } from '@/constants/network'
 import { useAsyncHandler } from '@/composables/useErrorHandler'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'

--- a/autobot-frontend/src/components/documents/AIDocumentEditor.vue
+++ b/autobot-frontend/src/components/documents/AIDocumentEditor.vue
@@ -214,7 +214,7 @@ async function saveChanges() {
     localDoc.value = updated
     isDirty.value = false
     emit('saved', updated)
-  } catch (err) {
+  } catch {
     emit('error', composable.error.value ?? 'Save failed')
   }
 }
@@ -236,7 +236,7 @@ async function submitRefine() {
     refineInstruction.value = ''
     showRefinePanel.value = false
     emit('refined', refined)
-  } catch (err) {
+  } catch {
     emit('error', composable.error.value ?? 'Refinement failed')
   }
 }

--- a/autobot-frontend/src/components/file-browser/FileBrowserHeader.vue
+++ b/autobot-frontend/src/components/file-browser/FileBrowserHeader.vue
@@ -48,12 +48,12 @@ interface Emits {
   (e: 'navigate-to-path', path: string): void
 }
 
-const props = withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<Props>(), {
   title: '',
   currentPath: '/'
 })
 
-const emit = defineEmits<Emits>()
+defineEmits<Emits>()
 </script>
 
 <style scoped>

--- a/autobot-frontend/src/components/knowledge/CleanupStatistics.vue
+++ b/autobot-frontend/src/components/knowledge/CleanupStatistics.vue
@@ -190,9 +190,9 @@ const runDryScan = async () => {
     } else {
       showStatus('success', t('knowledge.cleanup.noIssuesFound'))
     }
-  } catch (error: any) {
+  } catch (error) {
     logger.error('Failed to scan for issues:', error)
-    showStatus('error', error.message || t('knowledge.cleanup.errorScan'))
+    showStatus('error', (error as Error).message || t('knowledge.cleanup.errorScan'))
   }
 }
 
@@ -224,9 +224,9 @@ const runCleanup = async () => {
     } else {
       throw new Error((data.message as string) || 'Cleanup failed')
     }
-  } catch (error: any) {
+  } catch (error) {
     logger.error('Failed to run cleanup:', error)
-    showStatus('error', error.message || t('knowledge.cleanup.errorCleanup'))
+    showStatus('error', (error as Error).message || t('knowledge.cleanup.errorCleanup'))
   }
 }
 </script>

--- a/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
@@ -612,10 +612,6 @@ const sortEntries = () => {
   // Sorting is handled in the computed property
 }
 
-const toggleSelection = (id: string) => {
-  selection.toggleByKey(id)
-}
-
 const toggleSelectAll = () => {
   if (selection.allSelected.value) {
     // Deselect all on current page
@@ -662,10 +658,6 @@ const deleteSelected = async () => {
   } catch (error) {
     logger.error('Failed to delete entries:', error)
   }
-}
-
-const exportSelected = async () => {
-  handleExport('json')
 }
 
 // Issue #747: Enhanced export with multiple formats

--- a/autobot-frontend/src/components/knowledge/SessionOrphanManager.vue
+++ b/autobot-frontend/src/components/knowledge/SessionOrphanManager.vue
@@ -175,9 +175,9 @@ const scanSessionOrphans = async () => {
       showStatus('success',
         t('knowledge.sessionOrphan.allActive', { count: data.total_facts_checked }))
     }
-  } catch (error: any) {
+  } catch (error) {
     logger.error('Failed to scan for session orphans:', error)
-    showStatus('error', error.message || t('knowledge.sessionOrphan.scanError'))
+    showStatus('error', (error as Error).message || t('knowledge.sessionOrphan.scanError'))
   }
 }
 
@@ -199,9 +199,9 @@ const cleanupSessionOrphans = async () => {
       ? t('knowledge.sessionOrphan.preservedSuffix', { count: data.facts_preserved })
       : ''
     showStatus('success', t('knowledge.sessionOrphan.deleteSuccess', { count: data.facts_removed, preserved }))
-  } catch (error: any) {
+  } catch (error) {
     logger.error('Failed to cleanup session orphans:', error)
-    showStatus('error', error.message || t('knowledge.sessionOrphan.cleanupError'))
+    showStatus('error', (error as Error).message || t('knowledge.sessionOrphan.cleanupError'))
   }
 }
 </script>

--- a/autobot-frontend/tests/SecretsManager.memoization.test.ts
+++ b/autobot-frontend/tests/SecretsManager.memoization.test.ts
@@ -7,9 +7,19 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 
+interface TestSecret {
+  id: string;
+  name: string;
+  type: string;
+  scope: string;
+  description?: string;
+  tags?: string[];
+  expires_at?: string | null;
+}
+
 describe('SecretsManager - filteredSecrets Memoization', () => {
   // Mock cache behavior
-  let filterCache: Map<string, any[]>;
+  let filterCache: Map<string, TestSecret[]>;
   let cacheHits = 0;
   let cacheMisses = 0;
 
@@ -38,12 +48,12 @@ describe('SecretsManager - filteredSecrets Memoization', () => {
 
   // Test helper: simulate filtering with cache
   const filterSecretsWithCache = (
-    secrets: any[],
+    secrets: TestSecret[],
     selectedCategory: string,
     selectedScope: string,
     showExpiredOnly: boolean,
     debouncedSearch: string
-  ): any[] => {
+  ): TestSecret[] => {
     const cacheKey = mockGetFilterCacheKey(
       selectedCategory,
       selectedScope,


### PR DESCRIPTION
## Thinking Path
Toward green `frontend-tests` — all 29 eslint warnings across 14 files.

## What Changed (179 → ~150 problems)
- **any→typed**: LoginForm (`LoginResponse`/`LoginUser`), CodebaseAnalytics (`PatternAnalysisReport`), ImportTreeChart (`Record<string,unknown>`), SecretsManager.memoization.test (`TestSecret`), multiple `catch(error: any)`→`catch(error)`+`(error as Error).message`.
- **unused removed**: `t`/`useI18n` where template uses `$t`; unused imports (`watch`/`onMounted`/`nextTick`/`NetworkConstants`/`getCssVar`); `catch(err)`→`catch {}`; unused `props`/`emit` bindings (macros kept).
- **dead code removed** (confirmed orphaned): `truncateFunc` (FunctionCallGraph), `toggleSelection`/`exportSelected` (KnowledgeEntries — template wires the underlying calls directly).

## Behavioral fix (bonus)
**FindingsTable.vue**: `containerRef` from `useVirtualList` was unbound → virtual scrolling was inert. Wired `ref="containerRef"` to `.table-container` (has `overflow-y:auto; max-height:600px`). Rather than delete the "unused" ref, fixed the omission.

## Verification (independently re-run)
- `eslint` 14 files → **0 warnings, 0 errors**.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (whole project).
- `vitest` SecretsManager.memoization → 9/9. No emit/prop types tightened → no consumers affected.
- No eslint-disable/@ts-ignore; no runtime coercions.

## Model Used
Opus 4.8

Contributes to #9924 green frontend-tests.