### PR TITLE
feat(analytics): join runtime failure signal into anti-pattern ranking (#11183)

### DIFF
--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -20,6 +20,7 @@ Each anti-pattern includes:
 """
 
 import ast
+import os
 import re
 import time
 from dataclasses import dataclass, field
@@ -29,6 +30,7 @@ from typing import Any, Dict, List, Set, Tuple
 
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.repo_path import to_repo_relative
 from autobot_shared.status_enums import Severity  # #7253: consolidated onto canonical (#6689)
 
 # Anti-pattern severity → 0-100 integer score. Kept as a module-level helper
@@ -43,6 +45,12 @@ _ANTI_PATTERN_SCORES: Dict[Severity, int] = {
 
 # Minimum occurrences of a pattern_type to be included in the systemic rollup.
 _SYSTEMIC_THRESHOLD = 3
+
+# Multiplicative weight applied to the runtime_risk boost in the ranking key.
+# Sort key per finding: freq(type) * severity_score * (1 + ALPHA * runtime_risk).
+# At ALPHA=0 the boost is inactive; ALPHA=1.0 means a fully-risky file doubles
+# its effective score.  Override via env var when tuning signal weight.
+_RANKING_ALPHA: float = float(os.environ.get("AUTOBOT_RANKING_ALPHA", "1.0"))
 
 
 def anti_pattern_score(severity: Severity) -> int:
@@ -253,6 +261,9 @@ class AntiPatternInstance:
     suggestion: str
     refactoring_effort: str  # low, medium, high
     related_entities: List[str] = field(default_factory=list)
+    # Runtime failure risk for this instance's file; populated by _generate_report
+    # when a runtime_risk map is available (#11183).  Default 0.0 = no signal.
+    runtime_risk: float = 0.0
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for JSON serialization"""
@@ -268,6 +279,7 @@ class AntiPatternInstance:
             "suggestion": self.suggestion,
             "refactoring_effort": self.refactoring_effort,
             "related_entities": self.related_entities,
+            "runtime_risk": self.runtime_risk,
         }
 
 
@@ -498,10 +510,19 @@ class AntiPatternDetector:
         # Issue #6748: repeated Vue reactive boilerplate that should be a composable
         anti_patterns.extend(await self._detect_composable_opportunities(root_path))
 
-        # Phase 3: Generate report
+        # Phase 3: Fetch runtime failure risk map (#11183) then generate report.
+        # Imported lazily so the module can load without the services package.
+        runtime_risk: Dict[str, float] = {}
+        try:
+            from code_analysis.src.runtime_risk import build_runtime_risk_map
+
+            runtime_risk = await build_runtime_risk_map()
+        except Exception as _rr_exc:
+            logger.debug("runtime_risk unavailable (non-fatal): %s", _rr_exc)
+
         analysis_time = time.time() - start_time
 
-        report = self._generate_report(anti_patterns, analysis_time)
+        report = self._generate_report(anti_patterns, analysis_time, runtime_risk)
 
         # Cache results
         await self._cache_results(report)
@@ -2026,13 +2047,24 @@ class AntiPatternDetector:
 
     # ========== Report Generation ==========
 
-    def _generate_report(self, anti_patterns: List[AntiPatternInstance], analysis_time: float) -> AntiPatternReport:
+    def _generate_report(
+        self,
+        anti_patterns: List[AntiPatternInstance],
+        analysis_time: float,
+        runtime_risk: Dict[str, float] | None = None,
+    ) -> AntiPatternReport:
         """Generate comprehensive anti-pattern report.
 
-        Findings are ranked by prevalence × severity so a pattern_type that
-        appears many times across the codebase rises above a single one-off
-        finding of nominally higher severity (#11171).
+        Findings are ranked by prevalence × severity × runtime_risk_boost so
+        a pattern_type that appears many times AND whose file has a high
+        runtime failure rate rises above a same-frequency finding in a
+        low-risk file (#11173, #11183).
+
+        The boost factor ``(1 + ALPHA * runtime_risk[file])`` is always ≥ 1,
+        so adding runtime signal can only raise a finding's rank, never lower it.
         """
