### PR TITLE
fix(frontend): resolve any/unused-vars in knowledge/operations/plugins/secrets/settings (#9924)

### DIFF
--- a/autobot-frontend/src/components/file-browser/__tests__/FileUpload.spec.ts
+++ b/autobot-frontend/src/components/file-browser/__tests__/FileUpload.spec.ts
@@ -5,11 +5,12 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
+import type { App } from 'vue'
 import FileUpload from '../FileUpload.vue'
 
 // vue-i18n: provide a minimal $t stub so template calls resolve to the key
 const i18nPlugin = {
-  install(app: any) {
+  install(app: App) {
     app.config.globalProperties.$t = (key: string) => key
   }
 }

--- a/autobot-frontend/src/components/knowledge/BulkActionsToolbar.vue
+++ b/autobot-frontend/src/components/knowledge/BulkActionsToolbar.vue
@@ -18,11 +18,9 @@ import Icon from '@/components/ui/Icon.vue'
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseButton from '@/components/base/BaseButton.vue'
-import { createLogger } from '@/utils/debugUtils'
 
 const { t } = useI18n()
 
-const logger = createLogger('BulkActionsToolbar')
 
 // =============================================================================
 // Type Definitions

--- a/autobot-frontend/src/components/knowledge/ChromaDBExplorer.vue
+++ b/autobot-frontend/src/components/knowledge/ChromaDBExplorer.vue
@@ -238,7 +238,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 

--- a/autobot-frontend/src/components/knowledge/EntityGraphManager.vue
+++ b/autobot-frontend/src/components/knowledge/EntityGraphManager.vue
@@ -198,12 +198,10 @@ import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
-import { createLogger } from '@/utils/debugUtils'
 import { useKnowledgeEntityGraph } from '@/composables/knowledge/useKnowledgeEntityGraph'
 import EntityExtractor from './EntityExtractor.vue'
 import GraphRAGQuery from './GraphRAGQuery.vue'
 
-const logger = createLogger('EntityGraphManager')
 const { t } = useI18n()
 const router = useRouter()
 

--- a/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
@@ -172,7 +172,7 @@
 <script setup lang="ts">
 import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useKnowledgeStore } from '@/stores/useKnowledgeStore'
 import ApiClient from '@/utils/ApiClient'
@@ -250,12 +250,6 @@ watch(fakeProgress.progress, (value) => {
   } else {
     estimatedTimeRemaining.value = '<1s'
   }
-})
-
-// Computed
-const progressText = computed(() => {
-  if (!showProgress.value) return ''
-  return `${progressPercentage.value}% (${itemsProcessed.value}/${totalItems.value})`
 })
 
 // Methods

--- a/autobot-frontend/src/components/knowledge/KnowledgeContentViewer.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeContentViewer.vue
@@ -74,7 +74,7 @@ interface TreeNode {
   size?: number
   date?: string
   category?: string
-  metadata?: any
+  metadata?: Record<string, unknown>
   content?: string
   children?: TreeNode[]
 }

--- a/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
@@ -329,7 +329,6 @@ const {
   clear: deselectAllItems,
   selectedItems: selectedPendingItems,
   selectedCount,
-  selected: selectedKeys,
 } = useBatchSelection<PendingKnowledgeItem, string>(pendingItems, item => item.id);
 
 // someSelected is false when ALL items are selected — use selectedCount > 0 so

