### PR TITLE
feat(deploy): provision target Python interpreter in code-sync update path (#11343)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/configure-python-provision-permissions.yml
+++ b/autobot-slm-backend/ansible/playbooks/configure-python-provision-permissions.yml
@@ -1,0 +1,93 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+---
+# Python Provision Permissions Playbook (#11343)
+# Grants the autobot service user a narrowly-scoped NOPASSWD sudoers entry so
+# the SLM code-sync update path can install the target Python interpreter
+# (python3.14 for backends, python3.11 for NPU) when it is missing, by running
+# ONLY the provision-local-python.yml playbook via ansible-playbook.
+#
+# Mirrors configure-redis-service-management.yml: validated with visudo,
+# written 0440 root:root, applied once during provisioning.
+#
+# The grant is scoped to the exact ansible-playbook invocation that the
+# backend issues (services/api/code_sync.py::_ensure_target_python_installed).
+# The role itself performs the apt/add-apt-repository work under root — running
+# the whole ansible-playbook as root keeps the sudoers surface to ONE command
+# instead of a blanket apt/add-apt-repository grant.
+
+- name: "Configure Python Provision Permissions"
+  hosts: slm_server
+  become: true
+  gather_facts: true
+
+  vars:
+    sudoers_file: "/etc/sudoers.d/autobot-python-provision"
+    autobot_user: "autobot"
+    # Absolute paths the backend passes to sudo ansible-playbook. Sudoers
+    # matches the command literally, so these MUST equal the argv the backend
+    # builds in _ensure_target_python_installed.
+    ansible_playbook_bin: "/usr/bin/ansible-playbook"
+    provision_playbook: "/opt/autobot/code_source/autobot-slm-backend/ansible/playbooks/provision-local-python.yml"
+    provision_inventory: "/opt/autobot/code_source/autobot-slm-backend/ansible/inventory.yml"
+
+  pre_tasks:
+    - name: Display configuration information
+      ansible.builtin.debug:
+        msg:
+          - "Configuring Python Provision Permissions"
+          - "Host: {{ inventory_hostname }}"
+          - "User: {{ autobot_user }}"
+          - "Sudoers file: {{ sudoers_file }}"
+          - "Playbook: {{ provision_playbook }}"
+
+  tasks:
+    - name: Verify autobot user exists
+      ansible.builtin.command: id {{ autobot_user }}
+      register: user_check
+      failed_when: user_check.rc != 0
+      changed_when: false
+
+    - name: Create Python provision sudoers configuration
+      ansible.builtin.copy:
+        content: |
+          # AutoBot Python Provision (#11343)
+          # Allows the autobot user to install the target Python interpreter via
+          # the provision-local-python.yml playbook without a password. Scoped to
+          # the EXACT ansible-playbook invocation the SLM backend issues.
+          # Created by: Ansible playbook configure-python-provision-permissions.yml
+          # Date: {{ ansible_facts['date_time'].iso8601 }}
+
+          {{ autobot_user }} ALL=(root) NOPASSWD: {{ ansible_playbook_bin }} {{ provision_playbook }} --tags python314 --limit localhost -i {{ provision_inventory }} --connection local
+        dest: "{{ sudoers_file }}.tmp"
+        owner: root
+        group: root
+        mode: '0440'
+
+    - name: Validate sudoers file syntax
+      ansible.builtin.command: visudo -cf {{ sudoers_file }}.tmp
+      register: visudo_check
+      changed_when: false
+
+    - name: Move validated sudoers file to final location
+      ansible.builtin.command: mv {{ sudoers_file }}.tmp {{ sudoers_file }}
+      when: visudo_check.rc == 0
+      changed_when: true
+
+    - name: Ensure sudoers file has correct permissions
+      ansible.builtin.file:
+        path: "{{ sudoers_file }}"
+        owner: root
+        group: root
+        mode: '0440'
+        state: file
+
+  post_tasks:
+    - name: Display configuration summary
+      ansible.builtin.debug:
+        msg:
+          - "Python Provision Permissions Configuration Complete"
+          - "Sudoers file: {{ sudoers_file }}"
+          - "User: {{ autobot_user }}"
+          - "The autobot user can now run the interpreter provisioning playbook:"
+          - "  sudo {{ ansible_playbook_bin }} {{ provision_playbook }} --tags python314 --limit localhost -i {{ provision_inventory }} --connection local"

--- a/autobot-slm-backend/ansible/playbooks/provision-local-python.yml
+++ b/autobot-slm-backend/ansible/playbooks/provision-local-python.yml
@@ -1,0 +1,40 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+#
+# Provision the target Python interpreter on the LOCAL host (#11343).
+#
+# The SLM code-sync update path calls this when the target interpreter
+# (python3.14 for backends, python3.11 for NPU) is missing on the box it
+# runs on. Applying roles/python314 to localhost installs the deadsnakes
+# interpreter so the subsequent venv recreation + pip install succeed.
+#
+# The python314 role is idempotent: it first runs `python3.14 --version`
+# and does nothing when the interpreter is already present. This playbook
+# is intentionally scoped to localhost with connection: local so it can be
+# driven from the SLM backend without SSH.
+#
+# Usage (run from autobot-slm-backend/ansible):
+#   ansible-playbook playbooks/provision-local-python.yml \
+#     --tags python314 --limit localhost -i inventory.yml --connection local
+#
+# Privilege: the role's apt tasks use become: true. The autobot service
+# user is granted a narrowly-scoped NOPASSWD sudoers entry for exactly this
+# invocation by playbooks/configure-python-provision-permissions.yml, which
+# must be applied once during provisioning.
+---
+
+- name: "Provision local Python interpreter (#11343)"
+  hosts: localhost
+  connection: local
+  become: true
+  gather_facts: true
+
+  tasks:
+    - name: "Install target Python interpreter via python314 role"
+      ansible.builtin.include_role:
+        name: python314
+        apply:
+          tags: ['deps', 'python314']
+      tags: ['deps', 'python314']

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -752,6 +752,15 @@ _COMPONENT_PYTHON_TARGET: Dict[str, str] = {
     "autobot-npu-worker": "python3.11",
 }
 
+# Ansible assets that provision the target interpreter on THIS host (#11343).
+# Derived from the code_source layout (DEFAULT_REPO_PATH) so a non-standard
+# SLM_REPO_PATH works without editing these — never hardcode /opt/autobot here.
+# These paths MUST match the sudoers grant created by
+# ansible/playbooks/configure-python-provision-permissions.yml.
+_ANSIBLE_DIR: Path = Path(DEFAULT_REPO_PATH) / "autobot-slm-backend" / "ansible"
+_PROVISION_PYTHON_PLAYBOOK: Path = _ANSIBLE_DIR / "playbooks" / "provision-local-python.yml"
+_PROVISION_PYTHON_INVENTORY: Path = _ANSIBLE_DIR / "inventory.yml"
+
 # Deployed path for the top-level constraints/ dir (#11322).
 # `autobot-backend/requirements.txt` uses `-c ../constraints/shared.txt` so the
 # relative path resolves to /opt/autobot/constraints/ at runtime.  Code-sync
@@ -868,6 +877,72 @@ async def _deploy_repo_root_requirements(source_root: str, steps: List[str]) -> 
                 steps.append(f"root-reqs: cp {filename} failed (rc={proc.returncode})")
         except Exception as exc:
             steps.append(f"root-reqs: {filename} deploy error: {exc}")
+
+
+async def _run_python_provision_playbook(target: str, steps: List[str]) -> bool:
+    """Run the python314 role on localhost to install *target* (#11343).
+
+    Invokes ansible-playbook via an ARG LIST (never a shell string) under sudo.
+    The command matches the NOPASSWD sudoers grant from
+    configure-python-provision-permissions.yml. Returns True on rc==0.
+    """
+    # ARG LIST only — never a shell string. Matches the NOPASSWD sudoers grant.
+    cmd = ["sudo", "ansible-playbook", str(_PROVISION_PYTHON_PLAYBOOK)]
+    cmd += ["--tags", "python314", "--limit", "localhost"]
+    cmd += ["-i", str(_PROVISION_PYTHON_INVENTORY), "--connection", "local"]
+    steps.append(f"python-provision: installing {target} via {_PROVISION_PYTHON_PLAYBOOK.name}")
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=600.0)
+        out = stdout.decode(errors="replace") if stdout else ""
+        if proc.returncode == 0:
+            logger.info("drift resolve: provisioned interpreter %s", target)
+            steps.append(f"python-provision: {target} install ok")
+            return True
+        logger.error("drift resolve: interpreter provision failed (%d): %s", proc.returncode, out[-400:])
+        steps.append(f"python-provision: FAILED (rc={proc.returncode}): {out[-200:]}")
+        return False
+    except asyncio.TimeoutError:
+        logger.error("drift resolve: interpreter provision timed out for %s", target)
+        steps.append("python-provision: timed out after 600s")
+        return False
+    except Exception as exc:
+        logger.error("drift resolve: interpreter provision error for %s: %s", target, exc)
+        steps.append(f"python-provision: error: {exc}")
+        return False
+
+
+async def _ensure_target_python_installed(component: str, steps: List[str]) -> None:
+    """Install the target interpreter when missing, BEFORE venv recreation (#11343).
+
+    Runs the Ansible python314 role (deadsnakes) scoped to localhost when the
+    interpreter mapped in _COMPONENT_PYTHON_TARGET is absent from PATH. Preserves
+    the #11323 safety guard: on provision failure it appends a clear step and
+    RETURNS without touching the venv, so a running service is never bricked.
+    The target is looked up from the trusted map — never a user-derived name.
+    """
+    import shutil
+
+    target = _COMPONENT_PYTHON_TARGET.get(component)
+    if target is None:
+        return
+    if shutil.which(target):
+        steps.append(f"python-provision: {target} already present — skipped")
+        return
+    if not _PROVISION_PYTHON_PLAYBOOK.exists():
+        steps.append(f"python-provision: playbook {_PROVISION_PYTHON_PLAYBOOK} not found — skipped")
+        return
+    ok = await _run_python_provision_playbook(target, steps)
+    if not ok:
+        return
+    if shutil.which(target):
+        steps.append(f"python-provision: {target} now on PATH")
+    else:
+        steps.append(f"python-provision: {target} STILL not on PATH after install")
 
 
 async def _ensure_venv_python(component: str, steps: List[str]) -> None:
