### PR TITLE
feat(llc): declarative requires_approval_before on work items (#11140)

### DIFF
--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -154,6 +154,8 @@ class WorkItemCreate(BaseModel):
     created_by_agent_id: Optional[str] = None
     created_by_user_id: Optional[str] = None
     labels: Optional[List[str]] = None
+    # GH#11140: declarative approval-gated action categories (plan-time visibility).
+    requires_approval_before: Optional[List[str]] = None
 
 
 class WorkItemUpdate(BaseModel):
@@ -168,6 +170,8 @@ class WorkItemUpdate(BaseModel):
     goal_id: Optional[str] = None
     assignee_agent_id: Optional[str] = None
     assignee_user_id: Optional[str] = None
+    # GH#11140: declarative approval-gated action categories.
+    requires_approval_before: Optional[List[str]] = None
     # GH#9020: planned schedule for the Gantt/timeline view.
     scheduled_start: Optional[datetime] = None
     scheduled_end: Optional[datetime] = None
@@ -331,6 +335,7 @@ async def _item_to_dict(item: Any, session: AsyncSession) -> Dict[str, Any]:
         "story_points": item.story_points,
         "labels": item.labels,
         "linked_pr_urls": item.linked_pr_urls or [],  # GH#9625
+        "requires_approval_before": item.requires_approval_before or [],  # GH#11140
         "parent_id": str(item.parent_id) if item.parent_id else None,
         "project_id": str(item.project_id) if item.project_id else None,
         "sprint_id": str(item.sprint_id) if item.sprint_id else None,
@@ -388,6 +393,7 @@ async def create_work_item(
         created_by_agent_id=body.created_by_agent_id,
         created_by_user_id=body.created_by_user_id,
         labels=body.labels,
+        requires_approval_before=body.requires_approval_before,
     )
     await session.commit()
     await _kb_manager.ensure_collection(KbCollectionManager.WORK_ITEM_PREFIX, item.id)

--- a/autobot-backend/llc/models/work_item.py
+++ b/autobot-backend/llc/models/work_item.py
@@ -77,6 +77,17 @@ class LLCWorkItem(Base):
         server_default=sa.text("'[]'::jsonb"),
     )
 
+    # Declarative approval requirements (GH#11140): action categories that must be
+    # approved before the agent performs them (e.g. "pushing commits", "publishing",
+    # "destructive operations"). Makes governance visible at plan time; enforcement
+    # stays in the existing runtime approval flow. Empty list = no declared gates.
+    requires_approval_before: Mapped[list] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=list,
+        server_default=sa.text("'[]'::jsonb"),
+    )
+
     # Status / priority
     status: Mapped[str] = mapped_column(
         sa.Enum(WorkItemStatus, name="workitemstatus", create_type=False, values_callable=pg_enum_values),

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -247,6 +247,7 @@ class WorkItemService(LLCServiceBase):
         created_by_agent_id: Optional[str] = None,
         created_by_user_id: Optional[str] = None,
         labels: Optional[List[str]] = None,
+        requires_approval_before: Optional[List[str]] = None,
     ) -> LLCWorkItem:
         # GH#6469: inherit goal_id from parent when not explicitly provided
         resolved_goal_id: Optional[uuid.UUID] = uuid.UUID(goal_id) if goal_id else None
@@ -275,6 +276,7 @@ class WorkItemService(LLCServiceBase):
             created_by_agent_id=uuid.UUID(created_by_agent_id) if created_by_agent_id else None,
             created_by_user_id=uuid.UUID(created_by_user_id) if created_by_user_id else None,
             labels=labels or [],
+            requires_approval_before=requires_approval_before or [],
         )
         session.add(item)
         await session.flush()
@@ -300,6 +302,7 @@ class WorkItemService(LLCServiceBase):
             "priority",
             "story_points",
             "labels",
+            "requires_approval_before",
             "parent_id",
             "sprint_id",
             "goal_id",

