### PR TITLE
feat(companyos): project archive→dispose lifecycle + SLM-configurable disposal policy (Phase 2 of #11129)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/sources.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/sources.py
@@ -32,7 +32,7 @@ from ..source_models import (
     SourceSyncResponse,
 )
 from ..source_paths import CODE_SOURCES_BASE, make_clone_path
-from ..source_storage import delete_source, get_source, list_sources, save_source
+from ..source_storage import get_source, list_sources, save_source
 
 logger = get_logger(__name__)
 
@@ -335,17 +335,13 @@ async def update_code_source(source_id: str, request: CodeSourceUpdateRequest):
     error_code_prefix="CODEBASE",
 )
 async def delete_code_source(source_id: str):
-    """Delete a code source and remove its clone directory if present."""
+    """Delete a code source and remove its clone directory + index if present."""
+    from ..source_service import delete_source_and_cleanup  # noqa: PLC0415
+
     source = await get_source(source_id)
     if source is None:
         raise HTTPException(status_code=404, detail=f"Source {source_id} not found")
-    if source.clone_path and Path(source.clone_path).exists():
-        # Only remove clone directories we created (under CODE_SOURCES_BASE)
-        clone = Path(source.clone_path).resolve()
-        if clone.is_relative_to(CODE_SOURCES_BASE):
-            shutil.rmtree(source.clone_path, ignore_errors=True)
-    ok = await delete_source(source_id)
-    logger.info("Deleted code source %s", source_id)
+    ok = await delete_source_and_cleanup(source_id)
     return JSONResponse({"success": ok, "source_id": source_id})
 
 

--- a/autobot-backend/api/codebase_analytics/endpoints/sources.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/sources.py
@@ -341,7 +341,7 @@ async def delete_code_source(source_id: str):
     source = await get_source(source_id)
     if source is None:
         raise HTTPException(status_code=404, detail=f"Source {source_id} not found")
-    ok = await delete_source_and_cleanup(source_id)
+    ok = await delete_source_and_cleanup(source_id, source=source)
     return JSONResponse({"success": ok, "source_id": source_id})
 
 

--- a/autobot-backend/api/codebase_analytics/source_delete_service_test.py
+++ b/autobot-backend/api/codebase_analytics/source_delete_service_test.py
@@ -1,0 +1,19 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""delete_source_and_cleanup removes clone dir + index + record (#11129 P2)."""
+import ast
+from pathlib import Path
+
+_SVC = Path(__file__).parent / "source_service.py"
+_SOURCES = Path(__file__).parent / "endpoints" / "sources.py"
+
+
+def test_service_exposes_delete_and_cleanup():
+    tree = ast.parse(_SVC.read_text(encoding="utf-8"))
+    names = {n.name for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef)}
+    assert "delete_source_and_cleanup" in names
+
+
+def test_delete_handler_delegates_to_service():
+    src = _SOURCES.read_text(encoding="utf-8")
+    assert "delete_source_and_cleanup" in src, "DELETE handler must call the extracted service"

--- a/autobot-backend/api/codebase_analytics/source_delete_service_test.py
+++ b/autobot-backend/api/codebase_analytics/source_delete_service_test.py
@@ -1,6 +1,7 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
 """delete_source_and_cleanup removes clone dir + index + record (#11129 P2)."""
+
 import ast
 from pathlib import Path
 

--- a/autobot-backend/api/codebase_analytics/source_service.py
+++ b/autobot-backend/api/codebase_analytics/source_service.py
@@ -17,16 +17,20 @@ from .source_storage import save_source
 logger = get_logger(__name__)
 
 
