### PR TITLE
fix(llc): validate work-item requires_approval_before categories (#11206)

### DIFF
--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -375,26 +375,29 @@ async def create_work_item(
     body: WorkItemCreate,
     session: AsyncSession = Depends(get_session),
 ) -> Dict[str, Any]:
-    item = await _service().create(
-        session,
-        company_id=body.company_id,
-        type=body.type,
-        title=body.title,
-        description=body.description,
-        acceptance_criteria=body.acceptance_criteria,
-        priority=body.priority,
-        story_points=body.story_points,
-        parent_id=body.parent_id,
-        project_id=body.project_id,
-        sprint_id=body.sprint_id,
-        goal_id=body.goal_id,
-        assignee_agent_id=body.assignee_agent_id,
-        assignee_user_id=body.assignee_user_id,
-        created_by_agent_id=body.created_by_agent_id,
-        created_by_user_id=body.created_by_user_id,
-        labels=body.labels,
-        requires_approval_before=body.requires_approval_before,
-    )
+    try:
+        item = await _service().create(
+            session,
+            company_id=body.company_id,
+            type=body.type,
+            title=body.title,
+            description=body.description,
+            acceptance_criteria=body.acceptance_criteria,
+            priority=body.priority,
+            story_points=body.story_points,
+            parent_id=body.parent_id,
+            project_id=body.project_id,
+            sprint_id=body.sprint_id,
+            goal_id=body.goal_id,
+            assignee_agent_id=body.assignee_agent_id,
+            assignee_user_id=body.assignee_user_id,
+            created_by_agent_id=body.created_by_agent_id,
+            created_by_user_id=body.created_by_user_id,
+            labels=body.labels,
+            requires_approval_before=body.requires_approval_before,
+        )
+    except ValueError as exc:  # e.g. unknown approval category (GH#11206)
+        raise HTTPException(status_code=400, detail=str(exc))
     await session.commit()
     await _kb_manager.ensure_collection(KbCollectionManager.WORK_ITEM_PREFIX, item.id)
     return await _item_to_dict(item, session)
@@ -464,7 +467,10 @@ async def update_work_item(
     if existing is None or str(existing.company_id) != str(ctx.org_id):
         raise HTTPException(status_code=404, detail="Work item not found")
     fields = {k: v for k, v in body.model_dump(exclude_none=True).items()}
-    item = await _service().update(session, work_item_id, **fields)
+    try:
+        item = await _service().update(session, work_item_id, **fields)
+    except ValueError as exc:  # e.g. unknown approval category (GH#11206)
+        raise HTTPException(status_code=400, detail=str(exc))
     if item is None:
         raise HTTPException(status_code=404, detail="Work item not found")
     await session.commit()

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -67,6 +67,7 @@ def _validated_approval_categories(values: Optional[List[str]]) -> List[str]:
         raise ValueError(f"unknown approval categories: {unknown} (valid: {sorted(valid)})")
     return vals
 
+
 # Allowed status transitions: from → {to, ...}
 _ALLOWED_TRANSITIONS: Dict[WorkItemStatus, set] = {
     WorkItemStatus.BACKLOG: {WorkItemStatus.READY, WorkItemStatus.BLOCKED, WorkItemStatus.CANCELLED},

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -51,6 +51,22 @@ _bg_tasks: set = set()
 
 _CHECKOUT_TTL = 1800  # seconds
 
+
+def _validated_approval_categories(values: Optional[List[str]]) -> List[str]:
+    """Validate ``requires_approval_before`` entries against the controlled vocabulary (GH#11206).
+
+    A typo'd category matches no tools at the seam and silently disables the gate,
+    so reject unknown values here (fail-fast) rather than let governance no-op.
+    """
+    from autobot_shared.tool_catalogue import valid_approval_categories
+
+    vals = list(values or [])
+    valid = valid_approval_categories()
+    unknown = [v for v in vals if v not in valid]
+    if unknown:
+        raise ValueError(f"unknown approval categories: {unknown} (valid: {sorted(valid)})")
+    return vals
+
 # Allowed status transitions: from → {to, ...}
 _ALLOWED_TRANSITIONS: Dict[WorkItemStatus, set] = {
     WorkItemStatus.BACKLOG: {WorkItemStatus.READY, WorkItemStatus.BLOCKED, WorkItemStatus.CANCELLED},
@@ -276,7 +292,7 @@ class WorkItemService(LLCServiceBase):
             created_by_agent_id=uuid.UUID(created_by_agent_id) if created_by_agent_id else None,
             created_by_user_id=uuid.UUID(created_by_user_id) if created_by_user_id else None,
             labels=labels or [],
-            requires_approval_before=requires_approval_before or [],
+            requires_approval_before=_validated_approval_categories(requires_approval_before),
         )
         session.add(item)
         await session.flush()
@@ -320,6 +336,8 @@ class WorkItemService(LLCServiceBase):
         elif fields.get("assignee_agent_id"):
             item.assignee_user_id = None
             fields.setdefault("assignee_type", "agent")
+        if "requires_approval_before" in fields:
+            fields["requires_approval_before"] = _validated_approval_categories(fields["requires_approval_before"])
         for key, val in fields.items():
             if key not in allowed:
                 raise ValueError(f"Field '{key}' is not updatable via WorkItemService.update()")

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -52,19 +52,24 @@ _bg_tasks: set = set()
 _CHECKOUT_TTL = 1800  # seconds
 
 
-def _validated_approval_categories(values: Optional[List[str]]) -> List[str]:
+def _validated_approval_categories(
+    values: Optional[List[str]], existing: Optional[List[str]] = None
+) -> List[str]:
     """Validate ``requires_approval_before`` entries against the controlled vocabulary (GH#11206).
 
     A typo'd category matches no tools at the seam and silently disables the gate,
-    so reject unknown values here (fail-fast) rather than let governance no-op.
+    so reject unknown *newly-added* values (fail-fast) rather than let governance
+    no-op. Values already present in *existing* are exempt, so re-sending a
+    pre-controlled-vocabulary (legacy free-text) value while editing an item does
+    not block the edit.
     """
     from autobot_shared.tool_catalogue import valid_approval_categories
 
     vals = list(values or [])
-    valid = valid_approval_categories()
-    unknown = [v for v in vals if v not in valid]
+    allowed = valid_approval_categories() | set(existing or [])
+    unknown = [v for v in vals if v not in allowed]
     if unknown:
-        raise ValueError(f"unknown approval categories: {unknown} (valid: {sorted(valid)})")
+        raise ValueError(f"unknown approval categories: {unknown} (valid: {sorted(valid_approval_categories())})")
     return vals
 
 
@@ -338,7 +343,9 @@ class WorkItemService(LLCServiceBase):
             item.assignee_user_id = None
             fields.setdefault("assignee_type", "agent")
         if "requires_approval_before" in fields:
-            fields["requires_approval_before"] = _validated_approval_categories(fields["requires_approval_before"])
+            fields["requires_approval_before"] = _validated_approval_categories(
+                fields["requires_approval_before"], existing=item.requires_approval_before or []
+            )
         for key, val in fields.items():
             if key not in allowed:
                 raise ValueError(f"Field '{key}' is not updatable via WorkItemService.update()")

--- a/autobot-backend/llc/tests/test_work_item_requires_approval.py
+++ b/autobot-backend/llc/tests/test_work_item_requires_approval.py
@@ -83,3 +83,39 @@ class TestSerialization:
         ):
             result = await work_items._item_to_dict(item, session)
         assert result["requires_approval_before"] == ["pushing commits"]
+
+
+class TestApprovalCategoryValidation:
+    """GH#11206: reject unknown approval categories (typo → silent gate bypass)."""
+
+    async def test_create_accepts_valid_categories(self, service, mock_session):
+        with patch.object(service, "_next_identifier", new=AsyncMock(return_value="PRJ-9")):
+            item = await service.create(
+                mock_session,
+                company_id=str(uuid.uuid4()),
+                type=WorkItemType.TASK,
+                title="Valid",
+                requires_approval_before=["pushing commits", "destructive operations"],
+            )
+        assert item.requires_approval_before == ["pushing commits", "destructive operations"]
+
+    async def test_create_rejects_unknown_category(self, service, mock_session):
+        with patch.object(service, "_next_identifier", new=AsyncMock(return_value="PRJ-10")):
+            with pytest.raises(ValueError):
+                await service.create(
+                    mock_session,
+                    company_id=str(uuid.uuid4()),
+                    type=WorkItemType.TASK,
+                    title="Typo",
+                    requires_approval_before=["pushing commit"],  # typo → not a real category
+                )
+
+    async def test_update_rejects_unknown_category(self, service, mock_session):
+        item = MagicMock()
+        with patch.object(service, "get", new=AsyncMock(return_value=item)):
+            with pytest.raises(ValueError):
+                await service.update(
+                    mock_session,
+                    str(uuid.uuid4()),
+                    requires_approval_before=["not_a_category"],
+                )

--- a/autobot-backend/llc/tests/test_work_item_requires_approval.py
+++ b/autobot-backend/llc/tests/test_work_item_requires_approval.py
@@ -119,3 +119,29 @@ class TestApprovalCategoryValidation:
                     str(uuid.uuid4()),
                     requires_approval_before=["not_a_category"],
                 )
+
+    async def test_update_accepts_valid_categories(self, service, mock_session):
+        item = MagicMock()
+        item.requires_approval_before = []
+        with patch.object(service, "get", new=AsyncMock(return_value=item)):
+            await service.update(
+                mock_session, str(uuid.uuid4()), requires_approval_before=["publishing"]
+            )
+        assert item.requires_approval_before == ["publishing"]
+
+    async def test_update_exempts_preexisting_legacy_value(self, service, mock_session):
+        # A legacy free-text value already on the item is exempt (won't block an edit),
+        # but a genuinely-new unknown category is still rejected.
+        item = MagicMock()
+        item.requires_approval_before = ["legacy_freetext"]
+        with patch.object(service, "get", new=AsyncMock(return_value=item)):
+            await service.update(
+                mock_session, str(uuid.uuid4()),
+                requires_approval_before=["legacy_freetext", "pushing commits"],
+            )
+            assert item.requires_approval_before == ["legacy_freetext", "pushing commits"]
+            with pytest.raises(ValueError):
+                await service.update(
+                    mock_session, str(uuid.uuid4()),
+                    requires_approval_before=["legacy_freetext", "brand_new_typo"],
+                )

--- a/autobot_shared/tool_catalogue.py
+++ b/autobot_shared/tool_catalogue.py
@@ -16,6 +16,8 @@ catalogues exactly (asserted by parity tests) — this is a consolidation, not a
 behaviour change.
 """
 
+from enum import Enum
+
 # --- atoms -----------------------------------------------------------------
 
 SHELL_EXEC_TOOLS = ("bash", "shell", "execute_command", "run_command")
@@ -60,3 +62,22 @@ APPROVAL_CATEGORY_TOOLS = {
     "destructive operations": FILE_DELETE_TOOLS + SHELL_EXEC_TOOLS + CONTAINER_ORCH_TOOLS,
     "rotating credentials": ("rotate_credentials", "rotate_key", "vault_rotate"),
 }
+
+
+class ApprovalCategory(str, Enum):
+    """Controlled vocabulary for a work item's ``requires_approval_before`` (GH#11206).
+
+    Values match ``APPROVAL_CATEGORY_TOOLS`` keys exactly (enforced by test). A
+    declared category outside this set matches no tools at the seam and silently
+    disables the gate, so callers should validate against these values at set time.
+    """
+
+    PUSHING_COMMITS = "pushing commits"
+    PUBLISHING = "publishing"
+    DESTRUCTIVE_OPERATIONS = "destructive operations"
+    ROTATING_CREDENTIALS = "rotating credentials"
+
+
+def valid_approval_categories() -> "frozenset[str]":
+    """Return the set of valid ``requires_approval_before`` category strings."""
+    return frozenset(c.value for c in ApprovalCategory)

--- a/autobot_shared/tool_catalogue_test.py
+++ b/autobot_shared/tool_catalogue_test.py
@@ -13,6 +13,8 @@ from autobot_shared.tool_catalogue import (
     APPROVAL_CATEGORY_TOOLS,
     INFRA_AND_SHELL_TOOLS,
     SENSITIVE_TOOLS,
+    ApprovalCategory,
+    valid_approval_categories,
 )
 
 # --- frozen snapshots of the original literals (pre-#11206) -----------------
@@ -96,6 +98,13 @@ def test_approval_categories_parity():
     assert set(APPROVAL_CATEGORY_TOOLS) == set(_ORIG_APPROVAL)
     for category, tools in _ORIG_APPROVAL.items():
         assert set(APPROVAL_CATEGORY_TOOLS[category]) == tools, category
+
+
+def test_approval_category_enum_matches_catalogue_keys():
+    # The controlled vocabulary must stay in sync with the tool catalogue keys,
+    # else a valid category could match no tools (silent gate bypass).
+    assert valid_approval_categories() == set(APPROVAL_CATEGORY_TOOLS)
+    assert {c.value for c in ApprovalCategory} == set(APPROVAL_CATEGORY_TOOLS)
 
 
 def test_consumers_reexport_the_catalogue():


### PR DESCRIPTION
## Thinking Path

#11206 "ApprovalCategory enum" part — but analysis surfaced a real correctness bug behind it. A work item's `requires_approval_before` (#11140) is a free-text JSONB list; the seam matcher does `_APPROVAL_CATEGORY_TOOLS.get(category, ())`, so a **typo'd category silently matches no tools and disables the gate** — a governance bypass with no error.

## What Changed

- **`autobot_shared/tool_catalogue.py`** — `ApprovalCategory` (str enum: the 4 canonical categories) + `valid_approval_categories()`. Kept in sync with `APPROVAL_CATEGORY_TOOLS` keys (asserted by test).
- **`llc/services/work_item_service.py`** — `_validated_approval_categories()` rejects unknown categories (fail-fast `ValueError`) at `create()` and `update()`, mirroring the session-role validation pattern.
- Tests: enum↔catalogue parity; create accepts valid / rejects typo; update rejects unknown.

## Verification

```
$ python3 -m pytest autobot_shared/tool_catalogue_test.py -q          # 5 passed
$ python3 -m pytest llc/tests/test_work_item_requires_approval.py -q  # 7 passed
```

## Note

This closes the remaining actionable part of #11206. The two other listed opportunities are **de-scoped as not clean wins**: the shared claude-CLI builder (backend vs adapter have materially different signatures — forcing it reduces clarity), and the seam guard-chain loop (a lateral move — the explicit `if/yield/return` blocks are already clear/greppable). The high-value consolidation (tool-catalogue SSOT, #11208) + this validation fix are the substance.

## Model Used

Claude Opus 4.8 (1M context)

Closes #11206