### PR TITLE
fix(frontend): recover from Vite dynamic-import chunk failures after deploy (#11325)

### DIFF
--- a/autobot-frontend/src/components/async/AsyncErrorFallback.vue
+++ b/autobot-frontend/src/components/async/AsyncErrorFallback.vue
@@ -66,6 +66,7 @@ import { ref, computed, inject } from 'vue'
 import { useRouter } from 'vue-router'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { createLogger } from '@/utils/debugUtils'
+import { isChunkLoadError, isCssChunkLoadError } from '@/utils/chunkLoadError'
 import Icon from '@/components/ui/Icon.vue'
 import type rumAgent from '@/utils/RumAgent'
 
@@ -102,12 +103,14 @@ const errorMessage = computed(() => {
 
   if (!error) return 'An unknown error occurred while loading the component.'
 
-  if (error.message?.includes('Loading chunk') || error.message?.includes('ChunkLoadError')) {
-    return 'This page failed to load due to a network issue or application update. Please try refreshing the page.'
+  // CSS chunk is a more specific case, so it must be checked before the
+  // general chunk predicate (which also matches CSS chunk failures).
+  if (isCssChunkLoadError(error)) {
+    return 'The page styles failed to load. Your browser may be using an outdated version.'
   }
 
-  if (error.message?.includes('Loading CSS chunk')) {
-    return 'The page styles failed to load. Your browser may be using an outdated version.'
+  if (isChunkLoadError(error)) {
+    return 'This page failed to load due to a network issue or application update. Please try refreshing the page.'
   }
 
   if (error.message?.includes('Failed to fetch')) {

--- a/autobot-frontend/src/main.ts
+++ b/autobot-frontend/src/main.ts
@@ -6,6 +6,7 @@ import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 import App from './App.vue'
 import router from './router/index'
 import { createLogger } from '@/utils/debugUtils'
+import { isChunkLoadError } from '@/utils/chunkLoadError'
 
 const logger = createLogger('main');
 
@@ -111,9 +112,7 @@ app.config.errorHandler = (err, _instance, info) => {
 
   // Check if this is a chunk loading error
   const error = err as Error
-  if (error?.message?.includes('Loading chunk') ||
-      error?.message?.includes('ChunkLoadError') ||
-      error?.message?.includes('Loading CSS chunk')) {
+  if (isChunkLoadError(error)) {
     logger.warn('Chunk loading error detected, initiating cache clear...')
 
     // Import and use cache management

--- a/autobot-frontend/src/plugins/errorHandler.ts
+++ b/autobot-frontend/src/plugins/errorHandler.ts
@@ -8,6 +8,7 @@
 import type { App } from 'vue'
 import rumAgent from '../utils/RumAgent'
 import { createLogger } from '@/utils/debugUtils'
+import { isChunkLoadError } from '@/utils/chunkLoadError'
 
 // Create scoped logger for errorHandler
 const logger = createLogger('errorHandler')
@@ -226,14 +227,16 @@ class GlobalErrorHandler {
   private getUnhandledRejectionMessage(reason: unknown): string {
     const message = (reason as { message?: unknown })?.message
     if (typeof message === 'string') {
+      // Check chunk failures first: a stale-deploy dynamic-import error also
+      // contains "Failed to fetch", so this must precede that generic branch.
+      if (isChunkLoadError(message)) {
+        return 'Application update detected. Please reload the page.'
+      }
       if (message.includes('Failed to fetch')) {
         return 'Connection failed. Please check your internet connection and try again.'
       }
       if (message.includes('NetworkError')) {
         return 'Network error occurred. Please try again.'
-      }
-      if (message.includes('ChunkLoadError')) {
-        return 'Application update detected. Please reload the page.'
       }
     }
 
@@ -242,7 +245,7 @@ class GlobalErrorHandler {
 
   private getJavaScriptErrorMessage(error: Error, _filename?: string, _lineno?: number): string {
     if (error?.message) {
-      if (error.message.includes('ChunkLoadError')) {
+      if (isChunkLoadError(error)) {
         return 'Application files failed to load. Please reload the page.'
       }
       if (error.message.includes('ResizeObserver loop limit exceeded')) {

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -27,6 +27,7 @@ import { createRouter, createWebHistory, type RouteLocationNormalized, type Rout
 import { useAppStore } from '@/stores/useAppStore'
 import { useUserStore } from '@/stores/useUserStore'
 import { setupAsyncComponentErrorHandler } from '@/utils/asyncComponentHelpers'
+import { isChunkLoadError } from '@/utils/chunkLoadError'
 import { createLogger } from '@/utils/debugUtils'
 import { getBackendUrl, getSLMAdminUrl } from '@/config/ssot-config'
 import { llcCompanyParamGuard } from './llcGuards'
@@ -1245,9 +1246,7 @@ router.onError((error) => {
   logger.error('Navigation error:', error)
 
   // Handle chunk loading failures with enhanced error recovery
-  if (error.message.includes('Loading chunk') ||
-      error.message.includes('Loading CSS chunk') ||
-      error.message.includes('ChunkLoadError')) {
+  if (isChunkLoadError(error)) {
 
     logger.warn('Chunk loading failed, attempting recovery...', {
       error: error.message,

--- a/autobot-frontend/src/utils/asyncComponentHelpers.ts
+++ b/autobot-frontend/src/utils/asyncComponentHelpers.ts
@@ -6,6 +6,7 @@ import AsyncErrorFallback from '@/components/async/AsyncErrorFallback.vue'
 // Issue #156 Fix: Import RumAgent to get complete Window.rum type
 import '../utils/RumAgent'
 import { createLogger } from '@/utils/debugUtils'
+import { isChunkLoadError } from '@/utils/chunkLoadError'
 
 // Create scoped logger for asyncComponentHelpers
 const logger = createLogger('AsyncComponent')
@@ -136,9 +137,7 @@ export function defineRobustAsyncComponent(
       const errorMessage = (error as Error | undefined)?.message || String(error)
 
       // Check if this is a chunk loading error
-      const isChunkError = errorMessage.includes('Loading chunk') ||
-                           errorMessage.includes('ChunkLoadError') ||
-                           errorMessage.includes('Loading CSS chunk')
+      const isChunkError = isChunkLoadError(errorMessage)
 
       if (isChunkError) {
         logger.warn(`Chunk loading error detected for ${name}, using cache management...`)
@@ -243,9 +242,7 @@ export function createLazyComponent(
         return (module as { default?: Component }).default || (module as Component)
       } catch (error) {
         // Handle specific chunk loading errors
-        if ((error as Error)?.message?.includes('Loading chunk') ||
-            (error as Error)?.message?.includes('ChunkLoadError') ||
-            (error as Error)?.message?.includes('Loading CSS chunk')) {
+        if (isChunkLoadError(error)) {
 
           logger.warn(`Chunk loading failed for ${componentName}, attempting cache bust...`)
 
@@ -361,9 +358,7 @@ export function setupAsyncComponentErrorHandler() {
   window.addEventListener('unhandledrejection', async (event) => {
     const error = event.reason
 
-    if (error?.message?.includes('Loading chunk') ||
-        error?.message?.includes('ChunkLoadError') ||
-        error?.message?.includes('Loading CSS chunk')) {
+    if (isChunkLoadError(error)) {
 
       logger.warn('Detected chunk loading failure:', error)
 

--- a/autobot-frontend/src/utils/cacheManagement.ts
+++ b/autobot-frontend/src/utils/cacheManagement.ts
@@ -6,6 +6,7 @@
  */
 
 import { createLogger } from '@/utils/debugUtils'
+import { isChunkLoadError } from '@/utils/chunkLoadError'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { escapeHtml } from '@/utils/sanitize'
 import { getApiBase } from '@/config/ssot-config'
@@ -106,10 +107,9 @@ export async function handleChunkLoadingError(error: Error, componentName?: stri
     stack: error.stack
   })
 
-  // Check if this is a chunk loading error
-  const isChunkError = error.message?.includes('Loading chunk') ||
-                       error.message?.includes('ChunkLoadError') ||
-                       error.message?.includes('Loading CSS chunk') ||
+  // Check if this is a chunk loading error (a bare "Failed to fetch" is also
+  // treated as one here, since it usually means a chunk request was blocked).
+  const isChunkError = isChunkLoadError(error) ||
                        error.message?.includes('Failed to fetch')
 
   if (isChunkError) {
@@ -556,9 +556,7 @@ export function setupGlobalChunkErrorHandlers() {
   window.addEventListener('unhandledrejection', async (event) => {
     const error = event.reason
 
-    if (error?.message?.includes('Loading chunk') ||
-        error?.message?.includes('ChunkLoadError') ||
-        error?.message?.includes('Loading CSS chunk')) {
+    if (isChunkLoadError(error)) {
 
       logger.warn('Global chunk loading failure detected:', error)
 

--- a/autobot-frontend/src/utils/chunkLoadError.ts
+++ b/autobot-frontend/src/utils/chunkLoadError.ts
@@ -1,0 +1,39 @@
+/**
+ * Detect code-split chunk load failures.
+ *
+ * When a redeploy replaces hashed chunk filenames, a client still holding a
+ * stale index.html requests the old names and the import fails. Browsers and
+ * Vite report this in several ways — older bundlers say "Loading chunk" /
+ * "ChunkLoadError", while Vite 5+ emits "Failed to fetch dynamically imported
+ * module" (or "error loading dynamically imported module"). Recovery logic must
+ * match all of them, or the auto-reload never fires and the user is stuck on a
+ * failed navigation until a manual hard reload.
+ */
+
+function errorMessageOf(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as { message?: unknown }).message
+    if (typeof message === 'string') return message
+  }
+  return ''
+}
+
+/** True for any code-split chunk load failure (JS or CSS), across bundler versions. */
+export function isChunkLoadError(error: unknown): boolean {
+  const message = errorMessageOf(error)
+  if (!message) return false
+  return (
+    message.includes('Loading chunk') ||
+    message.includes('Loading CSS chunk') ||
+    message.includes('ChunkLoadError') ||
+    message.includes('Failed to fetch dynamically imported module') ||
+    message.includes('error loading dynamically imported module')
+  )
+}
+
+/** True specifically for a CSS chunk load failure (subset of isChunkLoadError). */
+export function isCssChunkLoadError(error: unknown): boolean {
+  return errorMessageOf(error).includes('Loading CSS chunk')
+}


### PR DESCRIPTION
## Thinking Path
RUM logged `ROUTER_NAVIGATION_ERROR: Failed to fetch dynamically imported module: .../CompanyDashboard-CtcKLtXE.js` — a stale-index-after-deploy chunk failure. The app already has chunk-error recovery (one-shot reload, cache bust), but every match site only checked `'Loading chunk'` / `'Loading CSS chunk'` / `'ChunkLoadError'` — none matched the Vite 5+/browser phrasing `Failed to fetch dynamically imported module`. So recovery never fired for the message that actually occurs, and the user stayed on a broken navigation until a manual hard reload.

## What Changed
- New `src/utils/chunkLoadError.ts`: shared `isChunkLoadError()` (matches all bundler phrasings incl. `Failed to fetch dynamically imported module` and `error loading dynamically imported module`) and `isCssChunkLoadError()`.
- Replaced the duplicated inline checks with the predicate at all recovery + message sites:
  - `router/index.ts` (`router.onError` reload recovery)
  - `main.ts` (global Vue error handler)
  - `utils/asyncComponentHelpers.ts` (3 sites)
  - `utils/cacheManagement.ts` (2 sites; kept the extra bare `Failed to fetch` clause)
  - `plugins/errorHandler.ts` + `components/async/AsyncErrorFallback.vue` (message pickers) — now check chunk failures **before** the generic `Failed to fetch` branch, and CSS-specific before general, so a stale-deploy import shows the "application update, reload" message rather than a generic connection error.
- Existing reload-count guard (max 2) preserved — no reload loops.
- No new user-facing strings, so no i18n changes.

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0; no new errors in changed files (only pre-existing baseline noise in unrelated transcriber/voice/secrets views).
- Lint: no local node_modules in worktree (WSL npm-install blocked); relying on the required `code-quality` CI check. Edits are mechanical (condition → predicate + imports) and follow existing patterns.

## Model Used
Opus 4.8

Closes #11325