### PR TITLE
Research extract via content_reach + URL-aware youtube/reddit routing (#10932)

### DIFF
--- a/.superpowers/sdd/task-extract-report.md
+++ b/.superpowers/sdd/task-extract-report.md
@@ -1,0 +1,85 @@
+# Task Report: research extract via content_reach (#10932)
+
+## Status
+COMPLETE — all parts implemented, tests green, linting clean, committed.
+
+## Commit
+`ec72a2760` — `feat(content-reach): research extract via content_reach + URL-aware youtube/reddit routing (#10932)`
+
+## What changed
+- `autobot-backend/agents/librarian_assistant.py`
+  - Added module-level `_source_for_url(url) -> str` — routes youtube.com/youtu.be → "youtube", reddit.com → "reddit", else → "web_page"; robust to missing scheme.
+  - Added `_content_data_from_result(result, url) -> dict` — maps ContentResult to the 8-key content_data shape (url/title/description/content/domain/is_trusted/timestamp/content_length); title falls back to netloc, description to content[:200], is_trusted via `self.trusted_domains` suffix check.
+  - Rewrote `extract_content(url)` — fetches via `get_content_source_registry().fetch(source, ContentRequest(...))` with lazy bootstrap guard; returns None on failure, empty text, or exception.
+  - Removed `_check_playwright_service`, `playwright_service_url`, `_build_content_data`, the Playwright gate in `research_query`, `http_client` attribute, and imports of `get_http_client`/`get_service_url`.
+- `autobot-backend/tests/agents/test_librarian_assistant_extract.py` (new) — 19 tests covering all plan cases.
+- `autobot-backend/tests/agents/test_librarian_assistant_search.py` (updated) — removed stale Playwright `/extract` test and dead stubs.
+
+## Test summary
+```
+25 passed in 0.36s   (19 new extract tests + 6 search tests)
+```
+Full gate (`tests/agents/ tests/content_reach/ tests/search/` minus pre-existing broken `test_subagent_spawning.py`): 215 passed, 7 pre-existing failures (test_causal_reasoning × 5, test_ledger_vs_executor × 2) — same count as base branch, zero regressions introduced.
+
+## Import smoke
+`python3 -c "import agents.librarian_assistant"` → OK (Redis/Ollama warnings are expected in dev; no import errors).
+
+## Linting
+- `ruff check` → All checks passed
+- `black --check --fast` → 3 files would be left unchanged
+- `isort --check-only` → clean (no output)
+
+## Playwright members removed (confirmed zero dangling refs)
+Grep on `agents/librarian_assistant.py` after change returns empty:
+- `playwright_service_url` — removed from `__init__`
+- `_check_playwright_service` — method deleted
+- `_build_content_data` — method replaced by `_content_data_from_result`
+- `http_client` — attribute removed; `get_http_client`/`get_service_url` imports removed
+- Playwright gate in `research_query` (lines ~513-516) — deleted
+
+## Concerns / notes
+- `is_trusted` now uses `self.trusted_domains` suffix check (same domains the class already held in `__init__`). This avoids importing `DomainSecurityManager` which has heavy deps (aiohttp, yaml, threat intel network calls) making it unsuitable for sync/lazy use. The effect is identical for the domains listed; the plan's "else False" fallback is effectively the non-matching path.
+- Pre-existing `test_subagent_spawning` collection error (`ModuleNotFoundError: services.agents`) and 7 `test_causal_reasoning`/`test_ledger_vs_executor` failures are confirmed pre-existing on base branch; not introduced by this PR.
+
+---
+
+## Code-review fixes: commit `768d69647`
+
+`fix(content-reach): guard on routed source + subdomain-safe is_trusted + degraded-extract summary (#10932)`
+
+### Fix 1 — Bootstrap guard checks routed source (not hardcoded "web_page")
+- `extract_content`: `source = _source_for_url(url)` moved BEFORE the guard; guard now checks `reg.get_chain(source)` so a registry missing only "youtube" will still bootstrap when a YouTube URL is requested.
+
+### Fix 2 — Subdomain-safe `is_trusted` (no more partial-suffix exploitation)
+- New module-level helper `_host_matches(host, domain) → bool`: `host == domain or host.endswith("." + domain)`.
+- `_content_data_from_result`: `netloc` lowercased at parse time; `is_trusted` rewritten as `any(_host_matches(netloc, td) for td in self.trusted_domains)`. `evilgithub.com` → False; `github.com` and `sub.github.com` → True.
+
+### Fix 3 — Degraded summary on total extraction failure
+- `_finalize_research_results`: added `elif research_results.get("search_results"):` branch that sets `summary = "Found N result(s) but could not extract content."` when search produced hits but extraction yielded nothing.
+
+### Fix 4 — Readability cleanups
+- `result.structured if result.structured else {}` → `result.structured or {}`.
+- Dropped `domain = netloc` alias; `netloc` used directly (lowercased).
+- `text = result.text or ""` bound once in `extract_content`; reused for `.strip()` guard and `len()` log.
+
+### Fix 5 — Domain-boundary routing in `_source_for_url`
+- Old naive `"youtube.com" in host` substring test misrouted `notyoutube.com` → "youtube".
+- Replaced with `_host_matches` calls: `_host_matches(host, "youtube.com") or _host_matches(host, "youtu.be")` → "youtube"; `_host_matches(host, "reddit.com")` → "reddit".
+- `_host_matches` reused by both `_source_for_url` and `is_trusted` (DRY).
+
+### Tests added (13 new, total 32 in file)
+- Fix 5 routing: `www.youtube.com`, `m.youtube.com`, `old.youtube.com`, `youtu.be` → "youtube"; `www.reddit.com`, `old.reddit.com` → "reddit"; `notyoutube.com`, `fakeyoutube.com`, `notyoutu.be`, `myreddit.com`, `example.com` → "web_page".
+- Fix 1 bootstrap-on-source: registry with only "youtube" missing → `register_default_sources` called on YouTube URL.
+- Fix 2 is_trusted: exact match, subdomain match, partial-suffix attack (evilgithub.com → False).
+- Fix 3 degraded summary: search_results non-empty + extracted_content empty → non-empty summary string.
+
+### Gate result
+```
+157 passed in 2.68s  (tests/agents/test_librarian_assistant_extract.py + test_librarian_assistant_search.py + tests/content_reach/)
+```
+Pre-existing failures: test_ledger_vs_executor × 2 — unchanged from base.
+
+### Linting
+- `ruff check` → All checks passed
+- `black --check --fast` → 2 files unchanged
+- `isort --check-only` → clean

--- a/autobot-backend/agents/librarian_assistant.py
+++ b/autobot-backend/agents/librarian_assistant.py
@@ -26,18 +26,27 @@ from services.llm_service import get_llm_service
 logger = get_logger(__name__)
 
 
+def _host_matches(host: str, domain: str) -> bool:
+    """Return True iff *host* is exactly *domain* or a subdomain of it.
+
+    Prevents partial-suffix attacks (e.g. ``notyoutube.com`` matching ``youtube.com``).
+    """
+    return host == domain or host.endswith("." + domain)
+
+
 def _source_for_url(url: str) -> str:
     """Route a URL to the appropriate content_reach source name.
 
     Returns "youtube" for YouTube URLs, "reddit" for Reddit URLs,
     "web_page" for everything else.  Robust to missing scheme.
+    Uses domain-boundary matching so ``notyoutube.com`` → "web_page".
     """
     if "://" not in url:
         url = "https://" + url
     host = urlparse(url).netloc.lower()
-    if "youtube.com" in host or "youtu.be" in host:
+    if _host_matches(host, "youtube.com") or _host_matches(host, "youtu.be"):
         return "youtube"
-    if "reddit.com" in host:
+    if _host_matches(host, "reddit.com"):
         return "reddit"
     return "web_page"
 
@@ -146,21 +155,20 @@ class LibrarianAssistant:
         """
         effective_url = result.url or url
         content = result.text or ""
-        structured = result.structured if result.structured else {}
-        netloc = urlparse(effective_url).netloc
+        structured = result.structured or {}
+        netloc = urlparse(effective_url).netloc.lower()
 
         title = structured.get("title") or netloc
         description = structured.get("description") or content[:200]
-        domain = netloc
 
-        is_trusted = any(domain.endswith(td) for td in self.trusted_domains) if domain else False
+        is_trusted = any(_host_matches(netloc, td) for td in self.trusted_domains) if netloc else False
 
         return {
             "url": effective_url,
             "title": title,
             "description": description,
             "content": content,
-            "domain": domain,
+            "domain": netloc,
             "is_trusted": is_trusted,
             "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             "content_length": len(content),
@@ -182,23 +190,24 @@ class LibrarianAssistant:
         from content_reach.registry import get_content_source_registry
 
         reg = get_content_source_registry()
-        if reg.get_chain("web_page") is None:
+        source = _source_for_url(url)
+        if reg.get_chain(source) is None:
             from content_reach.bootstrap import register_default_sources
 
             register_default_sources(reg)
 
-        source = _source_for_url(url)
         try:
             result = await reg.fetch(source, ContentRequest(url=url, query=url, source=source))
         except Exception as exc:
             logger.error("content_reach extract failed for %s (%s): %s", url, source, exc)
             return None
 
-        if not result.success or not (result.text or "").strip():
+        text = result.text or ""
+        if not result.success or not text.strip():
             logger.info("No content extracted for %s via %s", url, source)
             return None
 
-        logger.info("Extracted %d characters from %s via %s", len(result.text or ""), url, source)
+        logger.info("Extracted %d characters from %s via %s", len(text), url, source)
         return self._content_data_from_result(result, url)
 
     def _build_fallback_assessment(self, content_data: Dict[str, Any], error_msg: str | None = None) -> Dict[str, Any]:
@@ -540,6 +549,9 @@ class LibrarianAssistant:
         if extracted_content:
             research_results["summary"] = await self._create_research_summary(query, extracted_content)
             research_results["sources"] = [self._build_source_entry(c) for c in extracted_content]
+        elif research_results.get("search_results"):
+            n = len(research_results["search_results"])
+            research_results["summary"] = f"Found {n} result(s) but could not extract content."
 
         logger.info(
             "Research completed: %d sources analyzed, %d stored in KB",

--- a/autobot-backend/agents/librarian_assistant.py
+++ b/autobot-backend/agents/librarian_assistant.py
@@ -4,9 +4,9 @@
 # Author: mrveiss
 """Librarian Assistant Agent for Web Research.
 
-This agent performs web research using the Playwright service running on the
-browser VM (.25), presents results with proper source attribution, and stores
-quality information in the knowledge base for future reference.
+This agent performs web research using content_reach (youtube/reddit/web_page
+by URL-aware routing), presents results with proper source attribution, and
+stores quality information in the knowledge base for future reference.
 
 Architecture: called by the orchestrator when local KB results are insufficient
 or the query requires current/external data.
@@ -15,20 +15,35 @@ or the query requires current/external data.
 import json
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List
+from urllib.parse import urlparse
 
-from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
 from config import config
 from knowledge_base import KnowledgeBase
 from services.llm_service import get_llm_service
-from utils.service_registry import get_service_url
 
 logger = get_logger(__name__)
 
 
+def _source_for_url(url: str) -> str:
+    """Route a URL to the appropriate content_reach source name.
+
+    Returns "youtube" for YouTube URLs, "reddit" for Reddit URLs,
+    "web_page" for everything else.  Robust to missing scheme.
+    """
+    if "://" not in url:
+        url = "https://" + url
+    host = urlparse(url).netloc.lower()
+    if "youtube.com" in host or "youtu.be" in host:
+        return "youtube"
+    if "reddit.com" in host:
+        return "reddit"
+    return "web_page"
+
+
 class LibrarianAssistant:
-    """An agent that researches information using the browser VM Playwright service."""
+    """An agent that researches information using content_reach for extraction."""
 
     def __init__(self):
         """Initialize the Librarian Assistant Agent."""
@@ -38,10 +53,6 @@ class LibrarianAssistant:
 
         # Configuration
         self.enabled = self.config.get_nested("librarian_assistant.enabled", True)
-        self.playwright_service_url = self.config.get_nested(
-            "librarian_assistant.playwright_service_url",
-            get_service_url("playwright-vnc"),
-        )
         self.max_search_results = self.config.get_nested("librarian_assistant.max_search_results", 5)
         self.max_content_length = self.config.get_nested("librarian_assistant.max_content_length", 2000)
         self.quality_threshold = self.config.get_nested("librarian_assistant.quality_threshold", 0.7)
@@ -63,9 +74,6 @@ class LibrarianAssistant:
             ],
         )
 
