### PR TITLE
feat(security): SHA256 file-integrity manifest verified at startup (#11265)

### DIFF
--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -87,6 +87,7 @@ from services.security_posture_auditor import (
     start_security_posture_auditor,
     stop_security_posture_auditor,
 )
+from autobot_shared.integrity_manifest import verify_integrity_at_startup
 
 logging.basicConfig(
     level=logging.DEBUG if settings.debug else logging.INFO,
@@ -170,6 +171,11 @@ async def lifespan(app: FastAPI):
     )
     logger.info("Starting SLM Backend v1.0.0")
     logger.info("Debug mode: %s", settings.debug)
+
+    # Non-fatal file-integrity check — detects out-of-band tampering of
+    # security-critical config files (#11265).  No-op unless
+    # AUTOBOT_INTEGRITY_CHECK_ENABLED=1 and AUTOBOT_INTEGRITY_MANIFEST_PATH are set.
+    verify_integrity_at_startup()
 
     # Validate that the two Base MetaData objects share no tablenames (#1878).
     # Must run before create_all / migrations so conflicts are caught immediately.

--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -69,6 +69,7 @@ from api.performance import router as performance_router
 from api.personality_proxy import router as personality_proxy_router
 from api.roles import router as roles_router
 from api.voice_proxy import router as voice_proxy_router
+from autobot_shared.integrity_manifest import verify_integrity_at_startup
 from config import settings
 from middleware import ApiRequestCounterMiddleware, SecurityHeadersMiddleware
 from services.a2a_card_fetcher import start_card_refresh_task
@@ -87,7 +88,6 @@ from services.security_posture_auditor import (
     start_security_posture_auditor,
     stop_security_posture_auditor,
 )
-from autobot_shared.integrity_manifest import verify_integrity_at_startup
 
 logging.basicConfig(
     level=logging.DEBUG if settings.debug else logging.INFO,

--- a/autobot_shared/integrity_manifest.py
+++ b/autobot_shared/integrity_manifest.py
@@ -51,6 +51,7 @@ def _manifest_path() -> str:
 # Core helpers
 # ---------------------------------------------------------------------------
 
+
 def _sha256_file(path: str) -> str:
     """Return the hex SHA-256 digest of *path* (reads raw bytes)."""
     h = hashlib.sha256()
@@ -82,6 +83,7 @@ def _default_fileset(root: str) -> list[str]:
 # Manifest compute
 # ---------------------------------------------------------------------------
 
+
 def compute_manifest(files: Iterable[str], root: str = "") -> dict[str, str]:
     """Return ``{relative_path: sha256hex}`` for each existing file in *files*.
 
@@ -111,6 +113,7 @@ def write_manifest(manifest: dict[str, str], dest: str) -> None:
 # ---------------------------------------------------------------------------
 # Verify result
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class VerifyResult:
@@ -156,6 +159,7 @@ def verify_manifest(
 # Startup entrypoint
 # ---------------------------------------------------------------------------
 
+
 def verify_integrity_at_startup(root: str = "") -> None:
     """Non-fatal startup integrity check.
 
@@ -192,9 +196,7 @@ def verify_integrity_at_startup(root: str = "") -> None:
     result = verify_manifest(manifest, root=root)
 
     if result.clean:
-        logger.info(
-            "integrity_manifest: all %d tracked files verified OK", len(result.ok)
-        )
+        logger.info("integrity_manifest: all %d tracked files verified OK", len(result.ok))
         return
 
     if result.modified:

--- a/autobot_shared/integrity_manifest.py
+++ b/autobot_shared/integrity_manifest.py
@@ -1,0 +1,211 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+SHA256 file-integrity manifest for security-critical config files (GH#11265).
+
+Detects out-of-band tampering that ``config_guard`` cannot catch — external
+edits that bypass the app's write path.  Non-fatal by design: a missing or
+unreadable manifest logs a WARNING and returns cleanly; it never raises at
+startup.
+
+Environment variables
+---------------------
+AUTOBOT_INTEGRITY_CHECK_ENABLED : bool (default False)
+    Master switch.  When False every public function short-circuits immediately.
+AUTOBOT_INTEGRITY_MANIFEST_PATH : str (default "")
+    Absolute path to the JSON manifest file produced by :func:`write_manifest`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Iterable
+
+from autobot_shared.config_guard import _PROTECTED_BASENAMES, _PROTECTED_PREFIXES
+from autobot_shared.env_utils import env_flag
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Env-var constants (never hard-coded)
+# ---------------------------------------------------------------------------
+_ENV_ENABLED = "AUTOBOT_INTEGRITY_CHECK_ENABLED"
+_ENV_MANIFEST_PATH = "AUTOBOT_INTEGRITY_MANIFEST_PATH"
+
+
+def _check_enabled() -> bool:
+    return env_flag(_ENV_ENABLED, default=False)
+
+
+def _manifest_path() -> str:
+    return os.environ.get(_ENV_MANIFEST_PATH, "")
+
+
+# ---------------------------------------------------------------------------
+# Core helpers
+# ---------------------------------------------------------------------------
+
+def _sha256_file(path: str) -> str:
+    """Return the hex SHA-256 digest of *path* (reads raw bytes)."""
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _is_protected_basename(name: str) -> bool:
+    """True when *name* (basename) matches config_guard's protected set."""
+    lower = name.lower()
+    if lower in _PROTECTED_BASENAMES:
+        return True
+    return any(lower.startswith(p) for p in _PROTECTED_PREFIXES)
+
+
+def _default_fileset(root: str) -> list[str]:
+    """Walk *root* and return absolute paths whose basename is protected."""
+    found: list[str] = []
+    for dirpath, _dirs, files in os.walk(root):
+        for fname in files:
+            if _is_protected_basename(fname):
+                found.append(os.path.join(dirpath, fname))
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Manifest compute
+# ---------------------------------------------------------------------------
+
+def compute_manifest(files: Iterable[str], root: str = "") -> dict[str, str]:
+    """Return ``{relative_path: sha256hex}`` for each existing file in *files*.
+
+    Paths are stored relative to *root* (or absolute when *root* is empty).
+    Missing files are skipped with a WARNING.
+    """
+    manifest: dict[str, str] = {}
+    for abs_path in files:
+        if not os.path.isfile(abs_path):
+            logger.warning("integrity_manifest: skipping missing file %s", abs_path)
+            continue
+        key = os.path.relpath(abs_path, root) if root else abs_path
+        try:
+            manifest[key] = _sha256_file(abs_path)
+        except OSError as exc:
+            logger.warning("integrity_manifest: cannot hash %s: %s", abs_path, exc)
+    return manifest
+
+
+def write_manifest(manifest: dict[str, str], dest: str) -> None:
+    """Serialise *manifest* as JSON to *dest* (UTF-8, sorted keys)."""
+    with open(dest, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2, sort_keys=True)
+    logger.info("integrity_manifest: wrote %d entries to %s", len(manifest), dest)
+
+
+# ---------------------------------------------------------------------------
+# Verify result
+# ---------------------------------------------------------------------------
+
+@dataclass
+class VerifyResult:
+    """Structured outcome of :func:`verify_manifest`."""
+
+    ok: list[str] = field(default_factory=list)
+    modified: list[str] = field(default_factory=list)
+    missing: list[str] = field(default_factory=list)
+
+    @property
+    def clean(self) -> bool:
+        return not self.modified and not self.missing
+
+
+def verify_manifest(
+    manifest: dict[str, str],
+    root: str = "",
+) -> VerifyResult:
+    """Compare *manifest* against current disk state, returning a :class:`VerifyResult`.
+
+    Keys in *manifest* are resolved relative to *root* (or treated as absolute
+    when *root* is empty).  Any key that cannot be read is classified MISSING.
+    """
+    result = VerifyResult()
+    for rel_key, expected_hex in manifest.items():
+        abs_path = os.path.join(root, rel_key) if root else rel_key
+        if not os.path.isfile(abs_path):
+            result.missing.append(rel_key)
+            continue
+        try:
+            actual = _sha256_file(abs_path)
+        except OSError:
+            result.missing.append(rel_key)
+            continue
+        if actual == expected_hex:
+            result.ok.append(rel_key)
+        else:
+            result.modified.append(rel_key)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Startup entrypoint
+# ---------------------------------------------------------------------------
+
+def verify_integrity_at_startup(root: str = "") -> None:
+    """Non-fatal startup integrity check.
+
+    Reads AUTOBOT_INTEGRITY_MANIFEST_PATH and verifies current files against
+    the stored SHA-256 manifest.  Logs WARNING on any mismatch; never raises.
+
+    Guarded by AUTOBOT_INTEGRITY_CHECK_ENABLED (default False) — a no-op when
+    the flag is absent/false.
+
+    Call site: backend ``lifespan`` handler, after logging is initialised but
+    before the first request is served.
+    """
+    if not _check_enabled():
+        return
+
+    manifest_path = _manifest_path()
+    if not manifest_path:
+        logger.warning(
+            "integrity_manifest: AUTOBOT_INTEGRITY_CHECK_ENABLED=1 but "
+            "AUTOBOT_INTEGRITY_MANIFEST_PATH is not set — skipping check"
+        )
+        return
+
+    try:
+        with open(manifest_path, encoding="utf-8") as fh:
+            manifest: dict[str, str] = json.load(fh)
+    except FileNotFoundError:
+        logger.warning("integrity_manifest: manifest not found at %s", manifest_path)
+        return
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("integrity_manifest: cannot load manifest %s: %s", manifest_path, exc)
+        return
+
+    result = verify_manifest(manifest, root=root)
+
+    if result.clean:
+        logger.info(
+            "integrity_manifest: all %d tracked files verified OK", len(result.ok)
+        )
+        return
+
+    if result.modified:
+        logger.warning(
+            "integrity_manifest: TAMPERED files detected (%d): %s",
+            len(result.modified),
+            result.modified,
+        )
+    if result.missing:
+        logger.warning(
+            "integrity_manifest: MISSING files (%d): %s",
+            len(result.missing),
+            result.missing,
+        )

--- a/autobot_shared/integrity_manifest_test.py
+++ b/autobot_shared/integrity_manifest_test.py
@@ -7,22 +7,19 @@
 from __future__ import annotations
 
 import json
-import os
 
-import pytest
 
 from autobot_shared.integrity_manifest import (
-    VerifyResult,
     compute_manifest,
     verify_integrity_at_startup,
     verify_manifest,
     write_manifest,
 )
 
-
 # ---------------------------------------------------------------------------
 # compute_manifest
 # ---------------------------------------------------------------------------
+
 
 class TestComputeManifest:
     def test_deterministic(self, tmp_path):
@@ -72,6 +69,7 @@ class TestComputeManifest:
 # write_manifest + round-trip
 # ---------------------------------------------------------------------------
 
+
 class TestWriteManifest:
     def test_round_trip(self, tmp_path):
         f = tmp_path / "ruff.toml"
@@ -90,6 +88,7 @@ class TestWriteManifest:
 # ---------------------------------------------------------------------------
 # verify_manifest
 # ---------------------------------------------------------------------------
+
 
 class TestVerifyManifest:
     def _make_manifest(self, files: dict[str, bytes], tmp_path) -> dict[str, str]:
@@ -146,6 +145,7 @@ class TestVerifyManifest:
 # verify_integrity_at_startup
 # ---------------------------------------------------------------------------
 
+
 class TestVerifyIntegrityAtStartup:
     def test_disabled_flag_short_circuits(self, monkeypatch, tmp_path, caplog):
         """When AUTOBOT_INTEGRITY_CHECK_ENABLED is absent/false nothing happens."""
@@ -171,9 +171,7 @@ class TestVerifyIntegrityAtStartup:
 
     def test_missing_manifest_file_is_nonfatal(self, monkeypatch, tmp_path, caplog):
         monkeypatch.setenv("AUTOBOT_INTEGRITY_CHECK_ENABLED", "1")
-        monkeypatch.setenv(
-            "AUTOBOT_INTEGRITY_MANIFEST_PATH", str(tmp_path / "nonexistent.json")
-        )
+        monkeypatch.setenv("AUTOBOT_INTEGRITY_MANIFEST_PATH", str(tmp_path / "nonexistent.json"))
         import logging
 
         with caplog.at_level(logging.WARNING):

--- a/autobot_shared/integrity_manifest_test.py
+++ b/autobot_shared/integrity_manifest_test.py
@@ -1,0 +1,230 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for autobot_shared.integrity_manifest (GH#11265)."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from autobot_shared.integrity_manifest import (
+    VerifyResult,
+    compute_manifest,
+    verify_integrity_at_startup,
+    verify_manifest,
+    write_manifest,
+)
+
+
+# ---------------------------------------------------------------------------
+# compute_manifest
+# ---------------------------------------------------------------------------
+
+class TestComputeManifest:
+    def test_deterministic(self, tmp_path):
+        """Same file content always produces the same SHA-256 hex."""
+        f = tmp_path / ".eslintrc.json"
+        f.write_bytes(b"rule: on")
+
+        m1 = compute_manifest([str(f)])
+        m2 = compute_manifest([str(f)])
+
+        assert m1 == m2
+        assert len(m1) == 1
+        # SHA-256 hex is always 64 chars
+        assert len(next(iter(m1.values()))) == 64
+
+    def test_relative_key_when_root_given(self, tmp_path):
+        f = tmp_path / "ruff.toml"
+        f.write_bytes(b"[tool.ruff]")
+
+        manifest = compute_manifest([str(f)], root=str(tmp_path))
+
+        assert list(manifest.keys()) == ["ruff.toml"]
+
+    def test_absolute_key_when_no_root(self, tmp_path):
+        f = tmp_path / "mypy.ini"
+        f.write_bytes(b"[mypy]")
+
+        manifest = compute_manifest([str(f)])
+
+        assert str(f) in manifest
+
+    def test_missing_file_skipped(self, tmp_path):
+        absent = str(tmp_path / "ghost.toml")
+        manifest = compute_manifest([absent])
+        assert manifest == {}
+
+    def test_content_change_changes_hash(self, tmp_path):
+        f = tmp_path / ".editorconfig"
+        f.write_bytes(b"v1")
+        m1 = compute_manifest([str(f)])
+        f.write_bytes(b"v2-tampered")
+        m2 = compute_manifest([str(f)])
+        assert m1 != m2
+
+
+# ---------------------------------------------------------------------------
+# write_manifest + round-trip
+# ---------------------------------------------------------------------------
+
+class TestWriteManifest:
+    def test_round_trip(self, tmp_path):
+        f = tmp_path / "ruff.toml"
+        f.write_bytes(b"content")
+        manifest = compute_manifest([str(f)])
+
+        dest = tmp_path / "manifest.json"
+        write_manifest(manifest, str(dest))
+
+        with open(dest, encoding="utf-8") as fh:
+            loaded = json.load(fh)
+
+        assert loaded == manifest
+
+
+# ---------------------------------------------------------------------------
+# verify_manifest
+# ---------------------------------------------------------------------------
+
+class TestVerifyManifest:
+    def _make_manifest(self, files: dict[str, bytes], tmp_path) -> dict[str, str]:
+        for name, content in files.items():
+            (tmp_path / name).write_bytes(content)
+        paths = [str(tmp_path / n) for n in files]
+        return compute_manifest(paths, root=str(tmp_path))
+
+    def test_all_ok(self, tmp_path):
+        manifest = self._make_manifest({"ruff.toml": b"ok"}, tmp_path)
+        result = verify_manifest(manifest, root=str(tmp_path))
+        assert result.clean
+        assert result.ok == ["ruff.toml"]
+        assert result.modified == []
+        assert result.missing == []
+
+    def test_detects_modified(self, tmp_path):
+        manifest = self._make_manifest({"mypy.ini": b"original"}, tmp_path)
+        (tmp_path / "mypy.ini").write_bytes(b"tampered!")
+        result = verify_manifest(manifest, root=str(tmp_path))
+        assert not result.clean
+        assert "mypy.ini" in result.modified
+        assert result.missing == []
+
+    def test_detects_missing(self, tmp_path):
+        f = tmp_path / ".editorconfig"
+        f.write_bytes(b"data")
+        manifest = compute_manifest([str(f)], root=str(tmp_path))
+        f.unlink()
+
+        result = verify_manifest(manifest, root=str(tmp_path))
+        assert not result.clean
+        assert ".editorconfig" in result.missing
+        assert result.modified == []
+
+    def test_mixed_ok_modified_missing(self, tmp_path):
+        (tmp_path / "ruff.toml").write_bytes(b"r")
+        (tmp_path / "mypy.ini").write_bytes(b"m")
+        (tmp_path / ".editorconfig").write_bytes(b"e")
+        paths = [str(tmp_path / n) for n in ("ruff.toml", "mypy.ini", ".editorconfig")]
+        manifest = compute_manifest(paths, root=str(tmp_path))
+
+        (tmp_path / "mypy.ini").write_bytes(b"tampered")
+        (tmp_path / ".editorconfig").unlink()
+
+        result = verify_manifest(manifest, root=str(tmp_path))
+        assert "ruff.toml" in result.ok
+        assert "mypy.ini" in result.modified
+        assert ".editorconfig" in result.missing
+        assert not result.clean
+
+
+# ---------------------------------------------------------------------------
+# verify_integrity_at_startup
+# ---------------------------------------------------------------------------
+
+class TestVerifyIntegrityAtStartup:
+    def test_disabled_flag_short_circuits(self, monkeypatch, tmp_path, caplog):
+        """When AUTOBOT_INTEGRITY_CHECK_ENABLED is absent/false nothing happens."""
+        monkeypatch.delenv("AUTOBOT_INTEGRITY_CHECK_ENABLED", raising=False)
+        monkeypatch.setenv("AUTOBOT_INTEGRITY_MANIFEST_PATH", str(tmp_path / "x.json"))
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            verify_integrity_at_startup()
+
+        # No warnings — function bailed early
+        assert caplog.records == []
+
+    def test_missing_manifest_path_env_warns(self, monkeypatch, caplog):
+        monkeypatch.setenv("AUTOBOT_INTEGRITY_CHECK_ENABLED", "1")
+        monkeypatch.delenv("AUTOBOT_INTEGRITY_MANIFEST_PATH", raising=False)
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            verify_integrity_at_startup()
+
+        assert any("AUTOBOT_INTEGRITY_MANIFEST_PATH" in r.message for r in caplog.records)
+
+    def test_missing_manifest_file_is_nonfatal(self, monkeypatch, tmp_path, caplog):
+        monkeypatch.setenv("AUTOBOT_INTEGRITY_CHECK_ENABLED", "1")
+        monkeypatch.setenv(
+            "AUTOBOT_INTEGRITY_MANIFEST_PATH", str(tmp_path / "nonexistent.json")
+        )
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            verify_integrity_at_startup()  # must not raise
+
+        assert any("not found" in r.message for r in caplog.records)
+
+    def test_tampered_file_logs_warning(self, monkeypatch, tmp_path, caplog):
+        # Build a manifest, then tamper with the file
+        f = tmp_path / "ruff.toml"
+        f.write_bytes(b"clean")
+        manifest = compute_manifest([str(f)], root=str(tmp_path))
+        manifest_file = tmp_path / "manifest.json"
+        write_manifest(manifest, str(manifest_file))
+
+        f.write_bytes(b"TAMPERED")
+
+        monkeypatch.setenv("AUTOBOT_INTEGRITY_CHECK_ENABLED", "1")
+        monkeypatch.setenv("AUTOBOT_INTEGRITY_MANIFEST_PATH", str(manifest_file))
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            verify_integrity_at_startup(root=str(tmp_path))
+
+        assert any("TAMPERED" in r.message for r in caplog.records)
+
+    def test_clean_files_logs_info(self, monkeypatch, tmp_path, caplog):
+        f = tmp_path / "ruff.toml"
+        f.write_bytes(b"clean")
+        manifest = compute_manifest([str(f)], root=str(tmp_path))
+        manifest_file = tmp_path / "manifest.json"
+        write_manifest(manifest, str(manifest_file))
+
+        monkeypatch.setenv("AUTOBOT_INTEGRITY_CHECK_ENABLED", "1")
+        monkeypatch.setenv("AUTOBOT_INTEGRITY_MANIFEST_PATH", str(manifest_file))
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            verify_integrity_at_startup(root=str(tmp_path))
+
+        assert any("verified OK" in r.message for r in caplog.records)
+
+    def test_corrupt_json_manifest_is_nonfatal(self, monkeypatch, tmp_path, caplog):
+        bad = tmp_path / "bad.json"
+        bad.write_text("not json{{", encoding="utf-8")
+
+        monkeypatch.setenv("AUTOBOT_INTEGRITY_CHECK_ENABLED", "1")
+        monkeypatch.setenv("AUTOBOT_INTEGRITY_MANIFEST_PATH", str(bad))
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            verify_integrity_at_startup()  # must not raise
+
+        assert any("cannot load" in r.message for r in caplog.records)


### PR DESCRIPTION
## Thinking Path
`config_guard` blocks writes to security-critical config files but does no integrity verification — tampering outside the app's write path goes undetected. This adds a SHA256 manifest verified at startup, reusing config_guard's protected-file list as the single source of truth.

## What Changed
- **New** `autobot_shared/integrity_manifest.py`: `compute_manifest`, `write_manifest`, `verify_manifest` (→ OK/MODIFIED/MISSING), and `verify_integrity_at_startup()`. Reuses `config_guard`'s protected basenames/prefixes — no second list. Non-fatal: missing/unreadable manifest logs a WARNING, never raises.
- `autobot-slm-backend/main.py`: calls `verify_integrity_at_startup()` in `lifespan` after logging init.
- Defaults: `AUTOBOT_INTEGRITY_CHECK_ENABLED=false`, `AUTOBOT_INTEGRITY_MANIFEST_PATH=""`. No-op unless explicitly configured.

## Verification
- `autobot_shared/integrity_manifest_test.py` — **16 passed** (deterministic compute, detects MODIFIED + MISSING, disabled short-circuit, missing manifest non-fatal).

Closes #11265

## Model Used
Claude Opus 4.8
