### PR TITLE
refactor(frontend): migrate native confirm() to themed useConfirmDialog across 24 components (#11018 phase 2)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.vue
@@ -179,6 +179,7 @@ import Icon from '@/components/ui/Icon.vue'
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import { useSourcesListEndpoint } from '@/composables/analytics/useSourcesListEndpoint'
 import { usePollingJob } from '@/composables/usePollingJob'
@@ -188,6 +189,7 @@ import AddSourceModal from '@/components/analytics/AddSourceModal.vue'
 const logger = createLogger('CodebaseAnalyticsLanding')
 const router = useRouter()
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 // ---- Types ----------------------------------------------------------------
 
@@ -347,7 +349,7 @@ async function deleteSource(source: CodeSource) {
   const msg = t(
     'analytics.sources.confirmDelete', { name: source.name }
   )
-  if (!confirm(msg)) return
+  if (!(await confirm({ title: t('common.confirm'), message: msg }))) return
   deletingId.value = source.id
   const deleteEndpoint = useFetchEndpoint<unknown, true>({
     path: `/api/analytics/codebase/sources/${source.id}`,

--- a/autobot-frontend/src/components/analytics/PatternAnalysis.vue
+++ b/autobot-frontend/src/components/analytics/PatternAnalysis.vue
@@ -260,9 +260,11 @@
 import Icon from '@/components/ui/Icon.vue'
 import { watch, onMounted, reactive } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { usePatternAnalysis, type PatternAnalysisReport, type CodeLocation } from '@/composables/usePatternAnalysis'
 
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 // Props
 const props = defineProps<{
@@ -332,7 +334,7 @@ const runAnalysis = async () => {
 
 // Clear storage handler
 const clearStorage = async () => {
-  if (confirm(t('analytics.patterns.confirmClear'))) {
+  if (await confirm({ title: t('common.confirm'), message: t('analytics.patterns.confirmClear') })) {
     await clearStorageApi()
     await getStorageStats()
   }

--- a/autobot-frontend/src/components/analytics/SourceManager.vue
+++ b/autobot-frontend/src/components/analytics/SourceManager.vue
@@ -183,6 +183,7 @@ import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
 import { ref, watch, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
@@ -193,6 +194,7 @@ import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('SourceManager')
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 // ---- Types ----------------------------------------------------------------
 
@@ -331,7 +333,7 @@ async function syncSource(source: CodeSource) {
 }
 
 async function deleteSource(source: CodeSource) {
-  if (!confirm(t('analytics.sources.confirmDelete', { name: source.name }))) return
+  if (!(await confirm({ title: t('common.confirm'), message: t('analytics.sources.confirmDelete', { name: source.name }) }))) return
   deletingId.value = source.id
   try {
     await apiDeleteSource(source.id)

--- a/autobot-frontend/src/components/browser/BrowserSessionManager.vue
+++ b/autobot-frontend/src/components/browser/BrowserSessionManager.vue
@@ -220,6 +220,7 @@
 import type { IconName } from '@/components/ui/Icon.vue'
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { useBrowserAutomation } from '@/composables/useBrowserAutomation'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { BaseModal } from '@autobot/ui'
@@ -242,6 +243,7 @@ export default {
   },
   setup() {
     const { t } = useI18n()
+    const { confirm } = useConfirmDialog()
     const {
       sessions,
       launchSession,
@@ -337,8 +339,8 @@ export default {
       logger.info('Closed session', { id: sessionId })
     }
 
-    const deleteSession = (sessionId: string) => {
-      if (confirm(t('browser.sessionManager.deleteConfirm'))) {
+    const deleteSession = async (sessionId: string) => {
+      if (await confirm({ title: t('common.confirm'), message: t('browser.sessionManager.deleteConfirm') })) {
         deleteSessionHandler(sessionId)
         logger.info('Deleted session', { id: sessionId })
       }

--- a/autobot-frontend/src/components/chat/ChatFilePanel.vue
+++ b/autobot-frontend/src/components/chat/ChatFilePanel.vue
@@ -309,6 +309,7 @@
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { useConversationFiles, type SortField } from '@/composables/useConversationFiles'
 import { formatTimeAgo } from '@/utils/formatHelpers'
 import EmptyState from '@/components/ui/EmptyState.vue'
@@ -323,6 +324,7 @@ defineEmits<{
 }>()
 
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 // File management composable
 const {
@@ -405,7 +407,7 @@ const handleDrop = async (event: DragEvent) => {
 const handlePreview = async (fileId: string) => { await previewFile(fileId) }
 const handleDownload = async (fileId: string, filename: string) => { await downloadFile(fileId, filename) }
 const handleDelete = async (fileId: string, filename: string) => {
-  if (confirm(t('chat.filePanel.confirmDelete', { name: filename }))) {
+  if (await confirm({ title: t('common.confirm'), message: t('chat.filePanel.confirmDelete', { name: filename }) })) {
     await deleteFile(fileId)
   }
 }
@@ -456,7 +458,7 @@ const handleCopy = async (fileId: string) => {
 }
 
 const handleBulkDelete = async () => {
-  if (confirm(t('chat.filePanel.confirmBulkDelete', { count: selectedCount.value }))) {
+  if (await confirm({ title: t('common.confirm'), message: t('chat.filePanel.confirmBulkDelete', { count: selectedCount.value }) })) {
     await deleteSelectedFiles()
   }
 }

--- a/autobot-frontend/src/components/chat/ChatFolderNode.vue
+++ b/autobot-frontend/src/components/chat/ChatFolderNode.vue
@@ -149,11 +149,13 @@
 <script setup lang="ts">
 import { ref, computed, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import Icon from '@/components/ui/Icon.vue'
 import { useFolderStore, type ChatFolder } from '@/stores/useFolderStore'
 import type { ChatSession } from '@/stores/useChatStore'
 
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 const props = defineProps<{
   folder: ChatFolder
@@ -206,7 +208,7 @@ function cancelRename() {
 }
 
 async function deleteThisFolder() {
-  if (!confirm(t('chat.folders.confirmDelete', { name: props.folder.name }))) return
+  if (!(await confirm({ title: t('common.confirm'), message: t('chat.folders.confirmDelete', { name: props.folder.name }) }))) return
   await folderStore.deleteFolder(props.folder.id)
 }
 

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -272,6 +272,7 @@ import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, onMounted, onUnmounted, onActivated, onDeactivated, watch, provide } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { useBackoffPoller } from '@/composables/useBackoffPoller'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
@@ -344,6 +345,7 @@ interface DetectedToolCall {
 
 // i18n
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 // Router — tab routes (#6415)
 const route = useRoute()
@@ -755,7 +757,7 @@ const exportSession = async () => {
 const clearSession = async () => {
   if (!store.currentSessionId) return
 
-  if (confirm(t('chat.interface.confirmClear'))) {
+  if (await confirm({ title: t('common.confirm'), message: t('chat.interface.confirmClear') })) {
     try {
       await controller.resetCurrentChat()
     } catch (error) {

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -559,6 +559,7 @@ import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, nextTick, watch, onMounted } from 'vue'
 import { useExpansion } from '@/composables/useExpansion'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { useChatStore } from '@/stores/useChatStore'
 import { useChatController } from '@/models/controllers'
 import { useDisplaySettings } from '@/composables/useDisplaySettings'
@@ -602,6 +603,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 const store = useChatStore()
 const controller = useChatController()
 const { displaySettings } = useDisplaySettings()
@@ -1053,8 +1055,8 @@ const copyMessage = async (message: ChatMessage) => {
   }
 }
 
-const deleteMessage = (message: ChatMessage) => {
-  if (confirm(t('chat.messages.confirmDelete'))) {
+const deleteMessage = async (message: ChatMessage) => {
+  if (await confirm({ title: t('common.confirm'), message: t('chat.messages.confirmDelete') })) {
     controller.deleteMessage(message.id)
   }
 }

--- a/autobot-frontend/src/components/chat/ChatSidebar.vue
+++ b/autobot-frontend/src/components/chat/ChatSidebar.vue
@@ -401,6 +401,7 @@
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, nextTick, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 
 // #1804: emit close-mobile so ChatInterface can close the mobile overlay
 const emit = defineEmits<{ 'close-mobile': [] }>()
@@ -427,6 +428,7 @@ import { useNotificationBus } from '@/composables/useNotificationBus'
 const logger = createLogger('ChatSidebar')
 
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 const store = useChatStore()
 const controller = useChatController()
 const folderStore = useFolderStore()
@@ -755,7 +757,7 @@ const _toggleSelection = (sessionId: string) => {
 const deleteSelectedSessions = async () => {
   if (sessionSelection.selectedCount.value === 0) return
 
-  const confirmed = confirm(t('chat.sidebar.confirmDeleteSelected', { count: sessionSelection.selectedCount.value }))
+  const confirmed = await confirm({ title: t('common.confirm'), message: t('chat.sidebar.confirmDeleteSelected', { count: sessionSelection.selectedCount.value }) })
   if (!confirmed) return
 
   // Delete all selected sessions in parallel - eliminates N+1 sequential API calls

--- a/autobot-frontend/src/components/file-browser/FileBrowser.vue
+++ b/autobot-frontend/src/components/file-browser/FileBrowser.vue
@@ -87,6 +87,7 @@
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { useUserStore } from '@/stores/useUserStore'
 import { useFileBrowser } from '@/composables/file-browser/useFileBrowser'
 import type { FileBrowserItem, FileBrowserTreeNode, FilePreviewData } from '@/composables/file-browser/useFileBrowser'
@@ -98,6 +99,7 @@ import { useAsyncHandler } from '@/composables/useErrorHandler'
 import { useSessionActivityLogger } from '@/composables/useSessionActivityLogger'
 
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 // Issue #608: Activity logger for session tracking
 const { logFileActivity } = useSessionActivityLogger()
@@ -313,7 +315,7 @@ const { execute: performDelete, loading: _isDeletingFile } = useAsyncHandler(
 const deleteFile = async (file: FileBrowserItem) => {
   const message = t('fileBrowser.browser.deleteConfirm', { name: file.name })
 
-  if (confirm(message)) {
+  if (await confirm({ title: t('common.confirm'), message: message })) {
     await performDelete(file)
   }
 }

--- a/autobot-frontend/src/components/knowledge/DeduplicationManager.vue
+++ b/autobot-frontend/src/components/knowledge/DeduplicationManager.vue
@@ -188,6 +188,7 @@
 import Icon from '@/components/ui/Icon.vue'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { formatDate } from '@/utils/formatHelpers'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
@@ -196,6 +197,7 @@ import { useKnowledgeDeduplication } from '@/composables/knowledge/useKnowledgeD
 
 const logger = createLogger('DeduplicationManager')
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 const {
   duplicateStats,
@@ -239,7 +241,7 @@ const scanForIssues = async () => {
 
 // Cleanup duplicates
 const cleanupDuplicates = async () => {
-  if (!confirm(t('knowledge.deduplication.confirmRemoveDuplicates', { count: duplicateStats.value.total_duplicates }))) {
+  if (!(await confirm({ title: t('common.confirm'), message: t('knowledge.deduplication.confirmRemoveDuplicates', { count: duplicateStats.value.total_duplicates }) }))) {
     return
   }
 
@@ -261,7 +263,7 @@ const cleanupDuplicates = async () => {
 
 // Cleanup orphans
 const cleanupOrphans = async () => {
-  if (!confirm(t('knowledge.deduplication.confirmRemoveOrphans', { count: orphanStats.value.orphaned_count }))) {
+  if (!(await confirm({ title: t('common.confirm'), message: t('knowledge.deduplication.confirmRemoveOrphans', { count: orphanStats.value.orphaned_count }) }))) {
     return
   }
 

--- a/autobot-frontend/src/components/knowledge/DocumentChangeFeed.vue
+++ b/autobot-frontend/src/components/knowledge/DocumentChangeFeed.vue
@@ -207,11 +207,13 @@
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { createLogger } from '@/utils/debugUtils'
 import { useDocumentChanges } from '@/composables/useDocumentChanges'
 
 const logger = createLogger('DocumentChangeFeed')
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 import type { DocumentChange } from '@/composables/useDocumentChanges'
 import { formatBytes } from '@/utils/formatHelpers'
 import EmptyState from '@/components/ui/EmptyState.vue'
@@ -290,8 +292,8 @@ const handleAutoRefreshToggle = () => {
   }
 }
 
-const handleClearChanges = () => {
-  if (confirm(t('knowledge.changeFeed.confirmClearHistory'))) {
+const handleClearChanges = async () => {
+  if (await confirm({ title: t('common.confirm'), message: t('knowledge.changeFeed.confirmClearHistory') })) {
     clearChanges()
     activeFilter.value = 'all'
   }

--- a/autobot-frontend/src/components/knowledge/FailedVectorizationsManager.vue
+++ b/autobot-frontend/src/components/knowledge/FailedVectorizationsManager.vue
@@ -101,12 +101,14 @@
 import Icon from '@/components/ui/Icon.vue'
 import { onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { formatDateTime } from '@/utils/formatHelpers'
 import { useKnowledgeVectorization } from '@/composables/knowledge/useKnowledgeVectorization'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 const {
   failedJobs,
@@ -121,7 +123,7 @@ const {
 
 // Delete a single job — confirm before delegating to composable
 const deleteJob = async (jobId: string) => {
-  if (!confirm(t('knowledge.failedVectorizations.confirmDelete'))) {
+  if (!(await confirm({ title: t('common.confirm'), message: t('knowledge.failedVectorizations.confirmDelete') }))) {
     return
   }
   await deleteJobBase(jobId)
@@ -129,7 +131,7 @@ const deleteJob = async (jobId: string) => {
 
 // Clear all failed jobs — confirm before delegating to composable
 const clearAllFailed = async () => {
-  if (!confirm(t('knowledge.failedVectorizations.confirmClearAll', { count: failedJobs.value.length }))) {
+  if (!(await confirm({ title: t('common.confirm'), message: t('knowledge.failedVectorizations.confirmClearAll', { count: failedJobs.value.length }) }))) {
     return
   }
   await clearAllFailedBase()

--- a/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
@@ -174,6 +174,7 @@ import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
 import { ref, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { useKnowledgeStore } from '@/stores/useKnowledgeStore'
 import ApiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
@@ -183,6 +184,7 @@ import { useFakeProgress } from '@/composables/useFakeProgress'
 
 const logger = createLogger('KnowledgeAdvanced')
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 const store = useKnowledgeStore()
 
@@ -434,11 +436,11 @@ const clearAllKnowledge = async () => {
   if (isClearing.value || isPopulating.value) return
 
   // Double confirmation for destructive action
-  const firstConfirm = confirm(t('knowledge.advanced.confirmClearAll'))
+  const firstConfirm = await confirm({ title: t('common.confirm'), message: t('knowledge.advanced.confirmClearAll') })
 
   if (!firstConfirm) return
 
-  const secondConfirm = confirm(t('knowledge.advanced.confirmClearFinal'))
+  const secondConfirm = await confirm({ title: t('common.confirm'), message: t('knowledge.advanced.confirmClearFinal') })
 
   if (!secondConfirm) return
 

--- a/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
@@ -437,6 +437,7 @@
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, reactive, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { useKnowledgeStore } from '@/stores/useKnowledgeStore'
 import { useKnowledgeController } from '@/models/controllers'
 import type { KnowledgeDocument } from '@/stores/useKnowledgeStore'
@@ -465,6 +466,7 @@ type ExportFormat = 'json' | 'csv' | 'markdown'
 
 const logger = createLogger('KnowledgeEntries')
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 const store = useKnowledgeStore()
 const controller = useKnowledgeController()
@@ -640,7 +642,7 @@ const editEntry = (entry: KnowledgeDocument) => {
 }
 
 const deleteEntry = async (entry: KnowledgeDocument) => {
-  if (!confirm(t('knowledge.entries.confirmDelete', { title: entry.title || t('knowledge.entries.untitled') }))) return
+  if (!(await confirm({ title: t('common.confirm'), message: t('knowledge.entries.confirmDelete', { title: entry.title || t('knowledge.entries.untitled') }) }))) return
 
   try {
     await controller.deleteDocument(entry.id)
@@ -650,7 +652,7 @@ const deleteEntry = async (entry: KnowledgeDocument) => {
 }
 
 const deleteSelected = async () => {
-  if (!confirm(t('knowledge.entries.confirmDeleteSelected', { count: selection.selectedCount.value }))) return
+  if (!(await confirm({ title: t('common.confirm'), message: t('knowledge.entries.confirmDeleteSelected', { count: selection.selectedCount.value }) }))) return
 
   try {
     await controller.bulkDeleteDocuments([...selection.selected.value])

--- a/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
@@ -19,6 +19,7 @@ import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { BaseModal } from '@autobot/ui'
 import EmptyState from '@/components/ui/EmptyState.vue'
@@ -29,6 +30,7 @@ import type { Prompt, PromptVersion } from '@/composables/knowledge/useKnowledge
 const logger = createLogger('KnowledgePromptEditor')
 
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 // =============================================================================
 // State
@@ -131,9 +133,9 @@ async function loadPrompts(): Promise<void> {
   }
 }
 
-function selectPrompt(prompt: Prompt): void {
+async function selectPrompt(prompt: Prompt): Promise<void> {
   if (hasUnsavedChanges.value) {
-    if (!confirm(t('knowledge.promptEditor.confirmDiscardChanges'))) {
+    if (!(await confirm({ title: t('common.confirm'), message: t('knowledge.promptEditor.confirmDiscardChanges') }))) {
       return
     }
   }
@@ -186,7 +188,7 @@ async function loadHistory(): Promise<void> {
 async function revertToVersion(version: PromptVersion): Promise<void> {
   if (!selectedPrompt.value) return
 
-  if (!confirm(t('knowledge.promptEditor.confirmRevert', { version: version.version }))) {
+  if (!(await confirm({ title: t('common.confirm'), message: t('knowledge.promptEditor.confirmRevert', { version: version.version }) }))) {
     return
   }
 

--- a/autobot-frontend/src/components/knowledge/KnowledgeStats.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeStats.vue
@@ -384,6 +384,7 @@ import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { useKnowledgeStore } from '@/stores/useKnowledgeStore'
 import type { KnowledgeDocument } from '@/stores/useKnowledgeStore'
 import { useKnowledgeController } from '@/models/controllers/index'
@@ -406,6 +407,7 @@ import { createLogger } from '@/utils/debugUtils'
 const logger = createLogger('KnowledgeStats')
 
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 // Import shared document feed wrapper styles
 import '@/styles/document-feed-wrapper.css'
@@ -636,7 +638,7 @@ const exportStats = async () => {
 }
 
 const optimizeKnowledge = async () => {
-  if (!confirm(t('knowledge.stats.confirmOptimize'))) {
+  if (!(await confirm({ title: t('common.confirm'), message: t('knowledge.stats.confirmOptimize') }))) {
     return
   }
 

--- a/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
+++ b/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
@@ -117,11 +117,13 @@ import Icon from '@/components/ui/Icon.vue'
 import { BaseModal } from '@autobot/ui'
 import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { apiService } from '@/services/api'
 import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 const logger = createLogger('ShareKnowledgeDialog')
 
 /**
@@ -344,9 +346,9 @@ const saveChanges = async () => {
   }
 }
 
-const closeDialog = () => {
+const closeDialog = async () => {
   if (hasChanges.value) {
-    if (!confirm(t('knowledge.share.unsavedConfirm'))) {
+    if (!(await confirm({ title: t('common.confirm'), message: t('knowledge.share.unsavedConfirm') }))) {
       return
     }
   }

--- a/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue
+++ b/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue
@@ -187,6 +187,7 @@
 <script>
 import { ref, onMounted, computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useConfirmDialog } from '@/composables/useConfirmDialog';
 import { useMachineKnowledge } from '@/composables/knowledge/useMachineKnowledge';
 import { useManPages } from '@/composables/knowledge/useManPages';
 import { useKnowledgeJobs } from '@/composables/knowledge/useKnowledgeJobs';
@@ -211,6 +212,7 @@ export default {
 
   setup() {
     const { t } = useI18n();
+    const { confirm } = useConfirmDialog();
 
     // Domain composables (migrated from useKnowledgeBase BC shim in #5193).
     // `formatKey` is now imported from @/utils/formatHelpers as an alias for
@@ -307,7 +309,7 @@ export default {
     const initializeMachineKnowledge = async () => {
       if (isInitializing.value) return;
 
-      if (!confirm(t('knowledge.systemKnowledge.confirmInitialize'))) {
+      if (!(await confirm({ title: t('common.confirm'), message: t('knowledge.systemKnowledge.confirmInitialize') }))) {
         return;
       }
 
@@ -364,7 +366,7 @@ export default {
     const reindexDocuments = async () => {
       if (isReindexing.value) return;
 
-      if (!confirm(t('knowledge.systemKnowledge.confirmReindex'))) {
+      if (!(await confirm({ title: t('common.confirm'), message: t('knowledge.systemKnowledge.confirmReindex') }))) {
         return;
       }
 
@@ -484,7 +486,7 @@ export default {
     const refreshSystemKnowledge = async () => {
       if (isRefreshing.value) return;
 
-      if (!confirm(t('knowledge.systemKnowledge.confirmRefreshManPages'))) {
+      if (!(await confirm({ title: t('common.confirm'), message: t('knowledge.systemKnowledge.confirmRefreshManPages') }))) {
         return;
       }
 
@@ -576,7 +578,7 @@ export default {
       if (isDocPopulating.value) return;
 
       // Ask if user wants to force reindex all files
-      const forceReindex = confirm(t('knowledge.systemKnowledge.confirmIndexDocs'));
+      const forceReindex = await confirm({ title: t('common.confirm'), message: t('knowledge.systemKnowledge.confirmIndexDocs') });
 
       isDocPopulating.value = true;
       progressMessage.value = forceReindex ? 'Force reindexing ALL AutoBot documentation...' : 'Indexing AutoBot documentation...';
@@ -627,7 +629,7 @@ export default {
       const totalVectors = stats.value.total_vectors || 0;
       const needsVectorization = totalFacts - totalVectors;
 
-      if (!confirm(t('knowledge.systemKnowledge.confirmVectorize', { totalFacts, totalVectors, needsVectorization }))) {
+      if (!(await confirm({ title: t('common.confirm'), message: t('knowledge.systemKnowledge.confirmVectorize', { totalFacts, totalVectors, needsVectorization }) }))) {
         return;
       }
 

--- a/autobot-frontend/src/components/profile/DeviceManagementPanel.vue
+++ b/autobot-frontend/src/components/profile/DeviceManagementPanel.vue
@@ -107,12 +107,14 @@
 import type { IconName } from '@/components/ui/Icon.vue'
 import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import Icon from '@/components/ui/Icon.vue'
 import { useDevices } from '@/composables/useDevices'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('DeviceManagementPanel')
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 const {
   devices,
@@ -138,7 +140,7 @@ async function refresh() {
 }
 
 async function deleteDevice(deviceId: string) {
-  if (!confirm(t('devices.confirmDelete', 'Are you sure you want to unpair this device?'))) {
+  if (!(await confirm({ title: t('common.confirm'), message: t('devices.confirmDelete', 'Are you sure you want to unpair this device?') }))) {
     return
   }
 

--- a/autobot-frontend/src/components/terminal/TerminalWindow.vue
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.vue
@@ -283,6 +283,7 @@
 <script>
 import { ref, computed, onMounted, onUnmounted, nextTick, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useConfirmDialog } from '@/composables/useConfirmDialog';
 import { useTerminalService } from '@/services/TerminalService';
 import { useRoute } from 'vue-router';
 import AdvancedStepConfirmationModal from './AdvancedStepConfirmationModal.vue';
@@ -303,6 +304,7 @@ export default {
   },
   setup() {
     const { t } = useI18n();
+    const { confirm } = useConfirmDialog();
     const route = useRoute();
 
     // Get the terminal service with all its methods
@@ -1049,8 +1051,8 @@ export default {
       }
     };
 
-    const closeWindow = () => {
-      if (confirm('Are you sure you want to close this terminal window?')) {
+    const closeWindow = async () => {
+      if (await confirm({ title: t('common.confirm'), message: t('terminal.window.closeConfirm') })) {
         if (isConnected(sessionId.value)) {
           disconnect(sessionId.value);
         }

--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -175,9 +175,11 @@
 import Icon from '@/components/ui/Icon.vue'
 import { ref, reactive, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useConfirmDialog } from '@/composables/useConfirmDialog';
 import type { WorkflowNode } from '@/composables/useWorkflowBuilder';
 
 const { t } = useI18n();
+const { confirm } = useConfirmDialog();
 
 const props = defineProps<{ nodes: WorkflowNode[]; selectedNodeId: string | null }>();
 const emit = defineEmits<{
@@ -332,8 +334,8 @@ function deleteNode(id: string) {
 
 function selectNode(id: string) { emit('node-selected', id); }
 
-function clearCanvas() {
-  if (props.nodes.length && confirm(t('workflow.canvas.clearConfirm'))) {
+async function clearCanvas() {
+  if (props.nodes.length && (await confirm({ title: t('common.confirm'), message: t('workflow.canvas.clearConfirm') }))) {
     props.nodes.forEach(n => emit('node-removed', n.id));
     emit('node-selected', null);
   }

--- a/autobot-frontend/src/components/workflow/WorkflowProgressWidget.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowProgressWidget.vue
@@ -79,12 +79,14 @@
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { createLogger } from '@/utils/debugUtils'
 import { apiService } from '@/services/api'
 import { getApiBase } from '@/config/ssot-config'
 import { usePollingJob } from '@/composables/usePollingJob'
 
 const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 const logger = createLogger('WorkflowProgressWidget')
 
@@ -155,7 +157,7 @@ const openFullWorkflowView = () => {
 }
 
 const cancelWorkflow = async () => {
-  if (!confirm(t('workflow.progress.cancelConfirm'))) return
+  if (!(await confirm({ title: t('common.confirm'), message: t('workflow.progress.cancelConfirm') }))) return
 
   try {
     await apiService.delete(`${getApiBase()}/workflow/workflow/${props.workflowId}`)

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -4090,6 +4090,9 @@
         "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
         "resultTitle": "Extracted Data"
       }
+    },
+    "watchFolders": {
+      "confirmDelete": "Are you sure you want to delete this watch folder?"
     }
   },
   "workflow": {
@@ -4737,7 +4740,8 @@
       "statusError": "خطأ",
       "statusUnknown": "غير معروف",
       "stepProgress": "Step {current} of {total}",
-      "noStepData": "No step data available."
+      "noStepData": "No step data available.",
+      "closeConfirm": "Are you sure you want to close this terminal window?"
     },
     "modal": {
       "editCommandEmpty": "Command cannot be empty.",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -4090,6 +4090,9 @@
         "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
         "resultTitle": "Extracted Data"
       }
+    },
+    "watchFolders": {
+      "confirmDelete": "Möchten Sie diesen überwachten Ordner wirklich löschen?"
     }
   },
   "workflow": {
@@ -4737,7 +4740,8 @@
       "statusError": "Error",
       "statusUnknown": "Unknown",
       "stepProgress": "Step {current} of {total}",
-      "noStepData": "No step data available."
+      "noStepData": "No step data available.",
+      "closeConfirm": "Möchten Sie dieses Terminalfenster wirklich schließen?"
     },
     "modal": {
       "editCommandEmpty": "Command cannot be empty.",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -4090,6 +4090,9 @@
         "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
         "resultTitle": "Extracted Data"
       }
+    },
+    "watchFolders": {
+      "confirmDelete": "Are you sure you want to delete this watch folder?"
     }
   },
   "workflow": {
@@ -4737,7 +4740,8 @@
       "statusConnecting": "Connecting...",
       "statusDisconnected": "Disconnected",
       "statusError": "Error",
-      "statusUnknown": "Unknown"
+      "statusUnknown": "Unknown",
+      "closeConfirm": "Are you sure you want to close this terminal window?"
     },
     "modal": {
       "executeAll": "Execute All Remaining",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -4090,6 +4090,9 @@
         "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
         "resultTitle": "Extracted Data"
       }
+    },
+    "watchFolders": {
+      "confirmDelete": "¿Está seguro de que desea eliminar esta carpeta supervisada?"
     }
   },
   "workflow": {
@@ -4737,7 +4740,8 @@
       "statusError": "Error",
       "statusUnknown": "Unknown",
       "stepProgress": "Step {current} of {total}",
-      "noStepData": "No step data available."
+      "noStepData": "No step data available.",
+      "closeConfirm": "¿Está seguro de que desea cerrar esta ventana de terminal?"
     },
     "modal": {
       "editCommandEmpty": "Command cannot be empty.",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -3493,6 +3493,9 @@
         "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
         "resultTitle": "Extracted Data"
       }
+    },
+    "watchFolders": {
+      "confirmDelete": "Are you sure you want to delete this watch folder?"
     }
   },
   "reasoningTrace": {
@@ -3946,7 +3949,8 @@
       "emergencyKillTitle": "EMERGENCY KILL - Stop all running processes immediately",
       "takeControlDesc": "Pause automation and perform manual steps",
       "resumeAutomation": "Resume automated workflow",
-      "stepProgress": "Step {current} of {total}"
+      "stepProgress": "Step {current} of {total}",
+      "closeConfirm": "Are you sure you want to close this terminal window?"
     },
     "modals": {
       "executeDesc": "Run the command and continue with the workflow",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -4090,6 +4090,9 @@
         "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
         "resultTitle": "Extracted Data"
       }
+    },
+    "watchFolders": {
+      "confirmDelete": "Voulez-vous vraiment supprimer ce dossier surveillé ?"
     }
   },
   "workflow": {
@@ -4737,7 +4740,8 @@
       "statusError": "Error",
       "statusUnknown": "Unknown",
       "stepProgress": "Step {current} of {total}",
-      "noStepData": "No step data available."
+      "noStepData": "No step data available.",
+      "closeConfirm": "Voulez-vous vraiment fermer cette fenêtre de terminal ?"
     },
     "modal": {
       "editCommandEmpty": "Command cannot be empty.",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -3493,6 +3493,9 @@
         "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
         "resultTitle": "Extracted Data"
       }
+    },
+    "watchFolders": {
+      "confirmDelete": "Are you sure you want to delete this watch folder?"
     }
   },
   "reasoningTrace": {
@@ -3946,7 +3949,8 @@
       "emergencyKillTitle": "EMERGENCY KILL - Stop all running processes immediately",
       "takeControlDesc": "Pause automation and perform manual steps",
       "resumeAutomation": "Resume automated workflow",
-      "stepProgress": "Step {current} of {total}"
+      "stepProgress": "Step {current} of {total}",
+      "closeConfirm": "Are you sure you want to close this terminal window?"
     },
     "modals": {
       "executeDesc": "Run the command and continue with the workflow",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -4090,6 +4090,9 @@
         "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
         "resultTitle": "Extracted Data"
       }
+    },
+    "watchFolders": {
+      "confirmDelete": "Are you sure you want to delete this watch folder?"
     }
   },
   "workflow": {
@@ -4737,7 +4740,8 @@
       "statusError": "Error",
       "statusUnknown": "Unknown",
       "stepProgress": "Step {current} of {total}",
-      "noStepData": "No step data available."
+      "noStepData": "No step data available.",
+      "closeConfirm": "Are you sure you want to close this terminal window?"
     },
     "modal": {
       "editCommandEmpty": "Command cannot be empty.",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -4090,6 +4090,9 @@
         "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
         "resultTitle": "Extracted Data"
       }
+    },
+    "watchFolders": {
+      "confirmDelete": "Are you sure you want to delete this watch folder?"
     }
   },
   "workflow": {
@@ -4737,7 +4740,8 @@
       "statusError": "Error",
       "statusUnknown": "Unknown",
       "stepProgress": "Step {current} of {total}",
-      "noStepData": "No step data available."
+      "noStepData": "No step data available.",
+      "closeConfirm": "Are you sure you want to close this terminal window?"
     },
     "modal": {
       "editCommandEmpty": "Command cannot be empty.",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -4090,6 +4090,9 @@
         "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
         "resultTitle": "Extracted Data"
       }
+    },
+    "watchFolders": {
+      "confirmDelete": "Tem certeza de que deseja excluir esta pasta monitorada?"
     }
   },
   "workflow": {
@@ -4737,7 +4740,8 @@
       "statusError": "Error",
       "statusUnknown": "Unknown",
       "stepProgress": "Step {current} of {total}",
-      "noStepData": "No step data available."
+      "noStepData": "No step data available.",
+      "closeConfirm": "Tem certeza de que deseja fechar esta janela de terminal?"
     },
     "modal": {
       "editCommandEmpty": "Command cannot be empty.",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -3493,6 +3493,9 @@
         "emptyState": "Enter a URL and a JSON Schema, then click Get Data to extract structured information.",
         "resultTitle": "Extracted Data"
       }
+    },
+    "watchFolders": {
+      "confirmDelete": "Are you sure you want to delete this watch folder?"
     }
   },
   "reasoningTrace": {
@@ -3946,7 +3949,8 @@
       "emergencyKillTitle": "EMERGENCY KILL - Stop all running processes immediately",
       "takeControlDesc": "Pause automation and perform manual steps",
       "resumeAutomation": "Resume automated workflow",
-      "stepProgress": "Step {current} of {total}"
+      "stepProgress": "Step {current} of {total}",
+      "closeConfirm": "Are you sure you want to close this terminal window?"
     },
     "modals": {
       "executeDesc": "Run the command and continue with the workflow",

--- a/autobot-frontend/src/views/knowledge/WatchFoldersView.vue
+++ b/autobot-frontend/src/views/knowledge/WatchFoldersView.vue
@@ -269,7 +269,9 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useWatchFolders, type WatchFolderConfig } from '@/composables/knowledge/useWatchFolders'
+import { useConfirmDialog } from '@/composables/useConfirmDialog'
 
 const {
   watchFolders,
@@ -283,6 +285,9 @@ const {
   disableWatchFolder,
   loadStats,
 } = useWatchFolders()
+
+const { t } = useI18n()
+const { confirm } = useConfirmDialog()
 
 const showAddDialog = ref(false)
 const newFolderTags = ref('')
@@ -344,7 +349,7 @@ async function handleResume(folderId: string) {
 }
 
 async function handleDelete(folderId: string) {
-  if (confirm('Are you sure you want to delete this watch folder?')) {
+  if (await confirm({ title: t('common.confirm'), message: t('knowledge.watchFolders.confirmDelete') })) {
     await deleteWatchFolder(folderId)
     await loadStats()
   }


### PR DESCRIPTION
## Thinking Path
#11018 phase 2 — finish migrating native `confirm(...)` off the frontend. Native `confirm()` blocks the event loop and is un-themeable/un-i18n-able; `composables/useConfirmDialog.ts` (themed, promise-based, already wired via `<ConfirmDialog>` in App.vue) replaces it. Phase 1 (#11125) did the 4 settings panels; this does the remaining **24 components / 33 call sites**.

## What Changed
Each site: `const { confirm } = useConfirmDialog()` + `if (confirm(msg))` → `if (await confirm({ title: t('common.confirm'), message: msg }))`, making the enclosing handler `async`.
- **33 call sites across 24 files** (SystemKnowledgeManager ×5, FailedVectorizationsManager/KnowledgeAdvanced/KnowledgeEntries/DeduplicationManager/KnowledgePromptEditor/ChatFilePanel ×2, +17 singles across knowledge/chat/analytics/workflow/browser/terminal/profile/file-browser/views).
- Shared existing `common.confirm` title (present in all 11 locales) — **no title-key sprawl**.
- 2 previously **raw-English** confirms → new i18n keys `knowledge.watchFolders.confirmDelete` + `terminal.window.closeConfirm`, added to **all 11 locales** (de/es/fr/pt translated).
- 7 functions made `async` — all verified `@click`/`@close` event handlers (safe); KnowledgeAdvanced's two-step sequential confirm preserved.
- **Excluded** (correctly): `utils/chunkTestUtility.ts` (dev/test utility, not UI) and `NpuWorkerPairConfirmDialog.vue` (its own `function confirm()` — not native).

## Verification (independently re-run)
- Native `confirm(` grep across components/views → **0 remaining** (only match is NpuWorkerPairConfirmDialog's local method def)
- `vue-tsc --noEmit -p tsconfig.app.json` → **0 errors** (whole project — proves every object-form conversion + async chain type-checks)
- `eslint` (24 files) → **0 errors / 0 warnings**
- `check:i18n` + `check:locales` → **pass**; 2 new keys present in all 11 locales (verified per-locale); locale diffs additive-only (+2 keys each)
- `vitest` (ChatInterface, TerminalWindow, useKnowledgeStats) → **61 passed**

## Model Used
Opus 4.8 (implementation via frontend subagent against an exact spec; independently verified — grep/vue-tsc/eslint/i18n/locale-diff all re-run)

Closes #11018