### PR TITLE
fix(ansible): purge real ChromaDB data dir on node teardown (#11099)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/decommission-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/decommission-node.yml
@@ -35,7 +35,9 @@
     default_data_dirs:
       - /var/lib/redis
       - /var/lib/postgresql
-      - /var/lib/chromadb
+      - /var/lib/chromadb  # legacy path (kept so old nodes are still cleaned)
+      # Real ChromaDB data dir (#11099) — /var/lib/chromadb alone left it behind.
+      - "{{ chromadb_data_dir | default('/opt/autobot/autobot-db-stack/chromadb/data') }}"
       - /var/lib/autobot
       - /usr/share/ollama/.ollama
       - /var/lib/ollama
@@ -234,7 +236,9 @@
             state: absent
           loop:
             - /var/lib/autobot
-            - /var/lib/chromadb
+            - /var/lib/chromadb  # legacy path (kept so old nodes are still cleaned)
+            # Real ChromaDB data dir (#11099).
+            - "{{ chromadb_data_dir | default('/opt/autobot/autobot-db-stack/chromadb/data') }}"
             - /var/lib/ollama
             - /usr/share/ollama
             - /var/log/autobot

--- a/autobot-slm-backend/ansible/playbooks/remove-role.yml
+++ b/autobot-slm-backend/ansible/playbooks/remove-role.yml
@@ -40,7 +40,10 @@
       postgresql:
         - /var/lib/postgresql
       ai-stack:
-        - /var/lib/chromadb
+        - /var/lib/chromadb  # legacy path (kept so old nodes are still cleaned)
+        # Real ChromaDB data dir (#11099) — /var/lib/chromadb alone left the
+        # live vector store behind on 'remove ai-stack'.
+        - "{{ chromadb_data_dir | default('/opt/autobot/autobot-db-stack/chromadb/data') }}"
         # Issue #3097: ai-stack data moved to /var/lib/autobot-ai
         - /var/lib/autobot-ai
       llm:


### PR DESCRIPTION
## Thinking Path
Issue #11099: node teardown plays delete only the stale `/var/lib/chromadb`
path, so the **live** vector store at `chromadb_data_dir`
(`/opt/autobot/autobot-db-stack/chromadb/data`, set in
`roles/redis/defaults/main.yml:62`) is left behind — a data-remnant / privacy
bug on `decommission-node.yml` and `remove-role.yml` (ai-stack). The canonical
path moved but the destructive plays were never updated.

`chromadb_data_dir` is a redis-role default and is **not** in scope in these
standalone playbooks, so referencing it bare would evaluate undefined and
(worse, on a `state: absent` file task) risk deleting the wrong thing. Guard it
with `| default('/opt/autobot/autobot-db-stack/chromadb/data')` so it always
resolves to a valid path — using an inventory/group override when present, the
canonical default otherwise.

**Additive, not a swap:** the legacy `/var/lib/chromadb` line is kept so nodes
that still hold data there are also cleaned. Teardown now removes ChromaDB data
wherever it lives and never *less* than before — the safe direction for a
destructive play.

## What Changed
- `decommission-node.yml` — `default_data_dirs` list (~L38) and the explicit
  `state: absent` cleanup loop (~L237): add the real ChromaDB dir.
- `remove-role.yml` — `ai-stack` role-dir list (~L43): add the real ChromaDB dir.

## Verification
- `yaml.safe_load_all` parses both playbooks cleanly (both `YAML OK`).
- grep confirms both legacy + real path present at all 3 sites.
- No behavior change beyond adding one path to each destructive list.

## Model Used
Opus 4.8 (1M context)

Closes #11099