-        # Use HTTP client singleton for requests to Playwright service
-        self.http_client = get_http_client()
-
     @staticmethod
     async def _emit(callback: Callable | None, event: Dict[str, Any]) -> None:
         """Fire a progress event if a callback is registered. Issue #1256."""
@@ -75,20 +83,6 @@ class LibrarianAssistant:
             await callback(event)
         except Exception as exc:
             logger.warning("Progress callback error for event %s: %s", event, exc)
-
-    async def _check_playwright_service(self) -> bool:
-        """Check if browser VM Playwright service is available."""
-        try:
-            async with await self.http_client.get(f"{self.playwright_service_url}/health") as response:
-                if response.status == 200:
-                    logger.info("Playwright service is healthy")
-                    return True
-                else:
-                    logger.error("Playwright service unhealthy: status %s", response.status)
-                    return False
-        except Exception as e:
-            logger.error("Cannot reach Playwright service: %s", e)
-            return False
 
     async def search_web(
         self,
@@ -139,67 +133,73 @@ class LibrarianAssistant:
             logger.error("Error during web search: %s", e)
             return []
 
-    def _build_content_data(self, result: Dict[str, Any]) -> Dict[str, Any]:
-        """Build content data dictionary from extraction result.
+    def _content_data_from_result(self, result: Any, url: str) -> Dict[str, Any]:
+        """Map a ContentResult to the 8-key content_data shape. Issue #10932.
 
         Args:
-            result: Raw result from Playwright extraction service
+            result: ContentResult from content_reach registry
+            url: Original request URL (fallback when result.url is empty)
 
         Returns:
-            Formatted content data dictionary. Issue #620.
+            content_data dict with url/title/description/content/domain/
+            is_trusted/timestamp/content_length.
         """
+        effective_url = result.url or url
+        content = result.text or ""
+        structured = result.structured if result.structured else {}
+        netloc = urlparse(effective_url).netloc
+
+        title = structured.get("title") or netloc
+        description = structured.get("description") or content[:200]
+        domain = netloc
+
+        is_trusted = any(domain.endswith(td) for td in self.trusted_domains) if domain else False
+
         return {
-            "url": result["url"],
-            "title": result["title"],
-            "description": result["description"],
-            "content": result["content"],
-            "domain": result["domain"],
-            "is_trusted": result["is_trusted"],
-            "timestamp": result["timestamp"],
-            "content_length": result["content_length"],
+            "url": effective_url,
+            "title": title,
+            "description": description,
+            "content": content,
+            "domain": domain,
+            "is_trusted": is_trusted,
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            "content_length": len(content),
         }
 
     async def extract_content(self, url: str) -> Dict[str, Any] | None:
-        """Extract content from a web page using the browser VM Playwright service.
+        """Extract content from a URL via content_reach (URL-aware routing). Issue #10932.
+
+        Routes YouTube URLs to the "youtube" source, reddit.com URLs to
+        "reddit", and everything else to "web_page".
 
         Args:
             url: URL to extract content from
 
         Returns:
-            Dictionary containing extracted content and metadata
+            content_data dict or None on failure / empty content
         """
-        if not await self._check_playwright_service():
-            return None
+        from content_reach.base import ContentRequest
+        from content_reach.registry import get_content_source_registry
 
+        reg = get_content_source_registry()
+        if reg.get_chain("web_page") is None:
+            from content_reach.bootstrap import register_default_sources
+
+            register_default_sources(reg)
+
+        source = _source_for_url(url)
         try:
-            payload = {"url": url}
-            logger.info("Extracting content via Playwright service: %s", url)
-
-            async with await self.http_client.post(f"{self.playwright_service_url}/extract", json=payload) as response:
-                if response.status != 200:
-                    logger.error("Content extraction failed: status %s", response.status)
-                    return None
-
-                result = await response.json()
-
-                if result.get("success"):
-                    content_data = self._build_content_data(result)
-                    logger.info(
-                        "Extracted %s characters from %s",
-                        result["content_length"],
-                        result["domain"],
-                    )
-                    return content_data
-                else:
-                    logger.error(
-                        "Content extraction failed: %s",
-                        result.get("error", "Unknown error"),
-                    )
-                    return None
-
-        except Exception as e:
-            logger.error("Error extracting content from %s: %s", url, e)
+            result = await reg.fetch(source, ContentRequest(url=url, query=url, source=source))
+        except Exception as exc:
+            logger.error("content_reach extract failed for %s (%s): %s", url, source, exc)
             return None
+
+        if not result.success or not (result.text or "").strip():
+            logger.info("No content extracted for %s via %s", url, source)
+            return None
+
+        logger.info("Extracted %d characters from %s via %s", len(result.text or ""), url, source)
+        return self._content_data_from_result(result, url)
 
     def _build_fallback_assessment(self, content_data: Dict[str, Any], error_msg: str | None = None) -> Dict[str, Any]:
         """Build fallback assessment when LLM fails (Issue #665: extracted helper)."""
@@ -507,12 +507,6 @@ class LibrarianAssistant:
 
             if not search_results:
                 research_results["summary"] = "No search results found for the query."
-                return research_results
-
-            # Extract step still requires Playwright; skip gracefully if unavailable.
-            if not await self._check_playwright_service():
-                logger.warning("Playwright service not available; skipping content extraction")
-                research_results["summary"] = "Search completed but content extraction unavailable."
                 return research_results
 
             extracted_content = await self._extract_and_process_results(

--- a/autobot-backend/tests/agents/test_librarian_assistant_extract.py
+++ b/autobot-backend/tests/agents/test_librarian_assistant_extract.py
@@ -1,0 +1,468 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for LibrarianAssistant extract_content via content_reach (#10932).
+
+Verifies:
+- _source_for_url routes youtube.com/youtu.be → "youtube", reddit.com → "reddit",
+  everything else → "web_page"; handles missing scheme
+- extract_content fetches via get_content_source_registry().fetch with the
+  correct source name derived from the URL
+- content_data has exactly the 8 required keys with correct values
+- success=False or empty text → None
+- fetch raises → None (no propagation)
+- research_query no longer calls _check_playwright_service (removed)
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub heavy optional dependencies so LibrarianAssistant can be imported
+# without a live database or LLM.
+# ---------------------------------------------------------------------------
+_BACKEND_DIR = Path(__file__).resolve().parents[2]
+_AGENTS_DIR = _BACKEND_DIR / "agents"
+
+# Plant a minimal 'agents' package so relative imports in the module work.
+if "agents" not in sys.modules:
+    _agents_pkg = types.ModuleType("agents")
+    _agents_pkg.__path__ = [str(_AGENTS_DIR)]
+    _agents_pkg.__package__ = "agents"
+    sys.modules["agents"] = _agents_pkg
+
+
+def _make_stub(name: str) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    mod.__path__ = []  # type: ignore[assignment]
+    mod.__package__ = name
+    mock_attr = MagicMock()
+    mod.__getattr__ = lambda attr: mock_attr  # type: ignore[attr-defined]
+    sys.modules[name] = mod
+    return mod
+
+
+for _stub_name in [
+    "knowledge_base",
+    "services",
+    "services.llm_service",
+]:
+    sys.modules.setdefault(_stub_name, _make_stub(_stub_name))
+
+# Ensure 'utils' package stub is present only if not already a real module.
+if "utils" not in sys.modules:
+    _utils_pkg = types.ModuleType("utils")
+    _utils_pkg.__path__ = []  # type: ignore[assignment]
+    _utils_pkg.__package__ = "utils"
+    sys.modules["utils"] = _utils_pkg
+
+# Stub agent_loop.search.registry so any indirect import doesn't fail.
+_al_search_pkg = sys.modules.get("agent_loop.search")
+if _al_search_pkg is None or not hasattr(_al_search_pkg, "__path__"):
+    _al_search_pkg = types.ModuleType("agent_loop.search")
+    _al_search_pkg.__path__ = []  # type: ignore[assignment]
+    _al_search_pkg.__package__ = "agent_loop.search"
+    sys.modules["agent_loop.search"] = _al_search_pkg
+    _al_pkg = sys.modules.get("agent_loop")
+    if _al_pkg is not None:
+        _al_pkg.search = _al_search_pkg  # type: ignore[attr-defined]
+
+if "agent_loop.search.registry" not in sys.modules:
+    _al_search_registry_mod = types.ModuleType("agent_loop.search.registry")
+    _al_search_registry_mod.__package__ = "agent_loop.search"
+    _mock_search_singleton = MagicMock()
+    _al_search_registry_mod.get_search_registry = MagicMock(  # type: ignore[attr-defined]
+        return_value=_mock_search_singleton
+    )
+    sys.modules["agent_loop.search.registry"] = _al_search_registry_mod
+    setattr(_al_search_pkg, "registry", _al_search_registry_mod)
+
+# content_reach is a real installed package — do NOT stub it here.
+# Per-test patch.dict overrides for content_reach.base and content_reach.registry
+# are applied at call time to avoid contaminating the real modules.
+
+# ---------------------------------------------------------------------------
+# Patch config and singletons BEFORE importing the module under test.
+# ---------------------------------------------------------------------------
+_fake_config = MagicMock()
+_fake_config.get_nested = MagicMock(side_effect=lambda key, default=None: default)
+
+sys.modules.setdefault("config", types.SimpleNamespace(config=_fake_config))
+
+# Patch autobot_shared stubs if not already real modules.
+for _shared in ["autobot_shared.logging_manager"]:
+    if _shared not in sys.modules:
+        _make_stub(_shared)
+
+if "autobot_shared.singleton_factory" not in sys.modules:
+    _singleton_stub = _make_stub("autobot_shared.singleton_factory")
+    _singleton_stub.lazy_singleton = lambda cls: cls  # type: ignore[attr-defined]
+
+_logging_mod = sys.modules.get("autobot_shared.logging_manager")
+if _logging_mod is not None:
+    _logging_mod.get_logger = logging.getLogger  # type: ignore[attr-defined]
+
+_llm_mod = sys.modules.get("services.llm_service")
+if _llm_mod is not None:
+    _llm_mod.get_llm_service = MagicMock(return_value=MagicMock())  # type: ignore[attr-defined]
+
+_kb_mod = sys.modules.get("knowledge_base")
+if _kb_mod is not None:
+    _kb_mod.KnowledgeBase = MagicMock  # type: ignore[attr-defined]
+
+# ---------------------------------------------------------------------------
+# Load the module under test.
+# ---------------------------------------------------------------------------
+import importlib.util  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "agents.librarian_assistant",
+    str(_AGENTS_DIR / "librarian_assistant.py"),
+)
+_mod = importlib.util.module_from_spec(_spec)
+_mod.__package__ = "agents"
+sys.modules["agents.librarian_assistant"] = _mod
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+LibrarianAssistant = _mod.LibrarianAssistant
+_source_for_url = _mod._source_for_url
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EXPECTED_CONTENT_DATA_KEYS = frozenset(
+    {"url", "title", "description", "content", "domain", "is_trusted", "timestamp", "content_length"}
+)
+
+
+def _make_assistant() -> LibrarianAssistant:
+    """Construct a LibrarianAssistant with all heavy deps mocked out."""
+    assistant = LibrarianAssistant.__new__(LibrarianAssistant)
+    assistant.config = _fake_config
+    assistant.knowledge_base = MagicMock()
+    assistant.llm = MagicMock()
+    assistant.enabled = True
+    assistant.max_search_results = 5
+    assistant.max_content_length = 2000
+    assistant.quality_threshold = 0.7
+    assistant.auto_store_quality = True
+    assistant.trusted_domains = [
+        "wikipedia.org",
+        "github.com",
+        "stackoverflow.com",
+    ]
+    return assistant
+
+
+def _make_content_result(
+    success: bool = True,
+    text: str = "hello world content",
+    url: str = "",
+    structured: dict | None = None,
+) -> MagicMock:
+    """Build a mock ContentResult."""
+    r = MagicMock()
+    r.success = success
+    r.text = text
+    r.url = url
+    r.structured = structured or {}
+    return r
+
+
+def _make_registry(fetch_result: MagicMock) -> MagicMock:
+    """Build a mock content_reach registry whose fetch returns fetch_result."""
+    reg = MagicMock()
+    reg.get_chain = MagicMock(return_value=MagicMock())  # chain present → skip bootstrap
+    reg.fetch = AsyncMock(return_value=fetch_result)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# _source_for_url tests
+# ---------------------------------------------------------------------------
+
+
+def test_source_for_url_youtube_dot_com():
+    assert _source_for_url("https://www.youtube.com/watch?v=abc") == "youtube"
+
+
+def test_source_for_url_youtu_be():
+    assert _source_for_url("https://youtu.be/abc123") == "youtube"
+
+
+def test_source_for_url_reddit_dot_com():
+    assert _source_for_url("https://www.reddit.com/r/python/") == "reddit"
+
+
+def test_source_for_url_old_reddit():
+    assert _source_for_url("https://old.reddit.com/r/programming/") == "reddit"
+
+
+def test_source_for_url_generic():
+    assert _source_for_url("https://example.com/some/page") == "web_page"
+
+
+def test_source_for_url_no_scheme_youtube():
+    assert _source_for_url("youtube.com/watch?v=abc") == "youtube"
+
+
+def test_source_for_url_no_scheme_reddit():
+    assert _source_for_url("reddit.com/r/python") == "reddit"
+
+
+def test_source_for_url_no_scheme_generic():
+    assert _source_for_url("example.com/page") == "web_page"
+
+
+# ---------------------------------------------------------------------------
+# extract_content routing tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_content_routes_youtube_url():
+    """A youtube.com URL must call fetch with source='youtube'."""
+    assistant = _make_assistant()
+    result = _make_content_result(
+        url="https://www.youtube.com/watch?v=abc",
+        structured={"title": "My Video"},
+    )
+    reg = _make_registry(result)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "content_reach.registry": types.SimpleNamespace(get_content_source_registry=lambda: reg),
+            "content_reach.base": types.SimpleNamespace(ContentRequest=MagicMock(side_effect=lambda **kw: kw)),
+        },
+    ):
+        content = await assistant.extract_content("https://www.youtube.com/watch?v=abc")
+
+    assert content is not None
+    call_args = reg.fetch.call_args
+    assert call_args[0][0] == "youtube"
+
+
+@pytest.mark.asyncio
+async def test_extract_content_routes_reddit_url():
+    """A reddit.com URL must call fetch with source='reddit'."""
+    assistant = _make_assistant()
+    result = _make_content_result(url="https://www.reddit.com/r/python/", text="reddit post body")
+    reg = _make_registry(result)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "content_reach.registry": types.SimpleNamespace(get_content_source_registry=lambda: reg),
+            "content_reach.base": types.SimpleNamespace(ContentRequest=MagicMock(side_effect=lambda **kw: kw)),
+        },
+    ):
+        content = await assistant.extract_content("https://www.reddit.com/r/python/")
+
+    assert content is not None
+    assert reg.fetch.call_args[0][0] == "reddit"
+
+
+@pytest.mark.asyncio
+async def test_extract_content_routes_generic_to_web_page():
+    """A generic URL must call fetch with source='web_page'."""
+    assistant = _make_assistant()
+    result = _make_content_result(
+        url="https://example.com/page",
+        text="page body text",
+        structured={"title": "Example Page"},
+    )
+    reg = _make_registry(result)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "content_reach.registry": types.SimpleNamespace(get_content_source_registry=lambda: reg),
+            "content_reach.base": types.SimpleNamespace(ContentRequest=MagicMock(side_effect=lambda **kw: kw)),
+        },
+    ):
+        content = await assistant.extract_content("https://example.com/page")
+
+    assert content is not None
+    assert reg.fetch.call_args[0][0] == "web_page"
+
+
+@pytest.mark.asyncio
+async def test_extract_content_maps_content_data_shape():
+    """Returned dict must have exactly the 8 expected keys with correct values."""
+    assistant = _make_assistant()
+    result = _make_content_result(
+        url="https://example.com/page",
+        text="the main body text",
+        structured={"title": "Page Title", "description": "Short desc"},
+    )
+    reg = _make_registry(result)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "content_reach.registry": types.SimpleNamespace(get_content_source_registry=lambda: reg),
+            "content_reach.base": types.SimpleNamespace(ContentRequest=MagicMock(side_effect=lambda **kw: kw)),
+        },
+    ):
+        content = await assistant.extract_content("https://example.com/page")
+
+    assert content is not None
+    assert set(content.keys()) == _EXPECTED_CONTENT_DATA_KEYS
+    assert content["url"] == "https://example.com/page"
+    assert content["title"] == "Page Title"
+    assert content["description"] == "Short desc"
+    assert content["content"] == "the main body text"
+    assert content["domain"] == "example.com"
+    assert content["content_length"] == len("the main body text")
+    assert content["timestamp"]  # non-empty ISO string
+    assert isinstance(content["is_trusted"], bool)
+
+
+@pytest.mark.asyncio
+async def test_extract_content_trusted_domain_flagged():
+    """A domain matching trusted_domains list must yield is_trusted=True."""
+    assistant = _make_assistant()
+    result = _make_content_result(
+        url="https://github.com/some/repo",
+        text="repo readme text",
+        structured={"title": "Repo"},
+    )
+    reg = _make_registry(result)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "content_reach.registry": types.SimpleNamespace(get_content_source_registry=lambda: reg),
+            "content_reach.base": types.SimpleNamespace(ContentRequest=MagicMock(side_effect=lambda **kw: kw)),
+        },
+    ):
+        content = await assistant.extract_content("https://github.com/some/repo")
+
+    assert content is not None
+    assert content["is_trusted"] is True
+
+
+@pytest.mark.asyncio
+async def test_extract_content_returns_none_on_failure():
+    """success=False must return None."""
+    assistant = _make_assistant()
+    result = _make_content_result(success=False, text="")
+    reg = _make_registry(result)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "content_reach.registry": types.SimpleNamespace(get_content_source_registry=lambda: reg),
+            "content_reach.base": types.SimpleNamespace(ContentRequest=MagicMock(side_effect=lambda **kw: kw)),
+        },
+    ):
+        content = await assistant.extract_content("https://example.com/page")
+
+    assert content is None
+
+
+@pytest.mark.asyncio
+async def test_extract_content_returns_none_on_empty_text():
+    """success=True but empty/whitespace text must return None."""
+    assistant = _make_assistant()
+    result = _make_content_result(success=True, text="   ")
+    reg = _make_registry(result)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "content_reach.registry": types.SimpleNamespace(get_content_source_registry=lambda: reg),
+            "content_reach.base": types.SimpleNamespace(ContentRequest=MagicMock(side_effect=lambda **kw: kw)),
+        },
+    ):
+        content = await assistant.extract_content("https://example.com/page")
+
+    assert content is None
+
+
+@pytest.mark.asyncio
+async def test_extract_content_returns_none_on_fetch_exception():
+    """A fetch exception must be caught; returns None not raises."""
+    assistant = _make_assistant()
+    reg = MagicMock()
+    reg.get_chain = MagicMock(return_value=MagicMock())
+    reg.fetch = AsyncMock(side_effect=RuntimeError("network error"))
+
+    with patch.dict(
+        sys.modules,
+        {
+            "content_reach.registry": types.SimpleNamespace(get_content_source_registry=lambda: reg),
+            "content_reach.base": types.SimpleNamespace(ContentRequest=MagicMock(side_effect=lambda **kw: kw)),
+        },
+    ):
+        content = await assistant.extract_content("https://example.com/page")
+
+    assert content is None
+
+
+@pytest.mark.asyncio
+async def test_extract_content_title_falls_back_to_netloc():
+    """When structured has no title, title must default to the netloc."""
+    assistant = _make_assistant()
+    result = _make_content_result(
+        url="https://example.com/page",
+        text="body text",
+        structured={},
+    )
+    reg = _make_registry(result)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "content_reach.registry": types.SimpleNamespace(get_content_source_registry=lambda: reg),
+            "content_reach.base": types.SimpleNamespace(ContentRequest=MagicMock(side_effect=lambda **kw: kw)),
+        },
+    ):
+        content = await assistant.extract_content("https://example.com/page")
+
+    assert content is not None
+    assert content["title"] == "example.com"
+
+
+@pytest.mark.asyncio
+async def test_extract_content_description_falls_back_to_content_slice():
+    """When structured has no description, description must be content[:200]."""
+    assistant = _make_assistant()
+    body = "A" * 300
+    result = _make_content_result(url="https://example.com/page", text=body, structured={})
+    reg = _make_registry(result)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "content_reach.registry": types.SimpleNamespace(get_content_source_registry=lambda: reg),
+            "content_reach.base": types.SimpleNamespace(ContentRequest=MagicMock(side_effect=lambda **kw: kw)),
+        },
+    ):
+        content = await assistant.extract_content("https://example.com/page")
+
+    assert content is not None
+    assert content["description"] == body[:200]
+
+
+# ---------------------------------------------------------------------------
+# research_query no longer calls _check_playwright_service
+# ---------------------------------------------------------------------------
+
+
+def test_research_query_has_no_playwright_check():
+    """research_query must not call _check_playwright_service (method removed)."""
+    assert not hasattr(
+        LibrarianAssistant, "_check_playwright_service"
+    ), "_check_playwright_service was not removed from LibrarianAssistant"

