### PR TITLE
cleanup(backend): str(LLMType) enum trap + Literal outcome type (#11091)

### DIFF
--- a/autobot-backend/llm_shared/observability/langfuse_observer.py
+++ b/autobot-backend/llm_shared/observability/langfuse_observer.py
@@ -46,7 +46,10 @@ class LangFuseObserver:
             metadata={
                 "agent_id": request.metadata.get("agent_id"),
                 "run_id": request.metadata.get("run_id"),
-                "llm_type": str(request.llm_type),
+                # llm_type may be an LLMType(str, Enum) member or a plain str;
+                # use the enum value ('extraction'), not str(member) which yields
+                # 'LLMType.EXTRACTION' on Python <3.11 (#11091).
+                "llm_type": getattr(request.llm_type, "value", request.llm_type),
             },
         )
         self._pending[request.request_id] = gen

--- a/autobot-backend/memory/trajectory_store.py
+++ b/autobot-backend/memory/trajectory_store.py
@@ -53,7 +53,7 @@ import json
 import time
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Literal, Optional, Sequence
 
 from autobot_shared.logging_manager import get_logger
 
@@ -107,7 +107,7 @@ class Trajectory:
         task_text: str,
         start_state_hash: str,
         action_sequence: List[Dict[str, Any]],
-        outcome: str,
+        outcome: Literal["success", "partial", "failure"],
         reward: float,
         duration: float,
         agent_id: str,
@@ -222,7 +222,7 @@ class TrajectoryStore:
         self,
         task_text: str,
         action_sequence: Sequence[Dict[str, Any]],
-        outcome: str,
+        outcome: Literal["success", "partial", "failure"],
         reward: float,
         duration: float,
         agent_id: str = "",


### PR DESCRIPTION
## Thinking Path
Low-priority cleanups from the post-remediation audit (#11091), items 1 & 2.

## What Changed
1. **`langfuse_observer.py:49`**: `str(request.llm_type)` → `getattr(request.llm_type, "value", request.llm_type)`. `llm_type` is `LLMType(str, Enum) | str`; `str(member)` yields `'LLMType.EXTRACTION'` (not `'extraction'`) on Python <3.11. `getattr(...,"value",...)` returns the enum value for members and passes plain strings through unchanged.
2. **`trajectory_store.py`**: the two `add_trajectory`/`record` signatures' `outcome: str` → `outcome: Literal["success", "partial", "failure"]` for author-time typo safety (project-canonical form, no Enum). Runtime validation at :263 retained as defense for untyped callers.

## Deferred (item 3)
SSRF module consolidation (`_validate_outbound_url` → fold `require_allowlisted_https` into `url_safety.py`) is a larger refactor of security code — left for a dedicated PR/decision.

## Verification
- `python -m py_compile` ✓; `black --check` ✓; `isort --check` ✓; `flake8 --select=F,E9` → 0.
- Behavior: `getattr(LLMType.EXTRACTION,"value",...)` → `'extraction'`; `getattr("extraction","value",...)` → `'extraction'` (both cases correct).

## Model Used
Opus 4.8

Fixes items 1-2 of #11091.