### PR TITLE
fix(api): drop duplicate knowledge_vectorization router mount — fixes duplicate OpenAPI operation IDs (#11072)

### DIFF
--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -70,7 +70,9 @@ from api.knowledge_search_scoped import router as knowledge_search_scoped_router
 from api.knowledge_suggestions import router as knowledge_suggestions_router
 from api.knowledge_sync_queue import router as knowledge_sync_queue_router  # Issue #4453
 from api.knowledge_tags import router as knowledge_tags_router
-from api.knowledge_vectorization import router as knowledge_vectorization_router
+
+# #11072: knowledge_vectorization is included via api/knowledge.py's knowledge_router
+# (not registered standalone here) to avoid duplicate OpenAPI operation IDs.
 from api.knowledge_verification import router as knowledge_verification_router
 from api.live_events import router as live_events_router  # Issue #6229
 from api.llm import router as llm_router
@@ -353,12 +355,11 @@ def _get_knowledge_feature_routers() -> list:
             ["knowledge-multi-source", "knowledge-search"],
             "knowledge_search_aggregator",
         ),
-        (
-            knowledge_vectorization_router,
-            "/knowledge_base",
-            ["knowledge-vectorization"],
-            "knowledge_vectorization",
-        ),
+        # #11072: knowledge_vectorization is NOT registered here — api/knowledge.py
+        # already includes it into knowledge_router (mounted at /knowledge_base),
+        # so a second standalone mount at the same prefix produced duplicate
+        # OpenAPI operation IDs (get_/clear_failed_vectorization_jobs) and api.ts
+        # drift. The knowledge_router include is the single source.
         # Issue #4453: document sync queue admin endpoints
         (
             knowledge_sync_queue_router,


### PR DESCRIPTION
Closes #11072

## Thinking Path
FastAPI emitted `Duplicate Operation ID get_failed_vectorization_jobs_…` / `…clear_failed_vectorization_jobs_…` during OpenAPI generation (surfaced by the `api-wiring` CI check). The issue guessed the cause was `@with_error_handling` not preserving function identity — but that decorator **does** use `@functools.wraps`, and the two endpoints have distinct names/paths, so they can't collide with each other.

**Real root cause: the router is mounted twice.** `api/knowledge.py:231` does `router.include_router(vectorization_router)` (so the vectorization endpoints are part of `knowledge_router`, registered at `/knowledge_base` in `core_routers.py`), AND `core_routers.py` *also* registered `knowledge_vectorization_router` standalone at the same `/knowledge_base` prefix. Same functions, same paths, registered twice → duplicate operation IDs → ambiguous/colliding generated `api.ts` client methods (drift, #10817).

## What Changed
`initialization/router_registry/core_routers.py`: removed the standalone `knowledge_vectorization_router` registration (and its now-unused import). `api/knowledge.py`'s `include_router(vectorization_router)` remains the single source, so **every endpoint URL is unchanged** (`/api/knowledge_base/vectorize_jobs/...`). Verified nothing else referenced the standalone registration (no other use in core_routers; no test depends on it).

## Verification
- `core_routers.py` compiles; no lingering `knowledge_vectorization_router` reference; endpoints still registered via `api/knowledge.py:231`. `black` clean.
- The real proof is CI: `api-wiring` (no `Duplicate Operation ID` warning) and `Verify Generated Types` (api.ts regenerated under py3.14 with unique, stable operation IDs).

## Model Used
Opus 4.8 (1M context)
