### PR TITLE
refactor(security): consolidate provider-auth SSRF guard into autobot_shared.url_safety (#11091 item 3)

### DIFF
--- a/autobot-backend/api/provider_auth.py
+++ b/autobot-backend/api/provider_auth.py
@@ -21,11 +21,9 @@ DELETE /api/llm-auth/{provider_name}       — revoke / delete stored tokens
 
 from __future__ import annotations
 
-import ipaddress
 import os
 import time
 from typing import Any
-from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -34,6 +32,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.user_management.dependencies import get_db_session
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.url_safety import require_allowlisted_https
 from llm_shared.provider_auth import (
     _vault_read,
     _vault_write,
@@ -70,53 +69,18 @@ _ALLOWED_OAUTH_HOSTS: frozenset[str] = (
 
 
 def _validate_outbound_url(url: str) -> None:
-    """Reject URLs that could cause SSRF.
+    """Reject URLs that could cause SSRF (any violation → HTTP 400).
 
-    Rules enforced (any violation → HTTP 400):
-    - Scheme must be ``https``.
-    - Host must not parse as a valid IP address (blocks 127.0.0.1, 10.x,
-      169.254.169.254, ::1, etc.).
-    - Host must be present in the configured allowlist.
+    Delegates the https / IP-literal / allowlist / port-pinning rules to the shared
+    ``require_allowlisted_https`` guard in ``autobot_shared.url_safety`` so there is
+    a single SSRF module (#11091 item 3), translating its ``ValueError`` into an
+    HTTP 400. Behaviour is unchanged; ``_ALLOWED_OAUTH_HOSTS`` remains the
+    provider-OAuth allowlist passed to the shared check.
     """
     try:
-        parsed = urlparse(url)
-    except Exception:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid URL")
-
-    if parsed.scheme != "https":
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Only https URLs are permitted")
-
-    host = parsed.hostname or ""
-    if not host:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="URL has no host")
-
-    try:
-        ipaddress.ip_address(host)
-        # If ip_address() succeeds the host is an IP literal — reject unconditionally.
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="IP-literal hosts are not permitted")
-    except ValueError:
-        pass  # Not an IP address — continue to allowlist check.
-
-    if host.lower() not in _ALLOWED_OAUTH_HOSTS:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Host '{host}' is not in the provider OAuth allowlist",
-        )
-
-    # Port pinning (#11022): only the standard https port is allowed, so an
-    # allowlisted host can't be used to reach a non-HTTPS service on another port
-    # (e.g. https://api.github.com:22/...). urlparse defers port parsing to
-    # attribute access, so a malformed port (:99999) raises ValueError here —
-    # catch it and fail with 400, not an unhandled 500 (#11066 audit follow-up).
-    try:
-        port = parsed.port
-    except ValueError:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="URL has an invalid port")
-    if port not in (None, 443):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Only the standard https port (443) is permitted",
-        )
+        require_allowlisted_https(url, _ALLOWED_OAUTH_HOSTS)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 
 
 # The registry/app-factory prepends "/api" (see feature_routers.py), so this

--- a/autobot_shared/url_safety.py
+++ b/autobot_shared/url_safety.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import socket
+from collections.abc import Collection
 from urllib.parse import urlparse
 
 # TLDs that are never public — rejected before DNS resolution.
@@ -153,4 +154,66 @@ async def resolve_safe_ip_async(host: str, *, timeout: float = _DNS_TIMEOUT_SECO
     return safe_ip
 
 
-__all__ = ["is_public_url", "is_public_url_async", "resolve_safe_ip_async"]
+def require_allowlisted_https(url: str, allowed_hosts: Collection[str]) -> None:
+    """Validate *url* as a safe outbound endpoint or raise ``ValueError`` (#11091).
+
+    A superset SSRF guard for *server-configured* outbound endpoints (e.g. provider
+    OAuth / token URLs). Unlike :func:`is_public_url` — which DNS-resolves an
+    arbitrary user-supplied URL — this pins the request to an explicit host
+    allowlist and the standard https port, so an allowlisted name can't be pivoted
+    to reach another service or port. Consolidated here (per #11091 item 3) so the
+    https / IP-literal / allowlist / port-pinning rules live in one SSRF module
+    instead of being reimplemented at each caller.
+
+    Raises ``ValueError`` with a human-readable reason (stdlib only, no transport
+    dependency); callers translate it to their own error type (e.g. HTTP 400).
+
+    Rules — any violation raises:
+    - scheme must be ``https``
+    - host must be present and not an IP literal (blocks 127.0.0.1, 10.x,
+      169.254.169.254, ``::1``, …)
+    - host (lowercased) must be in *allowed_hosts*
+    - port must be the standard https port (``None`` or 443); a malformed port raises
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        raise ValueError("Invalid URL")
+
+    if parsed.scheme != "https":
+        raise ValueError("Only https URLs are permitted")
+
+    host = parsed.hostname or ""
+    if not host:
+        raise ValueError("URL has no host")
+
+    # ip_address() raises ValueError when host is NOT an IP; use a flag so the
+    # "is a literal" rejection isn't swallowed by the same except clause.
+    try:
+        ipaddress.ip_address(host)
+        is_ip_literal = True
+    except ValueError:
+        is_ip_literal = False
+    if is_ip_literal:
+        raise ValueError("IP-literal hosts are not permitted")
+
+    if host.lower() not in allowed_hosts:
+        raise ValueError(f"Host '{host}' is not in the allowlist")
+
+    # urlparse defers port parsing to attribute access, so a malformed port
+    # (e.g. ``:99999``) raises ValueError here — surface it as a clear reason
+    # rather than letting it escape unhandled (#11066).
+    try:
+        port = parsed.port
+    except ValueError:
+        raise ValueError("URL has an invalid port")
+    if port not in (None, 443):
+        raise ValueError("Only the standard https port (443) is permitted")
+
+
+__all__ = [
+    "is_public_url",
+    "is_public_url_async",
+    "resolve_safe_ip_async",
+    "require_allowlisted_https",
+]

--- a/autobot_shared/url_safety_test.py
+++ b/autobot_shared/url_safety_test.py
@@ -17,7 +17,12 @@ from unittest.mock import patch
 
 import pytest
 
-from autobot_shared.url_safety import is_public_url, is_public_url_async, resolve_safe_ip_async
+from autobot_shared.url_safety import (
+    is_public_url,
+    is_public_url_async,
+    require_allowlisted_https,
+    resolve_safe_ip_async,
+)
 
 # ---------------------------------------------------------------------------
 # Scheme/host rejection
@@ -188,6 +193,45 @@ async def test_resolve_safe_ip_no_usable_ip() -> None:
 # ---------------------------------------------------------------------------
 # Import-isolation contract (the whole point of #7477)
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# require_allowlisted_https — allowlist + port-pinning SSRF guard (#11091)
+# ---------------------------------------------------------------------------
+
+_ALLOW = frozenset({"accounts.google.com", "github.com", "api.anthropic.com"})
+
+
+def test_allowlisted_https_host_passes() -> None:
+    # Standard https on an allowlisted host (port None or explicit 443) is allowed.
+    require_allowlisted_https("https://accounts.google.com/o/oauth2/token", _ALLOW)
+    require_allowlisted_https("https://github.com:443/login/oauth/access_token", _ALLOW)
+
+
+@pytest.mark.parametrize(
+    "url, reason",
+    [
+        ("http://accounts.google.com/token", "https"),  # non-https scheme
+        ("https://169.254.169.254/latest/meta-data/", "IP-literal"),  # IMDS via IPv4 literal
+        ("https://127.0.0.1/token", "IP-literal"),
+        ("https://[::1]/token", "IP-literal"),  # IPv6 loopback literal
+        ("https://10.0.0.1/token", "IP-literal"),  # private range literal
+        ("https://evil-attacker.example.com/token", "allowlist"),  # not allowlisted
+        ("https://accounts.google.com:22/token", "port"),  # allowlisted host, non-443 port
+        ("https:///token", "host"),  # no host
+    ],
+)
+def test_require_allowlisted_https_rejects(url: str, reason: str) -> None:
+    with pytest.raises(ValueError) as exc:
+        require_allowlisted_https(url, _ALLOW)
+    assert reason.lower() in str(exc.value).lower()
+
+
+def test_malformed_port_raises_valueerror_not_unhandled() -> None:
+    # urlparse defers port parsing; an out-of-range port must surface as ValueError.
+    with pytest.raises(ValueError) as exc:
+        require_allowlisted_https("https://accounts.google.com:99999/token", _ALLOW)
+    assert "port" in str(exc.value).lower()
 
 
 def test_module_has_zero_autobot_dependencies() -> None:


### PR DESCRIPTION
## Thinking Path
#11091 item 3 (final item — items 1-2 landed in #11122). `api/provider_auth._validate_outbound_url` reimplemented https / IP-literal / allowlist / port-pinning SSRF checks inline. This folds that superset guard into the shared `autobot_shared/url_safety.py` so there is **one SSRF module**, per the audit finding.

## What Changed
- **New `url_safety.require_allowlisted_https(url, allowed_hosts)`** — raises `ValueError` (stdlib-only, no transport dep, preserving the module's zero-autobot-dependency contract) on: non-https scheme, missing/IP-literal host, non-allowlisted host, or non-443 port (incl. malformed-port `ValueError` surfaced cleanly). Distinct from `is_public_url` (which DNS-resolves arbitrary user URLs) — this pins server-configured endpoints to an explicit allowlist + standard port.
- **`provider_auth._validate_outbound_url`** now delegates to it and translates `ValueError` → HTTP 400. **Behaviour is identical** — same rejections, same 400s, `_ALLOWED_OAUTH_HOSTS` still the provider-OAuth allowlist. Net −35 lines in provider_auth; removed now-unused `ipaddress`/`urlparse` imports.

## Verification
- `test_provider_auth.py` → **48 passed** (all 8 SSRF cases: http-reject, IPv4/IPv6/private-IP literals, non-allowlisted, allowlisted-pass, non-443 port — unchanged behaviour)
- `url_safety_test.py` → **28 passed** (10 new: allowlist pass/reject matrix + malformed-port + no-host; existing 18 incl. the **zero-autobot-dependency contract** test still green → shared module stayed pure-stdlib)
- `black` clean, `flake8` 0
- Local Python 3.10; behaviour-preserving refactor.

## Review note
⚠️ **Security-sensitive (SSRF on the provider-auth path)** — opened for review rather than requesting admin-merge. Behaviour-preserving by construction, but a second set of eyes on the guard relocation is warranted.

## Model Used
Opus 4.8

Closes #11091