### PR TITLE
refactor(governance): one canonical tool-name matcher — dedup 3 copies (#11206)

### DIFF
--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -49,7 +49,7 @@ from autobot_shared.error_boundaries import (
     classify_error,
 )
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.tool_catalogue import SENSITIVE_TOOLS
+from autobot_shared.tool_catalogue import SENSITIVE_TOOLS, match_tool_name
 from autobot_shared.tracing import step_span
 from events import EventStreamManager, EventType
 from events.bus import PersistStrategy
@@ -1415,15 +1415,9 @@ Duration: {self._current_context.get_duration_ms():.0f}ms{belief_summary}
 
     @staticmethod
     def _sensitive_tool_name(tool: dict[str, Any]) -> str | None:
-        """Return the tool name if it is in SENSITIVE_TOOLS, else None."""
-        name = tool.get("tool_name", "").lower()
-        if name in SENSITIVE_TOOLS:
-            return name
-        # Also match by prefix so e.g. "bash_run" → "bash" is caught.
-        for sensitive in SENSITIVE_TOOLS:
-            if name.startswith(sensitive):
-                return sensitive
-        return None
+        """Return the matched SENSITIVE_TOOLS name (exact or prefix, e.g. "bash_run" →
+        "bash"), else None. GH#11206: uses the canonical ``match_tool_name``."""
+        return match_tool_name(tool.get("tool_name", ""), SENSITIVE_TOOLS)
 
     @staticmethod
     def _resolve_forbidden_tools(config: "AgentLoopConfig", agent_id: str | None) -> "AgentLoopConfig":

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 from async_chat_workflow import WorkflowMessage
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.tool_catalogue import APPROVAL_CATEGORY_TOOLS
+from autobot_shared.tool_catalogue import APPROVAL_CATEGORY_TOOLS, match_tool_name
 from tools.code_interpreter import CODE_INTERPRETER_SCHEMA
 from utils.errors import RepairableException
 
@@ -418,15 +418,13 @@ _APPROVAL_CATEGORY_TOOLS: dict[str, tuple[str, ...]] = APPROVAL_CATEGORY_TOOLS
 def _approval_category_for(tool_name: str, declared: list[str]) -> str | None:
     """Return the declared category that gates *tool_name*, else None (GH#11160).
 
-    Matches by exact name or ``<gated>_`` word-boundary prefix (so ``deploy`` gates
-    ``deploy_service`` but not ``deployment_status``). A false positive only ever
-    adds an approval hold — the fail-safe direction — never a bypass.
+    GH#11206: uses the canonical ``match_tool_name`` with word-boundary matching
+    (so ``deploy`` gates ``deploy_service`` but not ``deployment_status``). A false
+    positive only ever adds an approval hold — the fail-safe direction — never a bypass.
     """
-    name = tool_name.lower()
     for category in declared:
-        for gated in _APPROVAL_CATEGORY_TOOLS.get(category, ()):
-            if name == gated or name.startswith(gated + "_"):
-                return category
+        if match_tool_name(tool_name, _APPROVAL_CATEGORY_TOOLS.get(category, ()), word_boundary=True):
+            return category
     return None
 
 

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -52,9 +52,7 @@ _bg_tasks: set = set()
 _CHECKOUT_TTL = 1800  # seconds
 
 
-def _validated_approval_categories(
-    values: Optional[List[str]], existing: Optional[List[str]] = None
-) -> List[str]:
+def _validated_approval_categories(values: Optional[List[str]], existing: Optional[List[str]] = None) -> List[str]:
     """Validate ``requires_approval_before`` entries against the controlled vocabulary (GH#11206).
 
     A typo'd category matches no tools at the seam and silently disables the gate,

--- a/autobot-backend/llc/tests/test_work_item_requires_approval.py
+++ b/autobot-backend/llc/tests/test_work_item_requires_approval.py
@@ -124,9 +124,7 @@ class TestApprovalCategoryValidation:
         item = MagicMock()
         item.requires_approval_before = []
         with patch.object(service, "get", new=AsyncMock(return_value=item)):
-            await service.update(
-                mock_session, str(uuid.uuid4()), requires_approval_before=["publishing"]
-            )
+            await service.update(mock_session, str(uuid.uuid4()), requires_approval_before=["publishing"])
         assert item.requires_approval_before == ["publishing"]
 
     async def test_update_exempts_preexisting_legacy_value(self, service, mock_session):
@@ -136,12 +134,14 @@ class TestApprovalCategoryValidation:
         item.requires_approval_before = ["legacy_freetext"]
         with patch.object(service, "get", new=AsyncMock(return_value=item)):
             await service.update(
-                mock_session, str(uuid.uuid4()),
+                mock_session,
+                str(uuid.uuid4()),
                 requires_approval_before=["legacy_freetext", "pushing commits"],
             )
             assert item.requires_approval_before == ["legacy_freetext", "pushing commits"]
             with pytest.raises(ValueError):
                 await service.update(
-                    mock_session, str(uuid.uuid4()),
+                    mock_session,
+                    str(uuid.uuid4()),
                     requires_approval_before=["legacy_freetext", "brand_new_typo"],
                 )

--- a/autobot-backend/orchestration/agent_registry.py
+++ b/autobot-backend/orchestration/agent_registry.py
@@ -12,7 +12,7 @@ Contains agent registration, lookup, and management functionality.
 from typing import Dict, List, Set
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.tool_catalogue import INFRA_AND_SHELL_TOOLS
+from autobot_shared.tool_catalogue import INFRA_AND_SHELL_TOOLS, match_tool_name
 
 from .types import AgentCapability, AgentProfile
 
@@ -122,20 +122,12 @@ def get_default_agents() -> List[AgentProfile]:
 def match_forbidden_tool(tool_name: str, forbidden: "frozenset[str]") -> "str | None":
     """Return the ``forbidden_work`` pattern matching *tool_name*, else None (GH#11145).
 
-    Single source for forbidden-tool matching — the agent loop and the production
-    tool-dispatch seam both call this so the exact/prefix rule lives in one place.
-    Matching is case-insensitive; a manifest entry matches by exact name or as a
-    name prefix (e.g. ``deploy`` blocks ``deploy_service``).
+    Thin wrapper over the canonical ``match_tool_name`` (GH#11206) so the agent loop
+    and the production tool-dispatch seam share one exact/prefix rule. Case-insensitive;
+    a manifest entry matches by exact name or as a name prefix (``deploy`` blocks
+    ``deploy_service``).
     """
-    if not forbidden:
-        return None
-    name = tool_name.lower()
-    if name in forbidden:
-        return name
-    for pattern in forbidden:
-        if name.startswith(pattern):
-            return pattern
-    return None
+    return match_tool_name(tool_name, forbidden)
 
 
 class AgentRegistry:

--- a/autobot_shared/tool_catalogue.py
+++ b/autobot_shared/tool_catalogue.py
@@ -17,6 +17,28 @@ behaviour change.
 """
 
 from enum import Enum
+from typing import Iterable, Optional
+
+
+def match_tool_name(tool_name: str, patterns: Iterable[str], *, word_boundary: bool = False) -> Optional[str]:
+    """Return the pattern in *patterns* that matches *tool_name*, else ``None`` (GH#11206).
+
+    The single canonical tool-name matcher for every governance plane (forbidden_work,
+    sensitive-tool approval, work-item approval categories). Case-insensitive; an exact
+    match anywhere wins, otherwise the first prefix match is returned. *word_boundary*
+    requires a ``<pattern>_`` boundary (``deploy`` matches ``deploy_x`` but not
+    ``deployment``); the default plain prefix keeps the broader, fail-safe denylist
+    behaviour (``deploy`` also matches ``deployment``).
+    """
+    name = tool_name.lower()
+    pats = tuple(patterns)
+    if name in pats:
+        return name
+    for pattern in pats:
+        if name.startswith(f"{pattern}_") if word_boundary else name.startswith(pattern):
+            return pattern
+    return None
+
 
 # --- atoms -----------------------------------------------------------------
 
@@ -78,6 +100,9 @@ class ApprovalCategory(str, Enum):
     ROTATING_CREDENTIALS = "rotating credentials"
 
 
+_VALID_APPROVAL_CATEGORIES = frozenset(c.value for c in ApprovalCategory)
+
+
 def valid_approval_categories() -> "frozenset[str]":
     """Return the set of valid ``requires_approval_before`` category strings."""
-    return frozenset(c.value for c in ApprovalCategory)
+    return _VALID_APPROVAL_CATEGORIES

--- a/autobot_shared/tool_catalogue_test.py
+++ b/autobot_shared/tool_catalogue_test.py
@@ -14,8 +14,68 @@ from autobot_shared.tool_catalogue import (
     INFRA_AND_SHELL_TOOLS,
     SENSITIVE_TOOLS,
     ApprovalCategory,
+    match_tool_name,
     valid_approval_categories,
 )
+
+
+# --- match_tool_name (canonical matcher) -----------------------------------
+
+
+def test_match_tool_name_exact_and_case_insensitive():
+    assert match_tool_name("bash", ("bash", "deploy")) == "bash"
+    assert match_tool_name("BASH", ("bash",)) == "bash"
+
+
+def test_match_tool_name_plain_prefix():
+    assert match_tool_name("bash_run", ("bash",)) == "bash"
+    assert match_tool_name("deployment", ("deploy",)) == "deploy"  # plain prefix matches
+
+
+def test_match_tool_name_word_boundary():
+    assert match_tool_name("deploy_service", ("deploy",), word_boundary=True) == "deploy"
+    assert match_tool_name("deployment", ("deploy",), word_boundary=True) is None
+
+
+def test_match_tool_name_no_match_and_empty():
+    assert match_tool_name("web_search", ("bash", "deploy")) is None
+    assert match_tool_name("bash", ()) is None
+
+
+def _orig_forbidden(name, forbidden):
+    if not forbidden:
+        return None
+    name = name.lower()
+    if name in forbidden:
+        return name
+    for pattern in forbidden:
+        if name.startswith(pattern):
+            return pattern
+    return None
+
+
+def _orig_approval(name, declared):
+    name = name.lower()
+    for category in declared:
+        for gated in APPROVAL_CATEGORY_TOOLS.get(category, ()):
+            if name == gated or name.startswith(gated + "_"):
+                return category
+    return None
+
+
+def test_match_tool_name_parity_with_original_matchers():
+    from chat_workflow.tool_handler import _approval_category_for
+    from orchestration.agent_registry import match_forbidden_tool
+
+    forbidden = frozenset(INFRA_AND_SHELL_TOOLS)
+    cats = list(APPROVAL_CATEGORY_TOOLS)
+    names = [
+        "bash", "BASH", "bash_run", "deploy", "deployment", "deploy_service",
+        "git_push", "git_pusher", "web_search", "docker_compose", "unknown_tool", "",
+    ]
+    for n in names:
+        assert match_forbidden_tool(n, forbidden) == _orig_forbidden(n, forbidden), n
+        assert _approval_category_for(n, cats) == _orig_approval(n, cats), n
 
 # --- frozen snapshots of the original literals (pre-#11206) -----------------
 

--- a/autobot_shared/tool_catalogue_test.py
+++ b/autobot_shared/tool_catalogue_test.py
@@ -18,7 +18,6 @@ from autobot_shared.tool_catalogue import (
     valid_approval_categories,
 )
 
-
 # --- match_tool_name (canonical matcher) -----------------------------------
 
 
@@ -70,12 +69,23 @@ def test_match_tool_name_parity_with_original_matchers():
     forbidden = frozenset(INFRA_AND_SHELL_TOOLS)
     cats = list(APPROVAL_CATEGORY_TOOLS)
     names = [
-        "bash", "BASH", "bash_run", "deploy", "deployment", "deploy_service",
-        "git_push", "git_pusher", "web_search", "docker_compose", "unknown_tool", "",
+        "bash",
+        "BASH",
+        "bash_run",
+        "deploy",
+        "deployment",
+        "deploy_service",
+        "git_push",
+        "git_pusher",
+        "web_search",
+        "docker_compose",
+        "unknown_tool",
+        "",
     ]
     for n in names:
         assert match_forbidden_tool(n, forbidden) == _orig_forbidden(n, forbidden), n
         assert _approval_category_for(n, cats) == _orig_approval(n, cats), n
+
 
 # --- frozen snapshots of the original literals (pre-#11206) -----------------
 


### PR DESCRIPTION
## Thinking Path

Follow-up to #11208. It unified the tool-set **data**; but the **matching logic** over those sets was still copy-pasted three times — each an "exact-or-prefix match against a tool set", which is the same drift risk one layer up. Zero-duplication / canonical: one matcher.

## What Changed

- **`autobot_shared/tool_catalogue.py`** — `match_tool_name(tool_name, patterns, *, word_boundary=False)`: the single canonical matcher. Case-insensitive, exact-wins, then prefix (plain or `<pattern>_` word-boundary). Also caches `valid_approval_categories()`.
- **`orchestration/agent_registry.py`** — `match_forbidden_tool` → one-line delegate.
- **`agent_loop/loop.py`** — `_sensitive_tool_name` → delegate.
- **`chat_workflow/tool_handler.py`** — `_approval_category_for` → delegate (`word_boundary=True`).
- **`autobot_shared/tool_catalogue_test.py`** — `match_tool_name` unit tests **+ a parity test** asserting the refactored `match_forbidden_tool` / `_approval_category_for` return identical results to the original inline logic across 12 representative inputs.

`word_boundary` preserves each caller's **exact prior behaviour**: plain prefix for the fail-safe denylists (forbidden_work / sensitive), `<pattern>_` boundary for the approval categories. No behaviour change — a dedup.

## Verification

```
$ python3 -m pytest autobot_shared/tool_catalogue_test.py -q     # 10 passed (incl. parity)
$ python3 -m pytest orchestration/capability_audit_test.py \
    tests/unit/chat_workflow/test_governed_execution.py \
    tests/unit/chat_workflow/test_tool_handler_forbidden_work.py -q   # 22 passed (no regression)
```

## Model Used

Claude Opus 4.8 (1M context)

Part of #11206