### PR TITLE
fix(llm): providers implement abstract _chat_completion_impl — Ollama/all chat was dead (#11249)

### DIFF
--- a/autobot-backend/llm_shared/providers/custom_openai.py
+++ b/autobot-backend/llm_shared/providers/custom_openai.py
@@ -113,7 +113,7 @@ class CustomOpenAIProvider(BaseProvider):
                 params["tool_choice"] = request.tool_choice
         return params
 
-    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
         """Execute a non-streaming chat completion via the custom endpoint."""
         self._total_requests += 1
         start = time.time()

--- a/autobot-backend/llm_shared/providers/groq.py
+++ b/autobot-backend/llm_shared/providers/groq.py
@@ -92,7 +92,7 @@ class GroqProvider(BaseProvider):
         self._client = groq.AsyncGroq(api_key=api_key)
         return self._client
 
-    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
         """Execute a non-streaming chat completion via Groq."""
         self._total_requests += 1
         start = time.time()

--- a/autobot-backend/llm_shared/providers/huggingface.py
+++ b/autobot-backend/llm_shared/providers/huggingface.py
@@ -88,7 +88,7 @@ class HuggingFaceProvider(BaseProvider):
             payload["stop"] = request.stop
         return payload
 
-    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
         """Execute a non-streaming chat completion via HuggingFace Inference API."""
         self._total_requests += 1
         start = time.time()

--- a/autobot-backend/llm_shared/providers/ollama_provider.py
+++ b/autobot-backend/llm_shared/providers/ollama_provider.py
@@ -78,7 +78,7 @@ class OllamaProvider(BaseProvider):
         self._delegate.ollama_host = self._resolve_base_url()
         return self._delegate
 
-    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
         """Delegate to llm_shared OllamaProvider (carries OTel tracing + circuit breaker).
 
         When ``request.metadata["chat_template"]`` is set the messages are

--- a/autobot-backend/llm_shared/providers/vllm_base.py
+++ b/autobot-backend/llm_shared/providers/vllm_base.py
@@ -60,7 +60,7 @@ class VLLMBaseProvider(BaseProvider):
                 logger.error("Failed to initialize vLLM provider: %s", exc)
                 raise
 
-    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
         """Execute a chat completion request via vLLM."""
         try:
             self._total_requests += 1


### PR DESCRIPTION
## Thinking Path
User: "Company OS not loading" + "CEO chat just responds with a single phrase — Could you clarify? intent". Two bugs: (1) Company OS 500s from an unapplied DB migration (fixed separately on the box — see below), and (2) CEO chat → traced to `provider_registry: No available provider for chat request`. Ollama is up with models but the registry only had `['bedrock']`. Root cause: `OllamaProvider` (and 4 others) override the concrete `BaseProvider.chat_completion` wrapper instead of implementing the abstract `_chat_completion_impl`, so `__abstractmethods__` is non-empty → `TypeError` on instantiate → registration silently fails → no providers → all chat dead.

## What Changed
Renamed the `chat_completion` override → `_chat_completion_impl` in the 5 genuinely-broken `BaseProvider` subclasses: `OllamaProvider`, `CustomOpenAIProvider`, `GroqProvider`, `HuggingFaceProvider`, `VLLMBaseProvider`. They now also correctly run inside the base rate-limiter/backoff wrapper. (ollama.py/vllm.py/transformers/mock are standalone classes, not affected.)

## Verification
- `py_compile` clean on all 5.
- All 5 `__abstractmethods__` == `[]` (instantiable).
- **Live on the deployed box (hotfixed): registry now `['ollama','bedrock']`; `svc.chat()` returns real content via ollama/qwen3.5:9b (was empty).** CEO chat restored.

## Model Used
Opus 4.8 (1M context)

Closes #11249