### PR TITLE
fix(frontend): resolve any + no-unused-vars across 22 files (#9924)

### DIFF
--- a/autobot-frontend/src/components/__tests__/SettingsPanel.test.ts
+++ b/autobot-frontend/src/components/__tests__/SettingsPanel.test.ts
@@ -92,7 +92,7 @@ const mockHealthResponse = {
  *   GET /api/system/health       -> loadHealthStatus fallback
  */
 function setupAxiosMocks() {
-  vi.mocked(axios.get).mockImplementation((url: string, ..._args: any[]) => {
+  vi.mocked(axios.get).mockImplementation((url: string, ..._args: unknown[]) => {
     if (url === '/api/settings/') {
       return Promise.resolve({ data: mockSettingsResponse })
     }

--- a/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
+++ b/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
@@ -340,7 +340,7 @@ async function exportData() {
     URL.revokeObjectURL(url)
 
     showToast(t('analytics.codeEvolution.exportSuccess'), 'success')
-  } catch (e) {
+  } catch {
     showToast(t('analytics.codeEvolution.exportFailed'), 'error')
   }
 }

--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -597,7 +597,6 @@ const _qualityWsUrl = (() => {
 })();
 const {
   connect: wsConnect,
-  disconnect: wsDisconnect,
 } = useWebSocket(_qualityWsUrl, {
   autoConnect: false,
   autoReconnect: true,

--- a/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
+++ b/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
@@ -261,13 +261,10 @@
 import Icon from '@/components/ui/Icon.vue'
 import { BaseModal } from '@autobot/ui'
 import { ref, onMounted, computed } from 'vue'
-import { createLogger } from '@/utils/debugUtils'
 import {
   useConversationFlowData,
   type IntentPattern,
 } from '@/composables/analytics/useConversationFlowData'
-
-const logger = createLogger('ConversationFlowDashboard')
 
 // State
 const timeRange = ref(24)

--- a/autobot-frontend/src/components/analytics/DeclarationsSection.vue
+++ b/autobot-frontend/src/components/analytics/DeclarationsSection.vue
@@ -102,7 +102,6 @@
  * Issue #704: Migrated to design tokens
  */
 
-import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useGroupingMemo } from '@/composables/useComputedMemo'
 import { useExpansion } from '@/composables/useExpansion'

--- a/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
@@ -324,7 +324,6 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import { createLogger } from '@/utils/debugUtils'
 import { useExpansion } from '@/composables/useExpansion'
 import {
   useLLMPatternData,
@@ -335,8 +334,6 @@ import {
   type LLMPatternCacheOpportunity,
   type LLMPatternAnalysisResult
 } from '@/composables/analytics/useLLMPatternData'
-
-const logger = createLogger('LLMPatternDashboard')
 
 // Types (aliases for component-local readability)
 type Stats = LLMPatternStats

--- a/autobot-frontend/src/components/analytics/LogPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LogPatternDashboard.vue
@@ -231,7 +231,7 @@ import { createLogger } from '@/utils/debugUtils'
 import { getCssVar } from '@/composables/useCssVars'
 import { usePollingJob } from '@/composables/usePollingJob'
 import { useLogPatternData } from '@/composables/analytics/useLogPatternData'
-import type { LogPattern, LogAnomaly, LogTrend, MiningResult, RealtimeData } from '@/composables/analytics/useLogPatternData'
+import type { LogPattern, LogTrend, MiningResult, RealtimeData } from '@/composables/analytics/useLogPatternData'
 
 const { t } = useI18n()
 

--- a/autobot-frontend/src/components/analytics/SourceManager.vue
+++ b/autobot-frontend/src/components/analytics/SourceManager.vue
@@ -213,7 +213,7 @@ interface Props {
 
 const props = defineProps<Props>()
 
-const emit = defineEmits<{
+defineEmits<{
   (e: 'select-source', source: CodeSource): void
   (e: 'open-add-source'): void
   (e: 'edit-source', source: CodeSource): void

--- a/autobot-frontend/src/components/analytics/code-intelligence/FileScanModal.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/FileScanModal.vue
@@ -63,7 +63,7 @@ import { BaseModal } from '@autobot/ui'
 
 const { t } = useI18n()
 
-const props = defineProps<{
+defineProps<{
   show: boolean
 }>()
 

--- a/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
@@ -273,7 +273,7 @@ interface ApiEndpointAnalysisResult {
   [key: string]: unknown
 }
 
-const props = defineProps<{
+defineProps<{
   analysis: ApiEndpointAnalysisResult | null
   loading: boolean
   error: string | null

--- a/autobot-frontend/src/components/analytics/panels/CodebaseConfigDuplicatesPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseConfigDuplicatesPanel.vue
@@ -127,7 +127,7 @@ interface ConfigDuplicatesResult {
   report: string
 }
 
-const props = defineProps<{
+defineProps<{
   analysis: ConfigDuplicatesResult | null
   loading: boolean
   error: string | null

--- a/autobot-frontend/src/components/analytics/panels/CodebaseCrossLanguagePanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseCrossLanguagePanel.vue
@@ -381,7 +381,7 @@ interface CrossLanguageAnalysisResult {
   analysis_time_ms: number
 }
 
-const props = defineProps<{
+defineProps<{
   analysis: CrossLanguageAnalysisResult | null
   loading: boolean
   error: string | null

--- a/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
@@ -245,7 +245,7 @@ interface LLMFilteringResult {
   filter_priority: string | null
 }
 
-const props = defineProps<{
+defineProps<{
   analysis: EnvironmentAnalysisResult | null
   loading: boolean
   error: string | null

--- a/autobot-frontend/src/components/analytics/panels/CodebaseIntelligenceScoresPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseIntelligenceScoresPanel.vue
@@ -729,15 +729,6 @@ function getScoreClass(score: number): string {
   return 'score-low'
 }
 
-function getGradeClass(grade: string): string {
-  const g = grade?.toUpperCase() || ''
-  if (g === 'A' || g === 'A+') return 'grade-a'
-  if (g === 'B' || g === 'B+') return 'grade-b'
-  if (g === 'C' || g === 'C+') return 'grade-c'
-  if (g === 'D' || g === 'D+') return 'grade-d'
-  return 'grade-f'
-}
-
 function getSeverityClass(severity: string): string {
   switch (severity?.toLowerCase()) {
     case 'critical': return 'severity-critical'

--- a/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
@@ -420,7 +420,7 @@ interface OwnershipAnalysisResult {
   metrics: OwnershipMetrics
 }
 
-const props = defineProps<{
+defineProps<{
   analysis: OwnershipAnalysisResult | null
   loading: boolean
   error: string | null

--- a/autobot-frontend/src/test/vitest-setup.ts
+++ b/autobot-frontend/src/test/vitest-setup.ts
@@ -91,7 +91,7 @@ class MockWebSocket {
   })
 
   // Simulate message reception
-  simulateMessage(data: any) {
+  simulateMessage(data: unknown) {
     if (this.onmessage) {
       this.onmessage(new MessageEvent('message', { data: JSON.stringify(data) }))
     }
@@ -106,7 +106,7 @@ class MockWebSocket {
 }
 
 // Replace global WebSocket
-global.WebSocket = MockWebSocket as any
+global.WebSocket = MockWebSocket as unknown as typeof WebSocket
 
 // Global test setup
 beforeEach(() => {

--- a/autobot-frontend/src/utils/OptimizedHealthMonitor.d.ts
+++ b/autobot-frontend/src/utils/OptimizedHealthMonitor.d.ts
@@ -61,8 +61,8 @@ export interface HealthData {
 
 export interface HealthCheckResult {
   status: 'fulfilled' | 'rejected';
-  value?: any;
-  reason?: any;
+  value?: unknown;
+  reason?: unknown;
 }
 
 declare class OptimizedHealthMonitor {

--- a/autobot-frontend/src/utils/__tests__/iconMappings.test.ts
+++ b/autobot-frontend/src/utils/__tests__/iconMappings.test.ts
@@ -65,8 +65,8 @@ describe('iconMappings utility', () => {
     })
 
     it('should throw on null/undefined input', () => {
-      expect(() => getStatusIcon(null as any)).toThrow()
-      expect(() => getStatusIcon(undefined as any)).toThrow()
+      expect(() => getStatusIcon(null as unknown as string)).toThrow()
+      expect(() => getStatusIcon(undefined as unknown as string)).toThrow()
     })
 
     // Issue #156 Fix: Removed tests for options parameter that doesn't exist in current API

--- a/autobot-frontend/src/utils/cacheManagement.ts
+++ b/autobot-frontend/src/utils/cacheManagement.ts
@@ -307,14 +307,14 @@ export function showSubtleUpdateNotification(version: string, buildHash: string,
   }
 
   // Add safe reload function to global scope
-  (window as any).performSafeReload = () => {
+  (window as unknown as { performSafeReload: () => void }).performSafeReload = () => {
     // Record reload time to prevent loops
     localStorage.setItem('last-auto-reload', Date.now().toString())
     location.reload()
   }
 
   // Add cancel function to global scope
-  (window as any).cancelAutoReload = () => {
+  (window as unknown as { cancelAutoReload: () => void }).cancelAutoReload = () => {
     const intervalId = notification.getAttribute('data-countdown-interval')
     if (intervalId) {
       clearInterval(parseInt(intervalId))

--- a/autobot-frontend/src/views/MarketplaceView.vue
+++ b/autobot-frontend/src/views/MarketplaceView.vue
@@ -340,7 +340,7 @@ async function handleInstall(name: string): Promise<void> {
   try {
     // #6524: include source_id so backend resolves against the same catalog
     // the user was browsing (otherwise plugins from custom marketplaces 404).
-    await ApiClient.post<any>(`${getApiBase()}/marketplace/install`, {
+    await ApiClient.post(`${getApiBase()}/marketplace/install`, {
       plugin_name: name,
       source_id: selectedSourceId.value,
     })
@@ -358,7 +358,7 @@ async function handleUninstall(name: string): Promise<void> {
   actionLoading.value[name] = true
   error.value = null
   try {
-    await ApiClient.delete<any>(`${getApiBase()}/marketplace/install/${encodeURIComponent(name)}`)
+    await ApiClient.delete(`${getApiBase()}/marketplace/install/${encodeURIComponent(name)}`)
     const next = new Set(installedNames.value)
     next.delete(name)
     installedNames.value = next

--- a/autobot-frontend/src/views/knowledge/WatchFoldersView.vue
+++ b/autobot-frontend/src/views/knowledge/WatchFoldersView.vue
@@ -268,11 +268,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useWatchFolders, type WatchFolderConfig } from '@/composables/knowledge/useWatchFolders'
-import { createLogger } from '@/utils/debugUtils'
-
-const logger = createLogger('WatchFoldersView')
 
 const {
   watchFolders,

--- a/autobot-frontend/tests/e2e/thinking-mode.spec.ts
+++ b/autobot-frontend/tests/e2e/thinking-mode.spec.ts
@@ -67,7 +67,7 @@ test.describe('Thinking Mode E2E', () => {
     await expect(thinkingToggle).toHaveClass(/active/);
 
     // Set up request interception
-    const requests: any[] = [];
+    const requests: Array<{ url: string; body: Record<string, unknown> }> = [];
     page.on('request', request => {
       if (request.url().includes('/api/chat') && request.method() === 'POST') {
         requests.push({
@@ -171,7 +171,7 @@ test.describe('Thinking Mode E2E', () => {
     await expect(budgetSteps).not.toBeVisible();
 
     // Set up request interception
-    const requests: any[] = [];
+    const requests: Array<{ url: string; body: Record<string, unknown> }> = [];
     page.on('request', request => {
       if (request.url().includes('/api/chat') && request.method() === 'POST') {
         requests.push({


### PR DESCRIPTION
## Thinking Path
Toward green `frontend-tests` — all 29 eslint warnings across 22 files (long tail, 1-2/file).

## What Changed (118 → ~90 problems)
- **any→typed**: vitest-setup (`unknown`, `as unknown as typeof WebSocket`), OptimizedHealthMonitor.d.ts (`unknown`), e2e request arrays (concrete shape), test invalid-input casts, `ApiClient.*<any>`→default `unknown`.
- **unused removed**: dead `logger`/`createLogger`, unused imports (`computed`/`LogAnomaly`), unused `props`/`emit` bindings (macros kept), `catch(e)`→`catch {}`.
- **dead code removed** (confirmed): `getGradeClass()` in CodebaseIntelligenceScoresPanel (no caller, no matching CSS; grade passed straight to child).

## Verification (independently re-run)
- `vitest-setup.ts` intact (136=136 lines vs base; only the 2 intended `any` fixes; smoke run confirms setup executes).
- `eslint` 22 files → **0 warnings, 0 errors**.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (whole project).
- `vitest` (2 unit suites) → 38/38. No emit/prop types tightened → no consumers affected.
- No eslint-disable/@ts-ignore; no runtime coercions.

## Model Used
Opus 4.8

Contributes to #9924 green frontend-tests.