### PR TITLE
fix(deploy): resolve -c ../constraints on backend dep-install

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -578,9 +578,21 @@
     - restart backend
     - restart celery
 
+# The filtered file is written to /tmp, so its `-c ../constraints/shared.txt`
+# (kept from requirements.txt, #10524) would resolve relative to /tmp and fail
+# (pip errors on a missing constraint file). Rewrite it to the canonical
+# code_source constraints path, which always exists as the git checkout, so the
+# pinned constraints are actually applied on deploy (#11117).
+- name: Resolve absolute constraints path for filtered requirements
+  ansible.builtin.set_fact:
+    backend_constraints_abs: "{{ code_source_dir | default('/opt/autobot/code_source') }}/constraints/"
+
 - name: Create filtered backend requirements file
   ansible.builtin.shell:
-    cmd: "grep -Ev '^-e.*autobot[-_]shared|^-r' {{ backend_code_dir }}/requirements.txt > /tmp/requirements-filtered.txt"
+    cmd: >-
+      grep -Ev '^-e.*autobot[-_]shared|^-r' {{ backend_code_dir }}/requirements.txt
+      | sed 's|^-c \.\./constraints/|-c {{ backend_constraints_abs }}|'
+      > /tmp/requirements-filtered.txt
   become_user: "{{ backend_user }}"
 
 # (#2872) Removed failed_when: false — pip install failures must surface.


### PR DESCRIPTION
## Thinking Path
Investigating #10016 member 4 / #11069, a dry-run against the **live box** revealed the backend dependency install is broken:
```
$ /opt/autobot/autobot-backend/venv/bin/pip install --dry-run -r requirements.txt
ERROR: Could not open constraint file: '/opt/autobot/constraints/shared.txt'
```
The deploy rsyncs `autobot-backend/` but not its sibling `constraints/`, so `-c ../constraints/shared.txt` (#10524 SSOT) can't resolve; pip errors on a missing constraint file. The ansible role's filtered file lives in `/tmp`, so its `-c ../constraints/` → `/constraints/` (also missing). **#10524's pins were never applied on deploy.**

## What Changed
`roles/backend/tasks/main.yml`: when building `/tmp/requirements-filtered.txt`, rewrite `-c ../constraints/` → `{code_source_dir}/constraints/` (the git checkout, always present) via a `sed` + a resolved `backend_constraints_abs` fact.

## Verification
- Reproduced the failure on the live venv (dry-run).
- **Validated the fix**: same dry-run with the rewritten `-c` resolves cleanly — all 'Requirement already satisfied', no constraint error.
- pip `-c`-path resolution (relative to the requirements-file dir, not CWD) confirmed empirically.
- YAML parses.

## Model Used
Opus 4.8 (1M context)

Closes #11117. Refs #10016 (member 4), #10524. Unblocks #11069 (code-sync dep-install reuses this corrected filtered install).