+        risk_map = runtime_risk or {}
+
         # Count by severity
         critical_count = sum(1 for ap in anti_patterns if ap.severity == Severity.CRITICAL)
         high_count = sum(1 for ap in anti_patterns if ap.severity == Severity.HIGH)
@@ -2045,17 +2077,23 @@ class AntiPatternDetector:
             pattern_type = ap.pattern_type.value
             summary_by_type[pattern_type] = summary_by_type.get(pattern_type, 0) + 1
 
-        # #11171: rank each finding by freq(pattern_type) × severity_score.
+        # Annotate each instance with its file's runtime_risk (#11183).
+        # Use to_repo_relative so absolute and repo-relative file_paths both hit
+        # the same lookup key that the resolver stored.
+        for ap in anti_patterns:
+            rel = to_repo_relative(ap.file_path) or ap.file_path
+            ap.runtime_risk = risk_map.get(rel, 0.0)
+
+        # #11171/#11183: rank each finding by
+        #   freq(pattern_type) * severity_score * (1 + ALPHA * runtime_risk).
         # Stable secondary sort on severity_score keeps same-rank entries ordered
         # by their individual severity (highest first).
-        sorted_patterns = sorted(
-            anti_patterns,
-            key=lambda x: (
-                summary_by_type[x.pattern_type.value] * anti_pattern_score(x.severity),
-                anti_pattern_score(x.severity),
-            ),
-            reverse=True,
-        )
+        def _rank_key(x: AntiPatternInstance):
+            base = summary_by_type[x.pattern_type.value] * anti_pattern_score(x.severity)
+            boost = 1.0 + _RANKING_ALPHA * x.runtime_risk
+            return (base * boost, anti_pattern_score(x.severity))
+
+        sorted_patterns = sorted(anti_patterns, key=_rank_key, reverse=True)
 
         # #11171: systemic rollup — types exceeding _SYSTEMIC_THRESHOLD occurrences.
         systemic_patterns = _build_systemic_rollup(sorted_patterns, summary_by_type)

