### PR TITLE
fix(chat): move lightweight-mode badge to a task-local ContextVar (#11216)

### DIFF
--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import re
 import uuid
+from contextvars import ContextVar
 from typing import Any, Dict, FrozenSet, List
 
 from async_chat_workflow import WorkflowMessage
@@ -40,6 +41,13 @@ from .session_handler import SessionHandlerMixin
 from .tool_handler import ToolHandlerMixin
 
 logger = get_logger(__name__)
+
+# #11216 (MVA-1993): lightweight-mode cost indicator for the stream-metadata badge.
+# Held in a task-local ContextVar rather than shared instance state, so two
+# concurrent drivers of _execute_llm_continuation_loop (e.g. a real lightweight
+# chat and the internal delegation subagent) cannot clobber each other's flag.
+# Token-based set/reset also restores the caller's value for nested/inline drives.
+_current_lightweight_mode: ContextVar[bool] = ContextVar("current_lightweight_mode", default=False)
 
 # Issue #380: Module-level frozenset for terminal message types
 _TERMINAL_MESSAGE_TYPES: FrozenSet[str] = frozenset({"terminal_command", "terminal_output", "error"})
@@ -575,8 +583,9 @@ class ChatWorkflowManager(
             "used_knowledge": used_knowledge,
             "citations": self._build_source_list(used_knowledge, rag_citations, selected_model),
         }
-        # MVA-1993: Add lightweight mode indicator from instance variable or parameter
-        lw_mode = lightweight_mode_used or getattr(self, "_current_lightweight_mode", False)
+        # MVA-1993 / #11216: lightweight indicator from the explicit parameter or the
+        # task-local ContextVar (no longer shared instance state).
+        lw_mode = lightweight_mode_used or _current_lightweight_mode.get()
         if lw_mode:
             metadata["lightweight_mode_used"] = True
         streaming_msg.merge_metadata(metadata)
@@ -2642,8 +2651,9 @@ before summarizing.
 
         from autobot_shared.http_client import get_http_client
 
-        # MVA-1993: Store lightweight_mode_used from context for response metadata
-        self._current_lightweight_mode = ctx.context.get("lightweight_mode_used", False)
+        # MVA-1993 / #11216: store lightweight_mode_used in a task-local ContextVar
+        # (not on the shared singleton) for the response-metadata badge.
+        _lw_token = _current_lightweight_mode.set(ctx.context.get("lightweight_mode_used", False))
 
         try:
             http_client = get_http_client()
@@ -2661,8 +2671,8 @@ before summarizing.
             yield ([], [], error_msg)
 
         finally:
-            # MVA-1993: Clean up temporary flag
-            self._current_lightweight_mode = False
+            # MVA-1993 / #11216: restore the caller's task-local value (token reset).
+            _current_lightweight_mode.reset(_lw_token)
 
     async def _persist_workflow_messages(
         self,

--- a/autobot-backend/tests/unit/chat_workflow/test_lightweight_mode_isolation.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_lightweight_mode_isolation.py
@@ -1,0 +1,71 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression tests for the lightweight-mode badge isolation (#11216).
+
+The ``lightweight_mode_used`` stream-metadata cost indicator used to live on the
+shared ``ChatWorkflowManager`` singleton (``self._current_lightweight_mode``), so
+two concurrent drivers of ``_execute_llm_continuation_loop`` (e.g. a real
+lightweight chat and the internal delegation subagent) could clobber each
+other's flag. It now lives in a task-local ``ContextVar``; these tests pin the
+read behaviour and the cross-task isolation.
+"""
+
+import asyncio
+
+import pytest
+
+import chat_workflow.manager as manager_module
+from chat_workflow.manager import ChatWorkflowManager
+
+
+def _bare_manager() -> ChatWorkflowManager:
+    """A manager instance without the heavy ``__init__`` dependencies."""
+    return ChatWorkflowManager.__new__(ChatWorkflowManager)
+
+
+def _badge(manager: ChatWorkflowManager):
+    msg = manager._init_streaming_message("assistant_message", "gpt", None, False, None)
+    return msg.metadata.get("lightweight_mode_used")
+
+
+def test_badge_absent_by_default():
+    manager = _bare_manager()
+    token = manager_module._current_lightweight_mode.set(False)
+    try:
+        assert _badge(manager) is None
+    finally:
+        manager_module._current_lightweight_mode.reset(token)
+
+
+def test_badge_reflects_contextvar():
+    manager = _bare_manager()
+    token = manager_module._current_lightweight_mode.set(True)
+    try:
+        assert _badge(manager) is True
+    finally:
+        manager_module._current_lightweight_mode.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_drivers_do_not_clobber_each_other():
+    """Two concurrent loop drivers must each see their own lightweight flag (#11216)."""
+    manager = _bare_manager()
+    seen = {}
+
+    async def driver(name: str, flag: bool) -> None:
+        token = manager_module._current_lightweight_mode.set(flag)
+        try:
+            # Yield so the two tasks interleave between set and read — the exact
+            # window where shared instance state used to leak across drivers.
+            await asyncio.sleep(0)
+            seen[name] = _badge(manager)
+        finally:
+            manager_module._current_lightweight_mode.reset(token)
+
+    await asyncio.gather(driver("lightweight", True), driver("full", False))
+
+    assert seen["lightweight"] is True
+    # Would be True (clobbered) under the old shared-instance-state implementation.
+    assert seen["full"] is None


### PR DESCRIPTION
## Thinking Path
`ChatWorkflowManager._current_lightweight_mode` was set on the **shared singleton**
at entry to `_execute_llm_continuation_loop` (from `ctx.context`), reset in
`finally`, and read during streaming (`_init_streaming_message`, via the
un-threaded type-transition path). Two concurrent drivers of the loop (a real
lightweight chat + the internal delegation subagent, once
`AUTOBOT_DELEGATION_ENABLED`) can interleave entry/reset and mis-tag the
`lightweight_mode_used` cost badge.

Threading the flag down to the read site would touch 5+ methods of the streaming
hot path. Instead, the value is inherently **per-request**, so a task-local
`ContextVar` is the natural, minimal fix: each asyncio task carries its own value
(the exact concurrency isolation needed), and token-based set/reset restores the
caller's value for nested/inline drives — strictly better than the old
reset-to-`False`. This removes the shared-instance-var pattern entirely with no
hot-path parameter threading.

## What Changed
- `chat_workflow/manager.py` — replace `self._current_lightweight_mode` with a
  module-level `ContextVar` `_current_lightweight_mode`: set (token) at loop entry,
  `reset(token)` in `finally`, and `.get()` at the streaming read. 4 sites, no
  other logic touched.
- `tests/unit/chat_workflow/test_lightweight_mode_isolation.py` — new: badge
  reflects the ContextVar, and two concurrent drivers don't clobber each other
  (the assertion fails under the old shared-instance implementation).

## Verification
- New isolation test: **3 passed**. `py_compile` OK; `black --check -l120` clean;
  `isort --check-only` clean.
- No remaining `self._current_lightweight_mode` references.

## Model Used
Opus 4.8 (1M context)

Closes #11216
