### PR TITLE
fix(deploy): build SLM frontend with build:slm (VITE_API_URL=/slm) (#11316)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -738,6 +738,14 @@ _COMPONENT_FRONTEND_DIRS: Dict[str, str] = {
     "autobot-slm-frontend": "/opt/autobot/autobot-slm-frontend",
 }
 
+# npm build script per frontend component. The SLM frontend is co-located under
+# /slm and MUST bake VITE_API_URL=/slm (via `build:slm`), or its API calls hit
+# the root user backend instead of /slm/api — breaking login and every action
+# (#11310). vite.config.ts hard-errors on a co-located build without it.
+_COMPONENT_BUILD_SCRIPT: Dict[str, str] = {
+    "autobot-slm-frontend": "build:slm",
+}
+
 # Maps component name → systemd service names to restart after sync.
 _COMPONENT_SERVICES: Dict[str, List[str]] = {
     "autobot-backend": ["autobot-backend"],
@@ -904,10 +912,11 @@ async def _build_npm_frontend_for_component(component: str, steps: List[str]) ->
             steps.append(f"npm ci: failed (rc={proc.returncode}): {out[:150]}")
             return
 
+        build_script = _COMPONENT_BUILD_SCRIPT.get(component, "build")
         proc = await asyncio.create_subprocess_exec(
             "npm",
             "run",
-            "build",
+            build_script,
             "--prefix",
             frontend_dir,
             stdout=asyncio.subprocess.PIPE,
@@ -915,7 +924,7 @@ async def _build_npm_frontend_for_component(component: str, steps: List[str]) ->
         )
         stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=300.0)
         if proc.returncode == 0:
-            logger.info("drift resolve: npm build succeeded for %s", component)
+            logger.info("drift resolve: npm build (%s) succeeded for %s", build_script, component)
             steps.append("npm build: succeeded")
         else:
             out = stdout.decode(errors="replace")[:300] if stdout else ""


### PR DESCRIPTION
## Thinking Path
SLM GUI login hangs / clicks do nothing. Root cause: the deployed SLM bundle's `getApiUrl()` is empty, so API calls route to `/api/*` (user backend) instead of `/slm/api/*`. Contributing bug: code-sync rebuilds every frontend with plain `npm run build`, but the co-located SLM frontend must use `npm run build:slm` (`VITE_API_URL=/slm`).

## What Changed
`autobot-slm-backend/api/code_sync.py`: added `_COMPONENT_BUILD_SCRIPT` map so `autobot-slm-frontend` builds with `build:slm` (others keep `build`).

## Verification
- `py_compile` clean.

## Known-remaining (tracked in #11316, separate PR)
On this box, even `build:slm` did not bake `/slm` under Vite 8.1.0 (byte-identical bundle) — the Vite env/`define` baking needs a fix too. This PR is the necessary build-command half.

## Model Used
Opus 4.8 (1M context)

Refs #11316