### PR TITLE
feat(orchestration): capability-manifest consistency audit (#11165)

### DIFF
--- a/autobot-backend/orchestration/capability_audit.py
+++ b/autobot-backend/orchestration/capability_audit.py
@@ -1,0 +1,150 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Capability-manifest consistency audit (GH#11165).
+
+Governance-visibility companion to the enforcement wired in GH#11145: verifies
+each agent's declarative ``allowed_work``/``forbidden_work`` manifest is
+internally consistent and catches silent drift (a tool declared both allowed and
+forbidden, an allowed tool its own ``forbidden_work`` prefix-blocks, duplicate
+entries, or a non-executor agent with no boundary at all).
+
+Reuses the single ``match_forbidden_tool`` matcher and ``_INFRA_AND_SHELL_TOOLS``
+catalogue so audit and enforcement can never disagree on what "forbidden" means.
+"""
+
+from dataclasses import dataclass
+from typing import List
+
+from autobot_shared.logging_manager import get_logger
+
+from orchestration.agent_registry import (
+    _INFRA_AND_SHELL_TOOLS,
+    AgentRegistry,
+    get_default_agents,
+    match_forbidden_tool,
+)
+from orchestration.types import AgentProfile
+
+logger = get_logger(__name__)
+
+_INFRA_TOOLS = frozenset(t.lower() for t in _INFRA_AND_SHELL_TOOLS)
+
+
+@dataclass(frozen=True)
+class AuditFinding:
+    """A single manifest issue for one agent."""
+
+    agent_id: str
+    severity: str  # "error" | "warning"
+    code: str
+    message: str
+
+
+def _duplicates(items: List[str]) -> List[str]:
+    seen: set[str] = set()
+    dupes: set[str] = set()
+    for item in items:
+        key = item.lower()
+        if key in seen:
+            dupes.add(key)
+        seen.add(key)
+    return sorted(dupes)
+
+
+def _audit_profile(profile: AgentProfile) -> List[AuditFinding]:
+    """Return all manifest findings for a single agent profile."""
+    findings: List[AuditFinding] = []
+    allowed = list(profile.allowed_work or [])
+    forbidden = frozenset(t.lower() for t in (profile.forbidden_work or []))
+
+    overlap = sorted({a.lower() for a in allowed} & forbidden)
+    if overlap:
+        findings.append(
+            AuditFinding(
+                profile.agent_id,
+                "error",
+                "manifest_overlap",
+                f"tools in both allowed_work and forbidden_work: {overlap}",
+            )
+        )
+
+    # An allowed tool the agent's own forbidden_work prefix-blocks is a dead
+    # grant — reuses the enforcement matcher so the rule matches runtime exactly.
+    for tool in allowed:
+        matched = match_forbidden_tool(tool, forbidden)
+        if matched is not None and tool.lower() not in overlap:
+            findings.append(
+                AuditFinding(
+                    profile.agent_id,
+                    "error",
+                    "allowed_blocked_by_forbidden",
+                    f"allowed tool '{tool}' is blocked by forbidden_work pattern '{matched}'",
+                )
+            )
+
+    for field, values in (("allowed_work", allowed), ("forbidden_work", list(profile.forbidden_work or []))):
+        dupes = _duplicates(values)
+        if dupes:
+            findings.append(
+                AuditFinding(profile.agent_id, "warning", "duplicate_entries", f"{field} has duplicates: {dupes}")
+            )
+
+    # A non-executor agent (one not granted shell/infra tools) with no boundary
+    # at all is a posture gap — it can invoke anything.
+    is_executor = any(a.lower() in _INFRA_TOOLS for a in allowed)
+    if not forbidden and not is_executor:
+        findings.append(
+            AuditFinding(
+                profile.agent_id,
+                "warning",
+                "unbounded_non_executor",
+                "empty forbidden_work on a non-executor agent — no capability boundary",
+            )
+        )
+    return findings
+
+
+def audit_agent_manifests(profiles: List[AgentProfile]) -> List[AuditFinding]:
+    """Audit every profile's capability manifest for consistency and drift."""
+    findings: List[AuditFinding] = []
+    for profile in profiles:
+        findings.extend(_audit_profile(profile))
+    return findings
+
+
+def audit_registry(registry: AgentRegistry) -> List[AuditFinding]:
+    """Audit every profile in a live registry (incl. dynamically-registered agents)."""
+    return audit_agent_manifests(list(registry.get_all().values()))
+
+
+def run_capability_audit() -> dict:
+    """Scan the default agent registry, log findings by severity, return a report.
+
+    Callable from a scheduled job or an admin endpoint. Returns a report dict with
+    the finding list plus error/warning counts for monitoring.
+    """
+    profiles = get_default_agents()
+    findings = audit_agent_manifests(profiles)
+    errors = [f for f in findings if f.severity == "error"]
+    warnings = [f for f in findings if f.severity == "warning"]
+    for finding in errors:
+        logger.error("Capability audit [%s] %s: %s", finding.agent_id, finding.code, finding.message)
+    for finding in warnings:
+        logger.warning("Capability audit [%s] %s: %s", finding.agent_id, finding.code, finding.message)
+    logger.info(
+        "Capability audit complete: %d agents, %d error(s), %d warning(s)",
+        len(profiles),
+        len(errors),
+        len(warnings),
+    )
+    return {
+        "agent_count": len(profiles),
+        "error_count": len(errors),
+        "warning_count": len(warnings),
+        "findings": [
+            {"agent_id": f.agent_id, "severity": f.severity, "code": f.code, "message": f.message}
+            for f in findings
+        ],
+    }

--- a/autobot-backend/orchestration/capability_audit.py
+++ b/autobot-backend/orchestration/capability_audit.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass
 from typing import List
 
 from autobot_shared.logging_manager import get_logger
-
 from orchestration.agent_registry import (
     _INFRA_AND_SHELL_TOOLS,
     AgentRegistry,
@@ -144,7 +143,6 @@ def run_capability_audit() -> dict:
         "error_count": len(errors),
         "warning_count": len(warnings),
         "findings": [
-            {"agent_id": f.agent_id, "severity": f.severity, "code": f.code, "message": f.message}
-            for f in findings
+            {"agent_id": f.agent_id, "severity": f.severity, "code": f.code, "message": f.message} for f in findings
         ],
     }

--- a/autobot-backend/orchestration/capability_audit_test.py
+++ b/autobot-backend/orchestration/capability_audit_test.py
@@ -4,11 +4,11 @@
 # Author: mrveiss
 """Tests for the capability-manifest consistency audit (GH#11165)."""
 
+from orchestration.agent_registry import get_default_agents
 from orchestration.capability_audit import (
     audit_agent_manifests,
     run_capability_audit,
 )
-from orchestration.agent_registry import get_default_agents
 from orchestration.types import AgentCapability, AgentProfile
 
 

--- a/autobot-backend/orchestration/capability_audit_test.py
+++ b/autobot-backend/orchestration/capability_audit_test.py
@@ -1,0 +1,73 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the capability-manifest consistency audit (GH#11165)."""
+
+from orchestration.capability_audit import (
+    audit_agent_manifests,
+    run_capability_audit,
+)
+from orchestration.agent_registry import get_default_agents
+from orchestration.types import AgentCapability, AgentProfile
+
+
+def _profile(agent_id: str, allowed=None, forbidden=None) -> AgentProfile:
+    return AgentProfile(
+        agent_id=agent_id,
+        agent_type="test",
+        capabilities={AgentCapability.RESEARCH},
+        specializations=[],
+        allowed_work=allowed or [],
+        forbidden_work=forbidden or [],
+    )
+
+
+def _codes(findings) -> set[str]:
+    return {f.code for f in findings}
+
+
+def test_default_profiles_have_no_errors():
+    """The shipped default manifests must be internally consistent."""
+    findings = audit_agent_manifests(get_default_agents())
+    errors = [f for f in findings if f.severity == "error"]
+    assert errors == [], f"default profiles produced errors: {errors}"
+
+
+def test_detects_allowed_forbidden_overlap():
+    findings = audit_agent_manifests([_profile("a", allowed=["bash"], forbidden=["bash"])])
+    assert "manifest_overlap" in _codes(findings)
+    overlap = next(f for f in findings if f.code == "manifest_overlap")
+    assert overlap.severity == "error"
+    assert overlap.agent_id == "a"
+
+
+def test_detects_allowed_blocked_by_forbidden_prefix():
+    # allowed "deploy_service" is prefix-blocked by forbidden "deploy".
+    findings = audit_agent_manifests([_profile("a", allowed=["deploy_service"], forbidden=["deploy"])])
+    assert "allowed_blocked_by_forbidden" in _codes(findings)
+    assert all(f.severity == "error" for f in findings if f.code == "allowed_blocked_by_forbidden")
+
+
+def test_detects_duplicate_entries():
+    findings = audit_agent_manifests([_profile("a", allowed=["read_file", "read_file"], forbidden=["bash"])])
+    assert "duplicate_entries" in _codes(findings)
+
+
+def test_detects_unbounded_non_executor():
+    findings = audit_agent_manifests([_profile("a", allowed=["web_search"], forbidden=[])])
+    assert "unbounded_non_executor" in _codes(findings)
+
+
+def test_executor_agent_not_flagged_unbounded():
+    # An agent granted shell/infra tools is an intended executor — empty
+    # forbidden_work is expected, not a posture gap.
+    findings = audit_agent_manifests([_profile("sys", allowed=["bash", "deploy"], forbidden=[])])
+    assert "unbounded_non_executor" not in _codes(findings)
+
+
+def test_run_capability_audit_report_shape():
+    report = run_capability_audit()
+    assert report["agent_count"] >= 4
+    assert report["error_count"] == 0
+    assert isinstance(report["findings"], list)


### PR DESCRIPTION
## Thinking Path

#11145 wired manifest enforcement at the tool-dispatch seam, but nothing verified the manifests themselves are consistent. A manifest could declare a tool in both `allowed_work` and `forbidden_work`, grant a tool its own `forbidden_work` prefix-blocks, carry duplicates, or (for a non-executor) declare no boundary at all — all silent governance holes. This adds the audit layer, reusing the exact enforcement matcher so audit and runtime never disagree.

(Distinct from epic #11138 Task 3, which is an SLM ports/secrets *security-posture* audit — a separate, larger item left tracked in the epic.)

## What Changed

- **`orchestration/capability_audit.py`** (new)
  - `audit_agent_manifests(profiles)` / `audit_registry(registry)` → list of `AuditFinding(agent_id, severity, code, message)`.
  - Findings: `manifest_overlap` (error), `allowed_blocked_by_forbidden` (error, via the shared `match_forbidden_tool`), `duplicate_entries` (warning), `unbounded_non_executor` (warning; executors granted shell/infra tools are exempt).
  - `run_capability_audit()` → scans the default registry, logs by severity, returns a report dict (`agent_count` / `error_count` / `warning_count` / `findings`) for a scheduled job or admin endpoint.
  - Reuses `match_forbidden_tool` + `_INFRA_AND_SHELL_TOOLS` from `agent_registry` — no duplicated rule.
- **`orchestration/capability_audit_test.py`** (new) — baseline (defaults = zero errors) + each finding type + executor exemption + report shape.

## Verification

```
$ python3 -m pytest orchestration/capability_audit_test.py -q
7 passed
```

## Model Used

Claude Opus 4.8 (1M context)

Closes #11165