### PR TITLE
fix(frontend): green the frontend-tests coverage gate — Redis callback + test-pollution root fix (#9924, #10691)

### DIFF
--- a/autobot-frontend/src/components/services/RedisServiceControl.vue
+++ b/autobot-frontend/src/components/services/RedisServiceControl.vue
@@ -295,7 +295,9 @@ const getHealthCheckVariant = (status) => {
  * Lifecycle: Subscribe to WebSocket updates on mount
  */
 onMounted(() => {
-  subscribeToStatusUpdates()
+  // Subscribe to push updates; the composable also auto-refreshes internally,
+  // so this callback is a no-op subscription marker (param unused by design).
+  subscribeToStatusUpdates((_message) => {})
 })
 
 /**

--- a/autobot-frontend/src/test/vitest-setup.ts
+++ b/autobot-frontend/src/test/vitest-setup.ts
@@ -1,7 +1,15 @@
 // Copyright 2025-2026 mrveiss
 // SPDX-License-Identifier: Apache-2.0
 import '@testing-library/jest-dom'
-import { vi } from 'vitest'
+import { vi, afterAll } from 'vitest'
+
+// Prevent cross-file pollution: some test files call vi.stubGlobal() (e.g. window,
+// navigator, EventSource) at module scope without restoring. Under parallel file
+// execution these leak into later files' worker context, causing flaky failures
+// (async DOM updates/emits break). Restore all stubbed globals after each file.
+afterAll(() => {
+  vi.unstubAllGlobals()
+})
 
 // Wrap global fetch to resolve relative URLs against document origin (jsdom 29+ compat)
 const originalFetch = global.fetch


### PR DESCRIPTION
## Thinking Path
After #9924 greened the **lint** step, the `frontend-tests` job (ci.yml) still failed — its later steps (build/coverage) had been **masked for weeks** (Actions stops at the first failing step). Root-caused the coverage gate (step 9) to TWO issues:

1. **Regression (mine):** #9924 batch warn1 removed the `subscribeToStatusUpdates((message)=>{})` callback in `RedisServiceControl.vue` (deemed a dead no-op) — but `RedisServiceControl.spec.js` asserts a callback IS passed. Deterministic failure.
2. **Pre-existing cross-file test pollution (#10691):** several specs call `vi.stubGlobal(...)` at module scope (e.g. `useRealtimeVoice` stubs `window`/`navigator`) without restoring. `vitest.config` had `restoreMocks` but **not global-stub cleanup**, so stubs leaked into later files under parallel execution → flaky failures (ApprovalCard/KnowledgeUpload/etc. — all pass in isolation, fail nondeterministically together).

## What Changed (root-cause, not workarounds)
- `RedisServiceControl.vue`: restored `subscribeToStatusUpdates((_message) => {})` (contextually-typed, `_`-prefixed → lint-clean; preserves the component's subscribe contract + the test).
- `src/test/vitest-setup.ts`: added a per-file `afterAll(() => vi.unstubAllGlobals())` so stubbed globals are restored after each test file — prevents the leak WITHOUT forcing sequential execution.

## Verification
- **Parallel** `test:coverage` (default): **129 files / 1910 tests pass, exit 0 — TWICE consecutively** (before the fix: 2 consecutive fails on *different* tests). Coverage thresholds (70%) met.
- `RedisServiceControl.spec.js` → 43/43; `eslint` (both files) → 0; `vue-tsc` → 0.
- All other `frontend-tests` steps already green (lint/i18n/type-check/build).

## Model Used
Opus 4.8

Greens the full `frontend-tests` job. Root-fixes a slice of #10691 test-isolation pollution.