### PR TITLE
fix(slm): back up ChromaDB from real data dir, not stale path

### DIFF
--- a/autobot-slm-backend/ansible/backup-node-data.yml
+++ b/autobot-slm-backend/ansible/backup-node-data.yml
@@ -19,6 +19,11 @@
     backup_path: "{{ backup_dir }}/{{ backup_name }}"
     include_models: "{{ include_models | default(true) }}"
     postgres_user: "{{ postgres_user | default('postgres') }}"
+    # Canonical ChromaDB data dir — must match the redis role's chromadb_data_dir
+    # default (roles/redis/defaults/main.yml). The legacy /var/lib/chromadb path
+    # never existed on installed nodes, so the ChromaDB backup block was a silent
+    # no-op and ChromaDB collections were never captured (#10016 member 2).
+    chromadb_data_dir: "{{ chromadb_data_dir | default('/opt/autobot/autobot-db-stack/chromadb/data') }}"
 
   tasks:
     # =========================================================================
@@ -198,14 +203,14 @@
     # =========================================================================
     - name: Check if ChromaDB data exists
       ansible.builtin.stat:
-        path: /var/lib/chromadb
+        path: "{{ chromadb_data_dir }}"
       register: chromadb_dir
 
     - name: Backup ChromaDB collections
       block:
         - name: Tar ChromaDB data directory
           ansible.builtin.archive:
-            path: /var/lib/chromadb
+            path: "{{ chromadb_data_dir }}"
             dest: "{{ backup_path }}/chromadb-data.tar.gz"
             format: gz
 


### PR DESCRIPTION
## Thinking Path
Verifying #10016 member 2 (backup coverage) *in the exact commit*, I found the backup playbook already has a ChromaDB block and covers secrets (`/etc/autobot` archive holds `slm-secrets.env` where the master key `SLM_ENCRYPTION_KEY` lives). But the ChromaDB block stat's a stale path that never exists on installed nodes, so it silently never runs.

## What Changed
`autobot-slm-backend/ansible/backup-node-data.yml`: ChromaDB existence-check + archive now use `chromadb_data_dir` (default `/opt/autobot/autobot-db-stack/chromadb/data`, matching the redis role default). Previously stat'd `/var/lib/chromadb` → `when: chromadb_dir.stat.exists` always false → ChromaDB omitted from every backup. Var is overridable.

## Verification
- Canonical path confirmed in `roles/redis/defaults/main.yml:62`; `/var/lib/chromadb` appears only in this file + decommission/remove plays (all stale).
- `python3 -c 'yaml.safe_load_all(...)'` → YAML OK.
- Secrets coverage verified: master key = env → `/etc/autobot/slm-secrets.env` → already in the `/etc/autobot` config archive.

## Model Used
Opus 4.8 (1M context)

Closes #11098. Refs #10016 (member 2). Sibling stale-path in decommission/remove tracked in #11099.