### PR TITLE
fix(slm): backend code-sync dep-install uses venv + resolvable constraints

### DIFF
--- a/autobot-slm-backend/services/role_registry.py
+++ b/autobot-slm-backend/services/role_registry.py
@@ -103,8 +103,20 @@ _BACKEND_ROLES = [
         "auto_restart": True,
         "health_check_port": 8443,
         "health_check_path": "/api/health",
+        # Install deps into the backend venv, then migrate. Mirrors the backend
+        # ansible role (#11117): filter out the editable autobot_shared + -r
+        # includes, and rewrite -c ../constraints/ to the canonical code_source
+        # path so pip can resolve the #10524 constraints (bare `pip install -r
+        # requirements.txt` errors on the unresolvable -c and, via && short-
+        # circuit, silently skipped alembic every sync — #11069).
         "post_sync_cmd": (
-            f"cd {_BASE_DIR}/autobot-backend && " "pip install -r requirements.txt && " "alembic upgrade head"
+            f"cd {_BASE_DIR}/autobot-backend && "
+            "grep -Ev '^-e.*autobot[-_]shared|^-r' requirements.txt "
+            f"| sed 's|^-c \\.\\./constraints/|-c {_BASE_DIR}/code_source/constraints/|' "
+            "> /tmp/requirements-filtered-slm.txt && "
+            "PIP_USE_DEPRECATED=legacy-resolver PIP_DEFAULT_TIMEOUT=120 "
+            "venv/bin/pip install -r /tmp/requirements-filtered-slm.txt && "
+            "venv/bin/alembic upgrade head"
         ),
         "required": True,
         "degraded_without": [],


### PR DESCRIPTION
## Thinking Path
#10016 member 4 Part B. Investigating '#11069 code-sync doesn't pip-install' found it *does* — the backend role's `post_sync_cmd` runs `pip install -r requirements.txt && alembic upgrade head` every sync — but it's broken: system `pip` (not the venv) + unfiltered `requirements.txt` whose `-c ../constraints/` is unresolvable (#11117). pip errors, the `&&` short-circuits, and **`alembic upgrade head` silently never runs** — migrations skipped on every code-sync (`_run_post_sync_command` swallows the error).

## What Changed
`services/role_registry.py` backend `post_sync_cmd` now mirrors the backend ansible role: filter out `-e autobot_shared` + `-r` includes, rewrite `-c ../constraints/` → `{_BASE_DIR}/code_source/constraints/`, install with `venv/bin/pip` (legacy resolver), then `venv/bin/alembic upgrade head`.

## Verification (on the live box)
- `py_compile` OK.
- Rendered filtered file: **0** `-e`/`-r` lines; `-c` → `/opt/autobot/code_source/constraints/shared.txt`.
- `venv/bin/pip install --dry-run -r <filtered>`: no constraint error, all 'Requirement already satisfied'.

## Model Used
Opus 4.8 (1M context)

Closes #11069. Refs #10016 (member 4), #11117. Note: role_registry seeds DB Role records — a re-seed/deploy applies the corrected command. Follow-up: post_sync 300s timeout may be tight for a cold/large dep change (incremental changes are fine).