### PR TITLE
fix(security): close ProcessAdapter host RCE + workspace pids_limit/shlex hardening (#11291)

### DIFF
--- a/autobot-backend/llc/adapters/process_adapter.py
+++ b/autobot-backend/llc/adapters/process_adapter.py
@@ -13,43 +13,93 @@ adapter_config schema::
     }
 
 The ``run_id`` is the string-encoded PID of the spawned process.
+
+Security (GH#11059): ``command`` is tenant-writable, so this adapter runs
+host commands from untrusted config. It is therefore hardened three ways:
+
+* **Disabled by default** — an operator must set ``LLC_PROCESS_ADAPTER_ENABLED``
+  on the backend host; it can never be turned on from tenant configuration.
+* **No shell** — the command runs via ``create_subprocess_exec`` after
+  ``shlex.split`` (never ``create_subprocess_shell``), so shell metacharacters
+  in tenant config can't chain arbitrary commands.
+* **Minimal env** — the subprocess receives only an allowlist of non-secret
+  system vars plus the agent's declared extras and injected LLC token; the
+  backend's DB/LLC credentials are never inherited.
 """
 
 import asyncio
 import json
 import os
+import shlex
 
 from autobot_shared.logging_manager import get_logger
 
 from ..models.enums import LLCRunStatus
 from .base import AdapterRunStatus
-from .subprocess_support import probe_pid, terminate_pid
+from .subprocess_support import inject_agent_credentials, probe_pid, terminate_pid
 
 logger = get_logger(__name__)
 
 _LOG_NAME = "ProcessAdapter"
 _SIGTERM_GRACE_SECONDS = 5
 
+# GH#11059 (P0 RCE): ProcessAdapter executes a tenant-writable command on the
+# backend host. It is DISABLED unless an operator explicitly enables it via this
+# server-side env flag — never runnable from tenant config alone.
+_ENABLE_FLAG = "LLC_PROCESS_ADAPTER_ENABLED"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# Non-secret environment variables forwarded to the spawned subprocess. The full
+# backend environment (DB/LLC creds, API keys) is NEVER inherited — only these,
+# plus the agent's declared ``env`` extras and the injected LLC bearer token.
+_SAFE_ENV_PASSTHROUGH = ("PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TZ", "TMPDIR")
+
+
+def _process_adapter_enabled() -> bool:
+    """True only when an operator has explicitly enabled ProcessAdapter (GH#11059)."""
+    return os.environ.get(_ENABLE_FLAG, "").strip().lower() in _TRUTHY
+
+
+def _build_minimal_env(env_extra: dict, context: dict) -> dict:
+    """Build a minimal, secret-free environment for the spawned agent (GH#11059).
+
+    Starts from an allowlist of safe system vars (never the full ``os.environ``),
+    layers the agent's declared ``env`` extras, injects the LLC bearer token, and
+    attaches the invocation context as ``LLC_INVOKE_CONTEXT`` so the subprocess
+    can read it without a custom IPC channel.
+    """
+    env: dict = {k: os.environ[k] for k in _SAFE_ENV_PASSTHROUGH if k in os.environ}
+    env.update(env_extra or {})
+    inject_agent_credentials(env, context)
+    env["LLC_INVOKE_CONTEXT"] = json.dumps(context, default=str)
+    return env
+
 
 class ProcessAdapter:
     """Adapter that manages agent runs as OS subprocesses."""
 
     async def invoke(self, agent_config: dict, context: dict) -> str:
+        if not _process_adapter_enabled():
+            raise PermissionError(
+                "ProcessAdapter is disabled by policy (GH#11059). Set "
+                f"{_ENABLE_FLAG}=1 on the backend host to allow host command "
+                "execution; it must never be enabled from tenant configuration."
+            )
+
         cmd: str = agent_config["command"]
-        env_extra: dict = agent_config.get("env", {})
         cwd: str | None = agent_config.get("cwd")
+        env = _build_minimal_env(agent_config.get("env", {}), context)
 
-        env = {**os.environ, **env_extra}
-        # Pass the invocation context as a JSON environment variable so the
-        # subprocess can read it without requiring a custom IPC channel.
-        env["LLC_INVOKE_CONTEXT"] = json.dumps(context, default=str)
+        argv = shlex.split(cmd)
+        if not argv:
+            raise ValueError("ProcessAdapter: empty command")
 
-        proc = await asyncio.create_subprocess_shell(
-            cmd,
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
             env=env,
             cwd=cwd or None,
         )
-        logger.info("ProcessAdapter: spawned PID %d for command %r", proc.pid, cmd)
+        logger.info("ProcessAdapter: spawned PID %d for executable %r", proc.pid, argv[0])
         return str(proc.pid)
 
     async def status(self, agent_config: dict, run_id: str) -> AdapterRunStatus:

--- a/autobot-backend/llc/adapters/tests/test_adapters.py
+++ b/autobot-backend/llc/adapters/tests/test_adapters.py
@@ -59,15 +59,45 @@ class TestAdapterRunStatus:
 
 @pytest.mark.asyncio
 class TestProcessAdapter:
+    async def test_invoke_disabled_by_default_raises(self) -> None:
+        """GH#11059: ProcessAdapter is fail-closed — invoke raises unless an operator enables it."""
+        adapter = ProcessAdapter()
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as spawn:
+            with pytest.raises(PermissionError):
+                await adapter.invoke({"command": "echo hello"}, {})
+        spawn.assert_not_called()
+
     async def test_invoke_returns_pid_string(self) -> None:
         adapter = ProcessAdapter()
         fake_proc = MagicMock()
         fake_proc.pid = 12345
 
-        with patch("asyncio.create_subprocess_shell", new_callable=AsyncMock, return_value=fake_proc):
+        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
+            "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
+        ):
             run_id = await adapter.invoke({"command": "echo hello"}, {"key": "value"})
 
         assert run_id == "12345"
+
+    async def test_invoke_uses_exec_with_split_argv_not_shell(self) -> None:
+        """GH#11059: command runs via exec on shlex-split argv — no shell metacharacter RCE."""
+        adapter = ProcessAdapter()
+        fake_proc = MagicMock()
+        fake_proc.pid = 7
+
+        captured_argv: list = []
+
+        async def mock_exec(*argv, env, cwd):
+            captured_argv.extend(argv)
+            return fake_proc
+
+        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
+            "asyncio.create_subprocess_shell"
+        ) as shell, patch("asyncio.create_subprocess_exec", side_effect=mock_exec):
+            await adapter.invoke({"command": "python run_agent.py --flag"}, {})
+
+        assert captured_argv == ["python", "run_agent.py", "--flag"]
+        shell.assert_not_called()
 
     async def test_invoke_passes_context_as_env(self) -> None:
         adapter = ProcessAdapter()
