### PR TITLE
feat(analytics): capture in-repo traceback frames into FailurePattern (#11182)

### DIFF
--- a/autobot-backend/orchestration/workflow_runner.py
+++ b/autobot-backend/orchestration/workflow_runner.py
@@ -21,9 +21,11 @@ Moved from enhanced_orchestration.workflow_runner to orchestration.workflow_runn
 import asyncio
 import os
 import time
+import traceback
 from typing import Any, Dict, List, Set, Tuple
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.repo_path import to_repo_relative
 from autobot_shared.ssot_config import SELF_IMPROVEMENT_ENABLED
 from events.bus import PersistStrategy, publish_event
 
@@ -71,6 +73,33 @@ from orchestration.types import AgentTask, WorkflowDependencies, WorkflowPlan
 from orchestration.workflow_planning import StrategyPlanner
 
 logger = get_logger("workflow_runner")
+
+# Maximum in-repo frames to retain (innermost / "blame" frames).
+_MAX_FAILURE_FRAMES = 5
+
+
+def _extract_failure_locations(error: Exception) -> list[dict]:
+    """Extract in-repo traceback frames from *error* for pattern storage (#11182).
+
+    Returns at most ``_MAX_FAILURE_FRAMES`` innermost in-repo frames as a list
+    of dicts with keys ``file``, ``line``, ``func``.  Frames from stdlib,
+    site-packages, or venvs are excluded.  Returns ``[]`` if the traceback is
+    absent or extraction fails — never raises.
+    """
+    try:
+        tb = error.__traceback__
+        if tb is None:
+            return []
+        frames = traceback.extract_tb(tb)
+        in_repo = []
+        for f in frames:
+            rel = to_repo_relative(f.filename)
+            if rel is not None:
+                in_repo.append({"file": rel, "line": f.lineno, "func": f.name})
+        return in_repo[-_MAX_FAILURE_FRAMES:]
+    except Exception as exc:
+        logger.debug("Frame extraction failed (non-fatal): %s", exc)
+        return []
 
 
 class WorkflowRunner:
@@ -433,7 +462,8 @@ class WorkflowRunner:
             causal_chain = f"workflow:{plan.strategy.value}:{error_type}"
             detector = get_pattern_detector()
             known = await detector.detect_pattern(causal_chain, error_type)
-            await detector.learn_pattern(causal_chain, error_type)
+            locations = _extract_failure_locations(error)
+            await detector.learn_pattern(causal_chain, error_type, failure_locations=locations)
             if known and known.occurrence_count > 0:
                 return {
                     "pattern_id": known.pattern_id,

--- a/autobot-backend/services/failure_pattern_detector.py
+++ b/autobot-backend/services/failure_pattern_detector.py
@@ -49,6 +49,10 @@ class FailurePattern:
     confidence: float = 0.8  # How confident in this pattern's recovery strategy
     first_seen: str = field(default_factory=lambda: now_utc().isoformat())
     last_seen: str = field(default_factory=lambda: now_utc().isoformat())
+    # In-repo traceback frames captured when the pattern was first recorded
+    # (#11182).  Each entry: {"file": <repo-relative str>, "line": int,
+    # "func": str}.  Empty list for patterns recorded before this field existed.
+    failure_locations: List[Dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to dict."""
@@ -62,6 +66,7 @@ class FailurePattern:
             "confidence": self.confidence,
             "first_seen": self.first_seen,
             "last_seen": self.last_seen,
+            "failure_locations": self.failure_locations,
         }
 
     @classmethod
@@ -77,6 +82,7 @@ class FailurePattern:
             confidence=data.get("confidence", 0.8),
             first_seen=data.get("first_seen", ""),
             last_seen=data.get("last_seen", ""),
+            failure_locations=data.get("failure_locations", []),
         )
 
 
@@ -148,6 +154,7 @@ class FailurePatternDetector(AsyncRedisClientMixin):
         causal_chain: str,
         error_type: str,
         successful_action: str | None = None,
+        failure_locations: List[Dict[str, Any]] | None = None,
     ) -> FailurePattern:
         """
         Learn/update a pattern from error experience.
@@ -156,6 +163,8 @@ class FailurePatternDetector(AsyncRedisClientMixin):
             causal_chain: The causal chain
             error_type: The error type
             successful_action: If provided, update resolution stats
+            failure_locations: In-repo traceback frames from the error (#11182).
+                Stored only on the first occurrence; ignored on subsequent ones.
 
         Returns:
             Updated FailurePattern
@@ -174,6 +183,9 @@ class FailurePatternDetector(AsyncRedisClientMixin):
                     pattern = self._create_new_pattern(pattern_hash, causal_chain)
             else:
                 pattern = self._create_new_pattern(pattern_hash, causal_chain)
+                # Attach locations on first-time recording only.
+                if failure_locations:
+                    pattern.failure_locations = failure_locations
 
             if error_type not in pattern.error_types:
                 pattern.error_types.append(error_type)

--- a/autobot-backend/tests/orchestration/test_failure_locations.py
+++ b/autobot-backend/tests/orchestration/test_failure_locations.py
@@ -20,7 +20,6 @@ from unittest.mock import patch
 from orchestration.workflow_runner import _MAX_FAILURE_FRAMES, _extract_failure_locations
 from services.failure_pattern_detector import FailurePattern
 
-
 # ---------------------------------------------------------------------------
 # FailurePattern serialisation round-trip
 # ---------------------------------------------------------------------------
@@ -37,9 +36,7 @@ def _sample_pattern(**overrides) -> FailurePattern:
         "confidence": 0.8,
         "first_seen": "2026-01-01T00:00:00",
         "last_seen": "2026-01-02T00:00:00",
-        "failure_locations": [
-            {"file": "autobot-backend/services/x.py", "line": 42, "func": "run"}
-        ],
+        "failure_locations": [{"file": "autobot-backend/services/x.py", "line": 42, "func": "run"}],
     }
     base.update(overrides)
     return FailurePattern(**base)

--- a/autobot-backend/tests/orchestration/test_failure_locations.py
+++ b/autobot-backend/tests/orchestration/test_failure_locations.py
@@ -1,0 +1,184 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for FailurePattern.failure_locations field and frame extraction (#11182).
+
+Covers:
+- FailurePattern round-trip serialisation (to_dict / from_dict).
+- Backward compatibility: from_dict on old records without failure_locations.
+- _extract_failure_locations: keeps in-repo frames, drops out-of-repo frames,
+  caps at _MAX_FAILURE_FRAMES, is defensive when __traceback__ is None.
+"""
+
+from __future__ import annotations
+
+import traceback
+from typing import Any, Dict
+from unittest.mock import patch
+
+from orchestration.workflow_runner import _MAX_FAILURE_FRAMES, _extract_failure_locations
+from services.failure_pattern_detector import FailurePattern
+
+
+# ---------------------------------------------------------------------------
+# FailurePattern serialisation round-trip
+# ---------------------------------------------------------------------------
+
+
+def _sample_pattern(**overrides) -> FailurePattern:
+    base: Dict[str, Any] = {
+        "pattern_id": "abc123",
+        "causal_chain": "workflow:sequential:ValueError",
+        "error_types": ["ValueError"],
+        "occurrence_count": 2,
+        "successful_resolutions": [],
+        "resolution_success_rate": 0.0,
+        "confidence": 0.8,
+        "first_seen": "2026-01-01T00:00:00",
+        "last_seen": "2026-01-02T00:00:00",
+        "failure_locations": [
+            {"file": "autobot-backend/services/x.py", "line": 42, "func": "run"}
+        ],
+    }
+    base.update(overrides)
+    return FailurePattern(**base)
+
+
+def test_round_trip_preserves_failure_locations() -> None:
+    """from_dict(to_dict(p)) reproduces failure_locations exactly."""
+    p = _sample_pattern()
+    restored = FailurePattern.from_dict(p.to_dict())
+    assert restored.failure_locations == p.failure_locations
+
+
+def test_round_trip_empty_failure_locations() -> None:
+    """Empty failure_locations round-trips correctly."""
+    p = _sample_pattern(failure_locations=[])
+    restored = FailurePattern.from_dict(p.to_dict())
+    assert restored.failure_locations == []
+
+
+def test_from_dict_backward_compat_missing_field() -> None:
+    """Old records without failure_locations deserialise to an empty list."""
+    old_dict = {
+        "pattern_id": "old1",
+        "causal_chain": "workflow:parallel:RuntimeError",
+        "error_types": ["RuntimeError"],
+        "occurrence_count": 5,
+        "successful_resolutions": ["retry"],
+        "resolution_success_rate": 0.2,
+        "confidence": 0.75,
+        "first_seen": "2025-12-01T00:00:00",
+        "last_seen": "2025-12-15T00:00:00",
+        # failure_locations intentionally absent
+    }
+    p = FailurePattern.from_dict(old_dict)
+    assert p.failure_locations == []
+
+
+def test_to_dict_includes_failure_locations_key() -> None:
+    """to_dict() always emits the failure_locations key."""
+    p = _sample_pattern()
+    d = p.to_dict()
+    assert "failure_locations" in d
+    assert d["failure_locations"] == p.failure_locations
+
+
+# ---------------------------------------------------------------------------
+# _extract_failure_locations helper
+# ---------------------------------------------------------------------------
+
+
+def _in_repo_raiser() -> None:
+    """Helper that actually raises so we have a real traceback with frames."""
+    raise ValueError("test failure")
+
+
+def test_extract_returns_in_repo_frames() -> None:
+    """In-repo frames (repo-relative) appear in the extracted locations.
+
+    We patch to_repo_relative so that frames from *this test file* are treated
+    as in-repo (returns a fake repo-relative path) while everything else is
+    out-of-repo (returns None).
+    """
+    try:
+        _in_repo_raiser()
+    except ValueError as exc:
+        raw_frames = traceback.extract_tb(exc.__traceback__)
+        # Identify which filenames appear in our traceback
+        test_file = raw_frames[-1].filename  # innermost frame = _in_repo_raiser
+
+        def _fake_to_repo_relative(path: str) -> str | None:
+            if path == test_file:
+                return f"autobot-backend/tests/fake/{path.split('/')[-1]}"
+            return None
+
+        with patch(
+            "orchestration.workflow_runner.to_repo_relative",
+            side_effect=_fake_to_repo_relative,
+        ):
+            locations = _extract_failure_locations(exc)
+
+    assert len(locations) >= 1
+    innermost = locations[-1]
+    assert "file" in innermost
+    assert "line" in innermost
+    assert "func" in innermost
+    assert innermost["func"] == "_in_repo_raiser"
+
+
+def test_extract_drops_out_of_repo_frames() -> None:
+    """Frames where to_repo_relative returns None are excluded."""
+    try:
+        _in_repo_raiser()
+    except ValueError as exc:
+        with patch(
+            "orchestration.workflow_runner.to_repo_relative",
+            return_value=None,  # all frames look out-of-repo
+        ):
+            locations = _extract_failure_locations(exc)
+
+    assert locations == []
+
+
+def test_extract_caps_at_max_frames() -> None:
+    """At most _MAX_FAILURE_FRAMES frames are returned."""
+
+    def _make_deep_error(depth: int) -> Exception:
+        if depth <= 0:
+            raise RuntimeError("deep")
+        _make_deep_error(depth - 1)
+
+    try:
+        _make_deep_error(_MAX_FAILURE_FRAMES + 5)
+    except RuntimeError as exc:
+        with patch(
+            "orchestration.workflow_runner.to_repo_relative",
+            return_value="autobot-backend/fake.py",
+        ):
+            locations = _extract_failure_locations(exc)
+
+    assert len(locations) <= _MAX_FAILURE_FRAMES
+
+
+def test_extract_none_traceback_returns_empty_list() -> None:
+    """Exception with no traceback (e.g. raised outside a try) returns []."""
+    exc = ValueError("no tb")
+    assert exc.__traceback__ is None
+    locations = _extract_failure_locations(exc)
+    assert locations == []
+
+
+def test_extract_is_defensive_on_extractor_error() -> None:
+    """If frame extraction itself raises, an empty list is returned, not an exception."""
+    try:
+        _in_repo_raiser()
+    except ValueError as exc:
+        with patch(
+            "orchestration.workflow_runner.to_repo_relative",
+            side_effect=RuntimeError("broken"),
+        ):
+            locations = _extract_failure_locations(exc)
+
+    assert locations == []

--- a/autobot-backend/tests/orchestration/test_failure_pattern_wiring.py
+++ b/autobot-backend/tests/orchestration/test_failure_pattern_wiring.py
@@ -32,7 +32,7 @@ class _FakeDetector:
             return None
         return types.SimpleNamespace(pattern_id="p1", occurrence_count=self.prior, resolution_success_rate=0.5)
 
-    async def learn_pattern(self, causal_chain: str, error_type: str, successful_action=None):
+    async def learn_pattern(self, causal_chain: str, error_type: str, successful_action=None, failure_locations=None):
         self.learned.append((causal_chain, error_type))
         return None
 

--- a/autobot_shared/repo_path.py
+++ b/autobot_shared/repo_path.py
@@ -1,0 +1,91 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Repo-relative path normalizer (#11182).
+
+Converts absolute runtime paths (from tracebacks) to repo-relative POSIX
+paths that can be joined against the codebase for source mapping.
+
+Usage::
+
+    from autobot_shared.repo_path import to_repo_relative
+
+    rel = to_repo_relative("/opt/autobot/code_source/autobot-backend/services/x.py")
+    # → "autobot-backend/services/x.py"
+"""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath, PureWindowsPath
+
+# Out-of-repo markers: paths containing any of these segments are stdlib /
+# third-party and must be excluded from in-repo traceback frames.
+_OUT_OF_REPO_MARKERS: tuple[str, ...] = (
+    "/usr/",
+    "/lib/python",
+    "site-packages",
+    "dist-packages",
+    "/.venv/",
+    "/venv/",
+    "/.tox/",
+)
+
+# Canonical segment that marks the repo root in production paths.
+_CODE_SOURCE_SEGMENT = "code_source/"
+
+
+def to_repo_relative(path: str) -> str | None:
+    """Return a repo-relative POSIX path, or None if the path is out-of-repo.
+
+    Anchor logic (applied in order):
+    1. If the path contains ``code_source/``, strip everything up to and
+       including that segment — covers production paths such as
+       ``/opt/autobot/code_source/autobot-backend/services/x.py``.
+    2. If the path matches a known out-of-repo marker (stdlib, venv,
+       site-packages …), return ``None``.
+    3. Normalise OS separators to POSIX.  If the result already looks
+       repo-relative (does not start with ``/`` or a Windows drive), return
+       it as-is.
+    4. Otherwise return ``None`` — the path is absolute but not anchored.
+
+    Args:
+        path: Absolute or relative filesystem path from a traceback frame.
+
+    Returns:
+        Repo-relative POSIX string (e.g. ``"autobot-backend/services/x.py"``),
+        or ``None`` when the path is outside the repo (stdlib, venv, etc.).
+    """
+    if not path:
+        return None
+
+    # Normalise Windows backslashes to forward slashes.
+    normalised = path.replace("\\", "/")
+
+    # 1. Production code_source anchor.
+    if _CODE_SOURCE_SEGMENT in normalised:
+        idx = normalised.index(_CODE_SOURCE_SEGMENT) + len(_CODE_SOURCE_SEGMENT)
+        rel = normalised[idx:]
+        return rel if rel else None
+
+    # 2. Out-of-repo markers.
+    for marker in _OUT_OF_REPO_MARKERS:
+        if marker in normalised:
+            return None
+
+    # 3. Already repo-relative (no leading slash, no Windows drive letter).
+    posix = PurePosixPath(normalised)
+    if not posix.is_absolute():
+        # Reject Windows-drive-absolute paths like "C:/..."
+        try:
+            PureWindowsPath(normalised).drive  # non-empty means drive-absolute
+            if PureWindowsPath(normalised).drive:
+                return None
+        except Exception:
+            pass
+        # Canonicalize: drop leading "./" and interior "." segments so a path
+        # like "./autobot-backend/x.py" joins against "autobot-backend/x.py".
+        return posix.as_posix()
+
+    # 4. Absolute but no known anchor → out-of-repo.
+    return None

--- a/autobot_shared/repo_path_test.py
+++ b/autobot_shared/repo_path_test.py
@@ -14,9 +14,7 @@ class TestToRepoRelative:
 
     def test_production_code_source_absolute_path(self) -> None:
         """Absolute prod path under code_source/ is stripped to repo-relative."""
-        result = to_repo_relative(
-            "/opt/autobot/code_source/autobot-backend/services/x.py"
-        )
+        result = to_repo_relative("/opt/autobot/code_source/autobot-backend/services/x.py")
         assert result == "autobot-backend/services/x.py"
 
     def test_already_relative_path_returned_unchanged(self) -> None:
@@ -40,30 +38,22 @@ class TestToRepoRelative:
 
     def test_site_packages_returns_none(self) -> None:
         """A site-packages path is third-party and must return None."""
-        result = to_repo_relative(
-            "/usr/local/lib/python3.11/site-packages/fastapi/routing.py"
-        )
+        result = to_repo_relative("/usr/local/lib/python3.11/site-packages/fastapi/routing.py")
         assert result is None
 
     def test_venv_path_returns_none(self) -> None:
         """A path inside a .venv is out-of-repo and must return None."""
-        result = to_repo_relative(
-            "/home/user/project/.venv/lib/python3.11/site-packages/starlette/apps.py"
-        )
+        result = to_repo_relative("/home/user/project/.venv/lib/python3.11/site-packages/starlette/apps.py")
         assert result is None
 
     def test_windows_backslash_separator_normalised(self) -> None:
         """Backslash separators are converted to forward slashes before matching."""
-        result = to_repo_relative(
-            "autobot-backend\\services\\failure_pattern_detector.py"
-        )
+        result = to_repo_relative("autobot-backend\\services\\failure_pattern_detector.py")
         assert result == "autobot-backend/services/failure_pattern_detector.py"
 
     def test_code_source_with_nested_segments(self) -> None:
         """code_source/ anchor works even when prefix contains multiple path components."""
-        result = to_repo_relative(
-            "/srv/deploy/release/code_source/autobot_shared/repo_path.py"
-        )
+        result = to_repo_relative("/srv/deploy/release/code_source/autobot_shared/repo_path.py")
         assert result == "autobot_shared/repo_path.py"
 
     def test_empty_string_returns_none(self) -> None:

--- a/autobot_shared/repo_path_test.py
+++ b/autobot_shared/repo_path_test.py
@@ -1,0 +1,82 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for autobot_shared.repo_path.to_repo_relative (#11182)."""
+
+from __future__ import annotations
+
+from autobot_shared.repo_path import to_repo_relative
+
+
+class TestToRepoRelative:
+    """Tests for to_repo_relative()."""
+
+    def test_production_code_source_absolute_path(self) -> None:
+        """Absolute prod path under code_source/ is stripped to repo-relative."""
+        result = to_repo_relative(
+            "/opt/autobot/code_source/autobot-backend/services/x.py"
+        )
+        assert result == "autobot-backend/services/x.py"
+
+    def test_already_relative_path_returned_unchanged(self) -> None:
+        """A path without a leading slash is returned as-is."""
+        result = to_repo_relative("autobot-backend/services/x.py")
+        assert result == "autobot-backend/services/x.py"
+
+    def test_dot_slash_prefix_canonicalised(self) -> None:
+        """A "./"-prefixed relative path is canonicalised so it joins with the
+        code_source-stripped form (#11182 join-key equality)."""
+        assert to_repo_relative("./autobot-backend/services/x.py") == "autobot-backend/services/x.py"
+        # Equal to the production absolute form after normalization.
+        assert to_repo_relative("./autobot-backend/services/x.py") == to_repo_relative(
+            "/opt/autobot/code_source/autobot-backend/services/x.py"
+        )
+
+    def test_stdlib_path_returns_none(self) -> None:
+        """A stdlib path is out-of-repo and must return None."""
+        result = to_repo_relative("/usr/lib/python3.10/json/__init__.py")
+        assert result is None
+
+    def test_site_packages_returns_none(self) -> None:
+        """A site-packages path is third-party and must return None."""
+        result = to_repo_relative(
+            "/usr/local/lib/python3.11/site-packages/fastapi/routing.py"
+        )
+        assert result is None
+
+    def test_venv_path_returns_none(self) -> None:
+        """A path inside a .venv is out-of-repo and must return None."""
+        result = to_repo_relative(
+            "/home/user/project/.venv/lib/python3.11/site-packages/starlette/apps.py"
+        )
+        assert result is None
+
+    def test_windows_backslash_separator_normalised(self) -> None:
+        """Backslash separators are converted to forward slashes before matching."""
+        result = to_repo_relative(
+            "autobot-backend\\services\\failure_pattern_detector.py"
+        )
+        assert result == "autobot-backend/services/failure_pattern_detector.py"
+
+    def test_code_source_with_nested_segments(self) -> None:
+        """code_source/ anchor works even when prefix contains multiple path components."""
+        result = to_repo_relative(
+            "/srv/deploy/release/code_source/autobot_shared/repo_path.py"
+        )
+        assert result == "autobot_shared/repo_path.py"
+
+    def test_empty_string_returns_none(self) -> None:
+        """Empty string must return None, not raise."""
+        assert to_repo_relative("") is None
+
+    def test_absolute_path_without_anchor_returns_none(self) -> None:
+        """An absolute path with no code_source/ segment and no out-of-repo marker
+        still returns None — we cannot safely derive a repo root from it."""
+        result = to_repo_relative("/some/unknown/absolute/path.py")
+        assert result is None
+
+    def test_dist_packages_returns_none(self) -> None:
+        """dist-packages is treated as out-of-repo."""
+        result = to_repo_relative("/usr/lib/python3/dist-packages/pkg/mod.py")
+        assert result is None


### PR DESCRIPTION
## Thinking Path
Task 1 (rank static findings by runtime failure) needs a runtime→file join key, but investigation showed none exists: `causal_chain` is abstract and the exception traceback is discarded. This PR (Task 1a of epic #11170) manufactures the key by capturing in-repo traceback frames onto `FailurePattern`, and ships the shared path normalizer both 1a and 1b depend on.

## What Changed
- **`autobot_shared/repo_path.py`** (new): `to_repo_relative(path) -> str | None`. Strips up to/including a `code_source/` segment (prod paths), returns `None` for stdlib/site-packages/venv, canonicalizes already-relative paths (drops `./` so they join with the stripped form), rejects unanchored absolute + Windows-drive paths. Pure, no I/O.
- **`services/failure_pattern_detector.py`**: new `FailurePattern.failure_locations: list[{file,line,func}]`, serialized in `to_dict()`, restored via `from_dict(... .get("failure_locations", []))` — old Redis records tolerated. `learn_pattern()` takes optional `failure_locations`, stored on first occurrence only.
- **`orchestration/workflow_runner.py`**: `_extract_failure_locations(error)` — `traceback.extract_tb`, keep in-repo frames only, cap to innermost 5 (blame = `locations[-1]`); never raises. Wired into `_record_failure_pattern`. Only file/line/func stored — no source, no locals.

## Verification
- 26 tests pass (`repo_path_test.py`, `test_failure_locations.py`, `test_failure_pattern_wiring.py`) run from worktree root.
- Includes the join-key equality test: `to_repo_relative("./autobot-backend/services/x.py") == to_repo_relative("/opt/autobot/code_source/autobot-backend/services/x.py")`.
- Back-compat test: `from_dict` on a record lacking the field → `[]`.
- `ruff check` clean on all touched files (the 7 E402 in `workflow_runner.py` are pre-existing on base — a deliberate mid-file import block; left untouched to avoid circular-import risk).

## Model Used
Opus 4.8

Closes #11182
Part of #11170
