### PR TITLE
Content Reach Task 7: SSRF+robots guards + boot wiring + unified content_reach agent tool (#10932, closes #11095)

### DIFF
--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -208,6 +208,31 @@ MAP_SITE_SCHEMA: dict = {
     "required": ["domain"],
 }
 
+CONTENT_REACH_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "source": {
+            "type": "string",
+            "enum": ["web_search", "web_page", "youtube", "reddit", "social"],
+            "description": "Which content source chain to use.",
+        },
+        "query": {
+            "type": "string",
+            "description": "Search query (web_search, reddit, youtube search).",
+        },
+        "url": {
+            "type": "string",
+            "description": "Target URL (web_page, youtube, reddit, social).",
+        },
+        "limit": {
+            "type": "integer",
+            "default": 5,
+            "description": "Max results for search sources.",
+        },
+    },
+    "required": ["source"],
+}
+
 EXTRACT_STRUCTURED_DATA_SCHEMA: dict = {
     "type": "object",
     "properties": {
@@ -323,6 +348,8 @@ _BUILTIN_TOOL_SCHEMAS: dict[str, dict] = {
     "crawl_site": CRAWL_SITE_SCHEMA,
     "map_site": MAP_SITE_SCHEMA,
     "extract_structured_data": EXTRACT_STRUCTURED_DATA_SCHEMA,
+    # #10932: Unified content_reach gateway (5 source chains).
+    "content_reach": CONTENT_REACH_SCHEMA,
 }
 
 

--- a/autobot-backend/content_reach/_url_guard.py
+++ b/autobot-backend/content_reach/_url_guard.py
@@ -1,0 +1,131 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""content_reach._url_guard — SSRF + robots.txt guards for URL-fetching backends (#10932, #11095).
+
+Public API
+----------
+- :func:`ensure_public_url` — raises BackendError if url is falsy or non-public (SSRF guard).
+- :func:`ensure_robots_allowed` — raises BackendError if robots.txt disallows fetching url.
+  No-op when ``AUTOBOT_CONTENT_REACH_RESPECT_ROBOTS`` is ``0``, ``false``, or ``no``.
+  Fail-open on robots-fetch errors (log warning + allow).
+
+Both functions must be awaited BEFORE any httpx/browser/caption call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import urllib.robotparser
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# Module-level constant: read once at import time.
+_RESPECT_ROBOTS: bool = os.environ.get("AUTOBOT_CONTENT_REACH_RESPECT_ROBOTS", "1").strip().lower() not in (
+    "0",
+    "false",
+    "no",
+)
+
+# User-agent used when checking robots.txt.
+_ROBOTS_UA = "autobot-content-reach/1.0"
+
+# robots.txt per-domain cache (in-process, no Redis dependency).
+_robots_cache: dict[str, urllib.robotparser.RobotFileParser] = {}
+_robots_cache_lock = asyncio.Lock()
+
+# Robots fetch timeout in seconds.
+_ROBOTS_FETCH_TIMEOUT = 10.0
+
+
+def _extract_domain(url: str) -> str:
+    """Return scheme + netloc for a URL (robots cache granularity)."""
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+async def _fetch_robots_text(domain: str) -> str:
+    """Fetch robots.txt for domain; return empty string on any error (fail-open)."""
+    import aiohttp
+
+    robots_url = f"{domain}/robots.txt"
+    try:
+        timeout = aiohttp.ClientTimeout(total=_ROBOTS_FETCH_TIMEOUT)
+        async with aiohttp.ClientSession() as session:
+            async with session.get(robots_url, timeout=timeout, allow_redirects=True) as resp:
+                if resp.status == 200:
+                    return await resp.text(encoding="utf-8", errors="replace")
+        return ""
+    except Exception as exc:
+        logger.debug("content_reach robots.txt fetch failed for %s: %s", domain, exc)
+        return ""
+
+
+def _parse_robots(text: str, domain: str) -> urllib.robotparser.RobotFileParser:
+    """Parse robots.txt content into a RobotFileParser."""
+    parser = urllib.robotparser.RobotFileParser()
+    parser.set_url(f"{domain}/robots.txt")
+    parser.parse(text.splitlines())
+    return parser
+
+
+async def _get_robots_parser(domain: str) -> urllib.robotparser.RobotFileParser:
+    """Return cached RobotFileParser for domain, fetching if needed."""
+    async with _robots_cache_lock:
+        if domain not in _robots_cache:
+            text = await _fetch_robots_text(domain)
+            _robots_cache[domain] = _parse_robots(text, domain)
+        return _robots_cache[domain]
+
+
+async def _robots_is_allowed(url: str, ua: str) -> bool:
+    """Return True if robots.txt allows ua to fetch url.
+
+    Module-level so tests can monkeypatch without deep import surgery.
+    Fail-open: returns True on any parsing error.
+    """
+    domain = _extract_domain(url)
+    parser = await _get_robots_parser(domain)
+    return parser.can_fetch(ua, url)
+
+
+async def _is_public_url_async(url: str) -> bool:
+    """SSRF guard delegate — module-level so tests can monkeypatch."""
+    from autobot_shared.url_safety import is_public_url_async
+
+    return await is_public_url_async(url)
+
+
+async def ensure_public_url(url: str) -> None:
+    """Raise BackendError if url is falsy or resolves to a non-public address (SSRF guard).
+
+    Guards must run BEFORE any network call so a blocked url makes ZERO fetch calls.
+    """
+    from content_reach.base import BackendError
+
+    if not url or not await _is_public_url_async(url):
+        raise BackendError(f"blocked non-public or invalid url: {url!r}")
+
+
+async def ensure_robots_allowed(url: str) -> None:
+    """Raise BackendError if robots.txt disallows fetching url.
+
+    No-op when AUTOBOT_CONTENT_REACH_RESPECT_ROBOTS is 0/false/no.
+    Fail-open on robots-fetch errors (log warning, allow) — a broken robots endpoint
+    must not block content, matching web_fetch behavior.
+    """
+    if not _RESPECT_ROBOTS:
+        return
+    from content_reach.base import BackendError
+
+    try:
+        allowed = await _robots_is_allowed(url, _ROBOTS_UA)
+    except Exception as exc:
+        logger.warning("content_reach robots check failed for %r (fail-open): %s", url, exc)
+        return
+    if not allowed:
+        raise BackendError(f"robots.txt disallows fetching {url!r}")

--- a/autobot-backend/content_reach/backends/browser.py
+++ b/autobot-backend/content_reach/backends/browser.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from urllib.parse import quote_plus
 
 from autobot_shared.logging_manager import get_logger
+from content_reach._url_guard import ensure_public_url, ensure_robots_allowed
 from content_reach.base import BackendError, ContentBackend, ContentRequest, ContentResult
 from source_attribution import SourceReliability, SourceType
 
@@ -62,6 +63,18 @@ class BrowserBackend(ContentBackend):
         if not request.url:
             raise BackendError("BrowserBackend requires a non-empty url on the request")
 
+        await ensure_public_url(request.url)
+        await ensure_robots_allowed(request.url)
+
+        return await self._navigate(request)
+
+    async def _navigate(self, request: ContentRequest) -> ContentResult:
+        """Issue the browser navigation call and map result to ContentResult.
+
+        Guards (SSRF/robots) are NOT re-checked here — callers must run them
+        before calling _navigate (BrowserBackend.fetch does; BrowserSearchBackend
+        runs SSRF-only before delegating here, skipping robots for search results).
+        """
         manager = _get_manager()
         result = await manager.research_url(
             request.conversation_id,
@@ -92,8 +105,8 @@ class BrowserSearchBackend(BrowserBackend):
     """Browser backend for query-to-search: builds a DDG HTML search URL then delegates.
 
     Encodes request.query into a DuckDuckGo HTML search URL and passes it to the
-    parent BrowserBackend.fetch() so the browser navigates to the results page and
-    extracts content.
+    parent BrowserBackend._navigate() so the browser navigates to the results page and
+    extracts content. robots.txt is intentionally skipped for search-results pages.
     """
 
     def __init__(self, source_type: SourceType) -> None:
@@ -102,6 +115,7 @@ class BrowserSearchBackend(BrowserBackend):
     async def fetch(self, request: ContentRequest) -> ContentResult:
         """Build a DDG search URL from request.query and fetch via browser."""
         search_url = _DDG_SEARCH_URL.format(quote_plus(request.query))
+        await ensure_public_url(search_url)
         search_request = ContentRequest(
             query=request.query,
             url=search_url,
@@ -110,4 +124,4 @@ class BrowserSearchBackend(BrowserBackend):
             conversation_id=request.conversation_id,
             options=request.options,
         )
-        return await super().fetch(search_request)
+        return await self._navigate(search_request)

--- a/autobot-backend/content_reach/sources/reddit.py
+++ b/autobot-backend/content_reach/sources/reddit.py
@@ -17,6 +17,7 @@ import logging
 
 import httpx
 
+from content_reach._url_guard import ensure_public_url
 from content_reach.backends.browser import BrowserBackend
 from content_reach.base import BackendError, ContentBackend, ContentRequest, ContentResult
 from content_reach.chain import ContentSourceChain
@@ -56,6 +57,7 @@ class RedditJsonBackend(ContentBackend):
         headers = {"User-Agent": _USER_AGENT}
 
         if request.url and "reddit.com" in request.url:
+            await ensure_public_url(request.url)
             url = request.url if request.url.endswith(".json") else request.url + ".json"
             try:
                 if self._client is not None:

--- a/autobot-backend/content_reach/sources/web_page.py
+++ b/autobot-backend/content_reach/sources/web_page.py
@@ -17,6 +17,7 @@ import asyncio
 import httpx
 
 from autobot_shared.logging_manager import get_logger
+from content_reach._url_guard import ensure_public_url, ensure_robots_allowed
 from content_reach.backends.browser import BrowserBackend
 from content_reach.base import BackendError, ContentBackend, ContentRequest, ContentResult
 from content_reach.chain import ContentSourceChain
@@ -73,6 +74,9 @@ class TrafilaturaBackend(ContentBackend):
 
     async def fetch(self, request: ContentRequest) -> ContentResult:
         """GET request.url, extract text via trafilatura; raise BackendError on failure."""
+        await ensure_public_url(request.url)
+        await ensure_robots_allowed(request.url)
+
         try:
             _import_trafilatura()
         except ImportError:
@@ -131,6 +135,9 @@ class JinaReaderBackend(ContentBackend):
 
     async def fetch(self, request: ContentRequest) -> ContentResult:
         """GET https://r.jina.ai/<url>; raise BackendError on non-200 or empty body."""
+        await ensure_public_url(request.url)
+        await ensure_robots_allowed(request.url)
+
         url = f"{_JINA_READER_BASE}{request.url}"
         headers = {"Accept": "text/plain"}
 

--- a/autobot-backend/content_reach/sources/youtube.py
+++ b/autobot-backend/content_reach/sources/youtube.py
@@ -17,6 +17,7 @@ import re
 import httpx
 
 from autobot_shared.logging_manager import get_logger
+from content_reach._url_guard import ensure_public_url
 from content_reach.base import BackendError, ContentBackend, ContentRequest, ContentResult
 from content_reach.chain import ContentSourceChain
 from source_attribution import SourceReliability, SourceType
@@ -179,6 +180,8 @@ class YtDlpCaptionBackend(ContentBackend):
         _ytdlp_extract_info owns the yt_dlp import check and raises BackendError
         when yt_dlp is unavailable, so no separate guard is needed here.
         """
+        await ensure_public_url(request.url)
+
         info: dict = await asyncio.to_thread(_ytdlp_extract_info, request.url)
 
         track = _pick_caption_track(info)
@@ -190,6 +193,7 @@ class YtDlpCaptionBackend(ContentBackend):
             raise BackendError(f"YtDlpCaptionBackend: no English captions for {request.url!r}")
 
         caption_url, ext = track
+        await ensure_public_url(caption_url)
 
         try:
             if self._client is not None:

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1744,6 +1744,21 @@ async def _init_plugin_manager(app: FastAPI) -> None:
         logger.warning("Plugin manager startup failed (non-critical): %s", pm_err, exc_info=True)
 
 
+async def _init_content_reach_registry(app: FastAPI) -> None:
+    """Register default Content Reach sources and expose via app.state (#10932). NON-CRITICAL."""
+    try:
+        from content_reach.bootstrap import register_default_sources
+        from content_reach.registry import get_content_source_registry
+
+        registry = get_content_source_registry()
+        register_default_sources(registry)  # SYNC — do NOT await
+        app.state.content_reach_registry = registry
+        logger.info("Content Reach: registered %d default sources", len(registry.list_sources()))
+    except Exception as exc:
+        logger.warning("Content Reach registry init failed (non-critical): %s", exc)
+        app.state.content_reach_registry = None
+
+
 async def initialize_background_services(app: FastAPI):
     """
     Phase 2: Initialize background services (NON-BLOCKING).
@@ -1806,6 +1821,7 @@ async def initialize_background_services(app: FastAPI):
         await _start_autonomous_loop(app)
         await _start_community_clustering_loop(app)
         await _start_llc_notification_router(app)
+        await _init_content_reach_registry(app)
 
         await update_app_state_multi(
             initialization_status="ready",

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -11,6 +11,7 @@ and are imported at module level to fail fast if missing.
 """
 
 import api.pricing_health  # noqa: F401 — registers KnownProbes.PRICING probe (GH#6480)
+import content_reach.health  # noqa: F401 — registers KnownProbes.CONTENT_REACH probe (#10932)
 
 # Core router imports - these are required for basic functionality
 from api.adapters import router as adapters_router  # Issue #1403

--- a/autobot-backend/tests/content_reach/sources/test_social.py
+++ b/autobot-backend/tests/content_reach/sources/test_social.py
@@ -60,8 +60,14 @@ async def test_social_fetch_carries_social_source_type(monkeypatch):
         }
     )
 
+    import content_reach._url_guard as guard_mod
     import content_reach.backends.browser as browser_mod
 
+    async def _always_public(_url: str) -> bool:
+        return True
+
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _always_public)
+    monkeypatch.setattr(guard_mod, "_RESPECT_ROBOTS", False)
     monkeypatch.setattr(browser_mod, "_get_manager", lambda: stub_manager)
 
     from content_reach.sources.social import build_social_chain

--- a/autobot-backend/tests/content_reach/sources/test_youtube.py
+++ b/autobot-backend/tests/content_reach/sources/test_youtube.py
@@ -14,6 +14,12 @@ import pytest
 from content_reach.base import BackendError, ContentRequest
 from source_attribution import SourceType
 
+
+async def _always_public(_url: str) -> bool:
+    """Stub for _is_public_url_async that always returns True."""
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -127,8 +133,10 @@ async def test_ytdlp_probe_false_when_absent(monkeypatch):
 @pytest.mark.asyncio
 async def test_ytdlp_fetch_maps_caption_text(monkeypatch):
     """fetch() returns ContentResult with captions text when subtitles["en"] present."""
+    import content_reach._url_guard as guard_mod
     from content_reach.sources import youtube as yt_mod
 
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _always_public)
     monkeypatch.setattr(yt_mod, "_ytdlp_extract_info", lambda url: _FAKE_INFO)
 
     mock_response = MagicMock()
@@ -162,8 +170,10 @@ async def test_ytdlp_fetch_falls_back_to_automatic_captions(monkeypatch):
     json3 so the real _json3_to_text path is exercised (not the JSONDecodeError
     fallback that a VTT body would trigger).
     """
+    import content_reach._url_guard as guard_mod
     from content_reach.sources import youtube as yt_mod
 
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _always_public)
     monkeypatch.setattr(yt_mod, "_ytdlp_extract_info", lambda url: _FAKE_INFO_AUTO)
 
     mock_response = MagicMock()
@@ -195,8 +205,10 @@ async def test_ytdlp_fetch_falls_back_to_automatic_captions(monkeypatch):
 @pytest.mark.asyncio
 async def test_ytdlp_fetch_no_captions_raises(monkeypatch):
     """fetch() raises BackendError when no English captions are available."""
+    import content_reach._url_guard as guard_mod
     from content_reach.sources import youtube as yt_mod
 
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _always_public)
     monkeypatch.setattr(yt_mod, "_ytdlp_extract_info", lambda url: _FAKE_INFO_NO_CAPTIONS)
 
     from content_reach.sources.youtube import YtDlpCaptionBackend
@@ -215,8 +227,10 @@ async def test_ytdlp_fetch_no_captions_raises(monkeypatch):
 @pytest.mark.asyncio
 async def test_ytdlp_fetch_raises_when_yt_dlp_absent(monkeypatch):
     """fetch() raises BackendError (not ImportError) when yt_dlp is not installed."""
+    import content_reach._url_guard as guard_mod
     from content_reach.sources import youtube as yt_mod
 
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _always_public)
     monkeypatch.setattr(
         yt_mod,
         "_import_yt_dlp",
@@ -239,8 +253,10 @@ async def test_ytdlp_fetch_raises_when_yt_dlp_absent(monkeypatch):
 @pytest.mark.asyncio
 async def test_ytdlp_fetch_httpx_error_raises_backend_error(monkeypatch):
     """fetch() wraps httpx.HTTPError into BackendError."""
+    import content_reach._url_guard as guard_mod
     from content_reach.sources import youtube as yt_mod
 
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _always_public)
     monkeypatch.setattr(yt_mod, "_ytdlp_extract_info", lambda url: _FAKE_INFO)
 
     mock_client = AsyncMock(spec=httpx.AsyncClient)
@@ -288,8 +304,10 @@ def test_srv1_track_parsed():
 @pytest.mark.asyncio
 async def test_ytdlp_fetch_srv1_track(monkeypatch):
     """fetch() selects an srv1 track and returns correctly decoded plain text."""
+    import content_reach._url_guard as guard_mod
     from content_reach.sources import youtube as yt_mod
 
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _always_public)
     monkeypatch.setattr(yt_mod, "_ytdlp_extract_info", lambda url: _FAKE_INFO_SRV1)
 
     mock_response = MagicMock()

--- a/autobot-backend/tests/content_reach/test_boot_wiring.py
+++ b/autobot-backend/tests/content_reach/test_boot_wiring.py
@@ -1,0 +1,51 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for Part A boot wiring — health probe import + registry init (#10932)."""
+
+from __future__ import annotations
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# A1 — importing content_reach.health registers the CONTENT_REACH probe
+# ---------------------------------------------------------------------------
+
+
+def test_health_import_registers_probe() -> None:
+    """import content_reach.health → 'content_reach' appears in list_registered_probes()."""
+    import content_reach.health  # noqa: F401 — side-effect: registers the probe
+    from api.system_health import list_registered_probes
+
+    assert "content_reach" in list_registered_probes()
+
+
+# ---------------------------------------------------------------------------
+# A2 — register_default_sources populates all 5 sources
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _isolated_registry():
+    """Yield a fresh ContentSourceRegistry; restore empty state after the test."""
+    from content_reach.registry import get_content_source_registry
+
+    reg = get_content_source_registry()
+    reg.clear()
+    yield reg
+    reg.clear()
+
+
+def test_register_default_sources_populates_five_sources(_isolated_registry) -> None:
+    """register_default_sources adds all 5 expected sources to a cleared registry."""
+    from content_reach.bootstrap import register_default_sources
+
+    register_default_sources(_isolated_registry)
+    sources = _isolated_registry.list_sources()
+    assert set(sources) == {"web_search", "web_page", "youtube", "reddit", "social"}
+
+
+def test_registry_starts_empty_after_clear(_isolated_registry) -> None:
+    """Registry is empty after clear() — fixture isolation check."""
+    assert _isolated_registry.list_sources() == {}

--- a/autobot-backend/tests/content_reach/test_url_guard.py
+++ b/autobot-backend/tests/content_reach/test_url_guard.py
@@ -1,0 +1,524 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""TDD tests for content_reach._url_guard + inline enforcement in URL-fetching backends (#10932, #11095).
+
+Structure:
+  1. ensure_public_url direct unit tests
+  2. ensure_robots_allowed direct unit tests
+  3. TrafilaturaBackend SSRF block (no underlying fetch)
+  4. JinaReaderBackend SSRF block
+  5. BrowserBackend SSRF block
+  6. RedditJsonBackend url-mode SSRF block
+  7. YtDlpCaptionBackend: SSRF on request.url + caption_url
+  8. BrowserSearchBackend SSRF on built DDG url
+  9. robots: disallowed → BackendError; env=0 → passes; allowed+public → reaches mocked fetch
+  10. Real is_public_url_async: 169.254.169.254 blocked
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# 1. ensure_public_url — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_public_url_raises_on_empty():
+    """ensure_public_url raises BackendError for an empty string."""
+    from content_reach._url_guard import ensure_public_url
+    from content_reach.base import BackendError
+
+    with pytest.raises(BackendError, match="blocked"):
+        await ensure_public_url("")
+
+
+@pytest.mark.asyncio
+async def test_ensure_public_url_raises_when_not_public(monkeypatch):
+    """ensure_public_url raises BackendError when is_public_url_async returns False."""
+    import content_reach._url_guard as guard_mod
+    from content_reach.base import BackendError
+
+    async def _fake_public(url: str) -> bool:
+        return False
+
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _fake_public)
+
+    with pytest.raises(BackendError, match="blocked"):
+        from content_reach._url_guard import ensure_public_url
+
+        await ensure_public_url("http://10.0.0.1/secret")
+
+
+@pytest.mark.asyncio
+async def test_ensure_public_url_passes_for_public(monkeypatch):
+    """ensure_public_url does NOT raise when is_public_url_async returns True."""
+    import content_reach._url_guard as guard_mod
+
+    async def _fake_public(url: str) -> bool:
+        return True
+
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _fake_public)
+
+    from content_reach._url_guard import ensure_public_url
+
+    # Should not raise
+    await ensure_public_url("https://example.com/page")
+
+
+# ---------------------------------------------------------------------------
+# 2. ensure_robots_allowed — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_robots_raises_when_disallowed(monkeypatch):
+    """With robots enabled, ensure_robots_allowed raises BackendError when disallowed."""
+    import content_reach._url_guard as guard_mod
+    from content_reach.base import BackendError
+
+    monkeypatch.setattr(guard_mod, "_RESPECT_ROBOTS", True)
+
+    async def _mock_is_allowed(url: str, ua: str) -> bool:
+        return False
+
+    monkeypatch.setattr(guard_mod, "_robots_is_allowed", _mock_is_allowed)
+
+    with pytest.raises(BackendError, match="robots"):
+        from content_reach._url_guard import ensure_robots_allowed
+
+        await ensure_robots_allowed("https://example.com/restricted")
+
+
+@pytest.mark.asyncio
+async def test_ensure_robots_noop_when_disabled(monkeypatch):
+    """When _RESPECT_ROBOTS=False, ensure_robots_allowed is a no-op (no call to checker)."""
+    import content_reach._url_guard as guard_mod
+
+    monkeypatch.setattr(guard_mod, "_RESPECT_ROBOTS", False)
+
+    called = []
+
+    async def _mock_is_allowed(url: str, ua: str) -> bool:
+        called.append(url)
+        return False
+
+    monkeypatch.setattr(guard_mod, "_robots_is_allowed", _mock_is_allowed)
+
+    from content_reach._url_guard import ensure_robots_allowed
+
+    await ensure_robots_allowed("https://example.com/robots-disallowed")
+    assert called == [], "robots checker must not be called when disabled"
+
+
+@pytest.mark.asyncio
+async def test_ensure_robots_passes_when_allowed(monkeypatch):
+    """With robots enabled, ensure_robots_allowed does NOT raise when allowed."""
+    import content_reach._url_guard as guard_mod
+
+    monkeypatch.setattr(guard_mod, "_RESPECT_ROBOTS", True)
+
+    async def _mock_is_allowed(url: str, ua: str) -> bool:
+        return True
+
+    monkeypatch.setattr(guard_mod, "_robots_is_allowed", _mock_is_allowed)
+
+    from content_reach._url_guard import ensure_robots_allowed
+
+    await ensure_robots_allowed("https://example.com/allowed")
+
+
+@pytest.mark.asyncio
+async def test_ensure_robots_failopen_on_checker_error(monkeypatch):
+    """Robots checker raising an exception → fail-open (no BackendError)."""
+    import content_reach._url_guard as guard_mod
+
+    monkeypatch.setattr(guard_mod, "_RESPECT_ROBOTS", True)
+
+    async def _boom(url: str, ua: str) -> bool:
+        raise RuntimeError("network error")
+
+    monkeypatch.setattr(guard_mod, "_robots_is_allowed", _boom)
+
+    from content_reach._url_guard import ensure_robots_allowed
+
+    # Must NOT raise — fail-open
+    await ensure_robots_allowed("https://example.com/page")
+
+
+# ---------------------------------------------------------------------------
+# 3. TrafilaturaBackend — SSRF block (no underlying HTTP call)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trafilatura_ssrf_block_no_fetch(monkeypatch):
+    """TrafilaturaBackend.fetch raises BackendError on private URL and never calls client.get."""
+    from unittest.mock import AsyncMock
+
+    import content_reach._url_guard as guard_mod
+    from content_reach.base import BackendError, ContentRequest
+    from content_reach.sources.web_page import TrafilaturaBackend
+
+    async def _fake_public(url: str) -> bool:
+        return False
+
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _fake_public)
+
+    mock_client = AsyncMock()
+    backend = TrafilaturaBackend(client=mock_client)
+    request = ContentRequest(url="http://127.0.0.1/admin")
+
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+    mock_client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_trafilatura_ssrf_block_real_link_local():
+    """TrafilaturaBackend.fetch raises BackendError for 169.254.169.254 (real util)."""
+    from unittest.mock import AsyncMock
+
+    from content_reach.base import BackendError, ContentRequest
+    from content_reach.sources.web_page import TrafilaturaBackend
+
+    mock_client = AsyncMock()
+    backend = TrafilaturaBackend(client=mock_client)
+    request = ContentRequest(url="http://169.254.169.254/latest/meta-data/")
+
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+    mock_client.get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 4. JinaReaderBackend — SSRF block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_jina_reader_ssrf_block_no_fetch(monkeypatch):
+    """JinaReaderBackend.fetch raises BackendError on private URL and never calls client.get."""
+    from unittest.mock import AsyncMock
+
+    import content_reach._url_guard as guard_mod
+    from content_reach.base import BackendError, ContentRequest
+    from content_reach.sources.web_page import JinaReaderBackend
+
+    async def _fake_public(url: str) -> bool:
+        return False
+
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _fake_public)
+
+    mock_client = AsyncMock()
+    backend = JinaReaderBackend(client=mock_client)
+    request = ContentRequest(url="http://10.0.0.1/secret")
+
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+    mock_client.get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 5. BrowserBackend — SSRF block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_browser_backend_ssrf_block_no_manager_call(monkeypatch):
+    """BrowserBackend.fetch raises BackendError on private URL and never calls manager."""
+    import content_reach._url_guard as guard_mod
+    import content_reach.backends.browser as browser_mod
+    from content_reach.backends.browser import BrowserBackend
+    from content_reach.base import BackendError, ContentRequest
+    from source_attribution import SourceType
+
+    async def _fake_public(url: str) -> bool:
+        return False
+
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _fake_public)
+
+    manager_calls = []
+
+    class _StubManager:
+        async def research_url(self, cid, url, extract_content=True):
+            manager_calls.append(url)
+            return {"success": True, "content": {"text_content": "x", "structured_data": {}}}
+
+    monkeypatch.setattr(browser_mod, "_get_manager", lambda: _StubManager())
+
+    backend = BrowserBackend(source_type=SourceType.WEB_PAGE)
+    request = ContentRequest(url="http://192.168.1.1/internal")
+
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+    assert manager_calls == [], "manager.research_url must not be called on SSRF block"
+
+
+# ---------------------------------------------------------------------------
+# 6. RedditJsonBackend — url-mode SSRF block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reddit_url_mode_ssrf_block_no_fetch(monkeypatch):
+    """RedditJsonBackend url-mode raises BackendError on private URL and never calls client.get."""
+    from unittest.mock import AsyncMock
+
+    import content_reach._url_guard as guard_mod
+    from content_reach.base import BackendError, ContentRequest
+    from content_reach.sources.reddit import RedditJsonBackend
+
+    async def _fake_public(url: str) -> bool:
+        return False
+
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _fake_public)
+
+    mock_client = AsyncMock()
+    backend = RedditJsonBackend(client=mock_client)
+    # reddit.com URL so the url-mode branch is taken
+    request = ContentRequest(url="http://10.0.0.1/reddit.com/r/test")
+
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+    mock_client.get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 7. YtDlpCaptionBackend — SSRF on request.url + caption_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_yt_dlp_ssrf_block_request_url_no_extract(monkeypatch):
+    """YtDlpCaptionBackend.fetch raises BackendError on private request.url; extract_info not called."""
+    import content_reach._url_guard as guard_mod
+    import content_reach.sources.youtube as yt_mod
+    from content_reach.base import BackendError, ContentRequest
+    from content_reach.sources.youtube import YtDlpCaptionBackend
+
+    async def _fake_public(url: str) -> bool:
+        return False
+
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _fake_public)
+
+    extract_calls = []
+
+    def _mock_extract(url: str) -> dict:
+        extract_calls.append(url)
+        return {}
+
+    monkeypatch.setattr(yt_mod, "_ytdlp_extract_info", _mock_extract)
+
+    from unittest.mock import AsyncMock
+
+    mock_client = AsyncMock()
+    backend = YtDlpCaptionBackend(client=mock_client)
+    request = ContentRequest(url="http://127.0.0.1/video")
+
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+    assert extract_calls == [], "_ytdlp_extract_info must not be called on SSRF block"
+    mock_client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_yt_dlp_ssrf_block_caption_url_no_http(monkeypatch):
+    """YtDlpCaptionBackend raises BackendError if caption track URL is private; no HTTP call."""
+    from unittest.mock import AsyncMock
+
+    import content_reach._url_guard as guard_mod
+    import content_reach.sources.youtube as yt_mod
+    from content_reach.base import BackendError, ContentRequest
+    from content_reach.sources.youtube import YtDlpCaptionBackend
+
+    # request.url is public, caption url is private
+    public_urls = {"https://youtube.com/watch?v=abc": True}
+
+    async def _selective_public(url: str) -> bool:
+        return public_urls.get(url, False)
+
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _selective_public)
+
+    def _mock_extract(url: str) -> dict:
+        return {
+            "subtitles": {"en": [{"ext": "vtt", "url": "http://10.0.0.1/captions.vtt"}]},
+            "automatic_captions": {},
+        }
+
+    monkeypatch.setattr(yt_mod, "_ytdlp_extract_info", _mock_extract)
+
+    mock_client = AsyncMock()
+    backend = YtDlpCaptionBackend(client=mock_client)
+    request = ContentRequest(url="https://youtube.com/watch?v=abc")
+
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+    mock_client.get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 8. BrowserSearchBackend — SSRF on built DDG URL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_browser_search_ssrf_block_ddg_url(monkeypatch):
+    """BrowserSearchBackend raises BackendError when SSRF guard blocks the DDG URL."""
+    import content_reach._url_guard as guard_mod
+    import content_reach.backends.browser as browser_mod
+    from content_reach.backends.browser import BrowserSearchBackend
+    from content_reach.base import BackendError, ContentRequest
+    from source_attribution import SourceType
+
+    async def _fake_public(url: str) -> bool:
+        return False
+
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _fake_public)
+
+    manager_calls = []
+
+    class _StubManager:
+        async def research_url(self, cid, url, extract_content=True):
+            manager_calls.append(url)
+            return {"success": True, "content": {"text_content": "x", "structured_data": {}}}
+
+    monkeypatch.setattr(browser_mod, "_get_manager", lambda: _StubManager())
+
+    backend = BrowserSearchBackend(source_type=SourceType.WEB_SEARCH)
+    request = ContentRequest(query="test query")
+
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+    assert manager_calls == []
+
+
+# ---------------------------------------------------------------------------
+# 9. robots end-to-end: TrafilaturaBackend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trafilatura_robots_block_default(monkeypatch):
+    """With default env (robots respected), disallowed URL → BackendError; client.get not called."""
+    from unittest.mock import AsyncMock
+
+    import content_reach._url_guard as guard_mod
+    from content_reach.base import BackendError, ContentRequest
+    from content_reach.sources.web_page import TrafilaturaBackend
+
+    # SSRF passes, robots blocks
+    async def _always_public(url: str) -> bool:
+        return True
+
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _always_public)
+    monkeypatch.setattr(guard_mod, "_RESPECT_ROBOTS", True)
+
+    async def _disallowed(url: str, ua: str) -> bool:
+        return False
+
+    monkeypatch.setattr(guard_mod, "_robots_is_allowed", _disallowed)
+
+    mock_client = AsyncMock()
+    backend = TrafilaturaBackend(client=mock_client)
+    request = ContentRequest(url="https://example.com/restricted")
+
+    with pytest.raises(BackendError):
+        await backend.fetch(request)
+
+    mock_client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_trafilatura_robots_disabled_env_passes(monkeypatch):
+    """When _RESPECT_ROBOTS=False, disallowed URL proceeds to fetch."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import content_reach._url_guard as guard_mod
+    import content_reach.sources.web_page as wp_mod
+    from content_reach.base import ContentRequest
+    from content_reach.sources.web_page import TrafilaturaBackend
+
+    async def _always_public(url: str) -> bool:
+        return True
+
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _always_public)
+    monkeypatch.setattr(guard_mod, "_RESPECT_ROBOTS", False)
+
+    monkeypatch.setattr(wp_mod, "_trafilatura_extract", lambda html: "extracted text")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "<html><body>content</body></html>"
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    backend = TrafilaturaBackend(client=mock_client)
+    request = ContentRequest(url="https://example.com/page")
+
+    result = await backend.fetch(request)
+    assert result.success is True
+    mock_client.get.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_trafilatura_public_allowed_url_reaches_fetch(monkeypatch):
+    """Public + robots-allowed URL passes both guards and reaches client.get."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import content_reach._url_guard as guard_mod
+    import content_reach.sources.web_page as wp_mod
+    from content_reach.base import ContentRequest
+    from content_reach.sources.web_page import TrafilaturaBackend
+
+    async def _always_public(url: str) -> bool:
+        return True
+
+    monkeypatch.setattr(guard_mod, "_is_public_url_async", _always_public)
+    monkeypatch.setattr(guard_mod, "_RESPECT_ROBOTS", True)
+
+    async def _allowed(url: str, ua: str) -> bool:
+        return True
+
+    monkeypatch.setattr(guard_mod, "_robots_is_allowed", _allowed)
+    monkeypatch.setattr(wp_mod, "_trafilatura_extract", lambda html: "article body")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "<html><body>content</body></html>"
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    backend = TrafilaturaBackend(client=mock_client)
+    request = ContentRequest(url="https://example.com/article")
+
+    result = await backend.fetch(request)
+    assert result.success is True
+    mock_client.get.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 10. Real util: 169.254.169.254 is blocked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_real_util_blocks_link_local():
+    """Using the real is_public_url_async: 169.254.169.254 is blocked (returns False)."""
+    from autobot_shared.url_safety import is_public_url_async
+
+    result = await is_public_url_async("http://169.254.169.254/latest/meta-data/")
+    assert result is False

