### PR TITLE
feat(delegation): add governed internal-LLM engine, provider-agnostic runner (#11207)

### DIFF
--- a/autobot-backend/chat_workflow/delegation.py
+++ b/autobot-backend/chat_workflow/delegation.py
@@ -119,6 +119,10 @@ async def _run_internal_subagent(task: str, agent_type: str, depth: int) -> str:
     )
     logger.info("delegation: internal subagent agent=%s depth=%d model=%s", agent_type, depth, ctx.selected_model)
     responses: List[str] = []
+    # Uses the shared ChatWorkflowManager singleton — safe because the loop keys all
+    # state off the per-call ctx (sessions/history never touched). The lone shared
+    # instance var it toggles, ``_current_lightweight_mode``, only tags stream-cost
+    # metadata (best-effort; GH#11216 tracks moving it onto ctx for full isolation).
     async for item in get_chat_workflow_manager()._execute_llm_continuation_loop(ctx):
         # The loop streams WorkflowMessages, then yields a final
         # ``(all_llm_responses, execution_history, error)`` tuple.

--- a/autobot-backend/chat_workflow/delegation.py
+++ b/autobot-backend/chat_workflow/delegation.py
@@ -10,9 +10,14 @@ manifest constrains it — agent autonomy with backend-enforced oversight, witho
 re-entering the chat pipeline.
 
 Provider-agnostic by design: ``run_delegated_subtask`` dispatches to a named
