### PR TITLE
security(ws): apply CSWSH Origin guard to all WebSocket endpoints (#11088)

### DIFF
--- a/autobot-backend/api/advanced_control.py
+++ b/autobot-backend/api/advanced_control.py
@@ -34,6 +34,7 @@ from api.schemas_workflows import (
     AdvancedControlTakeoverSessionStatusResponse,
     AdvancedControlTakeoverSystemStatusResponse,
 )
+from api.ws_security import enforce_ws_origin
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -509,6 +510,8 @@ async def get_system_health(
 )
 async def monitoring_websocket(websocket: WebSocket):
     """WebSocket endpoint for real-time system monitoring"""
+    if not await enforce_ws_origin(websocket):
+        return
     await websocket.accept()
     logger.info("Monitoring WebSocket client connected")
 
@@ -547,6 +550,8 @@ async def monitoring_websocket(websocket: WebSocket):
 )
 async def desktop_streaming_websocket(websocket: WebSocket, session_id: str):
     """WebSocket endpoint for desktop streaming control"""
+    if not await enforce_ws_origin(websocket):
+        return
     await websocket.accept()
 
     try:

--- a/autobot-backend/api/analytics.py
+++ b/autobot-backend/api/analytics.py
@@ -28,7 +28,6 @@ from fastapi import (
     WebSocketDisconnect,
 )
 
-# Import controller class (extracted from this file - Issue #212)
 from api.analytics_controller import (
     analytics_controller,
     analytics_state,
@@ -52,6 +51,9 @@ from api.schemas_analytics import (
     AnalyticsUsageStatisticsResponse,
     RealTimeEvent,
 )
+
+# Import controller class (extracted from this file - Issue #212)
+from api.ws_security import enforce_ws_origin
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -677,6 +679,8 @@ async def _realtime_loop_iteration(websocket: WebSocket) -> tuple[bool, bool]:
 )
 async def websocket_realtime_analytics(websocket: WebSocket):
     """WebSocket endpoint for real-time analytics streaming"""
+    if not await enforce_ws_origin(websocket):
+        return
     await websocket.accept()
     analytics_state["websocket_connections"].add(websocket)
 
@@ -1098,6 +1102,8 @@ async def _live_analytics_loop_iteration(
 )
 async def websocket_live_analytics(websocket: WebSocket):
     """Enhanced WebSocket endpoint for live analytics with multiple channels"""
+    if not await enforce_ws_origin(websocket):
+        return
     await websocket.accept()
     analytics_state["websocket_connections"].add(websocket)
 

--- a/autobot-backend/api/analytics_quality.py
+++ b/autobot-backend/api/analytics_quality.py
@@ -36,6 +36,7 @@ from api.schemas_analytics import (
     QualityTrendsResponse,
 )
 from api.schemas_common import DataResponse
+from api.ws_security import enforce_ws_origin
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -1600,6 +1601,8 @@ async def websocket_quality_updates(websocket: WebSocket):
     Clients receive updates when quality metrics change.
     Issue #315: Refactored to use dictionary dispatch for message handling.
     """
+    if not await enforce_ws_origin(websocket):
+        return
     await manager.connect(websocket)
 
     # Send initial snapshot

--- a/autobot-backend/api/intelligent_agent.py
+++ b/autobot-backend/api/intelligent_agent.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 from fastapi import APIRouter, Depends, HTTPException, Request, WebSocket, WebSocketDisconnect
 
 from api.system_health import ComponentHealth, KnownProbes, register_health_probe
+from api.ws_security import enforce_ws_origin
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.logging_manager import get_logger
 
@@ -263,6 +264,8 @@ async def websocket_stream(websocket: WebSocket):
     Clients can send natural language goals and receive real-time updates
     as the agent processes and executes commands.
     """
+    if not await enforce_ws_origin(websocket):
+        return
     await websocket.accept()
     logger.info("WebSocket connection established")
     try:

--- a/autobot-backend/api/knowledge_research_ws.py
+++ b/autobot-backend/api/knowledge_research_ws.py
@@ -29,6 +29,7 @@ from typing import Any, Callable, Dict
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
 
