### PR TITLE
fix(health): render a found probe's real status instead of 'unavailable' (#11227)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useProbeBackedHealth.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useProbeBackedHealth.test.ts
@@ -123,12 +123,13 @@ describe('useProbeBackedHealth', () => {
     })
   })
 
-  it('returns buildUnavailable with probe.detail when status is not ok', async () => {
+  it('calls buildHealthy for a FOUND degraded probe (renders real status, not "unavailable") — #11227', async () => {
     apiGetSpy.mockResolvedValue({
       probes: [
         {
           name: 'batch_jobs',
           status: 'degraded',
+          data: { redis_connected: false },
           detail: 'redis is slow',
         },
       ],
@@ -141,17 +142,19 @@ describe('useProbeBackedHealth', () => {
     })
 
     const result = await getHealth()
+    // buildHealthy was called (not buildUnavailable) — the consumer, not the
+    // composable, decides how to render the degraded status + its detail.
     expect(result).toEqual({
-      status: 'unavailable',
+      status: 'healthy',
       active_jobs: 0,
       redis_connected: false,
       message: 'redis is slow',
     })
   })
 
-  it('falls back to "Service unavailable" when status is not ok and no detail', async () => {
+  it('calls buildHealthy for a FOUND probe even with a non-ok status and no detail — #11227', async () => {
     apiGetSpy.mockResolvedValue({
-      probes: [{ name: 'batch_jobs', status: 'unavailable' }],
+      probes: [{ name: 'batch_jobs', status: 'down' }],
     })
 
     const getHealth = useProbeBackedHealth<TestHealthResponse>({
@@ -161,7 +164,13 @@ describe('useProbeBackedHealth', () => {
     })
 
     const result = await getHealth()
-    expect(result?.message).toBe('Service unavailable')
+    // Found probe → buildHealthy path (message comes from probe.detail: undefined here).
+    expect(result).toEqual({
+      status: 'healthy',
+      active_jobs: 0,
+      redis_connected: false,
+      message: undefined,
+    })
   })
 
   it('returns buildUnavailable("Service unavailable") on fetch error', async () => {
@@ -192,8 +201,8 @@ describe('useProbeBackedHealth', () => {
   })
 })
 
-describe('useProbeBackedHealth — renderNonOkFromProbe option', () => {
-  it('calls buildHealthy (not buildUnavailable) for a degraded probe when renderNonOkFromProbe is true', async () => {
+describe('useProbeBackedHealth — found-probe routing (#11227)', () => {
+  it('routes a FOUND non-ok probe to buildHealthy, not buildUnavailable', async () => {
     apiGetSpy.mockResolvedValue({
       probes: [
         {
@@ -212,7 +221,6 @@ describe('useProbeBackedHealth — renderNonOkFromProbe option', () => {
       probeName: 'batch_jobs',
       buildHealthy: buildHealthySpy,
       buildUnavailable: buildUnavailableSpy,
-      renderNonOkFromProbe: true,
     })
 
     const result = await getHealth()
@@ -222,7 +230,7 @@ describe('useProbeBackedHealth — renderNonOkFromProbe option', () => {
     expect(result?.message).toBe('redis is slow')
   })
 
-  it('still calls buildUnavailable for a missing probe even when renderNonOkFromProbe is true', async () => {
+  it('reserves buildUnavailable for a genuinely missing probe', async () => {
     apiGetSpy.mockResolvedValue({ probes: [] })
 
     const buildHealthySpy = vi.fn(buildHealthy)
@@ -232,7 +240,6 @@ describe('useProbeBackedHealth — renderNonOkFromProbe option', () => {
       probeName: 'batch_jobs',
       buildHealthy: buildHealthySpy,
       buildUnavailable: buildUnavailableSpy,
-      renderNonOkFromProbe: true,
     })
 
     const result = await getHealth()
@@ -240,33 +247,5 @@ describe('useProbeBackedHealth — renderNonOkFromProbe option', () => {
     expect(buildHealthySpy).not.toHaveBeenCalled()
     expect(result?.status).toBe('unavailable')
     expect(result?.message).toBe('batch_jobs probe not registered')
-  })
-
-  it('default behavior (renderNonOkFromProbe absent) still routes degraded → buildUnavailable', async () => {
-    apiGetSpy.mockResolvedValue({
-      probes: [
-        {
-          name: 'batch_jobs',
-          status: 'degraded',
-          detail: 'degraded detail',
-        },
-      ],
-    })
-
-    const buildHealthySpy = vi.fn(buildHealthy)
-    const buildUnavailableSpy = vi.fn(buildUnavailable)
-
-    const getHealth = useProbeBackedHealth<TestHealthResponse>({
-      probeName: 'batch_jobs',
-      buildHealthy: buildHealthySpy,
-      buildUnavailable: buildUnavailableSpy,
-      // renderNonOkFromProbe not set → legacy behavior
-    })
-
-    const result = await getHealth()
-    expect(buildUnavailableSpy).toHaveBeenCalledOnce()
-    expect(buildHealthySpy).not.toHaveBeenCalled()
-    expect(result?.status).toBe('unavailable')
-    expect(result?.message).toBe('degraded detail')
   })
 })

--- a/autobot-frontend/src/composables/useProbeBackedHealth.ts
+++ b/autobot-frontend/src/composables/useProbeBackedHealth.ts
@@ -67,16 +67,6 @@ export interface ProbeBackedHealthOptions<R> {
 
   /** Error toast message when the underlying fetch fails. */
   errorMessage?: string
-
-  /**
-   * When true, calls `buildHealthy` for ANY status where the probe was FOUND
-   * (ok/degraded/down/etc.), reserving `buildUnavailable` only for a missing
-   * probe or fetch error. Defaults to false (legacy behavior: only `ok` calls
-   * `buildHealthy`).
-   *
-   * Opt-in only — existing callers are unaffected.
-   */
-  renderNonOkFromProbe?: boolean
 }
 
 /**
@@ -86,6 +76,12 @@ export interface ProbeBackedHealthOptions<R> {
  * The returned function ALWAYS resolves to `R` and never throws: on a fetch
  * error (or any failure) it returns `options.buildUnavailable(...)` rather
  * than `null`, so consumers never need a null branch (#10119).
+ *
+ * Any FOUND probe — whatever its status — is passed to `buildHealthy` so the
+ * consumer can render the real ok/degraded/down status. `buildUnavailable` is
+ * reserved for the cases where we genuinely couldn't get the probe: it isn't
+ * registered, or the fetch failed. "Unavailable" means "no probe", not "the
+ * probe reported a problem" (#11227).
  */
 export function useProbeBackedHealth<R>(
   options: ProbeBackedHealthOptions<R>,
@@ -101,10 +97,9 @@ export function useProbeBackedHealth<R>(
         return options.buildUnavailable(`${options.probeName} probe not registered`)
       }
       const data = probe.data ?? {}
-      if (probe.status === 'ok' || options.renderNonOkFromProbe) {
-        return options.buildHealthy(probe, data)
-      }
-      return options.buildUnavailable(probe.detail ?? 'Service unavailable')
+      // Probe was found — render its real status (ok/degraded/down) via
+      // buildHealthy. buildUnavailable is only for missing-probe/fetch-error.
+      return options.buildHealthy(probe, data)
     } catch (error: unknown) {
       logger.error(errorMessage, error)
       return options.buildUnavailable('Service unavailable')

--- a/autobot-frontend/src/views/SystemHealthView.vue
+++ b/autobot-frontend/src/views/SystemHealthView.vue
@@ -45,7 +45,6 @@ function toSourceMap(v: unknown): Record<string, string[]> {
 
 const getHealth = useProbeBackedHealth<ContentReachHealth>({
   probeName: PROBE_NAMES.CONTENT_REACH,
-  renderNonOkFromProbe: true,
   buildHealthy: (probe, data) => ({
     status: probe.status ?? 'unavailable',
     detail: probe.detail,


### PR DESCRIPTION
## Thinking Path
#11227 — `useProbeBackedHealth` only called `buildHealthy` for `status === 'ok'`; any FOUND-but-degraded/down probe fell through to `buildUnavailable`, so a partially-degraded backend rendered as "unavailable" — indistinguishable from an unregistered/unreachable probe. `useBatchProcessing` and `useOperationsApi` both had this gap (Content Reach had opted out of it via a `renderNonOkFromProbe` flag added in #11115).

## What Changed (Option A — the recommended fix)
- **`useProbeBackedHealth`:** any FOUND probe — whatever its status — now routes to `buildHealthy`, so the consumer renders the real ok/degraded/down status. `buildUnavailable` is reserved for the two cases where we genuinely couldn't get the probe: **not registered** or **fetch error**. "Unavailable" now means "no probe", not "the probe reported a problem".
- Removed the now-redundant `renderNonOkFromProbe` option (it *was* this behavior, opt-in) from the interface and from its only caller, `SystemHealthView.vue` — behaviour there is unchanged.
- `useBatchProcessing` / `useOperationsApi` need no call-site change: they already map `probe.status` inside `buildHealthy`, so they now render degraded/down faithfully.

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json` → **0 errors** (whole project — confirms no stray flag refs and both consumers still type-check)
- `eslint` → **0/0**
- `vitest` `useProbeBackedHealth.test.ts` → **8 passed** (updated: FOUND degraded/down → buildHealthy with real status; buildUnavailable reserved for missing-probe + fetch-error; removed the obsolete opt-in-flag suite)

## Model Used
Opus 4.8

Closes #11227
