### PR TITLE
fix(i18n): add missing llcBrowser.repo.* keys to all 10 non-en locales (unblocks frontend CI)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8483,7 +8483,26 @@
     "velocityAria": "Velocity for {name}",
     "target": "Target {date}",
     "backlogLink": "Backlog",
-    "timelineLink": "Timeline"
+    "timelineLink": "Timeline",
+    "repo": {
+      "linkedLabel": "Repository",
+      "clonePath": "Workspace path",
+      "status": "Status",
+      "attachBtn": "Attach repo",
+      "attachTitle": "Attach GitHub repository",
+      "repoLabel": "owner/repo",
+      "repoPlaceholder": "e.g. acme-org/backend",
+      "credentialLabel": "Credential ID",
+      "credentialPlaceholder": "Stored credential ID",
+      "submitBtn": "Attach",
+      "syncBtn": "Sync",
+      "detachBtn": "Detach",
+      "attachError": "Failed to attach repository.",
+      "detachError": "Failed to detach repository.",
+      "syncError": "Failed to trigger sync.",
+      "syncSuccess": "Sync started.",
+      "copyClonePath": "Copy workspace path"
+    }
   },
   "admin": {
     "systemHealth": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8483,7 +8483,26 @@
     "velocityAria": "Velocity für {name}",
     "target": "Ziel {date}",
     "backlogLink": "Backlog",
-    "timelineLink": "Zeitachse"
+    "timelineLink": "Zeitachse",
+    "repo": {
+      "linkedLabel": "Repository",
+      "clonePath": "Arbeitsbereich-Pfad",
+      "status": "Status",
+      "attachBtn": "Repo anhängen",
+      "attachTitle": "GitHub-Repository anhängen",
+      "repoLabel": "owner/repo",
+      "repoPlaceholder": "z. B. acme-org/backend",
+      "credentialLabel": "Anmeldedaten-ID",
+      "credentialPlaceholder": "Gespeicherte Anmeldedaten-ID",
+      "submitBtn": "Anhängen",
+      "syncBtn": "Synchronisieren",
+      "detachBtn": "Trennen",
+      "attachError": "Repository konnte nicht angehängt werden.",
+      "detachError": "Repository konnte nicht getrennt werden.",
+      "syncError": "Synchronisierung konnte nicht ausgelöst werden.",
+      "syncSuccess": "Synchronisierung gestartet.",
+      "copyClonePath": "Arbeitsbereich-Pfad kopieren"
+    }
   },
   "admin": {
     "systemHealth": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8483,7 +8483,26 @@
     "velocityAria": "Velocidad de {name}",
     "target": "Objetivo {date}",
     "backlogLink": "Backlog",
-    "timelineLink": "Cronograma"
+    "timelineLink": "Cronograma",
+    "repo": {
+      "linkedLabel": "Repositorio",
+      "clonePath": "Ruta del espacio de trabajo",
+      "status": "Estado",
+      "attachBtn": "Adjuntar repo",
+      "attachTitle": "Adjuntar repositorio de GitHub",
+      "repoLabel": "owner/repo",
+      "repoPlaceholder": "p. ej. acme-org/backend",
+      "credentialLabel": "ID de credencial",
+      "credentialPlaceholder": "ID de credencial almacenada",
+      "submitBtn": "Adjuntar",
+      "syncBtn": "Sincronizar",
+      "detachBtn": "Desvincular",
+      "attachError": "No se pudo adjuntar el repositorio.",
+      "detachError": "No se pudo desvincular el repositorio.",
+      "syncError": "No se pudo iniciar la sincronización.",
+      "syncSuccess": "Sincronización iniciada.",
+      "copyClonePath": "Copiar ruta del espacio de trabajo"
+    }
   },
   "admin": {
     "systemHealth": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8483,7 +8483,26 @@
     "velocityAria": "Velocity for {name}",
     "target": "Target {date}",
     "backlogLink": "Backlog",
-    "timelineLink": "Timeline"
+    "timelineLink": "Timeline",
+    "repo": {
+      "linkedLabel": "Repository",
+      "clonePath": "Workspace path",
+      "status": "Status",
+      "attachBtn": "Attach repo",
+      "attachTitle": "Attach GitHub repository",
+      "repoLabel": "owner/repo",
+      "repoPlaceholder": "e.g. acme-org/backend",
+      "credentialLabel": "Credential ID",
+      "credentialPlaceholder": "Stored credential ID",
+      "submitBtn": "Attach",
+      "syncBtn": "Sync",
+      "detachBtn": "Detach",
+      "attachError": "Failed to attach repository.",
+      "detachError": "Failed to detach repository.",
+      "syncError": "Failed to trigger sync.",
+      "syncSuccess": "Sync started.",
+      "copyClonePath": "Copy workspace path"
+    }
   },
   "admin": {
     "systemHealth": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8483,7 +8483,26 @@
     "velocityAria": "Vélocité pour {name}",
     "target": "Cible {date}",
     "backlogLink": "Backlog",
-    "timelineLink": "Chronologie"
+    "timelineLink": "Chronologie",
+    "repo": {
+      "linkedLabel": "Dépôt",
+      "clonePath": "Chemin de l'espace de travail",
+      "status": "Statut",
+      "attachBtn": "Attacher le dépôt",
+      "attachTitle": "Attacher un dépôt GitHub",
+      "repoLabel": "owner/repo",
+      "repoPlaceholder": "ex. acme-org/backend",
+      "credentialLabel": "ID d'identifiant",
+      "credentialPlaceholder": "ID d'identifiant enregistré",
+      "submitBtn": "Attacher",
+      "syncBtn": "Synchroniser",
+      "detachBtn": "Détacher",
+      "attachError": "Échec de l'attachement du dépôt.",
+      "detachError": "Échec du détachement du dépôt.",
+      "syncError": "Échec du déclenchement de la synchronisation.",
+      "syncSuccess": "Synchronisation démarrée.",
+      "copyClonePath": "Copier le chemin de l'espace de travail"
+    }
   },
   "admin": {
     "systemHealth": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8483,7 +8483,26 @@
     "velocityAria": "Velocity for {name}",
     "target": "Target {date}",
     "backlogLink": "Backlog",
-    "timelineLink": "Timeline"
+    "timelineLink": "Timeline",
+    "repo": {
+      "linkedLabel": "Repository",
+      "clonePath": "Workspace path",
+      "status": "Status",
+      "attachBtn": "Attach repo",
+      "attachTitle": "Attach GitHub repository",
+      "repoLabel": "owner/repo",
+      "repoPlaceholder": "e.g. acme-org/backend",
+      "credentialLabel": "Credential ID",
+      "credentialPlaceholder": "Stored credential ID",
+      "submitBtn": "Attach",
+      "syncBtn": "Sync",
+      "detachBtn": "Detach",
+      "attachError": "Failed to attach repository.",
+      "detachError": "Failed to detach repository.",
+      "syncError": "Failed to trigger sync.",
+      "syncSuccess": "Sync started.",
+      "copyClonePath": "Copy workspace path"
+    }
   },
   "admin": {
     "systemHealth": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8483,7 +8483,26 @@
     "velocityAria": "Velocity for {name}",
     "target": "Target {date}",
     "backlogLink": "Backlog",
-    "timelineLink": "Timeline"
+    "timelineLink": "Timeline",
+    "repo": {
+      "linkedLabel": "Repository",
+      "clonePath": "Workspace path",
+      "status": "Status",
+      "attachBtn": "Attach repo",
+      "attachTitle": "Attach GitHub repository",
+      "repoLabel": "owner/repo",
+      "repoPlaceholder": "e.g. acme-org/backend",
+      "credentialLabel": "Credential ID",
+      "credentialPlaceholder": "Stored credential ID",
+      "submitBtn": "Attach",
+      "syncBtn": "Sync",
+      "detachBtn": "Detach",
+      "attachError": "Failed to attach repository.",
+      "detachError": "Failed to detach repository.",
+      "syncError": "Failed to trigger sync.",
+      "syncSuccess": "Sync started.",
+      "copyClonePath": "Copy workspace path"
+    }
   },
   "admin": {
     "systemHealth": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8483,7 +8483,26 @@
     "velocityAria": "Velocity for {name}",
     "target": "Target {date}",
     "backlogLink": "Backlog",
-    "timelineLink": "Timeline"
+    "timelineLink": "Timeline",
+    "repo": {
+      "linkedLabel": "Repository",
+      "clonePath": "Workspace path",
+      "status": "Status",
+      "attachBtn": "Attach repo",
+      "attachTitle": "Attach GitHub repository",
+      "repoLabel": "owner/repo",
+      "repoPlaceholder": "e.g. acme-org/backend",
+      "credentialLabel": "Credential ID",
+      "credentialPlaceholder": "Stored credential ID",
+      "submitBtn": "Attach",
+      "syncBtn": "Sync",
+      "detachBtn": "Detach",
+      "attachError": "Failed to attach repository.",
+      "detachError": "Failed to detach repository.",
+      "syncError": "Failed to trigger sync.",
+      "syncSuccess": "Sync started.",
+      "copyClonePath": "Copy workspace path"
+    }
   },
   "admin": {
     "systemHealth": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8483,7 +8483,26 @@
     "velocityAria": "Velocidade de {name}",
     "target": "Meta {date}",
     "backlogLink": "Backlog",
-    "timelineLink": "Linha do tempo"
+    "timelineLink": "Linha do tempo",
+    "repo": {
+      "linkedLabel": "Repositório",
+      "clonePath": "Caminho do espaço de trabalho",
+      "status": "Estado",
+      "attachBtn": "Anexar repo",
+      "attachTitle": "Anexar repositório do GitHub",
+      "repoLabel": "owner/repo",
+      "repoPlaceholder": "ex.: acme-org/backend",
+      "credentialLabel": "ID de credencial",
+      "credentialPlaceholder": "ID de credencial armazenada",
+      "submitBtn": "Anexar",
+      "syncBtn": "Sincronizar",
+      "detachBtn": "Desanexar",
+      "attachError": "Falha ao anexar o repositório.",
+      "detachError": "Falha ao desanexar o repositório.",
+      "syncError": "Falha ao acionar a sincronização.",
+      "syncSuccess": "Sincronização iniciada.",
+      "copyClonePath": "Copiar caminho do espaço de trabalho"
+    }
   },
   "admin": {
     "systemHealth": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8483,7 +8483,26 @@
     "velocityAria": "Velocity for {name}",
     "target": "Target {date}",
     "backlogLink": "Backlog",
-    "timelineLink": "Timeline"
+    "timelineLink": "Timeline",
+    "repo": {
+      "linkedLabel": "Repository",
+      "clonePath": "Workspace path",
+      "status": "Status",
+      "attachBtn": "Attach repo",
+      "attachTitle": "Attach GitHub repository",
+      "repoLabel": "owner/repo",
+      "repoPlaceholder": "e.g. acme-org/backend",
+      "credentialLabel": "Credential ID",
+      "credentialPlaceholder": "Stored credential ID",
+      "submitBtn": "Attach",
+      "syncBtn": "Sync",
+      "detachBtn": "Detach",
+      "attachError": "Failed to attach repository.",
+      "detachError": "Failed to detach repository.",
+      "syncError": "Failed to trigger sync.",
+      "syncSuccess": "Sync started.",
+      "copyClonePath": "Copy workspace path"
+    }
   },
   "admin": {
     "systemHealth": {


### PR DESCRIPTION
## Thinking Path
Discovered while running the full frontend `test:coverage` gate for #11232: `locale-parity.test.ts` was **red for all 10 non-en locales** — the `llcBrowser.repo.*` block (17 keys, from the repo-linkage feature #11129) was added to `en.json` but not the other locales, violating the ALL-11-locales rule. Because `locale-parity` runs inside the required `Unit & Integration Tests` frontend job, this was **blocking every frontend PR's CI** on base.

## What Changed
Added the 17 `llcBrowser.repo.*` keys to all 10 non-en locales:
- **Translated:** de, es, fr, pt
- **English fallback** (key present, awaiting translation): ar, fa, he, lv, pl, ur

Additive-only (+17 keys per file, no existing keys touched); JSON round-trips byte-identically to the repo's `2-space / raw-unicode / trailing-newline` format.

## Verification
- `vitest src/i18n/__tests__/locale-parity.test.ts` → **21 passed** (was 10 failing)
- `npm run check:locales` → "All locale files complete."
- `npm run check:i18n` → "All translation keys found in en.json."

## Model Used
Opus 4.8

Fixes the base locale-parity break (discovered via #11232). Unblocks frontend-tests for all open frontend PRs.