@@ -76,17 +106,41 @@ class TestProcessAdapter:
 
         captured_env: dict = {}
 
-        async def mock_shell(cmd, *, env, cwd):
+        async def mock_exec(*argv, env, cwd):
             captured_env.update(env)
             return fake_proc
 
-        with patch("asyncio.create_subprocess_shell", side_effect=mock_shell):
+        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
+            "asyncio.create_subprocess_exec", side_effect=mock_exec
+        ):
             await adapter.invoke({"command": "x"}, {"task_id": "t1"})
 
         import json
 
         ctx = json.loads(captured_env["LLC_INVOKE_CONTEXT"])
         assert ctx["task_id"] == "t1"
+
+    async def test_invoke_minimal_env_excludes_backend_secrets(self, monkeypatch) -> None:
+        """GH#11059: the subprocess must NOT inherit backend secrets from os.environ."""
+        monkeypatch.setenv("DATABASE_URL", "postgres://secret")
+        monkeypatch.setenv("PATH", "/usr/bin")
+        adapter = ProcessAdapter()
+        fake_proc = MagicMock()
+        fake_proc.pid = 1
+
+        captured_env: dict = {}
+
+        async def mock_exec(*argv, env, cwd):
+            captured_env.update(env)
+            return fake_proc
+
+        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
+            "asyncio.create_subprocess_exec", side_effect=mock_exec
+        ):
+            await adapter.invoke({"command": "x"}, {})
+
+        assert "DATABASE_URL" not in captured_env  # backend secret NOT leaked
+        assert captured_env.get("PATH") == "/usr/bin"  # safe var passes through
 
     async def test_status_running_when_pid_alive(self) -> None:
         adapter = ProcessAdapter()

--- a/autobot-backend/llc/adapters/tests/test_adapters.py
+++ b/autobot-backend/llc/adapters/tests/test_adapters.py
@@ -72,8 +72,9 @@ class TestProcessAdapter:
         fake_proc = MagicMock()
         fake_proc.pid = 12345
 
-        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
-            "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
+        with (
+            patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
         ):
             run_id = await adapter.invoke({"command": "echo hello"}, {"key": "value"})
 
