### PR TITLE
refactor(cognify): consolidate 5× _process_batch flag-guard + Literal→prompt helpers (#11090)

### DIFF
--- a/autobot-backend/knowledge/pipeline/cognifiers/causal_relationship_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/causal_relationship_extractor.py
@@ -19,7 +19,9 @@ from autobot_shared.ssot_config import config
 from knowledge.pipeline.base import BaseCognifier, PipelineContext
 from knowledge.pipeline.cognifiers.llm_utils import (
     batched_chunk_extract,
+    literal_prompt_list,
     parse_llm_json_response,
+    render_prompt_sentinels,
 )
 from knowledge.pipeline.models.causal_edge import CausalEdge, EffectType
 from knowledge.pipeline.models.chunk import ProcessedChunk
@@ -32,9 +34,10 @@ logger = get_logger(__name__)
 # Allowed effect-type values derived from the EffectType Literal (#11017) so the
 # prompt fragment and the validation set can never drift from the type.
 _EFFECT_TYPES = tuple(get_args(EffectType))
-_EFFECT_TYPES_STR = ", ".join(_EFFECT_TYPES)
+_EFFECT_TYPES_STR = literal_prompt_list(EffectType)
 
-CAUSAL_EXTRACTION_PROMPT = """Extract CAUSAL relationships from the following text.
+CAUSAL_EXTRACTION_PROMPT = render_prompt_sentinels(
+    """Extract CAUSAL relationships from the following text.
 
 CRITICAL: Distinguish explicit causality from correlation:
 - ACCEPT: "X causes Y", "X leads to Y", "X results in Y", "if X then Y", "because X, Y happens"
@@ -63,9 +66,12 @@ Return empty array [] if no clear causal relationships found.
 
 Text:
 {text}
-""".replace("%%EFFECT_TYPES%%", _EFFECT_TYPES_STR)
+""",
+    {"EFFECT_TYPES": _EFFECT_TYPES_STR},
+)
 
-CAUSAL_EXTRACTION_BATCH_PROMPT = """Extract CAUSAL relationships from each of the following text chunks.
+CAUSAL_EXTRACTION_BATCH_PROMPT = render_prompt_sentinels(
+    """Extract CAUSAL relationships from each of the following text chunks.
 
 CRITICAL: Distinguish explicit causality from correlation:
 - ACCEPT: "X causes Y", "X leads to Y", "X results in Y", "if X then Y", "because X, Y happens"
@@ -89,7 +95,9 @@ no clear causality. Example for two chunks:
 
 Chunks:
 {chunks}
-""".replace("%%EFFECT_TYPES%%", _EFFECT_TYPES_STR)
+""",
+    {"EFFECT_TYPES": _EFFECT_TYPES_STR},
+)
 
 
 # NLP patterns for lightweight causal detection (fallback mode)
@@ -319,14 +327,9 @@ class CausalRelationshipExtractor(BaseCognifier):
         """Extract causal edges for a batch in ONE LLM call when batching is on (#10598).
 
         Routes through ``batched_chunk_extract`` (index-keyed prompt, per-chunk
-        fallback) so K chunks cost one round-trip instead of K. Falls back to the
-        legacy per-chunk loop when the config flag is disabled.
+        fallback) so K chunks cost one round-trip instead of K. The helper runs
+        the legacy per-chunk loop itself when the config flag is disabled (#11090).
         """
