### PR TITLE
feat(slm): implement GET /redis-service/status + POST /{action} router (#11340)

### DIFF
--- a/autobot-slm-backend/api/__init__.py
+++ b/autobot-slm-backend/api/__init__.py
@@ -34,6 +34,7 @@ from .nodes_execution import router as nodes_execution_router
 from .npu import router as npu_router
 from .orchestration import router as orchestration_router
 from .rdp import node_rdp_router, rdp_router
+from .redis_service import router as redis_service_router
 from .scim import router as scim_router
 from .secrets import router as secrets_router
 from .security import router as security_router
@@ -95,4 +96,5 @@ __all__ = [
     "secrets_router",
     "setup_wizard_router",
     "sso_auth_router",
+    "redis_service_router",
 ]

--- a/autobot-slm-backend/api/redis_service.py
+++ b/autobot-slm-backend/api/redis_service.py
@@ -1,0 +1,153 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Redis Service API Routes
+
+Local systemctl control for the redis-stack-server service on the SLM node.
+The Ansible sudoers playbook (configure-redis-service-management.yml) grants
+the `autobot` user passwordless sudo for start/stop/restart/status of this
+service.
+
+Related to Issue #11340.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, status
+
+logger = logging.getLogger(__name__)
+
+# Service name is a module constant — never interpolated from user input.
+_REDIS_SERVICE_NAME = "redis-stack-server"
+
+# Actions allowed through this API — validated as an allowlist.
+_ALLOWED_ACTIONS = frozenset({"start", "stop", "restart"})
+
+router = APIRouter(prefix="/redis-service", tags=["redis-service"])
+
+
+async def _run_systemctl(args: list[str], timeout: float = 15.0) -> tuple[int, str, str]:
+    """Run a systemctl command via asyncio subprocess (arg-list, no shell)."""
+    cmd = ["/usr/bin/sudo", "/usr/bin/systemctl"] + args
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        raw_out, raw_err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.communicate()
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail=f"systemctl {args[0]} timed out after {timeout}s",
+        )
+    return proc.returncode, raw_out.decode("utf-8", errors="replace"), raw_err.decode("utf-8", errors="replace")
+
+
+def _map_active_state(active_output: str) -> str:
+    """Map systemctl is-active output to the vocabulary expected by the panel."""
+    text = active_output.strip().lower()
+    if text == "active":
+        return "running"
+    if text in ("inactive", "deactivating"):
+        return "stopped"
+    if text in ("failed", "error"):
+        return "failed"
+    return "unknown"
+
+
+@router.get("/status")
+async def get_redis_status() -> dict:
+    """Return the current status of redis-stack-server."""
+    returncode, stdout, _stderr = await _run_systemctl(["is-active", _REDIS_SERVICE_NAME])
+    mapped = _map_active_state(stdout) if returncode == 0 else _map_active_state(stdout)
+
+    # Fetch richer stats from redis-cli INFO if running; gracefully degrade.
+    uptime_seconds = None
+    memory_used_bytes = None
+    memory_peak_bytes = None
+    connected_clients = None
+
+    if mapped == "running":
+        uptime_seconds, memory_used_bytes, memory_peak_bytes, connected_clients = await _fetch_redis_info()
+
+    return {
+        "status": mapped,
+        "uptime_seconds": uptime_seconds,
+        "memory_used_bytes": memory_used_bytes,
+        "memory_peak_bytes": memory_peak_bytes,
+        "connected_clients": connected_clients,
+        "last_checked": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+async def _fetch_redis_info() -> tuple[int | None, int | None, int | None, int | None]:
+    """Fetch uptime/memory/clients from redis-cli INFO; return Nones on any failure."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "/usr/bin/redis-cli",
+            "INFO",
+            "server",
+            "memory",
+            "clients",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        raw_out, _ = await asyncio.wait_for(proc.communicate(), timeout=5.0)
+    except Exception:
+        return None, None, None, None
+
+    if proc.returncode != 0:
+        return None, None, None, None
+
+    uptime = memory_used = memory_peak = clients = None
+    for line in raw_out.decode("utf-8", errors="replace").splitlines():
+        if line.startswith("uptime_in_seconds:"):
+            try:
+                uptime = int(line.split(":", 1)[1].strip())
+            except ValueError:
+                pass
+        elif line.startswith("used_memory:"):
+            try:
+                memory_used = int(line.split(":", 1)[1].strip())
+            except ValueError:
+                pass
+        elif line.startswith("used_memory_peak:"):
+            try:
+                memory_peak = int(line.split(":", 1)[1].strip())
+            except ValueError:
+                pass
+        elif line.startswith("connected_clients:"):
+            try:
+                clients = int(line.split(":", 1)[1].strip())
+            except ValueError:
+                pass
+    return uptime, memory_used, memory_peak, clients
+
+
+@router.post("/{action}")
+async def control_redis_service(action: str) -> dict:
+    """Start, stop, or restart redis-stack-server."""
+    if action not in _ALLOWED_ACTIONS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid action '{action}'. Allowed: {sorted(_ALLOWED_ACTIONS)}",
+        )
+
+    returncode, _stdout, stderr = await _run_systemctl([action, _REDIS_SERVICE_NAME])
+
+    if returncode != 0:
+        logger.error("systemctl %s %s failed (rc=%d): %s", action, _REDIS_SERVICE_NAME, returncode, stderr[:500])
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"systemctl {action} failed: {stderr[:300]}",
+        )
+
+    logger.info("redis-stack-server %s succeeded", action)
+    return {"action": action, "service": _REDIS_SERVICE_NAME, "success": True}

--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -49,6 +49,7 @@ from api import (
     npu_router,
     orchestration_router,
     rdp_router,
+    redis_service_router,
     scim_router,
     secrets_router,
     security_router,
@@ -643,6 +644,8 @@ app.include_router(api_keys_router, prefix="/api", dependencies=_SM)
 app.include_router(setup_wizard_router, prefix="/api", dependencies=_SM)
 # LLM Configuration (Issue #2371)
 app.include_router(llm_config_router, prefix="/api", dependencies=_SM)
+# Redis service lifecycle control (Issue #11340)
+app.include_router(redis_service_router, prefix="/api", dependencies=_SM)
 
 
 @app.get("/")

--- a/autobot-slm-backend/tests/test_redis_service_router.py
+++ b/autobot-slm-backend/tests/test_redis_service_router.py
@@ -1,0 +1,142 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for api/redis_service.py (#11340).
+
+Covers:
+- Status parsing (_map_active_state): all vocabulary values.
+- Action allowlist: valid actions pass; invalid actions raise 400.
+- GET /status: subprocess mock → correct status payload.
+- POST /{action}: subprocess mock → 200 on success, 500 on non-zero rc.
+- POST /{action}: unknown action → 400 (never runs subprocess).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from api.redis_service import _map_active_state, router
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# App fixture
+# ---------------------------------------------------------------------------
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Unit: _map_active_state
+# ---------------------------------------------------------------------------
+
+
+class TestMapActiveState:
+    def test_active_maps_to_running(self):
+        assert _map_active_state("active\n") == "running"
+
+    def test_inactive_maps_to_stopped(self):
+        assert _map_active_state("inactive") == "stopped"
+
+    def test_deactivating_maps_to_stopped(self):
+        assert _map_active_state("deactivating") == "stopped"
+
+    def test_failed_maps_to_failed(self):
+        assert _map_active_state("failed") == "failed"
+
+    def test_error_maps_to_failed(self):
+        assert _map_active_state("error") == "failed"
+
+    def test_unknown_text_maps_to_unknown(self):
+        assert _map_active_state("activating") == "unknown"
+
+    def test_empty_maps_to_unknown(self):
+        assert _map_active_state("") == "unknown"
+
+    def test_case_insensitive(self):
+        assert _map_active_state("ACTIVE") == "running"
+
+
+# ---------------------------------------------------------------------------
+# Integration: GET /status
+# ---------------------------------------------------------------------------
+
+
+class TestGetRedisStatus:
+    def test_running_status(self):
+        # Patch _run_systemctl to return "active" and _fetch_redis_info for metrics
+        with (
+            patch("api.redis_service._run_systemctl", new=AsyncMock(return_value=(0, "active\n", ""))),
+            patch("api.redis_service._fetch_redis_info", new=AsyncMock(return_value=(120, 1048576, 2097152, 3))),
+        ):
+            resp = client.get("/redis-service/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "running"
+        assert data["uptime_seconds"] == 120
+        assert data["connected_clients"] == 3
+        assert "last_checked" in data
+
+    def test_stopped_status(self):
+        with patch("api.redis_service._run_systemctl", new=AsyncMock(return_value=(3, "inactive\n", ""))):
+            resp = client.get("/redis-service/status")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "stopped"
+
+    def test_failed_status(self):
+        with patch("api.redis_service._run_systemctl", new=AsyncMock(return_value=(3, "failed\n", ""))):
+            resp = client.get("/redis-service/status")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "failed"
+
+    def test_unknown_state_maps_to_unknown(self):
+        with patch("api.redis_service._run_systemctl", new=AsyncMock(return_value=(3, "activating\n", ""))):
+            resp = client.get("/redis-service/status")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Integration: POST /{action}
+# ---------------------------------------------------------------------------
+
+
+class TestControlRedisService:
+    @pytest.mark.parametrize("action", ["start", "stop", "restart"])
+    def test_valid_action_succeeds(self, action: str):
+        with patch("api.redis_service._run_systemctl", new=AsyncMock(return_value=(0, "", ""))):
+            resp = client.post(f"/redis-service/{action}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["action"] == action
+
+    @pytest.mark.parametrize("action", ["start", "stop", "restart"])
+    def test_valid_action_subprocess_failure_returns_500(self, action: str):
+        with patch(
+            "api.redis_service._run_systemctl",
+            new=AsyncMock(return_value=(1, "", "permission denied")),
+        ):
+            resp = client.post(f"/redis-service/{action}")
+        assert resp.status_code == 500
+        assert "permission denied" in resp.json()["detail"]
+
+    @pytest.mark.parametrize(
+        "bad_action",
+        ["delete", "enable", "disable", "kill", "is-active"],
+    )
+    def test_invalid_action_returns_400_without_subprocess(self, bad_action: str):
+        with patch("api.redis_service._run_systemctl") as mock_systemctl:
+            resp = client.post(f"/redis-service/{bad_action}")
+        # _run_systemctl must NOT have been called for rejected actions
+        mock_systemctl.assert_not_called()
+        assert resp.status_code == 400
+        assert "Invalid action" in resp.json()["detail"]

--- a/autobot-slm-backend/tests/test_redis_service_router.py
+++ b/autobot-slm-backend/tests/test_redis_service_router.py
@@ -21,9 +21,10 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from api.redis_service import _map_active_state, router
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
+from api.redis_service import _map_active_state, router
 
 # ---------------------------------------------------------------------------
 # App fixture

--- a/autobot-slm-frontend/src/components/RedisServicePanel.vue
+++ b/autobot-slm-frontend/src/components/RedisServicePanel.vue
@@ -15,8 +15,11 @@
 
 import { ref, onMounted, onUnmounted } from 'vue'
 import { getBackendUrl } from '@/config/ssot-config'
+import i18n from '@/i18n'
 import { useAuthStore } from '@/stores/auth'
 import { createLogger } from '@/utils/debugUtils'
+
+const t = i18n.global.t.bind(i18n.global)
 
 const logger = createLogger('RedisServicePanel')
 const authStore = useAuthStore()
@@ -95,7 +98,9 @@ function statusTextClass(status: string | undefined): string {
 
 async function fetchStatus(): Promise<void> {
   try {
-    const response = await fetch(`${getBackendUrl()}/api/redis-service/status`)
+    const response = await fetch(`${getBackendUrl()}/api/redis-service/status`, {
+      headers: authHeaders(),
+    })
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`)
     }
@@ -103,7 +108,7 @@ async function fetchStatus(): Promise<void> {
     errorMessage.value = null
   } catch (err) {
     logger.error('Failed to fetch Redis status:', err)
-    errorMessage.value = 'Failed to fetch Redis service status'
+    errorMessage.value = t('redisServicePanel.fetchStatusFailed')
   } finally {
     isLoading.value = false
   }
@@ -125,13 +130,13 @@ async function performAction(action: 'start' | 'stop' | 'restart'): Promise<void
       const body = await response.json().catch(() => ({}))
       throw new Error(body.detail ?? `HTTP ${response.status}`)
     }
-    successMessage.value = `Redis service ${action} succeeded`
+    successMessage.value = t('redisServicePanel.actionSucceeded', { action })
     // Refresh status after action
     await fetchStatus()
     setTimeout(() => { successMessage.value = null }, 4000)
   } catch (err) {
     logger.error(`Failed to ${action} Redis service:`, err)
-    errorMessage.value = err instanceof Error ? err.message : `Failed to ${action} Redis service`
+    errorMessage.value = err instanceof Error ? err.message : t('redisServicePanel.actionFailed', { action })
   } finally {
     isActionInProgress.value = false
     currentAction.value = null

--- a/autobot-slm-frontend/src/locales/en.json
+++ b/autobot-slm-frontend/src/locales/en.json
@@ -916,9 +916,12 @@
     "sLOCompliance": "SLO Compliance:"
   },
   "redisServicePanel": {
+    "actionFailed": "Failed to {action} Redis service",
+    "actionSucceeded": "Redis service {action} succeeded",
     "cancel": "Cancel",
     "checking": "Checking…",
     "clients": "Clients",
+    "fetchStatusFailed": "Failed to fetch Redis service status",
     "inMemoryDataStore": "In-memory data store",
     "memoryUsed": "Memory Used",
     "peakMemory": "Peak Memory",


### PR DESCRIPTION
## Thinking Path

The `RedisServicePanel` on `/slm/services` showed "Failed to fetch Redis service status" because `GET /api/redis-service/status` (and the control actions) returned 404 — the router never existed. The Ansible sudoers playbook already grants the `autobot` user passwordless `sudo systemctl {start,stop,restart,status} redis-stack-server`.

Investigation steps:
1. Grepped `api/services.py` to learn the existing subprocess-exec pattern (`asyncio.create_subprocess_exec` with arg list, `wait_for` for timeout).
2. Read `slm/agent/health_collector.py` to understand `systemctl is-active` output vocabulary.
3. Read `main.py` to find the `_SM` dependency list and where to register new routers.
4. Read `RedisServicePanel.vue` — confirmed `fetchStatus` was missing `authHeaders()` and used three hardcoded strings.
5. Read `src/i18n/index.ts` — SLM frontend uses `legacy: true` with a single `en.json`.

## What Changed

**`autobot-slm-backend/api/redis_service.py`** (new)
- `router = APIRouter(prefix="/redis-service", tags=["redis-service"])`
- `GET /status`: runs `sudo systemctl is-active redis-stack-server` via `asyncio.create_subprocess_exec` (arg-list, no shell); maps output → `running | stopped | failed | unknown`; additionally calls `redis-cli INFO` for uptime/memory/clients (gracefully degrades to `null` on failure)
- `POST /{action}`: validates `action ∈ {"start","stop","restart"}` **before** any subprocess call (400 for anything else); then runs `sudo systemctl {action} redis-stack-server`; non-zero exit → 500 with stderr in `detail`
- Service name is module constant `_REDIS_SERVICE_NAME = "redis-stack-server"` (never interpolated from user input)
- Timeout → 504; non-zero rc → 500 with `detail` the frontend reads

**`autobot-slm-backend/api/__init__.py`** — exports `redis_service_router`

**`autobot-slm-backend/main.py`** — registers `redis_service_router` under `_SM` dependency list (same gate as all other service-management routers)

**`autobot-slm-backend/tests/test_redis_service_router.py`** (new, 23 tests)
- Unit: `_map_active_state` for all output strings including edge cases
- Integration (mocked `_run_systemctl`): `GET /status` → 200 with correct vocabulary; `POST /{action}` success → 200; non-zero rc → 500 with detail; 5 forbidden actions → 400, `_run_systemctl` not called

**`autobot-slm-frontend/src/components/RedisServicePanel.vue`**
- `fetchStatus` now sends `authHeaders()` (was missing; `performAction` already had them)
- Three script-section hardcoded strings moved to `i18n.global.t()` calls:
  - `'Failed to fetch Redis service status'` → `t('redisServicePanel.fetchStatusFailed')`
  - `` `Redis service ${action} succeeded` `` → `t('redisServicePanel.actionSucceeded', { action })`
  - `` `Failed to ${action} Redis service` `` → `t('redisServicePanel.actionFailed', { action })`

**`autobot-slm-frontend/src/locales/en.json`**
- Adds `fetchStatusFailed`, `actionSucceeded`, `actionFailed` keys to `redisServicePanel` block

## Verification

**Backend — 23/23 tests pass:**
```
collected 23 items
tests/test_redis_service_router.py::TestMapActiveState::* 8 PASSED
tests/test_redis_service_router.py::TestGetRedisStatus::* 4 PASSED
tests/test_redis_service_router.py::TestControlRedisService::* 11 PASSED
======================== 23 passed, 1 warning in 0.56s
```

**Backend — black + ruff clean:**
```
black --check: 4 files would be left unchanged.
ruff check: All checks passed!
```

**Frontend — vue-tsc:**
`RedisServicePanel.vue` produces only the pre-existing `TS2307: Cannot find module 'vue'` error that every component in this repo has (node_modules not installed in dev host). No new errors introduced by this PR.

**Security approach:**
- `asyncio.create_subprocess_exec(*cmd, ...)` — arg list, never a shell string
- `action` validated against `frozenset({"start","stop","restart"})` before any exec call
- Service name is a module-level constant — never derived from user input
- Registered under `_SM = [Depends(require_service_management)]` — requires admin/operator JWT

## Model Used

claude-sonnet-4-6

Closes #11340