### PR TITLE
fix(slm): logging tolerates a backend whose config lacks config_manager — SLM startup crash (#11283)

### DIFF
--- a/autobot_shared/logging_manager.py
+++ b/autobot_shared/logging_manager.py
@@ -31,11 +31,31 @@ def _get_config_manager() -> "ConfigManager":
     logging_manager -> config -> manager -> loader -> model_constants -> (back).
     Ref: issue #1862.
     """
-    from config import (  # type: ignore[attr-defined]  # GH#7105: local backend import  # noqa: PLC0415
-        config_manager as _cm,
-    )
+    try:
+        from config import (  # type: ignore[attr-defined]  # GH#7105: local backend import  # noqa: PLC0415
+            config_manager as _cm,
+        )
+    except ImportError:
+        # Some backends (e.g. autobot-slm-backend) don't expose `config_manager`
+        # on their local `config` module. Logging is foundational infra imported
+        # at startup — it must NOT crash the app. Fall back to a stub whose
+        # .get(key, default) returns the caller's default, so file-handler/format
+        # setup uses the built-in defaults instead of raising ImportError (#11283).
+        return _ConfigManagerFallback()
 
     return _cm
+
+
+class _ConfigManagerFallback:
+    """Config-manager stub for backends whose `config` module has no config_manager.
+
+    Every logging call site passes a default (or handles ``None``), so returning
+    the default keeps logging working without the real config manager (#11283).
+    """
+
+    @staticmethod
+    def get(key, default=None):  # noqa: ANN001, ANN205
+        return default
 
 
 class LoggingManager:


### PR DESCRIPTION
## Thinking Path
The smoke-test "flake" (#11283) is **not timing — autobot-slm crashes on startup.**
The failing run's container logs show:
```
ImportError: cannot import name 'config_manager' from 'config'
  (/app/autobot-slm-backend/config.py)
```
Chain: `main → autobot_shared.integrity_manifest → logging_manager.get_logger →
_get_file_handler → _get_config_manager`, which does `from config import
config_manager`. The **main** backend's `config` provides it; the **SLM**
backend's `config.py` does not → ImportError → uvicorn never serves
`/api/health` → compose marks the container unhealthy → smoke-test red. (Any SLM
deploy using file logging would crash the same way.)

Every logging call site already passes a default (or handles `None`) — only the
*import* was fatal.

## What Changed
- `autobot_shared/logging_manager.py` — wrap the lazy `config_manager` import in
  try/except; on ImportError return a `_ConfigManagerFallback` stub whose
  `.get(key, default)` returns the default, so logging uses its built-in defaults
  instead of crashing the app.

(The healthcheck `start_period` 60s→120s bump already landed via #11284 as a
defensive measure for the 25-migration startup; this PR is the actual root-cause fix.)

## Verification
- Reproduced: with a `config` module lacking `config_manager`,
  `_get_config_manager()` returns the stub and `.get(k, 5)` → `5` (no ImportError).
- `py_compile` + `black --check -l120` + `isort` clean.
- End-to-end confirmation is smoke-test going green with the SLM container healthy.

## Model Used
Opus 4.8 (1M context)

Closes #11283
