### PR TITLE
ci: add timeout-minutes to self-hosted jobs — fail fast instead of hanging 24h (#11077)

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   auto-update:
     runs-on: [self-hosted, linux]
+    timeout-minutes: 15  # #11077: fail fast (self-hosted); not GitHub's 24h default
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -59,6 +59,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.frontend == 'true'
     runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 30  # #11077: fail fast (self-hosted); not GitHub's 24h default
     # vue-tsc (the `type-check` and `check-ts-delta` steps) is near the default
     # V8 old-space ceiling on this project and intermittently OOMs
     # ("Reached heap limit … JavaScript heap out of memory"), flaking this
@@ -184,6 +185,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.frontend == 'true'
     runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 20  # #11077: fail fast (self-hosted); not GitHub's 24h default
 
     steps:
       - name: Checkout code
@@ -228,6 +230,7 @@ jobs:
   build-test:
     name: Build Test
     runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 30  # #11077: fail fast (self-hosted); not GitHub's 24h default
     # `changes` added so the dependency graph is consistent; build-test already
     # self-skips when unit-tests skips (path-untouched PRs).
     needs: [changes, unit-tests]
@@ -268,6 +271,7 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 15  # #11077: fail fast (self-hosted); not GitHub's 24h default
     needs: [unit-tests, security-scan, build-test]
     if: always()
 


### PR DESCRIPTION
Closes #11077

## Thinking Path
On the single self-hosted runner, a starved/stuck job sits until GitHub's default **24-hour** maximum instead of failing fast — the required "Unit & Integration Tests" check showed `fail 24h0m0s` on PRs #10895/#11009, blocking the PR (or forcing an admin bypass) and tying up the runner for a day.

## What Changed
Added `timeout-minutes` to every self-hosted job (none had one):
- `frontend-test.yml`: `unit-tests` (30), `security-scan` (20), `build-test` (30), `test-summary` (15) — the issue named the first three; `test-summary` had the same gap.
- **Audit** (per the issue's ask): swept all `.github/workflows/*` for self-hosted jobs missing `timeout-minutes` and found one more — `auto-update-pr-branches.yml` `auto-update` (15). Post-change re-audit: zero remaining gaps.

Values are comfortably above normal run times (unit/build ~ minutes) so they only trip on a genuine stall.

## Verification
- Both workflow files parse as valid YAML.
- Re-audit script confirms no self-hosted job across `.github/workflows/` lacks `timeout-minutes`.
- Static values only — no untrusted input in the change.

## Model Used
Opus 4.8 (1M context)
