### PR TITLE
test(conftest): load real llm_shared ProviderRegistry/BaseProvider — fixes provider-registry tests (#10917)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -335,7 +335,28 @@ if "llm_shared" not in sys.modules:
     # strategy classes without hitting the llm_shared MagicMock stub.
     _load_real_mod("llm_shared.provider_auth", _llm_root / "provider_auth.py")
     # #10551: base_provider — load real so BaseProvider tests can instantiate it.
+    # #10917: base_provider's real load (added in #10551) silently failed because
+    # the llm_shared stub has an empty __path__, so its relative imports
+    # (`from .cross_worker_rate_limiter`, `.observability`, `.rate_limit_backoff`)
+    # couldn't resolve on disk. Pre-load those transitive light deps in dependency
+    # order — all bare-env-importable (observability guards its langfuse/langsmith
+    # SDK imports inside methods and does not import otel_observer at top level) —
+    # so base_provider (and then provider_registry) load real.
+    _load_real_mod("llm_shared.cross_worker_rate_limiter", _llm_root / "cross_worker_rate_limiter.py")
+    _load_real_mod("llm_shared.observability", _llm_root / "observability" / "__init__.py")
+    _load_real_mod("llm_shared.rate_limit_backoff", _llm_root / "rate_limit_backoff.py")
     _load_real_mod("llm_shared.base_provider", _llm_root / "base_provider.py")
+    _load_real_mod("llm_shared.model_param_registry", _llm_root / "model_param_registry.py")
+    _load_real_mod("llm_shared.provider_registry", _llm_root / "provider_registry.py")
+    # Re-export the real classes onto the top-level stub so
+    # `from llm_shared import ProviderRegistry, BaseProvider` resolves to the real
+    # ones for tests that exercise them (tests/test_provider_registry.py, #10917).
+    _pr_mod = sys.modules.get("llm_shared.provider_registry")
+    if _pr_mod is not None and hasattr(_pr_mod, "ProviderRegistry"):
+        _llm_stub.ProviderRegistry = _pr_mod.ProviderRegistry  # type: ignore[attr-defined]
+    _bp_mod = sys.modules.get("llm_shared.base_provider")
+    if _bp_mod is not None and hasattr(_bp_mod, "BaseProvider"):
+        _llm_stub.BaseProvider = _bp_mod.BaseProvider  # type: ignore[attr-defined]
 
     # Stub llm_shared.optimization.model_inspector so complexity_router.py can
     # load without the full optimization stack (inspect_model is only called in


### PR DESCRIPTION
Closes #10917 · part of #11153

## Thinking Path
`tests/test_provider_registry.py` had 26/33 tests failing on a clean tree with `TypeError: object MagicMock can't be used in 'await' expression` — because `conftest.py` stubs the top-level `llm_shared` package with a MagicMock `ProviderRegistry`/`BaseProvider`, and this test needs the **real** classes.

The conftest already has a real-carve-out pattern (loads real `llm_shared.models`, `run_credentials`, `provider_auth`, etc. via `importlib`). It *claimed* to load real `base_provider` too (#10551), but that silently failed: the stub package has an empty `__path__`, so `base_provider`'s relative imports (`from .cross_worker_rate_limiter`, `.observability`, `.rate_limit_backoff`) couldn't resolve on disk → `_load_real_mod`'s `except` swallowed it → `BaseProvider` stayed a MagicMock and `provider_registry` never loaded.

## What Changed
`autobot-backend/conftest.py`: pre-load `base_provider`'s transitive **light** deps in dependency order before `base_provider` — `cross_worker_rate_limiter`, `observability` (bare-env importable: it guards langfuse/langsmith SDK imports inside methods and doesn't import `otel_observer` at top level), `rate_limit_backoff` — then `base_provider`, `model_param_registry`, `provider_registry`. Finally re-export the real `ProviderRegistry`/`BaseProvider` onto the top-level stub so `from llm_shared import ProviderRegistry, BaseProvider` resolves to the real classes. `get_provider_registry` stays a MagicMock (openai_compat tests patch it).

## Verification
- `tests/test_provider_registry.py`: **26 failed → 33 passed**.
- **Blast-radius check** (this conftest gates all backend collection): ran `security/`, `judges/`, `tests/orchestration/` on the **original vs patched** conftest — **identical results** (security 4 errors, judges 1 error, orchestration 13 failed/212 passed — all pre-existing, unchanged). Zero new failures introduced.
- `py_compile` + `black --check -l120` clean.

## Scope
Fixes the `llm_shared`-stub piece of the #11153 conftest reconciliation (#10917). The other test-infra issues under #11153 (#11123 causal_error_recovery, #10880 judge_integration, #11248 tail) have distinct root causes and are separate.

## Model Used
Opus 4.8 (1M context)
