### PR TITLE
fix(frontend): resolve any + no-unused-vars across 16 files (#9924)

### DIFF
--- a/autobot-frontend/src/components/knowledge/TreeNodeComponent.vue
+++ b/autobot-frontend/src/components/knowledge/TreeNodeComponent.vue
@@ -109,6 +109,21 @@ import Icon from '@/components/ui/Icon.vue'
 import { computed } from 'vue'
 import VectorizationStatusBadge from './VectorizationStatusBadge.vue'
 import { useKnowledgeVectorization } from '@/composables/useKnowledgeVectorization'
+import type { DocumentVectorizationState } from '@/composables/useKnowledgeVectorization'
+
+// Metadata attached to a knowledge tree node. Mirrors the KnowledgeFactLike
+// shape produced by the knowledge browser (all fields optional).
+export interface TreeNodeMetadata {
+  key?: string
+  title?: string
+  source?: string
+  content?: string
+  full_content?: string
+  timestamp?: string
+  created_at?: string
+  category?: string
+  metadata?: Record<string, unknown>
+}
 
 // Tree node interface
 export interface TreeNode {
@@ -120,7 +135,7 @@ export interface TreeNode {
   size?: number
   date?: string
   category?: string
-  metadata?: any
+  metadata?: TreeNodeMetadata
   content?: string
 }
 
@@ -130,7 +145,7 @@ interface Props {
   expandedNodes: Set<string>
   selectedId?: string
   selectedDocuments: Set<string>
-  vectorizationStates: Map<string, any>
+  vectorizationStates: Map<string, DocumentVectorizationState>
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
@@ -532,10 +532,10 @@ async function testConnection() {
       props.editConnector!.connector_id
     )
     testResult.value = result
-  } catch (error: any) {
+  } catch (error) {
     testResult.value = {
       success: false,
-      message: error.message || 'Test failed'
+      message: (error as Error).message || 'Test failed'
     }
   } finally {
     testing.value = false
@@ -562,8 +562,8 @@ async function handleSave() {
 
     emit('saved', result)
     emit('update:modelValue', false)
-  } catch (error: any) {
-    saveError.value = error.message || t('knowledge.connectors.config.saveFailed')
+  } catch (error) {
+    saveError.value = (error as Error).message || t('knowledge.connectors.config.saveFailed')
     logger.error('Failed to save connector: %s', error)
   } finally {
     saving.value = false

--- a/autobot-frontend/src/components/knowledge/connectors/__tests__/ConnectorConfigModal.gdrive.spec.ts
+++ b/autobot-frontend/src/components/knowledge/connectors/__tests__/ConnectorConfigModal.gdrive.spec.ts
@@ -11,6 +11,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import type { App } from 'vue'
 
 import ConnectorConfigModal from '../ConnectorConfigModal.vue'
 import { knowledgeRepository } from '@/models/repositories/KnowledgeRepository'
@@ -45,7 +46,7 @@ function mountModal() {
       },
       plugins: [
         {
-          install(app: any) {
+          install(app: App) {
             app.config.globalProperties.$t = (k: string) => k
           }
         }
@@ -96,7 +97,7 @@ describe('ConnectorConfigModal — Google Drive (#9003)', () => {
     await flushPromises()
 
     // Drive the component to call createConnector via its save handler.
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm as unknown as { connectorName: string; handleSave: () => Promise<void> }
     vm.connectorName = 'My Drive'
     await vm.handleSave()
     await flushPromises()

--- a/autobot-frontend/src/components/knowledge/connectors/__tests__/ConnectorConfigModal.onedrive.spec.ts
+++ b/autobot-frontend/src/components/knowledge/connectors/__tests__/ConnectorConfigModal.onedrive.spec.ts
@@ -11,6 +11,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import type { App } from 'vue'
 
 import ConnectorConfigModal from '../ConnectorConfigModal.vue'
 import { knowledgeRepository } from '@/models/repositories/KnowledgeRepository'
@@ -45,7 +46,7 @@ function mountModal() {
       },
       plugins: [
         {
-          install(app: any) {
+          install(app: App) {
             app.config.globalProperties.$t = (k: string) => k
           }
         }
@@ -96,7 +97,7 @@ describe('ConnectorConfigModal — OneDrive / SharePoint (#9004)', () => {
     await flushPromises()
 
     // Drive the component to call createConnector via its save handler.
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm as unknown as { connectorName: string; handleSave: () => Promise<void> }
     vm.connectorName = 'My OneDrive'
     await vm.handleSave()
     await flushPromises()

--- a/autobot-frontend/src/components/settings/DevicePairingSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/DevicePairingSettingsPanel.vue
@@ -190,7 +190,7 @@ Allows users to pair mobile devices for push notifications and offline sync
 
 <script setup lang="ts">
 import type { IconName } from '@/components/ui/Icon.vue'
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, onMounted } from 'vue'
 import Icon from '@/components/ui/Icon.vue'
 import { useNotificationBus } from '@/composables/useNotificationBus'
 import { createLogger } from '@/utils/debugUtils'

--- a/autobot-frontend/src/components/terminal/TerminalModals.vue
+++ b/autobot-frontend/src/components/terminal/TerminalModals.vue
@@ -235,7 +235,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, nextTick } from 'vue'
+import { ref } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 import BaseButton from '@/components/base/BaseButton.vue'
 
@@ -319,20 +319,25 @@ const clearMessages = () => {
 }
 
 // Standard error handler
-const handleError = (error: any, setter: (msg: string) => void) => {
+const handleError = (error: unknown, setter: (msg: string) => void) => {
   logger.error('Terminal modal error:', error)
 
   let errorMessage = 'An unexpected error occurred'
 
-  if (error?.message) {
-    errorMessage = error.message
-  } else if (error?.response?.data?.detail) {
-    errorMessage = error.response.data.detail
-  } else if (error?.response?.status === 408) {
+  const err = error as {
+    message?: string
+    response?: { data?: { detail?: string }; status?: number }
+  }
+
+  if (err?.message) {
+    errorMessage = err.message
+  } else if (err?.response?.data?.detail) {
+    errorMessage = err.response!.data!.detail!
+  } else if (err?.response?.status === 408) {
     errorMessage = 'Request timed out. Please try again.'
-  } else if (error?.response?.status === 500) {
+  } else if (err?.response?.status === 500) {
     errorMessage = 'Server error. Please try again later.'
-  } else if (error?.response?.status === 404) {
+  } else if (err?.response?.status === 404) {
     errorMessage = 'Service not found. Please check your connection.'
   } else if (typeof error === 'string') {
     errorMessage = error

--- a/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
@@ -165,7 +165,6 @@ import { createLogger } from '@/utils/debugUtils';
 import {
   useWorkflowNotificationConfig,
   ALL_EVENTS,
-  ALL_CHANNELS,
   type NotificationEvent,
   type NotificationChannel,
   type NotificationConfigPayload,
@@ -184,7 +183,7 @@ interface WorkflowSummary {
   [key: string]: unknown;
 }
 
-const props = defineProps<{
+defineProps<{
   workflows: WorkflowSummary[];
 }>();
 

--- a/autobot-frontend/src/components/workflow/WorkflowRunner.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowRunner.vue
@@ -157,7 +157,7 @@ import type { ActiveWorkflow } from '@/composables/useWorkflowBuilder';
 import NotificationConfigModal from './NotificationConfigModal.vue';
 
 const props = defineProps<{ workflows: ActiveWorkflow[]; currentWorkflow: ActiveWorkflow | null; loading: boolean }>();
-const emit = defineEmits<{
+defineEmits<{
   (e: 'start-workflow', id: string): void;
   (e: 'pause-workflow', id: string): void;
   (e: 'resume-workflow', id: string): void;
@@ -172,7 +172,7 @@ const showNotifConfig = ref(false);
 const completedSteps = computed(() => props.currentWorkflow?.steps.filter(s => s.status === 'completed').length ?? 0);
 const failedSteps = computed(() => props.currentWorkflow?.steps.filter(s => s.status === 'failed').length ?? 0);
 
-function selectWorkflow(wf: ActiveWorkflow) {
+function selectWorkflow(_wf: ActiveWorkflow) {
   // Parent should handle selection via props
 }
 

--- a/autobot-frontend/src/composables/__tests__/useSlashCommands.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useSlashCommands.test.ts
@@ -78,7 +78,7 @@ describe('useSlashCommands (GH#4449)', () => {
     const sc = useSlashCommands(input)
     // Inject a preset to produce suggestions
     void sc['presetsLoading'] // access to ensure store is wired
-    const _presetsStore = (sc as any)
+    const _presetsStore = sc
     // Manually set suggestions via store
     const { selectedIndex, moveDown, open } = sc
     // Without presets, moveDown is a no-op
@@ -115,7 +115,8 @@ describe('useSlashCommands (GH#4449)', () => {
 
   it('onInput opens dropdown when slash query present', () => {
     const input = ref('/gr')
-    const { isOpen: _isOpen, onInput } = useSlashCommands(input) as any
+    const { isOpen: _isOpen, onInput } =
+      useSlashCommands(input) as ReturnType<typeof useSlashCommands> & { isOpen: unknown }
     onInput()
     // isOpen is internal; showDropdown depends on suggestions too
     // We verify indirectly through slashQuery being active

--- a/autobot-frontend/src/composables/__tests__/useSvgIcons.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useSvgIcons.test.ts
@@ -84,7 +84,7 @@ describe('useSvgIcons', () => {
     it('should return default icon for invalid name', () => {
       const { icon } = useSvgIcons()
       // TypeScript should prevent invalid names, but JS fallback is safe
-      expect(icon('info' as any)).toBe('icon-info')
+      expect(icon('info' as unknown as keyof typeof ICON_IDS)).toBe('icon-info')
     })
 
     it('should return status ID for valid status name', () => {
@@ -97,7 +97,7 @@ describe('useSvgIcons', () => {
     it('should return default status for invalid status name', () => {
       const { status } = useSvgIcons()
       // TypeScript should prevent invalid names, but JS fallback is safe
-      expect(status('offline' as any)).toBe('status-offline')
+      expect(status('offline' as unknown as keyof typeof STATUS_IDS)).toBe('status-offline')
     })
 
     it('should return iconHref for icon name', () => {

--- a/autobot-frontend/src/composables/research/useCaptchaStatus.ts
+++ b/autobot-frontend/src/composables/research/useCaptchaStatus.ts
@@ -156,7 +156,7 @@ export function useCaptchaStatus() {
 
     isSubmitting.value = true
     try {
-      await apiClient.post<any>(`${getApiBase()}/captcha/${activeCaptcha.value.captcha_id}/resolve`)
+      await apiClient.post<unknown>(`${getApiBase()}/captcha/${activeCaptcha.value.captcha_id}/resolve`)
       activeCaptcha.value = null
       stopTimer()
     } catch (error) {
@@ -171,7 +171,7 @@ export function useCaptchaStatus() {
 
     isSubmitting.value = true
     try {
-      await apiClient.post<any>(`${getApiBase()}/captcha/${activeCaptcha.value.captcha_id}/skip`)
+      await apiClient.post<unknown>(`${getApiBase()}/captcha/${activeCaptcha.value.captcha_id}/skip`)
       activeCaptcha.value = null
       stopTimer()
     } catch (error) {

--- a/autobot-frontend/src/composables/useAgentRegistry.ts
+++ b/autobot-frontend/src/composables/useAgentRegistry.ts
@@ -104,7 +104,11 @@ export function useAgentRegistry(options: UseAgentRegistryOptions = {}) {
     errors.value = []
     return wrap(async () => {
       try {
-        const data = await ApiClient.get<any>(`${getApiBase()}/agent_config/agents/all`)
+        const data = await ApiClient.get<{
+          agents?: BackendAgent[]
+          specialized_agents?: SpecializedAgent[]
+          summary?: AgentSummary | null
+        }>(`${getApiBase()}/agent_config/agents/all`)
         backendAgents.value = data.agents || []
         specializedAgents.value = data.specialized_agents || []
         summary.value = data.summary || null
@@ -124,7 +128,7 @@ export function useAgentRegistry(options: UseAgentRegistryOptions = {}) {
   async function fetchAgentDetail(agentId: string) {
     return wrapDetail(async () => {
       try {
-        const data = await ApiClient.get<any>(
+        const data = await ApiClient.get<SpecializedAgent>(
           `${getApiBase()}/agent_config/agents/specialized/${agentId}`
         )
         selectedAgent.value = data

--- a/autobot-frontend/src/composables/useCommandPermissions.ts
+++ b/autobot-frontend/src/composables/useCommandPermissions.ts
@@ -51,10 +51,10 @@ export function useCommandPermissions() {
   ): Promise<ApproveResult> => {
     errorApprove.value = null
     return wrapApprove(async () => {
-      const result = await apiClient.post<any>(
+      const result = await apiClient.post<ApproveResult>(
         `${getApiBase()}/agent-terminal/sessions/${terminalSessionId}/approve`,
         { approved, user_id: userId }
-      ) as ApproveResult
+      )
       logger.debug('approveOrDeny response:', { approved, status: result.status })
       return result
     })
@@ -69,7 +69,7 @@ export function useCommandPermissions() {
   ): Promise<unknown> => {
     errorComment.value = null
     return wrapComment(async () => {
-      const response = await apiClient.post<any>(`${getApiBase()}/chat/direct`, {
+      const response = await apiClient.post<unknown>(`${getApiBase()}/chat/direct`, {
         message,
         chat_id: chatId ?? null
       })

--- a/autobot-frontend/src/composables/useConversationFiles.ts
+++ b/autobot-frontend/src/composables/useConversationFiles.ts
@@ -209,7 +209,7 @@ export function useConversationFiles(sessionId: string) {
 
     return wrap(async () => {
       try {
-        await api.delete<any>(`${getApiBase()}/conversation-files/conversation/${sessionId}/files/${fileId}`)
+        await api.delete<unknown>(`${getApiBase()}/conversation-files/conversation/${sessionId}/files/${fileId}`)
 
         // Remove file from local state
         files.value = files.value.filter(f => f.file_id !== fileId)
@@ -428,7 +428,7 @@ export function useConversationFiles(sessionId: string) {
     error.value = null
     return wrap(async () => {
       for (const fid of ids) {
-        try { await api.delete<any>(`${API}/files/${fid}`) } catch { /* continue */ }
+        try { await api.delete<unknown>(`${API}/files/${fid}`) } catch { /* continue */ }
       }
       fileSelection.clear()
       await loadFiles()

--- a/autobot-frontend/src/composables/useSessionActivityLogger.ts
+++ b/autobot-frontend/src/composables/useSessionActivityLogger.ts
@@ -265,7 +265,7 @@ export function useSessionActivityLogger(): UseSessionActivityLoggerReturn {
     if (!activity) return
 
     try {
-      await apiClient.post<any>(`/chat/sessions/${sessionId}/activities`, {
+      await apiClient.post<unknown>(`/chat/sessions/${sessionId}/activities`, {
         activity_id: activity.id,
         type: activity.type,
         user_id: activity.userId,
@@ -447,7 +447,7 @@ export function useSessionActivityLogger(): UseSessionActivityLoggerReturn {
     let success = true
     for (const [sessionId, activities] of bySession) {
       try {
-        await apiClient.post<any>(`/chat/sessions/${sessionId}/activities/batch`, {
+        await apiClient.post<unknown>(`/chat/sessions/${sessionId}/activities/batch`, {
           activities: activities.map(a => ({
             activity_id: a.id,
             type: a.type,

--- a/autobot-frontend/src/composables/useTheme.test.ts
+++ b/autobot-frontend/src/composables/useTheme.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 describe('useTheme', () => {
-  let useTheme: any
+  let useTheme: typeof import('./useTheme').useTheme
 
   beforeEach(async () => {
     // Mock matchMedia before each test
@@ -205,7 +205,7 @@ describe('useTheme', () => {
       const originalGetItem = localStorage.getItem
       localStorage.getItem = vi.fn(() => {
         throw new Error('localStorage not available')
-      }) as any
+      }) as typeof localStorage.getItem
       vi.resetModules()
       const module = await import('./useTheme')
       const { theme, accentColor } = module.useTheme()


### PR DESCRIPTION
## Thinking Path
Toward green `frontend-tests` — all 32 eslint warnings across 16 files. Consumer (KnowledgeBrowser ↔ TreeNodeComponent) verified per the boundary-type rule.

## What Changed (150 → ~118 problems)
- **any→typed**: TreeNodeComponent (`DocumentVectorizationState`, new exported `TreeNodeMetadata` matching KnowledgeBrowser's writes), useAgentRegistry (concrete response), TerminalModals (`unknown`+structured cast), test files (`App`, `ReturnType<...>`, `keyof typeof`), `apiClient.*<any>`→`<unknown>` for discarded responses, `catch(error: any)`→`catch(error)`+cast.
- **unused removed**: dead imports (`computed`/`watch`/`nextTick`/`ALL_CHANNELS`); unused `props`/`emit` bindings (macros kept); `selectWorkflow(_wf)`.

## Discovery (report-only, behavior unchanged)
`WorkflowRunner.vue` declares a `start-workflow` emit that is never fired — a possible pre-existing wiring gap (component appears prop-driven now). Left as-is.

## Verification (independently re-run)
- `eslint` 16 files + KnowledgeBrowser consumer → **0 warnings, 0 errors**.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (whole project).
- `vitest` (5 suites) → 58/58.
- No eslint-disable/@ts-ignore; runtime-coercion scan clean (TerminalModals `if (err?.message)` is the pre-existing guard, just the typed alias).

## Model Used
Opus 4.8

Contributes to #9924 green frontend-tests.