-        if not config.cognifier_multichunk_batching:
-            edges = []
-            for chunk in chunks:
-                edges.extend(await self._extract_from_chunk(chunk, context))
-            return edges
         return await batched_chunk_extract(
             chunks,
             llm=self.llm,

--- a/autobot-backend/knowledge/pipeline/cognifiers/entity_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/entity_extractor.py
@@ -290,14 +290,9 @@ class EntityExtractor(BaseCognifier):
         """Extract entities for a batch in ONE LLM call when batching is on (#10598).
 
         Routes through ``batched_chunk_extract`` (index-keyed prompt, per-chunk
-        fallback) so K chunks cost one round-trip instead of K. Falls back to the
-        legacy per-chunk loop when the config flag is disabled.
+        fallback) so K chunks cost one round-trip instead of K. The helper runs
+        the legacy per-chunk loop itself when the config flag is disabled (#11090).
         """
-        if not config.cognifier_multichunk_batching:
-            entities = []
-            for chunk in chunks:
-                entities.extend(await self._extract_from_chunk(chunk, context))
-            return entities
         return await batched_chunk_extract(
             chunks,
             llm=self.llm,

--- a/autobot-backend/knowledge/pipeline/cognifiers/event_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/event_extractor.py
@@ -10,7 +10,7 @@ Issue #759: Knowledge Pipeline Foundation - Extract, Cognify, Load (ECL).
 
 import re
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, get_args
+from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
@@ -18,7 +18,9 @@ from knowledge.pipeline.base import BaseCognifier, PipelineContext
 from knowledge.pipeline.cognifiers.llm_utils import (
     batched_chunk_extract,
     build_entity_map,
+    literal_prompt_list,
     parse_llm_json_response,
+    render_prompt_sentinels,
 )
 from knowledge.pipeline.models.chunk import ProcessedChunk
 from knowledge.pipeline.models.entity import Entity
@@ -31,11 +33,12 @@ logger = get_logger(__name__)
 
 # Prompt fragments derived from the TemporalType/EventType Literals (#11017) so the
 # prompt can never drift from the type (validation already uses ``__args__``).
-_TEMPORAL_TYPES_STR = ", ".join(get_args(TemporalType))
-_EVENT_TYPES_STR = ", ".join(get_args(EventType))
+_TEMPORAL_TYPES_STR = literal_prompt_list(TemporalType)
+_EVENT_TYPES_STR = literal_prompt_list(EventType)
 
 
-EVENT_EXTRACTION_PROMPT = """Extract temporal events from the text.
+EVENT_EXTRACTION_PROMPT = render_prompt_sentinels(
+    """Extract temporal events from the text.
 
 For each event:
 - name: Event title
@@ -51,9 +54,12 @@ Return JSON: [{{"name": "...", "description": "...", ...}}, ...]
 
 Text:
 {text}
-""".replace("%%TEMPORAL_TYPES%%", _TEMPORAL_TYPES_STR).replace("%%EVENT_TYPES%%", _EVENT_TYPES_STR)
+""",
+    {"TEMPORAL_TYPES": _TEMPORAL_TYPES_STR, "EVENT_TYPES": _EVENT_TYPES_STR},
+)
 
-EVENT_EXTRACTION_BATCH_PROMPT = """Extract temporal events from each of the following text chunks.
+EVENT_EXTRACTION_BATCH_PROMPT = render_prompt_sentinels(
+    """Extract temporal events from each of the following text chunks.
 
 Each chunk is labeled "Chunk N:". For each event provide:
 - name: Event title
@@ -76,7 +82,9 @@ Example for two chunks:
 
 Chunks:
 {chunks}
-""".replace("%%TEMPORAL_TYPES%%", _TEMPORAL_TYPES_STR).replace("%%EVENT_TYPES%%", _EVENT_TYPES_STR)
+""",
+    {"TEMPORAL_TYPES": _TEMPORAL_TYPES_STR, "EVENT_TYPES": _EVENT_TYPES_STR},
+)
 
 
 @TaskRegistry.register_cognifier("extract_events")
@@ -126,14 +134,9 @@ class EventExtractor(BaseCognifier):
         """Extract events for a batch in ONE LLM call when batching is on (#10598).
 
         Routes through ``batched_chunk_extract`` (index-keyed prompt, per-chunk
-        fallback) so K chunks cost one round-trip instead of K. Falls back to the
-        legacy per-chunk loop when the config flag is disabled.
+        fallback) so K chunks cost one round-trip instead of K. The helper runs
+        the legacy per-chunk loop itself when the config flag is disabled (#11090).
         """
