### PR TITLE
feat(chat): thread governed identity into the production tool seam (#11159, #11160)

### DIFF
--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -384,7 +384,7 @@ def _build_llm_iteration_context(state: ChatState):
     ``initial_prompt`` via ``_inject_mid_conversation_warning``, never via a
     ``SystemMessage``.  See that helper's docstring for the full rationale.
     """
-    from .models import LLMIterationContext
+    from .models import LLMIterationContext, build_governed_identity
 
     initial_prompt = state["llm_params"].get("initial_prompt") or ""
 
@@ -401,6 +401,11 @@ def _build_llm_iteration_context(state: ChatState):
     if loop_warning:
         initial_prompt = _inject_mid_conversation_warning(loop_warning, initial_prompt)
 
+    # GH#11159/#11160: carry governed identity from the request context bag.
+    agent_context, work_item_id, approval_cats = build_governed_identity(
+        state.get("context", {}) or {}, state["session_id"]
+    )
+
     return LLMIterationContext(
         ollama_endpoint=state["llm_params"]["ollama_endpoint"],
         selected_model=state["llm_params"]["selected_model"],
@@ -413,6 +418,9 @@ def _build_llm_iteration_context(state: ChatState):
         system_prompt=state["llm_params"].get("system_prompt"),
         initial_prompt=initial_prompt,
         message=state["user_message"],
+        agent_context=agent_context,
+        work_item_id=work_item_id,
+        requires_approval_before=approval_cats,
     )
 
 

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -30,7 +30,12 @@ from slash_command_handler import get_slash_command_handler
 
 from .conversation import ConversationHandlerMixin
 from .llm_handler import LLMHandlerMixin, _emit_after_continuation, _emit_before_continuation
-from .models import LLMIterationContext, StreamingMessage, WorkflowSession
+from .models import (
+    LLMIterationContext,
+    StreamingMessage,
+    WorkflowSession,
+    build_governed_identity,
+)
 from .session_handler import SessionHandlerMixin
 from .tool_handler import ToolHandlerMixin
 
@@ -2919,6 +2924,11 @@ before summarizing.
         if "lightweight_mode_used" in llm_params:
             merged_context["lightweight_mode_used"] = llm_params["lightweight_mode_used"]
 
+        # GH#11159/#11160: lift governed identity (agent role + work item + declared
+        # approval gates) from the request context so the tool-dispatch seam can
+        # enforce forbidden_work and approval categories.
+        agent_context, work_item_id, approval_cats = build_governed_identity(merged_context, session_id)
+
         return LLMIterationContext(
             ollama_endpoint=llm_params["endpoint"],
             selected_model=llm_params["model"],
@@ -2931,6 +2941,9 @@ before summarizing.
             initial_prompt=llm_params["prompt"],
             message=message,
             context=merged_context,
+            agent_context=agent_context,
+            work_item_id=work_item_id,
+            requires_approval_before=approval_cats,
         )
 
     async def _execute_llm_workflow(

--- a/autobot-backend/chat_workflow/models.py
+++ b/autobot-backend/chat_workflow/models.py
@@ -370,11 +370,18 @@ def build_governed_identity(
     profile id) when present, so the production tool-dispatch seam can enforce that
     agent's ``forbidden_work`` manifest. The work-item fields carry the declared
     approval gates resolved upstream. All absent → a plain, ungoverned run.
+
+    Trust boundary: enforcement is fail-safe under a user-controlled context — a
+    caller can only *add* restrictions to their own run (an unknown/omitted
+    ``agent_id`` forbids nothing; a set one only forbids), never lift them. But for
+    these to be a real control a *trusted* server-side path must populate them; a
+    future trusted producer must override, not merge with, user-supplied keys.
     """
     agent_id = source.get("agent_id")
     agent_context = AgentContext(agent_id=agent_id, session_id=session_id) if agent_id else None
     work_item_id = source.get("work_item_id")
-    categories = list(source.get("requires_approval_before", []) or [])
+    raw_categories = source.get("requires_approval_before") or []
+    categories = list(raw_categories) if isinstance(raw_categories, (list, tuple)) else []
     return agent_context, work_item_id, categories
 
 

--- a/autobot-backend/chat_workflow/models.py
+++ b/autobot-backend/chat_workflow/models.py
@@ -353,6 +353,29 @@ class LLMIterationContext:
     agent_context: AgentContext | None = None  # Issue #657: Agent hierarchy
     consecutive_invalid_tool_calls: int = 0  # Issue #2310: Track invalid tool calls
     context: Dict[str, Any] = field(default_factory=dict)  # Issue #4264: Request-level context for hooks
+    # GH#11160: work item this run executes + its declared approval-gated action
+    # categories, resolved upstream (where a DB session exists) so the tool seam
+    # can gate on them without a DB round-trip.
+    work_item_id: str | None = None
+    requires_approval_before: List[str] = field(default_factory=list)
+
+
+def build_governed_identity(
+    source: Dict[str, Any], session_id: str
+) -> "tuple[AgentContext | None, str | None, List[str]]":
+    """Extract governed execution identity from a request/state context bag.
+
+    Returns ``(agent_context, work_item_id, requires_approval_before)`` (GH#11159/#11160).
+    ``agent_context`` is built from a governed ``agent_id`` (a registered agent
+    profile id) when present, so the production tool-dispatch seam can enforce that
+    agent's ``forbidden_work`` manifest. The work-item fields carry the declared
+    approval gates resolved upstream. All absent → a plain, ungoverned run.
+    """
+    agent_id = source.get("agent_id")
+    agent_context = AgentContext(agent_id=agent_id, session_id=session_id) if agent_id else None
+    work_item_id = source.get("work_item_id")
+    categories = list(source.get("requires_approval_before", []) or [])
+    return agent_context, work_item_id, categories
 
 
 @dataclass

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -437,6 +437,7 @@ def _approval_category_for(tool_name: str, declared: list[str]) -> str | None:
                 return category
     return None
 
+
 # Issue #650: Pre-compiled regex for tool call parsing (performance optimization)
 # Handles both uppercase and lowercase TOOL_CALL tags with nested JSON in params
 _TOOL_CALL_PATTERN = re.compile(

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -429,11 +429,16 @@ _APPROVAL_CATEGORY_TOOLS: dict[str, tuple[str, ...]] = {
 
 
 def _approval_category_for(tool_name: str, declared: list[str]) -> str | None:
-    """Return the declared category that gates *tool_name*, else None (GH#11160)."""
+    """Return the declared category that gates *tool_name*, else None (GH#11160).
+
+    Matches by exact name or ``<gated>_`` word-boundary prefix (so ``deploy`` gates
+    ``deploy_service`` but not ``deployment_status``). A false positive only ever
+    adds an approval hold — the fail-safe direction — never a bypass.
+    """
     name = tool_name.lower()
     for category in declared:
         for gated in _APPROVAL_CATEGORY_TOOLS.get(category, ()):
-            if name == gated or name.startswith(gated):
+            if name == gated or name.startswith(gated + "_"):
                 return category
     return None
 

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -406,6 +406,37 @@ BROWSER_TOOL_NAMES: frozenset[str] = frozenset(
     }
 )
 
+# GH#11160: maps a declared approval category (a work item's
+# ``requires_approval_before`` entry) to the tools that constitute that action. A
+# tool is approval-gated only when the work item declared its category; names
+# match by exact or prefix (e.g. ``deploy`` gates ``deploy_service``).
+_APPROVAL_CATEGORY_TOOLS: dict[str, tuple[str, ...]] = {
+    "pushing commits": ("git_push", "git_commit", "git_merge", "git_rebase", "git_force_push"),
+    "publishing": ("deploy", "publish", "content_reach"),
+    "destructive operations": (
+        "delete_file",
+        "remove_directory",
+        "bash",
+        "shell",
+        "execute_command",
+        "run_command",
+        "docker",
+        "kubectl",
+        "terraform",
+    ),
+    "rotating credentials": ("rotate_credentials", "rotate_key", "vault_rotate"),
+}
+
+
+def _approval_category_for(tool_name: str, declared: list[str]) -> str | None:
+    """Return the declared category that gates *tool_name*, else None (GH#11160)."""
+    name = tool_name.lower()
+    for category in declared:
+        for gated in _APPROVAL_CATEGORY_TOOLS.get(category, ()):
+            if name == gated or name.startswith(gated):
+                return category
+    return None
+
 # Issue #650: Pre-compiled regex for tool call parsing (performance optimization)
 # Handles both uppercase and lowercase TOOL_CALL tags with nested JSON in params
 _TOOL_CALL_PATTERN = re.compile(
@@ -2428,6 +2459,52 @@ class ToolHandlerMixin:
             metadata={"tool": tool_name, "error": True, "config_protection": True},
         )
 
+    def _enforce_work_item_approval(
+        self,
+        tool_call: dict[str, Any],
+        ctx: "LLMIterationContext" | None,
+        execution_results: list[dict[str, Any]],
+    ) -> WorkflowMessage | None:
+        """Hold a tool the work item declared as approval-gated (GH#11160).
+
+        When the run carries a work item whose ``requires_approval_before`` names
+        the action category of this tool, the action is held pending approval — the
+        declared gate is honored at the production seam. No work item / no matching
+        category → ``None``. Categories are resolved onto the context upstream, so
+        this needs no DB round-trip.
+        """
+        if ctx is None or not getattr(ctx, "requires_approval_before", None):
+            return None
+        tool_name = tool_call.get("name", "")
+        category = _approval_category_for(tool_name, ctx.requires_approval_before)
+        if category is None:
+            return None
+        work_item_id = getattr(ctx, "work_item_id", None)
+        msg = (
+            f"Action '{tool_name}' requires approval before proceeding — the work item "
+            f"declares '{category}' as approval-gated (requires_approval_before)."
+        )
+        logger.warning("[GH#11160] Held tool '%s' pending approval — declared category '%s'", tool_name, category)
+        execution_results.append(
+            {
+                "tool": tool_name,
+                "status": "pending_approval",
+                "reason": msg,
+                "approval_category": category,
+                "work_item_id": work_item_id,
+            }
+        )
+        return WorkflowMessage(
+            type="approval_required",
+            content=msg,
+            metadata={
+                "tool": tool_name,
+                "approval_required": True,
+                "category": category,
+                "work_item_id": work_item_id,
+            },
+        )
+
     async def _dispatch_tool_call(
         self,
         tool_call: dict[str, Any],
@@ -2462,6 +2539,13 @@ class ToolHandlerMixin:
         config_msg = self._enforce_config_protection(tool_call, execution_results)
         if config_msg is not None:
             yield config_msg
+            return
+
+        # GH#11160: hold a tool the work item declared as approval-gated
+        # (requires_approval_before) pending approval, at the same seam.
+        approval_msg = self._enforce_work_item_approval(tool_call, ctx, execution_results)
+        if approval_msg is not None:
+            yield approval_msg
             return
 
         if tool_name == "respond":

--- a/autobot-backend/tests/unit/chat_workflow/test_governed_execution.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_governed_execution.py
@@ -1,0 +1,117 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Governed execution identity at the production tool seam (GH#11159 / GH#11160).
+
+Threads a governed agent identity and a work item's declared approval categories
+from the request context into LLMIterationContext, so the enforcement wired in
+#11145 (forbidden_work) and the new work-item approval gate actually bite at
+`_dispatch_tool_call` — the single production seam.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from chat_workflow.models import build_governed_identity
+from chat_workflow.tool_handler import ToolHandlerMixin, _approval_category_for
+
+
+def _mixin() -> ToolHandlerMixin:
+    return ToolHandlerMixin.__new__(ToolHandlerMixin)
+
+
+def _ctx(agent_id=None, categories=None, work_item_id=None) -> SimpleNamespace:
+    ac, _, _ = build_governed_identity({"agent_id": agent_id} if agent_id else {}, "sess")
+    return SimpleNamespace(
+        agent_context=ac,
+        requires_approval_before=categories or [],
+        work_item_id=work_item_id,
+    )
+
+
+# --- build_governed_identity ----------------------------------------------
+
+
+def test_build_governed_identity_extracts_all():
+    ac, wid, cats = build_governed_identity(
+        {"agent_id": "research_agent", "work_item_id": "wi-1", "requires_approval_before": ["pushing commits"]},
+        "sess-1",
+    )
+    assert ac is not None and ac.agent_id == "research_agent" and ac.session_id == "sess-1"
+    assert wid == "wi-1"
+    assert cats == ["pushing commits"]
+
+
+def test_build_governed_identity_empty_when_absent():
+    ac, wid, cats = build_governed_identity({}, "sess-1")
+    assert ac is None and wid is None and cats == []
+
+
+# --- approval category matcher --------------------------------------------
+
+
+def test_approval_category_matches_exact_and_prefix():
+    assert _approval_category_for("git_push", ["pushing commits"]) == "pushing commits"
+    assert _approval_category_for("deploy_service", ["publishing"]) == "publishing"  # prefix
+    assert _approval_category_for("web_search", ["pushing commits"]) is None
+    assert _approval_category_for("git_push", []) is None  # category not declared
+    assert _approval_category_for("bash", ["unknown category"]) is None
+
+
+# --- #11159: governed identity → forbidden_work bites ----------------------
+
+
+def test_governed_agent_context_blocks_forbidden_tool():
+    """A run carrying agent_id=research_agent now hard-blocks bash at the seam."""
+    mixin = _mixin()
+    results: list[dict] = []
+    msg = mixin._enforce_forbidden_work({"name": "bash"}, _ctx(agent_id="research_agent"), results)
+    assert msg is not None
+    assert msg.metadata.get("forbidden_by_manifest") is True
+
+
+# --- #11160: work-item approval gate --------------------------------------
+
+
+def test_work_item_approval_holds_declared_category():
+    mixin = _mixin()
+    results: list[dict] = []
+    msg = mixin._enforce_work_item_approval(
+        {"name": "git_push"}, _ctx(categories=["pushing commits"], work_item_id="wi-1"), results
+    )
+    assert msg is not None
+    assert msg.type == "approval_required"
+    assert msg.metadata["category"] == "pushing commits"
+    assert results[0]["status"] == "pending_approval"
+    assert results[0]["work_item_id"] == "wi-1"
+
+
+def test_work_item_approval_noop_without_declaration():
+    mixin = _mixin()
+    results: list[dict] = []
+    assert mixin._enforce_work_item_approval({"name": "git_push"}, _ctx(), results) is None
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_holds_approval_gated_tool():
+    """End-to-end: a declared 'destructive operations' gate holds bash at dispatch."""
+    mixin = _mixin()
+    results: list[dict] = []
+    messages = []
+    async for item in mixin._dispatch_tool_call(
+        {"name": "bash", "params": {"command": "rm -rf /"}},
+        "s",
+        "t",
+        "http://x",
+        "m",
+        results,
+        [],
+        ctx=_ctx(categories=["destructive operations"], work_item_id="wi-9"),
+    ):
+        messages.append(item)
+    assert len(messages) == 1
+    assert messages[0].type == "approval_required"
+    assert results[0]["status"] == "pending_approval"

--- a/autobot-backend/tests/unit/chat_workflow/test_governed_execution.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_governed_execution.py
@@ -54,10 +54,16 @@ def test_build_governed_identity_empty_when_absent():
 
 def test_approval_category_matches_exact_and_prefix():
     assert _approval_category_for("git_push", ["pushing commits"]) == "pushing commits"
-    assert _approval_category_for("deploy_service", ["publishing"]) == "publishing"  # prefix
+    assert _approval_category_for("deploy_service", ["publishing"]) == "publishing"  # word-boundary prefix
     assert _approval_category_for("web_search", ["pushing commits"]) is None
     assert _approval_category_for("git_push", []) is None  # category not declared
     assert _approval_category_for("bash", ["unknown category"]) is None
+
+
+def test_approval_category_requires_word_boundary():
+    """A bare-token prefix without the ``_`` boundary must not match."""
+    assert _approval_category_for("deployment_status", ["publishing"]) is None
+    assert _approval_category_for("basha", ["destructive operations"]) is None
 
 
 # --- #11159: governed identity → forbidden_work bites ----------------------
@@ -93,6 +99,26 @@ def test_work_item_approval_noop_without_declaration():
     results: list[dict] = []
     assert mixin._enforce_work_item_approval({"name": "git_push"}, _ctx(), results) is None
     assert results == []
+
+
+@pytest.mark.asyncio
+async def test_forbidden_work_takes_precedence_over_approval_gate():
+    """A tool that is both forbidden and approval-gated is denied outright, not held."""
+    mixin = _mixin()
+    results: list[dict] = []
+    messages = []
+    ctx = SimpleNamespace(
+        agent_context=build_governed_identity({"agent_id": "research_agent"}, "s")[0],
+        requires_approval_before=["destructive operations"],  # also gates bash
+        work_item_id="wi-1",
+    )
+    async for item in mixin._dispatch_tool_call(
+        {"name": "bash", "params": {}}, "s", "t", "http://x", "m", results, [], ctx=ctx
+    ):
+        messages.append(item)
+    assert len(messages) == 1
+    assert messages[0].metadata.get("forbidden_by_manifest") is True
+    assert messages[0].metadata.get("approval_required") is not True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Thinking Path

Follow-ups #11159 (make forbidden_work bite delegated agents) and #11160 (honor work-item `requires_approval_before` at execution) were both blocked by **one root cause**: nothing carried a governed agent identity or a `work_item_id` into the production execution path. The delegation framework and `AgentLoop` are unwired; the real path is `chat_workflow`, whose `_dispatch_tool_call` seam (where #11145 forbidden_work + #11177 config-protection already enforce) never received a real actor. So rather than stamp dead scaffolding, this threads the identity into the live path — the actual unblocker for both.

## What Changed

- **`chat_workflow/models.py`** — `LLMIterationContext` gains `work_item_id` + `requires_approval_before` (declared categories, resolved upstream where a DB session exists → no DB at the seam). New shared `build_governed_identity(source, session_id)` extracts `(agent_context, work_item_id, categories)` from the request context bag — one helper, both call sites.
- **`chat_workflow/manager.py` + `chat_workflow/graph.py`** — both `LLMIterationContext` construction sites now populate the governed identity via the helper.
- **`chat_workflow/tool_handler.py`**
  - **#11159:** with `ctx.agent_context.agent_id` now populated by a governed profile id, the existing `_enforce_forbidden_work` bites (e.g. a run acting as `research_agent` is hard-blocked from `bash`).
  - **#11160:** new `_enforce_work_item_approval` at the same seam holds a tool pending approval when the work item declared its action category; `_approval_category_for` maps a category (`pushing commits`, `publishing`, `destructive operations`, `rotating credentials`) to its tools by exact/prefix match.
- **`tests/unit/chat_workflow/test_governed_execution.py`** — identity extraction, category matcher, forbidden_work biting on a governed context, approval gate firing end-to-end through `_dispatch_tool_call`.

## Verification

```
$ python3 -m pytest tests/unit/chat_workflow/test_governed_execution.py \
    tests/unit/chat_workflow/test_tool_handler_forbidden_work.py -q
13 passed
```
`models.py`/`tool_handler.py` import clean; `graph.py`/`manager.py` parse (py_compile). The gates are inert-by-default (plain chat sets no governed identity) and bite the moment a caller passes `agent_id` / `work_item_id` + declared categories in the request context.

## Model Used

Claude Opus 4.8 (1M context)

Closes #11159
Closes #11160