### PR TITLE
fix(api): llm-auth OAuth served at /api/api/llm-auth — double-prefix 404 (#11092)

### DIFF
--- a/autobot-backend/api/provider_auth.py
+++ b/autobot-backend/api/provider_auth.py
@@ -113,7 +113,11 @@ def _validate_outbound_url(url: str) -> None:
         )
 
 
-router = APIRouter(prefix="/api/llm-auth", tags=["llm-auth"])
+# The registry/app-factory prepends "/api" (see feature_routers.py), so this
+# router carries only "/llm-auth" → resolves to /api/llm-auth. A "/api/llm-auth"
+# prefix here would wrongly yield /api/api/llm-auth and 404 every OAuth call
+# (matches the #9864 budget-policies fix; the frontend calls /api/llm-auth/*). #11092
+router = APIRouter(prefix="/llm-auth", tags=["llm-auth"])
 
 # System vault string — provider-level tokens are scoped to the system vault so
 # all authenticated users can use the shared provider connection.


### PR DESCRIPTION
## Thinking Path
Discovered via the api-wiring audit while merging #11084: 4 unwired `/api/llm-auth/*` calls from `ProviderOAuthConnect.vue`. Root cause = the same double-`/api` prefix class already fixed for budget-policies (#9864) and themes (#10472): `api/provider_auth.py` declared `prefix='/api/llm-auth'`, but the registry/app-factory prepends `/api` → the OAuth device-code endpoints were served at **/api/api/llm-auth** and 404'd every provider-OAuth connect.

## What Changed
- `api/provider_auth.py`: router prefix `/api/llm-auth` → `/llm-auth` (registry adds `/api` → `/api/llm-auth`, matching the frontend). Routes inside are relative; docstrings already describe the effective `/api/llm-auth` path.

## Verification
- `py_compile` OK. Authoritative openapi dump: llm-auth now at `/api/llm-auth/*` (was `/api/api/llm-auth`). **api-wiring audit: 0 unwired, exit 0** (this fix clears the gate — those 4 were its only unwired calls).

## Model Used
Opus 4.8

Closes #11092