### PR TITLE
test(#11248): fix notification 4xx mock + conflict_resolver stale redis attr

### DIFF
--- a/autobot-backend/tests/services/notification_service_test.py
+++ b/autobot-backend/tests/services/notification_service_test.py
@@ -360,12 +360,21 @@ class TestSendWebhook:
     @pytest.mark.asyncio
     async def test_raises_on_4xx_response(self):
         import aiohttp as _aiohttp
+        from multidict import CIMultiDict
+        from yarl import URL
 
         svc = self._svc()
         mock_resp = AsyncMock()
         mock_resp.status = 400
         mock_resp.text = AsyncMock(return_value="Bad Request")
-        mock_resp.raise_for_status = MagicMock(side_effect=_aiohttp.ClientResponseError(None, None, status=400))
+        # Build a well-formed ClientResponseError: passing request_info=None makes
+        # str(exc) raise (it reads request_info.real_url), which crashed the
+        # except-block logger.error() before the real re-raise reached the caller.
+        _req_url = URL("https://example.com/hook")
+        _req_info = _aiohttp.RequestInfo(_req_url, "POST", CIMultiDict(), _req_url)
+        mock_resp.raise_for_status = MagicMock(
+            side_effect=_aiohttp.ClientResponseError(_req_info, (), status=400, message="Bad Request")
+        )
         mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
         mock_resp.__aexit__ = AsyncMock(return_value=False)
 


### PR DESCRIPTION
## Thinking Path
Two items from the #11248 test-remediation umbrella, both confirmed **real
test-rot** (fail on both py3.10 and a py3.12 venv — not py-version artifacts;
the service code is correct in both cases):

1. **notification_service_test::test_raises_on_4xx_response** — the mock built
   `aiohttp.ClientResponseError(None, None, status=400)`; `request_info=None`
   makes `str(exc)` raise inside the except-block `logger.error("…: %s", url, exc)`,
   crashing before the service's real `raise` re-surfaced the error, so
   `pytest.raises(ClientResponseError)` never saw it. Built a well-formed
   `RequestInfo`.
2. **test_conflict_resolver** — `ConflictResolver` was migrated to
   `AsyncRedisClientMixin` (uses `self._redis` + `_get_redis()`), but the test
   still referenced the old `_redis_client` attribute (23×) → `AttributeError` +
   mock-redis injection that the code never read. Renamed `_redis_client → _redis`.

## What Changed
- `notification_service_test.py` — well-formed `ClientResponseError` (real `RequestInfo`).
- `test_conflict_resolver.py` — `_redis_client` → `_redis` (23 occurrences).

## Verification
- notification: was 1 failed → **45 passed** on both py3.10 and py3.12.
- conflict_resolver: was `AttributeError` → **51 passed** on py3.10 (init tests
  also pass on py3.12).
- `py_compile` + `black --check -l120` + `isort` clean on both.

## Model Used
Opus 4.8 (1M context)

Refs #11248 (checks off notification_service_test + test_conflict_resolver).