-        if not config.cognifier_multichunk_batching:
-            events = []
-            for chunk in chunks:
-                events.extend(await self._extract_from_chunk(chunk, entity_map, context))
-            return events
         return await batched_chunk_extract(
             chunks,
             llm=self.llm,

--- a/autobot-backend/knowledge/pipeline/cognifiers/fact_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/fact_extractor.py
@@ -17,7 +17,12 @@ from uuid import UUID
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
 from knowledge.pipeline.base import BaseCognifier, PipelineContext
-from knowledge.pipeline.cognifiers.llm_utils import batched_chunk_extract, parse_llm_json_response
+from knowledge.pipeline.cognifiers.llm_utils import (
+    batched_chunk_extract,
+    literal_prompt_list,
+    parse_llm_json_response,
+    render_prompt_sentinels,
+)
 from knowledge.pipeline.models.chunk import ProcessedChunk
 from knowledge.pipeline.models.fact import AtomicFact, FactType
 from knowledge.pipeline.registry import TaskRegistry
@@ -30,12 +35,13 @@ logger = get_logger(__name__)
 # the ``FactType`` Literal so the prompt fragment and the validation set can never
 # drift from the type. Adding a value to FactType updates both at once.
 _FACT_TYPES = tuple(get_args(FactType))
-_FACT_TYPES_STR = ", ".join(f"'{t}'" for t in _FACT_TYPES)
+_FACT_TYPES_STR = literal_prompt_list(FactType, quote=True)
 
 # Max characters of a chunk sent to the LLM (shared by per-chunk and batched paths).
 MAX_CHUNK_CHARS = 2000
 
-FACT_EXTRACTION_PROMPT = """Extract atomic facts from the following text.
+FACT_EXTRACTION_PROMPT = render_prompt_sentinels(
+    """Extract atomic facts from the following text.
 
 For each fact, provide:
 - subject: Main subject or entity (e.g., "AutoBot", "ChromaDB")
@@ -59,11 +65,14 @@ Return JSON array of facts:
 
 Text:
 {text}
-""".replace("%%FACT_TYPES%%", _FACT_TYPES_STR)
+""",
+    {"FACT_TYPES": _FACT_TYPES_STR},
+)
 
 # Batched variant (#10647): extract facts from multiple labeled chunks in one
 # call, keyed by chunk index, to cut LLM round-trips.
-FACT_EXTRACTION_BATCH_PROMPT = """Extract atomic facts from each of the following text chunks.
+FACT_EXTRACTION_BATCH_PROMPT = render_prompt_sentinels(
+    """Extract atomic facts from each of the following text chunks.
 
 Each chunk is labeled "Chunk N:". For each fact provide:
 - subject, predicate, object
@@ -83,7 +92,9 @@ no facts. Example for two chunks:
 
 Chunks:
 {chunks}
-""".replace("%%FACT_TYPES%%", _FACT_TYPES_STR)
+""",
+    {"FACT_TYPES": _FACT_TYPES_STR},
+)
 
 # NLP-based patterns for fact extraction (Issue #3395)
 # Used when sentence-level parsing can identify simple facts
@@ -255,13 +266,9 @@ class FactExtractor(BaseCognifier):
         of a fact-local reimplementation — so fact extraction honors the
         ``cognifier_multichunk_batching`` / ``cognifier_batch_max_chunk_chars``
         config like the other extractors and inherits the #11012 partial-response
