### PR TITLE
refactor(llc): extract shared WorkItemBadge, dedup badge palettes across 4 board views (#11076 part 3)

### DIFF
--- a/autobot-frontend/src/components/llc/WorkItemBadge.vue
+++ b/autobot-frontend/src/components/llc/WorkItemBadge.vue
@@ -1,0 +1,98 @@
+<!-- Copyright 2025-2026 mrveiss -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Author: mrveiss -->
+<script setup lang="ts">
+/**
+ * Shared work-item enum badge (#11076 part 3).
+ *
+ * Pairs a work-item `type` / `priority` / `status` enum value with its localized
+ * label (via useWorkItemLabels) and the shared color palette, replacing the
+ * `.type-*` / `.priority-*` / `.status-*` CSS that was duplicated across the LLC
+ * board views. `variant="dot"` renders the compact priority indicator used on
+ * dense cards; `size` matches each host context's original badge sizing so the
+ * extraction is visually identical.
+ */
+import { computed } from 'vue'
+import { useWorkItemLabels } from '@/composables/useWorkItemLabels'
+
+const props = withDefaults(
+  defineProps<{
+    kind: 'type' | 'priority' | 'status'
+    value: string | null | undefined
+    variant?: 'pill' | 'dot'
+    size?: 'xs' | 'sm' | 'md'
+  }>(),
+  { variant: 'pill', size: 'md' },
+)
+
+const { workItemTypeLabel, workItemStatusLabel, priorityLabel } = useWorkItemLabels()
+
+const label = computed(() => {
+  if (props.kind === 'type') return workItemTypeLabel(props.value)
+  if (props.kind === 'status') return workItemStatusLabel(props.value)
+  return priorityLabel(props.value)
+})
+
+const colorClass = computed(() =>
+  props.variant === 'dot' ? `dot-${props.value}` : `${props.kind}-${props.value}`,
+)
+</script>
+
+<template>
+  <span v-if="variant === 'dot'" class="wib-dot" :class="[`wib-dot--${size}`, colorClass]" :title="label" />
+  <span v-else class="wib" :class="[`wib--${size}`, colorClass]">{{ label }}</span>
+</template>
+
+<style scoped>
+.wib {
+  display: inline-block;
+  border-radius: 9999px;
+  font-weight: 500;
+  text-transform: capitalize;
+}
+.wib--xs { font-size: 0.6rem; padding: 0.1rem 0.35rem; }
+.wib--sm { font-size: 0.65rem; padding: 0.1rem 0.4rem; }
+.wib--md { font-size: 0.75rem; padding: 0.125rem 0.5rem; }
+
+.wib-dot {
+  display: inline-block;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+/* dot dimensions match each host: SprintBoard 0.5rem (md), Kanban 0.45rem (xs) */
+.wib-dot--md { width: 0.5rem; height: 0.5rem; }
+.wib-dot--sm { width: 0.5rem; height: 0.5rem; }
+.wib-dot--xs { width: 0.45rem; height: 0.45rem; }
+
+/* type palette (identical across all LLC boards) */
+.type-epic { background: #ddd6fe; color: #5b21b6; }
+.type-feature { background: #bfdbfe; color: #1d4ed8; }
+.type-pbi { background: #d1fae5; color: #065f46; }
+.type-task { background: #e0f2fe; color: #0369a1; }
+.type-bug { background: #fee2e2; color: #991b1b; }
+.type-spike { background: #fef3c7; color: #92400e; }
+.type-subtask { background: #f3f4f6; color: #374151; }
+.type-risk { background: #fce7f3; color: #9d174d; }
+
+/* work-item status palette (from WorkItemDetail) */
+.status-backlog { background: #f3f4f6; color: #374151; }
+.status-ready { background: #e0f2fe; color: #0369a1; }
+.status-in_progress { background: #ddd6fe; color: #5b21b6; }
+.status-in_review { background: #fef9c3; color: #713f12; }
+.status-done { background: #d1fae5; color: #065f46; }
+.status-blocked { background: #fee2e2; color: #991b1b; }
+.status-cancelled { background: #f3f4f6; color: #9ca3af; }
+
+/* priority pill palette (Backlog / WorkItemDetail) */
+.priority-critical { background: #fee2e2; color: #991b1b; }
+.priority-high { background: #ffedd5; color: #9a3412; }
+.priority-medium { background: #fef9c3; color: #713f12; }
+.priority-low { background: #f0fdf4; color: #14532d; }
+
+/* priority dot palette (SprintBoard / Kanban — solid fills) */
+.dot-critical { background: #ef4444; }
+.dot-high { background: #f97316; }
+.dot-medium { background: #eab308; }
+.dot-low { background: #22c55e; }
+</style>

--- a/autobot-frontend/src/components/llc/__tests__/WorkItemBadge.spec.ts
+++ b/autobot-frontend/src/components/llc/__tests__/WorkItemBadge.spec.ts
@@ -1,0 +1,61 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+// #11076 part 3 — shared WorkItemBadge: localized label + color/size/variant classes.
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+import WorkItemBadge from '../WorkItemBadge.vue'
+
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+const t = i18n.global.t as (key: string) => string
+
+function mountBadge(props: Record<string, unknown>) {
+  return mount(WorkItemBadge, { props, global: { plugins: [i18n] } })
+}
+
+describe('WorkItemBadge', () => {
+  it('renders a type pill with the localized label and md size by default', () => {
+    const w = mountBadge({ kind: 'type', value: 'epic' })
+    const span = w.get('span')
+    expect(span.classes()).toEqual(expect.arrayContaining(['wib', 'wib--md', 'type-epic']))
+    expect(span.text()).toBe(t('llc.enums.workItemType.epic'))
+  })
+
+  it('maps kind to the matching label + color class for status and priority', () => {
+    const status = mountBadge({ kind: 'status', value: 'in_progress' })
+    expect(status.get('span').classes()).toContain('status-in_progress')
+    expect(status.get('span').text()).toBe(t('llc.enums.workItemStatus.in_progress'))
+
+    const priority = mountBadge({ kind: 'priority', value: 'critical' })
+    expect(priority.get('span').classes()).toContain('priority-critical')
+    expect(priority.get('span').text()).toBe(t('llc.enums.priority.critical'))
+  })
+
+  it('honors the size prop for pills', () => {
+    expect(mountBadge({ kind: 'type', value: 'bug', size: 'xs' }).get('span').classes()).toContain('wib--xs')
+    expect(mountBadge({ kind: 'type', value: 'bug', size: 'sm' }).get('span').classes()).toContain('wib--sm')
+  })
+
+  it('renders the dot variant with dot color/size class, a title, and no text', () => {
+    const w = mountBadge({ kind: 'priority', value: 'high', variant: 'dot', size: 'xs' })
+    const span = w.get('span')
+    expect(span.classes()).toEqual(expect.arrayContaining(['wib-dot', 'wib-dot--xs', 'dot-high']))
+    expect(span.attributes('title')).toBe(t('llc.enums.priority.high'))
+    expect(span.text()).toBe('')
+  })
+
+  it('falls back to the humanized raw value when no translation key exists', () => {
+    const w = mountBadge({ kind: 'status', value: 'weird_custom' })
+    expect(w.get('span').text()).toBe('weird custom')
+  })
+
+  it('renders empty for a null value', () => {
+    const w = mountBadge({ kind: 'type', value: null })
+    expect(w.get('span').text()).toBe('')
+  })
+})

--- a/autobot-frontend/src/views/llc/BacklogView.vue
+++ b/autobot-frontend/src/views/llc/BacklogView.vue
@@ -93,13 +93,11 @@
               <span class="item-identifier">{{ item.identifier }}</span>
             </td>
             <td class="col-type">
-              <span class="type-badge" :class="`type-${item.type}`">{{ workItemTypeLabel(item.type) }}</span>
+              <WorkItemBadge kind="type" :value="item.type" />
             </td>
             <td class="col-title">{{ item.title }}</td>
             <td class="col-priority">
-              <span class="priority-badge" :class="`priority-${item.priority}`">
-                {{ priorityLabel(item.priority) }}
-              </span>
+              <WorkItemBadge kind="priority" :value="item.priority" />
             </td>
             <td class="col-points">{{ item.story_points ?? '—' }}</td>
             <td class="col-assignee">
@@ -220,16 +218,15 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { useWorkItemLabels } from '@/composables/useWorkItemLabels'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import WorkItemDetail from './WorkItemDetail.vue'
+import WorkItemBadge from '@/components/llc/WorkItemBadge.vue'
 
 const logger = createLogger('BacklogView')
 const api = useApiClient()
 const route = useRoute()
 const { t } = useI18n()
-const { workItemTypeLabel, priorityLabel } = useWorkItemLabels()
 
 const companyId = computed(() => route.params.companyId as string)
 
@@ -541,30 +538,6 @@ onMounted(fetchBacklog)
   font-size: 0.8rem;
   color: var(--text-secondary, #6b7280);
 }
-
-.type-badge,
-.priority-badge {
-  display: inline-block;
-  padding: 0.125rem 0.5rem;
-  border-radius: 9999px;
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: capitalize;
-}
-
-.type-epic { background: #ddd6fe; color: #5b21b6; }
-.type-feature { background: #bfdbfe; color: #1d4ed8; }
-.type-pbi { background: #d1fae5; color: #065f46; }
-.type-task { background: #e0f2fe; color: #0369a1; }
-.type-bug { background: #fee2e2; color: #991b1b; }
-.type-spike { background: #fef3c7; color: #92400e; }
-.type-subtask { background: #f3f4f6; color: #374151; }
-.type-risk { background: #fce7f3; color: #9d174d; }
-
-.priority-critical { background: #fee2e2; color: #991b1b; }
-.priority-high { background: #ffedd5; color: #9a3412; }
-.priority-medium { background: #fef9c3; color: #713f12; }
-.priority-low { background: #f0fdf4; color: #14532d; }
 
 .assignee-avatar {
   display: inline-flex;

--- a/autobot-frontend/src/views/llc/KanbanBoardView.vue
+++ b/autobot-frontend/src/views/llc/KanbanBoardView.vue
@@ -123,6 +123,7 @@ import { useRoute } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import WorkItemDetail from './WorkItemDetail.vue'
+import WorkItemBadge from '@/components/llc/WorkItemBadge.vue'
 import { useI18n } from 'vue-i18n'
 
 const logger = createLogger('KanbanBoardView')
@@ -249,14 +250,14 @@ const KanbanCard = defineComponent({
     return () => h('div', { class: 'kanban-card-inner' }, [
       h('div', { class: 'card-header-row' }, [
         h('span', { class: 'card-id' }, props.item.identifier),
-        h('span', { class: `card-type type-${props.item.type}` }, props.item.type),
+        h(WorkItemBadge, { kind: 'type', value: props.item.type, size: 'xs' }),
         props.item.linked_pr_urls?.length
           ? h('span', { class: 'pr-badge', title: t('llc.kanban.prLinked', { count: props.item.linked_pr_urls.length }) }, '🔗')
           : null,
       ]),
       h('p', { class: 'card-title' }, props.item.title),
       h('div', { class: 'card-footer-row' }, [
-        h('span', { class: `priority-dot priority-${props.item.priority}`, title: props.item.priority }),
+        h(WorkItemBadge, { kind: 'priority', value: props.item.priority, variant: 'dot', size: 'xs' }),
         props.item.story_points ? h('span', { class: 'card-pts' }, String(props.item.story_points)) : null,
         props.item.assignee_name
           ? h('span', { class: 'card-avatar', title: props.item.assignee_name }, initials(props.item.assignee_name))
@@ -449,14 +450,6 @@ onUnmounted(() => ws?.close())
   color: var(--text-secondary, #9ca3af);
 }
 
-.card-type {
-  font-size: 0.6rem;
-  padding: 0.1rem 0.35rem;
-  border-radius: 9999px;
-  font-weight: 500;
-  text-transform: capitalize;
-}
-
 .pr-badge {
   font-size: 0.7rem;
   cursor: help;
@@ -467,15 +460,6 @@ onUnmounted(() => ws?.close())
 .pr-badge:hover {
   opacity: 1;
 }
-
-.type-epic { background: #ddd6fe; color: #5b21b6; }
-.type-feature { background: #bfdbfe; color: #1d4ed8; }
-.type-pbi { background: #d1fae5; color: #065f46; }
-.type-task { background: #e0f2fe; color: #0369a1; }
-.type-bug { background: #fee2e2; color: #991b1b; }
-.type-spike { background: #fef3c7; color: #92400e; }
-.type-subtask { background: #f3f4f6; color: #374151; }
-.type-risk { background: #fce7f3; color: #9d174d; }
 
 .card-title {
   margin: 0;
@@ -488,18 +472,6 @@ onUnmounted(() => ws?.close())
   align-items: center;
   gap: 0.375rem;
 }
-
-.priority-dot {
-  width: 0.45rem;
-  height: 0.45rem;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.priority-critical { background: #ef4444; }
-.priority-high { background: #f97316; }
-.priority-medium { background: #eab308; }
-.priority-low { background: #22c55e; }
 
 .card-pts {
   font-size: 0.65rem;

--- a/autobot-frontend/src/views/llc/SprintBoardView.vue
+++ b/autobot-frontend/src/views/llc/SprintBoardView.vue
@@ -52,11 +52,11 @@
             >
               <div class="card-header">
                 <span class="card-identifier">{{ item.identifier }}</span>
-                <span class="card-type-badge" :class="`type-${item.type}`">{{ workItemTypeLabel(item.type) }}</span>
+                <WorkItemBadge kind="type" :value="item.type" size="sm" />
               </div>
               <p class="card-title">{{ item.title }}</p>
               <div class="card-footer">
-                <span class="priority-dot" :class="`priority-${item.priority}`" :title="priorityLabel(item.priority)" />
+                <WorkItemBadge kind="priority" :value="item.priority" variant="dot" />
                 <span v-if="item.story_points" class="card-points">{{ item.story_points }}</span>
                 <span v-if="item.assignee_name" class="card-assignee" :title="item.assignee_name">
                   {{ initials(item.assignee_name) }}
@@ -116,11 +116,12 @@ import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import { useWorkItemLabels } from '@/composables/useWorkItemLabels'
 import WorkItemDetail from './WorkItemDetail.vue'
+import WorkItemBadge from '@/components/llc/WorkItemBadge.vue'
 
 const logger = createLogger('SprintBoardView')
 const api = useApiClient()
 const route = useRoute()
-const { workItemTypeLabel, priorityLabel, sprintStatusLabel } = useWorkItemLabels()
+const { sprintStatusLabel } = useWorkItemLabels()
 
 const companyId = computed(() => route.params.companyId as string)
 const boardId = computed(() => route.params.boardId as string)
@@ -440,23 +441,6 @@ onUnmounted(() => {
   color: var(--text-secondary, #9ca3af);
 }
 
-.card-type-badge {
-  font-size: 0.65rem;
-  padding: 0.1rem 0.4rem;
-  border-radius: 9999px;
-  font-weight: 500;
-  text-transform: capitalize;
-}
-
-.type-epic { background: #ddd6fe; color: #5b21b6; }
-.type-feature { background: #bfdbfe; color: #1d4ed8; }
-.type-pbi { background: #d1fae5; color: #065f46; }
-.type-task { background: #e0f2fe; color: #0369a1; }
-.type-bug { background: #fee2e2; color: #991b1b; }
-.type-spike { background: #fef3c7; color: #92400e; }
-.type-subtask { background: #f3f4f6; color: #374151; }
-.type-risk { background: #fce7f3; color: #9d174d; }
-
 .card-title {
   margin: 0;
   font-size: 0.8rem;
@@ -470,18 +454,6 @@ onUnmounted(() => {
   gap: 0.5rem;
   margin-top: 0.125rem;
 }
-
-.priority-dot {
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.priority-critical { background: #ef4444; }
-.priority-high { background: #f97316; }
-.priority-medium { background: #eab308; }
-.priority-low { background: #22c55e; }
 
 .card-points {
   font-size: 0.7rem;

--- a/autobot-frontend/src/views/llc/WorkItemDetail.vue
+++ b/autobot-frontend/src/views/llc/WorkItemDetail.vue
@@ -8,8 +8,8 @@
       <div class="drawer-header">
         <div class="header-left">
           <span class="item-identifier">{{ item.identifier }}</span>
-          <span class="type-badge" :class="`type-${item.type}`">{{ workItemTypeLabel(item.type) }}</span>
-          <span class="status-badge" :class="`status-${item.status}`">{{ workItemStatusLabel(item.status) }}</span>
+          <WorkItemBadge kind="type" :value="item.type" />
+          <WorkItemBadge kind="status" :value="item.status" />
         </div>
         <button class="close-btn" @click="$emit('close')" :aria-label="$t('common.close')">
           <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" class="close-icon">
@@ -44,7 +44,7 @@
       <div class="meta-row">
         <div class="meta-field">
           <span class="meta-label">{{ $t('llc.workItem.priority') }}</span>
-          <span class="priority-badge" :class="`priority-${localItem.priority}`">{{ localItem.priority }}</span>
+          <WorkItemBadge kind="priority" :value="localItem.priority" />
         </div>
         <div class="meta-field">
           <span class="meta-label">{{ $t('llc.workItem.assignee') }}</span>
@@ -240,12 +240,11 @@ import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import HandoffModal from '@/components/llc/HandoffModal.vue'
 import { useCompanyPeople } from '@/composables/llc/useCompanyPeople'
-import { useWorkItemLabels } from '@/composables/useWorkItemLabels'
+import WorkItemBadge from '@/components/llc/WorkItemBadge.vue'
 
 const logger = createLogger('WorkItemDetail')
 const api = useApiClient()
 const { t } = useI18n()
-const { workItemTypeLabel, workItemStatusLabel } = useWorkItemLabels()
 
 import type { WorkItem } from './workItemTypes'
 
@@ -587,32 +586,6 @@ onMounted(() => {
   color: var(--text-secondary, #6b7280);
 }
 
-.type-badge,
-.status-badge {
-  font-size: 0.75rem;
-  padding: 0.125rem 0.5rem;
-  border-radius: 9999px;
-  font-weight: 500;
-  text-transform: capitalize;
-}
-
-.type-epic { background: #ddd6fe; color: #5b21b6; }
-.type-feature { background: #bfdbfe; color: #1d4ed8; }
-.type-pbi { background: #d1fae5; color: #065f46; }
-.type-task { background: #e0f2fe; color: #0369a1; }
-.type-bug { background: #fee2e2; color: #991b1b; }
-.type-spike { background: #fef3c7; color: #92400e; }
-.type-subtask { background: #f3f4f6; color: #374151; }
-.type-risk { background: #fce7f3; color: #9d174d; }
-
-.status-backlog { background: #f3f4f6; color: #374151; }
-.status-ready { background: #e0f2fe; color: #0369a1; }
-.status-in_progress { background: #ddd6fe; color: #5b21b6; }
-.status-in_review { background: #fef9c3; color: #713f12; }
-.status-done { background: #d1fae5; color: #065f46; }
-.status-blocked { background: #fee2e2; color: #991b1b; }
-.status-cancelled { background: #f3f4f6; color: #9ca3af; }
-
 .close-btn {
   background: none;
   border: none;
@@ -693,19 +666,6 @@ onMounted(() => {
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
-
-.priority-badge {
-  font-size: 0.75rem;
-  padding: 0.1rem 0.45rem;
-  border-radius: 9999px;
-  font-weight: 500;
-  text-transform: capitalize;
-}
-
-.priority-critical { background: #fee2e2; color: #991b1b; }
-.priority-high { background: #ffedd5; color: #9a3412; }
-.priority-medium { background: #fef9c3; color: #713f12; }
-.priority-low { background: #f0fdf4; color: #14532d; }
 
 .assignee-chip {
   font-size: 0.8rem;


### PR DESCRIPTION
## Thinking Path
#11076 part 3 — extract a shared `<WorkItemBadge>` to remove the work-item badge color CSS duplicated across the LLC board views. Recon corrected the issue's premise: the real surface is **4 files** (SprintBoardView, BacklogView, WorkItemDetail, KanbanBoardView) — `BusinessIntelligenceView.vue` doesn't exist, and `OperationDetail.vue` is a different domain (operation status/priority, not work-item enums) so it's left untouched.

## What Changed
New `src/components/llc/WorkItemBadge.vue` pairs a work-item `type`/`priority`/`status` enum value with its localized label (via `useWorkItemLabels`, from parts 1-2) and the shared color palette. Props: `kind`, `value`, `variant` (`pill`|`dot`), `size` (`xs`|`sm`|`md`).

Migrated all 4 views to the component and deleted the now-duplicated CSS:
- `.type-*` (8 rules) removed from **all 4** files (were byte-identical copies)
- `.priority-*` pill (4) removed from Backlog + WorkItemDetail; `.priority-dot` + solid palette removed from SprintBoard + Kanban
- `.status-*` (7) removed from WorkItemDetail
- **Kanban** builds cards via a `h()` render fn — its type + priority-dot were rendering **raw/untranslated** enum values; migrating to `h(WorkItemBadge, …)` also **localizes** them (in-scope per part 1). WorkItemDetail's raw `{{ localItem.priority }}` is likewise now localized.
- Untouched: SprintBoard's sprint-status badge (`sprintStatusLabel` + `.status-planning/active/review/closed` — a different enum) and OperationDetail.

**Zero visual regression:** every color value is byte-identical to base (verified by diff per palette), and the `size`/dot-size variants preserve each host's original sizing exactly (Kanban type 0.6rem + dot 0.45rem, SprintBoard type 0.65rem + dot 0.5rem, Backlog/Detail 0.75rem). Net −25 lines.

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json` → **0 errors** (whole project)
- `eslint` (component + 4 views) → **0 errors / 0 warnings**
- `vitest run BacklogView.reorder.test.ts` → **4 passed** (only spec touching these views; asserts reorder behavior, unaffected)
- Palette parity diff vs `origin/Dev_new_gui`: type / status / priority-pill / priority-dot all **identical**; orphaned-CSS grep clean

## Model Used
Opus 4.8 (implementation delegated to frontend subagent against an exact spec; independently verified + fixed the Kanban dot-size variant)

Closes #11076 (parts 1-3 fully deliver the issue: composable extended in #11126, shared `<WorkItemBadge>` here). Part 4 — optional union types in `workItemTypes.ts` — split to follow-up #11131.