### PR TITLE
feat(memory): nightly trajectory-store consolidation worker (#11263)

### DIFF
--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -218,6 +218,12 @@ celery_app.conf.beat_schedule = {
         "task": "workers.audit_claims",
         "schedule": crontab(hour=3, minute=0, day_of_week=1),  # Monday 03:00 UTC
     },
+    # GH#11263: nightly trajectory-store consolidation (dedupe + prune) so
+    # retrieval precision holds as the store grows. NORMAL priority (GH#11262).
+    "memory-consolidate-trajectories-daily": {
+        "task": "memory.consolidate_trajectories",
+        "schedule": crontab(hour=4, minute=0),  # 04:00 UTC, after nightly cleanup
+    },
     # GH#6471: nightly eviction of stale per-task git worktree workspaces
     "workspace-cleanup-nightly": {
         "task": "tasks.cleanup_stale_workspaces",

--- a/autobot-backend/memory/trajectory_consolidate_test.py
+++ b/autobot-backend/memory/trajectory_consolidate_test.py
@@ -1,0 +1,105 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Trajectory-store consolidation: dedupe + prune (GH#11263)."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from memory import trajectory_store as ts
+
+
+def _meta(reward, ts_dt, user_id="u1", tenant_id=""):
+    return {"reward": reward, "timestamp": ts_dt.isoformat(), "user_id": user_id, "tenant_id": tenant_id}
+
+
+NOW = datetime(2026, 7, 8, tzinfo=timezone.utc)
+RECENT = NOW - timedelta(days=1)
+OLD = NOW - timedelta(days=60)
+
+
+# --- pure helpers ----------------------------------------------------------
+
+
+def test_dedup_keeps_highest_reward_survivor():
+    ids = ["a", "b", "c"]
+    docs = ["Deploy X", "deploy x", "Other task"]
+    metas = [_meta(0.5, RECENT), _meta(0.9, RECENT), _meta(1.0, RECENT)]
+    drop = ts._dedup_delete_ids(ids, docs, metas)
+    assert drop == {"a"}  # "b" (0.9) beats "a" (0.5); "c" is unique
+
+
+def test_dedup_scopes_by_user_and_tenant():
+    ids = ["a", "b"]
+    docs = ["same task", "same task"]
+    metas = [_meta(0.5, RECENT, user_id="u1"), _meta(0.9, RECENT, user_id="u2")]
+    assert ts._dedup_delete_ids(ids, docs, metas) == set()  # different users → not duplicates
+
+
+def test_stale_prunes_only_old_low_reward():
+    ids = ["old_low", "old_high", "new_low"]
+    metas = [_meta(0.1, OLD), _meta(0.9, OLD), _meta(0.1, RECENT)]
+    drop = ts._stale_delete_ids(ids, metas, reward_floor=0.4, cutoff=NOW - timedelta(days=30), skip=set())
+    assert drop == {"old_low"}
+
+
+def test_stale_skips_already_dropped():
+    ids = ["x"]
+    metas = [_meta(0.1, OLD)]
+    drop = ts._stale_delete_ids(ids, metas, reward_floor=0.4, cutoff=NOW, skip={"x"})
+    assert drop == set()
+
+
+# --- consolidate() end to end ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_consolidate_deletes_dupes_and_stale():
+    collection = AsyncMock()
+    collection.get = AsyncMock(
+        return_value={
+            "ids": ["a", "b", "stale"],
+            "documents": ["task one", "task one", "task two"],
+            "metadatas": [_meta(0.9, RECENT), _meta(0.5, RECENT), _meta(0.1, OLD)],
+        }
+    )
+    store = ts.TrajectoryStore()
+    store._get_collection = AsyncMock(return_value=collection)
+
+    summary = await store.consolidate(reward_floor=0.4, max_age_days=30, now=NOW)
+
+    assert summary["scanned"] == 3
+    assert summary["duplicates_removed"] == 1  # "b"
+    assert summary["pruned"] == 1  # "stale"
+    assert summary["remaining"] == 1  # "a"
+    deleted = set(collection.delete.call_args.kwargs["ids"])
+    assert deleted == {"b", "stale"}
+
+
+@pytest.mark.asyncio
+async def test_consolidate_noop_when_empty():
+    collection = AsyncMock()
+    collection.get = AsyncMock(return_value={"ids": [], "documents": [], "metadatas": []})
+    store = ts.TrajectoryStore()
+    store._get_collection = AsyncMock(return_value=collection)
+
+    summary = await store.consolidate(now=NOW)
+
+    assert summary == {"scanned": 0, "duplicates_removed": 0, "pruned": 0, "remaining": 0}
+    collection.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_consolidate_non_fatal_on_read_error():
+    collection = AsyncMock()
+    collection.get = AsyncMock(side_effect=RuntimeError("chroma down"))
+    store = ts.TrajectoryStore()
+    store._get_collection = AsyncMock(return_value=collection)
+
+    summary = await store.consolidate(now=NOW)
+
+    assert summary["scanned"] == 0
+    collection.delete.assert_not_called()

--- a/autobot-backend/memory/trajectory_store.py
+++ b/autobot-backend/memory/trajectory_store.py
@@ -52,10 +52,10 @@ import hashlib
 import json
 import time
 import uuid
-from datetime import datetime, timezone
-from typing import Any, Dict, List, Literal, Optional, Sequence
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
 
-from autobot_shared.env_utils import env_flag
+from autobot_shared.env_utils import env_flag, env_float, env_int
 from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
@@ -63,6 +63,13 @@ logger = get_logger(__name__)
 _COLLECTION_NAME = "trajectories"
 _DEFAULT_TOP_K = 5
 _MIN_REWARD_DEFAULT = 0.7
+
+# #11263: consolidation defaults. Duplicate near-identical tasks hurt retrieval
+# precision, and stale low-reward failures are noise. Both thresholds are env-tunable.
+_CONSOLIDATE_MIN_REWARD_FLOOR = env_float("AUTOBOT_TRAJECTORY_PRUNE_REWARD_FLOOR", default=0.4)
+_CONSOLIDATE_MAX_AGE_DAYS = env_int("AUTOBOT_TRAJECTORY_PRUNE_MAX_AGE_DAYS", default=30)
+# Upper bound on rows scanned per pass so consolidation stays bounded on huge stores.
+_CONSOLIDATE_SCAN_LIMIT = env_int("AUTOBOT_TRAJECTORY_CONSOLIDATE_SCAN_LIMIT", default=50000)
 
 # #11089: retrieval scoping. tenant_id alone is insufficient in single-company
 # deployments (org_id is frequently empty/identical across all users), so a
@@ -180,6 +187,51 @@ def reward_from_execution(result: Dict[str, Any]) -> float:
     if isinstance(criteria, dict) and criteria.get("overall") == "partial":
         return 0.5
     return 0.0
+
+
+def _parse_ts(raw: str) -> Optional[datetime]:
+    """Parse a stored ISO timestamp, returning None when absent/malformed."""
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+def _dedup_delete_ids(ids: List[str], docs: List[str], metas: List[Dict[str, Any]]) -> set:
+    """IDs of duplicate trajectories to drop, keeping the best per (task, user, tenant).
+
+    Two entries collide when their task_text (normalised) and owner match. The
+    survivor is the highest reward, ties broken by the most recent timestamp.
+    """
+    groups: Dict[Tuple[str, str, str], List[Tuple[str, float, str]]] = {}
+    for tid, doc, meta in zip(ids, docs, metas):
+        key = ((doc or "").strip().lower(), meta.get("user_id", ""), meta.get("tenant_id", ""))
+        groups.setdefault(key, []).append((tid, float(meta.get("reward", 0.0)), meta.get("timestamp", "")))
+    drop: set = set()
+    for entries in groups.values():
+        if len(entries) < 2:
+            continue
+        ranked = sorted(entries, key=lambda e: (e[1], e[2]), reverse=True)
+        drop.update(tid for tid, _, _ in ranked[1:])
+    return drop
+
+
+def _stale_delete_ids(
+    ids: List[str], metas: List[Dict[str, Any]], reward_floor: float, cutoff: datetime, skip: set
+) -> set:
+    """IDs of low-reward trajectories older than *cutoff* (excludes already-dropped)."""
+    drop: set = set()
+    for tid, meta in zip(ids, metas):
+        if tid in skip:
+            continue
+        if float(meta.get("reward", 0.0)) >= reward_floor:
+            continue
+        ts = _parse_ts(meta.get("timestamp", ""))
+        if ts is not None and ts < cutoff:
+            drop.add(tid)
+    return drop
 
 
 # ---------------------------------------------------------------------------
@@ -426,6 +478,60 @@ class TrajectoryStore:
                 break
 
         return results
+
+    # ------------------------------------------------------------------
+    # Public API: maintenance path
+    # ------------------------------------------------------------------
+
+    async def consolidate(
+        self,
+        reward_floor: float = _CONSOLIDATE_MIN_REWARD_FLOOR,
+        max_age_days: int = _CONSOLIDATE_MAX_AGE_DAYS,
+        now: Optional[datetime] = None,
+    ) -> Dict[str, int]:
+        """Compact the ``trajectories`` collection (#11263).
+
+        Two passes, both delete-only so retrieval quality can only improve:
+        1. **dedup** — collapse near-identical (task, user, tenant) entries to the
+           single highest-reward survivor.
+        2. **prune** — drop low-reward (``< reward_floor``) entries older than
+           ``max_age_days``.
+
+        Returns a summary dict ``{scanned, duplicates_removed, pruned, remaining}``.
+        Non-fatal: on any read error an empty summary is returned and logged.
+        """
+        collection = await self._get_collection()
+        try:
+            raw = await collection.get(include=["documents", "metadatas"], limit=_CONSOLIDATE_SCAN_LIMIT)
+        except Exception as exc:
+            logger.warning("TrajectoryStore.consolidate: read failed (non-fatal): %s", exc)
+            return {"scanned": 0, "duplicates_removed": 0, "pruned": 0, "remaining": 0}
+
+        ids = raw.get("ids", []) or []
+        docs = raw.get("documents", []) or []
+        metas = raw.get("metadatas", []) or []
+
+        dup_ids = _dedup_delete_ids(ids, docs, metas)
+        cutoff = (now or datetime.now(tz=timezone.utc)) - timedelta(days=max_age_days)
+        stale_ids = _stale_delete_ids(ids, metas, reward_floor, cutoff, skip=dup_ids)
+
+        to_delete = list(dup_ids | stale_ids)
+        if to_delete:
+            await collection.delete(ids=to_delete)
+        summary = {
+            "scanned": len(ids),
+            "duplicates_removed": len(dup_ids),
+            "pruned": len(stale_ids),
+            "remaining": len(ids) - len(to_delete),
+        }
+        logger.info(
+            "TrajectoryStore.consolidate: scanned=%d dedup=%d pruned=%d remaining=%d",
+            summary["scanned"],
+            summary["duplicates_removed"],
+            summary["pruned"],
+            summary["remaining"],
+        )
+        return summary
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/workers/__init__.py
+++ b/autobot-backend/workers/__init__.py
@@ -5,5 +5,6 @@
 """Background worker tasks for periodic audit daemons (GH#7356)."""
 
 from .audit_tasks import audit_claims, audit_dead_code, audit_testgaps
+from .consolidate_tasks import consolidate_trajectories  # GH#11263
 
-__all__ = ["audit_testgaps", "audit_dead_code", "audit_claims"]
+__all__ = ["audit_testgaps", "audit_dead_code", "audit_claims", "consolidate_trajectories"]

--- a/autobot-backend/workers/consolidate_tasks.py
+++ b/autobot-backend/workers/consolidate_tasks.py
@@ -1,0 +1,52 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Memory consolidation Celery task (GH#11263).
+
+Periodically compacts the ``trajectories`` ChromaDB collection so retrieval
+precision does not degrade as the store grows: duplicate near-identical turns are
+collapsed to their best-reward survivor and stale low-reward failures are pruned.
+
+Registered in ``celery_app.py`` beat schedule under ``memory.consolidate_trajectories``
+(priority tier NORMAL, GH#11262). Runs as a normal Beat task; the heavy lifting
+lives in ``TrajectoryStore.consolidate`` which is fully delete-only.
+"""
+
+from datetime import datetime, timezone
+
+from autobot_shared.async_compat import run_or_schedule
+from autobot_shared.logging_manager import get_logger
+from celery_app import celery_app
+
+logger = get_logger(__name__)
+
+_LAST_RUN_KEY = "memory:consolidate_trajectories:last_run"
+
+
+def _get_redis():
+    """Sync Redis client (analytics DB) for last-run bookkeeping."""
+    from autobot_shared.redis_client import get_redis_client
+
+    return get_redis_client(async_client=False, database="analytics")
+
+
+async def _run_consolidation() -> dict:
+    """Open the store and run one consolidation pass, returning its summary."""
+    from memory.trajectory_store import get_trajectory_store
+
+    store = await get_trajectory_store()
+    return await store.consolidate()
+
+
+@celery_app.task(bind=True, name="memory.consolidate_trajectories")
+def consolidate_trajectories(self) -> dict:
+    """Daily task: dedupe + prune the trajectory store, then record the run time."""
+    run_at = datetime.now(timezone.utc).isoformat()
+    summary = run_or_schedule(_run_consolidation())
+    try:
+        _get_redis().set(_LAST_RUN_KEY, run_at)
+    except Exception as exc:  # noqa: BLE001 — bookkeeping only, never fail the task
+        logger.debug("consolidate_trajectories: last-run write skipped: %s", exc)
+    logger.info("consolidate_trajectories complete at %s: %s", run_at, summary)
+    return {"status": "success", "run_at": run_at, **(summary or {})}


### PR DESCRIPTION
## Thinking Path

The trajectory store (GH#7357) grows unbounded — retention jobs evict by TTL but nothing dedupes or prunes for *quality*. As near-identical turns and stale low-reward failures accumulate, similarity retrieval precision degrades. This adds a nightly consolidation pass that is strictly delete-only, so retrieval can only get better.

## What Changed

- `memory/trajectory_store.py`:
  - New `TrajectoryStore.consolidate(reward_floor, max_age_days, now)` — two delete-only passes: **dedup** (collapse near-identical (task, user, tenant) entries to the highest-reward survivor) and **prune** (drop `< reward_floor` entries older than `max_age_days`). Returns `{scanned, duplicates_removed, pruned, remaining}`; non-fatal on read error.
  - Pure helpers `_dedup_delete_ids`, `_stale_delete_ids`, `_parse_ts`; thresholds are env-tunable constants (`AUTOBOT_TRAJECTORY_PRUNE_REWARD_FLOOR`=0.4, `_PRUNE_MAX_AGE_DAYS`=30, `_CONSOLIDATE_SCAN_LIMIT`=50000).
- **New** `workers/consolidate_tasks.py` — Celery task `memory.consolidate_trajectories` (reuses `run_or_schedule` + `get_trajectory_store`), records last-run in Redis.
- `workers/__init__.py` — registers the new task (same pattern as audit tasks).
- `celery_app.py` — Beat entry `memory-consolidate-trajectories-daily` at 04:00 UTC (after nightly cleanup). Priority tier NORMAL is reserved by #11262.

## Verification

- `memory/trajectory_consolidate_test.py` — **7 passed**: dedup keeps highest-reward survivor, dedup scopes by user/tenant, prune only old+low-reward, prune skips already-dropped, end-to-end consolidate deletes the right ids, empty no-op, non-fatal on read error.
- `py_compile` clean on all 5 changed files.

Closes #11263

## Model Used

Claude Opus 4.8
