### PR TITLE
feat(security): enforce fact-forcing at the production dispatch seam (#11178)

### DIFF
--- a/autobot-backend/agent_loop/fact_forcing.py
+++ b/autobot-backend/agent_loop/fact_forcing.py
@@ -5,106 +5,24 @@
 """
 Fact-forcing gate for the agent loop (GH#11149).
 
-Blocks the FIRST mutating edit to an *existing* file until that file has been
-investigated (read / grepped) in the current task — the mechanical form of
-"read before you write". A blocked edit is self-clearing: once the agent reads
-the file, the retry proceeds.
-
-Creating a NEW file is never blocked (there is nothing to investigate), so the
-gate keys on ``exists_fn`` and fails open on existence ambiguity — it never
-wrongly blocks a create.
-
-Opt-in: off by default; enable via ``AgentLoopConfig.fact_forcing_enabled`` or
-``AUTOBOT_FACT_FORCING=1``.
+The detection logic now lives in the dependency-free
+``autobot_shared.fact_forcing_guard`` (GH#11178) so the production tool-dispatch
+seam can reuse it without importing the heavy ``agent_loop`` package. This module
+re-exports the loop-facing surface.
 """
 
-import os
-
-# Tools that count as investigating a path.
-_INVESTIGATION_TOOLS: frozenset[str] = frozenset(
-    {
-        "read_file",
-        "read",
-        "read_files",
-        "grep_search",
-        "grep",
-        "search_files",
-        "list_dir",
-        "list_directory",
-        "glob",
-        "glob_file_search",
-        "codebase_search",
-    }
+from autobot_shared.fact_forcing_guard import (
+    fact_forcing_env_enabled,
+    first_uninvestigated_edit,
+    record_investigation,
+    record_investigations,
+    uninvestigated_edit_path,
 )
 
-# Mutating edits to an existing file that the gate guards. Pure creators
-# (create_file / write-new) are handled by the exists check, not by name.
-_EDIT_TOOLS: frozenset[str] = frozenset(
-    {
-        "edit_file",
-        "write_file",
-        "multi_edit",
-        "apply_patch",
-        "delete_file",
-    }
-)
-
-_PATH_KEYS: tuple[str, ...] = ("file_path", "path", "directory", "target_file")
-
-
-def _extract_path(tool: dict) -> str | None:
-    args = tool.get("args") or tool.get("arguments") or tool.get("parameters") or {}
-    if not isinstance(args, dict):
-        return None
-    for key in _PATH_KEYS:
-        value = args.get(key)
-        if value:
-            return str(value)
-    return None
-
-
-def _norm(path: str) -> str:
-    # realpath (not normpath) so a file read by relative path and edited by
-    # absolute path — or via a symlink — normalize to the SAME key and the read
-    # is credited (GH#11179). Resolves against the process CWD + symlinks.
-    return os.path.realpath(path.strip())
-
-
-def record_investigations(tools: list[dict], investigated: set[str]) -> None:
-    """Add the normalized paths of any investigation tools in *tools* to *investigated*."""
-    for tool in tools:
-        if str(tool.get("tool_name", "")).lower() not in _INVESTIGATION_TOOLS:
-            continue
-        path = _extract_path(tool)
-        if path:
-            investigated.add(_norm(path))
-
-
-def first_uninvestigated_edit(
-    tool: dict,
-    investigated: set[str],
-    exists_fn=os.path.exists,
-) -> str | None:
-    """Return the target path if *tool* edits an existing, uninvestigated file, else None.
-
-    New files (``not exists_fn(path)``) are allowed — there is nothing to read.
-    """
-    if str(tool.get("tool_name", "")).lower() not in _EDIT_TOOLS:
-        return None
-    path = _extract_path(tool)
-    if not path:
-        return None
-    normalized = _norm(path)
-    if normalized in investigated:
-        return None
-    try:
-        if not exists_fn(normalized):
-            return None  # new file → nothing to investigate
-    except OSError:
-        return None  # existence ambiguous → fail open (never block a create)
-    return path
-
-
-def fact_forcing_env_enabled() -> bool:
-    """True when ``AUTOBOT_FACT_FORCING`` force-enables the gate regardless of config."""
-    return os.environ.get("AUTOBOT_FACT_FORCING", "").strip().lower() in {"1", "true", "yes", "on"}
+__all__ = [
+    "fact_forcing_env_enabled",
+    "first_uninvestigated_edit",
+    "record_investigation",
+    "record_investigations",
+    "uninvestigated_edit_path",
+]

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -2465,6 +2465,49 @@ class ToolHandlerMixin:
             metadata={"tool": tool_name, "error": True, "config_protection": True},
         )
 
+    def _enforce_fact_forcing(
+        self,
+        tool_call: dict[str, Any],
+        ctx: "LLMIterationContext" | None,
+        execution_results: list[dict[str, Any]],
+    ) -> WorkflowMessage | None:
+        """Block the first edit to an existing, uninvestigated file (GH#11178).
+
+        Records this call's read/grep target on the turn-scoped investigated set
+        (``ctx.context``), then blocks an edit to an existing file not yet read
+        this turn. New files are never blocked; the block self-clears once the
+        agent reads the file. Off unless ``AUTOBOT_FACT_FORCING`` is set, and a
+        no-op without a ``ctx`` to carry the per-turn state.
+        """
+        from autobot_shared.fact_forcing_guard import (
+            fact_forcing_env_enabled,
+            record_investigation,
+            uninvestigated_edit_path,
+        )
+
+        if not fact_forcing_env_enabled() or ctx is None:
+            return None
+        investigated: set[str] = ctx.context.setdefault("_fact_forcing_investigated", set())
+        name = tool_call.get("name", "")
+        args = tool_call.get("params") or tool_call.get("arguments") or {}
+        record_investigation(name, args, investigated)
+        path = uninvestigated_edit_path(name, args, investigated)
+        if path is None:
+            return None
+        error = (
+            f"Editing '{path}' is blocked (fact-forcing): read the file and its "
+            f"importers/call-sites first so the change is grounded, then retry."
+        )
+        logger.warning("[GH#11178] Blocked fact-forcing edit to '%s' (tool '%s')", path, name)
+        execution_results.append(
+            {"tool": name, "status": "error", "error": error, "fact_forcing": True}
+        )
+        return WorkflowMessage(
+            type="error",
+            content=error,
+            metadata={"tool": name, "error": True, "fact_forcing": True},
+        )
+
     def _enforce_work_item_approval(
         self,
         tool_call: dict[str, Any],
@@ -2545,6 +2588,13 @@ class ToolHandlerMixin:
         config_msg = self._enforce_config_protection(tool_call, execution_results)
         if config_msg is not None:
             yield config_msg
+            return
+
+        # GH#11178: fact-forcing — record reads/greps and block the first edit to
+        # an existing file not yet investigated this turn, at the same seam.
+        fact_msg = self._enforce_fact_forcing(tool_call, ctx, execution_results)
+        if fact_msg is not None:
+            yield fact_msg
             return
 
         # GH#11160: hold a tool the work item declared as approval-gated

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -2499,9 +2499,7 @@ class ToolHandlerMixin:
             f"importers/call-sites first so the change is grounded, then retry."
         )
         logger.warning("[GH#11178] Blocked fact-forcing edit to '%s' (tool '%s')", path, name)
-        execution_results.append(
-            {"tool": name, "status": "error", "error": error, "fact_forcing": True}
-        )
+        execution_results.append({"tool": name, "status": "error", "error": error, "fact_forcing": True})
         return WorkflowMessage(
             type="error",
             content=error,

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_fact_forcing.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_fact_forcing.py
@@ -37,9 +37,7 @@ def test_blocks_edit_to_existing_unread_file(tmp_path) -> None:
     target = tmp_path / "mod.py"
     target.write_text("x = 1\n", encoding="utf-8")
     results: list[dict] = []
-    msg = _mixin()._enforce_fact_forcing(
-        {"name": "edit_file", "params": {"file_path": str(target)}}, _ctx(), results
-    )
+    msg = _mixin()._enforce_fact_forcing({"name": "edit_file", "params": {"file_path": str(target)}}, _ctx(), results)
     assert msg is not None
     assert msg.type == "error"
     assert msg.metadata.get("fact_forcing") is True
@@ -53,20 +51,14 @@ def test_read_then_edit_same_ctx_is_allowed(tmp_path) -> None:
     mixin = _mixin()
     ctx = _ctx()
     # Read first (records into ctx.context)...
-    assert mixin._enforce_fact_forcing(
-        {"name": "read_file", "params": {"file_path": str(target)}}, ctx, []
-    ) is None
+    assert mixin._enforce_fact_forcing({"name": "read_file", "params": {"file_path": str(target)}}, ctx, []) is None
     # ...then edit is allowed through the same ctx.
-    assert mixin._enforce_fact_forcing(
-        {"name": "edit_file", "params": {"file_path": str(target)}}, ctx, []
-    ) is None
+    assert mixin._enforce_fact_forcing({"name": "edit_file", "params": {"file_path": str(target)}}, ctx, []) is None
 
 
 def test_new_file_write_is_allowed(tmp_path) -> None:
     new_file = tmp_path / "brand_new.py"  # does not exist
-    msg = _mixin()._enforce_fact_forcing(
-        {"name": "write_file", "params": {"file_path": str(new_file)}}, _ctx(), []
-    )
+    msg = _mixin()._enforce_fact_forcing({"name": "write_file", "params": {"file_path": str(new_file)}}, _ctx(), [])
     assert msg is None
 
 
@@ -74,18 +66,14 @@ def test_disabled_without_env(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.delenv("AUTOBOT_FACT_FORCING", raising=False)
     target = tmp_path / "mod.py"
     target.write_text("x = 1\n", encoding="utf-8")
-    msg = _mixin()._enforce_fact_forcing(
-        {"name": "edit_file", "params": {"file_path": str(target)}}, _ctx(), []
-    )
+    msg = _mixin()._enforce_fact_forcing({"name": "edit_file", "params": {"file_path": str(target)}}, _ctx(), [])
     assert msg is None
 
 
 def test_no_ctx_is_noop(tmp_path) -> None:
     target = tmp_path / "mod.py"
     target.write_text("x = 1\n", encoding="utf-8")
-    msg = _mixin()._enforce_fact_forcing(
-        {"name": "edit_file", "params": {"file_path": str(target)}}, None, []
-    )
+    msg = _mixin()._enforce_fact_forcing({"name": "edit_file", "params": {"file_path": str(target)}}, None, [])
     assert msg is None
 
 
@@ -95,9 +83,5 @@ def test_reads_via_arguments_key(tmp_path) -> None:
     target.write_text("x = 1\n", encoding="utf-8")
     mixin = _mixin()
     ctx = _ctx()
-    mixin._enforce_fact_forcing(
-        {"name": "read_file", "arguments": {"file_path": str(target)}}, ctx, []
-    )
-    assert mixin._enforce_fact_forcing(
-        {"name": "edit_file", "arguments": {"file_path": str(target)}}, ctx, []
-    ) is None
+    mixin._enforce_fact_forcing({"name": "read_file", "arguments": {"file_path": str(target)}}, ctx, [])
+    assert mixin._enforce_fact_forcing({"name": "edit_file", "arguments": {"file_path": str(target)}}, ctx, []) is None

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_fact_forcing.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_fact_forcing.py
@@ -1,0 +1,103 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Dispatch-level fact-forcing enforcement (GH#11178).
+
+Proves the fact-forcing gate (#11149) — previously only in the dead `AgentLoop`
+path — now fires on the real production tool-dispatch seam
+(`ToolHandlerMixin._dispatch_tool_call` via `_enforce_fact_forcing`), using a
+turn-scoped investigated-files set on `ctx.context`. An edit to an existing
+unread file is blocked; reading it first (same ctx) clears it; new files pass;
+off unless `AUTOBOT_FACT_FORCING` is set.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from chat_workflow.tool_handler import ToolHandlerMixin
+
+
+def _mixin() -> ToolHandlerMixin:
+    return ToolHandlerMixin.__new__(ToolHandlerMixin)
+
+
+def _ctx() -> SimpleNamespace:
+    """A per-turn context stand-in — only `.context` (a dict) is touched."""
+    return SimpleNamespace(context={})
+
+
+@pytest.fixture(autouse=True)
+def _enable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTOBOT_FACT_FORCING", "1")
+
+
+def test_blocks_edit_to_existing_unread_file(tmp_path) -> None:
+    target = tmp_path / "mod.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    results: list[dict] = []
+    msg = _mixin()._enforce_fact_forcing(
+        {"name": "edit_file", "params": {"file_path": str(target)}}, _ctx(), results
+    )
+    assert msg is not None
+    assert msg.type == "error"
+    assert msg.metadata.get("fact_forcing") is True
+    assert results and results[0]["fact_forcing"] is True
+    assert "fact-forcing" in msg.content.lower()
+
+
+def test_read_then_edit_same_ctx_is_allowed(tmp_path) -> None:
+    target = tmp_path / "mod.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    mixin = _mixin()
+    ctx = _ctx()
+    # Read first (records into ctx.context)...
+    assert mixin._enforce_fact_forcing(
+        {"name": "read_file", "params": {"file_path": str(target)}}, ctx, []
+    ) is None
+    # ...then edit is allowed through the same ctx.
+    assert mixin._enforce_fact_forcing(
+        {"name": "edit_file", "params": {"file_path": str(target)}}, ctx, []
+    ) is None
+
+
+def test_new_file_write_is_allowed(tmp_path) -> None:
+    new_file = tmp_path / "brand_new.py"  # does not exist
+    msg = _mixin()._enforce_fact_forcing(
+        {"name": "write_file", "params": {"file_path": str(new_file)}}, _ctx(), []
+    )
+    assert msg is None
+
+
+def test_disabled_without_env(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AUTOBOT_FACT_FORCING", raising=False)
+    target = tmp_path / "mod.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    msg = _mixin()._enforce_fact_forcing(
+        {"name": "edit_file", "params": {"file_path": str(target)}}, _ctx(), []
+    )
+    assert msg is None
+
+
+def test_no_ctx_is_noop(tmp_path) -> None:
+    target = tmp_path / "mod.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    msg = _mixin()._enforce_fact_forcing(
+        {"name": "edit_file", "params": {"file_path": str(target)}}, None, []
+    )
+    assert msg is None
+
+
+def test_reads_via_arguments_key(tmp_path) -> None:
+    """MCP tools carry the path in `arguments` rather than `params`."""
+    target = tmp_path / "mod.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    mixin = _mixin()
+    ctx = _ctx()
+    mixin._enforce_fact_forcing(
+        {"name": "read_file", "arguments": {"file_path": str(target)}}, ctx, []
+    )
+    assert mixin._enforce_fact_forcing(
+        {"name": "edit_file", "arguments": {"file_path": str(target)}}, ctx, []
+    ) is None

--- a/autobot_shared/fact_forcing_guard.py
+++ b/autobot_shared/fact_forcing_guard.py
@@ -1,0 +1,131 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Fact-forcing guard helpers (GH#11149 / GH#11178).
+
+Pure, dependency-free "read before you write" detection: block the FIRST mutating
+edit to an *existing* file until it has been investigated (read / grepped) in the
+current turn. A blocked edit is self-clearing — once the agent reads the file the
+retry proceeds. Creating a NEW file is never blocked (keys on ``exists_fn`` and
+fails open on ambiguity, so it never wrongly blocks a create).
+
+Lives in ``autobot_shared`` (not ``agent_loop``) so BOTH the agent loop
+(``agent_loop.fact_forcing``) and the production tool-dispatch seam
+(``chat_workflow.tool_handler``) reuse it without importing the heavy
+``agent_loop`` package. Off by default; enable via ``AUTOBOT_FACT_FORCING=1``.
+"""
+
+import os
+
+# Tools that count as investigating a path.
+INVESTIGATION_TOOLS: frozenset[str] = frozenset(
+    {
+        "read_file",
+        "read",
+        "read_files",
+        "grep_search",
+        "grep",
+        "search_files",
+        "list_dir",
+        "list_directory",
+        "glob",
+        "glob_file_search",
+        "codebase_search",
+    }
+)
+
+# Mutating edits to an existing file that the gate guards. Pure creators
+# (create_file / write-new) are handled by the exists check, not by name.
+EDIT_TOOLS: frozenset[str] = frozenset(
+    {
+        "edit_file",
+        "write_file",
+        "multi_edit",
+        "apply_patch",
+        "delete_file",
+    }
+)
+
+PATH_KEYS: tuple[str, ...] = ("file_path", "path", "directory", "target_file")
+
+
+def _path_from_args(args: dict) -> str | None:
+    if not isinstance(args, dict):
+        return None
+    for key in PATH_KEYS:
+        value = args.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _norm(path: str) -> str:
+    # realpath (not normpath) so a file read by relative path and edited by
+    # absolute path — or via a symlink — normalize to the SAME key and the read
+    # is credited (GH#11179). Resolves against the process CWD + symlinks.
+    return os.path.realpath(path.strip())
+
+
+# --- name+args core (production dispatch seam) -----------------------------
+
+
+def record_investigation(tool_name: str, args: dict, investigated: set[str]) -> None:
+    """Record *args*' path in *investigated* if *tool_name* is an investigation tool."""
+    if str(tool_name).lower() not in INVESTIGATION_TOOLS:
+        return
+    path = _path_from_args(args)
+    if path:
+        investigated.add(_norm(path))
+
+
+def uninvestigated_edit_path(
+    tool_name: str,
+    args: dict,
+    investigated: set[str],
+    exists_fn=os.path.exists,
+) -> str | None:
+    """Return the target path if (name, args) edits an existing, uninvestigated file.
+
+    New files (``not exists_fn(path)``) and existence errors return None (fail
+    open — never block a create).
+    """
+    if str(tool_name).lower() not in EDIT_TOOLS:
+        return None
+    path = _path_from_args(args)
+    if not path:
+        return None
+    if _norm(path) in investigated:
+        return None
+    try:
+        if not exists_fn(_norm(path)):
+            return None
+    except OSError:
+        return None
+    return path
+
+
+# --- dict-shaped wrappers (agent loop backward compat) ----------------------
+
+
+def record_investigations(tools: list[dict], investigated: set[str]) -> None:
+    """Add the normalized paths of any investigation tools in *tools* to *investigated*."""
+    for tool in tools:
+        args = tool.get("args") or tool.get("arguments") or tool.get("parameters") or {}
+        record_investigation(tool.get("tool_name", ""), args, investigated)
+
+
+def first_uninvestigated_edit(
+    tool: dict,
+    investigated: set[str],
+    exists_fn=os.path.exists,
+) -> str | None:
+    """Return the target path if *tool* edits an existing, uninvestigated file, else None."""
+    args = tool.get("args") or tool.get("arguments") or tool.get("parameters") or {}
+    return uninvestigated_edit_path(tool.get("tool_name", ""), args, investigated, exists_fn)
+
+
+def fact_forcing_env_enabled() -> bool:
+    """True when ``AUTOBOT_FACT_FORCING`` enables the gate."""
+    return os.environ.get("AUTOBOT_FACT_FORCING", "").strip().lower() in {"1", "true", "yes", "on"}


### PR DESCRIPTION
## Thinking Path

Completes the guard-stack production wiring. Like config-protection (#11177), the fact-forcing gate (#11149) lived only in `AgentLoop._check_fact_forcing` — and `AgentLoop` is never instantiated in production, so it never fired. This ports it to the real seam (`ToolHandlerMixin._dispatch_tool_call`), where forbidden_work (#11145) and config-protection (#11177) already enforce.

Fact-forcing differs from config-protection in needing **turn-scoped read state**: it must remember which files were read this turn to allow a read→edit sequence. `LLMIterationContext.context` — a dict constructed once per message and shared across every tool dispatch in that turn — is the right home.

## What Changed

- **`autobot_shared/fact_forcing_guard.py`** (new): the pure detection logic moved out of `agent_loop/fact_forcing.py` (which can't be imported cheaply — `agent_loop/__init__` eagerly loads `AgentLoop`). Adds name+args entry points `record_investigation(name, args, seen)` / `uninvestigated_edit_path(name, args, seen, exists_fn)` for the seam, keeps the dict-shaped wrappers for the loop. Carries the #11179 `realpath` normalization.
- **`autobot-backend/agent_loop/fact_forcing.py`**: now a thin re-export — loop-side #11149 behaviour and tests unchanged.
- **`autobot-backend/chat_workflow/tool_handler.py`**: new `_enforce_fact_forcing(tool_call, ctx, execution_results)`, wired into `_dispatch_tool_call` after config-protection. Records reads/greps and blocks the first edit to an existing unread file, using `ctx.context["_fact_forcing_investigated"]`. Reads path from `params` (built-in) / `arguments` (MCP).

Off unless `AUTOBOT_FACT_FORCING=1`; a no-op without a `ctx`. New files are never blocked (keys on `os.path.exists`, fails open).

## Verification

```
$ python3 -m pytest tests/unit/chat_workflow/test_tool_handler_fact_forcing.py \
    tests/agent_loop/test_fact_forcing.py tests/agent_loop/test_fact_forcing_realpath.py \
    tests/unit/chat_workflow/test_tool_handler_config_protection.py \
    tests/unit/chat_workflow/test_tool_handler_forbidden_work.py -q
35 passed in 0.77s
```

New seam tests prove: edit to an existing unread file is blocked (via `params` and `arguments`); read→edit in the same `ctx` is allowed; new-file writes pass; disabled without the env var; no-op without a `ctx`. Loop-side #11149 tests stay green through the re-export shim; the adjacent forbidden-work and config-protection seams are unaffected.

**Deploy note:** adds a new `autobot_shared` module — resolve `autobot_shared` drift first when syncing, or the backend 502s on the missing import.

## Model Used

Claude Opus 4.8 (1M context)

Closes #11178
