### PR TITLE
feat(memory): recency-weighted scoring for verbatim recall (#11163)

### DIFF
--- a/autobot-backend/memory/verbatim_recency_test.py
+++ b/autobot-backend/memory/verbatim_recency_test.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Recency-weighted verbatim recall (GH#11163).
+
+Covers the exponential decay factor and that VerbatimStore.search() re-ranks
+equally-similar chunks so recent turns win, while weight 0 preserves the prior
+pure-semantic order.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+from memory import verbatim_store
+from memory.verbatim_store import VerbatimStore, _recency_factor
+
+
+def _make_collection(items: List[Dict[str, Any]]) -> MagicMock:
+    """Mock collection: each item is {id, text, distance, timestamp}."""
+    collection = MagicMock()
+
+    async def _query(query_texts=None, n_results=10, where=None, include=None):
+        limit = min(n_results, len(items))
+        sliced = items[:limit]
+        return {
+            "ids": [[i["id"] for i in sliced]],
+            "documents": [[i["text"] for i in sliced]],
+            "metadatas": [[{"timestamp": i["timestamp"]} for i in sliced]],
+            "distances": [[i["distance"] for i in sliced]],
+        }
+
+    collection.query = _query
+    return collection
+
+
+def _store(items: List[Dict[str, Any]]) -> VerbatimStore:
+    store = VerbatimStore()
+    store._collection = _make_collection(items)
+    return store
+
+
+# --- _recency_factor -------------------------------------------------------
+
+
+def test_recency_factor_now_is_one():
+    now = datetime.now(tz=timezone.utc)
+    assert _recency_factor(now.isoformat(), now) == 1.0
+
+
+def test_recency_factor_halves_at_half_life():
+    now = datetime.now(tz=timezone.utc)
+    half_life = verbatim_store._RECENCY_HALFLIFE_SECONDS
+    ts = (now - timedelta(seconds=half_life)).isoformat()
+    assert _recency_factor(ts, now) == pytest.approx(0.5, abs=1e-6)
+
+
+def test_recency_factor_missing_or_bad_returns_none():
+    now = datetime.now(tz=timezone.utc)
+    assert _recency_factor(None, now) is None
+    assert _recency_factor("not-a-date", now) is None
+
+
+def test_recency_factor_naive_timestamp_treated_as_utc():
+    now = datetime.now(tz=timezone.utc)
+    naive = now.replace(tzinfo=None).isoformat()
+    assert _recency_factor(naive, now) == pytest.approx(1.0, abs=1e-3)
+
+
+# --- search re-ranking -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_recent_beats_equally_similar_stale(monkeypatch):
+    monkeypatch.setattr(verbatim_store, "_RECENCY_WEIGHT", 0.5)
+    now = datetime.now(tz=timezone.utc)
+    old = (now - timedelta(days=60)).isoformat()
+    # Same distance (equally similar); stale one is listed first by the vector store.
+    store = _store(
+        [
+            {"id": "stale", "text": "old", "distance": 0.1, "timestamp": old},
+            {"id": "fresh", "text": "new", "distance": 0.1, "timestamp": now.isoformat()},
+        ]
+    )
+    results = await store.search("q")
+    assert [r["id"] for r in results] == ["fresh", "stale"]
+    assert results[0]["score"] > results[1]["score"]
+
+
+@pytest.mark.asyncio
+async def test_search_weight_zero_preserves_semantic_order(monkeypatch):
+    monkeypatch.setattr(verbatim_store, "_RECENCY_WEIGHT", 0.0)
+    now = datetime.now(tz=timezone.utc)
+    old = (now - timedelta(days=60)).isoformat()
+    store = _store(
+        [
+            {"id": "closer_old", "text": "a", "distance": 0.1, "timestamp": old},
+            {"id": "farther_new", "text": "b", "distance": 0.4, "timestamp": now.isoformat()},
+        ]
+    )
+    results = await store.search("q")
+    # Weight 0 → pure semantic: the closer (lower distance) chunk stays first.
+    assert [r["id"] for r in results] == ["closer_old", "farther_new"]
+    assert results[0]["score"] == pytest.approx(0.9)

--- a/autobot-backend/memory/verbatim_store.py
+++ b/autobot-backend/memory/verbatim_store.py
@@ -20,6 +20,7 @@ Design decisions:
 """
 
 import asyncio
+import os
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List
@@ -31,6 +32,36 @@ logger = get_logger(__name__)
 _COLLECTION_NAME = "autobot_verbatim"
 _DEFAULT_LIMIT = 10
 _DEFAULT_RETENTION_DAYS: int = 90  # override via memory.verbatim.retention_days config
+
+# Recency-weighted re-ranking (GH#11163). Verbatim recall blends semantic
+# similarity with an exponential recency decay so recent turns surface over
+# equally-similar stale ones. Tunable per deployment; weight 0.0 disables the
+# blend entirely (pure semantic order — prior behaviour).
+_RECENCY_WEIGHT: float = float(os.environ.get("AUTOBOT_VERBATIM_RECENCY_WEIGHT", "0.2"))
+_RECENCY_HALFLIFE_SECONDS: float = float(
+    os.environ.get("AUTOBOT_VERBATIM_RECENCY_HALFLIFE_SECONDS", str(7 * 24 * 3600))
+)
+
+
+def _recency_factor(timestamp_iso: str | None, now: datetime) -> float | None:
+    """Exponential-decay recency score in ``[0, 1]`` from an ISO timestamp.
+
+    ``1.0`` for a just-now turn, halving every ``_RECENCY_HALFLIFE_SECONDS``.
+    Returns ``None`` when the timestamp is missing or unparseable so the caller
+    falls back to the pure semantic score for that chunk.
+    """
+    if not timestamp_iso:
+        return None
+    try:
+        ts = datetime.fromisoformat(timestamp_iso)
+    except (ValueError, TypeError):
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    age = (now - ts).total_seconds()
+    if age <= 0:
+        return 1.0
+    return 0.5 ** (age / _RECENCY_HALFLIFE_SECONDS)
 
 
 class VerbatimStore:
@@ -170,16 +201,28 @@ class VerbatimStore:
         metas = results.get("metadatas", [[]])[0]
         distances = results.get("distances", [[]])[0]
 
+        now = datetime.now(tz=timezone.utc)
         chunks = []
         for chunk_id, doc, meta, dist in zip(ids, docs, metas, distances):
+            semantic = 1.0 - dist
+            score = semantic
+            # GH#11163: blend recency so newer turns beat equally-similar stale
+            # ones. Skipped when disabled (weight 0) or the timestamp is absent.
+            if _RECENCY_WEIGHT > 0.0:
+                recency = _recency_factor((meta or {}).get("timestamp"), now)
+                if recency is not None:
+                    score = (1.0 - _RECENCY_WEIGHT) * semantic + _RECENCY_WEIGHT * recency
             chunks.append(
                 {
                     "id": chunk_id,
                     "text": doc,
-                    "score": 1.0 - dist,
+                    "score": score,
                     "metadata": meta,
                 }
             )
+        # ChromaDB returns distance order; the recency blend can reorder, so
+        # re-rank by the final score (stable no-op when weight is 0).
+        chunks.sort(key=lambda c: c["score"], reverse=True)
         return chunks
 
     async def delete_session(self, session_id: str) -> int:

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -29645,7 +29645,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/api/llm-auth/oauth/callback": {
+    "/api/llm-auth/oauth/callback": {
         parameters: {
             query?: never;
             header?: never;
@@ -29664,14 +29664,14 @@ export interface paths {
          *
          *     Requires admin — stored credential is system-wide (shared by all users).
          */
-        post: operations["oauth_callback_api_api_llm_auth_oauth_callback_post"];
+        post: operations["oauth_callback_api_llm_auth_oauth_callback_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/api/llm-auth/device/initiate": {
+    "/api/llm-auth/device/initiate": {
         parameters: {
             query?: never;
             header?: never;
@@ -29690,14 +29690,14 @@ export interface paths {
          *
          *     Requires admin — stored credential is system-wide (shared by all users).
          */
-        post: operations["device_initiate_api_api_llm_auth_device_initiate_post"];
+        post: operations["device_initiate_api_llm_auth_device_initiate_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/api/llm-auth/device/poll": {
+    "/api/llm-auth/device/poll": {
         parameters: {
             query?: never;
             header?: never;
@@ -29715,14 +29715,14 @@ export interface paths {
          *
          *     Requires admin — stored credential is system-wide (shared by all users).
          */
-        post: operations["device_poll_api_api_llm_auth_device_poll_post"];
+        post: operations["device_poll_api_llm_auth_device_poll_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/api/llm-auth/status/{provider_name}": {
+    "/api/llm-auth/status/{provider_name}": {
         parameters: {
             query?: never;
             header?: never;
@@ -29733,7 +29733,7 @@ export interface paths {
          * Provider Auth Status
          * @description Return the auth connection status for a provider.
          */
-        get: operations["provider_auth_status_api_api_llm_auth_status__provider_name__get"];
+        get: operations["provider_auth_status_api_llm_auth_status__provider_name__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -29742,7 +29742,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/api/llm-auth/{provider_name}": {
+    "/api/llm-auth/{provider_name}": {
         parameters: {
             query?: never;
             header?: never;
@@ -29758,7 +29758,7 @@ export interface paths {
          *
          *     Requires admin — credential is system-wide (shared by all users).
          */
-        delete: operations["revoke_provider_auth_api_api_llm_auth__provider_name__delete"];
+        delete: operations["revoke_provider_auth_api_llm_auth__provider_name__delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -46620,6 +46620,11 @@ export interface paths {
         /**
          * List Insights
          * @description List distilled experiment insights.
+         *
+         *     Resilient by design (#11081): on a fresh/empty deployment the insights
+         *     collection may not exist yet (or the vector store is unavailable), which
+         *     would otherwise 500 and crash the whole Experiments dashboard. Absence of
+         *     data is not an error — return an empty list instead.
          */
         get: operations["list_insights_api_autoresearch_insights_get"];
         put?: never;
@@ -48922,6 +48927,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/llc/projects/with-repos": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Projects With Repos
+         * @description Return all projects in the caller's org that have a code source linked (#11129).
+         */
+        get: operations["list_projects_with_repos_api_llc_projects_with_repos_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/llc/projects/{project_id}": {
         parameters: {
             query?: never;
@@ -48939,6 +48964,30 @@ export interface paths {
         head?: never;
         /** Update Project */
         patch: operations["update_project_api_llc_projects__project_id__patch"];
+        trace?: never;
+    };
+    "/api/llc/projects/{project_id}/repo": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Attach Project Repo
+         * @description Attach a GitHub repo to a project by creating a CodeSource and storing its id (#11129).
+         */
+        post: operations["attach_project_repo_api_llc_projects__project_id__repo_post"];
+        /**
+         * Detach Project Repo
+         * @description Unlink the repo from a project; the CodeSource record survives (#11129).
+         */
+        delete: operations["detach_project_repo_api_llc_projects__project_id__repo_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/api/llc/projects/{project_id}/sprints": {
@@ -56011,6 +56060,20 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** AttachRepoRequest */
+        AttachRepoRequest: {
+            /** Repo */
+            repo: string;
+            /** Credential Id */
+            credential_id?: string | null;
+            /**
+             * Branch
+             * @default main
+             */
+            branch: string;
+        } & {
+            [key: string]: unknown;
+        };
         /**
          * AudioIngestRequest
          * @description Request body for POST /api/knowledge_base/audio (URL-based ingestion).
@@ -60920,6 +60983,23 @@ export interface components {
             credential_id?: string | null;
             /** @default private */
             access: components["schemas"]["SourceAccess"];
+        } & {
+            [key: string]: unknown;
+        };
+        /** CodeSourceSummary */
+        CodeSourceSummary: {
+            /** Id */
+            id: string;
+            /** Repo */
+            repo?: string | null;
+            /** Branch */
+            branch?: string | null;
+            /** Clone Path */
+            clone_path?: string | null;
+            /** Status */
+            status?: string | null;
+            /** Error Message */
+            error_message?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -85295,6 +85375,9 @@ export interface components {
             open_work_item_count: number;
             /** Active Sprint Name */
             active_sprint_name?: string | null;
+            /** Code Source Id */
+            code_source_id?: string | null;
+            code_source?: components["schemas"]["CodeSourceSummary"] | null;
         } & {
             [key: string]: unknown;
         };
@@ -138219,7 +138302,7 @@ export interface operations {
             };
         };
     };
-    oauth_callback_api_api_llm_auth_oauth_callback_post: {
+    oauth_callback_api_llm_auth_oauth_callback_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -138252,7 +138335,7 @@ export interface operations {
             };
         };
     };
-    device_initiate_api_api_llm_auth_device_initiate_post: {
+    device_initiate_api_llm_auth_device_initiate_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -138285,7 +138368,7 @@ export interface operations {
             };
         };
     };
-    device_poll_api_api_llm_auth_device_poll_post: {
+    device_poll_api_llm_auth_device_poll_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -138318,7 +138401,7 @@ export interface operations {
             };
         };
     };
-    provider_auth_status_api_api_llm_auth_status__provider_name__get: {
+    provider_auth_status_api_llm_auth_status__provider_name__get: {
         parameters: {
             query?: never;
             header?: never;
@@ -138349,7 +138432,7 @@ export interface operations {
             };
         };
     };
-    revoke_provider_auth_api_api_llm_auth__provider_name__delete: {
+    revoke_provider_auth_api_llm_auth__provider_name__delete: {
         parameters: {
             query?: never;
             header?: never;
@@ -164929,6 +165012,26 @@ export interface operations {
             };
         };
     };
+    list_projects_with_repos_api_llc_projects_with_repos_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"][];
+                };
+            };
+        };
+    };
     get_project_api_llc_projects__project_id__get: {
         parameters: {
             query?: never;
@@ -165003,6 +165106,72 @@ export interface operations {
                 "application/json": components["schemas"]["llc__api__sprints__ProjectUpdate"];
             };
         };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    attach_project_repo_api_llc_projects__project_id__repo_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AttachRepoRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    detach_project_repo_api_llc_projects__project_id__repo_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {


### PR DESCRIPTION
## Thinking Path

Surfaced in the agent-framework research comparison: open-source memory stacks weight recency, but AutoBot's verbatim recall ranked purely by cosine similarity even though every chunk already stores a `timestamp`. So an old turn and a recent turn of equal similarity ranked identically, letting stale context crowd out newer relevant turns. Fix = blend an exponential recency decay into the score, tunable and off-by-config-if-desired.

## What Changed

- **`memory/verbatim_store.py`**
  - `_recency_factor(timestamp_iso, now)` — exponential decay in `[0,1]`, `1.0` now and halving every half-life; `None` on missing/unparseable timestamp (→ fall back to pure semantic for that chunk); naive timestamps treated as UTC.
  - `search()` blends `score = (1-w)*semantic + w*recency` and re-ranks by the blended score (ChromaDB returns distance order).
  - `AUTOBOT_VERBATIM_RECENCY_WEIGHT` (default `0.2`) and `AUTOBOT_VERBATIM_RECENCY_HALFLIFE_SECONDS` (default 7d) env-tunable module constants. Weight `0.0` disables the blend → prior pure-semantic order.
- **`memory/verbatim_recency_test.py`** (new) — decay factor (now / half-life / naive-tz / missing / bad) + search re-rank (recent beats equally-similar stale; weight 0 preserves semantic order).

## Verification

```
$ python3 -m pytest memory/verbatim_recency_test.py memory/verbatim_store_test.py -q
18 passed  (6 new + 12 existing, no regressions)
```

## Model Used

Claude Opus 4.8 (1M context)

Closes #11163