### PR TITLE
refactor(delegation): derive claude-tool mapping from canonical atoms (#11219)

### DIFF
--- a/autobot-backend/chat_workflow/delegation.py
+++ b/autobot-backend/chat_workflow/delegation.py
@@ -26,6 +26,7 @@ until delegation is explicitly enabled and validated.
 import os
 from typing import Awaitable, Callable, Dict, List
 
+from autobot_shared import tool_catalogue as _tc
 from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
@@ -37,34 +38,31 @@ MAX_DELEGATION_DEPTH: int = int(os.environ.get("AUTOBOT_MAX_DELEGATION_DEPTH", "
 
 # AutoBot ``forbidden_work`` token → claude_code CLI tool name to disallow. claude_code
 # exposes coarse tools (Bash/Edit/Write), so shell/infra/file-mutation tokens collapse
-# onto them. An unmapped token is simply not disallowed (fail-open on that token, but
-# the profile's other tokens still constrain the agent).
-_CLAUDE_TOOL_FOR: Dict[str, str] = {
-    "bash": "Bash",
-    "shell": "Bash",
-    "execute_command": "Bash",
-    "run_command": "Bash",
-    "system_exec": "Bash",
-    "terminal": "Bash",
-    "deploy": "Bash",
-    "ansible": "Bash",
-    "docker": "Bash",
-    "kubectl": "Bash",
-    "helm": "Bash",
-    "terraform": "Bash",
-    "delete_file": "Bash",
-    "remove_directory": "Bash",
-    "move_file": "Bash",
-    "copy_file": "Bash",
-    "create_directory": "Bash",
-    "write_file": "Write",
-    "edit_file": "Edit",
-}
+# onto them. The token lists are NOT duplicated here — they are derived from the
+# canonical atoms in ``autobot_shared/tool_catalogue.py`` so a token added there is
+# covered automatically (no drift / fail-open). ``write_file``/``edit_file`` map to the
+# dedicated Write/Edit tools; every other file-mutation + all shell/infra/terminal
+# tokens collapse onto Bash. An unmapped token is simply not disallowed (the profile's
+# other tokens still constrain the agent).
+_FILE_TOOL_FOR: Dict[str, str] = {"write_file": "Write", "edit_file": "Edit"}
+_BASH_TOKENS: "frozenset[str]" = frozenset(
+    _tc.INFRA_AND_SHELL_TOOLS
+    + _tc.TERMINAL_TOOLS
+    + _tc.FILE_DELETE_TOOLS
+    + tuple(t for t in _tc.FILE_WRITE_TOOLS if t not in _FILE_TOOL_FOR)
+)
+
+
+def _claude_tool_for(token: str) -> "str | None":
+    """Canonical ``forbidden_work`` token → claude_code tool name (or ``None``)."""
+    if token in _FILE_TOOL_FOR:
+        return _FILE_TOOL_FOR[token]
+    return "Bash" if token in _BASH_TOKENS else None
 
 
 def forbidden_to_claude_tools(forbidden: "frozenset[str] | list[str]") -> List[str]:
     """Map a profile's ``forbidden_work`` tokens to claude_code ``--disallowedTools``."""
-    return sorted({_CLAUDE_TOOL_FOR[f] for f in forbidden if f in _CLAUDE_TOOL_FOR})
+    return sorted({tool for tool in (_claude_tool_for(f) for f in forbidden) if tool})
 
 
 async def _run_claude_code_subagent(task: str, agent_type: str, depth: int) -> str:

--- a/autobot-backend/chat_workflow/delegation_test.py
+++ b/autobot-backend/chat_workflow/delegation_test.py
@@ -30,13 +30,27 @@ def test_forbidden_to_claude_tools_ignores_unmapped():
 def test_shipped_research_agent_has_no_fail_open_tokens():
     # Governance guard: every token the shipped research_agent forbids must map to a
     # claude_code --disallowedTools entry, so nothing silently fails open.
-    from chat_workflow.delegation import _CLAUDE_TOOL_FOR
+    from chat_workflow.delegation import _claude_tool_for
     from orchestration.agent_registry import resolve_forbidden_tools
 
     forbidden = resolve_forbidden_tools("research_agent")
     assert forbidden, "research_agent must declare forbidden_work"
-    unmapped = sorted(t for t in forbidden if t not in _CLAUDE_TOOL_FOR)
+    unmapped = sorted(t for t in forbidden if _claude_tool_for(t) is None)
     assert unmapped == [], f"forbidden tokens with no claude_code mapping (fail-open): {unmapped}"
+
+
+def test_claude_tool_mapping_derived_from_canonical_atoms():
+    # No duplicated token lists: the mapping must cover every shell/infra/terminal/
+    # delete atom (→ Bash) and the file-write atoms (Write/Edit/Bash) from tool_catalogue.
+    from autobot_shared import tool_catalogue as tc
+    from chat_workflow.delegation import _claude_tool_for
+
+    for token in tc.INFRA_AND_SHELL_TOOLS + tc.TERMINAL_TOOLS + tc.FILE_DELETE_TOOLS:
+        assert _claude_tool_for(token) == "Bash", token
+    assert _claude_tool_for("write_file") == "Write"
+    assert _claude_tool_for("edit_file") == "Edit"
+    for token in set(tc.FILE_WRITE_TOOLS) - {"write_file", "edit_file"}:
+        assert _claude_tool_for(token) == "Bash", token
 
 
 # --- run_delegated_subtask dispatch + guards -------------------------------


### PR DESCRIPTION
Closes #11219.

## Thinking Path

#11207 retrospective found `chat_workflow/delegation.py::_CLAUDE_TOOL_FOR` re-listing the forbidden_work token lists (bash/shell/docker/deploy/delete_file/…) that already live canonically in `autobot_shared/tool_catalogue.py` — a duplicated source of truth, and the root cause of the fail-open drift the PR1 review flagged (a token added to an atom wouldn't translate to a `--disallowedTools` entry).

## What Changed

- Removed the hardcoded `_CLAUDE_TOOL_FOR` dict. The Bash-mapped tokens are now **derived** from `INFRA_AND_SHELL_TOOLS + TERMINAL_TOOLS + FILE_DELETE_TOOLS + (FILE_WRITE_TOOLS − {write_file, edit_file})`; `write_file→Write` / `edit_file→Edit` stay explicit via `_FILE_TOOL_FOR`. New `_claude_tool_for(token)` helper; `forbidden_to_claude_tools` uses it.
- Single source of truth → a new atom token is covered automatically (drift-proof).

## Verification

Derivation reproduces the prior mapping **exactly** (empty symmetric diff — zero behaviour change). `chat_workflow/delegation_test.py` — 12 tests green (added `test_claude_tool_mapping_derived_from_canonical_atoms` asserting every canonical atom maps; kept the fail-open guard test, now via `_claude_tool_for`).

```
12 passed in 0.40s
```

## Model Used

Opus 4.8