### PR TITLE
fix(security): wire startup integrity check into autobot-backend lifespan (#11279)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -2072,6 +2072,14 @@ def create_lifespan_manager():
         configure_logging()
         logger.info("🚀 AutoBot Backend starting up...")
 
+        # #11279: run the non-fatal startup file-integrity check (mirrors the
+        # autobot-slm-backend lifespan wiring). No-op unless
+        # AUTOBOT_INTEGRITY_CHECK_ENABLED=1; logs a WARNING on any manifest
+        # mismatch and never raises, so it can't block startup.
+        from autobot_shared.integrity_manifest import verify_integrity_at_startup
+
+        verify_integrity_at_startup()
+
         # Create bounded thread pool executor to prevent thread explosion
         # This replaces the default unbounded asyncio executor
         _executor = ThreadPoolExecutor(max_workers=MAX_WORKER_THREADS, thread_name_prefix="autobot_worker")


### PR DESCRIPTION
Closes #11279

## Thinking Path
`autobot_shared/integrity_manifest.verify_integrity_at_startup()` was invoked only from `autobot-slm-backend/main.py:178`; the primary `autobot-backend` never called it, so the startup file-integrity check never ran there even with `AUTOBOT_INTEGRITY_CHECK_ENABLED=true` — the feature was half-wired.

## What Changed
`autobot-backend/initialization/lifespan.py`: call `verify_integrity_at_startup()` right after `configure_logging()` (before critical-service init), mirroring the slm-backend lifespan wiring. The entry point is guarded by `AUTOBOT_INTEGRITY_CHECK_ENABLED` (default OFF), logs a WARNING on any manifest mismatch, and **never raises**, so it cannot block backend startup.

## Verification
- `verify_integrity_at_startup()` imports cleanly and is a safe no-op when the flag is unset (verified by direct call — no exception).
- `py_compile` + `black --check -l120` clean.
- CI smoke-test boots the backend container, confirming the added call doesn't disrupt startup.

## Model Used
Opus 4.8 (1M context)