--- a/autobot-frontend/src/components/knowledge/KnowledgeScopeSelector.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeScopeSelector.vue
@@ -74,7 +74,7 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
-import { ref, computed, watch } from 'vue'
+import { ref, watch } from 'vue'
 
 /**
  * Knowledge Scope Selector Component

--- a/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
@@ -45,7 +45,6 @@ const categories = ref<DocCategory[]>([])
 const selectedCategory = ref<DocCategory | null>(null)
 const selectedDoc = ref<SystemDoc | null>(null)
 const categoryExpansion = useExpansion<string>()
-const expandedCategories = categoryExpansion.expanded
 
 // Export state
 const isExporting = ref(false)

--- a/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
+++ b/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
@@ -313,7 +313,7 @@ const removeEntity = (entity: ShareEntity) => {
   )
 }
 
-const handlePermissionChange = (entity: ShareEntity) => {
+const handlePermissionChange = (_entity: ShareEntity) => {
   // Permission changes are already bound via v-model
   // Permissions are updated automatically via v-model binding
 }

--- a/autobot-frontend/src/components/knowledge/graph/EntityDetail.vue
+++ b/autobot-frontend/src/components/knowledge/graph/EntityDetail.vue
@@ -131,7 +131,6 @@ import {
   ref,
 } from 'vue'
 import {
-  useKnowledgeGraph,
   type Entity,
 } from '@/composables/useKnowledgeGraph'
 import { useFocusTrap } from '@/composables/useFocusTrap'

--- a/autobot-frontend/src/components/knowledge/panels/SourcePreviewPanel.vue
+++ b/autobot-frontend/src/components/knowledge/panels/SourcePreviewPanel.vue
@@ -22,10 +22,8 @@ import { ref, computed, watch, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { createLogger } from '@/utils/debugUtils'
-import { useI18n } from 'vue-i18n'
 
 const logger = createLogger('SourcePreviewPanel')
-const { t } = useI18n()
 
 // =============================================================================
 // Type Definitions

--- a/autobot-frontend/src/components/knowledge/temporal/EventTimeline.vue
+++ b/autobot-frontend/src/components/knowledge/temporal/EventTimeline.vue
@@ -126,7 +126,6 @@
 // Author: mrveiss
 
 import Icon from '@/components/ui/Icon.vue'
-import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { TemporalEvent } from '@/composables/useKnowledgeGraph'
 import { useExpansion } from '@/composables/useExpansion'

--- a/autobot-frontend/src/components/manpage/ManPageManager.vue
+++ b/autobot-frontend/src/components/manpage/ManPageManager.vue
@@ -318,7 +318,6 @@
 <script>
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
-import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 
 // Create scoped logger for ManPageManager

--- a/autobot-frontend/src/components/operations/OperationDetail.vue
+++ b/autobot-frontend/src/components/operations/OperationDetail.vue
@@ -149,7 +149,6 @@
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 import type { Operation } from '@/types/operations'
 import {
   STATUS_CONFIG,
@@ -167,7 +166,6 @@ interface Props {
   operation: Operation
 }
 
-const { t } = useI18n()
 const props = defineProps<Props>()
 
 const emit = defineEmits<{

--- a/autobot-frontend/src/components/operations/OperationFilters.vue
+++ b/autobot-frontend/src/components/operations/OperationFilters.vue
@@ -76,11 +76,9 @@
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
 import type { OperationsFilter, OperationStatus, OperationType } from '@/types/operations'
 import { STATUS_CONFIG, OPERATION_TYPE_LABELS } from '@/types/operations'
 
-const { t } = useI18n()
 
 interface Props {
   filter: OperationsFilter

--- a/autobot-frontend/src/components/operations/OperationProgress.vue
+++ b/autobot-frontend/src/components/operations/OperationProgress.vue
@@ -60,8 +60,6 @@ const props = withDefaults(defineProps<Props>(), {
   showStep: true
 })
 
-const isRunning = computed(() => props.status === 'running')
-
 const progressClasses = computed(() => [
   `progress-${props.size}`,
   `status-${props.status}`

--- a/autobot-frontend/src/components/operations/OperationsList.vue
+++ b/autobot-frontend/src/components/operations/OperationsList.vue
@@ -148,7 +148,7 @@ interface Props {
   filter?: OperationsFilter
 }
 
-const props = withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<Props>(), {
   loading: false,
   selectedId: null,
   emptyMessage: undefined,

--- a/autobot-frontend/src/components/operations/OperationsPanel.vue
+++ b/autobot-frontend/src/components/operations/OperationsPanel.vue
@@ -52,7 +52,6 @@
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 import type { Operation, OperationsFilter } from '@/types/operations'
 import OperationsList from './OperationsList.vue'
 import OperationDetail from './OperationDetail.vue'
@@ -65,7 +64,6 @@ interface Props {
   filter?: OperationsFilter
 }
 
-const { t } = useI18n()
 
 const props = withDefaults(defineProps<Props>(), {
   loading: false,

--- a/autobot-frontend/src/components/plugins/CapabilityApprovalDialog.vue
+++ b/autobot-frontend/src/components/plugins/CapabilityApprovalDialog.vue
@@ -117,10 +117,8 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
 import { usePlugins, type CapabilityInfo } from '@/composables/usePlugins'
 
-const { t } = useI18n()
 
 const props = defineProps<{
   pluginName: string

--- a/autobot-frontend/src/components/plugins/CapabilityAuditLog.vue
+++ b/autobot-frontend/src/components/plugins/CapabilityAuditLog.vue
@@ -105,10 +105,8 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import { useI18n } from 'vue-i18n'
 import { usePlugins, type AuditLogEntry } from '@/composables/usePlugins'
 
-const { t } = useI18n()
 const { getAuditLog } = usePlugins()
 
 const loading = ref(false)

--- a/autobot-frontend/src/components/research/CaptchaNotification.vue
+++ b/autobot-frontend/src/components/research/CaptchaNotification.vue
@@ -75,10 +75,8 @@
 
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
-import { useI18n } from 'vue-i18n'
 import { useCaptchaStatus } from '@/composables/research/useCaptchaStatus'
 
-const { t } = useI18n()
 
 const {
   activeCaptcha,

--- a/autobot-frontend/src/components/secrets/SecretAuditLog.vue
+++ b/autobot-frontend/src/components/secrets/SecretAuditLog.vue
@@ -10,7 +10,7 @@
 
 import { ref, computed, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useSecretsAuditApi, type AuditLogEntry } from '@/composables/useSecretsAuditApi'
+import { useSecretsAuditApi } from '@/composables/useSecretsAuditApi'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('SecretAuditLog')

--- a/autobot-frontend/src/components/secrets/ShareSecretDialog.vue
+++ b/autobot-frontend/src/components/secrets/ShareSecretDialog.vue
@@ -8,7 +8,6 @@
  */
 
 import { ref, computed, toRef, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
 import { useSessionCollaboration } from '@/composables/useSessionCollaboration'
 import { useBatchSelection } from '@/composables/useBatchSelection'
 import { useFocusTrap } from '@/composables/useFocusTrap'
@@ -16,7 +15,6 @@ import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
 import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
 
-const { t } = useI18n()
 const { sessionPresence, shareSecretWithSession } = useSessionCollaboration()
 
 // Props

--- a/autobot-frontend/src/components/settings/SettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/SettingsPanel.vue
@@ -92,7 +92,6 @@ import {
 } from '@/types/settings'
 import type {
   SettingsStructure,
-  SettingsTab,
   ChatSettings as ChatSettingsType,
   UISettings as UISettingsType,
   LoggingSettings as LoggingSettingsType,
@@ -119,20 +118,6 @@ const isClearing = ref<boolean>(false)
 const healthStatus = ref<HealthStatus | null>(null)
 const cacheApiAvailable = ref<boolean>(false)
 
-const tabs = ref<SettingsTab[]>([
-  { id: 'user', label: 'User Management' },
-  { id: 'chat', label: 'Chat' },
-  { id: 'backend', label: 'Backend' },
-  { id: 'optimization', label: 'LLM Optimization' },
-  { id: 'ui', label: 'UI' },
-  { id: 'logging', label: 'Logging' },
-  { id: 'log-forwarding', label: 'Log Forwarding' },
-  { id: 'cache', label: 'Cache' },
-  { id: 'prompts', label: 'Prompts' },
-  { id: 'infrastructure', label: 'Infrastructure' },
-  { id: 'developer', label: 'Developer' },
-  { id: 'feature-flags', label: 'Feature Flags' }
-])
 const activeBackendSubTab = ref('agents')
 
 // Cache state

--- a/autobot-frontend/src/components/settings/VoiceSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/VoiceSettingsPanel.vue
@@ -156,7 +156,6 @@ const { t } = useI18n()
 const {
   voices,
   selectedVoiceId,
-  effectiveVoiceId,
   personalityVoiceId,
   personalityVoiceIds,
   loading,

--- a/autobot-frontend/src/components/transcriber/AiAnalysisPanel.vue
+++ b/autobot-frontend/src/components/transcriber/AiAnalysisPanel.vue
@@ -8,7 +8,7 @@ const props = defineProps<{ recordingId: number; open: boolean }>()
 const emit = defineEmits<{ (e: 'close'): void }>()
 
 const customQuestion = ref('')
-const { streaming, content, activeAction, ask } = useAiAnalysis(props.recordingId)
+const { streaming, content, ask } = useAiAnalysis(props.recordingId)
 
 function handleAsk(action: AiAnalysisAction) {
   ask({ action, customQuestion: action === 'custom' ? customQuestion.value : undefined })

--- a/autobot-frontend/src/components/ui/ThemeToggle.vue
+++ b/autobot-frontend/src/components/ui/ThemeToggle.vue
@@ -92,7 +92,7 @@ interface Props {
   showLabel?: boolean
 }
 
-const props = withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<Props>(), {
   mode: 'dropdown',
   compact: false,
   showLabel: true

--- a/autobot-frontend/src/components/ui/TouchFriendlyButton.vue
+++ b/autobot-frontend/src/components/ui/TouchFriendlyButton.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, nextTick } from 'vue'
+import { computed, ref } from 'vue'
 import LoadingSpinner from './LoadingSpinner.vue'
 import type { ComponentSize } from '@/types/component-props'
 

--- a/autobot-frontend/src/components/vision/GUIAutomationControls.vue
+++ b/autobot-frontend/src/components/vision/GUIAutomationControls.vue
@@ -186,7 +186,7 @@ const logger = createLogger('GUIAutomationControls');
 const { showToast } = useNotificationBus();
 
 // Props
-const props = defineProps<{
+defineProps<{
   opportunities: AutomationOpportunity[];
   loading: boolean;
 }>();


### PR DESCRIPTION
## Thinking Path
Toward green `frontend-tests` — 30 single-warning files (Set A of the final 59, run in parallel with Set B).

## What Changed
- **any→typed** (2): FileUpload.spec (`App`), KnowledgeContentViewer (`Record<string,unknown>`).
- **unused imports/bindings removed** (~25): `computed`/`ref`/`nextTick`/`ApiClient` imports; unused `{ t }`/`useI18n` (templates use `$t`) ×8; dead `createLogger` loggers; unused `const props` bindings (macros kept); composable-destructure drops.
- **dead code removed** (confirmed orphaned): `progressText`/`isRunning` computeds, `SettingsPanel` `tabs` ref (router-view-driven now).

## Verification (independently re-run)
- `eslint` 30 files → **0 warnings, 0 errors**.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (whole project).
- `vitest FileUpload.spec` → 9/9. No emit/prop types tightened → no consumers affected.
- No eslint-disable/@ts-ignore; no runtime coercions.

## Model Used
Opus 4.8

Contributes to #9924 green frontend-tests (final stretch).