### PR TITLE
feat(execution): enforce forbidden tools on the external claude_code CLI (#11186)

### DIFF
--- a/autobot-backend/services/execution/claude_code_backend.py
+++ b/autobot-backend/services/execution/claude_code_backend.py
@@ -440,7 +440,13 @@ class ClaudeCodeBackend(ExecutionBackend):
         # the agent's forbidden_work manifest). Each is injection-guarded; a value
         # that could be read as a flag is skipped.
         disallowed = task.metadata.get("disallowed_tools") or []
-        safe_disallowed = [str(t) for t in disallowed if str(t) and not str(t).startswith("-")]
+        # Drop empties, flag-looking values, and any name carrying the comma/newline
+        # join delimiters (a comma-bearing name would otherwise split into two entries).
+        safe_disallowed = [
+            str(t)
+            for t in disallowed
+            if str(t) and not str(t).startswith("-") and "," not in str(t) and "\n" not in str(t)
+        ]
         if safe_disallowed:
             cmd += ["--disallowedTools", ",".join(safe_disallowed)]
 

--- a/autobot-backend/services/execution/claude_code_backend.py
+++ b/autobot-backend/services/execution/claude_code_backend.py
@@ -410,13 +410,16 @@ class ClaudeCodeBackend(ExecutionBackend):
             except OSError:
                 pass
 
-    async def _run_cli_with_config(
-        self,
-        task: ExecutionTask,
-        cli: str,
-        mcp_cfg_path: str,
-    ) -> tuple[str, str, bool]:
-        """Spawn and stream from the Claude CLI subprocess."""
+    @staticmethod
+    def _build_cli_command(task: ExecutionTask, cli: str, mcp_cfg_path: str) -> list[str]:
+        """Build the ``claude`` CLI argv for *task* (GH#11186).
+
+        Pure and side-effect-free so the argv (incl. the governance flag below) is
+        unit-testable without spawning a subprocess. Every value-carrying flag is
+        guarded against option injection: a value that could be parsed as a flag
+        (starts with ``-``) is dropped, and the prompt is passed positionally after
+        ``--`` so it can never be read as an option.
+        """
         cmd = [
             cli,
             "--output-format",
@@ -432,10 +435,29 @@ class ClaudeCodeBackend(ExecutionBackend):
         if max_turns is not None:
             cmd += ["--max-turns", str(int(max_turns))]
 
+        # GH#11186: enforce a governed agent's forbidden tools on the external CLI.
+        # ``disallowed_tools`` holds claude_code tool names (resolved upstream from
+        # the agent's forbidden_work manifest). Each is injection-guarded; a value
+        # that could be read as a flag is skipped.
+        disallowed = task.metadata.get("disallowed_tools") or []
+        safe_disallowed = [str(t) for t in disallowed if str(t) and not str(t).startswith("-")]
+        if safe_disallowed:
+            cmd += ["--disallowedTools", ",".join(safe_disallowed)]
+
         # Security: `--` ends option parsing so a prompt starting with `-`/`--`
         # (e.g. "--dangerously-skip-permissions") can NOT be parsed as a flag.
         cmd.append("--")
         cmd.append(task.code)  # prompt is the task code/description (positional only)
+        return cmd
+
+    async def _run_cli_with_config(
+        self,
+        task: ExecutionTask,
+        cli: str,
+        mcp_cfg_path: str,
+    ) -> tuple[str, str, bool]:
+        """Spawn and stream from the Claude CLI subprocess."""
+        cmd = self._build_cli_command(task, cli, mcp_cfg_path)
 
         # Security: task-supplied env_vars are semi-untrusted. Start from the
         # trusted parent env, then contribute ONLY allowlisted AUTOBOT_* task

--- a/autobot-backend/tests/test_claude_code_cli_command.py
+++ b/autobot-backend/tests/test_claude_code_cli_command.py
@@ -1,0 +1,54 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""claude_code CLI command builder + forbidden-tool enforcement (GH#11186).
+
+Proves the external CLI backend enforces a governed agent's disallowed tools via
+``--disallowedTools`` and keeps its option-injection guards.
+"""
+
+from services.execution.base_backend import ExecutionTask
+from services.execution.claude_code_backend import ClaudeCodeBackend
+
+
+def _task(**metadata) -> ExecutionTask:
+    return ExecutionTask(task_id="t1", code="do the thing", metadata=metadata)
+
+
+def _build(task) -> list[str]:
+    return ClaudeCodeBackend._build_cli_command(task, "claude", "/tmp/mcp.json")
+
+
+def test_base_command_has_no_disallowed_flag():
+    cmd = _build(_task())
+    assert "--disallowedTools" not in cmd
+    # prompt is positional, after the `--` option terminator
+    assert cmd[-2] == "--"
+    assert cmd[-1] == "do the thing"
+
+
+def test_disallowed_tools_flag_added():
+    cmd = _build(_task(disallowed_tools=["Bash", "Edit"]))
+    i = cmd.index("--disallowedTools")
+    assert cmd[i + 1] == "Bash,Edit"
+    # governance flag must precede the `--` terminator (still an option)
+    assert i < cmd.index("--")
+
+
+def test_empty_disallowed_tools_omits_flag():
+    assert "--disallowedTools" not in _build(_task(disallowed_tools=[]))
+
+
+def test_disallowed_tools_injection_guarded():
+    # A value that could be parsed as a flag is dropped; safe ones remain.
+    cmd = _build(_task(disallowed_tools=["Bash", "--dangerously-skip-permissions", "Write"]))
+    i = cmd.index("--disallowedTools")
+    assert cmd[i + 1] == "Bash,Write"
+
+
+def test_model_injection_guard_preserved():
+    cmd = _build(_task(model="--evil"))
+    assert "--model" not in cmd
+    cmd2 = _build(_task(model="opus"))
+    assert cmd2[cmd2.index("--model") + 1] == "opus"

--- a/autobot-backend/tests/test_claude_code_cli_command.py
+++ b/autobot-backend/tests/test_claude_code_cli_command.py
@@ -47,6 +47,13 @@ def test_disallowed_tools_injection_guarded():
     assert cmd[i + 1] == "Bash,Write"
 
 
+def test_disallowed_tools_drops_delimiter_bearing_names():
+    # A comma/newline in a name would corrupt the joined value → dropped.
+    cmd = _build(_task(disallowed_tools=["Bash", "Edit,--evil", "Wr\nite", "Write"]))
+    i = cmd.index("--disallowedTools")
+    assert cmd[i + 1] == "Bash,Write"
+
+
 def test_model_injection_guard_preserved():
     cmd = _build(_task(model="--evil"))
     assert "--model" not in cmd


### PR DESCRIPTION
## Thinking Path

Part of #11186 (govern real agent execution across planes). Governed LLC agents execute on the **external claude_code** plane (`ClaudeCodeBackend`), which the internal `_dispatch_tool_call` enforcement never reaches. The claude_code CLI has a real `--disallowedTools` permission surface — so forbidden_work can be genuinely enforced there. This ships the external-plane enforcement primitive.

## What Changed

- **`services/execution/claude_code_backend.py`** — extracted the CLI argv build into a pure, side-effect-free `_build_cli_command(task, cli, mcp_cfg_path)` (unit-testable without spawning a subprocess) and added an injection-guarded `--disallowedTools` flag from `task.metadata["disallowed_tools"]` (claude_code tool names). Values that could be read as flags (start with `-`) are dropped; the prompt stays positional after `--`.
- **`tests/test_claude_code_cli_command.py`** — base command, flag added, empty omitted, injection guard, preserved `--model` guard.

## Verification

```
$ python3 -m pytest tests/test_claude_code_cli_command.py -q
5 passed
```

## Scope

External-plane **primitive** only. The producer that maps an agent's `forbidden_work` manifest → claude_code tool names and populates `task.metadata["disallowed_tools"]` is the next iteration (tracked in #11186); this PR does not yet close it.

## Model Used

Claude Opus 4.8 (1M context)

Part of #11186