### PR TITLE
test(chat): repair test_lightweight_mode.py to instantiate LLMHandlerMixin (#11244)

### DIFF
--- a/autobot-backend/tests/test_lightweight_mode.py
+++ b/autobot-backend/tests/test_lightweight_mode.py
@@ -78,15 +78,20 @@ class TestLightweightMode:
     @pytest.mark.asyncio
     async def test_prepare_llm_params_skips_rag_in_lightweight_mode(self):
         """Verify RAG is skipped when lightweight_mode=True."""
-        from chat_workflow.llm_handler import LLMHandler
+        from chat_workflow.llm_handler import LLMHandlerMixin
 
-        handler = LLMHandler()
+        # LLMHandlerMixin is mixed into ChatWorkflowManager; the test mocks every
+        # method it touches, so a bare instance exercises _prepare_llm_request_params
+        # in isolation (#11244 — class was renamed from the removed LLMHandler).
+        handler = LLMHandlerMixin.__new__(LLMHandlerMixin)
         handler.knowledge_service = MagicMock()
         handler._get_selected_model = MagicMock(return_value="test-model")
         handler._get_ollama_endpoint_for_model = MagicMock(return_value="http://test")
         handler._get_system_prompt = MagicMock(return_value="System prompt")
         handler._build_conversation_context = MagicMock(return_value="")
         handler._build_full_prompt = MagicMock(return_value="Full prompt")
+        # No SLM fleet endpoint in the unit test → fall back to the mocked endpoint.
+        handler._discover_ollama_from_slm = AsyncMock(return_value=None)
 
         mock_session = MagicMock()
         mock_session.session_id = "test-session"
@@ -124,9 +129,12 @@ class TestLightweightMode:
     @pytest.mark.asyncio
     async def test_prepare_llm_params_skips_memory_in_lightweight_mode(self):
         """Verify memory graph lookup is skipped when lightweight_mode=True."""
-        from chat_workflow.llm_handler import LLMHandler
+        from chat_workflow.llm_handler import LLMHandlerMixin
 
-        handler = LLMHandler()
+        # LLMHandlerMixin is mixed into ChatWorkflowManager; the test mocks every
+        # method it touches, so a bare instance exercises _prepare_llm_request_params
+        # in isolation (#11244 — class was renamed from the removed LLMHandler).
+        handler = LLMHandlerMixin.__new__(LLMHandlerMixin)
         handler.knowledge_service = None
         handler.memory_graph = MagicMock()
         handler._get_selected_model = MagicMock(return_value="test-model")
@@ -134,6 +142,8 @@ class TestLightweightMode:
         handler._get_system_prompt = MagicMock(return_value="System prompt")
         handler._build_conversation_context = MagicMock(return_value="")
         handler._build_full_prompt = MagicMock(return_value="Full prompt")
+        # No SLM fleet endpoint in the unit test → fall back to the mocked endpoint.
+        handler._discover_ollama_from_slm = AsyncMock(return_value=None)
 
         mock_session = MagicMock()
         mock_session.session_id = "test-session"


### PR DESCRIPTION
## Thinking Path
Discovered while fixing #11144/#11216: `tests/test_lightweight_mode.py` imported
`LLMHandler` (removed — renamed to `LLMHandlerMixin` in the role-based
restructuring), so both async tests failed at run with `ImportError`. They were
**half-migrated** — already calling the current method `_prepare_llm_request_params`
(renamed from `_prepare_llm_params`) — so only the class import + instantiation
were stale. The method also gained a `_discover_ollama_from_slm()` call the tests
didn't mock.

## What Changed
- `tests/test_lightweight_mode.py` (both tests): import `LLMHandlerMixin` and
  instantiate via `__new__` (the tests already mock every method they touch), and
  mock `_discover_ollama_from_slm` → `None` so it falls back to the mocked endpoint.

## Verification
- Was 4 passed / 2 ImportError → now **6 passed**.
- `black --check -l120` clean; `isort --check-only` clean; `py_compile` OK.

## Model Used
Opus 4.8 (1M context)

Closes #11244