--- a/autobot-backend/tests/agents/test_librarian_assistant_extract.py
+++ b/autobot-backend/tests/agents/test_librarian_assistant_extract.py
@@ -224,6 +224,38 @@ def test_source_for_url_no_scheme_generic():
     assert _source_for_url("example.com/page") == "web_page"
 
 
+def test_source_for_url_mobile_youtube():
+    assert _source_for_url("https://m.youtube.com/watch?v=abc") == "youtube"
+
+
+def test_source_for_url_old_youtube():
+    assert _source_for_url("https://old.youtube.com/watch?v=abc") == "youtube"
+
+
+def test_source_for_url_youtu_be_exact():
+    assert _source_for_url("https://youtu.be/abc123") == "youtube"
+
+
+def test_source_for_url_notyoutube_com_is_web_page():
+    assert _source_for_url("https://notyoutube.com/watch") == "web_page"
+
+
+def test_source_for_url_fakeyoutube_com_is_web_page():
+    assert _source_for_url("https://fakeyoutube.com/watch") == "web_page"
+
+
+def test_source_for_url_notyoutu_be_is_web_page():
+    assert _source_for_url("https://notyoutu.be/abc") == "web_page"
+
+
+def test_source_for_url_myreddit_com_is_web_page():
+    assert _source_for_url("https://myreddit.com/r/python") == "web_page"
+
+
+def test_source_for_url_example_is_web_page():
+    assert _source_for_url("https://example.com/page") == "web_page"
+
+
 # ---------------------------------------------------------------------------
 # extract_content routing tests
 # ---------------------------------------------------------------------------
