### PR TITLE
fix(grounded): case-insensitive claim annotation + verify causal CRITICAL path (#11248)

### DIFF
--- a/autobot-backend/services/grounded_agent.py
+++ b/autobot-backend/services/grounded_agent.py
@@ -28,6 +28,7 @@ Data flow:
 7. Return GroundedResponse with full provenance
 """
 
+import re
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -522,11 +523,16 @@ Format as JSON array of objects with fields: claim_text, subject, predicate, obj
 
         for verified in verified_claims:
             if verified.kb_source and verified.confidence > 0.7:
-                # Find claim text in response and annotate it
+                # Find claim text in response and annotate it. Match
+                # case-insensitively — LLM-extracted claims routinely differ in
+                # case from the source text — but keep the response's original
+                # casing in the output so the text isn't rewritten (#11248).
                 claim_text = verified.claim.claim_text
-                if claim_text in reconstructed:
-                    annotation = f"{claim_text} [KB source, {verified.confidence:.0%} confidence]"
-                    reconstructed = reconstructed.replace(claim_text, annotation)
+                match = re.search(re.escape(claim_text), reconstructed, re.IGNORECASE)
+                if match:
+                    matched = match.group(0)
+                    annotation = f"{matched} [KB source, {verified.confidence:.0%} confidence]"
+                    reconstructed = reconstructed[: match.start()] + annotation + reconstructed[match.end() :]
 
         return reconstructed
 

--- a/autobot-backend/tests/services/test_causal_inference_engine.py
+++ b/autobot-backend/tests/services/test_causal_inference_engine.py
@@ -412,17 +412,22 @@ class TestSeverityAssessment:
             confidence=0.85,
         )
 
+        # _assess_severity intentionally downgrades CRITICAL→DEGRADED when a
+        # high-confidence fix exists (predicted_success_rate>=0.8 AND
+        # confidence>=0.8). To verify the CRITICAL classification path itself
+        # (deep chain + high report confidence), use an intervention below that
+        # threshold so the downgrade doesn't fire. (#11248)
         interventions = [
             Intervention(
                 name="Fix",
                 description="",
                 mechanism="",
-                predicted_success_rate=0.9,
+                predicted_success_rate=0.6,
                 cost_level="low",
                 risk_level="low",
                 recommendation_type=RecommendationType.IMMEDIATE,
                 impact_rank=1,
-                confidence=0.9,
+                confidence=0.6,
             )
         ]
 

--- a/autobot-backend/tests/services/test_grounded_agent.py
+++ b/autobot-backend/tests/services/test_grounded_agent.py
@@ -243,11 +243,15 @@ async def test_reconstruct_response_with_annotation(grounded_agent):
         confidence=0.95,
     )
 
+    # The claim ("Latency increased") differs in case from the response
+    # ("the latency increased"); reconstruction matches case-insensitively and
+    # annotates it while preserving the response's original casing (#11248).
     original = "The latency increased by 15%."
     reconstructed = await grounded_agent._reconstruct_response(original, [verified])
 
-    assert "Latency increased" in reconstructed
-    assert reconstructed != original or "[KB source" in reconstructed
+    assert "latency increased" in reconstructed.lower()
+    assert "[KB source" in reconstructed
+    assert reconstructed != original
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Thinking Path
The two #11248 items you asked me to decide (biggest-gain wins):

**grounded_agent (real robustness bug)** — `_reconstruct_response` matched claims
case-**sensitively** (`claim_text in reconstructed`), so an LLM-extracted claim
whose case differs from the source (e.g. claim `"Latency increased"` vs response
`"the latency increased"`) silently got **no** KB-source annotation. Biggest gain:
match case-insensitively and **preserve the response's original casing** in the
output (don't rewrite the user's text). Fixes the production bug; source text stays
intact.

**causal severity (zero-risk path fix)** — `test_critical_severity` expected CRITICAL,
but `_assess_severity` *intentionally* downgrades CRITICAL→DEGRADED when a
high-confidence fix exists (documented in code). Rather than change that documented
semantics (a separate product call), make the test verify the true CRITICAL path
with a sub-threshold intervention — zero behaviour change.

## What Changed
- `services/grounded_agent.py` — case-insensitive `re.search(..., IGNORECASE)`,
  preserve matched (response) casing; annotate first match. (`import re` added.)
- `tests/services/test_grounded_agent.py` — assert the annotation fired + claim
  present case-insensitively (was asserting the claim's exact capitalisation).
- `tests/services/test_causal_inference_engine.py` — intervention 0.9/0.9 → 0.6/0.6
  so the documented high-confidence-fix downgrade doesn't fire.

## Verification
- grounded `test_reconstruct_response_with_annotation`: **passes on py3.10 and py3.12** (was failing both).
- causal `test_critical_severity`: **passes**.
- No regressions — `test_grounding_mixed` + `test_resolve_conflict` already fail on
  base (separate pre-existing #11248 items: Redis-None + verification-returns-0).
- `py_compile` + `black --check -l120` + `isort` clean.

## Model Used
Opus 4.8 (1M context)

Refs #11248.
