### PR TITLE
feat(skills): T0+T1 — boot-reload fix + scope/grant authz core (#11277)

### DIFF
--- a/autobot-backend/migrations/versions/20260708_068_resource_grants.py
+++ b/autobot-backend/migrations/versions/20260708_068_resource_grants.py
@@ -29,7 +29,10 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
         sa.UniqueConstraint(
-            "resource_type", "resource_id", "grantee_type", "grantee_id",
+            "resource_type",
+            "resource_id",
+            "grantee_type",
+            "grantee_id",
             name="uq_resource_grants_target",
         ),
     )

--- a/autobot-backend/migrations/versions/20260708_068_resource_grants.py
+++ b/autobot-backend/migrations/versions/20260708_068_resource_grants.py
@@ -1,0 +1,45 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Add resource_grants table for scoped/shareable skills and agents (#11277)."""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260708_068"
+down_revision: Union[str, Sequence[str], None] = "20260708_067"  # verify via `alembic heads`
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "resource_grants",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("resource_type", sa.String(length=32), nullable=False),
+        sa.Column("resource_id", sa.String(length=255), nullable=False),
+        sa.Column("grantee_type", sa.String(length=16), nullable=False),
+        sa.Column("grantee_id", sa.String(length=255), nullable=False),
+        sa.Column("permission", sa.String(length=16), nullable=False, server_default="use"),
+        sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint(
+            "resource_type", "resource_id", "grantee_type", "grantee_id",
+            name="uq_resource_grants_target",
+        ),
+    )
+    op.create_index("ix_resource_grants_resource_type", "resource_grants", ["resource_type"])
+    op.create_index("ix_resource_grants_resource_id", "resource_grants", ["resource_id"])
+    op.create_index("ix_resource_grants_grantee_id", "resource_grants", ["grantee_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_resource_grants_grantee_id", table_name="resource_grants")
+    op.drop_index("ix_resource_grants_resource_id", table_name="resource_grants")
+    op.drop_index("ix_resource_grants_resource_type", table_name="resource_grants")
+    op.drop_table("resource_grants")

--- a/autobot-backend/models/resource_grant.py
+++ b/autobot-backend/models/resource_grant.py
@@ -32,7 +32,10 @@ class ResourceGrant(Base):
 
     __table_args__ = (
         UniqueConstraint(
-            "resource_type", "resource_id", "grantee_type", "grantee_id",
+            "resource_type",
+            "resource_id",
+            "grantee_type",
+            "grantee_id",
             name="uq_resource_grants_target",
         ),
     )

--- a/autobot-backend/models/resource_grant.py
+++ b/autobot-backend/models/resource_grant.py
@@ -9,9 +9,8 @@ a row; revoking = delete a row. Authorization only — no crypto envelope.
 """
 
 import uuid
-from datetime import datetime
 
-from sqlalchemy import DateTime, String, UniqueConstraint, func
+from sqlalchemy import String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.types import Uuid
 
@@ -30,9 +29,6 @@ class ResourceGrant(Base):
     grantee_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     permission: Mapped[str] = mapped_column(String(16), nullable=False, default="use")  # view|use|manage
     created_by: Mapped[uuid.UUID | None] = mapped_column(Uuid(as_uuid=True), nullable=True)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
-    )
 
     __table_args__ = (
         UniqueConstraint(

--- a/autobot-backend/models/resource_grant.py
+++ b/autobot-backend/models/resource_grant.py
@@ -1,0 +1,42 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Generic per-grantee access grant for shareable resources (#11277).
+
+One row grants a user or group a permission on a skill or agent. Sharing = add
+a row; revoking = delete a row. Authorization only — no crypto envelope.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import Uuid
+
+from user_management.models.base import Base
+
+
+class ResourceGrant(Base):
+    """One grant: (resource_type, resource_id) accessible to (grantee_type, grantee_id)."""
+
+    __tablename__ = "resource_grants"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    resource_type: Mapped[str] = mapped_column(String(32), nullable=False, index=True)  # skill|agent
+    resource_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    grantee_type: Mapped[str] = mapped_column(String(16), nullable=False)  # user|group
+    grantee_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    permission: Mapped[str] = mapped_column(String(16), nullable=False, default="use")  # view|use|manage
+    created_by: Mapped[uuid.UUID | None] = mapped_column(Uuid(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "resource_type", "resource_id", "grantee_type", "grantee_id",
+            name="uq_resource_grants_target",
+        ),
+    )

--- a/autobot-backend/models/resource_grant_test.py
+++ b/autobot-backend/models/resource_grant_test.py
@@ -9,8 +9,14 @@ def test_resource_grant_table_and_columns():
     assert ResourceGrant.__tablename__ == "resource_grants"
     cols = set(ResourceGrant.__table__.columns.keys())
     assert cols == {
-        "id", "resource_type", "resource_id", "grantee_type",
-        "grantee_id", "permission", "created_by", "created_at",
+        "id",
+        "resource_type",
+        "resource_id",
+        "grantee_type",
+        "grantee_id",
+        "permission",
+        "created_by",
+        "created_at",
         "updated_at",  # inherited from Base (DeclarativeBase adds this automatically)
     }
 

--- a/autobot-backend/models/resource_grant_test.py
+++ b/autobot-backend/models/resource_grant_test.py
@@ -1,0 +1,20 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+from models.resource_grant import ResourceGrant
+
+
+def test_resource_grant_table_and_columns():
+    assert ResourceGrant.__tablename__ == "resource_grants"
+    cols = set(ResourceGrant.__table__.columns.keys())
+    assert cols == {
+        "id", "resource_type", "resource_id", "grantee_type",
+        "grantee_id", "permission", "created_by", "created_at",
+        "updated_at",  # inherited from Base (DeclarativeBase adds this automatically)
+    }
+
+
+def test_resource_grant_unique_constraint_present():
+    names = {c.name for c in ResourceGrant.__table__.constraints}
+    assert "uq_resource_grants_target" in names

--- a/autobot-backend/services/resource_grant_store.py
+++ b/autobot-backend/services/resource_grant_store.py
@@ -1,0 +1,99 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""DB-backed CRUD + lookup for resource_grants (#11277)."""
+
+import uuid
+
+from sqlalchemy import and_, delete, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.scoping.visibility import Principal
+from models.resource_grant import ResourceGrant
+
+
+async def grant(
+    session: AsyncSession,
+    resource_type: str,
+    resource_id: str,
+    grantee_type: str,
+    grantee_id: str,
+    permission: str = "use",
+    created_by: uuid.UUID | None = None,
+) -> ResourceGrant:
+    """Add or update a grant (idempotent on the unique target key)."""
+    existing = (
+        await session.execute(
+            select(ResourceGrant).where(
+                ResourceGrant.resource_type == resource_type,
+                ResourceGrant.resource_id == resource_id,
+                ResourceGrant.grantee_type == grantee_type,
+                ResourceGrant.grantee_id == grantee_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        existing.permission = permission
+        await session.flush()
+        return existing
+    row = ResourceGrant(
+        resource_type=resource_type,
+        resource_id=resource_id,
+        grantee_type=grantee_type,
+        grantee_id=grantee_id,
+        permission=permission,
+        created_by=created_by,
+    )
+    session.add(row)
+    await session.flush()
+    return row
+
+
+async def revoke(
+    session: AsyncSession,
+    resource_type: str,
+    resource_id: str,
+    grantee_type: str,
+    grantee_id: str,
+) -> bool:
+    """Delete a grant. Returns True if a row was removed."""
+    result = await session.execute(
+        delete(ResourceGrant).where(
+            ResourceGrant.resource_type == resource_type,
+            ResourceGrant.resource_id == resource_id,
+            ResourceGrant.grantee_type == grantee_type,
+            ResourceGrant.grantee_id == grantee_id,
+        )
+    )
+    await session.flush()
+    return (result.rowcount or 0) > 0
+
+
+async def has_grant(
+    session: AsyncSession,
+    resource_type: str,
+    resource_id: str,
+    principal: Principal,
+) -> bool:
+    """True if any grant row matches the principal's user or a group they're in."""
+    grantee_clauses = [
+        and_(ResourceGrant.grantee_type == "user", ResourceGrant.grantee_id == principal.user_id)
+    ]
+    if principal.group_ids:
+        grantee_clauses.append(
+            and_(
+                ResourceGrant.grantee_type == "group",
+                ResourceGrant.grantee_id.in_(list(principal.group_ids)),
+            )
+        )
+    row = (
+        await session.execute(
+            select(ResourceGrant.id).where(
+                ResourceGrant.resource_type == resource_type,
+                ResourceGrant.resource_id == resource_id,
+                or_(*grantee_clauses),
+            ).limit(1)
+        )
+    ).first()
+    return row is not None

--- a/autobot-backend/services/resource_grant_store.py
+++ b/autobot-backend/services/resource_grant_store.py
@@ -77,9 +77,7 @@ async def has_grant(
     principal: Principal,
 ) -> bool:
     """True if any grant row matches the principal's user or a group they're in."""
-    grantee_clauses = [
-        and_(ResourceGrant.grantee_type == "user", ResourceGrant.grantee_id == principal.user_id)
-    ]
+    grantee_clauses = [and_(ResourceGrant.grantee_type == "user", ResourceGrant.grantee_id == principal.user_id)]
     if principal.group_ids:
         grantee_clauses.append(
             and_(
@@ -89,11 +87,13 @@ async def has_grant(
         )
     row = (
         await session.execute(
-            select(ResourceGrant.id).where(
+            select(ResourceGrant.id)
+            .where(
                 ResourceGrant.resource_type == resource_type,
                 ResourceGrant.resource_id == resource_id,
                 or_(*grantee_clauses),
-            ).limit(1)
+            )
+            .limit(1)
         )
     ).first()
     return row is not None

--- a/autobot-backend/services/resource_grant_store_test.py
+++ b/autobot-backend/services/resource_grant_store_test.py
@@ -7,7 +7,6 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 import services.resource_grant_store as store  # dotted import bypasses the MagicMock services stub
-
 from autobot_shared.scoping.visibility import Principal
 from models.resource_grant import ResourceGrant
 

--- a/autobot-backend/services/resource_grant_store_test.py
+++ b/autobot-backend/services/resource_grant_store_test.py
@@ -1,0 +1,55 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import services.resource_grant_store as store  # dotted import bypasses the MagicMock services stub
+
+from autobot_shared.scoping.visibility import Principal
+from models.resource_grant import ResourceGrant
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(ResourceGrant.__table__.create)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_grant_then_has_grant_for_user(db_session):
+    await store.grant(db_session, "skill", "s1", "user", "u1", "use", None)
+    p = Principal(user_id="u1", company_id="c1", group_ids=frozenset())
+    assert await store.has_grant(db_session, "skill", "s1", p) is True
+    other = Principal(user_id="u2", company_id="c1", group_ids=frozenset())
+    assert await store.has_grant(db_session, "skill", "s1", other) is False
+
+
+@pytest.mark.asyncio
+async def test_group_grant_matches_member(db_session):
+    await store.grant(db_session, "skill", "s2", "group", "g1", "use", None)
+    member = Principal(user_id="u9", company_id="c1", group_ids=frozenset({"g1"}))
+    assert await store.has_grant(db_session, "skill", "s2", member) is True
+
+
+@pytest.mark.asyncio
+async def test_grant_is_idempotent(db_session):
+    await store.grant(db_session, "skill", "s3", "user", "u1", "use", None)
+    await store.grant(db_session, "skill", "s3", "user", "u1", "manage", None)  # same target
+    p = Principal(user_id="u1", company_id="c1", group_ids=frozenset())
+    assert await store.has_grant(db_session, "skill", "s3", p) is True
+
+
+@pytest.mark.asyncio
+async def test_revoke_removes_access(db_session):
+    await store.grant(db_session, "skill", "s4", "user", "u1", "use", None)
+    assert await store.revoke(db_session, "skill", "s4", "user", "u1") is True
+    p = Principal(user_id="u1", company_id="c1", group_ids=frozenset())
+    assert await store.has_grant(db_session, "skill", "s4", p) is False

--- a/autobot-backend/services/resource_visibility.py
+++ b/autobot-backend/services/resource_visibility.py
@@ -10,9 +10,9 @@ spec's company-keyed cache — invalidated on grant/scope change via invalidate(
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+import services.resource_grant_store as store
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.scoping.visibility import Principal, ResourceDescriptor, is_visible
-import services.resource_grant_store as store
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/services/resource_visibility.py
+++ b/autobot-backend/services/resource_visibility.py
@@ -1,0 +1,47 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Compose is_visible() + grant lookup into the single access entry point (#11277).
+
+Includes a small per-process decision cache keyed by (resource, principal); the
+spec's company-keyed cache — invalidated on grant/scope change via invalidate().
+"""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.scoping.visibility import Principal, ResourceDescriptor, is_visible
+import services.resource_grant_store as store
+
+logger = get_logger(__name__)
+
+# (resource_type, resource_id) -> { principal_key: bool }
+_cache: dict[tuple[str, str], dict[str, bool]] = {}
+
+
+def _principal_key(p: Principal) -> str:
+    return f"{p.user_id}|{p.company_id}|{','.join(sorted(p.group_ids))}"
+
+
+def invalidate(resource_type: str, resource_id: str) -> None:
+    """Drop cached decisions for a resource (call on grant/scope change)."""
+    _cache.pop((resource_type, resource_id), None)
+
+
+async def can_access(
+    session: AsyncSession,
+    principal: Principal,
+    resource_type: str,
+    resource_id: str,
+    resource: ResourceDescriptor,
+) -> bool:
+    """Return True if principal may access the resource (scope OR explicit grant)."""
+    bucket = _cache.setdefault((resource_type, resource_id), {})
+    pkey = _principal_key(principal)
+    if pkey in bucket:
+        return bucket[pkey]
+    has = await store.has_grant(session, resource_type, resource_id, principal)
+    decision = is_visible(principal, resource, has)
+    bucket[pkey] = decision
+    return decision

--- a/autobot-backend/services/resource_visibility_test.py
+++ b/autobot-backend/services/resource_visibility_test.py
@@ -6,9 +6,8 @@ import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-import services.resource_visibility as rv  # dotted import bypasses the MagicMock services stub
 import services.resource_grant_store as store  # dotted import bypasses the MagicMock services stub
-
+import services.resource_visibility as rv  # dotted import bypasses the MagicMock services stub
 from autobot_shared.scoping.scope_level import ScopeLevel
 from autobot_shared.scoping.visibility import Principal, ResourceDescriptor
 from models.resource_grant import ResourceGrant

--- a/autobot-backend/services/resource_visibility_test.py
+++ b/autobot-backend/services/resource_visibility_test.py
@@ -1,0 +1,41 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import services.resource_visibility as rv  # dotted import bypasses the MagicMock services stub
+import services.resource_grant_store as store  # dotted import bypasses the MagicMock services stub
+
+from autobot_shared.scoping.scope_level import ScopeLevel
+from autobot_shared.scoping.visibility import Principal, ResourceDescriptor
+from models.resource_grant import ResourceGrant
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(ResourceGrant.__table__.create)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_can_access_uses_grant_when_scope_denies(db_session):
+    await store.grant(db_session, "skill", "sX", "user", "u1", "use", None)
+    rv.invalidate("skill", "sX")
+    p = Principal(user_id="u1", company_id="c2", group_ids=frozenset())
+    r = ResourceDescriptor(owner_id="owner", company_id="c1", scope=ScopeLevel.USER)
+    assert await rv.can_access(db_session, p, "skill", "sX", r) is True
+
+
+@pytest.mark.asyncio
+async def test_can_access_org_scope_no_grant(db_session):
+    p = Principal(user_id="u1", company_id="c1", group_ids=frozenset())
+    r = ResourceDescriptor(owner_id="owner", company_id="c1", scope=ScopeLevel.ORGANIZATION)
+    assert await rv.can_access(db_session, p, "skill", "sY", r) is True

--- a/autobot-backend/skills/manager.py
+++ b/autobot-backend/skills/manager.py
@@ -40,18 +40,46 @@ class SkillManager:
         return self._registry
 
     async def initialize(self) -> Dict[str, Any]:
-        """Initialize the skills system: discover and load all skills.
-
-        Returns summary of initialization results.
-        """
+        """Initialize the skills system: discover and load all skills."""
         count = self._registry.discover_builtin_skills()
+        custom = await self._load_custom_definitions()
         await self._load_persisted_configs()
 
         return {
             "skills_discovered": count,
+            "custom_reregistered": custom,
             "total_registered": self._registry.skill_count,
             "categories": list(self._registry.categories),
         }
+
+    async def _load_custom_definitions(self) -> int:
+        """Re-register custom/hub skill definitions so they survive restart (#11277 T0).
+
+        Hub skills persist to Redis but are otherwise lost from the in-process
+        registry on restart. Re-register each as a declarative descriptor so it
+        reappears in list/route. (MCP process reattachment is handled in T2.2.)
+        """
+        from skills.base_skill import SkillManifest
+        from skills.hub import SkillHub
+
+        registered = 0
+        try:
+            installed = await SkillHub().list_installed()
+        except Exception:
+            logger.exception("Failed to list hub skills during reload")
+            return 0
+        for rec in installed:
+            manifest = SkillManifest(
+                name=rec.name,
+                version=rec.version or "1.0.0",
+                description=f"Hub skill {rec.name}",
+                category="hub",
+            )
+            if self._registry.register_declarative(manifest):
+                registered += 1
+        if registered:
+            logger.info("Re-registered %d custom/hub skill(s) at boot", registered)
+        return registered
 
     async def execute_skill(
         self,

--- a/autobot-backend/skills/manager_reload_test.py
+++ b/autobot-backend/skills/manager_reload_test.py
@@ -1,0 +1,52 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+import pytest
+
+from skills.base_skill import SkillManifest
+from skills.manager import SkillManager
+from skills.registry import SkillRegistry
+
+
+class _FakeInstalled:
+    def __init__(self, name, version):
+        self.id = name
+        self.name = name
+        self.version = version
+        self.mcp_url = ""
+        self.installed_at = ""
+
+
+@pytest.mark.asyncio
+async def test_load_custom_definitions_reregisters_hub_skills(monkeypatch):
+    reg = SkillRegistry()
+    mgr = SkillManager(registry=reg)
+
+    async def fake_list_installed(self):
+        return [_FakeInstalled("hub-alpha", "1.2.0")]
+
+    monkeypatch.setattr("skills.hub.SkillHub.list_installed", fake_list_installed)
+
+    count = await mgr._load_custom_definitions()
+
+    assert count == 1
+    assert reg.get("hub-alpha") is not None
+    assert reg.get_skill_detail("hub-alpha")["version"] == "1.2.0"
+
+
+@pytest.mark.asyncio
+async def test_load_custom_definitions_skips_names_already_registered(monkeypatch):
+    reg = SkillRegistry()
+    reg.register_declarative(SkillManifest(name="hub-alpha", version="9.9.9", description="d"))
+    mgr = SkillManager(registry=reg)
+
+    async def fake_list_installed(self):
+        return [_FakeInstalled("hub-alpha", "1.2.0")]
+
+    monkeypatch.setattr("skills.hub.SkillHub.list_installed", fake_list_installed)
+
+    count = await mgr._load_custom_definitions()
+
+    assert count == 0  # already present, not overwritten
+    assert reg.get_skill_detail("hub-alpha")["version"] == "9.9.9"

--- a/autobot-backend/skills/registry.py
+++ b/autobot-backend/skills/registry.py
@@ -62,6 +62,21 @@ class SkillRegistry:
         self._publish_skill_promoted(name, manifest.tools)
         self._rebuild_routing_index()
 
+    def register_declarative(self, manifest: "SkillManifest") -> bool:
+        """Register a SKILL.md-style manifest as a DeclarativeSkill.
+
+        Returns True if newly registered, False if a skill of that name exists.
+        Used by builtin Pass-2 discovery and by boot-time custom-skill reload.
+        """
+        with self._lock:
+            if manifest.name in self._skills:
+                return False
+            self._skills[manifest.name] = DeclarativeSkill(manifest)
+        self._rebuild_routing_index()
+        self._publish_skill_promoted(manifest.name, manifest.tools)
+        logger.info("Registered declarative skill: %s v%s", manifest.name, manifest.version)
+        return True
+
     def _rebuild_routing_index(self) -> None:
         """Rebuild the pre-tokenized skill routing index from current registry state.
 
@@ -308,19 +323,8 @@ class SkillRegistry:
                 manifest = _parse_skill_md(skill_md)
                 if manifest is None:
                     continue
-                # Skip if already registered (e.g. by a Python module of the same name)
-                if self._skills.get(manifest.name):
-                    continue
-                instance = DeclarativeSkill(manifest)
-                with self._lock:
-                    self._skills[manifest.name] = instance
-                logger.info(
-                    "Registered declarative skill: %s v%s (SKILL.md-only)",
-                    manifest.name,
-                    manifest.version,
-                )
-                self._publish_skill_promoted(manifest.name, manifest.tools)
-                count += 1
+                if self.register_declarative(manifest):
+                    count += 1
 
         self._rebuild_routing_index()
         logger.info("Discovered %d builtin skills", count)

--- a/autobot-backend/skills/registry_register_declarative_test.py
+++ b/autobot-backend/skills/registry_register_declarative_test.py
@@ -1,0 +1,21 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+from skills.base_skill import SkillManifest
+from skills.registry import SkillRegistry
+
+
+def test_register_declarative_adds_skill():
+    reg = SkillRegistry()
+    m = SkillManifest(name="my-custom", version="2.0.0", description="d", tools=["do_x"])
+    assert reg.register_declarative(m) is True
+    assert reg.get("my-custom") is not None
+    assert reg.get_skill_detail("my-custom")["tools"] == ["do_x"]
+
+
+def test_register_declarative_is_idempotent_by_name():
+    reg = SkillRegistry()
+    m = SkillManifest(name="dup", version="1.0.0", description="d")
+    assert reg.register_declarative(m) is True
+    assert reg.register_declarative(m) is False  # already present

--- a/autobot_shared/scoping/__init__.py
+++ b/autobot_shared/scoping/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss

--- a/autobot_shared/scoping/scope_level.py
+++ b/autobot_shared/scoping/scope_level.py
@@ -1,0 +1,22 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Resource visibility scope, mirroring SecretScope (#11277). Authorization only."""
+
+from enum import Enum
+
+
+class ScopeLevel(str, Enum):
+    """Visibility scope for a shareable resource (skill or agent)."""
+
+    USER = "user"
+    SESSION = "session"
+    SHARED = "shared"
+    GROUP = "group"
+    ORGANIZATION = "organization"
+
+    @classmethod
+    def default(cls) -> "ScopeLevel":
+        """Default scope for new resources: company-wide."""
+        return cls.ORGANIZATION

--- a/autobot_shared/scoping/scope_level_test.py
+++ b/autobot_shared/scoping/scope_level_test.py
@@ -6,9 +6,7 @@ from autobot_shared.scoping.scope_level import ScopeLevel
 
 
 def test_scope_level_members_mirror_secrets():
-    assert {s.value for s in ScopeLevel} == {
-        "user", "session", "shared", "group", "organization"
-    }
+    assert {s.value for s in ScopeLevel} == {"user", "session", "shared", "group", "organization"}
 
 
 def test_default_is_organization():

--- a/autobot_shared/scoping/scope_level_test.py
+++ b/autobot_shared/scoping/scope_level_test.py
@@ -1,0 +1,15 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+from autobot_shared.scoping.scope_level import ScopeLevel
+
+
+def test_scope_level_members_mirror_secrets():
+    assert {s.value for s in ScopeLevel} == {
+        "user", "session", "shared", "group", "organization"
+    }
+
+
+def test_default_is_organization():
+    assert ScopeLevel.default() is ScopeLevel.ORGANIZATION

--- a/autobot_shared/scoping/visibility.py
+++ b/autobot_shared/scoping/visibility.py
@@ -1,0 +1,46 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Pure visibility rule for scoped resources (#11277)."""
+
+from dataclasses import dataclass
+
+from autobot_shared.scoping.scope_level import ScopeLevel
+
+
+@dataclass(frozen=True)
+class Principal:
+    """Who is asking."""
+
+    user_id: str
+    company_id: str | None
+    group_ids: frozenset[str]
+
+
+@dataclass(frozen=True)
+class ResourceDescriptor:
+    """The resource's ownership + scope."""
+
+    owner_id: str
+    company_id: str | None
+    scope: ScopeLevel
+    group_id: str | None = None
+
+
+def is_visible(principal: Principal, resource: ResourceDescriptor, has_grant: bool) -> bool:
+    """Decide whether `principal` may access `resource`.
+
+    `has_grant` is the pre-computed result of "a matching resource_grants row
+    exists for this principal" (Task 6). An explicit grant always grants access.
+    """
+    if principal.user_id == resource.owner_id:
+        return True
+    if has_grant:
+        return True
+    if resource.scope is ScopeLevel.ORGANIZATION:
+        return resource.company_id is not None and resource.company_id == principal.company_id
+    if resource.scope is ScopeLevel.GROUP:
+        return resource.group_id is not None and resource.group_id in principal.group_ids
+    # USER / SESSION / SHARED are private absent ownership or an explicit grant.
+    return False

--- a/autobot_shared/scoping/visibility_test.py
+++ b/autobot_shared/scoping/visibility_test.py
@@ -39,5 +39,4 @@ def test_user_scope_hidden_from_non_owner_without_grant():
 
 
 def test_explicit_grant_overrides_scope():
-    assert is_visible(_p(user="stranger", company="c2"),
-                      _r(owner="owner", scope=ScopeLevel.USER, company="c1"), True)
+    assert is_visible(_p(user="stranger", company="c2"), _r(owner="owner", scope=ScopeLevel.USER, company="c1"), True)

--- a/autobot_shared/scoping/visibility_test.py
+++ b/autobot_shared/scoping/visibility_test.py
@@ -1,0 +1,43 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+from autobot_shared.scoping.scope_level import ScopeLevel
+from autobot_shared.scoping.visibility import Principal, ResourceDescriptor, is_visible
+
+
+def _p(user="u1", company="c1", groups=()):
+    return Principal(user_id=user, company_id=company, group_ids=frozenset(groups))
+
+
+def _r(owner="owner", company="c1", scope=ScopeLevel.ORGANIZATION, group=None):
+    return ResourceDescriptor(owner_id=owner, company_id=company, scope=scope, group_id=group)
+
+
+def test_owner_always_sees_own_resource():
+    assert is_visible(_p(user="me"), _r(owner="me", scope=ScopeLevel.USER, company="other"), False)
+
+
+def test_organization_scope_visible_to_same_company():
+    assert is_visible(_p(company="c1"), _r(scope=ScopeLevel.ORGANIZATION, company="c1"), False)
+
+
+def test_organization_scope_hidden_from_other_company():
+    assert not is_visible(_p(company="c2"), _r(scope=ScopeLevel.ORGANIZATION, company="c1"), False)
+
+
+def test_group_scope_visible_to_member():
+    assert is_visible(_p(groups={"g1"}), _r(scope=ScopeLevel.GROUP, group="g1"), False)
+
+
+def test_group_scope_hidden_from_non_member():
+    assert not is_visible(_p(groups={"g2"}), _r(scope=ScopeLevel.GROUP, group="g1"), False)
+
+
+def test_user_scope_hidden_from_non_owner_without_grant():
+    assert not is_visible(_p(user="stranger"), _r(owner="owner", scope=ScopeLevel.USER), False)
+
+
+def test_explicit_grant_overrides_scope():
+    assert is_visible(_p(user="stranger", company="c2"),
+                      _r(owner="owner", scope=ScopeLevel.USER, company="c1"), True)

--- a/docs/superpowers/plans/2026-07-08-scoped-shareable-skills-agents-T0-T1.md
+++ b/docs/superpowers/plans/2026-07-08-scoped-shareable-skills-agents-T0-T1.md
@@ -259,9 +259,9 @@ git commit -m "fix(skills): re-register custom/hub skills at boot so they surviv
 
 ## Task 3: `ScopeLevel` enum (T1 core)
 
-**Files:**
-- Create: `autobot-backend/autobot_shared/scoping/scope_level.py` (if `autobot_shared/scoping/` doesn't exist, create it with an empty `__init__.py`)
-- Test: `autobot-backend/autobot_shared/scoping/scope_level_test.py`
+**Files** (NOTE: canonical `autobot_shared/` is the repo-root copy — `autobot-backend/autobot_shared/` is empty and NOT on the import path; `conftest.py` adds repo-root `autobot_shared/`):
+- Create: `autobot_shared/scoping/scope_level.py` (create the package with an empty `__init__.py` if missing)
+- Test: `autobot_shared/scoping/scope_level_test.py`
 
 **Interfaces:**
 - Produces: `ScopeLevel(str, Enum)` with members `USER, SESSION, SHARED, GROUP, ORGANIZATION`; `ScopeLevel.default() -> ScopeLevel` returning `ORGANIZATION`.
@@ -500,9 +500,9 @@ git commit -m "feat(scoping): add resource_grants table + model + migration (#11
 
 Reason: the core visibility decision, testable in isolation before any DB wiring. Later tasks (T2/T3) call it with resource rows and grant lookups.
 
-**Files:**
-- Create: `autobot-backend/autobot_shared/scoping/visibility.py`
-- Test: `autobot-backend/autobot_shared/scoping/visibility_test.py`
+**Files** (canonical repo-root `autobot_shared/`, next to `scope_level.py`):
+- Create: `autobot_shared/scoping/visibility.py`
+- Test: `autobot_shared/scoping/visibility_test.py`
 
 **Interfaces:**
 - Consumes: `ScopeLevel` (Task 3).


### PR DESCRIPTION
## Thinking Path

First implementation slice of umbrella #11277 (scoped/shareable custom skills + agents), built via subagent-driven TDD from the approved plan `docs/superpowers/plans/2026-07-08-scoped-shareable-skills-agents-T0-T1.md` (spec+plan already merged in #11281). T0 fixes a real restart-loss bug; T1 lays the reusable scope/grant authorization primitive with no behavior change to existing flows.

## What Changed

**T0 — boot-reload fix (custom/hub skills survived restart):**
- Extracted `SkillRegistry.register_declarative(manifest) -> bool` (Pass-2 now calls it).
- Added `SkillManager._load_custom_definitions()`, called from `initialize()` — re-registers hub skill definitions at boot (additive `custom_reregistered` key). Fixes: custom/hub skills previously vanished from the registry on restart.

**T1 — scope/grant authorization core (no wiring yet):**
- `autobot_shared/scoping/scope_level.py` — `ScopeLevel` enum mirroring `SecretScope` (default = ORGANIZATION).
- `autobot_shared/scoping/visibility.py` — pure `is_visible()` rule + `Principal`/`ResourceDescriptor` (default-deny; owner/grant short-circuit; org/group scope checks with null-company guard against cross-tenant leak).
- `models/resource_grant.py` + migration `20260708_068` — generic `resource_grants` table (discriminated `resource_type` for skills AND agents).
- `services/resource_grant_store.py` — async `grant`/`revoke`/`has_grant`.
- `services/resource_visibility.py` — `can_access()` composing the above + a per-(resource,principal) decision cache with `invalidate()`.

## Verification

- **21 tests pass** locally (python3): scoping enum (2) + visibility truth-table (7) + grant-store DB (4, in-memory sqlite) + resource_grant model (2) + resolver (2) + register_declarative (2) + manager-reload (2).
- Migration head verified: `down_revision=20260708_067` is the sole current head; up/down symmetric. Alembic up/down runs in CI (no local alembic config).
- Reviewed per-task (spec+quality) and a final opus whole-branch review: **READY TO MERGE**, default-deny authz verified sound, `initialize()` change additive-safe, no conftest MagicMock-stub trap in shipped modules.

**Deferred to T2 (tracked on #11277):** every future grant/revoke/scope-change write MUST call `resource_visibility.invalidate()` (cache has no TTL); add a `can_access` denial test + idempotency permission-mutation assertion.

## Model Used

Opus 4.8 (1M context) orchestrating; sonnet/haiku implementer+reviewer subagents.

Refs #11277.