### PR TITLE
fix(security): stop detect_injection raising HardBlockError — enforce via result flags (#11278)

### DIFF
--- a/autobot-backend/security/content_firewall.py
+++ b/autobot-backend/security/content_firewall.py
@@ -32,7 +32,7 @@ from typing import Any
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
-from security.prompt_injection_detector import HardBlockError, InjectionRisk, PromptInjectionDetector
+from security.prompt_injection_detector import InjectionRisk, PromptInjectionDetector
 
 logger = get_logger(__name__)
 
@@ -164,20 +164,21 @@ class ContentFirewall:
         if not content or not content.strip():
             return FirewallVerdict(content=content, action=FirewallAction.PASS, risk=InjectionRisk.SAFE, source=source)
 
-        # issue #11264: HardBlockError is raised inside detect_injection when
-        # HARDBLOCK_ENABLED=true and confidence >= HARDBLOCK_THRESHOLD.  Catch it
-        # here so the block is enforced before any tool execution proceeds.
-        try:
-            detection = self._detector.detect_injection(content, context=f"untrusted_{source.value}")
-        except HardBlockError as exc:
+        detection = self._detector.detect_injection(content, context=f"untrusted_{source.value}")
+
+        # issue #11264 / #11278: when HARDBLOCK_ENABLED=true and confidence >=
+        # HARDBLOCK_THRESHOLD, detect_injection now flags result.hard_blocked
+        # (it no longer raises — see #11278). Enforce the hard block here before
+        # any tool execution proceeds.
+        if detection.hard_blocked:
             verdict = FirewallVerdict(
                 content="[FIREWALL: content hard-blocked — injection confidence too high]",
                 action=FirewallAction.BLOCK,
-                risk=exc.risk,
+                risk=detection.risk_level,
                 source=source,
-                detected_patterns=exc.patterns,
+                detected_patterns=detection.detected_patterns,
                 blocked=True,
-                metadata={"hard_blocked": True, "confidence": exc.confidence},
+                metadata={"hard_blocked": True, "confidence": detection.confidence_score},
             )
             self._log_verdict(verdict, context_label)
             await self._record_trajectory(verdict, task_id)

--- a/autobot-backend/security/prompt_injection_detector.py
+++ b/autobot-backend/security/prompt_injection_detector.py
@@ -29,7 +29,8 @@ logger = get_logger(__name__)
 # Hard-block feature flags (issue #11264)
 # ---------------------------------------------------------------------------
 
-# Enable hard-block mode: when ON and confidence >= threshold, raise HardBlockError.
+# Enable hard-block mode: when ON and confidence >= threshold, detect_injection
+# flags result.hard_blocked (and result.blocked) — it does NOT raise (#11278).
 # Default OFF so existing quarantine/flag behaviour is fully preserved.
 HARDBLOCK_ENABLED: bool = env_flag("AUTOBOT_INJECTION_HARDBLOCK_ENABLED", default=False)
 
@@ -45,22 +46,6 @@ _RISK_CONFIDENCE: dict[str, float] = {
     "high": 0.75,
     "critical": 1.0,
 }
-
-
-class HardBlockError(RuntimeError):
-    """Raised when hard-block mode is enabled and injection confidence exceeds threshold.
-
-    Callers (e.g. ContentFirewall) catch this to reject content before tool execution.
-    """
-
-    def __init__(self, confidence: float, risk: "InjectionRisk", patterns: List[str]) -> None:
-        self.confidence = confidence
-        self.risk = risk
-        self.patterns = patterns
-        super().__init__(
-            f"Hard-block: injection confidence {confidence:.2f} >= threshold "
-            f"{HARDBLOCK_THRESHOLD:.2f} (risk={risk.value})"
-        )
 
 
 # Issue #380: Pre-compiled regex patterns for sanitize_input()
@@ -438,11 +423,15 @@ class PromptInjectionDetector:
         # issue #11264: compute confidence and evaluate hard-block
         confidence = _RISK_CONFIDENCE.get(max_risk.value, 0.0)
         hard_blocked = self._check_hard_block(confidence, max_risk, detected_patterns)
+        # #11278: a hard-block is definitionally a block — fold it into `blocked`
+        # so every caller's existing `result.blocked` check enforces it, instead
+        # of an uncaught HardBlockError escaping the shared primitive.
+        blocked = blocked or hard_blocked
         metadata["confidence_score"] = confidence
         metadata["hard_blocked"] = hard_blocked
 
         # Log detection results
-        self._log_detection_result(max_risk, blocked or hard_blocked, detected_patterns)
+        self._log_detection_result(max_risk, blocked, detected_patterns)
 
         return InjectionDetectionResult(
             risk_level=max_risk,
@@ -541,37 +530,41 @@ class PromptInjectionDetector:
         risk: InjectionRisk,
         detected_patterns: List[str],
     ) -> bool:
-        """Evaluate hard-block decision for issue #11264.
+        """Evaluate the hard-block decision for issue #11264 / #11278.
 
-        Returns True and raises HardBlockError when:
+        Returns ``True`` (does NOT raise) when:
           - HARDBLOCK_ENABLED is True, AND
           - confidence >= HARDBLOCK_THRESHOLD.
 
         Returns False (no-op) when the feature is disabled — existing
         quarantine/flag behaviour is fully preserved in that case.
 
+        #11278: this used to ``raise HardBlockError`` from inside the shared
+        ``detect_injection`` primitive, which most callers don't catch — enabling
+        the flag turned their controlled ``result.blocked`` check into an uncaught
+        exception. The enforcement decision now rides ``result.hard_blocked`` /
+        ``result.blocked`` so every caller blocks via its existing code path.
+
         Args:
             confidence:        Normalised confidence score (0.0–1.0).
             risk:              Detected InjectionRisk level.
-            detected_patterns: Pattern list forwarded to HardBlockError.
+            detected_patterns: Pattern list (logged for context).
 
         Returns:
             True if hard-blocked; False otherwise.
-
-        Raises:
-            HardBlockError: When hard-block fires.
         """
         if not HARDBLOCK_ENABLED:
             return False
         if confidence < HARDBLOCK_THRESHOLD:
             return False
         logger.warning(
-            "HARD-BLOCK: injection confidence %.2f >= threshold %.2f (risk=%s)",
+            "HARD-BLOCK: injection confidence %.2f >= threshold %.2f (risk=%s, patterns=%d)",
             confidence,
             HARDBLOCK_THRESHOLD,
             risk.value,
+            len(detected_patterns),
         )
-        raise HardBlockError(confidence=confidence, risk=risk, patterns=detected_patterns)
+        return True
 
     def _detect_invisible_unicode(self, text: str) -> tuple[bool, List[str]]:
         """

--- a/autobot-backend/security/prompt_injection_hardblock_test.py
+++ b/autobot-backend/security/prompt_injection_hardblock_test.py
@@ -2,13 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Tests for hard-block mode added to PromptInjectionDetector (issue #11264).
+"""Tests for hard-block mode in PromptInjectionDetector (issues #11264, #11278).
 
 Covers:
 - Below-threshold → quarantine/flag only, not hard-blocked
-- Above-threshold + HARDBLOCK_ENABLED=True → HardBlockError raised
+- Above-threshold + HARDBLOCK_ENABLED=True → result.hard_blocked + result.blocked
+  set (NO exception — #11278: the shared primitive must not raise)
 - HARDBLOCK_ENABLED=False → never blocks even when confidence is above threshold
-- ContentFirewall.inspect() returns BLOCK verdict on HardBlockError
+- ContentFirewall.inspect() returns BLOCK verdict on a hard-block
+- Callers that only inspect result.blocked get a controlled block, not an
+  uncaught exception (the #11278 regression)
 """
 
 from __future__ import annotations
@@ -16,12 +19,9 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import patch
 
-import pytest
-
 from security.content_firewall import ContentFirewall, ContentSource, FirewallAction
 from security.prompt_injection_detector import (
     _RISK_CONFIDENCE,
-    HardBlockError,
     InjectionRisk,
     PromptInjectionDetector,
 )
@@ -52,8 +52,24 @@ def _detector_with_hardblock(enabled: bool, threshold: float = 0.75) -> PromptIn
 # ---------------------------------------------------------------------------
 
 
+class TestCallerSafety:
+    """#11278 regression: enabling hard-block must NOT make detect_injection raise —
+    callers that only inspect result.blocked must still get a controlled block."""
+
+    def test_caller_checking_blocked_gets_controlled_block_not_exception(self):
+        detector = PromptInjectionDetector(strict_mode=True)
+        with (
+            patch("security.prompt_injection_detector.HARDBLOCK_ENABLED", True),
+            patch("security.prompt_injection_detector.HARDBLOCK_THRESHOLD", 0.75),
+        ):
+            # A typical caller (e.g. secure_llm_command_parser) — no try/except.
+            result = detector.detect_injection(_CRITICAL_INPUT, context="llm_response")
+            enforced = result.blocked  # would have raised before #11278
+        assert enforced is True
+
+
 class TestHardBlockDisabled:
-    """When HARDBLOCK_ENABLED=False the detector must never raise HardBlockError."""
+    """When HARDBLOCK_ENABLED=False the detector must never hard-block."""
 
     def test_critical_input_no_raise_when_disabled(self):
         detector = PromptInjectionDetector(strict_mode=True)
@@ -87,30 +103,33 @@ class TestHardBlockDisabled:
 
 
 class TestHardBlockEnabledAboveThreshold:
-    """When enabled and confidence >= threshold, HardBlockError must be raised."""
+    """When enabled and confidence >= threshold, detect_injection flags the result
+    (hard_blocked + blocked) — #11278: it must NOT raise, so callers that only
+    check result.blocked still enforce a controlled block."""
 
-    def test_critical_input_raises_hard_block(self):
+    def test_critical_input_flags_hard_block(self):
         detector = PromptInjectionDetector(strict_mode=True)
         with (
             patch("security.prompt_injection_detector.HARDBLOCK_ENABLED", True),
             patch("security.prompt_injection_detector.HARDBLOCK_THRESHOLD", 0.75),
         ):
-            with pytest.raises(HardBlockError) as exc_info:
-                detector.detect_injection(_CRITICAL_INPUT)
-        err = exc_info.value
-        assert err.confidence == 1.0
-        assert err.risk == InjectionRisk.CRITICAL
-        assert len(err.patterns) > 0
+            result = detector.detect_injection(_CRITICAL_INPUT)
+        # #11278: no exception — the decision rides the result flags.
+        assert result.hard_blocked is True
+        assert result.blocked is True  # hard-block is folded into blocked
+        assert result.confidence_score == 1.0
+        assert result.risk_level == InjectionRisk.CRITICAL
+        assert len(result.detected_patterns) > 0
 
-    def test_error_message_contains_threshold(self):
+    def test_confidence_populated_on_hard_block(self):
         detector = PromptInjectionDetector(strict_mode=True)
         with (
             patch("security.prompt_injection_detector.HARDBLOCK_ENABLED", True),
             patch("security.prompt_injection_detector.HARDBLOCK_THRESHOLD", 0.75),
         ):
-            with pytest.raises(HardBlockError) as exc_info:
-                detector.detect_injection(_CRITICAL_INPUT)
-        assert "0.75" in str(exc_info.value)
+            result = detector.detect_injection(_CRITICAL_INPUT)
+        assert result.metadata.get("hard_blocked") is True
+        assert result.confidence_score >= 0.75
 
     def test_threshold_at_exact_confidence_triggers_block(self):
         """Threshold equal to confidence must trigger the block (>=)."""
@@ -119,8 +138,9 @@ class TestHardBlockEnabledAboveThreshold:
             patch("security.prompt_injection_detector.HARDBLOCK_ENABLED", True),
             patch("security.prompt_injection_detector.HARDBLOCK_THRESHOLD", 1.0),
         ):
-            with pytest.raises(HardBlockError):
-                detector.detect_injection(_CRITICAL_INPUT)
+            result = detector.detect_injection(_CRITICAL_INPUT)
+        assert result.hard_blocked is True
+        assert result.blocked is True
 
 
 # ---------------------------------------------------------------------------
@@ -163,7 +183,7 @@ class TestHardBlockEnabledBelowThreshold:
 
 
 class TestContentFirewallHardBlock:
-    """ContentFirewall.inspect() must return a BLOCK verdict when HardBlockError fires."""
+    """ContentFirewall.inspect() must return a BLOCK verdict when a hard-block fires."""
 
     def _run(self, coro):
         return asyncio.get_event_loop().run_until_complete(coro)


### PR DESCRIPTION
Closes #11278

## Thinking Path
`detect_injection()` (a widely-shared primitive) raised a **new** `HardBlockError` when `AUTOBOT_INJECTION_HARDBLOCK_ENABLED=true` and confidence ≥ threshold. Only `content_firewall.py` caught it — every other caller (secure_llm_command_parser ×3, intelligent_agent_security ×2, prompt_manager, and the detector's own recursive self-calls) invokes it and inspects `result.blocked`, so enabling the flag turned their controlled block into an **uncaught exception**. The feature was unsafe to actually enable. Throwing a new exception type from a shared function is a footgun; the enforcement decision belongs on the result.

## What Changed (Option 1 — remove the footgun)
- `security/prompt_injection_detector.py`:
  - `_check_hard_block()` now **returns `True`** instead of `raise HardBlockError(...)`.
  - `detect_injection()` folds the hard-block into the result: `blocked = blocked or hard_blocked`, so **every caller's existing `result.blocked` check enforces it** — no exception escapes. `result.hard_blocked` still carries the specific signal.
  - Removed the now-obsolete `HardBlockError` class (internal-only: not in `security.__init__.__all__`; only content_firewall + the test referenced it).
- `security/content_firewall.py`: replaced the `try/except HardBlockError` with an `if detection.hard_blocked:` check producing the same specific BLOCK verdict; dropped the unused import.
- `security/prompt_injection_hardblock_test.py`: converted the three `pytest.raises(HardBlockError)` cases to assert `result.hard_blocked`/`result.blocked`; added `TestCallerSafety` — the #11278 regression: a caller that only reads `result.blocked` gets a controlled block, not an exception.

## Verification (ran against the real detector)
- Enabled + above-threshold, caller with **no** try/except → **no exception**; `hard_blocked=True`, `blocked=True`, `confidence=1.0`, `risk=CRITICAL`. ✅
- Disabled → `hard_blocked=False`, `blocked=True` (existing behaviour preserved). ✅
- Enabled + below-threshold (MODERATE) → `hard_blocked=False`. ✅
- `py_compile` + `black --check -l120` clean; no lingering `HardBlockError` references.

## Not in scope (noted on the issue)
The "bonus" `_RISK_CONFIDENCE`→`InjectionRisk.confidence` consolidation is deferred to keep this focused on the footgun fix.

## Model Used
Opus 4.8 (1M context)