--- a/autobot-backend/tests/unit/tools/test_content_reach_tool.py
+++ b/autobot-backend/tests/unit/tools/test_content_reach_tool.py
@@ -1,0 +1,154 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for Part B — unified content_reach agent tool (#10932)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helper: build a ToolRegistry instance without real __init__
+# ---------------------------------------------------------------------------
+
+
+def _make_registry():
+    with patch("tools.tool_registry.ToolRegistry.__init__", return_value=None):
+        from tools.tool_registry import ToolRegistry
+
+        registry = ToolRegistry.__new__(ToolRegistry)
+        registry.logger = MagicMock()
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# B3 — content_reach in get_available_tools()
+# ---------------------------------------------------------------------------
+
+
+def test_content_reach_in_get_available_tools() -> None:
+    """'content_reach' appears in get_available_tools()."""
+    with patch("chat_workflow.tool_handler.BROWSER_TOOL_NAMES", frozenset()):
+        registry = _make_registry()
+        tools = registry.get_available_tools()
+
+    assert "content_reach" in tools
+
+
+# ---------------------------------------------------------------------------
+# B2 — dispatch key "contentreach" resolves
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_contentreach_resolves() -> None:
+    """Normalized 'contentreach' resolves to content_reach handler."""
+    registry = _make_registry()
+    handler = registry._get_tool_handler("contentreach")
+    assert handler is not None
+
+
+# ---------------------------------------------------------------------------
+# B4 — CONTENT_REACH_SCHEMA in _BUILTIN_TOOL_SCHEMAS with 5-source enum
+# ---------------------------------------------------------------------------
+
+
+def test_content_reach_schema_in_builtin_tool_schemas() -> None:
+    """'content_reach' key is present in _BUILTIN_TOOL_SCHEMAS."""
+    from chat_workflow.tool_handler import _BUILTIN_TOOL_SCHEMAS
+
+    assert "content_reach" in _BUILTIN_TOOL_SCHEMAS
+
+
+def test_content_reach_schema_has_five_source_enum() -> None:
+    """CONTENT_REACH_SCHEMA source enum lists all 5 sources."""
+    from chat_workflow.tool_handler import _BUILTIN_TOOL_SCHEMAS
+
+    schema = _BUILTIN_TOOL_SCHEMAS["content_reach"]
+    enum_values = set(schema["properties"]["source"]["enum"])
+    assert enum_values == {"web_search", "web_page", "youtube", "reddit", "social"}
+
+
+# ---------------------------------------------------------------------------
+# B1 — content_reach method: success path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_content_reach_success() -> None:
+    """content_reach returns status='success' and includes result text."""
+    from content_reach.base import ContentResult
+    from source_attribution import SourceType
+
+    registry = _make_registry()
+
+    mock_result = ContentResult(
+        success=True,
+        source_type=SourceType.WEB_SEARCH,
+        backend_used="ddgs",
+        text="Some search content",
+        url="",
+    )
+    mock_registry = MagicMock()
+    mock_registry.fetch = AsyncMock(return_value=mock_result)
+
+    with patch("content_reach.registry.get_content_source_registry", return_value=mock_registry):
+        result = await registry.content_reach("web_search", query="test query")
+
+    assert result["status"] == "success"
+    assert "Some search content" in result["result"]
+    assert result["tool_name"] == "content_reach"
+
+
+# ---------------------------------------------------------------------------
+# B1 — content_reach method: unsuccessful ContentResult (success=False)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_content_reach_unsuccessful_result() -> None:
+    """content_reach returns status='error' when ContentResult.success is False."""
+    from content_reach.base import ContentResult
+    from source_attribution import SourceType
+
+    registry = _make_registry()
+
+    mock_result = ContentResult.failure(SourceType.WEB_SEARCH, "backend timeout")
+    mock_registry = MagicMock()
+    mock_registry.fetch = AsyncMock(return_value=mock_result)
+
+    with patch("content_reach.registry.get_content_source_registry", return_value=mock_registry):
+        result = await registry.content_reach("web_search", query="test query")
+
+    assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# B1 + C3 — SSRF guard: private URL blocked at tool boundary, fetch NOT called
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_content_reach_blocks_private_url() -> None:
+    """content_reach blocks a private IP URL and does NOT call registry.fetch."""
+    registry = _make_registry()
+
+    mock_registry = MagicMock()
+    mock_registry.fetch = AsyncMock()
+
+    with patch("content_reach.registry.get_content_source_registry", return_value=mock_registry):
+        # Use the real ensure_public_url path but monkeypatch the underlying
+        # is_public_url_async so we control what "non-public" means in tests.
+        with patch(
+            "content_reach._url_guard._is_public_url_async",
+            new=AsyncMock(return_value=False),
+        ):
+            result = await registry.content_reach(
+                "web_page",
+                url="http://169.254.169.254/latest/meta-data/",
+            )
+
+    assert result["status"] == "error"
+    mock_registry.fetch.assert_not_called()

--- a/autobot-backend/tools/tool_registry.py
+++ b/autobot-backend/tools/tool_registry.py
@@ -190,6 +190,46 @@ class ToolRegistry:
 
     # Issue #7509: Web research tools — direct internal dispatch via web_fetch package.
 
+    async def content_reach(self, source: str, query: str = "", url: str = "", limit: int = 5) -> Dict[str, Any]:
+        """Fetch external content via a Content Reach source chain (#10932)."""
+        from content_reach.base import BackendError, ContentRequest
+        from content_reach.registry import get_content_source_registry
+
+        args: Dict[str, Any] = {"source": source, "query": query, "url": url}
+        # C3 belt-and-suspenders: SSRF-guard any explicit URL before dispatching.
+        if url:
+            try:
+                from content_reach._url_guard import ensure_public_url
+
+                await ensure_public_url(url)
+            except BackendError as guard_exc:
+                return {
+                    "tool_name": "content_reach",
+                    "tool_args": args,
+                    "result": f"Blocked: {guard_exc}",
+                    "status": "error",
+                }
+        try:
+            req = ContentRequest(query=query, url=url, source=source, limit=limit)
+            result = await get_content_source_registry().fetch(source, req)
+            if not result.success:
+                return {
+                    "tool_name": "content_reach",
+                    "tool_args": args,
+                    "result": f"No content: {result.metadata.get('error', 'unknown')}",
+                    "status": "error",
+                }
+            header = f"## {source} via {result.backend_used}" + (f" ({result.url})" if result.url else "")
+            return {
+                "tool_name": "content_reach",
+                "tool_args": args,
+                "result": f"{header}\n\n{result.text or '*(no content)*'}",
+                "status": "success",
+            }
+        except Exception as exc:
+            self.logger.error("content_reach failed for %s: %s", source, exc)
+            return {"tool_name": "content_reach", "tool_args": args, "result": f"Error: {exc}", "status": "error"}
+
     async def scrape_url(self, url: str, render: str = "auto") -> Dict[str, Any]:
         """Fetch a URL and return its markdown content."""
         from web_fetch import RenderMode, WebFetcher
@@ -594,6 +634,13 @@ class ToolRegistry:
             ),
             # Issue #7509: Web research tools
             "scrapeurl": lambda args: self.scrape_url(args.get("url", ""), args.get("render", "auto")),
