### PR TITLE
fix(migration): pg_enum() so create_table stops re-emitting CREATE TYPE (#11337)

### DIFF
--- a/autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py
+++ b/autobot-backend/migrations/versions/20260708_067_llc_project_lifecycle.py
@@ -7,6 +7,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
+from migrations.guards import drop_pg_enum, ensure_pg_enum, pg_enum
+
 # Merge migration: unifies the two dangling heads left by Phase 1 (#11129) —
 # 20260707_066 (project_code_source) and 20260701_066 (requires_approval_before)
 # both descended from 20260630_065, creating "Multiple head revisions". See #11253.
@@ -17,14 +19,14 @@ down_revision: Union[str, Sequence[str], None] = ("20260707_066", "20260701_066"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-_LIFECYCLE = sa.Enum(
-    "active", "archived", "pending_disposal", "disposed", name="projectlifecyclestate", create_type=False
-)
+# postgresql.ENUM with create_type=False — generic sa.Enum(create_type=False)
+# silently ignores the flag (#11337).  Harmless here (op.add_column never
+# auto-emits CREATE TYPE) but kept canonical for consistency.
+_LIFECYCLE = pg_enum("projectlifecyclestate", "active", "archived", "pending_disposal", "disposed")
 
 
 def upgrade() -> None:
-    bind = op.get_bind()
-    _LIFECYCLE.create(bind, checkfirst=True)
+    ensure_pg_enum(_LIFECYCLE)
     op.add_column(
         "llc_projects",
         sa.Column(
@@ -52,5 +54,5 @@ def downgrade() -> None:
     op.drop_column("llc_projects", "disposal_scheduled_at")
     op.drop_column("llc_projects", "archived_at")
     op.drop_column("llc_projects", "lifecycle_state")
-    _LIFECYCLE.drop(op.get_bind(), checkfirst=True)
+    drop_pg_enum(_LIFECYCLE)
     # Note: Postgres cannot drop an enum value; 'project_disposal' remains on approvaltype (harmless).

--- a/autobot-backend/migrations/versions/20260708_069_llc_finding_proposals.py
+++ b/autobot-backend/migrations/versions/20260708_069_llc_finding_proposals.py
@@ -8,17 +8,21 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
+from migrations.guards import drop_pg_enum, ensure_pg_enum, pg_enum
+
 revision: str = "20260708_069"
 down_revision: Union[str, Sequence[str], None] = "20260708_068"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-_FINDING_STATUS = sa.Enum("pending", "promoted", "dismissed", name="findingproposalstatus", create_type=False)
+# postgresql.ENUM with create_type=False — generic sa.Enum(create_type=False)
+# silently ignores the flag, so op.create_table re-emits CREATE TYPE after the
+# explicit .create() and trips DuplicateObjectError (#11337).
+_FINDING_STATUS = pg_enum("findingproposalstatus", "pending", "promoted", "dismissed")
 
 
 def upgrade() -> None:
-    bind = op.get_bind()
-    _FINDING_STATUS.create(bind, checkfirst=True)
+    ensure_pg_enum(_FINDING_STATUS)
     op.create_table(
         "llc_finding_proposals",
         sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
@@ -56,5 +60,5 @@ def downgrade() -> None:
     op.drop_index("ix_llc_finding_proposals_project_id", table_name="llc_finding_proposals")
     op.drop_index("ix_llc_finding_proposals_company_id", table_name="llc_finding_proposals")
     op.drop_table("llc_finding_proposals")
-    _FINDING_STATUS.drop(op.get_bind(), checkfirst=True)
+    drop_pg_enum(_FINDING_STATUS)
     # Note: Postgres cannot drop an enum value; 'finding_promotion' remains on approvaltype (harmless).


### PR DESCRIPTION
## Thinking Path
The #11337 fix merged via #11338 is **ineffective** — the migration-gate is still red on Dev_new_gui. It set `create_type=False` on the **generic** `sa.Enum`, but SQLAlchemy 2.0 only honours `create_type` on `postgresql.ENUM`. So `op.create_table` in migration 069 kept emitting `CREATE TYPE` after the explicit `.create(checkfirst=True)`, tripping `DuplicateObjectError: type "findingproposalstatus" already exists`.

**Proof (SQLAlchemy DDL capture):**
```
generic sa.Enum(create_type=False)  -> create_table emits CREATE TYPE: True   (still broken)
pg_enum() = postgresql.ENUM(...)    -> create_table emits CREATE TYPE: False  (fixed)
```

## What Changed
Migrations **067** and **069** now use the repo's canonical `migrations.guards` helpers — `pg_enum()` (`postgresql.ENUM(..., create_type=False)`), `ensure_pg_enum()`, `drop_pg_enum()` — matching 20+ passing migrations and the `test_guards.TestPgEnum` contract. The guarded `ensure_pg_enum` is the sole creator; `create_table` no longer double-creates.

## Verification
- `py_compile` both migrations — OK
- **End-to-end against real Postgres 16** (disposable DB, socket): `alembic upgrade head` reaches 067/068/069 with **exit 0**; 069 `downgrade -1` → `upgrade head` roundtrip both **exit 0** — no DuplicateObjectError.
- Full-tree audit: no other migration uses generic `sa.Enum`.

## Model Used
Opus 4.8

Closes #11337