### PR TITLE
fix(frontend): resolve any/unused-vars in composables/views/types/main (#9924)

### DIFF
--- a/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
@@ -265,12 +265,9 @@
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { createLogger } from '@/utils/debugUtils'
 import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n()
-
-const logger = createLogger('WorkflowVisualization')
 
 // Types
 interface WorkflowNode {

--- a/autobot-frontend/src/composables/__tests__/useFormValidation.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useFormValidation.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, it, expect, vi } from 'vitest'
 import { useFormValidation, quickValidate } from '../useFormValidation'
+import type { ValidationRule } from '../useFormValidation'
 
 describe('useFormValidation composable', () => {
   // ========================================
@@ -938,7 +939,7 @@ describe('useFormValidation composable', () => {
       const { validateField } = useFormValidation({
         username: {
           value: 'test',
-          rules: [{ rule: 'unknown' as any }]
+          rules: [{ rule: 'unknown' as unknown as ValidationRule }]
         }
       })
 

--- a/autobot-frontend/src/composables/__tests__/useTimeout.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useTimeout.test.ts
@@ -327,7 +327,7 @@ describe('useTimeout Composable', () => {
 
     it('should preserve function context', async () => {
       // vi.fn records invocation contexts — no manual `this` capture needed
-      const callback = vi.fn(function (this: any) {})
+      const callback = vi.fn(function (this: unknown) {})
 
       const context = { value: 'test-context' }
       const TestComponent = defineComponent({

--- a/autobot-frontend/src/composables/analytics/useAnalyticsDebug.ts
+++ b/autobot-frontend/src/composables/analytics/useAnalyticsDebug.ts
@@ -114,7 +114,7 @@ export function useAnalyticsDebug(deps: UseAnalyticsDebugDeps) {
       const results: string[] = []
       for (const ep of _testEndpointConfigs) {
         try {
-          await apiClient.get<any>(ep.path)
+          await apiClient.get<unknown>(ep.path)
           results.push(`${ep.name}: OK`)
         } catch (err) {
           const msg =

--- a/autobot-frontend/src/composables/file-browser/useFileBrowser.ts
+++ b/autobot-frontend/src/composables/file-browser/useFileBrowser.ts
@@ -120,7 +120,7 @@ export function useFileBrowser() {
   // ---- DELETE /files/delete ----
   const { execute: deleteFileOrFolder, loading: isDeletingFile } = useAsyncHandler(
     async (path: string) => {
-      await apiClient.delete<any>(`${getApiBase()}/files/delete?path=${encodeURIComponent(path)}`)
+      await apiClient.delete<unknown>(`${getApiBase()}/files/delete?path=${encodeURIComponent(path)}`)
     },
     {
       logErrors: true,

--- a/autobot-frontend/src/composables/knowledge/useConnectorJob.ts
+++ b/autobot-frontend/src/composables/knowledge/useConnectorJob.ts
@@ -24,8 +24,9 @@ export async function fetchConnectorJob(connectorId: string): Promise<ConnectorJ
     return await apiClient.get<ConnectorJobState>(
       `${getApiBase()}/knowledge_base/connectors/${connectorId}/job`
     )
-  } catch (err: any) {
-    if (err?.status === 404 || err?.response?.status === 404) {
+  } catch (err) {
+    const e = err as { status?: number; response?: { status?: number } }
+    if (e?.status === 404 || e?.response?.status === 404) {
       return null
     }
     logger.error('fetchConnectorJob error', err)

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeStats.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeStats.ts
@@ -53,11 +53,12 @@ export const fetchBasicStats = async (): Promise<KnowledgeStats | null> => {
  */
 export const fetchCategoryFacts = async (): Promise<Record<string, number> | null> => {
   try {
-    const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/facts/by_category`)
-    if (!data?.categories) return null
+    const data = await apiClient.get<{ categories?: Record<string, unknown[]> }>(`${getApiBase()}/knowledge_base/facts/by_category`)
+    const categories = data?.categories
+    if (!categories) return null
     const counts: Record<string, number> = {}
-    Object.keys(data.categories).forEach((category: string) => {
-      counts[category] = data.categories[category].length
+    Object.keys(categories).forEach((category: string) => {
+      counts[category] = categories[category].length
     })
     return counts
   } catch {

--- a/autobot-frontend/src/composables/security/useSecretsAuditApi.ts
+++ b/autobot-frontend/src/composables/security/useSecretsAuditApi.ts
@@ -53,7 +53,7 @@ export function useSecretsAuditApi() {
   /** Delete a legacy infrastructure host by id. */
   async function deleteInfraHost(id: string): Promise<void> {
     const backendUrl = getBackendUrl();
-    await apiClient.delete<any>(`${backendUrl}/api/infrastructure/hosts/${id}`);
+    await apiClient.delete<unknown>(`${backendUrl}/api/infrastructure/hosts/${id}`);
   }
 
   return { fetchInfraHosts, fetchSecretsUsage, deleteInfraHost };

--- a/autobot-frontend/src/composables/useAIDocument.ts
+++ b/autobot-frontend/src/composables/useAIDocument.ts
@@ -170,7 +170,7 @@ export function useAIDocument() {
   async function deleteDocument(docId: string): Promise<void> {
     error.value = null
     try {
-      await apiClient.delete<any>(`${_base()}/${docId}`)
+      await apiClient.delete<unknown>(`${_base()}/${docId}`)
       documents.value = documents.value.filter((d) => d.id !== docId)
       total.value = Math.max(0, total.value - 1)
       if (currentDocument.value?.id === docId) {

--- a/autobot-frontend/src/composables/useAvailableModels.ts
+++ b/autobot-frontend/src/composables/useAvailableModels.ts
@@ -58,7 +58,7 @@ export function useAvailableModels() {
     error.value = null
     return wrap(async () => {
       try {
-        const data: AvailableModelsResult = await ApiClient.get<any>(
+        const data = await ApiClient.get<AvailableModelsResult>(
           `${getApiBase()}/models/available`,
         )
         models.value = data.models ?? []

--- a/autobot-frontend/src/composables/useBackgroundTask.ts
+++ b/autobot-frontend/src/composables/useBackgroundTask.ts
@@ -56,7 +56,7 @@ async function getBackendUrl(): Promise<string> {
 async function clearStuckTasks(clearUrl: string, signal?: AbortSignal): Promise<void> {
   // Note: apiClient.post does not support AbortSignal; signal parameter kept for API compatibility.
   void signal
-  await apiClient.post<any>(`${clearUrl}?force=true`)
+  await apiClient.post<unknown>(`${clearUrl}?force=true`)
 }
 
 /**

--- a/autobot-frontend/src/composables/useCodeIntelligence.ts
+++ b/autobot-frontend/src/composables/useCodeIntelligence.ts
@@ -321,7 +321,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
   async function deleteAnalysis(analysisId: string): Promise<boolean> {
     startLoading()
     try {
-      await ApiClient.delete<any>(`${getApiBase()}/code-intelligence/analysis/${analysisId}`)
+      await ApiClient.delete<unknown>(`${getApiBase()}/code-intelligence/analysis/${analysisId}`)
       analysisHistory.value = analysisHistory.value.filter(a => a.id !== analysisId)
       logger.debug('Deleted analysis:', analysisId)
       return true

--- a/autobot-frontend/src/composables/useCommandApproval.ts
+++ b/autobot-frontend/src/composables/useCommandApproval.ts
@@ -410,10 +410,10 @@ export function useCommandApproval() {
     chatId: string | null | undefined,
     message: string
   ): Promise<unknown> => {
-    const response = await apiClient.post<any>(`${getApiBase()}/chat/direct`, {
+    const response = await apiClient.post<{ data?: unknown }>(`${getApiBase()}/chat/direct`, {
       message,
       chat_id: chatId
-    }) as { data?: unknown }
+    })
     return response
   }
 

--- a/autobot-frontend/src/composables/useNotificationConfig.ts
+++ b/autobot-frontend/src/composables/useNotificationConfig.ts
@@ -82,7 +82,7 @@ export function useNotificationConfig() {
     return wrapSaving(async () => {
       try {
         const url = `${getApiBase()}/workflow-automation/notification_config/${workflowId}`;
-        await apiClient.put<any>(url, config.value);
+        await apiClient.put<unknown>(url, config.value);
         logger.info('Saved notification config for workflow', workflowId);
         return true;
       } catch (err) {

--- a/autobot-frontend/src/composables/useProbeBackedHealth.ts
+++ b/autobot-frontend/src/composables/useProbeBackedHealth.ts
@@ -85,7 +85,7 @@ export function useProbeBackedHealth<R>(
 
   return async (): Promise<R> => {
     try {
-      const payload = await api.get<any>(`${getApiBase()}/system/health`)
+      const payload = await api.get<{ probes?: ProbeResponse[] }>(`${getApiBase()}/system/health`)
       const probe = await findProbeByName<ProbeResponse>(payload?.probes, options.probeName)
       if (!probe) {
         return options.buildUnavailable(`${options.probeName} probe not registered`)

--- a/autobot-frontend/src/composables/useToolApproval.ts
+++ b/autobot-frontend/src/composables/useToolApproval.ts
@@ -95,7 +95,7 @@ export function useToolApproval(): UseToolApprovalReturn {
     }
     submittingApproval.value = true
     try {
-      await apiClient.post<any>(
+      await apiClient.post<unknown>(
         `${getApiBase()}/agent-terminal/tools/approve/${encodeURIComponent(approval.approval_id)}`,
         { approved, comment: comment ?? null, task_id: approval.task_id ?? null }
       )

--- a/autobot-frontend/src/composables/useWorkflowNotificationConfig.ts
+++ b/autobot-frontend/src/composables/useWorkflowNotificationConfig.ts
@@ -110,7 +110,7 @@ export function useWorkflowNotificationConfig() {
     saving.value = true;
     configError.value = null;
     try {
-      await apiClient.put<any>(
+      await apiClient.put<unknown>(
         `${getApiBase()}/workflow-automation/notification_config/${workflowId}`,
         payload,
         { timeout: 30_000 },

--- a/autobot-frontend/src/main.ts
+++ b/autobot-frontend/src/main.ts
@@ -157,7 +157,7 @@ if ('serviceWorker' in navigator && !_swHostIsIp) {
 
       logger.debug('Service Worker registered successfully', {
         scope: registration.scope,
-        updateViaCache: (registration as any).updateViaCache
+        updateViaCache: registration.updateViaCache
       })
 
       // Check for updates periodically

--- a/autobot-frontend/src/plugins/errorHandler.ts
+++ b/autobot-frontend/src/plugins/errorHandler.ts
@@ -223,15 +223,16 @@ class GlobalErrorHandler {
     }
   }
 
-  private getUnhandledRejectionMessage(reason: any): string {
-    if (reason?.message) {
-      if (reason.message.includes('Failed to fetch')) {
+  private getUnhandledRejectionMessage(reason: unknown): string {
+    const message = (reason as { message?: unknown })?.message
+    if (typeof message === 'string') {
+      if (message.includes('Failed to fetch')) {
         return 'Connection failed. Please check your internet connection and try again.'
       }
-      if (reason.message.includes('NetworkError')) {
+      if (message.includes('NetworkError')) {
         return 'Network error occurred. Please try again.'
       }
-      if (reason.message.includes('ChunkLoadError')) {
+      if (message.includes('ChunkLoadError')) {
         return 'Application update detected. Please reload the page.'
       }
     }

--- a/autobot-frontend/src/stores/__tests__/useChatStore.test.ts
+++ b/autobot-frontend/src/stores/__tests__/useChatStore.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useChatStore } from '../useChatStore'
+import type { ChatSession } from '../useChatStore'
 
 describe('useChatStore', () => {
   beforeEach(() => {
@@ -179,7 +180,7 @@ describe('useChatStore', () => {
       store.createNewSession('Local Session 2')
 
       // Sync with backend returning empty (explicit logout)
-      const backendSessions: any[] = []
+      const backendSessions: ChatSession[] = []
 
       store.syncSessionsWithBackend(backendSessions, true)
 

--- a/autobot-frontend/src/test/templates/e2e-test.template.ts
+++ b/autobot-frontend/src/test/templates/e2e-test.template.ts
@@ -95,7 +95,7 @@ test.describe('Feature Name E2E Tests', () => {
     await page.click('[data-testid="feature-nav-button"]')
 
     // Monitor WebSocket connections
-    const wsMessages: any[] = []
+    const wsMessages: unknown[] = []
     page.on('websocket', ws => {
       ws.on('framereceived', event => {
         try {

--- a/autobot-frontend/src/types/knowledgeBase.ts
+++ b/autobot-frontend/src/types/knowledgeBase.ts
@@ -309,6 +309,42 @@ export type ConnectorType =
   | 'forgejo'
 
 /**
+ * Connector-specific settings bag. Each connector type populates a subset of
+ * these optional fields (see ConnectorConfigModal build/apply logic). Kept as a
+ * single flat interface because the backend stores them in one `config` object.
+ */
+export interface ConnectorSettings {
+  // file_server
+  base_path?: string
+  max_file_size_mb?: number
+  // web_crawler
+  urls?: string[]
+  max_depth?: number
+  // database
+  connection_string?: string
+  query?: string
+  id_column?: string
+  content_columns?: string[]
+  timestamp_column?: string
+  // gdrive / onedrive
+  source_type?: string
+  drive_id?: string
+  folder_id?: string
+  folder_path?: string
+  site_id?: string
+  sync_subfolders?: boolean
+  // gitlab / gitea / forgejo
+  gitlab_url?: string
+  gitea_url?: string
+  token?: string
+  project_ids?: string[]
+  repos?: string[]
+  sync_issues?: boolean
+  sync_merge_requests?: boolean
+  sync_files?: boolean
+}
+
+/**
  * Connector configuration as stored by the backend.
  * Each connector defines how to ingest data from an external source.
  */
@@ -316,7 +352,7 @@ export interface ConnectorConfig {
   connector_id: string
   connector_type: ConnectorType
   name: string
-  config: Record<string, any>
+  config: ConnectorSettings
   schedule_cron: string | null
   verification_mode: 'autonomous' | 'collaborative'
   enabled: boolean

--- a/autobot-frontend/src/types/system.ts
+++ b/autobot-frontend/src/types/system.ts
@@ -31,5 +31,5 @@ export interface ServiceHealth {
   consecutiveFailures?: number;
   error?: string;
   timestamp?: number;
-  details?: Record<string, any>;
+  details?: Record<string, unknown>;
 }

--- a/autobot-frontend/src/views/AboutView.vue
+++ b/autobot-frontend/src/views/AboutView.vue
@@ -53,9 +53,6 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n'
-
-const { t } = useI18n()
 
 // Read version from Vite's env injection (set in vite.config.ts via define)
 // Falls back to '—' if not injected

--- a/autobot-frontend/src/views/EvolutionView.vue
+++ b/autobot-frontend/src/views/EvolutionView.vue
@@ -356,7 +356,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { useEvolution } from '@/composables/useEvolution'
+import { useEvolution, type EvolutionAnalysisRequest } from '@/composables/useEvolution'
 import EvolutionTimelineChart from '@/components/charts/EvolutionTimelineChart.vue'
 import PatternEvolutionChart from '@/components/charts/PatternEvolutionChart.vue'
 import CodeEvolutionTimeline from '@/components/analytics/CodeEvolutionTimeline.vue'
@@ -415,7 +415,7 @@ async function applyFilters() {
 }
 
 async function runAnalysis() {
-  const request: any = {
+  const request: EvolutionAnalysisRequest = {
     repo_path: analysisForm.value.repo_path,
     commit_limit: analysisForm.value.commit_limit,
   }

--- a/autobot-frontend/src/views/NotFoundView.vue
+++ b/autobot-frontend/src/views/NotFoundView.vue
@@ -55,10 +55,7 @@
 <script setup lang="ts">
 // View-level component for 404 error page
 // Issue #753: Design token usage instead of Tailwind utilities
-import { useI18n } from 'vue-i18n'
 import Icon from '@/components/ui/Icon.vue'
-
-const { t } = useI18n()
 </script>
 
 <style scoped>

--- a/autobot-frontend/src/views/SlmNoVncView.vue
+++ b/autobot-frontend/src/views/SlmNoVncView.vue
@@ -27,14 +27,12 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
-import { useI18n } from 'vue-i18n'
 import type { SelectorHost } from '@/composables/useHostSelector'
 import HostSelector from '@/components/ui/HostSelector.vue'
 import DesktopInterface from '@/components/desktop/DesktopInterface.vue'
 import Icon from '@/components/ui/Icon.vue'
 
 const logger = createLogger('SlmNoVncView')
-const { t } = useI18n()
 
 const selectedHost = ref<SelectorHost | null>(null)
 

--- a/autobot-frontend/src/views/WorkflowBuilderView.vue
+++ b/autobot-frontend/src/views/WorkflowBuilderView.vue
@@ -695,7 +695,6 @@ import {
   useWorkflowBuilder,
   type WorkflowNode,
   type WorkflowTemplate,
-  type ExecutionStrategy,
 } from '@/composables/useWorkflowBuilder';
 import type { WorkflowTemplateSummary } from '@/types/workflowTemplates';
 import { useWorkflowTemplates } from '@/composables/useWorkflowTemplates';

--- a/autobot-frontend/src/views/llc/CompanyCreationWizard.vue
+++ b/autobot-frontend/src/views/llc/CompanyCreationWizard.vue
@@ -458,9 +458,10 @@ async function createCompany() {
     // boards, sprints, etc. with the sidebar) rather than the sidebar-less
     // standalone /llc/dashboard, which left all PM features unreachable.
     await router.push(`/llc/companies/${createdCompany.id}`)
-  } catch (err: any) {
+  } catch (err) {
     logger.error('Failed to create company', err)
-    error.value = err?.response?.data?.detail || err?.message || t('llc.wizard.createFailed')
+    const e = err as { response?: { data?: { detail?: string } }; message?: string }
+    error.value = e?.response?.data?.detail || e?.message || t('llc.wizard.createFailed')
   } finally {
     loading.value = false
   }


### PR DESCRIPTION
## Thinking Path
Final Set B of the frontend warning grind — 29 single-warning files (composables/views/types/main.ts).

## What Changed
- **any→typed**: reused response types (`AvailableModelsResult`, `EvolutionAnalysisRequest`, `ChatSession[]`, `ValidationRule`); `apiClient.*<any>`→`<unknown>` for discarded responses; new `ConnectorSettings` interface in `types/knowledgeBase.ts` (consumer ConnectorConfigModal verified, zero casts).
- **main.ts**: dropped unnecessary `(registration as any)` — `updateViaCache` is standard on `ServiceWorkerRegistration`.
- **unused removed**: dead loggers, `{ t }`/`useI18n` (templates use `$t`), orphaned type imports.

## Reviewer notes
- `useKnowledgeStats`/`useConnectorJob`: `if` guards are pre-existing (only typed-alias renames).
- `errorHandler.ts`: `if (reason?.message)` → `if (typeof message === 'string')` (needed since `message` is now `unknown`) — minor robustness gain (non-string message no longer risks a `.includes()` throw), edge-case-only.

## Verification (independently re-run)
- `eslint` 29 files → **0 warnings, 0 errors**.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (whole project, incl. ConnectorSettings consumer).
- `vitest` (useFormValidation/useTimeout/useChatStore) → 134/134.
- No eslint-disable/@ts-ignore.

## Model Used
Opus 4.8

Completes the #9924 no-explicit-any + no-unused-vars sweep.