### PR TITLE
fix(deploy): install espeak-ng — backend TTS 'no voices' (#10566)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -245,6 +245,10 @@
       - libsndfile1
       - libsndfile1-dev
       - portaudio19-dev
+      # Text-to-speech engine for pyttsx3 (#10566): without espeak-ng the backend
+      # reports "no speech voices installed" and TTS output is unavailable.
+      - espeak-ng
+      - espeak-ng-data
       # OCR / CAPTCHA solver (tesseract, Issue #206)
       - tesseract-ocr
       - libtesseract-dev


### PR DESCRIPTION
## Thinking Path
Operator: 'Text-to-speech is not available on this deployment — no speech voices are installed.' The backend TTS uses **pyttsx3**, which on Linux requires **espeak-ng** as its speech engine + voice data. The backend ansible role installs ffmpeg/libsndfile/portaudio but **not** espeak-ng — so pyttsx3 finds no voices.

## What Changed
- `ansible/roles/backend/tasks/main.yml`: add `espeak-ng` + `espeak-ng-data` to the backend system-dependency apt list (in the audio/voice section). Takes effect on next deploy/provision.

## Verification
- Ansible package-list change. After deploy, `espeak-ng --voices` will list voices and the backend's `list_voices()` will return them (the 'no voices' message clears). The Docker backend image doesn't install ffmpeg/audio via apt, so this native co-located deploy path is the correct one.

## Model Used
Opus 4.8

Closes #10566