### PR TITLE
polish(governance): clearer match_tool_name expr + _sensitive parity (#11206)

### DIFF
--- a/autobot_shared/tool_catalogue.py
+++ b/autobot_shared/tool_catalogue.py
@@ -34,8 +34,9 @@ def match_tool_name(tool_name: str, patterns: Iterable[str], *, word_boundary: b
     pats = tuple(patterns)
     if name in pats:
         return name
+    suffix = "_" if word_boundary else ""
     for pattern in pats:
-        if name.startswith(f"{pattern}_") if word_boundary else name.startswith(pattern):
+        if name.startswith(pattern + suffix):
             return pattern
     return None
 

--- a/autobot_shared/tool_catalogue_test.py
+++ b/autobot_shared/tool_catalogue_test.py
@@ -62,7 +62,18 @@ def _orig_approval(name, declared):
     return None
 
 
+def _orig_sensitive(name):
+    name = name.lower()
+    if name in SENSITIVE_TOOLS:
+        return name
+    for s in SENSITIVE_TOOLS:
+        if name.startswith(s):
+            return s
+    return None
+
+
 def test_match_tool_name_parity_with_original_matchers():
+    from agent_loop.loop import AgentLoop
     from chat_workflow.tool_handler import _approval_category_for
     from orchestration.agent_registry import match_forbidden_tool
 
@@ -85,6 +96,7 @@ def test_match_tool_name_parity_with_original_matchers():
     for n in names:
         assert match_forbidden_tool(n, forbidden) == _orig_forbidden(n, forbidden), n
         assert _approval_category_for(n, cats) == _orig_approval(n, cats), n
+        assert AgentLoop._sensitive_tool_name({"tool_name": n}) == _orig_sensitive(n), n
 
 
 # --- frozen snapshots of the original literals (pre-#11206) -----------------


### PR DESCRIPTION
Re-applies the review polish lost to a non-ff on PR #11210's merge (readability of the prefix expression + a `_sensitive_tool_name` parity assertion). Content already reviewed on #11210. 10 tests pass. Part of #11206.