+            # #10932: Unified content_reach gateway
+            "contentreach": lambda args: self.content_reach(
+                args.get("source", ""),
+                args.get("query", ""),
+                args.get("url", ""),
+                args.get("limit", 5),
+            ),
             "crawlsite": lambda args: self.crawl_site(
                 args.get("seed_urls", []),
                 args.get("max_depth", 1),
@@ -766,6 +813,8 @@ class ToolRegistry:
             "crawl_site",
             "map_site",
             "extract_structured_data",
+            # #10932: Unified content_reach gateway
+            "content_reach",
         ]
         # Issue #1368/#2609: Browser tools are defined once in BROWSER_TOOL_NAMES
         # and imported here so the two lists cannot drift independently.

--- a/docs/superpowers/plans/2026-07-07-content-reach-task7-wiring.md
+++ b/docs/superpowers/plans/2026-07-07-content-reach-task7-wiring.md
@@ -1,0 +1,161 @@
+# Content Reach — Task 7 (Hardening + Boot Wiring + Agent Tool) Plan
+
+**Goal:** Make Content Reach live end-to-end *safely*: add SSRF + robots.txt guards to the URL-fetching backends, register default sources at boot, surface the `CONTENT_REACH` health probe, and expose ONE unified `content_reach` agent tool. Umbrella #10932.
+
+**Design decisions:**
+
+- **Anti-duplication:** existing `web_search`/`scrape_url` tools overlap content_reach's web_search/web_page — so expose a single `content_reach(source, query, url)` gateway (all 5 sources incl. new youtube/reddit/social), NOT duplicate per-source tools.
+- **SSRF (required):** content_reach currently has NO URL guard while `web_fetch` enforces `autobot_shared.url_safety.is_public_url_async`. Add the same inline defense-in-depth before exposing the tool.
+- **robots.txt (configurable):** respect robots.txt by default (like `web_fetch`), with an env override `AUTOBOT_CONTENT_REACH_RESPECT_ROBOTS` (default `1`/true; set `0` to fetch regardless). Applies to the generic web-content backends.
+
+**Global constraints:** async-first (no blocking on async paths); no `print()`; logging via `get_logger`/`logging.getLogger`; no commit trailers (mrveiss sole author); commit `feat(content-reach): <desc> (#10932)`; Black 26.3.1 + isort + ruff clean; markdown-clean docs; TDD; python3.
+
+## Given (already on Dev_new_gui)
+
+- `content_reach.registry.get_content_source_registry()` → singleton with async `fetch(source, request) -> ContentResult`, `list_sources()`.
+- `content_reach.bootstrap.register_default_sources(registry) -> None` (SYNC).
+- `content_reach.base.ContentRequest`, `ContentResult`, `BackendError`.
+- `content_reach.health` already defines `@register_health_probe(KnownProbes.CONTENT_REACH)` — needs to be IMPORTED at boot.
+- `autobot_shared.url_safety.is_public_url_async(url) -> bool` — canonical SSRF guard (blocks private/link-local/localhost).
+- `web_fetch/robots.py` — robots.txt fetch + Redis-cached compliance check (reuse if its public API allows; else `urllib.robotparser`). `ERR_ROBOTS_BLOCKED` in `web_fetch.types`.
+- `api/system_health.list_registered_probes()`.
+
+## Part C (do FIRST) — SSRF + robots guards
+
+**C1. Shared guard module** — new `content_reach/_url_guard.py`:
+
+```python
+import os
+
+from content_reach.base import BackendError
+
+_RESPECT_ROBOTS = os.environ.get("AUTOBOT_CONTENT_REACH_RESPECT_ROBOTS", "1").strip().lower() not in ("0", "false", "no")
+
+
+async def ensure_public_url(url: str) -> None:
+    """Raise BackendError if url is not a public address (SSRF guard, #10932)."""
+    from autobot_shared.url_safety import is_public_url_async
+
+    if not url or not await is_public_url_async(url):
+        raise BackendError(f"blocked non-public or invalid url: {url!r}")
+
+
+async def ensure_robots_allowed(url: str) -> None:
+    """Raise BackendError if robots.txt disallows fetching url (respect-by-default, #10932).
+
+    No-op when AUTOBOT_CONTENT_REACH_RESPECT_ROBOTS is 0/false. Reuse web_fetch's
+    robots checker if its public API allows; otherwise urllib.robotparser with the
+    content_reach user-agent. Fail-open on robots-fetch errors (log, allow) — a broken
+    robots endpoint must not block content, matching web_fetch behavior.
+    """
+    if not _RESPECT_ROBOTS:
+        return
+    # Implementer: read web_fetch/robots.py for a reusable `is_allowed(url, ua)`-style
+    # helper. If none is cleanly importable, use urllib.robotparser (cache per-domain).
+    ...
+```
+
+Confirm the exact `web_fetch/robots.py` public surface before choosing reuse vs urllib. Keep the robots UA = the reddit UA constant style (`autobot-content-reach/1.0`).
+
+**C2. Enforce inline in every URL-fetching backend**, immediately before the httpx/browser/caption call — `await ensure_public_url(url)` (always) and `await ensure_robots_allowed(url)` (generic web pages only):
+
+- `sources/web_page.py` — `TrafilaturaBackend.fetch` + `JinaReaderBackend.fetch`: guard `request.url` (SSRF **and** robots) before fetching.
+- `backends/browser.py` — `BrowserBackend.fetch`: guard `request.url` (SSRF + robots) before `research_url`. `BrowserSearchBackend` builds a fixed DuckDuckGo host — SSRF-guard the final url (robots N/A for a search-results page; skip robots there).
+- `sources/reddit.py` — `RedditJsonBackend.fetch` url-mode: SSRF-guard `request.url` (robots N/A — reddit `.json` is an API endpoint, skip robots). Search-mode hits a fixed host — no guard.
+- `sources/youtube.py` — SSRF-guard `request.url` before `extract_info`, AND SSRF-guard the extracted caption-track URL before fetching it (untrusted external url). robots N/A (yt-dlp/API).
+- `sources/web_search.py` — `DdgsBackend`/`JinaSearchBackend` hit fixed API hosts; no per-url guard needed.
+
+**C3. Tests** — `tests/content_reach/test_url_guard.py`:
+
+- SSRF: `TrafilaturaBackend`, `RedditJsonBackend` url-mode, `BrowserBackend`, and youtube caption-url each raise `BackendError` on a private/link-local url (`169.254.169.254`, `127.0.0.1`, `10.0.0.1`) and make NO underlying fetch/browser call. Monkeypatch `is_public_url_async`→False (and one test with the real util to prove link-local is blocked).
+- robots: with `AUTOBOT_CONTENT_REACH_RESPECT_ROBOTS` unset (default), a disallowed url → `BackendError`, no fetch; with it `=0`, the same url proceeds (monkeypatch the robots checker + a mocked httpx). A public+allowed url passes both guards and reaches the mocked fetch.
+
+## Part A — Boot wiring
+
+**A1.** `initialization/router_registry/core_routers.py` (~line 13, next to `import api.pricing_health`): add
+`import content_reach.health  # noqa: F401 — registers KnownProbes.CONTENT_REACH probe (#10932)`
+
+**A2.** `initialization/lifespan.py`: add a Phase-2 (non-critical) helper mirroring `_init_heartbeat_scheduler`, and call it from `initialize_background_services(app)`:
+
+```python
+async def _init_content_reach_registry(app: FastAPI) -> None:
+    """Register default Content Reach sources (#10932). NON-CRITICAL."""
+    try:
+        from content_reach.bootstrap import register_default_sources
+        from content_reach.registry import get_content_source_registry
+
+        registry = get_content_source_registry()
+        register_default_sources(registry)  # SYNC — do NOT await
+        app.state.content_reach_registry = registry
+        logger.info("Content Reach: registered %d default sources", len(registry.list_sources()))
+    except Exception as exc:
+        logger.warning("Content Reach registry init failed (non-critical): %s", exc)
+        app.state.content_reach_registry = None
+```
+
+## Part B — Unified `content_reach` agent tool
+
+**B1.** `tools/tool_registry.py` — add after `scrape_url`, mirroring its return shape (`{tool_name, tool_args, result, status}`):
+
+```python
+async def content_reach(self, source: str, query: str = "", url: str = "", limit: int = 5) -> Dict[str, Any]:
+    """Fetch external content via a Content Reach source chain (#10932)."""
+    from content_reach.base import ContentRequest
+    from content_reach.registry import get_content_source_registry
+
+    args = {"source": source, "query": query, "url": url}
+    try:
+        req = ContentRequest(query=query, url=url, source=source, limit=limit)
+        result = await get_content_source_registry().fetch(source, req)
+        if not result.success:
+            return {"tool_name": "content_reach", "tool_args": args,
+                    "result": f"No content: {result.metadata.get('error', 'unknown')}", "status": "error"}
+        header = f"## {source} via {result.backend_used}" + (f" ({result.url})" if result.url else "")
+        return {"tool_name": "content_reach", "tool_args": args,
+                "result": f"{header}\n\n{result.text or '*(no content)*'}", "status": "success"}
+    except Exception as exc:
+        self.logger.error("content_reach failed for %s: %s", source, exc)
+        return {"tool_name": "content_reach", "tool_args": args, "result": f"Error: {exc}", "status": "error"}
+```
+
+**B2.** `_get_tool_handler()` dispatch dict (keys are normalized lowercase, no underscores), near the Issue #7509 web-research entries:
+
+```python
+"contentreach": lambda args: self.content_reach(
+    args.get("source", ""), args.get("query", ""), args.get("url", ""), args.get("limit", 5)
+),
+```
+
+**B3.** Add `"content_reach"` to the list returned by `get_available_tools()`.
+
+**B4.** `chat_workflow/tool_handler.py` — add `CONTENT_REACH_SCHEMA` near the other web schemas and register `"content_reach": CONTENT_REACH_SCHEMA` in `_BUILTIN_TOOL_SCHEMAS`:
+
+```python
+CONTENT_REACH_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "source": {"type": "string", "enum": ["web_search", "web_page", "youtube", "reddit", "social"],
+                    "description": "Which content source chain to use."},
+        "query": {"type": "string", "description": "Search query (web_search, reddit, youtube search)."},
+        "url": {"type": "string", "description": "Target URL (web_page, youtube, reddit, social)."},
+        "limit": {"type": "integer", "default": 5, "description": "Max results for search sources."},
+    },
+    "required": ["source"],
+}
+```
+
+## Tests (wiring)
+
+- `tests/content_reach/test_boot_wiring.py`: `import content_reach.health` → `"content_reach" in list_registered_probes()`; `register_default_sources(get_content_source_registry())` populates 5 sources (clear the singleton in a fixture).
+- `tests/tools/test_content_reach_tool.py`: tool success (mock `get_content_source_registry().fetch` AsyncMock → successful `ContentResult`, assert `status=="success"`); tool unsuccessful (`ContentResult.failure` → `status=="error"`); `"content_reach" in get_available_tools()`; `"content_reach"` in `_BUILTIN_TOOL_SCHEMAS` with the 5-source enum. (Mirror existing `tests/tools/` setup.)
+
+## Verification gate
+
+- `python3 -m pytest autobot-backend/tests/content_reach/ autobot-backend/tests/tools/test_content_reach_tool.py -v` all green.
+- `cd autobot-backend && python3 -c "import initialization.router_registry.core_routers"` clean AND registers the probe.
+- black/isort/ruff clean on changed files.
+
+## Out of scope (follow-ups)
+
+- Routing existing `web_search`/`scrape_url` through content_reach's resilient chains (bigger consolidation → discovery).
+- Frontend doctor panel = Task 8.


