### PR TITLE
fix(i18n): add missing chat.citations.modelOnly/modelOnlyTooltip keys to all 11 locales

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -400,7 +400,9 @@
       "reliabilityLow": "Low",
       "aiTrainingData": "AI Training Data",
       "webSource": "Web Source",
-      "knowledgeBase": "قاعدة المعرفة"
+      "knowledgeBase": "قاعدة المعرفة",
+      "modelOnly": "النموذج فقط",
+      "modelOnlyTooltip": "تستند هذه الإجابة إلى بيانات تدريب نموذج الذكاء الاصطناعي، وليس إلى مصدر معرفي موثّق."
     },
     "tabContent": {
       "openInNewWindow": "Open in new window",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -400,7 +400,9 @@
       "reliabilityLow": "Niedrig",
       "aiTrainingData": "KI-Trainingsdaten",
       "webSource": "Webquelle",
-      "knowledgeBase": "Wissensdatenbank"
+      "knowledgeBase": "Wissensdatenbank",
+      "modelOnly": "Nur Modell",
+      "modelOnlyTooltip": "Diese Antwort basiert auf den Trainingsdaten des KI-Modells, nicht auf einer fundierten Wissensquelle."
     },
     "tabContent": {
       "openInNewWindow": "In neuem Fenster öffnen",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -451,7 +451,9 @@
       "reliabilityLow": "Low",
       "aiTrainingData": "AI Training Data",
       "webSource": "Web Source",
-      "knowledgeBase": "Knowledge Base"
+      "knowledgeBase": "Knowledge Base",
+      "modelOnly": "Model only",
+      "modelOnlyTooltip": "This response is based on the AI model's training data, not a grounded knowledge source."
     },
     "tabContent": {
       "openInNewWindow": "Open in new window",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -400,7 +400,9 @@
       "reliabilityLow": "Bajo",
       "aiTrainingData": "Datos de entrenamiento de IA",
       "webSource": "Fuente web",
-      "knowledgeBase": "Base de conocimientos"
+      "knowledgeBase": "Base de conocimientos",
+      "modelOnly": "Solo modelo",
+      "modelOnlyTooltip": "Esta respuesta se basa en los datos de entrenamiento del modelo de IA, no en una fuente de conocimiento verificada."
     },
     "tabContent": {
       "openInNewWindow": "Abrir en nueva ventana",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -4954,7 +4954,9 @@
       "reliabilityVerified": "Verified",
       "reliabilityMedium": "Medium",
       "knowledgeBase": "Knowledge Base",
-      "model": "Model:"
+      "model": "Model:",
+      "modelOnly": "فقط مدل",
+      "modelOnlyTooltip": "این پاسخ بر اساس داده‌های آموزشی مدل هوش مصنوعی است، نه یک منبع دانش مستند."
     },
     "sidebar": {
       "deletedWithFactsPreserved": "Deleted {count} chats (facts preserved in knowledge base)",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -400,7 +400,9 @@
       "reliabilityLow": "Faible",
       "aiTrainingData": "Données de formation IA",
       "webSource": "Source Web",
-      "knowledgeBase": "Base de connaissances"
+      "knowledgeBase": "Base de connaissances",
+      "modelOnly": "Modèle seul",
+      "modelOnlyTooltip": "Cette réponse est basée sur les données d'entraînement du modèle d'IA, pas sur une source de connaissances vérifiée."
     },
     "tabContent": {
       "openInNewWindow": "Ouvrir dans une nouvelle fenêtre",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -4954,7 +4954,9 @@
       "reliabilityVerified": "Verified",
       "reliabilityMedium": "Medium",
       "knowledgeBase": "Knowledge Base",
-      "model": "Model:"
+      "model": "Model:",
+      "modelOnly": "מודל בלבד",
+      "modelOnlyTooltip": "תשובה זו מבוססת על נתוני האימון של מודל ה-AI, ולא על מקור ידע מבוסס."
     },
     "sidebar": {
       "deletedWithFactsPreserved": "Deleted {count} chats (facts preserved in knowledge base)",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -400,7 +400,9 @@
       "reliabilityLow": "Zems",
       "aiTrainingData": "AI apmācības dati",
       "webSource": "Tīmekļa avots",
-      "knowledgeBase": "Zināšanu bāze"
+      "knowledgeBase": "Zināšanu bāze",
+      "modelOnly": "Tikai modelis",
+      "modelOnlyTooltip": "Šī atbilde balstās uz AI modeļa apmācības datiem, nevis uz pārbaudītu zināšanu avotu."
     },
     "tabContent": {
       "openInNewWindow": "Atvērt jaunā logā",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -400,7 +400,9 @@
       "reliabilityLow": "Niski",
       "aiTrainingData": "Dane szkoleniowe AI",
       "webSource": "Źródło internetowe",
-      "knowledgeBase": "Baza wiedzy"
+      "knowledgeBase": "Baza wiedzy",
+      "modelOnly": "Tylko model",
+      "modelOnlyTooltip": "Ta odpowiedź opiera się na danych treningowych modelu AI, a nie na zweryfikowanym źródle wiedzy."
     },
     "tabContent": {
       "openInNewWindow": "Otwórz w nowym oknie",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -400,7 +400,9 @@
       "reliabilityLow": "Baixo",
       "aiTrainingData": "Dados de treinamento de IA",
       "webSource": "Fonte da Web",
-      "knowledgeBase": "Base de conhecimento"
+      "knowledgeBase": "Base de conhecimento",
+      "modelOnly": "Somente modelo",
+      "modelOnlyTooltip": "Esta resposta baseia-se nos dados de treino do modelo de IA, não numa fonte de conhecimento verificada."
     },
     "tabContent": {
       "openInNewWindow": "Abrir em nova janela",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -4954,7 +4954,9 @@
       "reliabilityVerified": "Verified",
       "reliabilityMedium": "Medium",
       "knowledgeBase": "Knowledge Base",
-      "model": "Model:"
+      "model": "Model:",
+      "modelOnly": "صرف ماڈل",
+      "modelOnlyTooltip": "یہ جواب AI ماڈل کے تربیتی ڈیٹا پر مبنی ہے، کسی مستند علمی ماخذ پر نہیں۔"
     },
     "sidebar": {
       "deletedWithFactsPreserved": "Deleted {count} chats (facts preserved in knowledge base)",


### PR DESCRIPTION
## Thinking Path
`frontend-tests` was RED on the current base — but not on lint (that's green now via #9924). Root-caused to the **`check:i18n`** step: `MessageItem.vue` uses `$t('chat.citations.modelOnly')` + `$t('chat.citations.modelOnlyTooltip')` (the ungrounded/model-only claim badge from the #10548 citations feature), but neither key existed in any locale.

## What Changed
Added both keys under `chat.citations` to **all 11 locales** (en/de/es/fr/pt/pl/lv/ar/fa/he/ur) with proper translations (not English placeholders) — per the "new keys to ALL locales" rule. Format-preserving script (2-space + trailing newline round-trip verified) → minimal diff: +2 keys per file, no reformatting.

## Verification
- `check:i18n` → **All translation keys found**.
- `check:locales` → **All locale files complete**.
- `type-check` (vue-tsc) → exit 0; `check-ts-delta` → 0 errors; `npm run lint` → exit 0.
- With this, all non-vitest `frontend-tests` steps pass (vitest already green).

## Model Used
Opus 4.8

Completes the green `frontend-tests` state (the lint step was #9924; this fixes the i18n step).