### PR TITLE
feat(delegation): wire delegate tool to governed subagent runner, flag-gated (#11207)

### DIFF
--- a/autobot-backend/chat_workflow/delegation.py
+++ b/autobot-backend/chat_workflow/delegation.py
@@ -1,0 +1,100 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Governed subagent delegation runner (GH#11207).
+
+Wires the (previously unwired) ``delegate`` tool to an isolated subagent runner:
+a delegated subtask runs as a *governed autonomous agent* whose ``forbidden_work``
+manifest constrains it — agent autonomy with backend-enforced oversight, without
+re-entering the chat pipeline.
+
+Provider-agnostic by design: ``run_delegated_subtask`` dispatches to a named
+engine. This module ships the **claude_code** engine (an ``ExecutionBackend`` that
+runs its own tool loop, governed via ``--disallowedTools`` from the profile — see
+GH#11188); the in-process internal-LLM engine is a follow-up that registers here.
+
+OFF by default (``AUTOBOT_DELEGATION_ENABLED``) so the live chat path is unchanged
+until delegation is explicitly enabled and validated.
+"""
+
+import os
+from typing import Awaitable, Callable, Dict, List
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+# Master switch — delegate tool keeps its current (record-only) behaviour when off.
+DELEGATION_ENABLED: bool = os.environ.get("AUTOBOT_DELEGATION_ENABLED", "").lower() in ("1", "true", "yes")
+# Bound on how deep delegation may nest (defence against runaway delegation).
+MAX_DELEGATION_DEPTH: int = int(os.environ.get("AUTOBOT_MAX_DELEGATION_DEPTH", "2"))
+
+# AutoBot ``forbidden_work`` token → claude_code CLI tool name to disallow. claude_code
+# exposes coarse tools (Bash/Edit/Write), so shell/infra/file-mutation tokens collapse
+# onto them. An unmapped token is simply not disallowed (fail-open on that token, but
+# the profile's other tokens still constrain the agent).
+_CLAUDE_TOOL_FOR: Dict[str, str] = {
+    "bash": "Bash",
+    "shell": "Bash",
+    "execute_command": "Bash",
+    "run_command": "Bash",
+    "system_exec": "Bash",
+    "terminal": "Bash",
+    "deploy": "Bash",
+    "ansible": "Bash",
+    "docker": "Bash",
+    "kubectl": "Bash",
+    "helm": "Bash",
+    "terraform": "Bash",
+    "delete_file": "Bash",
+    "remove_directory": "Bash",
+    "move_file": "Bash",
+    "copy_file": "Bash",
+    "create_directory": "Bash",
+    "write_file": "Write",
+    "edit_file": "Edit",
+}
+
+
+def forbidden_to_claude_tools(forbidden: "frozenset[str] | list[str]") -> List[str]:
+    """Map a profile's ``forbidden_work`` tokens to claude_code ``--disallowedTools``."""
+    return sorted({_CLAUDE_TOOL_FOR[f] for f in forbidden if f in _CLAUDE_TOOL_FOR})
+
+
+async def _run_claude_code_subagent(task: str, agent_type: str, depth: int) -> str:
+    """Run *task* as a governed claude_code subagent; return its output."""
+    from orchestration.agent_registry import resolve_forbidden_tools
+    from services.execution.base_backend import ExecutionTask
+    from services.execution.claude_code_backend import build_claude_code_backend
+
+    disallowed = forbidden_to_claude_tools(resolve_forbidden_tools(agent_type))
+    exec_task = ExecutionTask(
+        task_id=f"delegate-{agent_type}-d{depth}",
+        code=task,
+        metadata={"disallowed_tools": disallowed, "delegation_depth": depth + 1},
+    )
+    logger.info("delegation: claude_code subagent agent=%s depth=%d disallowed=%s", agent_type, depth, disallowed)
+    result = await build_claude_code_backend().execute(exec_task)
+    return result.stdout or result.stderr or ""
+
+
+# Engine registry — the internal-LLM engine registers here in a follow-up (GH#11207).
+_ENGINES: Dict[str, Callable[[str, str, int], Awaitable[str]]] = {
+    "claude_code": _run_claude_code_subagent,
+}
+
+
+async def run_delegated_subtask(
+    task: str, agent_type: str = "research_agent", depth: int = 0, engine: str = "claude_code"
+) -> str:
+    """Run a delegated subtask as a governed subagent (GH#11207).
+
+    Raises ``ValueError`` past ``MAX_DELEGATION_DEPTH`` or for an unknown engine.
+    """
+    if depth >= MAX_DELEGATION_DEPTH:
+        raise ValueError(f"max delegation depth {MAX_DELEGATION_DEPTH} reached (depth={depth})")
+    runner = _ENGINES.get(engine)
+    if runner is None:
+        raise ValueError(f"unknown delegation engine: {engine!r} (available: {sorted(_ENGINES)})")
+    return await runner(task, agent_type, depth)

--- a/autobot-backend/chat_workflow/delegation.py
+++ b/autobot-backend/chat_workflow/delegation.py
@@ -72,6 +72,9 @@ async def _run_claude_code_subagent(task: str, agent_type: str, depth: int) -> s
     exec_task = ExecutionTask(
         task_id=f"delegate-{agent_type}-d{depth}",
         code=task,
+        # ``delegation_depth`` is informational for the external claude_code engine
+        # (it runs out-of-process, so its own ctx never reads this back). Recursion
+        # depth is only enforced for delegation initiated within one AutoBot process.
         metadata={"disallowed_tools": disallowed, "delegation_depth": depth + 1},
     )
     logger.info("delegation: claude_code subagent agent=%s depth=%d disallowed=%s", agent_type, depth, disallowed)

--- a/autobot-backend/chat_workflow/delegation_test.py
+++ b/autobot-backend/chat_workflow/delegation_test.py
@@ -27,6 +27,18 @@ def test_forbidden_to_claude_tools_ignores_unmapped():
     assert forbidden_to_claude_tools(["totally_unknown_tool"]) == []
 
 
+def test_shipped_research_agent_has_no_fail_open_tokens():
+    # Governance guard: every token the shipped research_agent forbids must map to a
+    # claude_code --disallowedTools entry, so nothing silently fails open.
+    from chat_workflow.delegation import _CLAUDE_TOOL_FOR
+    from orchestration.agent_registry import resolve_forbidden_tools
+
+    forbidden = resolve_forbidden_tools("research_agent")
+    assert forbidden, "research_agent must declare forbidden_work"
+    unmapped = sorted(t for t in forbidden if t not in _CLAUDE_TOOL_FOR)
+    assert unmapped == [], f"forbidden tokens with no claude_code mapping (fail-open): {unmapped}"
+
+
 # --- run_delegated_subtask dispatch + guards -------------------------------
 
 

--- a/autobot-backend/chat_workflow/delegation_test.py
+++ b/autobot-backend/chat_workflow/delegation_test.py
@@ -1,0 +1,103 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Governed subagent delegation runner (GH#11207)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from chat_workflow import delegation
+from chat_workflow.delegation import (
+    MAX_DELEGATION_DEPTH,
+    forbidden_to_claude_tools,
+    run_delegated_subtask,
+)
+
+
+# --- forbidden_work → claude_code tool mapping -----------------------------
+
+
+def test_forbidden_to_claude_tools_maps_and_dedups():
+    out = forbidden_to_claude_tools(["bash", "execute_command", "write_file", "edit_file"])
+    assert out == ["Bash", "Edit", "Write"]  # bash+execute_command → single Bash, sorted
+
+
+def test_forbidden_to_claude_tools_ignores_unmapped():
+    assert forbidden_to_claude_tools(["totally_unknown_tool"]) == []
+
+
+# --- run_delegated_subtask dispatch + guards -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_delegated_subtask_depth_guard():
+    with pytest.raises(ValueError):
+        await run_delegated_subtask("t", depth=MAX_DELEGATION_DEPTH)
+
+
+@pytest.mark.asyncio
+async def test_run_delegated_subtask_unknown_engine():
+    with pytest.raises(ValueError):
+        await run_delegated_subtask("t", engine="not_an_engine")
+
+
+@pytest.mark.asyncio
+async def test_run_delegated_subtask_dispatches_to_engine():
+    engine = AsyncMock(return_value="subagent output")
+    with patch.dict(delegation._ENGINES, {"claude_code": engine}):
+        out = await run_delegated_subtask("do it", agent_type="research_agent", depth=0)
+    assert out == "subagent output"
+    engine.assert_awaited_once_with("do it", "research_agent", 0)
+
+
+@pytest.mark.asyncio
+async def test_claude_code_engine_passes_disallowed_from_forbidden_work():
+    # research_agent forbids infra/shell tools → they map to Bash on the CLI.
+    import services.execution.claude_code_backend as ccb
+
+    result = type("R", (), {"stdout": "ok", "stderr": ""})()
+    mock_exec = AsyncMock(return_value=result)
+    with patch.object(ccb.ClaudeCodeBackend, "execute", new=mock_exec):
+        out = await delegation._run_claude_code_subagent("subtask", "research_agent", 0)
+    assert out == "ok"
+    task = mock_exec.await_args.args[0]  # Mock class-attr is not bound → self not passed
+    assert "Bash" in task.metadata["disallowed_tools"]
+
+
+# --- _handle_delegate_tool: flag off = unchanged, on = runs subagent -------
+
+
+def _mixin():
+    from chat_workflow.tool_handler import ToolHandlerMixin
+
+    return ToolHandlerMixin.__new__(ToolHandlerMixin)
+
+
+@pytest.mark.asyncio
+async def test_delegate_tool_off_records_pending_delegation():
+    mixin = _mixin()
+    results = []
+    with patch.object(delegation, "DELEGATION_ENABLED", False):
+        msgs = [m async for m in mixin._handle_delegate_tool({"params": {"task": "x"}}, results, None)]
+    assert results[0]["status"] == "pending_delegation"
+    assert msgs[0].type == "delegation"
+
+
+@pytest.mark.asyncio
+async def test_delegate_tool_on_runs_governed_subagent():
+    mixin = _mixin()
+    results = []
+    with (
+        patch.object(delegation, "DELEGATION_ENABLED", True),
+        patch.object(delegation, "run_delegated_subtask", new=AsyncMock(return_value="done")),
+    ):
+        msgs = [
+            m
+            async for m in mixin._handle_delegate_tool(
+                {"params": {"task": "x", "agent_type": "research_agent"}}, results, None
+            )
+        ]
+    assert results[0]["status"] == "completed" and results[0]["result"] == "done"
+    assert msgs[0].type == "delegation"

--- a/autobot-backend/chat_workflow/delegation_test.py
+++ b/autobot-backend/chat_workflow/delegation_test.py
@@ -15,7 +15,6 @@ from chat_workflow.delegation import (
     run_delegated_subtask,
 )
 
-
 # --- forbidden_work → claude_code tool mapping -----------------------------
 
 

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -1794,45 +1794,65 @@ class ToolHandlerMixin:
 
         return message, break_loop_requested, respond_content
 
-    def _handle_delegate_tool(
-        self, tool_call: dict[str, Any], execution_results: list[dict[str, Any]]
-    ) -> WorkflowMessage:
-        """
-        Handle the 'delegate' tool for subordinate agent delegation.
+    async def _handle_delegate_tool(
+        self,
+        tool_call: dict[str, Any],
+        execution_results: list[dict[str, Any]],
+        ctx: "LLMIterationContext" | None = None,
+    ):
+        """Handle the 'delegate' tool (Issue #657; GH#11207 execution).
 
-        Issue #665: Extracted from _process_tool_calls for single responsibility.
-        Issue #657: Original delegate tool handling logic.
-
-        Returns:
-            WorkflowMessage for delegation status
+        When ``AUTOBOT_DELEGATION_ENABLED`` is off (default) this keeps the original
+        record-only behaviour — no change to the live chat path. When on, it runs
+        the subtask as a governed subagent (its ``forbidden_work`` constrains it) via
+        the selected engine and returns the result. Yields WorkflowMessage(s).
         """
+        from chat_workflow.delegation import DELEGATION_ENABLED, run_delegated_subtask
+
         params = tool_call.get("params", {})
         task = params.get("task", "")
         reason = params.get("reason", "Task delegation")
-        wait_for_result = params.get("wait_for_result", True)
 
-        logger.info("[Issue #657] Delegate tool invoked: task=%s, reason=%s", task[:100], reason)
+        if not DELEGATION_ENABLED:
+            logger.info("[Issue #657] Delegate tool invoked (record-only): task=%s", task[:100])
+            execution_results.append(
+                {
+                    "tool": "delegate",
+                    "task": task,
+                    "reason": reason,
+                    "wait_for_result": params.get("wait_for_result", True),
+                    "status": "pending_delegation",
+                }
+            )
+            yield WorkflowMessage(
+                type="delegation",
+                content=f"Delegating subtask: {task[:100]}...",
+                metadata={"message_type": "delegate_tool", "reason": reason, "task": task},
+            )
+            return
 
-        # Record delegation for manager to process
-        execution_results.append(
-            {
-                "tool": "delegate",
-                "task": task,
-                "reason": reason,
-                "wait_for_result": wait_for_result,
-                "status": "pending_delegation",
-            }
-        )
-
-        return WorkflowMessage(
-            type="delegation",
-            content=f"Delegating subtask: {task[:100]}...",
-            metadata={
-                "message_type": "delegate_tool",
-                "reason": reason,
-                "task": task,
-            },
-        )
+        agent_type = params.get("agent_type", "research_agent")
+        engine = params.get("engine", "claude_code")
+        depth = int((getattr(ctx, "context", None) or {}).get("delegation_depth", 0)) if ctx else 0
+        logger.info("[GH#11207] Delegating to %s subagent (engine=%s, depth=%d): %s", agent_type, engine, depth, task[:100])
+        try:
+            result = await run_delegated_subtask(task, agent_type=agent_type, depth=depth, engine=engine)
+            execution_results.append(
+                {"tool": "delegate", "task": task, "agent_type": agent_type, "engine": engine, "status": "completed", "result": result}
+            )
+            yield WorkflowMessage(
+                type="delegation",
+                content=f"Subagent ({agent_type}) completed: {result[:200]}",
+                metadata={"message_type": "delegate_tool", "agent_type": agent_type, "engine": engine},
+            )
+        except Exception as exc:
+            logger.warning("[GH#11207] Delegation failed: %s", exc)
+            execution_results.append({"tool": "delegate", "task": task, "status": "error", "error": str(exc)})
+            yield WorkflowMessage(
+                type="error",
+                content=f"Delegation failed: {exc}",
+                metadata={"message_type": "delegate_tool", "error": True},
+            )
 
     def _validate_browser_params(self, tool_name: str, params: dict[str, Any]) -> str | None:
         """Validate browser tool params. Returns error message or None. #1368."""
@@ -2598,7 +2618,8 @@ class ToolHandlerMixin:
         if tool_name == "delegate":
             if ctx is not None:
                 ctx.consecutive_invalid_tool_calls = 0
-            yield self._handle_delegate_tool(tool_call, execution_results)
+            async for msg in self._handle_delegate_tool(tool_call, execution_results, ctx):
+                yield msg
             return
 
         # Issue #1368: Route browser tools to browser VM

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -1834,11 +1834,20 @@ class ToolHandlerMixin:
         agent_type = params.get("agent_type", "research_agent")
         engine = params.get("engine", "claude_code")
         depth = int((getattr(ctx, "context", None) or {}).get("delegation_depth", 0)) if ctx else 0
-        logger.info("[GH#11207] Delegating to %s subagent (engine=%s, depth=%d): %s", agent_type, engine, depth, task[:100])
+        logger.info(
+            "[GH#11207] Delegating to %s subagent (engine=%s, depth=%d): %s", agent_type, engine, depth, task[:100]
+        )
         try:
             result = await run_delegated_subtask(task, agent_type=agent_type, depth=depth, engine=engine)
             execution_results.append(
-                {"tool": "delegate", "task": task, "agent_type": agent_type, "engine": engine, "status": "completed", "result": result}
+                {
+                    "tool": "delegate",
+                    "task": task,
+                    "agent_type": agent_type,
+                    "engine": engine,
+                    "status": "completed",
+                    "result": result,
+                }
             )
             yield WorkflowMessage(
                 type="delegation",

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -1814,7 +1814,7 @@ class ToolHandlerMixin:
         reason = params.get("reason", "Task delegation")
 
         if not DELEGATION_ENABLED:
-            logger.info("[Issue #657] Delegate tool invoked (record-only): task=%s", task[:100])
+            logger.info("[Issue #657] Delegate tool invoked (record-only): task=%s, reason=%s", task[:100], reason)
             execution_results.append(
                 {
                     "tool": "delegate",


### PR DESCRIPTION
Closes #11214 (PR1 sub-task of #11207).

## Thinking Path

The `delegate` tool existed but was **unwired** — `_handle_delegate_tool` only recorded a `pending_delegation` marker; nothing ran the subtask. #11207 asked for "Full" delegation: a subordinate that has **agent autonomy** *and* **backend-enforced oversight**.

Governed agents in AutoBot run **externally** as `ExecutionBackend`s (claude_code adapters run their own tool loop), not through the in-process seam. So the wiring belongs at the backend, constrained by the profile's `forbidden_work` manifest — mapped to the engine's disallow mechanism (`--disallowedTools`, GH#11188).

## What Changed

- **`chat_workflow/delegation.py`** (new): `run_delegated_subtask(task, agent_type, depth, engine)` dispatches to a named engine via a registry. Ships the **claude_code** engine: resolves the profile's `forbidden_work`, maps tokens → claude_code coarse tools (Bash/Edit/Write) via `forbidden_to_claude_tools`, and passes them as `disallowed_tools` on the `ExecutionTask`. Depth-bounded by `AUTOBOT_MAX_DELEGATION_DEPTH` (default 2).
- **`chat_workflow/tool_handler.py`**: `_handle_delegate_tool` is now an async generator. When `AUTOBOT_DELEGATION_ENABLED` is **off (default)** it keeps the exact record-only behaviour — live chat path unchanged. When on, it runs the governed subagent and yields the result. Dispatch site updated to `async for`.

**Provider-agnostic by design**: the engine registry (`_ENGINES`) currently registers `claude_code`; the in-process **internal-LLM** engine registers in a follow-up (PR2).

## Verification

`chat_workflow/delegation_test.py` — 8 tests green:
- forbidden_work → claude tool mapping (dedup/sort, ignores unmapped)
- depth guard raises past max; unknown engine raises
- dispatch routes to the registered engine
- claude_code engine puts mapped disallowed tools on the ExecutionTask
- delegate tool: flag-off = record-only unchanged; flag-on = runs governed subagent

```
8 passed in 0.57s
```

## Model Used

Opus 4.8