### PR TITLE
ci(types): auto-regenerate api.ts on PRs to self-heal verify-generated-types (#10817)

### DIFF
--- a/.github/workflows/auto-fix-generated-types.yml
+++ b/.github/workflows/auto-fix-generated-types.yml
@@ -1,0 +1,99 @@
+# Auto-regenerate the frontend generated types (api.ts) on PR branches.
+# Companion to verify-generated-types.yml (the REQUIRED gate): rather than
+# force every author to hand-run `npm run gen:types` against a py3.14 backend
+# (the deployed/dev boxes may run a different Python and produce a schema that
+# never matches the gate), this job regenerates api.ts in the SAME py3.14
+# environment the gate uses and commits it back to the PR branch — self-healing
+# the recurring drift (#10817). Runs on GitHub-hosted runners so it never
+# competes with the self-hosted runner.
+
+name: Auto-fix Generated Types
+
+on:
+  pull_request:
+    paths:
+      # Backend changes can alter the OpenAPI schema that api.ts is generated from.
+      - 'autobot-backend/**/*.py'
+      - 'autobot_shared/**/*.py'
+      - 'autobot-frontend/src/types/generated/api.ts'
+      - '.github/workflows/auto-fix-generated-types.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  autofix-types:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements*.txt
+            autobot-backend/requirements*.txt
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r requirements-ci.txt --prefer-binary
+
+      - name: Dump authoritative OpenAPI schema
+        run: |
+          set -o pipefail
+          export PYTHONPATH="$PWD:$PWD/autobot-backend:${PYTHONPATH:-}"
+          mkdir -p data logs static config
+          if ! python scripts/audit_api_wiring.py --dump-openapi openapi.raw.json; then
+            echo "::error::Backend app.openapi() build failed — cannot regenerate types (see startup-import-smoke)."
+            exit 1
+          fi
+          # Strip the audit-only x-websocket-paths extension so the schema matches
+          # exactly what verify-generated-types diffs against.
+          python -c "import json; s=json.load(open('openapi.raw.json')); s.pop('x-websocket-paths', None); json.dump(s, open('openapi.json','w'))"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: autobot-frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: autobot-frontend
+        run: npm ci
+
+      - name: Regenerate api.ts from authoritative schema
+        working-directory: autobot-frontend
+        run: npx --no-install openapi-typescript ../openapi.json -o src/types/generated/api.ts --additional-properties
+
+      - name: Commit regenerated types if drifted
+        run: |
+          rm -f openapi.raw.json openapi.json
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add autobot-frontend/src/types/generated/api.ts
+          if git diff --staged --quiet; then
+            echo "Generated types already fresh — nothing to commit."
+          else
+            git commit -m "$(cat <<'EOF'
+          chore(types): regenerate api.ts from backend OpenAPI schema
+
+          Auto-regenerated (py3.14) to match the backend schema so the required
+          verify-generated-types gate passes. Triggered by auto-fix-generated-types.yml.
+          EOF
+          )"
+            git push
+            echo "✅ api.ts regenerated and pushed to the PR branch."
+          fi

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -29645,7 +29645,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/api/llm-auth/oauth/callback": {
+    "/api/llm-auth/oauth/callback": {
         parameters: {
             query?: never;
             header?: never;
@@ -29664,14 +29664,14 @@ export interface paths {
          *
          *     Requires admin — stored credential is system-wide (shared by all users).
          */
-        post: operations["oauth_callback_api_api_llm_auth_oauth_callback_post"];
+        post: operations["oauth_callback_api_llm_auth_oauth_callback_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/api/llm-auth/device/initiate": {
+    "/api/llm-auth/device/initiate": {
         parameters: {
             query?: never;
             header?: never;
@@ -29690,14 +29690,14 @@ export interface paths {
          *
          *     Requires admin — stored credential is system-wide (shared by all users).
          */
-        post: operations["device_initiate_api_api_llm_auth_device_initiate_post"];
+        post: operations["device_initiate_api_llm_auth_device_initiate_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/api/llm-auth/device/poll": {
+    "/api/llm-auth/device/poll": {
         parameters: {
             query?: never;
             header?: never;
@@ -29715,14 +29715,14 @@ export interface paths {
          *
          *     Requires admin — stored credential is system-wide (shared by all users).
          */
-        post: operations["device_poll_api_api_llm_auth_device_poll_post"];
+        post: operations["device_poll_api_llm_auth_device_poll_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/api/llm-auth/status/{provider_name}": {
+    "/api/llm-auth/status/{provider_name}": {
         parameters: {
             query?: never;
             header?: never;
@@ -29733,7 +29733,7 @@ export interface paths {
          * Provider Auth Status
          * @description Return the auth connection status for a provider.
          */
-        get: operations["provider_auth_status_api_api_llm_auth_status__provider_name__get"];
+        get: operations["provider_auth_status_api_llm_auth_status__provider_name__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -29742,7 +29742,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/api/llm-auth/{provider_name}": {
+    "/api/llm-auth/{provider_name}": {
         parameters: {
             query?: never;
             header?: never;
@@ -29758,7 +29758,7 @@ export interface paths {
          *
          *     Requires admin — credential is system-wide (shared by all users).
          */
-        delete: operations["revoke_provider_auth_api_api_llm_auth__provider_name__delete"];
+        delete: operations["revoke_provider_auth_api_llm_auth__provider_name__delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -46620,6 +46620,11 @@ export interface paths {
         /**
          * List Insights
          * @description List distilled experiment insights.
+         *
+         *     Resilient by design (#11081): on a fresh/empty deployment the insights
+         *     collection may not exist yet (or the vector store is unavailable), which
+         *     would otherwise 500 and crash the whole Experiments dashboard. Absence of
+         *     data is not an error — return an empty list instead.
          */
         get: operations["list_insights_api_autoresearch_insights_get"];
         put?: never;
@@ -138219,7 +138224,7 @@ export interface operations {
             };
         };
     };
-    oauth_callback_api_api_llm_auth_oauth_callback_post: {
+    oauth_callback_api_llm_auth_oauth_callback_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -138252,7 +138257,7 @@ export interface operations {
             };
         };
     };
-    device_initiate_api_api_llm_auth_device_initiate_post: {
+    device_initiate_api_llm_auth_device_initiate_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -138285,7 +138290,7 @@ export interface operations {
             };
         };
     };
-    device_poll_api_api_llm_auth_device_poll_post: {
+    device_poll_api_llm_auth_device_poll_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -138318,7 +138323,7 @@ export interface operations {
             };
         };
     };
-    provider_auth_status_api_api_llm_auth_status__provider_name__get: {
+    provider_auth_status_api_llm_auth_status__provider_name__get: {
         parameters: {
             query?: never;
             header?: never;
@@ -138349,7 +138354,7 @@ export interface operations {
             };
         };
     };
-    revoke_provider_auth_api_api_llm_auth__provider_name__delete: {
+    revoke_provider_auth_api_llm_auth__provider_name__delete: {
         parameters: {
             query?: never;
             header?: never;


### PR DESCRIPTION
## Thinking Path
`verify-generated-types` is a required check that regenerates `api.ts` under **py3.14** and diffs. When an author's local/deployed backend runs a different Python (this environment is stuck on py3.12), `npm run gen:types` produces types that can never match the py3.14 schema — so the gate stays red and blocks the entire PR queue, and the drift keeps recurring. (The py3.14 environment unification is handled separately in the deploy/update procedure.)

## What Changed
New workflow `.github/workflows/auto-fix-generated-types.yml` — mirrors the trusted `auto-fix-formatting.yml` pattern:
- Triggers on backend `.py` / `api.ts` changes.
- Regenerates `api.ts` using the gate's **exact** recipe in the **same py3.14 env** (`audit_api_wiring.py --dump-openapi` → strip `x-websocket-paths` → `openapi-typescript --additional-properties`).
- Commits the regenerated `api.ts` back to the PR branch (no trailers, `github-actions[bot]`) only if it drifted — self-healing; the follow-up push re-runs the gate green.
- Runs on **GitHub-hosted** runners, so it never competes with the single self-hosted runner.

## Verification
- `yaml.safe_load` parses the workflow; `sh -n` validates the commit block; no untrusted `github.event.*` flows into any `run:` (commit message is a static heredoc; `ref: github.head_ref` matches the existing auto-fix pattern).

## Model Used
Opus 4.8 (1M context)

Refs #10817