### PR TITLE
feat(workers): priority tiers so audit preempts low-priority maintenance (#11262)

### DIFF
--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -88,6 +88,14 @@ celery_app = Celery(
     backend=ssot_config.celery_result_backend or _default_backend_url,
 )
 
+# GH#11262: priority tiers live in celery_priority (plain data so they can be
+# unit-tested without importing this heavy, pytest-stubbed module, issue #7766).
+from celery_priority import (  # noqa: E402
+    MAX_PRIORITY as _MAX_PRIORITY,
+    PRIORITY_NORMAL as _PRIORITY_NORMAL,
+    PRIORITY_TASK_ROUTES as _PRIORITY_TASK_ROUTES,
+)
+
 # Celery configuration
 celery_app.conf.update(
     # Serialization settings
@@ -99,6 +107,9 @@ celery_app.conf.update(
     enable_utc=True,
     # Task tracking
     task_track_started=True,
+    # GH#11262: enable priority queues so audit preempts low-priority maintenance.
+    task_queue_max_priority=_MAX_PRIORITY,
+    task_default_priority=_PRIORITY_NORMAL,
     # Task routing - route tasks to appropriate queues
     task_routes={
         "tasks.deploy_host": {"queue": "deployments"},
@@ -122,6 +133,8 @@ celery_app.conf.update(
         "analytics.run_bug_prediction_analysis": {"queue": "analytics"},
         "analytics.run_security_analysis": {"queue": "analytics"},
         "analytics.run_dashboard_analysis": {"queue": "analytics"},
+        # GH#11262: priority tiers on the shared default queue (audit > maintenance).
+        **_PRIORITY_TASK_ROUTES,
     },
     # Worker configuration for long-running Ansible playbooks
     # Uses centralized config from unified_config_manager
@@ -131,6 +144,9 @@ celery_app.conf.update(
     # Issue #725: Include SSL options when TLS is enabled
     broker_transport_options={
         "visibility_timeout": _visibility_timeout,
+        # GH#11262: drain higher-priority messages first so critical audit work
+        # is not stuck behind a backlog of low-priority cleanup on the same queue.
+        "queue_order_strategy": "priority",
         **(_broker_ssl_options or {}),
     },
     result_backend_transport_options={

--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -90,11 +90,9 @@ celery_app = Celery(
 
 # GH#11262: priority tiers live in celery_priority (plain data so they can be
 # unit-tested without importing this heavy, pytest-stubbed module, issue #7766).
-from celery_priority import (  # noqa: E402
-    MAX_PRIORITY as _MAX_PRIORITY,
-    PRIORITY_NORMAL as _PRIORITY_NORMAL,
-    PRIORITY_TASK_ROUTES as _PRIORITY_TASK_ROUTES,
-)
+from celery_priority import MAX_PRIORITY as _MAX_PRIORITY  # noqa: E402
+from celery_priority import PRIORITY_NORMAL as _PRIORITY_NORMAL
+from celery_priority import PRIORITY_TASK_ROUTES as _PRIORITY_TASK_ROUTES
 
 # Celery configuration
 celery_app.conf.update(

--- a/autobot-backend/celery_priority.py
+++ b/autobot-backend/celery_priority.py
@@ -1,0 +1,53 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Priority tiers for background Celery workers (GH#11262).
+
+Background work shares the default queue, so a burst of low-value cleanup could
+delay a critical audit. Redis honours per-message priority only when the queue is
+priority-enabled (``task_queue_max_priority``) and the worker drains high-priority
+sub-queues first (``queue_order_strategy="priority"``). Higher number = drained
+first (0..10).
+
+This module holds the policy as plain data so it can be unit-tested without
+importing the full ``celery_app`` (which pulls Redis/heavy deps and is stubbed
+under pytest, issue #7766). ``celery_app`` imports and applies it.
+"""
+
+# Priority levels (0..10; higher drains first).
+PRIORITY_CRITICAL = 9  # security/audit sweeps
+PRIORITY_NORMAL = 5  # default — memory consolidation, analytics
+PRIORITY_LOW = 2  # nightly cleanup / retention (yield to everything else)
+
+MAX_PRIORITY = 10
+
+# Per-task priority overrides merged into celery_app's task_routes. Tasks stay on
+# their existing queue; only the drain order changes.
+PRIORITY_TASK_ROUTES = {
+    # Critical — security/audit sweeps jump ahead of maintenance.
+    "workers.audit_testgaps": {"priority": PRIORITY_CRITICAL},
+    "workers.audit_dead_code": {"priority": PRIORITY_CRITICAL},
+    "workers.audit_claims": {"priority": PRIORITY_CRITICAL},
+    # Normal — memory consolidation (#11263 attaches its beat entry).
+    "memory.consolidate_trajectories": {"priority": PRIORITY_NORMAL},
+    # Low — nightly cleanup / retention yields to everything else.
+    "tasks.cleanup_orphan_documents": {"priority": PRIORITY_LOW},
+    "tasks.cleanup_generated_files": {"priority": PRIORITY_LOW},
+    "tasks.prune_sync_queue_done": {"priority": PRIORITY_LOW},
+    "tasks.cleanup_stale_workspaces": {"priority": PRIORITY_LOW},
+    "tasks.cleanup_stale_mobile_devices": {"priority": PRIORITY_LOW},
+    "tasks.cleanup_expired_snapshots": {"priority": PRIORITY_LOW},
+    "tasks.cleanup_expired_chats": {"priority": PRIORITY_LOW},
+    "tasks.cleanup_expired_files": {"priority": PRIORITY_LOW},
+    "tasks.cleanup_expired_audit_logs": {"priority": PRIORITY_LOW},
+    "tasks.cleanup_expired_kb_entries": {"priority": PRIORITY_LOW},
+}
+
+__all__ = [
+    "PRIORITY_CRITICAL",
+    "PRIORITY_NORMAL",
+    "PRIORITY_LOW",
+    "MAX_PRIORITY",
+    "PRIORITY_TASK_ROUTES",
+]

--- a/autobot-backend/celery_priority_test.py
+++ b/autobot-backend/celery_priority_test.py
@@ -1,0 +1,37 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Priority tiers for background Celery workers (GH#11262)."""
+
+import celery_priority as cp
+
+
+def test_priority_levels_ordered():
+    assert cp.PRIORITY_CRITICAL > cp.PRIORITY_NORMAL > cp.PRIORITY_LOW
+    assert 0 <= cp.PRIORITY_LOW and cp.PRIORITY_CRITICAL <= cp.MAX_PRIORITY
+
+
+def test_audit_tasks_are_critical_priority():
+    for name in ("workers.audit_testgaps", "workers.audit_dead_code", "workers.audit_claims"):
+        assert cp.PRIORITY_TASK_ROUTES[name]["priority"] == cp.PRIORITY_CRITICAL, name
+
+
+def test_cleanup_tasks_are_low_priority():
+    for name in (
+        "tasks.cleanup_expired_chats",
+        "tasks.cleanup_expired_files",
+        "tasks.cleanup_stale_workspaces",
+        "tasks.cleanup_orphan_documents",
+    ):
+        assert cp.PRIORITY_TASK_ROUTES[name]["priority"] == cp.PRIORITY_LOW, name
+
+
+def test_consolidation_slot_reserved_at_normal_priority():
+    # #11263 attaches the consolidation beat entry; its route is reserved here.
+    assert cp.PRIORITY_TASK_ROUTES["memory.consolidate_trajectories"]["priority"] == cp.PRIORITY_NORMAL
+
+
+def test_audit_outranks_cleanup():
+    routes = cp.PRIORITY_TASK_ROUTES
+    assert routes["workers.audit_testgaps"]["priority"] > routes["tasks.cleanup_expired_chats"]["priority"]


### PR DESCRIPTION
## Thinking Path

Audit sweeps (testgaps, dead-code, claims) and nightly cleanup/retention tasks share the default Celery queue with no ordering, so a backlog of low-value cleanup can delay a critical audit. Celery over Redis honours per-message priority only when the queue is priority-enabled and the worker drains high-priority sub-queues first. This adds a small, testable priority policy — no new queues, no worker topology changes.

## What Changed

- **New** `celery_priority.py` — dependency-free priority policy as plain data (`PRIORITY_CRITICAL=9 / NORMAL=5 / LOW=2`, `MAX_PRIORITY`, `PRIORITY_TASK_ROUTES`). Kept separate from `celery_app` so it is unit-testable without the heavy, pytest-stubbed app (issue #7766).
- `celery_app.py`:
  - `task_queue_max_priority=10`, `task_default_priority=5`.
  - `broker_transport_options["queue_order_strategy"]="priority"` so higher-priority messages drain first.
  - Merges `PRIORITY_TASK_ROUTES` into `task_routes`: audit → 9, cleanup/retention → 2, and reserves `memory.consolidate_trajectories` → 5 for the consolidation worker (#11263).
- **New** `celery_priority_test.py` — 5 tests.

Tasks keep their existing queues; only drain order changes. Existing queue routes (deployments/memory/analytics) are untouched.

## Verification

- `celery_priority_test.py` — **5 passed** (tier ordering, audit=critical, cleanup=low, consolidation slot reserved, audit outranks cleanup).
- Runtime check on the real `celery_app`: `task_queue_max_priority=10`, `task_default_priority=5`, `queue_order_strategy=priority`, `audit_testgaps.priority=9`, `cleanup_expired_chats.priority=2`, and existing `analytics.*` queue routes preserved.

Closes #11262

## Model Used

Claude Opus 4.8
