### PR TITLE
fix(web_fetch): silence spurious cache-TTL warning on unset env + fix stale resolver tests (#11246)

### DIFF
--- a/autobot-backend/tests/unit/web_fetch/test_cache.py
+++ b/autobot-backend/tests/unit/web_fetch/test_cache.py
@@ -5,11 +5,11 @@
 """Tests for web_fetch.cache — TTL resolver, content cache hit/miss."""
 
 import json
-import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from autobot_shared.ssot_config import config
 from web_fetch.cache import (
     _WEB_FETCH_CACHE_TTL,
     _content_cache_key,
@@ -20,30 +20,30 @@ from web_fetch.cache import (
 
 
 class TestTTLResolver:
+    # The resolver reads config.misc.web_fetch_cache_ttl (SSOT, loaded once at
+    # import), not os.environ directly — so these patch the config field (#11244-class).
     def test_default_is_24h(self) -> None:
-        with patch.dict(os.environ, {}, clear=False):
-            env = {k: v for k, v in os.environ.items() if k != "AUTOBOT_WEB_FETCH_CACHE_TTL"}
-            with patch.dict(os.environ, env, clear=True):
-                ttl = _resolve_web_fetch_cache_ttl()
+        with patch.object(config.misc, "web_fetch_cache_ttl", ""):
+            ttl = _resolve_web_fetch_cache_ttl()
         assert ttl == 86400
 
     def test_env_override(self) -> None:
-        with patch.dict(os.environ, {"AUTOBOT_WEB_FETCH_CACHE_TTL": "3600"}):
+        with patch.object(config.misc, "web_fetch_cache_ttl", "3600"):
             ttl = _resolve_web_fetch_cache_ttl()
         assert ttl == 3600
 
     def test_invalid_string_falls_back(self) -> None:
-        with patch.dict(os.environ, {"AUTOBOT_WEB_FETCH_CACHE_TTL": "not_a_number"}):
+        with patch.object(config.misc, "web_fetch_cache_ttl", "not_a_number"):
             ttl = _resolve_web_fetch_cache_ttl()
         assert ttl == 86400
 
     def test_zero_falls_back(self) -> None:
-        with patch.dict(os.environ, {"AUTOBOT_WEB_FETCH_CACHE_TTL": "0"}):
+        with patch.object(config.misc, "web_fetch_cache_ttl", "0"):
             ttl = _resolve_web_fetch_cache_ttl()
         assert ttl == 86400
 
     def test_negative_falls_back(self) -> None:
-        with patch.dict(os.environ, {"AUTOBOT_WEB_FETCH_CACHE_TTL": "-100"}):
+        with patch.object(config.misc, "web_fetch_cache_ttl", "-100"):
             ttl = _resolve_web_fetch_cache_ttl()
         assert ttl == 86400
 
@@ -129,26 +129,29 @@ class TestSetCachedResult:
 
 
 class TestMaxBytesResolver:
+    # The resolver reads config.misc.web_fetch_max_bytes (an int SSOT field,
+    # default 0), not os.environ directly — patch the config field (#11244-class).
     def test_default_max_bytes(self) -> None:
         from web_fetch.cache import _DEFAULT_MAX_BYTES, _resolve_max_bytes
 
-        with patch.dict(os.environ, {}, clear=False):
-            env = {k: v for k, v in os.environ.items() if k != "AUTOBOT_WEB_FETCH_MAX_BYTES"}
-            with patch.dict(os.environ, env, clear=True):
-                result = _resolve_max_bytes()
+        with patch.object(config.misc, "web_fetch_max_bytes", 0):
+            result = _resolve_max_bytes()
         assert result == _DEFAULT_MAX_BYTES
 
     def test_env_override(self) -> None:
         from web_fetch.cache import _resolve_max_bytes
 
-        with patch.dict(os.environ, {"AUTOBOT_WEB_FETCH_MAX_BYTES": "5242880"}):
+        with patch.object(config.misc, "web_fetch_max_bytes", 5242880):
             result = _resolve_max_bytes()
         assert result == 5242880
 
-    def test_invalid_falls_back(self) -> None:
+    def test_zero_falls_back(self) -> None:
+        # web_fetch_max_bytes is an int SSOT field, so a bad string can never reach
+        # the resolver (pydantic coerces / rejects at load); the only fallback path
+        # is a falsy (0) value, which must yield the 10 MB default.
         from web_fetch.cache import _DEFAULT_MAX_BYTES, _resolve_max_bytes
 
-        with patch.dict(os.environ, {"AUTOBOT_WEB_FETCH_MAX_BYTES": "nope"}):
+        with patch.object(config.misc, "web_fetch_max_bytes", 0):
             result = _resolve_max_bytes()
         assert result == _DEFAULT_MAX_BYTES
 

--- a/autobot-backend/web_fetch/cache.py
+++ b/autobot-backend/web_fetch/cache.py
@@ -29,7 +29,10 @@ def _resolve_web_fetch_cache_ttl() -> int:
     Override via AUTOBOT_WEB_FETCH_CACHE_TTL.  Falls back to 24h (86400s).
     """
     raw = config.misc.web_fetch_cache_ttl
-    if raw is None:
+    # Unset is the common case: the field defaults to "" (str). Treat empty/None as
+    # "use default" WITHOUT logging — only a non-empty, non-integer value is a
+    # misconfiguration worth warning about (previously int("") warned on every call).
+    if raw is None or raw == "":
         return TTL_24_HOURS
     try:
         value = int(raw)


### PR DESCRIPTION
## Thinking Path
Found by triaging scoped unit failures (distinguishing real bugs from co-collection
pollution): `web_fetch/test_cache.py::test_env_override` (TTL + MaxBytes) **fail even
run in isolation** — real bugs. Root cause: `_resolve_web_fetch_cache_ttl()` reads
`config.misc.web_fetch_cache_ttl` (a **str** SSOT field defaulting to `""`), but:

1. **Runtime bug:** the guard `if raw is None` misses the empty-string default, so the
   unset (common) case runs `int("")` → `ValueError` → logs a `WARNING` on **every
   call** and at import — pure log noise in normal operation.
2. **Stale tests:** the resolver tests patch `os.environ`, but the resolver reads
   `config.misc` (loaded once at import), so the override never applies. `test_env_override`
   failed; the invalid/zero/default cases passed only by accident (config stayed `""`/0).

## What Changed
- `web_fetch/cache.py` — `if raw is None or raw == "":` → return default silently;
  only a non-empty, non-integer value warns.
- `tests/unit/web_fetch/test_cache.py` — patch `config.misc.web_fetch_cache_ttl` /
  `config.misc.web_fetch_max_bytes` (the real source) instead of `os.environ`; reframe
  the MaxBytes "invalid string" case (impossible for an int field) to the zero-fallback path.

## Verification
- Was 20 passed / **2 failed** → now **22 passed**.
- Confirmed **no WARNING** when the TTL env var is unset.
- `py_compile` OK; `black --check -l120` clean; `isort --check-only` clean.

## Model Used
Opus 4.8 (1M context)

Closes #11246
