### PR TITLE
Content Reach hardening: parallel probe_all, env TTL, httpx DRY, bounded robots cache (closes #11078)

### DIFF
--- a/autobot-backend/content_reach/_http.py
+++ b/autobot-backend/content_reach/_http.py
@@ -39,7 +39,7 @@ async def http_get(
         kwargs["params"] = params
 
     if client is not None:
-        return await client.get(url, **kwargs)
+        return await client.get(url, timeout=timeout, **kwargs)
 
     async with httpx.AsyncClient(timeout=timeout) as c:
         return await c.get(url, **kwargs)

--- a/autobot-backend/content_reach/_http.py
+++ b/autobot-backend/content_reach/_http.py
@@ -1,0 +1,45 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shared httpx fetch helper for content_reach backends (#11078).
+
+Encapsulates the injected-client-vs-async-with branch so backends stay DRY.
+Error handling (httpx.HTTPError → BackendError) remains the caller's responsibility.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+# Default HTTP timeout in seconds — shared across all httpx-backed backends.
+_HTTP_TIMEOUT = 15.0
+
+
+async def http_get(
+    url: str,
+    *,
+    client: httpx.AsyncClient | None,
+    headers: dict[str, str] | None = None,
+    params: dict[str, Any] | None = None,
+    timeout: float = _HTTP_TIMEOUT,
+) -> httpx.Response:
+    """GET *url* with an optional injected client or a short-lived AsyncClient.
+
+    If *client* is not None, uses it directly (test injection path).
+    Otherwise opens a fresh AsyncClient, issues the request, and closes it.
+    Callers must wrap this with ``try/except httpx.HTTPError`` as appropriate.
+    """
+    kwargs: dict[str, Any] = {}
+    if headers is not None:
+        kwargs["headers"] = headers
+    if params is not None:
+        kwargs["params"] = params
+
+    if client is not None:
+        return await client.get(url, **kwargs)
+
+    async with httpx.AsyncClient(timeout=timeout) as c:
+        return await c.get(url, **kwargs)

--- a/autobot-backend/content_reach/_url_guard.py
+++ b/autobot-backend/content_reach/_url_guard.py
@@ -38,6 +38,9 @@ _ROBOTS_UA = "autobot-content-reach/1.0"
 _robots_cache: dict[str, urllib.robotparser.RobotFileParser] = {}
 _robots_cache_lock = asyncio.Lock()
 
+# Maximum number of domains cached before the whole cache is cleared (simple bound).
+_ROBOTS_CACHE_MAX = 512
+
 # Robots fetch timeout in seconds.
 _ROBOTS_FETCH_TIMEOUT = 10.0
 
@@ -61,7 +64,7 @@ async def _fetch_robots_text(domain: str) -> str:
                     return await resp.text(encoding="utf-8", errors="replace")
         return ""
     except Exception as exc:
-        logger.debug("content_reach robots.txt fetch failed for %s: %s", domain, exc)
+        logger.warning("content_reach robots.txt fetch failed for %s: %s", domain, exc)
         return ""
 
 
@@ -74,9 +77,15 @@ def _parse_robots(text: str, domain: str) -> urllib.robotparser.RobotFileParser:
 
 
 async def _get_robots_parser(domain: str) -> urllib.robotparser.RobotFileParser:
-    """Return cached RobotFileParser for domain, fetching if needed."""
+    """Return cached RobotFileParser for domain, fetching if needed.
+
+    Evicts the entire cache when it exceeds _ROBOTS_CACHE_MAX entries to bound memory.
+    """
     async with _robots_cache_lock:
         if domain not in _robots_cache:
+            if len(_robots_cache) >= _ROBOTS_CACHE_MAX:
+                _robots_cache.clear()
+                logger.debug("content_reach robots cache exceeded %d entries; cleared", _ROBOTS_CACHE_MAX)
             text = await _fetch_robots_text(domain)
             _robots_cache[domain] = _parse_robots(text, domain)
         return _robots_cache[domain]

--- a/autobot-backend/content_reach/backends/browser.py
+++ b/autobot-backend/content_reach/backends/browser.py
@@ -27,7 +27,7 @@ logger = get_logger(__name__)
 _DDG_SEARCH_URL = "https://duckduckgo.com/html/?q={}"
 
 
-def _get_manager():  # pragma: no cover — replaced by monkeypatch in tests
+def _get_manager():
     """Lazy accessor for the research browser manager (avoids import at module load)."""
     from research_browser_manager import get_research_browser_manager
 

--- a/autobot-backend/content_reach/registry.py
+++ b/autobot-backend/content_reach/registry.py
@@ -21,13 +21,18 @@ logger = get_logger(__name__)
 
 
 def _parse_probe_ttl() -> float:
-    """Read AUTOBOT_CONTENT_PROBE_TTL_S from env; fall back to 30.0 on bad value."""
+    """Read AUTOBOT_CONTENT_PROBE_TTL_S from env; fall back to 30.0 on bad or non-positive value."""
     raw = os.environ.get("AUTOBOT_CONTENT_PROBE_TTL_S", "")
     if raw:
         try:
-            return float(raw)
+            value = float(raw)
         except ValueError:
             logger.warning("AUTOBOT_CONTENT_PROBE_TTL_S=%r is not a valid float; using 30.0", raw)
+            return 30.0
+        if value <= 0:
+            logger.warning("AUTOBOT_CONTENT_PROBE_TTL_S=%r is non-positive; using 30.0", raw)
+            return 30.0
+        return value
     return 30.0
 
 

--- a/autobot-backend/content_reach/registry.py
+++ b/autobot-backend/content_reach/registry.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import os
 import time
 
 from autobot_shared.logging_manager import get_logger
@@ -17,8 +19,20 @@ from source_attribution import SourceType, track_source
 
 logger = get_logger(__name__)
 
-# Liveness-probe cache TTL, matching provider_registry's 30s convention.
-_PROBE_TTL_S = 30.0
+
+def _parse_probe_ttl() -> float:
+    """Read AUTOBOT_CONTENT_PROBE_TTL_S from env; fall back to 30.0 on bad value."""
+    raw = os.environ.get("AUTOBOT_CONTENT_PROBE_TTL_S", "")
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            logger.warning("AUTOBOT_CONTENT_PROBE_TTL_S=%r is not a valid float; using 30.0", raw)
+    return 30.0
+
+
+# Liveness-probe cache TTL — env-overridable per CLAUDE.md "never hard-code cache TTL".
+_PROBE_TTL_S: float = _parse_probe_ttl()
 
 
 class ContentSourceRegistry:
@@ -59,10 +73,22 @@ class ContentSourceRegistry:
         return live
 
     async def probe_all(self) -> dict[str, list[str]]:
-        """Return {source: [live backend names]} — powers the health probe."""
+        """Return {source: [live backend names]} — all (source, backend) pairs probed concurrently."""
+        # Collect all (source, backend) pairs preserving per-source order.
+        pairs: list[tuple[str, object]] = [
+            (source, backend) for source, chain in self._chains.items() for backend in chain.backends
+        ]
+        if not pairs:
+            return {}
+
+        live_flags: list[bool] = await asyncio.gather(*[self._is_live(b) for _, b in pairs])
+
         result: dict[str, list[str]] = {}
-        for source, chain in self._chains.items():
-            result[source] = [b.name for b in chain.backends if await self._is_live(b)]
+        for (source, backend), is_live in zip(pairs, live_flags):
+            if source not in result:
+                result[source] = []
+            if is_live:
+                result[source].append(backend.name)
         return result
 
     async def fetch(self, source: str, request: ContentRequest) -> ContentResult:

--- a/autobot-backend/content_reach/sources/reddit.py
+++ b/autobot-backend/content_reach/sources/reddit.py
@@ -17,6 +17,7 @@ import logging
 
 import httpx
 
+from content_reach._http import http_get
 from content_reach._url_guard import ensure_public_url
 from content_reach.backends.browser import BrowserBackend
 from content_reach.base import BackendError, ContentBackend, ContentRequest, ContentResult
@@ -24,9 +25,6 @@ from content_reach.chain import ContentSourceChain
 from source_attribution import SourceReliability, SourceType
 
 logger = logging.getLogger(__name__)
-
-# Module-level HTTP timeout constant (seconds).
-_HTTP_TIMEOUT = 15.0
 
 # Reddit API user-agent string.
 _USER_AGENT = "autobot-content-reach/1.0"
@@ -60,29 +58,18 @@ class RedditJsonBackend(ContentBackend):
             await ensure_public_url(request.url)
             url = request.url if request.url.endswith(".json") else request.url + ".json"
             try:
-                if self._client is not None:
-                    response = await self._client.get(url, headers=headers)
-                else:
-                    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-                        response = await client.get(url, headers=headers)
+                response = await http_get(url, client=self._client, headers=headers)
             except httpx.HTTPError as exc:
                 logger.debug("RedditJsonBackend: HTTP error for %r: %s", url, exc)
                 raise BackendError(str(exc)) from exc
         else:
             try:
-                if self._client is not None:
-                    response = await self._client.get(
-                        "https://www.reddit.com/search.json",
-                        params={"q": request.query, "limit": request.limit},
-                        headers=headers,
-                    )
-                else:
-                    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-                        response = await client.get(
-                            "https://www.reddit.com/search.json",
-                            params={"q": request.query, "limit": request.limit},
-                            headers=headers,
-                        )
+                response = await http_get(
+                    "https://www.reddit.com/search.json",
+                    client=self._client,
+                    headers=headers,
+                    params={"q": request.query, "limit": request.limit},
+                )
             except httpx.HTTPError as exc:
                 logger.debug("RedditJsonBackend: HTTP error for query %r: %s", request.query, exc)
                 raise BackendError(str(exc)) from exc
@@ -148,17 +135,11 @@ class HnAlgoliaBackend(ContentBackend):
     async def fetch(self, request: ContentRequest) -> ContentResult:
         """Fetch HN hits from Algolia; raise BackendError on failure."""
         try:
-            if self._client is not None:
-                response = await self._client.get(
-                    "https://hn.algolia.com/api/v1/search",
-                    params={"query": request.query, "hitsPerPage": request.limit},
-                )
-            else:
-                async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-                    response = await client.get(
-                        "https://hn.algolia.com/api/v1/search",
-                        params={"query": request.query, "hitsPerPage": request.limit},
-                    )
+            response = await http_get(
+                "https://hn.algolia.com/api/v1/search",
+                client=self._client,
+                params={"query": request.query, "hitsPerPage": request.limit},
+            )
         except httpx.HTTPError as exc:
             logger.debug("HnAlgoliaBackend: HTTP error for query %r: %s", request.query, exc)
             raise BackendError(str(exc)) from exc

--- a/autobot-backend/content_reach/sources/web_page.py
+++ b/autobot-backend/content_reach/sources/web_page.py
@@ -17,6 +17,7 @@ import asyncio
 import httpx
 
 from autobot_shared.logging_manager import get_logger
+from content_reach._http import http_get
 from content_reach._url_guard import ensure_public_url, ensure_robots_allowed
 from content_reach.backends.browser import BrowserBackend
 from content_reach.base import BackendError, ContentBackend, ContentRequest, ContentResult
@@ -24,9 +25,6 @@ from content_reach.chain import ContentSourceChain
 from source_attribution import SourceReliability, SourceType
 
 logger = get_logger(__name__)
-
-# Module-level HTTP timeout constant (seconds).
-_HTTP_TIMEOUT = 15.0
 
 # Jina Reader base URL.
 _JINA_READER_BASE = "https://r.jina.ai/"
@@ -83,11 +81,7 @@ class TrafilaturaBackend(ContentBackend):
             raise BackendError("trafilatura not installed")
 
         try:
-            if self._client is not None:
-                response = await self._client.get(request.url)
-            else:
-                async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-                    response = await client.get(request.url)
+            response = await http_get(request.url, client=self._client)
         except httpx.HTTPError as exc:
             raise BackendError(f"TrafilaturaBackend: HTTP error fetching {request.url!r}: {exc}") from exc
 
@@ -142,11 +136,7 @@ class JinaReaderBackend(ContentBackend):
         headers = {"Accept": "text/plain"}
 
         try:
-            if self._client is not None:
-                response = await self._client.get(url, headers=headers)
-            else:
-                async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-                    response = await client.get(url, headers=headers)
+            response = await http_get(url, client=self._client, headers=headers)
         except httpx.HTTPError as exc:
             raise BackendError(f"JinaReaderBackend: HTTP error fetching {request.url!r}: {exc}") from exc
 

--- a/autobot-backend/content_reach/sources/web_search.py
+++ b/autobot-backend/content_reach/sources/web_search.py
@@ -18,15 +18,13 @@ from urllib.parse import quote_plus
 import httpx
 
 from autobot_shared.logging_manager import get_logger
+from content_reach._http import http_get
 from content_reach.backends.browser import BrowserSearchBackend
 from content_reach.base import BackendError, ContentBackend, ContentRequest, ContentResult
 from content_reach.chain import ContentSourceChain
 from source_attribution import SourceReliability, SourceType
 
 logger = get_logger(__name__)
-
-# Module-level HTTP timeout constant (seconds).
-_HTTP_TIMEOUT = 15.0
 
 # Module-level name so tests can monkeypatch: content_reach.sources.web_search.DDGS
 DDGS = None  # populated lazily by _import_ddgs()
@@ -120,11 +118,7 @@ class JinaSearchBackend(ContentBackend):
         headers = {"Accept": "application/json"}
 
         try:
-            if self._client is not None:
-                response = await self._client.get(url, headers=headers)
-            else:
-                async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-                    response = await client.get(url, headers=headers)
+            response = await http_get(url, client=self._client, headers=headers)
         except httpx.HTTPError as exc:
             raise BackendError(f"JinaSearchBackend: HTTP error for query {request.query!r}: {exc}") from exc
 

--- a/autobot-backend/content_reach/sources/youtube.py
+++ b/autobot-backend/content_reach/sources/youtube.py
@@ -17,15 +17,13 @@ import re
 import httpx
 
 from autobot_shared.logging_manager import get_logger
+from content_reach._http import http_get
 from content_reach._url_guard import ensure_public_url
 from content_reach.base import BackendError, ContentBackend, ContentRequest, ContentResult
 from content_reach.chain import ContentSourceChain
 from source_attribution import SourceReliability, SourceType
 
 logger = get_logger(__name__)
-
-# Module-level HTTP timeout constant (seconds).
-_HTTP_TIMEOUT = 15.0
 
 # yt-dlp options used for all caption extractions.
 _YDL_OPTS: dict = {
@@ -196,11 +194,7 @@ class YtDlpCaptionBackend(ContentBackend):
         await ensure_public_url(caption_url)
 
         try:
-            if self._client is not None:
-                response = await self._client.get(caption_url)
-            else:
-                async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-                    response = await client.get(caption_url)
+            response = await http_get(caption_url, client=self._client)
         except httpx.HTTPError as exc:
             logger.debug(
                 "YtDlpCaptionBackend: HTTP error fetching caption track for %r: %s",

--- a/autobot-backend/tests/content_reach/backends/test_browser_get_manager.py
+++ b/autobot-backend/tests/content_reach/backends/test_browser_get_manager.py
@@ -1,0 +1,23 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Smoke test: _get_manager() actually resolves to the ResearchBrowserManager singleton (#11078).
+
+This test exercises the real import path so the line is covered and the pragma
+no-cover comment has been removed from browser.py.
+"""
+
+from __future__ import annotations
+
+
+def test_get_manager_returns_research_browser_manager_singleton():
+    """_get_manager() returns the ResearchBrowserManager singleton (import path works)."""
+    from content_reach.backends.browser import _get_manager
+    from research_browser_manager import ResearchBrowserManager, get_research_browser_manager
+
+    manager = _get_manager()
+
+    # Must be the same singleton returned by the canonical accessor.
+    assert manager is get_research_browser_manager()
+    assert isinstance(manager, ResearchBrowserManager)

--- a/autobot-backend/tests/content_reach/test_registry.py
+++ b/autobot-backend/tests/content_reach/test_registry.py
@@ -124,3 +124,101 @@ async def test_probe_all_lists_live_backends():
 def test_list_sources():
     reg = _registry(StubBackend("a"), StubBackend("b"))
     assert reg.list_sources() == {"web_search": ["a", "b"]}
+
+
+# ---------------------------------------------------------------------------
+# probe_all concurrency (#11078) — verify all pairs are probed and ordering
+# is preserved when multiple sources are registered.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_all_concurrent_multi_source():
+    """probe_all with two sources returns correct live maps for both."""
+    from content_reach.chain import ContentSourceChain
+    from source_attribution import SourceType
+
+    reg = ContentSourceRegistry()
+    reg.register_chain(
+        ContentSourceChain(
+            source="web_search",
+            source_type=SourceType.WEB_SEARCH,
+            backends=[StubBackend("a"), StubBackend("b", live=False)],
+        )
+    )
+    reg.register_chain(
+        ContentSourceChain(
+            source="reddit",
+            source_type=SourceType.REDDIT,
+            backends=[StubBackend("c", live=False), StubBackend("d")],
+        )
+    )
+    live = await reg.probe_all()
+    assert live == {"web_search": ["a"], "reddit": ["d"]}
+
+
+@pytest.mark.asyncio
+async def test_probe_all_empty_registry():
+    """probe_all returns {} for an empty registry."""
+    reg = ContentSourceRegistry()
+    assert await reg.probe_all() == {}
+
+
+@pytest.mark.asyncio
+async def test_probe_all_concurrent_probe_count():
+    """All backends are probed concurrently — probe count matches backend count."""
+    probe_calls: list[str] = []
+
+    class CountingBackend(StubBackend):
+        async def probe(self):
+            probe_calls.append(self.name)
+            return await super().probe()
+
+    reg = ContentSourceRegistry()
+    from content_reach.chain import ContentSourceChain
+    from source_attribution import SourceType
+
+    reg.register_chain(
+        ContentSourceChain(
+            source="web_search",
+            source_type=SourceType.WEB_SEARCH,
+            backends=[CountingBackend("x"), CountingBackend("y"), CountingBackend("z")],
+        )
+    )
+    await reg.probe_all()
+    assert sorted(probe_calls) == ["x", "y", "z"]
+
+
+# ---------------------------------------------------------------------------
+# env-overridable TTL (#11078)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_probe_ttl_default():
+    """_parse_probe_ttl returns 30.0 when env var is absent."""
+    import os
+
+    import content_reach.registry as reg_mod
+
+    env_bak = os.environ.pop("AUTOBOT_CONTENT_PROBE_TTL_S", None)
+    try:
+        assert reg_mod._parse_probe_ttl() == 30.0
+    finally:
+        if env_bak is not None:
+            os.environ["AUTOBOT_CONTENT_PROBE_TTL_S"] = env_bak
+
+
+def test_parse_probe_ttl_custom(monkeypatch):
+    """_parse_probe_ttl returns parsed float from env var."""
+    import content_reach.registry as reg_mod
+
+    monkeypatch.setenv("AUTOBOT_CONTENT_PROBE_TTL_S", "60.0")
+    assert reg_mod._parse_probe_ttl() == 60.0
+
+
+def test_parse_probe_ttl_invalid_falls_back(monkeypatch):
+    """_parse_probe_ttl falls back to 30.0 on a non-float env value."""
+    import content_reach.registry as reg_mod
+
+    monkeypatch.setenv("AUTOBOT_CONTENT_PROBE_TTL_S", "notanumber")
+    assert reg_mod._parse_probe_ttl() == 30.0

--- a/autobot-backend/tests/content_reach/test_registry.py
+++ b/autobot-backend/tests/content_reach/test_registry.py
@@ -222,3 +222,38 @@ def test_parse_probe_ttl_invalid_falls_back(monkeypatch):
 
     monkeypatch.setenv("AUTOBOT_CONTENT_PROBE_TTL_S", "notanumber")
     assert reg_mod._parse_probe_ttl() == 30.0
+
+
+def test_parse_probe_ttl_zero_falls_back(monkeypatch):
+    """_parse_probe_ttl falls back to 30.0 when the value is zero."""
+    import content_reach.registry as reg_mod
+
+    monkeypatch.setenv("AUTOBOT_CONTENT_PROBE_TTL_S", "0")
+    assert reg_mod._parse_probe_ttl() == 30.0
+
+
+def test_parse_probe_ttl_negative_falls_back(monkeypatch):
+    """_parse_probe_ttl falls back to 30.0 when the value is negative."""
+    import content_reach.registry as reg_mod
+
+    monkeypatch.setenv("AUTOBOT_CONTENT_PROBE_TTL_S", "-5.0")
+    assert reg_mod._parse_probe_ttl() == 30.0
+
+
+@pytest.mark.asyncio
+async def test_probe_all_all_dead_source_present():
+    """A source whose every backend is dead still appears in probe_all with an empty list."""
+    from content_reach.chain import ContentSourceChain
+    from source_attribution import SourceType
+
+    reg = ContentSourceRegistry()
+    reg.register_chain(
+        ContentSourceChain(
+            source="web_search",
+            source_type=SourceType.WEB_SEARCH,
+            backends=[StubBackend("a", live=False), StubBackend("b", live=False)],
+        )
+    )
+    live = await reg.probe_all()
+    assert "web_search" in live
+    assert live["web_search"] == []

--- a/autobot-backend/tests/content_reach/test_url_guard.py
+++ b/autobot-backend/tests/content_reach/test_url_guard.py
@@ -522,3 +522,109 @@ async def test_real_util_blocks_link_local():
 
     result = await is_public_url_async("http://169.254.169.254/latest/meta-data/")
     assert result is False
+
+
+# ---------------------------------------------------------------------------
+# 11. robots cache bound (#11078)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_robots_cache_cleared_when_max_reached(monkeypatch):
+    """Cache is cleared when it reaches _ROBOTS_CACHE_MAX before adding a new entry."""
+    import content_reach._url_guard as guard_mod
+
+    # Patch _ROBOTS_CACHE_MAX to a small value for the test.
+    monkeypatch.setattr(guard_mod, "_ROBOTS_CACHE_MAX", 3)
+
+    # Reset the cache state.
+    guard_mod._robots_cache.clear()
+
+    # Pre-populate with 3 entries (at the limit).
+    import urllib.robotparser
+
+    for i in range(3):
+        guard_mod._robots_cache[f"http://example{i}.com"] = urllib.robotparser.RobotFileParser()
+
+    assert len(guard_mod._robots_cache) == 3
+
+    # Mock fetch to return empty text.
+    async def _empty_fetch(domain: str) -> str:
+        return ""
+
+    monkeypatch.setattr(guard_mod, "_fetch_robots_text", _empty_fetch)
+
+    # Adding a 4th entry should trigger a clear and then add the new entry.
+    await guard_mod._get_robots_parser("http://new-domain.com")
+
+    # After clear + add new, cache should contain exactly 1 entry.
+    assert len(guard_mod._robots_cache) == 1
+    assert "http://new-domain.com" in guard_mod._robots_cache
+
+
+@pytest.mark.asyncio
+async def test_robots_cache_under_max_not_cleared(monkeypatch):
+    """Cache is NOT cleared when it is below _ROBOTS_CACHE_MAX."""
+    import content_reach._url_guard as guard_mod
+
+    monkeypatch.setattr(guard_mod, "_ROBOTS_CACHE_MAX", 10)
+    guard_mod._robots_cache.clear()
+
+    import urllib.robotparser
+
+    for i in range(5):
+        guard_mod._robots_cache[f"http://domain{i}.com"] = urllib.robotparser.RobotFileParser()
+
+    async def _empty_fetch(domain: str) -> str:
+        return ""
+
+    monkeypatch.setattr(guard_mod, "_fetch_robots_text", _empty_fetch)
+
+    await guard_mod._get_robots_parser("http://another.com")
+
+    # 5 existing + 1 new = 6
+    assert len(guard_mod._robots_cache) == 6
+
+
+# ---------------------------------------------------------------------------
+# 12. robots fetch-error log level is WARNING (#11078)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_robots_fetch_error_logs_at_warning(monkeypatch, caplog):
+    """_fetch_robots_text logs at WARNING (not DEBUG) on fetch failure."""
+    import logging
+
+    import content_reach._url_guard as guard_mod
+
+    async def _boom(domain: str) -> str:
+        raise RuntimeError("firewall blocked robots.txt")
+
+    # We need to trigger the real except path, so monkeypatch aiohttp to raise.
+    import aiohttp
+
+    class _FailSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            pass
+
+        def get(self, *a, **kw):
+            return _FailResp()
+
+    class _FailResp:
+        async def __aenter__(self):
+            raise aiohttp.ClientError("blocked")
+
+        async def __aexit__(self, *a):
+            pass
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda: _FailSession())
+
+    with caplog.at_level(logging.WARNING, logger="content_reach._url_guard"):
+        text = await guard_mod._fetch_robots_text("http://example.com")
+
+    assert text == ""
+    assert any("robots.txt fetch failed" in r.message for r in caplog.records if r.levelno == logging.WARNING)


### PR DESCRIPTION
## Thinking Path

Hardening follow-ups for the now-complete Content Reach layer (#10932), tracked in #11078 — surfaced by the Task 1 & Task 7 reviews and deferred as non-blocking. Behavior-preserving polish + resilience.

## What Changed

- **Parallel `probe_all()`** — fans out all `(source, backend)` liveness probes via `asyncio.gather` instead of serially, so the `CONTENT_REACH` health probe stays under the 2s aggregator budget with real network backends.
- **Env-overridable probe TTL** — `_PROBE_TTL_S` now reads `AUTOBOT_CONTENT_PROBE_TTL_S` (default 30.0; rejects bad/non-positive values), per the no-hardcoded-TTL rule.
- **DRY httpx helper** — new `content_reach/_http.py::http_get()` collapses the injected-client-vs-`async with` branch repeated across all 5 httpx backends (web_search, web_page×2, reddit×2, youtube); forwards timeout on both paths.
- **Bounded robots cache** — `_robots_cache` capped at 512 entries (clear-on-exceed under the lock; fail-open intact).
- **robots-fetch log level** DEBUG→WARNING (a firewall blocking robots.txt is now visible).
- **Browser smoke** — removed `# pragma: no cover` on `_get_manager`; a test now exercises the real import path.

Not done: the reviewer-suggested `__init_subclass__` name/source_type guard — incompatible with the instance-level `source_type` pattern (`BrowserBackend.__init__(source_type)`); noted on #11078.

## Verification

119 content_reach tests pass (+12 new across the items); ruff / black 26.3.1 / isort clean. Reviewed (approved) — parallel `probe_all` mapping verified correct, `http_get` preserves each backend's url/headers/params.

## Model Used

Opus 4.8 (orchestration + review), Sonnet 4.6 (implementer + fix).

Closes #11078. Follow-up to #10932.