@@ -1265,6 +1340,10 @@ async def _run_post_sync_steps(
         await _deploy_constraints_dir(source_root, steps)
         # Deploy repo-root files so `-r ../requirements.txt` resolves (#11336).
         await _deploy_repo_root_requirements(source_root, steps)
+        # Install the target interpreter if it is missing, BEFORE the venv
+        # check — otherwise _ensure_venv_python must skip recreation and the
+        # box stays stuck on the wrong Python (#11343).
+        await _ensure_target_python_installed(component, steps)
         # Recreate venv if its Python version doesn't match the target (#11323).
         await _ensure_venv_python(component, steps)
         pip_ok = await _install_pip_deps_for_component(component, steps)

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -71,11 +71,11 @@ import asyncio  # noqa: E402
 
 from api.code_sync import (  # noqa: E402
     _COMPONENT_PYTHON_TARGET,
-    _ensure_target_python_installed,
     _CONSTRAINTS_SOURCE_SUBDIR,
     _REPO_ROOT_REQUIREMENT_FILES,
     _deploy_constraints_dir,
     _deploy_repo_root_requirements,
+    _ensure_target_python_installed,
     _ensure_venv_python,
     _install_pip_deps_for_component,
     _run_post_sync_steps,

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -71,6 +71,7 @@ import asyncio  # noqa: E402
 
 from api.code_sync import (  # noqa: E402
     _COMPONENT_PYTHON_TARGET,
+    _ensure_target_python_installed,
     _CONSTRAINTS_SOURCE_SUBDIR,
     _REPO_ROOT_REQUIREMENT_FILES,
     _deploy_constraints_dir,
@@ -513,3 +514,118 @@ def test_run_post_sync_steps_calls_deploy_repo_root_requirements() -> None:
         _run(_run_post_sync_steps("autobot-backend", "/src/autobot-backend", "/opt/autobot/autobot-backend"))
 
     assert called, "_deploy_repo_root_requirements must be called for pip backend components"
+
+
+# ---------------------------------------------------------------------------
+# #11343 — _ensure_target_python_installed: provision interpreter when missing
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_target_python_skips_when_present() -> None:
+    """When shutil.which finds the target, no ansible playbook is invoked."""
+    steps: list[str] = []
+    with (
+        patch("shutil.which", return_value="/usr/bin/python3.14"),
+        patch("api.code_sync._run_python_provision_playbook", AsyncMock()) as run_pb,
+    ):
+        _run(_ensure_target_python_installed("autobot-backend", steps))
+    run_pb.assert_not_called()
+    assert any("already present" in s for s in steps)
+
+
+def test_ensure_target_python_invokes_ansible_when_missing() -> None:
+    """When the target is absent, the python314 provisioning playbook is run."""
+    steps: list[str] = []
+    with (
+        patch("shutil.which", return_value=None),
+        patch("api.code_sync._PROVISION_PYTHON_PLAYBOOK") as pb,
+        patch("api.code_sync._run_python_provision_playbook", AsyncMock(return_value=True)) as run_pb,
+    ):
+        pb.exists.return_value = True
+        _run(_ensure_target_python_installed("autobot-backend", steps))
+    run_pb.assert_awaited_once()
+
+
+def test_ensure_target_python_skipped_for_unknown_component() -> None:
+    """Non-Python components have no target and are a no-op."""
+    steps: list[str] = []
+    with patch("api.code_sync._run_python_provision_playbook", AsyncMock()) as run_pb:
+        _run(_ensure_target_python_installed("autobot-frontend", steps))
+    run_pb.assert_not_called()
+    assert steps == []
+
+
+def test_ensure_target_python_uses_arg_list_and_target_from_map(tmp_path) -> None:
+    """The ansible invocation is an arg-list (no shell) using the mapped target."""
+    steps: list[str] = []
+    captured: list = []
+
+    async def _fake_exec(*cmd, **kw):
+        captured.extend(cmd)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"ok", b""))
+        return proc
+
+    playbook = tmp_path / "provision-local-python.yml"
+    playbook.write_text("---\n", encoding="utf-8")
+    inventory = tmp_path / "inventory.yml"
+    inventory.write_text("all:\n", encoding="utf-8")
+
+    # shutil.which: None first (trigger provision), path after install re-check.
+    with (
+        patch("shutil.which", side_effect=[None, "/usr/bin/python3.14"]),
+        patch("api.code_sync._PROVISION_PYTHON_PLAYBOOK", playbook),
+        patch("api.code_sync._PROVISION_PYTHON_INVENTORY", inventory),
+        patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+    ):
+        _run(_ensure_target_python_installed("autobot-backend", steps))
+
+    assert captured[0] == "sudo"
+    assert captured[1] == "ansible-playbook"
+    assert "--tags" in captured and "python314" in captured
+    assert "--connection" in captured and "local" in captured
+    assert str(playbook) in captured
+    assert any("now on PATH" in s for s in steps)
+
+
+def test_ensure_target_python_does_not_recreate_venv_on_provision_failure() -> None:
+    """On ansible failure the venv is NOT removed/recreated (preserves #11323 guard)."""
+    steps: list[str] = []
+    with (
+        patch("shutil.which", return_value=None),
+        patch("api.code_sync._PROVISION_PYTHON_PLAYBOOK") as pb,
+        patch("api.code_sync._run_python_provision_playbook", AsyncMock(return_value=False)),
+        patch("api.code_sync._recreate_venv", AsyncMock()) as recreate,
+        patch("shutil.rmtree") as rmtree,
+    ):
+        pb.exists.return_value = True
+        _run(_ensure_target_python_installed("autobot-backend", steps))
+    recreate.assert_not_called()
+    rmtree.assert_not_called()
+
+
+def test_run_post_sync_steps_provisions_python_before_venv() -> None:
+    """_ensure_target_python_installed runs BEFORE _ensure_venv_python."""
+    order: list[str] = []
+
+    async def _provision(component, steps):
+        order.append("provision")
+
+    async def _venv(component, steps):
+        order.append("venv")
+
+    with (
+        patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
+        patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()),
+        patch("api.code_sync._ensure_target_python_installed", side_effect=_provision),
+        patch("api.code_sync._ensure_venv_python", side_effect=_venv),
+        patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)),
+        patch("api.code_sync._run_alembic_migrations", AsyncMock()),
+        patch("api.code_sync._ensure_autobot_shared_symlink", AsyncMock()),
+        patch("api.code_sync._restart_component_services", AsyncMock()),
+    ):
+        _run(_run_post_sync_steps("autobot-backend", "/src/autobot-backend", "/opt/autobot/autobot-backend"))
+
+    assert order == ["provision", "venv"], f"expected provision before venv, got {order}"