--- a/autobot-backend/llc/tests/test_work_item_requires_approval.py
+++ b/autobot-backend/llc/tests/test_work_item_requires_approval.py
@@ -1,0 +1,84 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Declarative requires_approval_before on LLC work items (GH#11140).
+
+Proves the plan-time approval declaration round-trips through the service
+(create + update) and the API serialization contract. Runtime enforcement of
+the declared categories is a separate follow-up (needs work_item_id threaded
+into the execution context).
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.models.enums import WorkItemType
+from llc.services.work_item_service import WorkItemService
+
+
+@pytest.fixture
+def service():
+    return WorkItemService()
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.flush = AsyncMock()
+    session.add = MagicMock()
+    return session
+
+
+class TestCreate:
+    async def test_create_persists_requires_approval_before(self, service, mock_session):
+        captured = {}
+        mock_session.add.side_effect = lambda obj: captured.__setitem__("item", obj)
+        with patch.object(service, "_next_identifier", new=AsyncMock(return_value="PRJ-1")):
+            item = await service.create(
+                mock_session,
+                company_id=str(uuid.uuid4()),
+                type=WorkItemType.TASK,
+                title="Deploy task",
+                requires_approval_before=["pushing commits", "destructive operations"],
+            )
+        assert item.requires_approval_before == ["pushing commits", "destructive operations"]
+
+    async def test_create_defaults_to_empty_list(self, service, mock_session):
+        with patch.object(service, "_next_identifier", new=AsyncMock(return_value="PRJ-2")):
+            item = await service.create(
+                mock_session,
+                company_id=str(uuid.uuid4()),
+                type=WorkItemType.TASK,
+                title="Plain task",
+            )
+        assert item.requires_approval_before == []
+
+
+class TestUpdate:
+    async def test_update_allows_requires_approval_before(self, service, mock_session):
+        item = MagicMock()
+        with patch.object(service, "get", new=AsyncMock(return_value=item)):
+            result = await service.update(
+                mock_session,
+                str(uuid.uuid4()),
+                requires_approval_before=["publishing"],
+            )
+        assert result is item
+        assert item.requires_approval_before == ["publishing"]
+
+
+class TestSerialization:
+    async def test_item_to_dict_includes_requires_approval_before(self):
+        from llc.api import work_items
+
+        item = MagicMock()
+        item.requires_approval_before = ["pushing commits"]
+        item.linked_pr_urls = []
+        item.labels = []
+        session = AsyncMock()
+        with patch.object(work_items, "_assignee_display", new=AsyncMock(return_value=None)), patch.object(
+            work_items, "_relations_to_list", return_value=[]
+        ):
+            result = await work_items._item_to_dict(item, session)
+        assert result["requires_approval_before"] == ["pushing commits"]

--- a/autobot-backend/llc/tests/test_work_item_requires_approval.py
+++ b/autobot-backend/llc/tests/test_work_item_requires_approval.py
@@ -77,8 +77,9 @@ class TestSerialization:
         item.linked_pr_urls = []
         item.labels = []
         session = AsyncMock()
-        with patch.object(work_items, "_assignee_display", new=AsyncMock(return_value=None)), patch.object(
-            work_items, "_relations_to_list", return_value=[]
+        with (
+            patch.object(work_items, "_assignee_display", new=AsyncMock(return_value=None)),
+            patch.object(work_items, "_relations_to_list", return_value=[]),
         ):
             result = await work_items._item_to_dict(item, session)
         assert result["requires_approval_before"] == ["pushing commits"]

--- a/autobot-backend/migrations/versions/20260701_066_llc_requires_approval_before.py
+++ b/autobot-backend/migrations/versions/20260701_066_llc_requires_approval_before.py
@@ -1,0 +1,41 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Add requires_approval_before to llc_work_items (GH#11140).
+
+Revision ID: 20260701_066
+Revises: 20260630_065
+Create Date: 2026-07-01 00:00:00.000000
+
+Adds a JSONB ``requires_approval_before`` column to ``llc_work_items`` storing
+the list of declarative approval-gated action categories (e.g. "pushing commits",
+"publishing", "destructive operations"). Makes governance visible at plan time;
+runtime enforcement stays in the existing approval flow. Defaults to an empty
+list so existing rows keep their current (no declared gates) behaviour.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "20260701_066"
+down_revision: Union[str, None] = "20260630_065"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "llc_work_items",
+        sa.Column(
+            "requires_approval_before",
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("llc_work_items", "requires_approval_before")


### PR DESCRIPTION
## Thinking Path

#11140 asks work items to **declare** approval-gated action categories at plan time so governance is visible before an agent runs, then honor them at execution. Investigation (mirroring #11145) showed the declaration and the enforcement are cleanly separable: the declaration is a self-contained model/API change, while enforcement requires threading a `work_item_id` into the chat execution context — which does not exist today (no `work_item_id` on `LLMIterationContext`; production approvals are command-risk-based in `CommandApprovalManager` / `tool_handler.py`, not work-item-based).

This PR delivers the declarative half (issue task 2.1). Runtime enforcement (task 2.2) is filed as **#11160** with the concrete threading plan, so no inert enforcement code ships here.

## What Changed

- **`llc/models/work_item.py`** — `requires_approval_before` JSONB list, mirroring `linked_pr_urls` (`nullable=False`, `default=list`, `server_default '[]'::jsonb`). Empty-list default → existing rows unchanged.
- **`migrations/versions/20260701_066_llc_requires_approval_before.py`** — reversible `add_column`, chained off current head `20260630_065`.
- **`llc/api/work_items.py`** — field on `WorkItemCreate` + `WorkItemUpdate`, passed through `create_work_item`, and surfaced in the `_item_to_dict` response contract.
- **`llc/services/work_item_service.py`** — `create()` persists it; `update()` allow-list accepts it.
- **`llc/tests/test_work_item_requires_approval.py`** — create persists + defaults to `[]`, update accepts it, serialization exposes it.

## Verification

```
$ python3 -m pytest llc/tests/test_work_item_requires_approval.py llc/tests/test_work_item.py -q
4 passed  +  13 passed (no regressions)
```
Migration validated: `revision 20260701_066 <- down 20260630_065`; `LLCWorkItem.__table__` carries `requires_approval_before`.

## Model Used

Claude Opus 4.8 (1M context)

Closes #11140

Runtime enforcement follow-up: #11160