### PR TITLE
feat(llc): enforce forbidden tools on the LLC claude_code agent adapter (#11186)

### DIFF
--- a/autobot-backend/llc/adapters/claude_code_adapter.py
+++ b/autobot-backend/llc/adapters/claude_code_adapter.py
@@ -37,6 +37,7 @@ import uuid
 from dataclasses import replace
 from typing import Optional
 
+from autobot_shared.cli_tool_flags import sanitize_tool_names
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
 
@@ -105,6 +106,23 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
     _state_path = staticmethod(_state_path)
     _required_cli = "claude"  # GH#9793: CLI-availability gate in heartbeat dispatch
 
+    @staticmethod
+    def _tool_permission_args(cfg: dict) -> list[str]:
+        """Build --allowedTools/--disallowedTools argv from adapter config (GH#11186).
+
+        ``disallowed_tools`` enforces a governed agent's forbidden tools on the
+        external claude CLI. Both lists are sanitized (empty/flag-looking/
+        delimiter-bearing names dropped) via the shared ``sanitize_tool_names``.
+        """
+        args: list[str] = []
+        allowed = sanitize_tool_names(cfg.get("allowed_tools"))
+        if allowed:
+            args += ["--allowedTools", ",".join(allowed)]
+        disallowed = sanitize_tool_names(cfg.get("disallowed_tools"))
+        if disallowed:
+            args += ["--disallowedTools", ",".join(disallowed)]
+        return args
+
     async def _invoke(self, agent_config: dict, context: dict) -> str:
         cli = _resolve_claude_cli()
         agent_id: str = agent_config.get("agent_id", "unknown")
@@ -114,7 +132,6 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
         timeout_sec: int = _resolve_timeout(cfg)
         model: Optional[str] = cfg.get("model")
         max_turns: Optional[int] = cfg.get("max_turns")
-        allowed_tools: Optional[list] = cfg.get("allowed_tools")
 
         session_id = str(uuid.uuid4())
         run_id_placeholder = f"0/{session_id}"
@@ -138,8 +155,7 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
                 cmd += ["--model", model]
             if max_turns is not None:
                 cmd += ["--max-turns", str(max_turns)]
-            if allowed_tools:
-                cmd += ["--allowedTools", ",".join(allowed_tools)]
+            cmd += self._tool_permission_args(cfg)
 
         cmd.append(prompt)
 

--- a/autobot-backend/llc/adapters/claude_code_adapter.py
+++ b/autobot-backend/llc/adapters/claude_code_adapter.py
@@ -123,6 +123,32 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
             args += ["--disallowedTools", ",".join(disallowed)]
         return args
 
+    @staticmethod
+    def _build_command(cli: str, resume_session_id: Optional[str], cfg: dict, prompt: str) -> list[str]:
+        """Build the claude CLI argv (GH#11186). Pure and unit-testable.
+
+        Tool-permission flags (``--allowedTools``/``--disallowedTools``) apply on
+        BOTH fresh and resumed invocations — they scope the current run, so a
+        governed agent's forbidden tools stay enforced across ``--resume``.
+        ``--model``/``--max-turns`` are session-establishment options (fresh only).
+        The prompt is passed positionally after ``--`` so a prompt starting with
+        ``-`` can never be parsed as an option (matches the execution backend).
+        """
+        cmd: list[str] = [cli, "--output-format", "stream-json", "--print"]
+        if resume_session_id:
+            cmd += ["--resume", resume_session_id]
+        else:
+            model = cfg.get("model")
+            if model:
+                cmd += ["--model", str(model)]
+            max_turns = cfg.get("max_turns")
+            if max_turns is not None:
+                cmd += ["--max-turns", str(max_turns)]
+        cmd += ClaudeCodeAdapter._tool_permission_args(cfg)
+        cmd.append("--")
+        cmd.append(prompt)
+        return cmd
+
     async def _invoke(self, agent_config: dict, context: dict) -> str:
         cli = _resolve_claude_cli()
         agent_id: str = agent_config.get("agent_id", "unknown")
@@ -130,8 +156,6 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
 
         output_dir: str = cfg.get("output_dir", _DEFAULT_OUTPUT_DIR)
         timeout_sec: int = _resolve_timeout(cfg)
-        model: Optional[str] = cfg.get("model")
-        max_turns: Optional[int] = cfg.get("max_turns")
 
         session_id = str(uuid.uuid4())
         run_id_placeholder = f"0/{session_id}"
@@ -144,20 +168,11 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
         replay_mode: bool = bool(context.get("replay"))
         resume_session_id = None if replay_mode else await self._get_resumable_session(agent_id)
 
-        cmd: list[str] = [cli, "--output-format", "stream-json", "--print"]
-
         if resume_session_id:
-            cmd += ["--resume", resume_session_id]
             session_id = resume_session_id
             logger.info("ClaudeCodeAdapter: resuming session %s for agent %s", session_id, agent_id)
-        else:
-            if model:
-                cmd += ["--model", model]
-            if max_turns is not None:
-                cmd += ["--max-turns", str(max_turns)]
-            cmd += self._tool_permission_args(cfg)
 
-        cmd.append(prompt)
+        cmd = self._build_command(cli, resume_session_id, cfg, prompt)
 
         workspace_dir: str | None = context.get("workspace_dir")
         env = {**os.environ, "LLC_INVOKE_CONTEXT": serialize_invoke_context(context)}

--- a/autobot-backend/llc/adapters/tests/test_claude_code_tool_permissions.py
+++ b/autobot-backend/llc/adapters/tests/test_claude_code_tool_permissions.py
@@ -35,3 +35,33 @@ def test_both_allowed_and_disallowed():
 def test_sanitizes_injection_and_delimiters():
     out = _args({"disallowed_tools": ["Bash", "--evil", "Edit,x", "Write"]})
     assert out == ["--disallowedTools", "Bash,Write"]
+
+
+def _cmd(resume, cfg, prompt="do it"):
+    return ClaudeCodeAdapter._build_command("claude", resume, cfg, prompt)
+
+
+def test_fresh_session_command_has_model_and_tools_and_terminator():
+    cmd = _cmd(None, {"model": "opus", "max_turns": 5, "disallowed_tools": ["Bash"]})
+    assert cmd[:4] == ["claude", "--output-format", "stream-json", "--print"]
+    assert cmd[cmd.index("--model") + 1] == "opus"
+    assert "--disallowedTools" in cmd
+    assert cmd[-2] == "--" and cmd[-1] == "do it"
+
+
+def test_resumed_session_still_enforces_disallowed_tools():
+    # GH#11186: the governance flags MUST apply on resume, not just fresh sessions.
+    cmd = _cmd("sess-123", {"disallowed_tools": ["Bash", "Edit"]})
+    assert cmd[cmd.index("--resume") + 1] == "sess-123"
+    assert cmd[cmd.index("--disallowedTools") + 1] == "Bash,Edit"
+    # session-establishment options are NOT re-sent on resume
+    assert "--model" not in cmd and "--max-turns" not in cmd
+    assert cmd[-2] == "--" and cmd[-1] == "do it"
+
+
+def test_prompt_is_positional_after_terminator():
+    # A prompt starting with '-' can never be parsed as an option.
+    cmd = _cmd(None, {}, prompt="--dangerously-skip-permissions")
+    assert cmd[-2] == "--"
+    assert cmd[-1] == "--dangerously-skip-permissions"
+    assert cmd.count("--dangerously-skip-permissions") == 1

--- a/autobot-backend/llc/adapters/tests/test_claude_code_tool_permissions.py
+++ b/autobot-backend/llc/adapters/tests/test_claude_code_tool_permissions.py
@@ -1,0 +1,37 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""ClaudeCodeAdapter tool-permission args — forbidden-tool enforcement (GH#11186).
+
+The LLC claude_code adapter is the real governed-agent execution path; a governed
+agent's forbidden tools must be blocked on the external CLI via --disallowedTools.
+"""
+
+from llc.adapters.claude_code_adapter import ClaudeCodeAdapter
+
+
+def _args(cfg) -> list[str]:
+    return ClaudeCodeAdapter._tool_permission_args(cfg)
+
+
+def test_empty_config_no_flags():
+    assert _args({}) == []
+
+
+def test_allowed_only():
+    assert _args({"allowed_tools": ["Bash", "Read"]}) == ["--allowedTools", "Bash,Read"]
+
+
+def test_disallowed_only():
+    assert _args({"disallowed_tools": ["Bash", "Edit"]}) == ["--disallowedTools", "Bash,Edit"]
+
+
+def test_both_allowed_and_disallowed():
+    out = _args({"allowed_tools": ["Read"], "disallowed_tools": ["Bash"]})
+    assert out == ["--allowedTools", "Read", "--disallowedTools", "Bash"]
+
+
+def test_sanitizes_injection_and_delimiters():
+    out = _args({"disallowed_tools": ["Bash", "--evil", "Edit,x", "Write"]})
+    assert out == ["--disallowedTools", "Bash,Write"]

--- a/autobot-backend/services/execution/claude_code_backend.py
+++ b/autobot-backend/services/execution/claude_code_backend.py
@@ -54,6 +54,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Dict, Optional
 
+from autobot_shared.cli_tool_flags import sanitize_tool_names
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.missing_dep import MissingDep as _MissingDep
 from autobot_shared.ssot_config import config
@@ -437,16 +438,8 @@ class ClaudeCodeBackend(ExecutionBackend):
 
         # GH#11186: enforce a governed agent's forbidden tools on the external CLI.
         # ``disallowed_tools`` holds claude_code tool names (resolved upstream from
-        # the agent's forbidden_work manifest). Each is injection-guarded; a value
-        # that could be read as a flag is skipped.
-        disallowed = task.metadata.get("disallowed_tools") or []
-        # Drop empties, flag-looking values, and any name carrying the comma/newline
-        # join delimiters (a comma-bearing name would otherwise split into two entries).
-        safe_disallowed = [
-            str(t)
-            for t in disallowed
-            if str(t) and not str(t).startswith("-") and "," not in str(t) and "\n" not in str(t)
-        ]
+        # the agent's forbidden_work manifest), sanitized via the shared helper.
+        safe_disallowed = sanitize_tool_names(task.metadata.get("disallowed_tools"))
         if safe_disallowed:
             cmd += ["--disallowedTools", ",".join(safe_disallowed)]
 

--- a/autobot_shared/cli_tool_flags.py
+++ b/autobot_shared/cli_tool_flags.py
@@ -1,0 +1,24 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shared sanitizer for claude_code tool-permission CLI flags (GH#11186).
+
+``--allowedTools`` / ``--disallowedTools`` take a comma-joined list of tool names.
+Both the execution backend and the LLC agent adapter build these, so the guard
+lives here once: drop empty names, flag-looking values (option injection), and any
+name carrying the ``,`` / newline join delimiters (which would split into extra
+entries). Values are passed as distinct argv elements (no shell), so this is
+defense-in-depth on top of that.
+"""
+
+from typing import Any, Iterable, List, Optional
+
+
+def sanitize_tool_names(values: Optional[Iterable[Any]]) -> List[str]:
+    """Return the safe subset of *values* usable in a comma-joined tool flag."""
+    return [
+        str(v)
+        for v in (values or [])
+        if str(v) and not str(v).startswith("-") and "," not in str(v) and "\n" not in str(v)
+    ]

--- a/autobot_shared/cli_tool_flags.py
+++ b/autobot_shared/cli_tool_flags.py
@@ -18,7 +18,7 @@ from typing import Any, Iterable, List, Optional
 def sanitize_tool_names(values: Optional[Iterable[Any]]) -> List[str]:
     """Return the safe subset of *values* usable in a comma-joined tool flag."""
     return [
-        str(v)
+        s
         for v in (values or [])
-        if str(v) and not str(v).startswith("-") and "," not in str(v) and "\n" not in str(v)
+        if (s := str(v)) and not s.startswith("-") and "," not in s and "\n" not in s
     ]

--- a/autobot_shared/cli_tool_flags_test.py
+++ b/autobot_shared/cli_tool_flags_test.py
@@ -1,0 +1,28 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the shared claude_code tool-flag sanitizer (GH#11186)."""
+
+from autobot_shared.cli_tool_flags import sanitize_tool_names
+
+
+def test_keeps_valid_names():
+    assert sanitize_tool_names(["Bash", "Read", "Write"]) == ["Bash", "Read", "Write"]
+
+
+def test_none_and_empty():
+    assert sanitize_tool_names(None) == []
+    assert sanitize_tool_names([]) == []
+
+
+def test_drops_empty_and_flag_looking():
+    assert sanitize_tool_names(["", "Bash", "--dangerously-skip-permissions"]) == ["Bash"]
+
+
+def test_drops_delimiter_bearing():
+    assert sanitize_tool_names(["Bash", "Edit,--evil", "Wr\nite", "Write"]) == ["Bash", "Write"]
+
+
+def test_coerces_non_str():
+    assert sanitize_tool_names([1, "Bash"]) == ["1", "Bash"]


### PR DESCRIPTION
## Thinking Path

Part of #11186. Iteration-1 (#11188) added `--disallowedTools` to the execution-manager backend. But governed LLC agents actually run through the **LLC claude_code adapter** (`llc/adapters/claude_code_adapter.py`), which already emits `--allowedTools` — that's the real enforcement point. This wires forbidden-tool enforcement there, and dedups the guard into one shared helper.

## What Changed

- **`autobot_shared/cli_tool_flags.py`** (new) — `sanitize_tool_names()`: one guard that drops empty, flag-looking (`-…`), and delimiter-bearing (`,`/newline) names from a tool list. Now the single source for building `--allowedTools`/`--disallowedTools` values.
- **`llc/adapters/claude_code_adapter.py`** — new `_tool_permission_args(cfg)` builds both flags from `adapter_config`; adds `--disallowedTools` from `disallowed_tools` (a governed agent's forbidden tools) and hardens the existing `--allowedTools` with the shared sanitizer.
- **`services/execution/claude_code_backend.py`** — refactored iteration-1's inline guard to reuse `sanitize_tool_names` (no duplication).

## Verification

```
$ python3 -m pytest autobot_shared/cli_tool_flags_test.py \
    autobot-backend/llc/adapters/tests/test_claude_code_tool_permissions.py \
    autobot-backend/tests/test_claude_code_cli_command.py -q
16 passed
```

## Scope

Genuine enforcement on the governed-agent adapter, sourced from `adapter_config.disallowed_tools`. Auto-resolving that from an agent's `forbidden_work` manifest (vs. explicit config) is the remaining producer step in #11186.

## Model Used

Claude Opus 4.8 (1M context)

Part of #11186