### PR TITLE
feat(i18n): runtime_risk quality-dimension label across 11 locales (#11194)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -96,11 +96,12 @@
         :key="metric.category"
         class="metric-card"
         :class="{ 'low-score': metric.value < 60 }"
+        :title="getMetricDescription(metric.category)"
         @click="drillDown(metric.category)"
       >
         <div class="metric-header">
           <span class="metric-icon">{{ getMetricIcon(metric.category) }}</span>
-          <span class="metric-name">{{ metric.name }}</span>
+          <span class="metric-name">{{ getMetricLabel(metric.category, metric.name) }}</span>
         </div>
         <div class="metric-body">
           <div class="metric-score">
@@ -450,6 +451,7 @@ import { ref, computed, onMounted, onUnmounted, watch, reactive } from 'vue';
 import type { DirectiveBinding } from 'vue';
 import { BaseModal } from '@autobot/ui'
 import { useRoute } from 'vue-router';
+import { useI18n } from 'vue-i18n';
 import { createLogger } from '@/utils/debugUtils';
 import { getCssVar } from '@/composables/useCssVars';
 import { useWebSocket } from '@/composables/useWebSocket';
@@ -460,6 +462,7 @@ import UnwiredTrackerTile from '@/components/analytics/UnwiredTrackerTile.vue';
 import EmptyState from '@/components/ui/EmptyState.vue';
 
 const logger = createLogger('CodeQualityDashboard');
+const { t, te } = useI18n();
 
 // Issue #3436: read sourceId from route param set by codebase/:sourceId parent
 const route = useRoute();
@@ -899,6 +902,7 @@ const METRIC_ICONS: Record<string, string> = {
   performance: '⚡',
   testability: '🧪',
   documentation: '📝',
+  runtime_risk: '⚠️',
 };
 
 // Pattern severity icons - static, created once
@@ -937,6 +941,19 @@ function getGradeDescription(grade: string): string {
 
 function getMetricIcon(category: string): string {
   return METRIC_ICONS[category] || '📊';
+}
+
+// Localised label for a quality dimension. Falls back to the backend-provided
+// display name when no i18n label is defined for the category.
+function getMetricLabel(category: string, fallback: string): string {
+  const key = `analytics.codeQuality.dimensions.${category}.label`;
+  return te(key) ? t(key) : fallback;
+}
+
+// Localised description for a quality dimension, or empty string when absent.
+function getMetricDescription(category: string): string {
+  const key = `analytics.codeQuality.dimensions.${category}.description`;
+  return te(key) ? t(key) : '';
 }
 
 function getPatternIcon(severity: string): string {

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -1836,7 +1836,37 @@
       "score": "Score",
       "topIssue": "Top Issue",
       "close": "إغلاق",
-      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard.",
+      "dimensions": {
+        "maintainability": {
+          "label": "قابلية الصيانة",
+          "description": "الحالة بناءً على سهولة تغيير الكود وتوسيعه."
+        },
+        "reliability": {
+          "label": "الموثوقية",
+          "description": "الحالة بناءً على مدى ثبات عمل الكود دون أعطال."
+        },
+        "security": {
+          "label": "الأمان",
+          "description": "الحالة بناءً على التعرض للثغرات المعروفة والأنماط غير الآمنة."
+        },
+        "performance": {
+          "label": "الأداء",
+          "description": "الحالة بناءً على كفاءة التشغيل واستخدام الموارد."
+        },
+        "testability": {
+          "label": "قابلية الاختبار",
+          "description": "الحالة بناءً على مدى تغطية الكود بالاختبارات."
+        },
+        "documentation": {
+          "label": "التوثيق",
+          "description": "الحالة بناءً على مدى جودة توثيق الكود."
+        },
+        "runtime_risk": {
+          "label": "مخاطر وقت التشغيل",
+          "description": "الحالة بناءً على المواضع التي يفشل فيها الكود فعليًا أثناء التشغيل."
+        }
+      }
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -1836,7 +1836,37 @@
       "score": "Bewertung",
       "topIssue": "Hauptproblem",
       "close": "Schließen",
-      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard.",
+      "dimensions": {
+        "maintainability": {
+          "label": "Wartbarkeit",
+          "description": "Zustand basierend darauf, wie leicht sich der Code ändern und erweitern lässt."
+        },
+        "reliability": {
+          "label": "Zuverlässigkeit",
+          "description": "Zustand basierend darauf, wie fehlerfrei sich der Code konstant verhält."
+        },
+        "security": {
+          "label": "Sicherheit",
+          "description": "Zustand basierend auf der Anfälligkeit für bekannte Schwachstellen und unsichere Muster."
+        },
+        "performance": {
+          "label": "Leistung",
+          "description": "Zustand basierend auf Laufzeiteffizienz und Ressourcennutzung."
+        },
+        "testability": {
+          "label": "Testbarkeit",
+          "description": "Zustand basierend darauf, wie gut der Code durch Tests abgedeckt ist."
+        },
+        "documentation": {
+          "label": "Dokumentation",
+          "description": "Zustand basierend darauf, wie gut der Code dokumentiert ist."
+        },
+        "runtime_risk": {
+          "label": "Laufzeitrisiko",
+          "description": "Zustand basierend darauf, wo der Code zur Laufzeit tatsächlich fehlschlägt."
+        }
+      }
     },
     "bugPrediction": {
       "title": "Fehlervorhersage",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -1836,7 +1836,37 @@
       "score": "Score",
       "topIssue": "Top Issue",
       "close": "Close",
-      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard.",
+      "dimensions": {
+        "maintainability": {
+          "label": "Maintainability",
+          "description": "Health based on how easy the code is to change and extend."
+        },
+        "reliability": {
+          "label": "Reliability",
+          "description": "Health based on how consistently the code behaves without faults."
+        },
+        "security": {
+          "label": "Security",
+          "description": "Health based on exposure to known vulnerabilities and unsafe patterns."
+        },
+        "performance": {
+          "label": "Performance",
+          "description": "Health based on runtime efficiency and resource usage."
+        },
+        "testability": {
+          "label": "Testability",
+          "description": "Health based on how well the code is covered by tests."
+        },
+        "documentation": {
+          "label": "Documentation",
+          "description": "Health based on how well the code is documented."
+        },
+        "runtime_risk": {
+          "label": "Runtime Risk",
+          "description": "Health based on where code actually fails at runtime."
+        }
+      }
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -1836,7 +1836,37 @@
       "score": "Puntuación",
       "topIssue": "Problema principal",
       "close": "Cerrar",
-      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard.",
+      "dimensions": {
+        "maintainability": {
+          "label": "Mantenibilidad",
+          "description": "Salud basada en lo fácil que es cambiar y ampliar el código."
+        },
+        "reliability": {
+          "label": "Fiabilidad",
+          "description": "Salud basada en la coherencia con que el código funciona sin fallos."
+        },
+        "security": {
+          "label": "Seguridad",
+          "description": "Salud basada en la exposición a vulnerabilidades conocidas y patrones inseguros."
+        },
+        "performance": {
+          "label": "Rendimiento",
+          "description": "Salud basada en la eficiencia en tiempo de ejecución y el uso de recursos."
+        },
+        "testability": {
+          "label": "Testabilidad",
+          "description": "Salud basada en la cobertura del código por las pruebas."
+        },
+        "documentation": {
+          "label": "Documentación",
+          "description": "Salud basada en lo bien documentado que está el código."
+        },
+        "runtime_risk": {
+          "label": "Riesgo en ejecución",
+          "description": "Salud basada en dónde falla realmente el código en tiempo de ejecución."
+        }
+      }
     },
     "bugPrediction": {
       "title": "Predicción de errores",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -1239,7 +1239,37 @@
       "score": "Score",
       "topIssue": "Top Issue",
       "close": "Close",
-      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard.",
+      "dimensions": {
+        "maintainability": {
+          "label": "قابلیت نگهداری",
+          "description": "سلامت بر پایه سهولت تغییر و توسعه کد."
+        },
+        "reliability": {
+          "label": "قابلیت اطمینان",
+          "description": "سلامت بر پایه پایداری عملکرد کد بدون خطا."
+        },
+        "security": {
+          "label": "امنیت",
+          "description": "سلامت بر پایه میزان در معرض آسیب‌پذیری‌های شناخته‌شده و الگوهای ناامن بودن."
+        },
+        "performance": {
+          "label": "کارایی",
+          "description": "سلامت بر پایه کارایی زمان اجرا و مصرف منابع."
+        },
+        "testability": {
+          "label": "قابلیت آزمون",
+          "description": "سلامت بر پایه میزان پوشش کد توسط آزمون‌ها."
+        },
+        "documentation": {
+          "label": "مستندسازی",
+          "description": "سلامت بر پایه کیفیت مستندسازی کد."
+        },
+        "runtime_risk": {
+          "label": "ریسک زمان اجرا",
+          "description": "سلامت بر پایه جایی که کد واقعاً در زمان اجرا شکست می‌خورد."
+        }
+      }
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -1836,7 +1836,37 @@
       "score": "Score",
       "topIssue": "Top Issue",
       "close": "Close",
-      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard.",
+      "dimensions": {
+        "maintainability": {
+          "label": "Maintenabilité",
+          "description": "Santé basée sur la facilité à modifier et à étendre le code."
+        },
+        "reliability": {
+          "label": "Fiabilité",
+          "description": "Santé basée sur la régularité avec laquelle le code fonctionne sans défaut."
+        },
+        "security": {
+          "label": "Sécurité",
+          "description": "Santé basée sur l'exposition aux vulnérabilités connues et aux motifs non sûrs."
+        },
+        "performance": {
+          "label": "Performance",
+          "description": "Santé basée sur l'efficacité à l'exécution et l'utilisation des ressources."
+        },
+        "testability": {
+          "label": "Testabilité",
+          "description": "Santé basée sur la couverture du code par les tests."
+        },
+        "documentation": {
+          "label": "Documentation",
+          "description": "Santé basée sur la qualité de la documentation du code."
+        },
+        "runtime_risk": {
+          "label": "Risque à l'exécution",
+          "description": "Santé basée sur les endroits où le code échoue réellement à l'exécution."
+        }
+      }
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -1239,7 +1239,37 @@
       "score": "Score",
       "topIssue": "Top Issue",
       "close": "Close",
-      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard.",
+      "dimensions": {
+        "maintainability": {
+          "label": "תחזוקתיות",
+          "description": "תקינות המבוססת על מידת הקלות בשינוי והרחבה של הקוד."
+        },
+        "reliability": {
+          "label": "אמינות",
+          "description": "תקינות המבוססת על עקביות פעולת הקוד ללא תקלות."
+        },
+        "security": {
+          "label": "אבטחה",
+          "description": "תקינות המבוססת על חשיפה לפגיעויות ידועות ולדפוסים לא בטוחים."
+        },
+        "performance": {
+          "label": "ביצועים",
+          "description": "תקינות המבוססת על יעילות זמן הריצה ושימוש במשאבים."
+        },
+        "testability": {
+          "label": "בדיקתיות",
+          "description": "תקינות המבוססת על מידת הכיסוי של הקוד בבדיקות."
+        },
+        "documentation": {
+          "label": "תיעוד",
+          "description": "תקינות המבוססת על איכות התיעוד של הקוד."
+        },
+        "runtime_risk": {
+          "label": "סיכון בזמן ריצה",
+          "description": "תקינות המבוססת על המקומות שבהם הקוד נכשל בפועל בזמן ריצה."
+        }
+      }
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -1836,7 +1836,37 @@
       "score": "Score",
       "topIssue": "Top Issue",
       "close": "Close",
-      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard.",
+      "dimensions": {
+        "maintainability": {
+          "label": "Uzturamība",
+          "description": "Stāvoklis, kas balstīts uz to, cik viegli kodu mainīt un paplašināt."
+        },
+        "reliability": {
+          "label": "Uzticamība",
+          "description": "Stāvoklis, kas balstīts uz to, cik konsekventi kods darbojas bez kļūdām."
+        },
+        "security": {
+          "label": "Drošība",
+          "description": "Stāvoklis, kas balstīts uz pakļautību zināmām ievainojamībām un nedrošiem paraugiem."
+        },
+        "performance": {
+          "label": "Veiktspēja",
+          "description": "Stāvoklis, kas balstīts uz izpildes efektivitāti un resursu izmantošanu."
+        },
+        "testability": {
+          "label": "Testējamība",
+          "description": "Stāvoklis, kas balstīts uz to, cik labi kodu pārklāj testi."
+        },
+        "documentation": {
+          "label": "Dokumentācija",
+          "description": "Stāvoklis, kas balstīts uz to, cik labi kods ir dokumentēts."
+        },
+        "runtime_risk": {
+          "label": "Izpildlaika risks",
+          "description": "Stāvoklis, kas balstīts uz to, kur kods patiešām sabrūk izpildes laikā."
+        }
+      }
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -1836,7 +1836,37 @@
       "score": "Score",
       "topIssue": "Top Issue",
       "close": "Close",
-      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard.",
+      "dimensions": {
+        "maintainability": {
+          "label": "Łatwość utrzymania",
+          "description": "Kondycja oparta na tym, jak łatwo można zmieniać i rozszerzać kod."
+        },
+        "reliability": {
+          "label": "Niezawodność",
+          "description": "Kondycja oparta na tym, jak niezawodnie kod działa bez usterek."
+        },
+        "security": {
+          "label": "Bezpieczeństwo",
+          "description": "Kondycja oparta na podatności na znane luki i niebezpieczne wzorce."
+        },
+        "performance": {
+          "label": "Wydajność",
+          "description": "Kondycja oparta na wydajności w czasie działania i zużyciu zasobów."
+        },
+        "testability": {
+          "label": "Testowalność",
+          "description": "Kondycja oparta na tym, jak dobrze kod jest pokryty testami."
+        },
+        "documentation": {
+          "label": "Dokumentacja",
+          "description": "Kondycja oparta na tym, jak dobrze kod jest udokumentowany."
+        },
+        "runtime_risk": {
+          "label": "Ryzyko w czasie działania",
+          "description": "Kondycja oparta na tym, gdzie kod faktycznie zawodzi w czasie działania."
+        }
+      }
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -1836,7 +1836,37 @@
       "score": "Score",
       "topIssue": "Top Issue",
       "close": "Close",
-      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard.",
+      "dimensions": {
+        "maintainability": {
+          "label": "Manutenibilidade",
+          "description": "Saúde com base na facilidade de alterar e ampliar o código."
+        },
+        "reliability": {
+          "label": "Confiabilidade",
+          "description": "Saúde com base na consistência com que o código funciona sem falhas."
+        },
+        "security": {
+          "label": "Segurança",
+          "description": "Saúde com base na exposição a vulnerabilidades conhecidas e padrões inseguros."
+        },
+        "performance": {
+          "label": "Desempenho",
+          "description": "Saúde com base na eficiência em tempo de execução e no uso de recursos."
+        },
+        "testability": {
+          "label": "Testabilidade",
+          "description": "Saúde com base na cobertura do código pelos testes."
+        },
+        "documentation": {
+          "label": "Documentação",
+          "description": "Saúde com base em quão bem o código está documentado."
+        },
+        "runtime_risk": {
+          "label": "Risco em execução",
+          "description": "Saúde com base em onde o código realmente falha em tempo de execução."
+        }
+      }
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -1239,7 +1239,37 @@
       "score": "Score",
       "topIssue": "Top Issue",
       "close": "Close",
-      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard."
+      "noScanData": "No analysis data yet — run a codebase scan to populate the quality dashboard.",
+      "dimensions": {
+        "maintainability": {
+          "label": "قابلِ نگہداشت",
+          "description": "کوڈ کو تبدیل اور توسیع دینے کی آسانی پر مبنی صحت۔"
+        },
+        "reliability": {
+          "label": "قابلِ اعتماد",
+          "description": "کوڈ کے بغیر خرابی کے مستقل کام کرنے پر مبنی صحت۔"
+        },
+        "security": {
+          "label": "سلامتی",
+          "description": "معلوم کمزوریوں اور غیر محفوظ نمونوں کے سامنے ہونے پر مبنی صحت۔"
+        },
+        "performance": {
+          "label": "کارکردگی",
+          "description": "رن ٹائم کارکردگی اور وسائل کے استعمال پر مبنی صحت۔"
+        },
+        "testability": {
+          "label": "قابلِ آزمائش",
+          "description": "کوڈ کے ٹیسٹوں سے احاطہ ہونے پر مبنی صحت۔"
+        },
+        "documentation": {
+          "label": "دستاویزسازی",
+          "description": "کوڈ کی دستاویزسازی کے معیار پر مبنی صحت۔"
+        },
+        "runtime_risk": {
+          "label": "رن ٹائم خطرہ",
+          "description": "اس بات پر مبنی صحت کہ کوڈ رن ٹائم پر دراصل کہاں ناکام ہوتا ہے۔"
+        }
+      }
     },
     "bugPrediction": {
       "title": "Bug Prediction Dashboard",


### PR DESCRIPTION
## Thinking Path
Fast-follow to epic #11170: give the new `runtime_risk` quality dimension a proper display label. Investigation found the dimension names were never i18n at all — the dashboard rendered backend-provided English (`cat.replace("_"," ").title()`). Fixed that root cause: labels now come from i18n across all 11 locales (respects the no-hardcoded-UI-strings rule).

## What Changed
- **`CodeQualityDashboard.vue`**: added `useI18n`, `getMetricLabel(category, fallback)` / `getMetricDescription(category)` helpers (fall back to backend `metric.name` when a key is absent), template renders `{{ getMetricLabel(...) }}` + `:title` description. Added `runtime_risk: '⚠️'` to `METRIC_ICONS`. No hardcoded UI strings.
- **i18n**: new `analytics.codeQuality.dimensions.<dim>.{label,description}` for all 7 dimensions (incl. `runtime_risk`) in **all 11 locales** (en/es/pt/fr/de/pl/lv/ar/he/fa/ur) — faithful native translations, no English placeholders.

## Verification
- `check:i18n` passes; per-locale parse confirms `runtime_risk.label` present in all 11 locales.
- `vue-tsc --noEmit -p tsconfig.app.json` exit 0; `eslint --max-warnings 0` exit 0; `prettier --check` clean on all locale files.

## Model Used
Opus 4.8

Closes #11194
Part of #11170
