### PR TITLE
fix(guards): canonical env_flag parser (AUTOBOT_ALLOW_CONFIG_EDITS=on now works) + shared PATH_KEYS (#11220)

### DIFF
--- a/autobot-backend/agent_loop/guard_profile.py
+++ b/autobot-backend/agent_loop/guard_profile.py
@@ -36,6 +36,7 @@ GH#11148) are controlled separately by design.
 
 import os
 
+from autobot_shared.env_utils import truthy
 from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
@@ -64,7 +65,7 @@ GUARD_PROFILES: dict[str, dict[str, object]] = {
 
 
 def _as_bool(raw: str) -> bool:
-    return raw.strip().lower() in {"1", "true", "yes", "on"}
+    return truthy(raw)
 
 
 # env var -> (config field, parser)

--- a/autobot-backend/tests/agent_loop/test_config_protection.py
+++ b/autobot-backend/tests/agent_loop/test_config_protection.py
@@ -98,9 +98,16 @@ class TestConfigEditsAllowed:
         monkeypatch.delenv("AUTOBOT_ALLOW_CONFIG_EDITS", raising=False)
         assert config_edits_allowed() is False
 
-    def test_env_opt_out(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("AUTOBOT_ALLOW_CONFIG_EDITS", "1")
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on", "On", "  on  "])
+    def test_env_opt_out(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        # #11220: ``on`` must opt out like every other truthy form (previously ignored).
+        monkeypatch.setenv("AUTOBOT_ALLOW_CONFIG_EDITS", value)
         assert config_edits_allowed() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "off", "", "nope"])
+    def test_env_non_truthy_stays_guarded(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv("AUTOBOT_ALLOW_CONFIG_EDITS", value)
+        assert config_edits_allowed() is False
 
 
 class TestExecuteToolsIntegration:

--- a/autobot_shared/config_guard.py
+++ b/autobot_shared/config_guard.py
@@ -20,6 +20,9 @@ content. Override with ``AUTOBOT_ALLOW_CONFIG_EDITS=1``.
 
 import os
 
+from autobot_shared.env_utils import env_flag
+from autobot_shared.tool_args import PATH_KEYS
+
 # Write-side tools whose target path is guarded. Read/list tools are ignored.
 WRITE_TOOLS: frozenset[str] = frozenset(
     {
@@ -33,10 +36,6 @@ WRITE_TOOLS: frozenset[str] = frozenset(
         "copy_file",
     }
 )
-
-# Arg keys under which a write tool carries its target path (see
-# tools/parallel/analyzer.py RESOURCE_EXTRACTORS).
-PATH_KEYS: tuple[str, ...] = ("file_path", "path", "destination", "target_file")
 
 # Dedicated linter/formatter config basenames (exact, case-insensitive).
 _PROTECTED_BASENAMES: frozenset[str] = frozenset(
@@ -90,8 +89,12 @@ def is_protected_config(path: str | None) -> str | None:
 
 
 def config_edits_allowed() -> bool:
-    """True when ``AUTOBOT_ALLOW_CONFIG_EDITS`` opts out of the guard."""
-    return os.environ.get("AUTOBOT_ALLOW_CONFIG_EDITS", "").strip().lower() in {"1", "true", "yes"}
+    """True when ``AUTOBOT_ALLOW_CONFIG_EDITS`` opts out of the guard.
+
+    Uses the shared :func:`env_flag` parser so ``on`` works like every other
+    flag (it previously did not — #11220).
+    """
+    return env_flag("AUTOBOT_ALLOW_CONFIG_EDITS")
 
 
 def protected_config_for(tool_name: str, args: dict) -> str | None:

--- a/autobot_shared/env_utils.py
+++ b/autobot_shared/env_utils.py
@@ -67,3 +67,29 @@ def env_int_clamped(
     if max_v is not None:
         value = min(max_v, value)
     return value
+
+
+# Canonical truthy set for boolean env flags. Single source of truth so guards
+# don't drift (config_guard used to omit "on", silently ignoring
+# ``AUTOBOT_ALLOW_CONFIG_EDITS=on`` — #11220).
+_TRUTHY_VALUES: frozenset[str] = frozenset({"1", "true", "yes", "on"})
+
+
+def truthy(raw: str | None) -> bool:
+    """Return True iff *raw* is a recognized truthy flag value (1/true/yes/on).
+
+    Case-insensitive and whitespace-tolerant. ``None`` and any other value
+    (``0``/``false``/``off``/empty) read as False.
+    """
+    return raw is not None and raw.strip().lower() in _TRUTHY_VALUES
+
+
+def env_flag(name: str, default: bool = False) -> bool:
+    """Read a boolean environment variable via the canonical truthy set.
+
+    Returns *default* when the var is absent; otherwise ``truthy(value)``. Using
+    this everywhere guarantees ``on``/``yes``/``true``/``1`` behave identically
+    across all flags.
+    """
+    raw = os.environ.get(name)
+    return default if raw is None else truthy(raw)

--- a/autobot_shared/env_utils_test.py
+++ b/autobot_shared/env_utils_test.py
@@ -3,7 +3,9 @@
 # AutoBot - AI-Powered Automation Platform
 import os
 
-from autobot_shared.env_utils import env_float, env_int, env_int_clamped
+import pytest
+
+from autobot_shared.env_utils import env_flag, env_float, env_int, env_int_clamped, truthy
 
 _VAR = "TEST_ENV_INT_CLAMPED_XYZ"
 _FLOAT_VAR = "TEST_ENV_FLOAT_XYZ"
@@ -159,3 +161,33 @@ def test_negative_value_allowed_without_bounds():
         assert env_int_clamped(_VAR, 0) == -3
     finally:
         _clean()
+
+
+# ---------------------------------------------------------------------------
+# truthy / env_flag tests (#11220 — one canonical bool parser; "on" works)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw", ["1", "true", "TRUE", "yes", "Yes", "on", "On", "  on  "])
+def test_truthy_recognizes_all_forms(raw):
+    assert truthy(raw) is True
+
+
+@pytest.mark.parametrize("raw", [None, "", "0", "false", "no", "off", "onn", "enabled"])
+def test_truthy_rejects_others(raw):
+    assert truthy(raw) is False
+
+
+def test_env_flag_default_when_absent(monkeypatch):
+    monkeypatch.delenv("AUTOBOT_TEST_FLAG_XYZ", raising=False)
+    assert env_flag("AUTOBOT_TEST_FLAG_XYZ") is False
+    assert env_flag("AUTOBOT_TEST_FLAG_XYZ", default=True) is True
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [("on", True), ("On", True), ("1", True), ("yes", True), ("false", False), ("off", False), ("", False)],
+)
+def test_env_flag_reads_value(monkeypatch, raw, expected):
+    monkeypatch.setenv("AUTOBOT_TEST_FLAG_XYZ", raw)
+    assert env_flag("AUTOBOT_TEST_FLAG_XYZ") is expected

--- a/autobot_shared/fact_forcing_guard.py
+++ b/autobot_shared/fact_forcing_guard.py
@@ -19,6 +19,9 @@ Lives in ``autobot_shared`` (not ``agent_loop``) so BOTH the agent loop
 
 import os
 
+from autobot_shared.env_utils import env_flag
+from autobot_shared.tool_args import path_from_tool_args
+
 # Tools that count as investigating a path.
 INVESTIGATION_TOOLS: frozenset[str] = frozenset(
     {
@@ -48,18 +51,6 @@ EDIT_TOOLS: frozenset[str] = frozenset(
     }
 )
 
-PATH_KEYS: tuple[str, ...] = ("file_path", "path", "directory", "target_file")
-
-
-def _path_from_args(args: dict) -> str | None:
-    if not isinstance(args, dict):
-        return None
-    for key in PATH_KEYS:
-        value = args.get(key)
-        if value:
-            return str(value)
-    return None
-
 
 def _norm(path: str) -> str:
     # realpath (not normpath) so a file read by relative path and edited by
@@ -75,7 +66,7 @@ def record_investigation(tool_name: str, args: dict, investigated: set[str]) -> 
     """Record *args*' path in *investigated* if *tool_name* is an investigation tool."""
     if str(tool_name).lower() not in INVESTIGATION_TOOLS:
         return
-    path = _path_from_args(args)
+    path = path_from_tool_args(args)
     if path:
         investigated.add(_norm(path))
 
@@ -93,7 +84,7 @@ def uninvestigated_edit_path(
     """
     if str(tool_name).lower() not in EDIT_TOOLS:
         return None
-    path = _path_from_args(args)
+    path = path_from_tool_args(args)
     if not path:
         return None
     if _norm(path) in investigated:
@@ -128,4 +119,4 @@ def first_uninvestigated_edit(
 
 def fact_forcing_env_enabled() -> bool:
     """True when ``AUTOBOT_FACT_FORCING`` enables the gate."""
-    return os.environ.get("AUTOBOT_FACT_FORCING", "").strip().lower() in {"1", "true", "yes", "on"}
+    return env_flag("AUTOBOT_FACT_FORCING")

--- a/autobot_shared/tool_args.py
+++ b/autobot_shared/tool_args.py
@@ -1,0 +1,27 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shared tool-call argument helpers for the guard modules (#11220).
+
+``config_guard`` and ``fact_forcing_guard`` both need to find the filesystem
+path a tool call targets and previously each defined its own ``PATH_KEYS`` +
+extractor — which had *drifted* (config had ``destination``; fact-forcing had
+``directory``), so each guard was blind to one key the other watched. This is
+the single source of truth for both.
+"""
+
+# Superset of the arg keys a tool call may carry a filesystem path under —
+# the union of the two guards' historical key sets so both inspect the same fields.
+PATH_KEYS: tuple[str, ...] = ("file_path", "path", "destination", "directory", "target_file")
+
+
+def path_from_tool_args(args: dict) -> str | None:
+    """Return the first non-empty filesystem path among :data:`PATH_KEYS` in *args*, else None."""
+    if not isinstance(args, dict):
+        return None
+    for key in PATH_KEYS:
+        value = args.get(key)
+        if value:
+            return str(value)
+    return None


### PR DESCRIPTION
## Thinking Path
#11220 — the three guard modules had divergent boolean env-flag parsing; `config_guard` omitted `on`, so `AUTOBOT_ALLOW_CONFIG_EDITS=on` silently failed to opt out of the on-by-default config-protection guard (a real footgun), while `AUTOBOT_FACT_FORCING=on` worked. Plus duplicated `PATH_KEYS` (drifted) + `_path_from_args`.

## What Changed (bug fix + DRY)
- **Bug fix — one canonical bool parser** in `autobot_shared/env_utils.py`: `truthy(raw)` (1/true/yes/on, case-insensitive) + `env_flag(name, default=False)`. Routed all three call sites through it: `config_guard.config_edits_allowed`, `fact_forcing_guard.fact_forcing_env_enabled`, `guard_profile._as_bool`. **`=on` now opts out identically everywhere.**
- **DRY — shared path helpers** in new `autobot_shared/tool_args.py`: single `PATH_KEYS` (superset of the two drifted sets — now includes both `destination` and `directory`) + `path_from_tool_args(args)`. Removed the local copies from both guards; each now inspects the full key set.

Left the optional canonical write/edit *tool-name taxonomy* (issue item "Optionally") as a follow-up — not required by the acceptance criteria and lower value.

## Verification
- **116 passed** — `env_utils_test` (incl. new `truthy`/`env_flag` matrix), `test_config_protection` (new: `=on`/`On`/`  on  ` opt out; `0`/`false`/`off`/empty stay guarded), `test_guard_profile`, `test_fact_forcing`(+realpath), `test_tool_handler_fact_forcing`. Guard behaviour otherwise unchanged.
- `black` + `flake8` clean; `py_compile` clean.

## Model Used
Opus 4.8

Closes #11220
