### PR TITLE
feat(delegation): harden governed delegation for enablement (#11266)

### DIFF
--- a/autobot-backend/chat_workflow/delegation.py
+++ b/autobot-backend/chat_workflow/delegation.py
@@ -14,27 +14,61 @@ engine. Two engines ship:
 
 - **claude_code** — an ``ExecutionBackend`` that runs its own tool loop out of
   process, governed via ``--disallowedTools`` mapped from the profile (GH#11188).
+  NOTE: this engine is out-of-process; ``delegation_depth`` is passed as metadata
+  but cannot be enforced inside the subprocess. The depth bound therefore only
+  prevents *this process* from initiating a delegation beyond MAX_DELEGATION_DEPTH.
+  Recursive delegation inside the claude_code subprocess is blocked by the
+  ``--disallowedTools`` list NOT including a ``delegate`` tool (it is an AutoBot
+  internal, not a claude_code native tool), so the subprocess cannot self-delegate.
 - **internal** — AutoBot's own LLM driving the production continuation loop, so
   the subagent's tools flow through the ``_dispatch_tool_call`` seam and inherit
   ``forbidden_work`` enforcement for free. Runs in process, so it also threads an
-  incremented ``delegation_depth`` — a nested ``delegate`` is depth-bounded.
+  incremented ``delegation_depth`` — a nested ``delegate`` is depth-bounded here.
 
 OFF by default (``AUTOBOT_DELEGATION_ENABLED``) so the live chat path is unchanged
 until delegation is explicitly enabled and validated.
+
+Enablement / validation plan
+-----------------------------
+Check all items before flipping ``AUTOBOT_DELEGATION_ENABLED=true`` in production:
+
+- [ ] Flag: ``AUTOBOT_DELEGATION_ENABLED`` remains OFF (default); enable per-env.
+- [ ] Depth bound: ``AUTOBOT_MAX_DELEGATION_DEPTH`` (default 2) is enforced in
+      ``run_delegated_subtask`` before any engine is invoked.  Verify via the
+      ``test_run_delegated_subtask_depth_guard`` test.
+- [ ] Per-turn subtask limit: ``AUTOBOT_MAX_DELEGATIONS_PER_TURN`` (default 5)
+      is enforced in ``_handle_delegate_tool`` (tool_handler.py) before calling
+      ``run_delegated_subtask``.  Verify via ``test_delegate_tool_per_turn_limit``.
+- [ ] Forbidden-work on internal engine: ``agent_context.agent_id`` is set on the
+      ``LLMIterationContext`` so every tool call goes through ``_enforce_forbidden_work``
+      at the ``_dispatch_tool_call`` seam. Verified by ``test_internal_engine_governs_and_bounds_depth``.
+- [ ] Forbidden-work on claude_code engine: ``forbidden_to_claude_tools`` maps tokens
+      to ``--disallowedTools``; out-of-process subprocess cannot call AutoBot's
+      ``delegate`` tool (it is not a claude_code native tool, so no recursive loop).
+      Verified by ``test_claude_code_engine_passes_disallowed_from_forbidden_work`` and
+      ``test_shipped_research_agent_has_no_fail_open_tokens``.
+- [ ] Observability: delegation dispatch emits an INFO log with engine, depth,
+      parent_agent_id, and child agent_type (in ``run_delegated_subtask``).  Check
+      log output for the ``[GH#11266]`` tag before enabling.
+- [ ] Smoke-test: enable flag in staging, send one research task, confirm INFO log
+      appears, depth-limit rejects a manually crafted depth=MAX request, and the
+      per-turn limit fires after MAX delegations in a single turn.
 """
 
-import os
 from typing import Awaitable, Callable, Dict, List
 
 from autobot_shared import tool_catalogue as _tc
+from autobot_shared.env_utils import env_flag, env_int
 from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
 
 # Master switch — delegate tool keeps its current (record-only) behaviour when off.
-DELEGATION_ENABLED: bool = os.environ.get("AUTOBOT_DELEGATION_ENABLED", "").lower() in ("1", "true", "yes")
+DELEGATION_ENABLED: bool = env_flag("AUTOBOT_DELEGATION_ENABLED", default=False)
 # Bound on how deep delegation may nest (defence against runaway delegation).
-MAX_DELEGATION_DEPTH: int = int(os.environ.get("AUTOBOT_MAX_DELEGATION_DEPTH", "2"))
+MAX_DELEGATION_DEPTH: int = env_int("AUTOBOT_MAX_DELEGATION_DEPTH", default=2)
+# Max number of ``delegate`` calls allowed per LLM turn (defence against fan-out).
+MAX_DELEGATIONS_PER_TURN: int = env_int("AUTOBOT_MAX_DELEGATIONS_PER_TURN", default=5)
 
 # AutoBot ``forbidden_work`` token → claude_code CLI tool name to disallow. claude_code
 # exposes coarse tools (Bash/Edit/Write), so shell/infra/file-mutation tokens collapse
@@ -137,15 +171,29 @@ _ENGINES: Dict[str, Callable[[str, str, int], Awaitable[str]]] = {
 
 
 async def run_delegated_subtask(
-    task: str, agent_type: str = "research_agent", depth: int = 0, engine: str = "claude_code"
+    task: str,
+    agent_type: str = "research_agent",
+    depth: int = 0,
+    engine: str = "claude_code",
+    parent_agent_id: str | None = None,
 ) -> str:
     """Run a delegated subtask as a governed subagent (GH#11207).
 
     Raises ``ValueError`` past ``MAX_DELEGATION_DEPTH`` or for an unknown engine.
+    Emits an INFO log with engine, depth, parent_agent_id, and child agent_type
+    for observability (GH#11266 validation plan gate).
     """
     if depth >= MAX_DELEGATION_DEPTH:
         raise ValueError(f"max delegation depth {MAX_DELEGATION_DEPTH} reached (depth={depth})")
     runner = _ENGINES.get(engine)
     if runner is None:
         raise ValueError(f"unknown delegation engine: {engine!r} (available: {sorted(_ENGINES)})")
+    logger.info(
+        "[GH#11266] delegation dispatch: parent=%s engine=%s child=%s depth=%d task=%.80r",
+        parent_agent_id or "root",
+        engine,
+        agent_type,
+        depth,
+        task,
+    )
     return await runner(task, agent_type, depth)

--- a/autobot-backend/chat_workflow/delegation_test.py
+++ b/autobot-backend/chat_workflow/delegation_test.py
@@ -171,8 +171,6 @@ async def test_delegate_tool_on_runs_governed_subagent():
 
 def test_delegation_enabled_default_is_false():
     """DELEGATION_ENABLED must default OFF — no side-effects on import."""
-    import importlib
-    import sys
 
     # Reload with env cleared to confirm default.
     saved = delegation.DELEGATION_ENABLED
@@ -244,10 +242,7 @@ async def test_delegate_tool_per_turn_limit_blocks_excess():
     )
     results = []
     with patch.object(delegation, "DELEGATION_ENABLED", True):
-        msgs = [
-            m
-            async for m in mixin._handle_delegate_tool({"params": {"task": "overflow"}}, results, ctx)
-        ]
+        msgs = [m async for m in mixin._handle_delegate_tool({"params": {"task": "overflow"}}, results, ctx)]
     assert results[0]["status"] == "error"
     assert "limit" in results[0]["error"]
     assert msgs[0].type == "error"

--- a/autobot-backend/chat_workflow/delegation_test.py
+++ b/autobot-backend/chat_workflow/delegation_test.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Governed subagent delegation runner (GH#11207)."""
+"""Governed subagent delegation runner (GH#11207, GH#11266)."""
 
 from unittest.mock import AsyncMock, patch
 
@@ -11,6 +11,7 @@ import pytest
 from chat_workflow import delegation
 from chat_workflow.delegation import (
     MAX_DELEGATION_DEPTH,
+    MAX_DELEGATIONS_PER_TURN,
     forbidden_to_claude_tools,
     run_delegated_subtask,
 )
@@ -163,3 +164,145 @@ async def test_delegate_tool_on_runs_governed_subagent():
         ]
     assert results[0]["status"] == "completed" and results[0]["result"] == "done"
     assert msgs[0].type == "delegation"
+
+
+# --- GH#11266: env_flag / env_int usage (canonical truthy set) ---------------
+
+
+def test_delegation_enabled_default_is_false():
+    """DELEGATION_ENABLED must default OFF — no side-effects on import."""
+    import importlib
+    import sys
+
+    # Reload with env cleared to confirm default.
+    saved = delegation.DELEGATION_ENABLED
+    with patch.dict("os.environ", {}, clear=False):
+        import os
+
+        os.environ.pop("AUTOBOT_DELEGATION_ENABLED", None)
+        # Re-evaluate the flag via env_flag to confirm semantics.
+        from autobot_shared.env_utils import env_flag
+
+        assert env_flag("AUTOBOT_DELEGATION_ENABLED", default=False) is False
+    # Module-level constant must also be False (loaded without the env var set).
+    assert saved is False, "DELEGATION_ENABLED must be OFF by default"
+
+
+def test_max_delegation_depth_from_env_int():
+    """MAX_DELEGATION_DEPTH is read via env_int so invalid values fall back gracefully."""
+    from autobot_shared.env_utils import env_int
+
+    assert env_int("AUTOBOT_MAX_DELEGATION_DEPTH", default=2) == MAX_DELEGATION_DEPTH
+
+
+def test_max_delegations_per_turn_exported():
+    """MAX_DELEGATIONS_PER_TURN constant is exported and positive."""
+    assert MAX_DELEGATIONS_PER_TURN > 0
+
+
+# --- GH#11266: run_delegated_subtask — parent_agent_id observability ---------
+
+
+@pytest.mark.asyncio
+async def test_run_delegated_subtask_logs_parent_agent_id(caplog):
+    """Dispatch must emit an INFO log containing parent_agent_id."""
+    import logging
+
+    engine = AsyncMock(return_value="result")
+    with patch.dict(delegation._ENGINES, {"claude_code": engine}):
+        with caplog.at_level(logging.INFO, logger="chat_workflow.delegation"):
+            await run_delegated_subtask("task", agent_type="research_agent", depth=0, parent_agent_id="root_agent")
+    assert any("root_agent" in r.message for r in caplog.records), "parent_agent_id must appear in INFO log"
+    assert any("research_agent" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_run_delegated_subtask_logs_root_when_no_parent(caplog):
+    """When parent_agent_id is None the log must show 'root'."""
+    import logging
+
+    engine = AsyncMock(return_value="result")
+    with patch.dict(delegation._ENGINES, {"claude_code": engine}):
+        with caplog.at_level(logging.INFO, logger="chat_workflow.delegation"):
+            await run_delegated_subtask("task", depth=0)
+    assert any("root" in r.message for r in caplog.records)
+
+
+# --- GH#11266: per-turn delegation fan-out limit ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_delegate_tool_per_turn_limit_blocks_excess():
+    """After MAX_DELEGATIONS_PER_TURN calls the next one is rejected with an error."""
+    from types import SimpleNamespace
+
+    mixin = _mixin()
+    # Fabricate a minimal ctx with context dict already at limit.
+    ctx = SimpleNamespace(
+        context={"delegations_this_turn": MAX_DELEGATIONS_PER_TURN},
+        agent_context=None,
+    )
+    results = []
+    with patch.object(delegation, "DELEGATION_ENABLED", True):
+        msgs = [
+            m
+            async for m in mixin._handle_delegate_tool({"params": {"task": "overflow"}}, results, ctx)
+        ]
+    assert results[0]["status"] == "error"
+    assert "limit" in results[0]["error"]
+    assert msgs[0].type == "error"
+
+
+@pytest.mark.asyncio
+async def test_delegate_tool_per_turn_counter_increments():
+    """Each successful delegation increments delegations_this_turn on ctx."""
+    from types import SimpleNamespace
+
+    mixin = _mixin()
+    ctx = SimpleNamespace(context={"delegations_this_turn": 0}, agent_context=None)
+    results = []
+    with (
+        patch.object(delegation, "DELEGATION_ENABLED", True),
+        patch.object(delegation, "run_delegated_subtask", new=AsyncMock(return_value="ok")),
+    ):
+        _ = [m async for m in mixin._handle_delegate_tool({"params": {"task": "t"}}, results, ctx)]
+    assert ctx.context["delegations_this_turn"] == 1
+
+
+@pytest.mark.asyncio
+async def test_delegate_tool_passes_parent_agent_id_to_runner():
+    """The parent agent_id from ctx.agent_context must reach run_delegated_subtask."""
+    from types import SimpleNamespace
+
+    mixin = _mixin()
+    agent_ctx = SimpleNamespace(agent_id="the_parent")
+    ctx = SimpleNamespace(context={"delegations_this_turn": 0, "delegation_depth": 0}, agent_context=agent_ctx)
+    captured = {}
+    mock_run = AsyncMock(side_effect=lambda *a, **kw: captured.update(kw) or "done")
+
+    with (
+        patch.object(delegation, "DELEGATION_ENABLED", True),
+        patch.object(delegation, "run_delegated_subtask", new=mock_run),
+    ):
+        _ = [m async for m in mixin._handle_delegate_tool({"params": {"task": "t"}}, [], ctx)]
+    assert captured.get("parent_agent_id") == "the_parent"
+
+
+# --- GH#11266: env_flag covers "on" (canonical truthy) ----------------------
+
+
+def test_env_flag_covers_on_truthy():
+    """env_flag('AUTOBOT_DELEGATION_ENABLED') must accept 'on' as truthy."""
+    from autobot_shared.env_utils import env_flag
+
+    with patch.dict("os.environ", {"AUTOBOT_DELEGATION_ENABLED": "on"}):
+        assert env_flag("AUTOBOT_DELEGATION_ENABLED") is True
+
+    with patch.dict("os.environ", {"AUTOBOT_DELEGATION_ENABLED": "yes"}):
+        assert env_flag("AUTOBOT_DELEGATION_ENABLED") is True
+
+    with patch.dict("os.environ", {"AUTOBOT_DELEGATION_ENABLED": "1"}):
+        assert env_flag("AUTOBOT_DELEGATION_ENABLED") is True
+
+    with patch.dict("os.environ", {"AUTOBOT_DELEGATION_ENABLED": "false"}):
+        assert env_flag("AUTOBOT_DELEGATION_ENABLED") is False

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -1854,7 +1854,7 @@ class ToolHandlerMixin:
         agent_type = params.get("agent_type", "research_agent")
         engine = params.get("engine", "claude_code")
         depth = int(ctx_dict.get("delegation_depth", 0))
-        parent_agent_id = (ctx.agent_context.agent_id if ctx and ctx.agent_context else None)
+        parent_agent_id = ctx.agent_context.agent_id if ctx and ctx.agent_context else None
         try:
             result = await run_delegated_subtask(
                 task,

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -1807,7 +1807,11 @@ class ToolHandlerMixin:
         the subtask as a governed subagent (its ``forbidden_work`` constrains it) via
         the selected engine and returns the result. Yields WorkflowMessage(s).
         """
-        from chat_workflow.delegation import DELEGATION_ENABLED, run_delegated_subtask
+        from chat_workflow.delegation import (
+            DELEGATION_ENABLED,
+            MAX_DELEGATIONS_PER_TURN,
+            run_delegated_subtask,
+        )
 
         params = tool_call.get("params", {})
         task = params.get("task", "")
@@ -1831,14 +1835,34 @@ class ToolHandlerMixin:
             )
             return
 
+        # GH#11266: enforce per-turn delegation fan-out limit.
+        ctx_dict = (getattr(ctx, "context", None) or {}) if ctx else {}
+        delegations_this_turn: int = ctx_dict.get("delegations_this_turn", 0)
+        if delegations_this_turn >= MAX_DELEGATIONS_PER_TURN:
+            error = f"per-turn delegation limit ({MAX_DELEGATIONS_PER_TURN}) reached"
+            logger.warning("[GH#11266] %s", error)
+            execution_results.append({"tool": "delegate", "task": task, "status": "error", "error": error})
+            yield WorkflowMessage(
+                type="error",
+                content=f"Delegation blocked: {error}",
+                metadata={"message_type": "delegate_tool", "error": True},
+            )
+            return
+        if ctx is not None and ctx.context is not None:
+            ctx.context["delegations_this_turn"] = delegations_this_turn + 1
+
         agent_type = params.get("agent_type", "research_agent")
         engine = params.get("engine", "claude_code")
-        depth = int((getattr(ctx, "context", None) or {}).get("delegation_depth", 0)) if ctx else 0
-        logger.info(
-            "[GH#11207] Delegating to %s subagent (engine=%s, depth=%d): %s", agent_type, engine, depth, task[:100]
-        )
+        depth = int(ctx_dict.get("delegation_depth", 0))
+        parent_agent_id = (ctx.agent_context.agent_id if ctx and ctx.agent_context else None)
         try:
-            result = await run_delegated_subtask(task, agent_type=agent_type, depth=depth, engine=engine)
+            result = await run_delegated_subtask(
+                task,
+                agent_type=agent_type,
+                depth=depth,
+                engine=engine,
+                parent_agent_id=parent_agent_id,
+            )
             execution_results.append(
                 {
                     "tool": "delegate",


### PR DESCRIPTION
## Thinking Path
The governed subagent runner (`chat_workflow/delegation.py`, #11207) is built and depth-bounded but dormant behind `AUTOBOT_DELEGATION_ENABLED` (default OFF). Rather than flip it blindly, this hardens the enforcement and documents a validation plan so enabling becomes a safe one-line config change.

## What Changed
- `chat_workflow/delegation.py`: switched raw `os.environ` reads to canonical `env_flag`/`env_int` (fixes a latent bug where `AUTOBOT_DELEGATION_ENABLED=on` was silently ignored); added `MAX_DELEGATIONS_PER_TURN` (default 5); added `parent_agent_id` observability to `run_delegated_subtask`; added an "Enablement / validation plan" checklist docstring. Flag stays **OFF** by default.
- `chat_workflow/tool_handler.py`: enforces the per-turn delegation fan-out limit and threads `parent_agent_id` through. Depth bound remains enforced centrally in `run_delegated_subtask` (both engines).

## Verification
- `chat_workflow/delegation_test.py` — **21 passed** (no-op when flag OFF, depth-limit rejects `depth=MAX`, per-turn fan-out limit, forbidden-work enforced, observability).

Closes #11266

## Model Used
Claude Opus 4.8
