### PR TITLE
fix(deploy): deploy constraints dir + enforce venv Python before pip (#11322 #11323)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -834,7 +834,14 @@ async def _ensure_venv_python(component: str, steps: List[str]) -> None:
     Mirrors the ensure_venv_version Ansible role: runs `<venv>/bin/python --version`,
     compares against _COMPONENT_PYTHON_TARGET, and if mismatched removes the venv
     so the subsequent `pythonX.Y -m venv` call rebuilds it on the right interpreter.
+
+    Safety: verifies the target interpreter is present on PATH (shutil.which) BEFORE
+    removing anything. If absent, the existing venv is left intact and a skip step is
+    recorded — the service stays running; operators must provision the interpreter
+    first (Ansible python314 role). (#11327 review)
     """
+    import shutil
+
     target = _COMPONENT_PYTHON_TARGET.get(component)
     paths = _COMPONENT_PIP_PATHS.get(component)
     if target is None or paths is None:
@@ -842,6 +849,13 @@ async def _ensure_venv_python(component: str, steps: List[str]) -> None:
     _, pip_bin = paths
     venv_python = str(Path(pip_bin).parent / "python")
     if not Path(venv_python).exists():
+        if not shutil.which(target):
+            logger.warning("drift resolve: %s not on PATH — skipping venv create for %s", target, component)
+            steps.append(
+                f"venv: {venv_python} missing and {target} not installed"
+                " — skipping recreation; provision the interpreter first (Ansible python314 role)"
+            )
+            return
         steps.append(f"venv: {venv_python} missing — will create with {target}")
         await _recreate_venv(component, target, pip_bin, steps)
         return
@@ -856,10 +870,23 @@ async def _ensure_venv_python(component: str, steps: List[str]) -> None:
         version_out = stdout.decode(errors="replace").strip() if stdout else ""
         expected_fragment = target.replace("python", "")  # "3.14" or "3.11"
         if expected_fragment not in version_out:
+            if not shutil.which(target):
+                logger.warning(
+                    "drift resolve: venv mismatch for %s (have %s, need %s) "
+                    "but %s not on PATH — leaving existing venv intact",
+                    component,
+                    version_out,
+                    expected_fragment,
+                    target,
+                )
+                steps.append(
+                    f"venv: mismatch (have '{version_out}', need {expected_fragment})"
+                    f" but {target} not installed — skipping recreation;"
+                    " provision the interpreter first (Ansible python314 role)"
+                )
+                return
             steps.append(f"venv: mismatch (have '{version_out}', need {expected_fragment}) — recreating")
             venv_dir = str(Path(pip_bin).parents[1])
-            import shutil
-
             shutil.rmtree(venv_dir, ignore_errors=True)
             await _recreate_venv(component, target, pip_bin, steps)
         else:

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -497,7 +497,18 @@ async def resolve_drift(
         )
 
     # --- Post-sync: install deps / rebuild / restart so synced code goes live (#9982) ---
-    deps_changed, post_steps = await _run_post_sync_steps(request.component, source_dir, deployed_dir)
+    deps_changed, post_steps, pip_ok = await _run_post_sync_steps(request.component, source_dir, deployed_dir)
+
+    if not pip_ok:
+        return DriftResolveResponse(
+            success=False,
+            component=request.component,
+            message="Resynced from code_source but pip install failed — see post_steps",
+            source_dir=source_dir,
+            deployed_dir=deployed_dir,
+            deps_changed=deps_changed,
+            post_steps=post_steps,
+        )
 
     return DriftResolveResponse(
         success=True,
@@ -732,6 +743,22 @@ _COMPONENT_PIP_PATHS: Dict[str, Tuple[str, str]] = {
     ),
 }
 
+# Target CPython interpreter per backend component (#11323).
+# NPU worker uses py3.11 (OpenVINO ABI); every other Python service uses py3.14.
+# This is the single authoritative mapping — do not hardcode elsewhere.
+_COMPONENT_PYTHON_TARGET: Dict[str, str] = {
+    "autobot-backend": "python3.14",
+    "autobot-slm-backend": "python3.14",
+    "autobot-npu-worker": "python3.11",
+}
+
+# Deployed path for the top-level constraints/ dir (#11322).
+# `autobot-backend/requirements.txt` uses `-c ../constraints/shared.txt` so the
+# relative path resolves to /opt/autobot/constraints/ at runtime.  Code-sync
+# only rsyncs component subdirs, so the constraints dir must be deployed
+# explicitly before pip runs.
+_CONSTRAINTS_SOURCE_SUBDIR: str = "constraints"
+
 # Maps component name → deployed frontend directory for npm rebuild.
 _COMPONENT_FRONTEND_DIRS: Dict[str, str] = {
     "autobot-frontend": "/opt/autobot/autobot-frontend",
@@ -767,19 +794,122 @@ _COMPONENT_SERVICES: Dict[str, List[str]] = {
 }
 
 
-async def _install_pip_deps_for_component(component: str, steps: List[str]) -> None:
+async def _deploy_constraints_dir(source_root: str, steps: List[str]) -> None:
+    """Rsync top-level constraints/ to /opt/autobot/constraints/ before pip (#11322).
+
+    autobot-backend/requirements.txt uses `-c ../constraints/shared.txt` so the
+    relative reference resolves to /opt/autobot/constraints/shared.txt at deploy
+    time. Code-sync only rsyncs component subdirs, so this helper deploys the
+    constraints dir explicitly — preventing the silent pip failure that occurred
+    when the file was absent.
+    """
+    src = f"{source_root}/{_CONSTRAINTS_SOURCE_SUBDIR}/"
+    dst = f"/opt/autobot/{_CONSTRAINTS_SOURCE_SUBDIR}/"
+    if not Path(src).exists():
+        steps.append(f"constraints: source {src} not found — skipped")
+        return
+    steps.append(f"constraints: deploying {src} -> {dst}")
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "rsync",
+            "-avz",
+            "--delete",
+            src,
+            dst,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        _, _ = await asyncio.wait_for(proc.communicate(), timeout=30.0)
+        if proc.returncode == 0:
+            steps.append("constraints: deployed ok")
+        else:
+            steps.append(f"constraints: rsync failed (rc={proc.returncode})")
+    except Exception as exc:
+        steps.append(f"constraints: deploy error: {exc}")
+
+
+async def _ensure_venv_python(component: str, steps: List[str]) -> None:
+    """Recreate the venv if its Python version doesn't match the target (#11323).
+
+    Mirrors the ensure_venv_version Ansible role: runs `<venv>/bin/python --version`,
+    compares against _COMPONENT_PYTHON_TARGET, and if mismatched removes the venv
+    so the subsequent `pythonX.Y -m venv` call rebuilds it on the right interpreter.
+    """
+    target = _COMPONENT_PYTHON_TARGET.get(component)
+    paths = _COMPONENT_PIP_PATHS.get(component)
+    if target is None or paths is None:
+        return
+    _, pip_bin = paths
+    venv_python = str(Path(pip_bin).parent / "python")
+    if not Path(venv_python).exists():
+        steps.append(f"venv: {venv_python} missing — will create with {target}")
+        await _recreate_venv(component, target, pip_bin, steps)
+        return
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            venv_python,
+            "--version",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10.0)
+        version_out = stdout.decode(errors="replace").strip() if stdout else ""
+        expected_fragment = target.replace("python", "")  # "3.14" or "3.11"
+        if expected_fragment not in version_out:
+            steps.append(f"venv: mismatch (have '{version_out}', need {expected_fragment}) — recreating")
+            venv_dir = str(Path(pip_bin).parents[1])
+            import shutil
+
+            shutil.rmtree(venv_dir, ignore_errors=True)
+            await _recreate_venv(component, target, pip_bin, steps)
+        else:
+            steps.append(f"venv: python version ok ({version_out})")
+    except Exception as exc:
+        logger.error("drift resolve: venv version check failed for %s: %s", component, exc)
+        steps.append(f"venv: version check error: {exc}")
+
+
+async def _recreate_venv(component: str, python_bin: str, pip_bin: str, steps: List[str]) -> None:
+    """Create a fresh venv using the target python interpreter (#11323)."""
+    venv_dir = str(Path(pip_bin).parents[1])
+    steps.append(f"venv: creating with {python_bin} at {venv_dir}")
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            python_bin,
+            "-m",
+            "venv",
+            venv_dir,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=120.0)
+        if proc.returncode == 0:
+            logger.info("drift resolve: recreated venv for %s with %s", component, python_bin)
+            steps.append(f"venv: recreated ok ({python_bin})")
+        else:
+            out = stdout.decode(errors="replace")[:200] if stdout else ""
+            logger.error("drift resolve: venv create failed (%d) for %s: %s", proc.returncode, component, out)
+            steps.append(f"venv: create failed (rc={proc.returncode}): {out}")
+    except Exception as exc:
+        logger.error("drift resolve: venv create error for %s: %s", component, exc)
+        steps.append(f"venv: create error: {exc}")
+
+
+async def _install_pip_deps_for_component(component: str, steps: List[str]) -> bool:
     """Install Python deps from the component's requirements.txt into its venv (#9982).
 
     Unconditional — pip is fast when nothing changed (same rationale as #1603).
     Appends human-readable step notes to *steps*.
+    Returns True on success, False when pip exits non-zero so callers can surface
+    the failure (previously the non-zero rc was swallowed — #11322).
     """
     paths = _COMPONENT_PIP_PATHS.get(component)
     if paths is None:
-        return
+        return True
     req_path, pip_bin = paths
     if not Path(req_path).exists():
         steps.append(f"pip: no requirements.txt at {req_path} — skipped")
-        return
+        return True
     steps.append(f"pip: installing {req_path} into {Path(pip_bin).parent}")
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -795,16 +925,19 @@ async def _install_pip_deps_for_component(component: str, steps: List[str]) -> N
         if proc.returncode == 0:
             logger.info("drift resolve: pip install ok for %s", component)
             steps.append("pip: install succeeded")
-        else:
-            out = stdout.decode(errors="replace")[:300] if stdout else ""
-            logger.error("drift resolve: pip install failed (%d) for %s: %s", proc.returncode, component, out)
-            steps.append(f"pip: install failed (rc={proc.returncode}): {out[:150]}")
+            return True
+        out = stdout.decode(errors="replace")[:300] if stdout else ""
+        logger.error("drift resolve: pip install failed (%d) for %s: %s", proc.returncode, component, out)
+        steps.append(f"pip: install failed (rc={proc.returncode}): {out[:150]}")
+        return False
     except asyncio.TimeoutError:
         logger.error("drift resolve: pip install timed out for %s", component)
         steps.append("pip: install timed out after 300s")
+        return False
     except Exception as exc:
         logger.error("drift resolve: pip install error for %s: %s", component, exc)
         steps.append(f"pip: install error: {exc}")
+        return False
 
 
 # Components whose deployed tree ships Alembic migrations, keyed to the
@@ -1034,21 +1167,22 @@ async def _run_post_sync_steps(
     component: str,
     source_dir: str,
     deployed_dir: str,
-) -> Tuple[bool, List[str]]:
+) -> Tuple[bool, List[str], bool]:
     """Run dep-install / rebuild / restart after a per-component rsync (#9982).
 
-    Returns (deps_changed, steps_log) where deps_changed mirrors the
-    _compute_deps_changed check (requirements.txt / package-lock.json hash delta)
-    detected BEFORE the rsync overwrote the deployed copy — but here we check
-    post-rsync to reflect what the operator sees after the sync.
+    Returns (deps_changed, steps_log, pip_ok).
+    pip_ok is False when pip exits non-zero so resolve_drift can surface the
+    failure via success=False rather than silently returning success=True (#11322).
 
     Component routing:
-      - Python backend (autobot-backend, autobot-slm-backend): pip install +
-        symlink restore (#10912) + restart
+      - Python backend (autobot-backend, autobot-slm-backend):
+          constraints deploy (#11322) + venv version check (#11323) +
+          pip install + symlink restore (#10912) + alembic + restart
       - Frontend (autobot-frontend, autobot-slm-frontend): npm ci + build + nginx reload
       - autobot_shared: restore BOTH backends' symlinks (#10912) + restart dependents
     """
     steps: List[str] = []
+    pip_ok = True
 
     # Compute deps_changed post-rsync (source == deployed now; any prior delta
     # is gone, so this is always False after a successful rsync — but we check
@@ -1057,7 +1191,12 @@ async def _run_post_sync_steps(
     deps_changed = await _compute_deps_changed(component)
 
     if component in _COMPONENT_PIP_PATHS:
-        await _install_pip_deps_for_component(component, steps)
+        # Deploy constraints dir so `-c ../constraints/shared.txt` resolves (#11322).
+        source_root = str(Path(source_dir).parent)
+        await _deploy_constraints_dir(source_root, steps)
+        # Recreate venv if its Python version doesn't match the target (#11323).
+        await _ensure_venv_python(component, steps)
+        pip_ok = await _install_pip_deps_for_component(component, steps)
         # Apply DB migrations BEFORE restart so the app starts against the
         # correct schema. Code-sync previously skipped Alembic, so a merge that
         # added columns 500'd (e.g. Company OS) until migrations were run by
@@ -1080,7 +1219,7 @@ async def _run_post_sync_steps(
     else:
         steps.append(f"post-sync: no service or build step for {component}")
 
-    return deps_changed, steps
+    return deps_changed, steps, pip_ok
 
 
 async def _build_slm_frontend() -> None:

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -276,7 +276,7 @@ def test_ensure_venv_python_noop_when_version_matches(tmp_path) -> None:
 
 
 def test_ensure_venv_python_recreates_on_version_mismatch(tmp_path) -> None:
-    """When the venv reports the wrong version, _recreate_venv is called."""
+    """When the venv reports the wrong version AND target is installed, _recreate_venv is called."""
     pip_bin = tmp_path / "venv" / "bin" / "pip"
     pip_bin.parent.mkdir(parents=True)
     py_bin = pip_bin.parent / "python"
@@ -302,15 +302,17 @@ def test_ensure_venv_python_recreates_on_version_mismatch(tmp_path) -> None:
         with (
             patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
             patch("api.code_sync._recreate_venv", side_effect=_fake_recreate),
+            # simulate host where python3.14 IS installed
+            patch("shutil.which", return_value="/usr/bin/python3.14"),
         ):
             _run(_ensure_venv_python("autobot-backend", steps))
 
-    assert recreated, "venv must be recreated on mismatch"
+    assert recreated, "venv must be recreated on mismatch when target is installed"
     assert any("mismatch" in s for s in steps)
 
 
 def test_ensure_venv_python_creates_when_missing(tmp_path) -> None:
-    """When <venv>/bin/python is absent, _recreate_venv is called."""
+    """When <venv>/bin/python is absent but target is installed, _recreate_venv is called."""
     pip_bin = tmp_path / "venv" / "bin" / "pip"
     # Do NOT create py_bin — simulates missing venv
 
@@ -324,10 +326,14 @@ def test_ensure_venv_python_creates_when_missing(tmp_path) -> None:
         async def _fake_recreate(*args, **kw):
             recreated.append(True)
 
-        with patch("api.code_sync._recreate_venv", side_effect=_fake_recreate):
+        with (
+            patch("api.code_sync._recreate_venv", side_effect=_fake_recreate),
+            # target interpreter is present on PATH
+            patch("shutil.which", return_value="/usr/bin/python3.14"),
+        ):
             _run(_ensure_venv_python("autobot-backend", steps))
 
-    assert recreated, "venv must be created when python binary is missing"
+    assert recreated, "venv must be created when python binary is missing and target is installed"
 
 
 def test_ensure_venv_python_skipped_for_unknown_component() -> None:
@@ -335,3 +341,74 @@ def test_ensure_venv_python_skipped_for_unknown_component() -> None:
     steps: list[str] = []
     _run(_ensure_venv_python("autobot-frontend", steps))
     assert steps == []
+
+
+# ---------------------------------------------------------------------------
+# #11327 safety guard — target interpreter absent: never destroy existing venv
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_venv_python_skips_recreation_when_target_not_installed_mismatch(tmp_path) -> None:
+    """Venv with wrong Python version is NOT removed when target interpreter is absent.
+
+    Scenario: venv reports Python 3.12 but target is python3.14 and python3.14 is
+    not installed on this host.  The existing venv must survive intact so the
+    service can keep running.  A skip step is recorded instead.
+    """
+    pip_bin = tmp_path / "venv" / "bin" / "pip"
+    pip_bin.parent.mkdir(parents=True)
+    py_bin = pip_bin.parent / "python"
+    py_bin.touch()
+    venv_dir = tmp_path / "venv"
+
+    with patch(
+        "api.code_sync._COMPONENT_PIP_PATHS",
+        {"autobot-backend": (str(tmp_path / "requirements.txt"), str(pip_bin))},
+    ):
+
+        async def _fake_exec(*cmd, **kw):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(b"Python 3.12.13", b""))
+            return proc
+
+        steps: list[str] = []
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+            # target interpreter is NOT on PATH
+            patch("shutil.which", return_value=None),
+        ):
+            _run(_ensure_venv_python("autobot-backend", steps))
+
+    # venv dir must still exist — rmtree must NOT have been called
+    assert venv_dir.exists(), "existing venv must not be removed when target interpreter is absent"
+    assert any("not installed" in s or "skipping" in s.lower() for s in steps), f"expected a skip step, got: {steps}"
+
+
+def test_ensure_venv_python_skips_creation_when_target_not_installed_missing(tmp_path) -> None:
+    """When <venv>/bin/python is absent AND the target interpreter is absent, skip gracefully.
+
+    Neither rmtree nor _recreate_venv should be called — a skip step is recorded.
+    """
+    pip_bin = tmp_path / "venv" / "bin" / "pip"
+    # Do NOT create py_bin — simulates missing venv
+
+    with patch(
+        "api.code_sync._COMPONENT_PIP_PATHS",
+        {"autobot-backend": (str(tmp_path / "requirements.txt"), str(pip_bin))},
+    ):
+        steps: list[str] = []
+        recreated: list[bool] = []
+
+        async def _fake_recreate(*args, **kw):
+            recreated.append(True)
+
+        with (
+            patch("api.code_sync._recreate_venv", side_effect=_fake_recreate),
+            # target interpreter is NOT on PATH
+            patch("shutil.which", return_value=None),
+        ):
+            _run(_ensure_venv_python("autobot-backend", steps))
+
+    assert not recreated, "must not attempt to recreate venv when target interpreter is absent"
+    assert any("not installed" in s or "skipping" in s.lower() for s in steps), f"expected a skip step, got: {steps}"

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -1,0 +1,337 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for drift/resolve deploy bugs fixed in #11322 and #11323.
+
+#11322 — constraints dir not deployed before pip:
+  _deploy_constraints_dir rsyncs constraints/ to /opt/autobot/constraints/ before pip
+  runs, so the relative `-c ../constraints/shared.txt` in requirements.txt resolves.
+  pip non-zero rc is surfaced as success=False in DriftResolveResponse.
+
+#11323 — code-sync didn't enforce target Python version in venvs:
+  _ensure_venv_python checks <venv>/bin/python --version and recreates the venv
+  via `pythonX.Y -m venv` when there is a version mismatch.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Dev-host stub: provide minimal real Pydantic models for models.schemas so
+# the router can be imported without a full SLM venv.
+# ---------------------------------------------------------------------------
+if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMock):
+    from pydantic import BaseModel as _BM
+
+    def _pydantic_stub(name: str, **fields) -> type:
+        return type(name, (_BM,), {"__annotations__": {k: type(v) for k, v in fields.items()}, **fields})
+
+    _schemas = types.ModuleType("models.schemas")
+    for _cls in [
+        "CodeSyncStatusResponse",
+        "CodeSyncRefreshResponse",
+        "CodeVersionNotification",
+        "CodeVersionNotificationResponse",
+        "DriftResolveRequest",
+        "DriftResolveResponse",
+        "FileDriftReport",
+        "FleetSyncJobStatus",
+        "FleetSyncNodeStatus",
+        "FleetSyncRequest",
+        "FleetSyncResponse",
+        "MarkSyncedResponse",
+        "NodeSyncRequest",
+        "NodeSyncResponse",
+        "PendingNodeResponse",
+        "PendingNodesResponse",
+        "ScheduleCreate",
+        "ScheduleResponse",
+        "ScheduleRunResponse",
+        "ScheduleUpdate",
+    ]:
+        setattr(_schemas, _cls, _pydantic_stub(_cls))
+    _models = sys.modules.get("models") or types.ModuleType("models")
+    _models.schemas = _schemas  # type: ignore[attr-defined]
+    sys.modules["models"] = _models
+    sys.modules["models.schemas"] = _schemas
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+import asyncio  # noqa: E402
+
+from api.code_sync import (  # noqa: E402
+    _COMPONENT_PYTHON_TARGET,
+    _CONSTRAINTS_SOURCE_SUBDIR,
+    _deploy_constraints_dir,
+    _ensure_venv_python,
+    _install_pip_deps_for_component,
+    _run_post_sync_steps,
+)
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# #11322 — constants are defined
+# ---------------------------------------------------------------------------
+
+
+def test_constraints_source_subdir_constant() -> None:
+    """_CONSTRAINTS_SOURCE_SUBDIR must be 'constraints'."""
+    assert _CONSTRAINTS_SOURCE_SUBDIR == "constraints"
+
+
+def test_component_python_target_has_backends() -> None:
+    """Both pip-backend components have a python target defined."""
+    assert _COMPONENT_PYTHON_TARGET["autobot-backend"] == "python3.14"
+    assert _COMPONENT_PYTHON_TARGET["autobot-slm-backend"] == "python3.14"
+    assert _COMPONENT_PYTHON_TARGET["autobot-npu-worker"] == "python3.11"
+
+
+# ---------------------------------------------------------------------------
+# #11322 — _deploy_constraints_dir
+# ---------------------------------------------------------------------------
+
+
+def test_deploy_constraints_dir_skipped_when_source_missing(tmp_path) -> None:
+    """Step says 'not found' when the source dir doesn't exist."""
+    steps: list[str] = []
+    _run(_deploy_constraints_dir(str(tmp_path / "no_such_root"), steps))
+    assert any("not found" in s for s in steps)
+
+
+def test_deploy_constraints_dir_calls_rsync(tmp_path) -> None:
+    """rsync is called when the source dir exists."""
+    src_root = tmp_path / "code_source"
+    (src_root / "constraints").mkdir(parents=True)
+
+    steps: list[str] = []
+    captured: list = []
+
+    async def _fake_exec(*cmd, **kw):
+        captured.extend(cmd)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        _run(_deploy_constraints_dir(str(src_root), steps))
+
+    assert "rsync" in captured
+    assert any("deployed ok" in s for s in steps)
+
+
+def test_deploy_constraints_dir_records_rsync_failure(tmp_path) -> None:
+    """Non-zero rsync rc is recorded in steps."""
+    src_root = tmp_path / "code_source"
+    (src_root / "constraints").mkdir(parents=True)
+
+    steps: list[str] = []
+
+    async def _fake_exec(*cmd, **kw):
+        proc = MagicMock()
+        proc.returncode = 23
+        proc.communicate = AsyncMock(return_value=(b"error", b""))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        _run(_deploy_constraints_dir(str(src_root), steps))
+
+    assert any("failed" in s for s in steps)
+
+
+# ---------------------------------------------------------------------------
+# #11322 — _install_pip_deps_for_component returns bool
+# ---------------------------------------------------------------------------
+
+
+def test_pip_returns_true_on_success(tmp_path) -> None:
+    req = tmp_path / "requirements.txt"
+    req.write_text("-r nothing\n", encoding="utf-8")
+    pip_bin = str(tmp_path / "venv" / "bin" / "pip")
+
+    with patch(
+        "api.code_sync._COMPONENT_PIP_PATHS",
+        {"test-comp": (str(req), pip_bin)},
+    ):
+
+        async def _fake_exec(*cmd, **kw):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+            result = _run(_install_pip_deps_for_component("test-comp", []))
+
+    assert result is True
+
+
+def test_pip_returns_false_on_failure(tmp_path) -> None:
+    req = tmp_path / "requirements.txt"
+    req.write_text("-r nothing\n", encoding="utf-8")
+    pip_bin = str(tmp_path / "venv" / "bin" / "pip")
+
+    with patch(
+        "api.code_sync._COMPONENT_PIP_PATHS",
+        {"test-comp": (str(req), pip_bin)},
+    ):
+
+        async def _fake_exec(*cmd, **kw):
+            proc = MagicMock()
+            proc.returncode = 1
+            proc.communicate = AsyncMock(return_value=(b"Could not open constraint file", b""))
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+            steps: list[str] = []
+            result = _run(_install_pip_deps_for_component("test-comp", steps))
+
+    assert result is False
+    assert any("failed" in s for s in steps)
+
+
+# ---------------------------------------------------------------------------
+# #11322 — _run_post_sync_steps surfaces pip failure via pip_ok=False
+# ---------------------------------------------------------------------------
+
+
+def test_run_post_sync_steps_pip_ok_false_on_pip_failure() -> None:
+    """When pip returns False, _run_post_sync_steps returns pip_ok=False."""
+    with (
+        patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
+        patch("api.code_sync._ensure_venv_python", AsyncMock()),
+        patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=False)),
+        patch("api.code_sync._run_alembic_migrations", AsyncMock()),
+        patch("api.code_sync._ensure_autobot_shared_symlink", AsyncMock()),
+        patch("api.code_sync._restart_component_services", AsyncMock()),
+    ):
+        _, _, pip_ok = _run(
+            _run_post_sync_steps("autobot-backend", "/src/autobot-backend", "/opt/autobot/autobot-backend")
+        )
+    assert pip_ok is False
+
+
+def test_run_post_sync_steps_pip_ok_true_on_success() -> None:
+    """When pip returns True, _run_post_sync_steps returns pip_ok=True."""
+    with (
+        patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
+        patch("api.code_sync._ensure_venv_python", AsyncMock()),
+        patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)),
+        patch("api.code_sync._run_alembic_migrations", AsyncMock()),
+        patch("api.code_sync._ensure_autobot_shared_symlink", AsyncMock()),
+        patch("api.code_sync._restart_component_services", AsyncMock()),
+    ):
+        _, _, pip_ok = _run(
+            _run_post_sync_steps("autobot-backend", "/src/autobot-backend", "/opt/autobot/autobot-backend")
+        )
+    assert pip_ok is True
+
+
+# ---------------------------------------------------------------------------
+# #11323 — _ensure_venv_python: version match → no-op
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_venv_python_noop_when_version_matches(tmp_path) -> None:
+    """When the venv reports the expected version, no recreate happens."""
+    pip_bin = tmp_path / "venv" / "bin" / "pip"
+    pip_bin.parent.mkdir(parents=True)
+    py_bin = pip_bin.parent / "python"
+    py_bin.write_text("#!/bin/sh\necho Python 3.14.0\n", encoding="utf-8")
+    py_bin.chmod(0o755)
+
+    with patch(
+        "api.code_sync._COMPONENT_PIP_PATHS",
+        {"autobot-backend": (str(tmp_path / "requirements.txt"), str(pip_bin))},
+    ):
+
+        async def _fake_exec(*cmd, **kw):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(b"Python 3.14.0", b""))
+            return proc
+
+        steps: list[str] = []
+        recreated: list[bool] = []
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+            patch("api.code_sync._recreate_venv", AsyncMock(side_effect=lambda *a, **k: recreated.append(True))),
+        ):
+            _run(_ensure_venv_python("autobot-backend", steps))
+
+    assert not recreated, "venv should not be recreated when version matches"
+    assert any("ok" in s for s in steps)
+
+
+def test_ensure_venv_python_recreates_on_version_mismatch(tmp_path) -> None:
+    """When the venv reports the wrong version, _recreate_venv is called."""
+    pip_bin = tmp_path / "venv" / "bin" / "pip"
+    pip_bin.parent.mkdir(parents=True)
+    py_bin = pip_bin.parent / "python"
+    py_bin.touch()
+
+    with patch(
+        "api.code_sync._COMPONENT_PIP_PATHS",
+        {"autobot-backend": (str(tmp_path / "requirements.txt"), str(pip_bin))},
+    ):
+
+        async def _fake_exec(*cmd, **kw):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(b"Python 3.12.13", b""))
+            return proc
+
+        steps: list[str] = []
+        recreated: list[bool] = []
+
+        async def _fake_recreate(*args, **kw):
+            recreated.append(True)
+
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+            patch("api.code_sync._recreate_venv", side_effect=_fake_recreate),
+        ):
+            _run(_ensure_venv_python("autobot-backend", steps))
+
+    assert recreated, "venv must be recreated on mismatch"
+    assert any("mismatch" in s for s in steps)
+
+
+def test_ensure_venv_python_creates_when_missing(tmp_path) -> None:
+    """When <venv>/bin/python is absent, _recreate_venv is called."""
+    pip_bin = tmp_path / "venv" / "bin" / "pip"
+    # Do NOT create py_bin — simulates missing venv
+
+    with patch(
+        "api.code_sync._COMPONENT_PIP_PATHS",
+        {"autobot-backend": (str(tmp_path / "requirements.txt"), str(pip_bin))},
+    ):
+        steps: list[str] = []
+        recreated: list[bool] = []
+
+        async def _fake_recreate(*args, **kw):
+            recreated.append(True)
+
+        with patch("api.code_sync._recreate_venv", side_effect=_fake_recreate):
+            _run(_ensure_venv_python("autobot-backend", steps))
+
+    assert recreated, "venv must be created when python binary is missing"
+
+
+def test_ensure_venv_python_skipped_for_unknown_component() -> None:
+    """Helper is a no-op for components not in _COMPONENT_PYTHON_TARGET."""
+    steps: list[str] = []
+    _run(_ensure_venv_python("autobot-frontend", steps))
+    assert steps == []

