### PR TITLE
feat(agent-loop): durable run checkpointing + resume_run (#11175)

### DIFF
--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -20,6 +20,7 @@ and Think Tool into a cohesive execution system.
 import asyncio
 import hashlib
 import json
+import os
 import time
 import uuid
 from typing import Any
@@ -127,6 +128,16 @@ _HALT_SENTINEL = "__repetition_halt__"
 
 # Sentinel key for stagnation halts (Issue #6627).
 _STAGNATION_SENTINEL = "__stagnation_halt__"
+
+# Durable run checkpointing (GH#11175). A run's progress snapshot is persisted to
+# Redis after each iteration so a crashed/restarted process can resume via
+# resume_run(). TTL is env-tunable so stale checkpoints self-expire.
+_RUN_CHECKPOINT_TTL_SECONDS: int = int(os.environ.get("AUTOBOT_RUN_CHECKPOINT_TTL_SECONDS", str(24 * 3600)))
+
+
+def _run_checkpoint_key(task_id: str) -> str:
+    """Redis key for a run's durable progress snapshot (GH#11175)."""
+    return f"autobot:run:checkpoint:{task_id}"
 
 # =============================================================================
 # Agent Loop
@@ -300,6 +311,9 @@ class AgentLoop:
             iteration_result = await self._run_iteration()
             results.append(iteration_result)
 
+            # GH#11175: persist progress so a crash/restart can resume_run().
+            await self._checkpoint_run()
+
             if not iteration_result.should_continue:
                 break
 
@@ -404,6 +418,9 @@ class AgentLoop:
             # Issue #620: Use helper for task finalization
             result = await self._finalize_task(results)
 
+            # GH#11175: run reached a terminal state — drop its resume checkpoint.
+            await self._clear_run_checkpoint(task_id)
+
             # Issue #4308: notify Slack on successful task completion
             duration = time.monotonic() - _task_start
             await slack.post_task_completion(
@@ -441,6 +458,31 @@ class AgentLoop:
 
         finally:
             self._current_phase = LoopPhase.STANDBY
+
+    async def resume_run(self, task_id: str) -> dict[str, Any]:
+        """Resume a crashed/restarted run from its last persisted checkpoint (GH#11175).
+
+        Loads the Redis snapshot written by :meth:`_checkpoint_run`, restores the
+        task context and iteration counter, and continues the main loop to a
+        terminal state. Raises ``ValueError`` when no checkpoint exists for
+        *task_id* (nothing to resume).
+        """
+        snapshot = await self.load_run_snapshot(task_id)
+        if snapshot is None:
+            raise ValueError(f"no run checkpoint found for task_id: {task_id}")
+
+        self._current_context = TaskContext.from_snapshot(snapshot)
+        self._iteration_count = self._current_context.iteration_count
+        logger.info(
+            "AgentLoop: resuming task %s from iteration %d",
+            task_id,
+            self._iteration_count,
+        )
+
+        results = await self._execute_main_loop()
+        result = await self._finalize_task(results)
+        await self._clear_run_checkpoint(task_id)
+        return result
 
     async def cancel(self) -> None:
         """Cancel the current task."""
@@ -1176,6 +1218,43 @@ class AgentLoop:
             await redis_delete(key)
         except Exception as exc:
             logger.warning("AgentLoop: ask_human checkpoint clear failed (non-critical): %s", exc)
+
+    async def _checkpoint_run(self) -> None:
+        """Persist the current run's progress snapshot to Redis (GH#11175).
+
+        Called after each iteration so a crashed/restarted process can resume via
+        :meth:`resume_run`. Best-effort — a checkpoint failure logs and never
+        interrupts the run.
+        """
+        if self._current_context is None:
+            return
+        try:
+            from autobot_shared.redis_client import redis_set
+
+            key = _run_checkpoint_key(self._current_context.task_id)
+            snapshot = self._current_context.to_snapshot()
+            await redis_set(key, json.dumps(snapshot), expire=_RUN_CHECKPOINT_TTL_SECONDS)
+        except Exception as exc:
+            logger.warning("AgentLoop: run checkpoint failed (non-critical): %s", exc)
+
+    async def _clear_run_checkpoint(self, task_id: str) -> None:
+        """Remove a run's Redis checkpoint once the run completes (GH#11175)."""
+        try:
+            from autobot_shared.redis_client import redis_delete
+
+            await redis_delete(_run_checkpoint_key(task_id))
+        except Exception as exc:
+            logger.warning("AgentLoop: run checkpoint clear failed (non-critical): %s", exc)
+
+    @staticmethod
+    async def load_run_snapshot(task_id: str) -> dict | None:
+        """Load a run's persisted progress snapshot, or None if absent (GH#11175)."""
+        from autobot_shared.redis_client import redis_get
+
+        raw = await redis_get(_run_checkpoint_key(task_id))
+        if not raw:
+            return None
+        return json.loads(raw)
 
     # =========================================================================
     # Think Tool Integration

--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -139,6 +139,7 @@ def _run_checkpoint_key(task_id: str) -> str:
     """Redis key for a run's durable progress snapshot (GH#11175)."""
     return f"autobot:run:checkpoint:{task_id}"
 
+
 # =============================================================================
 # Agent Loop
 # =============================================================================

--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -280,6 +280,20 @@ class AgentLoop:
         )
         self._state = LoopState.INITIALIZING
         self._iteration_count = 0
+        self._reset_run_flags()
+        # Clear any leftover steering messages from a previous run.
+        self._steering_inbox = asyncio.Queue()
+        # Clear answer inbox and waiting flag from a previous run (#10553).
+        self._human_answer_inbox = asyncio.Queue()
+        self._waiting_for_human = False
+
+    def _reset_run_flags(self) -> None:
+        """Reset per-run halt/error latch state (GH#11175).
+
+        Shared by ``_init_task_context`` (fresh run) and ``resume_run`` (crash
+        recovery) so a resumed run does not inherit a stale halt/abstain/error
+        latch that ``_should_continue`` would trip on immediately.
+        """
         self._consecutive_errors = 0
         self._investigated_files = set()  # GH#11149: reset fact-forcing state per task
         self._halted_on_repetition = False
@@ -291,11 +305,6 @@ class AgentLoop:
         self._halt_outcome = None
         self._halt_reason = ""
         self._error_budget_exhausted = False
-        # Clear any leftover steering messages from a previous run.
-        self._steering_inbox = asyncio.Queue()
-        # Clear answer inbox and waiting flag from a previous run (#10553).
-        self._human_answer_inbox = asyncio.Queue()
-        self._waiting_for_human = False
 
     async def _execute_main_loop(self) -> list[IterationResult]:
         """Execute the main iteration loop.
@@ -419,9 +428,6 @@ class AgentLoop:
             # Issue #620: Use helper for task finalization
             result = await self._finalize_task(results)
 
-            # GH#11175: run reached a terminal state — drop its resume checkpoint.
-            await self._clear_run_checkpoint(task_id)
-
             # Issue #4308: notify Slack on successful task completion
             duration = time.monotonic() - _task_start
             await slack.post_task_completion(
@@ -459,6 +465,10 @@ class AgentLoop:
 
         finally:
             self._current_phase = LoopPhase.STANDBY
+            # GH#11175: clear the resume checkpoint on any terminal path
+            # (success/failure/cancel). A hard process crash skips finally, so its
+            # checkpoint survives for resume_run() — which is the intended behaviour.
+            await self._clear_run_checkpoint(task_id)
 
     async def resume_run(self, task_id: str) -> dict[str, Any]:
         """Resume a crashed/restarted run from its last persisted checkpoint (GH#11175).
@@ -474,6 +484,7 @@ class AgentLoop:
 
         self._current_context = TaskContext.from_snapshot(snapshot)
         self._iteration_count = self._current_context.iteration_count
+        self._reset_run_flags()  # start from a clean halt/error latch (GH#11175)
         logger.info(
             "AgentLoop: resuming task %s from iteration %d",
             task_id,
@@ -1232,6 +1243,9 @@ class AgentLoop:
         try:
             from autobot_shared.redis_client import redis_set
 
+            # The live iteration counter is the AgentLoop attribute; mirror it onto
+            # the context so the snapshot records real progress (else resume → 0).
+            self._current_context.iteration_count = self._iteration_count
             key = _run_checkpoint_key(self._current_context.task_id)
             snapshot = self._current_context.to_snapshot()
             await redis_set(key, json.dumps(snapshot), expire=_RUN_CHECKPOINT_TTL_SECONDS)

--- a/autobot-backend/agent_loop/types.py
+++ b/autobot-backend/agent_loop/types.py
@@ -609,3 +609,54 @@ class TaskContext:
             "plan_id": self.plan_id,
             "current_step_id": self.current_step_id,
         }
+
+    #: Snapshot schema version — bump when the durable-core shape changes so a
+    #: resume can reject an incompatible checkpoint rather than mis-restore.
+    SNAPSHOT_VERSION = 1
+
+    def to_snapshot(self) -> dict:
+        """Serialize the durable core needed to resume this run (GH#11175).
+
+        Captures the JSON-serializable progress state — task identity, iteration
+        count, tools/errors/messages so far, plan position, metadata, and the
+        repetition-guard hashes. Transient reasoning/belief state (think_history,
+        observation_fingerprints, steering_events, human_questions, assertions,
+        contradictions, token windows) is intentionally NOT snapshotted; a resumed
+        run rebuilds it as it proceeds.
+        """
+        return {
+            "version": self.SNAPSHOT_VERSION,
+            "task_id": self.task_id,
+            "description": self.description,
+            "started_at": self.started_at.isoformat(),
+            "iteration_count": self.iteration_count,
+            "tools_executed": list(self.tools_executed),
+            "errors": list(self.errors),
+            "user_messages": list(self.user_messages),
+            "plan_id": self.plan_id,
+            "current_step_id": self.current_step_id,
+            "metadata": dict(self.metadata),
+            "tool_call_hashes": dict(self.tool_call_hashes),
+        }
+
+    @classmethod
+    def from_snapshot(cls, data: dict) -> "TaskContext":
+        """Reconstruct a TaskContext from :meth:`to_snapshot` output (GH#11175).
+
+        Raises ``ValueError`` on a missing/incompatible snapshot version so a
+        resume fails loud rather than silently continuing from partial state.
+        """
+        version = data.get("version")
+        if version != cls.SNAPSHOT_VERSION:
+            raise ValueError(f"unsupported TaskContext snapshot version: {version!r}")
+        ctx = cls(task_id=data["task_id"], description=data.get("description", ""))
+        ctx.started_at = datetime.fromisoformat(data["started_at"])
+        ctx.iteration_count = int(data.get("iteration_count", 0))
+        ctx.tools_executed = list(data.get("tools_executed", []))
+        ctx.errors = list(data.get("errors", []))
+        ctx.user_messages = list(data.get("user_messages", []))
+        ctx.plan_id = data.get("plan_id")
+        ctx.current_step_id = data.get("current_step_id")
+        ctx.metadata = dict(data.get("metadata", {}))
+        ctx.tool_call_hashes = dict(data.get("tool_call_hashes", {}))
+        return ctx

--- a/autobot-backend/tests/agent_loop/test_run_checkpoint.py
+++ b/autobot-backend/tests/agent_loop/test_run_checkpoint.py
@@ -9,12 +9,18 @@ and resume_run restoring state and continuing to a terminal result.
 """
 
 import json
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from agent_loop.loop import AgentLoop, _run_checkpoint_key
 from agent_loop.types import TaskContext
+
+# The stubbing conftest plants a fake ``agent_loop`` package, so string-target
+# patches like ``patch("agent_loop.loop.x")`` fail dot-lookup; patch the real
+# module object fetched from sys.modules instead.
+_loop_module = sys.modules["agent_loop.loop"]
 
 
 def _ctx() -> TaskContext:
@@ -65,6 +71,7 @@ def test_from_snapshot_rejects_incompatible_version():
 async def test_checkpoint_run_writes_snapshot_to_redis():
     loop = _loop()
     loop._current_context = _ctx()
+    loop._iteration_count = 3
     redis_set = AsyncMock()
     with patch("autobot_shared.redis_client.redis_set", redis_set):
         await loop._checkpoint_run()
@@ -72,6 +79,19 @@ async def test_checkpoint_run_writes_snapshot_to_redis():
     key, payload = redis_set.await_args.args[0], redis_set.await_args.args[1]
     assert key == _run_checkpoint_key("task-abc")
     assert json.loads(payload)["iteration_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_syncs_live_iteration_counter():
+    """Regression: the snapshot must record the loop's live counter, not the
+    context's stale default — nothing else advances context.iteration_count."""
+    loop = _loop()
+    loop._current_context = TaskContext(task_id="t", description="d")  # iteration_count defaults to 0
+    loop._iteration_count = 5
+    redis_set = AsyncMock()
+    with patch("autobot_shared.redis_client.redis_set", redis_set):
+        await loop._checkpoint_run()
+    assert json.loads(redis_set.await_args.args[1])["iteration_count"] == 5
 
 
 @pytest.mark.asyncio
@@ -118,3 +138,19 @@ async def test_resume_run_raises_when_no_checkpoint():
     with patch.object(AgentLoop, "load_run_snapshot", AsyncMock(return_value=None)):
         with pytest.raises(ValueError):
             await loop.resume_run("missing")
+
+
+@pytest.mark.asyncio
+async def test_run_task_clears_checkpoint_on_failure():
+    """A failed run must drop its checkpoint (finally path), not leave it resumable."""
+    loop = _loop()
+    slack = MagicMock()
+    slack.post_agent_status = AsyncMock()
+    slack.post_task_completion = AsyncMock()
+    loop._create_task_plan = AsyncMock()
+    loop._execute_main_loop = AsyncMock(side_effect=RuntimeError("boom"))
+    loop._clear_run_checkpoint = AsyncMock()
+    with patch.object(_loop_module, "get_slack_hook", return_value=slack):
+        with pytest.raises(RuntimeError):
+            await loop.run_task("do it", task_id="task-x")
+    loop._clear_run_checkpoint.assert_awaited_with("task-x")

--- a/autobot-backend/tests/agent_loop/test_run_checkpoint.py
+++ b/autobot-backend/tests/agent_loop/test_run_checkpoint.py
@@ -1,0 +1,120 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Durable run checkpointing + resume_run for AgentLoop (GH#11175).
+
+Covers the TaskContext snapshot round-trip, the per-iteration Redis checkpoint,
+and resume_run restoring state and continuing to a terminal result.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent_loop.loop import AgentLoop, _run_checkpoint_key
+from agent_loop.types import TaskContext
+
+
+def _ctx() -> TaskContext:
+    ctx = TaskContext(task_id="task-abc", description="do the thing")
+    ctx.iteration_count = 3
+    ctx.tools_executed = ["read_file", "web_search"]
+    ctx.errors = ["boom"]
+    ctx.user_messages = ["hi"]
+    ctx.plan_id = "plan-1"
+    ctx.current_step_id = "step-2"
+    ctx.metadata = {"k": "v"}
+    ctx.tool_call_hashes = {"h1": 2}
+    return ctx
+
+
+def _loop() -> AgentLoop:
+    return AgentLoop(event_stream=MagicMock())
+
+
+# --- snapshot round-trip ---------------------------------------------------
+
+
+def test_snapshot_roundtrip_preserves_durable_core():
+    restored = TaskContext.from_snapshot(_ctx().to_snapshot())
+    assert restored.task_id == "task-abc"
+    assert restored.description == "do the thing"
+    assert restored.iteration_count == 3
+    assert restored.tools_executed == ["read_file", "web_search"]
+    assert restored.errors == ["boom"]
+    assert restored.user_messages == ["hi"]
+    assert restored.plan_id == "plan-1"
+    assert restored.current_step_id == "step-2"
+    assert restored.metadata == {"k": "v"}
+    assert restored.tool_call_hashes == {"h1": 2}
+
+
+def test_from_snapshot_rejects_incompatible_version():
+    bad = _ctx().to_snapshot()
+    bad["version"] = 999
+    with pytest.raises(ValueError):
+        TaskContext.from_snapshot(bad)
+
+
+# --- checkpoint persistence ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_run_writes_snapshot_to_redis():
+    loop = _loop()
+    loop._current_context = _ctx()
+    redis_set = AsyncMock()
+    with patch("autobot_shared.redis_client.redis_set", redis_set):
+        await loop._checkpoint_run()
+    redis_set.assert_awaited_once()
+    key, payload = redis_set.await_args.args[0], redis_set.await_args.args[1]
+    assert key == _run_checkpoint_key("task-abc")
+    assert json.loads(payload)["iteration_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_run_noop_without_context():
+    loop = _loop()
+    loop._current_context = None
+    redis_set = AsyncMock()
+    with patch("autobot_shared.redis_client.redis_set", redis_set):
+        await loop._checkpoint_run()
+    redis_set.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_failure_is_swallowed():
+    loop = _loop()
+    loop._current_context = _ctx()
+    with patch("autobot_shared.redis_client.redis_set", AsyncMock(side_effect=RuntimeError("redis down"))):
+        await loop._checkpoint_run()  # must not raise
+
+
+# --- resume ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resume_run_restores_context_and_finalizes():
+    loop = _loop()
+    snapshot = _ctx().to_snapshot()
+    with patch.object(AgentLoop, "load_run_snapshot", AsyncMock(return_value=snapshot)):
+        loop._execute_main_loop = AsyncMock(return_value=[])
+        loop._finalize_task = AsyncMock(return_value={"status": "completed"})
+        loop._clear_run_checkpoint = AsyncMock()
+        result = await loop.resume_run("task-abc")
+
+    assert result == {"status": "completed"}
+    assert loop._current_context.task_id == "task-abc"
+    assert loop._iteration_count == 3
+    loop._finalize_task.assert_awaited_once()
+    loop._clear_run_checkpoint.assert_awaited_once_with("task-abc")
+
+
+@pytest.mark.asyncio
+async def test_resume_run_raises_when_no_checkpoint():
+    loop = _loop()
+    with patch.object(AgentLoop, "load_run_snapshot", AsyncMock(return_value=None)):
+        with pytest.raises(ValueError):
+            await loop.resume_run("missing")


### PR DESCRIPTION
## Thinking Path

From the agent-framework research comparison: LangGraph/eve treat durable execution as a first-class primitive, while AutoBot's `AgentLoop` kept `TaskContext` in memory only — a crash lost the whole run (only pending `ask_human` questions were checkpointed). This adds durable checkpointing on the exact pattern the loop already uses for `ask_human`, so it's consistent and needs no DB migration.

**Honest scoping (same lesson as #11145):** `AgentLoop` has no production caller today — real execution is the `chat_workflow` streaming generator. So this checkpointing is exercised at the loop level and ready for when the loop is adopted; it does not yet make production runs durable. Making the `chat_workflow` path durable is a separate, larger design, noted in the issue.

## What Changed

- **`agent_loop/types.py`** — `TaskContext.to_snapshot()` / `from_snapshot()`: versioned durable-core serialization (identity, iteration count, tools/errors/messages, plan position, metadata, repetition-guard hashes). Transient reasoning/belief state is rebuilt on resume, not snapshotted; incompatible version → `ValueError`.
- **`agent_loop/loop.py`**
  - `_checkpoint_run()` persists the snapshot to Redis (`autobot:run:checkpoint:{task_id}`, `AUTOBOT_RUN_CHECKPOINT_TTL_SECONDS` env-tunable) after each iteration in `_execute_main_loop`; best-effort (swallows failures), cleared on terminal completion.
  - `load_run_snapshot(task_id)` reader; `resume_run(task_id)` restores context + iteration counter and continues the main loop to a terminal result; raises when no checkpoint exists.

## Verification

```
$ python3 -m pytest tests/agent_loop/test_run_checkpoint.py -q
7 passed
```
Covers snapshot round-trip, version rejection, per-iteration Redis write, no-op/failure-swallow, resume restore+finalize+clear, and raise-when-absent.

_(Colocated `agent_loop/*_test.py` modules fail to collect under the stubbing conftest — a pre-existing packaging issue documented in PR #11152, unrelated to this change; the new test lives under `tests/agent_loop/` and passes.)_

## Model Used

Claude Opus 4.8 (1M context)

Closes #11175