@@ -466,3 +498,106 @@ def test_research_query_has_no_playwright_check():
     assert not hasattr(
         LibrarianAssistant, "_check_playwright_service"
     ), "_check_playwright_service was not removed from LibrarianAssistant"
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: Bootstrap guard checks routed source, not hardcoded "web_page"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_content_bootstrap_guard_on_routed_source():
+    """Bootstrap guard must trigger based on the routed source (e.g. 'youtube'),
+    not hardcoded 'web_page'.  A registry missing only 'youtube' must still call
+    register_default_sources when a YouTube URL is requested.
+    """
+    assistant = _make_assistant()
+    result = _make_content_result(
+        url="https://www.youtube.com/watch?v=test",
+        text="video transcript here",
+        structured={"title": "Test Video"},
+    )
+
+    reg = MagicMock()
+    # 'youtube' chain is missing; 'web_page' chain is present
+    reg.get_chain = MagicMock(side_effect=lambda name: None if name == "youtube" else MagicMock())
+    reg.fetch = AsyncMock(return_value=result)
+
+    bootstrap_called = []
+
+    def _fake_register(r):
+        bootstrap_called.append(True)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "content_reach.registry": types.SimpleNamespace(get_content_source_registry=lambda: reg),
+            "content_reach.base": types.SimpleNamespace(ContentRequest=MagicMock(side_effect=lambda **kw: kw)),
+            "content_reach.bootstrap": types.SimpleNamespace(register_default_sources=_fake_register),
+        },
+    ):
+        content = await assistant.extract_content("https://www.youtube.com/watch?v=test")
+
+    assert bootstrap_called, "register_default_sources must be called when 'youtube' chain is missing"
+    assert content is not None
+    assert reg.fetch.call_args[0][0] == "youtube"
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: is_trusted uses subdomain-safe matching
+# ---------------------------------------------------------------------------
+
+
+def test_is_trusted_exact_domain_match():
+    """Exact match on a trusted entry must yield is_trusted=True."""
+    assistant = _make_assistant()
+    result = _make_content_result(url="https://github.com/foo", text="body", structured={})
+    data = assistant._content_data_from_result(result, "https://github.com/foo")
+    assert data["is_trusted"] is True
+
+
+def test_is_trusted_subdomain_match():
+    """A subdomain of a trusted entry must yield is_trusted=True."""
+    assistant = _make_assistant()
+    result = _make_content_result(url="https://sub.github.com/foo", text="body", structured={})
+    data = assistant._content_data_from_result(result, "https://sub.github.com/foo")
+    assert data["is_trusted"] is True
+
+
+def test_is_trusted_evil_prefix_not_trusted():
+    """evilgithub.com must NOT be trusted even though it ends with 'github.com'."""
+    assistant = _make_assistant()
+    result = _make_content_result(url="https://evilgithub.com/foo", text="body", structured={})
+    data = assistant._content_data_from_result(result, "https://evilgithub.com/foo")
+    assert data["is_trusted"] is False
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: Degraded summary when search produced results but extraction failed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_research_results_degraded_summary():
+    """When search_results is non-empty but extracted_content is empty,
+    summary must be the degraded human-readable note, not an empty string.
+    """
+    assistant = _make_assistant()
+    assistant.llm = MagicMock()
+
+    research_results = {
+        "summary": "",
+        "sources": [],
+        "stored_in_kb": [],
+        "search_results": [
+            {"url": "https://example.com/a", "title": "A"},
+            {"url": "https://example.com/b", "title": "B"},
+        ],
+        "content_extracted": [],
+        "error": None,
+    }
+
+    await assistant._finalize_research_results("test query", [], research_results)
+
+    assert research_results["summary"] != "", "summary must not be empty when search results were found"
+    assert "2" in research_results["summary"] or "result" in research_results["summary"].lower()

