### PR TITLE
fix(llm): providers implement _chat_completion_impl so they instantiate + register (#11249)

### DIFF
--- a/autobot-backend/llm_shared/providers/custom_openai.py
+++ b/autobot-backend/llm_shared/providers/custom_openai.py
@@ -113,7 +113,7 @@ class CustomOpenAIProvider(BaseProvider):
                 params["tool_choice"] = request.tool_choice
         return params
 
-    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
         """Execute a non-streaming chat completion via the custom endpoint."""
         self._total_requests += 1
         start = time.time()

--- a/autobot-backend/llm_shared/providers/groq.py
+++ b/autobot-backend/llm_shared/providers/groq.py
@@ -92,7 +92,7 @@ class GroqProvider(BaseProvider):
         self._client = groq.AsyncGroq(api_key=api_key)
         return self._client
 
-    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
         """Execute a non-streaming chat completion via Groq."""
         self._total_requests += 1
         start = time.time()

--- a/autobot-backend/llm_shared/providers/huggingface.py
+++ b/autobot-backend/llm_shared/providers/huggingface.py
@@ -88,7 +88,7 @@ class HuggingFaceProvider(BaseProvider):
             payload["stop"] = request.stop
         return payload
 
-    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
         """Execute a non-streaming chat completion via HuggingFace Inference API."""
         self._total_requests += 1
         start = time.time()

--- a/autobot-backend/llm_shared/providers/ollama_provider.py
+++ b/autobot-backend/llm_shared/providers/ollama_provider.py
@@ -78,7 +78,7 @@ class OllamaProvider(BaseProvider):
         self._delegate.ollama_host = self._resolve_base_url()
         return self._delegate
 
-    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
         """Delegate to llm_shared OllamaProvider (carries OTel tracing + circuit breaker).
 
         When ``request.metadata["chat_template"]`` is set the messages are

--- a/autobot-backend/llm_shared/providers/vllm_base.py
+++ b/autobot-backend/llm_shared/providers/vllm_base.py
@@ -60,7 +60,7 @@ class VLLMBaseProvider(BaseProvider):
                 logger.error("Failed to initialize vLLM provider: %s", exc)
                 raise
 
-    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
         """Execute a chat completion request via vLLM."""
         try:
             self._total_requests += 1

--- a/autobot-backend/tests/test_provider_registry.py
+++ b/autobot-backend/tests/test_provider_registry.py
@@ -41,8 +41,9 @@ class MockProvider(BaseProvider):
         self.chat_completion_called = False
         self.stream_completion_called = False
 
-    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
-        """Mock chat completion."""
+    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
+        """Mock chat completion — implements the abstract hook so the base
+        rate-limiter/backoff wrapper (chat_completion) drives it (#11249)."""
         self.chat_completion_called = True
         self._total_requests += 1
         return LLMResponse(
@@ -575,6 +576,46 @@ class TestEdgeCases:
         # Should gracefully fall back to available providers
         selected = await registry.get_provider_for_request(conversation_id="conv-id", request=request)
         assert selected is provider
+
+
+# ============================================================================
+# #11249 — providers must implement _chat_completion_impl (not override the
+# concrete chat_completion wrapper), else the class stays abstract and silently
+# fails to register (TypeError: Can't instantiate abstract class).
+# ============================================================================
+
+
+class TestProviderConcreteness:
+    """Regression: every BaseProvider subclass must be instantiable.
+
+    Verified by source inspection (AST) rather than import, because several
+    providers carry optional SDK deps that are not installed in every test
+    environment — but the regression we guard (overriding the concrete
+    ``chat_completion`` wrapper instead of implementing the abstract
+    ``_chat_completion_impl``) is fully visible in the source.
+    """
+
+    @pytest.mark.parametrize(
+        "filename",
+        ["ollama_provider.py", "custom_openai.py", "groq.py", "huggingface.py", "vllm_base.py"],
+    )
+    def test_provider_implements_impl_not_override(self, filename):
+        import ast
+        from pathlib import Path
+
+        source = (Path(__file__).resolve().parents[1] / "llm_shared" / "providers" / filename).read_text(
+            encoding="utf-8"
+        )
+        methods = {n.name for n in ast.walk(ast.parse(source)) if isinstance(n, ast.AsyncFunctionDef)}
+        assert "_chat_completion_impl" in methods, f"{filename}: must implement _chat_completion_impl (#11249)"
+        assert "chat_completion" not in methods, (
+            f"{filename}: must not override the concrete chat_completion wrapper — "
+            f"that leaves the class abstract and it fails to register (#11249)"
+        )
+
+    def test_mock_provider_is_concrete(self):
+        # MockProvider is imported at module top, so the runtime check is reliable here.
+        assert not set(getattr(MockProvider, "__abstractmethods__", frozenset()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Thinking Path
`get_llm_service().chat()` failed with **"No available provider for chat
request"** on Ollama-only deployments. Root cause: `BaseProvider.chat_completion`
is a concrete wrapper (rate-limiter + backoff) around the `@abstractmethod
_chat_completion_impl`. Five providers still **overrode the concrete
`chat_completion`** and never implemented the abstract hook → the class stayed
abstract → `TypeError: Can't instantiate abstract class …` → registration threw
(caught at debug) → provider silently missing → registry left with only
unavailable providers → all LLM chat dead (CEO chat fell back to clarify).

## What Changed
- Renamed `chat_completion` → `_chat_completion_impl` (bodies unchanged) in the 5
  affected `BaseProvider` subclasses: **OllamaProvider, CustomOpenAIProvider,
  GroqProvider, HuggingFaceProvider, VLLMBaseProvider**. They now run inside the
  base rate-limiter/backoff wrapper (bonus).
- Same fix for the test's `MockProvider` (was abstract too).
- `TestProviderConcreteness` — AST-based regression guard (avoids optional-SDK
  import issues) asserting each provider implements `_chat_completion_impl` and
  never overrides the wrapper.

## Verification
- Direct import (no conftest): all 5 report `__abstractmethods__ == {}` → **CONCRETE**.
- `TestProviderConcreteness`: **6 passed**. `py_compile` + `black -l120` + `isort` clean.
- Note: the other `test_provider_registry.py` tests fail in-suite because the
  conftest stubs `llm_shared`/`ProviderRegistry` as a MagicMock (the #10691
  co-collection-stubbing class — pre-existing, unrelated to this fix; the whole
  file was already red on base from the abstract MockProvider).

## Model Used
Opus 4.8 (1M context)

Closes #11249
