### PR TITLE
test(llc): fix test_unauthenticated_returns_error — drive real auth rejection (#11142)

### DIFF
--- a/autobot-backend/llc/tests/test_backlog_reorder.py
+++ b/autobot-backend/llc/tests/test_backlog_reorder.py
@@ -255,18 +255,29 @@ class TestBacklogReorderRoute:
             patcher.stop()
 
     def test_unauthenticated_returns_error(self):
-        """No auth overrides installed → the real dependency rejects the request."""
+        """No authenticated user → the real ``get_current_user`` dependency rejects.
+
+        Omitting the auth dependency override is not enough on its own: the test
+        conftest stubs ``auth_middleware.get_auth_middleware`` as a MagicMock whose
+        ``get_user_from_request()`` returns a truthy mock, so the real
+        ``get_current_user`` would always see a "user" and never reject. Force the
+        (stubbed) middleware to yield no user so the route's real auth-rejection
+        path (``if not user_data: raise HTTPException``) actually runs. (#11142)
+        """
+        from unittest.mock import patch  # noqa: PLC0415
+
         client, patcher = self._client(install_auth=False)
         try:
-            company_id = str(uuid.uuid4())
-            ids = [str(uuid.uuid4())]
-            resp = client.post(
-                f"/companies/{company_id}/backlog/reorder",
-                json={"work_item_ids": ids},
-            )
-            # Any 4xx is acceptable — the dependency may raise 400/401/403/422
-            # depending on how the test client handles missing Authorization headers.
-            assert resp.status_code >= 400
+            with patch("api.user_management.dependencies.get_auth_middleware") as mock_gam:
+                mock_gam.return_value.get_user_from_request.return_value = None
+                company_id = str(uuid.uuid4())
+                ids = [str(uuid.uuid4())]
+                resp = client.post(
+                    f"/companies/{company_id}/backlog/reorder",
+                    json={"work_item_ids": ids},
+                )
+                # Real get_current_user raises 401 when the middleware yields no user.
+                assert resp.status_code >= 400
         finally:
             patcher.stop()
 


### PR DESCRIPTION
## Thinking Path
`test_backlog_reorder.py::TestBacklogReorderRoute::test_unauthenticated_returns_error`
fails (returns 200, expected ≥400) **in isolation and in-suite** — confirmed
pre-existing on `Dev_new_gui`.

The issue's stated root cause (an unpaired `patcher.start()` leaking the auth
patch) is **incorrect**: every test already pairs `patcher.stop()` in a `finally`,
each `_client()` builds a fresh `FastAPI` app with its own `dependency_overrides`,
and the `patcher` targets `BacklogService.bulk_reorder`, not auth.

Probed the real mechanism: `auth_middleware.get_auth_middleware()` resolves to a
`unittest.mock.MagicMock` (stubbed by the test conftest), so
`get_user_from_request()` returns a **truthy mock**. The route's real
`get_current_user` therefore always sees a "user" and never rejects — omitting the
dependency override (`install_auth=False`) can't simulate an anonymous caller.

## What Changed
- `test_unauthenticated_returns_error`: within the test, patch
  `api.user_management.dependencies.get_auth_middleware` so `get_user_from_request`
  returns `None`. This drives the route's real rejection path
  (`if not user_data: raise HTTPException`) → **401**. The test now genuinely
  verifies the reorder endpoint is auth-protected, instead of silently passing
  through a stubbed no-op middleware.

## Verification
- Was: `assert 200 >= 400` FAIL. Now: **401** → `1 passed` in isolation.
- Full `TestBacklogReorderRoute` class: **8 passed**, no regressions.
- `black --check -l120` clean.

## Model Used
Opus 4.8 (1M context)

Closes #11142
