### PR TITLE
fix(chat): render blocked-URL browser actions as friendly notices, not scary error banners (#10914)

### DIFF
--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -1888,13 +1888,19 @@ class ToolHandlerMixin:
             )
 
     def _validate_browser_params(self, tool_name: str, params: dict[str, Any]) -> str | None:
-        """Validate browser tool params. Returns error message or None. #1368."""
+        """Validate browser tool params. Returns a user-friendly block notice or None.
+
+        #1368 / #10914: a disallowed URL or unsafe script is an *expected* policy
+        outcome, so the returned text reads as a friendly notice (rendered as a
+        normal assistant message, not a scary error banner — see _handle_browser_tool).
+        """
         from api.browser_mcp import is_script_safe, is_url_allowed
 
         if tool_name == "navigate" and not is_url_allowed(params.get("url", "")):
-            return f"URL not allowed: {params.get('url', '')}"
+            url = params.get("url", "")
+            return f"I can't open that link ({url}) — it isn't on the list of sites I'm allowed to browse."
         if tool_name == "evaluate" and not is_script_safe(params.get("script", "")):
-            return "JavaScript blocked by security policy"
+            return "I can't run that browser action — it was blocked by the security policy."
         return None
 
     async def _handle_browser_tool(
@@ -1927,11 +1933,15 @@ class ToolHandlerMixin:
         try:
             validation_error = self._validate_browser_params(tool_name, params)
             if validation_error:
+                # Keep status="error" so the agent loop still knows the tool didn't run.
                 execution_results.append({"tool": tool_name, "status": "error", "error": validation_error})
+                # #10914: a disallowed URL / unsafe script is an expected policy block,
+                # not a system failure — surface it to the user as a normal assistant
+                # notice (tool_result) so the UI doesn't render a scary red "Error:" banner.
                 yield WorkflowMessage(
-                    type="error",
+                    type="tool_result",
                     content=validation_error,
-                    metadata={"tool": tool_name, "error": True},
+                    metadata={"tool": tool_name, "blocked": True},
                 )
                 return
 

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_browser_block.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_browser_block.py
@@ -1,0 +1,40 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Browser-tool policy-block messages are friendly, not raw errors (#10914).
+
+A disallowed navigate URL or unsafe script is an *expected* policy outcome. The
+validator must return user-friendly notice text (no raw ``URL not allowed:``),
+and the handler surfaces it as a ``tool_result`` — not a scary ``error`` banner.
+"""
+
+from unittest.mock import patch
+
+from chat_workflow.tool_handler import ToolHandlerMixin
+
+# _validate_browser_params does not use instance state — call it unbound.
+_validate = ToolHandlerMixin._validate_browser_params
+_SELF = object()
+
+
+def test_navigate_block_is_friendly_not_raw() -> None:
+    with patch("api.browser_mcp.is_url_allowed", return_value=False):
+        msg = _validate(_SELF, "navigate", {"url": "https://colorlib.com/x/#adminlte-4"})
+    assert msg is not None
+    assert "URL not allowed" not in msg  # no raw error string
+    assert "can't open that link" in msg.lower()
+    assert "https://colorlib.com/x/#adminlte-4" in msg  # still names the URL
+
+
+def test_unsafe_script_block_is_friendly() -> None:
+    with patch("api.browser_mcp.is_script_safe", return_value=False):
+        msg = _validate(_SELF, "evaluate", {"script": "while(true){}"})
+    assert msg is not None
+    assert "blocked by the security policy" in msg.lower()
+    assert "JavaScript blocked" not in msg  # not the old raw text
+
+
+def test_allowed_navigate_returns_none() -> None:
+    with patch("api.browser_mcp.is_url_allowed", return_value=True):
+        assert _validate(_SELF, "navigate", {"url": "https://github.com"}) is None


### PR DESCRIPTION
Closes #10914

## Thinking Path
Two symptoms on `/chat`:
1. **Vue `component_error` from an onClick→`router.push`** — already fixed by #10957 (`handleTabChange` now guards with `router.hasRoute()` before navigating, since Vue Router throws *synchronously* on an unregistered named route so `.catch()` can't swallow it). Verified present on Dev_new_gui.
2. **`ChatController` stream error `URL not allowed: https://colorlib.com/…#adminlte-4`** — a message referencing a URL triggered a browser `navigate` tool whose target was off the browse allowlist. `_validate_browser_params` returned the raw string `URL not allowed: <url>`, and `_handle_browser_tool` yielded it as `type="error"` → the frontend rendered a scary red `Error: URL not allowed: …` banner. This is the part fixed here.

A disallowed URL is an **expected policy outcome**, not a system failure, so it shouldn't render as a hard error.

## What Changed (backend only)
`autobot-backend/chat_workflow/tool_handler.py`:
- `_validate_browser_params` now returns friendly notice text — `"I can't open that link (<url>) — it isn't on the list of sites I'm allowed to browse."` / `"I can't run that browser action — it was blocked by the security policy."` (no raw `URL not allowed:` / `JavaScript blocked` strings).
- `_handle_browser_tool` yields the block as `type="tool_result"` (rendered as a normal assistant message) instead of `type="error"` (the red banner). The `execution_results` entry keeps `status="error"` so the agent loop still knows the tool didn't run.

No frontend change needed: the `ChatController` `type === 'error'` branch is the only one that renders the scary banner; `tool_result` already routes through the normal message path.

## Verification
- Validator logic verified directly (repo conftest needs `jinja2`/`llama_index`, absent locally): navigate-block → friendly text containing the URL, no raw `URL not allowed`; script-block → friendly; allowed URL → `None`.
- Added `tests/unit/chat_workflow/test_tool_handler_browser_block.py` (3 tests).
- `py_compile` + `black --check -l120` clean.

## Model Used
Opus 4.8 (1M context)
