### PR TITLE
feat(agent-loop): config-protection guard for linter/formatter configs (#11148)

### DIFF
--- a/autobot-backend/agent_loop/config_protection.py
+++ b/autobot-backend/agent_loop/config_protection.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Config-protection guard for the agent loop (GH#11148).
+
+Blocks agent write/edit/delete/move tools that target a linter or formatter
+config file, so the agent fixes the code to satisfy a quality gate instead of
+silently weakening the gate (e.g. adding an ``ignore`` rule to ``.eslintrc`` or
+``ruff.toml``). Mixed-purpose manifests (``pyproject.toml``, ``setup.cfg``) are
+intentionally NOT protected here — they carry legitimate non-lint content
+(dependencies, packaging) and blocking them would over-block.
+
+Override with ``AUTOBOT_ALLOW_CONFIG_EDITS=1`` when an intentional config change
+is required.
+"""
+
+import os
+
+# Write-side tools whose target path is guarded. Read/list tools are ignored.
+_WRITE_TOOLS: frozenset[str] = frozenset(
+    {
+        "write_file",
+        "edit_file",
+        "multi_edit",
+        "apply_patch",
+        "create_file",
+        "delete_file",
+        "move_file",
+        "copy_file",
+    }
+)
+
+# Arg keys under which a write tool carries its target path (see
+# tools/parallel/analyzer.py RESOURCE_EXTRACTORS).
+_PATH_KEYS: tuple[str, ...] = ("file_path", "path", "destination", "target_file")
+
+# Dedicated linter/formatter config basenames (exact, case-insensitive).
+_PROTECTED_BASENAMES: frozenset[str] = frozenset(
+    {
+        ".editorconfig",
+        ".pre-commit-config.yaml",
+        ".flake8",
+        "mypy.ini",
+        ".mypy.ini",
+        "ruff.toml",
+        ".ruff.toml",
+        ".isort.cfg",
+        ".pylintrc",
+        "tox.ini",
+        "eslint.config.js",
+        "eslint.config.cjs",
+        "eslint.config.mjs",
+        "prettier.config.js",
+        "prettier.config.cjs",
+        "prettier.config.mjs",
+        "commitlint.config.js",
+        "commitlint.config.cjs",
+        "commitlint.config.mjs",
+        "stylelint.config.js",
+        "biome.json",
+        "biome.jsonc",
+    }
+)
+
+# Basename prefixes covering the many dotfile variants (``.eslintrc.json``,
+# ``.prettierrc.yaml``, ``.markdownlint.json`` …).
+_PROTECTED_PREFIXES: tuple[str, ...] = (
+    ".eslintrc",
+    ".prettierrc",
+    ".stylelintrc",
+    ".markdownlint",
+)
+
+
+def is_protected_config(path: str | None) -> str | None:
+    """Return the matched config basename if *path* is a protected config, else None."""
+    if not path:
+        return None
+    base = os.path.basename(str(path).strip().rstrip("/\\"))
+    lower = base.lower()
+    if lower in _PROTECTED_BASENAMES:
+        return base
+    if any(lower.startswith(prefix) for prefix in _PROTECTED_PREFIXES):
+        return base
+    return None
+
+
+def config_edits_allowed() -> bool:
+    """True when ``AUTOBOT_ALLOW_CONFIG_EDITS`` opts out of the guard."""
+    return os.environ.get("AUTOBOT_ALLOW_CONFIG_EDITS", "").strip().lower() in {"1", "true", "yes"}
+
+
+def protected_config_write(tool: dict) -> str | None:
+    """Return the protected config basename a write-tool call targets, else None."""
+    name = str(tool.get("tool_name", "")).lower()
+    if name not in _WRITE_TOOLS:
+        return None
+    args = tool.get("args") or tool.get("arguments") or tool.get("parameters") or {}
+    if not isinstance(args, dict):
+        return None
+    for key in _PATH_KEYS:
+        matched = is_protected_config(args.get(key))
+        if matched:
+            return matched
+    return None

--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -827,6 +827,12 @@ class AgentLoop:
         if forbidden_results:
             return forbidden_results
 
+        # GH#11148: block writes that would weaken a linter/formatter config —
+        # steer the agent to fix the code, not the gate.
+        config_results = self._check_config_protection(tools)
+        if config_results:
+            return config_results
+
         # Issue #4092: Gate sensitive operations behind user approval.
         denied_results = await self._check_approvals(tools)
         if denied_results:
@@ -1377,6 +1383,36 @@ Duration: {self._current_context.get_duration_ms():.0f}ms{belief_summary}
                         "error": (
                             f"Tool '{tool_name}' is forbidden by this agent's capability "
                             f"manifest (matched '{matched}')"
+                        )
+                    }
+                }
+        return {}
+
+    def _check_config_protection(self, tools: list[dict[str, Any]]) -> dict[str, Any]:
+        """Block the first write that would weaken a linter/formatter config (GH#11148).
+
+        Returns a denial result dict for the first protected-config write, or
+        ``{}`` when none are protected or ``AUTOBOT_ALLOW_CONFIG_EDITS`` opts out.
+        """
+        from agent_loop.config_protection import config_edits_allowed, protected_config_write
+
+        if config_edits_allowed():
+            return {}
+        for tool in tools:
+            matched = protected_config_write(tool)
+            if matched is not None:
+                tool_name = tool.get("tool_name", "unknown")
+                logger.warning(
+                    "AgentLoop: tool '%s' blocked from editing linter/formatter config '%s' (config-protection)",
+                    tool_name,
+                    matched,
+                )
+                return {
+                    tool_name: {
+                        "error": (
+                            f"Editing linter/formatter config '{matched}' is blocked "
+                            f"(config-protection): fix the code to satisfy the gate instead of "
+                            f"weakening it. Set AUTOBOT_ALLOW_CONFIG_EDITS=1 for an intentional change."
                         )
                     }
                 }

--- a/autobot-backend/tests/agent_loop/test_config_protection.py
+++ b/autobot-backend/tests/agent_loop/test_config_protection.py
@@ -1,0 +1,157 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for the config-protection guard (GH#11148).
+
+Acceptance criteria:
+  - A write/edit/delete/move targeting a linter/formatter config is hard-blocked
+    in ``_execute_tools``, BEFORE the approval gate.
+  - Non-config writes and read/list tools are unaffected.
+  - Mixed-purpose manifests (pyproject.toml, setup.cfg) are NOT blocked.
+  - ``AUTOBOT_ALLOW_CONFIG_EDITS`` opts out of the guard.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent_loop.config_protection import (
+    config_edits_allowed,
+    is_protected_config,
+    protected_config_write,
+)
+from agent_loop.loop import AgentLoop
+from agent_loop.types import AgentLoopConfig
+
+
+def _make_loop() -> AgentLoop:
+    event_stream = MagicMock()
+    event_stream.get_latest = AsyncMock(return_value=[])
+    event_stream.publish = AsyncMock()
+    config = AgentLoopConfig(
+        mandatory_think_enabled=False,
+        think_on_completion=False,
+        log_iterations=False,
+    )
+    return AgentLoop(event_stream=event_stream, config=config)
+
+
+class TestIsProtectedConfig:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".eslintrc.json",
+            "frontend/.eslintrc.js",
+            ".prettierrc",
+            "/repo/.prettierrc.yaml",
+            "ruff.toml",
+            ".markdownlint.json",
+            "commitlint.config.js",
+            ".editorconfig",
+            ".pre-commit-config.yaml",
+            "mypy.ini",
+            "biome.json",
+        ],
+    )
+    def test_protected_paths_match(self, path: str) -> None:
+        assert is_protected_config(path) is not None
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "pyproject.toml",  # mixed-purpose: intentionally not protected
+            "setup.cfg",  # mixed-purpose: intentionally not protected
+            "autobot-backend/agent_loop/loop.py",
+            "src/main.ts",
+            "README.md",
+            "config.json",
+            "",
+            None,
+        ],
+    )
+    def test_non_config_paths_pass(self, path: str | None) -> None:
+        assert is_protected_config(path) is None
+
+
+class TestProtectedConfigWrite:
+    def test_write_file_to_config_matches(self) -> None:
+        tool = {"tool_name": "write_file", "args": {"file_path": ".eslintrc.json"}}
+        assert protected_config_write(tool) == ".eslintrc.json"
+
+    def test_edit_file_path_key_fallback(self) -> None:
+        tool = {"tool_name": "edit_file", "args": {"path": "ruff.toml"}}
+        assert protected_config_write(tool) == "ruff.toml"
+
+    def test_read_file_is_ignored(self) -> None:
+        tool = {"tool_name": "read_file", "args": {"file_path": ".eslintrc.json"}}
+        assert protected_config_write(tool) is None
+
+    def test_write_to_non_config_passes(self) -> None:
+        tool = {"tool_name": "write_file", "args": {"file_path": "src/app.ts"}}
+        assert protected_config_write(tool) is None
+
+
+class TestConfigEditsAllowed:
+    def test_default_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AUTOBOT_ALLOW_CONFIG_EDITS", raising=False)
+        assert config_edits_allowed() is False
+
+    def test_env_opt_out(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOBOT_ALLOW_CONFIG_EDITS", "1")
+        assert config_edits_allowed() is True
+
+
+class TestExecuteToolsIntegration:
+    """End-to-end: a protected-config write is blocked before approval."""
+
+    @pytest.mark.asyncio
+    async def test_config_write_blocked_before_approval(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("AUTOBOT_ALLOW_CONFIG_EDITS", raising=False)
+        loop = _make_loop()
+        loop._check_tool_call_repetition = MagicMock(return_value=None)
+        loop._check_approvals = AsyncMock(return_value={})
+        loop.tool_executor = MagicMock()
+
+        result = await loop._execute_tools(
+            [{"tool_name": "write_file", "args": {"file_path": ".prettierrc"}}]
+        )
+
+        assert "write_file" in result
+        assert "config-protection" in result["write_file"]["error"].lower()
+        loop._check_approvals.assert_not_awaited()
+        loop.tool_executor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_config_write_proceeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AUTOBOT_ALLOW_CONFIG_EDITS", raising=False)
+        loop = _make_loop()
+        loop._check_tool_call_repetition = MagicMock(return_value=None)
+        # Stop right after the config check to prove the write passed it.
+        loop._check_approvals = AsyncMock(return_value={"write_file": {"error": "stop"}})
+
+        result = await loop._execute_tools(
+            [{"tool_name": "write_file", "args": {"file_path": "src/app.ts"}}]
+        )
+
+        loop._check_approvals.assert_awaited_once()
+        assert result == {"write_file": {"error": "stop"}}
+
+    @pytest.mark.asyncio
+    async def test_env_override_lets_config_write_through(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AUTOBOT_ALLOW_CONFIG_EDITS", "1")
+        loop = _make_loop()
+        loop._check_tool_call_repetition = MagicMock(return_value=None)
+        loop._check_approvals = AsyncMock(return_value={"write_file": {"error": "stop"}})
+
+        result = await loop._execute_tools(
+            [{"tool_name": "write_file", "args": {"file_path": ".prettierrc"}}]
+        )
+
+        loop._check_approvals.assert_awaited_once()
+        assert result == {"write_file": {"error": "stop"}}

--- a/autobot-backend/tests/agent_loop/test_config_protection.py
+++ b/autobot-backend/tests/agent_loop/test_config_protection.py
@@ -107,18 +107,14 @@ class TestExecuteToolsIntegration:
     """End-to-end: a protected-config write is blocked before approval."""
 
     @pytest.mark.asyncio
-    async def test_config_write_blocked_before_approval(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_config_write_blocked_before_approval(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("AUTOBOT_ALLOW_CONFIG_EDITS", raising=False)
         loop = _make_loop()
         loop._check_tool_call_repetition = MagicMock(return_value=None)
         loop._check_approvals = AsyncMock(return_value={})
         loop.tool_executor = MagicMock()
 
-        result = await loop._execute_tools(
-            [{"tool_name": "write_file", "args": {"file_path": ".prettierrc"}}]
-        )
+        result = await loop._execute_tools([{"tool_name": "write_file", "args": {"file_path": ".prettierrc"}}])
 
         assert "write_file" in result
         assert "config-protection" in result["write_file"]["error"].lower()
@@ -133,25 +129,19 @@ class TestExecuteToolsIntegration:
         # Stop right after the config check to prove the write passed it.
         loop._check_approvals = AsyncMock(return_value={"write_file": {"error": "stop"}})
 
-        result = await loop._execute_tools(
-            [{"tool_name": "write_file", "args": {"file_path": "src/app.ts"}}]
-        )
+        result = await loop._execute_tools([{"tool_name": "write_file", "args": {"file_path": "src/app.ts"}}])
 
         loop._check_approvals.assert_awaited_once()
         assert result == {"write_file": {"error": "stop"}}
 
     @pytest.mark.asyncio
-    async def test_env_override_lets_config_write_through(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_env_override_lets_config_write_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("AUTOBOT_ALLOW_CONFIG_EDITS", "1")
         loop = _make_loop()
         loop._check_tool_call_repetition = MagicMock(return_value=None)
         loop._check_approvals = AsyncMock(return_value={"write_file": {"error": "stop"}})
 
-        result = await loop._execute_tools(
-            [{"tool_name": "write_file", "args": {"file_path": ".prettierrc"}}]
-        )
+        result = await loop._execute_tools([{"tool_name": "write_file", "args": {"file_path": ".prettierrc"}}])
 
         loop._check_approvals.assert_awaited_once()
         assert result == {"write_file": {"error": "stop"}}


### PR DESCRIPTION
## Thinking Path

ECC (`affaan-m/ecc`) ships a `config-protection` PreToolUse hook that blocks agent edits to linter/formatter config files, steering the agent to fix the code instead of weakening the quality gate. AutoBot's agent loop had the ideal insertion point — `_check_forbidden` runs before the approval gate ([agent_loop/loop.py](autobot-backend/agent_loop/loop.py)) — but nothing guarded config files, so an agent could silently relax `ruff`/`eslint`/`prettier` config to make a failing gate pass. This adds the missing guard next to the existing forbidden-tool check.

## What Changed

- **`autobot-backend/agent_loop/config_protection.py`** (new): pure helpers — `is_protected_config(path)`, `protected_config_write(tool)`, `config_edits_allowed()`. Matches dedicated linter/formatter config basenames (exact set + `.eslintrc*`/`.prettierrc*`/`.stylelintrc*`/`.markdownlint*` prefixes). Reads the write-tool target path from `file_path`/`path`/`destination`/`target_file`, consistent with `tools/parallel/analyzer.py`.
- **`autobot-backend/agent_loop/loop.py`**: `_check_config_protection(tools)` returns the same denial shape as `_check_forbidden`, wired into `_execute_tools` immediately after the forbidden check (before approval).
- **Scope choices:** mixed-purpose manifests (`pyproject.toml`, `setup.cfg`) are intentionally **not** protected — they carry legitimate deps/packaging content. `AUTOBOT_ALLOW_CONFIG_EDITS=1` opts out for intentional config changes.
- **`autobot-backend/tests/agent_loop/test_config_protection.py`** (new): module unit tests + end-to-end `_execute_tools` integration.

## Verification

```
$ python3 -m pytest tests/agent_loop/test_config_protection.py tests/agent_loop/test_forbidden_tools.py -q
37 passed in 0.27s
```

End-to-end AC proven: a `write_file` to `.prettierrc` is blocked with a `config-protection` error and never reaches `_check_approvals` or the executor; a write to `src/app.ts` proceeds; `pyproject.toml`/`setup.cfg` are not matched; `AUTOBOT_ALLOW_CONFIG_EDITS=1` lets the config write through.

## Model Used

Claude Opus 4.8 (1M context)

Closes #11148