-engine. This module ships the **claude_code** engine (an ``ExecutionBackend`` that
-runs its own tool loop, governed via ``--disallowedTools`` from the profile — see
-GH#11188); the in-process internal-LLM engine is a follow-up that registers here.
+engine. Two engines ship:
+
+- **claude_code** — an ``ExecutionBackend`` that runs its own tool loop out of
+  process, governed via ``--disallowedTools`` mapped from the profile (GH#11188).
+- **internal** — AutoBot's own LLM driving the production continuation loop, so
+  the subagent's tools flow through the ``_dispatch_tool_call`` seam and inherit
+  ``forbidden_work`` enforcement for free. Runs in process, so it also threads an
+  incremented ``delegation_depth`` — a nested ``delegate`` is depth-bounded.
 
 OFF by default (``AUTOBOT_DELEGATION_ENABLED``) so the live chat path is unchanged
 until delegation is explicitly enabled and validated.
@@ -82,9 +87,50 @@ async def _run_claude_code_subagent(task: str, agent_type: str, depth: int) -> s
     return result.stdout or result.stderr or ""
 
 
-# Engine registry — the internal-LLM engine registers here in a follow-up (GH#11207).
+async def _run_internal_subagent(task: str, agent_type: str, depth: int) -> str:
+    """Run *task* as a governed **internal-LLM** subagent; return its final text.
+
+    Drives the production continuation loop (``_execute_llm_continuation_loop``) with
+    a governed ``LLMIterationContext``: setting ``agent_context.agent_id`` makes every
+    tool the subagent calls pass through ``_dispatch_tool_call``'s ``forbidden_work``
+    enforcement. ``delegation_depth`` is placed on the ctx so an in-loop ``delegate``
+    call is depth-bounded. No DB/session is created — the loop runs on the bare ctx.
+    """
+    from autobot_shared.ssot_config import config
+    from chat_workflow import get_chat_workflow_manager
+    from chat_workflow.models import LLMIterationContext, build_governed_identity
+
+    session_id = f"delegate-{agent_type}-d{depth}"
+    agent_ctx, work_item_id, approval_categories = build_governed_identity({"agent_id": agent_type}, session_id)
+    ctx = LLMIterationContext(
+        ollama_endpoint=config.ollama_endpoint,
+        selected_model=config.llm.default_model,
+        session_id=session_id,
+        terminal_session_id=session_id,
+        used_knowledge=False,
+        rag_citations=[],
+        workflow_messages=[],
+        initial_prompt=task,
+        message=task,
+        agent_context=agent_ctx,
+        work_item_id=work_item_id,
+        requires_approval_before=approval_categories,
+        context={"delegation_depth": depth + 1},
+    )
+    logger.info("delegation: internal subagent agent=%s depth=%d model=%s", agent_type, depth, ctx.selected_model)
+    responses: List[str] = []
+    async for item in get_chat_workflow_manager()._execute_llm_continuation_loop(ctx):
+        # The loop streams WorkflowMessages, then yields a final
+        # ``(all_llm_responses, execution_history, error)`` tuple.
+        if isinstance(item, tuple) and len(item) == 3:
+            responses = item[0] or responses
+    return "\n".join(r for r in responses if r)
+
+
+# Engine registry — provider-agnostic dispatch; new engines register a name here.
 _ENGINES: Dict[str, Callable[[str, str, int], Awaitable[str]]] = {
     "claude_code": _run_claude_code_subagent,
+    "internal": _run_internal_subagent,
 }
 
 

--- a/autobot-backend/chat_workflow/delegation_test.py
+++ b/autobot-backend/chat_workflow/delegation_test.py
@@ -77,6 +77,43 @@ async def test_claude_code_engine_passes_disallowed_from_forbidden_work():
     assert "Bash" in task.metadata["disallowed_tools"]
 
 
+# --- internal-LLM engine ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_internal_engine_governs_and_bounds_depth():
+    # The internal engine drives the production loop with a governed ctx: agent_id
+    # set (→ forbidden_work enforced at the seam) and delegation_depth incremented
+    # (→ an in-loop delegate is bounded). It returns the joined LLM responses.
+    captured = {}
+
+    async def _fake_loop(ctx):
+        captured["ctx"] = ctx
+        yield ("progress message — ignored")  # non-tuple stream item
+        yield (["part one", "", "part two"], [], None)  # final (responses, history, error)
+
+    import chat_workflow
+
+    fake_mgr = type("M", (), {"_execute_llm_continuation_loop": staticmethod(_fake_loop)})()
+    with patch.object(chat_workflow, "get_chat_workflow_manager", return_value=fake_mgr):
+        out = await delegation._run_internal_subagent("do the thing", "research_agent", 1)
+
+    assert out == "part one\npart two"  # empty parts dropped, rest joined
+    ctx = captured["ctx"]
+    assert ctx.agent_context is not None and ctx.agent_context.agent_id == "research_agent"
+    assert ctx.context["delegation_depth"] == 2  # depth 1 → subagent sees 2
+    assert ctx.initial_prompt == "do the thing"
+
+
+@pytest.mark.asyncio
+async def test_internal_engine_registered_and_dispatches():
+    engine = AsyncMock(return_value="internal result")
+    with patch.dict(delegation._ENGINES, {"internal": engine}):
+        out = await run_delegated_subtask("t", agent_type="research_agent", depth=0, engine="internal")
+    assert out == "internal result"
+    engine.assert_awaited_once_with("t", "research_agent", 0)
+
+
 # --- _handle_delegate_tool: flag off = unchanged, on = runs subagent -------
 
 


### PR DESCRIPTION
Closes #11207.

## Thinking Path

PR1 (#11213) wired the `delegate` tool to a governed subagent runner with a `_ENGINES` registry and the **claude_code** engine. #11207 asked for the subordinate to be **provider-agnostic** — so this PR2 adds the second engine, **internal**, using AutoBot's own LLM.

The design choice (confirmed with the owner) was a **governed tool-loop with full autonomy**: the internal subagent must be able to call tools, but every call must be constrained by the profile's `forbidden_work`. AutoBot already has exactly one production seam where that enforcement lives — `chat_workflow/tool_handler.py::_dispatch_tool_call` (via `_enforce_forbidden_work`, reading `ctx.agent_context.agent_id`). So the internal engine drives the production continuation loop with a *governed* `LLMIterationContext` and inherits enforcement for free — no duplicated pipeline, no second governance path.

## What Changed

`chat_workflow/delegation.py`:
- **`_run_internal_subagent(task, agent_type, depth)`** — builds a governed `LLMIterationContext` via `build_governed_identity({"agent_id": agent_type}, session_id)`, then runs `get_chat_workflow_manager()._execute_llm_continuation_loop(ctx)` and returns the joined LLM responses.
  - `agent_context.agent_id` set → the subagent's tools funnel through `_dispatch_tool_call` and are blocked per `forbidden_work`.
  - `context={"delegation_depth": depth + 1}` → an in-loop `delegate` call is depth-bounded (in-process recursion the external claude_code engine can't enforce).
  - No DB/session created — runs on the bare ctx via the canonical `get_chat_workflow_manager()` singleton; model/endpoint from `config.llm.default_model` / `config.ollama_endpoint`.
- Registered as `_ENGINES["internal"]`.

Still **OFF by default** (`AUTOBOT_DELEGATION_ENABLED`).

## Verification

`chat_workflow/delegation_test.py` — 11 tests green (9 from PR1 + 2 new):
- `test_internal_engine_governs_and_bounds_depth` — asserts the governed ctx carries `agent_id=research_agent`, `delegation_depth` incremented (1 → 2), the task as prompt, and that empty response parts are dropped/joined.
- `test_internal_engine_registered_and_dispatches` — `run_delegated_subtask(engine="internal")` routes to it.

```
11 passed in 0.69s
```

## Model Used

Opus 4.8

## Review Note
Code review CLEAN (no blocker/major). MINOR: the internal engine reuses the shared `ChatWorkflowManager` singleton; safe because the loop keys all state off the per-call ctx. The one shared instance var it toggles (`_current_lightweight_mode`) is best-effort stream-cost metadata — full isolation tracked in #11216. Documented inline.