+from api.ws_security import enforce_ws_origin
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 
@@ -133,6 +134,8 @@ async def knowledge_research_ws(websocket: WebSocket) -> None:
 
     Issue #1256: Observable Research Panel.
     """
+    if not await enforce_ws_origin(websocket):
+        return
     await websocket.accept()
     logger.info("Knowledge research WS connected from %s", websocket.client)
 

--- a/autobot-backend/api/live_events.py
+++ b/autobot-backend/api/live_events.py
@@ -26,6 +26,7 @@ import json
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
 
+from api.ws_security import enforce_ws_origin
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from events.bus import get_event_bus
@@ -116,6 +117,8 @@ async def _keepalive_loop(ws: WebSocket, stop_event: asyncio.Event) -> None:
 )
 async def live_events_endpoint(websocket: WebSocket):
     """WebSocket endpoint for scoped real-time event streaming (#1408)."""
+    if not await enforce_ws_origin(websocket):
+        return
     # #9963: use the canonical WS auth (JWT), same as /api/ws — the local
     # raw-JWT check was too strict and rejected valid deployments.
     from auth_middleware import authenticate_websocket

--- a/autobot-backend/api/logs.py
+++ b/autobot-backend/api/logs.py
@@ -31,6 +31,7 @@ from api.schemas_code import (
     LogSourcesResponse,
 )
 from api.schemas_common import AgentMessageResponse
+from api.ws_security import enforce_ws_origin
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -852,6 +853,8 @@ async def stream_log(
 )
 async def tail_log(websocket: WebSocket, filename: str):
     """WebSocket endpoint to tail log file in real-time"""
+    if not await enforce_ws_origin(websocket):
+        return
     await websocket.accept()
 
     try:

--- a/autobot-backend/api/long_running_operations.py
+++ b/autobot-backend/api/long_running_operations.py
@@ -46,6 +46,7 @@ from api.schemas_workflows import (
     TestSuiteRequest,
 )
 from api.system_health import ComponentHealth, KnownProbes, register_health_probe
+from api.ws_security import enforce_ws_origin
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.security.path_validator import validate_path
@@ -498,6 +499,8 @@ async def resume_operation(operation_id: str, manager=Depends(get_operation_mana
 )
 async def websocket_progress_updates(websocket: WebSocket, operation_id: str):
     """WebSocket endpoint for real-time progress updates"""
+    if not await enforce_ws_origin(websocket):
+        return
     if not _OPERATIONS_AVAILABLE:
         await websocket.close(code=1003, reason="Service not available")
         return

--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -26,7 +26,6 @@ from fastapi import (
 )
 from fastapi.responses import JSONResponse, StreamingResponse
 
-# Hardware monitor moved to monitoring_hardware.py (Issue #213)
 from api.monitoring_hardware import local_hardware_monitor
 
 # Import monitoring utility functions
@@ -53,6 +52,9 @@ from api.schemas_system import (
     ThresholdUpdate,
     ThresholdUpdateResponse,
 )
+
+# Hardware monitor moved to monitoring_hardware.py (Issue #213)
+from api.ws_security import enforce_ws_origin
 from auth_middleware import check_admin_permission
 
 # Import AutoBot monitoring system
@@ -1133,6 +1135,8 @@ async def realtime_monitoring_websocket(websocket: WebSocket):
 
     Issue #315: Refactored to use dictionary dispatch for command handling.
     """
+    if not await enforce_ws_origin(websocket):
+        return
     await ws_manager.connect(websocket)
     try:
         while True:

--- a/autobot-backend/api/overseer_handlers.py
+++ b/autobot-backend/api/overseer_handlers.py
@@ -27,6 +27,7 @@ from agents.overseer.types import (
 from api.schemas_agent import OverseerQueryData
 from api.schemas_common import DataResponse
 from api.schemas_system import OverseerStatusResponse
+from api.ws_security import enforce_ws_origin
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -447,6 +448,8 @@ async def overseer_websocket(websocket: WebSocket, session_id: str):
     - Automatic command explanations (Part 1: what it does)
     - Automatic output explanations (Part 2: what we're looking at)
     """
+    if not await enforce_ws_origin(websocket):
+        return
     handler = OverseerWebSocketHandler(websocket, session_id)
 
     if not await handler.connect():

--- a/autobot-backend/api/presence_ws.py
+++ b/autobot-backend/api/presence_ws.py
@@ -11,6 +11,7 @@ Issue #3282: collaborative multi-user support — shared sessions and workspaces
 
 from fastapi import APIRouter, Query, WebSocket
 
+from api.ws_security import enforce_ws_origin
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from websocket.presence import presence_websocket_handler
@@ -43,5 +44,7 @@ async def session_presence(
         user_id: Caller's user ID (passed as query param until WS auth middleware
                  is extended to cover WebSocket handshakes for this path)
     """
+    if not await enforce_ws_origin(websocket):
+        return
     logger.info("Presence WS connect: user=%s session=%s", user_id, session_id)
     await presence_websocket_handler(websocket, session_id, user_id)

--- a/autobot-backend/api/process_management.py
+++ b/autobot-backend/api/process_management.py
@@ -23,6 +23,7 @@ from api.schemas_system import (
     SpawnRequest,
     SpawnResponse,
 )
+from api.ws_security import enforce_ws_origin
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.error_utils import safe_http_detail
@@ -183,6 +184,8 @@ async def stream_process_logs(
     Tails the log file and pushes new lines to the client every 500ms.
     Closes when the process completes or the client disconnects.
     """
+    if not await enforce_ws_origin(websocket):
+        return
     import asyncio
 
     await websocket.accept()

--- a/autobot-backend/api/startup.py
+++ b/autobot-backend/api/startup.py
@@ -25,6 +25,7 @@ import threading
 
 from api.schemas_common import DataResponse
 from api.schemas_system import StartupMessage, StartupPhase, StartupPhaseUpdateData, StartupStatusResponse
+from api.ws_security import enforce_ws_origin
 
 _startup_lock = threading.Lock()
 
@@ -132,6 +133,8 @@ async def get_startup_status():
 )
 async def startup_websocket(websocket: WebSocket):
     """WebSocket endpoint for real-time startup messages"""
+    if not await enforce_ws_origin(websocket):
+        return
     await websocket.accept()
 
     async with _ws_lock:

--- a/autobot-backend/api/task_workspace_ws.py
+++ b/autobot-backend/api/task_workspace_ws.py
@@ -43,6 +43,7 @@ import json
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect, status
 from pydantic import BaseModel
 
+from api.ws_security import validate_ws_origin as _validate_ws_origin
 from auth_middleware import (
     check_admin_permission,
     get_auth_middleware,
@@ -366,31 +367,6 @@ async def _ws_send(websocket: WebSocket, msg_type: str, content: str) -> None:
 
 async def _ws_error(websocket: WebSocket, content: str) -> None:
     await _ws_send(websocket, "error", content)
-
-
-def _validate_ws_origin(websocket: WebSocket) -> None:
-    """Reject cross-origin (CSWSH) WebSocket handshakes — Origin check ONLY.
-
-    WebSockets are exempt from the browser same-origin/CORS policy, so a malicious
-    page could otherwise open this socket using the victim's ambient cookies. When
-    an ``Origin`` header is present (browser client) it MUST be on the CORS
-    allowlist; non-browser clients omit ``Origin``. Authentication is decided
-    separately by :func:`_authenticate_ws_admin` (bearer header, cookie/session, or
-    the internal-service key), so this function no longer imposes an
-    Authorization-header precondition that locked out cookie/internal-key callers
-    (#11016). Fail-closed: a disallowed or unresolvable Origin raises.
-    """
-    origin = websocket.headers.get("origin", "")
-    if not origin:
-        return  # non-browser client (no Origin) — not subject to CSWSH
-    try:
-        from config.manager import get_config_manager  # noqa: PLC0415
-
-        allowed = set(get_config_manager().get_cors_origins() or [])
-    except Exception:  # config unavailable → fail closed, allow nothing cross-origin
-        allowed = set()
-    if origin not in allowed:
-        raise PermissionError(f"Origin not allowed for workspace shell: {origin}")
 
 
 def _authenticate_ws_admin(websocket: WebSocket) -> bool:

--- a/autobot-backend/api/terminal.py
+++ b/autobot-backend/api/terminal.py
@@ -120,8 +120,6 @@ from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException, Request, WebSocket, WebSocketDisconnect
 
-# Import models from dedicated module (Issue #185 - split oversized files)
-# Response schemas for OpenAPI documentation and response validation
 from api.schemas_terminal import (
     AdminExecuteRequest,
     AdminExecuteResponse,
@@ -152,6 +150,10 @@ from api.schemas_terminal import (
     TerminalSystemStatusResponse,
 )
 from api.system_health import ComponentHealth, register_health_probe
+
+# Import models from dedicated module (Issue #185 - split oversized files)
+# Response schemas for OpenAPI documentation and response validation
+from api.ws_security import enforce_ws_origin
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.error_utils import safe_http_detail
@@ -906,6 +908,8 @@ async def terminal_websocket(websocket: WebSocket, session_id: str):
     Issue #1088: Extracted _init_terminal_handler and _run_terminal_message_loop
     helpers to reduce to <=65 lines.
     """
+    if not await enforce_ws_origin(websocket):
+        return
     await websocket.accept()
 
     try:
@@ -1034,6 +1038,8 @@ async def ssh_terminal_websocket(
     This endpoint remains for backward compatibility but returns a deprecation
     message directing clients to use SLM for infrastructure connections.
     """
+    if not await enforce_ws_origin(websocket):
+        return
     await websocket.accept()
     session_id = f"ssh-{host_id}-{uuid.uuid4().hex[:8]}"
 

--- a/autobot-backend/api/transcripts.py
+++ b/autobot-backend/api/transcripts.py
@@ -28,6 +28,7 @@ from api.schemas_transcripts import (
     TranscriptKBPushRequest,
     TranscriptKBPushResponse,
 )
+from api.ws_security import enforce_ws_origin
 from auth_middleware import authenticate_websocket, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -163,6 +164,8 @@ async def analyze_transcript_ws(websocket: WebSocket, transcript_id: str):
 
     Security: Requires JWT authentication (Issue #2818 handshake-level rejection).
     """
+    if not await enforce_ws_origin(websocket):
+        return
     user = await authenticate_websocket(websocket)
     if user is None:
         await websocket.close(code=4001, reason="Unauthorized")

--- a/autobot-backend/api/vnc_proxy.py
+++ b/autobot-backend/api/vnc_proxy.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisco
 from fastapi.responses import Response
 
 from api.schemas_system import VncProxyStatusResponse
+from api.ws_security import enforce_ws_origin
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
@@ -245,6 +246,8 @@ async def websocket_proxy(websocket: WebSocket, vnc_type: str):
     Args:
         vnc_type: 'desktop' or 'browser'
     """
+    if not await enforce_ws_origin(websocket):
+        return
     if vnc_type not in VNC_ENDPOINTS:
         await websocket.close(code=1003, reason=f"Unknown VNC type: {vnc_type}")
         return

--- a/autobot-backend/api/voice_stream.py
+++ b/autobot-backend/api/voice_stream.py
@@ -35,6 +35,7 @@ from collections import deque
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
 
+from api.ws_security import enforce_ws_origin
 from autobot_shared.env_utils import env_int_clamped
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -421,6 +422,8 @@ async def _cleanup_ws_tasks(
 )
 async def voice_stream_ws(websocket: WebSocket) -> None:
     """Full-duplex voice conversation WebSocket (#1031, #1319)."""
+    if not await enforce_ws_origin(websocket):
+        return
     await websocket.accept()
     logger.info("Voice stream WebSocket connected")
 

--- a/autobot-backend/api/websockets.py
+++ b/autobot-backend/api/websockets.py
@@ -17,6 +17,7 @@ from typing import Callable, Dict, Optional, Tuple
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
 
+from api.ws_security import enforce_ws_origin
 from auth_middleware import authenticate_websocket
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
@@ -579,6 +580,8 @@ _canvas_tasks_lock = asyncio.Lock()
 )
 async def websocket_test_endpoint(websocket: WebSocket):
     """Simple test WebSocket endpoint without event manager integration."""
+    if not await enforce_ws_origin(websocket):
+        return
     # Issue #2818: Authenticate before accepting connection
     user = await authenticate_websocket(websocket)
     if user is None:
@@ -678,6 +681,8 @@ async def websocket_endpoint(websocket: WebSocket):
     Issue #665: Refactored to use extracted helper methods.
     Issue #2818: Authenticate before accepting connection.
     """
+    if not await enforce_ws_origin(websocket):
+        return
     # Issue #2818: Authenticate before accepting connection
     user = await authenticate_websocket(websocket)
     if user is None:
@@ -739,6 +744,8 @@ async def npu_workers_websocket_endpoint(websocket: WebSocket):
 
     Issue #2818: Authenticate before accepting connection.
     """
+    if not await enforce_ws_origin(websocket):
+        return
     # Issue #2818: Authenticate before accepting connection
     user = await authenticate_websocket(websocket)
     if user is None:

--- a/autobot-backend/api/ws_security.py
+++ b/autobot-backend/api/ws_security.py
@@ -1,0 +1,69 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shared WebSocket security helpers.
+
+WebSockets are exempt from the browser same-origin/CORS policy, so a malicious
+page can open an authenticated socket using the victim's ambient cookies
+(Cross-Site WebSocket Hijacking — CSWSH). :func:`validate_ws_origin` rejects a
+cross-origin handshake by checking the ``Origin`` header against the same CORS
+allowlist the HTTP layer uses.
+
+Originally added inline to ``api/task_workspace_ws.py`` (#11051); extracted here
+so every authenticated WS endpoint can reuse one audited implementation (#11088).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import WebSocket
+
+logger = logging.getLogger(__name__)
+
+
+def validate_ws_origin(websocket: WebSocket) -> None:
+    """Reject cross-origin (CSWSH) WebSocket handshakes — ``Origin`` check only.
+
+    When an ``Origin`` header is present (browser client) it MUST be on the CORS
+    allowlist; non-browser clients (native apps, server-to-server, CLI) omit
+    ``Origin`` and are not subject to CSWSH, so they are allowed through here.
+    Authentication/authorisation is decided separately by each endpoint's own
+    auth logic — this only closes the cross-origin hijacking vector.
+
+    Fail-closed: a disallowed or unresolvable ``Origin`` raises ``PermissionError``.
+    Callers close the socket with policy-violation code ``1008``.
+    """
+    origin = websocket.headers.get("origin", "")
+    if not origin:
+        return  # non-browser client (no Origin) — not subject to CSWSH
+    try:
+        from config.manager import get_config_manager  # noqa: PLC0415
+
+        allowed = set(get_config_manager().get_cors_origins() or [])
+    except Exception:  # config unavailable → fail closed, allow nothing cross-origin
+        allowed = set()
+    if origin not in allowed:
+        raise PermissionError(f"Cross-origin WebSocket handshake rejected: {origin}")
+
+
+async def enforce_ws_origin(websocket: WebSocket) -> bool:
+    """Validate the Origin and, on rejection, close the socket with ``1008``.
+
+    Convenience wrapper for the common pattern: call before ``websocket.accept()``
+    (or immediately after, per endpoint) and ``return`` when it yields ``False``.
+
+    Returns ``True`` when the handshake origin is allowed (or absent), ``False``
+    after having closed the socket for a cross-origin violation.
+    """
+    try:
+        validate_ws_origin(websocket)
+        return True
+    except PermissionError as exc:
+        logger.warning("Rejected WebSocket handshake: %s", exc)
+        try:
+            await websocket.close(code=1008)
+        except Exception:  # already closed / handshake not completed
+            pass
+        return False


### PR DESCRIPTION
## Thinking Path
#11051 added a CSWSH Origin-allowlist guard to **only** `api/task_workspace_ws.py`.
Audited every `@router.websocket`/`@app.websocket` handler in the backend.

**Premise correction:** the issue listed `vnc_mcp.py`/`git_mcp.py` as HIGH-priority
WS endpoints — those are MCP **HTTP** tool modules, not WebSockets. The real VNC
socket is `api/vnc_proxy.py`. And the true surface is **24 WS handlers across 19
files**, not 7 — nearly all lacked any Origin/CSWSH check. WebSockets bypass the
browser same-origin/CORS policy, so a malicious page could open these with the
victim's ambient cookies.

## What Changed
- **New** `api/ws_security.py` — shared, audited helper extracted from #11051's
  inline check: `validate_ws_origin()` (raises `PermissionError` on a cross-origin
  browser handshake) + `async enforce_ws_origin()` (closes with 1008, returns bool).
  Non-browser clients (no `Origin`) pass through; only cross-origin browser
  handshakes are rejected, reusing `get_config_manager().get_cors_origins()`.
- Applied `if not await enforce_ws_origin(websocket): return` as the **first**
  statement of all 23 unguarded handlers (terminal shell + ssh, vnc_proxy, desktop
  streaming, overseer, live_events, presence, analytics ×2, monitoring,
  analytics_quality, logs, process/transcript/long-running streams, voice_stream,
  intelligent_agent, knowledge_research, startup, npu-workers + `/ws` + `/ws-test`),
  before `accept()`/auth so a hijack handshake is rejected before any work.
- `api/task_workspace_ws.py` — dropped its inline `_validate_ws_origin`, now imports
  the shared helper (`validate_ws_origin as _validate_ws_origin`); behavior identical.

## Verification
- `python3 -m py_compile` — all 20 files compile.
- `black --check -l120` clean; `isort --check-only --line-length=120` clean.
- Grep: 24/24 WS handlers guarded (23 `enforce_ws_origin` + 1 aliased in
  task_workspace_ws). No auth/message-loop/other logic changed.

## Model Used
Opus 4.8 (1M context)

Closes #11088