--- a/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
@@ -264,10 +264,14 @@ def test_pip_backend_emits_symlink_step(tmp_path) -> None:
             patch("api.code_sync._get_deploy_base", return_value=tmp_path),
             patch("api.code_sync._ensure_autobot_shared_symlink", side_effect=_fake_ensure),
             patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
-            patch("api.code_sync._install_pip_deps_for_component", AsyncMock()),
+            # _install_pip_deps_for_component now returns bool (#11322)
+            patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)),
+            patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
+            patch("api.code_sync._ensure_venv_python", AsyncMock()),
+            patch("api.code_sync._run_alembic_migrations", AsyncMock()),
             patch("api.code_sync._restart_component_services", AsyncMock()),
         ):
-            _, steps = _run(_run_post_sync_steps(component, f"/src/{component}", f"/opt/autobot/{component}"))
+            _, steps, _ = _run(_run_post_sync_steps(component, f"/src/{component}", f"/opt/autobot/{component}"))
             steps_collected.extend(steps)
 
         assert any(


### PR DESCRIPTION
## Thinking Path

Two silent failures on every `drift/resolve` pip step for `autobot-backend`:

1. **constraints not deployed** — `requirements.txt` line 2 is `-c ../constraints/shared.txt`. pip resolves that relative to its CWD (`/opt/autobot/autobot-backend/`), producing `/opt/autobot/constraints/shared.txt`. Code-sync only rsyncs component subdirs, so that path never exists. pip exits rc=1 with "Could not open constraint file", but `resolve_drift` always returned `success: true` — swallowed completely.

2. **stale venv interpreter** — fleet nodes were left on Python 3.12.13 venvs after the 3.14 migration because `_install_pip_deps_for_component` installs into whatever venv exists without checking its Python version. The Ansible `ensure_venv_version.yml` role already has the right guard (run `<venv>/bin/python --version`, compare, remove+recreate on mismatch) — this PR replicates that guard in the code-sync path.

## What Changed

**`autobot-slm-backend/api/code_sync.py`**

New module-level constants:
- `_COMPONENT_PYTHON_TARGET` — single authoritative mapping of component → target interpreter (`autobot-backend`/`autobot-slm-backend` → `python3.14`; `autobot-npu-worker` → `python3.11`)
- `_CONSTRAINTS_SOURCE_SUBDIR` — `"constraints"`, documents the top-level dir that must be deployed

New helper functions (all ≤30 lines each):
- `_deploy_constraints_dir(source_root, steps)` — rsyncs `<code_source>/constraints/` to `/opt/autobot/constraints/` before pip runs; skips gracefully if source absent
- `_ensure_venv_python(component, steps)` — checks `<venv>/bin/python --version` against `_COMPONENT_PYTHON_TARGET`; calls `_recreate_venv` on mismatch or if python binary is missing
- `_recreate_venv(component, python_bin, pip_bin, steps)` — runs `pythonX.Y -m venv <venv_dir>`; appends step note

Changed signatures:
- `_install_pip_deps_for_component` → now returns `bool` (True=success, False=pip non-zero); previously `-> None`, silently swallowed all pip failures (#11322)
- `_run_post_sync_steps` → returns `(deps_changed, steps, pip_ok)` 3-tuple; previously 2-tuple
- `resolve_drift` → unpacks `pip_ok`; returns `success=False` with a clear message when pip fails

**`autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py`**

- `test_pip_backend_emits_symlink_step`: updated to 3-tuple unpack; added mocks for `_deploy_constraints_dir`, `_ensure_venv_python`, `_run_alembic_migrations` (alembic now reached for `autobot-backend` in this path)
- `_install_pip_deps_for_component` mock changed to `AsyncMock(return_value=True)` to match new bool return

**`autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py`** (new, 13 tests)

Covers: constants present, `_deploy_constraints_dir` skip/success/failure, `_install_pip_deps_for_component` true/false return, `_run_post_sync_steps` pip_ok propagation, `_ensure_venv_python` match/mismatch/missing/unknown-component paths.

## Verification

```
$ python3 -m pytest tests/api/test_code_sync_symlink_restore.py \
    tests/api/test_code_sync_protected_excludes.py \
    tests/api/test_code_sync_deploy_bugs.py -v

28 passed in 1.92s

$ black --check autobot-slm-backend/api/code_sync.py \
    autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py \
    autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
3 files would be left unchanged.

$ ruff check (changed files only)
→ 0 new errors (pre-existing E402 at line 2696 and noqa-warning at line 1436
  present on base branch, not touched by this PR)
```

## Model Used

claude-sonnet-4-6