-        fix. Falls back to the legacy per-chunk loop when the flag is disabled.
+        fix. ``batched_chunk_extract`` honors the flag itself, running the legacy
+        per-chunk loop when it is disabled (#11090).
         """
-        if not config.cognifier_multichunk_batching:
-            facts: List[AtomicFact] = []
-            for chunk in chunks:
-                facts.extend(await self._extract_from_chunk(chunk, context))
-            return facts
         return await batched_chunk_extract(
             chunks,
             llm=self.llm,

--- a/autobot-backend/knowledge/pipeline/cognifiers/llm_utils.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/llm_utils.py
@@ -12,9 +12,10 @@ call keyed by chunk index, with per-chunk fallback (generalizes #10647).
 
 import json
 import os
-from typing import Any, Awaitable, Callable, Dict, List, TypeVar
+from typing import Any, Awaitable, Callable, Dict, List, TypeVar, get_args
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.ssot_config import config
 from knowledge.pipeline.models.entity import Entity
 
 logger = get_logger(__name__)
@@ -64,6 +65,48 @@ def parse_llm_json_response(
         if fallback_dict:
             return {"summary": content, "key_topics": [], "key_entities": []}
         return []
+
+
+def literal_prompt_list(literal_type: Any, *, quote: bool = False) -> str:
+    """Render a ``Literal[...]``'s allowed values as a ``', '``-joined prompt fragment.
+
+    Derived from the type via ``get_args`` so the prompt's allowed-value list and
+    the model can never drift (#11017). ``quote=True`` wraps each value in single
+    quotes (fact-type style); the default emits bare values (event/causal style) —
+    the flag makes the fact-vs-event/causal quoting difference explicit instead of
+    an accidental divergence between per-extractor join expressions (#11045).
+
+    Args:
+        literal_type: A ``typing.Literal[...]`` alias whose args are the values.
+        quote: Wrap each value in single quotes.
+
+    Returns:
+        ``"'a', 'b'"`` when quoted, else ``"a, b"``.
+    """
+    values = get_args(literal_type)
+    if quote:
+        return ", ".join(f"'{v}'" for v in values)
+    return ", ".join(str(v) for v in values)
+
+
+def render_prompt_sentinels(template: str, replacements: Dict[str, str]) -> str:
+    """Substitute ``%%NAME%%`` sentinels in a ``str.format``-bearing prompt (#11045).
+
+    Extractor prompts embed literal ``{{`` / ``}}`` JSON braces for a later
+    ``.format(...)`` call, so the allowed-value list can't be injected with
+    ``.format`` without escaping every brace. Sentinels sidestep that: author the
+    type list as ``%%NAME%%`` and replace it here at module load.
+
+    Args:
+        template: Prompt text containing ``%%NAME%%`` sentinels.
+        replacements: Mapping of sentinel name (without the ``%%``) to its value.
+
+    Returns:
+        ``template`` with every ``%%NAME%%`` replaced.
+    """
+    for name, value in replacements.items():
+        template = template.replace(f"%%{name}%%", value)
+    return template
 
 
 def build_entity_map(
@@ -156,6 +199,7 @@ async def batched_chunk_extract(
     extract_one: Callable[[Any], Awaitable[List[_R]]],
     content_of: Callable[[Any], str] = lambda c: c.content,
     aux_of: Callable[[Any], str] | None = None,
+    batching_enabled: bool | None = None,
 ) -> List[_R]:
     """Extract items from many chunks in ONE structured LLM call (#10598).
 
@@ -164,6 +208,11 @@ async def batched_chunk_extract(
     preserving per-chunk mapping and order. On any structural failure (non-object
     response, disjoint keys, or exception) it falls back to ``extract_one(chunk)``
     per chunk so correctness never regresses. A single-chunk batch skips batching.
+
+    When ``cognifier_multichunk_batching`` is disabled (or ``batching_enabled`` is
+    passed ``False``) it runs ``extract_one`` per chunk — the legacy path every
+    extractor used to guard inline before delegating here (#11090). The flag is
+    read at call time, not import, so tests can monkeypatch it.
 
     Args:
         chunks: The chunk objects to process.
@@ -176,14 +225,23 @@ async def batched_chunk_extract(
         content_of: Extract the text of a chunk (default ``chunk.content``).
         aux_of: Optional per-chunk auxiliary text folded into each indexed block —
             e.g. a chunk-relevant entity list for entity-conditioned extraction (#11044).
+        batching_enabled: Override the ``cognifier_multichunk_batching`` config flag;
+            ``None`` (default) reads the flag at call time.
 
     Returns:
         Flattened list of extracted items across all chunks, in chunk order.
     """
     if not chunks:
         return []
-    if len(chunks) == 1:
-        return await extract_one(chunks[0])
+    if batching_enabled is None:
+        batching_enabled = config.cognifier_multichunk_batching
+    # Batching off, or a single chunk (nothing to batch) → extract per chunk. This
+    # is the legacy fallback loop the extractors used to repeat inline (#11090).
+    if not batching_enabled or len(chunks) == 1:
+        results: List[_R] = []
+        for chunk in chunks:
+            results.extend(await extract_one(chunk))
+        return results
     try:
         aux = [aux_of(c) for c in chunks] if aux_of is not None else None
         blocks = build_indexed_chunk_blocks([content_of(c) for c in chunks], max_chunk_chars, aux=aux)

--- a/autobot-backend/knowledge/pipeline/cognifiers/multichunk_batching_test.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/multichunk_batching_test.py
@@ -149,6 +149,63 @@ async def test_helper_single_chunk_skips_batching():
     assert items == ["one"]
 
 
+@pytest.mark.asyncio
+async def test_helper_batching_disabled_runs_per_chunk():
+    """batching_enabled=False runs extract_one per chunk without any batched LLM
+    call — the legacy guard the extractors used to repeat inline now lives here (#11090)."""
+    c0, c1 = _chunk("c0"), _chunk("c1")
+    llm = types.SimpleNamespace(chat=AsyncMock())  # must NOT be called for the batch path
+    seen: list = []
+
+    async def extract_one(chunk):
+        seen.append(chunk.id)
+        return [chunk.id]
+
+    items = await llm_utils.batched_chunk_extract(
+        [c0, c1],
+        llm=llm,
+        batch_prompt_template="{chunks}",
+        llm_type="extraction",
+        max_chunk_chars=0,
+        convert=lambda raw, chunk: raw,
+        extract_one=extract_one,
+        batching_enabled=False,
+    )
+
+    assert llm.chat.call_count == 0  # no batched call
+    assert seen == [c0.id, c1.id]  # each chunk extracted individually, in order
+    assert items == [c0.id, c1.id]
+
+
+@pytest.mark.asyncio
+async def test_helper_batching_flag_read_from_config_when_unset(monkeypatch):
+    """When batching_enabled is not passed, the flag is read from config at call
+    time (not import) so monkeypatching it takes effect (#11090)."""
+    from autobot_shared.ssot_config import config
+
+    monkeypatch.setattr(config, "cognifier_multichunk_batching", False)
+    c0, c1 = _chunk("c0"), _chunk("c1")
+    llm = types.SimpleNamespace(chat=AsyncMock())
+    calls: list = []
+
+    async def extract_one(chunk):
+        calls.append(chunk.id)
+        return []
+
+    await llm_utils.batched_chunk_extract(
+        [c0, c1],
+        llm=llm,
+        batch_prompt_template="{chunks}",
+        llm_type="extraction",
+        max_chunk_chars=0,
+        convert=lambda raw, chunk: raw,
+        extract_one=extract_one,
+    )
+
+    assert llm.chat.call_count == 0  # config flag off -> per-chunk
+    assert calls == [c0.id, c1.id]
+
+
 def test_indexed_blocks_truncate_and_label():
     blocks = llm_utils.build_indexed_chunk_blocks(["abcdef", "xyz"], max_chars=3)
     assert blocks == "Chunk 0:\nabc\n\nChunk 1:\nxyz"

--- a/autobot-backend/knowledge/pipeline/cognifiers/relationship_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/relationship_extractor.py
@@ -262,14 +262,9 @@ class RelationshipExtractor(BaseCognifier):
 
         Routes through the shared ``batched_chunk_extract`` helper, folding each
         chunk's relevant entity list into its block via ``aux_of`` so the
-        entity-conditioning of the per-chunk path is preserved. Falls back to the
-        legacy per-chunk loop when the config flag is disabled.
+        entity-conditioning of the per-chunk path is preserved. The helper runs
+        the legacy per-chunk loop itself when the config flag is disabled (#11090).
         """
-        if not config.cognifier_multichunk_batching:
-            relationships = []
-            for chunk in chunks:
-                relationships.extend(await self._extract_from_chunk(chunk, entities, entity_map))
-            return relationships
         return await batched_chunk_extract(
             chunks,
             llm=self.llm,


### PR DESCRIPTION
## Thinking Path
Post-remediation consolidation (#11090): two small, low-blast-radius dedups in `knowledge/pipeline/cognifiers/`. Both had a clear existing home in `llm_utils`.

## What Changed
**Part 1 — 5× copy-pasted batching flag-guard → the helper.** Every extractor's `_process_batch` repeated `if not config.cognifier_multichunk_batching: <per-chunk loop>` before delegating to `batched_chunk_extract`. That per-chunk loop is exactly the helper's own fallback, so the flag now lives *in* the helper: it reads `cognifier_multichunk_batching` **at call time** (`batching_enabled=None` sentinel → monkeypatch-safe; an import-time default would not be) and runs `extract_one` per chunk when batching is off. New `batching_enabled` kwarg lets callers override explicitly. The 5 guard blocks are deleted from fact/event/entity/relationship/causal.

**Part 2 — 3× Literal→prompt derivation + `%%SENTINEL%%`.replace() → two helpers.**
- `literal_prompt_list(LiteralType, *, quote=False)` replaces the three divergent `', '.join(get_args(...))` expressions. The `quote` flag makes the fact-vs-event/causal quoting difference **explicit** rather than an accidental divergence between per-extractor join expressions.
- `render_prompt_sentinels(template, {name: value})` replaces the `.replace("%%X%%", ...)` chains — a `{{}}`-safe substitution (prompts embed literal JSON braces for a later `.format()`, so `.format` can't inject the type list).

Rendered prompts are **byte-identical to base**: fact stays quoted, event/causal stay bare, no `%%` leaks, `.format()` braces intact (asserted).

## Verification
- Full cognifiers suite: **156 passed / 2 dep-skipped** (2 new helper tests: `batching_enabled=False` + config-default paths).
- `literal_derivation_test` (values-present + no-sentinel-leak) green; explicit prompt-parity assertion run.
- `black` + `ruff` clean; `py_compile` clean on all 6 files.

## Model Used
Opus 4.8

Closes #11090