### PR TITLE
fix(deploy): top-level requirements.txt not deployed + migration enum double-create (#11336 #11337)

### DIFF
--- a/autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py
+++ b/autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py
@@ -17,7 +17,9 @@ down_revision: Union[str, Sequence[str], None] = ("20260707_066", "20260701_066"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-_LIFECYCLE = sa.Enum("active", "archived", "pending_disposal", "disposed", name="projectlifecyclestate")
+_LIFECYCLE = sa.Enum(
+    "active", "archived", "pending_disposal", "disposed", name="projectlifecyclestate", create_type=False
+)
 
 
 def upgrade() -> None:

--- a/autobot-backend/migrations/versions/20260708_069_llc_finding_proposals.py
+++ b/autobot-backend/migrations/versions/20260708_069_llc_finding_proposals.py
@@ -13,7 +13,7 @@ down_revision: Union[str, Sequence[str], None] = "20260708_068"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-_FINDING_STATUS = sa.Enum("pending", "promoted", "dismissed", name="findingproposalstatus")
+_FINDING_STATUS = sa.Enum("pending", "promoted", "dismissed", name="findingproposalstatus", create_type=False)
 
 
 def upgrade() -> None:

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -759,6 +759,13 @@ _COMPONENT_PYTHON_TARGET: Dict[str, str] = {
 # explicitly before pip runs.
 _CONSTRAINTS_SOURCE_SUBDIR: str = "constraints"
 
+# Repo-root files referenced via `-r ../X` in component requirements (#11336).
+# `autobot-backend/requirements.txt` uses `-r ../requirements.txt` which from
+# /opt/autobot/autobot-backend/ resolves to /opt/autobot/requirements.txt — a
+# path code-sync never writes.  This tuple lists the bare filenames (relative to
+# the repo root) that must be copied to /opt/autobot/ before pip runs.
+_REPO_ROOT_REQUIREMENT_FILES: tuple[str, ...] = ("requirements.txt",)
+
 # Maps component name → deployed frontend directory for npm rebuild.
 _COMPONENT_FRONTEND_DIRS: Dict[str, str] = {
     "autobot-frontend": "/opt/autobot/autobot-frontend",
@@ -826,6 +833,41 @@ async def _deploy_constraints_dir(source_root: str, steps: List[str]) -> None:
             steps.append(f"constraints: rsync failed (rc={proc.returncode})")
     except Exception as exc:
         steps.append(f"constraints: deploy error: {exc}")
+
+
+async def _deploy_repo_root_requirements(source_root: str, steps: List[str]) -> None:
+    """Copy top-level repo-root files to /opt/autobot/ before pip (#11336).
+
+    autobot-backend/requirements.txt uses `-r ../requirements.txt` so the
+    relative reference resolves to /opt/autobot/requirements.txt at deploy time.
+    Code-sync only rsyncs component subdirs, so each file listed in
+    _REPO_ROOT_REQUIREMENT_FILES is copied explicitly from source_root.
+    Skips gracefully when the source file is absent (non-fatal).
+    """
+    base = _get_deploy_base()
+    for filename in _REPO_ROOT_REQUIREMENT_FILES:
+        src = Path(source_root) / filename
+        dst = base / filename
+        if not src.exists():
+            steps.append(f"root-reqs: {src} not found — skipped")
+            continue
+        steps.append(f"root-reqs: copying {src} -> {dst}")
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "cp",
+                "--",
+                str(src),
+                str(dst),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            _, _ = await asyncio.wait_for(proc.communicate(), timeout=10.0)
+            if proc.returncode == 0:
+                steps.append(f"root-reqs: {filename} deployed ok")
+            else:
+                steps.append(f"root-reqs: cp {filename} failed (rc={proc.returncode})")
+        except Exception as exc:
+            steps.append(f"root-reqs: {filename} deploy error: {exc}")
 
 
 async def _ensure_venv_python(component: str, steps: List[str]) -> None:
@@ -1221,6 +1263,8 @@ async def _run_post_sync_steps(
         # Deploy constraints dir so `-c ../constraints/shared.txt` resolves (#11322).
         source_root = str(Path(source_dir).parent)
         await _deploy_constraints_dir(source_root, steps)
+        # Deploy repo-root files so `-r ../requirements.txt` resolves (#11336).
+        await _deploy_repo_root_requirements(source_root, steps)
         # Recreate venv if its Python version doesn't match the target (#11323).
         await _ensure_venv_python(component, steps)
         pip_ok = await _install_pip_deps_for_component(component, steps)
@@ -1460,7 +1504,7 @@ async def _sync_slm_from_code_source(node_id: str) -> None:
     if is_local_source:
         logger.info("SLM self-sync: code source is local at %s, using direct rsync", repo_path)
     else:
-        ssh_key = os.environ.get("SLM_SSH_KEY", "/home/autobot/.ssh/autobot_key")  # noqa: ssot-path
+        ssh_key = os.environ.get("SLM_SSH_KEY", "/home/autobot/.ssh/autobot_key")
         if not Path(ssh_key).exists():
             logger.error("SLM self-sync failed: SSH key not found at %s", ssh_key)
             return
@@ -2720,7 +2764,7 @@ async def sync_role(
 # One-Click Full-Pipeline Update (Issue #9971)
 # =============================================================================
 
-import json as _json
+import json as _json  # noqa: E402
 
 _UPDATE_ALL_RESUME_KEY = "slm_update_all_resume"
 _DEPS_FILES = ["requirements.txt", "package-lock.json"]

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Tests for drift/resolve deploy bugs fixed in #11322 and #11323.
+"""Tests for drift/resolve deploy bugs fixed in #11322, #11323, and #11336.
 
 #11322 — constraints dir not deployed before pip:
   _deploy_constraints_dir rsyncs constraints/ to /opt/autobot/constraints/ before pip
@@ -12,6 +12,10 @@
 #11323 — code-sync didn't enforce target Python version in venvs:
   _ensure_venv_python checks <venv>/bin/python --version and recreates the venv
   via `pythonX.Y -m venv` when there is a version mismatch.
+
+#11336 — top-level requirements.txt not deployed before pip:
+  _deploy_repo_root_requirements copies repo-root files (e.g. requirements.txt)
+  to /opt/autobot/ before pip runs, so `-r ../requirements.txt` resolves.
 """
 
 from __future__ import annotations
@@ -68,7 +72,9 @@ import asyncio  # noqa: E402
 from api.code_sync import (  # noqa: E402
     _COMPONENT_PYTHON_TARGET,
     _CONSTRAINTS_SOURCE_SUBDIR,
+    _REPO_ROOT_REQUIREMENT_FILES,
     _deploy_constraints_dir,
+    _deploy_repo_root_requirements,
     _ensure_venv_python,
     _install_pip_deps_for_component,
     _run_post_sync_steps,
@@ -210,6 +216,7 @@ def test_run_post_sync_steps_pip_ok_false_on_pip_failure() -> None:
     with (
         patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
         patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
+        patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()),
         patch("api.code_sync._ensure_venv_python", AsyncMock()),
         patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=False)),
         patch("api.code_sync._run_alembic_migrations", AsyncMock()),
@@ -227,6 +234,7 @@ def test_run_post_sync_steps_pip_ok_true_on_success() -> None:
     with (
         patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
         patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
+        patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()),
         patch("api.code_sync._ensure_venv_python", AsyncMock()),
         patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)),
         patch("api.code_sync._run_alembic_migrations", AsyncMock()),
@@ -412,3 +420,96 @@ def test_ensure_venv_python_skips_creation_when_target_not_installed_missing(tmp
 
     assert not recreated, "must not attempt to recreate venv when target interpreter is absent"
     assert any("not installed" in s or "skipping" in s.lower() for s in steps), f"expected a skip step, got: {steps}"
+
+
+# ---------------------------------------------------------------------------
+# #11336 — _deploy_repo_root_requirements
+# ---------------------------------------------------------------------------
+
+
+def test_repo_root_requirement_files_constant() -> None:
+    """_REPO_ROOT_REQUIREMENT_FILES must include requirements.txt."""
+    assert "requirements.txt" in _REPO_ROOT_REQUIREMENT_FILES
+
+
+def test_deploy_repo_root_requirements_skipped_when_file_missing(tmp_path) -> None:
+    """Step says 'not found' when the source file doesn't exist."""
+    steps: list[str] = []
+    with patch("api.code_sync._get_deploy_base", return_value=tmp_path):
+        _run(_deploy_repo_root_requirements(str(tmp_path / "no_such_root"), steps))
+    assert any("not found" in s for s in steps)
+
+
+def test_deploy_repo_root_requirements_calls_cp(tmp_path) -> None:
+    """cp is called when the source file exists."""
+    src_root = tmp_path / "code_source"
+    src_root.mkdir()
+    (src_root / "requirements.txt").write_text("paramiko>=5.0.0\n", encoding="utf-8")
+    dst_base = tmp_path / "opt_autobot"
+    dst_base.mkdir()
+
+    steps: list[str] = []
+    captured: list = []
+
+    async def _fake_exec(*cmd, **kw):
+        captured.extend(cmd)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with (
+        patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+        patch("api.code_sync._get_deploy_base", return_value=dst_base),
+    ):
+        _run(_deploy_repo_root_requirements(str(src_root), steps))
+
+    assert "cp" in captured
+    assert any("deployed ok" in s for s in steps)
+
+
+def test_deploy_repo_root_requirements_records_cp_failure(tmp_path) -> None:
+    """Non-zero cp rc is recorded in steps."""
+    src_root = tmp_path / "code_source"
+    src_root.mkdir()
+    (src_root / "requirements.txt").write_text("paramiko>=5.0.0\n", encoding="utf-8")
+    dst_base = tmp_path / "opt_autobot"
+    dst_base.mkdir()
+
+    steps: list[str] = []
+
+    async def _fake_exec(*cmd, **kw):
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.communicate = AsyncMock(return_value=(b"permission denied", b""))
+        return proc
+
+    with (
+        patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+        patch("api.code_sync._get_deploy_base", return_value=dst_base),
+    ):
+        _run(_deploy_repo_root_requirements(str(src_root), steps))
+
+    assert any("failed" in s for s in steps)
+
+
+def test_run_post_sync_steps_calls_deploy_repo_root_requirements() -> None:
+    """_deploy_repo_root_requirements is called for pip backend components."""
+    called: list[bool] = []
+
+    async def _fake_deploy(source_root: str, steps: list) -> None:
+        called.append(True)
+
+    with (
+        patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
+        patch("api.code_sync._deploy_repo_root_requirements", side_effect=_fake_deploy),
+        patch("api.code_sync._ensure_venv_python", AsyncMock()),
+        patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)),
+        patch("api.code_sync._run_alembic_migrations", AsyncMock()),
+        patch("api.code_sync._ensure_autobot_shared_symlink", AsyncMock()),
+        patch("api.code_sync._restart_component_services", AsyncMock()),
+    ):
+        _run(_run_post_sync_steps("autobot-backend", "/src/autobot-backend", "/opt/autobot/autobot-backend"))
+
+    assert called, "_deploy_repo_root_requirements must be called for pip backend components"

--- a/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
@@ -267,6 +267,7 @@ def test_pip_backend_emits_symlink_step(tmp_path) -> None:
             # _install_pip_deps_for_component now returns bool (#11322)
             patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)),
             patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
