### PR TITLE
fix(orchestration): guard Redis-None in failure-pattern detector/recovery + stub Redis in tests (#11144)

### DIFF
--- a/autobot-backend/orchestration/causal_error_recovery.py
+++ b/autobot-backend/orchestration/causal_error_recovery.py
@@ -230,6 +230,9 @@ class CausalErrorRecovery:
         """Check if a pattern is known and return frequency."""
         try:
             redis = self._get_redis()
+            if redis is None:
+                logger.warning("Pattern-frequency check degraded — Redis unavailable (hash=%s)", pattern_hash)
+                return 0, False
             count_key = f"{FAILURE_PATTERN_PREFIX}{pattern_hash}{FAILURE_PATTERN_COUNT_SUFFIX}"
             count = redis.get(count_key)
             if count:
@@ -415,6 +418,9 @@ class CausalErrorRecovery:
 
         try:
             redis = self._get_redis()
+            if redis is None:
+                logger.warning("Recovery-attempt recording degraded — Redis unavailable (hash=%s)", pattern_hash)
+                return
 
             # Increment pattern count
             count_key = f"{FAILURE_PATTERN_PREFIX}{pattern_hash}{FAILURE_PATTERN_COUNT_SUFFIX}"

--- a/autobot-backend/services/failure_pattern_detector.py
+++ b/autobot-backend/services/failure_pattern_detector.py
@@ -122,6 +122,9 @@ class FailurePatternDetector(AsyncRedisClientMixin):
 
         try:
             redis = await self._get_redis()
+            if redis is None:
+                logger.warning("Pattern detection degraded — Redis unavailable (hash=%s)", pattern_hash)
+                return None
             pattern_key = f"{PATTERN_KEY_PREFIX}{pattern_hash}"
 
             pattern_data = await asyncio.wait_for(redis.get(pattern_key), timeout=_REDIS_OP_TIMEOUT)
@@ -173,6 +176,9 @@ class FailurePatternDetector(AsyncRedisClientMixin):
 
         try:
             redis = await self._get_redis()
+            if redis is None:
+                logger.warning("Pattern learning degraded — Redis unavailable (hash=%s)", pattern_hash)
+                return self._degraded_pattern(pattern_hash, causal_chain, error_type)
             pattern_key = f"{PATTERN_KEY_PREFIX}{pattern_hash}"
 
             pattern_data = await asyncio.wait_for(redis.get(pattern_key), timeout=_REDIS_OP_TIMEOUT)
@@ -214,13 +220,21 @@ class FailurePatternDetector(AsyncRedisClientMixin):
 
         except Exception as exc:
             logger.warning("Failed to learn pattern: %s", exc)
-            return FailurePattern(
-                pattern_id=pattern_hash,
-                causal_chain=causal_chain,
-                error_types=[error_type],
-                occurrence_count=1,
-                confidence=0.5,
-            )
+            return self._degraded_pattern(pattern_hash, causal_chain, error_type)
+
+    def _degraded_pattern(self, pattern_hash: str, causal_chain: str, error_type: str) -> FailurePattern:
+        """Unpersisted fallback pattern returned when Redis is unavailable.
+
+        Keeps ``learn_pattern`` returning a usable (low-confidence) pattern so the
+        error-recovery path degrades gracefully instead of raising.
+        """
+        return FailurePattern(
+            pattern_id=pattern_hash,
+            causal_chain=causal_chain,
+            error_types=[error_type],
+            occurrence_count=1,
+            confidence=0.5,
+        )
 
     def _create_new_pattern(self, pattern_hash: str, causal_chain: str) -> FailurePattern:
         """Create a new failure pattern."""
@@ -238,6 +252,9 @@ class FailurePatternDetector(AsyncRedisClientMixin):
         """Store a pattern to Redis (async-native, bounded by _REDIS_OP_TIMEOUT)."""
         try:
             redis = await self._get_redis()
+            if redis is None:
+                logger.warning("Pattern persistence degraded — Redis unavailable (hash=%s)", pattern_hash)
+                return
             pattern_key = f"{PATTERN_KEY_PREFIX}{pattern_hash}"
 
             await asyncio.wait_for(
@@ -262,8 +279,17 @@ class FailurePatternDetector(AsyncRedisClientMixin):
 
     async def get_pattern_statistics(self) -> Dict[str, Any]:
         """Get overall statistics about learned patterns."""
+        _empty_stats = {
+            "total_patterns": 0,
+            "total_occurrences": 0,
+            "average_success_rate": 0.0,
+            "high_confidence_patterns": 0,
+        }
         try:
             redis = await self._get_redis()
+            if redis is None:
+                logger.warning("Pattern statistics degraded — Redis unavailable")
+                return dict(_empty_stats)
 
             raw = await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT)
             pattern_hashes = self._decode_members(raw or set())
@@ -325,6 +351,9 @@ class FailurePatternDetector(AsyncRedisClientMixin):
         """
         try:
             redis = await self._get_redis()
+            if redis is None:
+                logger.warning("Listing known patterns degraded — Redis unavailable")
+                return []
             raw = await asyncio.wait_for(redis.smembers(KNOWN_PATTERNS_KEY), timeout=_REDIS_OP_TIMEOUT)
             pattern_hashes = self._decode_members(raw or set())
 

--- a/autobot-backend/tests/orchestration/test_causal_error_recovery.py
+++ b/autobot-backend/tests/orchestration/test_causal_error_recovery.py
@@ -329,13 +329,92 @@ class TestCausalErrorRecovery:
 # =============================================================================
 
 
+class _FakeAsyncRedis:
+    """Minimal in-memory async Redis stand-in for the pattern-detector tests.
+
+    Implements only the ops ``FailurePatternDetector`` uses
+    (get/set/sadd/smembers/expire) so the learn→detect→statistics roundtrip
+    works without a live Redis. Previously these tests hit the real client,
+    whose circuit breaker is open in CI, so every op returned ``None`` and the
+    detector silently no-opped — 4 tests failed on ``assert ... is not None``
+    (#11144).
+    """
+
+    def __init__(self):
+        self._kv = {}
+        self._sets = {}
+
+    async def get(self, key):
+        return self._kv.get(key)
+
+    async def set(self, key, value, ex=None):
+        self._kv[key] = value
+        return True
+
+    async def sadd(self, key, *members):
+        self._sets.setdefault(key, set()).update(members)
+        return len(members)
+
+    async def smembers(self, key):
+        return set(self._sets.get(key, set()))
+
+    async def expire(self, key, ttl):
+        return True
+
+    async def delete(self, key):
+        self._kv.pop(key, None)
+        self._sets.pop(key, None)
+        return True
+
+
+class _FakeSyncRedis:
+    """Minimal in-memory *sync* Redis stand-in for ``CausalErrorRecovery``.
+
+    ``CausalErrorRecovery`` uses a synchronous client (get/incr/expire/set/hset);
+    like the detector it silently no-ops when the real client's circuit breaker
+    is open, which broke the feedback-loop integration test (#11144).
+    """
+
+    def __init__(self):
+        self._kv = {}
+        self._hashes = {}
+
+    def get(self, key):
+        return self._kv.get(key)
+
+    def set(self, key, value, ex=None):
+        self._kv[key] = value
+        return True
+
+    def incr(self, key):
+        self._kv[key] = str(int(self._kv.get(key, 0)) + 1)
+        return int(self._kv[key])
+
+    def expire(self, key, ttl):
+        return True
+
+    def hset(self, key, *args, **kwargs):
+        mapping = kwargs.get("mapping") or {}
+        if len(args) >= 2:
+            mapping[args[0]] = args[1]
+        self._hashes.setdefault(key, {}).update(mapping)
+        return len(mapping)
+
+
+def _make_detector_with_fake_redis() -> FailurePatternDetector:
+    """A detector wired to an in-memory Redis so persistence roundtrips (#11144)."""
+    detector = FailurePatternDetector()
+    detector._redis = _FakeAsyncRedis()
+    return detector
+
+
 class TestFailurePatternDetector:
     """Test failure pattern detection and learning."""
 
     @pytest.fixture
     def detector(self):
-        """Create a pattern detector instance."""
-        return FailurePatternDetector()
+        """Create a pattern detector instance backed by an in-memory Redis."""
+        return _make_detector_with_fake_redis()
 
     def test_hash_causal_chain_consistency(self, detector):
         """Test that hashing is consistent."""
@@ -513,8 +592,9 @@ class TestCausalErrorRecoveryIntegration:
     @pytest.mark.asyncio
     async def test_pattern_feedback_improves_confidence(self):
         """Test that feedback loops improve confidence in recommendations."""
-        detector = FailurePatternDetector()
+        detector = _make_detector_with_fake_redis()
         recovery_sys = CausalErrorRecovery()
+        recovery_sys._redis = _FakeSyncRedis()  # in-memory sync Redis so feedback roundtrips (#11144)
 
         causal_chain = "Pool exhaustion → Connection denied"
         error = RuntimeError("Connection denied")


### PR DESCRIPTION
## Thinking Path
4 tests in `tests/orchestration/test_causal_error_recovery.py` failed on
`Dev_new_gui` (pre-existing). Reproduced → root cause: `_get_redis()` returns
**None** when the circuit breaker is open (Redis unavailable in CI), and both
`FailurePatternDetector` and its sibling `CausalErrorRecovery` immediately call
`.get()`/`.smembers()`/`.incr()` on it. The `None` deref raised `AttributeError`
that the broad `except` **swallowed**, so learn/detect/record silently no-opped
and the roundtrip assertions (`assert … is not None`) failed. Two problems: a
**runtime robustness bug** (pattern learning silently disabled whenever Redis is
down) and a **test gap** (tests assumed a live Redis).

## What Changed
- **Runtime guards** — `if redis is None:` after every `_get_redis()`, logging an
  explicit `"… degraded — Redis unavailable"` and returning a safe default,
  instead of a swallowed `NoneType` error:
  - `services/failure_pattern_detector.py` — `detect_pattern`, `learn_pattern`,
    `_store_pattern`, `get_pattern_statistics`, `list_known_patterns` (learn's
    fallback extracted into `_degraded_pattern`).
  - `orchestration/causal_error_recovery.py` — `_check_pattern`,
    `record_recovery_attempt`.
- **Test stubs** — minimal in-memory `_FakeAsyncRedis` (detector) and
  `_FakeSyncRedis` (recovery) injected via `detector._redis` / `recovery_sys._redis`,
  so learn→detect→statistics and the feedback-confidence loop roundtrip without a
  live Redis. Dependency-free (no fakeredis needed).

## Verification
- Was: 4 failed. Now: **all 20 tests in the file pass**; broader
  `tests/orchestration/` = **225 passed**, no regressions.
- `py_compile` OK; `black --check -l120` clean; `isort --check-only` clean.

## Model Used
Opus 4.8 (1M context)

Closes #11144
