### PR TITLE
fix(slm): seed_default_roles upserts registry-owned fields on existing rows (was insert-only) (#11132)

### DIFF
--- a/autobot-slm-backend/services/role_registry.py
+++ b/autobot-slm-backend/services/role_registry.py
@@ -442,17 +442,38 @@ ROLE_DEPENDENCIES: Dict[str, List[str]] = {
 
 
 async def seed_default_roles(db: AsyncSession) -> int:
-    """Seed default roles if they don't exist."""
+    """Seed default roles, upserting registry-owned fields on existing rows (#11132).
+
+    Previously insert-only, so any edit to ``DEFAULT_ROLES`` (post_sync_cmd,
+    source_paths, health checks, …) reached only a *fresh* DB — an already-seeded
+    SLM DB kept the stale values, silently reverting historical registry fixes
+    (e.g. #11069's post_sync_cmd correction stayed broken). Now every field the
+    registry defines for a role is refreshed on the existing row when it differs;
+    DB-managed columns (``id``/``created_at``) and any column a role doesn't define
+    are left untouched, so operator-set fields outside the registry are preserved.
+
+    Returns the number of roles *created* (new rows), preserving the prior contract.
+    """
     created = 0
+    updated = 0
     for role_data in DEFAULT_ROLES:
         result = await db.execute(select(Role).where(Role.name == role_data["name"]))
-        if not result.scalar_one_or_none():
-            role = Role(**role_data)
-            db.add(role)
+        role = result.scalar_one_or_none()
+        if role is None:
+            db.add(Role(**role_data))
             created += 1
             logger.info("Created default role: %s", role_data["name"])
+            continue
+        # Refresh only the registry-owned fields this role defines, and only when a
+        # value actually changed (avoids spurious updated_at churn).
+        changed = [f for f, v in role_data.items() if getattr(role, f) != v]
+        if changed:
+            for field in changed:
+                setattr(role, field, role_data[field])
+            updated += 1
+            logger.info("Synced default role %s from registry (fields: %s)", role_data["name"], ", ".join(changed))
 
-    if created > 0:
+    if created or updated:
         await db.commit()
 
     return created

--- a/autobot-slm-backend/tests/services/test_role_registry.py
+++ b/autobot-slm-backend/tests/services/test_role_registry.py
@@ -240,3 +240,59 @@ def test_optional_roles_are_not_required():
     for name in optional_names:
         role = _role(name)
         assert role["required"] is False, f"{name} should be optional (required=False)"
+
+
+# ---------------------------------------------------------------------------
+# seed_default_roles upsert logic (#11132)
+#
+# The SLM conftest stubs sqlalchemy, so a real-DB test isn't feasible here; this
+# drives seed_default_roles against a mock async session to prove it refreshes a
+# stale registry-owned field on an already-seeded row (the insert-only bug).
+# ---------------------------------------------------------------------------
+import asyncio as _asyncio
+from unittest.mock import AsyncMock as _AsyncMock
+
+
+class _Result:
+    def __init__(self, obj):
+        self._obj = obj
+
+    def scalar_one_or_none(self):
+        return self._obj
+
+
+def test_seed_default_roles_upserts_stale_field_on_existing_row():
+    target_idx, target = next((i, r) for i, r in enumerate(DEFAULT_ROLES) if r.get("post_sync_cmd"))
+    existing = _types.SimpleNamespace(**dict(target))
+    existing.post_sync_cmd = "STALE_BROKEN_CMD"
+    existing.source_paths = ["WRONG/"]
+
+    # execute() is called once per role in order → existing row only at the target index.
+    results = [_Result(existing if i == target_idx else None) for i in range(len(DEFAULT_ROLES))]
+    db = _AsyncMock()
+    db.execute = _AsyncMock(side_effect=results)
+    db.commit = _AsyncMock()
+    db.add = _MagicMock()
+
+    created = _asyncio.run(_rr.seed_default_roles(db))
+
+    # Stale registry-owned fields refreshed from DEFAULT_ROLES; created counts new rows only.
+    assert existing.post_sync_cmd == target["post_sync_cmd"]
+    assert existing.source_paths == target["source_paths"]
+    assert created == len(DEFAULT_ROLES) - 1
+    db.commit.assert_awaited()
+
+
+def test_seed_default_roles_no_write_when_existing_rows_match_registry():
+    # Every role already exists with registry-identical values → no commit, created == 0.
+    existing_rows = [_types.SimpleNamespace(**dict(r)) for r in DEFAULT_ROLES]
+    db = _AsyncMock()
+    db.execute = _AsyncMock(side_effect=[_Result(row) for row in existing_rows])
+    db.commit = _AsyncMock()
+    db.add = _MagicMock()
+
+    created = _asyncio.run(_rr.seed_default_roles(db))
+
+    assert created == 0
+    db.commit.assert_not_awaited()
+    db.add.assert_not_called()


### PR DESCRIPTION
## Thinking Path
#11132 — `services/role_registry.seed_default_roles` was **insert-only** (`if not exists: db.add(...)`), so any edit to `DEFAULT_ROLES` (post_sync_cmd, source_paths, health checks) reached only a *fresh* DB. On an already-seeded SLM DB the stale values persisted — e.g. #11069's post_sync_cmd fix stayed broken, so alembic migrations remained silently skipped on code-sync.

## What Changed
`seed_default_roles` now **upserts** existing rows: for each `DEFAULT_ROLES` entry, if the row exists, refresh every registry-owned field it defines **when the value differs** (avoids spurious `updated_at` churn). New rows are still created. DB-managed columns (`id`/`created_at`) and any column a role doesn't define are left untouched, so operator-set fields outside the registry are preserved. Return value stays "number created" (prior contract).

## Verification
- `tests/services/test_role_registry.py` → **16 passed** (14 existing data-shape + 2 new upsert-logic tests):
  - stale `post_sync_cmd`/`source_paths` on an existing row are refreshed to the registry values; `created` counts only new rows
  - all-rows-match → no `commit`, no `add`, `created == 0` (idempotent, no churn)
- `black` + `flake8` clean.
- Note: the SLM `conftest` stubs `sqlalchemy`, so a real in-memory-DB test isn't feasible in that harness (#10691-family limitation) — the new tests drive the function against a mock async session to prove the field-refresh logic.

## Model Used
Opus 4.8

Closes #11132
