### PR TITLE
fix(ceo_chat): resolve intents instead of always clarifying

### DIFF
--- a/autobot-backend/llc/services/ceo_chat.py
+++ b/autobot-backend/llc/services/ceo_chat.py
@@ -29,7 +29,6 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import services.llm_service as _llm_service_mod
-
 from autobot_shared.ssot_config import config as _cfg
 from llm_shared.types import LLMType
 

--- a/autobot-backend/llc/services/ceo_chat.py
+++ b/autobot-backend/llc/services/ceo_chat.py
@@ -21,11 +21,17 @@ Resolution intents:
 
 import json
 import logging
+import re
 import uuid
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
+
+import services.llm_service as _llm_service_mod
+
+from autobot_shared.ssot_config import config as _cfg
+from llm_shared.types import LLMType
 
 from ..models.ceo_chat import LLCCeoChatMessage, LLCCeoChatThread
 from .base import LLCServiceBase
@@ -37,9 +43,19 @@ _BOARD_SYSTEM_PROMPT = (
     "Your goal is to resolve this message into one of: "
     "[create_task, update_goal, request_approval, record_decision, clarify]. "
     "Return structured JSON with keys: "
-    '{"intent": "<one of the above>", "summary": "<brief>", "entity": {<relevant fields>}}. '
-    "Respond ONLY with valid JSON."
+    '{{"intent": "<one of the above>", "summary": "<brief>", "entity": {{<relevant fields>}}}}. '
+    "Respond ONLY with valid JSON. Do NOT include any explanation, markdown, or thinking text."
 )
+
+_BOARD_RETRY_PROMPT = (
+    "Your previous response could not be parsed as JSON. "
+    "You MUST reply with ONLY a raw JSON object — no markdown, no explanation. "
+    'Example: {"intent":"create_task","summary":"Write Q3 report","entity":{"title":"Q3 report"}}'
+)
+
+_VALID_INTENTS = frozenset({"create_task", "update_goal", "request_approval", "record_decision", "clarify"})
+_THINK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+_CEO_CHAT_TIMEOUT = 30  # seconds — fast model; qwen3.5:9b was hanging >60s
 
 _AUTHOR_HUMAN = "human"
 _AUTHOR_SYSTEM = "system"
@@ -204,6 +220,31 @@ class CeoChatService(LLCServiceBase):
             logger.warning("Decisions RAG query failed for company %s: %s", company_id, exc)
             return []
 
+    @staticmethod
+    def _extract_json(raw: str) -> Dict[str, Any]:
+        """Strip think blocks + prose and extract the first balanced JSON object."""
+        # Remove <think>…</think> reasoning blocks emitted by some models.
+        cleaned = _THINK_RE.sub("", raw).strip()
+        # Strip markdown fences.
+        cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.MULTILINE)
+        cleaned = re.sub(r"\s*```$", "", cleaned, flags=re.MULTILINE).strip()
+        # Find the first balanced { … } block.
+        start = cleaned.find("{")
+        if start == -1:
+            raise ValueError("No JSON object found in LLM response")
+        depth, end = 0, -1
+        for i, ch in enumerate(cleaned[start:], start):
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i
+                    break
+        if end == -1:
+            raise ValueError("Unbalanced JSON braces in LLM response")
+        return json.loads(cleaned[start : end + 1])
+
     async def _resolve_via_llm(
         self,
         *,
@@ -212,37 +253,61 @@ class CeoChatService(LLCServiceBase):
         company_name: str,
         conversation_id: str,
     ) -> Dict[str, Any]:
-        """Call the LLM and return parsed resolution dict."""
-        try:
-            from llm_shared.types import LLMType
-            from services.llm_service import get_llm_service
+        """Call the LLM and return parsed resolution dict.
 
-            svc = get_llm_service()
+        Uses a fast non-thinking model (light_processing_model, default phi3:mini)
+        with Ollama JSON mode (structured_output=True) so responses are reliably
+        machine-parseable.  Falls back to clarify only after one retry.
+        """
+        try:
+            svc = _llm_service_mod.get_llm_service()
+            fast_model: str = _cfg.light_processing_model  # phi3:mini by default
             context = "\n".join(kb_chunks) if kb_chunks else ""
             system_prompt = _BOARD_SYSTEM_PROMPT.format(company_name=company_name)
 
