### PR TITLE
test(rag): patch real publish_event (was stale publish_live_event) — fixes 37/38 (#11248)

### DIFF
--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -511,7 +511,7 @@ class RAGService:
     ) -> None:
         """Publish a rag_retrieval live event after each search. Issue #1516.
 
-        Fires publish_live_event("global", RAG_RETRIEVAL, ...) so that
+        Fires publish_event("global", RAG_RETRIEVAL, ...) so that
         Neural Mesh RAG (#1994) consumers can observe retrieval patterns in
         real time via the /ws/live WebSocket endpoint.
 

--- a/autobot-backend/tests/services/rag_service_events_test.py
+++ b/autobot-backend/tests/services/rag_service_events_test.py
@@ -30,9 +30,9 @@ class TestEmitRetrievalFeedback:
         return svc
 
     @pytest.mark.asyncio
-    async def test_calls_publish_live_event(self):
-        """_emit_retrieval_feedback calls publish_live_event exactly once."""
-        with patch("services.rag_service.publish_live_event", new_callable=AsyncMock) as mock_pub:
+    async def test_calls_publish_event(self):
+        """_emit_retrieval_feedback calls publish_event exactly once."""
+        with patch("services.rag_service.publish_event", new_callable=AsyncMock) as mock_pub:
             svc = self._make_service()
             await svc._emit_retrieval_feedback(
                 query="test query",
@@ -44,7 +44,7 @@ class TestEmitRetrievalFeedback:
     @pytest.mark.asyncio
     async def test_channel_is_global(self):
         """Event is published to the 'global' channel."""
-        with patch("services.rag_service.publish_live_event", new_callable=AsyncMock) as mock_pub:
+        with patch("services.rag_service.publish_event", new_callable=AsyncMock) as mock_pub:
             svc = self._make_service()
             await svc._emit_retrieval_feedback(
                 query="q",
@@ -57,7 +57,7 @@ class TestEmitRetrievalFeedback:
     @pytest.mark.asyncio
     async def test_event_type_is_rag_retrieval(self):
         """Event type is 'rag_retrieval'."""
-        with patch("services.rag_service.publish_live_event", new_callable=AsyncMock) as mock_pub:
+        with patch("services.rag_service.publish_event", new_callable=AsyncMock) as mock_pub:
             svc = self._make_service()
             await svc._emit_retrieval_feedback(
                 query="q",
@@ -70,7 +70,7 @@ class TestEmitRetrievalFeedback:
     @pytest.mark.asyncio
     async def test_payload_contains_query_text(self):
         """Payload includes query_text field."""
-        with patch("services.rag_service.publish_live_event", new_callable=AsyncMock) as mock_pub:
+        with patch("services.rag_service.publish_event", new_callable=AsyncMock) as mock_pub:
             svc = self._make_service()
             await svc._emit_retrieval_feedback(
                 query="what is redis",
@@ -83,7 +83,7 @@ class TestEmitRetrievalFeedback:
     @pytest.mark.asyncio
     async def test_payload_contains_retrieved_chunk_ids(self):
         """Payload includes retrieved_chunk_ids field."""
-        with patch("services.rag_service.publish_live_event", new_callable=AsyncMock) as mock_pub:
+        with patch("services.rag_service.publish_event", new_callable=AsyncMock) as mock_pub:
             svc = self._make_service()
             await svc._emit_retrieval_feedback(
                 query="q",
@@ -96,7 +96,7 @@ class TestEmitRetrievalFeedback:
     @pytest.mark.asyncio
     async def test_payload_contains_final_ranked_ids(self):
         """Payload includes final_ranked_ids field."""
-        with patch("services.rag_service.publish_live_event", new_callable=AsyncMock) as mock_pub:
+        with patch("services.rag_service.publish_event", new_callable=AsyncMock) as mock_pub:
             svc = self._make_service()
             await svc._emit_retrieval_feedback(
                 query="q",
@@ -109,7 +109,7 @@ class TestEmitRetrievalFeedback:
     @pytest.mark.asyncio
     async def test_payload_contains_timestamp(self):
         """Payload includes a numeric timestamp."""
-        with patch("services.rag_service.publish_live_event", new_callable=AsyncMock) as mock_pub:
+        with patch("services.rag_service.publish_event", new_callable=AsyncMock) as mock_pub:
             svc = self._make_service()
             await svc._emit_retrieval_feedback(
                 query="q",
@@ -122,9 +122,9 @@ class TestEmitRetrievalFeedback:
 
     @pytest.mark.asyncio
     async def test_publish_error_does_not_propagate(self):
-        """If publish_live_event raises, _emit_retrieval_feedback does not re-raise."""
+        """If publish_event raises, _emit_retrieval_feedback does not re-raise."""
         with patch(
-            "services.rag_service.publish_live_event",
+            "services.rag_service.publish_event",
             new_callable=AsyncMock,
             side_effect=RuntimeError("ws down"),
         ):
@@ -298,7 +298,7 @@ class TestComplexityInEmitRetrievalFeedback:
     @pytest.mark.asyncio
     async def test_payload_contains_complexity_field(self):
         """Payload includes a complexity field when explicitly provided."""
-        with patch("services.rag_service.publish_live_event", new_callable=AsyncMock) as mock_pub:
+        with patch("services.rag_service.publish_event", new_callable=AsyncMock) as mock_pub:
             svc = self._make_service()
             await svc._emit_retrieval_feedback(
                 query="what is redis",
@@ -321,7 +321,7 @@ class TestComplexityInEmitRetrievalFeedback:
         query = "compare redis and memcached advantages and disadvantages"
         expected_complexity = classifier.classify(query).value
 
-        with patch("services.rag_service.publish_live_event", new_callable=AsyncMock) as mock_pub:
+        with patch("services.rag_service.publish_event", new_callable=AsyncMock) as mock_pub:
             svc = self._make_service()
             await svc._emit_retrieval_feedback(
                 query=query,
@@ -336,7 +336,7 @@ class TestComplexityInEmitRetrievalFeedback:
     @pytest.mark.asyncio
     async def test_default_complexity_is_simple(self):
         """When no complexity is passed, the default is 'simple'."""
-        with patch("services.rag_service.publish_live_event", new_callable=AsyncMock) as mock_pub:
+        with patch("services.rag_service.publish_event", new_callable=AsyncMock) as mock_pub:
             svc = self._make_service()
             await svc._emit_retrieval_feedback(
                 query="q",

--- a/autobot_shared/integrity_manifest_test.py
+++ b/autobot_shared/integrity_manifest_test.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import json
 
-
 from autobot_shared.integrity_manifest import (
     compute_manifest,
     verify_integrity_at_startup,


### PR DESCRIPTION
## Thinking Path
Item from the #11248 test-remediation umbrella. `rag_service_events_test` patched
`services.rag_service.publish_live_event`, but the code (`rag_service.py:532`)
calls `publish_event` (imported from `events.bus`; `events/bus.py` has no
`publish_live_event`). The stale name doesn't exist on the module, so `patch(...)`
raised `AttributeError` at setup — the whole file was erroring. Clean test-rot
(function renamed, test not updated).

## What Changed
- `rag_service_events_test.py` — rename the 14 stale `publish_live_event` patch
  targets → `publish_event` (the real function).
- `rag_service.py` — fix the matching stale docstring ("Fires publish_live_event").

## Verification
- Was ~all erroring → now **37 of 38 pass**.
- **Known residual (not regressed):** `test_calls_publish_event` still reports 0
  mock calls though its 7 identical sibling tests intercept fine and the code
  demonstrably calls `publish_event` (debug log shows a real publish) — a
  mock-interception anomaly specific to this one test; pre-existing (it errored
  before this change) and flagged on #11248 for follow-up.
- `py_compile` + `black --check -l120` + `isort` clean.

## Model Used
Opus 4.8 (1M context)

Refs #11248.