### PR TITLE
Content Reach Task 8: /admin/system-health doctor panel for CONTENT_REACH probe (#10932)

### DIFF
--- a/.superpowers/sdd/task-8-report.md
+++ b/.superpowers/sdd/task-8-report.md
@@ -1,0 +1,65 @@
+# Task 8 Report — Frontend System Health Panel (#10932)
+
+## Status: DONE
+
+**Commit:** `2e4379e65` — `feat(content-reach): frontend System Health panel for CONTENT_REACH probe (#10932)`
+
+## Gate Results
+
+| Gate | Result |
+|---|---|
+| `npm run type-check` | PASS — 0 errors |
+| `npm run lint:oxlint` | PASS — 0 warnings/errors |
+| `npm run lint:eslint` | PASS — 0 warnings/errors (auto-fixed 2 pre-existing missing i18n keys in chat.citations.*) |
+| `npm run test:unit -- SystemHealthView` | PASS — 2/2 tests green |
+| `npm run check:i18n` | PASS — All translation keys found in en.json |
+
+## Files Changed
+
+- `autobot-frontend/src/types/probe-names.ts` — Added `CONTENT_REACH: 'content_reach'`
+- `autobot-frontend/src/views/SystemHealthView.vue` — New admin view (script-setup, fully typed, no `any`)
+- `autobot-frontend/src/views/__tests__/SystemHealthView.spec.ts` — New spec: 2 tests (sources/live/dead + unavailable path)
+- `autobot-frontend/src/router/index.ts` — Route `/admin/system-health` (name `admin-system-health`, meta: requiresAuth, admin, hideInNav)
+- `autobot-frontend/src/config/navItems.ts` — `{ to: '/admin/system-health', labelKey: 'nav.systemHealth', iconStroke: true }` added to adminMenuItems
+- `autobot-frontend/src/i18n/locales/en.json` — Added `nav.systemHealth` + `admin.systemHealth` block (14 keys)
+- `autobot-frontend/src/i18n/locales/{ar,de,es,fa,fr,he,lv,pl,pt,ur}.json` — Same keys added to all 11 locales
+
+---
+
+## Review Fixes — Commit `d05a779ec`
+
+**Commit:** `d05a779ec` — `fix(content-reach): render degraded/down probe status in System Health panel + runtime-narrow probe data (#10932)`
+
+### Fix 1 — Fidelity: degraded/down probes now reach buildHealthy
+- Added `renderNonOkFromProbe?: boolean` (default: undefined/false) to `ProbeBackedHealthOptions<R>`.
+- When true: `buildHealthy` is called for any found probe regardless of status; `buildUnavailable` reserved for missing probe or fetch error.
+- When false/absent: exact pre-existing behavior (`ok`→buildHealthy, else buildUnavailable). All other consumers unaffected.
+- `SystemHealthView.vue` passes `renderNonOkFromProbe: true` so degraded/down status + sources/live render correctly.
+
+### Fix 2 — Type safety: runtime-narrowing for data.sources / data.live
+- Added `toSourceMap(v: unknown): Record<string, string[]>` helper in `SystemHealthView.vue`.
+- Replaces `data.sources as Record<string,string[]>` / `data.live as ...` unchecked casts. No `any`.
+
+### Fix 3 — Tests
+- `useProbeBackedHealth.test.ts`: 3 new tests under `renderNonOkFromProbe option` describe block — degraded→buildHealthy (flag true), missing probe→buildUnavailable (flag true), degraded→buildUnavailable (flag absent/legacy).
+- `SystemHealthView.spec.ts`: 2 new tests — Degraded badge, Down badge with real status strings.
+- Total: 13 tests green (9 composable + 4 view).
+
+### Gate Results (review fixes)
+
+| Gate | Result |
+|---|---|
+| `npm run type-check` | PASS — 0 errors |
+| `npm run lint:oxlint` | PASS — 0 |
+| `npm run lint:eslint` | PASS — 0 |
+| `npm run test:unit -- useProbeBackedHealth SystemHealthView` | PASS — 13/13 green |
+| `npm run check:i18n` | PASS — All keys found |
+| Pre-existing consumer failures (baseline) | 2 pre-existing failures unrelated to these changes (RedisServiceControl.spec.js, useModal.test.ts) — confirmed present before changes via git stash baseline run |
+
+---
+
+## Concerns / Notes
+
+- Pre-existing `chat.citations.modelOnly` and `chat.citations.modelOnlyTooltip` keys were missing from en.json and were fixed as a side effect (Rule 6: fix pre-existing issues discovered along the way).
+- The view uses Tailwind utility classes matching the existing SystemHealthView.vue template style (already present in the file when the worktree was created).
+- Backend Tasks 1–7 are already live; this is a read-only UI surface only.

--- a/autobot-frontend/src/composables/__tests__/useProbeBackedHealth.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useProbeBackedHealth.test.ts
@@ -191,3 +191,82 @@ describe('useProbeBackedHealth', () => {
     expect(result?.status).toBe('unavailable')
   })
 })
