### PR TITLE
test(analytics): fix cross-suite collection of codebase_analytics tests (#11256)

### DIFF
--- a/autobot-backend/llc/tests/conftest.py
+++ b/autobot-backend/llc/tests/conftest.py
@@ -50,6 +50,16 @@ def _make_knowledge_submodule_stubs() -> None:
     ku.sanitize_metadata_for_chromadb = MagicMock(return_value={})  # type: ignore[attr-defined]
     sys.modules["knowledge.utils"] = ku
 
+    # codebase_analytics/storage.py does ``from knowledge.backends import
+    # get_async_default_client, get_default_client`` at module level. Without a
+    # backends stub, the bare ``knowledge`` stub above shadows the real package and
+    # any cross-suite run (llc tests collected before analytics tests) fails to
+    # collect them with ModuleNotFoundError: No module named 'knowledge.backends' (#11256).
+    kb = types.ModuleType("knowledge.backends")
+    kb.get_default_client = MagicMock(return_value=MagicMock())  # type: ignore[attr-defined]
+    kb.get_async_default_client = AsyncMock(return_value=MagicMock())  # type: ignore[attr-defined]
+    sys.modules["knowledge.backends"] = kb
+
 
 # The ``knowledge`` module imports lazily but fails when attributes are accessed
 # because chromadb → opentelemetry has a broken dependency in the dev venv.


### PR DESCRIPTION
## Thinking Path
#11256 reported that `api/codebase_analytics/*_test.py` are uncollectable in the dev venv (`ModuleNotFoundError: No module named 'knowledge.backends'`). Root-causing showed the analytics tests are fine in isolation (137 collected) — the abort only happens when **llc/tests are collected first in the same session**: `llc/tests/conftest.py` replaces `sys.modules["knowledge"]` with a bare stub that provides `embedding_cache`/`utils` submodules but **not `backends`**, so `codebase_analytics/storage.py`'s module-level `from knowledge.backends import get_async_default_client, get_default_client` resolves against the stub and fails. The fix belongs in the conftest (the leak source), not in each analytics file.

## What Changed
`autobot-backend/llc/tests/conftest.py` — `_make_knowledge_submodule_stubs()` now also registers a `knowledge.backends` stub exposing `get_default_client` / `get_async_default_client`, mirroring the existing `knowledge.embedding_cache` / `knowledge.utils` stubs. One targeted change fixes all analytics test files at once (no per-file `importorskip`).

## Verification
- Cross-suite collection: `pytest llc/tests/test_project_lifecycle_model.py api/codebase_analytics/chromadb_storage_test.py --collect-only` — **1 error → 6 collected**.
- Broad cross-suite collection: `pytest llc/tests/ api/codebase_analytics/ --collect-only` — **1237 tests collected, no abort** (previously aborted).
- `chromadb_storage_test.py` now collects **and runs**: combined `llc/tests/ + chromadb_storage_test.py` = **1103 passed, 0 failed** (its 4 tests pass under the stub).
- No regression: full `llc/tests/` suite **1099 passed, 1 skipped, 0 failed**.
- black `-l120` + isort clean on the changed file.

Note: the redis/chromadb-dependent runtime failures in the analytics suite (e.g. `progress_tracker`, `parallel_processing`) are a separate infra concern (require live services) and are out of scope for this collection fix.

## Model Used
Claude Opus 4.8.

Closes #11256