### PR TITLE
feat(agent-loop): unified AUTOBOT_GUARD_PROFILE switch (#11150)

### DIFF
--- a/autobot-backend/agent_loop/guard_profile.py
+++ b/autobot-backend/agent_loop/guard_profile.py
@@ -1,0 +1,109 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unified guard profile for the agent loop (GH#11150).
+
+Consolidates the loop's discretionary safety guards behind one switch,
+``AUTOBOT_GUARD_PROFILE``, so a deployment can describe its posture in one place
+instead of flipping several independently-named env vars.
+
+Guard matrix (fields are ``AgentLoopConfig`` guard booleans / limits):
+
+    field                          minimal   standard(*)  strict
+    -----------------------------  --------  -----------  ------
+    require_approval_for_sensitive   False       True      True
+    pre_action_verifier_enabled      False       True      True
+    halt_on_stagnation               False       True      True
+    abstain_on_low_confidence        False       True      True
+    max_identical_tool_calls           5           3        2
+
+(*) ``standard`` is the default and reproduces today's ``AgentLoopConfig``
+defaults exactly.
+
+Per-guard env vars override the profile (and win over it):
+    AUTOBOT_GUARD_REQUIRE_APPROVAL   -> require_approval_for_sensitive (bool)
+    AUTOBOT_GUARD_VERIFIER           -> pre_action_verifier_enabled    (bool)
+    AUTOBOT_GUARD_STAGNATION_HALT    -> halt_on_stagnation             (bool)
+    AUTOBOT_GUARD_ABSTAIN            -> abstain_on_low_confidence       (bool)
+    AUTOBOT_GUARD_MAX_IDENTICAL      -> max_identical_tool_calls        (int)
+
+Always-on safety guards are NOT governed here: forbidden_work enforcement
+(agent identity, GH#11145) and config-protection (``AUTOBOT_ALLOW_CONFIG_EDITS``,
+GH#11148) are controlled separately by design.
+"""
+
+import os
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_PROFILE = "standard"
+
+# ``standard`` intentionally carries NO overrides so it reproduces the
+# AgentLoopConfig dataclass defaults exactly (the AC's "no behaviour change").
+GUARD_PROFILES: dict[str, dict[str, object]] = {
+    "minimal": {
+        "require_approval_for_sensitive": False,
+        "pre_action_verifier_enabled": False,
+        "halt_on_stagnation": False,
+        "abstain_on_low_confidence": False,
+        "max_identical_tool_calls": 5,
+    },
+    "standard": {},
+    "strict": {
+        "require_approval_for_sensitive": True,
+        "pre_action_verifier_enabled": True,
+        "halt_on_stagnation": True,
+        "abstain_on_low_confidence": True,
+        "max_identical_tool_calls": 2,
+    },
+}
+
+
+def _as_bool(raw: str) -> bool:
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+# env var -> (config field, parser)
+_ENV_OVERRIDES: dict[str, tuple[str, object]] = {
+    "AUTOBOT_GUARD_REQUIRE_APPROVAL": ("require_approval_for_sensitive", _as_bool),
+    "AUTOBOT_GUARD_VERIFIER": ("pre_action_verifier_enabled", _as_bool),
+    "AUTOBOT_GUARD_STAGNATION_HALT": ("halt_on_stagnation", _as_bool),
+    "AUTOBOT_GUARD_ABSTAIN": ("abstain_on_low_confidence", _as_bool),
+    "AUTOBOT_GUARD_MAX_IDENTICAL": ("max_identical_tool_calls", int),
+}
+
+
+def resolve_profile_name() -> str:
+    """Return the active profile name, defaulting to ``standard`` for unset/unknown."""
+    name = os.environ.get("AUTOBOT_GUARD_PROFILE", "").strip().lower() or DEFAULT_PROFILE
+    if name not in GUARD_PROFILES:
+        logger.warning(
+            "AUTOBOT_GUARD_PROFILE='%s' is not a known profile (%s); using '%s'.",
+            name,
+            ", ".join(GUARD_PROFILES),
+            DEFAULT_PROFILE,
+        )
+        return DEFAULT_PROFILE
+    return name
+
+
+def resolve_guard_config_overrides() -> dict[str, object]:
+    """Resolve ``AgentLoopConfig`` guard overrides from profile + per-guard env vars.
+
+    Per-guard env vars win over the profile. An empty dict means "no overrides"
+    (i.e. the standard profile with no env overrides → today's defaults).
+    """
+    overrides = dict(GUARD_PROFILES[resolve_profile_name()])
+    for env_var, (field_name, parser) in _ENV_OVERRIDES.items():
+        raw = os.environ.get(env_var)
+        if raw is None or raw.strip() == "":
+            continue
+        try:
+            overrides[field_name] = parser(raw)  # type: ignore[operator]
+        except (ValueError, TypeError) as exc:
+            logger.warning("Ignoring invalid %s=%r: %s", env_var, raw, exc)
+    return overrides

--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -170,7 +170,11 @@ class AgentLoop:
         self.tool_executor = tool_executor
         self.think_tool = think_tool or ThinkTool()
         self.agent_id = agent_id
-        self.config = self._resolve_forbidden_tools(config or AgentLoopConfig(), agent_id)
+        # GH#11150: when no explicit config is supplied, resolve the discretionary
+        # guard defaults from AUTOBOT_GUARD_PROFILE (standard == today's defaults).
+        # An explicitly-passed config is respected as-is — the caller owns it.
+        base_config = config if config is not None else AgentLoopConfig.with_guard_profile()
+        self.config = self._resolve_forbidden_tools(base_config, agent_id)
         self._belief_updater = BeliefStateUpdater(
             contradiction_surface_threshold=self.config.contradiction_surface_threshold
         )

--- a/autobot-backend/agent_loop/types.py
+++ b/autobot-backend/agent_loop/types.py
@@ -262,6 +262,20 @@ class AgentLoopConfig:
     log_tool_results: bool = True  # Log tool execution results
     emit_progress_events: bool = True  # Emit progress to event stream
 
+    @classmethod
+    def with_guard_profile(cls, **overrides: object) -> "AgentLoopConfig":
+        """Build a config with guard fields resolved from ``AUTOBOT_GUARD_PROFILE`` (GH#11150).
+
+        Profile + per-guard env vars set the discretionary guard defaults;
+        explicit ``**overrides`` win over both. The default profile (``standard``)
+        yields the same values as ``AgentLoopConfig()``.
+        """
+        from agent_loop.guard_profile import resolve_guard_config_overrides
+
+        merged = resolve_guard_config_overrides()
+        merged.update(overrides)
+        return cls(**merged)  # type: ignore[arg-type]
+
 
 # =============================================================================
 # Message Types (Manus Pattern)

--- a/autobot-backend/tests/agent_loop/test_guard_profile.py
+++ b/autobot-backend/tests/agent_loop/test_guard_profile.py
@@ -1,0 +1,137 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for the unified AUTOBOT_GUARD_PROFILE switch (GH#11150).
+
+Acceptance criteria:
+  - The profile selects a documented guard matrix (minimal / standard / strict).
+  - Per-guard env vars override the profile.
+  - The default (standard) profile reproduces today's AgentLoopConfig defaults.
+  - Unknown/unset profile falls back to standard.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent_loop.guard_profile import (
+    DEFAULT_PROFILE,
+    resolve_guard_config_overrides,
+    resolve_profile_name,
+)
+from agent_loop.loop import AgentLoop
+from agent_loop.types import AgentLoopConfig
+
+_GUARD_FIELDS = (
+    "require_approval_for_sensitive",
+    "pre_action_verifier_enabled",
+    "halt_on_stagnation",
+    "abstain_on_low_confidence",
+    "max_identical_tool_calls",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_guard_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "AUTOBOT_GUARD_PROFILE",
+        "AUTOBOT_GUARD_REQUIRE_APPROVAL",
+        "AUTOBOT_GUARD_VERIFIER",
+        "AUTOBOT_GUARD_STAGNATION_HALT",
+        "AUTOBOT_GUARD_ABSTAIN",
+        "AUTOBOT_GUARD_MAX_IDENTICAL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestProfileName:
+    def test_unset_is_standard(self) -> None:
+        assert resolve_profile_name() == "standard"
+
+    def test_unknown_falls_back_to_standard(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOBOT_GUARD_PROFILE", "bananas")
+        assert resolve_profile_name() == DEFAULT_PROFILE
+
+    def test_case_insensitive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOBOT_GUARD_PROFILE", "STRICT")
+        assert resolve_profile_name() == "strict"
+
+
+class TestOverrides:
+    def test_standard_has_no_overrides(self) -> None:
+        assert resolve_guard_config_overrides() == {}
+
+    def test_minimal_relaxes_guards(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOBOT_GUARD_PROFILE", "minimal")
+        o = resolve_guard_config_overrides()
+        assert o["require_approval_for_sensitive"] is False
+        assert o["pre_action_verifier_enabled"] is False
+        assert o["max_identical_tool_calls"] == 5
+
+    def test_strict_tightens_guards(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOBOT_GUARD_PROFILE", "strict")
+        o = resolve_guard_config_overrides()
+        assert o["require_approval_for_sensitive"] is True
+        assert o["max_identical_tool_calls"] == 2
+
+    def test_per_guard_env_overrides_profile(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOBOT_GUARD_PROFILE", "minimal")
+        # minimal disables approval; explicit env re-enables it.
+        monkeypatch.setenv("AUTOBOT_GUARD_REQUIRE_APPROVAL", "1")
+        monkeypatch.setenv("AUTOBOT_GUARD_MAX_IDENTICAL", "9")
+        o = resolve_guard_config_overrides()
+        assert o["require_approval_for_sensitive"] is True
+        assert o["max_identical_tool_calls"] == 9
+
+    def test_invalid_int_override_is_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOBOT_GUARD_MAX_IDENTICAL", "not-a-number")
+        assert "max_identical_tool_calls" not in resolve_guard_config_overrides()
+
+
+class TestConfigMapping:
+    def test_standard_equals_default_config(self) -> None:
+        profiled = AgentLoopConfig.with_guard_profile()
+        default = AgentLoopConfig()
+        for field_name in _GUARD_FIELDS:
+            assert getattr(profiled, field_name) == getattr(default, field_name)
+
+    def test_strict_profile_applied_to_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOBOT_GUARD_PROFILE", "strict")
+        cfg = AgentLoopConfig.with_guard_profile()
+        assert cfg.max_identical_tool_calls == 2
+        assert cfg.abstain_on_low_confidence is True
+
+    def test_explicit_override_wins_over_profile(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOBOT_GUARD_PROFILE", "strict")
+        cfg = AgentLoopConfig.with_guard_profile(max_identical_tool_calls=7)
+        assert cfg.max_identical_tool_calls == 7
+
+
+class TestLoopWiring:
+    def _loop(self, config: AgentLoopConfig | None = None) -> AgentLoop:
+        event_stream = MagicMock()
+        event_stream.get_latest = AsyncMock(return_value=[])
+        event_stream.publish = AsyncMock()
+        return AgentLoop(event_stream=event_stream, config=config)
+
+    def test_no_config_applies_profile(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOBOT_GUARD_PROFILE", "minimal")
+        loop = self._loop()
+        assert loop.config.require_approval_for_sensitive is False
+        assert loop.config.max_identical_tool_calls == 5
+
+    def test_explicit_config_is_respected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOBOT_GUARD_PROFILE", "minimal")
+        # Caller passes an explicit config → profile must NOT override it.
+        explicit = AgentLoopConfig(require_approval_for_sensitive=True, max_identical_tool_calls=3)
+        loop = self._loop(config=explicit)
+        assert loop.config.require_approval_for_sensitive is True
+        assert loop.config.max_identical_tool_calls == 3
+
+    def test_default_loop_matches_today(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        loop = self._loop()
+        default = AgentLoopConfig()
+        for field_name in _GUARD_FIELDS:
+            assert getattr(loop.config, field_name) == getattr(default, field_name)

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -48927,6 +48927,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/llc/projects/with-repos": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Projects With Repos
+         * @description Return all projects in the caller's org that have a code source linked (#11129).
+         */
+        get: operations["list_projects_with_repos_api_llc_projects_with_repos_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/llc/projects/{project_id}": {
         parameters: {
             query?: never;
@@ -48944,6 +48964,30 @@ export interface paths {
         head?: never;
         /** Update Project */
         patch: operations["update_project_api_llc_projects__project_id__patch"];
+        trace?: never;
+    };
+    "/api/llc/projects/{project_id}/repo": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Attach Project Repo
+         * @description Attach a GitHub repo to a project by creating a CodeSource and storing its id (#11129).
+         */
+        post: operations["attach_project_repo_api_llc_projects__project_id__repo_post"];
+        /**
+         * Detach Project Repo
+         * @description Unlink the repo from a project; the CodeSource record survives (#11129).
+         */
+        delete: operations["detach_project_repo_api_llc_projects__project_id__repo_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/api/llc/projects/{project_id}/sprints": {
@@ -56016,6 +56060,20 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** AttachRepoRequest */
+        AttachRepoRequest: {
+            /** Repo */
+            repo: string;
+            /** Credential Id */
+            credential_id?: string | null;
+            /**
+             * Branch
+             * @default main
+             */
+            branch: string;
+        } & {
+            [key: string]: unknown;
+        };
         /**
          * AudioIngestRequest
          * @description Request body for POST /api/knowledge_base/audio (URL-based ingestion).
@@ -60925,6 +60983,23 @@ export interface components {
             credential_id?: string | null;
             /** @default private */
             access: components["schemas"]["SourceAccess"];
+        } & {
+            [key: string]: unknown;
+        };
+        /** CodeSourceSummary */
+        CodeSourceSummary: {
+            /** Id */
+            id: string;
+            /** Repo */
+            repo?: string | null;
+            /** Branch */
+            branch?: string | null;
+            /** Clone Path */
+            clone_path?: string | null;
+            /** Status */
+            status?: string | null;
+            /** Error Message */
+            error_message?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -85300,6 +85375,9 @@ export interface components {
             open_work_item_count: number;
             /** Active Sprint Name */
             active_sprint_name?: string | null;
+            /** Code Source Id */
+            code_source_id?: string | null;
+            code_source?: components["schemas"]["CodeSourceSummary"] | null;
         } & {
             [key: string]: unknown;
         };
@@ -164934,6 +165012,26 @@ export interface operations {
             };
         };
     };
+    list_projects_with_repos_api_llc_projects_with_repos_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"][];
+                };
+            };
+        };
+    };
     get_project_api_llc_projects__project_id__get: {
         parameters: {
             query?: never;
@@ -165008,6 +165106,72 @@ export interface operations {
                 "application/json": components["schemas"]["llc__api__sprints__ProjectUpdate"];
             };
         };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    attach_project_repo_api_llc_projects__project_id__repo_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AttachRepoRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    detach_project_repo_api_llc_projects__project_id__repo_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {


### PR DESCRIPTION
## Thinking Path

ECC (`affaan-m/ecc`) centralizes hook gating under one switch (`ECC_HOOK_PROFILE=minimal|standard|strict`). AutoBot's agent-loop guards were gated by scattered, independently-named switches — now more of them after #11145 (forbidden_work) and #11148 (config-protection) landed. This unifies the *discretionary* guards behind one legible switch so a deployment can describe its safety posture in one place. Built directly on the two just-merged guards.

## What Changed

- **`autobot-backend/agent_loop/guard_profile.py`** (new): the `AUTOBOT_GUARD_PROFILE` matrix (`minimal` / `standard` / `strict`) over the discretionary guard fields, plus per-guard `AUTOBOT_GUARD_*` env overrides. `standard` carries **no overrides** so it reproduces `AgentLoopConfig()` exactly.
- **`autobot-backend/agent_loop/types.py`**: `AgentLoopConfig.with_guard_profile(**overrides)` classmethod — resolves profile + env, explicit kwargs win.
- **`autobot-backend/agent_loop/loop.py`**: `AgentLoop.__init__` uses `with_guard_profile()` **only when no explicit config is passed** — an explicitly-supplied config is respected as-is (the caller owns it), so existing callers/tests are unchanged.
- **Scope:** governs discretionary guards only (approval gate, pre-action verifier, stagnation halt, low-confidence abstention, repetition limit). Always-on safety — `forbidden_work` (#11145) and config-protection (#11148) — is controlled separately by design and documented as such.

Guard matrix:

| field | minimal | standard (default) | strict |
|---|---|---|---|
| `require_approval_for_sensitive` | False | True | True |
| `pre_action_verifier_enabled` | False | True | True |
| `halt_on_stagnation` | False | True | True |
| `abstain_on_low_confidence` | False | True | True |
| `max_identical_tool_calls` | 5 | 3 | 2 |

## Verification

```
$ python3 -m pytest tests/agent_loop/test_guard_profile.py \
    tests/agent_loop/test_forbidden_tools_wiring.py \
    tests/agent_loop/test_config_protection.py -q
50 passed in 0.50s
```

AC proven: `standard` == today's config for every guard field; `strict`/`minimal` apply the matrix; per-guard env vars override the profile; unknown/unset profile → standard; an explicitly-passed config is never overridden by the profile.

## Model Used

Claude Opus 4.8 (1M context)

Closes #11150