--- a/autobot-backend/code_analysis/src/anti_pattern_detector_runtime_risk_test.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector_runtime_risk_test.py
@@ -1,0 +1,360 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for runtime failure-risk → anti-pattern ranking join (#11183).
+
+Tests cover:
+1. Resolver aggregation math: raw_risk = occurrence * (1-resolution_rate),
+   bounded-exp normalization, blame-frame attribution (locations[-1]).
+2. Empty source → {} no error.
+3. Ranking boost: a finding whose file has runtime_risk > 0 sorts at or above
+   the same finding with risk 0 (monotonic-up guarantee).
+4. Critical join test: absolute prod path joins against repo-relative file_path.
+5. Back-compat: to_dict() has all prior keys plus runtime_risk.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import textwrap
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module loader helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_apd():
+    """Load anti_pattern_detector module from worktree-relative path."""
+    spec = importlib.util.spec_from_file_location(
+        "apd_rr_test",
+        "autobot-backend/code_analysis/src/anti_pattern_detector.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:
+        pytest.skip(f"AntiPatternDetector dep chain unavailable: {exc}")
+    if not hasattr(mod, "config"):
+        mod.config = None
+    return mod
+
+
+def _load_rr():
+    """Load runtime_risk module from worktree-relative path."""
+    spec = importlib.util.spec_from_file_location(
+        "rr_test",
+        "autobot-backend/code_analysis/src/runtime_risk.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:
+        pytest.skip(f"runtime_risk dep chain unavailable: {exc}")
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Stub FailurePattern
+# ---------------------------------------------------------------------------
+
+
+def _make_pattern(occurrence_count: int, resolution_success_rate: float, blame_file: str):
+    """Build a minimal FailurePattern-shaped stub."""
+    return SimpleNamespace(
+        occurrence_count=occurrence_count,
+        resolution_success_rate=resolution_success_rate,
+        failure_locations=[{"file": blame_file, "line": 1, "func": "f"}],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: aggregation math
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_risk_aggregation_math():
+    """raw_risk per file == sum(occ * (1-rate)); bounded-exp applied."""
+    rr = _load_rr()
+
+    # File "autobot-backend/x.py": two patterns each contributing to it.
+    # Pattern A: occ=10, rate=0.5 → weight=5.0
+    # Pattern B: occ=4,  rate=0.0 → weight=4.0
+    # raw_risk = 9.0; K default=5.0; expected = 1 - exp(-9/5)
+    patterns = [
+        _make_pattern(10, 0.5, "autobot-backend/x.py"),
+        _make_pattern(4, 0.0, "autobot-backend/x.py"),
+    ]
+
+    with patch.object(rr, "_blame_file", side_effect=lambda p: p.failure_locations[-1]["file"]):
+        result = rr._aggregate_risk(patterns)
+
+    assert "autobot-backend/x.py" in result
+    expected = 1.0 - math.exp(-9.0 / rr._RISK_K)
+    assert abs(result["autobot-backend/x.py"] - expected) < 1e-9
+    # Bounded: [0, 1)
+    assert 0.0 <= result["autobot-backend/x.py"] < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Test 2: blame-frame is locations[-1]
+# ---------------------------------------------------------------------------
+
+
+def test_blame_frame_is_last_location():
+    """_blame_file should attribute to the innermost (last) location."""
+    rr = _load_rr()
+
+    pattern = SimpleNamespace(
+        failure_locations=[
+            {"file": "autobot-backend/outer.py", "line": 1, "func": "outer"},
+            {"file": "autobot-backend/inner.py", "line": 5, "func": "inner"},
+        ]
+    )
+    blame = rr._blame_file(pattern)
+    # inner.py is the last frame → blame
+    assert blame is not None
+    assert "inner.py" in blame
+    assert "outer.py" not in blame
+
+
+# ---------------------------------------------------------------------------
+# Test 3: empty source → {} no error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_patterns_returns_empty_dict():
+    """When list_known_patterns returns [], build_runtime_risk_map returns {}."""
+    rr = _load_rr()
+
+    mock_detector = AsyncMock()
+    mock_detector.list_known_patterns = AsyncMock(return_value=[])
+
+    with patch("services.failure_pattern_detector.get_pattern_detector", return_value=mock_detector):
+        result = await rr.build_runtime_risk_map()
+
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Test 4: ranking boost is monotonic-up
+# ---------------------------------------------------------------------------
+
+
+def test_ranking_boost_monotonic_up():
+    """A finding with runtime_risk>0 must sort at or above the same finding with risk=0."""
+    apd = _load_apd()
+
+    detector = apd.AntiPatternDetector()
+
+    high_sev = apd.Severity.HIGH
+    pattern_type = apd.AntiPatternType.LONG_METHOD
+
+    # Two identical findings except file_path; risk_map will give risk only to "risky.py"
+    ap_risky = apd.AntiPatternInstance(
+        pattern_type=pattern_type,
+        severity=high_sev,
+        file_path="autobot-backend/risky.py",
+        line_number=10,
+        entity_name="SomeClass.long_method",
+        description="too long",
+        metrics={},
+        suggestion="refactor",
+        refactoring_effort="medium",
+    )
+    ap_safe = apd.AntiPatternInstance(
+        pattern_type=pattern_type,
+        severity=high_sev,
+        file_path="autobot-backend/safe.py",
+        line_number=10,
+        entity_name="OtherClass.long_method",
+        description="too long",
+        metrics={},
+        suggestion="refactor",
+        refactoring_effort="medium",
+    )
+
+    risk_map = {"autobot-backend/risky.py": 0.8}
+    report = detector._generate_report([ap_risky, ap_safe], 0.0, risk_map)
+
+    sorted_paths = [ap.file_path for ap in report.anti_patterns]
+    # risky.py must appear before or at the same position as safe.py
+    assert sorted_paths.index("autobot-backend/risky.py") <= sorted_paths.index("autobot-backend/safe.py")
+    # Also verify risk was stamped onto the instance
+    risky_inst = next(ap for ap in report.anti_patterns if ap.file_path == "autobot-backend/risky.py")
+    assert risky_inst.runtime_risk == pytest.approx(0.8)
+    safe_inst = next(ap for ap in report.anti_patterns if ap.file_path == "autobot-backend/safe.py")
+    assert safe_inst.runtime_risk == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: CRITICAL JOIN TEST
+# Absolute prod path + repo-relative file_path → same key after to_repo_relative
+# ---------------------------------------------------------------------------
+
+
+def test_critical_join_absolute_prod_path_to_repo_relative():
+    """Absolute prod path in failure_locations joins against repo-relative file_path.
+
+    Scenario:
+      - FailurePattern.failure_locations[-1]["file"] =
+            "/opt/autobot/code_source/autobot-backend/x.py"
+      - AntiPatternInstance.file_path = "autobot-backend/x.py"
+
+    After to_repo_relative() both normalize to "autobot-backend/x.py",
+    so the risk score is applied to the anti-pattern instance.
+    """
+    rr = _load_rr()
+    apd = _load_apd()
+
+    prod_path = "/opt/autobot/code_source/autobot-backend/x.py"
+    repo_rel_path = "autobot-backend/x.py"
+
+    # Verify the normalizer equates both paths
+    from autobot_shared.repo_path import to_repo_relative
+
+    assert to_repo_relative(prod_path) == repo_rel_path
+    assert to_repo_relative(repo_rel_path) == repo_rel_path
+
+    # Build a pattern that attributes to the prod path
+    pattern = _make_pattern(10, 0.0, prod_path)
+    blame = rr._blame_file(pattern)
+    assert blame == repo_rel_path, f"Expected '{repo_rel_path}', got '{blame}'"
+
+    risk_result = rr._aggregate_risk([pattern])
+    assert repo_rel_path in risk_result, f"risk key '{repo_rel_path}' not in {list(risk_result.keys())}"
+
+    # Now verify it lands on the anti-pattern instance
+    detector = apd.AntiPatternDetector()
+    ap = apd.AntiPatternInstance(
+        pattern_type=apd.AntiPatternType.GOD_CLASS,
+        severity=apd.Severity.HIGH,
+        file_path=repo_rel_path,
+        line_number=1,
+        entity_name="BigClass",
+        description="too big",
+        metrics={},
+        suggestion="refactor",
+        refactoring_effort="high",
+    )
+
+    report = detector._generate_report([ap], 0.0, risk_result)
+    assert len(report.anti_patterns) == 1
+    assert report.anti_patterns[0].runtime_risk > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Test 6: back-compat — to_dict() has all prior keys plus runtime_risk
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_back_compat():
+    """to_dict() must include all pre-existing keys AND the new runtime_risk."""
+    apd = _load_apd()
+
+    ap = apd.AntiPatternInstance(
+        pattern_type=apd.AntiPatternType.DEAD_CODE,
+        severity=apd.Severity.LOW,
+        file_path="autobot-backend/utils.py",
+        line_number=42,
+        entity_name="OldHelper",
+        description="unused",
+        metrics={"lines_of_code": 5},
+        suggestion="remove",
+        refactoring_effort="low",
+        related_entities=["OtherClass"],
+    )
+    d = ap.to_dict()
+
+    # Pre-existing keys
+    for key in (
+        "pattern_type",
+        "severity",
+        "severity_score",
+        "file_path",
+        "line_number",
+        "entity_name",
+        "description",
+        "metrics",
+        "suggestion",
+        "refactoring_effort",
+        "related_entities",
+    ):
+        assert key in d, f"Missing pre-existing key: {key}"
+
+    # New key
+    assert "runtime_risk" in d
+    assert d["runtime_risk"] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Test 7: pattern with no failure_locations is skipped (no AttributeError)
+# ---------------------------------------------------------------------------
+
+
+def test_pattern_with_empty_locations_skipped():
+    """Patterns with failure_locations=[] produce no risk entry."""
+    rr = _load_rr()
+
+    pattern = SimpleNamespace(
+        occurrence_count=5,
+        resolution_success_rate=0.0,
+        failure_locations=[],
+    )
+    result = rr._aggregate_risk([pattern])
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Test 8: write_module fixture for full round-trip with file on disk
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_report_with_risk_map(tmp_path):
+    """End-to-end: scan a minimal codebase; risk map is applied if supplied."""
+    apd = _load_apd()
+
+    source = tmp_path / "big.py"
+    source.write_text(
+        textwrap.dedent("""\
+            class BigClass:
+                def m1(self): pass
+            """),
+        encoding="utf-8",
+    )
+
+    detector = apd.AntiPatternDetector()
+    await detector._parse_codebase(str(tmp_path), ["**/*.py"], [])
+
+    # Manufacture one instance pointing to our source file
+    ap = apd.AntiPatternInstance(
+        pattern_type=apd.AntiPatternType.GOD_CLASS,
+        severity=apd.Severity.MEDIUM,
+        file_path=str(source),
+        line_number=1,
+        entity_name="BigClass",
+        description="test",
+        metrics={},
+        suggestion="refactor",
+        refactoring_effort="low",
+    )
+
+    # Supply risk for the source file's repo-relative path
+    from autobot_shared.repo_path import to_repo_relative
+
+    rel = to_repo_relative(str(source)) or str(source)
+    risk_map = {rel: 0.5}
+
+    report = detector._generate_report([ap], 0.0, risk_map)
+    inst = report.anti_patterns[0]
+    assert inst.runtime_risk == pytest.approx(0.5)
+    d = inst.to_dict()
+    assert d["runtime_risk"] == pytest.approx(0.5)

--- a/autobot-backend/code_analysis/src/runtime_risk.py
+++ b/autobot-backend/code_analysis/src/runtime_risk.py
@@ -1,0 +1,94 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Runtime failure risk resolver for anti-pattern ranking (#11183).
+
+Aggregates ``FailurePattern`` records from Redis into a per-file risk score
+that the anti-pattern ranking can use as an additive boost.
+
+Attribution model (blame-frame):
+    Each pattern's ``failure_locations`` list is attributed to the innermost
+    (last) entry only — ``locations[-1]`` — rather than all frames.  This
+    avoids over-counting shared infrastructure frames that appear in many
+    patterns: e.g., a common dispatcher that shows up in every traceback
+    would otherwise inflate *its* risk far beyond its actual culpability.
+    The trade-off is that utility functions deep in a call stack are not
+    credited; the call-site is.  This is the intended behaviour.
+
+Risk formula:
+    raw_risk[f] = sum(occurrence_count * (1 - resolution_success_rate))
+                  over all patterns whose blame frame is file f
+
+    runtime_risk[f] = 1 - exp(-raw_risk[f] / K)
+
+where K is a module-level constant (env var ``AUTOBOT_RISK_K``, default 5.0).
+The output is bounded to [0, 1).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+# Decay constant K: controls how steeply risk saturates toward 1.
+# A file with raw_risk == K gets runtime_risk ≈ 0.63.
+# Override via env var when tuning sensitivity.
+_RISK_K: float = float(os.environ.get("AUTOBOT_RISK_K", "5.0"))
+
+
+async def build_runtime_risk_map() -> dict[str, float]:
+    """Return a mapping from repo-relative file path to runtime_risk in [0, 1).
+
+    Reads all known ``FailurePattern`` objects from the shared
+    ``FailurePatternDetector`` singleton (reuses its ``list_known_patterns``
+    method, which already handles Redis connection, timeout, and error
+    graceful-degradation).
+
+    Returns an empty dict when Redis is unavailable or no patterns are stored.
+    """
+    try:
+        from services.failure_pattern_detector import get_pattern_detector
+
+        detector = get_pattern_detector()
+        patterns = await detector.list_known_patterns(limit=10000)
+    except Exception as exc:
+        logger.warning("runtime_risk: could not load failure patterns: %s", exc)
+        return {}
+
+    return _aggregate_risk(patterns)
+
+
+def _blame_file(pattern) -> str | None:
+    """Return the repo-relative blame-frame file for a pattern, or None."""
+    from autobot_shared.repo_path import to_repo_relative
+
+    locs = getattr(pattern, "failure_locations", None) or []
+    if not locs:
+        return None
+    # Blame the innermost (last) frame — see module docstring.
+    blame = locs[-1].get("file", "") if isinstance(locs[-1], dict) else ""
+    return to_repo_relative(blame) if blame else None
+
+
+def _aggregate_risk(patterns) -> dict[str, float]:
+    """Accumulate raw risk per file then apply bounded-exp normalization."""
+    raw: dict[str, float] = {}
+    for pattern in patterns:
+        blame = _blame_file(pattern)
+        if blame is None:
+            continue
+        weight = pattern.occurrence_count * (1.0 - pattern.resolution_success_rate)
+        raw[blame] = raw.get(blame, 0.0) + weight
+
+    return {f: _bounded_exp(r) for f, r in raw.items()}
+
+
+def _bounded_exp(raw_risk: float) -> float:
+    """Apply 1 - exp(-raw_risk / K) bounding to [0, 1)."""
+    k = _RISK_K if _RISK_K > 0 else 5.0
+    return 1.0 - math.exp(-raw_risk / k)


### PR DESCRIPTION
## Thinking Path
Task 1b of epic #11170: with the join key manufactured in 1a (#11187), join runtime failure signal into the anti-pattern ranking as a bounded, additive boost that promotes debt in code that actually fails — without ever demoting a static finding.

## What Changed
- **`code_analysis/src/runtime_risk.py`** (new): `build_runtime_risk_map()` reads all `FailurePattern`s via the existing `FailurePatternDetector.list_known_patterns()` (no new Redis plumbing). Per file: `raw_risk = Σ occurrence_count × (1 − resolution_success_rate)` attributed to the **blame frame** (`failure_locations[-1]`, innermost — avoids over-crediting shared dispatchers). Bounded: `runtime_risk = 1 − exp(−raw/K)`, `K` env-backed (`AUTOBOT_RISK_K`, default 5.0). Redis down / no patterns → `{}`.
- **`anti_pattern_detector.py`**: `analyze()` (already async) awaits the risk map inside try/except (non-fatal). `_generate_report()` stamps each `AntiPatternInstance.runtime_risk` (file normalized via `to_repo_relative`) and ranks by `freq × severity × (1 + ALPHA·runtime_risk)`, `ALPHA` env-backed (`AUTOBOT_RANKING_ALPHA`, default 1.0). Boost is **always ≥ 1** — additive only. `runtime_risk` field exposed additively in `to_dict()`.

## Verification
- 36 tests pass (8 new + 28 prior LSP/consolidation).
- **Critical join test** proves an absolute prod failure path `/opt/autobot/code_source/autobot-backend/x.py` and an analyzer `file_path` of `autobot-backend/x.py` normalize to the same key and the risk is applied.
- Monotonic-up test: a finding with runtime_risk > 0 never ranks below the same finding at risk 0.
- `ruff check` and `black --check --line-length=120` both clean.

## Model Used
Opus 4.8

Closes #11183
Part of #11170
