### PR TITLE
fix(agent-loop,api): review hardening — fact-forcing realpath + import bounds (#11179)

### DIFF
--- a/autobot-backend/agent_loop/fact_forcing.py
+++ b/autobot-backend/agent_loop/fact_forcing.py
@@ -64,7 +64,10 @@ def _extract_path(tool: dict) -> str | None:
 
 
 def _norm(path: str) -> str:
-    return os.path.normpath(path.strip())
+    # realpath (not normpath) so a file read by relative path and edited by
+    # absolute path — or via a symlink — normalize to the SAME key and the read
+    # is credited (GH#11179). Resolves against the process CWD + symlinks.
+    return os.path.realpath(path.strip())
 
 
 def record_investigations(tools: list[dict], investigated: set[str]) -> None:

--- a/autobot-backend/api/agents_self_improvement.py
+++ b/autobot-backend/api/agents_self_improvement.py
@@ -36,6 +36,9 @@ _DEFAULT_MIN_CONFIDENCE = float(os.environ.get("AUTOBOT_KNOWLEDGE_EXPORT_MIN_CON
 # Max chars kept from untrusted imported free-text (mirrors the learned-template
 # sanitization limit in orchestration/orchestrator_prompts.py, #11060).
 _IMPORT_TEXT_MAX = int(os.environ.get("AUTOBOT_LEARNED_TEMPLATE_MAX", "500"))
+# Max failure patterns scanned for a knowledge export (explicit, not the store's
+# default 50) so a governance export doesn't silently omit patterns (GH#11179).
+_EXPORT_PATTERN_LIMIT = int(os.environ.get("AUTOBOT_KNOWLEDGE_EXPORT_PATTERN_LIMIT", "500"))
 
 # Module-level singletons initialized on first use
 _judge = None
@@ -176,7 +179,7 @@ async def export_agent_knowledge(
     strategy = await learner.get_learned_strategy(effective_type)
     strategy_resp = LearnedStrategyResponse(**strategy.__dict__) if strategy else None
 
-    patterns = await detector.list_known_patterns()
+    patterns = await detector.list_known_patterns(limit=_EXPORT_PATTERN_LIMIT)
     high_conf = [
         FailurePatternRecord(
             pattern_id=p.pattern_id,

--- a/autobot-backend/api/schemas_agent.py
+++ b/autobot-backend/api/schemas_agent.py
@@ -1942,9 +1942,12 @@ class LearnedKnowledgeImport(BaseModel):
     task_type: str
     best_approach: str
     best_prompt_template: str
-    avg_score: float = 0.0
-    sample_size: int = 0
-    confidence: float = 0.0
+    # GH#11179: bound the scoring fields so an import can't inject out-of-range
+    # values into the planner's strategy selection (symmetric with export's
+    # min_confidence ge/le).
+    avg_score: float = Field(default=0.0, ge=0.0, le=1.0)
+    sample_size: int = Field(default=0, ge=0)
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
     failure_patterns: List[str] = Field(default_factory=list)
 
 

--- a/autobot-backend/tests/agent_loop/test_fact_forcing.py
+++ b/autobot-backend/tests/agent_loop/test_fact_forcing.py
@@ -13,6 +13,7 @@ Acceptance criteria:
   - Off by default; enabled by config or AUTOBOT_FACT_FORCING=1.
 """
 
+import os
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -50,9 +51,10 @@ class TestRecordInvestigations:
             ],
             seen,
         )
-        assert "a/b.py" in seen
-        assert "c/d.py" in seen
-        assert "e/f.py" not in seen  # writes are not investigations
+        # Paths are stored realpath-normalized (GH#11179).
+        assert os.path.realpath("a/b.py") in seen
+        assert os.path.realpath("c/d.py") in seen
+        assert os.path.realpath("e/f.py") not in seen  # writes are not investigations
 
 
 class TestFirstUninvestigatedEdit:
@@ -62,7 +64,9 @@ class TestFirstUninvestigatedEdit:
 
     def test_investigated_edit_passes(self) -> None:
         tool = {"tool_name": "edit_file", "args": {"file_path": "x.py"}}
-        assert first_uninvestigated_edit(tool, {"x.py"}, exists_fn=lambda _p: True) is None
+        # The investigated set holds realpath-normalized paths (GH#11179).
+        seen = {os.path.realpath("x.py")}
+        assert first_uninvestigated_edit(tool, seen, exists_fn=lambda _p: True) is None
 
     def test_new_file_is_never_flagged(self) -> None:
         tool = {"tool_name": "write_file", "args": {"file_path": "new.py"}}

--- a/autobot-backend/tests/agent_loop/test_fact_forcing_realpath.py
+++ b/autobot-backend/tests/agent_loop/test_fact_forcing_realpath.py
@@ -21,12 +21,7 @@ def test_relative_read_then_absolute_edit_is_credited(tmp_path, monkeypatch) -> 
     # Read by RELATIVE path...
     record_investigations([{"tool_name": "read_file", "args": {"file_path": "mod.py"}}], seen)
     # ...edit by ABSOLUTE path — same real file, so not flagged.
-    assert (
-        first_uninvestigated_edit(
-            {"tool_name": "edit_file", "args": {"file_path": str(target)}}, seen
-        )
-        is None
-    )
+    assert first_uninvestigated_edit({"tool_name": "edit_file", "args": {"file_path": str(target)}}, seen) is None
 
 
 def test_symlink_read_then_target_edit_is_credited(tmp_path) -> None:
@@ -37,21 +32,13 @@ def test_symlink_read_then_target_edit_is_credited(tmp_path) -> None:
 
     seen: set[str] = set()
     record_investigations([{"tool_name": "read_file", "args": {"file_path": str(link)}}], seen)
-    assert (
-        first_uninvestigated_edit(
-            {"tool_name": "edit_file", "args": {"file_path": str(target)}}, seen
-        )
-        is None
-    )
+    assert first_uninvestigated_edit({"tool_name": "edit_file", "args": {"file_path": str(target)}}, seen) is None
 
 
 def test_unread_existing_file_still_blocked(tmp_path) -> None:
     target = tmp_path / "mod.py"
     target.write_text("x = 1\n", encoding="utf-8")
     # No read recorded → still flagged.
-    assert (
-        first_uninvestigated_edit(
-            {"tool_name": "edit_file", "args": {"file_path": str(target)}}, set()
-        )
-        == str(target)
+    assert first_uninvestigated_edit({"tool_name": "edit_file", "args": {"file_path": str(target)}}, set()) == str(
+        target
     )

--- a/autobot-backend/tests/agent_loop/test_fact_forcing_realpath.py
+++ b/autobot-backend/tests/agent_loop/test_fact_forcing_realpath.py
@@ -1,0 +1,57 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Fact-forcing path normalization via realpath (GH#11179).
+
+A file read by one path and edited by another that resolve to the SAME real
+file (relative vs absolute, or through a symlink) must credit the read and NOT
+block the edit. Previously `_norm` used `os.path.normpath` and mismatched.
+"""
+
+from agent_loop.fact_forcing import first_uninvestigated_edit, record_investigations
+
+
+def test_relative_read_then_absolute_edit_is_credited(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "mod.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    seen: set[str] = set()
+    # Read by RELATIVE path...
+    record_investigations([{"tool_name": "read_file", "args": {"file_path": "mod.py"}}], seen)
+    # ...edit by ABSOLUTE path — same real file, so not flagged.
+    assert (
+        first_uninvestigated_edit(
+            {"tool_name": "edit_file", "args": {"file_path": str(target)}}, seen
+        )
+        is None
+    )
+
+
+def test_symlink_read_then_target_edit_is_credited(tmp_path) -> None:
+    target = tmp_path / "mod.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    link = tmp_path / "link.py"
+    link.symlink_to(target)
+
+    seen: set[str] = set()
+    record_investigations([{"tool_name": "read_file", "args": {"file_path": str(link)}}], seen)
+    assert (
+        first_uninvestigated_edit(
+            {"tool_name": "edit_file", "args": {"file_path": str(target)}}, seen
+        )
+        is None
+    )
+
+
+def test_unread_existing_file_still_blocked(tmp_path) -> None:
+    target = tmp_path / "mod.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    # No read recorded → still flagged.
+    assert (
+        first_uninvestigated_edit(
+            {"tool_name": "edit_file", "args": {"file_path": str(target)}}, set()
+        )
+        == str(target)
+    )

--- a/autobot-backend/tests/api/test_knowledge_import_bounds.py
+++ b/autobot-backend/tests/api/test_knowledge_import_bounds.py
@@ -1,0 +1,48 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""LearnedKnowledgeImport numeric bounds (GH#11179).
+
+The import scoring fields must be range-bounded (symmetric with the export
+endpoint's min_confidence ge/le) so an admin import can't inject out-of-range
+values into the planner's strategy selection.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from api.schemas_agent import LearnedKnowledgeImport
+
+
+def _payload(**overrides):
+    base = dict(task_type="research", best_approach="a", best_prompt_template="t")
+    base.update(overrides)
+    return base
+
+
+def test_confidence_above_one_rejected() -> None:
+    with pytest.raises(ValidationError):
+        LearnedKnowledgeImport(**_payload(confidence=1.5))
+
+
+def test_confidence_below_zero_rejected() -> None:
+    with pytest.raises(ValidationError):
+        LearnedKnowledgeImport(**_payload(confidence=-0.1))
+
+
+def test_avg_score_out_of_range_rejected() -> None:
+    with pytest.raises(ValidationError):
+        LearnedKnowledgeImport(**_payload(avg_score=42.0))
+
+
+def test_negative_sample_size_rejected() -> None:
+    with pytest.raises(ValidationError):
+        LearnedKnowledgeImport(**_payload(sample_size=-1))
+
+
+def test_values_within_bounds_accepted() -> None:
+    model = LearnedKnowledgeImport(**_payload(confidence=0.9, avg_score=0.5, sample_size=3))
+    assert model.confidence == 0.9
+    assert model.avg_score == 0.5
+    assert model.sample_size == 3


### PR DESCRIPTION
## Thinking Path

The code review of the ECC guard-stack PRs (#11149, #11151) surfaced two MEDIUM correctness items and one LOW. This lands them as a focused hardening pass. Neither is a correctness-breaker on its own, but both harden live paths (the fact-forcing normalization is currently fail-safe but UX-degrading; the import bounds guard a live admin endpoint).

## What Changed

- **`agent_loop/fact_forcing.py`** — `_norm` now uses `os.path.realpath` instead of `os.path.normpath`. A file read by a relative (or symlinked) path and edited by its absolute path — or vice versa — now resolves to the **same** key, so the read is credited and the edit isn't wrongly blocked. (MEDIUM, #11149)
- **`api/schemas_agent.py`** — `LearnedKnowledgeImport` bounds `avg_score`/`confidence` to `[0.0, 1.0]` and `sample_size` to `>= 0`, symmetric with the export endpoint's `min_confidence` `ge/le`. Stops an admin import from injecting out-of-range scores into the planner's strategy selection. (MEDIUM, #11151)
- **`api/agents_self_improvement.py`** — `knowledge-export` now calls `list_known_patterns(limit=_EXPORT_PATTERN_LIMIT)` (env-tunable, default 500) instead of relying on the store's silent default of 50, so a governance export doesn't quietly omit patterns. (LOW, #11151)

Two existing `test_fact_forcing.py` unit assertions were updated to the corrected realpath contract (they had hard-coded the old relative-string normalization).

## Verification

```
$ python3 -m pytest tests/agent_loop/test_fact_forcing_realpath.py \
    tests/api/test_knowledge_import_bounds.py \
    tests/agent_loop/test_fact_forcing.py \
    tests/api/test_knowledge_export_import.py -q
26 passed in 3.55s
```

New tests prove: relative-read→absolute-edit and symlink-read→target-edit are credited (no false block) while an unread existing file is still blocked; import rejects `confidence>1`, `confidence<0`, `avg_score` out of range, and negative `sample_size`, and accepts in-range values.

## Model Used

Claude Opus 4.8 (1M context)

Closes #11179
