### PR TITLE
fix(slm): sync Ansible slm_agent role copy with canonical agent (#11254)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
@@ -236,10 +236,12 @@ class SLMAgent:
         """
         Build list of listening ports for heartbeat payload.
 
-        Returns a list of dictionaries with port, process, and pid info.
-        Issue #620.
+        Returns a list of dictionaries with port, process, pid, and bind address.
+        Issue #620; ``address`` added for the security-posture audit (GH#11224).
         """
-        return [{"port": p.port, "process": p.process, "pid": p.pid} for p in get_listening_ports()]
+        return [
+            {"port": p.port, "process": p.process, "pid": p.pid, "address": p.address} for p in get_listening_ports()
+        ]
 
     def _build_heartbeat_payload(self, health: dict, os_info: str, code_version: str | None) -> dict:
         """

--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/port_scanner.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/port_scanner.py
@@ -23,6 +23,10 @@ class PortInfo:
     port: int
     process: str | None = None
     pid: int | None = None
+    # GH#11224: bind interface ("0.0.0.0", "*", "::", "127.0.0.1", a concrete IP).
+    # Lets the fleet security-posture audit distinguish public exposure from
+    # loopback-only. None when the source line can't be parsed.
+    address: str | None = None
 
 
 def _parse_port_from_address(local_addr: str) -> int | None:
@@ -45,6 +49,20 @@ def _parse_port_from_address(local_addr: str) -> int | None:
         return int(port_str)
     except ValueError:
         return None
+
+
+def _parse_bind_address(local_addr: str) -> str | None:
+    """
+    Extract the bind interface from an ss/netstat local-address string (GH#11224).
+
+    Handles ``*:port``, ``0.0.0.0:port``, ``:::port``, ``[::]:port``,
+    ``127.0.0.1:port``, ``[::1]:port``. Returns the address with the port and any
+    IPv6 brackets stripped, or None if it can't be parsed.
+    """
+    if ":" not in local_addr:
+        return None
+    addr = local_addr.rsplit(":", 1)[0].strip("[]")
+    return addr or None
 
 
 def _parse_process_info(parts: List[str]) -> tuple:
@@ -77,9 +95,10 @@ def _parse_process_info(parts: List[str]) -> tuple:
 
 def _deduplicate_ports(ports: List[PortInfo]) -> List[PortInfo]:
     """
-    Remove duplicate ports from list, keeping first occurrence.
+    Remove duplicate (port, address) pairs, keeping first occurrence.
 
-    Issue #620.
+    Issue #620; keyed on (port, address) since GH#11224 so a public bind is not
+    collapsed into a loopback bind on the same port.
 
     Args:
         ports: List of PortInfo objects
@@ -90,8 +109,11 @@ def _deduplicate_ports(ports: List[PortInfo]) -> List[PortInfo]:
     seen = set()
     unique_ports = []
     for p in ports:
-        if p.port not in seen:
-            seen.add(p.port)
+        # GH#11224: key on (port, address) so a public bind is not masked by a
+        # loopback bind on the same port for the security-posture audit.
+        key = (p.port, p.address)
+        if key not in seen:
+            seen.add(key)
             unique_ports.append(p)
     return unique_ports
 
@@ -127,7 +149,7 @@ def get_listening_ports() -> List[PortInfo]:
                 continue
 
             process, pid = _parse_process_info(parts)
-            ports.append(PortInfo(port=port, process=process, pid=pid))
+            ports.append(PortInfo(port=port, process=process, pid=pid, address=_parse_bind_address(parts[3])))
 
     except subprocess.TimeoutExpired:
         logger.warning("Port scan timed out")
@@ -165,7 +187,7 @@ def _get_ports_netstat() -> List[PortInfo]:
 
             try:
                 port = int(port_str)
-                ports.append(PortInfo(port=port))
+                ports.append(PortInfo(port=port, address=_parse_bind_address(local_addr)))
             except ValueError:
                 continue
 


### PR DESCRIPTION
## Thinking Path
Discovered while merging #11089: the `code-quality` **Check Ansible agent code
drift (#1629)** step fails on `Dev_new_gui` and every PR — a repo-wide red
required gate forcing admin-bypass on each merge. Root cause: the canonical
`autobot-slm-backend/slm/agent/{agent.py,port_scanner.py}` gained the **GH#11224**
security-posture-audit bind-`address` feature, but the Ansible role copy
(`ansible/roles/slm_agent/files/slm/agent/`) was never synced — so
ansible-deployed SLM agents lack the #11224 bind-address capture (the fleet
security-posture audit is inert on them).

## What Changed
- Synced the two drifted files (`agent.py`, `port_scanner.py`) from canonical
  into the Ansible role `files/` copy. Pure sync — the canonical is source of truth.

## Verification
- `detect-agent-code-drift.sh` → **"Agent code in sync: canonical == Ansible copy"** (exit 0).
- Both synced files `py_compile` cleanly.

## Model Used
Opus 4.8 (1M context)

Closes #11254
