### PR TITLE
refactor(llc): narrow WorkItem type/priority/status to closed union types (#11131)

### DIFF
--- a/autobot-frontend/src/views/llc/workItemTypes.ts
+++ b/autobot-frontend/src/views/llc/workItemTypes.ts
@@ -11,13 +11,30 @@
  * `column_id` and `assignee_type` are only present on board API responses,
  * hence optional here.
  */
+
+/**
+ * Closed work-item enum sets (#11131). Kept in sync with the `llc.enums.*`
+ * i18n keys and the `<WorkItemBadge>` color classes so the allowed values are
+ * enforced at compile time rather than being bare `string`.
+ */
+export type WorkItemType = 'epic' | 'feature' | 'pbi' | 'task' | 'bug' | 'spike' | 'subtask' | 'risk'
+export type WorkItemPriority = 'critical' | 'high' | 'medium' | 'low'
+export type WorkItemStatus =
+  | 'backlog'
+  | 'ready'
+  | 'in_progress'
+  | 'in_review'
+  | 'done'
+  | 'blocked'
+  | 'cancelled'
+
 export interface WorkItem {
   id: string
   identifier: string
-  type: string
+  type: WorkItemType
   title: string
   description: string
-  priority: string
+  priority: WorkItemPriority
   story_points: number | null
   assignee_name: string | null
   assignee_type?: 'human' | 'agent' | null
@@ -28,7 +45,7 @@ export interface WorkItem {
   reviewer_agent_id?: string | null
   sprint_id: string | null
   column_id?: string
-  status: string
+  status: WorkItemStatus
   labels: string[]
   acceptance_criteria: string[]
   linked_pr_urls?: string[]


### PR DESCRIPTION
## Thinking Path
#11131 (split from #11076 part 4) — `views/llc/workItemTypes.ts` typed work-item `type`/`priority`/`status` as bare `string`. Now that the enum sets are closed and centralized (the `<WorkItemBadge>` color classes + `llc.enums.*` i18n keys from #11076), narrow them to string-literal unions so out-of-set values are caught at compile time.

## What Changed
Added three exported aliases and applied them to `WorkItem`:
- `WorkItemType` = epic | feature | pbi | task | bug | spike | subtask | risk
- `WorkItemPriority` = critical | high | medium | low
- `WorkItemStatus` = backlog | ready | in_progress | in_review | done | blocked | cancelled

Purely additive type tightening — no runtime change. `WorkItem` is consumed via `api.get<WorkItem[]>()` casts and read for rendering across the 5 LLC views; there are no object-literal constructions or arbitrary field writes, so the narrowing is zero-blast-radius.

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json` → **0 errors** (whole project — this is exactly CI's type-check step; confirms no consumer passes a value outside the unions)
- `eslint` → **0 errors / 0 warnings**

_Note: self-hosted runner is currently offline; this change is fully validated by the local whole-project vue-tsc (identical to the CI type-check gate). Merge when CI is back._

## Model Used
Opus 4.8

Closes #11131