### PR TITLE
test(conftest): real-load services.tool_output_filter so _strip_ansi tests pass (#11248)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -191,6 +191,26 @@ for _svc_mod in [
         _svc_stub.pytest_plugins = []  # type: ignore[attr-defined]
         sys.modules[_svc_mod] = _svc_stub
 
+# #11248: tool_output_filter is lightweight (stdlib + yaml + autobot_shared; Redis
+# is only touched lazily inside methods, not at import), so its unit tests exercise
+# the *real* pure helper (_strip_ansi). Load it real — overwriting the package stub
+# above — so those tests don't get a MagicMock. Other tests that patch this module
+# still work (patch targets a real module just as well).
+import importlib.util as _svc_ilu  # noqa: E402
+
+for _real_svc, _real_rel in [
+    ("services.tool_output_filter", "services/tool_output_filter.py"),
+]:
+    _rspec = _svc_ilu.spec_from_file_location(_real_svc, str(backend_root / _real_rel))
+    if _rspec and _rspec.loader:
+        _rmod = _svc_ilu.module_from_spec(_rspec)
+        sys.modules[_real_svc] = _rmod
+        try:
+            _rspec.loader.exec_module(_rmod)
+        except Exception:
+            # Fall back to the stub if the real module can't load in this env.
+            sys.modules[_real_svc] = _make_pkg_stub(_real_svc)
+
 # npu_pipeline — stub the package and its sub-modules so that the __init__.py
 # import chain (which pulls in Redis/config) doesn't break test collection.
 # pytest_plugins must be explicitly set to [] so that pytest doesn't call


### PR DESCRIPTION
Part of #11248 (and the #11153 conftest reconciliation)

## Thinking Path
One of #11248's "conftest-stub artifacts" was `test_tool_output_filter::test_strip_ansi_*` — it got a `MagicMock` because `conftest.py` stubs the whole `services` package (its `__init__` pulls the heavy npu_client/Redis stack). Same root cause as #10917. `services.tool_output_filter` is lightweight (stdlib + yaml + autobot_shared; Redis only touched lazily inside methods), so it can be real-loaded.

## What Changed
`autobot-backend/conftest.py`: after the `services` package stubs, real-load `services.tool_output_filter` (overwriting the stub) so its unit tests exercise the real `_strip_ansi` helper. Falls back to the stub if it can't load. Tests that `patch("services.tool_output_filter.…")` still work.

## Verification
- `tests/services/test_tool_output_filter.py`: **82 passed** (was failing `_strip_ansi` → MagicMock).
- Blast-radius (baseline vs patched, `security/`+`judges/`): identical (3 pre-existing collection errors both) — zero new failures.
- `py_compile` + `black --check -l120` clean.

## Scope / follow-up
Fixes the `tool_output_filter` (`_strip_ansi`) artifact. The sibling `llm_api_key_service` (`_parse_key_id_from_bearer`) artifact is deliberately NOT included: real-loading that module cuts its failures 88→14 but the remaining `model_allowed`/budget/auth tests show a `LLMApiKeyRecord`-appears-mock behavior I haven't fully root-caused — not shipping until understood (tracked on #11248). `concurrent_limiter` still needs py3.14.

## Model Used
Opus 4.8 (1M context)
