### PR TITLE
refactor(llc): apply useWorkItemLabels to 4 untranslated enum render sites (#11076 parts 1-2)

### DIFF
--- a/autobot-frontend/src/components/llc/TemplateBrowser.vue
+++ b/autobot-frontend/src/components/llc/TemplateBrowser.vue
@@ -169,7 +169,7 @@
             <h4><Icon name="tasks" /> Initial Work Items</h4>
             <div class="work-list">
               <div v-for="(item, i) in previewTemplate.work_items.slice(0, 5)" :key="i" class="work-item">
-                <span class="work-type">{{ item.type }}</span>
+                <span class="work-type">{{ workItemTypeLabel(item.type) }}</span>
                 <span class="work-title">{{ item.title }}</span>
               </div>
               <span v-if="previewTemplate.work_items.length > 5" class="work-more">
@@ -200,6 +200,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useCompanyTemplates, type CompanyTemplate, type TemplateCategory } from '@/composables/llc/useCompanyTemplates'
 import Icon from '@/components/ui/Icon.vue'
+import { useWorkItemLabels } from '@/composables/useWorkItemLabels'
 
 const props = withDefaults(
   defineProps<{
@@ -218,6 +219,7 @@ const emit = defineEmits<{
 }>()
 
 const { templates, loading, error, listBuiltInTemplates } = useCompanyTemplates()
+const { workItemTypeLabel } = useWorkItemLabels()
 
 const searchQuery = ref('')
 const selectedCategory = ref<TemplateCategory | 'all'>('all')

--- a/autobot-frontend/src/composables/useWorkItemLabels.ts
+++ b/autobot-frontend/src/composables/useWorkItemLabels.ts
@@ -6,9 +6,9 @@
  * Work-item enum label composable (#10818).
  *
  * LLC board views (Sprint Board, Backlog, Work Item Detail) render work-item
- * type / priority / sprint-status enum values directly in the UI. This maps
- * those closed enum sets to localized labels under `llc.enums.*`, falling back
- * to the humanized raw value for any value without a translation key (board
+ * type / priority / status / sprint-status enum values directly in the UI. This
+ * maps those closed enum sets to localized labels under `llc.enums.*`, falling
+ * back to the humanized raw value for any value without a translation key (board
  * statuses are configurable, so a missing key must not surface a raw key path).
  */
 
@@ -25,6 +25,7 @@ export function useWorkItemLabels() {
 
   return {
     workItemTypeLabel: (value: string | null | undefined) => label('workItemType', value),
+    workItemStatusLabel: (value: string | null | undefined) => label('workItemStatus', value),
     priorityLabel: (value: string | null | undefined) => label('priority', value),
     sprintStatusLabel: (value: string | null | undefined) => label('sprintStatus', value),
   }

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8201,6 +8201,15 @@
         "subtask": "Subtask",
         "risk": "Risk"
       },
+      "workItemStatus": {
+        "backlog": "قائمة الأعمال",
+        "ready": "جاهز",
+        "in_progress": "قيد التنفيذ",
+        "in_review": "قيد المراجعة",
+        "done": "منجز",
+        "blocked": "محظور",
+        "cancelled": "ملغى"
+      },
       "priority": {
         "critical": "Critical",
         "high": "High",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8201,6 +8201,15 @@
         "subtask": "Teilaufgabe",
         "risk": "Risiko"
       },
+      "workItemStatus": {
+        "backlog": "Backlog",
+        "ready": "Bereit",
+        "in_progress": "In Bearbeitung",
+        "in_review": "In Prüfung",
+        "done": "Erledigt",
+        "blocked": "Blockiert",
+        "cancelled": "Abgebrochen"
+      },
       "priority": {
         "critical": "Kritisch",
         "high": "Hoch",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8190,6 +8190,15 @@
         "subtask": "Subtask",
         "risk": "Risk"
       },
+      "workItemStatus": {
+        "backlog": "Backlog",
+        "ready": "Ready",
+        "in_progress": "In Progress",
+        "in_review": "In Review",
+        "done": "Done",
+        "blocked": "Blocked",
+        "cancelled": "Cancelled"
+      },
       "priority": {
         "critical": "Critical",
         "high": "High",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8201,6 +8201,15 @@
         "subtask": "Subtarea",
         "risk": "Riesgo"
       },
+      "workItemStatus": {
+        "backlog": "Pendientes",
+        "ready": "Listo",
+        "in_progress": "En Progreso",
+        "in_review": "En Revisión",
+        "done": "Hecho",
+        "blocked": "Bloqueado",
+        "cancelled": "Cancelado"
+      },
       "priority": {
         "critical": "Crítica",
         "high": "Alta",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8201,6 +8201,15 @@
         "subtask": "Subtask",
         "risk": "Risk"
       },
+      "workItemStatus": {
+        "backlog": "بک‌لاگ",
+        "ready": "آماده",
+        "in_progress": "در حال انجام",
+        "in_review": "در حال بررسی",
+        "done": "انجام شده",
+        "blocked": "مسدود",
+        "cancelled": "لغو شده"
+      },
       "priority": {
         "critical": "Critical",
         "high": "High",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8201,6 +8201,15 @@
         "subtask": "Sous-tâche",
         "risk": "Risque"
       },
+      "workItemStatus": {
+        "backlog": "Backlog",
+        "ready": "Prêt",
+        "in_progress": "En Cours",
+        "in_review": "En Révision",
+        "done": "Terminé",
+        "blocked": "Bloqué",
+        "cancelled": "Annulé"
+      },
       "priority": {
         "critical": "Critique",
         "high": "Élevée",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8201,6 +8201,15 @@
         "subtask": "Subtask",
         "risk": "Risk"
       },
+      "workItemStatus": {
+        "backlog": "מאגר משימות",
+        "ready": "מוכן",
+        "in_progress": "בתהליך",
+        "in_review": "בבדיקה",
+        "done": "הושלם",
+        "blocked": "חסום",
+        "cancelled": "בוטל"
+      },
       "priority": {
         "critical": "Critical",
         "high": "High",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8201,6 +8201,15 @@
         "subtask": "Subtask",
         "risk": "Risk"
       },
+      "workItemStatus": {
+        "backlog": "Uzdevumu saraksts",
+        "ready": "Gatavs",
+        "in_progress": "Procesā",
+        "in_review": "Pārskatīšanā",
+        "done": "Pabeigts",
+        "blocked": "Bloķēts",
+        "cancelled": "Atcelts"
+      },
       "priority": {
         "critical": "Critical",
         "high": "High",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8201,6 +8201,15 @@
         "subtask": "Subtask",
         "risk": "Risk"
       },
+      "workItemStatus": {
+        "backlog": "Backlog",
+        "ready": "Gotowe",
+        "in_progress": "W Toku",
+        "in_review": "W Recenzji",
+        "done": "Ukończone",
+        "blocked": "Zablokowane",
+        "cancelled": "Anulowane"
+      },
       "priority": {
         "critical": "Critical",
         "high": "High",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8201,6 +8201,15 @@
         "subtask": "Subtarefa",
         "risk": "Risco"
       },
+      "workItemStatus": {
+        "backlog": "Backlog",
+        "ready": "Pronto",
+        "in_progress": "Em Progresso",
+        "in_review": "Em Revisão",
+        "done": "Concluído",
+        "blocked": "Bloqueado",
+        "cancelled": "Cancelado"
+      },
       "priority": {
         "critical": "Crítica",
         "high": "Alta",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8201,6 +8201,15 @@
         "subtask": "Subtask",
         "risk": "Risk"
       },
+      "workItemStatus": {
+        "backlog": "بیک لاگ",
+        "ready": "تیار",
+        "in_progress": "جاری",
+        "in_review": "زیر جائزہ",
+        "done": "مکمل",
+        "blocked": "مسدود",
+        "cancelled": "منسوخ"
+      },
       "priority": {
         "critical": "Critical",
         "high": "High",

--- a/autobot-frontend/src/views/llc/GoalTree.vue
+++ b/autobot-frontend/src/views/llc/GoalTree.vue
@@ -8,6 +8,7 @@ import { useI18n } from 'vue-i18n'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import { useLlcCompanyContext } from '@/composables/llc/useLlcCompanyContext'
+import { useWorkItemLabels } from '@/composables/useWorkItemLabels'
 import { markExpanded, buildTreeFromParent } from '@/composables/llc/useLlcTree'
 import GoalTreeNode from './GoalTreeNode.vue'
 import type { Goal } from './GoalTreeNode.vue'
@@ -16,6 +17,7 @@ const logger = createLogger('GoalTree')
 const api = useApiClient()
 const { t } = useI18n()
 const { resolveCompanyId } = useLlcCompanyContext()
+const { workItemStatusLabel } = useWorkItemLabels()
 
 const goals = ref<Goal[]>([])
 const isLoading = ref(false)
@@ -151,7 +153,7 @@ onMounted(fetchGoals)
               <span class="text-xs text-autobot-text-muted mr-1">{{ item.identifier }}</span>
               {{ item.title }}
             </span>
-            <span class="text-xs font-medium" :class="itemStatusColor(item.status)">{{ item.status }}</span>
+            <span class="text-xs font-medium" :class="itemStatusColor(item.status)">{{ workItemStatusLabel(item.status) }}</span>
           </li>
         </ul>
       </div>

--- a/autobot-frontend/src/views/llc/ReviewInboxView.vue
+++ b/autobot-frontend/src/views/llc/ReviewInboxView.vue
@@ -23,7 +23,7 @@
         <button type="button" class="review-row" @click="detailItem = item">
           <span class="review-identifier">{{ item.identifier }}</span>
           <span class="review-title">{{ item.title }}</span>
-          <span class="review-type">{{ item.type }}</span>
+          <span class="review-type">{{ workItemTypeLabel(item.type) }}</span>
         </button>
       </li>
     </ul>
@@ -48,10 +48,12 @@ import { createLogger } from '@/utils/debugUtils'
 import LlcBreadcrumb, { type BreadcrumbItem } from '@/components/llc/LlcBreadcrumb.vue'
 import WorkItemDetail from './WorkItemDetail.vue'
 import type { WorkItem } from './workItemTypes'
+import { useWorkItemLabels } from '@/composables/useWorkItemLabels'
 
 const route = useRoute()
 const api = useApiClient()
 const { t } = useI18n()
+const { workItemTypeLabel } = useWorkItemLabels()
 const userStore = useUserStore()
 const logger = createLogger('ReviewInboxView')
 

--- a/autobot-frontend/src/views/llc/WorkItemDetail.vue
+++ b/autobot-frontend/src/views/llc/WorkItemDetail.vue
@@ -9,7 +9,7 @@
         <div class="header-left">
           <span class="item-identifier">{{ item.identifier }}</span>
           <span class="type-badge" :class="`type-${item.type}`">{{ workItemTypeLabel(item.type) }}</span>
-          <span class="status-badge" :class="`status-${item.status}`">{{ item.status.replace('_', ' ') }}</span>
+          <span class="status-badge" :class="`status-${item.status}`">{{ workItemStatusLabel(item.status) }}</span>
         </div>
         <button class="close-btn" @click="$emit('close')" :aria-label="$t('common.close')">
           <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" class="close-icon">
@@ -245,7 +245,7 @@ import { useWorkItemLabels } from '@/composables/useWorkItemLabels'
 const logger = createLogger('WorkItemDetail')
 const api = useApiClient()
 const { t } = useI18n()
-const { workItemTypeLabel } = useWorkItemLabels()
+const { workItemTypeLabel, workItemStatusLabel } = useWorkItemLabels()
 
 import type { WorkItem } from './workItemTypes'
 


### PR DESCRIPTION
## Thinking Path
#11076 parts 1-2: 4 LLC views/components still rendered work-item enums raw (e.g. `{{ item.status }}` → "in_progress" instead of "In Progress"). The `useWorkItemLabels` composable (#10818) already covers type/priority/sprint-status; extend it with `status` and apply at the remaining sites.

## What Changed
- **Composable**: added `workItemStatusLabel(value)` → `label('workItemStatus', value)`.
- **Locales**: added `llc.enums.workItemStatus.{backlog,ready,in_progress,in_review,done,blocked,cancelled}` (closed enum, confirmed vs `.status-*` CSS + transition map) to ALL 11 locales, translated for de/es/fr/pt/pl/lv/ar/fa/he/ur.
- **4 sites migrated**: GoalTree.vue (`workItemStatusLabel`), ReviewInboxView.vue + TemplateBrowser.vue (`workItemTypeLabel`), WorkItemDetail.vue (raw `.replace('_',' ')` → `workItemStatusLabel`).

## Verification (independently re-run)
- `eslint` → 0/0; `vue-tsc` → exit 0.
- `check:i18n` + `check:locales` → both pass; locale diffs are clean additions (+9/-0 per file, valid JSON).
- No raw enum renders remain; no spec references these files.

## Follow-up (left in #11076)
Part 3 (shared `<WorkItemBadge>` to dedup `.type-*`/`.priority-*`/`.status-*` CSS across 6 files) + part 4 (union types in workItemTypes.ts).

## Model Used
Opus 4.8

Closes #11076 parts 1-2.