### PR DESCRIPTION
## Thinking Path

Final piece of Content Reach (#10932): make the capability live end-to-end AND hardened. During wiring, a review surfaced that content_reach fetched arbitrary URLs with **no SSRF guard** (while the existing `web_fetch` enforces one) — so this PR adds that guard before exposing the capability to agents. robots.txt is now a deliberate, configurable choice.

Built via subagent-driven TDD: a dedicated security pass (Part C) reviewed for SSRF bypasses, a wiring pass (Parts A+B), and an opus whole-branch review that traced every source chain end-to-end — **Ready to merge, no Critical/Important**.

## What Changed

**Security (SSRF + robots — #11095):** new `content_reach/_url_guard.py`.
- `ensure_public_url()` — validates via canonical `autobot_shared.url_safety.is_public_url_async` (DNS-based, fail-closed) **before every network call** in every URL-fetching backend (web_page, reddit url-mode, browser, youtube page + untrusted caption-track URL). Blocks link-local/loopback/private/non-http/DNS-rebind. Also re-guarded at the agent-tool boundary (defense-in-depth).
- `ensure_robots_allowed()` — respects robots.txt by default; `AUTOBOT_CONTENT_REACH_RESPECT_ROBOTS=0` disables. Fail-open on fetch errors; search-result pages skip robots but keep SSRF.

**Live wiring:**
- `core_routers.py` — imports `content_reach.health` so the `CONTENT_REACH` health probe registers at boot (surfaces on `/api/system/health`).
- `lifespan.py` — `_init_content_reach_registry()` (Phase-2, non-critical) registers the 5 default sources into the singleton registry.

**Agent capability:** single unified `content_reach(source, query, url, limit)` tool in `tool_registry.py` (+ schema in `tool_handler.py`) routing to the registry — reaches all 5 sources incl. the new youtube/reddit/social, without duplicating the existing `web_search`/`scrape_url` tools.

## Verification

- **113 content_reach + tool tests pass** (incl. 19 SSRF/robots tests asserting private URLs make ZERO fetch; boot-registration; tool success/error/blocked-url).
- black 26.3.1 / isort / flake8 clean.
- **Probe registration verified live:** `import core_routers` → `content_reach probe registered: True`.
- Opus review traced every source path: no SSRF bypass, single shared registry across boot/tool/probe, non-fatal init, async-first upheld.

## Model Used

Opus 4.8 (orchestration, whole-branch + security review), Sonnet 4.6 (implementers + task reviews).

Closes #11095. Part of #10932 (Task 7). Follow-up minors (unbounded robots cache, robots-fetch log level) → #11078.