-            messages: List[Dict[str, str]] = []
-            if context:
-                messages.append({"role": "system", "content": f"{system_prompt}\n\nContext:\n{context}"})
-            else:
-                messages.append({"role": "system", "content": system_prompt})
-            messages.append({"role": "user", "content": message})
+            messages: List[Dict[str, str]] = [
+                {
+                    "role": "system",
+                    "content": f"{system_prompt}\n\nContext:\n{context}" if context else system_prompt,
+                },
+                {"role": "user", "content": message},
+            ]
 
-            response = await svc.chat(
-                messages=messages,
-                conversation_id=conversation_id,
-                llm_type=LLMType.EXTRACTION,
-            )
+            async def _call(msgs: List[Dict[str, str]]) -> str:
+                resp = await svc.chat(
+                    messages=msgs,
+                    conversation_id=conversation_id,
+                    llm_type=LLMType.EXTRACTION,
+                    model_name=fast_model,
+                    structured_output=True,  # → Ollama format:"json"
+                    timeout=_CEO_CHAT_TIMEOUT,
+                    use_cache=False,  # don't serve stale/empty cached failures
+                )
+                if resp.error:
+                    raise RuntimeError(f"LLM provider error: {resp.error}")
+                return (resp.content or "").strip()
 
-            raw = (response.content or "").strip()
-            if raw.startswith("```"):
-                raw = raw.split("```")[1]
-                if raw.startswith("json"):
-                    raw = raw[4:]
-            return json.loads(raw)
+            # First attempt.
+            raw = await _call(messages)
+            try:
+                parsed = self._extract_json(raw)
+            except (ValueError, json.JSONDecodeError):
+                # Retry once with an explicit reminder to return only JSON.
+                logger.debug("CEO chat JSON parse failed on first attempt, retrying")
+                messages.append({"role": "assistant", "content": raw})
+                messages.append({"role": "user", "content": _BOARD_RETRY_PROMPT})
+                raw = await _call(messages)
+                parsed = self._extract_json(raw)
+
+            intent = parsed.get("intent", "clarify")
+            if intent not in _VALID_INTENTS:
+                logger.warning("CEO chat: unknown intent %r — treating as clarify", intent)
+                parsed["intent"] = "clarify"
+            return parsed
+
         except Exception as exc:
             logger.warning("LLM resolution failed: %s", exc)
