### PR TITLE
fix(tests): un-stub agent_loop submodules + real-load loop for in-package tests

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -624,9 +624,34 @@ sys.modules["orchestration.causal_error_analyzer"] = _cea_stub
 
 _al_stub = sys.modules.get("agent_loop") or _make_pkg_stub("agent_loop")
 _al_stub.AgentLoop = MagicMock()  # type: ignore[attr-defined]
+# Give the injected stub a REAL __path__ so the package's light submodules
+# (types, belief_state, pre_action_verifier, slack_hook, …) resolve on-demand from
+# disk for the in-package agent_loop/ tests (#11153) — WITHOUT running agent_loop/
+# __init__.py, which pulls the heavy agent_loop.loop → tools → code_intelligence
+# cascade. The heavy submodules stay explicitly stubbed just below, so importing
+# them still hits the stub (sys.modules wins over the on-disk file).
+_al_stub.__path__ = [str(backend_root / "agent_loop")]  # type: ignore[attr-defined]
 sys.modules["agent_loop"] = _al_stub
-sys.modules.setdefault("agent_loop.loop", _make_pkg_stub("agent_loop.loop"))
-sys.modules.setdefault("agent_loop.think_tool", _make_pkg_stub("agent_loop.think_tool"))
+
+
+def _try_real_load_agent_loop_heavy():
+    """#11153: agent_loop.loop / think_tool real-import cleanly on py3.12+ (the
+    py3.10 annotation incompatibility that motivated stubbing them is gone). Attempt
+    a real load so the in-package agent_loop/ tests exercise real code; fall back to
+    a stub if the environment can't satisfy the import (missing dev-venv deps). Loop
+    tolerates the stubbed code_intelligence at import time (verified: full-suite
+    collection drops from 294 to 287 errors, +108 tests collected, no regressions)."""
+    import importlib as _al_il
+
+    for _al_mod in ("agent_loop.loop", "agent_loop.think_tool"):
+        try:
+            sys.modules.pop(_al_mod, None)
+            sys.modules[_al_mod] = _al_il.import_module(_al_mod)
+        except Exception:
+            sys.modules[_al_mod] = _make_pkg_stub(_al_mod)
+
+
+_try_real_load_agent_loop_heavy()
 
 # Package stubs for SQLAlchemy and alembic sub-packages (need __path__ so
 # dotted sub-module imports like ``sqlalchemy.dialects.postgresql`` resolve).


### PR DESCRIPTION
Closes #11153. Fast-follow for residual test bugs: #11333.

## Thinking Path
`autobot-backend/conftest.py` stubs the `agent_loop` package (empty `__path__`) to block the heavy `agent_loop.loop → tools → code_intelligence` cascade that once carried py3.10-incompatible annotations. That empty `__path__` also shadowed the package's *light* submodules, so the in-package `agent_loop/` tests failed to collect (`ModuleNotFoundError: No module named 'agent_loop.types'`), which is #11153. On py3.12+ the annotation incompatibility is gone — `agent_loop.loop` real-imports cleanly (verified standalone) — so the stub is no longer needed to protect collection.

## What Changed
`autobot-backend/conftest.py`, in the existing `agent_loop` stub block:
- Give the injected `agent_loop` stub a **real `__path__`** (`backend_root/agent_loop`) so its light submodules (`types`, `belief_state`, `pre_action_verifier`, `slack_hook`, …) resolve on-demand from disk — *without* running `agent_loop/__init__.py` (which imports the heavy `loop`/`think_tool`).
- Replace the two `setdefault(..., stub)` lines for `agent_loop.loop` / `agent_loop.think_tool` with `_try_real_load_agent_loop_heavy()`: real-load both via `importlib.import_module`, falling back to a stub if the environment can't satisfy the import. Same "real-load after the stubs are in place" pattern as the merged #11314 (provider_registry) and #11329/#11332 (tool_output_filter, llm_api_key_service) carve-outs. Loop tolerates the still-stubbed `code_intelligence` at import time.

## Verification (dev venv, py3.12)
- In-package `agent_loop/`: **7 collection-errors → 130 passed / 11 failed**. The 11 are pre-existing latent test bugs newly *visible* (env/infra assumptions: slack config-caching, stubbed redis/events/providers) — unrelated to the co-collection stubbing #11153 targets, tracked in #11333.
- Blast radius — full-suite `--collect-only`: **13291 → 13399 collected (+108)**, **294 → 287 errors (−7)**. Real-loading `agent_loop.loop` under the stubbed `code_intelligence` broke nothing and reduced adjacent collection errors. The `orchestration.*` tests the stub protected are unaffected (error count dropped, not rose).
- `black --check -l120` clean.

## Model Used
Claude Opus 4.8