### PR TITLE
fix(security): domain-boundary host matching — fix web_researcher trust-boost bypass + shared host_matches (#11226)

### DIFF
--- a/autobot-backend/agents/librarian_assistant.py
+++ b/autobot-backend/agents/librarian_assistant.py
@@ -19,19 +19,12 @@ from urllib.parse import urlparse
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
+from autobot_shared.url_safety import host_matches
 from config import config
 from knowledge_base import KnowledgeBase
 from services.llm_service import get_llm_service
 
 logger = get_logger(__name__)
-
-
-def _host_matches(host: str, domain: str) -> bool:
-    """Return True iff *host* is exactly *domain* or a subdomain of it.
-
-    Prevents partial-suffix attacks (e.g. ``notyoutube.com`` matching ``youtube.com``).
-    """
-    return host == domain or host.endswith("." + domain)
 
 
 def _source_for_url(url: str) -> str:
@@ -44,9 +37,9 @@ def _source_for_url(url: str) -> str:
     if "://" not in url:
         url = "https://" + url
     host = urlparse(url).netloc.lower()
-    if _host_matches(host, "youtube.com") or _host_matches(host, "youtu.be"):
+    if host_matches(host, "youtube.com") or host_matches(host, "youtu.be"):
         return "youtube"
-    if _host_matches(host, "reddit.com"):
+    if host_matches(host, "reddit.com"):
         return "reddit"
     return "web_page"
 
@@ -161,7 +154,7 @@ class LibrarianAssistant:
         title = structured.get("title") or netloc
         description = structured.get("description") or content[:200]
 
-        is_trusted = any(_host_matches(netloc, td) for td in self.trusted_domains) if netloc else False
+        is_trusted = any(host_matches(netloc, td) for td in self.trusted_domains) if netloc else False
 
         return {
             "url": effective_url,

--- a/autobot-backend/agents/web_researcher.py
+++ b/autobot-backend/agents/web_researcher.py
@@ -25,6 +25,7 @@ from urllib.parse import urlparse
 from pydantic import BaseModel
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.url_safety import host_matches
 from circuit_breaker import CircuitBreaker, CircuitBreakerConfig
 from constants.security_constants import SecurityConstants
 from constants.threshold_constants import CircuitBreakerDefaults, TimingConstants
@@ -853,7 +854,9 @@ class WebResearcher:
         """Calculate quality score for search result."""
         score = 0.5
         domain = result.get("domain", "")
-        if any(t in domain for t in self._TRUSTED_DOMAINS):
+        # Domain-boundary match so a hostile name that merely contains a trusted
+        # label (e.g. ``evilgithub.com``) doesn't earn the trust boost (#11226).
+        if domain and any(host_matches(domain, t) for t in self._TRUSTED_DOMAINS):
             score += 0.3
         content_length = result.get("content_length", 0)
         if content_length > 2000:

--- a/autobot_shared/url_safety.py
+++ b/autobot_shared/url_safety.py
@@ -211,9 +211,24 @@ def require_allowlisted_https(url: str, allowed_hosts: Collection[str]) -> None:
         raise ValueError("Only the standard https port (443) is permitted")
 
 
+def host_matches(host: str, domain: str) -> bool:
+    """Return True iff *host* is exactly *domain* or a subdomain of it (#11226).
+
+    Domain-boundary-aware trust check. Unlike a substring test (``domain in host``)
+    or an unanchored ``host.endswith(domain)``, this cannot be fooled by an
+    attacker-controlled name that merely *contains* or *ends with* a trusted label:
+    ``evilgithub.com`` does NOT match ``github.com``, while ``github.com`` and
+    ``sub.github.com`` do. Case-insensitive and tolerant of a trailing FQDN dot.
+    """
+    host = host.lower().rstrip(".")
+    domain = domain.lower().rstrip(".")
+    return host == domain or host.endswith("." + domain)
+
+
 __all__ = [
     "is_public_url",
     "is_public_url_async",
     "resolve_safe_ip_async",
     "require_allowlisted_https",
+    "host_matches",
 ]

--- a/autobot_shared/url_safety_test.py
+++ b/autobot_shared/url_safety_test.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 import pytest
 
 from autobot_shared.url_safety import (
+    host_matches,
     is_public_url,
     is_public_url_async,
     require_allowlisted_https,
@@ -232,6 +233,40 @@ def test_malformed_port_raises_valueerror_not_unhandled() -> None:
     with pytest.raises(ValueError) as exc:
         require_allowlisted_https("https://accounts.google.com:99999/token", _ALLOW)
     assert "port" in str(exc.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# host_matches — domain-boundary trust check (#11226)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "host, domain",
+    [
+        ("github.com", "github.com"),  # exact
+        ("sub.github.com", "github.com"),  # subdomain
+        ("a.b.github.com", "github.com"),  # deep subdomain
+        ("GitHub.com", "github.com"),  # case-insensitive
+        ("github.com.", "github.com"),  # trailing FQDN dot
+    ],
+)
+def test_host_matches_true(host: str, domain: str) -> None:
+    assert host_matches(host, domain) is True
+
+
+@pytest.mark.parametrize(
+    "host, domain",
+    [
+        ("evilgithub.com", "github.com"),  # substring-prefix attack
+        ("github.com.evil.com", "github.com"),  # trusted label as a subdomain of attacker
+        ("notstackoverflow.com", "stackoverflow.com"),
+        ("fakewikipedia.org", "wikipedia.org"),
+        ("mygithub.com", "github.com"),
+        ("", "github.com"),  # empty host
+    ],
+)
+def test_host_matches_false(host: str, domain: str) -> None:
+    assert host_matches(host, domain) is False
 
 
 def test_module_has_zero_autobot_dependencies() -> None:


### PR DESCRIPTION
## Thinking Path
#11226 — several trust checks used **substring `in` / unanchored `endswith`**, so an attacker domain that merely contains a trusted label was treated as trusted. Consolidate a canonical boundary-aware helper and fix the confirmed vulnerable site.

## What Changed
- **New `autobot_shared/url_safety.host_matches(host, domain)`** — `host == domain or host.endswith('.' + domain)`, case-insensitive + FQDN-dot tolerant. Domain-boundary-aware: `evilgithub.com` does NOT match `github.com`; `github.com`/`sub.github.com` do.
- **Fix the real bug in `agents/web_researcher.py` `_calculate_quality_score`:** `any(t in domain for t in _TRUSTED_DOMAINS)` → `any(host_matches(domain, t) ...)`. Previously `evilgithub.com`/`notstackoverflow.com` earned the +0.3 trust/quality boost shown to the LLM; now they don't.
- **DRY:** removed the local `agents/librarian_assistant._host_matches` (added in #11162); its 3 call sites now use the shared helper.

## Reviewed, intentionally left as-is
- **`judges/security_risk_judge.py:737`** (`any(suspicious in host ...)` for localhost/127.0.0.1/0.0.0.0): this is *suspicious-host detection*, where substring **over**-matches (false positives) but has no false negatives for the listed values — so it's not a vulnerability, and switching to `host_matches` (subdomain semantics, wrong for IP literals) would *reduce* detection. Left unchanged with this rationale.

## Verification
- `url_safety_test.py` → **39 passed** (11 new: exact/subdomain/case/FQDN-dot match; `evilgithub.com`, `github.com.evil.com`, prefix-attack, empty-host rejected)
- `test_librarian_assistant_{extract,search}.py` → **38 passed** (DRY migration behaviour-preserved)
- `black` + `flake8` clean; zero-autobot-dependency contract on `url_safety` preserved.

## Model Used
Opus 4.8

Closes #11226
