### PR TITLE
fix(tests): real-load llm_api_key_service in conftest + honor injected redis DI

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -532,6 +532,7 @@ try:
 except Exception:
     pass
 
+
 # orchestration.causal_error_recovery / causal_error_analyzer stubs (#7431).
 # orchestration/__init__.py imports CausalErrorRecovery from causal_error_recovery,
 # which cascades through agent_loop → tools → code_intelligence — a chain of
@@ -819,3 +820,29 @@ def set_test_environment():
 
     os.environ.clear()
     os.environ.update(original_env)
+
+
+def pytest_configure(config):  # noqa: ANN001
+    """#11248: real-load lightweight service modules whose unit tests need the real
+    helpers, AFTER every module-level stub above is in place.
+
+    ``services.llm_api_key_service`` imports ``autobot_shared.redis_client`` /
+    ``logging_manager`` / ``singleton_factory`` at module top — all stubbed/patched
+    during conftest import — so it can only be real-loaded once conftest import has
+    fully completed. pytest_configure runs after that and before collection, so the
+    real module (LLMApiKeyRecord, model_allowed, _parse_key_id_from_bearer, …) is in
+    place when tests/services/test_llm_api_key_service.py is imported. Overwrites the
+    services-package MagicMock stub; falls back to the stub if it can't load here.
+    """
+    import importlib.util as _cfg_ilu
+
+    _spec = _cfg_ilu.spec_from_file_location(
+        "services.llm_api_key_service", str(backend_root / "services" / "llm_api_key_service.py")
+    )
+    if _spec and _spec.loader:
+        _mod = _cfg_ilu.module_from_spec(_spec)
+        sys.modules["services.llm_api_key_service"] = _mod
+        try:
+            _spec.loader.exec_module(_mod)
+        except Exception:
+            sys.modules["services.llm_api_key_service"] = _make_pkg_stub("services.llm_api_key_service")

--- a/autobot-backend/services/llm_api_key_service.py
+++ b/autobot-backend/services/llm_api_key_service.py
@@ -111,7 +111,11 @@ class LLMApiKeyService:
     """Manages virtual LLM API keys backed by Redis MAIN database."""
 
     async def _r(self):
-        redis = await get_async_redis_client(database="main")
+        # Honor an injected handle (self._redis) when present; production uses the
+        # lazy-singleton accessor and never sets it, so it resolves via the factory.
+        redis = getattr(self, "_redis", None)
+        if redis is None:
+            redis = await get_async_redis_client(database="main")
         if redis is None:
             raise RuntimeError("Redis MAIN unavailable")
         return redis

--- a/autobot-backend/tests/services/test_llm_api_key_service.py
+++ b/autobot-backend/tests/services/test_llm_api_key_service.py
@@ -103,19 +103,15 @@ def test_model_allowed_prefix():
 @pytest.mark.asyncio
 async def test_issue_key():
     mock_redis = AsyncMock()
-    mock_pipe = AsyncMock()
-    mock_redis.pipeline.return_value.__aenter__ = AsyncMock(return_value=mock_pipe)
-    mock_redis.pipeline.return_value.__aexit__ = AsyncMock(return_value=False)
-    mock_pipe.execute = AsyncMock(return_value=[True, True, True])
 
     svc = LLMApiKeyService.__new__(LLMApiKeyService)
     svc._redis = mock_redis
 
-    # pipeline() is used as a context manager in issue_key — but actually it's
-    # called synchronously; use the non-context-manager approach
-    mock_pipe2 = MagicMock()
-    mock_pipe2.execute = AsyncMock(return_value=[1, 1, 1])
-    mock_redis.pipeline.return_value = mock_pipe2
+    # issue_key uses redis.pipeline() synchronously (redis-py returns a Pipeline
+    # even for async clients); only pipe.execute() is awaited.
+    mock_pipe = MagicMock()
+    mock_pipe.execute = AsyncMock(return_value=[1, 1, 1])
+    mock_redis.pipeline = MagicMock(return_value=mock_pipe)
 
     record, raw_key = await svc.issue_key(team_id="t1", label="test", monthly_budget_usd=5.0, allowed_models=["gpt-4"])
     assert raw_key.startswith("sk-")


### PR DESCRIPTION
Closes #11331 (sub-task of #11248 / #11153 conftest-reconciliation).

## Thinking Path
`tests/services/test_llm_api_key_service.py` ran against the `services.*` MagicMock package stub the conftest installs so tests can collect in a minimal dev venv — so `LLMApiKeyRecord`, `_parse_key_id_from_bearer`, `model_allowed` and the budget/auth helpers were all mocks (8 failed / 10 passed scoped). Real-loading the module then surfaced two bugs the stub had masked: the service ignored the injected redis handle the tests rely on, and one test mocked `pipeline()` as async when redis-py's is synchronous.

## What Changed
- **`autobot-backend/conftest.py`** — added a `pytest_configure` hook that real-loads `services.llm_api_key_service` **after** every module-level stub is in place (the module imports `autobot_shared.redis_client`/`logging_manager`/`singleton_factory` at top, so it can only load once conftest import completes). Falls back to the stub if it can't load in-env. Same "real-load a light module after its required stubs" pattern as the merged #11314 (provider_registry) and #11329 (tool_output_filter) carve-outs.
- **`autobot-backend/services/llm_api_key_service.py`** — `_r()` now honors an injected `self._redis` when present, else resolves via the factory. Production uses the `lazy_singleton` accessor and never sets `_redis`, so prod behavior is unchanged; the 10 tests that set `svc._redis = mock_redis` now work as intended.
- **`autobot-backend/tests/services/test_llm_api_key_service.py`** — fixed `test_issue_key`: `pipeline()` is synchronous in redis-py (only `execute()` is awaited); replaced the async-mock + dead context-manager scaffolding with a sync `MagicMock` pipeline whose `execute()` is an `AsyncMock`.

## Verification
- `tests/services/test_llm_api_key_service.py`: **8 failed / 10 passed → 18 passed** (post-rebase re-run: 18 passed).
- Blast radius (dev venv, py3.12): full-suite `--collect-only` identical to HEAD baseline — **13291 collected, 294 dep-missing errors** both before and after. `services/` dir has the same 2 pre-existing errors on HEAD and patched (`test_concurrent_limiter` py3.14-blocked, `test_workflow_notification_persistence`). Zero regressions.
- `black --check -l120` clean on all 3 files.

## Model Used
Claude Opus 4.8