### PR TITLE
fix(frontend): dedup VisionAnalysisModal intent options via v-for (#11110)

### DIFF
--- a/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
+++ b/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
@@ -49,7 +49,7 @@ const analysisResult = ref<MultiModalResponse | null>(null)
 const error = ref<string | null>(null)
 const showRawJson = ref(false)
 
-const _intentLabels = computed(() => ({
+const intentLabels = computed<Record<string, string>>(() => ({
   analysis: t('chat.vision.intentAnalysis'),
   visual_qa: t('chat.vision.intentVisualQA'),
   automation: t('chat.vision.intentAutomation'),
@@ -214,10 +214,7 @@ onUnmounted(() => {
           <div class="option-group">
             <label>{{ $t('chat.vision.intent') }}</label>
             <select v-model="selectedIntent">
-              <option value="analysis">{{ $t('chat.vision.intentAnalysis') }}</option>
-              <option value="visual_qa">{{ $t('chat.vision.intentVisualQA') }}</option>
-              <option value="automation">{{ $t('chat.vision.intentAutomation') }}</option>
-              <option value="content_generation">{{ $t('chat.vision.intentContentGeneration') }}</option>
+              <option v-for="(label, value) in intentLabels" :key="value" :value="value">{{ label }}</option>
             </select>
           </div>
           <div v-if="selectedIntent === 'visual_qa'" class="option-group flex-1">


### PR DESCRIPTION
## Thinking Path
#11110 item 2: `VisionAnalysisModal._intentLabels` computed duplicated the 4 hardcoded `<option>` intent labels in the template (the computed was `_`-prefixed/unused). "Wire it in" rather than leave dead.

## What Changed
- Renamed `_intentLabels` → `intentLabels` (now used); typed `computed<Record<string, string>>`.
- Replaced the 4 duplicated `<option>` elements with `<option v-for="(label, value) in intentLabels" :key="value" :value="value">{{ label }}</option>` — single source of truth, identical rendered options/values/labels.

## Verification
- `eslint` → 0 (the previously-unused computed is now referenced).
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0.
- No dedicated test exists for this modal; behavior unchanged (same 4 intent options).

## Remaining in #11110
BasePanel collapse-toggle (declared `collapsible`/`collapsed` props + `toggle` emit, no UI control) needs a UX/design decision (where the control goes, icon, aria) — left for owner input.

## Model Used
Opus 4.8

Partial fix for #11110.