@@ -91,9 +92,11 @@ class TestProcessAdapter:
             captured_argv.extend(argv)
             return fake_proc
 
-        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
-            "asyncio.create_subprocess_shell"
-        ) as shell, patch("asyncio.create_subprocess_exec", side_effect=mock_exec):
+        with (
+            patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True),
+            patch("asyncio.create_subprocess_shell") as shell,
+            patch("asyncio.create_subprocess_exec", side_effect=mock_exec),
+        ):
             await adapter.invoke({"command": "python run_agent.py --flag"}, {})
 
         assert captured_argv == ["python", "run_agent.py", "--flag"]
@@ -110,8 +113,9 @@ class TestProcessAdapter:
             captured_env.update(env)
             return fake_proc
 
-        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
-            "asyncio.create_subprocess_exec", side_effect=mock_exec
+        with (
+            patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True),
+            patch("asyncio.create_subprocess_exec", side_effect=mock_exec),
         ):
             await adapter.invoke({"command": "x"}, {"task_id": "t1"})
 
@@ -134,8 +138,9 @@ class TestProcessAdapter:
             captured_env.update(env)
             return fake_proc
 
-        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
-            "asyncio.create_subprocess_exec", side_effect=mock_exec
+        with (
+            patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True),
+            patch("asyncio.create_subprocess_exec", side_effect=mock_exec),
         ):
             await adapter.invoke({"command": "x"}, {})
 

--- a/autobot-backend/llc/tests/test_adapters.py
+++ b/autobot-backend/llc/tests/test_adapters.py
@@ -59,15 +59,45 @@ class TestAdapterRunStatus:
 
 @pytest.mark.asyncio
 class TestProcessAdapter:
+    async def test_invoke_disabled_by_default_raises(self) -> None:
+        """GH#11059: ProcessAdapter is fail-closed — invoke raises unless an operator enables it."""
+        adapter = ProcessAdapter()
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as spawn:
+            with pytest.raises(PermissionError):
+                await adapter.invoke({"command": "echo hello"}, {})
+        spawn.assert_not_called()
+
     async def test_invoke_returns_pid_string(self) -> None:
         adapter = ProcessAdapter()
         fake_proc = MagicMock()
         fake_proc.pid = 12345
 
-        with patch("asyncio.create_subprocess_shell", new_callable=AsyncMock, return_value=fake_proc):
+        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
+            "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
+        ):
             run_id = await adapter.invoke({"command": "echo hello"}, {"key": "value"})
 
         assert run_id == "12345"
+
+    async def test_invoke_uses_exec_with_split_argv_not_shell(self) -> None:
+        """GH#11059: command runs via exec on shlex-split argv — no shell metacharacter RCE."""
+        adapter = ProcessAdapter()
+        fake_proc = MagicMock()
+        fake_proc.pid = 7
+
+        captured_argv: list = []
+
+        async def mock_exec(*argv, env, cwd):
+            captured_argv.extend(argv)
+            return fake_proc
+
+        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
+            "asyncio.create_subprocess_shell"
+        ) as shell, patch("asyncio.create_subprocess_exec", side_effect=mock_exec):
+            await adapter.invoke({"command": "python run_agent.py --flag"}, {})
+
+        assert captured_argv == ["python", "run_agent.py", "--flag"]
+        shell.assert_not_called()
 
     async def test_invoke_passes_context_as_env(self) -> None:
         adapter = ProcessAdapter()
@@ -76,17 +106,41 @@ class TestProcessAdapter:
 
         captured_env: dict = {}
 
-        async def mock_shell(cmd, *, env, cwd):
+        async def mock_exec(*argv, env, cwd):
             captured_env.update(env)
             return fake_proc
 
-        with patch("asyncio.create_subprocess_shell", side_effect=mock_shell):
+        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
+            "asyncio.create_subprocess_exec", side_effect=mock_exec
+        ):
             await adapter.invoke({"command": "x"}, {"task_id": "t1"})
 
         import json
 
         ctx = json.loads(captured_env["LLC_INVOKE_CONTEXT"])
         assert ctx["task_id"] == "t1"
