### PR TITLE
fix(backup): prune expired redis backups per redis_backup_retention_days (#11133)

### DIFF
--- a/autobot-slm-backend/ansible/roles/access_control/tasks/backup.yml
+++ b/autobot-slm-backend/ansible/roles/access_control/tasks/backup.yml
@@ -41,6 +41,24 @@
     group: "{{ service_group }}"
     mode: '0644'
 
+# Enforce the advertised retention — without this the backup_*.txt files
+# under backups/redis accumulate forever (#11133; mirrors #11112 node-data prune).
+- name: Find Redis backups older than retention
+  ansible.builtin.find:
+    paths: "{{ project_root }}/backups/redis"
+    patterns: "backup_*.txt"
+    age: "{{ redis_backup_retention_days }}d"
+    age_stamp: mtime
+  register: expired_redis_backups
+
+- name: Remove expired Redis backups
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ expired_redis_backups.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+
 - name: Display backup status
   debug:
     msg: "Redis backup completed: {{ ansible_facts['date_time'].iso8601 }}"


### PR DESCRIPTION
## Thinking Path
#11133 — `access_control/tasks/backup.yml` writes `Retention: {{ redis_backup_retention_days }} days` into each backup metadata file but has **no prune task**, so `backup_*.txt` files under `{{ project_root }}/backups/redis` accumulate forever. Sibling of the node-data retention gap fixed in #11112, on a separate backup path.

## What Changed
Added a find-by-age + delete prune after the backup step, mirroring #11112's canonical pattern:
- `ansible.builtin.find` on `backups/redis/backup_*.txt` with `age: "{{ redis_backup_retention_days }}d"` (mtime)
- `ansible.builtin.file: state=absent` over the expired files (`| default([])` guard; `loop_control.label` for clean output)

`redis_backup_retention_days` already defaults to 30 (access_control/defaults). Idempotent — removes only files older than the retention window.

## Verification
- YAML parses cleanly (`yaml.safe_load_all`).
- Task structure matches the proven #11112 node-data prune (`backup-node-data.yml:303-318`) exactly.
- Ansible isn't run against live hosts here; the change is a standard, self-contained find/file prune.

## Model Used
Opus 4.8

Closes #11133
