### PR TITLE
feat(analytics): runtime_risk dimension on the quality dashboard (#11184)

### DIFF
--- a/autobot-backend/api/analytics_quality.py
+++ b/autobot-backend/api/analytics_quality.py
@@ -44,6 +44,19 @@ logger = get_logger(__name__)
 
 router = APIRouter(tags=["code-quality", "analytics"])  # Prefix set in router_registry
 
+# Single source of truth for quality dimension weights (must sum to 1.0).
+# runtime_risk funded by -0.05 maintainability and -0.05 testability (#11184).
+_QUALITY_WEIGHTS: dict[str, float] = {
+    "maintainability": 0.20,
+    "reliability": 0.20,
+    "security": 0.20,
+    "performance": 0.15,
+    "testability": 0.05,
+    "documentation": 0.10,
+    "runtime_risk": 0.10,
+}
+assert abs(sum(_QUALITY_WEIGHTS.values()) - 1.0) < 1e-9, "Quality weights must sum to 1.0"
+
 
 # ============================================================================
 # Models
@@ -70,16 +83,7 @@ def get_grade(score: float) -> QualityGrade:
 
 def calculate_health_score(metrics: dict[str, float]) -> HealthScore:
     """Calculate overall health score from individual metrics."""
-    weights = {
-        "maintainability": 0.25,
-        "reliability": 0.20,
-        "security": 0.20,
-        "performance": 0.15,
-        "testability": 0.10,
-        "documentation": 0.10,
-    }
-
-    weighted_sum = sum(metrics.get(category, 70) * weight for category, weight in weights.items())
+    weighted_sum = sum(metrics.get(category, 70) * weight for category, weight in _QUALITY_WEIGHTS.items())
 
     overall = min(100, max(0, weighted_sum))
     grade = get_grade(overall)
@@ -453,6 +457,21 @@ def _calculate_documentation_score(stats: dict[str, Any]) -> float:
     return max(0.0, min(100.0, scaled_score))
 
 
+def _calculate_runtime_risk_score(runtime_risk_map: dict[str, float]) -> float:
+    """Return a HEALTH score (higher = better) from the runtime-risk map.
+
+    Inverts the mean risk across all known files: score = 100 * (1 - mean_risk).
+    When the map is empty (Redis unavailable or no failure data), returns 100.0
+    as a neutral signal so this dimension never degrades the health score without
+    real evidence (#11184).
+    """
+    if not runtime_risk_map:
+        logger.info("runtime_risk: no failure data — returning neutral 100.0")
+        return 100.0
+    mean_risk = sum(runtime_risk_map.values()) / len(runtime_risk_map)
+    return 100.0 * (1.0 - mean_risk)
+
+
 def _categorize_problems_for_patterns(
     problems: list[dict],
 ) -> list[dict[str, Any]]:
@@ -563,17 +582,7 @@ def _build_quality_trends(metrics: dict[str, float], days: int = 30) -> list[dic
     Returns:
         List of trend data points with date and weighted score
     """
-    # Weights for calculating overall weighted score
-    weights = {
-        "maintainability": 0.25,
-        "reliability": 0.20,
-        "security": 0.20,
-        "performance": 0.15,
-        "testability": 0.10,
-        "documentation": 0.10,
-    }
-
-    weighted_score = sum(metrics.get(category, 0) * weight for category, weight in weights.items())
+    weighted_score = sum(metrics.get(category, 0) * weight for category, weight in _QUALITY_WEIGHTS.items())
 
     return [
         {
@@ -588,19 +597,19 @@ def _calculate_all_quality_scores(
     problems: list[dict],
     stats: dict[str, Any],
     total_files: int,
+    runtime_risk_map: dict[str, float] | None = None,
 ) -> dict[str, float]:
-    """
-    Calculate all quality metric scores from problems and stats.
+    """Calculate all quality metric scores from problems, stats, and runtime risk.
 
     Issue #620: Extracted from calculate_real_quality_metrics.
+    Issue #11184: Added runtime_risk dimension (health-inverted, neutral when empty).
 
     Args:
         problems: List of problem dictionaries from analysis
         stats: Codebase statistics from analysis
         total_files: Total number of files in codebase
-
-    Returns:
-        Dictionary mapping metric categories to scores
+        runtime_risk_map: Per-file runtime_risk scores from build_runtime_risk_map();
+                          pass None or empty dict when unavailable — returns neutral 100.
     """
     metrics = {
         "maintainability": _calculate_maintainability_score(problems, total_files),
@@ -609,17 +618,20 @@ def _calculate_all_quality_scores(
         "performance": _calculate_performance_score(problems),
         "testability": _calculate_testability_score(stats, total_files),
         "documentation": _calculate_documentation_score(stats),
+        "runtime_risk": _calculate_runtime_risk_score(runtime_risk_map or {}),
     }
 
     logger.info(
         "Calculated quality metrics: maintainability=%.1f, reliability=%.1f, "
-        "security=%.1f, performance=%.1f, testability=%.1f, documentation=%.1f",
+        "security=%.1f, performance=%.1f, testability=%.1f, documentation=%.1f, "
+        "runtime_risk=%.1f",
         metrics["maintainability"],
         metrics["reliability"],
         metrics["security"],
         metrics["performance"],
         metrics["testability"],
         metrics["documentation"],
+        metrics["runtime_risk"],
     )
 
     return metrics
@@ -658,8 +670,14 @@ async def calculate_real_quality_metrics(
     total_files = int(stats.get("total_files", 0)) or 100  # Default estimate
     total_lines = int(stats.get("total_lines", 0)) or 10000
 
-    # Calculate metrics using helper (Issue #620)
-    metrics = _calculate_all_quality_scores(problems, stats, total_files)
+    # Resolve runtime-risk map once (async) then pass into the sync helper (#11184).
+    # Awaited here so the sync helper never touches async infrastructure.
+    from code_analysis.src.runtime_risk import build_runtime_risk_map
+
+    runtime_risk_map = await build_runtime_risk_map()
+
+    # Calculate metrics using helper (Issue #620, #11184)
+    metrics = _calculate_all_quality_scores(problems, stats, total_files, runtime_risk_map)
 
     return {
         "metrics": {k: round(v, 1) for k, v in metrics.items()},
@@ -985,14 +1003,7 @@ async def get_quality_metrics(
                     "value": value,
                     "grade": get_grade(value).value,
                     "trend": 0,  # Would be calculated from historical data
-                    "weight": {
-                        "maintainability": 0.25,
-                        "reliability": 0.20,
-                        "security": 0.20,
-                        "performance": 0.15,
-                        "testability": 0.10,
-                        "documentation": 0.10,
-                    }.get(cat, 0.1),
+                    "weight": _QUALITY_WEIGHTS.get(cat, 0.0),
                 }
             )
         except ValueError:
@@ -1291,6 +1302,27 @@ async def get_quality_snapshot(
     }
 
 
+async def _drill_down_runtime_risk(limit: int = 50) -> dict[str, Any]:
+    """Return top files by runtime_risk score, sorted descending (#11184).
+
+    Each entry: {file: str, runtime_risk: float}.  Returns no_data shape when
+    Redis is unavailable or no failure patterns are recorded.
+    """
+    from code_analysis.src.runtime_risk import build_runtime_risk_map
+
+    risk_map = await build_runtime_risk_map()
+    if not risk_map:
+        return _no_data_response("No runtime failure data available.")
+    sorted_files = sorted(risk_map.items(), key=lambda kv: kv[1], reverse=True)[:limit]
+    return {
+        "status": "success",
+        "category": "runtime_risk",
+        "display_name": "Runtime Risk",
+        "files": [{"file": f, "runtime_risk": round(r, 4)} for f, r in sorted_files],
+        "total_files": len(sorted_files),
+    }
+
+
 @router.get("/drill-down/{category}", response_model=QualityDrillDownResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -1316,6 +1348,11 @@ async def drill_down_category(
     project's clone directory so only files under source_root contribute.
     """
     source_root = await _resolve_source_root_or_404(source_id)
+
+    # Issue #11184: runtime_risk category resolves via the dedicated risk map.
+    if category.lower() == "runtime_risk":
+        return await _drill_down_runtime_risk(limit=limit)
+
     problems, stats = await _get_problems_from_chromadb(source_root=source_root)
 
     if not problems:

--- a/autobot-backend/api/analytics_quality_test.py
+++ b/autobot-backend/api/analytics_quality_test.py
@@ -279,3 +279,122 @@ class TestPerSourceStatsLookup:
         assert ["codebase_stats"] in id_queries
         assert all(q != ["codebase_stats_None"] for q in id_queries)
         assert stats["total_files"] == 99
+
+
+# ============================================================================
+# Issue #11184: runtime_risk dimension tests
+# ============================================================================
+
+
+class TestQualityWeights:
+    """Weights dict must sum to 1.0 after adding runtime_risk (#11184)."""
+
+    def test_weights_sum_to_one(self):
+        from api.analytics_quality import _QUALITY_WEIGHTS
+
+        total = sum(_QUALITY_WEIGHTS.values())
+        assert abs(total - 1.0) < 1e-9, f"Weights sum to {total}, expected 1.0"
+
+    def test_runtime_risk_key_present(self):
+        from api.analytics_quality import _QUALITY_WEIGHTS
+
+        assert "runtime_risk" in _QUALITY_WEIGHTS
+
+    def test_runtime_risk_weight_is_0_10(self):
+        from api.analytics_quality import _QUALITY_WEIGHTS
+
+        assert abs(_QUALITY_WEIGHTS["runtime_risk"] - 0.10) < 1e-9
+
+    def test_maintainability_reduced_to_0_20(self):
+        from api.analytics_quality import _QUALITY_WEIGHTS
+
+        assert abs(_QUALITY_WEIGHTS["maintainability"] - 0.20) < 1e-9
+
+    def test_testability_reduced_to_0_05(self):
+        from api.analytics_quality import _QUALITY_WEIGHTS
+
+        assert abs(_QUALITY_WEIGHTS["testability"] - 0.05) < 1e-9
+
+
+class TestCalculateRuntimeRiskScore:
+    """Unit tests for _calculate_runtime_risk_score (#11184)."""
+
+    def test_empty_map_returns_neutral_100(self):
+        """Empty map must return 100.0 — neutral, never drags health down."""
+        from api.analytics_quality import _calculate_runtime_risk_score
+
+        assert _calculate_runtime_risk_score({}) == 100.0
+
+    def test_high_risk_yields_low_health(self):
+        """High mean runtime_risk → low health score."""
+        from api.analytics_quality import _calculate_runtime_risk_score
+
+        # All files near max risk → health near 0
+        risk_map = {"a.py": 0.9, "b.py": 0.8, "c.py": 0.95}
+        score = _calculate_runtime_risk_score(risk_map)
+        assert score < 20.0, f"Expected low health for high risk, got {score}"
+
+    def test_zero_risk_yields_100_health(self):
+        """Zero risk across all files → perfect health of 100."""
+        from api.analytics_quality import _calculate_runtime_risk_score
+
+        risk_map = {"a.py": 0.0, "b.py": 0.0}
+        assert _calculate_runtime_risk_score(risk_map) == 100.0
+
+    def test_health_inversion_formula(self):
+        """score == 100 * (1 - mean(risk)) for non-empty map."""
+        from api.analytics_quality import _calculate_runtime_risk_score
+
+        risk_map = {"x.py": 0.4, "y.py": 0.6}
+        expected = 100.0 * (1.0 - 0.5)  # mean = 0.5
+        assert abs(_calculate_runtime_risk_score(risk_map) - expected) < 1e-9
+
+    def test_single_file_uses_that_value(self):
+        from api.analytics_quality import _calculate_runtime_risk_score
+
+        risk_map = {"solo.py": 0.3}
+        expected = 100.0 * (1.0 - 0.3)
+        assert abs(_calculate_runtime_risk_score(risk_map) - expected) < 1e-9
+
+
+class TestDrillDownRuntimeRisk:
+    """Tests for the runtime_risk drill-down path (#11184)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_top_files_sorted_desc(self):
+        """drill-down returns files sorted by runtime_risk descending."""
+        risk_map = {"low.py": 0.1, "high.py": 0.9, "mid.py": 0.5}
+
+        with patch("code_analysis.src.runtime_risk.build_runtime_risk_map", new=AsyncMock(return_value=risk_map)):
+            from api import analytics_quality as aq
+
+            result = await aq._drill_down_runtime_risk(limit=10)
+
+        assert result["status"] == "success"
+        files = result["files"]
+        assert len(files) == 3
+        risks = [f["runtime_risk"] for f in files]
+        assert risks == sorted(risks, reverse=True)
+        assert files[0]["file"] == "high.py"
+
+    @pytest.mark.asyncio
+    async def test_empty_map_returns_no_data(self):
+        """Empty risk map yields no_data response, not a crash."""
+        with patch("code_analysis.src.runtime_risk.build_runtime_risk_map", new=AsyncMock(return_value={})):
+            from api import analytics_quality as aq
+
+            result = await aq._drill_down_runtime_risk()
+
+        assert result["status"] == "no_data"
+
+    @pytest.mark.asyncio
+    async def test_limit_is_respected(self):
+        """Only `limit` top files are returned."""
+        risk_map = {f"file{i}.py": i / 100.0 for i in range(20)}
+
+        with patch("code_analysis.src.runtime_risk.build_runtime_risk_map", new=AsyncMock(return_value=risk_map)):
+            from api import analytics_quality as aq
+
+            result = await aq._drill_down_runtime_risk(limit=5)
+
+        assert len(result["files"]) == 5

--- a/autobot-backend/api/schemas_analytics.py
+++ b/autobot-backend/api/schemas_analytics.py
@@ -2840,6 +2840,7 @@ class MetricCategory(str, Enum):
     PERFORMANCE = "performance"
     TESTABILITY = "testability"
     DOCUMENTATION = "documentation"
+    RUNTIME_RISK = "runtime_risk"
 
 
 class QualityMetric(BaseModel):

--- a/autobot_shared/cli_tool_flags.py
+++ b/autobot_shared/cli_tool_flags.py
@@ -17,8 +17,4 @@ from typing import Any, Iterable, List, Optional
 
 def sanitize_tool_names(values: Optional[Iterable[Any]]) -> List[str]:
     """Return the safe subset of *values* usable in a comma-joined tool flag."""
-    return [
-        s
-        for v in (values or [])
-        if (s := str(v)) and not s.startswith("-") and "," not in s and "\n" not in s
-    ]
+    return [s for v in (values or []) if (s := str(v)) and not s.startswith("-") and "," not in s and "\n" not in s]


### PR DESCRIPTION
## Thinking Path
Task 1c of epic #11170, final piece of Task 1: surface the runtime-risk signal (built in 1b) as a health dimension on the quality dashboard, so operators see codebase health reflect where code actually fails at runtime.

## What Changed
- **`api/analytics_quality.py`**: new `_calculate_runtime_risk_score(map)` → HEALTH: `100 × (1 − mean(runtime_risk))` (higher = better, consistent with other dims). Empty map → neutral **100.0** (Redis down / no failures never drags health down). Registered in the metrics dict; weights consolidated to a single `_QUALITY_WEIGHTS` constant (removed 3 duplicated copies) with a module-load `assert sum == 1.0`. New `_drill_down_runtime_risk` (async) returns top files by runtime_risk desc.
- **`api/schemas_analytics.py`**: `MetricCategory.RUNTIME_RISK` — without it the `except ValueError: continue` guard in `get_quality_metrics` would silently skip the new dimension.
- Weight rebalance (sums to 1.0): maintainability 0.25→0.20, testability 0.10→0.05, runtime_risk +0.10.
- Async: `build_runtime_risk_map()` awaited once at the async entry (`calculate_real_quality_metrics`), dict threaded into the sync scorer — no sync-in-async, no `asyncio.run()`.

## Verification
- 31 tests pass (18 prior + 13 new: weights sum, each weight, health inversion, empty-map neutral, high-risk→low-health, drill-down sort/limit, no_data response).
- `ruff check` and `black --check --line-length=120` both clean.

## Model Used
Opus 4.8

Closes #11184
Part of #11170
