### PR TITLE
feat(analytics): frequency-weighted systemic ranking in anti_pattern_detector (#11171)

### DIFF
--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -41,29 +41,39 @@ _ANTI_PATTERN_SCORES: Dict[Severity, int] = {
     Severity.LOW: 25,
 }
 
-
-def anti_pattern_score(severity: Severity) -> int:
-    """Numeric anti-pattern score for `severity` (higher = worse, 0-100 scale)."""
-    return _ANTI_PATTERN_SCORES[severity]
-
-
-from autobot_shared.async_compat import run_or_schedule
-from autobot_shared.status_enums import Severity  # #7253: consolidated onto canonical (#6689)
-
-# Anti-pattern severity → 0-100 integer score. Kept as a module-level helper
-# rather than an enum method so the canonical `Severity` enum stays clean
-# (canonical `to_score()` returns 0.0–0.9 floats, a different scale).
-_ANTI_PATTERN_SCORES: Dict[Severity, int] = {
-    Severity.CRITICAL: 100,
-    Severity.HIGH: 75,
-    Severity.MEDIUM: 50,
-    Severity.LOW: 25,
-}
+# Minimum occurrences of a pattern_type to be included in the systemic rollup.
+_SYSTEMIC_THRESHOLD = 3
 
 
 def anti_pattern_score(severity: Severity) -> int:
     """Numeric anti-pattern score for `severity` (higher = worse, 0-100 scale)."""
     return _ANTI_PATTERN_SCORES[severity]
+
+
+def _build_systemic_rollup(
+    sorted_patterns: "List[Any]",
+    summary_by_type: Dict[str, int],
+) -> "List[Dict[str, Any]]":
+    """Return systemic pattern entries for types with count >= _SYSTEMIC_THRESHOLD.
+
+    Each entry is {pattern_type, count, top_severity} where top_severity is the
+    highest-scoring severity seen for that type.  Result is sorted by count desc
+    so callers get "god_class ×14" style summaries first (#11171).
+    """
+    top_severity: Dict[str, int] = {}
+    for ap in sorted_patterns:
+        pt = ap.pattern_type.value
+        score = anti_pattern_score(ap.severity)
+        if score > top_severity.get(pt, 0):
+            top_severity[pt] = score
+
+    result = [
+        {"pattern_type": pt, "count": cnt, "top_severity_score": top_severity.get(pt, 0)}
+        for pt, cnt in summary_by_type.items()
+        if cnt >= _SYSTEMIC_THRESHOLD
+    ]
+    result.sort(key=lambda e: e["count"], reverse=True)
+    return result
 
 
 # Initialize configuration
@@ -341,6 +351,9 @@ class AntiPatternReport:
     summary_by_type: Dict[str, int]
     recommendations: List[str]
     analysis_time_seconds: float
+    # #11171: systemic rollup — pattern types with count >= _SYSTEMIC_THRESHOLD,
+    # sorted by count desc.  Each entry: {pattern_type, count, top_severity}.
+    systemic_patterns: List[Dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for JSON serialization"""
@@ -355,6 +368,7 @@ class AntiPatternReport:
             "summary_by_type": self.summary_by_type,
             "recommendations": self.recommendations,
             "analysis_time_seconds": round(self.analysis_time_seconds, 3),
+            "systemic_patterns": self.systemic_patterns,
         }
 
     # === Issue #372: Feature Envy Reduction Methods ===
@@ -2013,8 +2027,12 @@ class AntiPatternDetector:
     # ========== Report Generation ==========
 
     def _generate_report(self, anti_patterns: List[AntiPatternInstance], analysis_time: float) -> AntiPatternReport:
-        """Generate comprehensive anti-pattern report"""
+        """Generate comprehensive anti-pattern report.
 
+        Findings are ranked by prevalence × severity so a pattern_type that
+        appears many times across the codebase rises above a single one-off
+        finding of nominally higher severity (#11171).
+        """
         # Count by severity
         critical_count = sum(1 for ap in anti_patterns if ap.severity == Severity.CRITICAL)
         high_count = sum(1 for ap in anti_patterns if ap.severity == Severity.HIGH)
@@ -2027,12 +2045,25 @@ class AntiPatternDetector:
             pattern_type = ap.pattern_type.value
             summary_by_type[pattern_type] = summary_by_type.get(pattern_type, 0) + 1
 
+        # #11171: rank each finding by freq(pattern_type) × severity_score.
+        # Stable secondary sort on severity_score keeps same-rank entries ordered
+        # by their individual severity (highest first).
+        sorted_patterns = sorted(
+            anti_patterns,
+            key=lambda x: (
+                summary_by_type[x.pattern_type.value] * anti_pattern_score(x.severity),
+                anti_pattern_score(x.severity),
+            ),
+            reverse=True,
+        )
+
+        # #11171: systemic rollup — types exceeding _SYSTEMIC_THRESHOLD occurrences.
+        systemic_patterns = _build_systemic_rollup(sorted_patterns, summary_by_type)
+
         # Calculate health score (0-100, higher is better)
-        # Weighted penalty for each severity level
         total_penalty = critical_count * 20 + high_count * 10 + medium_count * 5 + low_count * 2
         health_score = max(0, 100 - total_penalty)
 
-        # Generate recommendations
         recommendations = self._generate_recommendations(anti_patterns, summary_by_type)
 
         return AntiPatternReport(
@@ -2042,10 +2073,11 @@ class AntiPatternDetector:
             medium_count=medium_count,
             low_count=low_count,
             health_score=health_score,
-            anti_patterns=anti_patterns,
+            anti_patterns=sorted_patterns,
             summary_by_type=summary_by_type,
             recommendations=recommendations,
             analysis_time_seconds=analysis_time,
+            systemic_patterns=systemic_patterns,
         )
 
     # Issue #372: Class-level recommendation mapping reduces feature envy

--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -56,8 +56,8 @@ def _build_systemic_rollup(
 ) -> "List[Dict[str, Any]]":
     """Return systemic pattern entries for types with count >= _SYSTEMIC_THRESHOLD.
 
-    Each entry is {pattern_type, count, top_severity} where top_severity is the
-    highest-scoring severity seen for that type.  Result is sorted by count desc
+    Each entry is {pattern_type, count, top_severity_score} where top_severity_score
+    is the highest severity score seen for that type.  Result is sorted by count desc
     so callers get "god_class ×14" style summaries first (#11171).
     """
     top_severity: Dict[str, int] = {}
@@ -352,7 +352,7 @@ class AntiPatternReport:
     recommendations: List[str]
     analysis_time_seconds: float
     # #11171: systemic rollup — pattern types with count >= _SYSTEMIC_THRESHOLD,
-    # sorted by count desc.  Each entry: {pattern_type, count, top_severity}.
+    # sorted by count desc.  Each entry: {pattern_type, count, top_severity_score}.
     systemic_patterns: List[Dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:

--- a/autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py
@@ -614,3 +614,191 @@ async def test_composable_opportunity_excludes_composables_dir(tmp_path):
 
     composable = [f for f in findings if f.pattern_type.value == "composable_opportunity"]
     assert not composable, "composables/ dir is excluded; only 3 real components remain — below threshold"
+
+
+# ---------------------------------------------------------------------------
+# #11171: frequency-weighted systemic ranking and systemic_patterns rollup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_frequency_weighted_ranking_outranks_single_high_severity(fixture_root):
+    """A lower-severity pattern that appears many times outranks a single
+    higher-severity one-off when freq × severity is larger (#11171).
+
+    Scenario:
+    - 1 GOD_CLASS (score=100, freq=1) → effective rank = 100
+    - 5 LAZY_CLASS  (score=25,  freq=5) → effective rank = 125
+
+    The 5 lazy-class findings must all appear before the god-class finding
+    in report.anti_patterns (the stored sorted list).
+    """
+    apd = _load_detector_module()
+    # God-class: one very large class with many methods (>20) and attributes (>15).
+    methods = "\n".join(f"    def method_{i}(self): pass" for i in range(25))
+    attrs = "\n".join(f"        self.attr_{i} = {i}" for i in range(20))
+    god_body = f"""
+class BigGodClass:
+    def __init__(self):
+{attrs}
+{methods}
+"""
+    _write_module(fixture_root, "big_god", god_body)
+
+    # Lazy-class: five tiny classes with only 1 public method and <20 LOC.
+    for i in range(5):
+        lazy_body = f"""
+class TinyLazy{i}:
+    def do_it(self): pass
+"""
+        _write_module(fixture_root, f"lazy_{i}", lazy_body)
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],
+    )
+
+    god_indices = [i for i, ap in enumerate(report.anti_patterns) if ap.pattern_type.value == "god_class"]
+    lazy_indices = [i for i, ap in enumerate(report.anti_patterns) if ap.pattern_type.value == "lazy_class"]
+
+    assert god_indices, "expected at least one god_class finding"
+    assert len(lazy_indices) >= 5, f"expected 5 lazy_class findings, got {len(lazy_indices)}"
+    # The last lazy-class index must appear before (lower index = higher rank)
+    # OR at the same position group as the god-class.
+    # freq×score for lazy = 5×25=125 > 1×100=100 → lazy ranks first.
+    assert max(lazy_indices) < min(god_indices), (
+        f"lazy_class (freq×sev=125) should outrank god_class (freq×sev=100); "
+        f"lazy indices={lazy_indices}, god index={god_indices}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_frequency_weighted_ranking_tie_breaking_stability(fixture_root):
+    """Within a tie (same freq × sev), secondary sort on severity keeps
+    higher individual severity first — result must be stable (#11171).
+    """
+    apd = _load_detector_module()
+    # Two classes each appear once: one god-class (HIGH sev expected),
+    # one lazy-class (LOW sev).  Both freq=1.
+    # god_class effective rank = 1×100 = 100 (CRITICAL or HIGH)
+    # lazy_class effective rank = 1×25  = 25
+    # god_class must appear first even with freq=1.
+    methods = "\n".join(f"    def method_{i}(self): pass" for i in range(22))
+    attrs = "\n".join(f"        self.attr_{i} = {i}" for i in range(16))
+    _write_module(
+        fixture_root,
+        "tie_god",
+        f"""
+class TieGod:
+    def __init__(self):
+{attrs}
+{methods}
+""",
+    )
+    _write_module(
+        fixture_root,
+        "tie_lazy",
+        """
+class TieLazy:
+    def do_it(self): pass
+""",
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],
+    )
+
+    god_idx = next((i for i, ap in enumerate(report.anti_patterns) if ap.pattern_type.value == "god_class"), None)
+    lazy_idx = next((i for i, ap in enumerate(report.anti_patterns) if ap.pattern_type.value == "lazy_class"), None)
+
+    assert god_idx is not None, "god_class finding expected"
+    assert lazy_idx is not None, "lazy_class finding expected"
+    assert god_idx < lazy_idx, (
+        f"god_class (higher severity) must precede lazy_class; got god={god_idx}, lazy={lazy_idx}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_systemic_patterns_rollup_contents(fixture_root):
+    """systemic_patterns lists types with count >= 3, sorted by count desc (#11171)."""
+    apd = _load_detector_module()
+    # Create 4 lazy classes (count=4 >= threshold of 3) and 1 god class (count=1).
+    for i in range(4):
+        _write_module(
+            fixture_root,
+            f"sys_lazy_{i}",
+            f"""
+class SysLazy{i}:
+    def do_it(self): pass
+""",
+        )
+    methods = "\n".join(f"    def method_{i}(self): pass" for i in range(22))
+    attrs = "\n".join(f"        self.attr_{i} = {i}" for i in range(16))
+    _write_module(
+        fixture_root,
+        "sys_god",
+        f"""
+class SysGod:
+    def __init__(self):
+{attrs}
+{methods}
+""",
+    )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],
+    )
+
+    sp = report.systemic_patterns
+    # lazy_class should appear in systemic_patterns (count=4 >= 3)
+    lazy_entry = next((e for e in sp if e["pattern_type"] == "lazy_class"), None)
+    assert lazy_entry is not None, "lazy_class (count=4) must appear in systemic_patterns"
+    assert lazy_entry["count"] >= 4
+    assert lazy_entry["top_severity_score"] == 25  # LOW score
+
+    # god_class count=1 is below threshold — must NOT be in systemic_patterns
+    god_entry = next((e for e in sp if e["pattern_type"] == "god_class"), None)
+    assert god_entry is None, "god_class (count=1) must not appear in systemic_patterns (below threshold=3)"
+
+    # systemic_patterns must be sorted by count desc
+    counts = [e["count"] for e in sp]
+    assert counts == sorted(counts, reverse=True), "systemic_patterns must be sorted by count desc"
+
+    # to_dict() must include systemic_patterns key
+    d = report.to_dict()
+    assert "systemic_patterns" in d, "to_dict() must include systemic_patterns key"
+    assert isinstance(d["systemic_patterns"], list)
+
+
+@pytest.mark.asyncio
+async def test_systemic_patterns_below_threshold_empty(fixture_root):
+    """When no pattern_type reaches the threshold, systemic_patterns is empty (#11171)."""
+    apd = _load_detector_module()
+    # Two lazy classes — count=2 is below threshold=3
+    for i in range(2):
+        _write_module(
+            fixture_root,
+            f"below_{i}",
+            f"""
+class BelowLazy{i}:
+    def do_it(self): pass
+""",
+        )
+
+    detector = apd.AntiPatternDetector()
+    report = await detector.analyze(
+        root_path=str(fixture_root),
+        patterns=["*.py"],
+        exclude_patterns=["__pycache__"],
+    )
+    assert report.systemic_patterns == [], (
+        f"count=2 is below threshold=3; expected [], got {report.systemic_patterns}"
+    )

--- a/autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py
@@ -718,9 +718,9 @@ class TieLazy:
 
     assert god_idx is not None, "god_class finding expected"
     assert lazy_idx is not None, "lazy_class finding expected"
-    assert god_idx < lazy_idx, (
-        f"god_class (higher severity) must precede lazy_class; got god={god_idx}, lazy={lazy_idx}"
-    )
+    assert (
+        god_idx < lazy_idx
+    ), f"god_class (higher severity) must precede lazy_class; got god={god_idx}, lazy={lazy_idx}"
 
 
 @pytest.mark.asyncio
@@ -799,6 +799,4 @@ class BelowLazy{i}:
         patterns=["*.py"],
         exclude_patterns=["__pycache__"],
     )
-    assert report.systemic_patterns == [], (
-        f"count=2 is below threshold=3; expected [], got {report.systemic_patterns}"
-    )
+    assert report.systemic_patterns == [], f"count=2 is below threshold=3; expected [], got {report.systemic_patterns}"

--- a/autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector_consolidation_test.py
@@ -675,9 +675,9 @@ class TinyLazy{i}:
 
 
 @pytest.mark.asyncio
-async def test_frequency_weighted_ranking_tie_breaking_stability(fixture_root):
-    """Within a tie (same freq × sev), secondary sort on severity keeps
-    higher individual severity first — result must be stable (#11171).
+async def test_equal_frequency_orders_by_severity(fixture_root):
+    """At equal frequency (both freq=1), the higher-severity finding ranks
+    first — the secondary severity term in the sort key decides (#11171).
     """
     apd = _load_detector_module()
     # Two classes each appear once: one god-class (HIGH sev expected),

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -36646,6 +36646,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/agents/{agent_id}/knowledge-export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export an agent's learned strategy + high-confidence failure patterns
+         * @description Render an agent's opaque learned knowledge as a human-reviewable document (GH#11151).
+         */
+        get: operations["export_agent_knowledge_api_agents__agent_id__knowledge_export_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/{agent_id}/knowledge-import": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Import an operator-curated learned strategy
+         * @description Persist a reviewer-curated strategy, sanitizing untrusted free-text first (GH#11151).
+         */
+        post: operations["import_agent_knowledge_api_agents__agent_id__knowledge_import_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/analytics/code/code/index": {
         parameters: {
             query?: never;
@@ -71191,6 +71231,26 @@ export interface components {
             [key: string]: unknown;
         };
         /**
+         * FailurePatternRecord
+         * @description Serialized failure pattern for the knowledge-export document (GH#11151).
+         */
+        FailurePatternRecord: {
+            /** Pattern Id */
+            pattern_id: string;
+            /** Causal Chain */
+            causal_chain: string;
+            /** Occurrence Count */
+            occurrence_count: number;
+            /** Successful Resolutions */
+            successful_resolutions: string[];
+            /** Resolution Success Rate */
+            resolution_success_rate: number;
+            /** Confidence */
+            confidence: number;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
          * FeatureCategory
          * @description Categories of enterprise features
          * @enum {string}
@@ -76090,6 +76150,20 @@ export interface components {
             [key: string]: unknown;
         };
         /**
+         * KnowledgeImportResponse
+         * @description Response for a knowledge-import operation (GH#11151).
+         */
+        KnowledgeImportResponse: {
+            /** Success */
+            success: boolean;
+            /** Message */
+            message: string;
+            /** Task Type */
+            task_type: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
          * KnowledgeMainCategoriesResponse
          * @description Shape of ``GET /api/knowledge_base/categories/main``.
          *
@@ -78150,6 +78224,55 @@ export interface components {
             count: number;
             /** Messages */
             messages: components["schemas"]["ServiceMessageResponse"][];
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * LearnedKnowledgeExport
+         * @description Human-reviewable export of an agent's learned knowledge (GH#11151).
+         */
+        LearnedKnowledgeExport: {
+            /** Task Type */
+            task_type: string;
+            learned_strategy: components["schemas"]["LearnedStrategyResponse"] | null;
+            /** High Confidence Threshold */
+            high_confidence_threshold: number;
+            /** High Confidence Failure Patterns */
+            high_confidence_failure_patterns: components["schemas"]["FailurePatternRecord"][];
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * LearnedKnowledgeImport
+         * @description Operator-curated learned strategy to import (GH#11151).
+         *
+         *     ``best_prompt_template`` and ``best_approach`` are treated as untrusted and
+         *     sanitized before persistence (reuses the #11060 data-only framing).
+         */
+        LearnedKnowledgeImport: {
+            /** Task Type */
+            task_type: string;
+            /** Best Approach */
+            best_approach: string;
+            /** Best Prompt Template */
+            best_prompt_template: string;
+            /**
+             * Avg Score
+             * @default 0
+             */
+            avg_score: number;
+            /**
+             * Sample Size
+             * @default 0
+             */
+            sample_size: number;
+            /**
+             * Confidence
+             * @default 0
+             */
+            confidence: number;
+            /** Failure Patterns */
+            failure_patterns?: string[];
         } & {
             [key: string]: unknown;
         };
@@ -98462,6 +98585,8 @@ export interface components {
             created_by_user_id?: string | null;
             /** Labels */
             labels?: string[] | null;
+            /** Requires Approval Before */
+            requires_approval_before?: string[] | null;
         } & {
             [key: string]: unknown;
         };
@@ -98546,6 +98671,8 @@ export interface components {
             assignee_agent_id?: string | null;
             /** Assignee User Id */
             assignee_user_id?: string | null;
+            /** Requires Approval Before */
+            requires_approval_before?: string[] | null;
             /** Scheduled Start */
             scheduled_start?: string | null;
             /** Scheduled End */
@@ -148096,6 +148223,77 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ResetLearningResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    export_agent_knowledge_api_agents__agent_id__knowledge_export_get: {
+        parameters: {
+            query?: {
+                /** @description Task type to export */
+                task_type?: string | null;
+                /** @description Only export failure patterns at or above this confidence */
+                min_confidence?: number;
+            };
+            header?: never;
+            path: {
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LearnedKnowledgeExport"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    import_agent_knowledge_api_agents__agent_id__knowledge_import_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LearnedKnowledgeImport"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["KnowledgeImportResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Thinking Path
Findings were stored in detection order and only ranked by static severity in the `__main__` display path. A single high-severity one-off could outrank a pattern that recurs dozens of times across the codebase. Ranking by prevalence × severity surfaces systemic debt first (Task 3 of epic #11170).

## What Changed
- `code_analysis/src/anti_pattern_detector.py`:
  - `_generate_report()` now sorts stored `anti_patterns` by `freq(pattern_type) × severity_score`, with `severity_score` as a stable secondary key. A `lazy_class ×5` (125) outranks a solo `god_class` (100); a solo `god_class` still beats a solo `lazy_class`.
  - New `_build_systemic_rollup()` + `AntiPatternReport.systemic_patterns` field — types with count ≥ `_SYSTEMIC_THRESHOLD` (3), sorted by count desc, each `{pattern_type, count, top_severity_score}` — "god_class ×14" style summaries.
  - `to_dict()` gains `systemic_patterns` additively; no keys removed (backward compatible).
  - Removed a verbatim-duplicate `_ANTI_PATTERN_SCORES`/`anti_pattern_score` block (canonical copies retained).

## Verification
- 28/28 tests pass: 16 pre-existing consolidation + 8 pre-existing LSP + 4 new:
  - frequency outranks single high-severity, tie-break stability, rollup contents/threshold/sort, below-threshold empty.
- AST parse OK; de-duplicated imports confirmed still present (lines 30/32).

## Model Used
Opus 4.8

Closes #11171
Part of #11170
