### PR TITLE
fix(security): scope trajectory retrieval by user_id, not tenant alone (#11089)

### DIFF
--- a/autobot-backend/memory/trajectory_store.py
+++ b/autobot-backend/memory/trajectory_store.py
@@ -55,6 +55,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional, Sequence
 
+from autobot_shared.env_utils import env_flag
 from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
@@ -62,6 +63,13 @@ logger = get_logger(__name__)
 _COLLECTION_NAME = "trajectories"
 _DEFAULT_TOP_K = 5
 _MIN_REWARD_DEFAULT = 0.7
+
+# #11089: retrieval scoping. tenant_id alone is insufficient in single-company
+# deployments (org_id is frequently empty/identical across all users), so a
+# low-privilege user's trajectory could still be retrieved into another user's
+# plan within the same org. Default to strict per-user isolation; an org can
+# opt back into shared org-level learning by setting this flag false.
+_USER_SCOPED_RETRIEVAL = env_flag("AUTOBOT_TRAJECTORY_USER_SCOPED", default=True)
 
 
 # ---------------------------------------------------------------------------
@@ -310,6 +318,7 @@ class TrajectoryStore:
         top_k: int = _DEFAULT_TOP_K,
         min_reward: float = _MIN_REWARD_DEFAULT,
         tenant_id: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Return the *top_k* most-similar past trajectories above *min_reward*.
 
@@ -322,6 +331,11 @@ class TrajectoryStore:
             top_k: Maximum number of trajectories to return.  The store queries
                 ``top_k * 4`` candidates internally to absorb reward filtering.
             min_reward: Only return trajectories with ``reward >= min_reward``.
+            tenant_id: When set, restrict matches to this tenant (#11015).
+            user_id: When set and ``AUTOBOT_TRAJECTORY_USER_SCOPED`` is enabled
+                (default), also restrict matches to this user — strict
+                intra-tenant isolation so one user's trajectory cannot surface in
+                another's plan (#11089).
 
         Returns:
             List of dicts (subset of :class:`Trajectory`.to_dict()) plus a
@@ -340,13 +354,24 @@ class TrajectoryStore:
         # one org's trajectories can never surface in another's plan. A None/empty
         # tenant_id keeps the un-scoped behaviour (backward compatible for callers
         # and legacy trajectories that predate tenant tagging).
+        # #11089: additionally scope by user_id when supplied and user-scoping is
+        # enabled (default) — closes intra-tenant cross-user leakage, which
+        # tenant-only scoping misses when org_id is empty/shared.
         query_kwargs: Dict[str, Any] = {
             "query_texts": [task_text],
             "n_results": fetch_k,
             "include": ["documents", "metadatas", "distances"],
         }
+        scope_user = bool(user_id) and _USER_SCOPED_RETRIEVAL
+        where_conditions: List[Dict[str, Any]] = []
         if tenant_id:
-            query_kwargs["where"] = {"tenant_id": tenant_id}
+            where_conditions.append({"tenant_id": tenant_id})
+        if scope_user:
+            where_conditions.append({"user_id": user_id})
+        if len(where_conditions) == 1:
+            query_kwargs["where"] = where_conditions[0]
+        elif len(where_conditions) > 1:
+            query_kwargs["where"] = {"$and": where_conditions}
         t0 = time.perf_counter()
         try:
             raw = await collection.query(**query_kwargs)
@@ -369,10 +394,13 @@ class TrajectoryStore:
 
         results = []
         for traj_id, doc, meta, dist in zip(ids, docs, metas, distances):
-            # Client-side tenant backstop — the ChromaDB `where` filter is the
+            # Client-side tenant/user backstop — the ChromaDB `where` filter is the
             # primary guard, but enforce again here so a version whose metadata
-            # filter is lenient can never leak another tenant's trajectory (#11015).
+            # filter is lenient can never leak another tenant's (#11015) or another
+            # user's (#11089) trajectory.
             if tenant_id and meta.get("tenant_id", "") != tenant_id:
+                continue
+            if scope_user and meta.get("user_id", "") != user_id:
                 continue
             reward = float(meta.get("reward", 0.0))
             if reward < min_reward:

--- a/autobot-backend/orchestration/workflow_planner.py
+++ b/autobot-backend/orchestration/workflow_planner.py
@@ -292,9 +292,13 @@ class WorkflowPlanner:
 
             # #11015: scope to the caller's tenant so one org's trajectories can't
             # surface in another's plan. Absent tenant → un-scoped (legacy).
+            # #11089: also scope to the caller's user (strict intra-tenant isolation).
             tenant_id = str(context.get("tenant_id") or "") or None
+            user_id = str(context.get("user_id") or "") or None
             store = await get_trajectory_store()
-            similar = await store.find_similar_trajectories(user_request, top_k=5, min_reward=0.7, tenant_id=tenant_id)
+            similar = await store.find_similar_trajectories(
+                user_request, top_k=5, min_reward=0.7, tenant_id=tenant_id, user_id=user_id
+            )
             if similar:
                 context["similar_trajectories"] = similar
                 logger.debug(

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -675,7 +675,10 @@ class Orchestrator(_DeprecatedRequestMixin):
             from memory.trajectory_store import get_trajectory_store
 
             store = await get_trajectory_store()
-            similar = await store.find_similar_trajectories(goal, top_k=5, min_reward=0.7, tenant_id=tenant_id or None)
+            user_id = str(ctx.get("user_id") or "")
+            similar = await store.find_similar_trajectories(
+                goal, top_k=5, min_reward=0.7, tenant_id=tenant_id or None, user_id=user_id or None
+            )
             if similar:
                 result["similar_trajectories"] = similar
         except Exception as exc:

--- a/autobot-backend/tests/memory/test_trajectory_user_scoping.py
+++ b/autobot-backend/tests/memory/test_trajectory_user_scoping.py
@@ -1,0 +1,81 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11089 — trajectory retrieval must isolate by user, not only by tenant.
+
+In single-company deployments ``tenant_id`` is frequently empty/identical across
+all users, so tenant-only scoping leaves an intra-tenant cross-user injection
+gap. ``find_similar_trajectories`` now also scopes by ``user_id`` (default on via
+``AUTOBOT_TRAJECTORY_USER_SCOPED``): the ChromaDB ``where`` filter is the primary
+guard and a client-side backstop enforces it again.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import memory.trajectory_store as ts
+
+
+def _collection_returning(*users: str) -> AsyncMock:
+    coll = AsyncMock()
+    coll.query = AsyncMock(
+        return_value={
+            "ids": [[f"t{i}" for i in range(len(users))]],
+            "documents": [[f"task from {u}" for u in users]],
+            "metadatas": [
+                [{"tenant_id": "org1", "user_id": u, "reward": 0.9, "action_sequence_json": "[]"} for u in users]
+            ],
+            "distances": [[0.1] * len(users)],
+        }
+    )
+    return coll
+
+
+async def _run(store, coll, **kwargs):
+    with patch.object(store, "_get_collection", AsyncMock(return_value=coll)):
+        return await store.find_similar_trajectories("task", top_k=5, min_reward=0.5, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_where_clause_scopes_by_tenant_and_user():
+    store = ts.TrajectoryStore()
+    coll = _collection_returning("alice")
+    with patch.object(ts, "_USER_SCOPED_RETRIEVAL", True):
+        await _run(store, coll, tenant_id="org1", user_id="alice")
+    where = coll.query.call_args.kwargs.get("where")
+    assert where == {"$and": [{"tenant_id": "org1"}, {"user_id": "alice"}]}
+
+
+@pytest.mark.asyncio
+async def test_backstop_drops_other_users_trajectories():
+    store = ts.TrajectoryStore()
+    coll = _collection_returning("alice", "bob")  # a lenient filter could leak bob
+    with patch.object(ts, "_USER_SCOPED_RETRIEVAL", True):
+        results = await _run(store, coll, tenant_id="org1", user_id="alice")
+    docs = [r["task_text"] for r in results]
+    assert docs == ["task from alice"]
+    assert "task from bob" not in docs
+
+
+@pytest.mark.asyncio
+async def test_user_only_scope_when_no_tenant():
+    store = ts.TrajectoryStore()
+    coll = _collection_returning("alice")
+    with patch.object(ts, "_USER_SCOPED_RETRIEVAL", True):
+        await _run(store, coll, user_id="alice")
+    assert coll.query.call_args.kwargs.get("where") == {"user_id": "alice"}
+
+
+@pytest.mark.asyncio
+async def test_flag_disabled_keeps_tenant_only_scope():
+    store = ts.TrajectoryStore()
+    coll = _collection_returning("alice", "bob")
+    with patch.object(ts, "_USER_SCOPED_RETRIEVAL", False):
+        results = await _run(store, coll, tenant_id="org1", user_id="alice")
+    # With user-scoping off, the org shares learning — no user filter applied.
+    assert coll.query.call_args.kwargs.get("where") == {"tenant_id": "org1"}
+    assert len(results) == 2


### PR DESCRIPTION
## Thinking Path
Issue #11089 (owner-directed): `find_similar_trajectories` scoped retrieval only
by `tenant_id` (#11015). In AutoBot's common single-company mode `tenant_id`/
`org_id` is frequently empty or identical across all users, so tenant-only
scoping leaves an **intra-tenant cross-user injection** gap: user A's trajectory
`task_text` can surface (and inject advisory priors) into user B's plan.

Chose the **"best of both"** policy: default to **strict per-user isolation**
(closes the gap in the common case), with an opt-out for orgs that want shared
org-level learning. `user_id` was already captured on write (`capture()`), so
only the retrieval path and the two callers needed wiring.

## What Changed
- `memory/trajectory_store.py` — `find_similar_trajectories` takes `user_id`;
  when set and `AUTOBOT_TRAJECTORY_USER_SCOPED` (default **true**) is on, add it
  to the ChromaDB `where` filter (`$and` with tenant) **and** a client-side
  backstop, exactly mirroring the tenant guard. New module flag `env_flag(...)`.
- `orchestrator.py` / `orchestration/workflow_planner.py` — thread `user_id` from
  `ctx`/`context` into the call (both already sourced `tenant_id` there).
- `tests/memory/test_trajectory_user_scoping.py` — where-clause is
  `{$and:[tenant,user]}`; backstop drops another user's trajectory; user-only
  scope; flag-off keeps tenant-only org learning.

## Verification
- New tests: **4 passed**. Existing wiring test: **11 passed** (callers unchanged
  in behaviour). `py_compile` OK; `black --check -l120` + `isort` clean.
- Legacy/untagged (`user_id=""`) trajectories fall out of a user-scoped query —
  the safe direction (they can't be attributed to the querying user).

## Model Used
Opus 4.8 (1M context)

Closes #11089
