### PR TITLE
fix(ui): wire BasePanel collapse toggle to complete collapsible feature

### DIFF
--- a/autobot-frontend/src/components/base/BasePanel.vue
+++ b/autobot-frontend/src/components/base/BasePanel.vue
@@ -1,9 +1,21 @@
 <template>
   <div class="base-panel" :class="panelClasses">
-    <div class="panel-header" v-if="$slots.header || title">
-      <slot name="header">
-        <h3 class="panel-title">{{ title }}</h3>
-      </slot>
+    <div class="panel-header" v-if="$slots.header || title || collapsible">
+      <div class="panel-header-lead">
+        <button
+          v-if="collapsible"
+          type="button"
+          class="panel-collapse-toggle"
+          :aria-expanded="!collapsed"
+          :aria-label="collapsed ? t('base.panel.expand') : t('base.panel.collapse')"
+          @click="toggleCollapse"
+        >
+          <span class="panel-collapse-icon" :class="{ 'is-collapsed': collapsed }" aria-hidden="true">▾</span>
+        </button>
+        <slot name="header">
+          <h3 class="panel-title">{{ title }}</h3>
+        </slot>
+      </div>
       <div class="panel-actions" v-if="$slots.actions">
         <slot name="actions"></slot>
       </div>
@@ -21,7 +33,10 @@
 
 <script setup lang="ts">
 import { computed, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
+
+const { t } = useI18n()
 
 const PANEL_SIZES = ['sm', 'md', 'lg'] as const
 const PANEL_VARIANTS = ['default', 'bordered', 'elevated', 'flat', 'dark'] as const
@@ -69,7 +84,7 @@ const contentClasses = computed(() => [
   }
 ])
 
-const _toggleCollapse = () => {
+const toggleCollapse = () => {
   if (props.collapsible) {
     emit('toggle', !props.collapsed)
   }
@@ -151,6 +166,40 @@ if (import.meta.env.DEV) {
   justify-content: space-between;
   padding: var(--spacing-4);
   border-bottom: 1px solid var(--border-default);
+}
+
+.panel-header-lead {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  min-width: 0;
+}
+
+.panel-collapse-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-1);
+  background-color: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.panel-collapse-toggle:hover {
+  color: var(--text-primary);
+  background-color: var(--bg-secondary);
+}
+
+.panel-collapse-icon {
+  display: inline-block;
+  line-height: 1;
+  transition: transform var(--duration-200) var(--ease-out);
+}
+
+.panel-collapse-icon.is-collapsed {
+  transform: rotate(-90deg);
 }
 
 .panel-title {

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -5731,6 +5731,10 @@
       "actions": "إجراءات",
       "noDataAvailable": "No data available",
       "selectRow": "Select row {row}"
+    },
+    "panel": {
+      "collapse": "Collapse panel",
+      "expand": "Expand panel"
     }
   },
   "views": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -5731,6 +5731,10 @@
       "actions": "Aktionen",
       "noDataAvailable": "Keine Daten verfügbar",
       "selectRow": "Zeile {row} auswählen"
+    },
+    "panel": {
+      "collapse": "Bereich einklappen",
+      "expand": "Bereich ausklappen"
     }
   },
   "views": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -5738,6 +5738,10 @@
       "actions": "Actions",
       "noDataAvailable": "No data available",
       "selectRow": "Select row {row}"
+    },
+    "panel": {
+      "collapse": "Collapse panel",
+      "expand": "Expand panel"
     }
   },
   "views": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -5731,6 +5731,10 @@
       "actions": "Acciones",
       "noDataAvailable": "No hay datos disponibles",
       "selectRow": "Seleccionar fila {row}"
+    },
+    "panel": {
+      "collapse": "Contraer panel",
+      "expand": "Expandir panel"
     }
   },
   "views": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -7230,6 +7230,10 @@
     },
     "input": {
       "clearInput": "Clear input"
+    },
+    "panel": {
+      "collapse": "Collapse panel",
+      "expand": "Expand panel"
     }
   },
   "voice": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -5731,6 +5731,10 @@
       "actions": "Actions",
       "noDataAvailable": "Aucune donnée disponible",
       "selectRow": "Sélectionner la ligne {row}"