-async def delete_source_and_cleanup(source_id: str) -> bool:
+async def delete_source_and_cleanup(source_id: str, source: CodeSource | None = None) -> bool:
     """Delete a CodeSource: its clone dir (only under CODE_SOURCES_BASE), its
-    ChromaDB documents, and its Redis record. Idempotent; returns Redis-delete result."""
+    ChromaDB documents, and its Redis record. Idempotent; returns Redis-delete result.
+
+    Callers that already loaded the record (e.g. the DELETE handler's 404 check) may
+    pass ``source`` to avoid a redundant Redis read."""
     import shutil  # noqa: PLC0415
     from pathlib import Path  # noqa: PLC0415
 
     from .source_paths import CODE_SOURCES_BASE  # noqa: PLC0415
     from .source_storage import delete_source, get_source  # noqa: PLC0415
 
-    source = await get_source(source_id)
+    if source is None:
+        source = await get_source(source_id)
     if source is None:
         return False
     if source.clone_path and Path(source.clone_path).exists():

--- a/autobot-backend/api/codebase_analytics/source_service.py
+++ b/autobot-backend/api/codebase_analytics/source_service.py
@@ -17,6 +17,41 @@ from .source_storage import save_source
 logger = get_logger(__name__)
 
 
+async def delete_source_and_cleanup(source_id: str) -> bool:
+    """Delete a CodeSource: its clone dir (only under CODE_SOURCES_BASE), its
+    ChromaDB documents, and its Redis record. Idempotent; returns Redis-delete result."""
+    import shutil  # noqa: PLC0415
+    from pathlib import Path  # noqa: PLC0415
+
+    from .source_paths import CODE_SOURCES_BASE  # noqa: PLC0415
+    from .source_storage import delete_source, get_source  # noqa: PLC0415
+
+    source = await get_source(source_id)
+    if source is None:
+        return False
+    if source.clone_path and Path(source.clone_path).exists():
+        clone = Path(source.clone_path).resolve()
+        if clone.is_relative_to(CODE_SOURCES_BASE):
+            shutil.rmtree(source.clone_path, ignore_errors=True)
+    await _purge_source_index(source_id)
+    ok = await delete_source(source_id)
+    logger.info("Deleted code source %s (clone+index+record)", source_id)
+    return ok
+
+
+async def _purge_source_index(source_id: str) -> None:
+    """Best-effort ChromaDB document removal for a source; never raises."""
+    try:
+        from .chromadb_storage import _delete_source_documents  # noqa: PLC0415
+        from .storage import get_code_collection_async  # noqa: PLC0415
+
+        collection = await get_code_collection_async()
+        if collection is not None:
+            await _delete_source_documents(collection, task_id="dispose", source_id=source_id)
+    except Exception as exc:  # noqa: BLE001 — index cleanup is best-effort
+        logger.warning("ChromaDB purge for source %s failed: %s", source_id, exc)
+
+
 async def create_github_source(
     *,
     name: str,

--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -276,11 +276,11 @@ celery_app.conf.beat_schedule = {
     },
 }
 
+import llc.scheduler.project_disposal_sweep  # noqa: F401
 import tasks.audit_log_retention  # noqa: F401
 
 # GH#8995: import retention tasks so Celery registers them at worker startup
 import tasks.chat_retention  # noqa: F401
-import llc.scheduler.project_disposal_sweep  # noqa: F401
 import tasks.file_retention  # noqa: F401
 import tasks.knowledge_retention  # noqa: F401
 

--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -204,6 +204,11 @@ celery_app.conf.beat_schedule = {
         "task": "llc.scheduler.sprint_autoclose.run_daily_check",
         "schedule": crontab(hour=0, minute=5),
     },
+    # #11129 P2: dispose pending_disposal projects whose retention has elapsed
+    "llc-project-disposal-sweep": {
+        "task": "llc.scheduler.project_disposal_sweep.run_disposal_sweep",
+        "schedule": crontab(hour=1, minute=0),
+    },
     # GH#7356: background audit daemon — testgaps, dead-code, claims
     # Beat pidfile must NOT reside on tmpfs (/run/autobot/ is wiped on reboot).
     "audit-testgaps-6h": {
@@ -275,6 +280,7 @@ import tasks.audit_log_retention  # noqa: F401
 
 # GH#8995: import retention tasks so Celery registers them at worker startup
 import tasks.chat_retention  # noqa: F401
+import llc.scheduler.project_disposal_sweep  # noqa: F401
 import tasks.file_retention  # noqa: F401
 import tasks.knowledge_retention  # noqa: F401
 

--- a/autobot-backend/llc/api/sprints.py
+++ b/autobot-backend/llc/api/sprints.py
@@ -764,6 +764,8 @@ async def _apply_disposal(project: LLCProject, session: AsyncSession, ctx: Tenan
         if policy.retention_days > 0:
             project.disposal_scheduled_at = datetime.now(timezone.utc) + timedelta(days=policy.retention_days)
         await session.commit()
+        # Notify reviewers the disposal gate is pending (Redis event, post-commit).
+        await _approval_svc.publish_requested(approval)
         return {"result": "pending_approval", "approval_id": str(approval.id)}
     if policy.retention_days > 0:
         project.lifecycle_state = "pending_disposal"

--- a/autobot-backend/llc/api/sprints.py
+++ b/autobot-backend/llc/api/sprints.py
@@ -710,6 +710,7 @@ async def archive_project(
     project.lifecycle_state = "archived"
     project.archived_at = datetime.now(timezone.utc)
     await session.commit()
+    await session.refresh(project)
     return ProjectResponse.model_validate(project)
 
 
@@ -729,6 +730,7 @@ async def restore_project(
     project.disposal_scheduled_at = None
     project.disposal_approval_id = None
     await session.commit()
+    await session.refresh(project)
     return ProjectResponse.model_validate(project)
 
 
@@ -750,7 +752,7 @@ async def _apply_disposal(project: LLCProject, session: AsyncSession, ctx: Tenan
     """Consult the SLM disposal policy and dispose immediately / schedule / gate on approval."""
     policy = await get_disposal_policy()
     if policy.require_approval:
-        approval = await ApprovalService().request_approval(
+        approval = await _approval_svc.request_approval(
             session,
             company_id=ctx.org_id,
             gate_type=ApprovalType.PROJECT_DISPOSAL,

--- a/autobot-backend/llc/api/sprints.py
+++ b/autobot-backend/llc/api/sprints.py
@@ -31,7 +31,7 @@ Routes:
 """
 
 import uuid
-from datetime import date, datetime
+from datetime import date, datetime, timedelta, timezone
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -45,10 +45,12 @@ from llc.deps import get_session
 from user_management.services import TenantContext
 
 from ..kb.collections import KbCollectionManager
-from ..models.enums import SprintStatus, WorkItemRelationType, WorkItemStatus
+from ..models.enums import ApprovalType, SprintStatus, WorkItemRelationType, WorkItemStatus
 from ..models.sprint import LLCPortfolio, LLCProgram, LLCProject, LLCSprint
 from ..models.work_item import LLCWorkItem, LLCWorkItemRelation
 from ..services.approval import ApprovalNotFoundError, ApprovalService, ApprovalStateError
+from ..services.disposal_policy import get_disposal_policy
+from ..services.project_disposal import dispose
 from ..services.sprint_autoclose import SprintAutoCloseService
 from ..services.sprint_planning import SprintNotFound, SprintPlanningService
 from ..services.timeline import compute_critical_path, duration_days
@@ -172,6 +174,11 @@ class ProjectResponse(BaseModel):
     # Company OS ↔ codebase-analytics link (#11129).
     code_source_id: Optional[str] = None
     code_source: Optional[CodeSourceSummary] = None
+    # Archive→dispose lifecycle (#11129 P2).
+    lifecycle_state: str = "active"
+    archived_at: Optional[datetime] = None
+    disposal_scheduled_at: Optional[datetime] = None
+    disposal_approval_id: Optional[uuid.UUID] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -682,20 +689,102 @@ async def update_project(
     return project
 
 
-@router.delete("/projects/{project_id}", status_code=204)
-async def delete_project(
+async def _load_owned_project(project_id: uuid.UUID, session: AsyncSession, ctx: TenantContext) -> LLCProject:
+    """Load project by id; 404 when missing or owned by a different org (IDOR guard)."""
+    result = await session.execute(select(LLCProject).where(LLCProject.id == project_id))
+    project = result.scalar_one_or_none()
+    if project is None or str(project.company_id) != str(ctx.org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+    return project
+
+
+@router.post("/projects/{project_id}/archive", response_model=ProjectResponse)
+async def archive_project(
     project_id: uuid.UUID,
     session: AsyncSession = Depends(get_session),
     _current_user: dict = Depends(get_current_user),
     ctx: TenantContext = Depends(require_org_context),
-) -> None:
-    result = await session.execute(select(LLCProject).where(LLCProject.id == project_id))
-    project = result.scalar_one_or_none()
-    # IDOR guard (#10148).
-    if project is None or str(project.company_id) != str(ctx.org_id):
-        raise HTTPException(status_code=404, detail="Project not found")
-    await session.delete(project)
+) -> ProjectResponse:
+    """Move a project to the archived lifecycle state (#11129 P2)."""
+    project = await _load_owned_project(project_id, session, ctx)
+    project.lifecycle_state = "archived"
+    project.archived_at = datetime.now(timezone.utc)
     await session.commit()
+    return ProjectResponse.model_validate(project)
+
+
+@router.post("/projects/{project_id}/restore", response_model=ProjectResponse)
+async def restore_project(
+    project_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> ProjectResponse:
+    """Restore an archived / pending-disposal project to active (#11129 P2)."""
+    project = await _load_owned_project(project_id, session, ctx)
+    if project.lifecycle_state not in ("archived", "pending_disposal"):
+        raise HTTPException(status_code=409, detail="Project is not archived")
+    project.lifecycle_state = "active"
+    project.archived_at = None
+    project.disposal_scheduled_at = None
+    project.disposal_approval_id = None
+    await session.commit()
+    return ProjectResponse.model_validate(project)
+
+
+@router.post("/projects/{project_id}/dispose")
+async def dispose_project(
+    project_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> dict:
+    """Dispose an archived project (immediate / scheduled / approval-gated per SLM policy; #11129 P2)."""
+    project = await _load_owned_project(project_id, session, ctx)
+    if project.lifecycle_state != "archived":
+        raise HTTPException(status_code=409, detail="Project must be archived before disposal")
+    return await _apply_disposal(project, session, ctx, current_user)
+
+
+async def _apply_disposal(project: LLCProject, session: AsyncSession, ctx: TenantContext, current_user: dict) -> dict:
+    """Consult the SLM disposal policy and dispose immediately / schedule / gate on approval."""
+    policy = await get_disposal_policy()
+    if policy.require_approval:
+        approval = await ApprovalService().request_approval(
+            session,
+            company_id=ctx.org_id,
+            gate_type=ApprovalType.PROJECT_DISPOSAL,
+            payload={"project_id": str(project.id)},
+            requested_by=uuid.UUID(str(current_user["id"])),
+        )
+        project.lifecycle_state = "pending_disposal"
+        project.disposal_approval_id = approval.id
+        if policy.retention_days > 0:
+            project.disposal_scheduled_at = datetime.now(timezone.utc) + timedelta(days=policy.retention_days)
+        await session.commit()
+        return {"result": "pending_approval", "approval_id": str(approval.id)}
+    if policy.retention_days > 0:
+        project.lifecycle_state = "pending_disposal"
+        project.disposal_scheduled_at = datetime.now(timezone.utc) + timedelta(days=policy.retention_days)
+        await session.commit()
+        return {"result": "scheduled", "disposal_scheduled_at": project.disposal_scheduled_at.isoformat()}
+    await dispose(project, session)
+    await session.commit()
+    return {"result": "disposed"}
+
+
+@router.delete("/projects/{project_id}", status_code=204)
+async def delete_project(
+    project_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> None:
+    """Delete a project — must be archived first; routes through the disposal workflow (#11129 P2)."""
+    project = await _load_owned_project(project_id, session, ctx)
+    if project.lifecycle_state != "archived":
+        raise HTTPException(status_code=409, detail="Archive the project before deleting")
+    await _apply_disposal(project, session, ctx, current_user)
 
 
 # ------------------------------------------------------------------ Sprint routes

--- a/autobot-backend/llc/models/enums.py
+++ b/autobot-backend/llc/models/enums.py
@@ -125,6 +125,7 @@ class ApprovalType(str, Enum):
     STRATEGY = "strategy"
     BUDGET_OVERRIDE = "budget_override"
     SPRINT_CLOSE = "sprint_close"
+    PROJECT_DISPOSAL = "project_disposal"
 
 
 class ApprovalStatus(str, Enum):

--- a/autobot-backend/llc/models/sprint.py
+++ b/autobot-backend/llc/models/sprint.py
@@ -135,6 +135,24 @@ class LLCProject(Base):
     env: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
     # Company OS project ↔ codebase-analytics CodeSource link (#11129).
     code_source_id: Mapped[Optional[str]] = mapped_column(String(64), nullable=True, index=True)
+    # Archive→dispose lifecycle, orthogonal to work-status `status` (#11129 P2).
+    lifecycle_state: Mapped[str] = mapped_column(
+        sa.Enum(
+            "active",
+            "archived",
+            "pending_disposal",
+            "disposed",
+            name="projectlifecyclestate",
+            create_type=True,
+        ),
+        nullable=False,
+        server_default="active",
+        default="active",
+        index=True,
+    )
+    archived_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    disposal_scheduled_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    disposal_approval_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True)
     # Per-project rollover behaviour (overrides company default when set).
     auto_rollover: Mapped[Optional[bool]] = mapped_column(sa.Boolean, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=sa.func.now())

--- a/autobot-backend/llc/scheduler/project_disposal_sweep.py
+++ b/autobot-backend/llc/scheduler/project_disposal_sweep.py
@@ -1,0 +1,80 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Celery-beat sweep: dispose due + approved pending_disposal projects (#11129 P2).
+
+Runs nightly at 01:00 UTC. Selects LLCProject rows where lifecycle_state ==
+'pending_disposal' and disposal_scheduled_at <= now(UTC), then disposes each
+that passes the approval gate (no approval required, or LLCApproval.status ==
+APPROVED).
+
+Beat schedule entry:
+    "llc-project-disposal-sweep": {
+        "task": "llc.scheduler.project_disposal_sweep.run_disposal_sweep",
+        "schedule": crontab(hour=1, minute=0),
+    }
+
+The schedule is registered in celery_app.py so that beat picks it up.
+"""
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from celery import shared_task
+from sqlalchemy import select
+
+from llc.models.approval import LLCApproval
+from llc.models.enums import ApprovalStatus
+from llc.models.sprint import LLCProject
+from llc.services.project_disposal import dispose
+from user_management.database import get_async_session_factory
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(name="llc.scheduler.project_disposal_sweep.run_disposal_sweep", bind=True, max_retries=3)
+def run_disposal_sweep(self: object) -> dict:  # type: ignore[type-arg]
+    """Sync Celery entry point — disposes projects whose retention has elapsed."""
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    disposed = loop.run_until_complete(_async_sweep())
+    return {"disposed": disposed}
+
+
+async def _async_sweep() -> int:
+    """Inner async body — select due pending_disposal projects and dispose them."""
+    factory = get_async_session_factory()
+    disposed = 0
+    async with factory() as session:
+        result = await session.execute(
+            select(LLCProject).where(
+                LLCProject.lifecycle_state == "pending_disposal",
+                LLCProject.disposal_scheduled_at <= datetime.now(timezone.utc),
+            )
+        )
+        for project in result.scalars().all():
+            if not await _is_disposal_allowed(project, session):
+                continue
+            await dispose(project, session)
+            disposed += 1
+        await session.commit()
+    logger.info("Disposal sweep disposed %d project(s)", disposed)
+    return disposed
+
+
+async def _is_disposal_allowed(project: LLCProject, session: object) -> bool:
+    """Approval-gated projects dispose only once their LLCApproval is APPROVED."""
+    if project.disposal_approval_id is None:
+        return True
+    result = await session.execute(
+        select(LLCApproval).where(LLCApproval.id == project.disposal_approval_id)
+    )
+    approval = result.scalar_one_or_none()
+    return approval is not None and approval.status == ApprovalStatus.APPROVED.value
+
+
+__all__ = ["run_disposal_sweep", "_async_sweep", "_is_disposal_allowed"]

--- a/autobot-backend/llc/scheduler/project_disposal_sweep.py
+++ b/autobot-backend/llc/scheduler/project_disposal_sweep.py
@@ -17,6 +17,7 @@ Beat schedule entry:
 
 The schedule is registered in celery_app.py so that beat picks it up.
 """
+
 import asyncio
 import logging
 from datetime import datetime, timezone
@@ -76,9 +77,7 @@ async def _is_disposal_allowed(project: LLCProject, session: object) -> bool:
     """Approval-gated projects dispose only once their LLCApproval is APPROVED."""
     if project.disposal_approval_id is None:
         return True
-    result = await session.execute(
-        select(LLCApproval).where(LLCApproval.id == project.disposal_approval_id)
-    )
+    result = await session.execute(select(LLCApproval).where(LLCApproval.id == project.disposal_approval_id))
     approval = result.scalar_one_or_none()
     return approval is not None and approval.status == ApprovalStatus.APPROVED.value
 

--- a/autobot-backend/llc/scheduler/project_disposal_sweep.py
+++ b/autobot-backend/llc/scheduler/project_disposal_sweep.py
@@ -22,7 +22,7 @@ import logging
 from datetime import datetime, timezone
 
 from celery import shared_task
-from sqlalchemy import select
+from sqlalchemy import or_, select
 
 from llc.models.approval import LLCApproval
 from llc.models.enums import ApprovalStatus
@@ -50,10 +50,16 @@ async def _async_sweep() -> int:
     factory = get_async_session_factory()
     disposed = 0
     async with factory() as session:
+        # A NULL disposal_scheduled_at means "no retention window" (approval-only
+        # path): treat it as immediately due. A bare ``<= now`` would exclude NULL
+        # rows via SQL three-valued logic, stranding approval-only projects forever.
         result = await session.execute(
             select(LLCProject).where(
                 LLCProject.lifecycle_state == "pending_disposal",
-                LLCProject.disposal_scheduled_at <= datetime.now(timezone.utc),
+                or_(
+                    LLCProject.disposal_scheduled_at.is_(None),
+                    LLCProject.disposal_scheduled_at <= datetime.now(timezone.utc),
+                ),
             )
         )
         for project in result.scalars().all():
@@ -77,4 +83,4 @@ async def _is_disposal_allowed(project: LLCProject, session: object) -> bool:
     return approval is not None and approval.status == ApprovalStatus.APPROVED.value
 
 
-__all__ = ["run_disposal_sweep", "_async_sweep", "_is_disposal_allowed"]
+__all__ = ["run_disposal_sweep"]

--- a/autobot-backend/llc/services/disposal_policy.py
+++ b/autobot-backend/llc/services/disposal_policy.py
@@ -1,0 +1,52 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Read the SLM-configured project disposal policy with safe defaults (#11129 P2)."""
+import json
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from services.slm_client import get_slm_client
+
+logger = logging.getLogger(__name__)
+
+POLICY_SETTING_KEY = "llc.project_disposal_policy"
+
+
+@dataclass(frozen=True)
+class DisposalPolicy:
+    retention_days: int = 0
+    require_approval: bool = False
+
+
+async def _fetch_policy_json() -> Optional[dict]:
+    """GET the policy setting from the SLM settings API; None on any failure."""
+    client = get_slm_client()
+    if client is None:
+        return None
+    try:
+        session = await client._get_session()
+        url = f"{client.slm_url}/api/settings/{POLICY_SETTING_KEY}"
+        async with session.get(url) as response:
+            if response.status != 200:
+                return None
+            setting = await response.json()
+            raw = setting.get("value")
+            return json.loads(raw) if raw else None
+    except Exception as exc:  # noqa: BLE001 — policy read is best-effort
+        logger.warning("Disposal policy read failed: %s", exc)
+        return None
+
+
+async def get_disposal_policy() -> DisposalPolicy:
+    """Return the configured policy, or safe defaults (immediate/no-approval)."""
+    data = await _fetch_policy_json()
+    if not isinstance(data, dict):
+        return DisposalPolicy()
+    try:
+        return DisposalPolicy(
+            retention_days=max(0, int(data["retention_days"])),
+            require_approval=bool(data["require_approval"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return DisposalPolicy()

--- a/autobot-backend/llc/services/disposal_policy.py
+++ b/autobot-backend/llc/services/disposal_policy.py
@@ -4,7 +4,6 @@
 import json
 import logging
 from dataclasses import dataclass
-from typing import Optional
 
 from services.slm_client import get_slm_client
 
@@ -19,7 +18,7 @@ class DisposalPolicy:
     require_approval: bool = False
 
 
-async def _fetch_policy_json() -> Optional[dict]:
+async def _fetch_policy_json() -> dict | None:
     """GET the policy setting from the SLM settings API; None on any failure."""
     client = get_slm_client()
     if client is None:
@@ -32,6 +31,9 @@ async def _fetch_policy_json() -> Optional[dict]:
                 return None
             setting = await response.json()
             raw = setting.get("value")
+            # ``value`` is stored as an escaped JSON string; if the SLM API is ever
+            # changed to return it pre-decoded (a dict), json.loads raises TypeError
+            # and the outer except returns None → get_disposal_policy uses defaults.
             return json.loads(raw) if raw else None
     except Exception as exc:  # noqa: BLE001 — policy read is best-effort
         logger.warning("Disposal policy read failed: %s", exc)

--- a/autobot-backend/llc/services/disposal_policy.py
+++ b/autobot-backend/llc/services/disposal_policy.py
@@ -1,6 +1,7 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
 """Read the SLM-configured project disposal policy with safe defaults (#11129 P2)."""
+
 import json
 import logging
 from dataclasses import dataclass

--- a/autobot-backend/llc/services/project_disposal.py
+++ b/autobot-backend/llc/services/project_disposal.py
@@ -1,0 +1,51 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Project disposal: cascade-delete AutoBot data + linked non-shared CodeSource (#11129 P2).
+
+NEVER deletes the GitHub repo. A source shared with other users is unlinked, not deleted.
+
+Import strategy: ``get_source`` and ``delete_source_and_cleanup`` are lazy-imported inside
+``_dispose_source`` to avoid heavy/circular imports from codebase_analytics.  Tests patch
+them at their source modules:
+  patch("api.codebase_analytics.source_storage.get_source", ...)
+  patch("api.codebase_analytics.source_service.delete_source_and_cleanup", ...)
+"""
+import logging
+
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from llc.models.sprint import LLCProject, LLCSprint
+from llc.models.work_item import LLCWorkItem
+
+logger = logging.getLogger(__name__)
+
+
+async def dispose(project: LLCProject, session: AsyncSession) -> None:
+    """Delete the project's work-items, sprints, the project row, and — when the
+    linked CodeSource is not shared with other users — that source's clone + index.
+    Idempotent; caller owns the surrounding transaction/commit."""
+    project_id = project.id
+    code_source_id = project.code_source_id
+
+    await session.execute(delete(LLCWorkItem).where(LLCWorkItem.project_id == project_id))
+    await session.execute(delete(LLCSprint).where(LLCSprint.project_id == project_id))
+    await session.execute(delete(LLCProject).where(LLCProject.id == project_id))
+
+    if code_source_id:
+        await _dispose_source(code_source_id)
+    logger.info("Disposed project %s (source=%s)", project_id, code_source_id)
+
+
+async def _dispose_source(code_source_id: str) -> None:
+    """Delete the linked source's clone+index only when it is not shared with others."""
+    from api.codebase_analytics.source_storage import get_source  # noqa: PLC0415
+    from api.codebase_analytics.source_service import delete_source_and_cleanup  # noqa: PLC0415
+
+    source = await get_source(code_source_id)
+    if source is None:
+        return
+    if getattr(source, "shared_with", None):
+        logger.info("Source %s is shared; unlinking only (not deleting)", code_source_id)
+        return
+    await delete_source_and_cleanup(code_source_id)

--- a/autobot-backend/llc/services/project_disposal.py
+++ b/autobot-backend/llc/services/project_disposal.py
@@ -10,6 +10,7 @@ them at their source modules:
   patch("api.codebase_analytics.source_storage.get_source", ...)
   patch("api.codebase_analytics.source_service.delete_source_and_cleanup", ...)
 """
+
 import logging
 
 from sqlalchemy import delete
@@ -39,8 +40,8 @@ async def dispose(project: LLCProject, session: AsyncSession) -> None:
 
 async def _dispose_source(code_source_id: str) -> None:
     """Delete the linked source's clone+index only when it is not shared with others."""
-    from api.codebase_analytics.source_storage import get_source  # noqa: PLC0415
     from api.codebase_analytics.source_service import delete_source_and_cleanup  # noqa: PLC0415
+    from api.codebase_analytics.source_storage import get_source  # noqa: PLC0415
 
     source = await get_source(code_source_id)
     if source is None:

--- a/autobot-backend/llc/tests/conftest.py
+++ b/autobot-backend/llc/tests/conftest.py
@@ -247,6 +247,11 @@ def _make_mock_project(company_id: uuid.UUID, code_source_id: str | None = None)
     proj.open_work_item_count = 0
     proj.created_at = datetime.now(timezone.utc)
     proj.updated_at = datetime.now(timezone.utc)
+    # Pin lifecycle fields (#11129 P2) so model_validate doesn't auto-vivify Mocks.
+    proj.lifecycle_state = "active"
+    proj.archived_at = None
+    proj.disposal_scheduled_at = None
+    proj.disposal_approval_id = None
     return proj
 
 

--- a/autobot-backend/llc/tests/conftest.py
+++ b/autobot-backend/llc/tests/conftest.py
@@ -69,9 +69,15 @@ def _make_services_stub() -> types.ModuleType:
     llm_mod.__package__ = "services"
     llm_mod.get_llm_service = MagicMock(return_value=MagicMock())  # type: ignore[attr-defined]
 
+    slm_mod = types.ModuleType("services.slm_client")
+    slm_mod.__package__ = "services"
+    slm_mod.get_slm_client = MagicMock(return_value=None)  # type: ignore[attr-defined]
+
     services_mod.llm_service = llm_mod  # type: ignore[attr-defined]
+    services_mod.slm_client = slm_mod  # type: ignore[attr-defined]
     sys.modules["services"] = services_mod
     sys.modules["services.llm_service"] = llm_mod
+    sys.modules["services.slm_client"] = slm_mod
     return services_mod
 
 

--- a/autobot-backend/llc/tests/conftest.py
+++ b/autobot-backend/llc/tests/conftest.py
@@ -134,6 +134,14 @@ def _shield_codebase_analytics_package() -> None:
     pkg.__path__ = [str(_pkg_dir)]  # type: ignore[attr-defined]
     pkg.__package__ = "api.codebase_analytics"
     sys.modules["api.codebase_analytics"] = pkg
+    # Expose as an attribute on the parent ``api`` package so that
+    # ``mock.patch("api.codebase_analytics.<submodule>.<attr>")`` — whose dotted
+    # lookup runs ``getattr(api, "codebase_analytics")`` — resolves to this shield
+    # (#11129 P2). Without it, patching a lazily-imported analytics helper raises
+    # ``AttributeError: module 'api' has no attribute 'codebase_analytics'``.
+    import importlib  # noqa: PLC0415
+
+    importlib.import_module("api").codebase_analytics = pkg  # type: ignore[attr-defined]
 
 
 _shield_codebase_analytics_package()

--- a/autobot-backend/llc/tests/test_disposal_policy.py
+++ b/autobot-backend/llc/tests/test_disposal_policy.py
@@ -1,0 +1,33 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""SLM-configurable disposal policy read + safe defaults (#11129 P2)."""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from llc.services.disposal_policy import DisposalPolicy, get_disposal_policy
+
+
+@pytest.mark.asyncio
+async def test_defaults_when_no_slm_client():
+    with patch("llc.services.disposal_policy.get_slm_client", return_value=None):
+        policy = await get_disposal_policy()
+    assert policy == DisposalPolicy(retention_days=0, require_approval=False)
+
+
+@pytest.mark.asyncio
+async def test_parses_policy_from_slm():
+    with patch(
+        "llc.services.disposal_policy._fetch_policy_json",
+        AsyncMock(return_value={"retention_days": 30, "require_approval": True}),
+    ):
+        policy = await get_disposal_policy()
+    assert policy.retention_days == 30
+    assert policy.require_approval is True
+
+
+@pytest.mark.asyncio
+async def test_defaults_on_malformed():
+    with patch("llc.services.disposal_policy._fetch_policy_json", AsyncMock(return_value={"bad": "x"})):
+        policy = await get_disposal_policy()
+    assert policy == DisposalPolicy(retention_days=0, require_approval=False)

--- a/autobot-backend/llc/tests/test_disposal_policy.py
+++ b/autobot-backend/llc/tests/test_disposal_policy.py
@@ -1,6 +1,7 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
 """SLM-configurable disposal policy read + safe defaults (#11129 P2)."""
+
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/autobot-backend/llc/tests/test_project_disposal_service.py
+++ b/autobot-backend/llc/tests/test_project_disposal_service.py
@@ -35,8 +35,8 @@ async def test_dispose_deletes_children_then_project_and_source():
     ) as del_src:
         await dispose(project, session)
     del_src.assert_awaited_once_with("src-1")
-    # work-items + sprints deleted via bulk delete statements, then project.
-    assert session.execute.await_count >= 2
+    # Exactly three bulk-delete statements: work-items, sprints, then project.
+    assert session.execute.await_count == 3
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/llc/tests/test_project_disposal_service.py
+++ b/autobot-backend/llc/tests/test_project_disposal_service.py
@@ -2,38 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 """Disposal cascade: work-items→sprints→project→linked non-shared source (#11129 P2).
 
-Patch strategy: lazy imports inside _dispose_source → patch at source modules.
-The source modules are pre-imported so patch() can resolve the attribute path.
+Patch strategy: project_disposal lazy-imports get_source / delete_source_and_cleanup
+inside _dispose_source. The llc/tests/conftest.py ``_shield_codebase_analytics_package``
+hook registers a package stub whose __path__ points at the real directory, so
+``patch("api.codebase_analytics.source_storage.get_source")`` loads the REAL submodule
+(without running the heavy __init__.py) and auto-restores at the end of each ``with`` —
+no module-level sys.modules surgery, so nothing leaks into sibling analytics suites.
 """
-import sys
-import types
 import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-# Pre-stub the codebase_analytics modules so patch() can resolve them
-# without triggering their heavy optional dependencies (Redis, ChromaDB).
-import api as _api_pkg  # noqa: E402 — must precede sys.modules surgery
-
-_analytics_pkg = types.ModuleType("api.codebase_analytics")
-sys.modules["api.codebase_analytics"] = _analytics_pkg
-_api_pkg.codebase_analytics = _analytics_pkg  # type: ignore[attr-defined]
-
-_storage_mod = types.ModuleType("api.codebase_analytics.source_storage")
-_storage_mod.get_source = AsyncMock()  # type: ignore[attr-defined]
-sys.modules["api.codebase_analytics.source_storage"] = _storage_mod
-
-_service_mod = types.ModuleType("api.codebase_analytics.source_service")
-_service_mod.delete_source_and_cleanup = AsyncMock()  # type: ignore[attr-defined]
-sys.modules["api.codebase_analytics.source_service"] = _service_mod
-
-# Attach as attributes on the parent so dotted patch targets resolve.
-_analytics_pkg.source_storage = _storage_mod  # type: ignore[attr-defined]
-_analytics_pkg.source_service = _service_mod  # type: ignore[attr-defined]
-
-from llc.services.project_disposal import dispose  # noqa: E402
+from llc.services.project_disposal import dispose
 
 
 def _project(code_source_id=None):

--- a/autobot-backend/llc/tests/test_project_disposal_service.py
+++ b/autobot-backend/llc/tests/test_project_disposal_service.py
@@ -1,0 +1,84 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Disposal cascade: work-items→sprints→project→linked non-shared source (#11129 P2).
+
+Patch strategy: lazy imports inside _dispose_source → patch at source modules.
+The source modules are pre-imported so patch() can resolve the attribute path.
+"""
+import sys
+import types
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Pre-stub the codebase_analytics modules so patch() can resolve them
+# without triggering their heavy optional dependencies (Redis, ChromaDB).
+import api as _api_pkg  # noqa: E402 — must precede sys.modules surgery
+
+_analytics_pkg = types.ModuleType("api.codebase_analytics")
+sys.modules["api.codebase_analytics"] = _analytics_pkg
+_api_pkg.codebase_analytics = _analytics_pkg  # type: ignore[attr-defined]
+
+_storage_mod = types.ModuleType("api.codebase_analytics.source_storage")
+_storage_mod.get_source = AsyncMock()  # type: ignore[attr-defined]
+sys.modules["api.codebase_analytics.source_storage"] = _storage_mod
+
+_service_mod = types.ModuleType("api.codebase_analytics.source_service")
+_service_mod.delete_source_and_cleanup = AsyncMock()  # type: ignore[attr-defined]
+sys.modules["api.codebase_analytics.source_service"] = _service_mod
+
+# Attach as attributes on the parent so dotted patch targets resolve.
+_analytics_pkg.source_storage = _storage_mod  # type: ignore[attr-defined]
+_analytics_pkg.source_service = _service_mod  # type: ignore[attr-defined]
+
+from llc.services.project_disposal import dispose  # noqa: E402
+
+
+def _project(code_source_id=None):
+    return SimpleNamespace(id=uuid.uuid4(), company_id=uuid.uuid4(), code_source_id=code_source_id)
+
+
+@pytest.mark.asyncio
+async def test_dispose_deletes_children_then_project_and_source():
+    project = _project(code_source_id="src-1")
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    non_shared_source = SimpleNamespace(id="src-1", shared_with=[])
+    with patch(
+        "api.codebase_analytics.source_storage.get_source", AsyncMock(return_value=non_shared_source)
+    ), patch(
+        "api.codebase_analytics.source_service.delete_source_and_cleanup", AsyncMock(return_value=True)
+    ) as del_src:
+        await dispose(project, session)
+    del_src.assert_awaited_once_with("src-1")
+    # work-items + sprints deleted via bulk delete statements, then project.
+    assert session.execute.await_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_dispose_keeps_shared_source():
+    project = _project(code_source_id="src-2")
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    shared = SimpleNamespace(id="src-2", shared_with=["someone-else"])
+    with patch(
+        "api.codebase_analytics.source_storage.get_source", AsyncMock(return_value=shared)
+    ), patch(
+        "api.codebase_analytics.source_service.delete_source_and_cleanup", AsyncMock()
+    ) as del_src:
+        await dispose(project, session)
+    del_src.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispose_no_source_is_noop_on_source():
+    project = _project(code_source_id=None)
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    with patch(
+        "api.codebase_analytics.source_service.delete_source_and_cleanup", AsyncMock()
+    ) as del_src:
+        await dispose(project, session)
+    del_src.assert_not_awaited()

--- a/autobot-backend/llc/tests/test_project_disposal_service.py
+++ b/autobot-backend/llc/tests/test_project_disposal_service.py
@@ -9,6 +9,7 @@ hook registers a package stub whose __path__ points at the real directory, so
 (without running the heavy __init__.py) and auto-restores at the end of each ``with`` —
 no module-level sys.modules surgery, so nothing leaks into sibling analytics suites.
 """
+
 import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -28,11 +29,12 @@ async def test_dispose_deletes_children_then_project_and_source():
     session = AsyncMock()
     session.execute = AsyncMock()
     non_shared_source = SimpleNamespace(id="src-1", shared_with=[])
-    with patch(
-        "api.codebase_analytics.source_storage.get_source", AsyncMock(return_value=non_shared_source)
-    ), patch(
-        "api.codebase_analytics.source_service.delete_source_and_cleanup", AsyncMock(return_value=True)
-    ) as del_src:
+    with (
+        patch("api.codebase_analytics.source_storage.get_source", AsyncMock(return_value=non_shared_source)),
+        patch(
+            "api.codebase_analytics.source_service.delete_source_and_cleanup", AsyncMock(return_value=True)
+        ) as del_src,
+    ):
         await dispose(project, session)
     del_src.assert_awaited_once_with("src-1")
     # Exactly three bulk-delete statements: work-items, sprints, then project.
@@ -45,11 +47,10 @@ async def test_dispose_keeps_shared_source():
     session = AsyncMock()
     session.execute = AsyncMock()
     shared = SimpleNamespace(id="src-2", shared_with=["someone-else"])
-    with patch(
-        "api.codebase_analytics.source_storage.get_source", AsyncMock(return_value=shared)
-    ), patch(
-        "api.codebase_analytics.source_service.delete_source_and_cleanup", AsyncMock()
-    ) as del_src:
+    with (
+        patch("api.codebase_analytics.source_storage.get_source", AsyncMock(return_value=shared)),
+        patch("api.codebase_analytics.source_service.delete_source_and_cleanup", AsyncMock()) as del_src,
+    ):
         await dispose(project, session)
     del_src.assert_not_awaited()
 
@@ -59,8 +60,6 @@ async def test_dispose_no_source_is_noop_on_source():
     project = _project(code_source_id=None)
     session = AsyncMock()
     session.execute = AsyncMock()
-    with patch(
-        "api.codebase_analytics.source_service.delete_source_and_cleanup", AsyncMock()
-    ) as del_src:
+    with patch("api.codebase_analytics.source_service.delete_source_and_cleanup", AsyncMock()) as del_src:
         await dispose(project, session)
     del_src.assert_not_awaited()

--- a/autobot-backend/llc/tests/test_project_disposal_sweep.py
+++ b/autobot-backend/llc/tests/test_project_disposal_sweep.py
@@ -1,6 +1,7 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
 """Beat sweep disposes only due + approved pending_disposal projects (#11129 P2)."""
+
 import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -38,10 +39,10 @@ def _sweep_session(due):
 async def test_sweep_disposes_due_projects():
     due = [SimpleNamespace(id=uuid.uuid4(), code_source_id=None, disposal_approval_id=None)]
     session = _sweep_session(due)
-    with patch(
-        "llc.scheduler.project_disposal_sweep.get_async_session_factory", return_value=_factory_for(session)
-    ), patch("llc.scheduler.project_disposal_sweep.dispose", AsyncMock()) as disp, patch(
-        "llc.scheduler.project_disposal_sweep._is_disposal_allowed", AsyncMock(return_value=True)
+    with (
+        patch("llc.scheduler.project_disposal_sweep.get_async_session_factory", return_value=_factory_for(session)),
+        patch("llc.scheduler.project_disposal_sweep.dispose", AsyncMock()) as disp,
+        patch("llc.scheduler.project_disposal_sweep._is_disposal_allowed", AsyncMock(return_value=True)),
     ):
         count = await _async_sweep()
     assert count == 1
@@ -52,10 +53,10 @@ async def test_sweep_disposes_due_projects():
 async def test_sweep_skips_unapproved_projects():
     due = [SimpleNamespace(id=uuid.uuid4(), code_source_id=None, disposal_approval_id=uuid.uuid4())]
     session = _sweep_session(due)
-    with patch(
-        "llc.scheduler.project_disposal_sweep.get_async_session_factory", return_value=_factory_for(session)
-    ), patch("llc.scheduler.project_disposal_sweep.dispose", AsyncMock()) as disp, patch(
-        "llc.scheduler.project_disposal_sweep._is_disposal_allowed", AsyncMock(return_value=False)
+    with (
+        patch("llc.scheduler.project_disposal_sweep.get_async_session_factory", return_value=_factory_for(session)),
+        patch("llc.scheduler.project_disposal_sweep.dispose", AsyncMock()) as disp,
+        patch("llc.scheduler.project_disposal_sweep._is_disposal_allowed", AsyncMock(return_value=False)),
     ):
         count = await _async_sweep()
     assert count == 0

--- a/autobot-backend/llc/tests/test_project_disposal_sweep.py
+++ b/autobot-backend/llc/tests/test_project_disposal_sweep.py
@@ -7,18 +7,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from llc.scheduler.project_disposal_sweep import _async_sweep
+from llc.models.enums import ApprovalStatus
+from llc.scheduler.project_disposal_sweep import _async_sweep, _is_disposal_allowed
 
 
-@pytest.mark.asyncio
-async def test_sweep_disposes_due_projects():
-    due = [SimpleNamespace(id=uuid.uuid4(), code_source_id=None, disposal_approval_id=None)]
-    session = AsyncMock()
-    scal = MagicMock()
-    scal.scalars.return_value.all.return_value = due
-    session.execute = AsyncMock(return_value=scal)
-    session.commit = AsyncMock()
-
+def _factory_for(session):
     class _Factory:
         def __call__(self):
             return self
@@ -29,11 +22,72 @@ async def test_sweep_disposes_due_projects():
         async def __aexit__(self, *a):
             return False
 
-    with patch("llc.scheduler.project_disposal_sweep.get_async_session_factory", return_value=_Factory()), patch(
-        "llc.scheduler.project_disposal_sweep.dispose", AsyncMock()
-    ) as disp, patch(
+    return _Factory()
+
+
+def _sweep_session(due):
+    session = AsyncMock()
+    scal = MagicMock()
+    scal.scalars.return_value.all.return_value = due
+    session.execute = AsyncMock(return_value=scal)
+    session.commit = AsyncMock()
+    return session
+
+
+@pytest.mark.asyncio
+async def test_sweep_disposes_due_projects():
+    due = [SimpleNamespace(id=uuid.uuid4(), code_source_id=None, disposal_approval_id=None)]
+    session = _sweep_session(due)
+    with patch(
+        "llc.scheduler.project_disposal_sweep.get_async_session_factory", return_value=_factory_for(session)
+    ), patch("llc.scheduler.project_disposal_sweep.dispose", AsyncMock()) as disp, patch(
         "llc.scheduler.project_disposal_sweep._is_disposal_allowed", AsyncMock(return_value=True)
     ):
         count = await _async_sweep()
     assert count == 1
     disp.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sweep_skips_unapproved_projects():
+    due = [SimpleNamespace(id=uuid.uuid4(), code_source_id=None, disposal_approval_id=uuid.uuid4())]
+    session = _sweep_session(due)
+    with patch(
+        "llc.scheduler.project_disposal_sweep.get_async_session_factory", return_value=_factory_for(session)
+    ), patch("llc.scheduler.project_disposal_sweep.dispose", AsyncMock()) as disp, patch(
+        "llc.scheduler.project_disposal_sweep._is_disposal_allowed", AsyncMock(return_value=False)
+    ):
+        count = await _async_sweep()
+    assert count == 0
+    disp.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_is_disposal_allowed_no_approval_required():
+    project = SimpleNamespace(disposal_approval_id=None)
+    assert await _is_disposal_allowed(project, AsyncMock()) is True
+
+
+@pytest.mark.asyncio
+async def test_is_disposal_allowed_gates_on_approved_status():
+    approval_id = uuid.uuid4()
+    project = SimpleNamespace(disposal_approval_id=approval_id)
+
+    def _session_returning(status):
+        session = AsyncMock()
+        res = MagicMock()
+        res.scalar_one_or_none.return_value = SimpleNamespace(status=status)
+        session.execute = AsyncMock(return_value=res)
+        return session
+
+    approved = _session_returning(ApprovalStatus.APPROVED.value)
+    pending = _session_returning(ApprovalStatus.PENDING.value)
+    assert await _is_disposal_allowed(project, approved) is True
+    assert await _is_disposal_allowed(project, pending) is False
+
+    # Missing approval row → not allowed.
+    missing = AsyncMock()
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = None
+    missing.execute = AsyncMock(return_value=res)
+    assert await _is_disposal_allowed(project, missing) is False

--- a/autobot-backend/llc/tests/test_project_disposal_sweep.py
+++ b/autobot-backend/llc/tests/test_project_disposal_sweep.py
@@ -1,0 +1,39 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Beat sweep disposes only due + approved pending_disposal projects (#11129 P2)."""
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.scheduler.project_disposal_sweep import _async_sweep
+
+
+@pytest.mark.asyncio
+async def test_sweep_disposes_due_projects():
+    due = [SimpleNamespace(id=uuid.uuid4(), code_source_id=None, disposal_approval_id=None)]
+    session = AsyncMock()
+    scal = MagicMock()
+    scal.scalars.return_value.all.return_value = due
+    session.execute = AsyncMock(return_value=scal)
+    session.commit = AsyncMock()
+
+    class _Factory:
+        def __call__(self):
+            return self
+
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, *a):
+            return False
+
+    with patch("llc.scheduler.project_disposal_sweep.get_async_session_factory", return_value=_Factory()), patch(
+        "llc.scheduler.project_disposal_sweep.dispose", AsyncMock()
+    ) as disp, patch(
+        "llc.scheduler.project_disposal_sweep._is_disposal_allowed", AsyncMock(return_value=True)
+    ):
+        count = await _async_sweep()
+    assert count == 1
+    disp.assert_awaited_once()

--- a/autobot-backend/llc/tests/test_project_lifecycle_api.py
+++ b/autobot-backend/llc/tests/test_project_lifecycle_api.py
@@ -114,6 +114,28 @@ def test_dispose_schedules_when_retention():
     assert p.lifecycle_state == "pending_disposal"
 
 
+def test_dispose_pending_approval_when_policy_requires_it():
+    from types import SimpleNamespace  # noqa: PLC0415
+
+    p = _project("archived")
+    client, _ = _mk_client(p)
+    approval_id = uuid.uuid4()
+    fake_svc = MagicMock()
+    fake_svc.request_approval = AsyncMock(return_value=SimpleNamespace(id=approval_id))
+    with patch("llc.api.sprints.get_disposal_policy", AsyncMock(return_value=_policy(0, True))), patch(
+        "llc.api.sprints.dispose", AsyncMock()
+    ) as disp, patch("llc.api.sprints._approval_svc", fake_svc):
+        resp = client.post(f"/projects/{p.id}/dispose")
+    assert resp.status_code == 200
+    disp.assert_not_awaited()
+    body = resp.json()
+    assert body["result"] == "pending_approval"
+    assert body["approval_id"] == str(approval_id)
+    assert p.lifecycle_state == "pending_disposal"
+    assert p.disposal_approval_id == approval_id
+    fake_svc.request_approval.assert_awaited_once()
+
+
 def _policy(days, approval):
     from llc.services.disposal_policy import DisposalPolicy  # noqa: PLC0415
 

--- a/autobot-backend/llc/tests/test_project_lifecycle_api.py
+++ b/autobot-backend/llc/tests/test_project_lifecycle_api.py
@@ -122,6 +122,7 @@ def test_dispose_pending_approval_when_policy_requires_it():
     approval_id = uuid.uuid4()
     fake_svc = MagicMock()
     fake_svc.request_approval = AsyncMock(return_value=SimpleNamespace(id=approval_id))
+    fake_svc.publish_requested = AsyncMock()
     with patch("llc.api.sprints.get_disposal_policy", AsyncMock(return_value=_policy(0, True))), patch(
         "llc.api.sprints.dispose", AsyncMock()
     ) as disp, patch("llc.api.sprints._approval_svc", fake_svc):
@@ -134,6 +135,7 @@ def test_dispose_pending_approval_when_policy_requires_it():
     assert p.lifecycle_state == "pending_disposal"
     assert p.disposal_approval_id == approval_id
     fake_svc.request_approval.assert_awaited_once()
+    fake_svc.publish_requested.assert_awaited_once()
 
 
 def _policy(days, approval):

--- a/autobot-backend/llc/tests/test_project_lifecycle_api.py
+++ b/autobot-backend/llc/tests/test_project_lifecycle_api.py
@@ -1,0 +1,120 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Archive→dispose lifecycle endpoints (#11129 P2)."""
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_USER = uuid.UUID("77777777-7777-7777-7777-777777777777")
+
+
+def _mk_client(project):
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.sprints import router  # noqa: PLC0415
+    from llc.deps import get_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(router)
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = project
+    session.execute = AsyncMock(return_value=result)
+    session.commit = AsyncMock()
+
+    async def _sess():
+        yield session
+
+    app.dependency_overrides[get_session] = _sess
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_USER)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=project.company_id, user_id=_USER, is_platform_admin=False
+    )
+    return TestClient(app), session
+
+
+def _project(lifecycle="active"):
+    from datetime import datetime, timezone  # noqa: PLC0415
+
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    org = uuid.uuid4()
+    p = MagicMock()
+    p.id = uuid.uuid4()
+    p.company_id = org
+    p.lifecycle_state = lifecycle
+    p.code_source_id = None
+    p.code_source = None
+    # Pin all ProjectResponse fields so model_validate doesn't choke on Mocks.
+    p.program_id = None
+    p.goal_id = None
+    p.name = "Test Project"
+    p.description = None
+    p.status = "active"
+    p.lead_agent_id = None
+    p.lead_user_id = None
+    p.target_date = None
+    p.auto_rollover = None
+    p.created_at = now
+    p.updated_at = now
+    p.open_work_item_count = 0
+    p.active_sprint_name = None
+    p.archived_at = None
+    p.disposal_scheduled_at = None
+    p.disposal_approval_id = None
+    return p
+
+
+def test_archive_sets_state():
+    p = _project("active")
+    client, _ = _mk_client(p)
+    resp = client.post(f"/projects/{p.id}/archive")
+    assert resp.status_code == 200
+    assert p.lifecycle_state == "archived"
+
+
+def test_dispose_requires_archived():
+    p = _project("active")
+    client, _ = _mk_client(p)
+    resp = client.post(f"/projects/{p.id}/dispose")
+    assert resp.status_code == 409
+
+
+def test_delete_requires_archived():
+    p = _project("active")
+    client, _ = _mk_client(p)
+    resp = client.request("DELETE", f"/projects/{p.id}")
+    assert resp.status_code == 409
+
+
+def test_dispose_immediate_when_policy_default():
+    p = _project("archived")
+    client, _ = _mk_client(p)
+    with patch("llc.api.sprints.get_disposal_policy", AsyncMock(return_value=_policy(0, False))), patch(
+        "llc.api.sprints.dispose", AsyncMock()
+    ) as disp:
+        resp = client.post(f"/projects/{p.id}/dispose")
+    assert resp.status_code == 200
+    disp.assert_awaited_once()
+    assert resp.json()["result"] == "disposed"
+
+
+def test_dispose_schedules_when_retention():
+    p = _project("archived")
+    client, _ = _mk_client(p)
+    with patch("llc.api.sprints.get_disposal_policy", AsyncMock(return_value=_policy(7, False))), patch(
+        "llc.api.sprints.dispose", AsyncMock()
+    ) as disp:
+        resp = client.post(f"/projects/{p.id}/dispose")
+    assert resp.status_code == 200
+    disp.assert_not_awaited()
+    assert resp.json()["result"] == "scheduled"
+    assert p.lifecycle_state == "pending_disposal"
+
+
+def _policy(days, approval):
+    from llc.services.disposal_policy import DisposalPolicy  # noqa: PLC0415
+
+    return DisposalPolicy(retention_days=days, require_approval=approval)

--- a/autobot-backend/llc/tests/test_project_lifecycle_api.py
+++ b/autobot-backend/llc/tests/test_project_lifecycle_api.py
@@ -1,6 +1,7 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
 """Archive→dispose lifecycle endpoints (#11129 P2)."""
+
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -92,9 +93,10 @@ def test_delete_requires_archived():
 def test_dispose_immediate_when_policy_default():
     p = _project("archived")
     client, _ = _mk_client(p)
-    with patch("llc.api.sprints.get_disposal_policy", AsyncMock(return_value=_policy(0, False))), patch(
-        "llc.api.sprints.dispose", AsyncMock()
-    ) as disp:
+    with (
+        patch("llc.api.sprints.get_disposal_policy", AsyncMock(return_value=_policy(0, False))),
+        patch("llc.api.sprints.dispose", AsyncMock()) as disp,
+    ):
         resp = client.post(f"/projects/{p.id}/dispose")
     assert resp.status_code == 200
     disp.assert_awaited_once()
@@ -104,9 +106,10 @@ def test_dispose_immediate_when_policy_default():
 def test_dispose_schedules_when_retention():
     p = _project("archived")
     client, _ = _mk_client(p)
-    with patch("llc.api.sprints.get_disposal_policy", AsyncMock(return_value=_policy(7, False))), patch(
-        "llc.api.sprints.dispose", AsyncMock()
-    ) as disp:
+    with (
+        patch("llc.api.sprints.get_disposal_policy", AsyncMock(return_value=_policy(7, False))),
+        patch("llc.api.sprints.dispose", AsyncMock()) as disp,
+    ):
         resp = client.post(f"/projects/{p.id}/dispose")
     assert resp.status_code == 200
     disp.assert_not_awaited()
@@ -123,9 +126,11 @@ def test_dispose_pending_approval_when_policy_requires_it():
     fake_svc = MagicMock()
     fake_svc.request_approval = AsyncMock(return_value=SimpleNamespace(id=approval_id))
     fake_svc.publish_requested = AsyncMock()
-    with patch("llc.api.sprints.get_disposal_policy", AsyncMock(return_value=_policy(0, True))), patch(
-        "llc.api.sprints.dispose", AsyncMock()
-    ) as disp, patch("llc.api.sprints._approval_svc", fake_svc):
+    with (
+        patch("llc.api.sprints.get_disposal_policy", AsyncMock(return_value=_policy(0, True))),
+        patch("llc.api.sprints.dispose", AsyncMock()) as disp,
+        patch("llc.api.sprints._approval_svc", fake_svc),
+    ):
         resp = client.post(f"/projects/{p.id}/dispose")
     assert resp.status_code == 200
     disp.assert_not_awaited()

--- a/autobot-backend/llc/tests/test_project_lifecycle_model.py
+++ b/autobot-backend/llc/tests/test_project_lifecycle_model.py
@@ -1,0 +1,18 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Model contract for the project archive→dispose lifecycle (#11129 P2)."""
+from llc.models.enums import ApprovalType
+from llc.models.sprint import LLCProject
+
+
+def test_project_has_lifecycle_columns():
+    cols = LLCProject.__table__.columns
+    assert "lifecycle_state" in cols
+    assert "archived_at" in cols
+    assert "disposal_scheduled_at" in cols
+    assert "disposal_approval_id" in cols
+    assert cols["lifecycle_state"].default.arg == "active"
+
+
+def test_approval_type_has_project_disposal():
+    assert ApprovalType.PROJECT_DISPOSAL.value == "project_disposal"

--- a/autobot-backend/llc/tests/test_project_lifecycle_model.py
+++ b/autobot-backend/llc/tests/test_project_lifecycle_model.py
@@ -12,6 +12,9 @@ def test_project_has_lifecycle_columns():
     assert "disposal_scheduled_at" in cols
     assert "disposal_approval_id" in cols
     assert cols["lifecycle_state"].default.arg == "active"
+    # server_default (DDL-level) protects existing rows during the migration.
+    assert cols["lifecycle_state"].server_default is not None
+    assert "active" in str(cols["lifecycle_state"].server_default.arg)
 
 
 def test_approval_type_has_project_disposal():

--- a/autobot-backend/llc/tests/test_project_lifecycle_model.py
+++ b/autobot-backend/llc/tests/test_project_lifecycle_model.py
@@ -1,6 +1,7 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
 """Model contract for the project archive→dispose lifecycle (#11129 P2)."""
+
 from llc.models.enums import ApprovalType
 from llc.models.sprint import LLCProject
 

--- a/autobot-backend/llc/tests/test_sprints_enrichment.py
+++ b/autobot-backend/llc/tests/test_sprints_enrichment.py
@@ -56,6 +56,11 @@ def _project(company_id):
     # them into non-serializable Mocks when ProjectResponse.model_validate reads.
     m.code_source_id = None
     m.code_source = None
+    # Pin lifecycle fields (#11129 P2) — must not auto-vivify into Mocks.
+    m.lifecycle_state = "active"
+    m.archived_at = None
+    m.disposal_scheduled_at = None
+    m.disposal_approval_id = None
     return m
 
 

--- a/autobot-backend/llc/tests/test_sprints_idor.py
+++ b/autobot-backend/llc/tests/test_sprints_idor.py
@@ -94,6 +94,15 @@ def _make_project(company_id: str, program_id: Optional[uuid.UUID] = None) -> Ma
     m.auto_rollover = None
     m.created_at = None
     m.updated_at = None
+    # Pin repo-link and lifecycle fields (#11129 / #11129 P2) — prevent MagicMock auto-vivify.
+    m.code_source_id = None
+    m.code_source = None
+    m.open_work_item_count = 0
+    m.active_sprint_name = None
+    m.lifecycle_state = "active"
+    m.archived_at = None
+    m.disposal_scheduled_at = None
+    m.disposal_approval_id = None
     return m
 
 
@@ -229,6 +238,20 @@ def _make_app(
             obj.velocity_actual = 0
         if not getattr(obj, "pending_close_approval_id", None):
             obj.pending_close_approval_id = None
+        # Lifecycle fields (#11129 P2) — pin so ProjectResponse.model_validate doesn't choke.
+        if not getattr(obj, "lifecycle_state", None):
+            obj.lifecycle_state = "active"
+        if not hasattr(obj, "archived_at") or callable(getattr(obj, "archived_at", None)):
+            obj.archived_at = None
+        if not hasattr(obj, "disposal_scheduled_at") or callable(getattr(obj, "disposal_scheduled_at", None)):
+            obj.disposal_scheduled_at = None
+        if not hasattr(obj, "disposal_approval_id") or callable(getattr(obj, "disposal_approval_id", None)):
+            obj.disposal_approval_id = None
+        # Repo-link fields (#11129) — prevent auto-vivification.
+        if not hasattr(obj, "code_source_id") or callable(getattr(obj, "code_source_id", None)):
+            obj.code_source_id = None
+        if not hasattr(obj, "code_source") or callable(getattr(obj, "code_source", None)):
+            obj.code_source = None
 
     mock_session.refresh = _fake_refresh
 

--- a/autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py
+++ b/autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py
@@ -6,8 +6,11 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
+# Merge migration: unifies the two dangling heads left by Phase 1 (#11129) —
+# 20260707_066 (project_code_source) and 20260701_066 (requires_approval_before)
+# both descended from 20260630_065, creating "Multiple head revisions". See #11253.
 revision: str = "20260708_067"
-down_revision: Union[str, None] = "20260707_066"
+down_revision: Union[str, Sequence[str], None] = ("20260707_066", "20260701_066")
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py
+++ b/autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py
@@ -1,6 +1,7 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
 """Add project archive→dispose lifecycle columns + PROJECT_DISPOSAL approval type (#11129 P2)."""
+
 from typing import Sequence, Union
 
 import sqlalchemy as sa
@@ -16,9 +17,7 @@ down_revision: Union[str, Sequence[str], None] = ("20260707_066", "20260701_066"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-_LIFECYCLE = sa.Enum(
-    "active", "archived", "pending_disposal", "disposed", name="projectlifecyclestate"
-)
+_LIFECYCLE = sa.Enum("active", "archived", "pending_disposal", "disposed", name="projectlifecyclestate")
 
 
 def upgrade() -> None:
@@ -35,9 +34,7 @@ def upgrade() -> None:
     )
     op.create_index("ix_llc_projects_lifecycle_state", "llc_projects", ["lifecycle_state"])
     op.add_column("llc_projects", sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True))
-    op.add_column(
-        "llc_projects", sa.Column("disposal_scheduled_at", sa.DateTime(timezone=True), nullable=True)
-    )
+    op.add_column("llc_projects", sa.Column("disposal_scheduled_at", sa.DateTime(timezone=True), nullable=True))
     op.add_column(
         "llc_projects",
         sa.Column("disposal_approval_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True),

--- a/autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py
+++ b/autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py
@@ -1,0 +1,47 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Add project archive→dispose lifecycle columns + PROJECT_DISPOSAL approval type (#11129 P2)."""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260708_067"
+down_revision: Union[str, None] = "20260707_066"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_LIFECYCLE = sa.Enum(
+    "active", "archived", "pending_disposal", "disposed", name="projectlifecyclestate"
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    _LIFECYCLE.create(bind, checkfirst=True)
+    op.add_column(
+        "llc_projects",
+        sa.Column("lifecycle_state", _LIFECYCLE, nullable=False, server_default="active"),
+    )
+    op.create_index("ix_llc_projects_lifecycle_state", "llc_projects", ["lifecycle_state"])
+    op.add_column("llc_projects", sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "llc_projects", sa.Column("disposal_scheduled_at", sa.DateTime(timezone=True), nullable=True)
+    )
+    op.add_column(
+        "llc_projects",
+        sa.Column("disposal_approval_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    # ALTER TYPE ... ADD VALUE cannot run inside a transaction block.
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE approvaltype ADD VALUE IF NOT EXISTS 'project_disposal'")
+
+
+def downgrade() -> None:
+    op.drop_index("ix_llc_projects_lifecycle_state", table_name="llc_projects")
+    op.drop_column("llc_projects", "disposal_approval_id")
+    op.drop_column("llc_projects", "disposal_scheduled_at")
+    op.drop_column("llc_projects", "archived_at")
+    op.drop_column("llc_projects", "lifecycle_state")
+    _LIFECYCLE.drop(op.get_bind(), checkfirst=True)
+    # Note: Postgres cannot drop an enum value; 'project_disposal' remains on approvaltype (harmless).

--- a/autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py
+++ b/autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py
@@ -9,6 +9,8 @@ from alembic import op
 # Merge migration: unifies the two dangling heads left by Phase 1 (#11129) —
 # 20260707_066 (project_code_source) and 20260701_066 (requires_approval_before)
 # both descended from 20260630_065, creating "Multiple head revisions". See #11253.
+# This revision is BOTH a merge (two parents) AND functional (adds lifecycle columns);
+# Alembic runs upgrade() exactly once, after both parents are confirmed applied.
 revision: str = "20260708_067"
 down_revision: Union[str, Sequence[str], None] = ("20260707_066", "20260701_066")
 branch_labels: Union[str, Sequence[str], None] = None
@@ -24,7 +26,12 @@ def upgrade() -> None:
     _LIFECYCLE.create(bind, checkfirst=True)
     op.add_column(
         "llc_projects",
-        sa.Column("lifecycle_state", _LIFECYCLE, nullable=False, server_default="active"),
+        sa.Column(
+            "lifecycle_state",
+            _LIFECYCLE,
+            nullable=False,
+            server_default=sa.text("'active'::projectlifecyclestate"),
+        ),
     )
     op.create_index("ix_llc_projects_lifecycle_state", "llc_projects", ["lifecycle_state"])
     op.add_column("llc_projects", sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True))

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8463,7 +8463,14 @@
       "loadError": "Failed to load projects.",
       "create": "New Project",
       "createTitle": "Create Project",
-      "createError": "Failed to create project."
+      "createError": "Failed to create project.",
+      "archive": "أرشفة",
+      "restore": "استعادة",
+      "delete": "حذف",
+      "confirmDelete": "حذف هذا المشروع المؤرشف وسباقاته؟ لا يمكن التراجع عن هذا.",
+      "archiveError": "فشل أرشفة المشروع.",
+      "restoreError": "فشل استعادة المشروع.",
+      "deleteError": "فشل حذف المشروع."
     },
     "approvals": {
       "decideError": "Failed to record your decision. Please try again."
@@ -8502,6 +8509,12 @@
       "syncError": "Failed to trigger sync.",
       "syncSuccess": "Sync started.",
       "copyClonePath": "Copy workspace path"
+    },
+    "lifecycle": {
+      "active": "نشط",
+      "archived": "مؤرشف",
+      "pending_disposal": "في انتظار الحذف",
+      "disposed": "محذوف"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8463,7 +8463,14 @@
       "loadError": "Projekte konnten nicht geladen werden.",
       "create": "Neues Projekt",
       "createTitle": "Projekt erstellen",
-      "createError": "Projekt konnte nicht erstellt werden."
+      "createError": "Projekt konnte nicht erstellt werden.",
+      "archive": "Archivieren",
+      "restore": "Wiederherstellen",
+      "delete": "Löschen",
+      "confirmDelete": "Dieses archivierte Projekt und seine Sprints löschen? Dies kann nicht rückgängig gemacht werden.",
+      "archiveError": "Projekt konnte nicht archiviert werden.",
+      "restoreError": "Projekt konnte nicht wiederhergestellt werden.",
+      "deleteError": "Projekt konnte nicht gelöscht werden."
     },
     "approvals": {
       "decideError": "Ihre Entscheidung konnte nicht gespeichert werden. Bitte versuchen Sie es erneut."
@@ -8502,6 +8509,12 @@
       "syncError": "Synchronisierung konnte nicht ausgelöst werden.",
       "syncSuccess": "Synchronisierung gestartet.",
       "copyClonePath": "Arbeitsbereich-Pfad kopieren"
+    },
+    "lifecycle": {
+      "active": "Aktiv",
+      "archived": "Archiviert",
+      "pending_disposal": "Ausstehende Löschung",
+      "disposed": "Gelöscht"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8463,7 +8463,14 @@
       "loadError": "Failed to load projects.",
       "create": "New Project",
       "createTitle": "Create Project",
-      "createError": "Failed to create project."
+      "createError": "Failed to create project.",
+      "archive": "Archive",
+      "restore": "Restore",
+      "delete": "Delete",
+      "confirmDelete": "Delete this archived project and its sprints? This cannot be undone.",
+      "archiveError": "Failed to archive project.",
+      "restoreError": "Failed to restore project.",
+      "deleteError": "Failed to delete project."
     },
     "approvals": {
       "decideError": "Failed to record your decision. Please try again."
@@ -8502,6 +8509,12 @@
       "syncError": "Failed to trigger sync.",
       "syncSuccess": "Sync started.",
       "copyClonePath": "Copy workspace path"
+    },
+    "lifecycle": {
+      "active": "Active",
+      "archived": "Archived",
+      "pending_disposal": "Pending disposal",
+      "disposed": "Disposed"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8463,7 +8463,14 @@
       "loadError": "No se pudieron cargar los proyectos.",
       "create": "Nuevo proyecto",
       "createTitle": "Crear proyecto",
-      "createError": "No se pudo crear el proyecto."
+      "createError": "No se pudo crear el proyecto.",
+      "archive": "Archivar",
+      "restore": "Restaurar",
+      "delete": "Eliminar",
+      "confirmDelete": "¿Eliminar este proyecto archivado y sus sprints? Esta acción no se puede deshacer.",
+      "archiveError": "Error al archivar el proyecto.",
+      "restoreError": "Error al restaurar el proyecto.",
+      "deleteError": "Error al eliminar el proyecto."
     },
     "approvals": {
       "decideError": "No se pudo registrar tu decisión. Inténtalo de nuevo."
@@ -8502,6 +8509,12 @@
       "syncError": "No se pudo iniciar la sincronización.",
       "syncSuccess": "Sincronización iniciada.",
       "copyClonePath": "Copiar ruta del espacio de trabajo"
+    },
+    "lifecycle": {
+      "active": "Activo",
+      "archived": "Archivado",
+      "pending_disposal": "Eliminación pendiente",
+      "disposed": "Eliminado"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8463,7 +8463,14 @@
       "loadError": "Failed to load projects.",
       "create": "New Project",
       "createTitle": "Create Project",
-      "createError": "Failed to create project."
+      "createError": "Failed to create project.",
+      "archive": "بایگانی",
+      "restore": "بازیابی",
+      "delete": "حذف",
+      "confirmDelete": "این پروژه بایگانی‌شده و اسپرینت‌های آن حذف شوند؟ این عمل قابل بازگشت نیست.",
+      "archiveError": "بایگانی پروژه ناموفق بود.",
+      "restoreError": "بازیابی پروژه ناموفق بود.",
+      "deleteError": "حذف پروژه ناموفق بود."
     },
     "approvals": {
       "decideError": "Failed to record your decision. Please try again."
@@ -8502,6 +8509,12 @@
       "syncError": "Failed to trigger sync.",
       "syncSuccess": "Sync started.",
       "copyClonePath": "Copy workspace path"
+    },
+    "lifecycle": {
+      "active": "فعال",
+      "archived": "بایگانی‌شده",
+      "pending_disposal": "در انتظار حذف",
+      "disposed": "حذف‌شده"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8463,7 +8463,14 @@
       "loadError": "Échec du chargement des projets.",
       "create": "Nouveau projet",
       "createTitle": "Créer un projet",
-      "createError": "Échec de la création du projet."
+      "createError": "Échec de la création du projet.",
+      "archive": "Archiver",
+      "restore": "Restaurer",
+      "delete": "Supprimer",
+      "confirmDelete": "Supprimer ce projet archivé et ses sprints ? Cette action est irréversible.",
+      "archiveError": "Échec de l'archivage du projet.",
+      "restoreError": "Échec de la restauration du projet.",
+      "deleteError": "Échec de la suppression du projet."
     },
     "approvals": {
       "decideError": "Échec de l'enregistrement de votre décision. Veuillez réessayer."
@@ -8502,6 +8509,12 @@
       "syncError": "Échec du déclenchement de la synchronisation.",
       "syncSuccess": "Synchronisation démarrée.",
       "copyClonePath": "Copier le chemin de l'espace de travail"
+    },
+    "lifecycle": {
+      "active": "Actif",
+      "archived": "Archivé",
+      "pending_disposal": "Suppression en attente",
+      "disposed": "Supprimé"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8463,7 +8463,14 @@
       "loadError": "Failed to load projects.",
       "create": "New Project",
       "createTitle": "Create Project",
-      "createError": "Failed to create project."
+      "createError": "Failed to create project.",
+      "archive": "ארכיון",
+      "restore": "שחזור",
+      "delete": "מחיקה",
+      "confirmDelete": "למחוק את הפרויקט הממוקם בארכיון ואת הספרינטים שלו? לא ניתן לבטל פעולה זו.",
+      "archiveError": "כשל בארכיון הפרויקט.",
+      "restoreError": "כשל בשחזור הפרויקט.",
+      "deleteError": "כשל במחיקת הפרויקט."
     },
     "approvals": {
       "decideError": "Failed to record your decision. Please try again."
@@ -8502,6 +8509,12 @@
       "syncError": "Failed to trigger sync.",
       "syncSuccess": "Sync started.",
       "copyClonePath": "Copy workspace path"
+    },
+    "lifecycle": {
+      "active": "פעיל",
+      "archived": "בארכיון",
+      "pending_disposal": "ממתין למחיקה",
+      "disposed": "נמחק"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8463,7 +8463,14 @@
       "loadError": "Neizdevās ielādēt projektus.",
       "create": "Jauns projekts",
       "createTitle": "Izveidot projektu",
-      "createError": "Neizdevās izveidot projektu."
+      "createError": "Neizdevās izveidot projektu.",
+      "archive": "Arhivēt",
+      "restore": "Atjaunot",
+      "delete": "Dzēst",
+      "confirmDelete": "Dzēst šo arhivēto projektu un tā sprintus? Šo darbību nevar atcelt.",
+      "archiveError": "Neizdevās arhivēt projektu.",
+      "restoreError": "Neizdevās atjaunot projektu.",
+      "deleteError": "Neizdevās dzēst projektu."
     },
     "approvals": {
       "decideError": "Neizdevās saglabāt jūsu lēmumu. Lūdzu, mēģiniet vēlreiz."
@@ -8502,6 +8509,12 @@
       "syncError": "Failed to trigger sync.",
       "syncSuccess": "Sync started.",
       "copyClonePath": "Copy workspace path"
+    },
+    "lifecycle": {
+      "active": "Aktīvs",
+      "archived": "Arhivēts",
+      "pending_disposal": "Gaida dzēšanu",
+      "disposed": "Dzēsts"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8463,7 +8463,14 @@
       "loadError": "Nie udało się załadować projektów.",
       "create": "Nowy projekt",
       "createTitle": "Utwórz projekt",
-      "createError": "Nie udało się utworzyć projektu."
+      "createError": "Nie udało się utworzyć projektu.",
+      "archive": "Archiwizuj",
+      "restore": "Przywróć",
+      "delete": "Usuń",
+      "confirmDelete": "Usunąć ten zarchiwizowany projekt i jego sprinty? Tej operacji nie można cofnąć.",
+      "archiveError": "Nie udało się zarchiwizować projektu.",
+      "restoreError": "Nie udało się przywrócić projektu.",
+      "deleteError": "Nie udało się usunąć projektu."
     },
     "approvals": {
       "decideError": "Nie udało się zapisać Twojej decyzji. Spróbuj ponownie."
@@ -8502,6 +8509,12 @@
       "syncError": "Failed to trigger sync.",
       "syncSuccess": "Sync started.",
       "copyClonePath": "Copy workspace path"
+    },
+    "lifecycle": {
+      "active": "Aktywny",
+      "archived": "Zarchiwizowany",
+      "pending_disposal": "Oczekuje na usunięcie",
+      "disposed": "Usunięty"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8463,7 +8463,14 @@
       "loadError": "Falha ao carregar os projetos.",
       "create": "Novo projeto",
       "createTitle": "Criar projeto",
-      "createError": "Falha ao criar o projeto."
+      "createError": "Falha ao criar o projeto.",
+      "archive": "Arquivar",
+      "restore": "Restaurar",
+      "delete": "Excluir",
+      "confirmDelete": "Excluir este projeto arquivado e seus sprints? Esta ação não pode ser desfeita.",
+      "archiveError": "Falha ao arquivar o projeto.",
+      "restoreError": "Falha ao restaurar o projeto.",
+      "deleteError": "Falha ao excluir o projeto."
     },
     "approvals": {
       "decideError": "Falha ao registrar sua decisão. Tente novamente."
@@ -8502,6 +8509,12 @@
       "syncError": "Falha ao acionar a sincronização.",
       "syncSuccess": "Sincronização iniciada.",
       "copyClonePath": "Copiar caminho do espaço de trabalho"
+    },
+    "lifecycle": {
+      "active": "Ativo",
+      "archived": "Arquivado",
+      "pending_disposal": "Exclusão pendente",
+      "disposed": "Excluído"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8463,7 +8463,14 @@
       "loadError": "Failed to load projects.",
       "create": "New Project",
       "createTitle": "Create Project",
-      "createError": "Failed to create project."
+      "createError": "Failed to create project.",
+      "archive": "آرکائیو",
+      "restore": "بحال",
+      "delete": "حذف",
+      "confirmDelete": "اس آرکائیو شدہ پروجیکٹ اور اس کے اسپرنٹس کو حذف کریں؟ یہ واپس نہیں ہو سکتا۔",
+      "archiveError": "پروجیکٹ آرکائیو کرنے میں ناکامی۔",
+      "restoreError": "پروجیکٹ بحال کرنے میں ناکامی۔",
+      "deleteError": "پروجیکٹ حذف کرنے میں ناکامی۔"
     },
     "approvals": {
       "decideError": "Failed to record your decision. Please try again."
@@ -8502,6 +8509,12 @@
       "syncError": "Failed to trigger sync.",
       "syncSuccess": "Sync started.",
       "copyClonePath": "Copy workspace path"
+    },
+    "lifecycle": {
+      "active": "فعال",
+      "archived": "آرکائیو شدہ",
+      "pending_disposal": "حذف کا انتظار",
+      "disposed": "حذف شدہ"
     }
   },
   "admin": {

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -21272,7 +21272,7 @@ export interface paths {
         post?: never;
         /**
          * Delete Code Source
-         * @description Delete a code source and remove its clone directory if present.
+         * @description Delete a code source and remove its clone directory + index if present.
          */
         delete: operations["delete_code_source_api_analytics_codebase_sources__source_id__delete"];
         options?: never;
@@ -49087,7 +49087,10 @@ export interface paths {
         get: operations["get_project_api_llc_projects__project_id__get"];
         put?: never;
         post?: never;
-        /** Delete Project */
+        /**
+         * Delete Project
+         * @description Delete a project — must be archived first; routes through the disposal workflow (#11129 P2).
+         */
         delete: operations["delete_project_api_llc_projects__project_id__delete"];
         options?: never;
         head?: never;
@@ -49114,6 +49117,66 @@ export interface paths {
          * @description Unlink the repo from a project; the CodeSource record survives (#11129).
          */
         delete: operations["detach_project_repo_api_llc_projects__project_id__repo_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/projects/{project_id}/archive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Archive Project
+         * @description Move a project to the archived lifecycle state (#11129 P2).
+         */
+        post: operations["archive_project_api_llc_projects__project_id__archive_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/projects/{project_id}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Restore Project
+         * @description Restore an archived / pending-disposal project to active (#11129 P2).
+         */
+        post: operations["restore_project_api_llc_projects__project_id__restore_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/projects/{project_id}/dispose": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Dispose Project
+         * @description Dispose an archived project (immediate / scheduled / approval-gated per SLM policy; #11129 P2).
+         */
+        post: operations["dispose_project_api_llc_projects__project_id__dispose_post"];
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -85604,6 +85667,17 @@ export interface components {
             /** Code Source Id */
             code_source_id?: string | null;
             code_source?: components["schemas"]["CodeSourceSummary"] | null;
+            /**
+             * Lifecycle State
+             * @default active
+             */
+            lifecycle_state: string;
+            /** Archived At */
+            archived_at?: string | null;
+            /** Disposal Scheduled At */
+            disposal_scheduled_at?: string | null;
+            /** Disposal Approval Id */
+            disposal_approval_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -100140,7 +100214,7 @@ export interface components {
          * @description Gate type for a board approval request (GH#8214).
          * @enum {string}
          */
-        llc__models__enums__ApprovalType: "hire" | "strategy" | "budget_override" | "sprint_close";
+        llc__models__enums__ApprovalType: "hire" | "strategy" | "budget_override" | "sprint_close" | "project_disposal";
         /**
          * TemplateSearchResponse
          * @description Response for GET /llc/templates/search (GH#8260).
@@ -165708,6 +165782,101 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProjectResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    archive_project_api_llc_projects__project_id__archive_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    restore_project_api_llc_projects__project_id__restore_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    dispose_project_api_llc_projects__project_id__dispose_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */

--- a/autobot-frontend/src/views/llc/ProjectBrowserView.vue
+++ b/autobot-frontend/src/views/llc/ProjectBrowserView.vue
@@ -7,6 +7,7 @@
   the company-scoped Backlog and Timeline views. A header "Create" action opens
   a modal that POSTs a new project and prepends it to the list (#10750 B1).
   GH#11129: repo linkage UI — Attach / Sync / Detach a GitHub repo per project.
+  GH#11129 P2: lifecycle badge + Archive / Delete / Restore affordances.
 -->
 <template>
   <div class="llc-browser">
@@ -41,7 +42,15 @@
       <article v-for="p in projects" :key="p.id" class="entity-card">
         <div class="card-top">
           <h3 class="card-name">{{ p.name }}</h3>
-          <span class="status-badge" :class="`status-${p.status}`">{{ p.status }}</span>
+          <div class="card-badges">
+            <span class="status-badge" :class="`status-${p.status}`">{{ p.status }}</span>
+            <!-- GH#11129 P2: lifecycle state badge -->
+            <span
+              v-if="p.lifecycle_state"
+              class="lifecycle-badge"
+              :class="`lifecycle-${p.lifecycle_state}`"
+            >{{ t(`llcBrowser.lifecycle.${p.lifecycle_state}`) }}</span>
+          </div>
         </div>
         <p v-if="p.description" class="card-desc">{{ p.description }}</p>
         <div class="card-stats">
@@ -114,6 +123,45 @@
           >
             {{ t('llcBrowser.repo.attachBtn') }}
           </BaseButton>
+        </div>
+
+        <!-- GH#11129 P2: lifecycle actions -->
+        <div class="card-lifecycle-actions">
+          <BaseButton
+            v-if="p.lifecycle_state === 'active' || !p.lifecycle_state"
+            variant="secondary"
+            size="sm"
+            :loading="archivingProject === p.id"
+            :disabled="archivingProject === p.id"
+            @click="archiveProject(p)"
+          >
+            {{ t('llcBrowser.projects.archive') }}
+          </BaseButton>
+          <template v-if="p.lifecycle_state === 'archived' || p.lifecycle_state === 'pending_disposal'">
+            <BaseButton
+              variant="secondary"
+              size="sm"
+              :loading="restoringProject === p.id"
+              :disabled="restoringProject === p.id"
+              @click="restoreProject(p)"
+            >
+              {{ t('llcBrowser.projects.restore') }}
+            </BaseButton>
+            <BaseButton
+              variant="secondary"
+              size="sm"
+              :loading="deletingProject === p.id"
+              :disabled="deletingProject === p.id"
+              @click="deleteProject(p)"
+            >
+              {{ t('llcBrowser.projects.delete') }}
+            </BaseButton>
+          </template>
+          <ErrorBanner
+            v-if="lifecycleError[p.id]"
+            :message="lifecycleError[p.id]"
+            class="browser-error"
+          />
         </div>
 
         <div class="card-actions">
@@ -250,6 +298,8 @@ interface ProjectResponse {
   // GH#11129: repo linkage fields (present when backend Task 1-3 is active)
   code_source_id?: string | null
   code_source?: CodeSourceSummary | null
+  // GH#11129 P2: lifecycle state (active | archived | pending_disposal | disposed)
+  lifecycle_state?: string | null
 }
 
 interface VelocityHistory {
@@ -290,6 +340,13 @@ const detachingRepo = ref<string | null>(null)
 const syncingRepo = ref<string | null>(null)
 // per-project error messages (keyed by project id)
 const repoError = ref<Record<string, string>>({})
+
+// GH#11129 P2: lifecycle action state
+const archivingProject = ref<string | null>(null)
+const restoringProject = ref<string | null>(null)
+const deletingProject = ref<string | null>(null)
+// per-project lifecycle error messages (keyed by project id)
+const lifecycleError = ref<Record<string, string>>({})
 
 function velocityFor(projectId: string): number[] {
   return velocities.value[projectId] ?? []
@@ -440,6 +497,51 @@ async function syncRepo(project: ProjectResponse): Promise<void> {
     repoError.value = { ...repoError.value, [project.id]: t('llcBrowser.repo.syncError') }
   } finally {
     syncingRepo.value = null
+  }
+}
+
+// GH#11129 P2: lifecycle actions -------------------------------------------
+
+async function archiveProject(project: ProjectResponse): Promise<void> {
+  archivingProject.value = project.id
+  lifecycleError.value = { ...lifecycleError.value, [project.id]: '' }
+  try {
+    await api.post(`/api/llc/projects/${project.id}/archive`)
+    await loadProjects()
+  } catch (err) {
+    logger.error('Failed to archive project', err)
+    lifecycleError.value = { ...lifecycleError.value, [project.id]: t('llcBrowser.projects.archiveError') }
+  } finally {
+    archivingProject.value = null
+  }
+}
+
+async function restoreProject(project: ProjectResponse): Promise<void> {
+  restoringProject.value = project.id
+  lifecycleError.value = { ...lifecycleError.value, [project.id]: '' }
+  try {
+    await api.post(`/api/llc/projects/${project.id}/restore`)
+    await loadProjects()
+  } catch (err) {
+    logger.error('Failed to restore project', err)
+    lifecycleError.value = { ...lifecycleError.value, [project.id]: t('llcBrowser.projects.restoreError') }
+  } finally {
+    restoringProject.value = null
+  }
+}
+
+async function deleteProject(project: ProjectResponse): Promise<void> {
+  if (!window.confirm(t('llcBrowser.projects.confirmDelete'))) return
+  deletingProject.value = project.id
+  lifecycleError.value = { ...lifecycleError.value, [project.id]: '' }
+  try {
+    await api.post(`/api/llc/projects/${project.id}/dispose`)
+    await loadProjects()
+  } catch (err) {
+    logger.error('Failed to delete project', err)
+    lifecycleError.value = { ...lifecycleError.value, [project.id]: t('llcBrowser.projects.deleteError') }
+  } finally {
+    deletingProject.value = null
   }
 }
 
@@ -716,5 +818,55 @@ onMounted(loadProjects)
 
 .clone-copy-btn:hover {
   color: var(--text-primary);
+}
+
+/* GH#11129 P2: card top badge row */
+.card-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  align-items: center;
+}
+
+/* GH#11129 P2: lifecycle badge */
+.lifecycle-badge {
+  flex: none;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+.lifecycle-active {
+  color: var(--color-success, #16a34a);
+  background: var(--color-success-bg, #dcfce7);
+}
+
+.lifecycle-archived {
+  color: var(--color-warning, #d97706);
+  background: var(--color-warning-bg, #fef3c7);
+}
+
+.lifecycle-pending_disposal {
+  color: var(--color-error, #dc2626);
+  background: var(--color-error-bg, #fee2e2);
+}
+
+.lifecycle-disposed {
+  color: var(--text-secondary);
+  background: var(--bg-hover);
+}
+
+/* GH#11129 P2: lifecycle action buttons row */
+.card-lifecycle-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border-default);
 }
 </style>

--- a/autobot-frontend/src/views/llc/__tests__/ProjectBrowserView.lifecycle.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/ProjectBrowserView.lifecycle.test.ts
@@ -1,0 +1,257 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// GH#11129 P2: archive / delete (dispose) / restore lifecycle affordances on
+// ProjectBrowserView — lifecycle badge, Archive, Delete, Restore actions.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+const get = vi.fn()
+const post = vi.fn()
+const del = vi.fn()
+
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+const mountOpts = { global: { plugins: [i18n], stubs: { LlcBreadcrumb: true } } }
+
+vi.mock('@/plugins/api', () => ({ useApiClient: () => ({ get, post, delete: del }) }))
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { companyId: 'c1', programId: 'pr1' } }),
+  RouterLink: { template: '<a><slot /></a>' },
+}))
+vi.mock('@autobot/ui', () => ({
+  BaseModal: {
+    name: 'BaseModal',
+    props: ['modelValue', 'title', 'size'],
+    template: '<div v-if="modelValue" class="modal-stub"><slot /><slot name="actions" /></div>',
+  },
+}))
+
+import ProjectBrowserView from '../ProjectBrowserView.vue'
+
+const ACTIVE_PROJECT = {
+  id: 'p-active',
+  company_id: 'c1',
+  program_id: 'pr1',
+  goal_id: null,
+  name: 'Active Project',
+  description: null,
+  status: 'active',
+  lifecycle_state: 'active',
+  lead_agent_id: null,
+  lead_user_id: null,
+  target_date: null,
+  auto_rollover: false,
+  created_at: '2026-01-01',
+  updated_at: '2026-01-01',
+  open_work_item_count: 2,
+  active_sprint_name: null,
+  code_source_id: null,
+  code_source: null,
+}
+
+const ARCHIVED_PROJECT = {
+  id: 'p-archived',
+  company_id: 'c1',
+  program_id: 'pr1',
+  goal_id: null,
+  name: 'Archived Project',
+  description: null,
+  status: 'active',
+  lifecycle_state: 'archived',
+  lead_agent_id: null,
+  lead_user_id: null,
+  target_date: null,
+  auto_rollover: false,
+  created_at: '2026-01-01',
+  updated_at: '2026-01-01',
+  open_work_item_count: 0,
+  active_sprint_name: null,
+  code_source_id: null,
+  code_source: null,
+}
+
+const PENDING_DISPOSAL_PROJECT = {
+  ...ARCHIVED_PROJECT,
+  id: 'p-pending',
+  name: 'Pending Disposal Project',
+  lifecycle_state: 'pending_disposal',
+}
+
+describe('ProjectBrowserView lifecycle affordances (GH#11129 P2)', () => {
+  beforeEach(() => {
+    get.mockReset()
+    post.mockReset()
+    del.mockReset()
+    vi.restoreAllMocks()
+  })
+
+  it('shows the lifecycle badge for an active project', async () => {
+    get.mockImplementation((url?: string) => {
+      if (url?.endsWith('/projects')) return Promise.resolve([ACTIVE_PROJECT])
+      if (url?.includes('/velocity')) return Promise.resolve({ sprints: [] })
+      return Promise.resolve([])
+    })
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    // The lifecycle badge should display "Active" (from i18n key llcBrowser.lifecycle.active)
+    expect(wrapper.text()).toContain('Active')
+    const badge = wrapper.find('.lifecycle-badge')
+    expect(badge.exists()).toBe(true)
+  })
+
+  it('shows the lifecycle badge for an archived project', async () => {
+    get.mockImplementation((url?: string) => {
+      if (url?.endsWith('/projects')) return Promise.resolve([ARCHIVED_PROJECT])
+      if (url?.includes('/velocity')) return Promise.resolve({ sprints: [] })
+      return Promise.resolve([])
+    })
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    const badge = wrapper.find('.lifecycle-badge')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toContain('Archived')
+  })
+
+  it('shows Archive button for an active project', async () => {
+    get.mockImplementation((url?: string) => {
+      if (url?.endsWith('/projects')) return Promise.resolve([ACTIVE_PROJECT])
+      if (url?.includes('/velocity')) return Promise.resolve({ sprints: [] })
+      return Promise.resolve([])
+    })
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    const archiveBtn = wrapper.findAll('button').find(b => b.text().includes('Archive'))
+    expect(archiveBtn).toBeDefined()
+    expect(archiveBtn!.exists()).toBe(true)
+  })
+
+  it('clicking Archive calls POST /api/llc/projects/{id}/archive and refreshes', async () => {
+    get.mockImplementation((url?: string) => {
+      if (url?.endsWith('/projects')) return Promise.resolve([ACTIVE_PROJECT])
+      if (url?.includes('/velocity')) return Promise.resolve({ sprints: [] })
+      return Promise.resolve([])
+    })
+    post.mockResolvedValue({ ...ACTIVE_PROJECT, lifecycle_state: 'archived' })
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    const archiveBtn = wrapper.findAll('button').find(b => b.text().includes('Archive'))
+    expect(archiveBtn).toBeDefined()
+    await archiveBtn!.trigger('click')
+    await flushPromises()
+
+    expect(post).toHaveBeenCalledWith('/api/llc/projects/p-active/archive')
+  })
+
+  it('shows Delete and Restore buttons for an archived project', async () => {
+    get.mockImplementation((url?: string) => {
+      if (url?.endsWith('/projects')) return Promise.resolve([ARCHIVED_PROJECT])
+      if (url?.includes('/velocity')) return Promise.resolve({ sprints: [] })
+      return Promise.resolve([])
+    })
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    const buttons = wrapper.findAll('button')
+    const deleteBtn = buttons.find(b => b.text().includes('Delete'))
+    const restoreBtn = buttons.find(b => b.text().includes('Restore'))
+
+    expect(deleteBtn).toBeDefined()
+    expect(deleteBtn!.exists()).toBe(true)
+    expect(restoreBtn).toBeDefined()
+    expect(restoreBtn!.exists()).toBe(true)
+  })
+
+  it('clicking Restore calls POST /api/llc/projects/{id}/restore and refreshes', async () => {
+    get.mockImplementation((url?: string) => {
+      if (url?.endsWith('/projects')) return Promise.resolve([ARCHIVED_PROJECT])
+      if (url?.includes('/velocity')) return Promise.resolve({ sprints: [] })
+      return Promise.resolve([])
+    })
+    post.mockResolvedValue({ ...ARCHIVED_PROJECT, lifecycle_state: 'active' })
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    const restoreBtn = wrapper.findAll('button').find(b => b.text().includes('Restore'))
+    expect(restoreBtn).toBeDefined()
+    await restoreBtn!.trigger('click')
+    await flushPromises()
+
+    expect(post).toHaveBeenCalledWith('/api/llc/projects/p-archived/restore')
+  })
+
+  it('clicking confirmed Delete calls POST /api/llc/projects/{id}/dispose and refreshes', async () => {
+    get.mockImplementation((url?: string) => {
+      if (url?.endsWith('/projects')) return Promise.resolve([ARCHIVED_PROJECT])
+      if (url?.includes('/velocity')) return Promise.resolve({ sprints: [] })
+      return Promise.resolve([])
+    })
+    post.mockResolvedValue({ result: 'disposed' })
+
+    // Confirm dialog should return true
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    const deleteBtn = wrapper.findAll('button').find(b => b.text().includes('Delete'))
+    expect(deleteBtn).toBeDefined()
+    await deleteBtn!.trigger('click')
+    await flushPromises()
+
+    expect(window.confirm).toHaveBeenCalled()
+    expect(post).toHaveBeenCalledWith('/api/llc/projects/p-archived/dispose')
+  })
+
+  it('cancelled Delete does NOT call POST dispose', async () => {
+    get.mockImplementation((url?: string) => {
+      if (url?.endsWith('/projects')) return Promise.resolve([ARCHIVED_PROJECT])
+      if (url?.includes('/velocity')) return Promise.resolve({ sprints: [] })
+      return Promise.resolve([])
+    })
+
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    const deleteBtn = wrapper.findAll('button').find(b => b.text().includes('Delete'))
+    expect(deleteBtn).toBeDefined()
+    await deleteBtn!.trigger('click')
+    await flushPromises()
+
+    expect(window.confirm).toHaveBeenCalled()
+    expect(post).not.toHaveBeenCalled()
+  })
+
+  it('shows Delete and Restore for pending_disposal project', async () => {
+    get.mockImplementation((url?: string) => {
+      if (url?.endsWith('/projects')) return Promise.resolve([PENDING_DISPOSAL_PROJECT])
+      if (url?.includes('/velocity')) return Promise.resolve({ sprints: [] })
+      return Promise.resolve([])
+    })
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    const buttons = wrapper.findAll('button')
+    const deleteBtn = buttons.find(b => b.text().includes('Delete'))
+    const restoreBtn = buttons.find(b => b.text().includes('Restore'))
+    expect(deleteBtn?.exists()).toBe(true)
+    expect(restoreBtn?.exists()).toBe(true)
+  })
+})

--- a/autobot-slm-frontend/package-lock.json
+++ b/autobot-slm-frontend/package-lock.json
@@ -27,15 +27,18 @@
         "@tailwindcss/postcss": "^4.3.2",
         "@types/node": "^26.1.0",
         "@vitejs/plugin-vue": "^6.0.6",
+        "@vue/test-utils": "^2.4.11",
         "@vue/tsconfig": "^0.9.1",
         "eslint": "^10.6.0",
         "eslint-plugin-vue": "^10.9.2",
+        "jsdom": "^26.1.0",
         "postcss": "^8.5.16",
         "storybook": "^10.4.6",
         "tailwindcss": "^4.3.0",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.62.1",
         "vite": "^8.0.13",
+        "vitest": "^4.1.5",
         "vue-tsc": "^3.3.6"
       }
     },
@@ -92,6 +95,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@autobot/terminal": {
       "resolved": "../autobot-plugins/terminal",
@@ -235,6 +259,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -918,6 +1057,24 @@
         "url": "https://github.com/sponsors/kazupon"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -998,6 +1155,13 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
       "version": "0.127.0",
@@ -1704,6 +1868,17 @@
         "win32"
       ]
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
@@ -2000,6 +2175,13 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@storybook/addon-docs": {
@@ -2952,6 +3134,53 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/@vitest/pretty-format": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
@@ -2963,6 +3192,112 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@vitest/spy": {
@@ -3251,6 +3586,27 @@
       "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.11.tgz",
+      "integrity": "sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-dom": "3.x",
+        "@vue/server-renderer": "3.x",
+        "vue": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vue/tsconfig": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.9.1.tgz",
@@ -3297,6 +3653,16 @@
       "workspaces": [
         "addons/*"
       ]
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.17.0",
@@ -3362,7 +3728,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3629,6 +3994,26 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3641,11 +4026,32 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/confbox": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
     },
     "node_modules/constantinople": {
       "version": "4.0.1",
@@ -3657,6 +4063,13 @@
         "@babel/parser": "^7.6.0",
         "@babel/types": "^7.6.1"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/copy-anything": {
       "version": "4.0.5",
@@ -3708,11 +4121,39 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
@@ -3737,6 +4178,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -3856,6 +4304,72 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.21.6",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
@@ -3899,6 +4413,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -4196,6 +4717,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
@@ -4311,6 +4842,23 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
@@ -4387,6 +4935,28 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4398,6 +4968,39 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gopd": {
@@ -4481,6 +5084,43 @@
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -4492,6 +5132,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -4523,6 +5176,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
@@ -4590,6 +5250,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -4621,6 +5291,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-promise": {
       "version": "2.2.2",
@@ -4683,6 +5360,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -4692,6 +5385,35 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-stringify": {
       "version": "1.0.2",
@@ -4707,6 +5429,80 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -5191,6 +5987,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -5263,6 +6069,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -5276,6 +6098,13 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5284,6 +6113,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/open": {
@@ -5424,6 +6267,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -5457,6 +6333,30 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -5607,6 +6507,13 @@
       "dependencies": {
         "asap": "~2.0.3"
       }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
@@ -5926,6 +6833,13 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -5937,6 +6851,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -5988,6 +6922,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6015,6 +6969,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/storybook": {
       "version": "10.4.6",
@@ -6063,6 +7031,103 @@
         }
       }
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -6100,6 +7165,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
@@ -6142,6 +7214,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -6178,12 +7267,58 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/token-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
       "integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -6437,6 +7572,172 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/void-elements": {
@@ -6803,11 +8104,82 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/w3c-xmlserializer/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6823,6 +8195,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/with": {
@@ -6849,6 +8238,107 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ws": {
@@ -6898,6 +8388,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yaml": {
       "version": "2.9.0",

--- a/autobot-slm-frontend/package.json
+++ b/autobot-slm-frontend/package.json
@@ -12,6 +12,8 @@
     "preview": "vite preview",
     "lint": "eslint . --fix",
     "type-check": "vue-tsc --noEmit -p tsconfig.json",
+    "test": "vitest",
+    "test:unit": "vitest run",
     "storybook": "VITE_API_URL=/slm storybook dev -p 6007",
     "build-storybook": "VITE_API_URL=/slm storybook build"
   },
@@ -28,6 +30,9 @@
     "vue-router": "^5.1.0"
   },
   "devDependencies": {
+    "@vue/test-utils": "^2.4.11",
+    "jsdom": "^26.1.0",
+    "vitest": "^4.1.5",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/vue3": "^10.4.6",
     "@storybook/vue3-vite": "^10.4.6",

--- a/autobot-slm-frontend/src/router/index.ts
+++ b/autobot-slm-frontend/src/router/index.ts
@@ -287,6 +287,13 @@ const router = createRouter({
           component: () => import('@/views/settings/admin/SSOSettings.vue'),
           meta: { title: 'SSO / OIDC', parent: 'settings', admin: true }
         },
+        {
+          // Issue #11129 P2: Company OS project disposal policy (SLM operator panel)
+          path: 'disposal-policy',
+          name: 'settings-disposal-policy',
+          component: () => import('@/views/settings/DisposalPolicySettings.vue'),
+          meta: { title: 'Disposal Policy', parent: 'settings' }
+        },
       ]
     },
     {

--- a/autobot-slm-frontend/src/views/SettingsView.vue
+++ b/autobot-slm-frontend/src/views/SettingsView.vue
@@ -33,6 +33,8 @@ const tabs = [
   { id: 'security', name: 'Security', path: '/settings/security', icon: 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z' },
   { id: 'api', name: 'API', path: '/settings/api', icon: 'M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4' },
   { id: 'backend', name: 'Backend', path: '/settings/backend', icon: 'M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2' },
+  // Issue #11129 P2: Company OS project disposal policy operator panel
+  { id: 'disposal-policy', name: 'Disposal Policy', path: '/settings/disposal-policy', icon: 'M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16' },
   // Migrated from main AutoBot frontend - Issue #729
   { id: 'users', name: 'Users', path: '/settings/admin/users', icon: 'M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z' },
   { id: 'cache', name: 'Cache', path: '/settings/admin/cache', icon: 'M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4' },

--- a/autobot-slm-frontend/src/views/settings/DisposalPolicySettings.test.ts
+++ b/autobot-slm-frontend/src/views/settings/DisposalPolicySettings.test.ts
@@ -1,0 +1,39 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import DisposalPolicySettings from './DisposalPolicySettings.vue'
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    getApiUrl: () => '',
+    getAuthHeaders: () => ({}),
+  }),
+}))
+
+describe('DisposalPolicySettings', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ value: JSON.stringify({ retention_days: 14, require_approval: true }) }),
+    })) as unknown as typeof fetch
+  })
+
+  it('loads the current policy on mount', async () => {
+    const wrapper = mount(DisposalPolicySettings)
+    await flushPromises()
+    const number = wrapper.find('input[type="number"]').element as HTMLInputElement
+    expect(number.value).toBe('14')
+  })
+
+  it('PUTs the policy as JSON on save', async () => {
+    const wrapper = mount(DisposalPolicySettings)
+    await flushPromises()
+    await wrapper.find('button[data-test="save-policy"]').trigger('click')
+    await flushPromises()
+    const putCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.find((c) => c[1]?.method === 'PUT')
+    expect(putCall).toBeTruthy()
+    expect(putCall![0]).toContain('/api/settings/llc.project_disposal_policy')
+  })
+})

--- a/autobot-slm-frontend/src/views/settings/DisposalPolicySettings.vue
+++ b/autobot-slm-frontend/src/views/settings/DisposalPolicySettings.vue
@@ -1,0 +1,136 @@
+<!-- Copyright 2025-2026 mrveiss -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * DisposalPolicySettings - SLM operator panel for project disposal policy
+ *
+ * Reads/writes the SLM setting key `llc.project_disposal_policy` (stored as a
+ * JSON string: {retention_days: int, require_approval: bool}) via the SLM
+ * settings API. Mirrors the GeneralSettings.vue auth-store + fetch pattern.
+ * Issue #11129 P2.
+ */
+
+import { onMounted, reactive, ref } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+
+const KEY = 'llc.project_disposal_policy'
+const authStore = useAuthStore()
+const policy = reactive({ retention_days: 0, require_approval: false })
+const saving = ref(false)
+const saved = ref(false)
+const error = ref<string | null>(null)
+
+async function load(): Promise<void> {
+  error.value = null
+  try {
+    const res = await fetch(`${authStore.getApiUrl()}/api/settings/${KEY}`, {
+      headers: authStore.getAuthHeaders(),
+    })
+    if (res.ok) {
+      const setting = await res.json()
+      const parsed = setting.value ? JSON.parse(setting.value) : {}
+      policy.retention_days = Number(parsed.retention_days ?? 0)
+      policy.require_approval = Boolean(parsed.require_approval ?? false)
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to load disposal policy'
+  }
+}
+
+async function save(): Promise<void> {
+  saving.value = true
+  saved.value = false
+  error.value = null
+  const body = JSON.stringify({
+    value: JSON.stringify({ retention_days: policy.retention_days, require_approval: policy.require_approval }),
+    description: 'Company OS project disposal policy',
+  })
+  const url = `${authStore.getApiUrl()}/api/settings/${KEY}`
+  const headers = { ...authStore.getAuthHeaders(), 'Content-Type': 'application/json' }
+  try {
+    let res = await fetch(url, { method: 'PUT', headers, body })
+    if (res.status === 404) {
+      res = await fetch(url, { method: 'POST', headers, body })
+    }
+    saved.value = res.ok
+    if (!res.ok) {
+      error.value = 'Failed to save disposal policy'
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to save disposal policy'
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="p-6">
+    <div class="bg-white rounded-lg shadow-xs border border-gray-200 p-6">
+      <h2 class="text-lg font-semibold text-gray-900 mb-2">Project Disposal Policy</h2>
+      <p class="text-sm text-gray-500 mb-6">
+        Controls how Company OS projects are disposed after archiving. Default: immediate, no approval.
+      </p>
+
+      <div v-if="error" class="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+        {{ error }}
+      </div>
+      <div v-if="saved" class="mb-4 p-4 bg-green-50 border border-green-200 rounded-lg text-green-700 text-sm">
+        Policy saved successfully.
+      </div>
+
+      <div class="space-y-6">
+        <!-- Retention period -->
+        <div class="flex items-center justify-between pb-4 border-b border-gray-100">
+          <div>
+            <label class="block text-sm font-medium text-gray-900">Retention period (days)</label>
+            <p class="text-xs text-gray-500 mt-1">
+              How many days an archived project waits before disposal. Set 0 for immediate.
+            </p>
+          </div>
+          <input
+            v-model.number="policy.retention_days"
+            type="number"
+            min="0"
+            class="w-32 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          />
+        </div>
+
+        <!-- Require approval -->
+        <div class="flex items-center justify-between">
+          <div>
+            <label class="block text-sm font-medium text-gray-900">Require second-pair-of-eyes approval</label>
+            <p class="text-xs text-gray-500 mt-1">
+              When enabled, disposal creates an approval request before the project is deleted.
+            </p>
+          </div>
+          <label class="relative inline-flex items-center cursor-pointer">
+            <input type="checkbox" v-model="policy.require_approval" class="sr-only peer" />
+            <div class="w-11 h-6 bg-gray-200 peer-focus:outline-hidden peer-focus:ring-4 peer-focus:ring-primary-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-600"></div>
+          </label>
+        </div>
+      </div>
+
+      <!-- Save Button -->
+      <div class="mt-8 pt-6 border-t border-gray-200 flex justify-end">
+        <button
+          data-test="save-policy"
+          :disabled="saving"
+          class="px-6 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors flex items-center gap-2 disabled:opacity-50"
+          @click="save"
+        >
+          <svg v-if="saving" class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+          {{ saving ? 'Saving…' : 'Save Policy' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/autobot-slm-frontend/vitest.config.ts
+++ b/autobot-slm-frontend/vitest.config.ts
@@ -1,0 +1,32 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+import { fileURLToPath } from 'node:url'
+import { mergeConfig, defineConfig, configDefaults, type UserConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+
+export default mergeConfig(
+  defineConfig({
+    plugins: [vue()],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+      },
+    },
+  }),
+  defineConfig({
+    test: {
+      environment: 'jsdom',
+      globals: true,
+      include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+      exclude: [...configDefaults.exclude],
+      root: fileURLToPath(new URL('./', import.meta.url)),
+      testTimeout: 10000,
+      clearMocks: true,
+      mockReset: true,
+      restoreMocks: true,
+    },
+  }) as UserConfig,
+)

--- a/docs/superpowers/plans/2026-07-08-companyos-project-repo-phase2.md
+++ b/docs/superpowers/plans/2026-07-08-companyos-project-repo-phase2.md
@@ -1,0 +1,1232 @@
+# Company OS Project Archive→Dispose Lifecycle — Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Company OS (LLC) projects an `active → archived → pending_disposal → disposed` lifecycle (replacing hard-delete), governed by an SLM-configurable disposal policy (retention period + optional second-pair-of-eyes approval; default immediate), where disposal also deletes the linked codebase-analytics `CodeSource` (clone + index) but never the GitHub repo.
+
+**Architecture:** A new nullable `lifecycle_state` column on `LLCProject` (orthogonal to the existing work-status `status` enum). Archive/restore/dispose endpoints on the projects router. A `project_disposal` service performs the cascade delete (work-items → sprints → project → linked non-shared `CodeSource`). A `disposal_policy` reader fetches `{retention_days, require_approval}` from the SLM settings store over HTTP with safe defaults. A Celery-beat sweep disposes due, approved `pending_disposal` projects. A small SLM-frontend panel edits the policy; Company OS frontend gains archive/delete/restore affordances.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0 (async, Postgres), Alembic, Celery (beat), Pydantic v2, Vue 3 + TS (autobot-frontend + autobot-slm-frontend), pytest, vitest.
+
+## Global Constraints
+
+- **Branch target:** `Dev_new_gui`. Worktree `.worktrees/issue-11129-p2`, branch `issue-11129-p2`.
+- **Commit format:** `<type>(scope): <description> (#11129)`. **NO commit trailers** (no Co-Authored-By / Generated-with) — mrveiss is sole author.
+- **Copyright header** on every new file: `# Copyright 2025-2026 mrveiss` + `# SPDX-License-Identifier: Apache-2.0`.
+- **≤30-line functions**; no `_v2`/`_fix`/`Enhanced`/`Unified` suffix names.
+- **Async-first** — never add sync calls to async paths; lazy-import heavy `codebase_analytics` modules inside functions (avoids circular + heavy `__init__`, per Phase 1).
+- **Route prefix gotcha:** the LLC router is mounted at `/api/llc`; routes in `sprints.py` use bare paths (e.g. `/projects/{id}/archive` → served at `/api/llc/projects/{id}/archive`). Do NOT add an `/api` prefix inside the router.
+- **NEVER delete the GitHub repo** on disposal — only local AutoBot data + the linked `CodeSource` clone/index (and only when that source is not `shared_with` others; else unlink).
+- **Logging:** `logging.getLogger(__name__)` / `createLogger('Name')` — no `print()`/`console.*`.
+- **Encoding:** always `encoding='utf-8'` explicitly in Python file I/O.
+- **Frontend user-facing strings (autobot-frontend / Company OS):** i18n keys added to ALL 11 locale files — no hardcoded UI strings. SLM-frontend panel: follow the SLM console's existing string convention (operator console; match `GeneralSettings.vue`).
+- **Disposal policy defaults when unset/unreadable:** `{retention_days: 0, require_approval: false}` (immediate, no approval, no retention).
+
+---
+
+## File Structure
+
+**Backend — new:**
+- `autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py` — lifecycle columns + `PROJECT_DISPOSAL` enum value.
+- `autobot-backend/llc/services/project_disposal.py` — `dispose(project, session)` cascade.
+- `autobot-backend/llc/services/disposal_policy.py` — `get_disposal_policy()` (SLM read + defaults) + `DisposalPolicy` dataclass.
+- `autobot-backend/llc/scheduler/project_disposal_sweep.py` — Celery-beat sweep task.
+
+**Backend — modified:**
+- `autobot-backend/llc/models/sprint.py` — `LLCProject`: add `lifecycle_state`, `archived_at`, `disposal_scheduled_at`, `disposal_approval_id`.
+- `autobot-backend/llc/models/enums.py` — `ApprovalType.PROJECT_DISPOSAL`.
+- `autobot-backend/api/codebase_analytics/source_service.py` — extract `delete_source_and_cleanup(source_id)`.
+- `autobot-backend/api/codebase_analytics/endpoints/sources.py` — repoint DELETE handler to the service.
+- `autobot-backend/llc/api/sprints.py` — `ProjectResponse` lifecycle fields; `POST …/archive`, `POST …/restore`, `POST …/dispose`; reroute `DELETE /projects/{id}` through disposal.
+- `autobot-backend/celery_app.py` — register the sweep task in `beat_schedule` + explicit import.
+
+**Frontend — modified/new:**
+- `autobot-slm-frontend/src/views/settings/DisposalPolicySettings.vue` (new) + its route/nav entry.
+- `autobot-frontend/src/views/llc/ProjectBrowserView.vue` — archive/delete/restore actions + lifecycle badge.
+- 11 locale files under `autobot-frontend/src/locales/` — new i18n keys.
+
+---
+
+## Task 1: Model + migration (lifecycle columns + PROJECT_DISPOSAL enum)
+
+**Files:**
+- Modify: `autobot-backend/llc/models/sprint.py` (`LLCProject`, after `code_source_id` at line 137)
+- Modify: `autobot-backend/llc/models/enums.py` (`ApprovalType`, after `SPRINT_CLOSE`)
+- Create: `autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py`
+- Test: `autobot-backend/llc/tests/test_project_lifecycle_model.py`
+
+**Interfaces:**
+- Produces: `LLCProject.lifecycle_state: Optional[str]` (values `active|archived|pending_disposal|disposed`, default `active`), `LLCProject.archived_at: Optional[datetime]`, `LLCProject.disposal_scheduled_at: Optional[datetime]`, `LLCProject.disposal_approval_id: Optional[uuid.UUID]`; `ApprovalType.PROJECT_DISPOSAL = "project_disposal"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# autobot-backend/llc/tests/test_project_lifecycle_model.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Model contract for the project archive→dispose lifecycle (#11129 P2)."""
+from llc.models.enums import ApprovalType
+from llc.models.sprint import LLCProject
+
+
+def test_project_has_lifecycle_columns():
+    cols = LLCProject.__table__.columns
+    assert "lifecycle_state" in cols
+    assert "archived_at" in cols
+    assert "disposal_scheduled_at" in cols
+    assert "disposal_approval_id" in cols
+    assert cols["lifecycle_state"].default.arg == "active"
+
+
+def test_approval_type_has_project_disposal():
+    assert ApprovalType.PROJECT_DISPOSAL.value == "project_disposal"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-backend && python -m pytest llc/tests/test_project_lifecycle_model.py -v`
+Expected: FAIL (no `lifecycle_state`; no `PROJECT_DISPOSAL`).
+
+- [ ] **Step 3: Add the enum value**
+
+In `llc/models/enums.py`, `ApprovalType` (currently `HIRE`/`STRATEGY`/`BUDGET_OVERRIDE`/`SPRINT_CLOSE`), append:
+
+```python
+    PROJECT_DISPOSAL = "project_disposal"
+```
+
+- [ ] **Step 4: Add the columns**
+
+In `llc/models/sprint.py`, `LLCProject`, immediately after the `code_source_id` column (line 137), add:
+
+```python
+    # Archive→dispose lifecycle, orthogonal to work-status `status` (#11129 P2).
+    lifecycle_state: Mapped[str] = mapped_column(
+        sa.Enum(
+            "active",
+            "archived",
+            "pending_disposal",
+            "disposed",
+            name="projectlifecyclestate",
+            create_type=True,
+        ),
+        nullable=False,
+        server_default="active",
+        default="active",
+        index=True,
+    )
+    archived_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    disposal_scheduled_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    disposal_approval_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True)
+```
+
+- [ ] **Step 5: Write the migration**
+
+```python
+# autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Add project archive→dispose lifecycle columns + PROJECT_DISPOSAL approval type (#11129 P2)."""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260708_067"
+down_revision: Union[str, None] = "20260707_066"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_LIFECYCLE = sa.Enum(
+    "active", "archived", "pending_disposal", "disposed", name="projectlifecyclestate"
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    _LIFECYCLE.create(bind, checkfirst=True)
+    op.add_column(
+        "llc_projects",
+        sa.Column("lifecycle_state", _LIFECYCLE, nullable=False, server_default="active"),
+    )
+    op.create_index("ix_llc_projects_lifecycle_state", "llc_projects", ["lifecycle_state"])
+    op.add_column("llc_projects", sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "llc_projects", sa.Column("disposal_scheduled_at", sa.DateTime(timezone=True), nullable=True)
+    )
+    op.add_column(
+        "llc_projects",
+        sa.Column("disposal_approval_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    # ALTER TYPE ... ADD VALUE cannot run inside a transaction block.
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE approvaltype ADD VALUE IF NOT EXISTS 'project_disposal'")
+
+
+def downgrade() -> None:
+    op.drop_index("ix_llc_projects_lifecycle_state", table_name="llc_projects")
+    op.drop_column("llc_projects", "disposal_approval_id")
+    op.drop_column("llc_projects", "disposal_scheduled_at")
+    op.drop_column("llc_projects", "archived_at")
+    op.drop_column("llc_projects", "lifecycle_state")
+    _LIFECYCLE.drop(op.get_bind(), checkfirst=True)
+    # Note: Postgres cannot drop an enum value; 'project_disposal' remains on approvaltype (harmless).
+```
+
+- [ ] **Step 6: Run the model test to verify it passes**
+
+Run: `cd autobot-backend && python -m pytest llc/tests/test_project_lifecycle_model.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Verify migration chains cleanly (offline)**
+
+Run: `cd autobot-backend && python -c "from alembic.config import Config; from alembic.script import ScriptDirectory; s=ScriptDirectory.from_config(Config('alembic.ini')); print(s.get_revision('head').revision)"`
+Expected: prints `20260708_067` (single head, no branch).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add autobot-backend/llc/models/sprint.py autobot-backend/llc/models/enums.py \
+        autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py \
+        autobot-backend/llc/tests/test_project_lifecycle_model.py
+git commit -m "feat(companyos): project lifecycle_state columns + PROJECT_DISPOSAL approval type (#11129)"
+```
+
+---
+
+## Task 2: Extract `delete_source_and_cleanup` service
+
+**Files:**
+- Modify: `autobot-backend/api/codebase_analytics/source_service.py` (add function)
+- Modify: `autobot-backend/api/codebase_analytics/endpoints/sources.py` (`delete_code_source` handler → call service)
+- Test: `autobot-backend/api/codebase_analytics/source_delete_service_test.py`
+
+**Interfaces:**
+- Produces: `async def delete_source_and_cleanup(source_id: str) -> bool` — removes clone dir (only under `CODE_SOURCES_BASE`), purges ChromaDB docs for the source, deletes the Redis record; returns the Redis-delete bool. Returns `False` if the source is missing (idempotent).
+- Consumes: `get_source`, `delete_source` (source_storage), `CODE_SOURCES_BASE` (source_paths), ChromaDB `_delete_source_documents`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# autobot-backend/api/codebase_analytics/source_delete_service_test.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""delete_source_and_cleanup removes clone dir + index + record (#11129 P2)."""
+import ast
+from pathlib import Path
+
+_SVC = Path(__file__).parent / "source_service.py"
+_SOURCES = Path(__file__).parent / "endpoints" / "sources.py"
+
+
+def test_service_exposes_delete_and_cleanup():
+    tree = ast.parse(_SVC.read_text(encoding="utf-8"))
+    names = {n.name for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef)}
+    assert "delete_source_and_cleanup" in names
+
+
+def test_delete_handler_delegates_to_service():
+    src = _SOURCES.read_text(encoding="utf-8")
+    assert "delete_source_and_cleanup" in src, "DELETE handler must call the extracted service"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-backend && python -m pytest api/codebase_analytics/source_delete_service_test.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the service function**
+
+In `api/codebase_analytics/source_service.py`, add (mirror the current `endpoints/sources.py::delete_code_source` body — clone removal guarded by `CODE_SOURCES_BASE`, ChromaDB purge, Redis delete):
+
+```python
+async def delete_source_and_cleanup(source_id: str) -> bool:
+    """Delete a CodeSource: its clone dir (only under CODE_SOURCES_BASE), its
+    ChromaDB documents, and its Redis record. Idempotent; returns Redis-delete result."""
+    import shutil  # noqa: PLC0415
+    from pathlib import Path  # noqa: PLC0415
+
+    from .source_paths import CODE_SOURCES_BASE  # noqa: PLC0415
+    from .source_storage import delete_source, get_source  # noqa: PLC0415
+
+    source = await get_source(source_id)
+    if source is None:
+        return False
+    if source.clone_path and Path(source.clone_path).exists():
+        clone = Path(source.clone_path).resolve()
+        if clone.is_relative_to(CODE_SOURCES_BASE):
+            shutil.rmtree(source.clone_path, ignore_errors=True)
+    await _purge_source_index(source_id)
+    ok = await delete_source(source_id)
+    logger.info("Deleted code source %s (clone+index+record)", source_id)
+    return ok
+
+
+async def _purge_source_index(source_id: str) -> None:
+    """Best-effort ChromaDB document removal for a source; never raises."""
+    try:
+        from .chromadb_storage import get_code_collection, _delete_source_documents  # noqa: PLC0415
+
+        collection = await get_code_collection()
+        if collection is not None:
+            await _delete_source_documents(collection, task_id="dispose", source_id=source_id)
+    except Exception as exc:  # noqa: BLE001 — index cleanup is best-effort
+        logger.warning("ChromaDB purge for source %s failed: %s", source_id, exc)
+```
+
+> Implementer note: verify the exact accessor for the code collection in `chromadb_storage.py` (e.g. `get_code_collection`); if the name differs, use the real one and keep the try/except best-effort. Ensure `logger` exists in `source_service.py` (add `logger = logging.getLogger(__name__)` if missing).
+
+- [ ] **Step 4: Repoint the HTTP handler**
+
+In `endpoints/sources.py`, replace the body of `delete_code_source` so it delegates:
+
+```python
+@router.delete("/sources/{source_id}")
+@with_error_handling(category=ErrorCategory.SERVER_ERROR, operation="delete_source", error_code_prefix="CODEBASE")
+async def delete_code_source(source_id: str):
+    """Delete a code source and remove its clone directory + index if present."""
+    from ..source_service import delete_source_and_cleanup  # noqa: PLC0415
+
+    source = await get_source(source_id)
+    if source is None:
+        raise HTTPException(status_code=404, detail=f"Source {source_id} not found")
+    ok = await delete_source_and_cleanup(source_id)
+    return JSONResponse({"success": ok, "source_id": source_id})
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd autobot-backend && python -m pytest api/codebase_analytics/source_delete_service_test.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add autobot-backend/api/codebase_analytics/source_service.py \
+        autobot-backend/api/codebase_analytics/endpoints/sources.py \
+        autobot-backend/api/codebase_analytics/source_delete_service_test.py
+git commit -m "refactor(analytics): extract delete_source_and_cleanup service for reuse (#11129)"
+```
+
+---
+
+## Task 3: Project disposal service
+
+**Files:**
+- Create: `autobot-backend/llc/services/project_disposal.py`
+- Test: `autobot-backend/llc/tests/test_project_disposal_service.py`
+
+**Interfaces:**
+- Consumes: `LLCProject`, `LLCSprint`, `LLCWorkItem`; `delete_source_and_cleanup` (Task 2); `get_source`.
+- Produces: `async def dispose(project: LLCProject, session: AsyncSession) -> None` — deletes work-items (by `project_id`) → sprints (by `project_id`) → project; then, if `project.code_source_id` set and the source is **not** `shared_with` others, calls `delete_source_and_cleanup`; else leaves the source (unlink). Sets `lifecycle_state='disposed'` is N/A (row deleted). Idempotent (missing project/source is a no-op). Never touches GitHub.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# autobot-backend/llc/tests/test_project_disposal_service.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Disposal cascade: work-items→sprints→project→linked non-shared source (#11129 P2)."""
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.services.project_disposal import dispose
+
+
+def _project(code_source_id=None):
+    return SimpleNamespace(id=uuid.uuid4(), company_id=uuid.uuid4(), code_source_id=code_source_id)
+
+
+@pytest.mark.asyncio
+async def test_dispose_deletes_children_then_project_and_source():
+    project = _project(code_source_id="src-1")
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    shared_source = SimpleNamespace(id="src-1", shared_with=[])
+    with patch("llc.services.project_disposal.get_source", AsyncMock(return_value=shared_source)), patch(
+        "llc.services.project_disposal.delete_source_and_cleanup", AsyncMock(return_value=True)
+    ) as del_src:
+        await dispose(project, session)
+    del_src.assert_awaited_once_with("src-1")
+    # work-items + sprints deleted via bulk delete statements, then project.
+    assert session.execute.await_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_dispose_keeps_shared_source():
+    project = _project(code_source_id="src-2")
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    shared = SimpleNamespace(id="src-2", shared_with=["someone-else"])
+    with patch("llc.services.project_disposal.get_source", AsyncMock(return_value=shared)), patch(
+        "llc.services.project_disposal.delete_source_and_cleanup", AsyncMock()
+    ) as del_src:
+        await dispose(project, session)
+    del_src.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispose_no_source_is_noop_on_source():
+    project = _project(code_source_id=None)
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    with patch("llc.services.project_disposal.delete_source_and_cleanup", AsyncMock()) as del_src:
+        await dispose(project, session)
+    del_src.assert_not_awaited()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-backend && python -m pytest llc/tests/test_project_disposal_service.py -v`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement the service**
+
+```python
+# autobot-backend/llc/services/project_disposal.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Project disposal: cascade-delete AutoBot data + linked non-shared CodeSource (#11129 P2).
+
+NEVER deletes the GitHub repo. A source shared with other users is unlinked, not deleted.
+"""
+import logging
+
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from llc.models.sprint import LLCProject, LLCSprint
+from llc.models.work_item import LLCWorkItem
+
+logger = logging.getLogger(__name__)
+
+
+async def dispose(project: LLCProject, session: AsyncSession) -> None:
+    """Delete the project's work-items, sprints, the project row, and — when the
+    linked CodeSource is not shared with other users — that source's clone + index.
+    Idempotent; caller owns the surrounding transaction/commit."""
+    project_id = project.id
+    code_source_id = project.code_source_id
+
+    await session.execute(delete(LLCWorkItem).where(LLCWorkItem.project_id == project_id))
+    await session.execute(delete(LLCSprint).where(LLCSprint.project_id == project_id))
+    await session.execute(delete(LLCProject).where(LLCProject.id == project_id))
+
+    if code_source_id:
+        await _dispose_source(code_source_id)
+    logger.info("Disposed project %s (source=%s)", project_id, code_source_id)
+
+
+async def _dispose_source(code_source_id: str) -> None:
+    """Delete the linked source's clone+index only when it is not shared with others."""
+    from api.codebase_analytics.source_service import delete_source_and_cleanup  # noqa: PLC0415
+    from api.codebase_analytics.source_storage import get_source  # noqa: PLC0415
+
+    source = await get_source(code_source_id)
+    if source is None:
+        return
+    if getattr(source, "shared_with", None):
+        logger.info("Source %s is shared; unlinking only (not deleting)", code_source_id)
+        return
+    await delete_source_and_cleanup(code_source_id)
+```
+
+> The test patches `get_source` and `delete_source_and_cleanup` as attributes of `project_disposal`. Because they are lazy-imported inside `_dispose_source`, add module-level re-exports so the patch targets resolve: at import time the names must exist on the module. Implementer: add near the top, after the logger, guarded re-exports OR change the test patch target — prefer making the lazy imports patchable by importing them at module top only if that does not reintroduce the heavy-import/circular problem. If top-level import is unsafe, instead patch `api.codebase_analytics.source_service.delete_source_and_cleanup` and `api.codebase_analytics.source_storage.get_source` in the test. **Adjust the test's patch targets to whichever import strategy you choose so the three tests pass.**
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd autobot-backend && python -m pytest llc/tests/test_project_disposal_service.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add autobot-backend/llc/services/project_disposal.py \
+        autobot-backend/llc/tests/test_project_disposal_service.py
+git commit -m "feat(companyos): project disposal cascade service (#11129)"
+```
+
+---
+
+## Task 4: Disposal-policy reader (SLM settings)
+
+**Files:**
+- Create: `autobot-backend/llc/services/disposal_policy.py`
+- Test: `autobot-backend/llc/tests/test_disposal_policy.py`
+
+**Interfaces:**
+- Produces: `@dataclass(frozen=True) class DisposalPolicy: retention_days: int = 0; require_approval: bool = False`; `async def get_disposal_policy() -> DisposalPolicy` — reads SLM setting key `llc.project_disposal_policy` (JSON) via the `SLMClient`; returns defaults on missing/unreadable/malformed.
+- Constant: `POLICY_SETTING_KEY = "llc.project_disposal_policy"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# autobot-backend/llc/tests/test_disposal_policy.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""SLM-configurable disposal policy read + safe defaults (#11129 P2)."""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from llc.services.disposal_policy import DisposalPolicy, get_disposal_policy
+
+
+@pytest.mark.asyncio
+async def test_defaults_when_no_slm_client():
+    with patch("llc.services.disposal_policy.get_slm_client", return_value=None):
+        policy = await get_disposal_policy()
+    assert policy == DisposalPolicy(retention_days=0, require_approval=False)
+
+
+@pytest.mark.asyncio
+async def test_parses_policy_from_slm():
+    with patch(
+        "llc.services.disposal_policy._fetch_policy_json",
+        AsyncMock(return_value={"retention_days": 30, "require_approval": True}),
+    ):
+        policy = await get_disposal_policy()
+    assert policy.retention_days == 30
+    assert policy.require_approval is True
+
+
+@pytest.mark.asyncio
+async def test_defaults_on_malformed():
+    with patch("llc.services.disposal_policy._fetch_policy_json", AsyncMock(return_value={"bad": "x"})):
+        policy = await get_disposal_policy()
+    assert policy == DisposalPolicy(retention_days=0, require_approval=False)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-backend && python -m pytest llc/tests/test_disposal_policy.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the reader**
+
+```python
+# autobot-backend/llc/services/disposal_policy.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Read the SLM-configured project disposal policy with safe defaults (#11129 P2)."""
+import json
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from services.slm_client import get_slm_client
+
+logger = logging.getLogger(__name__)
+
+POLICY_SETTING_KEY = "llc.project_disposal_policy"
+
+
+@dataclass(frozen=True)
+class DisposalPolicy:
+    retention_days: int = 0
+    require_approval: bool = False
+
+
+async def _fetch_policy_json() -> Optional[dict]:
+    """GET the policy setting from the SLM settings API; None on any failure."""
+    client = get_slm_client()
+    if client is None:
+        return None
+    try:
+        session = await client._get_session()
+        url = f"{client.slm_url}/api/settings/{POLICY_SETTING_KEY}"
+        async with session.get(url) as response:
+            if response.status != 200:
+                return None
+            setting = await response.json()
+            raw = setting.get("value")
+            return json.loads(raw) if raw else None
+    except Exception as exc:  # noqa: BLE001 — policy read is best-effort
+        logger.warning("Disposal policy read failed: %s", exc)
+        return None
+
+
+async def get_disposal_policy() -> DisposalPolicy:
+    """Return the configured policy, or safe defaults (immediate/no-approval)."""
+    data = await _fetch_policy_json()
+    if not isinstance(data, dict):
+        return DisposalPolicy()
+    try:
+        return DisposalPolicy(
+            retention_days=max(0, int(data["retention_days"])),
+            require_approval=bool(data["require_approval"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return DisposalPolicy()
+```
+
+> Implementer: confirm `services.slm_client.get_slm_client` and the `client.slm_url` / `client._get_session()` accessors exist (they do per exploration). If the SLM client exposes a public GET helper, prefer it over `_get_session()`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd autobot-backend && python -m pytest llc/tests/test_disposal_policy.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add autobot-backend/llc/services/disposal_policy.py \
+        autobot-backend/llc/tests/test_disposal_policy.py
+git commit -m "feat(companyos): SLM disposal-policy reader with safe defaults (#11129)"
+```
+
+---
+
+## Task 5: Lifecycle endpoints (archive / restore / dispose / DELETE reroute)
+
+**Files:**
+- Modify: `autobot-backend/llc/api/sprints.py` (`ProjectResponse`; new endpoints; `delete_project`)
+- Test: `autobot-backend/llc/tests/test_project_lifecycle_api.py`
+
+**Interfaces:**
+- Consumes: `dispose` (Task 3), `get_disposal_policy`/`DisposalPolicy` (Task 4), `ApprovalService.request_approval` + `ApprovalType.PROJECT_DISPOSAL` (Task 1), `get_session`/`get_current_user`/`require_org_context`.
+- Produces routes (served under `/api/llc`): `POST /projects/{id}/archive`, `POST /projects/{id}/restore`, `POST /projects/{id}/dispose`, and a rerouted `DELETE /projects/{id}`. `ProjectResponse` gains `lifecycle_state`, `archived_at`, `disposal_scheduled_at`, `disposal_approval_id`.
+
+- [ ] **Step 1: Add lifecycle fields to `ProjectResponse`**
+
+In `sprints.py`, `ProjectResponse` (after `code_source`), add:
+
+```python
+    lifecycle_state: str = "active"
+    archived_at: Optional[datetime] = None
+    disposal_scheduled_at: Optional[datetime] = None
+    disposal_approval_id: Optional[uuid.UUID] = None
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+```python
+# autobot-backend/llc/tests/test_project_lifecycle_api.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Archive→dispose lifecycle endpoints (#11129 P2)."""
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+_USER = uuid.UUID("77777777-7777-7777-7777-777777777777")
+
+
+def _mk_client(project):
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.sprints import router  # noqa: PLC0415
+    from llc.deps import get_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(router)
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = project
+    session.execute = AsyncMock(return_value=result)
+    session.commit = AsyncMock()
+
+    async def _sess():
+        yield session
+
+    app.dependency_overrides[get_session] = _sess
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_USER)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=project.company_id, user_id=_USER, is_platform_admin=False
+    )
+    return TestClient(app), session
+
+
+def _project(lifecycle="active"):
+    org = uuid.uuid4()
+    p = MagicMock()
+    p.id = uuid.uuid4()
+    p.company_id = org
+    p.lifecycle_state = lifecycle
+    p.code_source_id = None
+    return p
+
+
+def test_archive_sets_state():
+    p = _project("active")
+    client, _ = _mk_client(p)
+    resp = client.post(f"/projects/{p.id}/archive")
+    assert resp.status_code == 200
+    assert p.lifecycle_state == "archived"
+
+
+def test_dispose_requires_archived():
+    p = _project("active")
+    client, _ = _mk_client(p)
+    resp = client.post(f"/projects/{p.id}/dispose")
+    assert resp.status_code == 409
+
+
+def test_delete_requires_archived():
+    p = _project("active")
+    client, _ = _mk_client(p)
+    resp = client.request("DELETE", f"/projects/{p.id}")
+    assert resp.status_code == 409
+
+
+def test_dispose_immediate_when_policy_default():
+    p = _project("archived")
+    client, _ = _mk_client(p)
+    with patch("llc.api.sprints.get_disposal_policy", AsyncMock(return_value=_policy(0, False))), patch(
+        "llc.api.sprints.dispose", AsyncMock()
+    ) as disp:
+        resp = client.post(f"/projects/{p.id}/dispose")
+    assert resp.status_code == 200
+    disp.assert_awaited_once()
+    assert resp.json()["result"] == "disposed"
+
+
+def test_dispose_schedules_when_retention():
+    p = _project("archived")
+    client, _ = _mk_client(p)
+    with patch("llc.api.sprints.get_disposal_policy", AsyncMock(return_value=_policy(7, False))), patch(
+        "llc.api.sprints.dispose", AsyncMock()
+    ) as disp:
+        resp = client.post(f"/projects/{p.id}/dispose")
+    assert resp.status_code == 200
+    disp.assert_not_awaited()
+    assert resp.json()["result"] == "scheduled"
+    assert p.lifecycle_state == "pending_disposal"
+
+
+def _policy(days, approval):
+    from llc.services.disposal_policy import DisposalPolicy  # noqa: PLC0415
+
+    return DisposalPolicy(retention_days=days, require_approval=approval)
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd autobot-backend && python -m pytest llc/tests/test_project_lifecycle_api.py -v`
+Expected: FAIL (routes 404 / missing patch targets).
+
+- [ ] **Step 4: Implement the endpoints**
+
+Add to `sprints.py` (near the other `/projects` handlers). Import at module top (or lazy where heavy): `from datetime import datetime, timezone`, `from llc.services.project_disposal import dispose`, `from llc.services.disposal_policy import get_disposal_policy`, `from llc.services.approval import ApprovalService`, `from llc.models.enums import ApprovalType`.
+
+```python
+async def _load_owned_project(project_id, session, ctx):
+    result = await session.execute(select(LLCProject).where(LLCProject.id == project_id))
+    project = result.scalar_one_or_none()
+    if project is None or str(project.company_id) != str(ctx.org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+    return project
+
+
+@router.post("/projects/{project_id}/archive", response_model=ProjectResponse)
+async def archive_project(
+    project_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> ProjectResponse:
+    project = await _load_owned_project(project_id, session, ctx)
+    project.lifecycle_state = "archived"
+    project.archived_at = datetime.now(timezone.utc)
+    await session.commit()
+    return ProjectResponse.model_validate(project)
+
+
+@router.post("/projects/{project_id}/restore", response_model=ProjectResponse)
+async def restore_project(
+    project_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> ProjectResponse:
+    project = await _load_owned_project(project_id, session, ctx)
+    if project.lifecycle_state not in ("archived", "pending_disposal"):
+        raise HTTPException(status_code=409, detail="Project is not archived")
+    project.lifecycle_state = "active"
+    project.archived_at = None
+    project.disposal_scheduled_at = None
+    project.disposal_approval_id = None
+    await session.commit()
+    return ProjectResponse.model_validate(project)
+
+
+@router.post("/projects/{project_id}/dispose")
+async def dispose_project(
+    project_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> dict:
+    project = await _load_owned_project(project_id, session, ctx)
+    if project.lifecycle_state != "archived":
+        raise HTTPException(status_code=409, detail="Project must be archived before disposal")
+    return await _apply_disposal(project, session, ctx, current_user)
+
+
+async def _apply_disposal(project, session, ctx, current_user) -> dict:
+    """Consult SLM policy and dispose now / schedule / gate on approval."""
+    policy = await get_disposal_policy()
+    if policy.require_approval:
+        approval = await ApprovalService().request_approval(
+            session,
+            company_id=ctx.org_id,
+            gate_type=ApprovalType.PROJECT_DISPOSAL,
+            payload={"project_id": str(project.id)},
+            requested_by=uuid.UUID(str(current_user["id"])),
+        )
+        project.lifecycle_state = "pending_disposal"
+        project.disposal_approval_id = approval.id
+        if policy.retention_days > 0:
+            project.disposal_scheduled_at = datetime.now(timezone.utc) + timedelta(days=policy.retention_days)
+        await session.commit()
+        return {"result": "pending_approval", "approval_id": str(approval.id)}
+    if policy.retention_days > 0:
+        project.lifecycle_state = "pending_disposal"
+        project.disposal_scheduled_at = datetime.now(timezone.utc) + timedelta(days=policy.retention_days)
+        await session.commit()
+        return {"result": "scheduled", "disposal_scheduled_at": project.disposal_scheduled_at.isoformat()}
+    await dispose(project, session)
+    await session.commit()
+    return {"result": "disposed"}
+```
+
+Add `from datetime import timedelta` to the imports. Then **replace** `delete_project` so it reroutes:
+
+```python
+@router.delete("/projects/{project_id}", status_code=204)
+async def delete_project(
+    project_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> None:
+    project = await _load_owned_project(project_id, session, ctx)
+    if project.lifecycle_state != "archived":
+        raise HTTPException(status_code=409, detail="Archive the project before deleting")
+    await _apply_disposal(project, session, ctx, current_user)
+```
+
+> Note: `DELETE` now returns 204 with no body on success; when policy schedules/gates, the row still exists (that is intended — delete "requests" disposal per the configured workflow). The 409-before-archived guard is the two-step gate.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd autobot-backend && python -m pytest llc/tests/test_project_lifecycle_api.py -v`
+Expected: PASS (6 tests). Then run the Phase-1 enrichment test to confirm no regression: `python -m pytest llc/tests/test_sprints_enrichment.py -v` (pin `lifecycle_state`/`archived_at`/`disposal_*` on the `_project()` mock if `model_validate` now reads them — set `m.lifecycle_state="active"`, the three others `= None`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add autobot-backend/llc/api/sprints.py autobot-backend/llc/tests/test_project_lifecycle_api.py \
+        autobot-backend/llc/tests/test_sprints_enrichment.py
+git commit -m "feat(companyos): archive/restore/dispose endpoints + DELETE reroute (#11129)"
+```
+
+---
+
+## Task 6: Celery-beat disposal sweep
+
+**Files:**
+- Create: `autobot-backend/llc/scheduler/project_disposal_sweep.py`
+- Modify: `autobot-backend/celery_app.py` (beat schedule + import)
+- Test: `autobot-backend/llc/tests/test_project_disposal_sweep.py`
+
+**Interfaces:**
+- Consumes: `dispose` (Task 3); `LLCProject`; `LLCApproval` + `ApprovalStatus` (to confirm granted approvals); `get_async_session_factory`.
+- Produces: `@shared_task(name="llc.scheduler.project_disposal_sweep.run_disposal_sweep")` sync entry + `async def _async_sweep() -> int` (returns disposed count). Selects `lifecycle_state == "pending_disposal"` AND `disposal_scheduled_at <= now` AND (`disposal_approval_id IS NULL` OR its `LLCApproval.status == APPROVED`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# autobot-backend/llc/tests/test_project_disposal_sweep.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Beat sweep disposes only due + approved pending_disposal projects (#11129 P2)."""
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.scheduler.project_disposal_sweep import _async_sweep
+
+
+@pytest.mark.asyncio
+async def test_sweep_disposes_due_projects():
+    due = [SimpleNamespace(id=uuid.uuid4(), code_source_id=None, disposal_approval_id=None)]
+    session = AsyncMock()
+    scal = MagicMock()
+    scal.scalars.return_value.all.return_value = due
+    session.execute = AsyncMock(return_value=scal)
+    session.commit = AsyncMock()
+
+    class _Factory:
+        def __call__(self):
+            return self
+
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, *a):
+            return False
+
+    with patch("llc.scheduler.project_disposal_sweep.get_async_session_factory", return_value=_Factory()), patch(
+        "llc.scheduler.project_disposal_sweep.dispose", AsyncMock()
+    ) as disp, patch(
+        "llc.scheduler.project_disposal_sweep._is_disposal_allowed", AsyncMock(return_value=True)
+    ):
+        count = await _async_sweep()
+    assert count == 1
+    disp.assert_awaited_once()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-backend && python -m pytest llc/tests/test_project_disposal_sweep.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the sweep**
+
+```python
+# autobot-backend/llc/scheduler/project_disposal_sweep.py
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Celery-beat sweep: dispose due + approved pending_disposal projects (#11129 P2)."""
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from celery import shared_task
+from sqlalchemy import select
+
+from llc.models.enums import ApprovalStatus
+from llc.models.approval import LLCApproval
+from llc.models.sprint import LLCProject
+from llc.services.project_disposal import dispose
+from user_management.database import get_async_session_factory
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(name="llc.scheduler.project_disposal_sweep.run_disposal_sweep", bind=True, max_retries=3)
+def run_disposal_sweep(self: object) -> dict:
+    """Sync Celery entry point — disposes projects whose retention has elapsed."""
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    disposed = loop.run_until_complete(_async_sweep())
+    return {"disposed": disposed}
+
+
+async def _async_sweep() -> int:
+    factory = get_async_session_factory()
+    disposed = 0
+    async with factory() as session:
+        result = await session.execute(
+            select(LLCProject).where(
+                LLCProject.lifecycle_state == "pending_disposal",
+                LLCProject.disposal_scheduled_at <= datetime.now(timezone.utc),
+            )
+        )
+        for project in result.scalars().all():
+            if not await _is_disposal_allowed(project, session):
+                continue
+            await dispose(project, session)
+            disposed += 1
+        await session.commit()
+    logger.info("Disposal sweep disposed %d project(s)", disposed)
+    return disposed
+
+
+async def _is_disposal_allowed(project: LLCProject, session) -> bool:
+    """Approval-gated projects dispose only once their LLCApproval is APPROVED."""
+    if project.disposal_approval_id is None:
+        return True
+    result = await session.execute(
+        select(LLCApproval).where(LLCApproval.id == project.disposal_approval_id)
+    )
+    approval = result.scalar_one_or_none()
+    return approval is not None and approval.status == ApprovalStatus.APPROVED.value
+```
+
+- [ ] **Step 4: Register in the beat schedule**
+
+In `celery_app.py`, add to `celery_app.conf.beat_schedule` (near `llc-sprint-autoclose-daily`):
+
+```python
+    "llc-project-disposal-sweep": {
+        "task": "llc.scheduler.project_disposal_sweep.run_disposal_sweep",
+        "schedule": crontab(hour=1, minute=0),
+    },
+```
+
+And ensure the task module is imported (add near the other explicit imports, e.g. after `import tasks.knowledge_retention`):
+
+```python
+import llc.scheduler.project_disposal_sweep  # noqa: F401 — register beat task
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd autobot-backend && python -m pytest llc/tests/test_project_disposal_sweep.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add autobot-backend/llc/scheduler/project_disposal_sweep.py autobot-backend/celery_app.py \
+        autobot-backend/llc/tests/test_project_disposal_sweep.py
+git commit -m "feat(companyos): celery-beat disposal sweep for due projects (#11129)"
+```
+
+---
+
+## Task 7: SLM-frontend disposal-policy panel
+
+**Files:**
+- Create: `autobot-slm-frontend/src/views/settings/DisposalPolicySettings.vue`
+- Modify: the SLM router + settings nav (find where `GeneralSettings.vue` is routed — likely `src/router/index.ts` and a settings nav list)
+- Test: `autobot-slm-frontend/src/views/settings/DisposalPolicySettings.test.ts`
+
+**Interfaces:**
+- Reads/writes SLM setting key `llc.project_disposal_policy` as a JSON string via `GET/PUT/POST /api/settings/llc.project_disposal_policy` using `authStore.getApiUrl()` + `authStore.getAuthHeaders()` (mirror `GeneralSettings.vue`).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// autobot-slm-frontend/src/views/settings/DisposalPolicySettings.test.ts
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import DisposalPolicySettings from './DisposalPolicySettings.vue'
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    getApiUrl: () => '',
+    getAuthHeaders: () => ({}),
+  }),
+}))
+
+describe('DisposalPolicySettings', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ value: JSON.stringify({ retention_days: 14, require_approval: true }) }),
+    })) as unknown as typeof fetch
+  })
+
+  it('loads the current policy on mount', async () => {
+    const wrapper = mount(DisposalPolicySettings)
+    await flushPromises()
+    const number = wrapper.find('input[type="number"]').element as HTMLInputElement
+    expect(number.value).toBe('14')
+  })
+
+  it('PUTs the policy as JSON on save', async () => {
+    const wrapper = mount(DisposalPolicySettings)
+    await flushPromises()
+    await wrapper.find('button[data-test="save-policy"]').trigger('click')
+    await flushPromises()
+    const putCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.find((c) => c[1]?.method === 'PUT')
+    expect(putCall).toBeTruthy()
+    expect(putCall![0]).toContain('/api/settings/llc.project_disposal_policy')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd autobot-slm-frontend && npx vitest run src/views/settings/DisposalPolicySettings.test.ts`
+Expected: FAIL (component missing).
+
+- [ ] **Step 3: Implement the component** (mirror `GeneralSettings.vue` card + save pattern)
+
+```vue
+<!-- autobot-slm-frontend/src/views/settings/DisposalPolicySettings.vue -->
+<!-- Copyright 2025-2026 mrveiss -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<template>
+  <div class="bg-white rounded-lg shadow-xs border border-gray-200 p-6">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Project Disposal Policy</h2>
+    <p class="text-sm text-gray-500 mb-4">
+      Controls how Company OS projects are disposed after archiving. Default: immediate, no approval.
+    </p>
+    <div class="flex items-center gap-3 mb-4">
+      <label class="w-56 text-sm text-gray-700">Retention period (days)</label>
+      <input
+        v-model.number="policy.retention_days"
+        type="number"
+        min="0"
+        class="w-32 px-3 py-2 border border-gray-300 rounded-md"
+      />
+    </div>
+    <div class="flex items-center gap-3 mb-6">
+      <label class="w-56 text-sm text-gray-700">Require second-pair-of-eyes approval</label>
+      <input v-model="policy.require_approval" type="checkbox" class="h-4 w-4" />
+    </div>
+    <button
+      data-test="save-policy"
+      :disabled="saving"
+      class="px-4 py-2 bg-indigo-600 text-white rounded-md disabled:opacity-50"
+      @click="save"
+    >
+      {{ saving ? 'Saving…' : 'Save policy' }}
+    </button>
+    <span v-if="saved" class="ml-3 text-sm text-green-600">Saved</span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+
+const KEY = 'llc.project_disposal_policy'
+const authStore = useAuthStore()
+const policy = reactive({ retention_days: 0, require_approval: false })
+const saving = ref(false)
+const saved = ref(false)
+
+async function load(): Promise<void> {
+  const res = await fetch(`${authStore.getApiUrl()}/api/settings/${KEY}`, {
+    headers: authStore.getAuthHeaders(),
+  })
+  if (res.ok) {
+    const setting = await res.json()
+    const parsed = setting.value ? JSON.parse(setting.value) : {}
+    policy.retention_days = Number(parsed.retention_days ?? 0)
+    policy.require_approval = Boolean(parsed.require_approval ?? false)
+  }
+}
+
+async function save(): Promise<void> {
+  saving.value = true
+  saved.value = false
+  const body = JSON.stringify({
+    value: JSON.stringify({ retention_days: policy.retention_days, require_approval: policy.require_approval }),
+    description: 'Company OS project disposal policy',
+  })
+  const url = `${authStore.getApiUrl()}/api/settings/${KEY}`
+  const headers = { ...authStore.getAuthHeaders(), 'Content-Type': 'application/json' }
+  let res = await fetch(url, { method: 'PUT', headers, body })
+  if (res.status === 404) res = await fetch(url, { method: 'POST', headers, body })
+  saving.value = false
+  saved.value = res.ok
+}
+
+onMounted(load)
+</script>
+```
+
+- [ ] **Step 4: Route + nav**
+
+Add a route for `DisposalPolicySettings.vue` alongside the existing settings routes, and a settings-nav entry labelled "Disposal Policy" (match how `GeneralSettings` is registered). Implementer: read the SLM router + settings nav to place it consistently.
+
+- [ ] **Step 5: Run the test + build**
+
+Run: `cd autobot-slm-frontend && npx vitest run src/views/settings/DisposalPolicySettings.test.ts`
+Expected: PASS (2 tests).
+Run: `cd autobot-slm-frontend && npm run build:slm`
+Expected: build succeeds (VITE_API_URL is set by the script).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add autobot-slm-frontend/src/views/settings/DisposalPolicySettings.vue \
+        autobot-slm-frontend/src/views/settings/DisposalPolicySettings.test.ts \
+        autobot-slm-frontend/src/router
+git commit -m "feat(slm): project disposal policy settings panel (#11129)"
+```
+
+---
+
+## Task 8: Company OS frontend — archive / delete / restore
+
+**Files:**
+- Modify: `autobot-frontend/src/views/llc/ProjectBrowserView.vue`
+- Modify: all 11 locale files under `autobot-frontend/src/locales/` (add i18n keys)
+- Test: `autobot-frontend/src/views/llc/ProjectBrowserView.lifecycle.test.ts`
+
+**Interfaces:**
+- Calls `POST /api/llc/projects/{id}/archive`, `POST …/restore`, `POST …/dispose` via the app's `ApiClient` (parsed-JSON return, no envelope). Shows a lifecycle badge from `project.lifecycle_state`; "Archive" on active projects, "Delete" (→ confirm → dispose) + "Restore" on archived/pending. All button labels + confirm text via `t('...')` i18n keys.
+
+- [ ] **Step 1: Add i18n keys (English first)**
+
+In `autobot-frontend/src/locales/en.json` (or the LLC namespace file used by this view), add keys such as:
+
+```json
+"llc": {
+  "project": {
+    "archive": "Archive",
+    "restore": "Restore",
+    "delete": "Delete",
+    "confirmDelete": "Delete this archived project and its sprints? This cannot be undone.",
+    "lifecycle": {
+      "active": "Active",
+      "archived": "Archived",
+      "pending_disposal": "Pending disposal",
+      "disposed": "Disposed"
+    }
+  }
+}
+```
+
+Mirror the same keys into the other 10 locale files (translated where a translation exists; English fallback otherwise) — no hardcoded strings in the template.
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+// autobot-frontend/src/views/llc/ProjectBrowserView.lifecycle.test.ts
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi } from 'vitest'
+// Mount ProjectBrowserView with a stubbed ApiClient + i18n; assert an archived
+// project renders a Restore action and calls POST …/dispose on confirmed delete,
+// and an active project renders an Archive action calling POST …/archive.
+// (Follow the existing ProjectBrowserView.repo.test.ts harness from Phase 1.)
+```
+
+Implementer: model this on the Phase-1 `ProjectBrowserView.repo.test.ts` (same mount/stub harness). Assert: (a) active project shows Archive → click calls `ApiClient` POST `.../archive`; (b) archived project shows Delete + Restore → confirmed Delete calls POST `.../dispose`, Restore calls POST `.../restore`.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd autobot-frontend && npx vitest run src/views/llc/ProjectBrowserView.lifecycle.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement the UI**
+
+Add to `ProjectBrowserView.vue`: a lifecycle badge (`t('llc.project.lifecycle.' + project.lifecycle_state)`); conditional actions — Archive when `lifecycle_state === 'active'`; Delete (window-confirm with `t('llc.project.confirmDelete')`, then `POST …/dispose`) and Restore (`POST …/restore`) when `archived`/`pending_disposal`; refresh the list after each. Use the existing `ApiClient`/composable already used for repo attach in Phase 1.
+
+- [ ] **Step 5: Run test + typecheck + lint**
+
+Run: `cd autobot-frontend && npx vitest run src/views/llc/ProjectBrowserView.lifecycle.test.ts`
+Expected: PASS.
+Run: `cd autobot-frontend && npx vue-tsc --noEmit -p tsconfig.app.json && npx eslint src/views/llc/ProjectBrowserView.vue --max-warnings 0`
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add autobot-frontend/src/views/llc/ProjectBrowserView.vue \
+        autobot-frontend/src/views/llc/ProjectBrowserView.lifecycle.test.ts \
+        autobot-frontend/src/locales
+git commit -m "feat(companyos): project archive/delete/restore UI + i18n (#11129)"
+```
+
+---
+
+## Self-Review Checklist (run before final review)
+
+1. **Spec coverage:** lifecycle states ✔ (Task 1/5), archive→dispose two-step ✔ (Task 5 DELETE 409-gate), SLM policy retention+approval ✔ (Task 4/5/6/7), disposal deletes linked non-shared source, never GitHub ✔ (Task 2/3), analytics reuse ✔ (Phase 1). 
+2. **Type consistency:** `lifecycle_state` string values identical across model enum, endpoints, sweep, frontend badge (`active|archived|pending_disposal|disposed`); `DisposalPolicy` fields identical across Task 4/5/6/7.
+3. **No placeholders:** every code step has real code; the two frontend test bodies reference the concrete Phase-1 harness to copy.
+4. **Migration head:** `20260708_067` chains onto `20260707_066`; single head.
+5. **Global constraints:** no commit trailers, copyright headers, ≤30-line funcs, i18n all 11 locales, no `/api` double-prefix.


### PR DESCRIPTION
## Thinking Path
Phase 2 of Company OS #11129 (Phase 1 = repo↔CodeSource linkage, merged in #11146). Projects needed a real **archive → dispose** lifecycle instead of a hard delete, governed by an **SLM-configurable disposal policy** (retention period + optional second-pair-of-eyes approval; default immediate). Built via subagent-driven development: 8 TDD tasks, each independently reviewed, plus a final whole-branch review (verdict: MERGE).

The lifecycle is a **separate `lifecycle_state` column**, orthogonal to the existing work-status `status` enum (which is `backlog/planned/…`, not `active/archived`). Disposal reuses the Phase-1 `CodeSource` linkage: it deletes the linked source's clone + ChromaDB index (only when not `shared_with` others) but **never the GitHub repo**.

## What Changed
**Backend**
- `LLCProject`: `lifecycle_state` (active/archived/pending_disposal/disposed) + `archived_at`/`disposal_scheduled_at`/`disposal_approval_id`; `ApprovalType.PROJECT_DISPOSAL`.
- Alembic `20260708_067` — adds the columns/enum **and** is a merge migration unifying the pre-existing `20260707_066`+`20260701_066` double head (#11253).
- `api/codebase_analytics/source_service.py::delete_source_and_cleanup` — service-level source delete (clone dir + ChromaDB index + Redis record); DELETE handler now delegates.
- `llc/services/project_disposal.py::dispose` — cascade delete work-items→sprints→project, then the linked non-shared CodeSource; never GitHub; idempotent.
- `llc/services/disposal_policy.py` — reads SLM setting `llc.project_disposal_policy` over HTTP with safe defaults `{0, false}`.
- `llc/api/sprints.py` — `POST /projects/{id}/archive|restore|dispose` + `DELETE` reroute (409-unless-archived); policy branches: immediate / retention-scheduled / approval-gated (emits `approval_requested` event).
- `llc/scheduler/project_disposal_sweep.py` + celery beat — nightly sweep of due + approved `pending_disposal` projects.

**Frontend**
- SLM `DisposalPolicySettings.vue` — operator panel for `{retention_days, require_approval}`.
- Company OS `ProjectBrowserView.vue` — lifecycle badge + Archive/Restore/Delete actions; i18n across **all 11 locales**.

**Pre-existing issues fixed/filed along the way:** #11253 (double head, fixed in-scope) · #11256 (analytics test hard-imports) · #11269 (remaining alembic multi-heads).

## Verification
- Backend: full LLC suite **1096 passed, 1 skipped, 0 failed** (`python3 -m pytest llc/tests/`); analytics delete/regression tests green alongside (no cross-suite leak).
- New tests: lifecycle model, source-delete service, disposal cascade (3), disposal policy (3), lifecycle API (6 incl. pending-approval), sweep (4 incl. approval gate).
- Review loop caught + fixed **2 production bugs**: missing `session.refresh` after commit (MissingGreenlet, hidden by mock sessions); NULL `disposal_scheduled_at` stranding approval-only projects in the sweep.
- SLM frontend: `npx vitest run` 2/2, `npm run build:slm` SUCCESS.
- Company OS frontend: `npx vitest run …lifecycle.test.ts` 9/9, `vue-tsc` 0 errors, `eslint --max-warnings 0` 0 warnings; i18n verified complete in all 11 locales.
- Final Opus whole-branch review: **MERGE** (state-machine, disposal-scope safety, migration head, transaction/expiry, IDOR, no Phase-1 regression all verified).

## Model Used
Claude Opus 4.8 (orchestration + final review); Sonnet 4.6 (task implementers + per-task reviewers).

Closes #11129