### PR TITLE
feat(agent-loop): wire forbidden_work → AgentLoopConfig.forbidden_tools (#11145)

### DIFF
--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -148,6 +148,7 @@ class AgentLoop:
         tool_executor: ParallelToolExecutor | None = None,
         think_tool: ThinkTool | None = None,
         config: AgentLoopConfig | None = None,
+        agent_id: str | None = None,
     ):
         """
         Initialize the agent loop.
@@ -158,12 +159,18 @@ class AgentLoop:
             tool_executor: Optional parallel tool executor
             think_tool: Optional think tool for reasoning
             config: Loop configuration
+            agent_id: Optional agent identity (GH#11145). When set, the agent's
+                ``forbidden_work`` manifest is resolved from ``AgentRegistry`` and
+                applied to ``config.forbidden_tools`` so ``_check_forbidden`` hard-
+                blocks out-of-manifest tools. When unset (the default), the loop
+                runs as no particular agent and the manifest is empty (no change).
         """
         self.event_stream = event_stream
         self.planner = planner
         self.tool_executor = tool_executor
         self.think_tool = think_tool or ThinkTool()
-        self.config = config or AgentLoopConfig()
+        self.agent_id = agent_id
+        self.config = self._resolve_forbidden_tools(config or AgentLoopConfig(), agent_id)
         self._belief_updater = BeliefStateUpdater(
             contradiction_surface_threshold=self.config.contradiction_surface_threshold
         )
@@ -1339,6 +1346,43 @@ Duration: {self._current_context.get_duration_ms():.0f}ms{belief_summary}
             if name.startswith(sensitive):
                 return sensitive
         return None
+
+    @staticmethod
+    def _resolve_forbidden_tools(
+        config: "AgentLoopConfig", agent_id: str | None
+    ) -> "AgentLoopConfig":
+        """Populate ``config.forbidden_tools`` from the agent's manifest (GH#11145).
+
+        Reads ``forbidden_work`` off the agent's ``AgentProfile`` via
+        ``AgentRegistry`` and returns a config with those tools hard-blocked. When
+        no ``agent_id`` is given, or the config already carries an explicit
+        ``forbidden_tools`` set, or the agent has no boundary, the config is
+        returned unchanged. Registry resolution never raises into the loop — a
+        lookup failure logs and falls back to the (unbounded) config.
+        """
+        if not agent_id or config.forbidden_tools:
+            return config
+        try:
+            from dataclasses import replace
+
+            from orchestration.agent_registry import AgentRegistry
+
+            forbidden = AgentRegistry(initialize_defaults=True).forbidden_tools(agent_id)
+        except Exception as exc:  # pragma: no cover - defensive; registry import/lookup
+            logger.warning(
+                "AgentLoop: could not resolve forbidden_work for agent '%s': %s",
+                agent_id,
+                exc,
+            )
+            return config
+        if not forbidden:
+            return config
+        logger.info(
+            "AgentLoop: agent '%s' forbidden_work manifest active (%d tools)",
+            agent_id,
+            len(forbidden),
+        )
+        return replace(config, forbidden_tools=forbidden)
 
     def _forbidden_tool_name(self, tool: dict[str, Any]) -> str | None:
         """Return the matched forbidden-tool name for *tool*, else None (GH#11139).

--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -1348,9 +1348,7 @@ Duration: {self._current_context.get_duration_ms():.0f}ms{belief_summary}
         return None
 
     @staticmethod
-    def _resolve_forbidden_tools(
-        config: "AgentLoopConfig", agent_id: str | None
-    ) -> "AgentLoopConfig":
+    def _resolve_forbidden_tools(config: "AgentLoopConfig", agent_id: str | None) -> "AgentLoopConfig":
         """Populate ``config.forbidden_tools`` from the agent's manifest (GH#11145).
 
         Reads ``forbidden_work`` off the agent's ``AgentProfile`` via

--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -1363,9 +1363,9 @@ Duration: {self._current_context.get_duration_ms():.0f}ms{belief_summary}
         try:
             from dataclasses import replace
 
-            from orchestration.agent_registry import AgentRegistry
+            from orchestration.agent_registry import resolve_forbidden_tools
 