+
+    async def test_invoke_minimal_env_excludes_backend_secrets(self, monkeypatch) -> None:
+        """GH#11059: the subprocess must NOT inherit backend secrets from os.environ."""
+        monkeypatch.setenv("DATABASE_URL", "postgres://secret")
+        monkeypatch.setenv("PATH", "/usr/bin")
+        adapter = ProcessAdapter()
+        fake_proc = MagicMock()
+        fake_proc.pid = 1
+
+        captured_env: dict = {}
+
+        async def mock_exec(*argv, env, cwd):
+            captured_env.update(env)
+            return fake_proc
+
+        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
+            "asyncio.create_subprocess_exec", side_effect=mock_exec
+        ):
+            await adapter.invoke({"command": "x"}, {})
+
+        assert "DATABASE_URL" not in captured_env  # backend secret NOT leaked
+        assert captured_env.get("PATH") == "/usr/bin"  # safe var passes through
 
     async def test_status_running_when_pid_alive(self) -> None:
         adapter = ProcessAdapter()

--- a/autobot-backend/llc/tests/test_adapters.py
+++ b/autobot-backend/llc/tests/test_adapters.py
@@ -72,8 +72,9 @@ class TestProcessAdapter:
         fake_proc = MagicMock()
         fake_proc.pid = 12345
 
-        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
-            "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
+        with (
+            patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
         ):
             run_id = await adapter.invoke({"command": "echo hello"}, {"key": "value"})
 
@@ -91,9 +92,11 @@ class TestProcessAdapter:
             captured_argv.extend(argv)
             return fake_proc
 
-        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
-            "asyncio.create_subprocess_shell"
-        ) as shell, patch("asyncio.create_subprocess_exec", side_effect=mock_exec):
+        with (
+            patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True),
+            patch("asyncio.create_subprocess_shell") as shell,
+            patch("asyncio.create_subprocess_exec", side_effect=mock_exec),
+        ):
             await adapter.invoke({"command": "python run_agent.py --flag"}, {})
 
         assert captured_argv == ["python", "run_agent.py", "--flag"]
@@ -110,8 +113,9 @@ class TestProcessAdapter:
             captured_env.update(env)
             return fake_proc
 
-        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
-            "asyncio.create_subprocess_exec", side_effect=mock_exec
+        with (
+            patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True),
+            patch("asyncio.create_subprocess_exec", side_effect=mock_exec),
         ):
             await adapter.invoke({"command": "x"}, {"task_id": "t1"})
 
@@ -134,8 +138,9 @@ class TestProcessAdapter:
             captured_env.update(env)
             return fake_proc
 