### PR DESCRIPTION
## Thinking Path

`_ensure_venv_python` (added in #11327/#11323) correctly SKIPS venv recreation when `shutil.which(target)` is None — but nothing installed the interpreter, so a py3.12 box stayed stuck and pip failed (`autobot-shared requires >=3.14`). The fix is to PROVISION the missing interpreter (deadsnakes) BEFORE the venv check, reusing the existing `python314` Ansible role rather than reimplementing apt logic. The install must run under privilege without granting blanket sudo, and it must never brick a running service if provisioning fails.

## What Changed

**`autobot-slm-backend/api/code_sync.py`**
- New module constants `_ANSIBLE_DIR`, `_PROVISION_PYTHON_PLAYBOOK`, `_PROVISION_PYTHON_INVENTORY` derived from `DEFAULT_REPO_PATH` (code_source layout) — no hardcoded `/opt/autobot` literals.
- New `_ensure_target_python_installed(component, steps)` (26-line span): resolves the target from the trusted `_COMPONENT_PYTHON_TARGET` map (no user-derived interpreter names). If `shutil.which(target)` present → append "already present" step and return. If missing → invoke the provisioning playbook, then re-check `shutil.which`. On failure → append a clear step and RETURN WITHOUT touching the venv (preserves the #11323 guard).
- New helper `_run_python_provision_playbook(target, steps)`: runs `sudo ansible-playbook <playbook> --tags python314 --limit localhost -i <inventory> --connection local` via `asyncio.create_subprocess_exec` with an **arg list** (never a shell string).
- Wired into `_run_post_sync_steps` BEFORE `_ensure_venv_python`, only for Python backend components.

**`autobot-slm-backend/ansible/playbooks/provision-local-python.yml`** (new)
- Applies `roles/python314` to `localhost` with `connection: local`. The role is idempotent (checks `python3.14 --version` first).

**`autobot-slm-backend/ansible/playbooks/configure-python-provision-permissions.yml`** (new)
- Creates `/etc/sudoers.d/autobot-python-provision` granting the `autobot` user a **narrowly-scoped NOPASSWD** entry for exactly the one `ansible-playbook ... provision-local-python.yml --tags python314 ...` invocation. Mirrors `configure-redis-service-management.yml` (visudo-validated, 0440 root:root). Running the whole playbook as root keeps the sudoers surface to ONE command instead of a blanket apt/add-apt-repository grant. **Must be applied once during provisioning.**

**`autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py`**
- 6 new tests: present→skip provisioning; missing→invokes ansible; arg-list + mapped-target shape; provision-failure→venv NOT removed/recreated; unknown component no-op; provision runs BEFORE venv.

## Verification

- `black --check api/code_sync.py` — unchanged; `ruff check` — All checks passed.
- `pytest tests/api/test_code_sync_deploy_bugs.py` — **26 passed** (6 new).
- `ansible-playbook --syntax-check` — both new playbooks OK. (`slm_server`/group-pattern warning with the bare `inventory.yml` is expected — same as `provision-fleet-roles.yml`/redis playbook, which resolve against the fleet inventory.)

Exact ansible invocation:
```
sudo ansible-playbook /opt/autobot/code_source/autobot-slm-backend/ansible/playbooks/provision-local-python.yml --tags python314 --limit localhost -i /opt/autobot/code_source/autobot-slm-backend/ansible/inventory.yml --connection local
```

## Model Used

Opus 4.8 (1M context)

Closes #11343

Note: self-hosted CI runner is currently offline; checks may be delayed.