### PR TITLE
feat(companyos): analytics findings → project work items (proposal-only, FP-verified) — Phase 3 of #11129 (#11271)

### DIFF
--- a/.superpowers/sdd/11271/task-6-report.md
+++ b/.superpowers/sdd/11271/task-6-report.md
@@ -1,0 +1,69 @@
+# Task 6 Report — Findings API Endpoints (#11271)
+
+## Files Created / Modified
+
+- **Created:** `autobot-backend/llc/api/findings.py` (FastAPI APIRouter, 169 lines)
+- **Created:** `autobot-backend/llc/tests/test_findings_api.py` (9 tests)
+- **Modified:** `autobot-backend/llc/api/__init__.py` (added `findings_router` import + `include_router`)
+
+## Mount / Prefix Confirmed
+
+The LLC `__init__.py` defines `router = APIRouter(prefix="/llc", ...)` and the main FastAPI app mounts at `/api`. Routes serve at:
+- `POST /api/llc/projects/{project_id}/findings/scan`
+- `GET  /api/llc/projects/{project_id}/findings/proposals`
+- `POST /api/llc/findings/proposals/{proposal_id}/promote`
+- `POST /api/llc/findings/proposals/{proposal_id}/dismiss`
+
+No double `/api` prefix — bare paths used inside the router (no `/api/llc` duplicated).
+
+## Real Signatures Used
+
+All imported at module level so tests can patch `llc.api.findings.*`:
+
+- `from llc.services.finding_proposal_service import FindingsDisabledError, dismiss, promote, scan`
+- `from llc.services.findings_policy import get_findings_policy`
+- `from llc.models.finding_proposal import LLCFindingProposal` (all fields in `FindingProposalResponse`)
+- `from llc.models.sprint import LLCProject` (for IDOR guard)
+- `from llc.deps import get_session`
+- `from api.user_management.dependencies import get_current_user, require_org_context`
+
+### `scan(project, session) -> dict` — confirmed in `finding_proposal_service.py:170`
+### `promote(proposal, session, actor_user_id: uuid.UUID) -> LLCWorkItem | dict` — line 217
+### `dismiss(proposal, session, reason: str) -> None` — line 258
+### `FindingsDisabledError` — line 34
+### `get_findings_policy() -> FindingsPolicy` — confirmed in `findings_policy.py:46`
+
+## Test Output
+
+```
+llc/tests/test_findings_api.py::test_scan_403_when_policy_disabled PASSED
+llc/tests/test_findings_api.py::test_scan_409_when_no_code_source_id PASSED
+llc/tests/test_findings_api.py::test_scan_success_returns_counts PASSED
+llc/tests/test_findings_api.py::test_list_proposals_returns_proposals PASSED
+llc/tests/test_findings_api.py::test_list_proposals_filter_by_status PASSED
+llc/tests/test_findings_api.py::test_promote_calls_service PASSED
+llc/tests/test_findings_api.py::test_dismiss_calls_service PASSED
+llc/tests/test_findings_api.py::test_dismiss_requires_reason PASSED
+llc/tests/test_findings_api.py::test_scan_idor_404_wrong_org PASSED
+======================== 9 passed, 5 warnings in 3.62s
+```
+
+## Full LLC Suite
+
+```
+1118 passed, 1 skipped, 24 warnings in 39.38s
+```
+
+No regressions.
+
+## Formatting
+
+`black -l120` + `isort` clean on all three files.
+
+## Commit SHA
+
+(populated after commit)
+
+## Concerns
+
+None. The `_load_owned_proposal` IDOR guard requires `proposal.company_id == ctx.org_id`, mirroring `_load_owned_project`. The `_mk_client` helper in the test routes both project and proposal queries correctly via the SQLAlchemy statement string inspection pattern established by `test_project_lifecycle_api.py`.

--- a/autobot-backend/llc/api/__init__.py
+++ b/autobot-backend/llc/api/__init__.py
@@ -24,6 +24,7 @@ from .context import router as context_router
 from .controls import router as controls_router
 from .costs import router as costs_router
 from .decisions import router as decisions_router
+from .findings import router as findings_router
 from .github_webhooks import router as github_webhooks_router
 from .goals import router as goals_router
 from .health import router as health_router
@@ -56,6 +57,7 @@ router.include_router(agent_hires_router)
 router.include_router(goals_router)
 router.include_router(health_router)
 router.include_router(secrets_router)
+router.include_router(findings_router)
 router.include_router(sprints_router)
 router.include_router(work_items_router)
 router.include_router(github_webhooks_router)

