### PR TITLE
fix(deploy): rewrite -r ../requirements.txt to code_source so root runtime deps install on deploy (#11135)

### DIFF
--- a/autobot-slm-backend/services/role_registry.py
+++ b/autobot-slm-backend/services/role_registry.py
@@ -104,15 +104,20 @@ _BACKEND_ROLES = [
         "health_check_port": 8443,
         "health_check_path": "/api/health",
         # Install deps into the backend venv, then migrate. Mirrors the backend
-        # ansible role (#11117): filter out the editable autobot_shared + -r
-        # includes, and rewrite -c ../constraints/ to the canonical code_source
-        # path so pip can resolve the #10524 constraints (bare `pip install -r
-        # requirements.txt` errors on the unresolvable -c and, via && short-
-        # circuit, silently skipped alembic every sync — #11069).
+        # ansible role (#11117): strip only the editable autobot_shared, and
+        # rewrite the two sibling-relative includes to the canonical code_source
+        # path so pip can resolve them — `-c ../constraints/` (#10524 constraints)
+        # and `-r ../requirements.txt` (the ~23 root runtime deps: paramiko,
+        # asyncssh, pypdf, python-docx/pptx, openpyxl, …). Both siblings live in
+        # code_source but NOT next to the synced autobot-backend/, so stripping
+        # `-r` (as before) silently dropped those deps on deploy — #11135. A bare
+        # `pip install -r requirements.txt` would error on the unresolvable
+        # include and, via the && short-circuit, silently skip alembic (#11069).
         "post_sync_cmd": (
             f"cd {_BASE_DIR}/autobot-backend && "
-            "grep -Ev '^-e.*autobot[-_]shared|^-r' requirements.txt "
-            f"| sed 's|^-c \\.\\./constraints/|-c {_BASE_DIR}/code_source/constraints/|' "
+            "grep -Ev '^-e.*autobot[-_]shared' requirements.txt "
+            f"| sed 's|^-c \\.\\./constraints/|-c {_BASE_DIR}/code_source/constraints/|;"
+            f" s|^-r \\.\\./requirements.txt|-r {_BASE_DIR}/code_source/requirements.txt|' "
             "> /tmp/requirements-filtered-slm.txt && "
             "PIP_USE_DEPRECATED=legacy-resolver PIP_DEFAULT_TIMEOUT=120 "
             "venv/bin/pip install -r /tmp/requirements-filtered-slm.txt && "

--- a/autobot-slm-backend/tests/services/test_role_registry.py
+++ b/autobot-slm-backend/tests/services/test_role_registry.py
@@ -296,3 +296,18 @@ def test_seed_default_roles_no_write_when_existing_rows_match_registry():
     assert created == 0
     db.commit.assert_not_awaited()
     db.add.assert_not_called()
+
+
+def test_backend_post_sync_rewrites_root_requirements_not_strips_it():
+    """The backend post_sync_cmd must REWRITE `-r ../requirements.txt` to the
+    code_source path (so the root runtime deps install on deploy), not strip it
+    like the old `grep -Ev '...|^-r'` did — #11135."""
+    backend = next(r for r in DEFAULT_ROLES if r["name"] == "backend")
+    cmd = backend["post_sync_cmd"]
+    # rewrite present (sed maps the sibling include to code_source)
+    assert "s|^-r \\.\\./requirements.txt|-r " in cmd
+    assert "/code_source/requirements.txt|" in cmd
+    # and the grep no longer drops -r lines
+    assert "^-r" not in cmd.split("| sed")[0]
+    # the -c constraints rewrite (#11117) is preserved
+    assert "s|^-c \\.\\./constraints/|-c " in cmd


### PR DESCRIPTION
## Thinking Path
#11135 — `autobot-backend/requirements.txt:60` is `-r ../requirements.txt` (repo-root, ~23 runtime deps: paramiko, asyncssh, pypdf, python-docx/pptx, openpyxl, protobuf…). On deploy the sibling `../requirements.txt` doesn't exist next to the synced `autobot-backend/`, and the backend role's `post_sync_cmd` **stripped** `^-r` lines — so those deps were silently dropped. Same class as #11117, which correctly *rewrote* `-c ../constraints/` to the resolvable `code_source` path but only *stripped* `-r`.

## What Changed
In `services/role_registry.py` the backend `post_sync_cmd` now:
- **stops stripping `-r`** (grep filters only the editable `autobot_shared`), and
- **rewrites** `-r ../requirements.txt` → `-r {BASE}/code_source/requirements.txt` via the same `sed` that already rewrites `-c ../constraints/` (both siblings live in `code_source`, the full-repo clone).

Root `requirements.txt` has no nested `-c/-r/-e` includes, so it resolves cleanly.

## Verification
- Ran the exact `grep | sed` pipeline on the real `requirements.txt`: `-c ../constraints/shared.txt` → `code_source/constraints/…`, **`-r ../requirements.txt` → `/opt/autobot/code_source/requirements.txt`**, `-e autobot_shared` stripped (0 residual). ✅
- `tests/services/test_role_registry.py` → **17 passed** (new regression test asserts the backend post_sync rewrites `-r` and no longer strips it, and preserves the `-c` rewrite).
- `black` + `flake8` clean.
- Bonus: now that #11132 (upsert seeding) is merged, this post_sync_cmd correction will actually reach already-seeded SLM DBs on the next sync.

## Review note
⚠️ **Deploy-path change** — pipeline output is verified locally and mirrors the proven #11117 pattern, but a real code-sync deploy is the ultimate confirmation the ~23 root deps install. Opened for review rather than blind admin-merge.

## Model Used
Opus 4.8

Closes #11135
