### PR TITLE
fix(security): tenant-scope learned-strategy Redis stores, fail-closed (#11071)

### DIFF
--- a/autobot-backend/agents/agent_orchestration/routing.py
+++ b/autobot-backend/agents/agent_orchestration/routing.py
@@ -59,7 +59,7 @@ class AgentRouter:
         self.llm_interface = llm_interface
         # Issue #2209: in-memory TTL cache for learned strategies.
         # Avoids Redis GET + TaskPatternLearner instantiation per routing call.
-        self._strategy_cache: Dict[str, tuple] = {}  # task_type -> (strategy, expires)
+        self._strategy_cache: Dict[tuple, tuple] = {}  # (tenant_id, task_type) -> (strategy, expires)  # GH#11071
         self._strategy_cache_ttl = 60  # seconds
         # Issue #2092: Q-learning RL router (lazy-initialised on first use).
         self._rl_router = None
@@ -82,6 +82,10 @@ class AgentRouter:
         task type derived from context or quick-route analysis.
         """
         task_type = (context or {}).get("task_type")
+        # GH#11071: scope the learned-strategy read AND its in-memory cache to the
+        # caller's tenant, so one org's strategy can't be served to another via
+        # Redis or the process-local cache.
+        tenant_id = str((context or {}).get("tenant_id") or "")
         if not task_type:
             quick = self.quick_route_analysis(request)
             agent = quick.get("primary_agent")
@@ -95,10 +99,11 @@ class AgentRouter:
 
             learner = TaskPatternLearner()
             task_type = learner.normalize_task_type(task_type)
+            cache_key = (tenant_id, task_type)
 
             # Issue #2209: check in-memory cache before hitting Redis.
             now = time.monotonic()
-            cached = self._strategy_cache.get(task_type)
+            cached = self._strategy_cache.get(cache_key)
             if cached is not None:
                 strategy, expires = cached
                 if now < expires:
@@ -106,8 +111,8 @@ class AgentRouter:
                         return self._build_learned_result(strategy, task_type)
                     return None
 
-            strategy = await learner.get_learned_strategy(task_type)
-            self._strategy_cache[task_type] = (strategy, now + self._strategy_cache_ttl)
+            strategy = await learner.get_learned_strategy(task_type, tenant_id=tenant_id)
+            self._strategy_cache[cache_key] = (strategy, now + self._strategy_cache_ttl)
 
             if strategy and strategy.confidence > LEARNED_STRATEGY_CONFIDENCE:
                 return self._build_learned_result(strategy, task_type)

--- a/autobot-backend/agents/task_pattern_learner.py
+++ b/autobot-backend/agents/task_pattern_learner.py
@@ -19,8 +19,26 @@ from autobot_shared.time_utils import utc_timestamp
 
 logger = get_logger(__name__)
 
-REDIS_PATTERNS_KEY = "task:patterns:{task_type}"
+# GH#11071: keys are tenant-scoped so one org's synthesized strategy can never be
+# read into another org's planning prompt. An empty tenant_id fails closed
+# (retrieval/persistence is skipped) rather than falling back to a shared bucket.
+REDIS_PATTERNS_KEY = "task:patterns:{tenant_id}:{task_type}"
 REDIS_PATTERNS_TTL = 60 * 60 * 24 * 7  # 7 days
+
+
+def _scoped_tenant(tenant_id: str, op: str) -> str | None:
+    """Return the normalized tenant_id, or None (fail-closed) when it is empty.
+
+    GH#11071: learned-strategy reads/writes must be tenant-scoped. A missing
+    tenant_id is a misconfiguration, not a licence to touch a shared bucket, so
+    the caller skips the Redis op and logs a warning.
+    """
+    tid = (tenant_id or "").strip()
+    if not tid:
+        logger.warning("TaskPatternLearner.%s: empty tenant_id — skipping (fail-closed, GH#11071)", op)
+        return None
+    return tid
+
 
 # Minimum outcomes required before learning is triggered
 MIN_OUTCOMES_TO_LEARN = 3
@@ -74,16 +92,22 @@ class TaskPatternLearner(AsyncRedisClientMixin):
         """
         return task_type.strip().lower().replace("-", "_").replace(" ", "_")
 
-    async def learn_from_outcomes(self, task_type: str, outcomes: List[Dict]) -> LearnedStrategy | None:
+    async def learn_from_outcomes(
+        self, task_type: str, outcomes: List[Dict], tenant_id: str = ""
+    ) -> LearnedStrategy | None:
         """Analyze recent outcomes and extract the best strategy.
 
         Args:
             task_type: Task category to analyze (normalised to AgentType vocab)
             outcomes: List of outcome dicts with score, strategy_used, rationale
+            tenant_id: Owning tenant — the learned strategy is stored under it
+                so it can never be read into another tenant's plan (GH#11071).
 
         Returns:
             LearnedStrategy if enough data, else None
         """
+        if _scoped_tenant(tenant_id, "learn_from_outcomes") is None:
+            return None
         task_type = self.normalize_task_type(task_type)
         if len(outcomes) < MIN_OUTCOMES_TO_LEARN:
             logger.debug("Not enough outcomes to learn from for %s", task_type)
@@ -92,7 +116,7 @@ class TaskPatternLearner(AsyncRedisClientMixin):
         best_outcome = max(recent, key=lambda o: o.get("score", 0.0))
         strategy = await self._synthesize_strategy(task_type, recent, best_outcome)
         if strategy:
-            await self._persist_strategy(task_type, strategy)
+            await self._persist_strategy(task_type, strategy, tenant_id)
         return strategy
 
     async def _synthesize_strategy(
@@ -181,21 +205,27 @@ class TaskPatternLearner(AsyncRedisClientMixin):
             confidence=0.3,
         )
 
-    async def _persist_strategy(self, task_type: str, strategy: LearnedStrategy) -> None:
-        """Persist learned strategy to Redis."""
+    async def _persist_strategy(self, task_type: str, strategy: LearnedStrategy, tenant_id: str = "") -> None:
+        """Persist learned strategy to Redis, scoped to *tenant_id* (GH#11071)."""
+        tid = _scoped_tenant(tenant_id, "_persist_strategy")
+        if tid is None:
+            return
         try:
             redis = await self._get_redis()
-            key = REDIS_PATTERNS_KEY.format(task_type=task_type)
+            key = REDIS_PATTERNS_KEY.format(tenant_id=tid, task_type=task_type)
             await redis.set(key, json.dumps(strategy.__dict__), ex=REDIS_PATTERNS_TTL)
         except Exception as exc:
             logger.warning("Failed to persist learned strategy: %s", exc)
 
-    async def get_learned_strategy(self, task_type: str) -> LearnedStrategy | None:
-        """Retrieve persisted learned strategy for a task type (#2208)."""
+    async def get_learned_strategy(self, task_type: str, tenant_id: str = "") -> LearnedStrategy | None:
+        """Retrieve persisted learned strategy for a task type, scoped to *tenant_id* (#2208, GH#11071)."""
+        tid = _scoped_tenant(tenant_id, "get_learned_strategy")
+        if tid is None:
+            return None
         task_type = self.normalize_task_type(task_type)
         try:
             redis = await self._get_redis()
-            key = REDIS_PATTERNS_KEY.format(task_type=task_type)
+            key = REDIS_PATTERNS_KEY.format(tenant_id=tid, task_type=task_type)
             raw = await redis.get(key)
             if raw:
                 return LearnedStrategy(**json.loads(raw))
@@ -203,39 +233,50 @@ class TaskPatternLearner(AsyncRedisClientMixin):
             logger.warning("Failed to retrieve learned strategy: %s", exc)
         return None
 
-    async def save_strategy(self, strategy: LearnedStrategy) -> None:
+    async def save_strategy(self, strategy: LearnedStrategy, tenant_id: str = "") -> None:
         """Persist an externally-curated strategy for its task type (GH#11151).
 
         The public import entry point — normalises the task type and reuses the
         same Redis persistence as learned strategies so a reviewer-edited record
-        is stored identically to a synthesized one.
+        is stored identically to a synthesized one. Scoped to *tenant_id* (GH#11071).
         """
         task_type = self.normalize_task_type(strategy.task_type)
         strategy.task_type = task_type
-        await self._persist_strategy(task_type, strategy)
+        await self._persist_strategy(task_type, strategy, tenant_id)
 
-    async def clear_strategy(self, task_type: str) -> None:
-        """Clear the learned strategy for a task type (#2325)."""
+    async def clear_strategy(self, task_type: str, tenant_id: str = "") -> None:
+        """Clear the learned strategy for a task type, scoped to *tenant_id* (#2325, GH#11071)."""
+        tid = _scoped_tenant(tenant_id, "clear_strategy")
+        if tid is None:
+            return
         task_type = self.normalize_task_type(task_type)
         try:
             redis = await self._get_redis()
-            key = REDIS_PATTERNS_KEY.format(task_type=task_type)
+            key = REDIS_PATTERNS_KEY.format(tenant_id=tid, task_type=task_type)
             await redis.delete(key)
         except Exception as exc:
             logger.warning("Failed to clear learned strategy: %s", exc)
 
-    async def get_all_task_types(self) -> List[str]:
-        """List all task types that have stored outcomes in Redis."""
+    async def get_all_task_types(self, tenant_id: str = "") -> List[str]:
+        """List task types that have stored outcomes for *tenant_id* (GH#11071).
+
+        Scoped by tenant so a caller can only enumerate its own task types; an
+        empty tenant_id fails closed (returns []), mirroring the store keys.
+        """
+        tid = _scoped_tenant(tenant_id, "get_all_task_types")
+        if tid is None:
+            return []
         try:
             redis = await self._get_redis()
-            pattern = "task:outcomes:*"
+            prefix = f"task:outcomes:{tid}:"
+            pattern = f"{prefix}*"
             cursor = 0
             types: List[str] = []
             while True:
                 cursor, keys = await redis.scan(cursor, match=pattern, count=100)
                 for k in keys:
-                    task_type = k.decode() if isinstance(k, bytes) else k
-                    types.append(task_type.replace("task:outcomes:", ""))
+                    key = k.decode() if isinstance(k, bytes) else k
+                    types.append(key.replace(prefix, "", 1))
                 if cursor == 0:
                     break
             return types

--- a/autobot-backend/agents/task_pattern_learner_test.py
+++ b/autobot-backend/agents/task_pattern_learner_test.py
@@ -50,7 +50,7 @@ class TestLearnedStrategy:
 class TestTaskPatternLearner:
     @pytest.mark.asyncio
     async def test_learn_from_outcomes_not_enough_data(self, learner):
-        result = await learner.learn_from_outcomes("t", [{"score": 0.5}])
+        result = await learner.learn_from_outcomes("t", [{"score": 0.5}], tenant_id="org1")
         assert result is None
 
     @pytest.mark.asyncio
@@ -72,11 +72,13 @@ class TestTaskPatternLearner:
         mock_redis.set = AsyncMock()
         learner._redis = mock_redis
 
-        result = await learner.learn_from_outcomes("t", sample_outcomes)
+        result = await learner.learn_from_outcomes("t", sample_outcomes, tenant_id="org1")
         assert result is not None
         assert result.best_approach == "use step-by-step"
         assert result.confidence == 0.8
         mock_redis.set.assert_awaited_once()
+        # GH#11071: persisted under the tenant-scoped key
+        assert mock_redis.set.await_args.args[0] == "task:patterns:org1:t"
 
     @pytest.mark.asyncio
     async def test_learn_from_outcomes_fallback_on_llm_error(self, learner, sample_outcomes):
@@ -88,18 +90,27 @@ class TestTaskPatternLearner:
         mock_redis.set = AsyncMock()
         learner._redis = mock_redis
 
-        result = await learner.learn_from_outcomes("t", sample_outcomes)
+        result = await learner.learn_from_outcomes("t", sample_outcomes, tenant_id="org1")
         # Fallback creates strategy from best outcome
         assert result is not None
         assert result.task_type == "t"
         assert result.confidence == 0.3  # fallback confidence
 
     @pytest.mark.asyncio
+    async def test_learn_from_outcomes_fails_closed_without_tenant(self, learner, sample_outcomes):
+        """GH#11071: an empty tenant_id skips learning entirely (no Redis write)."""
+        mock_redis = AsyncMock()
+        learner._redis = mock_redis
+        result = await learner.learn_from_outcomes("t", sample_outcomes, tenant_id="")
+        assert result is None
+        mock_redis.set.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_get_learned_strategy_returns_none_when_missing(self, learner):
         mock_redis = AsyncMock()
         mock_redis.get = AsyncMock(return_value=None)
         learner._redis = mock_redis
-        result = await learner.get_learned_strategy("missing_type")
+        result = await learner.get_learned_strategy("missing_type", tenant_id="org1")
         assert result is None
 
     @pytest.mark.asyncio
@@ -115,16 +126,43 @@ class TestTaskPatternLearner:
         mock_redis = AsyncMock()
         mock_redis.get = AsyncMock(return_value=json.dumps(strategy.__dict__).encode())
         learner._redis = mock_redis
-        result = await learner.get_learned_strategy("t")
+        result = await learner.get_learned_strategy("t", tenant_id="org1")
         assert result is not None
         assert result.best_approach == "direct"
         assert result.avg_score == 0.75
+        # GH#11071: read from the tenant-scoped key
+        assert mock_redis.get.await_args.args[0] == "task:patterns:org1:t"
+
+    @pytest.mark.asyncio
+    async def test_get_learned_strategy_fails_closed_without_tenant(self, learner):
+        """GH#11071: no tenant → no Redis read, returns None (can't see a shared bucket)."""
+        mock_redis = AsyncMock()
+        learner._redis = mock_redis
+        result = await learner.get_learned_strategy("t", tenant_id="")
+        assert result is None
+        mock_redis.get.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_learned_strategy_isolated_per_tenant(self, learner):
+        """GH#11071: org B reads its own key, never org A's."""
+        seen_keys = []
+
+        async def _get(key):
+            seen_keys.append(key)
+            return None
+
+        mock_redis = AsyncMock()
+        mock_redis.get = _get
+        learner._redis = mock_redis
+        await learner.get_learned_strategy("t", tenant_id="orgA")
+        await learner.get_learned_strategy("t", tenant_id="orgB")
+        assert seen_keys == ["task:patterns:orgA:t", "task:patterns:orgB:t"]
 
     @pytest.mark.asyncio
     async def test_clear_strategy(self, learner):
         mock_redis = AsyncMock()
         learner._redis = mock_redis
-        await learner.clear_strategy("mytype")
+        await learner.clear_strategy("mytype", tenant_id="org1")
         mock_redis.delete.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -133,13 +171,15 @@ class TestTaskPatternLearner:
         mock_redis.scan = AsyncMock(
             return_value=(
                 0,
-                [b"task:outcomes:code_gen", b"task:outcomes:analysis"],
+                [b"task:outcomes:org1:code_gen", b"task:outcomes:org1:analysis"],
             )
         )
         learner._redis = mock_redis
-        types = await learner.get_all_task_types()
+        types = await learner.get_all_task_types(tenant_id="org1")
         assert "code_gen" in types
         assert "analysis" in types
+        # GH#11071: scan is scoped to the tenant prefix
+        assert mock_redis.scan.await_args.kwargs["match"] == "task:outcomes:org1:*"
 
     @pytest.mark.parametrize(
         "raw, expected",
@@ -156,8 +196,8 @@ class TestTaskPatternLearner:
     async def test_clear_strategy_normalizes_task_type(self, learner):
         mock_redis = AsyncMock()
         learner._redis = mock_redis
-        await learner.clear_strategy("Code-Gen")
-        mock_redis.delete.assert_awaited_once_with("task:patterns:code_gen")
+        await learner.clear_strategy("Code-Gen", tenant_id="org1")
+        mock_redis.delete.assert_awaited_once_with("task:patterns:org1:code_gen")
 
     def test_build_synthesis_prompt_includes_task_type(self, learner, sample_outcomes):
         best = sample_outcomes[2]

--- a/autobot-backend/agents/task_pattern_learner_test.py
+++ b/autobot-backend/agents/task_pattern_learner_test.py
@@ -56,7 +56,8 @@ class TestTaskPatternLearner:
     @pytest.mark.asyncio
     async def test_learn_from_outcomes_triggers_synthesis(self, learner, sample_outcomes):
         mock_llm = AsyncMock()
-        mock_llm.chat_completion = AsyncMock(
+        # The learner calls ``llm.chat(...)`` (not chat_completion).
+        mock_llm.chat = AsyncMock(
             return_value=json.dumps(
                 {
                     "best_approach": "use step-by-step",
@@ -83,7 +84,7 @@ class TestTaskPatternLearner:
     @pytest.mark.asyncio
     async def test_learn_from_outcomes_fallback_on_llm_error(self, learner, sample_outcomes):
         mock_llm = AsyncMock()
-        mock_llm.chat_completion = AsyncMock(side_effect=Exception("LLM down"))
+        mock_llm.chat = AsyncMock(side_effect=Exception("LLM down"))
         learner._llm = mock_llm
 
         mock_redis = AsyncMock()

--- a/autobot-backend/api/agents_self_improvement.py
+++ b/autobot-backend/api/agents_self_improvement.py
@@ -76,6 +76,15 @@ def _get_detector():
     return _detector
 
 
+def _caller_tenant(user: Any) -> str:
+    """Tenant (org) scope for the authenticated caller (GH#11071).
+
+    Learned-strategy/outcome reads and writes are keyed by this so one org can
+    never see or mutate another org's learned state through the API.
+    """
+    return str((user or {}).get("org_id") or "")
+
+
 @router.get(
     "/{agent_id}/outcomes",
     response_model=List[TaskOutcomeResponse],
@@ -90,12 +99,12 @@ async def get_agent_outcomes(
     agent_id: str,
     task_type: str | None = Query(None, description="Filter by task type"),
     limit: int = Query(20, ge=1, le=100),
-    _user: Any = Depends(get_current_user),
+    current_user: Any = Depends(get_current_user),
 ) -> List[TaskOutcomeResponse]:
     """Return recent task outcome records for an agent or task type."""
     judge = _get_judge()
     effective_type = task_type or agent_id
-    outcomes = await judge.get_outcomes(effective_type, limit=limit)
+    outcomes = await judge.get_outcomes(effective_type, limit=limit, tenant_id=_caller_tenant(current_user))
     return [TaskOutcomeResponse(**o.__dict__) for o in outcomes]
 
 
@@ -112,12 +121,12 @@ async def get_agent_outcomes(
 async def get_learned_strategies(
     agent_id: str,
     task_type: str | None = Query(None, description="Task type to retrieve"),
-    _user: Any = Depends(get_current_user),
+    current_user: Any = Depends(get_current_user),
 ) -> LearnedStrategyResponse | None:
     """Return the current learned best strategy for a given task type."""
     learner = _get_learner()
     effective_type = task_type or agent_id
-    strategy = await learner.get_learned_strategy(effective_type)
+    strategy = await learner.get_learned_strategy(effective_type, tenant_id=_caller_tenant(current_user))
     if not strategy:
         return None
     return LearnedStrategyResponse(**strategy.__dict__)
@@ -137,13 +146,15 @@ async def reset_agent_learning(
     agent_id: str,
     task_type: str | None = Query(None, description="Task type to reset"),
     _admin: bool = Depends(check_admin_permission),
+    current_user: Any = Depends(get_current_user),
 ) -> ResetLearningResponse:
     """Clear all learned outcomes and strategies for an agent or task type."""
     judge = _get_judge()
     learner = _get_learner()
     effective_type = task_type or agent_id
-    await judge.clear_outcomes(effective_type)
-    await learner.clear_strategy(effective_type)
+    tenant_id = _caller_tenant(current_user)
+    await judge.clear_outcomes(effective_type, tenant_id=tenant_id)
+    await learner.clear_strategy(effective_type, tenant_id=tenant_id)
     return ResetLearningResponse(
         success=True,
         message=f"Learning state cleared for task type '{effective_type}'",
@@ -169,14 +180,14 @@ async def export_agent_knowledge(
         le=1.0,
         description="Only export failure patterns at or above this confidence",
     ),
-    _user: Any = Depends(get_current_user),
+    current_user: Any = Depends(get_current_user),
 ) -> LearnedKnowledgeExport:
     """Render an agent's opaque learned knowledge as a human-reviewable document (GH#11151)."""
     learner = _get_learner()
     detector = _get_detector()
     effective_type = task_type or agent_id
 
-    strategy = await learner.get_learned_strategy(effective_type)
+    strategy = await learner.get_learned_strategy(effective_type, tenant_id=_caller_tenant(current_user))
     strategy_resp = LearnedStrategyResponse(**strategy.__dict__) if strategy else None
 
     patterns = await detector.list_known_patterns(limit=_EXPORT_PATTERN_LIMIT)
@@ -214,6 +225,7 @@ async def import_agent_knowledge(
     agent_id: str,
     payload: LearnedKnowledgeImport,
     _admin: bool = Depends(check_admin_permission),
+    current_user: Any = Depends(get_current_user),
 ) -> KnowledgeImportResponse:
     """Persist a reviewer-curated strategy, sanitizing untrusted free-text first (GH#11151)."""
     from agents.task_pattern_learner import LearnedStrategy, TaskPatternLearner
@@ -232,7 +244,7 @@ async def import_agent_knowledge(
         confidence=payload.confidence,
         failure_patterns=[_sanitize_injected(fp, _IMPORT_TEXT_MAX) for fp in payload.failure_patterns],
     )
-    await learner.save_strategy(strategy)
+    await learner.save_strategy(strategy, tenant_id=_caller_tenant(current_user))
     return KnowledgeImportResponse(
         success=True,
         message=f"Imported curated strategy for task type '{strategy.task_type}'",

--- a/autobot-backend/chat_workflow/trajectory_context.py
+++ b/autobot-backend/chat_workflow/trajectory_context.py
@@ -161,6 +161,7 @@ async def capture_chat_trajectory(
                 goal=user_message,
                 output=assistant_response[:500],
                 strategy_used=_CHAT_STRATEGY,
+                tenant_id=tenant_id,  # GH#11071: keep chat-outcome persistence tenant-isolated
             )
             # overall_score is already normalised to [0.0, 1.0].
             reward = max(0.0, min(1.0, float(getattr(judgment, "overall_score", 0.0))))

--- a/autobot-backend/judges/task_outcome_judge.py
+++ b/autobot-backend/judges/task_outcome_judge.py
@@ -19,10 +19,21 @@ from judges import BaseLLMJudge, JudgmentDimension, JudgmentResult
 
 logger = get_logger(__name__)
 
-# Redis key pattern for task outcomes
-REDIS_OUTCOMES_KEY = "task:outcomes:{task_type}"
+# GH#11071: outcome keys are tenant-scoped so one org's task history can never be
+# read into another org's learning/plan. Empty tenant_id fails closed (the Redis
+# read/write is skipped) rather than touching a shared cross-tenant bucket.
+REDIS_OUTCOMES_KEY = "task:outcomes:{tenant_id}:{task_type}"
 REDIS_OUTCOMES_TTL = 60 * 60 * 24 * 30  # 30 days
 MAX_OUTCOMES_PER_TYPE = 100
+
+
+def _scoped_tenant(tenant_id: str, op: str) -> str | None:
+    """Return the normalized tenant_id, or None (fail-closed) when empty (GH#11071)."""
+    tid = (tenant_id or "").strip()
+    if not tid:
+        logger.warning("TaskOutcomeJudge.%s: empty tenant_id — skipping (fail-closed, GH#11071)", op)
+        return None
+    return tid
 
 
 @dataclass
@@ -63,6 +74,7 @@ class TaskOutcomeJudge(BaseLLMJudge):
         goal: str,
         output: str,
         strategy_used: str = "default",
+        tenant_id: str = "",
     ) -> JudgmentResult:
         """Evaluate quality of a task output and persist to Redis.
 
@@ -71,6 +83,9 @@ class TaskOutcomeJudge(BaseLLMJudge):
             goal: The original task goal/objective
             output: The task's actual output
             strategy_used: Description of the strategy/approach used
+            tenant_id: Owning tenant — persistence is scoped to it (GH#11071).
+                The judgment result is always returned (used for plan scoring)
+                even when tenant_id is empty; only the Redis write is skipped.
 
         Returns:
             JudgmentResult with quality assessment
@@ -90,7 +105,7 @@ class TaskOutcomeJudge(BaseLLMJudge):
             criteria=criteria,
             context=context,
         )
-        await self._persist_outcome(task_type, goal, output, strategy_used, result)
+        await self._persist_outcome(task_type, goal, output, strategy_used, result, tenant_id)
         return result
 
     async def _persist_outcome(
@@ -100,11 +115,15 @@ class TaskOutcomeJudge(BaseLLMJudge):
         output: str,
         strategy_used: str,
         result: JudgmentResult,
+        tenant_id: str = "",
     ) -> None:
-        """Store outcome in Redis list, keeping only the last MAX_OUTCOMES_PER_TYPE."""
+        """Store outcome in Redis list (scoped to *tenant_id*), keeping the last MAX_OUTCOMES_PER_TYPE."""
+        tid = _scoped_tenant(tenant_id, "_persist_outcome")
+        if tid is None:
+            return
         try:
             redis = await self._get_redis()
-            key = REDIS_OUTCOMES_KEY.format(task_type=task_type)
+            key = REDIS_OUTCOMES_KEY.format(tenant_id=tid, task_type=task_type)
             record = TaskOutcomeRecord(
                 task_type=task_type,
                 goal=goal[:200],
@@ -119,30 +138,37 @@ class TaskOutcomeJudge(BaseLLMJudge):
         except Exception as exc:
             logger.warning("Failed to persist task outcome: %s", exc)
 
-    async def get_outcomes(self, task_type: str, limit: int = 20) -> List[TaskOutcomeRecord]:
-        """Retrieve recent outcomes for a task type from Redis.
+    async def get_outcomes(self, task_type: str, limit: int = 20, tenant_id: str = "") -> List[TaskOutcomeRecord]:
+        """Retrieve recent outcomes for a task type from Redis, scoped to *tenant_id* (GH#11071).
 
         Args:
             task_type: Task category to retrieve outcomes for
             limit: Maximum number of outcomes to return
+            tenant_id: Owning tenant; empty fails closed (returns []).
 
         Returns:
             List of TaskOutcomeRecord sorted newest-first
         """
+        tid = _scoped_tenant(tenant_id, "get_outcomes")
+        if tid is None:
+            return []
         try:
             redis = await self._get_redis()
-            key = REDIS_OUTCOMES_KEY.format(task_type=task_type)
+            key = REDIS_OUTCOMES_KEY.format(tenant_id=tid, task_type=task_type)
             raw = await redis.lrange(key, 0, limit - 1)
             return [TaskOutcomeRecord(**json.loads(r)) for r in raw]
         except Exception as exc:
             logger.warning("Failed to retrieve task outcomes: %s", exc)
             return []
 
-    async def clear_outcomes(self, task_type: str) -> None:
-        """Clear all stored outcomes for a task type."""
+    async def clear_outcomes(self, task_type: str, tenant_id: str = "") -> None:
+        """Clear all stored outcomes for a task type, scoped to *tenant_id* (GH#11071)."""
+        tid = _scoped_tenant(tenant_id, "clear_outcomes")
+        if tid is None:
+            return
         try:
             redis = await self._get_redis()
-            key = REDIS_OUTCOMES_KEY.format(task_type=task_type)
+            key = REDIS_OUTCOMES_KEY.format(tenant_id=tid, task_type=task_type)
             await redis.delete(key)
         except Exception as exc:
             logger.warning("Failed to clear task outcomes: %s", exc)

--- a/autobot-backend/judges/task_outcome_judge_test.py
+++ b/autobot-backend/judges/task_outcome_judge_test.py
@@ -69,8 +69,16 @@ class TestTaskOutcomeJudge:
     async def test_get_outcomes_empty(self, judge, mock_redis):
         judge._redis_client = mock_redis
         mock_redis.lrange.return_value = []
-        outcomes = await judge.get_outcomes("unknown_type")
+        outcomes = await judge.get_outcomes("unknown_type", tenant_id="org1")
         assert outcomes == []
+
+    @pytest.mark.asyncio
+    async def test_get_outcomes_fails_closed_without_tenant(self, judge, mock_redis):
+        """GH#11071: no tenant → no Redis read, returns [] (can't see a shared bucket)."""
+        judge._redis_client = mock_redis
+        outcomes = await judge.get_outcomes("t", tenant_id="")
+        assert outcomes == []
+        mock_redis.lrange.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_get_outcomes_returns_records(self, judge, mock_redis):
@@ -85,15 +93,17 @@ class TestTaskOutcomeJudge:
             timestamp="2025-01-01T00:00:00",
         )
         mock_redis.lrange.return_value = [json.dumps(record.__dict__).encode()]
-        outcomes = await judge.get_outcomes("t")
+        outcomes = await judge.get_outcomes("t", tenant_id="org1")
         assert len(outcomes) == 1
         assert outcomes[0].score == 0.7
+        # GH#11071: read from the tenant-scoped key
+        assert mock_redis.lrange.await_args.args[0] == "task:outcomes:org1:t"
 
     @pytest.mark.asyncio
     async def test_clear_outcomes(self, judge, mock_redis):
         judge._redis_client = mock_redis
-        await judge.clear_outcomes("mytype")
-        mock_redis.delete.assert_awaited_once_with(REDIS_OUTCOMES_KEY.format(task_type="mytype"))
+        await judge.clear_outcomes("mytype", tenant_id="org1")
+        mock_redis.delete.assert_awaited_once_with(REDIS_OUTCOMES_KEY.format(tenant_id="org1", task_type="mytype"))
 
     @pytest.mark.asyncio
     async def test_persist_outcome_trims_list(self, judge, mock_redis):
@@ -115,9 +125,9 @@ class TestTaskOutcomeJudge:
             processing_time_ms=10.0,
             llm_model_used="test",
         )
-        await judge._persist_outcome("t", "goal", "output", "strategy", result)
+        await judge._persist_outcome("t", "goal", "output", "strategy", result, tenant_id="org1")
         mock_redis.ltrim.assert_awaited_once_with(
-            REDIS_OUTCOMES_KEY.format(task_type="t"), 0, MAX_OUTCOMES_PER_TYPE - 1
+            REDIS_OUTCOMES_KEY.format(tenant_id="org1", task_type="t"), 0, MAX_OUTCOMES_PER_TYPE - 1
         )
 
     @pytest.mark.asyncio
@@ -142,7 +152,7 @@ class TestTaskOutcomeJudge:
             llm_model_used="test",
         )
         # Should not raise
-        await judge._persist_outcome("t", "g", "o", "s", result)
+        await judge._persist_outcome("t", "g", "o", "s", result, tenant_id="org1")
 
     @pytest.mark.asyncio
     async def test_prepare_judgment_prompt_contains_goal(self):

--- a/autobot-backend/llc/kb/diary_writer.py
+++ b/autobot-backend/llc/kb/diary_writer.py
@@ -238,6 +238,9 @@ class AgentDiaryKbWriter:
             snap = context_snapshot or {}
             task_type = snap.get("task_type", "llc_heartbeat")
             outcomes = snap.get("outcomes", [])
+            # GH#11071: scope learning to the owning company/tenant; absent → the
+            # learner fails closed (skips) rather than writing a shared strategy.
+            tenant_id = str(snap.get("tenant_id") or snap.get("company_id") or "")
 
             if not outcomes:
                 return
@@ -245,7 +248,7 @@ class AgentDiaryKbWriter:
             from agents.task_pattern_learner import TaskPatternLearner
 
             learner = TaskPatternLearner()
-            strategy = await learner.learn_from_outcomes(task_type, outcomes)
+            strategy = await learner.learn_from_outcomes(task_type, outcomes, tenant_id=tenant_id)
             if strategy is None:
                 return
 

--- a/autobot-backend/llc/kb/diary_writer.py
+++ b/autobot-backend/llc/kb/diary_writer.py
@@ -113,7 +113,7 @@ class AgentDiaryKbWriter:
                 exc_info=True,
             )
         try:
-            await self._write_patterns(run_id, agent_id, status, context_snapshot)
+            await self._write_patterns(run_id, agent_id, status, context_snapshot, company_id)
         except Exception:
             logger.warning(
                 "AgentDiaryKbWriter.write_from_run: pattern write failed for run_id=%s",
@@ -232,15 +232,18 @@ class AgentDiaryKbWriter:
         agent_id: str,
         status: str,
         context_snapshot: Optional[Dict[str, Any]],
+        company_id: Optional[str] = None,
     ) -> None:
         """Run TaskPatternLearner on available outcomes and index results."""
         try:
             snap = context_snapshot or {}
             task_type = snap.get("task_type", "llc_heartbeat")
             outcomes = snap.get("outcomes", [])
-            # GH#11071: scope learning to the owning company/tenant; absent → the
-            # learner fails closed (skips) rather than writing a shared strategy.
-            tenant_id = str(snap.get("tenant_id") or snap.get("company_id") or "")
+            # GH#11071: scope learning to the owning company/tenant. Prefer the
+            # authoritative company_id passed by the caller; fall back to the
+            # snapshot. Absent → the learner fails closed (skips) rather than
+            # writing a shared strategy.
+            tenant_id = str(company_id or snap.get("tenant_id") or snap.get("company_id") or "")
 
             if not outcomes:
                 return

--- a/autobot-backend/orchestration/workflow_runner.py
+++ b/autobot-backend/orchestration/workflow_runner.py
@@ -423,19 +423,26 @@ class WorkflowRunner:
             async with self._learning_semaphore:
                 task_type = getattr(plan, "task_type", None) or plan.strategy.value
                 output_summary = str(result.get("results", ""))[:500]
+                # GH#11071: scope outcome persistence + learning to the owning tenant
+                # so a synthesized strategy never crosses into another org's plan.
+                plan_meta = getattr(plan, "metadata", None) or {}
+                tenant_id = str(plan_meta.get("tenant_id") or "")
                 judge = _get_task_outcome_judge()
                 await judge.evaluate_task_outcome(
                     task_type=task_type,
                     goal=plan.goal,
                     output=output_summary,
                     strategy_used=plan.strategy.value,
+                    tenant_id=tenant_id,
                 )
 
                 # Trigger learning when enough outcomes have accumulated.
                 min_outcomes, learner = _get_task_pattern_learner()
-                outcomes = await judge.get_outcomes(task_type, limit=min_outcomes + 1)
+                outcomes = await judge.get_outcomes(task_type, limit=min_outcomes + 1, tenant_id=tenant_id)
                 if len(outcomes) >= min_outcomes:
-                    await learner.learn_from_outcomes(task_type, [_outcome_to_dict(o) for o in outcomes])
+                    await learner.learn_from_outcomes(
+                        task_type, [_outcome_to_dict(o) for o in outcomes], tenant_id=tenant_id
+                    )
                     logger.info(
                         "Self-improvement: learned from %d outcomes for task_type='%s'",
                         len(outcomes),

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -659,7 +659,9 @@ class Orchestrator(_DeprecatedRequestMixin):
             if task_type:
                 learner = TaskPatternLearner()
                 task_type = learner.normalize_task_type(task_type)
-                strategy = await learner.get_learned_strategy(task_type)
+                # GH#11071: scope the learned-strategy read to the caller's tenant so
+                # one org's synthesized template can't be injected into another's plan.
+                strategy = await learner.get_learned_strategy(task_type, tenant_id=tenant_id)
                 if strategy and strategy.confidence > LEARNED_STRATEGY_CONFIDENCE and strategy.best_prompt_template:
                     result["learned_prompt_template"] = strategy.best_prompt_template
                     logger.info(
@@ -710,11 +712,15 @@ class Orchestrator(_DeprecatedRequestMixin):
             from judges.task_outcome_judge import TaskOutcomeJudge
 
             judge = TaskOutcomeJudge()
+            # GH#11071: scope planning-outcome persistence to the plan's tenant; the
+            # score is returned regardless, but the write stays tenant-isolated.
+            tenant_id = str((getattr(plan, "metadata", None) or {}).get("tenant_id") or "")
             result = await judge.evaluate_task_outcome(
                 task_type="planning",
                 goal=goal,
                 output=str(plan.tasks),
                 strategy_used=str(plan.execution_strategy),
+                tenant_id=tenant_id,
             )
             return result.overall_score
         except Exception as exc:

--- a/autobot-backend/phase_progression_manager.py
+++ b/autobot-backend/phase_progression_manager.py
@@ -728,33 +728,19 @@ class PhaseProgressionManager:
     async def _enable_self_improvement(self):
         """Enable self-improvement when idle (Issue #930).
 
-        Reviews recent low-score task outcomes and triggers pattern learning
-        so future tasks benefit from accumulated execution history.
+        GH#11071: the previous implementation swept ``get_all_task_types()`` and
+        re-learned globally — but the learned-strategy stores are now
+        tenant-scoped, so a tenant-less global sweep would read/write across org
+        boundaries (the exact cross-tenant bleed being closed) and now fails
+        closed. Per-tenant learning is already driven online by the tenant-aware
+        writers (``WorkflowRunner._record_outcome_for_learning`` and the LLC
+        diary writer), so this idle hook no longer runs a global sweep. A
+        per-tenant background re-learn pass is tracked as a follow-up.
         """
-        from agents.task_pattern_learner import TaskPatternLearner
-        from judges.task_outcome_judge import TaskOutcomeJudge
-
-        judge = TaskOutcomeJudge()
-        learner = TaskPatternLearner()
-        try:
-            task_types = await learner.get_all_task_types()
-            for task_type in task_types:
-                outcomes = await judge.get_outcomes(task_type, limit=20)
-                if not outcomes:
-                    continue
-                outcome_dicts = [o.__dict__ for o in outcomes]
-                low_score_count = sum(1 for o in outcome_dicts if o.get("score", 1.0) < 0.6)
-                if low_score_count > 0:
-                    await learner.learn_from_outcomes(task_type, outcome_dicts)
-                    logger.info(
-                        "Self-improvement: learned from %d outcomes " "(%d low-score) for task type '%s'",
-                        len(outcome_dicts),
-                        low_score_count,
-                        task_type,
-                    )
-        except Exception as exc:
-            logger.error("Self-improvement activation error: %s", exc)
-        logger.info("🧠 Self-improvement capability enabled and active")
+        logger.info(
+            "🧠 Self-improvement active — per-tenant learning runs online via the "
+            "tenant-scoped outcome writers (global idle sweep retired, GH#11071)"
+        )
 
     async def _enable_error_recovery(self):
         """Enable error recovery from failed subtasks"""

--- a/autobot-backend/tests/api/test_knowledge_export_import.py
+++ b/autobot-backend/tests/api/test_knowledge_export_import.py
@@ -59,7 +59,7 @@ class TestExport:
             patch.object(api_mod, "_get_detector", return_value=detector),
         ):
             result = await api_mod.export_agent_knowledge(
-                agent_id="research_agent", task_type=None, min_confidence=0.8, _user=None
+                agent_id="research_agent", task_type=None, min_confidence=0.8, current_user={"org_id": "org1"}
             )
         assert result.learned_strategy is not None
         assert result.learned_strategy.best_approach == "read first"
@@ -78,7 +78,7 @@ class TestExport:
             patch.object(api_mod, "_get_detector", return_value=detector),
         ):
             result = await api_mod.export_agent_knowledge(
-                agent_id="research_agent", task_type=None, min_confidence=0.8, _user=None
+                agent_id="research_agent", task_type=None, min_confidence=0.8, current_user={"org_id": "org1"}
             )
         assert result.learned_strategy is None
         assert result.high_confidence_failure_patterns == []
@@ -89,8 +89,9 @@ class TestImportSanitization:
     async def test_import_sanitizes_untrusted_template(self) -> None:
         captured: dict = {}
 
-        async def _capture(strategy: LearnedStrategy) -> None:
+        async def _capture(strategy: LearnedStrategy, tenant_id: str = "") -> None:
             captured["strategy"] = strategy
+            captured["tenant_id"] = tenant_id
 
         learner = MagicMock()
         learner.save_strategy = AsyncMock(side_effect=_capture)
@@ -103,7 +104,12 @@ class TestImportSanitization:
             confidence=0.7,
         )
         with patch.object(api_mod, "_get_learner", return_value=learner):
-            resp = await api_mod.import_agent_knowledge(agent_id="research_agent", payload=payload, _admin=True)
+            resp = await api_mod.import_agent_knowledge(
+                agent_id="research_agent", payload=payload, _admin=True, current_user={"org_id": "org1"}
+            )
+
+        # GH#11071: import is scoped to the caller's tenant
+        assert captured["tenant_id"] == "org1"
 
         saved = captured["strategy"]
         # Marker delimiters stripped; newlines collapsed → cannot escape the frame.
@@ -123,7 +129,7 @@ class TestSaveStrategy:
         learner = TaskPatternLearner()
         fake_redis = AsyncMock()
         with patch.object(learner, "_get_redis", AsyncMock(return_value=fake_redis)):
-            await learner.save_strategy(_strategy(task_type="Research Agent"))
+            await learner.save_strategy(_strategy(task_type="Research Agent"), tenant_id="org1")
         assert fake_redis.set.await_count == 1
         key = fake_redis.set.await_args.args[0]
-        assert key == "task:patterns:research_agent"
+        assert key == "task:patterns:org1:research_agent"


### PR DESCRIPTION
Closes #11071

## Thinking Path
The self-improvement P0s (unauth router + prompt-injection) landed in #11068, but the **Redis learned-strategy leg** was still global-keyed — Org A's synthesized `best_prompt_template` could be read into Org B's planning prompt (#11015 only fixed the ChromaDB trajectory leg). This is the remaining CRIT cross-tenant bleed (child of umbrella #11058).

Keying the Redis keys by tenant closes the bleed structurally (Org B, reading with its own tenant, can never address Org A's key); fail-closed on an empty tenant is defense-in-depth. `tenant_id` is already available on the plan path (`_fetch_planning_context`), the workflow writers (`plan.metadata`), the diary/chat capture, and the API (`current_user.org_id`).

## What Changed
**Stores — tenant-scoped keys + fail-closed** (`agents/task_pattern_learner.py`, `judges/task_outcome_judge.py`):
- Keys are now `task:patterns:{tenant_id}:{task_type}` / `task:outcomes:{tenant_id}:{task_type}`.
- Every read/write/scan/clear takes `tenant_id`; an empty tenant **fails closed** (skips the Redis op + warns) instead of touching a shared bucket. `evaluate_task_outcome` still returns its judgment (used for plan scoring) even when persistence is skipped.
- `get_all_task_types(tenant_id)` scans only the tenant prefix.

**Call sites threaded:**
- Read path: `orchestrator._fetch_planning_context` + `_score_plan`; `agent_orchestration/routing._check_learned_strategy` — **and its in-memory `_strategy_cache` is now keyed by `(tenant_id, task_type)`** (a second bleed vector).
- Writers: `WorkflowRunner._record_outcome_for_learning` (tenant from `plan.metadata`), LLC `diary_writer` (company_id), `chat_workflow/trajectory_context` (tenant param).
- API `agents_self_improvement`: all endpoints scope to `current_user.org_id` (added `get_current_user` to the two admin endpoints too).
- `PhaseProgressionManager._enable_self_improvement`: the old **global cross-tenant sweep** (itself the mixing engine) is retired — per-tenant learning now runs online via the tenant-aware writers. A periodic per-tenant sweep is tracked as a follow-up (#11294).

## Verification
- Store logic verified directly (deps stubbed): tenant-scoped read/write/scan keys, fail-closed on empty tenant for read/persist/get_all_task_types/get_outcomes/clear, and per-tenant isolation (`orgA` vs `orgB` address distinct keys). All assertions pass.
- Updated existing store + API tests for the new signatures/keys; added fail-closed + isolation tests (`task_pattern_learner_test.py`, `task_outcome_judge_test.py`, `test_knowledge_export_import.py`). Mock-based wiring tests unaffected.
- `py_compile` + `black --check -l120` clean on all 9 source + 3 test files.

## Acceptance criteria (#11071)
- [x] Learned-strategy reads/writes tenant-scoped; no cross-tenant read on the plan path (Redis **and** the in-memory cache).
- [x] Missing tenant fails closed (no global read) + warns.
- [x] Tests cover tenant isolation + the fail-closed path.

## Model Used
Opus 4.8 (1M context)