+    },
+    "panel": {
+      "collapse": "Réduire le panneau",
+      "expand": "Développer le panneau"
     }
   },
   "views": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -7230,6 +7230,10 @@
     },
     "input": {
       "clearInput": "Clear input"
+    },
+    "panel": {
+      "collapse": "Collapse panel",
+      "expand": "Expand panel"
     }
   },
   "voice": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -5731,6 +5731,10 @@
       "actions": "Darbības",
       "noDataAvailable": "Nav pieejamu datu",
       "selectRow": "Atlasīt rindu {row}"
+    },
+    "panel": {
+      "collapse": "Sakļaut paneli",
+      "expand": "Izvērst paneli"
     }
   },
   "views": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -5731,6 +5731,10 @@
       "actions": "Akcje",
       "noDataAvailable": "Brak dostępnych danych",
       "selectRow": "Zaznacz wiersz {row}"
+    },
+    "panel": {
+      "collapse": "Zwiń panel",
+      "expand": "Rozwiń panel"
     }
   },
   "views": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -5731,6 +5731,10 @@
       "actions": "Ações",
       "noDataAvailable": "Sem dados disponíveis",
       "selectRow": "Selecionar linha {row}"
+    },
+    "panel": {
+      "collapse": "Recolher painel",
+      "expand": "Expandir painel"
     }
   },
   "views": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -7230,6 +7230,10 @@
     },
     "input": {
       "clearInput": "Clear input"
+    },
+    "panel": {
+      "collapse": "Collapse panel",
+      "expand": "Expand panel"
     }
   },
   "voice": {


### PR DESCRIPTION
Closes #11110.

## Thinking Path
`BasePanel.vue` shipped a half-built collapsible feature — `collapsible`/`collapsed` props, a `toggle` emit, a `_toggleCollapse` handler (`_`-prefixed to dodge no-unused-vars), and `panel-collapsible`/`panel-collapsed`/`content-collapsed` CSS — but **no header control ever wired the handler**, so the feature was inert (surfaced by the #9924 lint sweep). Part 2 of #11110 (VisionAnalysisModal `intentLabels`) already merged via #11121; this completes part 1. Per the "wire it in, don't delete" principle (and consistent with how part 2 was resolved by wiring), I completed the feature rather than stripping the scaffolding.

## What Changed
- **`BasePanel.vue`** — added a collapse-toggle `<button>` in the header (rendered only when `collapsible`), wired to the now-used `toggleCollapse` handler (renamed from `_toggleCollapse`). Includes `aria-expanded` and an i18n `aria-label`, plus a chevron that rotates when collapsed. Header `v-if` now also shows when `collapsible` so a title-less collapsible panel still gets the control. Wrapped the toggle + header slot in a `panel-header-lead` flex group so the existing `panel-actions` stays right-aligned. Added scoped styles for the button/icon.
- **11 locale files** — new `base.panel.collapse` / `base.panel.expand` aria-label strings (real translations for en/de/es/fr/lv/pl/pt; English fallback for ar/he/fa/ur, matching the existing convention in this file).

## Verification
- Purely additive: `collapsible` defaults `false`, so every existing `BasePanel` usage is visually unchanged; only opt-in collapsible panels render the toggle. No current consumer passes `collapsible`, so no behavioral change to shipping UI.
- All 11 locales verified to contain `base.panel.collapse` + `base.panel.expand` (Python key-presence check); each locale diff is exactly +4 lines.
- `_toggleCollapse`→`toggleCollapse` is now referenced in the template, clearing the no-unused-vars `_` prefix the lint sweep flagged.
- Type-check/lint run in CI (no local frontend node_modules in this WSL env).

## Model Used
Claude Opus 4.8