### PR TITLE
fix(security): enforce config-protection at the production dispatch seam (#11177)

### DIFF
--- a/autobot-backend/agent_loop/config_protection.py
+++ b/autobot-backend/agent_loop/config_protection.py
@@ -5,103 +5,21 @@
 """
 Config-protection guard for the agent loop (GH#11148).
 
-Blocks agent write/edit/delete/move tools that target a linter or formatter
-config file, so the agent fixes the code to satisfy a quality gate instead of
-silently weakening the gate (e.g. adding an ``ignore`` rule to ``.eslintrc`` or
-``ruff.toml``). Mixed-purpose manifests (``pyproject.toml``, ``setup.cfg``) are
-intentionally NOT protected here — they carry legitimate non-lint content
-(dependencies, packaging) and blocking them would over-block.
-
-Override with ``AUTOBOT_ALLOW_CONFIG_EDITS=1`` when an intentional config change
-is required.
+The detection logic now lives in the dependency-free ``autobot_shared.config_guard``
+(GH#11177) so the production tool-dispatch seam can reuse it without importing the
+heavy ``agent_loop`` package. This module re-exports the loop-facing surface.
 """
 
-import os
-
-# Write-side tools whose target path is guarded. Read/list tools are ignored.
-_WRITE_TOOLS: frozenset[str] = frozenset(
-    {
-        "write_file",
-        "edit_file",
-        "multi_edit",
-        "apply_patch",
-        "create_file",
-        "delete_file",
-        "move_file",
-        "copy_file",
-    }
+from autobot_shared.config_guard import (
+    config_edits_allowed,
+    is_protected_config,
+    protected_config_for,
+    protected_config_write,
 )
 
-# Arg keys under which a write tool carries its target path (see
-# tools/parallel/analyzer.py RESOURCE_EXTRACTORS).
-_PATH_KEYS: tuple[str, ...] = ("file_path", "path", "destination", "target_file")
-
-# Dedicated linter/formatter config basenames (exact, case-insensitive).
-_PROTECTED_BASENAMES: frozenset[str] = frozenset(
-    {
-        ".editorconfig",
-        ".pre-commit-config.yaml",
-        ".flake8",
-        "mypy.ini",
-        ".mypy.ini",
-        "ruff.toml",
-        ".ruff.toml",
-        ".isort.cfg",
-        ".pylintrc",
-        "tox.ini",
-        "eslint.config.js",
-        "eslint.config.cjs",
-        "eslint.config.mjs",
-        "prettier.config.js",
-        "prettier.config.cjs",
-        "prettier.config.mjs",
-        "commitlint.config.js",
-        "commitlint.config.cjs",
-        "commitlint.config.mjs",
-        "stylelint.config.js",
-        "biome.json",
-        "biome.jsonc",
-    }
-)
-
-# Basename prefixes covering the many dotfile variants (``.eslintrc.json``,
-# ``.prettierrc.yaml``, ``.markdownlint.json`` …).
-_PROTECTED_PREFIXES: tuple[str, ...] = (
-    ".eslintrc",
-    ".prettierrc",
-    ".stylelintrc",
-    ".markdownlint",
-)
-
-
-def is_protected_config(path: str | None) -> str | None:
-    """Return the matched config basename if *path* is a protected config, else None."""
-    if not path:
-        return None
-    base = os.path.basename(str(path).strip().rstrip("/\\"))
-    lower = base.lower()
-    if lower in _PROTECTED_BASENAMES:
-        return base
-    if any(lower.startswith(prefix) for prefix in _PROTECTED_PREFIXES):
-        return base
-    return None
-
-
-def config_edits_allowed() -> bool:
-    """True when ``AUTOBOT_ALLOW_CONFIG_EDITS`` opts out of the guard."""
-    return os.environ.get("AUTOBOT_ALLOW_CONFIG_EDITS", "").strip().lower() in {"1", "true", "yes"}
-
-
-def protected_config_write(tool: dict) -> str | None:
-    """Return the protected config basename a write-tool call targets, else None."""
-    name = str(tool.get("tool_name", "")).lower()
-    if name not in _WRITE_TOOLS:
-        return None
-    args = tool.get("args") or tool.get("arguments") or tool.get("parameters") or {}
-    if not isinstance(args, dict):
-        return None
-    for key in _PATH_KEYS:
-        matched = is_protected_config(args.get(key))
-        if matched:
-            return matched
-    return None
+__all__ = [
+    "config_edits_allowed",
+    "is_protected_config",
+    "protected_config_for",
+    "protected_config_write",
+]

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -2421,9 +2421,7 @@ class ToolHandlerMixin:
             f"Set AUTOBOT_ALLOW_CONFIG_EDITS=1 for an intentional change."
         )
         logger.warning("[GH#11177] Blocked config-protection write to '%s' (tool '%s')", matched, tool_name)
-        execution_results.append(
-            {"tool": tool_name, "status": "error", "error": error, "config_protection": True}
-        )
+        execution_results.append({"tool": tool_name, "status": "error", "error": error, "config_protection": True})
         return WorkflowMessage(
             type="error",
             content=error,

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -2393,6 +2393,43 @@ class ToolHandlerMixin:
             metadata={"tool": tool_name, "error": True, "forbidden_by_manifest": True},
         )
 
+    def _enforce_config_protection(
+        self,
+        tool_call: dict[str, Any],
+        execution_results: list[dict[str, Any]],
+    ) -> WorkflowMessage | None:
+        """Block a write that would weaken a linter/formatter config (GH#11177).
+
+        Reuses the dependency-free ``autobot_shared.config_guard`` matcher against
+        the tool's target path (``params`` for built-in tools, ``arguments`` for
+        MCP). Records the failure and returns an error ``WorkflowMessage`` when the
+        target is a protected config, else ``None``. ``AUTOBOT_ALLOW_CONFIG_EDITS``
+        opts out.
+        """
+        from autobot_shared.config_guard import config_edits_allowed, protected_config_for
+
+        if config_edits_allowed():
+            return None
+        args = tool_call.get("params") or tool_call.get("arguments") or {}
+        matched = protected_config_for(tool_call.get("name", ""), args)
+        if matched is None:
+            return None
+        tool_name = tool_call.get("name", "")
+        error = (
+            f"Editing linter/formatter config '{matched}' is blocked (config-protection): "
+            f"fix the code to satisfy the gate instead of weakening it. "
+            f"Set AUTOBOT_ALLOW_CONFIG_EDITS=1 for an intentional change."
+        )
+        logger.warning("[GH#11177] Blocked config-protection write to '%s' (tool '%s')", matched, tool_name)
+        execution_results.append(
+            {"tool": tool_name, "status": "error", "error": error, "config_protection": True}
+        )
+        return WorkflowMessage(
+            type="error",
+            content=error,
+            metadata={"tool": tool_name, "error": True, "config_protection": True},
+        )
+
     async def _dispatch_tool_call(
         self,
         tool_call: dict[str, Any],
@@ -2420,6 +2457,13 @@ class ToolHandlerMixin:
         forbidden_msg = self._enforce_forbidden_work(tool_call, ctx, execution_results)
         if forbidden_msg is not None:
             yield forbidden_msg
+            return
+
+        # GH#11177: block writes that would weaken a linter/formatter config at the
+        # same production seam — steer the agent to fix the code, not the gate.
+        config_msg = self._enforce_config_protection(tool_call, execution_results)
+        if config_msg is not None:
+            yield config_msg
             return
 
         if tool_name == "respond":

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_config_protection.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_config_protection.py
@@ -41,27 +41,21 @@ def test_blocks_write_to_config_via_params() -> None:
 def test_blocks_write_to_config_via_arguments() -> None:
     """MCP tools carry the path in `arguments`."""
     results: list[dict] = []
-    msg = _mixin()._enforce_config_protection(
-        {"name": "edit_file", "arguments": {"path": "ruff.toml"}}, results
-    )
+    msg = _mixin()._enforce_config_protection({"name": "edit_file", "arguments": {"path": "ruff.toml"}}, results)
     assert msg is not None
     assert "config-protection" in msg.content.lower()
 
 
 def test_allows_ordinary_write() -> None:
     results: list[dict] = []
-    msg = _mixin()._enforce_config_protection(
-        {"name": "write_file", "params": {"file_path": "src/app.ts"}}, results
-    )
+    msg = _mixin()._enforce_config_protection({"name": "write_file", "params": {"file_path": "src/app.ts"}}, results)
     assert msg is None
     assert results == []
 
 
 def test_allows_read_of_config() -> None:
     results: list[dict] = []
-    msg = _mixin()._enforce_config_protection(
-        {"name": "read_file", "params": {"file_path": ".eslintrc.json"}}, results
-    )
+    msg = _mixin()._enforce_config_protection({"name": "read_file", "params": {"file_path": ".eslintrc.json"}}, results)
     assert msg is None
 
 
@@ -76,7 +70,5 @@ def test_mixed_purpose_manifest_not_blocked() -> None:
 def test_env_optout_allows_config_write(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AUTOBOT_ALLOW_CONFIG_EDITS", "1")
     results: list[dict] = []
-    msg = _mixin()._enforce_config_protection(
-        {"name": "write_file", "params": {"file_path": ".prettierrc"}}, results
-    )
+    msg = _mixin()._enforce_config_protection({"name": "write_file", "params": {"file_path": ".prettierrc"}}, results)
     assert msg is None

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_config_protection.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_config_protection.py
@@ -1,0 +1,82 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Dispatch-level config-protection enforcement (GH#11177).
+
+Proves the config-protection guard (#11148) — previously only in the dead
+`AgentLoop` path — now fires on the real production tool-dispatch seam
+(`ToolHandlerMixin._dispatch_tool_call` via `_enforce_config_protection`). A
+write to a linter/formatter config is blocked before any handler runs; ordinary
+writes pass; `AUTOBOT_ALLOW_CONFIG_EDITS=1` opts out.
+"""
+
+import pytest
+
+from chat_workflow.tool_handler import ToolHandlerMixin
+
+
+def _mixin() -> ToolHandlerMixin:
+    return ToolHandlerMixin.__new__(ToolHandlerMixin)
+
+
+@pytest.fixture(autouse=True)
+def _no_optout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AUTOBOT_ALLOW_CONFIG_EDITS", raising=False)
+
+
+def test_blocks_write_to_config_via_params() -> None:
+    """Built-in write tools carry the path in `params`."""
+    results: list[dict] = []
+    msg = _mixin()._enforce_config_protection(
+        {"name": "write_file", "params": {"file_path": "frontend/.eslintrc.json"}}, results
+    )
+    assert msg is not None
+    assert msg.type == "error"
+    assert msg.metadata.get("config_protection") is True
+    assert results and results[0]["config_protection"] is True
+    assert results[0]["status"] == "error"
+
+
+def test_blocks_write_to_config_via_arguments() -> None:
+    """MCP tools carry the path in `arguments`."""
+    results: list[dict] = []
+    msg = _mixin()._enforce_config_protection(
+        {"name": "edit_file", "arguments": {"path": "ruff.toml"}}, results
+    )
+    assert msg is not None
+    assert "config-protection" in msg.content.lower()
+
+
+def test_allows_ordinary_write() -> None:
+    results: list[dict] = []
+    msg = _mixin()._enforce_config_protection(
+        {"name": "write_file", "params": {"file_path": "src/app.ts"}}, results
+    )
+    assert msg is None
+    assert results == []
+
+
+def test_allows_read_of_config() -> None:
+    results: list[dict] = []
+    msg = _mixin()._enforce_config_protection(
+        {"name": "read_file", "params": {"file_path": ".eslintrc.json"}}, results
+    )
+    assert msg is None
+
+
+def test_mixed_purpose_manifest_not_blocked() -> None:
+    results: list[dict] = []
+    msg = _mixin()._enforce_config_protection(
+        {"name": "write_file", "params": {"file_path": "pyproject.toml"}}, results
+    )
+    assert msg is None
+
+
+def test_env_optout_allows_config_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTOBOT_ALLOW_CONFIG_EDITS", "1")
+    results: list[dict] = []
+    msg = _mixin()._enforce_config_protection(
+        {"name": "write_file", "params": {"file_path": ".prettierrc"}}, results
+    )
+    assert msg is None

--- a/autobot_shared/config_guard.py
+++ b/autobot_shared/config_guard.py
@@ -1,0 +1,118 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Config-protection guard helpers (GH#11148 / GH#11177).
+
+Pure, dependency-free detection of write/edit/delete/move tool calls that target
+a linter or formatter config file — so the agent fixes the code to satisfy a
+quality gate instead of silently weakening the gate (e.g. adding an ``ignore``
+rule to ``.eslintrc`` or ``ruff.toml``).
+
+Lives in ``autobot_shared`` (not ``agent_loop``) so BOTH the agent loop
+(``agent_loop.config_protection``) and the production tool-dispatch seam
+(``chat_workflow.tool_handler``) can reuse it without importing the heavy
+``agent_loop`` package. Mixed-purpose manifests (``pyproject.toml``,
+``setup.cfg``) are intentionally NOT protected — they carry legitimate non-lint
+content. Override with ``AUTOBOT_ALLOW_CONFIG_EDITS=1``.
+"""
+
+import os
+
+# Write-side tools whose target path is guarded. Read/list tools are ignored.
+WRITE_TOOLS: frozenset[str] = frozenset(
+    {
+        "write_file",
+        "edit_file",
+        "multi_edit",
+        "apply_patch",
+        "create_file",
+        "delete_file",
+        "move_file",
+        "copy_file",
+    }
+)
+
+# Arg keys under which a write tool carries its target path (see
+# tools/parallel/analyzer.py RESOURCE_EXTRACTORS).
+PATH_KEYS: tuple[str, ...] = ("file_path", "path", "destination", "target_file")
+
+# Dedicated linter/formatter config basenames (exact, case-insensitive).
+_PROTECTED_BASENAMES: frozenset[str] = frozenset(
+    {
+        ".editorconfig",
+        ".pre-commit-config.yaml",
+        ".flake8",
+        "mypy.ini",
+        ".mypy.ini",
+        "ruff.toml",
+        ".ruff.toml",
+        ".isort.cfg",
+        ".pylintrc",
+        "tox.ini",
+        "eslint.config.js",
+        "eslint.config.cjs",
+        "eslint.config.mjs",
+        "prettier.config.js",
+        "prettier.config.cjs",
+        "prettier.config.mjs",
+        "commitlint.config.js",
+        "commitlint.config.cjs",
+        "commitlint.config.mjs",
+        "stylelint.config.js",
+        "biome.json",
+        "biome.jsonc",
+    }
+)
+
+# Basename prefixes covering the many dotfile variants (``.eslintrc.json``,
+# ``.prettierrc.yaml``, ``.markdownlint.json`` …).
+_PROTECTED_PREFIXES: tuple[str, ...] = (
+    ".eslintrc",
+    ".prettierrc",
+    ".stylelintrc",
+    ".markdownlint",
+)
+
+
+def is_protected_config(path: str | None) -> str | None:
+    """Return the matched config basename if *path* is a protected config, else None."""
+    if not path:
+        return None
+    base = os.path.basename(str(path).strip().rstrip("/\\"))
+    lower = base.lower()
+    if lower in _PROTECTED_BASENAMES:
+        return base
+    if any(lower.startswith(prefix) for prefix in _PROTECTED_PREFIXES):
+        return base
+    return None
+
+
+def config_edits_allowed() -> bool:
+    """True when ``AUTOBOT_ALLOW_CONFIG_EDITS`` opts out of the guard."""
+    return os.environ.get("AUTOBOT_ALLOW_CONFIG_EDITS", "").strip().lower() in {"1", "true", "yes"}
+
+
+def protected_config_for(tool_name: str, args: dict) -> str | None:
+    """Return the protected config basename a (name, args) write-call targets, else None.
+
+    The canonical entry point — callers that hold a tool name and its argument
+    dict directly (e.g. the production dispatch seam) use this; dict-shaped
+    callers use :func:`protected_config_write`.
+    """
+    if str(tool_name).lower() not in WRITE_TOOLS:
+        return None
+    if not isinstance(args, dict):
+        return None
+    for key in PATH_KEYS:
+        matched = is_protected_config(args.get(key))
+        if matched:
+            return matched
+    return None
+
+
+def protected_config_write(tool: dict) -> str | None:
+    """Return the protected config basename a write-tool call dict targets, else None."""
+    args = tool.get("args") or tool.get("arguments") or tool.get("parameters") or {}
+    return protected_config_for(tool.get("tool_name", ""), args)


### PR DESCRIPTION
## Thinking Path

Tracing the real production execution path (after the ECC research) revealed that **`AgentLoop` is never instantiated in production** — it's prototype/test-only. The live tool-dispatch seam is `ToolHandlerMixin._dispatch_tool_call`, where forbidden_work (#11145) already enforces via `_enforce_forbidden_work`. That means the config-protection guard shipped in #11148 — which lives only in `AgentLoop._check_config_protection` — **never fired in production**: an agent could weaken `.eslintrc`/`ruff.toml` through the live path unimpeded. This wires it into the real seam.

## What Changed

- **`autobot_shared/config_guard.py`** (new): the pure, dependency-free config-protection detection logic (moved out of `agent_loop/config_protection.py`, which can't be imported cheaply because `agent_loop/__init__.py` eagerly loads `AgentLoop`). Adds `protected_config_for(name, args)` — a name+args entry point for the production seam. Lives next to `url_safety.py`.
- **`autobot-backend/agent_loop/config_protection.py`**: now a thin re-export of the shared module — loop-side #11148 behaviour and all its tests unchanged (no logic duplication).
- **`autobot-backend/chat_workflow/tool_handler.py`**: new `_enforce_config_protection(tool_call, execution_results)`, wired into `_dispatch_tool_call` immediately after `_enforce_forbidden_work`, mirroring its `WorkflowMessage`/early-return shape. Reads the path from `params` (built-in tools) and `arguments` (MCP).

`AUTOBOT_ALLOW_CONFIG_EDITS=1` still opts out. No behaviour change for the plain chat agent editing normal files.

## Verification

```
$ python3 -m pytest tests/unit/chat_workflow/test_tool_handler_config_protection.py \
    tests/agent_loop/test_config_protection.py \
    tests/unit/chat_workflow/test_tool_handler_forbidden_work.py -q
40 passed in 1.06s
```

- 6 new seam tests: config write via `params` and `arguments` is blocked; ordinary writes, config *reads*, and `pyproject.toml` pass; env opt-out works.
- 28 loop-side #11148 tests still green through the re-export shim (backward compat).
- 6 forbidden-work seam tests still green (no regression to the adjacent guard).

**Deploy note:** this adds a new `autobot_shared` module — per the deploy runbook, resolve `autobot_shared` drift first when syncing, or the backend 502s on the missing import.

## Model Used

Claude Opus 4.8 (1M context)

Closes #11177
