### PR TITLE
fix(frontend): resolve 1-per-file any/unused-vars across 30 components (#9924)

### DIFF
--- a/autobot-frontend/src/components/artifact-cells/ChartCell.vue
+++ b/autobot-frontend/src/components/artifact-cells/ChartCell.vue
@@ -108,7 +108,7 @@ defineEmits<ChartCellEmits>()
 const chartId = ref<string>(`chart-${crypto.randomUUID()}`)
 const hasError = ref<boolean>(false)
 const errorMessage = ref<string>('')
-let vegaEmbed: any = null
+let vegaEmbed: typeof import('vega-embed') | null = null
 
 // Computed
 const chartAriaLabel = computed(() => {
@@ -183,7 +183,8 @@ const renderChart = async () => {
       }
     }
 
-    await vega.embed(containerEl, spec, {
+    const embed = (vega as unknown as { embed: typeof import('vega-embed').default }).embed
+    await embed(containerEl, spec, {
       renderer: props.renderer,
       actions: props.actions
     })

--- a/autobot-frontend/src/components/artifact-cells/ImageCell.vue
+++ b/autobot-frontend/src/components/artifact-cells/ImageCell.vue
@@ -135,9 +135,7 @@
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
 import { computed, nextTick, ref } from 'vue'
-import { useI18n } from 'vue-i18n'
 
-const { t } = useI18n()
 
 interface GeneratedImage {
   url: string

--- a/autobot-frontend/src/components/artifact-cells/VideoCell.vue
+++ b/autobot-frontend/src/components/artifact-cells/VideoCell.vue
@@ -87,9 +87,7 @@
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
 import { computed, ref } from 'vue'
-import { useI18n } from 'vue-i18n'
 
-const { t } = useI18n()
 
 interface VideoCellProps {
   richPayload?: Record<string, unknown> | null

--- a/autobot-frontend/src/components/async/AsyncComponentWrapper.vue
+++ b/autobot-frontend/src/components/async/AsyncComponentWrapper.vue
@@ -131,8 +131,6 @@ async function loadComponent(attempt = 1): Promise<void> {
         emit('loaded', asyncComponent.value)
       }
 
-      const loadTime = Date.now() - loadingStartTime
-
       // Reset error state on success
       asyncError.value = null
       showAsyncError.value = false

--- a/autobot-frontend/src/components/async/AsyncErrorFallback.vue
+++ b/autobot-frontend/src/components/async/AsyncErrorFallback.vue
@@ -67,6 +67,7 @@ import { useRouter } from 'vue-router'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { createLogger } from '@/utils/debugUtils'
 import Icon from '@/components/ui/Icon.vue'
+import type rumAgent from '@/utils/RumAgent'
 
 const logger = createLogger('AsyncErrorFallback')
 
@@ -93,7 +94,7 @@ const showDetails = ref(false)
 const retrying = ref(false)
 
 // Inject RUM agent if available
-const rum = inject('rum', null) as any
+const rum = inject('rum', null) as typeof rumAgent | null
 
 // Compute user-friendly error message based on error type
 const errorMessage = computed(() => {

--- a/autobot-frontend/src/components/audit/AuditTimeline.vue
+++ b/autobot-frontend/src/components/audit/AuditTimeline.vue
@@ -112,7 +112,7 @@
 <script setup lang="ts">
 import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
 import { useExpansion } from '@/composables/useExpansion'
 import type { AuditEntry } from '@/types/audit'
 import { AUDIT_RESULT_CONFIG } from '@/types/audit'

--- a/autobot-frontend/src/components/base/BaseButton.vue
+++ b/autobot-frontend/src/components/base/BaseButton.vue
@@ -22,6 +22,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watchEffect, useSlots, Comment } from 'vue'
+import type { VNode } from 'vue'
 import type { ButtonVariant, ComponentSize } from '@/types/component-props'
 import { size as SIZE_VALUES } from '@/design-tokens/tokens'
 import { createLogger } from '@/utils/debugUtils'
@@ -69,7 +70,7 @@ const slots = useSlots()
 if (import.meta.env.DEV) {
   watchEffect(() => {
     const hasVisibleText = !!props.label || !!slots.default?.()?.some(
-      (vnode: any) => vnode.type !== Comment && vnode.children
+      (vnode: VNode) => vnode.type !== Comment && vnode.children
     )
     if (!hasVisibleText && !props.ariaLabel) {
       logger.warn(

--- a/autobot-frontend/src/components/base/BasePanel.vue
+++ b/autobot-frontend/src/components/base/BasePanel.vue
@@ -69,7 +69,7 @@ const contentClasses = computed(() => [
   }
 ])
 
-const toggleCollapse = () => {
+const _toggleCollapse = () => {
   if (props.collapsible) {
     emit('toggle', !props.collapsed)
   }

--- a/autobot-frontend/src/components/browser/ScrapeTemplatePanel.vue
+++ b/autobot-frontend/src/components/browser/ScrapeTemplatePanel.vue
@@ -264,9 +264,9 @@ export default {
       try {
         const resp = await api.runTemplate(runDialog.value.template.id, runDialog.value.url.trim())
         runDialog.value.results = resp.results
-      } catch (err: any) {
+      } catch (err) {
         logger.warn('Template run failed', err)
-        runDialog.value.error = err?.message ?? String(err)
+        runDialog.value.error = (err as { message?: string })?.message ?? String(err)
       } finally {
         isRunning.value = false
       }

--- a/autobot-frontend/src/components/canvas/CanvasPanel.vue
+++ b/autobot-frontend/src/components/canvas/CanvasPanel.vue
@@ -84,7 +84,7 @@ import CanvasConflictBanner from './CanvasConflictBanner.vue'
 import CanvasEdgeStates from './CanvasEdgeStates.vue'
 import CanvasExportSheet from './CanvasExportSheet.vue'
 
-const props = defineProps<{
+defineProps<{
   canvasId: string
   autoSave: ReturnType<typeof useCanvasAutoSave>
   loadError?: boolean

--- a/autobot-frontend/src/components/canvas/CodeCell.spec.ts
+++ b/autobot-frontend/src/components/canvas/CodeCell.spec.ts
@@ -25,7 +25,7 @@ describe('CodeCell.vue', () => {
     // Mock clipboard API
     global.navigator.clipboard = {
       writeText: vi.fn().mockResolvedValue(undefined),
-    } as any
+    } as unknown as Clipboard
   })
 
   it('renders loading state when no payload', () => {

--- a/autobot-frontend/src/components/charts/BaseChart.vue
+++ b/autobot-frontend/src/components/charts/BaseChart.vue
@@ -107,7 +107,7 @@ const hasData = computed(() => {
  * All values are read from design-tokens.css and adapt to dark/light theme
  * Hardcoded fallbacks match design-tokens.css defaults for SSR compatibility
  */
-const darkTheme: any = {
+const darkTheme: Record<string, unknown> = {
   chart: {
     background: 'transparent',
     foreColor: getCssVar('--text-primary', '#e2e8f0'),

--- a/autobot-frontend/src/components/charts/SeverityBarChart.vue
+++ b/autobot-frontend/src/components/charts/SeverityBarChart.vue
@@ -22,7 +22,7 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseChart from './BaseChart.vue'
-import { getCssVar, getSeverityColors } from '@/composables/useCssVars'
+import { getSeverityColors } from '@/composables/useCssVars'
 import type { ApexOptions } from 'apexcharts'
 
 const { t } = useI18n()

--- a/autobot-frontend/src/components/charts/TopFilesChart.vue
+++ b/autobot-frontend/src/components/charts/TopFilesChart.vue
@@ -22,7 +22,6 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseChart from './BaseChart.vue'
-import type { ApexOptions } from 'apexcharts'
 import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n()

--- a/autobot-frontend/src/components/chat/ApprovalRequestCard.vue
+++ b/autobot-frontend/src/components/chat/ApprovalRequestCard.vue
@@ -222,10 +222,8 @@
 
 import Icon from '@/components/ui/Icon.vue'
 import { ref, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
 import BaseButton from '@/components/base/BaseButton.vue'
 
-const { t } = useI18n()
 
 interface Props {
   status?: string | null // 'pre_approved' | 'approved' | 'denied' | null

--- a/autobot-frontend/src/components/chat/ChatFolderTree.vue
+++ b/autobot-frontend/src/components/chat/ChatFolderTree.vue
@@ -45,13 +45,11 @@
 
 <script setup lang="ts">
 import { ref, nextTick, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
 import Icon from '@/components/ui/Icon.vue'
 import FolderNode from './ChatFolderNode.vue'
 import { useFolderStore } from '@/stores/useFolderStore'
 import type { ChatSession } from '@/stores/useChatStore'
 
-const { t } = useI18n()
 
 defineProps<{
   sessions: ChatSession[]

--- a/autobot-frontend/src/components/chat/ChatInput.vue
+++ b/autobot-frontend/src/components/chat/ChatInput.vue
@@ -1100,7 +1100,7 @@ const uploadFile = async (upload: UploadItem, file: File): Promise<void> => {
             }, 2000)
 
             resolve(response.file_info?.file_id || '')
-          } catch (e) {
+          } catch {
             reject(new Error('Invalid response from server'))
           }
         } else {

--- a/autobot-frontend/src/components/chat/ChatTabContent.vue
+++ b/autobot-frontend/src/components/chat/ChatTabContent.vue
@@ -126,10 +126,8 @@
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
 import { ref, watch, defineAsyncComponent } from 'vue'
-import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
 
-const { t } = useI18n()
 
 const logger = createLogger('ChatTabContent')
 

--- a/autobot-frontend/src/components/chat/ChatTabs.vue
+++ b/autobot-frontend/src/components/chat/ChatTabs.vue
@@ -33,7 +33,7 @@ interface Emits {
   (e: 'tab-change', tabKey: string): void
 }
 
-const props = withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<Props>(), {
   tabs: () => [
     { key: 'chat', label: 'Chat', icon: 'comments' },
     { key: 'files', label: 'Files', icon: 'folder' },

--- a/autobot-frontend/src/components/chat/DocumentationCategoryFilter.vue
+++ b/autobot-frontend/src/components/chat/DocumentationCategoryFilter.vue
@@ -93,9 +93,7 @@
 import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
-const { t } = useI18n()
 
 interface Category {
   id: string

--- a/autobot-frontend/src/components/chat/McpPromptPicker.vue
+++ b/autobot-frontend/src/components/chat/McpPromptPicker.vue
@@ -287,7 +287,7 @@ async function insertPrompt() {
           }
           if (Array.isArray(msg.content)) {
             return msg.content
-              .map((c: any) => (typeof c === 'string' ? c : c.text || ''))
+              .map((c: unknown) => (typeof c === 'string' ? c : (c as { text?: string })?.text || ''))
               .join('\n')
           }
         }

--- a/autobot-frontend/src/components/chat/OverseerPlanMessage.vue
+++ b/autobot-frontend/src/components/chat/OverseerPlanMessage.vue
@@ -51,11 +51,9 @@
  */
 
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 import type { OverseerPlan, OverseerStep } from '@/composables/useOverseerAgent'
 import Icon from '@/components/ui/Icon.vue'
 
-const { t } = useI18n()
 
 const props = defineProps<{
   plan: OverseerPlan

--- a/autobot-frontend/src/components/chat/ReasoningTrace.vue
+++ b/autobot-frontend/src/components/chat/ReasoningTrace.vue
@@ -77,7 +77,7 @@ interface Props {
   isActive?: boolean
 }
 
-const props = withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<Props>(), {
   isActive: false,
 })
 

--- a/autobot-frontend/src/components/chat/TypingIndicator.vue
+++ b/autobot-frontend/src/components/chat/TypingIndicator.vue
@@ -47,7 +47,7 @@
  * Issue #691: Display actual streaming content instead of placeholder text
  */
 
-import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
+import { computed, ref, watch, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import LoadingSpinner from '@/components/ui/LoadingSpinner.vue'
 

--- a/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
+++ b/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
@@ -49,7 +49,7 @@ const analysisResult = ref<MultiModalResponse | null>(null)
 const error = ref<string | null>(null)
 const showRawJson = ref(false)
 
-const intentLabels = computed(() => ({
+const _intentLabels = computed(() => ({
   analysis: t('chat.vision.intentAnalysis'),
   visual_qa: t('chat.vision.intentVisualQA'),
   automation: t('chat.vision.intentAutomation'),

--- a/autobot-frontend/src/components/collaboration/SecretNotifications.vue
+++ b/autobot-frontend/src/components/collaboration/SecretNotifications.vue
@@ -8,13 +8,11 @@
  */
 
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 import {
   useSessionCollaboration,
   type SecretSharingNotification
 } from '@/composables/useSessionCollaboration'
 
-const { t } = useI18n()
 const { secretNotifications, clearSecretNotifications } = useSessionCollaboration()
 
 // Format timestamp

--- a/autobot-frontend/src/components/common/PermissionDenied.vue
+++ b/autobot-frontend/src/components/common/PermissionDenied.vue
@@ -82,7 +82,7 @@ interface Props {
   contactAdmin?: boolean
 }
 
-const props = withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<Props>(), {
   title: undefined,
   message: undefined,
   requiredPermission: undefined,

--- a/autobot-frontend/src/components/desktop/ConnectionSettingsPanel.vue
+++ b/autobot-frontend/src/components/desktop/ConnectionSettingsPanel.vue
@@ -85,7 +85,7 @@ import { useVncConnection } from '@/composables/useVncConnection'
 import { usePollingJob } from '@/composables/usePollingJob'
 
 const { t } = useI18n()
-const { loading, error, settings, metrics, loadSettings, updateSettings, loadMetrics, setQualityPreset } = useVncConnection()
+const { error, settings, metrics, loadSettings, updateSettings, loadMetrics, setQualityPreset } = useVncConnection()
 
 const { start: startMetricsPolling } = usePollingJob<void>(
   async () => { await loadMetrics() },

--- a/autobot-frontend/src/components/file-browser/FilePathNavigation.vue
+++ b/autobot-frontend/src/components/file-browser/FilePathNavigation.vue
@@ -41,7 +41,7 @@ interface Emits {
 }
 
 const props = defineProps<Props>()
-const emit = defineEmits<Emits>()
+defineEmits<Emits>()
 
 // Local state for path input
 const pathInput = ref(props.currentPath)

--- a/autobot-frontend/src/components/file-browser/FilePreview.vue
+++ b/autobot-frontend/src/components/file-browser/FilePreview.vue
@@ -89,7 +89,6 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
-import { computed } from 'vue'
 
 interface FilePreviewData {
   name: string


### PR DESCRIPTION
## Thinking Path
Toward green `frontend-tests` — the single warning in each of 30 files.

## What Changed (89 → ~59 problems)
- **unused `{ t }`/`useI18n`** removed (8 files, template uses global `$t`).
- **unused `const props`/`const emit`** bindings dropped, macros kept (5 files).
- **unused imports** removed (5); `catch(e)`→`catch {}`; dead `loadTime` const.
- **any→typed** (6): `VNode`, `Record<string,unknown>`, RUM default-export type, `unknown`+use-site casts, `Clipboard`, vega-embed interop cast.

## Flagged for follow-up (preserved via `_`, not deleted)
- `BasePanel.vue::_toggleCollapse`: declares `collapsible`/`collapsed` props + `toggle` emit but the header has no collapse control — incomplete feature (needs design decision to wire vs remove).
- `VisionAnalysisModal.vue::_intentLabels`: computed duplicates the inline `<option>` labels — redundant (drive `v-for` or remove).

## Verification (independently re-run)
- `eslint` 30 files → **0 warnings, 0 errors**.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (whole project).
- `vitest` (CodeCell/ChartCell/VideoCell) → 23/23.
- No eslint-disable/@ts-ignore; runtime-coercion scan clean (ScrapeTemplatePanel `?? String(err)` is pre-existing).

## Model Used
Opus 4.8

Contributes to #9924 green frontend-tests.