-            forbidden = AgentRegistry(initialize_defaults=True).forbidden_tools(agent_id)
+            forbidden = resolve_forbidden_tools(agent_id)
         except Exception as exc:  # pragma: no cover - defensive; registry import/lookup
             logger.warning(
                 "AgentLoop: could not resolve forbidden_work for agent '%s': %s",
@@ -1385,19 +1385,13 @@ Duration: {self._current_context.get_duration_ms():.0f}ms{belief_summary}
     def _forbidden_tool_name(self, tool: dict[str, Any]) -> str | None:
         """Return the matched forbidden-tool name for *tool*, else None (GH#11139).
 
-        Uses the same name/prefix matching as ``_sensitive_tool_name`` but against
-        the agent's ``forbidden_work`` manifest (``config.forbidden_tools``).
+        Delegates to the shared ``match_forbidden_tool`` matcher (GH#11145) so the
+        loop and the production tool-dispatch seam apply the identical name/prefix
+        rule against the agent's ``forbidden_work`` manifest.
         """
-        forbidden = self.config.forbidden_tools
-        if not forbidden:
-            return None
-        name = tool.get("tool_name", "").lower()
-        if name in forbidden:
-            return name
-        for f in forbidden:
-            if name.startswith(f):
-                return f
-        return None
+        from orchestration.agent_registry import match_forbidden_tool
+
+        return match_forbidden_tool(tool.get("tool_name", ""), self.config.forbidden_tools)
 
     def _check_forbidden(self, tools: list[dict[str, Any]]) -> dict[str, Any]:
         """Hard-block the first tool the agent's manifest forbids (GH#11139).

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -2386,9 +2386,7 @@ class ToolHandlerMixin:
             agent_id,
             matched,
         )
-        execution_results.append(
-            {"tool": tool_name, "status": "error", "error": error, "forbidden_by_manifest": True}
-        )
+        execution_results.append({"tool": tool_name, "status": "error", "error": error, "forbidden_by_manifest": True})
         return WorkflowMessage(
             type="error",
             content=error,

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -2355,6 +2355,46 @@ class ToolHandlerMixin:
             metadata={"message_type": "unknown_tool", "tool_name": tool_name},
         )
 
+    def _enforce_forbidden_work(
+        self,
+        tool_call: dict[str, Any],
+        ctx: "LLMIterationContext" | None,
+        execution_results: list[dict[str, Any]],
+    ) -> WorkflowMessage | None:
+        """Hard-block a tool the acting agent's forbidden_work manifest forbids (GH#11145).
+
+        Resolves the acting agent id from ``ctx.agent_context`` and matches the tool
+        against that agent's manifest via the shared ``match_forbidden_tool`` matcher.
+        Records the failure in ``execution_results`` and returns an error
+        ``WorkflowMessage`` when the tool is forbidden, else ``None``. Profile-less
+        agents resolve to an empty manifest and are never blocked here.
+        """
+        from orchestration.agent_registry import match_forbidden_tool, resolve_forbidden_tools
+
+        agent_id = ctx.agent_context.agent_id if (ctx is not None and ctx.agent_context is not None) else None
+        forbidden = resolve_forbidden_tools(agent_id)
+        if not forbidden:
+            return None
+        tool_name = tool_call.get("name", "")
+        matched = match_forbidden_tool(tool_name, forbidden)
+        if matched is None:
+            return None
+        error = f"Tool '{tool_name}' is forbidden by agent '{agent_id}' capability manifest (matched '{matched}')"
+        logger.warning(
+            "[GH#11145] Blocked forbidden tool '%s' for agent '%s' (matched '%s')",
+            tool_name,
+            agent_id,
+            matched,
+        )
+        execution_results.append(
+            {"tool": tool_name, "status": "error", "error": error, "forbidden_by_manifest": True}
+        )
+        return WorkflowMessage(
+            type="error",
+            content=error,
+            metadata={"tool": tool_name, "error": True, "forbidden_by_manifest": True},
+        )
+
     async def _dispatch_tool_call(
         self,
         tool_call: dict[str, Any],
@@ -2373,6 +2413,16 @@ class ToolHandlerMixin:
         for the respond tool. Helpers handle MCP, browser, web_search, and execute_command.
         """
         tool_name = tool_call["name"]
+
+        # GH#11145: enforce the acting agent's forbidden_work manifest at the single
+        # production dispatch seam — before any tool-specific branch. Every tool call
+        # funnels through here, so this is the one place the capability boundary is
+        # applied. No-ops for the plain chat agent (no profile → empty manifest);
+        # bites profile-bound agents (e.g. a delegated research_agent cannot run bash).
+        forbidden_msg = self._enforce_forbidden_work(tool_call, ctx, execution_results)
+        if forbidden_msg is not None:
+            yield forbidden_msg
+            return
 
         if tool_name == "respond":
             if ctx is not None:

--- a/autobot-backend/orchestration/agent_registry.py
+++ b/autobot-backend/orchestration/agent_registry.py
@@ -129,6 +129,25 @@ def get_default_agents() -> List[AgentProfile]:
     ]
 
 