+
+describe('useProbeBackedHealth — renderNonOkFromProbe option', () => {
+  it('calls buildHealthy (not buildUnavailable) for a degraded probe when renderNonOkFromProbe is true', async () => {
+    apiGetSpy.mockResolvedValue({
+      probes: [
+        {
+          name: 'batch_jobs',
+          status: 'degraded',
+          data: { redis_connected: false },
+          detail: 'redis is slow',
+        },
+      ],
+    })
+
+    const buildHealthySpy = vi.fn(buildHealthy)
+    const buildUnavailableSpy = vi.fn(buildUnavailable)
+
+    const getHealth = useProbeBackedHealth<TestHealthResponse>({
+      probeName: 'batch_jobs',
+      buildHealthy: buildHealthySpy,
+      buildUnavailable: buildUnavailableSpy,
+      renderNonOkFromProbe: true,
+    })
+
+    const result = await getHealth()
+    expect(buildHealthySpy).toHaveBeenCalledOnce()
+    expect(buildUnavailableSpy).not.toHaveBeenCalled()
+    expect(result?.status).toBe('healthy')
+    expect(result?.message).toBe('redis is slow')
+  })
+
+  it('still calls buildUnavailable for a missing probe even when renderNonOkFromProbe is true', async () => {
+    apiGetSpy.mockResolvedValue({ probes: [] })
+
+    const buildHealthySpy = vi.fn(buildHealthy)
+    const buildUnavailableSpy = vi.fn(buildUnavailable)
+
+    const getHealth = useProbeBackedHealth<TestHealthResponse>({
+      probeName: 'batch_jobs',
+      buildHealthy: buildHealthySpy,
+      buildUnavailable: buildUnavailableSpy,
+      renderNonOkFromProbe: true,
+    })
+
+    const result = await getHealth()
+    expect(buildUnavailableSpy).toHaveBeenCalledOnce()
+    expect(buildHealthySpy).not.toHaveBeenCalled()
+    expect(result?.status).toBe('unavailable')
+    expect(result?.message).toBe('batch_jobs probe not registered')
+  })
+
+  it('default behavior (renderNonOkFromProbe absent) still routes degraded → buildUnavailable', async () => {
+    apiGetSpy.mockResolvedValue({
+      probes: [
+        {
+          name: 'batch_jobs',
+          status: 'degraded',
+          detail: 'degraded detail',
+        },
+      ],
+    })
+
+    const buildHealthySpy = vi.fn(buildHealthy)
+    const buildUnavailableSpy = vi.fn(buildUnavailable)
+
+    const getHealth = useProbeBackedHealth<TestHealthResponse>({
+      probeName: 'batch_jobs',
+      buildHealthy: buildHealthySpy,
+      buildUnavailable: buildUnavailableSpy,
+      // renderNonOkFromProbe not set → legacy behavior
+    })
+
+    const result = await getHealth()
+    expect(buildUnavailableSpy).toHaveBeenCalledOnce()
+    expect(buildHealthySpy).not.toHaveBeenCalled()
+    expect(result?.status).toBe('unavailable')
+    expect(result?.message).toBe('degraded detail')
+  })
+})

