### PR TITLE
fix(security): session-ownership (IDOR) on role endpoints — lost in #11198 merge (#11186)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -1071,6 +1071,7 @@ async def set_session_role(
     session_id: str,
     role: str = Body(..., embed=True),
     current_user: dict = Depends(get_current_user),
+    request: Request = None,
 ):
     """Pin a chat session to a governed agent role (GH#11186).
 
@@ -1079,6 +1080,7 @@ async def set_session_role(
     """
     from chat_workflow.session_role import SessionRoleService
 
+    await validate_chat_ownership(session_id, request)  # SECURITY: caller must own the session
     try:
         await SessionRoleService().set_role(session_id, role)
     except ValueError as exc:
@@ -1095,10 +1097,12 @@ async def set_session_role(
 async def get_session_role(
     session_id: str,
     current_user: dict = Depends(get_current_user),
+    request: Request = None,
 ):
     """Return the session's pinned governed role (or null) plus the valid roles."""
     from chat_workflow.session_role import SessionRoleService, valid_roles
 
+    await validate_chat_ownership(session_id, request)  # SECURITY: caller must own the session
     role = await SessionRoleService().get_role(session_id)
     return DataResponse(data={"session_id": session_id, "role": role, "valid_roles": sorted(valid_roles())})
 
@@ -1112,10 +1116,12 @@ async def get_session_role(
 async def clear_session_role(
     session_id: str,
     current_user: dict = Depends(get_current_user),
+    request: Request = None,
 ):
     """Remove a session's governed-role binding (reverts to ungoverned chat)."""
     from chat_workflow.session_role import SessionRoleService
 
+    await validate_chat_ownership(session_id, request)  # SECURITY: caller must own the session
     await SessionRoleService().clear_role(session_id)
     return DataResponse(data={"session_id": session_id, "role": None})
 

--- a/autobot-backend/chat_workflow/session_role.py
+++ b/autobot-backend/chat_workflow/session_role.py
@@ -72,7 +72,7 @@ class SessionRoleService(AsyncRedisClientMixin):
             if raw is None:
                 return None
             return raw.decode() if isinstance(raw, bytes) else str(raw)
-        except Exception as exc:  # pragma: no cover - defensive; resolution must not break chat
+        except Exception as exc:  # defensive; resolution must never break chat
             logger.warning("session_role.get failed for session=%s: %s", session_id, exc)
             return None
 

--- a/autobot-backend/chat_workflow/session_role_test.py
+++ b/autobot-backend/chat_workflow/session_role_test.py
@@ -89,3 +89,25 @@ async def test_get_role_swallows_redis_failure():
     svc = SessionRoleService()
     svc._get_redis = AsyncMock(side_effect=RuntimeError("redis down"))
     assert await svc.get_role("s3") is None  # must not raise into chat
+
+
+# --- end-to-end: pinned role → forbidden tool blocked at the seam ----------
+
+
+def test_pinned_role_blocks_forbidden_tool_end_to_end():
+    """apply_role → build_governed_identity → _enforce_forbidden_work must block."""
+    from types import SimpleNamespace
+
+    from chat_workflow.models import build_governed_identity
+    from chat_workflow.tool_handler import ToolHandlerMixin
+
+    # A session pinned to research_agent (which forbids infra/shell tools).
+    context = apply_role({"agent_id": "client_supplied_ignored"}, "research_agent")
+    agent_context, _, _ = build_governed_identity(context, "sess-e2e")
+    assert agent_context.agent_id == "research_agent"  # trusted role won
+
+    mixin = ToolHandlerMixin.__new__(ToolHandlerMixin)
+    ctx = SimpleNamespace(agent_context=agent_context, requires_approval_before=[], work_item_id=None)
+    results: list[dict] = []
+    msg = mixin._enforce_forbidden_work({"name": "bash"}, ctx, results)
+    assert msg is not None and msg.metadata.get("forbidden_by_manifest") is True


### PR DESCRIPTION
## Thinking Path

Retrospective audit finding. The review fix for PR #11198 — the session-ownership (IDOR) check on the role endpoints — **never merged**: its push silently failed on a non-fast-forward (auto-fix bot) and the squash merged the pre-fix tip. Verified on `Dev_new_gui`: the three `/chat/sessions/{id}/role` endpoints have **zero** `validate_chat_ownership` calls, and the end-to-end test is absent.

This is a live IDOR: any authenticated user can pin — or **clear** — the governed role on another user's session. Clearing lifts a server-assigned restriction, directly defeating the feature's trust guarantee.

## What Changed (re-applies the lost, already-reviewed fix)

- **`api/chat.py`** — `await validate_chat_ownership(session_id, request)` on all three role endpoints (matching the established IDOR-fix pattern used across chat endpoints).
- **`chat_workflow/session_role_test.py`** — restores the end-to-end test proving a pinned `research_agent` blocks `bash` at the seam.
- **`chat_workflow/session_role.py`** — drops the contradictory `# pragma: no cover`.

## Verification

```
$ python3 -m pytest chat_workflow/session_role_test.py -q
8 passed
```
Ownership present on all 3 endpoints; `api/chat.py` compiles.

## Model Used

Claude Opus 4.8 (1M context)

Part of #11186