+def match_forbidden_tool(tool_name: str, forbidden: "frozenset[str]") -> "str | None":
+    """Return the ``forbidden_work`` pattern matching *tool_name*, else None (GH#11145).
+
+    Single source for forbidden-tool matching — the agent loop and the production
+    tool-dispatch seam both call this so the exact/prefix rule lives in one place.
+    Matching is case-insensitive; a manifest entry matches by exact name or as a
+    name prefix (e.g. ``deploy`` blocks ``deploy_service``).
+    """
+    if not forbidden:
+        return None
+    name = tool_name.lower()
+    if name in forbidden:
+        return name
+    for pattern in forbidden:
+        if name.startswith(pattern):
+            return pattern
+    return None
+
+
 class AgentRegistry:
     """Static profile registry for orchestration agent capabilities.
 
@@ -351,3 +370,25 @@ class AgentRegistry:
     def __contains__(self, agent_id: str) -> bool:
         """Check if agent is registered."""
         return agent_id in self._agents
+
+
+# GH#11145: process-wide read-only registry of the default capability manifests,
+# seeded once from get_default_agents() (the same SSOT the orchestrator uses, so
+# no drift). Lets the production tool-dispatch seam resolve an agent's boundary
+# cheaply without constructing an Orchestrator on every tool call.
+_default_registry: "AgentRegistry | None" = None
+
+
+def resolve_forbidden_tools(agent_id: "str | None") -> "frozenset[str]":
+    """Resolve *agent_id*'s ``forbidden_work`` manifest from the default profiles.
+
+    Cached, read-only lookup reused by both the agent loop and the production tool
+    dispatch (GH#11145). An unknown or ``None`` ``agent_id`` returns an empty set —
+    no boundary — so callers no-op safely for the plain (profile-less) chat agent.
+    """
+    if not agent_id:
+        return frozenset()
+    global _default_registry  # noqa: PLW0603
+    if _default_registry is None:
+        _default_registry = AgentRegistry(initialize_defaults=True)
+    return _default_registry.forbidden_tools(agent_id)

--- a/autobot-backend/tests/agent_loop/test_forbidden_tools_wiring.py
+++ b/autobot-backend/tests/agent_loop/test_forbidden_tools_wiring.py
@@ -1,0 +1,102 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+End-to-end wiring: AgentProfile.forbidden_work -> AgentLoopConfig.forbidden_tools (GH#11145).
+
+#11139 delivered the enforcement primitive (``_check_forbidden``); this proves the
+connective tissue: constructing ``AgentLoop`` with an ``agent_id`` resolves that
+agent's ``forbidden_work`` manifest from ``AgentRegistry`` and hard-blocks the
+forbidden tools through a real dispatch path.
+
+Acceptance criteria:
+  - ``agent_id`` populates ``config.forbidden_tools`` from the agent's profile.
+  - The designated executor (``system_agent``, no ``forbidden_work``) stays unbounded.
+  - No / unknown ``agent_id`` is a no-op (backward compatible).
+  - An explicit ``config.forbidden_tools`` is never overwritten by the manifest.
+  - A forbidden tool is blocked in ``_execute_tools`` before the approval gate.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent_loop.loop import AgentLoop
+from agent_loop.types import AgentLoopConfig
+
+
+def _make_loop(agent_id: str | None = None, config: AgentLoopConfig | None = None) -> AgentLoop:
+    event_stream = MagicMock()
+    event_stream.get_latest = AsyncMock(return_value=[])
+    event_stream.publish = AsyncMock()
+    cfg = config or AgentLoopConfig(
+        mandatory_think_enabled=False,
+        think_on_completion=False,
+        log_iterations=False,
+    )
+    return AgentLoop(event_stream=event_stream, config=cfg, agent_id=agent_id)
+
+
+class TestManifestWiring:
+    def test_agent_id_populates_forbidden_tools_from_registry(self) -> None:
+        # research_agent.forbidden_work == _INFRA_AND_SHELL_TOOLS (bash, deploy, ...)
+        loop = _make_loop(agent_id="research_agent")
+        assert "bash" in loop.config.forbidden_tools
+        assert "deploy" in loop.config.forbidden_tools
+
+    def test_executor_agent_has_no_boundary(self) -> None:
+        # system_agent is the designated executor: intentionally no forbidden_work.
+        loop = _make_loop(agent_id="system_agent")
+        assert loop.config.forbidden_tools == frozenset()
+
+    def test_no_agent_id_is_unbounded(self) -> None:
+        loop = _make_loop(agent_id=None)
+        assert loop.config.forbidden_tools == frozenset()
+
+    def test_unknown_agent_is_unbounded(self) -> None:
+        loop = _make_loop(agent_id="does_not_exist")
+        assert loop.config.forbidden_tools == frozenset()
+
+    def test_explicit_config_forbidden_tools_not_overwritten(self) -> None:
+        cfg = AgentLoopConfig(
+            mandatory_think_enabled=False,
+            think_on_completion=False,
+            log_iterations=False,
+            forbidden_tools=frozenset({"custom_tool"}),
+        )
+        loop = _make_loop(agent_id="research_agent", config=cfg)
+        assert loop.config.forbidden_tools == frozenset({"custom_tool"})
+
+    def test_agent_id_is_recorded(self) -> None:
+        loop = _make_loop(agent_id="research_agent")
+        assert loop.agent_id == "research_agent"
+
+
+class TestEndToEndDispatch:
+    """Prove enforcement is active end-to-end when the loop runs as an agent."""
+
+    @pytest.mark.asyncio
+    async def test_research_agent_cannot_execute_bash(self) -> None:
+        loop = _make_loop(agent_id="research_agent")
+        loop._check_tool_call_repetition = MagicMock(return_value=None)
+        loop._check_approvals = AsyncMock(return_value={})
+        loop.tool_executor = MagicMock()
+
+        result = await loop._execute_tools([{"tool_name": "bash", "args": {"cmd": "ls"}}])
+
+        assert "bash" in result and "forbidden" in result["bash"]["error"].lower()
+        loop._check_approvals.assert_not_awaited()
+        loop.tool_executor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_research_agent_allows_non_forbidden_tool(self) -> None:
+        loop = _make_loop(agent_id="research_agent")
+        loop._check_tool_call_repetition = MagicMock(return_value=None)
+        # Stop right after the forbidden check to prove read_file passed it.
+        loop._check_approvals = AsyncMock(return_value={"read_file": {"error": "stop"}})
+
+        result = await loop._execute_tools([{"tool_name": "read_file", "args": {}}])
+
+        loop._check_approvals.assert_awaited_once()
+        assert result == {"read_file": {"error": "stop"}}

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_forbidden_work.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_forbidden_work.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Dispatch-level enforcement of the forbidden_work manifest (GH#11145).
+
+Proves the capability boundary is active on the real production tool-dispatch
+seam (`ToolHandlerMixin._dispatch_tool_call`) — not just inside the agent loop.
+A profile-bound agent (research_agent) is hard-blocked from an out-of-manifest
+tool (bash/execute_command) before any handler runs, while the designated
+executor (system_agent) and the profile-less chat agent are unaffected.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from chat_workflow.models import AgentContext
+from chat_workflow.tool_handler import ToolHandlerMixin
+
+
+def _mixin() -> ToolHandlerMixin:
+    """Bare mixin instance — enforcement short-circuits before any other state."""
+    return ToolHandlerMixin.__new__(ToolHandlerMixin)
+
+
+def _ctx(agent_id: str | None) -> SimpleNamespace:
+    agent_context = AgentContext(agent_id=agent_id) if agent_id is not None else None
+    return SimpleNamespace(agent_context=agent_context)
+
+
+def test_enforce_blocks_out_of_manifest_tool() -> None:
+    """research_agent forbids bash — the seam returns an error and records it."""
+    mixin = _mixin()
+    results: list[dict] = []
+    msg = mixin._enforce_forbidden_work({"name": "bash"}, _ctx("research_agent"), results)
+
+    assert msg is not None
+    assert msg.type == "error"
+    assert msg.metadata.get("forbidden_by_manifest") is True
+    assert results and results[0]["forbidden_by_manifest"] is True
+    assert results[0]["status"] == "error"
+
+
+def test_enforce_matches_by_prefix() -> None:
+    """A manifest entry blocks by prefix (execute_command variant)."""
+    mixin = _mixin()
+    results: list[dict] = []
+    msg = mixin._enforce_forbidden_work({"name": "execute_command"}, _ctx("research_agent"), results)
+
+    assert msg is not None
+    assert "forbidden" in msg.content
+
+
+def test_enforce_allows_in_manifest_tool() -> None:
+    """research_agent may web_search — no block, nothing recorded."""
+    mixin = _mixin()
+    results: list[dict] = []
+    msg = mixin._enforce_forbidden_work({"name": "web_search"}, _ctx("research_agent"), results)
+
+    assert msg is None
+    assert results == []
+
+
+def test_enforce_noop_for_executor_agent() -> None:
+    """system_agent is the designated executor (empty forbidden_work) — bash allowed."""
+    mixin = _mixin()
+    results: list[dict] = []
+    msg = mixin._enforce_forbidden_work({"name": "bash"}, _ctx("system_agent"), results)
+
+    assert msg is None
+    assert results == []
+
+
+def test_enforce_noop_for_profileless_chat_agent() -> None:
+    """No agent_context (plain chat) → empty manifest → never blocked."""
+    mixin = _mixin()
+    results: list[dict] = []
+    assert mixin._enforce_forbidden_work({"name": "bash"}, None, results) is None
+    assert mixin._enforce_forbidden_work({"name": "bash"}, _ctx("unknown_agent"), results) is None
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_short_circuits_forbidden_tool() -> None:
+    """End-to-end: _dispatch_tool_call blocks a forbidden tool before any handler."""
+    mixin = _mixin()
+    results: list[dict] = []
+    messages = []
+    async for item in mixin._dispatch_tool_call(
+        {"name": "bash", "params": {"command": "rm -rf /"}},
+        "session-1",
+        "term-1",
+        "http://localhost:11434",
+        "test-model",
+        results,
+        [],
+        ctx=_ctx("research_agent"),
+    ):
+        messages.append(item)
+
+    # Only the forbidden-work error is yielded; dispatch returns before any branch.
+    assert len(messages) == 1
+    assert messages[0].type == "error"
+    assert messages[0].metadata.get("forbidden_by_manifest") is True
+    assert results[0]["tool"] == "bash"
+    assert results[0]["forbidden_by_manifest"] is True


### PR DESCRIPTION
## Thinking Path

#11139 / PR #11143 shipped the capability-manifest **primitive** — `AgentProfile.forbidden_work` (SSOT), `AgentRegistry.forbidden_tools()`, and `AgentLoop._check_forbidden()` which hard-blocks forbidden tools before the approval gate. But the connective tissue was missing: nothing populated `AgentLoopConfig.forbidden_tools`, `AgentLoop` had no agent identity, and the registry accessors had no non-test callers — so enforcement was **inert in every real run** (issue #11145).

Per #11145's stated choice between "orchestrator per-task dispatch" and "loop-level agent identity", I took the loop-level route: it is self-contained, testable end-to-end today, and adds no coupling to the (heavy) orchestrator. `AgentLoop` gains an optional `agent_id`; when set it resolves that agent's `forbidden_work` from `AgentRegistry` and applies it to the config.

## What Changed

- **`autobot-backend/agent_loop/loop.py`**
  - `AgentLoop.__init__` gains `agent_id: str | None = None`; stored as `self.agent_id`.
  - New `_resolve_forbidden_tools(config, agent_id)` staticmethod: resolves `forbidden_work` via `AgentRegistry` and returns a `dataclasses.replace`'d config with `forbidden_tools` populated.
  - No-op / backward-compatible when `agent_id` is unset or unknown, when the agent has no boundary (e.g. `system_agent`, the designated executor), or when the caller already set an explicit `config.forbidden_tools`. Registry import/lookup failures log and fall back to the unbounded config — never raise into the loop.
- **`autobot-backend/tests/agent_loop/test_forbidden_tools_wiring.py`** (new): manifest-resolution + end-to-end dispatch tests.

## Verification

```
$ python3 -m pytest tests/agent_loop/test_forbidden_tools_wiring.py tests/agent_loop/test_forbidden_tools.py -q
17 passed in 0.28s
```

End-to-end AC proven: `AgentLoop(agent_id="research_agent")` → `_execute_tools([{tool_name: bash}])` returns a forbidden denial and never reaches `_check_approvals` or the executor; `system_agent` stays unbounded; no/unknown `agent_id` is a no-op.

**Full `agent_loop` suite:** `258 passed, 14 failed`. The 14 failures are **pre-existing and unrelated** — identical set on the base branch (`250 passed, 14 failed`; this PR adds the 8 new passing wiring tests). They stem from in-package `agent_loop/` tests conflicting with the stubbing `conftest` when co-collected (`module 'agent_loop' has no attribute 'loop'`), not from this change. Filed as a discovery issue.

Note: #11145's *secondary* item (routing id-namespace divergence, `system_agent` vs `system_commands`) is left for a follow-up — it is a routing-overlay concern independent of forbidden-tool enforcement, which is now active end-to-end.

## Update — production-seam enforcement (meets AC)

Follow-up review found the loop-level route above was **necessary but not sufficient**: `AgentLoop.run_task` has **no production caller** (its only reference is the module docstring), so `config.forbidden_tools` never gated a real run — enforcement stayed inert exactly where #11145's AC requires it ("active end-to-end in production, proven by a dispatch-level test").

Real production tool calls funnel through `ToolHandlerMixin._dispatch_tool_call` (chat_workflow/tool_handler.py). Enforcement now lives there — the single seam every browser/web/MCP/execute_command call passes through — with **zero duplication**:

- **`orchestration/agent_registry.py`** — one SSOT matcher/resolver: `match_forbidden_tool(tool_name, forbidden)` (exact/prefix rule) and `resolve_forbidden_tools(agent_id)` (cached, seeded from the existing `get_default_agents()` SSOT; empty for unknown/None → safe no-op).
- **`chat_workflow/tool_handler.py`** — `_dispatch_tool_call` hard-blocks out-of-manifest tools at the top via new `_enforce_forbidden_work`, keyed on `ctx.agent_context.agent_id`. Profile-bound agents (e.g. a delegated `research_agent`) can't run `bash`; the profile-less chat agent and executor `system_agent` are unaffected.
- **`agent_loop/loop.py`** — `_forbidden_tool_name` and `_resolve_forbidden_tools` now delegate to the shared helpers (dedups the loop's private matcher + per-call registry build).
- **`tests/unit/chat_workflow/test_tool_handler_forbidden_work.py`** (new) — dispatch-level test proving `research_agent` is blocked from `bash`/`execute_command` before any handler runs.

**Remaining link (follow-up issue):** subagent/delegate spawn must stamp `agent_context.agent_id` with the acting profile id for the seam to bite delegated agents in every path — filing a discovery issue.

### Updated verification

```
$ python3 -m pytest tests/unit/chat_workflow/test_tool_handler_forbidden_work.py \
    tests/agent_loop/test_forbidden_tools_wiring.py tests/agent_loop/test_forbidden_tools.py -q
23 passed
```

## Model Used

Claude Opus 4.8 (1M context)

Closes #11145