-            return {"intent": "clarify", "summary": str(exc), "entity": {}}
+            return {"intent": "clarify", "summary": "I couldn't understand that — could you rephrase?", "entity": {}}
 
     async def _dispatch_intent(
         self,

--- a/autobot-backend/llc/tests/test_ceo_chat.py
+++ b/autobot-backend/llc/tests/test_ceo_chat.py
@@ -275,13 +275,14 @@ async def test_rag_query_graceful_failure(svc: CeoChatService) -> None:
 
 @pytest.mark.asyncio
 async def test_resolve_via_llm_malformed_json(svc: CeoChatService) -> None:
-    """_resolve_via_llm falls back to 'clarify' on malformed LLM output."""
+    """_resolve_via_llm falls back to 'clarify' on malformed LLM output (both attempts)."""
     mock_response = MagicMock()
     mock_response.content = "NOT JSON"
+    mock_response.error = None
     mock_svc = MagicMock()
     mock_svc.chat = AsyncMock(return_value=mock_response)
 
-    with patch("llc.services.ceo_chat.get_llm_service", return_value=mock_svc, create=True):
+    with patch("llc.services.ceo_chat._llm_service_mod.get_llm_service", return_value=mock_svc):
         resolution = await svc._resolve_via_llm(
             message="hello",
             kb_chunks=[],
@@ -290,3 +291,121 @@ async def test_resolve_via_llm_malformed_json(svc: CeoChatService) -> None:
         )
 
     assert resolution["intent"] == "clarify"
+    # Friendly message — not a raw exception string.
+    assert "exception" not in resolution["summary"].lower()
+    assert resolution["summary"]
+
+
+# --------------------------------- _extract_json parser
+
+
+def test_extract_json_clean() -> None:
+    raw = '{"intent":"create_task","summary":"ok","entity":{}}'
+    result = CeoChatService._extract_json(raw)
+    assert result["intent"] == "create_task"
+
+
+def test_extract_json_think_block_stripped() -> None:
+    raw = "<think>I should parse this carefully.</think>\n" '{"intent":"create_task","summary":"ok","entity":{}}'
+    result = CeoChatService._extract_json(raw)
+    assert result["intent"] == "create_task"
+
+
+def test_extract_json_prose_wrapper() -> None:
+    raw = (
+        'Here is my answer:\n```json\n{"intent":"update_goal","summary":"raise target","entity":{"goal_id":"g1"}}\n```'
+    )
+    result = CeoChatService._extract_json(raw)
+    assert result["intent"] == "update_goal"
+
+
+def test_extract_json_think_plus_prose() -> None:
+    """Models that emit <think> blocks AND wrap in prose are handled correctly."""
+    raw = (
+        "<think>Let me think step by step.</think>\n"
+        "Sure! Here is the JSON:\n"
+        '{"intent":"record_decision","summary":"approved","entity":{}}\n'
+        "That should be all."
+    )
+    result = CeoChatService._extract_json(raw)
+    assert result["intent"] == "record_decision"
+
+
+def test_extract_json_no_object_raises() -> None:
+    import pytest as _pytest
+
+    with _pytest.raises((ValueError, Exception)):
+        CeoChatService._extract_json("no json here at all")
+
+
+# --------------------------------- _resolve_via_llm retry path
+
+
+@pytest.mark.asyncio
+async def test_resolve_via_llm_recovers_on_retry(svc: CeoChatService) -> None:
+    """First response has think block + prose; second attempt returns clean JSON."""
+    first = MagicMock()
+    first.content = "<think>thinking…</think>\nHere you go: some prose before the JSON"
+    first.error = None
+
+    second = MagicMock()
+    second.content = '{"intent":"create_task","summary":"Write Q3 report","entity":{"title":"Q3 report"}}'
+    second.error = None
+
+    mock_svc = MagicMock()
+    mock_svc.chat = AsyncMock(side_effect=[first, second])
+
+    with patch("llc.services.ceo_chat._llm_service_mod.get_llm_service", return_value=mock_svc):
+        result = await svc._resolve_via_llm(
+            message="Create a task to write the Q3 report",
+            kb_chunks=[],
+            company_name="TestCo",
+            conversation_id="verify",
+        )
+
+    assert result["intent"] == "create_task"
+    assert mock_svc.chat.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_resolve_via_llm_think_block_recovered_first_pass(svc: CeoChatService) -> None:
+    """Think block on first response — parser should extract JSON without needing retry."""
+    resp = MagicMock()
+    resp.content = (
+        "<think>I should figure out the intent.</think>"
+        '{"intent":"create_task","summary":"Draft Q3 report","entity":{"title":"Q3 report"}}'
+    )
+    resp.error = None
+    mock_svc = MagicMock()
+    mock_svc.chat = AsyncMock(return_value=resp)
+
+    with patch("llc.services.ceo_chat._llm_service_mod.get_llm_service", return_value=mock_svc):
+        result = await svc._resolve_via_llm(
+            message="Create a task to write the Q3 report",
+            kb_chunks=[],
+            company_name="TestCo",
+            conversation_id="verify",
+        )
+
+    assert result["intent"] == "create_task"
+    # Only one LLM call needed — parser succeeded first pass.
+    assert mock_svc.chat.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_resolve_via_llm_unknown_intent_becomes_clarify(svc: CeoChatService) -> None:
+    resp = MagicMock()
+    resp.content = '{"intent":"do_something_weird","summary":"x","entity":{}}'
+    resp.error = None
+    mock_svc = MagicMock()
+    mock_svc.chat = AsyncMock(return_value=resp)
+
+    with patch("llc.services.ceo_chat._llm_service_mod.get_llm_service", return_value=mock_svc):
+        result = await svc._resolve_via_llm(
+            message="Do something weird",
+            kb_chunks=[],
+            company_name="Acme",
+            conversation_id="t",
+        )
+
+    assert result["intent"] == "clarify"

--- a/autobot-backend/llm_shared/cache.py
+++ b/autobot-backend/llm_shared/cache.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List
 import xxhash
 
 from autobot_shared.logging_manager import get_logger
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config
 
@@ -196,7 +196,7 @@ class LLMResponseCache:
         Returns:
             CachedResponse if found, None otherwise
         """
-        redis_client = get_redis_client(async_client=True, database=self._redis_database)
+        redis_client = await get_async_redis_client(database=self._redis_database)
         if not redis_client:
             return None
 
@@ -296,7 +296,7 @@ class LLMResponseCache:
 
         # Store in L2 Redis cache
         try:
-            redis_client = get_redis_client(async_client=True, database=self._redis_database)
+            redis_client = await get_async_redis_client(database=self._redis_database)
             if redis_client:
                 # Optimize metadata storage - only keep essential data
                 essential_metadata = {
@@ -388,7 +388,7 @@ class LLMResponseCache:
             Number of entries deleted
         """
         try:
-            redis_client = get_redis_client(async_client=True, database=self._redis_database)
+            redis_client = await get_async_redis_client(database=self._redis_database)
             if redis_client:
                 keys = []
                 async for key in redis_client.scan_iter(match=pattern):


### PR DESCRIPTION
Closes #11315

## Thinking Path

Traced the symptom (`intent=clarify` every time) backward through the call chain and found **four independent root causes** compounding each other — any one of them alone would have caused failure.

1. **`_BOARD_SYSTEM_PROMPT.format()` blew up before the LLM was ever called** — the JSON example in the prompt has literal `{` / `}` which `str.format()` interprets as placeholders, producing `KeyError('"intent"')`. The outer `except` caught this and returned `clarify`. This was the primary failure — zero LLM calls were ever made.

2. **Wrong model** — even if the prompt had been correct, `_select_chat_model` returns `None` when `chat_tiered_routing=False` (the default), so the registry default `qwen3.5:9b` would have been used. That model emits `<think>…</think>` blocks + prose rather than clean JSON, causing parse failure and streaming for >60s.

3. **No JSON enforcement** — `structured_output=True` on `LLMRequest` maps to Ollama's `format:"json"` which constrains token sampling to valid JSON. Without it even cooperative models occasionally prose-wrap their response.

4. **Broken L2 Redis cache** — `get_redis_client(async_client=True, ...)` returns a coroutine (not the client); three `await redis_client.get/set/scan_iter` calls were awaiting the coroutine object rather than the client, producing `RuntimeWarning: coroutine was never awaited` and silently bypassing L2.

## What Changed

**`autobot-backend/llc/services/ceo_chat.py`**
- Escape JSON braces in `_BOARD_SYSTEM_PROMPT` (`{{`/`}}`) so `.format(company_name=...)` works correctly.
- Move `services.llm_service` import to module level via `import services.llm_service as _llm_service_mod` (patchable by tests without `create=True`).
- Add `_extract_json()` static method: strips `<think>…</think>` blocks, markdown fences, and leading prose; extracts first balanced `{…}` object.
- Rewrite `_resolve_via_llm`: pin `model_name=config.light_processing_model` (phi3:mini), pass `structured_output=True`, `timeout=30`, `use_cache=False`; one-shot retry with a stricter reminder prompt on parse failure; validate `intent` is in `_VALID_INTENTS`; friendly fallback summary instead of raw exception string.

**`autobot-backend/llm_shared/cache.py`**
- Replace all three `get_redis_client(async_client=True, database=...)` calls with `await get_async_redis_client(database=...)` — the correct awaited form. Eliminates the `RuntimeWarning`.

**`autobot-backend/llc/tests/test_ceo_chat.py`**
- 8 new tests: `_extract_json` (clean, think-block, prose-fence, think+prose, no-object), `_resolve_via_llm` retry recovery, think-block first-pass recovery, unknown-intent→clarify.
- Updated existing `test_resolve_via_llm_malformed_json` to assert friendly summary (not raw exception string).

## Verification

Live 3× runs against phi3:mini at `http://127.0.0.1:11434`:

```
Run 1: 'Create a task to write the Q3 report'
  intent : create_task  [OK]
  summary: Assign writing of Q3 report.
  elapsed: 13.49s  (cold start)

Run 2: 'We need to update the Q4 revenue goal to $2M'
  intent : update_goal  [OK]
  summary: Updateing quarterly revenue target for TestCo.
  elapsed: 2.93s

Run 3: 'I want to record our decision to hire 3 engineers in Q3'
  intent : record_decision  [OK]
  summary: Decision recorded for the board regarding new engineer hires.
  elapsed: 1.91s
```

Unit tests: 22/22 passed. `black --line-length=120` + `ruff check` clean on all 3 files.

## Residual Risk

- **Run 1 cold-start latency (13s)**: phi3:mini needs to be loaded into GPU memory on first call. Subsequent calls are 2-3s. Acceptable for board-interface use — not a real-time chat.
- **phi3:mini JSON quality**: phi3:mini occasionally returns valid JSON but with fields beyond the schema (extra keys). The parser handles this gracefully since we only call `.get("intent", "clarify")`.
- **Retry budget**: one retry only. If the second attempt also produces unparseable output, we fall back to clarify with a friendly message. In practice phi3:mini + `format:"json"` is reliable.

## Model Used

claude-sonnet-4-6