+            patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()),
             patch("api.code_sync._ensure_venv_python", AsyncMock()),
             patch("api.code_sync._run_alembic_migrations", AsyncMock()),
             patch("api.code_sync._restart_component_services", AsyncMock()),


### PR DESCRIPTION
## Thinking Path

**Bug 1 (#11336):** `autobot-backend/requirements.txt` line 60 uses `-r ../requirements.txt`. From the deployed dir `/opt/autobot/autobot-backend/` that resolves to `/opt/autobot/requirements.txt` — a file code-sync never writes. PR #11327 already introduced `_deploy_constraints_dir` to handle the analogous `-c ../constraints/shared.txt` reference. The fix extends the same pattern: a new `_deploy_repo_root_requirements` helper copies each file listed in `_REPO_ROOT_REQUIREMENT_FILES` from the code_source root to `_get_deploy_base()` using async subprocess `cp`, called from `_run_post_sync_steps` immediately after `_deploy_constraints_dir`.

**Bug 2 (#11337):** `sa.Enum(..., name="X")` without `create_type=False` causes SQLAlchemy to emit `CREATE TYPE X` a second time when the enum object is passed to `op.add_column()` / `op.create_table()`, even if an explicit `.create(bind, checkfirst=True)` ran first. The fix is `create_type=False` — only the explicit `.create()` manages type lifecycle. Audit of sibling migrations 066 (both variants) and 068: neither uses a named `sa.Enum` in a column, so no change needed there. Migrations 067 and 069 both had the pattern.

## What Changed

**`autobot-slm-backend/api/code_sync.py`**
- Added `_REPO_ROOT_REQUIREMENT_FILES: tuple[str, ...]` constant listing repo-root files referenced via `-r ../X` in component requirements (currently `"requirements.txt"`).
- Added `_deploy_repo_root_requirements(source_root, steps)` — async helper that copies each listed file from `source_root` to `_get_deploy_base()` via `cp`, skipping gracefully if source is absent. Mirrors `_deploy_constraints_dir` style.
- Wired into `_run_post_sync_steps` after `_deploy_constraints_dir` for all pip backend components.
- Fixed pre-existing ruff warnings: invalid `# noqa: ssot-path` custom tag removed; `# noqa: E402` added to mid-file `import json as _json`.

**`autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py`**
- Added `_REPO_ROOT_REQUIREMENT_FILES` and `_deploy_repo_root_requirements` to imports.
- Added 5 new tests: constant check, skip-when-missing, calls-cp, records-failure, and `_run_post_sync_steps` integration.
- Updated two existing `_run_post_sync_steps` tests to mock `_deploy_repo_root_requirements` (required since the new call would otherwise try to exec `cp`).

**`autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py`**
- Added `_deploy_repo_root_requirements` mock to `test_pip_backend_emits_symlink_step`.

**`autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py`**
- Added `create_type=False` to `_LIFECYCLE = sa.Enum(...)`.

**`autobot-backend/migrations/versions/20260708_069_llc_finding_proposals.py`**
- Added `create_type=False` to `_FINDING_STATUS = sa.Enum(...)`.

## Verification

```
pytest autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py \
       autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py -v
# 31 passed in 1.38s

black --check --fast <5 files>
# All done! 5 files would be left unchanged.

ruff check <5 files>
# All checks passed!

python3 -c "ast.parse(migration_067); ast.parse(migration_069)"
# Both parse OK; create_type=False confirmed present in both.
```

Full alembic run requires a live DB (not available in CI without PostgreSQL); the `create_type=False` fix is the canonical SQLAlchemy solution documented in the Alembic migration guide and confirmed by AST inspection.

Migrations changed: 20260708_067 (`_LIFECYCLE`), 20260708_069 (`_FINDING_STATUS`).
Migrations audited and unchanged: 20260701_066, 20260707_066, 20260708_068.

## Model Used

claude-sonnet-4-6

Closes #11336
Closes #11337