### PR TITLE
fix(telemetry): persist consent-prompt dismissal for any authenticated user (#11344)

### DIFF
--- a/autobot-backend/api/settings.py
+++ b/autobot-backend/api/settings.py
@@ -984,49 +984,22 @@ async def get_telemetry_settings():
     )
 
 
-@router.post("/telemetry", response_model=TelemetrySettingsResponse)
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="update_telemetry_settings",
-    error_code_prefix="SETTINGS",
-)
-async def update_telemetry_settings(
-    request: TelemetrySettingsRequest,
-    session: Optional[AsyncSession] = Depends(get_optional_db_session),
-    current_user: dict = Depends(get_current_user),
-    _: None = Depends(check_admin_permission),
-):
-    """Update telemetry settings (Issue #9035).
+async def _persist_telemetry_patch(
+    fields: dict,
+    session: Optional[AsyncSession],
+    created_by: str,
+) -> dict:
+    """Merge *fields* into the telemetry config, persist, and audit.
 
-    Allows users to opt in/out of telemetry collection. When telemetry
-    is disabled, the AnalyticsMiddleware and VoiceRealtimeTelemetry
-    services skip data collection.
-
-    Requires admin permission.  The consent state is persisted to
-    settings.json via ConfigService; a DB audit-trail revision is also
-    recorded (Issue #10000).
-
-    Args:
-        request: New telemetry settings
-
-    Returns:
-        Updated telemetry settings
+    Shared save path for both the admin consent POST and the authenticated
+    prompt-dismissal endpoint (#11344). Only the keys present in *fields* are
+    written, so a dismissal never clobbers the enable/disable flags. Returns
+    the merged telemetry sub-config.
     """
-    before_config: dict = ConfigService.get_full_config()
-
-    # Build the minimal patch
-    patch: dict = {
-        "telemetry": {
-            "enabled": request.enabled,
-            "anonymous_usage_stats": request.anonymous_usage_stats,
-            "first_run_prompt_shown": request.first_run_prompt_shown,
-        }
-    }
-
-    # Deep-merge into a copy
     from config.loader import deep_merge
 
-    merged_config = deep_merge(copy.deepcopy(before_config), patch)
+    before_config: dict = ConfigService.get_full_config()
+    merged_config = deep_merge(copy.deepcopy(before_config), {"telemetry": fields})
     ConfigService.save_full_config(merged_config)
     ConfigService.clear_cache()
 
@@ -1041,20 +1014,88 @@ async def update_telemetry_settings(
             before_config=before_config,
             after_config=merged_config,
             source="api",
-            created_by=current_user.get("id", "unknown"),
+            created_by=created_by,
         )
     else:
         logger.debug("Telemetry audit trail skipped: Postgres unavailable in current deployment mode")
 
-    logger.info(
-        "Telemetry settings updated: enabled=%s, anonymous_usage_stats=%s (changed keys: %d)",
-        request.enabled,
-        request.anonymous_usage_stats,
-        len(changed),
+    logger.info("Telemetry settings updated (changed keys: %d)", len(changed))
+    return merged_config.get("telemetry", {})
+
+
+@router.post("/telemetry", response_model=TelemetrySettingsResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="update_telemetry_settings",
+    error_code_prefix="SETTINGS",
+)
+async def update_telemetry_settings(
+    request: TelemetrySettingsRequest,
+    session: Optional[AsyncSession] = Depends(get_optional_db_session),
+    current_user: dict = Depends(get_current_user),
+    _: None = Depends(check_admin_permission),
+):
+    """Update telemetry settings (Issue #9035).
+
+    Allows admins to opt in/out of telemetry collection. When telemetry
+    is disabled, the AnalyticsMiddleware and VoiceRealtimeTelemetry
+    services skip data collection.
+
+    Requires admin permission.  The consent state is persisted to
+    settings.json via ConfigService; a DB audit-trail revision is also
+    recorded (Issue #10000).
+
+    Args:
+        request: New telemetry settings
+
+    Returns:
+        Updated telemetry settings
+    """
+    await _persist_telemetry_patch(
+        {
+            "enabled": request.enabled,
+            "anonymous_usage_stats": request.anonymous_usage_stats,
+            "first_run_prompt_shown": request.first_run_prompt_shown,
+        },
+        session,
+        current_user.get("id", "unknown"),
     )
 
     return TelemetrySettingsResponse(
         enabled=request.enabled,
         anonymous_usage_stats=request.anonymous_usage_stats,
         first_run_prompt_shown=request.first_run_prompt_shown,
+    )
+
+
+@router.post("/telemetry/prompt-shown", response_model=TelemetrySettingsResponse)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="dismiss_telemetry_prompt",
+    error_code_prefix="SETTINGS",
+)
+async def dismiss_telemetry_prompt(
+    session: Optional[AsyncSession] = Depends(get_optional_db_session),
+    current_user: dict = Depends(get_current_user),
+):
+    """Mark the first-run telemetry prompt as shown (Issue #11344).
+
+    Records a UI-dismissal state only — it never changes the enable/disable
+    flags — so it is available to any authenticated user (not just admins).
+    This lets non-admins dismiss the consent modal without a 403, which
+    previously caused it to re-appear on every refresh. Toggling telemetry
+    itself still requires the admin-gated POST /telemetry endpoint.
+    """
+    from autobot_shared.ssot_config import config
+
+    await _persist_telemetry_patch(
+        {"first_run_prompt_shown": True},
+        session,
+        current_user.get("id", "unknown"),
+    )
+
+    return TelemetrySettingsResponse(
+        enabled=config.telemetry.enabled,
+        anonymous_usage_stats=config.telemetry.anonymous_usage_stats,
+        first_run_prompt_shown=True,
     )

--- a/autobot-backend/api/settings_telemetry_test.py
+++ b/autobot-backend/api/settings_telemetry_test.py
@@ -75,6 +75,7 @@ def _registered_deps(method: str, path_suffix: str) -> dict:
 # Cache at module level so we extract once per test session.
 _POST_DEPS = _registered_deps("POST", "/telemetry")
 _GET_DEPS = _registered_deps("GET", "/telemetry")
+_PROMPT_SHOWN_DEPS = _registered_deps("POST", "/telemetry/prompt-shown")
 
 # ---------------------------------------------------------------------------
 # Shared admin stubs
@@ -249,6 +250,94 @@ class TestPostTelemetryNoSession:
 # ---------------------------------------------------------------------------
 # GET /api/settings/telemetry
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# POST /api/settings/telemetry/prompt-shown — authenticated, non-admin (#11344)
+# ---------------------------------------------------------------------------
+
+
+def _non_admin_user() -> dict:
+    return {"username": "member", "role": "member", "id": "user-2"}
+
+
+def _make_prompt_shown_app(*, with_session: bool = True) -> FastAPI:
+    """App mounting the settings router with a NON-admin authenticated user.
+
+    Intentionally does NOT override check_admin_permission — the prompt-shown
+    endpoint must not depend on it (#11344).
+    """
+    app = FastAPI()
+    app.include_router(router, prefix="/api/settings")
+    app.dependency_overrides[get_optional_db_session] = _session_present if with_session else _session_absent
+    if "current_user" in _PROMPT_SHOWN_DEPS:
+        app.dependency_overrides[_PROMPT_SHOWN_DEPS["current_user"]] = _non_admin_user
+    return app
+
+
+class TestDismissTelemetryPrompt:
+    """POST /api/settings/telemetry/prompt-shown — any authenticated user."""
+
+    def test_non_admin_can_dismiss_returns_200(self):
+        """A non-admin marks the prompt shown without a 403 (#11344)."""
+        app = _make_prompt_shown_app(with_session=True)
+
+        fake_cfg = {"telemetry": {"enabled": True, "anonymous_usage_stats": True, "first_run_prompt_shown": False}}
+
+        class _FakeTelemetry:
+            enabled = True
+            anonymous_usage_stats = True
+            first_run_prompt_shown = True
+
+        class _FakeConfig:
+            telemetry = _FakeTelemetry()
+
+        with (
+            patch("api.settings.ConfigService.get_full_config", return_value=dict(fake_cfg)),
+            patch("api.settings.ConfigService.save_full_config", return_value={"status": "ok"}),
+            patch("api.settings.ConfigService.clear_cache"),
+            patch("api.settings.ConfigRevisionService", return_value=MagicMock(create_revision=AsyncMock())),
+            patch("autobot_shared.ssot_config.config", _FakeConfig()),
+        ):
+            client = TestClient(app, raise_server_exceptions=True)
+            resp = client.post("/api/settings/telemetry/prompt-shown", json={})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["first_run_prompt_shown"] is True
+
+    def test_dismiss_only_writes_prompt_flag(self):
+        """The dismissal patch must NOT clobber enabled/anonymous flags (#11344)."""
+        app = _make_prompt_shown_app(with_session=False)
+
+        save_mock = MagicMock(return_value={"status": "ok"})
+        fake_cfg = {"telemetry": {"enabled": True, "anonymous_usage_stats": True, "first_run_prompt_shown": False}}
+
+        class _FakeTelemetry:
+            enabled = True
+            anonymous_usage_stats = True
+            first_run_prompt_shown = True
+
+        class _FakeConfig:
+            telemetry = _FakeTelemetry()
+
+        with (
+            patch("api.settings.ConfigService.get_full_config", return_value=dict(fake_cfg)),
+            patch("api.settings.ConfigService.save_full_config", save_mock),
+            patch("api.settings.ConfigService.clear_cache"),
+            patch("api.settings.ConfigRevisionService", return_value=MagicMock()),
+            patch("autobot_shared.ssot_config.config", _FakeConfig()),
+        ):
+            client = TestClient(app, raise_server_exceptions=True)
+            resp = client.post("/api/settings/telemetry/prompt-shown", json={})
+
+        assert resp.status_code == 200
+        save_mock.assert_called_once()
+        saved = save_mock.call_args.args[0]["telemetry"]
+        # Original enable flags preserved; only the prompt flag flipped true.
+        assert saved["enabled"] is True
+        assert saved["anonymous_usage_stats"] is True
+        assert saved["first_run_prompt_shown"] is True
 
 
 class TestGetTelemetry:

--- a/autobot-frontend/src/components/modals/TelemetryConsentModal.vue
+++ b/autobot-frontend/src/components/modals/TelemetryConsentModal.vue
@@ -131,21 +131,31 @@ async function updateConsent(enabled: boolean) {
   isProcessing.value = true
 
   try {
+    // Persist the enable/disable choice (admin-gated). Non-admins will get a
+    // 403 here — that is expected and handled below by the prompt-shown call.
     await api.post('/api/settings/telemetry', {
       enabled,
       anonymous_usage_stats: enabled,
       first_run_prompt_shown: true,
     })
-
-    localStorage.setItem(CONSENT_STORAGE_KEY, 'true')
-    isVisible.value = false
-
     logger.debug(`Telemetry consent: ${enabled ? 'accepted' : 'declined'}`)
   } catch (error) {
     logger.error('Failed to save telemetry consent', error)
-    // Close the modal even on error to avoid blocking the user
-    isVisible.value = false
   } finally {
+    // Record the dismissal for ANY authenticated user (#11344). This is a
+    // non-admin endpoint, so it persists server-side even when the admin POST
+    // above 403s. Best-effort: a failure here still falls through to the
+    // localStorage flag so the modal never re-nags on this browser.
+    try {
+      await api.post('/api/settings/telemetry/prompt-shown', {})
+    } catch (error) {
+      logger.error('Failed to persist telemetry prompt dismissal', error)
+    }
+
+    // Always mark shown locally and close, regardless of POST success/failure,
+    // so the consent modal never re-appears on refresh (#11344).
+    localStorage.setItem(CONSENT_STORAGE_KEY, 'true')
+    isVisible.value = false
     isProcessing.value = false
   }
 }

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -2823,7 +2823,7 @@ export interface paths {
          * Update Telemetry Settings
          * @description Update telemetry settings (Issue #9035).
          *
-         *     Allows users to opt in/out of telemetry collection. When telemetry
+         *     Allows admins to opt in/out of telemetry collection. When telemetry
          *     is disabled, the AnalyticsMiddleware and VoiceRealtimeTelemetry
          *     services skip data collection.
          *
@@ -2838,6 +2838,32 @@ export interface paths {
          *         Updated telemetry settings
          */
         post: operations["update_telemetry_settings_api_settings_telemetry_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/settings/telemetry/prompt-shown": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Dismiss Telemetry Prompt
+         * @description Mark the first-run telemetry prompt as shown (Issue #11344).
+         *
+         *     Records a UI-dismissal state only — it never changes the enable/disable
+         *     flags — so it is available to any authenticated user (not just admins).
+         *     This lets non-admins dismiss the consent modal without a 403, which
+         *     previously caused it to re-appear on every refresh. Toggling telemetry
+         *     itself still requires the admin-gated POST /telemetry endpoint.
+         */
+        post: operations["dismiss_telemetry_prompt_api_settings_telemetry_prompt_shown_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -104397,6 +104423,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    dismiss_telemetry_prompt_api_settings_telemetry_prompt_shown_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TelemetrySettingsResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Thinking Path

The "Local Usage Metrics" consent modal re-appeared on every refresh because the user's choice never persisted. Two compounding causes:

1. **Frontend:** `updateConsent()` set the `localStorage` shown-flag only *after* a successful admin-gated `POST /api/settings/telemetry`. Any POST failure (403/401/500/network) closed the modal but skipped the flag, so `checkShouldShow` re-showed it next refresh.
2. **Backend:** `POST /api/settings/telemetry` requires admin (`check_admin_permission`), but the modal is mounted for **all** users. A non-admin's consent POST 403'd, and `first_run_prompt_shown` never flipped server-side either — infinite nag.

Chosen approach: **new authenticated (non-admin) endpoint** (the preferred option), because it lets non-admins durably dismiss the prompt server-side, not just locally. The security-sensitive enable/disable toggle stays admin-gated.

## What Changed

**Frontend** — `autobot-frontend/src/components/modals/TelemetryConsentModal.vue`
- Moved `localStorage.setItem(CONSENT_STORAGE_KEY, 'true')` and modal close into the `finally` block of `updateConsent()`, so the shown-flag is set unconditionally on either button click regardless of POST outcome.
- Added a best-effort `POST /api/settings/telemetry/prompt-shown` in `finally` so the dismissal persists server-side even when the admin POST 403s for non-admins. Existing admin POST (enable/disable) kept.

**Backend** — `autobot-backend/api/settings.py`
- Extracted the ConfigService save + audit-trail path into a shared `_persist_telemetry_patch()` helper (no duplication). It merges only the supplied keys, so a dismissal never clobbers the enable flags.
- Refactored the admin `update_telemetry_settings` to use the helper.
- Added `POST /api/settings/telemetry/prompt-shown` — authenticated, **not** admin-gated — that writes only `first_run_prompt_shown=true`. Round-trips through `ConfigService.save_full_config`; `GET /telemetry` then returns `first_run_prompt_shown: true`.

**Tests** — `autobot-backend/api/settings_telemetry_test.py`
- `test_non_admin_can_dismiss_returns_200` — non-admin marks prompt shown without 403.
- `test_dismiss_only_writes_prompt_flag` — asserts the patch preserves `enabled`/`anonymous_usage_stats`.

No new user-facing strings added, so no i18n changes. The generated `api.ts` (OpenAPI SoT) picks up the new route via the CI regen job — no hand-edit.

## Verification

- Backend: `black --check --line-length 120` clean; `ruff check` — All checks passed.
- Backend tests: `pytest api/settings_telemetry_test.py` — **8 passed**.
- Frontend: `vue-tsc --noEmit -p tsconfig.app.json` — no errors on the changed modal (unrelated baseline noise pre-existing).
- Frontend: `eslint TelemetryConsentModal.vue` — exit 0, clean.

## Model Used

Opus 4.8 (1M context)

Closes #11344
