### PR TITLE
fix(schedulers): register LLC heartbeat/routine schedulers; exclude migrations from scheduler discovery (#11248)

### DIFF
--- a/autobot-backend/services/scheduler_registry.py
+++ b/autobot-backend/services/scheduler_registry.py
@@ -125,4 +125,28 @@ REGISTRY: list[ScheduledJob] = [
             "ssot_config.knowledge_sync_queue_prune_schedule (crontab)."
         ),
     ),
+    ScheduledJob(
+        name="LLCHeartbeatScheduler",
+        interval_seconds=5,
+        owner_file="llc/scheduler/heartbeat_scheduler.py",
+        runtime="asyncio_per_worker",
+        description=(
+            "Preferred agent-heartbeat dispatcher (GH#8225). Polls the "
+            "llc:heartbeat:schedule Redis sorted set every 5 s and fires due "
+            "agent heartbeat runs. Started in initialization/lifespan."
+            "_init_heartbeat_scheduler; the legacy services/heartbeat_scheduler.py "
+            "is the fallback when the LLC package is unavailable."
+        ),
+    ),
+    ScheduledJob(
+        name="LLCRoutineScheduler",
+        interval_seconds=5,
+        owner_file="llc/scheduler/routine_scheduler.py",
+        runtime="asyncio_per_worker",
+        description=(
+            "Fires cron-based routines (GH#8229). Loads ACTIVE routines into the "
+            "llc:heartbeat:schedule sorted set and polls every 5 s for due entries. "
+            "Started in initialization/lifespan._init_llc_routine_scheduler."
+        ),
+    ),
 ]

--- a/autobot-backend/tests/services/test_scheduler_registry.py
+++ b/autobot-backend/tests/services/test_scheduler_registry.py
@@ -36,7 +36,9 @@ def _discover_scheduler_files() -> list[str]:
     """Return background scheduler implementation paths relative to the backend root.
 
     Excludes __pycache__, test files (test_*.py and *_test.py), api/ endpoint
-    modules, and the registry file itself — only actual scheduler implementations.
+    modules, Alembic migrations (migrations/versions/*scheduler*.py are DB
+    migrations, not scheduler implementations), and the registry file itself —
+    only actual scheduler implementations.
     """
     return [
         str(p.relative_to(_BACKEND_ROOT))
@@ -45,6 +47,7 @@ def _discover_scheduler_files() -> list[str]:
         and not p.name.startswith("test_")
         and not p.name.endswith("_test.py")
         and "autobot-backend/api/" not in str(p).replace("\\", "/")
+        and "/migrations/" not in str(p).replace("\\", "/")
         and p.resolve() != _REGISTRY_PATH.resolve()
     ]
 


### PR DESCRIPTION
Closes #11289

## Thinking Path
`test_scheduler_registry::test_all_scheduler_files_registered` (a #11248 remediation item) fails: three `*scheduler*.py` files on disk are absent from `services/scheduler_registry.REGISTRY`. Triaged each:
- `llc/scheduler/heartbeat_scheduler.py` — **real gap**: preferred agent-heartbeat dispatcher (GH#8225), 5 s poll of the `llc:heartbeat:schedule` Redis sorted set, started at boot in `initialization/lifespan._init_heartbeat_scheduler` (the registered `services/heartbeat_scheduler.py` is only the legacy fallback).
- `llc/scheduler/routine_scheduler.py` — **real gap**: cron-routine firer (GH#8229), 5 s poll, started in `initialization/lifespan._init_llc_routine_scheduler`.
- `migrations/versions/20260523_036_llc_heartbeat_scheduler.py` — **false positive**: an Alembic migration, not a scheduler implementation; the discovery glob shouldn't match `migrations/`.

The enforcement test (GH#6594) exists to prevent *silent* scheduler additions — so the two real LLC schedulers genuinely belong in REGISTRY, and the migration is out of scope by design.

## What Changed
- `services/scheduler_registry.py`: add `LLCHeartbeatScheduler` + `LLCRoutineScheduler` entries (runtime `asyncio_per_worker`, 5 s, owner_file + description documenting their lifespan start sites).
- `tests/services/test_scheduler_registry.py`: exclude `/migrations/` from `_discover_scheduler_files()` (matches the existing test/api/registry exclusions; migration files are not scheduler implementations).

## Verification
```
$ pytest tests/services/test_scheduler_registry.py -q
5 passed in 0.15s
```
All 5 tests pass — including `test_all_scheduler_files_registered` (was failing), plus `test_registry_names_are_unique` and `test_registry_runtimes_are_valid` which confirm the two new entries are well-formed (unique names, valid runtime). `py_compile` clean on both files.

## Model Used
Opus 4.8 (1M context)