--- a/autobot-backend/tests/agents/test_librarian_assistant_search.py
+++ b/autobot-backend/tests/agents/test_librarian_assistant_search.py
@@ -9,7 +9,6 @@ Verifies:
 - emits research:result_found per result
 - returns {url,title,snippet} dicts
 - returns [] on exception
-- extract_content path is UNCHANGED (still calls Playwright /extract)
 """
 
 from __future__ import annotations
@@ -51,7 +50,6 @@ for _stub_name in [
     "knowledge_base",
     "services",
     "services.llm_service",
-    "utils.service_registry",
 ]:
     sys.modules.setdefault(_stub_name, _make_stub(_stub_name))
 
@@ -99,7 +97,7 @@ _fake_config.get_nested = MagicMock(side_effect=lambda key, default=None: defaul
 sys.modules.setdefault("config", types.SimpleNamespace(config=_fake_config))
 
 # Patch autobot_shared stubs if not already real modules.
-for _shared in ["autobot_shared.http_client", "autobot_shared.logging_manager"]:
+for _shared in ["autobot_shared.logging_manager"]:
     if _shared not in sys.modules:
         _make_stub(_shared)
 
@@ -114,16 +112,6 @@ if "autobot_shared.singleton_factory" not in sys.modules:
 _logging_mod = sys.modules.get("autobot_shared.logging_manager")
 if _logging_mod is not None:
     _logging_mod.get_logger = logging.getLogger  # type: ignore[attr-defined]
-
-# get_http_client must return a mock with async context-manager methods.
-_http_mod = sys.modules.get("autobot_shared.http_client")
-if _http_mod is not None:
-    _http_mod.get_http_client = MagicMock(return_value=MagicMock())  # type: ignore[attr-defined]
-
-# get_service_url can return any string.
-_utils_mod = sys.modules.get("utils.service_registry")
-if _utils_mod is not None:
-    _utils_mod.get_service_url = MagicMock(return_value="http://playwright:3000")  # type: ignore[attr-defined]
 
 # get_llm_service can return a mock.
 _llm_mod = sys.modules.get("services.llm_service")
@@ -163,14 +151,12 @@ def _make_assistant() -> LibrarianAssistant:
         assistant.knowledge_base = MagicMock()
         assistant.llm = MagicMock()
         assistant.enabled = True
-        assistant.playwright_service_url = "http://playwright:3000"
         assistant.max_search_results = 5
         assistant.max_content_length = 2000
         assistant.quality_threshold = 0.7
         assistant.auto_store_quality = True
         assistant.trusted_domains = []
-        assistant.http_client = MagicMock()
-    return assistant
+        return assistant
 
 
 def _sr(n: int) -> MagicMock:
@@ -210,8 +196,8 @@ async def test_search_web_uses_registry_not_playwright():
         results = await assistant.search_web("python asyncio")
 
     mock_registry.search.assert_awaited_once()
-    # Must NOT have called the Playwright /search endpoint.
-    assistant.http_client.post.assert_not_called()
+    # http_client is removed — no Playwright endpoint can be called.
+    assert not hasattr(assistant, "http_client")
     assert len(results) == 2
     assert results[0]["url"] == "https://example.com/1"
     assert results[0]["title"] == "Title 1"
@@ -296,44 +282,3 @@ async def test_search_web_returns_dicts_not_search_result_objects():
     assert "url" in results[0]
     assert "title" in results[0]
     assert "snippet" in results[0]
-
-
-@pytest.mark.asyncio
-async def test_extract_content_still_calls_playwright_extract():
-    """extract_content must POST to Playwright /extract (unchanged path)."""
-    assistant = _make_assistant()
-
-    extract_response = MagicMock()
-    extract_response.status = 200
-    extract_response.json = AsyncMock(
-        return_value={
-            "success": True,
-            "url": "https://example.com/page",
-            "title": "Page Title",
-            "description": "desc",
-            "content": "content text",
-            "domain": "example.com",
-            "is_trusted": True,
-            "timestamp": "2026-01-01T00:00:00Z",
-            "content_length": 12,
-        }
-    )
-    extract_response.__aenter__ = AsyncMock(return_value=extract_response)
-    extract_response.__aexit__ = AsyncMock(return_value=False)
-
-    health_response = MagicMock()
-    health_response.status = 200
-    health_response.__aenter__ = AsyncMock(return_value=health_response)
-    health_response.__aexit__ = AsyncMock(return_value=False)
-
-    assistant.http_client.get = AsyncMock(return_value=health_response)
-    assistant.http_client.post = AsyncMock(return_value=extract_response)
-
-    result = await assistant.extract_content("https://example.com/page")
-
-    assert result is not None
-    assert result["url"] == "https://example.com/page"
-    # Confirm the POST went to /extract, not /search.
-    call_url = assistant.http_client.post.call_args[0][0]
-    assert "/extract" in call_url
-    assert "/search" not in call_url

--- a/docs/superpowers/plans/2026-07-07-content-reach-research-extract.md
+++ b/docs/superpowers/plans/2026-07-07-content-reach-research-extract.md
@@ -1,0 +1,86 @@
+# Wire content_reach into research EXTRACTION + URL-aware source routing (#10932)
+
+**Goal:** (a) route the research flow's content extraction through `content_reach` (`web_page`: trafilatura→Jina→browser), and (b) URL-aware routing so YouTube/Reddit result URLs use content_reach's `youtube`/`reddit` sources. Together this makes `LibrarianAssistant` fully content_reach-backed (search already is, from PR #11154) and removes its dependency on the external Playwright `/extract` service.
+
+**Constraints:** async-first; preserve the `content_data` dict shape consumed by `assess_content_quality`/`store_in_knowledge_base`; lazy-import content_reach; no print(); no commit trailers (mrveiss); commit `feat(content-reach): ... (#10932)`; black 26.3.1/isort/ruff; TDD; no dead code; don't break startup-import-smoke.
+
+## Given (verified)
+- `agents/librarian_assistant.py`:
+  - `extract_content(url) -> dict|None` (line 162): gates on `_check_playwright_service()`, POSTs Playwright `/extract`, maps via `_build_content_data(result)`.
+  - `_build_content_data` (142) → `content_data = {url, title, description, content, domain, is_trusted, timestamp, content_length}`.
+  - Consumers use: `content` (main text), `title`, `url`, `domain`, `is_trusted`, `timestamp`, `content_length`, `description`.
+  - `_extract_and_process_results` calls `extract_content(result["url"])` (line 372).
+  - `research_query` (476) has a Playwright gate at line 513 before `_extract_and_process_results` (added in #11154).
+  - Playwright bits: `playwright_service_url` (41), `_check_playwright_service` (79) — after this change, used NOWHERE (search moved off in #11154; extract moves off here).
+- `content_reach.registry.get_content_source_registry()` → async `fetch(source, ContentRequest) -> ContentResult(success, text, structured, url, backend_used, reliability, metadata)`. Sources: `web_page`, `youtube`, `reddit` (+ web_search/social). `content_reach.bootstrap.register_default_sources`.
+- `content_reach` `web_page`/`youtube`/`reddit` use httpx + in-process `research_browser_manager` — NONE need the external Playwright `/extract` service.
+- `security/domain_security.py` has a trusted-domain whitelist (reuse for `is_trusted` if cleanly importable; else default False).
+
+## Part 1 — URL→source router
+Add `_source_for_url(url: str) -> str` (module-level or method):
+- host contains `youtube.com` or `youtu.be` → `"youtube"`
+- host contains `reddit.com` (incl. `old.reddit.com`, `www.reddit.com`) → `"reddit"`
+- else → `"web_page"`
+Use `urllib.parse.urlparse(url).netloc.lower()`. Be robust to missing scheme.
+
+## Part 2 — map ContentResult → content_data
+Add `_content_data_from_result(result: ContentResult, url: str) -> dict`:
+- `content` = `result.text or ""`
+- `url` = `result.url or url`
+- `title` = `result.structured.get("title")` if present else the netloc (fallback)
+- `description` = `result.structured.get("description")` if present else `content[:200]`
+- `domain` = `urlparse(result.url or url).netloc`
+- `is_trusted` = trusted-domain check on `domain` (reuse `security/domain_security` helper if importable; else `False`)
+- `timestamp` = `datetime.now(tz=timezone.utc).isoformat()`
+- `content_length` = `len(content)`
+Return exactly those 8 keys (same shape as `_build_content_data`).
+
+## Part 3 — repoint `extract_content`
+Rewrite `extract_content(url)`:
+```python
+async def extract_content(self, url: str) -> Dict[str, Any] | None:
+    from content_reach.base import ContentRequest
+    from content_reach.registry import get_content_source_registry
+    reg = get_content_source_registry()
+    # defensive: ensure sources registered regardless of boot order
+    if reg.get_chain("web_page") is None:
+        from content_reach.bootstrap import register_default_sources
+        register_default_sources(reg)
+    source = _source_for_url(url)
+    try:
+        result = await reg.fetch(source, ContentRequest(url=url, query=url, source=source))
+    except Exception as e:
+        logger.error("content_reach extract failed for %s (%s): %s", url, source, e)
+        return None
+    if not result.success or not (result.text or "").strip():
+        logger.info("No content extracted for %s via %s", url, source)
+        return None
+    return self._content_data_from_result(result, url)
+```
+- Remove the `_check_playwright_service()` gate + the Playwright `/extract` POST. Keep `extract_content`'s `-> dict|None` contract (callers unchanged).
+- Note: `youtube` source needs a YouTube `url`; `reddit` accepts a reddit url or falls back to query — passing both `url` and `query=url` is harmless.
+
+## Part 4 — remove now-dead Playwright code
+- Remove the Playwright gate in `research_query` (line ~513) — extraction now always proceeds via content_reach; keep the rest of the pipeline (extract→assess→store) intact. Preserve any "no results" graceful summary that isn't Playwright-specific.
+- Remove `_check_playwright_service` and `playwright_service_url` (and `_build_content_data` if now unused) — VERIFY no remaining references first (grep). No dead code.
+- If `self.http_client`/Playwright `/health` becomes unused, remove it too (verify).
+
+## Tests (TDD) — `tests/agents/test_librarian_assistant_extract.py` (+ update existing)
+- `_source_for_url`: youtube.com / youtu.be → "youtube"; reddit.com / old.reddit.com → "reddit"; example.com → "web_page"; no-scheme urls handled.
+- `extract_content`: monkeypatch `get_content_source_registry().fetch` (AsyncMock) →
+  - a YouTube url routes to source `"youtube"` and maps text→`content`, structured title→`title`; assert the fetch was called with source `"youtube"`.
+  - a reddit url routes to `"reddit"`.
+  - a generic url routes to `"web_page"`; maps domain/content_length/timestamp correctly.
+  - `result.success=False` or empty text → `None`.
+  - fetch raises → `None`.
+- `content_data` shape has exactly the 8 keys the downstream expects.
+- Update/replace any existing extract test that asserted the Playwright `/extract` POST (now removed).
+- Assert `research_query` no longer calls `_check_playwright_service` (removed).
+
+## Gate
+- `cd autobot-backend && python3 -m pytest tests/agents/ tests/content_reach/ tests/search/ -q` → green.
+- import smoke: `python3 -c "import agents.librarian_assistant"` (from backend dir).
+- ruff + black(26.3.1) + isort clean on changed files.
+
+## Out of scope
+Frontend panel unchanged (same events/shape). web_search path already wired (#11154).


### PR DESCRIPTION
## Thinking Path

Completes the research integration: after PR #11154 made `/knowledge/research` SEARCH via content_reach, this wires EXTRACTION through content_reach too, with URL-aware source routing — so YouTube/Reddit links use the captions/thread sources and everything else uses `web_page` (trafilatura→Jina→browser). The research flow (`LibrarianAssistant`) becomes fully content_reach-backed, and the external Playwright `/extract` dependency is removed.

## What Changed

- **URL→source router** `_source_for_url()` (domain-boundary-safe via `_host_matches`): `youtube.com`/`youtu.be`→`youtube`, `reddit.com`→`reddit`, else `web_page`.
- **`extract_content` repointed** to `content_reach.registry.fetch(source, ...)`; maps `ContentResult` → the 8-key `content_data` shape the quality-assessment/KB-store steps expect. Defensive source bootstrap keyed on the routed source.
- **Playwright dependency removed** from `LibrarianAssistant` (`_check_playwright_service`, `playwright_service_url`, `_build_content_data`, the `research_query` gate) — content_reach's httpx + in-process browser cover extraction; no dangling refs.
- **`is_trusted`** now subdomain-boundary-safe (shared `_host_matches`), so `evilgithub.com` is not trusted.
- **Degraded-service summary** when search finds results but extraction yields none (restores a signal the old Playwright gate provided).

## Verification

32 extract tests (13 added by an 8-angle adversarial review that caught domain-boundary misrouting + the trust-suffix bug — all fixed); full `tests/agents/ tests/content_reach/` suite 157 passed with only 2 pre-existing unrelated failures. ruff/black 26.3.1/isort clean. Playwright removal grep-verified.

## Model Used

Opus 4.8 (orchestration + adversarial review fleet), Sonnet 4.6 (implementer + fix).

Follow-up to #10932 / #11154 — research flow now fully content_reach-backed.