--- a/autobot-backend/llc/api/findings.py
+++ b/autobot-backend/llc/api/findings.py
@@ -24,6 +24,7 @@ from llc.models.finding_proposal import LLCFindingProposal
 from llc.models.sprint import LLCProject
 from llc.services.finding_proposal_service import (
     FindingsDisabledError,
+    ProposalStateError,
     dismiss,
     promote,
     scan,
@@ -143,7 +144,10 @@ async def promote_proposal(
     """Promote a pending proposal to a work item (or gate on approval)."""
     proposal = await _load_owned_proposal(proposal_id, session, ctx)
     actor_id = uuid.UUID(str(current_user.get("id") or current_user.get("user_id")))
-    result = await promote(proposal, session, actor_id)
+    try:
+        result = await promote(proposal, session, actor_id)
+    except ProposalStateError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     if isinstance(result, dict):
         return result
     # Return a summary of the created work item.
@@ -165,5 +169,8 @@ async def dismiss_proposal(
 ) -> dict:
     """Dismiss a pending proposal with a reason."""
     proposal = await _load_owned_proposal(proposal_id, session, ctx)
-    await dismiss(proposal, session, body.reason)
+    try:
+        await dismiss(proposal, session, body.reason)
+    except ProposalStateError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     return {"result": "dismissed"}

--- a/autobot-backend/llc/api/findings.py
+++ b/autobot-backend/llc/api/findings.py
@@ -115,6 +115,10 @@ async def scan_findings(
         return await scan(project, session)
     except FindingsDisabledError as exc:
         raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except ValueError as exc:
+        # The linked source was deleted / left "ready" between the check above and
+        # the scan (gather/clone-path resolution) — treat as a 409, not a 500.
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.get("/projects/{project_id}/findings/proposals", response_model=List[FindingProposalResponse])

--- a/autobot-backend/llc/api/findings.py
+++ b/autobot-backend/llc/api/findings.py
@@ -1,0 +1,169 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""LLC findings API — scan / proposals / promote / dismiss (#11271).
+
+Routes (all served under /api/llc via the parent router):
+  POST /projects/{project_id}/findings/scan
+  GET  /projects/{project_id}/findings/proposals
+  POST /findings/proposals/{proposal_id}/promote
+  POST /findings/proposals/{proposal_id}/dismiss
+"""
+
+import uuid
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.user_management.dependencies import get_current_user, require_org_context
+from autobot_shared.logging_manager import get_logger
+from llc.deps import get_session
+from llc.models.finding_proposal import LLCFindingProposal
+from llc.models.sprint import LLCProject
+from llc.services.finding_proposal_service import (
+    FindingsDisabledError,
+    dismiss,
+    promote,
+    scan,
+)
+from llc.services.findings_policy import get_findings_policy
+from user_management.services import TenantContext
+
+logger = get_logger(__name__)
+router = APIRouter(tags=["llc-findings"])
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class FindingProposalResponse(BaseModel):
+    id: uuid.UUID
+    company_id: uuid.UUID
+    project_id: uuid.UUID
+    source_id: str
+    finding_key: str
+    finding_type: str
+    severity: str
+    file_path: str
+    line_number: Optional[int]
+    description: str
+    suggestion: Optional[str]
+    verdict_is_real: Optional[bool]
+    verdict_confidence: Optional[float]
+    verdict_rationale: Optional[str]
+    status: str
+    work_item_id: Optional[uuid.UUID]
+    dismiss_reason: Optional[str]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DismissRequest(BaseModel):
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# IDOR guards
+# ---------------------------------------------------------------------------
+
+
+async def _load_owned_project(project_id: uuid.UUID, session: AsyncSession, ctx: TenantContext) -> LLCProject:
+    """Load project by id; 404 when missing or owned by a different org."""
+    result = await session.execute(select(LLCProject).where(LLCProject.id == project_id))
+    project = result.scalar_one_or_none()
+    if project is None or str(project.company_id) != str(ctx.org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+    return project
+
+
+async def _load_owned_proposal(proposal_id: uuid.UUID, session: AsyncSession, ctx: TenantContext) -> LLCFindingProposal:
+    """Load proposal by id; 404 when missing or owned by a different org."""
+    result = await session.execute(select(LLCFindingProposal).where(LLCFindingProposal.id == proposal_id))
+    proposal = result.scalar_one_or_none()
+    if proposal is None or str(proposal.company_id) != str(ctx.org_id):
+        raise HTTPException(status_code=404, detail="Proposal not found")
+    return proposal
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/projects/{project_id}/findings/scan")
+async def scan_findings(
+    project_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> dict:
+    """Scan a project's linked repo for findings and queue real ones as proposals."""
+    policy = await get_findings_policy()
+    if not policy.enabled:
+        raise HTTPException(status_code=403, detail="Findings feature is disabled")
+
+    project = await _load_owned_project(project_id, session, ctx)
+    if not project.code_source_id:
+        raise HTTPException(status_code=409, detail="Project has no linked code source")
+
+    try:
+        return await scan(project, session)
+    except FindingsDisabledError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+
+@router.get("/projects/{project_id}/findings/proposals", response_model=List[FindingProposalResponse])
+async def list_proposals(
+    project_id: uuid.UUID,
+    status: Optional[str] = Query(None),
+    session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> List[LLCFindingProposal]:
+    """List finding proposals for a project, optionally filtered by status."""
+    await _load_owned_project(project_id, session, ctx)
+    stmt = select(LLCFindingProposal).where(LLCFindingProposal.project_id == project_id)
+    if status is not None:
+        stmt = stmt.where(LLCFindingProposal.status == status)
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+@router.post("/findings/proposals/{proposal_id}/promote")
+async def promote_proposal(
+    proposal_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> dict:
+    """Promote a pending proposal to a work item (or gate on approval)."""
+    proposal = await _load_owned_proposal(proposal_id, session, ctx)
+    actor_id = uuid.UUID(str(current_user.get("id") or current_user.get("user_id")))
+    result = await promote(proposal, session, actor_id)
+    if isinstance(result, dict):
+        return result
+    # Return a summary of the created work item.
+    return {
+        "result": "promoted",
+        "work_item_id": str(result.id),
+        "identifier": getattr(result, "identifier", None),
+        "title": getattr(result, "title", None),
+    }
+
+
+@router.post("/findings/proposals/{proposal_id}/dismiss")
+async def dismiss_proposal(
+    proposal_id: uuid.UUID,
+    body: DismissRequest,
+    session: AsyncSession = Depends(get_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> dict:
+    """Dismiss a pending proposal with a reason."""
+    proposal = await _load_owned_proposal(proposal_id, session, ctx)
+    await dismiss(proposal, session, body.reason)
+    return {"result": "dismissed"}

--- a/autobot-backend/llc/models/__init__.py
+++ b/autobot-backend/llc/models/__init__.py
@@ -25,6 +25,7 @@ from .enums import (
     BoardType,
     ContextMode,
     CoWorkerType,
+    FindingProposalStatus,
     HeartbeatInvocationSource,
     LLCAgentStatus,
     LLCCompanyStatus,
@@ -39,6 +40,7 @@ from .enums import (
     WorkItemType,
     WorkProductType,
 )
+from .finding_proposal import LLCFindingProposal
 from .goal import GoalLevel, GoalStatus, LLCGoal
 from .heartbeat_run import LLCHeartbeatRun
 from .membership import LLCCompanyMembership
@@ -60,6 +62,8 @@ __all__ = [
     "ContextMode",
     "CoWorkerType",
     "CompanyAncestor",
+    "FindingProposalStatus",
+    "LLCFindingProposal",
     "CompanyCreate",
     "CompanyRead",
     "CompanyTreeNode",

--- a/autobot-backend/llc/models/enums.py
+++ b/autobot-backend/llc/models/enums.py
@@ -126,6 +126,15 @@ class ApprovalType(str, Enum):
     BUDGET_OVERRIDE = "budget_override"
     SPRINT_CLOSE = "sprint_close"
     PROJECT_DISPOSAL = "project_disposal"
+    FINDING_PROMOTION = "finding_promotion"
+
+
+class FindingProposalStatus(str, Enum):
+    """Status of an analytics finding proposal (#11271)."""
+
+    PENDING = "pending"
+    PROMOTED = "promoted"
+    DISMISSED = "dismissed"
 
 
 class ApprovalStatus(str, Enum):

--- a/autobot-backend/llc/models/finding_proposal.py
+++ b/autobot-backend/llc/models/finding_proposal.py
@@ -51,7 +51,7 @@ class LLCFindingProposal(Base):
         sa.Enum(
             FindingProposalStatus,
             name="findingproposalstatus",
-            create_type=True,
+            create_type=False,
             values_callable=pg_enum_values,
         ),
         nullable=False,

--- a/autobot-backend/llc/models/finding_proposal.py
+++ b/autobot-backend/llc/models/finding_proposal.py
@@ -1,0 +1,77 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""LLCFindingProposal model — analytics finding proposals awaiting promotion (#11271)."""
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+import sqlalchemy as sa
+from sqlalchemy import DateTime, ForeignKey, Integer, Numeric, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from user_management.models.base import Base
+
+from .enums import FindingProposalStatus, pg_enum_values
+
+
+class LLCFindingProposal(Base):
+    """A codebase-analytics finding staged for human/agent promotion (#11271).
+
+    Dedup key: (project_id, finding_key).  Status transitions:
+      pending → promoted (creates LLCWorkItem)
+      pending → dismissed (with dismiss_reason)
+    """
+
+    __tablename__ = "llc_finding_proposals"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")
+    )
+    company_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("llc_projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    source_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    finding_key: Mapped[str] = mapped_column(String(512), nullable=False)
+    finding_type: Mapped[str] = mapped_column(String(128), nullable=False)
+    severity: Mapped[str] = mapped_column(String(32), nullable=False)
+    file_path: Mapped[str] = mapped_column(Text, nullable=False)
+    line_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    suggestion: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    verdict_is_real: Mapped[Optional[bool]] = mapped_column(sa.Boolean, nullable=True)
+    verdict_confidence: Mapped[Optional[float]] = mapped_column(Numeric(5, 4), nullable=True)
+    verdict_rationale: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(
+        sa.Enum(
+            FindingProposalStatus,
+            name="findingproposalstatus",
+            create_type=True,
+            values_callable=pg_enum_values,
+        ),
+        nullable=False,
+        server_default=FindingProposalStatus.PENDING.value,
+        index=True,
+    )
+    work_item_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True)
+    dismiss_reason: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=sa.func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+    )
+
+    __table_args__ = (UniqueConstraint("project_id", "finding_key", name="uq_finding_proposal_project_key"),)
+
+    def __repr__(self) -> str:
+        return f"<LLCFindingProposal id={self.id!r} status={self.status!r} key={self.finding_key!r}>"
+
+
+__all__ = ["LLCFindingProposal"]

--- a/autobot-backend/llc/services/finding_proposal_service.py
+++ b/autobot-backend/llc/services/finding_proposal_service.py
@@ -1,0 +1,262 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Orchestrate the findings → proposal → work-item pipeline (#11271).
+
+Public async API:
+    scan(project, session) -> dict{gathered, verified_real, queued}
+    promote(proposal, session, actor_user_id) -> LLCWorkItem | dict
+    dismiss(proposal, session, reason) -> None
+
+Helpers used in tests (patchable wrappers over lazy-imported services):
+    _work_item_service_create(session, company_id, type, title, **kwargs)
+    _approval_service_request(session, *, company_id, gate_type, payload, requested_by)
+    _get_clone_path(project) -> str
+"""
+
+import logging
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.enums import ApprovalType, FindingProposalStatus, WorkItemPriority, WorkItemType
+from ..models.finding_proposal import LLCFindingProposal
+from .findings_gather import gather_findings
+from .findings_policy import get_findings_policy
+from .findings_verify import verify_finding
+
+logger = logging.getLogger(__name__)
+
+# Finding types that map to WorkItemType.BUG
+_BUG_TYPES = frozenset({"bug", "race_condition", "security", "vulnerability", "null_dereference"})
+
+
+class FindingsDisabledError(Exception):
+    """Raised when scan/promote is called but the feature flag is OFF."""
+
+
+class ProposalStateError(Exception):
+    """Raised when a proposal is in the wrong state for the requested action."""
+
+
+# ---------------------------------------------------------------------------
+# Patchable thin wrappers (lazy-import heavy service classes)
+# ---------------------------------------------------------------------------
+
+
+async def _work_item_service_create(session: AsyncSession, company_id: str, type, title: str, **kwargs):
+    """Thin wrapper around WorkItemService.create so tests can patch at module level."""
+    from llc.services.work_item_service import WorkItemService  # noqa: PLC0415
+
+    return await WorkItemService().create(session, company_id=company_id, type=type, title=title, **kwargs)
+
+
+async def _approval_service_request(session: AsyncSession, *, company_id, gate_type, payload, requested_by):
+    """Thin wrapper around ApprovalService.request_approval so tests can patch at module level."""
+    from llc.services.approval import ApprovalService  # noqa: PLC0415
+
+    return await ApprovalService().request_approval(
+        session,
+        company_id=company_id,
+        gate_type=gate_type,
+        payload=payload,
+        requested_by=requested_by,
+    )
+
+
+async def _get_clone_path(project) -> str:
+    """Resolve clone_path for *project* via the code source (lazy-import)."""
+    from api.codebase_analytics.source_storage import get_source  # noqa: PLC0415
+
+    source = await get_source(str(project.code_source_id))
+    return getattr(source, "clone_path", "") or ""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _type_for(finding_type: str) -> WorkItemType:
+    """Map analytics finding type to WorkItemType (BUG for defect-ish, TASK otherwise)."""
+    return WorkItemType.BUG if (finding_type or "").lower() in _BUG_TYPES else WorkItemType.TASK
+
+
+def _priority(severity: str) -> WorkItemPriority:
+    """Map analytics severity to WorkItemPriority."""
+    _map = {"high": WorkItemPriority.HIGH, "medium": WorkItemPriority.MEDIUM, "low": WorkItemPriority.LOW}
+    return _map.get((severity or "").lower(), WorkItemPriority.MEDIUM)
+
+
+def _title(proposal: LLCFindingProposal) -> str:
+    """Build a concise work-item title from a finding proposal."""
+    loc = f"{proposal.file_path}:{proposal.line_number}" if proposal.line_number else proposal.file_path
+    return f"[{proposal.finding_type}] {proposal.description[:80]} ({loc})"
+
+
+def _body(proposal: LLCFindingProposal) -> str:
+    """Build a work-item description from a finding proposal."""
+    loc = f"{proposal.file_path}:{proposal.line_number}" if proposal.line_number else proposal.file_path
+    parts = [
+        f"**Location:** `{loc}`",
+        f"**Finding type:** {proposal.finding_type}  **Severity:** {proposal.severity}",
+        "",
+        f"**Description:** {proposal.description}",
+    ]
+    if proposal.suggestion:
+        parts += ["", f"**Suggestion:** {proposal.suggestion}"]
+    if proposal.verdict_rationale:
+        parts += ["", f"**Verifier rationale:** {proposal.verdict_rationale}"]
+    return "\n".join(parts)
+
+
+def _finding_key(source_id: str, finding: dict) -> str:
+    """Compute the dedup key for a finding dict."""
+    return f"{source_id}:{finding.get('file_path', '')}:{finding.get('line_number', '')}:{finding.get('type', '')}"
+
+
+async def _lookup_existing(project_id, finding_key: str, session: AsyncSession):
+    """Return an existing LLCFindingProposal for (project_id, finding_key) or None."""
+    stmt = sa.select(LLCFindingProposal).where(
+        LLCFindingProposal.project_id == project_id,
+        LLCFindingProposal.finding_key == finding_key,
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def _upsert_proposal(project, finding: dict, key: str, verdict, session: AsyncSession) -> None:
+    """Insert or update a pending LLCFindingProposal with verdict fields."""
+    existing = await _lookup_existing(project.id, key, session)
+    if existing is not None:
+        existing.verdict_is_real = verdict.is_real
+        existing.verdict_confidence = float(verdict.confidence)
+        existing.verdict_rationale = verdict.rationale
+        existing.status = FindingProposalStatus.PENDING
+    else:
+        proposal = LLCFindingProposal(
+            id=uuid.uuid4(),
+            company_id=project.company_id,
+            project_id=project.id,
+            source_id=str(project.code_source_id),
+            finding_key=key,
+            finding_type=finding.get("type", ""),
+            severity=finding.get("severity", ""),
+            file_path=finding.get("file_path", ""),
+            line_number=finding.get("line_number"),
+            description=finding.get("description", ""),
+            suggestion=finding.get("suggestion"),
+            verdict_is_real=verdict.is_real,
+            verdict_confidence=float(verdict.confidence),
+            verdict_rationale=verdict.rationale,
+            status=FindingProposalStatus.PENDING,
+        )
+        session.add(proposal)
+    await session.flush()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def scan(project, session: AsyncSession) -> dict:
+    """Gather + verify findings for *project* and upsert pending proposals.
+
+    Returns:
+        dict with keys: gathered, verified_real, queued.
+
+    Raises:
+        FindingsDisabledError: When the policy flag is off (feature-gated).
+    """
+    policy = await get_findings_policy()
+    if not policy.enabled:
+        raise FindingsDisabledError("findings feature is disabled (policy.enabled=False)")
+
+    clone_path = await _get_clone_path(project)
+    findings = await gather_findings(project, policy.min_severity, session)
+    source_id = str(project.code_source_id)
+
+    gathered = len(findings)
+    verified_real = 0
+    queued = 0
+
+    batch_size = max(1, policy.verify_batch_size)
+    for batch_start in range(0, len(findings), batch_size):
+        batch = findings[batch_start : batch_start + batch_size]
+        for finding in batch:
+            key = _finding_key(source_id, finding)
+            existing = await _lookup_existing(project.id, key, session)
+            if existing is not None and existing.status in (
+                FindingProposalStatus.PROMOTED,
+                FindingProposalStatus.DISMISSED,
+            ):
+                logger.debug("scan: skip key=%s (status=%s)", key, existing.status)
+                continue
+
+            verdict = await verify_finding(finding, clone_path)
+            if not verdict.is_real:
+                logger.debug("scan: FP key=%s rationale=%s", key, verdict.rationale)
+                continue
+
+            verified_real += 1
+            await _upsert_proposal(project, finding, key, verdict, session)
+            queued += 1
+
+    logger.info("scan: project=%s gathered=%d verified_real=%d queued=%d", project.id, gathered, verified_real, queued)
+    return {"gathered": gathered, "verified_real": verified_real, "queued": queued}
+
+
+async def promote(proposal: LLCFindingProposal, session: AsyncSession, actor_user_id: uuid.UUID):
+    """Promote a pending finding proposal to a work item (or gate on approval).
+
+    Returns:
+        LLCWorkItem on immediate promote, or dict{result, approval_id} when gated.
+
+    Raises:
+        ProposalStateError: When proposal is not in PENDING status.
+    """
+    if proposal.status != FindingProposalStatus.PENDING:
+        raise ProposalStateError(f"Cannot promote a proposal in status {proposal.status!r}")
+
+    policy = await get_findings_policy()
+
+    if policy.require_approval_to_promote:
+        approval = await _approval_service_request(
+            session,
+            company_id=uuid.UUID(str(proposal.company_id)),
+            gate_type=ApprovalType.FINDING_PROMOTION,
+            payload={"proposal_id": str(proposal.id), "finding_key": proposal.finding_key},
+            requested_by=uuid.UUID(str(actor_user_id)),
+        )
+        await session.flush()
+        return {"result": "pending_approval", "approval_id": str(approval.id)}
+
+    item = await _work_item_service_create(
+        session,
+        company_id=str(proposal.company_id),
+        type=_type_for(proposal.finding_type),
+        title=_title(proposal),
+        description=_body(proposal),
+        priority=_priority(proposal.severity),
+        project_id=str(proposal.project_id),
+        labels=["analytics-finding", f"severity:{proposal.severity}"],
+    )
+    proposal.status = FindingProposalStatus.PROMOTED
+    proposal.work_item_id = item.id
+    await session.flush()
+    return item
+
+
+async def dismiss(proposal: LLCFindingProposal, session: AsyncSession, reason: str) -> None:
+    """Dismiss a pending finding proposal.
+
+    Raises:
+        ProposalStateError: When proposal is not in PENDING status.
+    """
+    if proposal.status != FindingProposalStatus.PENDING:
+        raise ProposalStateError(f"Cannot dismiss a proposal in status {proposal.status!r}")
+
+    proposal.status = FindingProposalStatus.DISMISSED
+    proposal.dismiss_reason = reason
+    await session.flush()

--- a/autobot-backend/llc/services/finding_proposal_service.py
+++ b/autobot-backend/llc/services/finding_proposal_service.py
@@ -69,6 +69,8 @@ async def _get_clone_path(project) -> str:
     from api.codebase_analytics.source_storage import get_source  # noqa: PLC0415
 
     source = await get_source(str(project.code_source_id))
+    if source is None:
+        raise ValueError(f"CodeSource {project.code_source_id!r} not found for project {project.id!r}")
     return getattr(source, "clone_path", "") or ""
 
 
@@ -129,6 +131,11 @@ async def _upsert_proposal(project, finding: dict, key: str, verdict, session: A
     """Insert or update a pending LLCFindingProposal with verdict fields."""
     existing = await _lookup_existing(project.id, key, session)
     if existing is not None:
+        # Never regress a terminal proposal: a PROMOTED/DISMISSED row must not be
+        # reset to PENDING by a re-scan (guards the race where the scan-level dedup
+        # missed a concurrently-inserted terminal row).
+        if existing.status != FindingProposalStatus.PENDING:
+            return
         existing.verdict_is_real = verdict.is_real
         existing.verdict_confidence = float(verdict.confidence)
         existing.verdict_rationale = verdict.rationale

--- a/autobot-backend/llc/services/findings_gather.py
+++ b/autobot-backend/llc/services/findings_gather.py
@@ -1,0 +1,116 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Gather analytics findings for a project, scoped by code source (#11271).
+
+Real analytics fetch call (from api/codebase_analytics/endpoints/stats.py):
+  - ``get_code_collection()`` from ``api.codebase_analytics.storage`` (sync, run via asyncio.to_thread)
+  - ``_fetch_problems_from_chromadb(collection, problem_type=None, source_id=<str>)``
+    from ``api.codebase_analytics.endpoints.stats``
+  Both are lazy-imported here to avoid the heavy ``api.codebase_analytics.__init__``
+  which pulls in routes/tasks/audit chains.
+
+Patch targets for tests:
+  - ``api.codebase_analytics.source_storage.get_source``
+  - ``api.codebase_analytics.endpoints.stats._fetch_problems_from_chromadb``
+  - ``api.codebase_analytics.storage.get_code_collection``
+"""
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+_SEVERITY_ORDER = ("high", "medium", "low")
+
+
+def _at_or_above(sev: str) -> tuple[str, ...]:
+    """Return severity values that are >= ``sev`` in priority order (high first).
+
+    >>> _at_or_above("medium")
+    ('high', 'medium')
+    >>> _at_or_above("low")
+    ('high', 'medium', 'low')
+    >>> _at_or_above("high")
+    ('high',)
+    """
+    sev = sev.lower()
+    try:
+        idx = _SEVERITY_ORDER.index(sev)
+    except ValueError:
+        return _SEVERITY_ORDER  # unknown severity → keep all
+    return _SEVERITY_ORDER[: idx + 1]
+
+
+async def gather_findings(project, min_severity: str, session) -> list[dict]:
+    """Fetch analytics findings for *project*, filtered to >= *min_severity*.
+
+    Resolves ``project.code_source_id`` → CodeSource via source_storage,
+    then calls the real ChromaDB query used by the /problems endpoint.
+
+    Args:
+        project: ORM row or SimpleNamespace with a ``code_source_id`` attribute.
+        min_severity: Minimum severity to include (``"high"``, ``"medium"``, or ``"low"``).
+        session: AsyncSession (passed through; not used directly here but required by
+                 the service-layer contract so callers have a consistent signature).
+
+    Returns:
+        List of finding dicts with keys: type, severity, file_path, line_number,
+        description, suggestion — ordered high → medium → low, then by insertion order.
+
+    Raises:
+        ValueError: When ``project.code_source_id`` is None or the CodeSource is
+                    missing / not in ``ready`` status.
+    """
+    code_source_id = getattr(project, "code_source_id", None)
+    if not code_source_id:
+        raise ValueError(f"Project {getattr(project, 'id', project)!r} has no code_source_id")
+
+    source = await _get_source(code_source_id)
+    if source is None:
+        raise ValueError(f"CodeSource {code_source_id!r} not found")
+    status = getattr(source, "status", None)
+    status_val = status.value if hasattr(status, "value") else str(status)
+    if status_val != "ready":
+        raise ValueError(f"CodeSource {code_source_id!r} is not ready (status={status_val!r})")
+
+    raw = await _fetch_all_problems(code_source_id)
+    keep = set(_at_or_above(min_severity))
+    filtered = [f for f in raw if f.get("severity", "").lower() in keep]
+    _sev_rank = {s: i for i, s in enumerate(_SEVERITY_ORDER)}
+    filtered.sort(key=lambda f: _sev_rank.get(f.get("severity", "low").lower(), len(_SEVERITY_ORDER)))
+
+    logger.info(
+        "gather_findings: source=%s min=%s raw=%d kept=%d",
+        code_source_id,
+        min_severity,
+        len(raw),
+        len(filtered),
+    )
+    return filtered
+
+
+async def _get_source(code_source_id: str):
+    """Lazy-import get_source and call it."""
+    from api.codebase_analytics.source_storage import get_source  # noqa: PLC0415
+
+    return await get_source(code_source_id)
+
+
+async def _fetch_all_problems(source_id: str) -> list[dict]:
+    """Lazy-import ChromaDB helpers and return all problems for *source_id*.
+
+    Mirrors the /problems endpoint (stats.py):
+      1. get_code_collection()  — sync, run in thread
+      2. _fetch_problems_from_chromadb(collection, problem_type=None, source_id=source_id)
+    Returns an empty list when ChromaDB is unavailable.
+    """
+    from api.codebase_analytics.endpoints.stats import (  # noqa: PLC0415
+        _fetch_problems_from_chromadb,
+    )
+    from api.codebase_analytics.storage import get_code_collection  # noqa: PLC0415
+
+    collection = await asyncio.to_thread(get_code_collection)
+    if not collection:
+        logger.warning("_fetch_all_problems: ChromaDB collection unavailable for source=%s", source_id)
+        return []
+    return _fetch_problems_from_chromadb(collection, problem_type=None, source_id=source_id)

--- a/autobot-backend/llc/services/findings_gather.py
+++ b/autobot-backend/llc/services/findings_gather.py
@@ -17,6 +17,7 @@ Patch targets for tests:
 
 import asyncio
 import logging
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,7 @@ def _at_or_above(sev: str) -> tuple[str, ...]:
     try:
         idx = _SEVERITY_ORDER.index(sev)
     except ValueError:
+        logger.warning("gather_findings: unknown min_severity %r — keeping all findings", sev)
         return _SEVERITY_ORDER  # unknown severity → keep all
     return _SEVERITY_ORDER[: idx + 1]
 
@@ -73,7 +75,12 @@ async def gather_findings(project, min_severity: str, session) -> list[dict]:
     if status_val != "ready":
         raise ValueError(f"CodeSource {code_source_id!r} is not ready (status={status_val!r})")
 
-    raw = await _fetch_all_problems(code_source_id)
+    # Pass the source's checkout as source_root so the analytics query's
+    # file-existence filter (#2724) drops findings referencing files that no
+    # longer exist in THIS source — matching the /problems endpoint.
+    clone_path = getattr(source, "clone_path", None)
+    source_root = Path(clone_path) if clone_path else None
+    raw = await _fetch_all_problems(code_source_id, source_root)
     keep = set(_at_or_above(min_severity))
     filtered = [f for f in raw if f.get("severity", "").lower() in keep]
     _sev_rank = {s: i for i, s in enumerate(_SEVERITY_ORDER)}
@@ -96,12 +103,13 @@ async def _get_source(code_source_id: str):
     return await get_source(code_source_id)
 
 
-async def _fetch_all_problems(source_id: str) -> list[dict]:
+async def _fetch_all_problems(source_id: str, source_root: Path | None) -> list[dict]:
     """Lazy-import ChromaDB helpers and return all problems for *source_id*.
 
     Mirrors the /problems endpoint (stats.py):
       1. get_code_collection()  — sync, run in thread
-      2. _fetch_problems_from_chromadb(collection, problem_type=None, source_id=source_id)
+      2. _fetch_problems_from_chromadb(collection, problem_type=None, source_id=source_id,
+         source_root=source_root)  — source_root drives the file-existence filter (#2724)
     Returns an empty list when ChromaDB is unavailable.
     """
     from api.codebase_analytics.endpoints.stats import (  # noqa: PLC0415
@@ -113,4 +121,4 @@ async def _fetch_all_problems(source_id: str) -> list[dict]:
     if not collection:
         logger.warning("_fetch_all_problems: ChromaDB collection unavailable for source=%s", source_id)
         return []
-    return _fetch_problems_from_chromadb(collection, problem_type=None, source_id=source_id)
+    return _fetch_problems_from_chromadb(collection, problem_type=None, source_id=source_id, source_root=source_root)

--- a/autobot-backend/llc/services/findings_policy.py
+++ b/autobot-backend/llc/services/findings_policy.py
@@ -1,0 +1,62 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Read the SLM-configured findings policy with safe defaults (#11271)."""
+
+import json
+import logging
+from dataclasses import dataclass
+
+from services.slm_client import get_slm_client
+
+logger = logging.getLogger(__name__)
+
+POLICY_SETTING_KEY = "llc.findings_policy"
+
+_VALID_SEVERITIES = frozenset({"high", "medium", "low"})
+
+
+@dataclass(frozen=True)
+class FindingsPolicy:
+    enabled: bool = False
+    min_severity: str = "medium"
+    require_approval_to_promote: bool = False
+    run_on_index: bool = False
+    verify_batch_size: int = 10
+
+
+async def _fetch_policy_json() -> dict | None:
+    """GET the policy setting from the SLM settings API; None on any failure."""
+    client = get_slm_client()
+    if client is None:
+        return None
+    try:
+        session = await client._get_session()
+        url = f"{client.slm_url}/api/settings/{POLICY_SETTING_KEY}"
+        async with session.get(url) as response:
+            if response.status != 200:
+                return None
+            setting = await response.json()
+            raw = setting.get("value")
+            return json.loads(raw) if raw else None
+    except Exception as exc:  # noqa: BLE001 — policy read is best-effort
+        logger.warning("Findings policy read failed: %s", exc)
+        return None
+
+
+async def get_findings_policy() -> FindingsPolicy:
+    """Return the configured policy, or safe defaults (feature OFF)."""
+    data = await _fetch_policy_json()
+    if not isinstance(data, dict):
+        return FindingsPolicy()
+    try:
+        raw_severity = str(data.get("min_severity", "medium"))
+        min_severity = raw_severity if raw_severity in _VALID_SEVERITIES else "medium"
+        return FindingsPolicy(
+            enabled=bool(data["enabled"]),
+            min_severity=min_severity,
+            require_approval_to_promote=bool(data["require_approval_to_promote"]),
+            run_on_index=bool(data["run_on_index"]),
+            verify_batch_size=max(1, int(data["verify_batch_size"])),
+        )
+    except (KeyError, TypeError, ValueError):
+        return FindingsPolicy()

--- a/autobot-backend/llc/services/findings_verify.py
+++ b/autobot-backend/llc/services/findings_verify.py
@@ -1,0 +1,114 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Fail-closed false-positive verifier for codebase-analytics findings (#11271).
+
+Real LLM service call (services/llm_service.py:179):
+    svc = get_llm_service()           # returns LLMService singleton
+    response = await svc.chat(
+        messages=[{"role": "user", "content": "<prompt>"}],
+        # all other kwargs are optional
+    )
+    # response is LLMResponse (llm_shared/models.py:120):
+    #   .content: str   — the generated text (may be "" on error)
+    #   .error:   str | None — non-None/non-empty when the provider failed
+    text = response.content           # extract the text
+
+FAIL CLOSED: any failure → Verdict(is_real=False, confidence=0.0, rationale="unverifiable: <reason>")
+"""
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from services.llm_service import get_llm_service
+
+logger = logging.getLogger(__name__)
+
+_WINDOW_LINES = 15  # ±lines around the finding's line number
+
+
+@dataclass(frozen=True)
+class Verdict:
+    is_real: bool
+    confidence: float
+    rationale: str
+
+
+def _fail_closed(reason: str) -> Verdict:
+    """Return the canonical fail-closed verdict."""
+    return Verdict(is_real=False, confidence=0.0, rationale=f"unverifiable: {reason}")
+
+
+def _read_code_window(clone_path: str, file_path: str, line_number: int | None) -> str:
+    """Read ±_WINDOW_LINES lines around line_number from clone_path/file_path.
+
+    Returns an empty string when the file is missing or line_number is None.
+    """
+    if not file_path or line_number is None:
+        return ""
+    full = Path(clone_path) / file_path
+    try:
+        lines = full.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ""
+    lo = max(0, line_number - 1 - _WINDOW_LINES)
+    hi = min(len(lines), line_number + _WINDOW_LINES)
+    numbered = [f"{lo + i + 1}: {line}" for i, line in enumerate(lines[lo:hi])]
+    return "\n".join(numbered)
+
+
+def _build_prompt(finding: dict, code_window: str) -> str:
+    """Build the one-shot verification prompt from finding dict + code context."""
+    parts = [
+        "You are auditing a static-analysis finding for false positives.",
+        f"FINDING: type={finding.get('type')}, severity={finding.get('severity')},",
+        f"  file={finding.get('file_path')}, line={finding.get('line_number')},",
+        f"  description={finding.get('description')},",
+        f"  suggestion={finding.get('suggestion')}.",
+    ]
+    if code_window:
+        parts.append(f"CODE CONTEXT:\n{code_window}")
+    parts.append(
+        'Answer strictly as JSON {"is_real": bool, "confidence": 0..1, "rationale": "..."}.'
+        " Judge is_real=false if the finding does not correspond to a genuine problem in this code."
+    )
+    return "\n".join(parts)
+
+
+def _parse_verdict(text: str) -> Verdict:
+    """Parse a strict-JSON verdict string into a Verdict; raise on any issue."""
+    data = json.loads(text)
+    return Verdict(
+        is_real=bool(data["is_real"]),
+        confidence=float(data["confidence"]),
+        rationale=str(data["rationale"]),
+    )
+
+
+async def verify_finding(finding: dict, clone_path: str) -> Verdict:
+    """Ask the internal SLM engine whether a finding is a real bug.
+
+    FAIL CLOSED: any exception, empty/None response, or JSON-parse failure
+    returns Verdict(is_real=False, confidence=0.0, rationale="unverifiable: …").
+    This function never raises.
+    """
+    try:
+        code_window = _read_code_window(clone_path, finding.get("file_path", ""), finding.get("line_number"))
+        prompt = _build_prompt(finding, code_window)
+        svc = get_llm_service()
+        response = await svc.chat(messages=[{"role": "user", "content": prompt}])
+        if response.error:
+            logger.warning("findings_verify: LLM engine error: %s", response.error)
+            return _fail_closed(f"engine error: {response.error}")
+        text = (response.content or "").strip()
+        if not text:
+            logger.warning("findings_verify: empty response from engine")
+            return _fail_closed("empty response")
+        return _parse_verdict(text)
+    except json.JSONDecodeError as exc:
+        logger.warning("findings_verify: JSON parse failure: %s", exc)
+        return _fail_closed(f"json parse failure: {exc}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("findings_verify: unexpected error: %s", exc)
+        return _fail_closed(str(exc))

--- a/autobot-backend/llc/services/findings_verify.py
+++ b/autobot-backend/llc/services/findings_verify.py
@@ -16,6 +16,7 @@ Real LLM service call (services/llm_service.py:179):
 FAIL CLOSED: any failure → Verdict(is_real=False, confidence=0.0, rationale="unverifiable: <reason>")
 """
 
+import itertools
 import json
 import logging
 from dataclasses import dataclass
@@ -48,8 +49,11 @@ def _read_code_window(clone_path: str, file_path: str, line_number: int | None) 
     if not file_path or line_number is None:
         return ""
     full = Path(clone_path) / file_path
+    # Bounded read (only up to the window's last line) + errors="replace" so a
+    # huge/minified or non-UTF-8 file degrades to verify-by-context, never crashes.
     try:
-        lines = full.read_text(encoding="utf-8").splitlines()
+        with full.open(encoding="utf-8", errors="replace") as fh:
+            lines = [ln.rstrip("\n") for ln in itertools.islice(fh, line_number + _WINDOW_LINES)]
     except OSError:
         return ""
     lo = max(0, line_number - 1 - _WINDOW_LINES)
@@ -77,13 +81,21 @@ def _build_prompt(finding: dict, code_window: str) -> str:
 
 
 def _parse_verdict(text: str) -> Verdict:
-    """Parse a strict-JSON verdict string into a Verdict; raise on any issue."""
+    """Parse a strict-JSON verdict string into a Verdict; raise on any issue.
+
+    ``is_real`` MUST be a JSON boolean — a truthy string like "false" is rejected
+    (``bool("false")`` is True), so nothing is queued as real unless the engine
+    explicitly said so. Out-of-range confidence is also rejected. Any raise is
+    caught upstream and turned into a fail-closed verdict.
+    """
     data = json.loads(text)
-    return Verdict(
-        is_real=bool(data["is_real"]),
-        confidence=float(data["confidence"]),
-        rationale=str(data["rationale"]),
-    )
+    raw = data["is_real"]
+    if not isinstance(raw, bool):
+        raise ValueError(f"is_real must be a JSON boolean, got {type(raw).__name__!r}")
+    confidence = float(data["confidence"])
+    if not 0.0 <= confidence <= 1.0:
+        raise ValueError(f"confidence {confidence!r} out of [0, 1]")
+    return Verdict(is_real=raw, confidence=confidence, rationale=str(data["rationale"]))
 
 
 async def verify_finding(finding: dict, clone_path: str) -> Verdict:

--- a/autobot-backend/llc/tests/test_finding_proposal_model.py
+++ b/autobot-backend/llc/tests/test_finding_proposal_model.py
@@ -1,0 +1,54 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Model contract for LLCFindingProposal (#11271)."""
+
+import sqlalchemy as sa
+
+from llc.models.enums import ApprovalType, FindingProposalStatus
+from llc.models.finding_proposal import LLCFindingProposal
+
+
+def test_finding_proposal_has_all_columns():
+    cols = LLCFindingProposal.__table__.columns
+    expected = [
+        "company_id",
+        "project_id",
+        "source_id",
+        "finding_key",
+        "finding_type",
+        "severity",
+        "file_path",
+        "line_number",
+        "description",
+        "suggestion",
+        "verdict_is_real",
+        "verdict_confidence",
+        "verdict_rationale",
+        "status",
+        "work_item_id",
+        "dismiss_reason",
+    ]
+    for col in expected:
+        assert col in cols, f"Missing column: {col}"
+
+
+def test_status_server_default_is_pending():
+    col = LLCFindingProposal.__table__.columns["status"]
+    assert col.server_default is not None
+    assert "pending" in str(col.server_default.arg)
+
+
+def test_unique_constraint_project_finding_key():
+    constraints = LLCFindingProposal.__table__.constraints
+    unique_names = {c.name for c in constraints if isinstance(c, sa.UniqueConstraint)}
+    assert "uq_finding_proposal_project_key" in unique_names
+
+
+def test_finding_proposal_status_enum_values():
+    assert FindingProposalStatus.PENDING.value == "pending"
+    assert FindingProposalStatus.PROMOTED.value == "promoted"
+    assert FindingProposalStatus.DISMISSED.value == "dismissed"
+
+
+def test_approval_type_has_finding_promotion():
+    assert ApprovalType.FINDING_PROMOTION.value == "finding_promotion"

--- a/autobot-backend/llc/tests/test_finding_proposal_model.py
+++ b/autobot-backend/llc/tests/test_finding_proposal_model.py
@@ -27,6 +27,8 @@ def test_finding_proposal_has_all_columns():
         "status",
         "work_item_id",
         "dismiss_reason",
+        "created_at",
+        "updated_at",
     ]
     for col in expected:
         assert col in cols, f"Missing column: {col}"

--- a/autobot-backend/llc/tests/test_finding_proposal_service.py
+++ b/autobot-backend/llc/tests/test_finding_proposal_service.py
@@ -12,6 +12,7 @@ from llc.models.enums import FindingProposalStatus
 from llc.services.finding_proposal_service import (
     FindingsDisabledError,
     ProposalStateError,
+    _upsert_proposal,
     dismiss,
     promote,
     scan,
@@ -290,3 +291,34 @@ async def test_promote_from_non_pending_raises():
 
     with pytest.raises(ProposalStateError):
         await promote(proposal, session, uuid.uuid4())
+
+
+@pytest.mark.asyncio
+async def test_dismiss_from_non_pending_raises():
+    proposal = MagicMock()
+    proposal.status = FindingProposalStatus.PROMOTED
+    session = AsyncMock()
+
+    with pytest.raises(ProposalStateError):
+        await dismiss(proposal, session, "already promoted")
+
+
+@pytest.mark.asyncio
+async def test_upsert_does_not_regress_terminal_proposal():
+    """A re-scan must NOT reset a PROMOTED/DISMISSED proposal back to PENDING."""
+    project = _make_project()
+    finding = _make_finding()
+    verdict = SimpleNamespace(is_real=True, confidence=0.9, rationale="real")
+    session = AsyncMock()
+
+    terminal = MagicMock()
+    terminal.status = FindingProposalStatus.DISMISSED
+
+    with patch(
+        "llc.services.finding_proposal_service._lookup_existing",
+        AsyncMock(return_value=terminal),
+    ):
+        await _upsert_proposal(project, finding, "k1", verdict, session)
+
+    assert terminal.status == FindingProposalStatus.DISMISSED  # unchanged
+    session.add.assert_not_called()  # no new row inserted

--- a/autobot-backend/llc/tests/test_finding_proposal_service.py
+++ b/autobot-backend/llc/tests/test_finding_proposal_service.py
@@ -1,0 +1,292 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for finding_proposal_service — scan / promote / dismiss (#11271)."""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.models.enums import FindingProposalStatus
+from llc.services.finding_proposal_service import (
+    FindingsDisabledError,
+    ProposalStateError,
+    dismiss,
+    promote,
+    scan,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_project(code_source_id: str = "src-1") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        company_id=uuid.uuid4(),
+        code_source_id=code_source_id,
+    )
+
+
+def _make_policy(enabled: bool = True, require_approval: bool = False, batch_size: int = 5):
+    from llc.services.findings_policy import FindingsPolicy
+
+    return FindingsPolicy(
+        enabled=enabled,
+        min_severity="medium",
+        require_approval_to_promote=require_approval,
+        run_on_index=False,
+        verify_batch_size=batch_size,
+    )
+
+
+def _make_finding(severity: str = "high", ftype: str = "bug") -> dict:
+    return {
+        "type": ftype,
+        "severity": severity,
+        "file_path": "src/foo.py",
+        "line_number": 42,
+        "description": "Null pointer deref",
+        "suggestion": "Check for None",
+    }
+
+
+def _async_none(*_, **__):
+    """AsyncMock return that yields None (SQLAlchemy select dedup lookup)."""
+    m = MagicMock()
+    m.scalar_one_or_none = MagicMock(return_value=None)
+    return m
+
+
+def _make_session(existing_proposal=None):
+    """Return an AsyncMock session with execute returning a row or None for dedup."""
+    session = AsyncMock()
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = existing_proposal
+    session.execute = AsyncMock(return_value=result_mock)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# scan — disabled policy raises FindingsDisabledError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scan_raises_when_disabled():
+    policy = _make_policy(enabled=False)
+    project = _make_project()
+    session = _make_session()
+
+    with patch("llc.services.finding_proposal_service.get_findings_policy", AsyncMock(return_value=policy)):
+        with pytest.raises(FindingsDisabledError):
+            await scan(project, session)
+
+
+# ---------------------------------------------------------------------------
+# scan — only is_real findings queued; promoted key skipped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scan_queues_only_real_and_skips_promoted():
+    """Verifies three behaviours in one scan call:
+    1. A real finding with no existing proposal → queued.
+    2. A false-positive finding → NOT queued.
+    3. A finding whose key already has a PROMOTED proposal → skipped (dedup).
+    """
+    policy = _make_policy(enabled=True, batch_size=5)
+    project = _make_project(code_source_id="src-42")
+
+    # Three distinct findings (different file_path → distinct finding_keys)
+    finding_real = {
+        "type": "bug",
+        "severity": "high",
+        "file_path": "a.py",
+        "line_number": 1,
+        "description": "D1",
+        "suggestion": None,
+    }
+    finding_fake = {
+        "type": "style",
+        "severity": "high",
+        "file_path": "b.py",
+        "line_number": 2,
+        "description": "D2",
+        "suggestion": None,
+    }
+    finding_promoted = {
+        "type": "bug",
+        "severity": "high",
+        "file_path": "c.py",
+        "line_number": 3,
+        "description": "D3",
+        "suggestion": None,
+    }
+
+    real_verdict = SimpleNamespace(is_real=True, confidence=0.95, rationale="Real bug")
+    fake_verdict = SimpleNamespace(is_real=False, confidence=0.1, rationale="FP")
+
+    promoted_proposal = MagicMock()
+    promoted_proposal.status = FindingProposalStatus.PROMOTED
+
+    source_id = "src-42"
+    key_real = f"{source_id}:a.py:1:bug"
+    key_fake = f"{source_id}:b.py:2:style"
+    key_promoted = f"{source_id}:c.py:3:bug"
+    existing_map = {key_real: None, key_fake: None, key_promoted: promoted_proposal}
+
+    async def mock_lookup(project_id, fk, sess):
+        return existing_map.get(fk)
+
+    async def mock_upsert(proj, finding, key, verdict, sess):
+        pass  # no-op so we control queued via the service logic
+
+    clone_path = "/tmp/clone"
+
+    async def mock_gather(proj, min_sev, sess):
+        return [finding_real, finding_fake, finding_promoted]
+
+    async def mock_verify(finding, cp):
+        return fake_verdict if finding["file_path"] == "b.py" else real_verdict
+
+    session = AsyncMock()
+
+    with (
+        patch("llc.services.finding_proposal_service.get_findings_policy", AsyncMock(return_value=policy)),
+        patch("llc.services.finding_proposal_service.gather_findings", side_effect=mock_gather),
+        patch("llc.services.finding_proposal_service.verify_finding", side_effect=mock_verify),
+        patch("llc.services.finding_proposal_service._get_clone_path", return_value=clone_path),
+        patch("llc.services.finding_proposal_service._lookup_existing", side_effect=mock_lookup),
+        patch("llc.services.finding_proposal_service._upsert_proposal", side_effect=mock_upsert),
+    ):
+        result = await scan(project, session)
+
+    assert result["gathered"] == 3
+    # finding_fake is FP; finding_promoted is skipped before verify; only finding_real is verified+queued
+    assert result["verified_real"] == 1
+    assert result["queued"] == 1
+
+
+# ---------------------------------------------------------------------------
+# promote — immediate (no approval required)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_promote_immediate_creates_work_item():
+    project = _make_project()
+    policy = _make_policy(require_approval=False)
+
+    proposal = MagicMock()
+    proposal.status = FindingProposalStatus.PENDING
+    proposal.project_id = project.id
+    proposal.company_id = project.company_id
+    proposal.source_id = "src-1"
+    proposal.finding_type = "bug"
+    proposal.severity = "high"
+    proposal.file_path = "src/foo.py"
+    proposal.line_number = 10
+    proposal.description = "A real bug"
+    proposal.suggestion = "Fix it"
+    proposal.verdict_rationale = "Confirmed"
+
+    fake_item = MagicMock()
+    fake_item.id = uuid.uuid4()
+
+    session = AsyncMock()
+    actor_id = uuid.uuid4()
+
+    async def fake_create(sess, company_id, type, title, **kwargs):
+        return fake_item
+
+    with (
+        patch("llc.services.finding_proposal_service.get_findings_policy", AsyncMock(return_value=policy)),
+        patch("llc.services.finding_proposal_service._work_item_service_create", side_effect=fake_create),
+    ):
+        result = await promote(proposal, session, actor_id)
+
+    assert result is fake_item
+    assert proposal.status == FindingProposalStatus.PROMOTED
+    assert proposal.work_item_id == fake_item.id
+
+
+# ---------------------------------------------------------------------------
+# promote — approval required → pending_approval
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_promote_approval_required_returns_pending():
+    project = _make_project()
+    policy = _make_policy(require_approval=True)
+
+    proposal = MagicMock()
+    proposal.status = FindingProposalStatus.PENDING
+    proposal.project_id = project.id
+    proposal.company_id = project.company_id
+    proposal.source_id = "src-1"
+    proposal.finding_type = "bug"
+    proposal.severity = "high"
+    proposal.file_path = "src/foo.py"
+    proposal.line_number = 10
+    proposal.description = "A real bug"
+    proposal.suggestion = "Fix it"
+    proposal.verdict_rationale = "Confirmed"
+
+    fake_approval = MagicMock()
+    fake_approval.id = uuid.uuid4()
+
+    session = AsyncMock()
+    actor_id = uuid.uuid4()
+
+    async def fake_request(sess, *, company_id, gate_type, payload, requested_by):
+        return fake_approval
+
+    with (
+        patch("llc.services.finding_proposal_service.get_findings_policy", AsyncMock(return_value=policy)),
+        patch("llc.services.finding_proposal_service._approval_service_request", side_effect=fake_request),
+    ):
+        result = await promote(proposal, session, actor_id)
+
+    assert isinstance(result, dict)
+    assert result["result"] == "pending_approval"
+    assert result["approval_id"] == str(fake_approval.id)
+    # Status must NOT be promoted yet
+    assert proposal.status == FindingProposalStatus.PENDING
+
+
+# ---------------------------------------------------------------------------
+# dismiss — pending → dismissed + reason
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dismiss_sets_reason():
+    proposal = MagicMock()
+    proposal.status = FindingProposalStatus.PENDING
+
+    session = AsyncMock()
+    await dismiss(proposal, session, "Not reproducible")
+
+    assert proposal.status == FindingProposalStatus.DISMISSED
+    assert proposal.dismiss_reason == "Not reproducible"
+    session.flush.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# promote — wrong status raises ProposalStateError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_promote_from_non_pending_raises():
+    proposal = MagicMock()
+    proposal.status = FindingProposalStatus.DISMISSED
+
+    session = AsyncMock()
+
+    with pytest.raises(ProposalStateError):
+        await promote(proposal, session, uuid.uuid4())

--- a/autobot-backend/llc/tests/test_findings_api.py
+++ b/autobot-backend/llc/tests/test_findings_api.py
@@ -10,7 +10,6 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -176,6 +175,20 @@ def test_scan_success_returns_counts():
         resp = client.post(f"/projects/{project.id}/findings/scan")
     assert resp.status_code == 200
     assert resp.json() == counts
+
+
+def test_scan_409_when_source_not_ready():
+    """scan raising ValueError (source deleted/not-ready mid-request) → 409, not 500."""
+    from llc.services.findings_policy import FindingsPolicy  # noqa: PLC0415
+
+    project = _mk_project(code_source_id="src-001")
+    client, _ = _mk_client(project)
+    with (
+        patch("llc.api.findings.get_findings_policy", AsyncMock(return_value=FindingsPolicy(enabled=True))),
+        patch("llc.api.findings.scan", AsyncMock(side_effect=ValueError("CodeSource not ready"))),
+    ):
+        resp = client.post(f"/projects/{project.id}/findings/scan")
+    assert resp.status_code == 409
 
 
 def test_list_proposals_returns_proposals():

--- a/autobot-backend/llc/tests/test_findings_api.py
+++ b/autobot-backend/llc/tests/test_findings_api.py
@@ -293,3 +293,37 @@ def test_scan_idor_404_wrong_org():
     with patch("llc.api.findings.get_findings_policy", AsyncMock(return_value=FindingsPolicy(enabled=True))):
         resp = idor_client.post(f"/projects/{project.id}/findings/scan")
     assert resp.status_code == 404
+
+
+def test_promote_idor_404_wrong_org():
+    """POST /findings/proposals/{id}/promote → 404 when proposal.company_id != ctx.org_id."""
+    project = _mk_project(company_id=_ORG_ID)  # ctx org = _ORG_ID
+    foreign = _mk_proposal(company_id=_OTHER_ORG_ID)
+    client, _ = _mk_client(project, proposals=[foreign])
+    with patch("llc.api.findings.promote", AsyncMock()) as prom:
+        resp = client.post(f"/findings/proposals/{foreign.id}/promote")
+    assert resp.status_code == 404
+    prom.assert_not_awaited()  # never reached the service
+
+
+def test_dismiss_idor_404_wrong_org():
+    """POST /findings/proposals/{id}/dismiss → 404 when proposal.company_id != ctx.org_id."""
+    project = _mk_project(company_id=_ORG_ID)
+    foreign = _mk_proposal(company_id=_OTHER_ORG_ID)
+    client, _ = _mk_client(project, proposals=[foreign])
+    with patch("llc.api.findings.dismiss", AsyncMock()) as dis:
+        resp = client.post(f"/findings/proposals/{foreign.id}/dismiss", json={"reason": "x"})
+    assert resp.status_code == 404
+    dis.assert_not_awaited()
+
+
+def test_promote_conflict_when_non_pending():
+    """Promoting a non-pending proposal → 409 (ProposalStateError), not 500."""
+    from llc.services.finding_proposal_service import ProposalStateError  # noqa: PLC0415
+
+    project = _mk_project()
+    proposal = _mk_proposal()
+    client, _ = _mk_client(project, proposals=[proposal])
+    with patch("llc.api.findings.promote", AsyncMock(side_effect=ProposalStateError("already promoted"))):
+        resp = client.post(f"/findings/proposals/{proposal.id}/promote")
+    assert resp.status_code == 409

--- a/autobot-backend/llc/tests/test_findings_api.py
+++ b/autobot-backend/llc/tests/test_findings_api.py
@@ -1,0 +1,295 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Findings API endpoint tests — scan/proposals/promote/dismiss (#11271).
+
+Mirrors the TestClient + dependency_overrides pattern from test_project_lifecycle_api.py.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from user_management.services import TenantContext
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ORG_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_USER_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+_PROJECT_ID = uuid.uuid4()
+_PROPOSAL_ID = uuid.uuid4()
+_OTHER_ORG_ID = uuid.UUID("99999999-9999-9999-9999-999999999999")
+
+_NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _mk_project(*, code_source_id="src-001", company_id=_ORG_ID):
+    p = MagicMock()
+    p.id = _PROJECT_ID
+    p.company_id = company_id
+    p.code_source_id = code_source_id
+    p.program_id = None
+    p.goal_id = None
+    p.name = "Test"
+    p.description = None
+    p.status = "active"
+    p.lead_agent_id = None
+    p.lead_user_id = None
+    p.target_date = None
+    p.auto_rollover = None
+    p.lifecycle_state = "active"
+    p.archived_at = None
+    p.disposal_scheduled_at = None
+    p.disposal_approval_id = None
+    p.open_work_item_count = 0
+    p.active_sprint_name = None
+    p.created_at = _NOW
+    p.updated_at = _NOW
+    return p
+
+
+def _mk_proposal(*, status="pending", company_id=_ORG_ID, project_id=_PROJECT_ID):
+    from llc.models.enums import FindingProposalStatus  # noqa: PLC0415
+
+    prop = MagicMock()
+    prop.id = _PROPOSAL_ID
+    prop.company_id = company_id
+    prop.project_id = project_id
+    prop.source_id = "src-001"
+    prop.finding_key = "src-001:main.py:10:bug"
+    prop.finding_type = "bug"
+    prop.severity = "high"
+    prop.file_path = "main.py"
+    prop.line_number = 10
+    prop.description = "a bug"
+    prop.suggestion = "fix it"
+    prop.verdict_is_real = True
+    prop.verdict_confidence = 0.9
+    prop.verdict_rationale = "looks real"
+    prop.status = FindingProposalStatus.PENDING if status == "pending" else status
+    prop.work_item_id = None
+    prop.dismiss_reason = None
+    prop.created_at = _NOW
+    prop.updated_at = _NOW
+    return prop
+
+
+def _mk_client(project, proposals=None):
+    """Build a TestClient wired to the findings router."""
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.findings import router  # noqa: PLC0415
+    from llc.deps import get_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(router)
+
+    session = AsyncMock()
+    session.commit = AsyncMock()
+    session.flush = AsyncMock()
+
+    # Wire execute() to return project for project lookups and proposals for proposal lookups
+    def _make_result(entity, is_list=False):
+        result = MagicMock()
+        if is_list:
+            sc = MagicMock()
+            sc.all = MagicMock(return_value=entity or [])
+            result.scalars = MagicMock(return_value=sc)
+        else:
+            result.scalar_one_or_none = MagicMock(return_value=entity)
+        return result
+
+    async def _execute(stmt, *args, **kwargs):
+        stmt_str = str(stmt).lower()
+        if "llc_finding_proposals" in stmt_str:
+            # List query (scalars) vs single-row (scalar_one_or_none)
+            if proposals is not None and "select" in stmt_str:
+                # If filtering by id (single) or project_id (list)
+                try:
+                    params = stmt.compile().params
+                    param_vals = set(str(v) for v in params.values())
+                except Exception:
+                    param_vals = set()
+                if str(_PROPOSAL_ID) in param_vals:
+                    return _make_result(proposals[0] if proposals else None)
+                return _make_result(proposals, is_list=True)
+            return _make_result(proposals[0] if proposals else None)
+        # Default: return project
+        return _make_result(project)
+
+    session.execute = _execute
+
+    async def _sess():
+        yield session
+
+    app.dependency_overrides[get_session] = _sess
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_USER_ID)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=project.company_id, user_id=_USER_ID, is_platform_admin=False
+    )
+    return TestClient(app), session
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_scan_403_when_policy_disabled():
+    """POST /projects/{id}/findings/scan → 403 when policy.enabled=False."""
+    from llc.services.findings_policy import FindingsPolicy  # noqa: PLC0415
+
+    project = _mk_project()
+    client, _ = _mk_client(project)
+    with patch("llc.api.findings.get_findings_policy", AsyncMock(return_value=FindingsPolicy(enabled=False))):
+        resp = client.post(f"/projects/{project.id}/findings/scan")
+    assert resp.status_code == 403
+
+
+def test_scan_409_when_no_code_source_id():
+    """POST /projects/{id}/findings/scan → 409 when project has no code_source_id."""
+    from llc.services.findings_policy import FindingsPolicy  # noqa: PLC0415
+
+    project = _mk_project(code_source_id=None)
+    client, _ = _mk_client(project)
+    with patch("llc.api.findings.get_findings_policy", AsyncMock(return_value=FindingsPolicy(enabled=True))):
+        resp = client.post(f"/projects/{project.id}/findings/scan")
+    assert resp.status_code == 409
+
+
+def test_scan_success_returns_counts():
+    """POST /projects/{id}/findings/scan → 200 with gathered/verified_real/queued."""
+    from llc.services.findings_policy import FindingsPolicy  # noqa: PLC0415
+
+    project = _mk_project(code_source_id="src-001")
+    client, _ = _mk_client(project)
+    counts = {"gathered": 5, "verified_real": 3, "queued": 3}
+    with (
+        patch("llc.api.findings.get_findings_policy", AsyncMock(return_value=FindingsPolicy(enabled=True))),
+        patch("llc.api.findings.scan", AsyncMock(return_value=counts)),
+    ):
+        resp = client.post(f"/projects/{project.id}/findings/scan")
+    assert resp.status_code == 200
+    assert resp.json() == counts
+
+
+def test_list_proposals_returns_proposals():
+    """GET /projects/{id}/findings/proposals → 200 with proposal list."""
+    project = _mk_project()
+    proposal = _mk_proposal()
+    client, _ = _mk_client(project, proposals=[proposal])
+    resp = client.get(f"/projects/{project.id}/findings/proposals")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["finding_type"] == "bug"
+
+
+def test_list_proposals_filter_by_status():
+    """GET /projects/{id}/findings/proposals?status=pending → 200."""
+    project = _mk_project()
+    proposal = _mk_proposal()
+    client, _ = _mk_client(project, proposals=[proposal])
+    resp = client.get(f"/projects/{project.id}/findings/proposals?status=pending")
+    assert resp.status_code == 200
+
+
+def test_promote_calls_service():
+    """POST /findings/proposals/{id}/promote → 200; service invoked."""
+    project = _mk_project()
+    proposal = _mk_proposal()
+    client, _ = _mk_client(project, proposals=[proposal])
+    fake_item = SimpleNamespace(
+        id=uuid.uuid4(),
+        identifier="LLC-1",
+        title="title",
+        type="bug",
+        status="open",
+        description="desc",
+        priority="high",
+        project_id=_PROJECT_ID,
+        company_id=_ORG_ID,
+        created_at=_NOW,
+        updated_at=_NOW,
+        assignee_agent_id=None,
+        assignee_user_id=None,
+        sprint_id=None,
+        story_points=None,
+        labels=[],
+        scheduled_start=None,
+        scheduled_end=None,
+        started_at=None,
+        completed_at=None,
+        due_date=None,
+        estimated_hours=None,
+        actual_hours=None,
+        comment_count=0,
+    )
+    with patch("llc.api.findings.promote", AsyncMock(return_value=fake_item)):
+        resp = client.post(f"/findings/proposals/{proposal.id}/promote")
+    assert resp.status_code == 200
+
+
+def test_dismiss_calls_service():
+    """POST /findings/proposals/{id}/dismiss {reason} → 200."""
+    project = _mk_project()
+    proposal = _mk_proposal()
+    client, _ = _mk_client(project, proposals=[proposal])
+    with patch("llc.api.findings.dismiss", AsyncMock(return_value=None)):
+        resp = client.post(f"/findings/proposals/{proposal.id}/dismiss", json={"reason": "not applicable"})
+    assert resp.status_code == 200
+
+
+def test_dismiss_requires_reason():
+    """POST /findings/proposals/{id}/dismiss with missing reason → 422."""
+    project = _mk_project()
+    proposal = _mk_proposal()
+    client, _ = _mk_client(project, proposals=[proposal])
+    with patch("llc.api.findings.dismiss", AsyncMock(return_value=None)):
+        resp = client.post(f"/findings/proposals/{proposal.id}/dismiss", json={})
+    assert resp.status_code == 422
+
+
+def test_scan_idor_404_wrong_org():
+    """POST /projects/{id}/findings/scan → 404 when project.company_id != ctx.org_id."""
+    from llc.services.findings_policy import FindingsPolicy  # noqa: PLC0415
+
+    project = _mk_project(company_id=_OTHER_ORG_ID)
+    project2 = _mk_project(company_id=_ORG_ID)  # client is wired to _ORG_ID
+    client, _ = _mk_client(project2, proposals=[])
+
+    # Override execute to return the project owned by OTHER org
+    from api.user_management.dependencies import get_current_user, require_org_context  # noqa: PLC0415
+    from llc.api.findings import router  # noqa: PLC0415
+    from llc.deps import get_session  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(router)
+    session = AsyncMock()
+
+    async def _execute(stmt, *args, **kwargs):
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=project)
+        return result
+
+    session.execute = _execute
+
+    async def _sess():
+        yield session
+
+    app.dependency_overrides[get_session] = _sess
+    app.dependency_overrides[get_current_user] = lambda: {"id": str(_USER_ID)}
+    app.dependency_overrides[require_org_context] = lambda: TenantContext(
+        org_id=_ORG_ID, user_id=_USER_ID, is_platform_admin=False
+    )
+    idor_client = TestClient(app)
+
+    with patch("llc.api.findings.get_findings_policy", AsyncMock(return_value=FindingsPolicy(enabled=True))):
+        resp = idor_client.post(f"/projects/{project.id}/findings/scan")
+    assert resp.status_code == 404

--- a/autobot-backend/llc/tests/test_findings_gather.py
+++ b/autobot-backend/llc/tests/test_findings_gather.py
@@ -1,0 +1,191 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for llc.services.findings_gather (#11271).
+
+Patch strategy
+--------------
+``gather_findings`` lazy-imports two helpers inside private async wrappers:
+  - ``api.codebase_analytics.source_storage.get_source``
+  - ``api.codebase_analytics.endpoints.stats._fetch_problems_from_chromadb``
+  - ``api.codebase_analytics.storage.get_code_collection``
+
+The llc/tests/conftest.py ``_shield_codebase_analytics_package`` hook already installs
+a thin package stub whose ``__path__`` points at the real directory, so
+``patch("api.codebase_analytics.source_storage.get_source", ...)`` loads the
+real submodule (without __init__.py) and auto-restores on exit.
+
+For the ChromaDB helpers we patch at their real module paths:
+  - ``api.codebase_analytics.storage.get_code_collection``
+  - ``api.codebase_analytics.endpoints.stats._fetch_problems_from_chromadb``
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_HIGH = {
+    "type": "bug",
+    "severity": "high",
+    "file_path": "a.py",
+    "line_number": 1,
+    "description": "d1",
+    "suggestion": "s1",
+}
+_MEDIUM = {
+    "type": "style",
+    "severity": "medium",
+    "file_path": "b.py",
+    "line_number": 2,
+    "description": "d2",
+    "suggestion": "s2",
+}
+_LOW = {
+    "type": "smell",
+    "severity": "low",
+    "file_path": "c.py",
+    "line_number": 3,
+    "description": "d3",
+    "suggestion": "s3",
+}
+
+_THREE_FINDINGS = [_HIGH, _MEDIUM, _LOW]
+
+
+def _ready_source(source_id: str = "src-abc") -> SimpleNamespace:
+    return SimpleNamespace(id=source_id, clone_path="/opt/autobot/code-sources/src-abc/", status="ready")
+
+
+def _project(code_source_id: str | None = "src-abc") -> SimpleNamespace:
+    return SimpleNamespace(id="proj-1", code_source_id=code_source_id)
+
+
+_FAKE_COLLECTION = MagicMock()
+
+
+def _patch_all(source, findings):
+    """Context-manager stack: patch get_source, get_code_collection, _fetch_problems_from_chromadb."""
+    return (
+        patch("api.codebase_analytics.source_storage.get_source", AsyncMock(return_value=source)),
+        patch("api.codebase_analytics.storage.get_code_collection", return_value=_FAKE_COLLECTION),
+        patch("api.codebase_analytics.endpoints.stats._fetch_problems_from_chromadb", return_value=findings),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests — severity filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_min_severity_medium_drops_low():
+    """min_severity='medium' → only high + medium returned (2 findings)."""
+    from llc.services.findings_gather import gather_findings
+
+    p1, p2, p3 = _patch_all(_ready_source(), _THREE_FINDINGS)
+    with p1, p2, p3:
+        result = await gather_findings(_project(), min_severity="medium", session=AsyncMock())
+
+    severities = [f["severity"] for f in result]
+    assert "low" not in severities
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_min_severity_low_returns_all():
+    """min_severity='low' → all 3 findings returned."""
+    from llc.services.findings_gather import gather_findings
+
+    p1, p2, p3 = _patch_all(_ready_source(), _THREE_FINDINGS)
+    with p1, p2, p3:
+        result = await gather_findings(_project(), min_severity="low", session=AsyncMock())
+
+    assert len(result) == 3
+
+
+@pytest.mark.asyncio
+async def test_min_severity_high_returns_only_high():
+    """min_severity='high' → only high finding returned."""
+    from llc.services.findings_gather import gather_findings
+
+    p1, p2, p3 = _patch_all(_ready_source(), _THREE_FINDINGS)
+    with p1, p2, p3:
+        result = await gather_findings(_project(), min_severity="high", session=AsyncMock())
+
+    assert len(result) == 1
+    assert result[0]["severity"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_results_sorted_high_before_medium():
+    """Results are ordered high → medium → low."""
+    from llc.services.findings_gather import gather_findings
+
+    shuffled = [_LOW, _HIGH, _MEDIUM]
+    p1, p2, p3 = _patch_all(_ready_source(), shuffled)
+    with p1, p2, p3:
+        result = await gather_findings(_project(), min_severity="low", session=AsyncMock())
+
+    assert [f["severity"] for f in result] == ["high", "medium", "low"]
+
+
+# ---------------------------------------------------------------------------
+# Tests — ValueError cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_code_source_id_raises():
+    """project.code_source_id is None → ValueError."""
+    from llc.services.findings_gather import gather_findings
+
+    with pytest.raises(ValueError, match="no code_source_id"):
+        await gather_findings(_project(code_source_id=None), min_severity="medium", session=AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_missing_source_raises():
+    """get_source returns None → ValueError."""
+    from llc.services.findings_gather import gather_findings
+
+    with patch("api.codebase_analytics.source_storage.get_source", AsyncMock(return_value=None)):
+        with pytest.raises(ValueError, match="not found"):
+            await gather_findings(_project(), min_severity="medium", session=AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_source_not_ready_raises():
+    """Source with status != ready → ValueError."""
+    from llc.services.findings_gather import gather_findings
+
+    not_ready = SimpleNamespace(id="src-abc", clone_path="/x/", status="configured")
+    with patch("api.codebase_analytics.source_storage.get_source", AsyncMock(return_value=not_ready)):
+        with pytest.raises(ValueError, match="not ready"):
+            await gather_findings(_project(), min_severity="medium", session=AsyncMock())
+
+
+# ---------------------------------------------------------------------------
+# Tests — helper unit
+# ---------------------------------------------------------------------------
+
+
+def test_at_or_above_medium():
+    from llc.services.findings_gather import _at_or_above
+
+    assert _at_or_above("medium") == ("high", "medium")
+
+
+def test_at_or_above_low():
+    from llc.services.findings_gather import _at_or_above
+
+    assert _at_or_above("low") == ("high", "medium", "low")
+
+
+def test_at_or_above_high():
+    from llc.services.findings_gather import _at_or_above
+
+    assert _at_or_above("high") == ("high",)

--- a/autobot-backend/llc/tests/test_findings_policy.py
+++ b/autobot-backend/llc/tests/test_findings_policy.py
@@ -1,0 +1,58 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""SLM-configurable findings policy read + safe defaults (#11271)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from llc.services.findings_policy import FindingsPolicy, get_findings_policy
+
+
+@pytest.mark.asyncio
+async def test_defaults_when_no_slm_client():
+    with patch("llc.services.findings_policy.get_slm_client", return_value=None):
+        policy = await get_findings_policy()
+    assert policy == FindingsPolicy(
+        enabled=False,
+        min_severity="medium",
+        require_approval_to_promote=False,
+        run_on_index=False,
+        verify_batch_size=10,
+    )
+    assert policy.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_parses_policy_from_slm():
+    with patch(
+        "llc.services.findings_policy._fetch_policy_json",
+        AsyncMock(
+            return_value={
+                "enabled": True,
+                "min_severity": "high",
+                "require_approval_to_promote": True,
+                "run_on_index": True,
+                "verify_batch_size": 5,
+            }
+        ),
+    ):
+        policy = await get_findings_policy()
+    assert policy.enabled is True
+    assert policy.min_severity == "high"
+    assert policy.require_approval_to_promote is True
+    assert policy.run_on_index is True
+    assert policy.verify_batch_size == 5
+
+
+@pytest.mark.asyncio
+async def test_defaults_on_malformed():
+    with patch("llc.services.findings_policy._fetch_policy_json", AsyncMock(return_value={"bad": "x"})):
+        policy = await get_findings_policy()
+    assert policy == FindingsPolicy(
+        enabled=False,
+        min_severity="medium",
+        require_approval_to_promote=False,
+        run_on_index=False,
+        verify_batch_size=10,
+    )

--- a/autobot-backend/llc/tests/test_findings_policy.py
+++ b/autobot-backend/llc/tests/test_findings_policy.py
@@ -56,3 +56,23 @@ async def test_defaults_on_malformed():
         run_on_index=False,
         verify_batch_size=10,
     )
+
+
+@pytest.mark.asyncio
+async def test_unknown_min_severity_coerces_to_medium():
+    """An unknown/invalid min_severity is coerced to 'medium' (not passed through)."""
+    for bad in ("critical", "", 1, None):
+        with patch(
+            "llc.services.findings_policy._fetch_policy_json",
+            AsyncMock(
+                return_value={
+                    "enabled": True,
+                    "min_severity": bad,
+                    "require_approval_to_promote": False,
+                    "run_on_index": False,
+                    "verify_batch_size": 3,
+                }
+            ),
+        ):
+            policy = await get_findings_policy()
+        assert policy.min_severity == "medium", f"min_severity={bad!r} should coerce to medium"

--- a/autobot-backend/llc/tests/test_findings_verify.py
+++ b/autobot-backend/llc/tests/test_findings_verify.py
@@ -1,0 +1,145 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for llc.services.findings_verify (#11271).
+
+Patch strategy
+--------------
+``verify_finding`` imports ``get_llm_service`` at module level so it is
+patchable via ``llc.services.findings_verify.get_llm_service``.
+
+The mock LLM service returns an LLMResponse-like SimpleNamespace with
+``.content`` holding the JSON string and ``.error`` set to None (success) or
+a non-empty string (failure).
+"""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.services.findings_verify import Verdict, verify_finding
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FINDING = {
+    "type": "bug",
+    "severity": "high",
+    "file_path": "src/app.py",
+    "line_number": 5,
+    "description": "Null dereference",
+    "suggestion": "Add None check",
+}
+
+_GOOD_VERDICT_JSON = json.dumps({"is_real": True, "confidence": 0.9, "rationale": "real bug"})
+_FALSE_VERDICT_JSON = json.dumps({"is_real": False, "confidence": 0.1, "rationale": "false positive"})
+
+
+def _make_response(content: str, error: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(content=content, error=error)
+
+
+def _mock_service(chat_return=None, chat_side_effect=None) -> MagicMock:
+    """Build a mock LLM service whose `chat` is an AsyncMock."""
+    svc = MagicMock()
+    if chat_side_effect is not None:
+        svc.chat = AsyncMock(side_effect=chat_side_effect)
+    else:
+        svc.chat = AsyncMock(return_value=chat_return)
+    return svc
+
+
+@pytest.fixture()
+def clone_dir(tmp_path: Path) -> Path:
+    """Create a minimal clone dir with a source file containing 20 lines."""
+    src = tmp_path / "src"
+    src.mkdir()
+    target = src / "app.py"
+    lines = [f"line {i}\n" for i in range(1, 21)]
+    target.write_text("".join(lines), encoding="utf-8")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_success(clone_dir: Path) -> None:
+    """Happy path: chat returns valid JSON → Verdict.is_real is True."""
+    svc = _mock_service(chat_return=_make_response(_GOOD_VERDICT_JSON))
+    with patch("llc.services.findings_verify.get_llm_service", return_value=svc):
+        verdict = await verify_finding(_FINDING, str(clone_dir))
+    assert isinstance(verdict, Verdict)
+    assert verdict.is_real is True
+    assert verdict.confidence == pytest.approx(0.9)
+    assert "real bug" in verdict.rationale
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_false_positive(clone_dir: Path) -> None:
+    """Chat returns JSON with is_real=False → Verdict.is_real is False."""
+    svc = _mock_service(chat_return=_make_response(_FALSE_VERDICT_JSON))
+    with patch("llc.services.findings_verify.get_llm_service", return_value=svc):
+        verdict = await verify_finding(_FINDING, str(clone_dir))
+    assert verdict.is_real is False
+    assert verdict.confidence == pytest.approx(0.1)
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_chat_raises_fails_closed(clone_dir: Path) -> None:
+    """If chat() raises → fail-closed Verdict(is_real=False, confidence=0.0)."""
+    svc = _mock_service(chat_side_effect=RuntimeError("engine down"))
+    with patch("llc.services.findings_verify.get_llm_service", return_value=svc):
+        verdict = await verify_finding(_FINDING, str(clone_dir))
+    assert verdict.is_real is False
+    assert verdict.confidence == 0.0
+    assert "unverifiable" in verdict.rationale
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_non_json_fails_closed(clone_dir: Path) -> None:
+    """If chat() returns non-JSON garbage → fail-closed."""
+    svc = _mock_service(chat_return=_make_response("not json at all !!!"))
+    with patch("llc.services.findings_verify.get_llm_service", return_value=svc):
+        verdict = await verify_finding(_FINDING, str(clone_dir))
+    assert verdict.is_real is False
+    assert verdict.confidence == 0.0
+    assert "unverifiable" in verdict.rationale
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_missing_file_fails_closed(tmp_path: Path) -> None:
+    """Finding pointing at a nonexistent file → still returns a Verdict, never raises."""
+    svc = _mock_service(chat_return=_make_response(_GOOD_VERDICT_JSON))
+    finding_no_file = dict(_FINDING, file_path="does/not/exist.py")
+    with patch("llc.services.findings_verify.get_llm_service", return_value=svc):
+        verdict = await verify_finding(finding_no_file, str(tmp_path))
+    # Even with missing file it should not raise; may be real or unverifiable
+    assert isinstance(verdict, Verdict)
+    assert isinstance(verdict.is_real, bool)
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_error_response_fails_closed(clone_dir: Path) -> None:
+    """LLMResponse.error non-empty → treat as engine failure → fail-closed."""
+    svc = _mock_service(chat_return=_make_response("", error="provider unavailable"))
+    with patch("llc.services.findings_verify.get_llm_service", return_value=svc):
+        verdict = await verify_finding(_FINDING, str(clone_dir))
+    assert verdict.is_real is False
+    assert verdict.confidence == 0.0
+    assert "unverifiable" in verdict.rationale
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_empty_content_fails_closed(clone_dir: Path) -> None:
+    """LLMResponse.content is empty string → fail-closed."""
+    svc = _mock_service(chat_return=_make_response(""))
+    with patch("llc.services.findings_verify.get_llm_service", return_value=svc):
+        verdict = await verify_finding(_FINDING, str(clone_dir))
+    assert verdict.is_real is False
+    assert verdict.confidence == 0.0

--- a/autobot-backend/llc/tests/test_findings_verify.py
+++ b/autobot-backend/llc/tests/test_findings_verify.py
@@ -113,7 +113,28 @@ async def test_verify_finding_non_json_fails_closed(clone_dir: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_verify_finding_missing_file_fails_closed(tmp_path: Path) -> None:
+async def test_verify_finding_string_false_fails_closed(clone_dir: Path) -> None:
+    """is_real as the JSON string "false" must NOT coerce to True (bool('false') is True)."""
+    bad = json.dumps({"is_real": "false", "confidence": 0.9, "rationale": "ok"})
+    svc = _mock_service(chat_return=_make_response(bad))
+    with patch("llc.services.findings_verify.get_llm_service", return_value=svc):
+        verdict = await verify_finding(_FINDING, str(clone_dir))
+    assert verdict.is_real is False
+    assert verdict.confidence == 0.0
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_out_of_range_confidence_fails_closed(clone_dir: Path) -> None:
+    """A verdict with confidence outside [0,1] is rejected → fail-closed."""
+    bad = json.dumps({"is_real": True, "confidence": 1.5, "rationale": "ok"})
+    svc = _mock_service(chat_return=_make_response(bad))
+    with patch("llc.services.findings_verify.get_llm_service", return_value=svc):
+        verdict = await verify_finding(_FINDING, str(clone_dir))
+    assert verdict.is_real is False
+
+
+@pytest.mark.asyncio
+async def test_verify_finding_missing_file_does_not_raise(tmp_path: Path) -> None:
     """Finding pointing at a nonexistent file → still returns a Verdict, never raises."""
     svc = _mock_service(chat_return=_make_response(_GOOD_VERDICT_JSON))
     finding_no_file = dict(_FINDING, file_path="does/not/exist.py")

--- a/autobot-backend/migrations/versions/20260708_069_llc_finding_proposals.py
+++ b/autobot-backend/migrations/versions/20260708_069_llc_finding_proposals.py
@@ -1,0 +1,60 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Create llc_finding_proposals table + findingproposalstatus enum (#11271)."""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260708_069"
+down_revision: Union[str, Sequence[str], None] = "20260708_068"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_FINDING_STATUS = sa.Enum("pending", "promoted", "dismissed", name="findingproposalstatus")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    _FINDING_STATUS.create(bind, checkfirst=True)
+    op.create_table(
+        "llc_finding_proposals",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("company_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("source_id", sa.String(64), nullable=False),
+        sa.Column("finding_key", sa.String(512), nullable=False),
+        sa.Column("finding_type", sa.String(128), nullable=False),
+        sa.Column("severity", sa.String(32), nullable=False),
+        sa.Column("file_path", sa.Text, nullable=False),
+        sa.Column("line_number", sa.Integer, nullable=True),
+        sa.Column("description", sa.Text, nullable=False),
+        sa.Column("suggestion", sa.Text, nullable=True),
+        sa.Column("verdict_is_real", sa.Boolean, nullable=True),
+        sa.Column("verdict_confidence", sa.Numeric(5, 4), nullable=True),
+        sa.Column("verdict_rationale", sa.Text, nullable=True),
+        sa.Column("status", _FINDING_STATUS, nullable=False, server_default="pending"),
+        sa.Column("work_item_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("dismiss_reason", sa.Text, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["project_id"], ["llc_projects.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("project_id", "finding_key", name="uq_finding_proposal_project_key"),
+    )
+    op.create_index("ix_llc_finding_proposals_company_id", "llc_finding_proposals", ["company_id"])
+    op.create_index("ix_llc_finding_proposals_project_id", "llc_finding_proposals", ["project_id"])
+    op.create_index("ix_llc_finding_proposals_status", "llc_finding_proposals", ["status"])
+    # ALTER TYPE ... ADD VALUE cannot run inside a transaction block.
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE approvaltype ADD VALUE IF NOT EXISTS 'finding_promotion'")
+
+
+def downgrade() -> None:
+    op.drop_index("ix_llc_finding_proposals_status", table_name="llc_finding_proposals")
+    op.drop_index("ix_llc_finding_proposals_project_id", table_name="llc_finding_proposals")
+    op.drop_index("ix_llc_finding_proposals_company_id", table_name="llc_finding_proposals")
+    op.drop_table("llc_finding_proposals")
+    _FINDING_STATUS.drop(op.get_bind(), checkfirst=True)
+    # Note: Postgres cannot drop an enum value; 'finding_promotion' remains on approvaltype (harmless).

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8515,6 +8515,18 @@
       "archived": "مؤرشف",
       "pending_disposal": "في انتظار الحذف",
       "disposed": "محذوف"
+    },
+    "findings": {
+      "scan": "البحث عن النتائج",
+      "scanning": "جارٍ الفحص…",
+      "empty": "لا توجد نتائج معلقة.",
+      "promote": "ترقية",
+      "dismiss": "رفض",
+      "dismissReason": "سبب الرفض",
+      "verdictReal": "الحكم: حقيقي",
+      "verdictRationale": "المبرر",
+      "disabled": "البحث عن النتائج معطّل.",
+      "severity": "الخطورة"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8515,6 +8515,18 @@
       "archived": "Archiviert",
       "pending_disposal": "Ausstehende Löschung",
       "disposed": "Gelöscht"
+    },
+    "findings": {
+      "scan": "Nach Befunden suchen",
+      "scanning": "Wird gescannt…",
+      "empty": "Keine ausstehenden Befunde.",
+      "promote": "Hochstufen",
+      "dismiss": "Verwerfen",
+      "dismissReason": "Grund für Verwerfung",
+      "verdictReal": "Urteil: real",
+      "verdictRationale": "Begründung",
+      "disabled": "Befundsuche ist deaktiviert.",
+      "severity": "Schweregrad"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8515,6 +8515,18 @@
       "archived": "Archived",
       "pending_disposal": "Pending disposal",
       "disposed": "Disposed"
+    },
+    "findings": {
+      "scan": "Scan for findings",
+      "scanning": "Scanning…",
+      "empty": "No pending findings.",
+      "promote": "Promote",
+      "dismiss": "Dismiss",
+      "dismissReason": "Reason for dismissal",
+      "verdictReal": "Verdict: real",
+      "verdictRationale": "Rationale",
+      "disabled": "Findings scanning is disabled.",
+      "severity": "Severity"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8515,6 +8515,18 @@
       "archived": "Archivado",
       "pending_disposal": "Eliminación pendiente",
       "disposed": "Eliminado"
+    },
+    "findings": {
+      "scan": "Buscar hallazgos",
+      "scanning": "Escaneando…",
+      "empty": "No hay hallazgos pendientes.",
+      "promote": "Promover",
+      "dismiss": "Descartar",
+      "dismissReason": "Motivo del descarte",
+      "verdictReal": "Veredicto: real",
+      "verdictRationale": "Justificación",
+      "disabled": "La búsqueda de hallazgos está deshabilitada.",
+      "severity": "Severidad"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8515,6 +8515,18 @@
       "archived": "بایگانی‌شده",
       "pending_disposal": "در انتظار حذف",
       "disposed": "حذف‌شده"
+    },
+    "findings": {
+      "scan": "جستجوی یافته‌ها",
+      "scanning": "در حال اسکن…",
+      "empty": "هیچ یافته معلقی وجود ندارد.",
+      "promote": "ارتقا",
+      "dismiss": "رد کردن",
+      "dismissReason": "دلیل رد کردن",
+      "verdictReal": "حکم: واقعی",
+      "verdictRationale": "استدلال",
+      "disabled": "جستجوی یافته‌ها غیرفعال است.",
+      "severity": "شدت"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8515,6 +8515,18 @@
       "archived": "Archivé",
       "pending_disposal": "Suppression en attente",
       "disposed": "Supprimé"
+    },
+    "findings": {
+      "scan": "Rechercher des résultats",
+      "scanning": "Analyse en cours…",
+      "empty": "Aucun résultat en attente.",
+      "promote": "Promouvoir",
+      "dismiss": "Rejeter",
+      "dismissReason": "Motif du rejet",
+      "verdictReal": "Verdict : réel",
+      "verdictRationale": "Justification",
+      "disabled": "La recherche de résultats est désactivée.",
+      "severity": "Sévérité"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8515,6 +8515,18 @@
       "archived": "בארכיון",
       "pending_disposal": "ממתין למחיקה",
       "disposed": "נמחק"
+    },
+    "findings": {
+      "scan": "סריקת ממצאים",
+      "scanning": "סורק…",
+      "empty": "אין ממצאים ממתינים.",
+      "promote": "קדם",
+      "dismiss": "דחה",
+      "dismissReason": "סיבת הדחייה",
+      "verdictReal": "פסיקה: אמיתי",
+      "verdictRationale": "נימוק",
+      "disabled": "סריקת ממצאים מושבתת.",
+      "severity": "חומרה"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8515,6 +8515,18 @@
       "archived": "Arhivēts",
       "pending_disposal": "Gaida dzēšanu",
       "disposed": "Dzēsts"
+    },
+    "findings": {
+      "scan": "Meklēt atklājumus",
+      "scanning": "Skenēšana…",
+      "empty": "Nav neviena gaidāmā atklājuma.",
+      "promote": "Veicināt",
+      "dismiss": "Noraidīt",
+      "dismissReason": "Noraidīšanas iemesls",
+      "verdictReal": "Spriedums: īsts",
+      "verdictRationale": "Pamatojums",
+      "disabled": "Atklājumu meklēšana ir atspējota.",
+      "severity": "Nopietnība"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8515,6 +8515,18 @@
       "archived": "Zarchiwizowany",
       "pending_disposal": "Oczekuje na usunięcie",
       "disposed": "Usunięty"
+    },
+    "findings": {
+      "scan": "Skanuj w poszukiwaniu wyników",
+      "scanning": "Skanowanie…",
+      "empty": "Brak oczekujących wyników.",
+      "promote": "Promuj",
+      "dismiss": "Odrzuć",
+      "dismissReason": "Powód odrzucenia",
+      "verdictReal": "Werdykt: prawdziwy",
+      "verdictRationale": "Uzasadnienie",
+      "disabled": "Skanowanie wyników jest wyłączone.",
+      "severity": "Powaga"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8515,6 +8515,18 @@
       "archived": "Arquivado",
       "pending_disposal": "Exclusão pendente",
       "disposed": "Excluído"
+    },
+    "findings": {
+      "scan": "Verificar resultados",
+      "scanning": "Verificando…",
+      "empty": "Nenhum resultado pendente.",
+      "promote": "Promover",
+      "dismiss": "Descartar",
+      "dismissReason": "Motivo do descarte",
+      "verdictReal": "Veredicto: real",
+      "verdictRationale": "Justificativa",
+      "disabled": "A verificação de resultados está desativada.",
+      "severity": "Severidade"
     }
   },
   "admin": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8515,6 +8515,18 @@
       "archived": "آرکائیو شدہ",
       "pending_disposal": "حذف کا انتظار",
       "disposed": "حذف شدہ"
+    },
+    "findings": {
+      "scan": "نتائج تلاش کریں",
+      "scanning": "اسکین ہو رہا ہے…",
+      "empty": "کوئی زیر التواء نتیجہ نہیں۔",
+      "promote": "ترقی دیں",
+      "dismiss": "مسترد کریں",
+      "dismissReason": "مسترد کرنے کی وجہ",
+      "verdictReal": "فیصلہ: حقیقی",
+      "verdictRationale": "دلیل",
+      "disabled": "نتائج کا اسکین غیر فعال ہے۔",
+      "severity": "شدت"
     }
   },
   "admin": {

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -48943,6 +48943,86 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/llc/projects/{project_id}/findings/scan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Scan Findings
+         * @description Scan a project's linked repo for findings and queue real ones as proposals.
+         */
+        post: operations["scan_findings_api_llc_projects__project_id__findings_scan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/projects/{project_id}/findings/proposals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Proposals
+         * @description List finding proposals for a project, optionally filtered by status.
+         */
+        get: operations["list_proposals_api_llc_projects__project_id__findings_proposals_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/findings/proposals/{proposal_id}/promote": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Promote Proposal
+         * @description Promote a pending proposal to a work item (or gate on approval).
+         */
+        post: operations["promote_proposal_api_llc_findings_proposals__proposal_id__promote_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/llc/findings/proposals/{proposal_id}/dismiss": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Dismiss Proposal
+         * @description Dismiss a pending proposal with a reason.
+         */
+        post: operations["dismiss_proposal_api_llc_findings_proposals__proposal_id__dismiss_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/llc/companies/{company_id}/portfolios": {
         parameters: {
             query?: never;
@@ -69497,6 +69577,13 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** DismissRequest */
+        DismissRequest: {
+            /** Reason */
+            reason: string;
+        } & {
+            [key: string]: unknown;
+        };
         /**
          * DockerContainerSpec
          * @description Specification for a single Docker container to deploy.
@@ -72388,6 +72475,54 @@ export interface components {
              * @default []
              */
             orphaned_facts: unknown[];
+        } & {
+            [key: string]: unknown;
+        };
+        /** FindingProposalResponse */
+        FindingProposalResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Company Id
+             * Format: uuid
+             */
+            company_id: string;
+            /**
+             * Project Id
+             * Format: uuid
+             */
+            project_id: string;
+            /** Source Id */
+            source_id: string;
+            /** Finding Key */
+            finding_key: string;
+            /** Finding Type */
+            finding_type: string;
+            /** Severity */
+            severity: string;
+            /** File Path */
+            file_path: string;
+            /** Line Number */
+            line_number: number | null;
+            /** Description */
+            description: string;
+            /** Suggestion */
+            suggestion: string | null;
+            /** Verdict Is Real */
+            verdict_is_real: boolean | null;
+            /** Verdict Confidence */
+            verdict_confidence: number | null;
+            /** Verdict Rationale */
+            verdict_rationale: string | null;
+            /** Status */
+            status: string;
+            /** Work Item Id */
+            work_item_id: string | null;
+            /** Dismiss Reason */
+            dismiss_reason: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -100214,7 +100349,7 @@ export interface components {
          * @description Gate type for a board approval request (GH#8214).
          * @enum {string}
          */
-        llc__models__enums__ApprovalType: "hire" | "strategy" | "budget_override" | "sprint_close" | "project_disposal";
+        llc__models__enums__ApprovalType: "hire" | "strategy" | "budget_override" | "sprint_close" | "project_disposal" | "finding_promotion";
         /**
          * TemplateSearchResponse
          * @description Response for GET /llc/templates/search (GH#8260).
@@ -165183,6 +165318,142 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    scan_findings_api_llc_projects__project_id__findings_scan_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_proposals_api_llc_projects__project_id__findings_proposals_get: {
+        parameters: {
+            query?: {
+                status?: string | null;
+            };
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FindingProposalResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    promote_proposal_api_llc_findings_proposals__proposal_id__promote_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                proposal_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    dismiss_proposal_api_llc_findings_proposals__proposal_id__dismiss_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                proposal_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DismissRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
             };
             /** @description Validation Error */
             422: {

--- a/autobot-frontend/src/views/llc/ProjectBrowserView.vue
+++ b/autobot-frontend/src/views/llc/ProjectBrowserView.vue
@@ -183,7 +183,10 @@
           </div>
           <ul v-else-if="proposals[p.id]" class="findings-list">
             <li v-for="prop in proposals[p.id]" :key="prop.id" class="finding-row">
-              <span class="finding-severity">{{ prop.severity }}</span>
+              <span class="finding-severity" :title="t('llcBrowser.findings.severity')">{{ prop.severity }}</span>
+              <span v-if="prop.verdict_is_real" class="finding-verdict">
+                {{ t('llcBrowser.findings.verdictReal') }}
+              </span>
               <span class="finding-location">{{ prop.file_path }}:{{ prop.line_number }}</span>
               <span class="finding-desc">{{ prop.description }}</span>
               <span v-if="prop.verdict_rationale" class="finding-rationale">

--- a/autobot-frontend/src/views/llc/ProjectBrowserView.vue
+++ b/autobot-frontend/src/views/llc/ProjectBrowserView.vue
@@ -164,6 +164,51 @@
           />
         </div>
 
+        <!-- GH#11271: findings proposal queue -->
+        <div v-if="p.code_source_id" class="card-findings">
+          <div class="findings-header">
+            <BaseButton
+              variant="secondary"
+              size="sm"
+              :loading="scanningProject === p.id"
+              :disabled="scanningProject === p.id"
+              @click="scanFindings(p)"
+            >
+              {{ scanningProject === p.id ? t('llcBrowser.findings.scanning') : t('llcBrowser.findings.scan') }}
+            </BaseButton>
+          </div>
+          <ErrorBanner v-if="findingsError[p.id]" :message="findingsError[p.id]" class="browser-error" />
+          <div v-if="proposals[p.id] && proposals[p.id].length === 0" class="findings-empty">
+            {{ t('llcBrowser.findings.empty') }}
+          </div>
+          <ul v-else-if="proposals[p.id]" class="findings-list">
+            <li v-for="prop in proposals[p.id]" :key="prop.id" class="finding-row">
+              <span class="finding-severity">{{ prop.severity }}</span>
+              <span class="finding-location">{{ prop.file_path }}:{{ prop.line_number }}</span>
+              <span class="finding-desc">{{ prop.description }}</span>
+              <span v-if="prop.verdict_rationale" class="finding-rationale">
+                {{ prop.verdict_rationale }}
+              </span>
+              <div class="finding-actions">
+                <BaseButton
+                  variant="secondary"
+                  size="sm"
+                  @click="promoteProposal(p, prop)"
+                >
+                  {{ t('llcBrowser.findings.promote') }}
+                </BaseButton>
+                <BaseButton
+                  variant="secondary"
+                  size="sm"
+                  @click="dismissProposal(p, prop)"
+                >
+                  {{ t('llcBrowser.findings.dismiss') }}
+                </BaseButton>
+              </div>
+            </li>
+          </ul>
+        </div>
+
         <div class="card-actions">
           <RouterLink class="action-link" :to="`/llc/companies/${companyId}/backlog`">
             {{ t('llcBrowser.backlogLink') }}
@@ -269,6 +314,24 @@ import BaseInput from '@/components/base/BaseInput.vue'
 import { BaseModal } from '@autobot/ui'
 import ErrorBanner from '@/components/base/ErrorBanner.vue'
 
+// GH#11271: finding proposal returned from the API.
+interface FindingProposal {
+  id: string
+  project_id: string
+  finding_type: string
+  severity: string
+  file_path: string
+  line_number: number | null
+  description: string
+  suggestion: string | null
+  verdict_is_real: boolean
+  verdict_confidence: number | null
+  verdict_rationale: string | null
+  status: string
+  work_item_id: string | null
+  dismiss_reason: string | null
+}
+
 // GH#11129: linked code-source summary on a project.
 interface CodeSourceSummary {
   id: string
@@ -348,6 +411,11 @@ const deletingProject = ref<string | null>(null)
 // per-project lifecycle error messages (keyed by project id)
 const lifecycleError = ref<Record<string, string>>({})
 
+// GH#11271: findings proposal queue state (keyed by project id)
+const proposals = ref<Record<string, FindingProposal[]>>({})
+const scanningProject = ref<string | null>(null)
+const findingsError = ref<Record<string, string>>({})
+
 function velocityFor(projectId: string): number[] {
   return velocities.value[projectId] ?? []
 }
@@ -376,6 +444,7 @@ async function loadProjects(): Promise<void> {
       `/api/llc/programs/${programId.value}/projects`,
     )
     void loadVelocities()
+    void loadAllProposals()
   } catch (err) {
     logger.error('Failed to load projects', err)
     loadError.value = true
@@ -383,6 +452,14 @@ async function loadProjects(): Promise<void> {
   } finally {
     loading.value = false
   }
+}
+
+async function loadAllProposals(): Promise<void> {
+  await Promise.all(
+    projects.value
+      .filter(p => p.code_source_id)
+      .map(p => loadProposals(p.id)),
+  )
 }
 
 // Fetch each project's velocity history in parallel (reuses the #9861 endpoint).
@@ -542,6 +619,56 @@ async function deleteProject(project: ProjectResponse): Promise<void> {
     lifecycleError.value = { ...lifecycleError.value, [project.id]: t('llcBrowser.projects.deleteError') }
   } finally {
     deletingProject.value = null
+  }
+}
+
+// GH#11271: findings proposal queue actions ---------------------------------
+
+async function loadProposals(projectId: string): Promise<void> {
+  try {
+    const list = await api.get<FindingProposal[]>(
+      `/api/llc/projects/${projectId}/findings/proposals?status=pending`,
+    )
+    proposals.value = { ...proposals.value, [projectId]: list }
+  } catch (err) {
+    logger.error('Failed to load proposals', err)
+    proposals.value = { ...proposals.value, [projectId]: [] }
+  }
+}
+
+async function scanFindings(project: ProjectResponse): Promise<void> {
+  scanningProject.value = project.id
+  findingsError.value = { ...findingsError.value, [project.id]: '' }
+  try {
+    await api.post(`/api/llc/projects/${project.id}/findings/scan`)
+    await loadProposals(project.id)
+  } catch (err) {
+    logger.error('Failed to scan findings', err)
+    findingsError.value = { ...findingsError.value, [project.id]: t('llcBrowser.findings.disabled') }
+  } finally {
+    scanningProject.value = null
+  }
+}
+
+async function promoteProposal(project: ProjectResponse, proposal: FindingProposal): Promise<void> {
+  try {
+    await api.post(`/api/llc/findings/proposals/${proposal.id}/promote`)
+    await loadProposals(project.id)
+  } catch (err) {
+    logger.error('Failed to promote proposal', err)
+    findingsError.value = { ...findingsError.value, [project.id]: t('llcBrowser.findings.disabled') }
+  }
+}
+
+async function dismissProposal(project: ProjectResponse, proposal: FindingProposal): Promise<void> {
+  const reason = window.prompt(t('llcBrowser.findings.dismissReason'))
+  if (reason === null) return
+  try {
+    await api.post(`/api/llc/findings/proposals/${proposal.id}/dismiss`, { reason })
+    await loadProposals(project.id)
+  } catch (err) {
+    logger.error('Failed to dismiss proposal', err)
+    findingsError.value = { ...findingsError.value, [project.id]: t('llcBrowser.findings.disabled') }
   }
 }
 

--- a/autobot-frontend/src/views/llc/__tests__/ProjectBrowserView.findings.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/ProjectBrowserView.findings.test.ts
@@ -1,0 +1,187 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// GH#11271 T8: project findings proposal queue UI — scan / promote / dismiss affordances.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+const get = vi.fn()
+const post = vi.fn()
+const del = vi.fn()
+
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+const mountOpts = { global: { plugins: [i18n], stubs: { LlcBreadcrumb: true } } }
+
+vi.mock('@/plugins/api', () => ({ useApiClient: () => ({ get, post, delete: del }) }))
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { companyId: 'c1', programId: 'pr1' } }),
+  RouterLink: { template: '<a><slot /></a>' },
+}))
+vi.mock('@autobot/ui', () => ({
+  BaseModal: {
+    name: 'BaseModal',
+    props: ['modelValue', 'title', 'size'],
+    template: '<div v-if="modelValue" class="modal-stub"><slot /><slot name="actions" /></div>',
+  },
+}))
+
+import ProjectBrowserView from '../ProjectBrowserView.vue'
+
+const PROJECT_WITH_REPO = {
+  id: 'p-with-repo',
+  company_id: 'c1',
+  program_id: 'pr1',
+  goal_id: null,
+  name: 'Repo Project',
+  description: null,
+  status: 'active',
+  lifecycle_state: 'active',
+  lead_agent_id: null,
+  lead_user_id: null,
+  target_date: null,
+  auto_rollover: false,
+  created_at: '2026-01-01',
+  updated_at: '2026-01-01',
+  open_work_item_count: 0,
+  active_sprint_name: null,
+  code_source_id: 'src-1',
+  code_source: {
+    id: 'src-1',
+    repo: 'acme/backend',
+    branch: 'main',
+    clone_path: '/tmp/acme',
+    status: 'ready',
+    error_message: null,
+  },
+}
+
+const PROPOSAL = {
+  id: 'prop-1',
+  project_id: 'p-with-repo',
+  company_id: 'c1',
+  source_id: 'src-1',
+  finding_key: 'src-1:src/app.py:42:bug',
+  finding_type: 'bug',
+  severity: 'high',
+  file_path: 'src/app.py',
+  line_number: 42,
+  description: 'Unhandled exception in handler',
+  suggestion: 'Add try/except',
+  verdict_is_real: true,
+  verdict_confidence: 0.92,
+  verdict_rationale: 'The exception is genuinely unhandled.',
+  status: 'pending',
+  work_item_id: null,
+  dismiss_reason: null,
+}
+
+function makeGetMock(proposals: unknown[] = [PROPOSAL]) {
+  return (url?: string) => {
+    if (url?.endsWith('/projects')) return Promise.resolve([PROJECT_WITH_REPO])
+    if (url?.includes('/velocity')) return Promise.resolve({ sprints: [] })
+    if (url?.includes('/findings/proposals')) return Promise.resolve(proposals)
+    return Promise.resolve([])
+  }
+}
+
+describe('ProjectBrowserView findings proposal queue (GH#11271 T8)', () => {
+  beforeEach(() => {
+    get.mockReset()
+    post.mockReset()
+    del.mockReset()
+    vi.restoreAllMocks()
+  })
+
+  it('renders a proposal row with severity badge, file:line, description, verdict rationale', async () => {
+    get.mockImplementation(makeGetMock())
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    // Proposal list is loaded; expect the severity, file:line and rationale to be visible.
+    expect(wrapper.text()).toContain('src/app.py:42')
+    expect(wrapper.text()).toContain('Unhandled exception in handler')
+    expect(wrapper.text()).toContain('The exception is genuinely unhandled.')
+    // Severity badge should be present
+    const badge = wrapper.find('.finding-severity')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toContain('high')
+  })
+
+  it('Scan button calls POST /api/llc/projects/{id}/findings/scan and refreshes proposals', async () => {
+    get.mockImplementation(makeGetMock([]))
+    post.mockResolvedValue({ gathered: 3, verified_real: 2, queued: 2 })
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    const scanBtn = wrapper.findAll('button').find(b => b.text().includes('Scan'))
+    expect(scanBtn).toBeDefined()
+    await scanBtn!.trigger('click')
+    await flushPromises()
+
+    expect(post).toHaveBeenCalledWith('/api/llc/projects/p-with-repo/findings/scan')
+    // After scan, proposals list re-fetch should have been called
+    const getCalls = get.mock.calls.map(c => c[0] as string)
+    expect(getCalls.some(u => u?.includes('/findings/proposals'))).toBe(true)
+  })
+
+  it('Promote button calls POST /api/llc/findings/proposals/{id}/promote and refreshes', async () => {
+    get.mockImplementation(makeGetMock())
+    post.mockResolvedValue({ id: 'wi-1', title: 'Unhandled exception in handler' })
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    const promoteBtn = wrapper.findAll('button').find(b => b.text().includes('Promote'))
+    expect(promoteBtn).toBeDefined()
+    await promoteBtn!.trigger('click')
+    await flushPromises()
+
+    expect(post).toHaveBeenCalledWith('/api/llc/findings/proposals/prop-1/promote')
+    // Proposals list should have been refreshed
+    const getCalls = get.mock.calls.map(c => c[0] as string)
+    expect(getCalls.filter(u => u?.includes('/findings/proposals')).length).toBeGreaterThan(1)
+  })
+
+  it('Dismiss button prompts for reason, then calls POST /api/llc/findings/proposals/{id}/dismiss', async () => {
+    get.mockImplementation(makeGetMock())
+    post.mockResolvedValue({})
+    vi.spyOn(window, 'prompt').mockReturnValue('Not a real bug')
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    const dismissBtn = wrapper.findAll('button').find(b => b.text().includes('Dismiss'))
+    expect(dismissBtn).toBeDefined()
+    await dismissBtn!.trigger('click')
+    await flushPromises()
+
+    expect(window.prompt).toHaveBeenCalled()
+    expect(post).toHaveBeenCalledWith(
+      '/api/llc/findings/proposals/prop-1/dismiss',
+      { reason: 'Not a real bug' },
+    )
+  })
+
+  it('Dismiss with cancelled prompt does NOT call POST dismiss', async () => {
+    get.mockImplementation(makeGetMock())
+    vi.spyOn(window, 'prompt').mockReturnValue(null)
+
+    const wrapper = mount(ProjectBrowserView, mountOpts)
+    await flushPromises()
+
+    const dismissBtn = wrapper.findAll('button').find(b => b.text().includes('Dismiss'))
+    expect(dismissBtn).toBeDefined()
+    await dismissBtn!.trigger('click')
+    await flushPromises()
+
+    expect(window.prompt).toHaveBeenCalled()
+    expect(post).not.toHaveBeenCalled()
+  })
+})

--- a/autobot-slm-frontend/src/router/index.ts
+++ b/autobot-slm-frontend/src/router/index.ts
@@ -294,6 +294,13 @@ const router = createRouter({
           component: () => import('@/views/settings/DisposalPolicySettings.vue'),
           meta: { title: 'Disposal Policy', parent: 'settings' }
         },
+        {
+          // Issue #11271 P3: Company OS findings policy (SLM operator panel)
+          path: 'findings-policy',
+          name: 'settings-findings-policy',
+          component: () => import('@/views/settings/FindingsPolicySettings.vue'),
+          meta: { title: 'Findings Policy', parent: 'settings' }
+        },
       ]
     },
     {

--- a/autobot-slm-frontend/src/views/SettingsView.vue
+++ b/autobot-slm-frontend/src/views/SettingsView.vue
@@ -35,6 +35,8 @@ const tabs = [
   { id: 'backend', name: 'Backend', path: '/settings/backend', icon: 'M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2' },
   // Issue #11129 P2: Company OS project disposal policy operator panel
   { id: 'disposal-policy', name: 'Disposal Policy', path: '/settings/disposal-policy', icon: 'M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16' },
+  // Issue #11271 P3: Company OS findings policy operator panel
+  { id: 'findings-policy', name: 'Findings Policy', path: '/settings/findings-policy', icon: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4' },
   // Migrated from main AutoBot frontend - Issue #729
   { id: 'users', name: 'Users', path: '/settings/admin/users', icon: 'M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z' },
   { id: 'cache', name: 'Cache', path: '/settings/admin/cache', icon: 'M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4' },

--- a/autobot-slm-frontend/src/views/settings/FindingsPolicySettings.test.ts
+++ b/autobot-slm-frontend/src/views/settings/FindingsPolicySettings.test.ts
@@ -1,0 +1,49 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import FindingsPolicySettings from './FindingsPolicySettings.vue'
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    getApiUrl: () => '',
+    getAuthHeaders: () => ({}),
+  }),
+}))
+
+describe('FindingsPolicySettings', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        value: JSON.stringify({
+          enabled: true,
+          min_severity: 'high',
+          require_approval_to_promote: true,
+          run_on_index: false,
+          verify_batch_size: 25,
+        }),
+      }),
+    })) as unknown as typeof fetch
+  })
+
+  it('loads the current policy on mount', async () => {
+    const wrapper = mount(FindingsPolicySettings)
+    await flushPromises()
+    const batchInput = wrapper.find('input[data-test="input-verify-batch-size"]').element as HTMLInputElement
+    expect(batchInput.value).toBe('25')
+    const severitySelect = wrapper.find('select[data-test="select-min-severity"]').element as HTMLSelectElement
+    expect(severitySelect.value).toBe('high')
+  })
+
+  it('PUTs the policy as JSON on save', async () => {
+    const wrapper = mount(FindingsPolicySettings)
+    await flushPromises()
+    await wrapper.find('button[data-test="save-policy"]').trigger('click')
+    await flushPromises()
+    const putCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.find((c) => c[1]?.method === 'PUT')
+    expect(putCall).toBeTruthy()
+    expect(putCall![0]).toContain('/api/settings/llc.findings_policy')
+  })
+})

--- a/autobot-slm-frontend/src/views/settings/FindingsPolicySettings.vue
+++ b/autobot-slm-frontend/src/views/settings/FindingsPolicySettings.vue
@@ -1,0 +1,200 @@
+<!-- Copyright 2025-2026 mrveiss -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * FindingsPolicySettings - SLM operator panel for Company OS findings policy
+ *
+ * Reads/writes the SLM setting key `llc.findings_policy` (stored as a
+ * JSON string: {enabled: bool, min_severity: str, require_approval_to_promote: bool,
+ * run_on_index: bool, verify_batch_size: int}) via the SLM settings API.
+ * Mirrors the DisposalPolicySettings.vue auth-store + fetch pattern.
+ * Issue #11271 P3.
+ */
+
+import { onMounted, reactive, ref } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+
+const KEY = 'llc.findings_policy'
+const authStore = useAuthStore()
+const policy = reactive({
+  enabled: false,
+  min_severity: 'medium' as 'high' | 'medium' | 'low',
+  require_approval_to_promote: false,
+  run_on_index: false,
+  verify_batch_size: 10,
+})
+const saving = ref(false)
+const saved = ref(false)
+const error = ref<string | null>(null)
+
+async function load(): Promise<void> {
+  error.value = null
+  try {
+    const res = await fetch(`${authStore.getApiUrl()}/api/settings/${KEY}`, {
+      headers: authStore.getAuthHeaders(),
+    })
+    if (res.ok) {
+      const setting = await res.json()
+      const parsed = setting.value ? JSON.parse(setting.value) : {}
+      policy.enabled = Boolean(parsed.enabled ?? false)
+      policy.min_severity = (parsed.min_severity ?? 'medium') as 'high' | 'medium' | 'low'
+      policy.require_approval_to_promote = Boolean(parsed.require_approval_to_promote ?? false)
+      policy.run_on_index = Boolean(parsed.run_on_index ?? false)
+      policy.verify_batch_size = Number(parsed.verify_batch_size ?? 10)
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to load findings policy'
+  }
+}
+
+async function save(): Promise<void> {
+  saving.value = true
+  saved.value = false
+  error.value = null
+  const body = JSON.stringify({
+    value: JSON.stringify({
+      enabled: policy.enabled,
+      min_severity: policy.min_severity,
+      require_approval_to_promote: policy.require_approval_to_promote,
+      run_on_index: policy.run_on_index,
+      verify_batch_size: policy.verify_batch_size,
+    }),
+    description: 'Company OS findings policy',
+  })
+  const url = `${authStore.getApiUrl()}/api/settings/${KEY}`
+  const headers = { ...authStore.getAuthHeaders(), 'Content-Type': 'application/json' }
+  try {
+    let res = await fetch(url, { method: 'PUT', headers, body })
+    if (res.status === 404) {
+      res = await fetch(url, { method: 'POST', headers, body })
+    }
+    saved.value = res.ok
+    if (!res.ok) {
+      error.value = 'Failed to save findings policy'
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to save findings policy'
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="p-6">
+    <div class="bg-white rounded-lg shadow-xs border border-gray-200 p-6">
+      <h2 class="text-lg font-semibold text-gray-900 mb-2">Findings Policy</h2>
+      <p class="text-sm text-gray-500 mb-6">
+        Controls how Company OS code-analysis findings are surfaced and promoted to work items.
+      </p>
+
+      <div v-if="error" class="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+        {{ error }}
+      </div>
+      <div v-if="saved" class="mb-4 p-4 bg-green-50 border border-green-200 rounded-lg text-green-700 text-sm">
+        Policy saved successfully.
+      </div>
+
+      <div class="space-y-6">
+        <!-- Enabled -->
+        <div class="flex items-center justify-between pb-4 border-b border-gray-100">
+          <div>
+            <label class="block text-sm font-medium text-gray-900">Enable findings policy</label>
+            <p class="text-xs text-gray-500 mt-1">
+              When disabled, no findings are promoted to work items regardless of other settings.
+            </p>
+          </div>
+          <label class="relative inline-flex items-center cursor-pointer">
+            <input type="checkbox" v-model="policy.enabled" class="sr-only peer" data-test="toggle-enabled" />
+            <div class="w-11 h-6 bg-gray-200 peer-focus:outline-hidden peer-focus:ring-4 peer-focus:ring-primary-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-600"></div>
+          </label>
+        </div>
+
+        <!-- Minimum severity -->
+        <div class="flex items-center justify-between pb-4 border-b border-gray-100">
+          <div>
+            <label class="block text-sm font-medium text-gray-900">Minimum severity</label>
+            <p class="text-xs text-gray-500 mt-1">
+              Only findings at or above this severity level are promoted.
+            </p>
+          </div>
+          <select
+            v-model="policy.min_severity"
+            class="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            data-test="select-min-severity"
+          >
+            <option value="high">High</option>
+            <option value="medium">Medium</option>
+            <option value="low">Low</option>
+          </select>
+        </div>
+
+        <!-- Require approval to promote -->
+        <div class="flex items-center justify-between pb-4 border-b border-gray-100">
+          <div>
+            <label class="block text-sm font-medium text-gray-900">Require approval to promote</label>
+            <p class="text-xs text-gray-500 mt-1">
+              When enabled, findings require operator approval before becoming work items.
+            </p>
+          </div>
+          <label class="relative inline-flex items-center cursor-pointer">
+            <input type="checkbox" v-model="policy.require_approval_to_promote" class="sr-only peer" data-test="toggle-require-approval" />
+            <div class="w-11 h-6 bg-gray-200 peer-focus:outline-hidden peer-focus:ring-4 peer-focus:ring-primary-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-600"></div>
+          </label>
+        </div>
+
+        <!-- Run on index -->
+        <div class="flex items-center justify-between pb-4 border-b border-gray-100">
+          <div>
+            <label class="block text-sm font-medium text-gray-900">Run on index</label>
+            <p class="text-xs text-gray-500 mt-1">
+              Automatically trigger findings analysis whenever the code index is refreshed.
+            </p>
+          </div>
+          <label class="relative inline-flex items-center cursor-pointer">
+            <input type="checkbox" v-model="policy.run_on_index" class="sr-only peer" data-test="toggle-run-on-index" />
+            <div class="w-11 h-6 bg-gray-200 peer-focus:outline-hidden peer-focus:ring-4 peer-focus:ring-primary-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-600"></div>
+          </label>
+        </div>
+
+        <!-- Verify batch size -->
+        <div class="flex items-center justify-between">
+          <div>
+            <label class="block text-sm font-medium text-gray-900">Verify batch size</label>
+            <p class="text-xs text-gray-500 mt-1">
+              Number of findings processed per verification batch. Lower values reduce peak load.
+            </p>
+          </div>
+          <input
+            v-model.number="policy.verify_batch_size"
+            type="number"
+            min="1"
+            class="w-32 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            data-test="input-verify-batch-size"
+          />
+        </div>
+      </div>
+
+      <!-- Save Button -->
+      <div class="mt-8 pt-6 border-t border-gray-200 flex justify-end">
+        <button
+          data-test="save-policy"
+          :disabled="saving"
+          class="px-6 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors flex items-center gap-2 disabled:opacity-50"
+          @click="save"
+        >
+          <svg v-if="saving" class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+          {{ saving ? 'Saving…' : 'Save Policy' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/docs/superpowers/plans/2026-07-08-companyos-findings-to-workitems-phase3.md
+++ b/docs/superpowers/plans/2026-07-08-companyos-findings-to-workitems-phase3.md
@@ -1,0 +1,162 @@
+# Company OS Phase 3 — findings → work items (proposal-only, FP-verified) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Codebase-analytics findings for a project's linked repo become project work items only after a fail-closed false-positive check and a human/agent promotion. Nothing auto-creates work items.
+
+**Architecture:** New Postgres `llc_finding_proposals` queue. A gather service pulls findings by `source_id`; a verify service asks the internal SLM engine whether each finding is real (fail-closed); a proposal service upserts verified proposals (dedup by `finding_key`), promotes them to `LLCWorkItem` (optionally approval-gated), or dismisses them. SLM-configurable policy, flag-gated default OFF. Company OS Findings tab + SLM policy panel.
+
+**Tech stack:** FastAPI, SQLAlchemy 2 async (Postgres), Alembic, Pydantic v2, Vue 3 + TS, pytest, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-08-companyos-findings-to-workitems-design.md` (source of truth).
+
+## Global Constraints
+
+- Branch `issue-11271`, worktree `.worktrees/issue-11271`, target `Dev_new_gui`.
+- **NO commit trailers**; copyright `# Copyright 2025-2026 mrveiss` + `# SPDX-License-Identifier: Apache-2.0` on new files.
+- ≤30-line functions; async-first; lazy-import heavy `api.codebase_analytics` modules inside functions.
+- Routes under `/api/llc` (the llc router already prepends it — bare paths, **no** extra `/api`).
+- **Feature flag default OFF** (`findings_policy.enabled=false`): `scan`/`promote` return 403 when disabled.
+- **FP-verify FAILS CLOSED**: any engine/parse error → `is_real=False` → NOT queued.
+- **No hardcoded UI strings** — autobot-frontend strings i18n to ALL 11 locales; SLM panel follows the SLM console's inline-English convention (mirror `DisposalPolicySettings.vue`).
+- `black -l120` + `isort` clean before every commit. Copyright headers.
+- `verify-generated-types` is REQUIRED: new endpoints change the OpenAPI schema → `api.ts` regen is handled by the CI autofix bot (do not hand-generate).
+- Commit format `<type>(scope): <desc> (#11271)`.
+
+## File Structure
+
+- Create: `autobot-backend/llc/models/finding_proposal.py`, migration `autobot-backend/migrations/versions/20260708_069_llc_finding_proposals.py`, `autobot-backend/llc/services/findings_gather.py`, `.../findings_verify.py`, `.../findings_policy.py`, `.../finding_proposal_service.py`, `autobot-backend/llc/api/findings.py`, `autobot-slm-frontend/src/views/settings/FindingsPolicySettings.vue`.
+- Modify: `autobot-backend/llc/models/enums.py` (statuses), `autobot-backend/llc/api/__init__.py` (include findings router), `autobot-frontend/src/views/llc/ProjectBrowserView.vue` (+11 locale files).
+- Enum values reused: `WorkItemType.BUG="bug"`/`TASK="task"`, `WorkItemPriority` CRITICAL/HIGH/MEDIUM/LOW (`llc/models/enums.py`).
+
+---
+
+## Task 1: Model + migration (`LLCFindingProposal`)
+
+**Files:** Create `llc/models/finding_proposal.py`, `llc/models/enums.py` (add `FindingProposalStatus`), migration `20260708_069_llc_finding_proposals.py` (chains onto head `20260708_068` — verify head with `alembic ... get_heads()` before writing). Test `llc/tests/test_finding_proposal_model.py`.
+
+**Interfaces — Produces:** `LLCFindingProposal` (table `llc_finding_proposals`) with columns per the spec's data-model section; `FindingProposalStatus` enum `pending|promoted|dismissed`; unique constraint `uq_finding_proposal_project_key (project_id, finding_key)`.
+
+- [ ] **Step 1 — failing test** `test_finding_proposal_model.py`: assert table has columns `company_id, project_id, source_id, finding_key, finding_type, severity, file_path, line_number, description, suggestion, verdict_is_real, verdict_confidence, verdict_rationale, status, work_item_id, dismiss_reason`; `status` server_default `"pending"`; a unique constraint over `(project_id, finding_key)`; `FindingProposalStatus.PROMOTED.value == "promoted"`.
+- [ ] **Step 2 — run, expect fail.** `cd autobot-backend && python3 -m pytest llc/tests/test_finding_proposal_model.py -v`.
+- [ ] **Step 3 — enum** in `llc/models/enums.py` (mirror existing `str, Enum` classes + `pg_enum_values`): `class FindingProposalStatus(str, Enum): PENDING="pending"; PROMOTED="promoted"; DISMISSED="dismissed"`.
+- [ ] **Step 4 — model** `llc/models/finding_proposal.py` (mirror `LLCProject` column style: `Mapped[...]`, `mapped_column`, `sa.Enum(FindingProposalStatus, name="findingproposalstatus", create_type=True, values_callable=pg_enum_values)`; `project_id` FK `llc_projects.id` ondelete CASCADE, indexed; `finding_key` String(512); `status` indexed server_default `"pending"`; `line_number` Integer nullable; `verdict_confidence` Numeric nullable; `work_item_id` UUID nullable; `UniqueConstraint("project_id","finding_key",name="uq_finding_proposal_project_key")` in `__table_args__`).
+- [ ] **Step 5 — migration** `20260708_069_llc_finding_proposals.py` (revision `20260708_069`, down_revision `20260708_068`): create the enum type + table + indexes + unique constraint; downgrade drops table then enum. Follow the Phase-2 migration `20260708_067` structure for enum create/drop.
+- [ ] **Step 6 — run, expect pass**; also verify single head: `python3 -c "from alembic.config import Config; from alembic.script import ScriptDirectory; c=Config(); c.set_main_option('script_location','migrations'); print(ScriptDirectory.from_config(c).get_heads())"` → `['20260708_069']`.
+- [ ] **Step 7 — commit** `feat(companyos): LLCFindingProposal model + migration (#11271)`.
+
+---
+
+## Task 2: Findings gather service
+
+**Files:** Create `llc/services/findings_gather.py`; test `llc/tests/test_findings_gather.py`.
+
+**Interfaces — Produces:** `async gather_findings(project, min_severity: str, session) -> list[dict]`. **Consumes:** `project.code_source_id`; `api.codebase_analytics.source_storage.get_source`; the analytics problems query. Returns finding dicts `{type, severity, file_path, line_number, description, suggestion}`.
+
+- Implementation: lazy-import inside the function `from api.codebase_analytics.source_storage import get_source`; if `project.code_source_id` falsy → raise `ValueError("project has no linked repo")`. Resolve source; if `source is None` or not ready → `ValueError`. Fetch findings for `source.id` and filter to `severity in _at_or_above(min_severity)` (order high>medium>low). **Verify the exact analytics call**: read `api/codebase_analytics/endpoints/report.py::_fetch_problems_from_chromadb` (line ~1217) + `resolve_source_root` + `api/codebase_analytics/storage.py::get_code_collection_async`; call them at service level (lazy import). If a clean service function doesn't exist, call `_fetch_problems_from_chromadb(collection, None, source_id=source.id, source_root=resolve_source_root(source.id))` exactly as the `/problems` endpoint does. Document the real call in the code comment.
+
+- [ ] **Step 1 — failing test**: patch `llc.services.findings_gather.get_source` (AsyncMock → SimpleNamespace(id, clone_path, status)) and the analytics fetch (patch at its source module) to return 3 findings of mixed severity; assert `min_severity="medium"` drops the `low` one; assert no-`code_source_id` project raises `ValueError`.
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement** per above (helper `_at_or_above(sev)` returns the set of acceptable severities; ≤30-line functions).
+- [ ] **Step 4 — run, expect pass.**
+- [ ] **Step 5 — commit** `feat(companyos): findings gather service (project→source→findings) (#11271)`.
+
+---
+
+## Task 3: FP-verify service (internal SLM, fail-closed)
+
+**Files:** Create `llc/services/findings_verify.py`; test `llc/tests/test_findings_verify.py`.
+
+**Interfaces — Produces:** `@dataclass(frozen=True) Verdict(is_real: bool, confidence: float, rationale: str)`; `async verify_finding(finding: dict, clone_path: str) -> Verdict`. **Consumes:** `services.llm_service.get_llm_service()` → its async `chat(...)` (VERIFY the exact signature/return at `services/llm_service.py:179` — determine how to get a one-shot text completion; the plan's code below names the call but the implementer MUST match the real signature).
+
+- Implementation: read a bounded code window (e.g. ±15 lines) around `finding["line_number"]` from `Path(clone_path)/finding["file_path"]` (utf-8; if file/line missing → still verify with description only). Build a prompt: "You are auditing a static-analysis finding for false positives. FINDING: {type/severity/file/line/description/suggestion}. CODE CONTEXT: {window}. Answer strictly as JSON {\"is_real\": bool, \"confidence\": 0..1, \"rationale\": \"...\"}. Judge is_real=false if the finding does not correspond to a genuine problem in this code." Call `get_llm_service().chat(...)`, extract the text, parse the JSON. **FAIL CLOSED:** any exception, missing file, empty response, or JSON-parse failure → `Verdict(is_real=False, confidence=0.0, rationale="unverifiable: <reason>")`. Wrap the whole body in try/except returning the fail-closed verdict. Log at warning on failure.
+
+- [ ] **Step 1 — failing test**: (a) patch `get_llm_service` to return an object whose `chat` (AsyncMock) yields a valid JSON verdict `{"is_real": true, "confidence": 0.9, "rationale": "..."}` → assert `Verdict.is_real is True`; (b) patch `chat` to raise → assert fail-closed `is_real is False`; (c) patch `chat` to return non-JSON → fail-closed. Use a `tmp_path` clone dir with a small file so the code-window read works.
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement**; split code-window read + prompt-build + parse into ≤30-line helpers. **Verify `chat` signature against `services/llm_service.py:179` and adapt the call + response extraction to the real shape.**
+- [ ] **Step 4 — run, expect pass.**
+- [ ] **Step 5 — commit** `feat(companyos): fail-closed FP-verify via internal SLM engine (#11271)`.
+
+---
+
+## Task 4: Findings-policy SLM reader
+
+**Files:** Create `llc/services/findings_policy.py`; test `llc/tests/test_findings_policy.py`. **Mirror `llc/services/disposal_policy.py` exactly** (same SLM-client read + safe-default pattern).
+
+**Interfaces — Produces:** `@dataclass(frozen=True) FindingsPolicy(enabled=False, min_severity="medium", require_approval_to_promote=False, run_on_index=False, verify_batch_size=10)`; `POLICY_SETTING_KEY="llc.findings_policy"`; `async get_findings_policy() -> FindingsPolicy` (safe defaults on missing/unreadable/malformed — defaults leave the feature OFF).
+
+- [ ] **Step 1 — failing test** (mirror `test_disposal_policy.py`): defaults when no SLM client; parse a full policy dict; defaults on malformed. Assert default `enabled is False`.
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement** (copy `disposal_policy.py` structure; coerce types with `max(0,int(...))`/`bool(...)`/`str(...)`; unknown min_severity → "medium").
+- [ ] **Step 4 — run, expect pass.**
+- [ ] **Step 5 — commit** `feat(companyos): SLM findings-policy reader with safe defaults (#11271)`.
+
+---
+
+## Task 5: Proposal service (scan / promote / dismiss)
+
+**Files:** Create `llc/services/finding_proposal_service.py`; test `llc/tests/test_finding_proposal_service.py`.
+
+**Interfaces — Produces:**
+- `async scan(project, session) -> dict{gathered, verified_real, queued}` — reads policy; if `not policy.enabled` → raise `FindingsDisabledError`. `gather_findings(project, policy.min_severity, session)` → for each finding compute `finding_key=f"{source_id}:{file_path}:{line_number}:{type}"`; skip keys whose existing proposal is `promoted`/`dismissed`; `verify_finding(finding, clone_path)`; only `verdict.is_real` → upsert `LLCFindingProposal` (pending) with the verdict fields. Process in `policy.verify_batch_size` chunks. Returns counts.
+- `async promote(proposal, session, actor_user_id) -> LLCWorkItem | dict` — only from `pending`; read policy; if `require_approval_to_promote` → create `LLCApproval` (type `finding_promotion` — add to `ApprovalType` enum + migration note; reuse Phase-2 `ApprovalService`), keep `pending`, return `{"result":"pending_approval","approval_id":...}`; else `WorkItemService.create(session, company_id=str(project.company_id), type=_type_for(finding_type), title=_title(p), description=_body(p), priority=_priority(p.severity), project_id=str(p.project_id), labels=["analytics-finding", f"severity:{p.severity}"])`, set `status=promoted`, `work_item_id=item.id`; return the item.
+- `async dismiss(proposal, session, reason) -> None` — `pending`→`dismissed` + `dismiss_reason`.
+- Helpers: `_type_for` (BUG for defect-ish types else TASK), `_priority` (high→HIGH, medium→MEDIUM, low→LOW), `_title`/`_body` (body carries `file:line`, suggestion, and the verdict rationale). **Add `ApprovalType.FINDING_PROMOTION="finding_promotion"`** in `enums.py` + an `ALTER TYPE approvaltype ADD VALUE` in Task 1's migration (autocommit_block, mirror Phase-2 `20260708_067`).
+
+- [ ] **Step 1 — failing tests**: scan disabled→raises; scan queues only `is_real` findings and skips a finding_key already promoted (dedup); promote immediate creates a work item (patch `WorkItemService.create`) and sets promoted+work_item_id; promote with approval-required returns pending_approval (patch policy + ApprovalService); dismiss sets reason. Use AsyncMock session + patched gather/verify/policy.
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement** (lazy-import `WorkItemService`/`ApprovalService` to avoid heavy chains; ≤30-line functions; verify `WorkItemService.create` kwargs at `llc/services/work_item_service.py:250`).
+- [ ] **Step 4 — run, expect pass**; then run full `llc/tests/ -q` to confirm no regression.
+- [ ] **Step 5 — commit** `feat(companyos): finding-proposal scan/promote/dismiss service (#11271)`.
+
+---
+
+## Task 6: API endpoints (`llc/api/findings.py`)
+
+**Files:** Create `llc/api/findings.py`; modify `llc/api/__init__.py` to `include_router`; test `llc/tests/test_findings_api.py`.
+
+**Interfaces — Produces routes under `/api/llc`:** `POST /projects/{project_id}/findings/scan` (403 if `not policy.enabled`; 409 if no `code_source_id`; returns scan counts); `GET /projects/{project_id}/findings/proposals?status=pending`; `POST /findings/proposals/{proposal_id}/promote`; `POST /findings/proposals/{proposal_id}/dismiss` (`{reason}`). All load-and-IDOR-guard (mirror `_load_owned_project` in `sprints.py`; add `_load_owned_proposal`). Import `get_findings_policy`, `scan`, `promote`, `dismiss` at module level so tests can patch `llc.api.findings.*`. Response models: `FindingProposalResponse` (all proposal fields incl. verdict).
+
+- [ ] **Step 1 — failing tests** (mirror `test_project_lifecycle_api.py` harness with FastAPI TestClient + dependency overrides): scan returns 403 when policy disabled; 409 when project has no `code_source_id`; scan success returns counts (patch `llc.api.findings.scan`); list returns proposals; promote calls the service; dismiss requires a reason; IDOR 404 when `company_id != org_id`.
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement** the router + `_load_owned_project`/`_load_owned_proposal`; register in `llc/api/__init__.py`. Confirm the mount serves `/api/llc/projects/{id}/findings/scan` (no double `/api`).
+- [ ] **Step 4 — run, expect pass**; full `llc/tests/ -q` green.
+- [ ] **Step 5 — commit** `feat(companyos): findings scan/proposals/promote/dismiss endpoints (#11271)`.
+
+---
+
+## Task 7: SLM findings-policy panel
+
+**Files:** Create `autobot-slm-frontend/src/views/settings/FindingsPolicySettings.vue`; route + settings-nav entry; test `.../FindingsPolicySettings.test.ts`. **Mirror `DisposalPolicySettings.vue`** (GET/PUT/POST setting key `llc.findings_policy` as JSON; `authStore.getApiUrl()`/`getAuthHeaders()`; `data-test="save-policy"`).
+
+- Fields: enabled (toggle), min_severity (select high/medium/low), require_approval_to_promote (toggle), run_on_index (toggle), verify_batch_size (number).
+- [ ] **Step 1 — failing vitest** (mirror the disposal test): loads policy on mount; PUTs JSON on save to `/api/settings/llc.findings_policy`.
+- [ ] **Step 2 — run, expect fail:** `cd autobot-slm-frontend && npx vitest run src/views/settings/FindingsPolicySettings.test.ts`.
+- [ ] **Step 3 — implement** component + route (`/settings/findings-policy`) + nav tab (mirror how DisposalPolicy is registered).
+- [ ] **Step 4 — run test + `npm run build:slm`** (must succeed).
+- [ ] **Step 5 — commit** `feat(slm): findings policy settings panel (#11271)`.
+
+---
+
+## Task 8: Company OS Findings tab + i18n
+
+**Files:** Modify `autobot-frontend/src/views/llc/ProjectBrowserView.vue` (or the project detail view — follow where Phase-2 lifecycle actions live); add i18n keys to ALL 11 locale files under `autobot-frontend/src/i18n/locales/`; test `.../__tests__/ProjectBrowserView.findings.test.ts`.
+
+- UI: a "Scan for findings" action (`POST /api/llc/projects/{id}/findings/scan`) and a proposal list — each row shows severity badge, `file:line`, description, the **verdict + rationale**, and **Promote** (`POST /findings/proposals/{id}/promote`) / **Dismiss** (prompt for reason → `POST …/dismiss`). Refresh after each action. Use the existing `ApiClient` (parsed JSON, no `.data`). All strings via i18n keys under the view's existing `llcBrowser` namespace (`llcBrowser.findings.*`), added to every one of the 11 locales.
+- [ ] **Step 1 — i18n keys** (English first, then mirror to the other 10): `llcBrowser.findings.{scan, scanning, promote, dismiss, dismissReason, empty, verdictReal, verdictRationale, disabled, severity}`.
+- [ ] **Step 2 — failing vitest** (mirror `ProjectBrowserView.lifecycle.test.ts`): a proposal renders with verdict; Scan click calls POST `.../findings/scan`; Promote calls POST `.../promote`; Dismiss (with reason) calls POST `.../dismiss`.
+- [ ] **Step 3 — run, expect fail.**
+- [ ] **Step 4 — implement** UI + i18n (confirm all 11 locale files edited).
+- [ ] **Step 5 — verify:** `npx vitest run …findings.test.ts`; `npx vue-tsc --noEmit -p tsconfig.app.json`; `npx eslint <changed .vue> --max-warnings 0`.
+- [ ] **Step 6 — commit** `feat(companyos): project findings proposal queue UI + i18n (#11271)`.
+
+---
+
+## Self-Review Checklist (before final review)
+
+1. **Spec coverage:** gather (T2), fail-closed FP-verify (T3), proposal queue+dedup (T1/T5), promote→work item + approval-gate (T5), dismiss (T5), SLM policy+panel (T4/T7), Findings UI (T8), flag-off 403 (T6). ✔ each.
+2. **FP-verify fails closed** — T3 tests cover engine error + parse failure → not queued.
+3. **Type consistency:** `FindingProposalStatus` values identical across model/service/API; `FindingsPolicy` fields identical across T4/T6/T7; `finding_key` format identical in T5 (write) and any dedup read.
+4. **Migration head:** `20260708_069` chains onto `20260708_068`; single head; enum ADD VALUE for `finding_promotion` in autocommit_block.
+5. **Constraints:** no commit trailers; copyright headers; ≤30-line funcs; i18n 11 locales; flag default OFF; no double `/api` prefix; black/isort clean.
+6. **verify-generated-types:** new endpoints → api.ts regen via CI autofix bot (close/reopen to re-trigger).

--- a/docs/superpowers/specs/2026-07-08-companyos-findings-to-workitems-design.md
+++ b/docs/superpowers/specs/2026-07-08-companyos-findings-to-workitems-design.md
@@ -1,0 +1,176 @@
+# Company OS Phase 3 — analytics findings → project work items (proposal-only, FP-verified) — design
+
+**Date:** 2026-07-08
+**Umbrella:** #11129 (Phase 3) · Issue: #11271
+**Status:** design — decisions captured; ready for writing-plans
+
+## Goal
+
+Turn codebase-analytics **findings** for a Company OS project's linked repo into **actionable
+project work items** that agents pick up — but **only after** each finding is inspected for
+false positives and a human/agent promotes it. Nothing auto-creates work items. This closes the
+loop the user described: "the codebase analytics should show repos of projects" (Phase 1) → "this
+would allow agent when working on code act on problems" (Phase 3).
+
+## Pipeline
+
+```
+analytics findings (per source_id)
+   → FP-verify (internal SLM inspects each finding vs. the actual code → is_real + rationale)
+   → proposal queue (only is_real findings; LLCFindingProposal, status=pending)
+   → promote (human OR agent) → LLCWorkItem   [optionally LLCApproval-gated]
+   → dismiss (human marks false-positive / won't-fix with reason)
+```
+
+**Proposal-only**: findings never become work items automatically. **FP-verification is a
+first-class stage** — a finding cannot enter the queue until the verifier judges it real, and the
+verdict + rationale are stored so a human sees *why*.
+
+## Key reuse (everything the seams need already exists)
+
+- **Findings** (`api/codebase_analytics/`): per-file dicts `{type, severity, file_path,
+  line_number, description, suggestion, file_category}`, indexed in ChromaDB with `source_id`
+  metadata. Queryable via `endpoints/report.py::_fetch_problems_from_chromadb(source_id,
+  source_root)` (already validates file existence, #2724). Findings have a stable identity
+  `{source_id, file_path, line_number, type}` → dedup key.
+- **Proposal-only pattern** (#11170 `code_analysis/src/remediation_loop.py`): `select_targets`
+  (ranked, capped selection) + `dispatch_proposal` (flag-gated, default OFF, builds work-item
+  payloads without creating them). Phase 3 mirrors this shape.
+- **Project↔source join** (Phase 1): `LLCProject.code_source_id` → `CodeSource.id` →
+  `clone_path` (local checkout to read code for verification) + findings by `source_id`.
+  `llc/api/sprints.py::_project_source_summary` already resolves project→source.
+- **Work-item creation**: `llc/services/work_item_service.py::WorkItemService.create(session,
+  company_id, type, title, *, description, priority, project_id, labels,
+  requires_approval_before, …)` — auto-identifier, returns `LLCWorkItem`. Agent pickup via
+  `checkout()` (Redis-fenced).
+- **Internal SLM engine** (#11215): `chat_workflow/delegation.py` internal engine +
+  `chat_workflow/llm_handler.py` — the verifier calls this (self-hosted; no external cost).
+- **SLM-configurable policy** (Phase 2 pattern): `services.slm_client` + a settings key, read with
+  safe defaults.
+- **Approval** (Phase 2): `llc/services/approval.py` `ApprovalService` + `LLCApproval`.
+
+## Decisions (brainstorm 2026-07-08)
+
+- **FP-verifier model** = the **internal SLM engine** (self-hosted; consistent with governed
+  delegation).
+- **Scan trigger** = **manual on-demand** ("Scan for findings" project action). An
+  `run_on_index` auto-scan is a *config toggle only*, deferred (not built now).
+- **Storage** = a new Postgres table `llc_finding_proposals` (project-scoped, statused,
+  dedup-keyed) — not Redis; proposals are durable, queryable, and human-reviewed.
+- **Safety** = feature flag-gated, default **OFF** (mirrors `REMEDIATION_DISPATCH_ENABLED`).
+  Promotion may require an `LLCApproval` per policy.
+- **Promotion** creates one `LLCWorkItem` per proposal (type `BUG` for defect-type findings else
+  `TASK`), `project_id` set, labels `["analytics-finding", f"severity:{sev}"]`, description
+  carries `file:line` + suggestion + the verifier's rationale.
+
+## Data model — `LLCFindingProposal` (`llc/models/finding_proposal.py`)
+
+```
+id                UUID PK
+company_id        UUID (index)
+project_id        UUID  FK llc_projects(id) ondelete=CASCADE (index)
+source_id         str   (the CodeSource id the finding came from)
+finding_key       str   unique per project = f"{source_id}:{file_path}:{line_number}:{type}"  (dedup)
+finding_type      str
+severity          str   (high|medium|low)
+file_path         str
+line_number       int | null
+description        text
+suggestion        text | null
+verdict_is_real   bool | null      (null until verified)
+verdict_confidence float | null    (0..1)
+verdict_rationale text | null      (why the verifier judged real/FP)
+status            enum finding_proposal_status: pending | promoted | dismissed  (default pending, index)
+work_item_id      UUID | null      (set on promote)
+dismiss_reason    text | null      (set on dismiss)
+created_at / updated_at
+```
+
+- **Unique constraint** `(project_id, finding_key)` — a re-scan updates the existing proposal
+  rather than duplicating; already-promoted/dismissed proposals are not re-queued.
+
+## Services
+
+### `llc/services/findings_gather.py`
+`async gather_findings(project, session) -> list[dict]` — resolve `project.code_source_id` →
+source → call the analytics problems query (service-level, reusing
+`_fetch_problems_from_chromadb`) filtered by `source_id` and the SLM policy's `min_severity`.
+Returns raw finding dicts. No writes.
+
+### `llc/services/findings_verify.py`  ← the novel/risky stage
+`async verify_finding(finding, clone_path) -> Verdict{is_real, confidence, rationale}` — reads the
+code context around `file_path:line_number` from `clone_path`, prompts the **internal SLM engine**
+("Here is a static-analysis finding and the surrounding code. Is this a REAL issue or a false
+positive? Return is_real, confidence 0..1, and a one-paragraph rationale."), parses a structured
+verdict. Best-effort + bounded: on engine error, verdict defaults to `is_real=false` (fail-closed —
+an unverifiable finding does NOT enter the queue) with rationale noting the failure. Concurrency
+capped; large batches processed in bounded chunks.
+
+### `llc/services/finding_proposal_service.py`
+- `async scan(project, session) -> {gathered, verified_real, queued}` — orchestrates gather →
+  verify (each finding) → upsert `LLCFindingProposal` for `is_real` findings (dedup by
+  `finding_key`; skip keys already `promoted`/`dismissed`). Stores the verdict on every proposal.
+- `async promote(proposal, session, actor) -> LLCWorkItem` — only from `pending`; if policy
+  `require_approval_to_promote` → create `LLCApproval` (type `finding_promotion`) and set
+  status accordingly; else create the work item via `WorkItemService.create` and set
+  `status=promoted`, `work_item_id`.
+- `async dismiss(proposal, session, reason)` — `pending` → `dismissed` + `dismiss_reason`.
+
+## API (`llc/api/sprints.py` or a new `llc/api/findings.py` under the same `/api/llc` mount)
+
+- `POST /api/llc/projects/{id}/findings/scan` → runs `scan` (flag-gated; 409 if no
+  `code_source_id`; 403 if feature flag OFF). Returns counts.
+- `GET  /api/llc/projects/{id}/findings/proposals?status=pending` → list proposals (with verdict).
+- `POST /api/llc/findings/proposals/{pid}/promote` → promote → work item (or approval-pending).
+- `POST /api/llc/findings/proposals/{pid}/dismiss` `{reason}` → dismiss.
+- All IDOR-guarded (`company_id == ctx.org_id`).
+
+## SLM-configurable findings policy
+
+Key `llc.findings_policy` (read via `services.slm_client`, safe defaults):
+`{ enabled: bool = false, min_severity: "medium", require_approval_to_promote: bool = false,
+   run_on_index: bool = false, verify_batch_size: int = 10 }`. SLM-frontend panel mirrors the
+Phase 2 `DisposalPolicySettings.vue`.
+
+## Frontend (Company OS — `autobot-frontend`)
+
+- Project detail: a **"Findings"** tab → "Scan for findings" button (calls `scan`) + the proposal
+  queue: each row shows severity badge, `file:line`, description, the **verifier verdict +
+  rationale**, and **Promote** / **Dismiss** actions (Dismiss prompts for a reason). Promoted rows
+  link to the created work item. i18n across all 11 locales; no hardcoded strings.
+- Reuse problem-formatting from `report.py::_format_problem_entry` semantics where practical.
+
+## Governance / safety
+
+- Feature flag default OFF; `scan` and `promote` are no-ops/403 when disabled.
+- FP-verify **fails closed** (unverifiable → not queued).
+- Promotion optionally `LLCApproval`-gated.
+- Dedup by `finding_key`; promoted/dismissed proposals are never silently re-queued.
+- Verifier is the internal SLM engine (no external data egress; consistent with
+  [[autobot_telemetry_local_only]]).
+
+## Error handling
+
+- No `code_source_id` → `scan` 409. Source not `READY`/missing clone_path → 409 (can't read code
+  to verify). Analytics query failure → surfaced, no partial queue. Verifier engine down → each
+  finding fails closed with rationale; `scan` still returns counts. SLM policy unreadable → safe
+  defaults (feature effectively OFF).
+
+## Testing
+
+- Gather: project→source→findings join; min_severity filter; no source → error.
+- Verify: real→queued; FP→not queued; engine error→fail-closed (not queued) with rationale; code
+  context read from clone_path.
+- Proposal service: upsert dedup by finding_key; skip promoted/dismissed on re-scan; promote
+  creates work item with correct fields + links; approval-gated path; dismiss sets reason.
+- API: scan 409 (no source) / 403 (flag OFF); list; promote; dismiss; IDOR guards.
+- Policy: read + safe defaults; frontend panel round-trip.
+- Frontend: scan action, queue render incl. verdict/rationale, promote/dismiss flows, i18n 11
+  locales.
+
+## Scope
+
+**In:** the full pipeline above (manual scan trigger, internal-SLM FP-verify, Postgres proposal
+queue, promote/dismiss, SLM policy + panel, Findings UI). **Out (deferred toggles/roadmap):**
+auto-scan `run_on_index` wiring (config field ships, wiring later); cross-project findings
+dashboards; auto-promotion without human/agent action; editing findings.


### PR DESCRIPTION
## Thinking Path
Phase 3 of Company OS #11129 (P1 repo linkage #11146, P2 archive→dispose #11270). Closes the loop the user described — "analytics should show repos of projects … so the agent can act on problems" — but safely: codebase-analytics findings become project work items **only** after a fail-closed false-positive check and an explicit human/agent promotion. Built via subagent-driven development (8 TDD tasks + per-task reviews + final Opus whole-branch review: MERGE).

Pipeline: **findings → FP-verify (internal SLM, fail-closed) → proposal queue → promote (→ work item) / dismiss**.

## What Changed
**Backend**
- `LLCFindingProposal` model + migration `20260708_069` (`findingproposalstatus` enum, `ApprovalType.FINDING_PROMOTION`, unique `(project_id, finding_key)`).
- `findings_gather.py` — project→`code_source_id`→analytics findings (reuses `_fetch_problems_from_chromadb` with `source_root` file-existence filter), `min_severity` filter.
- `findings_verify.py` — **fail-closed** FP verifier: reads the code window, calls the internal SLM engine (`get_llm_service().chat`), parses strict JSON; ANY failure (engine error, `.error`, empty, non-JSON, non-bool `is_real`, out-of-range confidence, missing file) → `is_real=False` → never queued. Never raises, no external egress.
- `findings_policy.py` — SLM `llc.findings_policy`, safe defaults, **feature flag default OFF**.
- `finding_proposal_service.py` — `scan` (gather→verify→upsert **only** `is_real`; dedup by `finding_key`; never regress terminal proposals), `promote` (→ `WorkItemService.create` or `LLCApproval`), `dismiss`.
- `llc/api/findings.py` — scan (403 flag-off / 409 no-or-not-ready source) / list / promote / dismiss; IDOR guards on every route; `ProposalStateError`→409.

**Frontend**
- SLM `FindingsPolicySettings.vue` operator panel.
- Company OS `ProjectBrowserView.vue` findings proposal queue — Scan action, rows showing severity + `file:line` + description + **the verifier verdict + rationale**, Promote/Dismiss; i18n across **all 11 locales**.

## Verification
- Backend: full LLC suite **1121 passed, 1 skipped, 0 failed**; new tests for model, gather, fail-closed verify (9, incl. non-bool/`.error`/empty/non-JSON/missing-file), policy (4), proposal service (8, incl. dedup + no-regress), API (13, incl. 403/409/IDOR/ProposalStateError→409).
- Review loop fixed real issues in-scope: the `bool("false")` fail-closed hole, proposal status-regression, `source_root` filtering, `ProposalStateError`→409, and the source-race 500→409 (final review).
- SLM frontend: `vitest` 2/2, `npm run build:slm` SUCCESS. Company OS: `vitest` 5/5, `vue-tsc` 0, `eslint --max-warnings 0` 0; i18n verified in all 11 locales.
- Final Opus whole-branch review: **MERGE** (fail-closed guarantee, promotion integrity, IDOR, migration single-head, no-egress all verified).

Deferred Minor polish tracked in #11320.

## Model Used
Claude Opus 4.8 (orchestration + final review); Sonnet 4.6 (task implementers + per-task reviewers).

Closes #11271