-        with patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True), patch(
-            "asyncio.create_subprocess_exec", side_effect=mock_exec
+        with (
+            patch("llc.adapters.process_adapter._process_adapter_enabled", return_value=True),
+            patch("asyncio.create_subprocess_exec", side_effect=mock_exec),
         ):
             await adapter.invoke({"command": "x"}, {})
 

--- a/autobot-backend/services/docker_task_workspace.py
+++ b/autobot-backend/services/docker_task_workspace.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import shlex
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -56,6 +57,9 @@ _DISK_QUOTA_MB: int = int(os.environ.get("AUTOBOT_WORKSPACE_DISK_MB", "2048"))
 _IDLE_EXPIRY_SECONDS: int = int(os.environ.get("AUTOBOT_WORKSPACE_IDLE_SECONDS", str(4 * 3600)))
 _WORKSPACE_MEMORY_LIMIT: str = os.environ.get("AUTOBOT_WORKSPACE_MEM_LIMIT", "512m")
 _WORKSPACE_CPU_QUOTA: int = int(os.environ.get("AUTOBOT_WORKSPACE_CPU_QUOTA", "100000"))
+# GH#11059: cap process count so a fork-bomb in the workspace can't exhaust host
+# PIDs. Universally supported by the Linux pids cgroup controller.
+_WORKSPACE_PIDS_LIMIT: int = int(os.environ.get("AUTOBOT_WORKSPACE_PIDS_LIMIT", "512"))
 _WORKSPACE_IMAGE: str = os.environ.get("AUTOBOT_WORKSPACE_IMAGE", "alpine:3.18")
 _CONTAINER_PREFIX: str = "autobot-workspace-"
 _REDIS_KEY_PREFIX: str = "autobot:workspace:"
@@ -204,7 +208,9 @@ class TaskWorkspaceManager:
         rejected before any Docker call is made.
         """
         _validate_task_id(task_id)
-        cmd_list = command if isinstance(command, list) else command.split()
+        # GH#11059: shlex.split (not str.split) so quoted args tokenize correctly
+        # and the base-command denylist check sees the real argv[0].
+        cmd_list = command if isinstance(command, list) else shlex.split(command)
         if not validate_exec_command(cmd_list):
             logger.warning("workspace: exec blocked for task=%s cmd=%s", task_id, cmd_list)
             return ExecResult(
@@ -470,6 +476,7 @@ def _apply_sandbox_security(task_id: str, volume_name: str) -> dict[str, Any]:
         "memswap_limit": _WORKSPACE_MEMORY_LIMIT,
         "cpu_quota": _WORKSPACE_CPU_QUOTA,
         "cpu_period": 100000,
+        "pids_limit": _WORKSPACE_PIDS_LIMIT,  # GH#11059: fork-bomb / host-PID exhaustion guard
         "volumes": {volume_name: {"bind": "/workspace", "mode": "rw"}},
         "working_dir": "/workspace",
         "environment": {

--- a/autobot-backend/tests/test_task_workspace.py
+++ b/autobot-backend/tests/test_task_workspace.py
@@ -235,6 +235,15 @@ def test_sandbox_security_memory_limit():
     assert kwargs["mem_limit"] == _WORKSPACE_MEMORY_LIMIT
 
 
+def test_sandbox_security_pids_limited():
+    """GH#11059: workspace containers cap PIDs to survive a fork-bomb."""
+    from services.docker_task_workspace import _WORKSPACE_PIDS_LIMIT
+
+    kwargs = _apply_sandbox_security("task-abc", "vol-abc")
+    assert kwargs["pids_limit"] == _WORKSPACE_PIDS_LIMIT
+    assert kwargs["pids_limit"] > 0
+
+
 # ---------------------------------------------------------------------------
 # TaskWorkspaceManager.create — idempotent
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #11291

## Thinking Path
Highest-severity item in the open backlog: `ProcessAdapter` (`llc/adapters/process_adapter.py`) executed a **tenant-writable** `command` via `create_subprocess_shell` with the **full backend env** (DB/LLC creds) inherited — anyone who could edit an agent got host RCE with backend credentials (umbrella #11058, child #11059 CRIT). Its sibling adapters (`claude_code_adapter`, `copilot_subscription_adapter`) already use `create_subprocess_exec`; ProcessAdapter was the lone `_shell` caller.

`exec + shlex` alone doesn't fully close it (a tenant can still set `command="/bin/sh -c '…'"`), so per the chosen approach this lands the **fullest** fix: capability gate + exec + minimal env. Also picked up the two unambiguous HIGH workspace findings in the same audit.

## What Changed
**ProcessAdapter RCE (P0):**
- **Disabled by default** — `invoke()` raises `PermissionError` unless an operator sets `LLC_PROCESS_ADAPTER_ENABLED` on the host. Never enableable from tenant config. (Fail-closed.)
- **No shell** — `create_subprocess_exec(*shlex.split(cmd))` replaces `create_subprocess_shell`; shell metacharacters can't chain commands.
- **Minimal env** — subprocess gets only an allowlist of non-secret system vars (`PATH`, `HOME`, `LANG`, …) + the agent's declared `env` extras + injected LLC token (reusing `inject_agent_credentials`). Backend DB/LLC creds are never inherited.

**Workspace hardening (HIGH), `services/docker_task_workspace.py`:**
- `pids_limit` on the sandbox container (fork-bomb / host-PID exhaustion guard), env-configurable `AUTOBOT_WORKSPACE_PIDS_LIMIT` (default 512).
- `exec_command` tokenizes with `shlex.split` (not `str.split`) so quoted args and the base-command denylist check are correct.

## Verification
- ProcessAdapter logic verified directly (deps stubbed): disabled-by-default raises `PermissionError` (no spawn); `exec` receives `["python","run_agent.py","--flag"]`; `create_subprocess_shell` never called; `LLC_INVOKE_CONTEXT` present; `DATABASE_URL` **excluded** from child env; `PATH` passes through. 5 new unit tests added (both `test_adapters.py` copies).
- `tests/test_task_workspace.py -k "sandbox_security or exec"` → **17 passed** (incl. new `test_sandbox_security_pids_limited`).
- `py_compile` clean on all four files.

## Scope / follow-up (tracked on #11059)
Remaining #11059 findings deliberately **not** shipped blind — each needs Docker-env verification or an access-model decision, documented on #11059:
- non-root `user` + `storage_opt` disk quota (named-volume ownership + storage-driver support);
- workspace REST/WS task-owner scoping (endpoints are currently **admin-only**, i.e. *more* restrictive than owner-or-admin — "scoping" via `verify_task_owner` would *loosen* to owner-or-admin; that's a product decision);
- worktree-cleanup TOCTOU lock, deterministic container-name collision, WS-output DoS cap, `/tmp` adapter-state perms.

## Model Used
Opus 4.8 (1M context)
