### PR TITLE
fix(agent_loop): wire get_slack_hook default channel + repair 11 in-package tests

### DIFF
--- a/autobot-backend/agent_loop/slack_hook.py
+++ b/autobot-backend/agent_loop/slack_hook.py
@@ -191,8 +191,8 @@ def get_slack_hook() -> Any:
         _hook = _NullSlackHook()
         return _hook
 
-    notifications_channel = config.slack_notifications_channel.strip()
-    approvals_channel = config.slack_approvals_channel.strip()
+    notifications_channel = config.slack_notifications_channel.strip() or _SLACK_NOTIFICATIONS_CHANNEL_DEFAULT
+    approvals_channel = config.slack_approvals_channel.strip() or notifications_channel
 
     logger.info(
         "Slack notifications enabled (channel=%s, approvals=%s)",

--- a/autobot-backend/agent_loop/test_approval_workflow.py
+++ b/autobot-backend/agent_loop/test_approval_workflow.py
@@ -116,21 +116,16 @@ class TestRequestApproval:
         loop = _make_loop()
         approval_id = "appr-001"
 
-        # Simulate an APPROVAL_RESPONSE event that matches
+        # Simulate an APPROVAL_RESPONSE event that matches. _request_approval uses
+        # event_stream.subscribe() (async generator), not get_latest() polling.
         resp_event = MagicMock()
         resp_event.event_type = EventType.APPROVAL_RESPONSE
         resp_event.content = {"approval_id": approval_id, "approved": True}
 
-        call_count = 0
+        async def mock_subscribe(**kwargs):
+            yield resp_event
 
-        async def mock_get_latest(**kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count >= 2:
-                return [resp_event]
-            return []
-
-        loop.event_stream.get_latest = mock_get_latest
+        loop.event_stream.subscribe = mock_subscribe
 
         result = await loop._request_approval(_make_tool("bash"), approval_id)
         assert result is True
@@ -170,16 +165,12 @@ class TestRequestApproval:
         matching.event_type = EventType.APPROVAL_RESPONSE
         matching.content = {"approval_id": approval_id, "approved": True}
 
-        call_count = 0
+        async def mock_subscribe(**kwargs):
+            # The unrelated approval_id must be skipped; the matching one resolves.
+            yield unrelated
+            yield matching
 
-        async def mock_get_latest(**kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return [unrelated]
-            return [matching]
-
-        loop.event_stream.get_latest = mock_get_latest
+        loop.event_stream.subscribe = mock_subscribe
         result = await loop._request_approval(_make_tool("bash"), approval_id)
         assert result is True
 

--- a/autobot-backend/agent_loop/test_slack_hook.py
+++ b/autobot-backend/agent_loop/test_slack_hook.py
@@ -20,6 +20,7 @@ Covers:
   - SLACK_APPROVALS_CHANNEL falls back to SLACK_NOTIFICATIONS_CHANNEL
 """
 
+from contextlib import contextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -121,34 +122,31 @@ class TestNullSlackHook:
 class TestGetSlackHookWithToken:
     """get_slack_hook() builds a _SlackHook when SLACK_BOT_TOKEN is present."""
 
-    def _env(self, extra: dict | None = None) -> dict:
-        base = {"SLACK_BOT_TOKEN": "xoxb-test-token"}
-        if extra:
-            base.update(extra)
-        return base
+    @contextmanager
+    def _slack_env(self, *, token: str = "xoxb-test-token", notifications: str = "", approvals: str = ""):
+        """Patch the SSOT config values get_slack_hook reads and the integration
+        classes _SlackHook builds.
 
-    def test_returns_slack_hook_when_token_present(self):
-        env = self._env()
-        fake_config_cls = MagicMock()
-        fake_integration = MagicMock()
-        fake_integration_cls = MagicMock(return_value=fake_integration)
+        The config object is instantiated once at import, so patching os.environ does
+        NOT propagate to config.slack_* — the values must be patched on config directly.
+        """
+        fake_integration_cls = MagicMock(return_value=MagicMock())
         with (
-            patch.dict("os.environ", env, clear=False),
-            patch("integrations.base.IntegrationConfig", fake_config_cls),
+            patch.object(slack_hook_module.config, "slack_bot_token", token),
+            patch.object(slack_hook_module.config, "slack_notifications_channel", notifications),
+            patch.object(slack_hook_module.config, "slack_approvals_channel", approvals),
+            patch("integrations.base.IntegrationConfig", MagicMock()),
             patch("integrations.slack_integration.SlackNotificationIntegration", fake_integration_cls),
         ):
+            yield fake_integration_cls
+
+    def test_returns_slack_hook_when_token_present(self):
+        with self._slack_env():
             hook = slack_hook_module.get_slack_hook()
         assert isinstance(hook, slack_hook_module._SlackHook)
 
     def test_singleton_reused_after_init(self):
-        env = self._env()
-        fake_integration_cls = MagicMock(return_value=MagicMock())
-        fake_config_cls = MagicMock()
-        with (
-            patch.dict("os.environ", env, clear=False),
-            patch("integrations.base.IntegrationConfig", fake_config_cls),
-            patch("integrations.slack_integration.SlackNotificationIntegration", fake_integration_cls),
-        ):
+        with self._slack_env() as fake_integration_cls:
             h1 = slack_hook_module.get_slack_hook()
             h2 = slack_hook_module.get_slack_hook()
             # SlackNotificationIntegration must be called exactly once
@@ -156,52 +154,17 @@ class TestGetSlackHookWithToken:
         assert h1 is h2
 
     def test_notifications_channel_defaults(self):
-        env = self._env()
-        env.pop("SLACK_NOTIFICATIONS_CHANNEL", None)
-        fake_integration_cls = MagicMock(return_value=MagicMock())
-        fake_config_cls = MagicMock()
-        with (
-            patch.dict("os.environ", env, clear=False),
-            patch("integrations.base.IntegrationConfig", fake_config_cls),
-            patch("integrations.slack_integration.SlackNotificationIntegration", fake_integration_cls),
-        ):
-            import os
-
-            os.environ.pop("SLACK_NOTIFICATIONS_CHANNEL", None)
-            os.environ.pop("SLACK_APPROVALS_CHANNEL", None)
+        with self._slack_env(notifications="", approvals=""):
             hook = slack_hook_module.get_slack_hook()
         assert hook._notifications_channel == "#agent-notifications"
 
     def test_approvals_channel_falls_back_to_notifications_channel(self):
-        env = self._env({"SLACK_NOTIFICATIONS_CHANNEL": "#notifs"})
-        env.pop("SLACK_APPROVALS_CHANNEL", None)
-        fake_integration_cls = MagicMock(return_value=MagicMock())
-        fake_config_cls = MagicMock()
-        with (
-            patch.dict("os.environ", env, clear=False),
-            patch("integrations.base.IntegrationConfig", fake_config_cls),
-            patch("integrations.slack_integration.SlackNotificationIntegration", fake_integration_cls),
-        ):
-            import os
-
-            os.environ.pop("SLACK_APPROVALS_CHANNEL", None)
+        with self._slack_env(notifications="#notifs", approvals=""):
             hook = slack_hook_module.get_slack_hook()
         assert hook._approvals_channel == "#notifs"
 
     def test_approvals_channel_overridden(self):
-        env = self._env(
-            {
-                "SLACK_NOTIFICATIONS_CHANNEL": "#notifs",
-                "SLACK_APPROVALS_CHANNEL": "#approvals",
-            }
-        )
-        fake_integration_cls = MagicMock(return_value=MagicMock())
-        fake_config_cls = MagicMock()
-        with (
-            patch.dict("os.environ", env, clear=False),
-            patch("integrations.base.IntegrationConfig", fake_config_cls),
-            patch("integrations.slack_integration.SlackNotificationIntegration", fake_integration_cls),
-        ):
+        with self._slack_env(notifications="#notifs", approvals="#approvals"):
             hook = slack_hook_module.get_slack_hook()
         assert hook._approvals_channel == "#approvals"
 

--- a/autobot-backend/agent_loop/tests/test_belief_cache.py
+++ b/autobot-backend/agent_loop/tests/test_belief_cache.py
@@ -174,7 +174,7 @@ async def test_cached_tool_not_in_tools_executed():
 
     tool = {"tool_name": "read_file", "args": {"path": "/tmp/f.txt"}}
 
-    with patch("events.bus.publish_event", new_callable=AsyncMock) as mock_pub:
+    with patch("agent_loop.loop._bus_publish_event", new_callable=AsyncMock):
         with patch.object(loop, "_execute_tools", new_callable=AsyncMock, return_value={}) as mock_exec:
             with patch.object(loop, "_select_tools", new_callable=AsyncMock, return_value=[tool]):
                 with patch.object(loop, "_analyze_events", new_callable=AsyncMock, return_value={"events": []}):
@@ -183,8 +183,9 @@ async def test_cached_tool_not_in_tools_executed():
 
                         result = await loop._execute_iteration_phases(IterationResult(iteration_number=1))
 
-    # Tool was cached — _execute_tools should have been called with empty list
-    mock_exec.assert_called_once_with([])
+    # Tool was cached — no live tools remain, so _execute_tools is skipped entirely
+    # (loop.py: `_execute_tools(tools_to_run) if tools_to_run else {}`).
+    mock_exec.assert_not_called()
     # No live tools → tools_executed is empty
     assert result.tools_executed == []
     # Cached result is in tool_results
@@ -206,7 +207,7 @@ async def test_belief_cache_hit_event_published():
     async def _capture_publish(channel, event_type, payload, **kwargs):
         published_events.append((event_type, payload))
 
-    with patch("events.bus.publish_event", side_effect=_capture_publish):
+    with patch("agent_loop.loop._bus_publish_event", side_effect=_capture_publish):
         with patch.object(loop, "_execute_tools", new_callable=AsyncMock, return_value={}):
             with patch.object(loop, "_select_tools", new_callable=AsyncMock, return_value=[tool]):
                 with patch.object(loop, "_analyze_events", new_callable=AsyncMock, return_value={"events": []}):

--- a/autobot-backend/agent_loop/tests/test_pre_action_verifier.py
+++ b/autobot-backend/agent_loop/tests/test_pre_action_verifier.py
@@ -242,7 +242,7 @@ class TestDistinctProvider:
         mock_registry.get_provider = _get_prov
 
         with (
-            patch("agent_loop.pre_action_verifier.get_provider_registry", return_value=mock_registry),
+            patch("llm_shared.provider_registry.get_provider_registry", return_value=mock_registry),
             patch("agent_loop.pre_action_verifier.VERIFIER_ENABLED", True),
         ):
             from agent_loop.pre_action_verifier import _select_verifier_provider
@@ -264,7 +264,7 @@ class TestDistinctProvider:
 
         mock_registry.get_provider = _get_prov
 
-        with patch("agent_loop.pre_action_verifier.get_provider_registry", return_value=mock_registry):
+        with patch("llm_shared.provider_registry.get_provider_registry", return_value=mock_registry):
             from agent_loop.pre_action_verifier import _select_verifier_provider
 
             chosen = await _select_verifier_provider(actor_provider="ollama")


### PR DESCRIPTION
Closes #11333 (fast-follow of #11153).

## Thinking Path
After #11334 un-stubbed the `agent_loop` package, 130 in-package tests passed and 11 remained red — pre-existing latent test bugs newly *visible* now that the files collect. Root-causing all four clusters found **one real product bug** plus test-vs-code drift from refactors.

## What Changed
**Product fix — `agent_loop/slack_hook.py`:** `get_slack_hook()` defined `_SLACK_NOTIFICATIONS_CHANNEL_DEFAULT = "#agent-notifications"` (and documents the default) but never applied it — it passed the empty config value straight through, so Slack notifications had no channel when `SLACK_NOTIFICATIONS_CHANNEL` was unset. Now: `notifications_channel = config.slack_notifications_channel.strip() or _SLACK_NOTIFICATIONS_CHANNEL_DEFAULT` and `approvals_channel = ... or notifications_channel` (approvals inherits notifications), matching the documented/tested intent. Only consumer is agent_loop itself; strictly safer.

**Test repairs (all test-vs-code drift):**
- `test_slack_hook.py` (5) — the SSOT `config` is instantiated once at import, so `patch.dict(os.environ, …)` never reached `config.slack_*`. Rewrote `TestGetSlackHookWithToken` to patch the config attributes directly via a `_slack_env` contextmanager.
- `test_approval_workflow.py` (2) — `_request_approval` was refactored from `get_latest()` polling to `event_stream.subscribe()` (async generator); updated the two tests to mock `subscribe` as an async generator.
- `test_belief_cache.py` (2) — (a) `_execute_tools` is now skipped entirely when all tools are cache-hits (`… if tools_to_run else {}`), so `assert_called_once_with([])` → `assert_not_called()`; (b) the `belief_cache_hit` event publishes via the import-bound `agent_loop.loop._bus_publish_event`, not `events.bus.publish_event` — repointed the patch.
- `test_pre_action_verifier.py` (2) — `_select_verifier_provider` imports `get_provider_registry` locally from `llm_shared.provider_registry`; repointed the patch from the (nonexistent) `agent_loop.pre_action_verifier.get_provider_registry` to the source module.

## Verification (dev venv, py3.12)
- `agent_loop/`: **130 passed/11 failed → 141 passed/0 failed.**
- No prod caller depends on the old empty-channel behavior (grep).
- Full-suite `--collect-only` unchanged vs base: **13399 collected, 287 errors**. Zero regressions.
- `black --check -l120` clean on all 5 files.

## Model Used
Claude Opus 4.8