### PR TITLE
feat(llc): govern the subscription claude_code adapter via inherited builder (#11186)

### DIFF
--- a/autobot-backend/llc/adapters/claude_code_subscription_adapter.py
+++ b/autobot-backend/llc/adapters/claude_code_subscription_adapter.py
@@ -66,9 +66,6 @@ class ClaudeCodeSubscriptionAdapter(ClaudeCodeAdapter):
 
         output_dir: str = cfg.get("output_dir", "/tmp")  # nosec B108
         timeout_sec: int = int(cfg.get("timeout_seconds", 3600))
-        model: Optional[str] = cfg.get("model")
-        max_turns: Optional[int] = cfg.get("max_turns")
-        allowed_tools: Optional[list] = cfg.get("allowed_tools")
 
         session_id = str(uuid.uuid4())
         run_id_placeholder = f"0/{session_id}"
@@ -78,25 +75,18 @@ class ClaudeCodeSubscriptionAdapter(ClaudeCodeAdapter):
         prompt = self._build_prompt(context)
         resume_session_id = await self._get_resumable_session(agent_id)
 
-        cmd: list[str] = [cli, "--output-format", "stream-json", "--print"]
-
         if resume_session_id:
-            cmd += ["--resume", resume_session_id]
             session_id = resume_session_id
             logger.info(
                 "ClaudeCodeSubscriptionAdapter: resuming session %s for agent %s",
                 session_id,
                 agent_id,
             )
-        else:
-            if model:
-                cmd += ["--model", model]
-            if max_turns is not None:
-                cmd += ["--max-turns", str(max_turns)]
-            if allowed_tools:
-                cmd += ["--allowedTools", ",".join(allowed_tools)]
 
-        cmd.append(prompt)
+        # GH#11186: reuse the parent's governed command builder so this adapter
+        # inherits --disallowedTools (fresh + resume), input sanitization, and the
+        # `--` prompt terminator instead of the old inline build that lacked them.
+        cmd = self._build_command(cli, resume_session_id, cfg, prompt)
 
         workspace_dir: str | None = context.get("workspace_dir")
 

--- a/autobot-backend/llc/adapters/tests/test_claude_code_subscription_governance.py
+++ b/autobot-backend/llc/adapters/tests/test_claude_code_subscription_governance.py
@@ -1,0 +1,38 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""ClaudeCodeSubscriptionAdapter inherits governed command building (GH#11186).
+
+The subscription adapter is a second governed-agent execution path; it must apply
+the same forbidden-tool enforcement + hardening as its ClaudeCodeAdapter parent
+(previously it had its own inline build lacking --disallowedTools, resume
+enforcement, and the `--` terminator).
+"""
+
+from llc.adapters.claude_code_subscription_adapter import ClaudeCodeSubscriptionAdapter
+
+
+def _cmd(resume, cfg, prompt="do it"):
+    return ClaudeCodeSubscriptionAdapter._build_command("claude", resume, cfg, prompt)
+
+
+def test_fresh_session_enforces_disallowed_and_terminator():
+    cmd = _cmd(None, {"allowed_tools": ["Read"], "disallowed_tools": ["Bash"]})
+    assert cmd[cmd.index("--allowedTools") + 1] == "Read"
+    assert cmd[cmd.index("--disallowedTools") + 1] == "Bash"
+    assert cmd[-2] == "--" and cmd[-1] == "do it"
+
+
+def test_resumed_session_still_enforces_disallowed():
+    cmd = _cmd("sess-9", {"disallowed_tools": ["Bash", "Edit"]})
+    assert cmd[cmd.index("--resume") + 1] == "sess-9"
+    assert cmd[cmd.index("--disallowedTools") + 1] == "Bash,Edit"
+    assert cmd[-2] == "--" and cmd[-1] == "do it"
+
+
+def test_injection_and_prompt_are_neutralized():
+    cmd = _cmd(None, {"disallowed_tools": ["Bash", "--evil"]}, prompt="--dangerously-skip-permissions")
+    # flag-looking disallowed value dropped; prompt neutralized after `--`
+    assert cmd[cmd.index("--disallowedTools") + 1] == "Bash"
+    assert cmd[-2] == "--" and cmd[-1] == "--dangerously-skip-permissions"

--- a/autobot_shared/cli_tool_flags.py
+++ b/autobot_shared/cli_tool_flags.py
@@ -17,8 +17,4 @@ from typing import Any, Iterable, List, Optional
 
 def sanitize_tool_names(values: Optional[Iterable[Any]]) -> List[str]:
     """Return the safe subset of *values* usable in a comma-joined tool flag."""
-    return [
-        s
-        for v in (values or [])
-        if (s := str(v)) and not s.startswith("-") and "," not in s and "\n" not in s
-    ]
+    return [s for v in (values or []) if (s := str(v)) and not s.startswith("-") and "," not in s and "\n" not in s]


### PR DESCRIPTION
## Thinking Path

Part of #11186. The #11191 review flagged a **second** governed-agent adapter, `ClaudeCodeSubscriptionAdapter`, which subclasses `ClaudeCodeAdapter` but overrode `_invoke` with its own inline CLI build — carrying the exact gaps just fixed in the parent: no `--disallowedTools`, tool flags skipped on `--resume`, unsanitized `--allowedTools`, and no `--` prompt terminator. Extending the merged enforcement here closes the external-agent plane across both adapters.

## What Changed

- **`llc/adapters/claude_code_subscription_adapter.py`** — replaced the inline command build in `_invoke` with the parent's tested `_build_command`, so this adapter inherits `--disallowedTools` (fresh + resume), the shared `sanitize_tool_names` guard, and the positional-prompt `--` terminator. Removed the now-unused `model`/`max_turns`/`allowed_tools` locals. No duplication — reuses the parent helper.
- **`llc/adapters/tests/test_claude_code_subscription_governance.py`** — fresh + resumed enforcement, injection-drop, prompt neutralization.

## Verification

```
$ python3 -m pytest llc/adapters/tests/test_claude_code_subscription_governance.py -q
3 passed
```

## Model Used

Claude Opus 4.8 (1M context)

Part of #11186