### PR TITLE
fix(security): SSRF-validate OAuth token_url in llm_shared + admin-gate /status (#11298)

### DIFF
--- a/autobot-backend/api/provider_auth.py
+++ b/autobot-backend/api/provider_auth.py
@@ -21,7 +21,6 @@ DELETE /api/llm-auth/{provider_name}       — revoke / delete stored tokens
 
 from __future__ import annotations
 
-import os
 import time
 from typing import Any
 
@@ -32,7 +31,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.user_management.dependencies import get_db_session
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.url_safety import require_allowlisted_https
+from autobot_shared.url_safety import get_oauth_allowed_hosts, require_allowlisted_https
 from llm_shared.provider_auth import (
     _vault_read,
     _vault_write,
@@ -43,29 +42,9 @@ logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # SSRF allowlist — hosts that provider OAuth/token endpoints may live on.
-# Override via AUTOBOT_PROVIDER_OAUTH_ALLOWED_HOSTS (comma-separated hostnames).
+# The list lives in autobot_shared.url_safety (single source of truth).
+# Override at runtime via AUTOBOT_PROVIDER_OAUTH_ALLOWED_HOSTS (comma-separated).
 # ---------------------------------------------------------------------------
-
-_DEFAULT_ALLOWED_HOSTS: frozenset[str] = frozenset(
-    {
-        "accounts.google.com",
-        "oauth2.googleapis.com",
-        "github.com",
-        "api.github.com",
-        "huggingface.co",
-        "login.microsoftonline.com",
-        "api.openai.com",
-        "auth.openai.com",
-        "api.anthropic.com",
-        "api.mistral.ai",
-    }
-)
-
-_ALLOWED_OAUTH_HOSTS: frozenset[str] = (
-    frozenset(h.strip().lower() for h in os.environ["AUTOBOT_PROVIDER_OAUTH_ALLOWED_HOSTS"].split(",") if h.strip())
-    if os.environ.get("AUTOBOT_PROVIDER_OAUTH_ALLOWED_HOSTS")
-    else _DEFAULT_ALLOWED_HOSTS
-)
 
 
 def _validate_outbound_url(url: str) -> None:
@@ -74,11 +53,11 @@ def _validate_outbound_url(url: str) -> None:
     Delegates the https / IP-literal / allowlist / port-pinning rules to the shared
     ``require_allowlisted_https`` guard in ``autobot_shared.url_safety`` so there is
     a single SSRF module (#11091 item 3), translating its ``ValueError`` into an
-    HTTP 400. Behaviour is unchanged; ``_ALLOWED_OAUTH_HOSTS`` remains the
-    provider-OAuth allowlist passed to the shared check.
+    HTTP 400. The allowlist is evaluated at call time via ``get_oauth_allowed_hosts()``
+    so AUTOBOT_PROVIDER_OAUTH_ALLOWED_HOSTS env-var overrides are always respected.
     """
     try:
-        require_allowlisted_https(url, _ALLOWED_OAUTH_HOSTS)
+        require_allowlisted_https(url, get_oauth_allowed_hosts())
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 
@@ -346,6 +325,7 @@ async def provider_auth_status(
     provider_name: str,
     session: AsyncSession = Depends(get_db_session),
     _: Any = Depends(get_current_user),
+    _admin: bool = Depends(check_admin_permission),
 ) -> ProviderAuthStatus:
     """Return the auth connection status for a provider."""
     token_data = await _vault_read(

--- a/autobot-backend/llm_shared/provider_auth.py
+++ b/autobot-backend/llm_shared/provider_auth.py
@@ -276,7 +276,15 @@ class OAuthAuth(ProviderAuthStrategy):
         return await self._refresh(session, token_data, refresh_token)
 
     async def _refresh(self, session: Any, old_data: dict, refresh_token: str) -> str:
+        from autobot_shared.url_safety import get_oauth_allowed_hosts, require_allowlisted_https  # noqa: PLC0415
         from knowledge.connectors.oauth_flow import refresh_access_token  # noqa: PLC0415
+
+        try:
+            require_allowlisted_https(self._token_url, get_oauth_allowed_hosts())
+        except ValueError as exc:
+            raise ProviderAuthError(
+                f"OAuth refresh blocked: unsafe token_url for {self._provider_name!r}: {exc}"
+            ) from exc
 
         logger.info("Refreshing OAuth token for provider %s", self._provider_name)
         try:

--- a/autobot-backend/llm_shared/tests/test_provider_auth.py
+++ b/autobot-backend/llm_shared/tests/test_provider_auth.py
@@ -624,3 +624,146 @@ class TestProviderAuthSecurity:
         with pytest.raises(HTTPException) as exc_info:
             _validate_outbound_url("https://accounts.google.com:99999/token")
         assert exc_info.value.status_code == 400
+
+    def test_status_endpoint_requires_admin(self):
+        """provider_auth_status must declare check_admin_permission (MED finding #11061)."""
+        from api.provider_auth import provider_auth_status
+        from auth_middleware import check_admin_permission
+
+        deps = self._get_endpoint_dependencies(provider_auth_status)
+        assert check_admin_permission in deps, "provider_auth_status missing check_admin_permission dependency"
+
+
+# ---------------------------------------------------------------------------
+# #11061: get_oauth_allowed_hosts — shared SSRF allowlist (url_safety)
+# ---------------------------------------------------------------------------
+
+
+class TestGetOauthAllowedHosts:
+    """Verify get_oauth_allowed_hosts() single-source-of-truth behaviour."""
+
+    def test_default_includes_known_providers(self):
+        import os
+
+        from autobot_shared.url_safety import get_oauth_allowed_hosts
+
+        env_key = "AUTOBOT_PROVIDER_OAUTH_ALLOWED_HOSTS"
+        old = os.environ.pop(env_key, None)
+        try:
+            hosts = get_oauth_allowed_hosts()
+            assert "accounts.google.com" in hosts
+            assert "github.com" in hosts
+            assert "api.anthropic.com" in hosts
+            assert "login.microsoftonline.com" in hosts
+        finally:
+            if old is not None:
+                os.environ[env_key] = old
+
+    def test_env_override_replaces_defaults(self):
+        import os
+
+        from autobot_shared.url_safety import get_oauth_allowed_hosts
+
+        env_key = "AUTOBOT_PROVIDER_OAUTH_ALLOWED_HOSTS"
+        old = os.environ.get(env_key)
+        os.environ[env_key] = "custom.provider.com, other.example.com"
+        try:
+            hosts = get_oauth_allowed_hosts()
+            assert "custom.provider.com" in hosts
+            assert "other.example.com" in hosts
+            assert "accounts.google.com" not in hosts
+        finally:
+            if old is None:
+                del os.environ[env_key]
+            else:
+                os.environ[env_key] = old
+
+    def test_allowlisted_host_passes_require_allowlisted_https(self):
+        from autobot_shared.url_safety import get_oauth_allowed_hosts, require_allowlisted_https
+
+        # Should not raise for a default-allowlisted host.
+        require_allowlisted_https("https://accounts.google.com/o/oauth2/token", get_oauth_allowed_hosts())
+
+    def test_non_allowlisted_host_raises_value_error(self):
+        from autobot_shared.url_safety import get_oauth_allowed_hosts, require_allowlisted_https
+
+        with pytest.raises(ValueError, match="allowlist"):
+            require_allowlisted_https("https://evil.example.com/token", get_oauth_allowed_hosts())
+
+
+# ---------------------------------------------------------------------------
+# #11061 HIGH: OAuthAuth._refresh validates token_url before outbound POST
+# ---------------------------------------------------------------------------
+
+
+class TestOAuthRefreshSsrfGuard:
+    """Verify the SSRF guard fires in _refresh before any network call."""
+
+    _BAD_URL = "https://internal.corp/steal-tokens"
+    _GOOD_URL = "https://accounts.google.com/o/oauth2/token"
+
+    def _make_auth(self, token_url: str) -> OAuthAuth:
+        return OAuthAuth(
+            provider_name="test_provider",
+            token_url=token_url,
+            client_id="cid",
+            client_secret="csec",
+            owner_vault_str="system",
+            subject="global",
+        )
+
+    def _expired_token_data(self) -> dict:
+        return {
+            "access_token": "at-expired",
+            "refresh_token": "rt-valid",
+            "expires_at": time.time() - 1,
+            "created_by": "00000000-0000-0000-0000-000000000000",
+        }
+
+    def test_bad_token_url_raises_provider_auth_error(self):
+        """_refresh must raise ProviderAuthError for a non-allowlisted token_url."""
+        auth = self._make_auth(self._BAD_URL)
+        expired = self._expired_token_data()
+        session = AsyncMock()
+
+        with (
+            patch.object(_PA_MOD, "_vault_read", new=AsyncMock(return_value=expired)),
+            patch(
+                "knowledge.connectors.oauth_flow.refresh_access_token",
+                new=AsyncMock(return_value={}),
+            ) as mock_post,
+        ):
+            with pytest.raises(ProviderAuthError, match="OAuth refresh blocked"):
+                _sync(auth.resolve_token(session))
+            # The outbound call must NOT have been made.
+            mock_post.assert_not_awaited()
+
+    def test_bad_token_url_error_message_names_provider(self):
+        """Error message must include the provider name for debuggability."""
+        auth = self._make_auth(self._BAD_URL)
+        expired = self._expired_token_data()
+        session = AsyncMock()
+
+        with patch.object(_PA_MOD, "_vault_read", new=AsyncMock(return_value=expired)):
+            with pytest.raises(ProviderAuthError, match="test_provider"):
+                _sync(auth.resolve_token(session))
+
+    def test_allowlisted_token_url_proceeds_to_network(self):
+        """A valid token_url still reaches the downstream refresh call."""
+        auth = self._make_auth(self._GOOD_URL)
+        expired = self._expired_token_data()
+        refreshed = {"access_token": "at-new", "expires_in": 3600}
+        session = AsyncMock()
+
+        with (
+            patch.object(_PA_MOD, "_vault_read", new=AsyncMock(return_value=expired)),
+            patch.object(_PA_MOD, "_vault_write", new=AsyncMock()),
+            patch(
+                "knowledge.connectors.oauth_flow.refresh_access_token",
+                new=AsyncMock(return_value=refreshed),
+            ) as mock_post,
+        ):
+            result = _sync(auth.resolve_token(session))
+
+        assert result == "at-new"
+        mock_post.assert_awaited_once()

--- a/autobot_shared/url_safety.py
+++ b/autobot_shared/url_safety.py
@@ -34,9 +34,45 @@ from __future__ import annotations
 
 import asyncio
 import ipaddress
+import os
 import socket
 from collections.abc import Collection
 from urllib.parse import urlparse
+
+# ---------------------------------------------------------------------------
+# OAuth provider allowlist — single source of truth for SSRF-safe OAuth hosts.
+# Shared by api/provider_auth.py and llm_shared/provider_auth.py so neither
+# duplicates the list.  Override at runtime via AUTOBOT_PROVIDER_OAUTH_ALLOWED_HOSTS.
+# ---------------------------------------------------------------------------
+
+_DEFAULT_OAUTH_ALLOWED_HOSTS: frozenset[str] = frozenset(
+    {
+        "accounts.google.com",
+        "oauth2.googleapis.com",
+        "github.com",
+        "api.github.com",
+        "huggingface.co",
+        "login.microsoftonline.com",
+        "api.openai.com",
+        "auth.openai.com",
+        "api.anthropic.com",
+        "api.mistral.ai",
+    }
+)
+
+
+def get_oauth_allowed_hosts() -> frozenset[str]:
+    """Return the OAuth provider SSRF allowlist.
+
+    Uses AUTOBOT_PROVIDER_OAUTH_ALLOWED_HOSTS (comma-separated hostnames) when
+    set and non-empty; falls back to ``_DEFAULT_OAUTH_ALLOWED_HOSTS`` otherwise.
+    Evaluated at call time so runtime env-var changes are reflected without restart.
+    """
+    raw = os.environ.get("AUTOBOT_PROVIDER_OAUTH_ALLOWED_HOSTS", "")
+    if raw.strip():
+        return frozenset(h.strip().lower() for h in raw.split(",") if h.strip())
+    return _DEFAULT_OAUTH_ALLOWED_HOSTS
+
 
 # TLDs that are never public — rejected before DNS resolution.
 _PRIVATE_TLDS = (".onion", ".internal", ".local", ".localhost", ".lan", ".home", ".corp")
@@ -230,5 +266,6 @@ __all__ = [
     "is_public_url_async",
     "resolve_safe_ip_async",
     "require_allowlisted_https",
+    "get_oauth_allowed_hosts",
     "host_matches",
 ]


### PR DESCRIPTION
Closes #11298

## Thinking Path
From the #11061 adversarial audit of provider-auth. Two contained findings closed here; the headline HIGH (callback state/PKCE binding) is split to #11297 (larger — new endpoint + Redis state lifecycle + frontend), and the remaining MEDs stay on #11061.

- **HIGH — refresh/device path bypasses the SSRF allowlist.** `_validate_outbound_url` lived only in the API layer; the strategy layer `llm_shared/provider_auth.OAuthAuth._refresh` POSTed to `self._token_url` (config-reachable) unvalidated. `DeviceCodeAuth` refreshes through the same `_refresh`, so it shared the gap. (The initial device-code poll is already API-layer-validated at `device_poll`.)
- **MED — `/status/{provider}` not admin-gated** — only `get_current_user`, unlike every other endpoint.

## What Changed
- `autobot_shared/url_safety.py`: new `get_oauth_allowed_hosts()` + `_DEFAULT_OAUTH_ALLOWED_HOSTS` — the OAuth SSRF allowlist is now a **single source of truth** shared by both provider-auth layers, evaluated at call time so `AUTOBOT_PROVIDER_OAUTH_ALLOWED_HOSTS` overrides still apply.
- `api/provider_auth.py`: dropped the duplicated local allowlist, `_validate_outbound_url` now uses `get_oauth_allowed_hosts()` (behavior identical); `/status` gains `check_admin_permission`.
- `llm_shared/provider_auth.py`: `_refresh` validates `self._token_url` via `require_allowlisted_https(...)` before the outbound POST, raising `ProviderAuthError` on a non-allowlisted URL (covers OAuth **and** device-code refresh).

## Verification
- Direct-import verification (repo conftest imports `llama_index`, unavailable locally): default allowlist present; `evil.example.com` rejected; `oauth2.googleapis.com` allowed; `_refresh` raises `ProviderAuthError` and does **not** call `refresh_access_token` when `token_url` is off-allowlist; `/status` Depends set includes `check_admin_permission`.
- New tests in `llm_shared/tests/test_provider_auth.py`: `TestGetOauthAllowedHosts` (4), `TestOAuthRefreshSsrfGuard` (3), `test_status_endpoint_requires_admin`.
- `py_compile` + `black --check -l120` clean on all 4 files.

## Scope / follow-up
- State/PKCE callback binding (HIGH) → **#11297** (implementation-ready design attached).
- Remaining #11061 MEDs (device-poll rate-limit + `slow_down`, DNS-rebinding pin-IP, per-tenant vault scoping, token audience/issuer) → tracked on #11061.

## Model Used
Opus 4.8 (1M context) + senior-backend-engineer subagent (implementation), reviewed here.
