### PR TITLE
fix(slm-frontend): bake VITE_API_URL via explicit define so /slm resolves (#11316)

### DIFF
--- a/autobot-slm-frontend/vite.config.ts
+++ b/autobot-slm-frontend/vite.config.ts
@@ -19,6 +19,22 @@ function isCoLocated(): boolean {
 }
 
 /**
+ * Resolve VITE_API_URL from every source Vite would consult, in priority order:
+ *   1. inline / shell env  (process.env.VITE_API_URL — how `build:slm` passes it)
+ *   2. .env* files         (loadEnv result)
+ *
+ * loadEnv() ONLY reads .env* files — it does NOT include inline `VAR=x vite build`
+ * env vars. Relying on Vite's implicit `import.meta.env.VITE_*` replacement for an
+ * inline var is fragile: the value must be resolved explicitly here and baked via
+ * `define` so the built bundle is deterministic regardless of how the var arrives.
+ */
+function resolveApiUrl(fileEnv: Record<string, string>): string {
+  const inline = process.env.VITE_API_URL
+  if (inline !== undefined && inline !== '') return inline
+  return fileEnv.VITE_API_URL || ''
+}
+
+/**
  * Vite plugin that errors when VITE_API_URL is unset in a co-located build.
  *
  * NOTE: This guard only applies to `vite build` (built artifacts).
@@ -26,13 +42,13 @@ function isCoLocated(): boolean {
  * below, so VITE_API_URL is never read — the dev server never bakes it into
  * the bundle.  No guard is needed (or useful) for the dev server.
  */
-function coLocatedApiUrlGuard(): import('vite').Plugin {
+function coLocatedApiUrlGuard(apiUrl: string): import('vite').Plugin {
   return {
     name: 'slm-co-located-api-url-guard',
     configResolved(config) {
       // Only check during builds — dev server uses proxy config, not baked VITE_API_URL.
       if (config.command !== 'build') return
-      if (process.env.VITE_API_URL) return
+      if (apiUrl) return
       if (!isCoLocated()) return
       // Co-located build without VITE_API_URL — the baked-in base URL will be
       // empty string, so all API calls will silently route to the wrong backend
@@ -53,9 +69,21 @@ export default defineConfig(({ mode }) => {
   const slmTarget = env.VITE_SLM_PROXY_TARGET || 'https://localhost'
   const autobotTarget = env.VITE_AUTOBOT_PROXY_TARGET || 'http://localhost:8001'
 
+  // Resolve the API base once, from inline env or .env files, and bake it
+  // explicitly via `define`. This is immune to Vite version changes and to
+  // shell/npm quirks in how `VAR=x vite build` propagates the inline var —
+  // the bundle always contains the value resolved here.
+  const apiUrl = resolveApiUrl(env)
+
   return {
     base: '/slm/',
-    plugins: [vue(), coLocatedApiUrlGuard()],
+    plugins: [vue(), coLocatedApiUrlGuard(apiUrl)],
+    // Statically replace import.meta.env.VITE_API_URL in the source. Without
+    // this, baking relied on Vite implicitly exposing an inline process.env
+    // var — fragile across versions and invocation styles. See resolveApiUrl().
+    define: {
+      'import.meta.env.VITE_API_URL': JSON.stringify(apiUrl),
+    },
     resolve: {
       // preserveSymlinks: true keeps module resolution relative to the symlink
       // path (node_modules/@autobot/vnc, @autobot/terminal) rather than the


### PR DESCRIPTION
## Thinking Path

The SLM GUI login routed to the wrong backend because the served bundle's
`getApiUrl()` resolved to `""` instead of `/slm`, so `fetch(\`${getApiUrl()}/api/auth/login\`)`
hit the user backend (port 8001) instead of the SLM backend.

Reproduced against Vite 8.1.0. Findings:

- With a **clean** cache, `VITE_API_URL=/slm vite build` *does* bake `/slm` today
  (`function u(){return\`/slm\`}`). So "Vite 8 stopped exposing inline vars" is not
  literally true for a clean invocation.
- But the mechanism was **fragile**: `loadEnv(mode, cwd, '')` only reads `.env*`
  files — it never includes inline `VITE_API_URL=/slm vite build` vars. Baking the
  inline var relied entirely on Vite's *implicit* `import.meta.env.VITE_*`
  replacement, which is exactly the behavior that shifts between Vite versions /
  invocation styles and produced the reporter's empty-base bundle. A `.env.production`
  attempt tripped the guard because the guard read `process.env` (unset for file env).
- Confirmed `vite build` does **not** use `node_modules/.vite` (that is the dev-server
  optimizeDeps cache), so the "byte-identical bundle" was not a build cache; it was the
  env var not reaching the replacement path.

Root cause: baking depended on Vite's implicit inline-env exposure instead of an
explicit, deterministic replacement.

## What Changed

`autobot-slm-frontend/vite.config.ts`:

- Added `resolveApiUrl()` — resolves `VITE_API_URL` from `process.env` (inline/shell,
  how `build:slm` passes it) first, then `.env*` files via `loadEnv`.
- Added `define: { 'import.meta.env.VITE_API_URL': JSON.stringify(apiUrl) }` so the
  value is statically replaced in the bundle regardless of Vite version or invocation.
- `coLocatedApiUrlGuard()` now checks the same resolved `apiUrl` (so `.env`-file-only
  configs no longer falsely trip it).
- `build:slm` remains the entry point; the proxy-based dev server is untouched (guard
  and bake only affect `vite build`).

## Verification

Vite 8.1.0, clean cache each build (`rm -rf node_modules/.vite node_modules/.vite-temp`):

```
A build:slm (VITE_API_URL=/slm)  -> index-MO2WkoVK.js  getApiUrl: function u(){return`/slm`}
                                    ssot base: VITE_API_URL:`/slm`
                                    login:     await fetch(`${u()}/api/auth/login
B VITE_API_URL=/DIFFERENT         -> index-Ca_t-cyv.js  getApiUrl: function u(){return`/DIFFERENT`}
C empty / no VITE (broken case)   -> index-BaEcwjA8.js  getApiUrl: function u(){return``}
```

Three distinct hashes prove the `define` deterministically drives the baked value;
the `/slm` build differs from the empty (previously-served) bundle. `vue-tsc --noEmit`
exits 0. `vite dev` boots without the guard firing.

Refs #11316 (companion PR #11317 wires code-sync to call `build:slm`).

## Model Used

Opus 4.8 (1M context)
