### PR TITLE
fix(browser): point automation view at real status/sessions endpoints (#11324)

### DIFF
--- a/autobot-frontend/src/composables/useBrowserAutomation.ts
+++ b/autobot-frontend/src/composables/useBrowserAutomation.ts
@@ -14,8 +14,14 @@ import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
 import { usePollingJob } from '@/composables/usePollingJob'
 import { useLoadingState } from '@/composables/useLoadingState'
+import type { components } from '@/types/generated/api'
 
 const logger = createLogger('useBrowserAutomation')
+
+// Backend response shapes (source of truth: generated api.ts)
+type BrowserMcpStatusResponse = components['schemas']['BrowserMcpStatusResponse']
+type BrowserSessionListData = components['schemas']['BrowserSessionListData']
+type DataResponseBrowserSessionList = components['schemas']['DataResponse_BrowserSessionListData_']
 
 // ===== Type Definitions =====
 
@@ -69,6 +75,62 @@ export interface UseBrowserAutomationOptions {
   pollInterval?: number
 }
 
+// ===== Response Mapping Helpers =====
+
+/**
+ * Map the Browser MCP bridge status (`/api/browser/mcp/status`) onto the
+ * dashboard's BrowserWorkerStatus shape. The MCP bridge only reports Browser
+ * VM connectivity, so resource metrics (cpu/memory/uptime) and session caps
+ * that the bridge does not expose degrade to safe defaults rather than being
+ * fabricated. active_sessions is populated separately from fetchSessions().
+ */
+function mapMcpStatusToWorkerStatus(data: BrowserMcpStatusResponse): BrowserWorkerStatus {
+  const vmStatus = String((data.browser_vm as Record<string, unknown>)?.status ?? '')
+  let status: BrowserWorkerStatus['status'] = 'offline'
+  if (vmStatus === 'healthy') {
+    status = 'online'
+  } else if (vmStatus === 'degraded') {
+    status = 'degraded'
+  }
+
+  return {
+    status,
+    active_sessions: 0, // populated by fetchSessions() (MCP status has no count)
+    max_sessions: 0, // not reported by the MCP bridge
+    cpu_usage: 0, // not reported by the MCP bridge
+    memory_usage: 0, // not reported by the MCP bridge
+    uptime_seconds: 0, // not reported by the MCP bridge
+  }
+}
+
+/**
+ * Map a single research-browser session record onto BrowserSession.
+ * The backend session dict (research_browser.py list_sessions) exposes
+ * session_id/current_url/status/created_at/last_activity; page title and
+ * viewport are not tracked server-side and degrade to safe defaults.
+ */
+function mapSessionRecord(record: Record<string, unknown>): BrowserSession {
+  const rawStatus = String(record.status ?? '')
+  let status: BrowserSession['status'] = 'idle'
+  if (rawStatus === 'error' || rawStatus === 'failed') {
+    status = 'error'
+  } else if (rawStatus === 'active' || rawStatus === 'running' || rawStatus === 'navigating') {
+    status = 'active'
+  }
+
+  const createdAt = typeof record.created_at === 'string' ? record.created_at : ''
+
+  return {
+    id: String(record.session_id ?? ''),
+    url: typeof record.current_url === 'string' ? record.current_url : '',
+    title: '', // not tracked server-side
+    status,
+    created_at: createdAt,
+    last_activity: typeof record.last_activity === 'string' ? record.last_activity : createdAt,
+    viewport: { width: 0, height: 0 }, // not tracked server-side
+  }
+}
+
 // ===== Composable Implementation =====
 
 export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) {
@@ -86,9 +148,12 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
 
   async function fetchWorkerStatus(): Promise<void> {
     try {
-      const data = await ApiClient.get<BrowserWorkerStatus>(`${getApiBase()}/browser/status`)
-      workerStatus.value = data
-      logger.debug('Fetched worker status:', data)
+      const data = await ApiClient.get<BrowserMcpStatusResponse>(`${getApiBase()}/browser/mcp/status`)
+      const mapped = mapMcpStatusToWorkerStatus(data)
+      // Preserve the active_sessions count already derived from fetchSessions().
+      mapped.active_sessions = sessions.value.length
+      workerStatus.value = mapped
+      logger.debug('Fetched worker status:', mapped)
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch worker status'
       logger.error('Failed to fetch worker status:', err)
@@ -132,8 +197,19 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
 
   async function fetchSessions(): Promise<void> {
     try {
-      const data = await ApiClient.get<{ sessions: BrowserSession[] }>(`${getApiBase()}/browser/sessions`)
-      sessions.value = data.sessions || []
+      // research-browser is a distinct router prefix from /browser (MCP bridge).
+      // ApiClient.get returns parsed JSON directly; DataResponse wraps the
+      // payload under `data`.
+      const response = await ApiClient.get<DataResponseBrowserSessionList>(
+        `${getApiBase()}/research-browser/sessions`,
+      )
+      const listData: BrowserSessionListData | null | undefined = response?.data
+      const records = listData?.sessions ?? []
+      sessions.value = records.map(mapSessionRecord)
+      // Keep the worker-status session count in sync when it is present.
+      if (workerStatus.value) {
+        workerStatus.value.active_sessions = sessions.value.length
+      }
       logger.debug('Fetched sessions:', sessions.value.length)
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch sessions'


### PR DESCRIPTION
## Thinking Path
The Browser Automation view (`/automation/browser-automation`) 404'd because `useBrowserAutomation.ts` targeted `/api/browser/status` and `/api/browser/sessions`, neither of which is registered. Confirmed against the generated `api.ts` (source of truth):
- The `browser_mcp` router is mounted at `/api/browser` and exposes only `/mcp/*` — the real status route is `/api/browser/mcp/status` → `BrowserMcpStatusResponse`.
- Sessions live under a different prefix: `/api/research-browser/sessions` → `DataResponse[BrowserSessionListData]` (payload under `data`).

I read the backend handlers (`api/browser_mcp.py` `get_browser_mcp_status`, `api/research_browser.py` `list_sessions`) to learn the exact runtime field values, and the view (`BrowserAutomationView.vue`) to confirm which fields the UI actually reads, so the mapping neither breaks the view nor fabricates data.

## What Changed
`autobot-frontend/src/composables/useBrowserAutomation.ts`:

**Status** — `fetchWorkerStatus` now GETs `/api/browser/mcp/status` and maps `BrowserMcpStatusResponse` → `BrowserWorkerStatus` via `mapMcpStatusToWorkerStatus`:
- `browser_vm.status` `healthy` → `online`, `degraded` → `degraded`, `unavailable`/other → `offline`
- `active_sessions` ← derived from the sessions list (MCP status carries no count)
- `max_sessions`, `cpu_usage`, `memory_usage`, `uptime_seconds` ← **not exposed by the MCP bridge**, degrade to `0` (no fabrication; see note below)

**Sessions** — `fetchSessions` now GETs `/api/research-browser/sessions`, unwraps the `DataResponse` envelope (`response.data.sessions`), and maps each record → `BrowserSession` via `mapSessionRecord`:
- `id` ← `session_id`, `url` ← `current_url`, `created_at`/`last_activity` ← backend
- `status`: backend status string mapped to `active` | `idle` | `error`
- `title` ← `''` and `viewport` ← `{width:0,height:0}` — **not tracked server-side**, degrade to safe defaults

Both calls use `getApiBase()` (`/api`) with the correct path segment (`/browser/mcp/status` vs `/research-browser/sessions`).

### Graceful-degradation note
`BrowserWorkerStatus` fields with no backend source (`max_sessions`, `cpu_usage`, `memory_usage`, `uptime_seconds`, and session `title`/`viewport`) default to `0`/empty rather than being invented. The view already renders `active`/`max` sessions and status; `max` will show `0` until a backend field exists. No new user-facing strings were added, so no i18n changes were needed.

## Verification
- `npx vue-tsc --noEmit -p tsconfig.app.json` → exit 0 (no errors)
- `npx eslint src/composables/useBrowserAutomation.ts --max-warnings 0` → exit 0 (clean)

## Model Used
Opus 4.8 (1M context)

Closes #11324