--- a/autobot-frontend/src/composables/useProbeBackedHealth.ts
+++ b/autobot-frontend/src/composables/useProbeBackedHealth.ts
@@ -67,6 +67,16 @@ export interface ProbeBackedHealthOptions<R> {
 
   /** Error toast message when the underlying fetch fails. */
   errorMessage?: string
+
+  /**
+   * When true, calls `buildHealthy` for ANY status where the probe was FOUND
+   * (ok/degraded/down/etc.), reserving `buildUnavailable` only for a missing
+   * probe or fetch error. Defaults to false (legacy behavior: only `ok` calls
+   * `buildHealthy`).
+   *
+   * Opt-in only — existing callers are unaffected.
+   */
+  renderNonOkFromProbe?: boolean
 }
 
 /**
@@ -91,7 +101,7 @@ export function useProbeBackedHealth<R>(
         return options.buildUnavailable(`${options.probeName} probe not registered`)
       }
       const data = probe.data ?? {}
-      if (probe.status === 'ok') {
+      if (probe.status === 'ok' || options.renderNonOkFromProbe) {
         return options.buildHealthy(probe, data)
       }
       return options.buildUnavailable(probe.detail ?? 'Service unavailable')

--- a/autobot-frontend/src/config/navItems.ts
+++ b/autobot-frontend/src/config/navItems.ts
@@ -114,4 +114,6 @@ export const adminMenuItems: NavItem[] = [
   // Issue #7513: Host inventory management
   // GH#6470: Budget policy management
   { to: '/admin/budget-policies', labelKey: 'nav.budgetPolicies', icon: 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z', iconStroke: true },
+  // Issue #10932: System Health panel — CONTENT_REACH probe
+  { to: '/admin/system-health', labelKey: 'nav.systemHealth', icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z', iconStroke: true },
 ];

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -400,7 +400,9 @@
       "reliabilityLow": "Low",
       "aiTrainingData": "AI Training Data",
       "webSource": "Web Source",
-      "knowledgeBase": "قاعدة المعرفة"
+      "knowledgeBase": "قاعدة المعرفة",
+      "modelOnly": "النموذج فقط",
+      "modelOnlyTooltip": "هذا الادعاء يستند فقط إلى بيانات تدريب النموذج — لم يتم استرداد أي مصادر"
     },
     "tabContent": {
       "openInNewWindow": "Open in new window",
@@ -7614,7 +7616,8 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
+    "systemHealth": "صحة النظام"
   },
   "llcMembers": {
     "title": "الأعضاء",
@@ -8383,5 +8386,23 @@
     "target": "Target {date}",
     "backlogLink": "Backlog",
     "timelineLink": "Timeline"
+  },
+  "admin": {
+    "systemHealth": {
+      "title": "صحة النظام",
+      "subtitle": "إمكانية الوصول المباشر للواجهات الخلفية لمصادر المحتوى",
+      "status": "الحالة",
+      "sources": "المصادر",
+      "live": "مباشر",
+      "backends": "الواجهات الخلفية",
+      "healthy": "سليم",
+      "degraded": "متدهور",
+      "down": "معطل",
+      "unavailable": "غير متاح",
+      "loading": "جاري تحميل بيانات الصحة...",
+      "error": "فشل تحميل صحة النظام",
+      "refresh": "تحديث",
+      "noSources": "لا توجد مصادر محتوى مهيأة"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -400,7 +400,9 @@
       "reliabilityLow": "Niedrig",
       "aiTrainingData": "KI-Trainingsdaten",
       "webSource": "Webquelle",
-      "knowledgeBase": "Wissensdatenbank"
+      "knowledgeBase": "Wissensdatenbank",
+      "modelOnly": "Nur Modell",
+      "modelOnlyTooltip": "Diese Aussage basiert nur auf Modell-Trainingsdaten — es wurden keine Quellen abgerufen"
     },
     "tabContent": {
       "openInNewWindow": "In neuem Fenster öffnen",
@@ -7614,7 +7616,8 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
+    "systemHealth": "Systemzustand"
   },
   "llcMembers": {
     "title": "Mitglieder",
@@ -8383,5 +8386,23 @@
     "target": "Ziel {date}",
     "backlogLink": "Backlog",
     "timelineLink": "Zeitachse"
+  },
+  "admin": {
+    "systemHealth": {
+      "title": "Systemzustand",
+      "subtitle": "Live-Backend-Erreichbarkeit für Inhaltsquellen",
+      "status": "Status",
+      "sources": "Quellen",
+      "live": "Live",
+      "backends": "Backends",
+      "healthy": "Gesund",
+      "degraded": "Eingeschränkt",
+      "down": "Ausgefallen",
+      "unavailable": "Nicht verfügbar",
+      "loading": "Gesundheitsdaten werden geladen...",
+      "error": "Systemzustand konnte nicht geladen werden",
+      "refresh": "Aktualisieren",
+      "noSources": "Keine Inhaltsquellen konfiguriert"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -451,7 +451,9 @@
       "reliabilityLow": "Low",
       "aiTrainingData": "AI Training Data",
       "webSource": "Web Source",
-      "knowledgeBase": "Knowledge Base"
+      "knowledgeBase": "Knowledge Base",
+      "modelOnly": "Model only",
+      "modelOnlyTooltip": "This claim is based on model training data only — no sources were retrieved"
     },
     "tabContent": {
       "openInNewWindow": "Open in new window",
@@ -7626,6 +7628,7 @@
     "adminHosts": "Host Inventory",
     "adminSandbox": "Sandbox",
     "budgetPolicies": "Budget Policies",
+    "systemHealth": "System Health",
     "sharedLinks": "Shared Chat Links",
     "companyOs": "Company OS",
     "llcDashboard": "Dashboard",
@@ -8383,5 +8386,23 @@
     "target": "Target {date}",
     "backlogLink": "Backlog",
     "timelineLink": "Timeline"
+  },
+  "admin": {
+    "systemHealth": {
+      "title": "System Health",
+      "subtitle": "Live backend reachability for content sources",
+      "status": "Status",
+      "sources": "Sources",
+      "live": "Live",
+      "backends": "Backends",
+      "healthy": "Healthy",
+      "degraded": "Degraded",
+      "down": "Down",
+      "unavailable": "Unavailable",
+      "loading": "Loading health data...",
+      "error": "Failed to load system health",
+      "refresh": "Refresh",
+      "noSources": "No content sources configured"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -400,7 +400,9 @@
       "reliabilityLow": "Bajo",
       "aiTrainingData": "Datos de entrenamiento de IA",
       "webSource": "Fuente web",
-      "knowledgeBase": "Base de conocimientos"
+      "knowledgeBase": "Base de conocimientos",
+      "modelOnly": "Solo modelo",
+      "modelOnlyTooltip": "Esta afirmación se basa únicamente en datos de entrenamiento del modelo — no se recuperaron fuentes"
     },
     "tabContent": {
       "openInNewWindow": "Abrir en nueva ventana",
@@ -7614,7 +7616,8 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
+    "systemHealth": "Salud del sistema"
   },
   "llcMembers": {
     "title": "Miembros",
@@ -8383,5 +8386,23 @@
     "target": "Objetivo {date}",
     "backlogLink": "Backlog",
     "timelineLink": "Cronograma"
+  },
+  "admin": {
+    "systemHealth": {
+      "title": "Salud del sistema",
+      "subtitle": "Disponibilidad en vivo de backends para fuentes de contenido",
+      "status": "Estado",
+      "sources": "Fuentes",
+      "live": "En vivo",
+      "backends": "Backends",
+      "healthy": "Saludable",
+      "degraded": "Degradado",
+      "down": "Caído",
+      "unavailable": "No disponible",
+      "loading": "Cargando datos de salud...",
+      "error": "Error al cargar la salud del sistema",
+      "refresh": "Actualizar",
+      "noSources": "No hay fuentes de contenido configuradas"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -189,7 +189,8 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
+    "systemHealth": "سلامت سیستم"
   },
   "llcMembers": {
     "title": "اعضا",
@@ -4954,7 +4955,9 @@
       "reliabilityVerified": "Verified",
       "reliabilityMedium": "Medium",
       "knowledgeBase": "Knowledge Base",
-      "model": "Model:"
+      "model": "Model:",
+      "modelOnly": "فقط مدل",
+      "modelOnlyTooltip": "این ادعا فقط بر اساس داده‌های آموزشی مدل است — هیچ منبعی بازیابی نشد"
     },
     "sidebar": {
       "deletedWithFactsPreserved": "Deleted {count} chats (facts preserved in knowledge base)",
@@ -8383,5 +8386,23 @@
     "target": "Target {date}",
     "backlogLink": "Backlog",
     "timelineLink": "Timeline"
+  },
+  "admin": {
+    "systemHealth": {
+      "title": "سلامت سیستم",
+      "subtitle": "دسترسی زنده به بک‌اندها برای منابع محتوا",
+      "status": "وضعیت",
+      "sources": "منابع",
+      "live": "زنده",
+      "backends": "بک‌اندها",
+      "healthy": "سالم",
+      "degraded": "تخریب‌شده",
+      "down": "خاموش",
+      "unavailable": "در دسترس نیست",
+      "loading": "در حال بارگذاری داده‌های سلامت...",
+      "error": "بارگذاری سلامت سیستم ناموفق بود",
+      "refresh": "بازنشانی",
+      "noSources": "هیچ منبع محتوایی پیکربندی نشده است"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -400,7 +400,9 @@
       "reliabilityLow": "Faible",
       "aiTrainingData": "Données de formation IA",
       "webSource": "Source Web",
-      "knowledgeBase": "Base de connaissances"
+      "knowledgeBase": "Base de connaissances",
+      "modelOnly": "Modèle uniquement",
+      "modelOnlyTooltip": "Cette affirmation est basée uniquement sur les données d'entraînement du modèle — aucune source n'a été récupérée"
     },
     "tabContent": {
       "openInNewWindow": "Ouvrir dans une nouvelle fenêtre",
@@ -7614,7 +7616,8 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
+    "systemHealth": "Santé du système"
   },
   "llcMembers": {
     "title": "Membres",
@@ -8383,5 +8386,23 @@
     "target": "Cible {date}",
     "backlogLink": "Backlog",
     "timelineLink": "Chronologie"
+  },
+  "admin": {
+    "systemHealth": {
+      "title": "Santé du système",
+      "subtitle": "Disponibilité en direct des backends pour les sources de contenu",
+      "status": "Statut",
+      "sources": "Sources",
+      "live": "En direct",
+      "backends": "Backends",
+      "healthy": "Sain",
+      "degraded": "Dégradé",
+      "down": "Hors ligne",
+      "unavailable": "Non disponible",
+      "loading": "Chargement des données de santé...",
+      "error": "Échec du chargement de la santé du système",
+      "refresh": "Actualiser",
+      "noSources": "Aucune source de contenu configurée"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -189,7 +189,8 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
+    "systemHealth": "בריאות המערכת"
   },
   "llcMembers": {
     "title": "חברים",
@@ -4954,7 +4955,9 @@
       "reliabilityVerified": "Verified",
       "reliabilityMedium": "Medium",
       "knowledgeBase": "Knowledge Base",
-      "model": "Model:"
+      "model": "Model:",
+      "modelOnly": "מודל בלבד",
+      "modelOnlyTooltip": "טענה זו מבוססת על נתוני אימון המודל בלבד — לא אוחזרו מקורות"
     },
     "sidebar": {
       "deletedWithFactsPreserved": "Deleted {count} chats (facts preserved in knowledge base)",
@@ -8383,5 +8386,23 @@
     "target": "Target {date}",
     "backlogLink": "Backlog",
     "timelineLink": "Timeline"
+  },
+  "admin": {
+    "systemHealth": {
+      "title": "בריאות המערכת",
+      "subtitle": "נגישות חיה לבק-אנד עבור מקורות תוכן",
+      "status": "סטטוס",
+      "sources": "מקורות",
+      "live": "חי",
+      "backends": "בק-אנד",
+      "healthy": "בריא",
+      "degraded": "מדורדר",
+      "down": "מושבת",
+      "unavailable": "לא זמין",
+      "loading": "טוען נתוני בריאות...",
+      "error": "טעינת בריאות המערכת נכשלה",
+      "refresh": "רענן",
+      "noSources": "לא הוגדרו מקורות תוכן"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -400,7 +400,9 @@
       "reliabilityLow": "Zems",
       "aiTrainingData": "AI apmācības dati",
       "webSource": "Tīmekļa avots",
-      "knowledgeBase": "Zināšanu bāze"
+      "knowledgeBase": "Zināšanu bāze",
+      "modelOnly": "Tikai modelis",
+      "modelOnlyTooltip": "Šis apgalvojums ir balstīts tikai uz modeļa apmācības datiem — avoti netika iegūti"
     },
     "tabContent": {
       "openInNewWindow": "Atvērt jaunā logā",
@@ -7614,7 +7616,8 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
+    "systemHealth": "Sistēmas veselība"
   },
   "llcMembers": {
     "title": "Dalibnieki",
@@ -8383,5 +8386,23 @@
     "target": "Target {date}",
     "backlogLink": "Backlog",
     "timelineLink": "Timeline"
+  },
+  "admin": {
+    "systemHealth": {
+      "title": "Sistēmas veselība",
+      "subtitle": "Tiešsaistes sasniedzamība satura avotu aizmugursistēmām",
+      "status": "Statuss",
+      "sources": "Avoti",
+      "live": "Tiešraidē",
+      "backends": "Aizmugursistēmas",
+      "healthy": "Vesela",
+      "degraded": "Pasliktināta",
+      "down": "Nedarbojas",
+      "unavailable": "Nav pieejama",
+      "loading": "Ielādē veselības datus...",
+      "error": "Neizdevās ielādēt sistēmas veselību",
+      "refresh": "Atsvaidzināt",
+      "noSources": "Nav konfigurētu satura avotu"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -400,7 +400,9 @@
       "reliabilityLow": "Niski",
       "aiTrainingData": "Dane szkoleniowe AI",
       "webSource": "Źródło internetowe",
-      "knowledgeBase": "Baza wiedzy"
+      "knowledgeBase": "Baza wiedzy",
+      "modelOnly": "Tylko model",
+      "modelOnlyTooltip": "To twierdzenie jest oparte wyłącznie na danych treningowych modelu — nie pobrano żadnych źródeł"
     },
     "tabContent": {
       "openInNewWindow": "Otwórz w nowym oknie",
@@ -7614,7 +7616,8 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
+    "systemHealth": "Kondycja systemu"
   },
   "llcMembers": {
     "title": "Czlonkowie",
@@ -8383,5 +8386,23 @@
     "target": "Target {date}",
     "backlogLink": "Backlog",
     "timelineLink": "Timeline"
+  },
+  "admin": {
+    "systemHealth": {
+      "title": "Kondycja systemu",
+      "subtitle": "Dostępność na żywo backendów dla źródeł treści",
+      "status": "Status",
+      "sources": "Źródła",
+      "live": "Na żywo",
+      "backends": "Backendy",
+      "healthy": "Zdrowy",
+      "degraded": "Obniżona jakość",
+      "down": "Niedostępny",
+      "unavailable": "Niedostępny",
+      "loading": "Ładowanie danych kondycji...",
+      "error": "Nie udało się załadować kondycji systemu",
+      "refresh": "Odśwież",
+      "noSources": "Brak skonfigurowanych źródeł treści"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -400,7 +400,9 @@
       "reliabilityLow": "Baixo",
       "aiTrainingData": "Dados de treinamento de IA",
       "webSource": "Fonte da Web",
-      "knowledgeBase": "Base de conhecimento"
+      "knowledgeBase": "Base de conhecimento",
+      "modelOnly": "Somente modelo",
+      "modelOnlyTooltip": "Esta afirmação é baseada apenas nos dados de treinamento do modelo — nenhuma fonte foi recuperada"
     },
     "tabContent": {
       "openInNewWindow": "Abrir em nova janela",
@@ -7614,7 +7616,8 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
+    "systemHealth": "Saúde do sistema"
   },
   "llcMembers": {
     "title": "Membros",
@@ -8383,5 +8386,23 @@
     "target": "Meta {date}",
     "backlogLink": "Backlog",
     "timelineLink": "Linha do tempo"
+  },
+  "admin": {
+    "systemHealth": {
+      "title": "Saúde do sistema",
+      "subtitle": "Acessibilidade ao vivo dos backends para fontes de conteúdo",
+      "status": "Status",
+      "sources": "Fontes",
+      "live": "Ao vivo",
+      "backends": "Backends",
+      "healthy": "Saudável",
+      "degraded": "Degradado",
+      "down": "Inativo",
+      "unavailable": "Indisponível",
+      "loading": "Carregando dados de saúde...",
+      "error": "Falha ao carregar a saúde do sistema",
+      "refresh": "Atualizar",
+      "noSources": "Nenhuma fonte de conteúdo configurada"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -189,7 +189,8 @@
     "llcNoCompanies": "No companies yet.",
     "llcCreateCompany": "Create a company",
     "companyOsUnavailableTitle": "Company OS is not available",
-    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it."
+    "companyOsUnavailableDesc": "Company OS requires company mode (PostgreSQL). This deployment does not have company mode enabled, so company workspaces are disabled. Switch to single_company or multi_company mode to enable it.",
+    "systemHealth": "سسٹم کی صحت"
   },
   "llcMembers": {
     "title": "اراکین",
@@ -4954,7 +4955,9 @@
       "reliabilityVerified": "Verified",
       "reliabilityMedium": "Medium",
       "knowledgeBase": "Knowledge Base",
-      "model": "Model:"
+      "model": "Model:",
+      "modelOnly": "صرف ماڈل",
+      "modelOnlyTooltip": "یہ دعوی صرف ماڈل کے تربیتی ڈیٹا پر مبنی ہے — کوئی ذریعہ نہیں ملا"
     },
     "sidebar": {
       "deletedWithFactsPreserved": "Deleted {count} chats (facts preserved in knowledge base)",
@@ -8383,5 +8386,23 @@
     "target": "Target {date}",
     "backlogLink": "Backlog",
     "timelineLink": "Timeline"
+  },
+  "admin": {
+    "systemHealth": {
+      "title": "سسٹم کی صحت",
+      "subtitle": "مواد کے ذرائع کے لیے بیک اینڈ کی براہ راست رسائی",
+      "status": "حیثیت",
+      "sources": "ذرائع",
+      "live": "براہ راست",
+      "backends": "بیک اینڈ",
+      "healthy": "صحت مند",
+      "degraded": "کمزور",
+      "down": "بند",
+      "unavailable": "دستیاب نہیں",
+      "loading": "صحت کا ڈیٹا لوڈ ہو رہا ہے...",
+      "error": "سسٹم کی صحت لوڈ کرنے میں ناکامی",
+      "refresh": "تازہ کریں",
+      "noSources": "کوئی مواد کا ذریعہ ترتیب نہیں دیا گیا"
+    }
   }
 }

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -890,6 +890,18 @@ export const routes: RouteRecordRaw[] = [
       hideInNav: true,
     },
   },
+  // Issue #10932: Admin System Health panel — CONTENT_REACH probe
+  {
+    path: '/admin/system-health',
+    name: 'admin-system-health',
+    component: () => import('@/views/SystemHealthView.vue'),
+    meta: {
+      title: 'System Health',
+      hideInNav: true,
+      requiresAuth: true,
+      admin: true,
+    },
+  },
   // /desktop removed from nav — noVNC is accessible via the Chat tab's noVNC tab.
   // Redirect any bookmarked /desktop URLs to /chat.
   { path: '/desktop', redirect: '/chat' },

--- a/autobot-frontend/src/types/probe-names.ts
+++ b/autobot-frontend/src/types/probe-names.ts
@@ -20,6 +20,7 @@ export const PROBE_NAMES = {
   KNOWLEDGE: 'knowledge',
   ERROR_RESILIENCE: 'error_resilience',
   INTELLIGENT_AGENT: 'intelligent_agent',
+  CONTENT_REACH: 'content_reach',
 } as const
 
 export type ProbeName = (typeof PROBE_NAMES)[keyof typeof PROBE_NAMES]

--- a/autobot-frontend/src/views/SystemHealthView.vue
+++ b/autobot-frontend/src/views/SystemHealthView.vue
@@ -1,0 +1,207 @@
+<!-- Copyright 2025-2026 mrveiss -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+  AutoBot - AI-Powered Automation Platform
+  Author: mrveiss
+
+  Admin System Health view — surfaces the CONTENT_REACH probe (#10932).
+  Shows per-source live/dead backend status from the health aggregator.
+-->
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useProbeBackedHealth } from '@/composables/useProbeBackedHealth'
+import { PROBE_NAMES } from '@/types/probe-names'
+
+const { t } = useI18n()
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ContentReachHealth {
+  status: string
+  detail: string | undefined
+  sources: Record<string, string[]>
+  live: Record<string, string[]>
+}
+
+// ---------------------------------------------------------------------------
+// Composable wiring
+// ---------------------------------------------------------------------------
+
+const getHealth = useProbeBackedHealth<ContentReachHealth>({
+  probeName: PROBE_NAMES.CONTENT_REACH,
+  buildHealthy: (probe, data) => ({
+    status: probe.status ?? 'unavailable',
+    detail: probe.detail,
+    sources: (data.sources as Record<string, string[]>) ?? {},
+    live: (data.live as Record<string, string[]>) ?? {},
+  }),
+  buildUnavailable: (message) => ({
+    status: 'unavailable',
+    detail: message,
+    sources: {},
+    live: {},
+  }),
+  errorMessage: t('admin.systemHealth.error'),
+})
+
+// ---------------------------------------------------------------------------
+// Reactive state
+// ---------------------------------------------------------------------------
+
+const loading = ref(false)
+const health = ref<ContentReachHealth | null>(null)
+
+const sourceNames = computed(() => Object.keys(health.value?.sources ?? {}))
+const noSources = computed(() => !loading.value && sourceNames.value.length === 0)
+
+// ---------------------------------------------------------------------------
+// Status badge helpers
+// ---------------------------------------------------------------------------
+
+type BadgeVariant = 'green' | 'yellow' | 'red' | 'gray'
+
+function statusBadgeClass(status: string): string {
+  const variants: Record<string, BadgeVariant> = {
+    ok: 'green',
+    degraded: 'yellow',
+    down: 'red',
+  }
+  const variant: BadgeVariant = variants[status] ?? 'gray'
+  const map: Record<BadgeVariant, string> = {
+    green: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+    yellow: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+    red: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+    gray: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+  }
+  return map[variant]
+}
+
+function statusLabel(status: string): string {
+  const map: Record<string, string> = {
+    ok: t('admin.systemHealth.healthy'),
+    degraded: t('admin.systemHealth.degraded'),
+    down: t('admin.systemHealth.down'),
+    unavailable: t('admin.systemHealth.unavailable'),
+  }
+  return map[status] ?? status
+}
+
+function isLive(source: string, backend: string): boolean {
+  return (health.value?.live[source] ?? []).includes(backend)
+}
+
+// ---------------------------------------------------------------------------
+// Load / refresh
+// ---------------------------------------------------------------------------
+
+async function refresh(): Promise<void> {
+  loading.value = true
+  health.value = await getHealth()
+  loading.value = false
+}
+
+onMounted(refresh)
+</script>
+
+<template>
+  <div class="p-6 max-w-4xl mx-auto">
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          {{ $t('admin.systemHealth.title') }}
+        </h1>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          {{ $t('admin.systemHealth.subtitle') }}
+        </p>
+      </div>
+      <button
+        class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        :disabled="loading"
+        @click="refresh"
+      >
+        {{ $t('admin.systemHealth.refresh') }}
+      </button>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="flex items-center justify-center py-16 text-gray-400 dark:text-gray-500">
+      <span class="animate-spin mr-2">&#8987;</span>
+      {{ $t('admin.systemHealth.loading') }}
+    </div>
+
+    <!-- Health data -->
+    <template v-else-if="health">
+      <!-- Overall status row -->
+      <div class="flex items-start gap-4 mb-6 p-4 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
+        <div class="flex-1">
+          <span class="text-sm font-medium text-gray-600 dark:text-gray-400">
+            {{ $t('admin.systemHealth.status') }}
+          </span>
+          <div class="mt-1 flex items-center gap-3">
+            <span
+              class="inline-flex px-2.5 py-0.5 rounded-full text-xs font-semibold"
+              :class="statusBadgeClass(health.status)"
+            >
+              {{ statusLabel(health.status) }}
+            </span>
+            <span v-if="health.detail" class="text-sm text-gray-500 dark:text-gray-400">
+              {{ health.detail }}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- No sources empty state -->
+      <div
+        v-if="noSources"
+        class="py-12 text-center text-gray-400 dark:text-gray-500"
+      >
+        {{ $t('admin.systemHealth.noSources') }}
+      </div>
+
+      <!-- Sources grid -->
+      <div v-else>
+        <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3">
+          {{ $t('admin.systemHealth.sources') }}
+        </h2>
+        <div class="space-y-4">
+          <div
+            v-for="source in sourceNames"
+            :key="source"
+            class="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+          >
+            <div class="flex items-center justify-between mb-3">
+              <span class="font-medium text-gray-900 dark:text-gray-100 capitalize">{{ source }}</span>
+              <span class="text-xs text-gray-500 dark:text-gray-400">
+                {{ $t('admin.systemHealth.backends') }}
+              </span>
+            </div>
+            <div class="flex flex-wrap gap-2">
+              <span
+                v-for="backend in health.sources[source]"
+                :key="backend"
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium"
+                :class="isLive(source, backend)
+                  ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+                  : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300'"
+              >
+                <span
+                  class="h-1.5 w-1.5 rounded-full"
+                  :class="isLive(source, backend) ? 'bg-green-500' : 'bg-red-500'"
+                />
+                {{ backend }}
+                <span class="sr-only">
+                  {{ isLive(source, backend) ? $t('admin.systemHealth.live') : $t('admin.systemHealth.down') }}
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/autobot-frontend/src/views/SystemHealthView.vue
+++ b/autobot-frontend/src/views/SystemHealthView.vue
@@ -27,16 +27,30 @@ interface ContentReachHealth {
 }
 
 // ---------------------------------------------------------------------------
+// Runtime-narrowing helper (Fix 2 — no unchecked casts)
+// ---------------------------------------------------------------------------
+
+function toSourceMap(v: unknown): Record<string, string[]> {
+  if (!v || typeof v !== 'object') return {}
+  const out: Record<string, string[]> = {}
+  for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+    if (Array.isArray(val)) out[k] = val.filter((x): x is string => typeof x === 'string')
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
 // Composable wiring
 // ---------------------------------------------------------------------------
 
 const getHealth = useProbeBackedHealth<ContentReachHealth>({
   probeName: PROBE_NAMES.CONTENT_REACH,
+  renderNonOkFromProbe: true,
   buildHealthy: (probe, data) => ({
     status: probe.status ?? 'unavailable',
     detail: probe.detail,
-    sources: (data.sources as Record<string, string[]>) ?? {},
-    live: (data.live as Record<string, string[]>) ?? {},
+    sources: toSourceMap(data.sources),
+    live: toSourceMap(data.live),
   }),
   buildUnavailable: (message) => ({
     status: 'unavailable',

--- a/autobot-frontend/src/views/__tests__/SystemHealthView.spec.ts
+++ b/autobot-frontend/src/views/__tests__/SystemHealthView.spec.ts
@@ -1,0 +1,104 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// Tests for SystemHealthView.vue (#10932).
+// Mocks useProbeBackedHealth so no real HTTP calls are made.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// getHealth mock function — replaced per test in beforeEach
+const mockGetHealth = vi.fn()
+
+vi.mock('@/composables/useProbeBackedHealth', () => ({
+  useProbeBackedHealth: () => mockGetHealth,
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ debug: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() }),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// vue-i18n installed as a real plugin so $t() resolves in templates.
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+import SystemHealthView from '../SystemHealthView.vue'
+
+function mountView() {
+  return mount(SystemHealthView, {
+    global: { plugins: [i18n] },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SystemHealthView.vue', () => {
+  beforeEach(() => {
+    mockGetHealth.mockReset()
+  })
+
+  it('renders source names and marks live vs dead backends', async () => {
+    mockGetHealth.mockResolvedValue({
+      status: 'degraded',
+      detail: 'one backend down',
+      sources: { web: ['ddgs', 'jina'], youtube: ['ytdlp'] },
+      live: { web: ['ddgs'], youtube: ['ytdlp'] },
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    // Status badge is present
+    expect(wrapper.text()).toContain('Degraded')
+
+    // Source names appear
+    expect(wrapper.text()).toContain('web')
+    expect(wrapper.text()).toContain('youtube')
+
+    // 'ddgs' is live — find its span and check for live class
+    const backendSpans = wrapper.findAll('span.inline-flex.items-center')
+    const ddgsSpan = backendSpans.find((s) => s.text().includes('ddgs'))
+    expect(ddgsSpan).toBeTruthy()
+    expect(ddgsSpan?.classes()).toContain('bg-green-100')
+
+    // 'jina' is dead — present in sources but not in live
+    const jinaSpan = backendSpans.find((s) => s.text().includes('jina'))
+    expect(jinaSpan).toBeTruthy()
+    expect(jinaSpan?.classes()).toContain('bg-red-100')
+  })
+
+  it('renders unavailable / empty state when no sources are returned', async () => {
+    mockGetHealth.mockResolvedValue({
+      status: 'unavailable',
+      detail: 'probe unavailable',
+      sources: {},
+      live: {},
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    // Status badge shows 'Unavailable'
+    expect(wrapper.text()).toContain('Unavailable')
+
+    // No source rows are rendered
+    const backendSpans = wrapper.findAll('span.inline-flex.items-center')
+    expect(backendSpans).toHaveLength(0)
+
+    // noSources message is visible
+    expect(wrapper.text()).toContain('No content sources configured')
+  })
+})

--- a/autobot-frontend/src/views/__tests__/SystemHealthView.spec.ts
+++ b/autobot-frontend/src/views/__tests__/SystemHealthView.spec.ts
@@ -80,6 +80,37 @@ describe('SystemHealthView.vue', () => {
     expect(jinaSpan?.classes()).toContain('bg-red-100')
   })
 
+  it('renders Degraded badge when probe returns degraded status', async () => {
+    mockGetHealth.mockResolvedValue({
+      status: 'degraded',
+      detail: 'partial outage',
+      sources: { web: ['ddgs'] },
+      live: {},
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Degraded')
+    expect(wrapper.text()).toContain('partial outage')
+    expect(wrapper.text()).toContain('web')
+  })
+
+  it('renders Down badge when probe returns down status', async () => {
+    mockGetHealth.mockResolvedValue({
+      status: 'down',
+      detail: 'all backends unreachable',
+      sources: { web: ['ddgs'] },
+      live: {},
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Down')
+    expect(wrapper.text()).toContain('all backends unreachable')
+  })
+
   it('renders unavailable / empty state when no sources are returned', async () => {
     mockGetHealth.mockResolvedValue({
       status: 'unavailable',

--- a/docs/superpowers/plans/2026-07-07-content-reach-task8-frontend.md
+++ b/docs/superpowers/plans/2026-07-07-content-reach-task8-frontend.md
@@ -1,0 +1,37 @@
+# Content Reach — Task 8 (Frontend doctor/status panel) Plan
+
+**Goal:** Surface the backend `CONTENT_REACH` health probe in the UI — a standalone admin System Health view showing per-source/per-backend live status. Umbrella #10932. Makes the layer 100% end-to-end (backend capability → visible in app).
+
+**Constraints:** reuse `useProbeBackedHealth` (no new fetch plumbing); all user-facing strings via `$t()` with keys in ALL 11 locales; clear the frontend gate — `type-check` (vue-tsc), `lint` (oxlint `-D correctness` + eslint, 0 warnings), `test:unit` (vitest), `check:i18n`. No commit trailers (mrveiss). Commit `feat(content-reach): <desc> (#10932)`.
+
+## Given (from scout)
+- `useProbeBackedHealth<R>({ probeName, buildHealthy, buildUnavailable, errorMessage })` → returns `() => Promise<R>`. `ProbeResponse = { name, status?, data?, detail? }`. Example consumer: `useBatchProcessing.ts`.
+- `PROBE_NAMES` in `src/types/probe-names.ts` (add `CONTENT_REACH: 'content_reach'`).
+- content_reach probe `data`: `{ sources: {source: [backend...]}, live: {source: [live backend...]} }`, `status` ∈ ok/degraded/down.
+- No existing system-health view → create standalone admin view.
+- Router admin pattern: `src/router/index.ts` (~line 856); nav: `src/config/navItems.ts` `adminMenuItems` (~line 108).
+- Locales: 11 files in `src/i18n/locales/` (ar,de,en,es,fa,fr,he,lv,pl,pt,ur).
+- Test pattern: `src/composables/__tests__/useProbeBackedHealth.test.ts`, `@vue/test-utils` `mount`.
+- Node/npm present; node_modules symlinked into the worktree.
+
+## Files
+1. **`src/types/probe-names.ts`** — add `CONTENT_REACH: 'content_reach',` to `PROBE_NAMES`.
+2. **`src/views/SystemHealthView.vue`** (new) — admin view:
+   - Use `useProbeBackedHealth<ContentReachHealth>({ probeName: PROBE_NAMES.CONTENT_REACH, buildHealthy: (probe, data) => ({ status: probe.status ?? 'unavailable', detail: probe.detail, sources: data.sources ?? {}, live: data.live ?? {} }), buildUnavailable: (message) => ({ status: 'unavailable', detail: message, sources: {}, live: {} }), errorMessage: t('admin.systemHealth.error') })`.
+   - On mount + a refresh button: call the getter, store reactive state (loading/error/data).
+   - Render: overall status badge (ok/degraded/down/unavailable, color-coded), `detail`; then a grid/list of sources — for each source in `data.sources`, show the source name and each backend as live (present in `data.live[source]`) or dead (in sources but not live), with a per-source health indicator. Reuse `components/admin/HealthBar.vue` if it fits, else a simple badge grid.
+   - Loading + error + empty states. ALL strings via `$t('admin.systemHealth.*')`. `<script setup lang="ts">`.
+3. **`src/router/index.ts`** — add route: `{ path: '/admin/system-health', name: 'admin-system-health', component: () => import('@/views/SystemHealthView.vue'), meta: { title: 'System Health', hideInNav: true, requiresAuth: true, admin: true } }`.
+4. **`src/config/navItems.ts`** — add to `adminMenuItems`: `{ to: '/admin/system-health', labelKey: 'nav.systemHealth', icon: <existing icon convention> }`.
+5. **i18n** — add to ALL 11 locale files (translate reasonably; en canonical):
+   - `nav.systemHealth`, and an `admin.systemHealth` block: `title`, `subtitle`, `status`, `sources`, `live`, `backends`, `healthy`, `degraded`, `down`, `unavailable`, `loading`, `error`, `refresh`, `noSources`.
+6. **`src/views/__tests__/SystemHealthView.spec.ts`** (new) — mount the view with `useProbeBackedHealth` mocked to resolve a fake content_reach health (2 sources, one with a dead backend); assert the sources + live/dead backends render and the status badge shows. Also a test for the unavailable/error path. Mock i18n (`$t` → key or global mock) per existing view-test convention.
+
+## Verification gate (run ALL from `autobot-frontend/`)
+- `npm run type-check` → 0 errors.
+- `npm run lint:oxlint` and `npm run lint:eslint` → 0 warnings/errors (fix any). (`--max-warnings 0` posture per #9924.)
+- `npm run test:unit -- SystemHealthView` (and the full run if fast) → green.
+- `npm run check:i18n` → passes (all keys present in all locales, no orphans).
+
+## Out of scope
+Backend already live (Tasks 1–7). This is purely the read-only UI surface.


### PR DESCRIPTION
## Thinking Path

Final umbrella piece of Content Reach (#10932): surface the now-live `CONTENT_REACH` backend health probe in the UI. Makes the capability 100% end-to-end — backend live (Tasks 1–7) + visible/observable in the app. Built via subagent-driven TDD; a review caught a real fidelity bug (degraded/down states rendering as "Unavailable"), fixed additively.

## What Changed

- **`SystemHealthView.vue`** (new admin view, `/admin/system-health`, `hideInNav`, admin-only) — reuses `useProbeBackedHealth` to fetch the `content_reach` probe and renders overall status (ok/degraded/down/unavailable, color-coded) + per-source rows marking each backend **live** (green) vs **dead** (red) from the probe's `sources`/`live` maps. Loading/error/empty states, refresh.
- **`useProbeBackedHealth.ts`** — additive opt-in `renderNonOkFromProbe` (default off → existing consumers unchanged): when on, degraded/down probes render with real data instead of collapsing to "Unavailable". Runtime-narrowing `toSourceMap` replaces an unchecked cast (no `any`).
- Wiring: `PROBE_NAMES.CONTENT_REACH`, router entry, `adminMenuItems` nav entry.
- **i18n:** `nav.systemHealth` + `admin.systemHealth.*` in **all 11 locales**; incidentally fixed 2 pre-existing missing `chat.citations.modelOnly*` keys (Rule 6).

## Verification

- Frontend gate all green (verified independently): **type-check 0 errors, eslint 0 warnings, vitest 13/13, check:i18n passes.**
- Tests assert real DOM: Degraded/Down badges, per-source live/dead backends, unavailable path, and the composable opt-in routing (true/false/absent). Backwards-compat of the shared composable confirmed (other consumers unaffected).

## Model Used

Opus 4.8 (orchestration + reviews), Sonnet 4.6 (implementer + fix + reviews).

Part of #10932 (Task 8, final umbrella item).
