### PR TITLE
feat(agent-loop): fact-forcing gate — read before first edit per file (#11149)

### DIFF
--- a/autobot-backend/agent_loop/fact_forcing.py
+++ b/autobot-backend/agent_loop/fact_forcing.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Fact-forcing gate for the agent loop (GH#11149).
+
+Blocks the FIRST mutating edit to an *existing* file until that file has been
+investigated (read / grepped) in the current task — the mechanical form of
+"read before you write". A blocked edit is self-clearing: once the agent reads
+the file, the retry proceeds.
+
+Creating a NEW file is never blocked (there is nothing to investigate), so the
+gate keys on ``exists_fn`` and fails open on existence ambiguity — it never
+wrongly blocks a create.
+
+Opt-in: off by default; enable via ``AgentLoopConfig.fact_forcing_enabled`` or
+``AUTOBOT_FACT_FORCING=1``.
+"""
+
+import os
+
+# Tools that count as investigating a path.
+_INVESTIGATION_TOOLS: frozenset[str] = frozenset(
+    {
+        "read_file",
+        "read",
+        "read_files",
+        "grep_search",
+        "grep",
+        "search_files",
+        "list_dir",
+        "list_directory",
+        "glob",
+        "glob_file_search",
+        "codebase_search",
+    }
+)
+
+# Mutating edits to an existing file that the gate guards. Pure creators
+# (create_file / write-new) are handled by the exists check, not by name.
+_EDIT_TOOLS: frozenset[str] = frozenset(
+    {
+        "edit_file",
+        "write_file",
+        "multi_edit",
+        "apply_patch",
+        "delete_file",
+    }
+)
+
+_PATH_KEYS: tuple[str, ...] = ("file_path", "path", "directory", "target_file")
+
+
+def _extract_path(tool: dict) -> str | None:
+    args = tool.get("args") or tool.get("arguments") or tool.get("parameters") or {}
+    if not isinstance(args, dict):
+        return None
+    for key in _PATH_KEYS:
+        value = args.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _norm(path: str) -> str:
+    return os.path.normpath(path.strip())
+
+
+def record_investigations(tools: list[dict], investigated: set[str]) -> None:
+    """Add the normalized paths of any investigation tools in *tools* to *investigated*."""
+    for tool in tools:
+        if str(tool.get("tool_name", "")).lower() not in _INVESTIGATION_TOOLS:
+            continue
+        path = _extract_path(tool)
+        if path:
+            investigated.add(_norm(path))
+
+
+def first_uninvestigated_edit(
+    tool: dict,
+    investigated: set[str],
+    exists_fn=os.path.exists,
+) -> str | None:
+    """Return the target path if *tool* edits an existing, uninvestigated file, else None.
+
+    New files (``not exists_fn(path)``) are allowed — there is nothing to read.
+    """
+    if str(tool.get("tool_name", "")).lower() not in _EDIT_TOOLS:
+        return None
+    path = _extract_path(tool)
+    if not path:
+        return None
+    normalized = _norm(path)
+    if normalized in investigated:
+        return None
+    try:
+        if not exists_fn(normalized):
+            return None  # new file → nothing to investigate
+    except OSError:
+        return None  # existence ambiguous → fail open (never block a create)
+    return path
+
+
+def fact_forcing_env_enabled() -> bool:
+    """True when ``AUTOBOT_FACT_FORCING`` force-enables the gate regardless of config."""
+    return os.environ.get("AUTOBOT_FACT_FORCING", "").strip().lower() in {"1", "true", "yes", "on"}

--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -186,6 +186,8 @@ class AgentLoop:
         self._current_context: TaskContext | None = None
         self._iteration_count = 0
         self._consecutive_errors = 0
+        # GH#11149: files read/grepped this task, for the fact-forcing gate.
+        self._investigated_files: set[str] = set()
         # Steering inbox: human guidance messages queued for the next iteration (#10543)
         self._steering_inbox: asyncio.Queue[SteeringEntry] = asyncio.Queue()
         # Human-answer inbox: answers arrive here via answer() and resolve ask_human() waits (#10553)
@@ -263,6 +265,7 @@ class AgentLoop:
         self._state = LoopState.INITIALIZING
         self._iteration_count = 0
         self._consecutive_errors = 0
+        self._investigated_files = set()  # GH#11149: reset fact-forcing state per task
         self._halted_on_repetition = False
         self._abstained = False
         self._abstention_reason = None
@@ -839,6 +842,13 @@ class AgentLoop:
         config_results = self._check_config_protection(tools)
         if config_results:
             return config_results
+
+        # GH#11149: fact-forcing — block the first edit to an existing file until
+        # it has been read/grepped this task. Records reads in this batch first so
+        # a read+edit of the same file in one turn is allowed.
+        fact_results = self._check_fact_forcing(tools)
+        if fact_results:
+            return fact_results
 
         # Issue #4092: Gate sensitive operations behind user approval.
         denied_results = await self._check_approvals(tools)
@@ -1449,6 +1459,42 @@ Duration: {self._current_context.get_duration_ms():.0f}ms{belief_summary}
                             f"Editing linter/formatter config '{matched}' is blocked "
                             f"(config-protection): fix the code to satisfy the gate instead of "
                             f"weakening it. Set AUTOBOT_ALLOW_CONFIG_EDITS=1 for an intentional change."
+                        )
+                    }
+                }
+        return {}
+
+    def _check_fact_forcing(self, tools: list[dict[str, Any]]) -> dict[str, Any]:
+        """Block the first edit to an existing, uninvestigated file (GH#11149).
+
+        Records this batch's investigations first (so read+edit in one turn is
+        allowed), then blocks the first edit to an existing file not yet read this
+        task. New files are never blocked. Self-clearing: the agent reads the file
+        and retries. Returns ``{}`` when disabled or nothing is gated.
+        """
+        from agent_loop.fact_forcing import (
+            fact_forcing_env_enabled,
+            first_uninvestigated_edit,
+            record_investigations,
+        )
+
+        if not (self.config.fact_forcing_enabled or fact_forcing_env_enabled()):
+            return {}
+        record_investigations(tools, self._investigated_files)
+        for tool in tools:
+            path = first_uninvestigated_edit(tool, self._investigated_files)
+            if path is not None:
+                tool_name = tool.get("tool_name", "unknown")
+                logger.warning(
+                    "AgentLoop: edit to '%s' blocked by fact-forcing gate — read it first (%s)",
+                    path,
+                    tool_name,
+                )
+                return {
+                    tool_name: {
+                        "error": (
+                            f"Editing '{path}' is blocked (fact-forcing): read the file and "
+                            f"its importers/call-sites first so the change is grounded, then retry."
                         )
                     }
                 }

--- a/autobot-backend/agent_loop/types.py
+++ b/autobot-backend/agent_loop/types.py
@@ -257,6 +257,11 @@ class AgentLoopConfig:
     # Enable independent second-model refutation before consequential actions.
     pre_action_verifier_enabled: bool = True
 
+    # Fact-forcing gate (GH#11149) — block the first edit to an existing file
+    # until it has been read/grepped this task. Off by default (opt-in); also
+    # force-enabled by AUTOBOT_FACT_FORCING=1.
+    fact_forcing_enabled: bool = False
+
     # Logging
     log_iterations: bool = True  # Log each iteration
     log_tool_results: bool = True  # Log tool execution results

--- a/autobot-backend/tests/agent_loop/test_fact_forcing.py
+++ b/autobot-backend/tests/agent_loop/test_fact_forcing.py
@@ -100,9 +100,7 @@ class TestLoopIntegration:
         loop._check_approvals = AsyncMock(return_value={})
         loop.tool_executor = MagicMock()
 
-        result = await loop._execute_tools(
-            [{"tool_name": "edit_file", "args": {"file_path": str(target)}}]
-        )
+        result = await loop._execute_tools([{"tool_name": "edit_file", "args": {"file_path": str(target)}}])
 
         assert str(target) in next(iter(result.values()))["error"]
         assert "fact-forcing" in next(iter(result.values()))["error"].lower()
@@ -139,9 +137,7 @@ class TestLoopIntegration:
         await loop._execute_tools([{"tool_name": "read_file", "args": {"file_path": str(target)}}])
         loop._check_approvals.reset_mock()
         # Later iteration: edit is now allowed.
-        result = await loop._execute_tools(
-            [{"tool_name": "edit_file", "args": {"file_path": str(target)}}]
-        )
+        result = await loop._execute_tools([{"tool_name": "edit_file", "args": {"file_path": str(target)}}])
 
         loop._check_approvals.assert_awaited_once()
         assert result == {"edit_file": {"error": "stop"}}
@@ -153,9 +149,7 @@ class TestLoopIntegration:
         loop._check_tool_call_repetition = MagicMock(return_value=None)
         loop._check_approvals = AsyncMock(return_value={"write_file": {"error": "stop"}})
 
-        result = await loop._execute_tools(
-            [{"tool_name": "write_file", "args": {"file_path": str(new_file)}}]
-        )
+        result = await loop._execute_tools([{"tool_name": "write_file", "args": {"file_path": str(new_file)}}])
 
         loop._check_approvals.assert_awaited_once()
         assert result == {"write_file": {"error": "stop"}}
@@ -168,9 +162,7 @@ class TestLoopIntegration:
         loop._check_tool_call_repetition = MagicMock(return_value=None)
         loop._check_approvals = AsyncMock(return_value={"edit_file": {"error": "stop"}})
 
-        result = await loop._execute_tools(
-            [{"tool_name": "edit_file", "args": {"file_path": str(target)}}]
-        )
+        result = await loop._execute_tools([{"tool_name": "edit_file", "args": {"file_path": str(target)}}])
 
         loop._check_approvals.assert_awaited_once()
         assert result == {"edit_file": {"error": "stop"}}
@@ -185,9 +177,7 @@ class TestLoopIntegration:
         loop._check_approvals = AsyncMock(return_value={})
         loop.tool_executor = MagicMock()
 
-        result = await loop._execute_tools(
-            [{"tool_name": "edit_file", "args": {"file_path": str(target)}}]
-        )
+        result = await loop._execute_tools([{"tool_name": "edit_file", "args": {"file_path": str(target)}}])
 
         assert "fact-forcing" in next(iter(result.values()))["error"].lower()
         loop._check_approvals.assert_not_awaited()

--- a/autobot-backend/tests/agent_loop/test_fact_forcing.py
+++ b/autobot-backend/tests/agent_loop/test_fact_forcing.py
@@ -1,0 +1,193 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for the fact-forcing gate (GH#11149).
+
+Acceptance criteria:
+  - The first edit to an existing, not-yet-investigated file is blocked before
+    the approval gate; reading it (this task) clears the gate.
+  - A read + edit of the same file in one batch is allowed.
+  - Creating a NEW (non-existent) file is never blocked.
+  - Off by default; enabled by config or AUTOBOT_FACT_FORCING=1.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent_loop.fact_forcing import (
+    fact_forcing_env_enabled,
+    first_uninvestigated_edit,
+    record_investigations,
+)
+from agent_loop.loop import AgentLoop
+from agent_loop.types import AgentLoopConfig
+
+
+def _make_loop(fact_forcing: bool = True) -> AgentLoop:
+    event_stream = MagicMock()
+    event_stream.get_latest = AsyncMock(return_value=[])
+    event_stream.publish = AsyncMock()
+    config = AgentLoopConfig(
+        mandatory_think_enabled=False,
+        think_on_completion=False,
+        log_iterations=False,
+        fact_forcing_enabled=fact_forcing,
+    )
+    return AgentLoop(event_stream=event_stream, config=config)
+
+
+class TestRecordInvestigations:
+    def test_records_read_paths(self) -> None:
+        seen: set[str] = set()
+        record_investigations(
+            [
+                {"tool_name": "read_file", "args": {"file_path": "a/b.py"}},
+                {"tool_name": "grep_search", "args": {"path": "c/d.py"}},
+                {"tool_name": "write_file", "args": {"file_path": "e/f.py"}},
+            ],
+            seen,
+        )
+        assert "a/b.py" in seen
+        assert "c/d.py" in seen
+        assert "e/f.py" not in seen  # writes are not investigations
+
+
+class TestFirstUninvestigatedEdit:
+    def test_existing_uninvestigated_edit_is_flagged(self) -> None:
+        tool = {"tool_name": "edit_file", "args": {"file_path": "x.py"}}
+        assert first_uninvestigated_edit(tool, set(), exists_fn=lambda _p: True) == "x.py"
+
+    def test_investigated_edit_passes(self) -> None:
+        tool = {"tool_name": "edit_file", "args": {"file_path": "x.py"}}
+        assert first_uninvestigated_edit(tool, {"x.py"}, exists_fn=lambda _p: True) is None
+
+    def test_new_file_is_never_flagged(self) -> None:
+        tool = {"tool_name": "write_file", "args": {"file_path": "new.py"}}
+        assert first_uninvestigated_edit(tool, set(), exists_fn=lambda _p: False) is None
+
+    def test_non_edit_tool_passes(self) -> None:
+        tool = {"tool_name": "read_file", "args": {"file_path": "x.py"}}
+        assert first_uninvestigated_edit(tool, set(), exists_fn=lambda _p: True) is None
+
+    def test_existence_error_fails_open(self) -> None:
+        def _boom(_p: str) -> bool:
+            raise OSError("nope")
+
+        tool = {"tool_name": "edit_file", "args": {"file_path": "x.py"}}
+        assert first_uninvestigated_edit(tool, set(), exists_fn=_boom) is None
+
+
+class TestEnvToggle:
+    def test_default_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AUTOBOT_FACT_FORCING", raising=False)
+        assert fact_forcing_env_enabled() is False
+
+    def test_env_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOBOT_FACT_FORCING", "1")
+        assert fact_forcing_env_enabled() is True
+
+
+class TestLoopIntegration:
+    @pytest.mark.asyncio
+    async def test_edit_existing_uninvestigated_is_blocked(self, tmp_path) -> None:
+        target = tmp_path / "mod.py"
+        target.write_text("x = 1\n", encoding="utf-8")
+        loop = _make_loop(fact_forcing=True)
+        loop._check_tool_call_repetition = MagicMock(return_value=None)
+        loop._check_approvals = AsyncMock(return_value={})
+        loop.tool_executor = MagicMock()
+
+        result = await loop._execute_tools(
+            [{"tool_name": "edit_file", "args": {"file_path": str(target)}}]
+        )
+
+        assert str(target) in next(iter(result.values()))["error"]
+        assert "fact-forcing" in next(iter(result.values()))["error"].lower()
+        loop._check_approvals.assert_not_awaited()
+        loop.tool_executor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_read_then_edit_same_batch_is_allowed(self, tmp_path) -> None:
+        target = tmp_path / "mod.py"
+        target.write_text("x = 1\n", encoding="utf-8")
+        loop = _make_loop(fact_forcing=True)
+        loop._check_tool_call_repetition = MagicMock(return_value=None)
+        loop._check_approvals = AsyncMock(return_value={"edit_file": {"error": "stop"}})
+
+        result = await loop._execute_tools(
+            [
+                {"tool_name": "read_file", "args": {"file_path": str(target)}},
+                {"tool_name": "edit_file", "args": {"file_path": str(target)}},
+            ]
+        )
+
+        loop._check_approvals.assert_awaited_once()
+        assert result == {"edit_file": {"error": "stop"}}
+
+    @pytest.mark.asyncio
+    async def test_edit_after_prior_read_is_allowed(self, tmp_path) -> None:
+        target = tmp_path / "mod.py"
+        target.write_text("x = 1\n", encoding="utf-8")
+        loop = _make_loop(fact_forcing=True)
+        loop._check_tool_call_repetition = MagicMock(return_value=None)
+        loop._check_approvals = AsyncMock(return_value={"edit_file": {"error": "stop"}})
+
+        # Prior iteration: read the file (also passes through to approval).
+        await loop._execute_tools([{"tool_name": "read_file", "args": {"file_path": str(target)}}])
+        loop._check_approvals.reset_mock()
+        # Later iteration: edit is now allowed.
+        result = await loop._execute_tools(
+            [{"tool_name": "edit_file", "args": {"file_path": str(target)}}]
+        )
+
+        loop._check_approvals.assert_awaited_once()
+        assert result == {"edit_file": {"error": "stop"}}
+
+    @pytest.mark.asyncio
+    async def test_new_file_write_is_allowed(self, tmp_path) -> None:
+        new_file = tmp_path / "brand_new.py"  # does not exist
+        loop = _make_loop(fact_forcing=True)
+        loop._check_tool_call_repetition = MagicMock(return_value=None)
+        loop._check_approvals = AsyncMock(return_value={"write_file": {"error": "stop"}})
+
+        result = await loop._execute_tools(
+            [{"tool_name": "write_file", "args": {"file_path": str(new_file)}}]
+        )
+
+        loop._check_approvals.assert_awaited_once()
+        assert result == {"write_file": {"error": "stop"}}
+
+    @pytest.mark.asyncio
+    async def test_disabled_by_default_allows_edit(self, tmp_path) -> None:
+        target = tmp_path / "mod.py"
+        target.write_text("x = 1\n", encoding="utf-8")
+        loop = _make_loop(fact_forcing=False)
+        loop._check_tool_call_repetition = MagicMock(return_value=None)
+        loop._check_approvals = AsyncMock(return_value={"edit_file": {"error": "stop"}})
+
+        result = await loop._execute_tools(
+            [{"tool_name": "edit_file", "args": {"file_path": str(target)}}]
+        )
+
+        loop._check_approvals.assert_awaited_once()
+        assert result == {"edit_file": {"error": "stop"}}
+
+    @pytest.mark.asyncio
+    async def test_env_enables_when_config_off(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("AUTOBOT_FACT_FORCING", "1")
+        target = tmp_path / "mod.py"
+        target.write_text("x = 1\n", encoding="utf-8")
+        loop = _make_loop(fact_forcing=False)
+        loop._check_tool_call_repetition = MagicMock(return_value=None)
+        loop._check_approvals = AsyncMock(return_value={})
+        loop.tool_executor = MagicMock()
+
+        result = await loop._execute_tools(
+            [{"tool_name": "edit_file", "args": {"file_path": str(target)}}]
+        )
+
+        assert "fact-forcing" in next(iter(result.values()))["error"].lower()
+        loop._check_approvals.assert_not_awaited()


### PR DESCRIPTION
## Thinking Path

ECC (`affaan-m/ecc`) ships a `GateGuard` hook that blocks the first Edit/Write per file until the agent has investigated it — the mechanical form of AutoBot's own "deep-dive premise before editing" discipline. AutoBot had no such precondition. This adds a self-clearing "read before you write" gate in the same loop-guard surface as #11145/#11148, keyed on file existence so it never blocks legitimate new-file creation.

## What Changed

- **`autobot-backend/agent_loop/fact_forcing.py`** (new): pure helpers — `record_investigations(tools, seen)` (reads/greps → investigated set), `first_uninvestigated_edit(tool, seen, exists_fn)` (returns the path of an edit to an existing, unread file, else None), `fact_forcing_env_enabled()`.
- **`autobot-backend/agent_loop/loop.py`**:
  - `self._investigated_files: set[str]` state, reset per task alongside `_iteration_count`.
  - `_check_fact_forcing(tools)` wired into `_execute_tools` after config-protection, before approval. Records this batch's investigations first (so read+edit in one turn is allowed), then blocks the first edit to an existing, unread file.
- **`autobot-backend/agent_loop/types.py`**: `fact_forcing_enabled: bool = False` (opt-in).

**Design choices:**
- **New files are never blocked** — the gate keys on `os.path.exists` and **fails open** on existence errors, so a create is never wrongly blocked.
- **Self-clearing** — the denial tells the agent to read the file + its importers/call-sites; the retry proceeds once it has.
- **Opt-in** — off by default (like `belief_state_enabled`); enable via config or `AUTOBOT_FACT_FORCING=1`. No behaviour change at defaults.

## Verification

```
$ python3 -m pytest tests/agent_loop/test_fact_forcing.py \
    tests/agent_loop/test_config_protection.py \
    tests/agent_loop/test_forbidden_tools_wiring.py -q
50 passed in 0.52s
```

AC proven: edit to an existing unread file is blocked before approval; reading it (same batch or a prior iteration) clears the gate; creating a new file is allowed; disabled-by-default allows edits; `AUTOBOT_FACT_FORCING=1` enables when config is off.

## Model Used

Claude Opus 4.8 (1M context)

Closes #11149
