### PR TITLE
feat(code-sync): async component drift/resolve job so the SLM GUI stays responsive (#11303 T1)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -156,9 +156,7 @@ async def reconcile_stale_component_sync_jobs() -> int:
     from services.database import db_service
 
     async with db_service.session() as db:
-        result = await db.execute(
-            select(ComponentSyncJobModel).where(ComponentSyncJobModel.status == "running")
-        )
+        result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.status == "running"))
         stale_jobs = result.scalars().all()
         count = len(stale_jobs)
 
@@ -167,8 +165,7 @@ async def reconcile_stale_component_sync_jobs() -> int:
             job.completed_at = datetime.now(timezone.utc)
             job.message = "reconciled: server restarted while job was running"
             logger.warning(
-                "Reconciled stale component sync job %s "
-                "(was 'running', marked 'failed')",
+                "Reconciled stale component sync job %s " "(was 'running', marked 'failed')",
                 job.job_id,
             )
 
@@ -193,9 +190,7 @@ async def _run_component_resolve_job(job_id: str, component: str) -> None:
             source_dir = get_default_source_dir(component)
         except ValueError as exc:
             async with db_service.session() as db:
-                result = await db.execute(
-                    select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id)
-                )
+                result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id))
                 job_row = result.scalar_one_or_none()
                 if job_row:
                     job_row.status = "failed"
@@ -227,9 +222,7 @@ async def _run_component_resolve_job(job_id: str, component: str) -> None:
 
         if not ok:
             async with db_service.session() as db:
-                result = await db.execute(
-                    select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id)
-                )
+                result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id))
                 job_row = result.scalar_one_or_none()
                 if job_row:
                     job_row.status = "failed"
@@ -247,9 +240,7 @@ async def _run_component_resolve_job(job_id: str, component: str) -> None:
         # Commit the job row BEFORE the restart — the whole point of this async
         # path.  If the restart kills this process the row is already durable.
         async with db_service.session() as db:
-            result = await db.execute(
-                select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id)
-            )
+            result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id))
             job_row = result.scalar_one_or_none()
             if job_row:
                 job_row.status = "completed" if pip_ok else "failed"
@@ -283,9 +274,7 @@ async def _run_component_resolve_job(job_id: str, component: str) -> None:
             from services.database import db_service as _db_svc
 
             async with _db_svc.session() as db:
-                result = await db.execute(
-                    select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id)
-                )
+                result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id))
                 job_row = result.scalar_one_or_none()
                 if job_row:
                     job_row.status = "failed"
@@ -293,9 +282,7 @@ async def _run_component_resolve_job(job_id: str, component: str) -> None:
                     job_row.completed_at = datetime.now(timezone.utc)
                     await db.commit()
         except Exception as inner:
-            logger.error(
-                "component resolve job %s: failed to persist error state: %s", job_id, inner
-            )
+            logger.error("component resolve job %s: failed to persist error state: %s", job_id, inner)
     finally:
         _running_tasks.pop(job_id, None)
 
@@ -739,9 +726,7 @@ async def get_component_resolve_status(
 
     Raises 404 if job_id is unknown.
     """
-    result = await db.execute(
-        select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id)
-    )
+    result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id))
     row = result.scalar_one_or_none()
 
     if row is None:

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -29,6 +29,7 @@ from typing_extensions import Annotated
 
 from config import settings
 from models.database import CodeSource, CodeStatus
+from models.database import ComponentSyncJob as ComponentSyncJobModel
 from models.database import FleetSyncJob as FleetSyncJobModel
 from models.database import FleetSyncNodeState as FleetSyncNodeStateModel
 from models.database import Node, NodeRole, Setting, UpdateSchedule
@@ -37,6 +38,8 @@ from models.schemas import (
     CodeSyncStatusResponse,
     CodeVersionNotification,
     CodeVersionNotificationResponse,
+    ComponentSyncJobStatus,
+    DriftResolveJobResponse,
     DriftResolveRequest,
     DriftResolveResponse,
     FileDriftReport,
@@ -138,6 +141,163 @@ async def reconcile_stale_fleet_sync_jobs() -> int:
             await db.commit()
 
     return count
+
+
+async def reconcile_stale_component_sync_jobs() -> int:
+    """Mark stale 'running' component sync jobs as failed on startup (#11303).
+
+    Called during SLM backend lifespan init.  Any job left in 'running' status
+    from a prior process crash (including a self-restart triggered by the job
+    itself) is marked 'failed' with an explanatory message.
+
+    Returns:
+        Number of stale jobs reconciled.
+    """
+    from services.database import db_service
+
+    async with db_service.session() as db:
+        result = await db.execute(
+            select(ComponentSyncJobModel).where(ComponentSyncJobModel.status == "running")
+        )
+        stale_jobs = result.scalars().all()
+        count = len(stale_jobs)
+
+        for job in stale_jobs:
+            job.status = "failed"
+            job.completed_at = datetime.now(timezone.utc)
+            job.message = "reconciled: server restarted while job was running"
+            logger.warning(
+                "Reconciled stale component sync job %s "
+                "(was 'running', marked 'failed')",
+                job.job_id,
+            )
+
+        if count:
+            await db.commit()
+
+    return count
+
+
+async def _run_component_resolve_job(job_id: str, component: str) -> None:
+    """Background executor for an async component drift/resolve job (#11303).
+
+    Runs rsync + post-sync steps (pip/build/alembic) then commits the job row
+    to DB BEFORE triggering the service restart.  This guarantees the status is
+    durable even if the restart kills this process (the autobot-slm-backend
+    self-resolve case).
+    """
+    from services.database import db_service
+
+    try:
+        try:
+            source_dir = get_default_source_dir(component)
+        except ValueError as exc:
+            async with db_service.session() as db:
+                result = await db.execute(
+                    select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id)
+                )
+                job_row = result.scalar_one_or_none()
+                if job_row:
+                    job_row.status = "failed"
+                    job_row.success = False
+                    job_row.message = f"Failed to determine source path: {exc}"
+                    job_row.completed_at = datetime.now(timezone.utc)
+                    await db.commit()
+            logger.error("component resolve job %s: source path error: %s", job_id, exc)
+            return
+
+        deployed_dir = get_default_deployed_dir(component)
+        source_root = str(Path(source_dir).parent)
+
+        excludes_map = {comp: excl for comp, excl in _SLM_COMPONENTS}
+        excludes = excludes_map.get(
+            component,
+            ["__pycache__", "*.pyc", ".git", "node_modules", "dist", "venv", "*.log"],
+        )
+
+        logger.info(
+            "component resolve job %s: rsync source=%s/%s deployed=%s",
+            job_id,
+            source_root,
+            component,
+            deployed_dir,
+        )
+
+        ok, msg = await _rsync_component_local(source_root, component, excludes)
+
+        if not ok:
+            async with db_service.session() as db:
+                result = await db.execute(
+                    select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id)
+                )
+                job_row = result.scalar_one_or_none()
+                if job_row:
+                    job_row.status = "failed"
+                    job_row.success = False
+                    job_row.message = msg or "rsync failed"
+                    job_row.completed_at = datetime.now(timezone.utc)
+                    await db.commit()
+            logger.error("component resolve job %s: rsync failed: %s", job_id, msg)
+            return
+
+        deps_changed, post_steps, pip_ok = await _run_post_sync_steps(
+            component, source_dir, deployed_dir, restart=False
+        )
+
+        # Commit the job row BEFORE the restart — the whole point of this async
+        # path.  If the restart kills this process the row is already durable.
+        async with db_service.session() as db:
+            result = await db.execute(
+                select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id)
+            )
+            job_row = result.scalar_one_or_none()
+            if job_row:
+                job_row.status = "completed" if pip_ok else "failed"
+                job_row.success = pip_ok
+                job_row.deps_changed = deps_changed
+                job_row.post_steps = "\n".join(post_steps)
+                if pip_ok:
+                    job_row.message = f"Resynced {component} from code_source"
+                else:
+                    job_row.message = "pip install failed — see post_steps"
+                job_row.completed_at = datetime.now(timezone.utc)
+                await db.commit()
+
+        if not pip_ok:
+            logger.error("component resolve job %s: pip install failed", job_id)
+            return
+
+        logger.info(
+            "component resolve job %s: completed; triggering deferred restart for %s",
+            job_id,
+            component,
+        )
+        # Deferred restart — may kill this process for autobot-slm-backend; that
+        # is fine because the job row is already committed above.
+        steps2: List[str] = []
+        await _restart_component_services(component, steps2)
+
+    except Exception as exc:
+        logger.error("component resolve job %s: unexpected error: %s", job_id, exc, exc_info=True)
+        try:
+            from services.database import db_service as _db_svc
+
+            async with _db_svc.session() as db:
+                result = await db.execute(
+                    select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id)
+                )
+                job_row = result.scalar_one_or_none()
+                if job_row:
+                    job_row.status = "failed"
+                    job_row.message = str(exc)
+                    job_row.completed_at = datetime.now(timezone.utc)
+                    await db.commit()
+        except Exception as inner:
+            logger.error(
+                "component resolve job %s: failed to persist error state: %s", job_id, inner
+            )
+    finally:
+        _running_tasks.pop(job_id, None)
 
 
 async def _persist_fleet_sync_job(
@@ -519,6 +679,84 @@ async def resolve_drift(
         deployed_dir=deployed_dir,
         deps_changed=deps_changed,
         post_steps=post_steps,
+    )
+
+
+@router.post("/drift/resolve-async", response_model=DriftResolveJobResponse, status_code=202)
+async def resolve_drift_async(
+    request: DriftResolveRequest,
+    _: Annotated[dict, Depends(get_current_user)],
+) -> DriftResolveJobResponse:
+    """
+    Kick off an async per-component drift/resolve job (#11303).
+
+    Identical validation to POST /drift/resolve but returns immediately with a
+    job_id.  The rsync + post-sync steps (pip/build/alembic) run in the
+    background.  Job status is persisted to DB so it survives the SLM backend
+    restarting itself when autobot-slm-backend is the resolved component.
+
+    Poll GET /drift/resolve/status/{job_id} to track progress.
+    """
+    if request.component not in ALLOWED_COMPONENTS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid component '{request.component}'. Must be one of: {sorted(ALLOWED_COMPONENTS)}",
+        )
+
+    from services.database import db_service
+
+    job_id = uuid.uuid4().hex
+
+    async with db_service.session() as db:
+        db.add(
+            ComponentSyncJobModel(
+                job_id=job_id,
+                component=request.component,
+                status="running",
+            )
+        )
+        await db.commit()
+
+    task = asyncio.create_task(_run_component_resolve_job(job_id, request.component))
+    _running_tasks[job_id] = task
+
+    logger.info(
+        "drift resolve-async: spawned job %s for component %s",
+        job_id,
+        request.component,
+    )
+    return DriftResolveJobResponse(job_id=job_id, component=request.component, status="running")
+
+
+@router.get("/drift/resolve/status/{job_id}", response_model=ComponentSyncJobStatus)
+async def get_component_resolve_status(
+    job_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[dict, Depends(get_current_user)],
+) -> ComponentSyncJobStatus:
+    """
+    Return the status of an async component drift/resolve job (#11303).
+
+    Raises 404 if job_id is unknown.
+    """
+    result = await db.execute(
+        select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id)
+    )
+    row = result.scalar_one_or_none()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"No component sync job found for id '{job_id}'")
+
+    return ComponentSyncJobStatus(
+        job_id=row.job_id,
+        component=row.component,
+        status=row.status,
+        success=row.success,
+        deps_changed=bool(row.deps_changed),
+        message=row.message,
+        post_steps=row.post_steps.split("\n") if row.post_steps else [],
+        created_at=row.created_at,
+        completed_at=row.completed_at,
     )
 
 
@@ -1385,6 +1623,7 @@ async def _run_post_sync_steps(
     component: str,
     source_dir: str,
     deployed_dir: str,
+    restart: bool = True,
 ) -> Tuple[bool, List[str], bool]:
     """Run dep-install / rebuild / restart after a per-component rsync (#9982).
 
@@ -1392,6 +1631,11 @@ async def _run_post_sync_steps(
     pip_ok is False when pip or npm exits non-zero so resolve_drift can surface
     the failure via success=False rather than silently returning success=True
     (#11322, #11351).
+
+    restart=False defers the final service restart so the async job path (#11303)
+    can commit the job row to DB before restarting (surviving a self-restart of
+    autobot-slm-backend).  All other steps still run; restart=True (default) keeps
+    the existing synchronous behaviour for all current callers.
 
     Component routing:
       - Python backend (autobot-backend, autobot-slm-backend):
@@ -1430,19 +1674,28 @@ async def _run_post_sync_steps(
         # Restore symlink BEFORE restart so the process imports the correct shared
         # code the moment it starts (#10912).
         await _ensure_autobot_shared_symlink(component, steps)
-        await _restart_component_services(component, steps)
+        if restart:
+            await _restart_component_services(component, steps)
+        else:
+            steps.append("post-sync: restart deferred")
     elif component in _COMPONENT_FRONTEND_DIRS:
         npm_ok = await _build_npm_frontend_for_component(component, steps)
         if not npm_ok:
             pip_ok = False
-        await _restart_component_services(component, steps)
+        if restart:
+            await _restart_component_services(component, steps)
+        else:
+            steps.append("post-sync: restart deferred")
     elif component in _COMPONENT_SERVICES:
         # Library component (autobot_shared): no build step, but every service
         # that imports it must restart so the new shared code is loaded (#10248).
         # Restore both backends' symlinks first so services start cleanly (#10912).
         for backend in sorted(_BACKEND_COMPONENTS):
             await _ensure_autobot_shared_symlink(backend, steps)
-        await _restart_component_services(component, steps)
+        if restart:
+            await _restart_component_services(component, steps)
+        else:
+            steps.append("post-sync: restart deferred")
     else:
         steps.append(f"post-sync: no service or build step for {component}")
 

--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -251,6 +251,16 @@ async def lifespan(app: FastAPI):
     except Exception:
         logger.exception("Failed to reconcile stale fleet sync jobs")
 
+    # Reconcile stale component sync jobs from prior crash (#11303)
+    try:
+        from api.code_sync import reconcile_stale_component_sync_jobs
+
+        reconciled_comp = await reconcile_stale_component_sync_jobs()
+        if reconciled_comp:
+            logger.warning("Reconciled %d stale component sync job(s)", reconciled_comp)
+    except Exception:
+        logger.exception("Failed to reconcile stale component sync jobs")
+
     # Resume any update-all fleet stage interrupted by SLM self-update restart (#9971)
     try:
         from api.code_sync import resume_update_all_orchestration

--- a/autobot-slm-backend/migrations/add_component_sync_jobs_table.py
+++ b/autobot-slm-backend/migrations/add_component_sync_jobs_table.py
@@ -41,10 +41,7 @@ def _create_component_sync_jobs(cursor) -> None:
             completed_at TIMESTAMPTZ
         )
     """)
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_component_sync_jobs_job_id "
-        "ON component_sync_jobs (job_id)"
-    )
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_component_sync_jobs_job_id " "ON component_sync_jobs (job_id)")
     logger.info("Created component_sync_jobs table")
 
 

--- a/autobot-slm-backend/migrations/add_component_sync_jobs_table.py
+++ b/autobot-slm-backend/migrations/add_component_sync_jobs_table.py
@@ -1,0 +1,69 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Migration: Add component_sync_jobs table.
+
+Persists per-component drift/resolve job tracking to survive SLM backend
+restarts.  When the resolved component is autobot-slm-backend, the final
+service restart kills the in-flight request.  The job row is committed before
+the restart so the GUI can poll for completion (#11303, same rationale as
+#1707 for fleet_sync_jobs).
+"""
+
+import logging
+import sys
+
+from migrations.utils import get_connection, table_exists
+
+logger = logging.getLogger(__name__)
+
+
+def _create_component_sync_jobs(cursor) -> None:
+    """Create component_sync_jobs table if not exists (#11303)."""
+    if table_exists(cursor, "component_sync_jobs"):
+        logger.info("component_sync_jobs table already exists")
+        return
+
+    logger.info("Creating component_sync_jobs table...")
+    cursor.execute("""
+        CREATE TABLE component_sync_jobs (
+            id SERIAL PRIMARY KEY,
+            job_id VARCHAR(64) UNIQUE NOT NULL,
+            component VARCHAR(64) NOT NULL,
+            status VARCHAR(20) DEFAULT 'pending',
+            success BOOLEAN,
+            deps_changed BOOLEAN DEFAULT FALSE,
+            message TEXT,
+            post_steps TEXT,
+            created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+            completed_at TIMESTAMPTZ
+        )
+    """)
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_component_sync_jobs_job_id "
+        "ON component_sync_jobs (job_id)"
+    )
+    logger.info("Created component_sync_jobs table")
+
+
+def migrate(db_url: str) -> None:
+    """Add component sync job tracking table (#11303)."""
+    conn = get_connection(db_url)
+    cursor = conn.cursor()
+
+    _create_component_sync_jobs(cursor)
+
+    conn.commit()
+    conn.close()
+    logger.info("Migration completed successfully!")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    from migrations.runner import get_db_url
+
+    db_url = sys.argv[1] if len(sys.argv) > 1 else get_db_url()
+    logger.info("Migrating database: %s", db_url)
+    migrate(db_url)

--- a/autobot-slm-backend/migrations/runner.py
+++ b/autobot-slm-backend/migrations/runner.py
@@ -66,6 +66,9 @@ MIGRATIONS = [
     # Issue #10764: rename the integer-PK SLM node audit table off 'audit_logs'
     # so the UUID/org-aware user_management model is the sole owner of that name.
     "rename_audit_logs_to_slm_node_audit_logs",
+    # Issue #11303: per-component async drift/resolve job tracking table so job
+    # status survives the SLM backend restarting itself during a self-resolve.
+    "add_component_sync_jobs_table",
 ]
 
 

--- a/autobot-slm-backend/models/database.py
+++ b/autobot-slm-backend/models/database.py
@@ -409,6 +409,27 @@ class FleetSyncNodeState(Base):
     completed_at = Column(DateTime(timezone=True), nullable=True)
 
 
+class ComponentSyncJob(Base):
+    """Async per-component drift/resolve job (#11303).
+
+    DB-backed so status survives the SLM backend restarting itself when the
+    resolved component is autobot-slm-backend (same rationale as #1707).
+    """
+
+    __tablename__ = "component_sync_jobs"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    job_id = Column(String(64), unique=True, nullable=False, index=True)
+    component = Column(String(64), nullable=False)
+    status = Column(String(20), default="pending")  # pending|running|completed|failed
+    success = Column(Boolean, nullable=True)
+    deps_changed = Column(Boolean, default=False)
+    message = Column(Text, nullable=True)
+    post_steps = Column(Text, nullable=True)  # newline-joined step log
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+
+
 class Service(Base):
     """Service tracking for systemd services on nodes."""
 

--- a/autobot-slm-backend/models/schemas.py
+++ b/autobot-slm-backend/models/schemas.py
@@ -1631,6 +1631,28 @@ class DriftResolveResponse(BaseModel):
     post_steps: List[str] = []
 
 
+class DriftResolveJobResponse(BaseModel):
+    """Accepted async component-resolve job (#11303)."""
+
+    job_id: str
+    component: str
+    status: str
+
+
+class ComponentSyncJobStatus(BaseModel):
+    """Status of an async component-resolve job (#11303)."""
+
+    job_id: str
+    component: str
+    status: str
+    success: bool | None = None
+    deps_changed: bool = False
+    message: str | None = None
+    post_steps: List[str] = []
+    created_at: datetime | None = None
+    completed_at: datetime | None = None
+
+
 class PendingNodeResponse(BaseModel):
     """Node that needs code update."""
 

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -41,6 +41,8 @@ if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMoc
         "CodeSyncRefreshResponse",
         "CodeVersionNotification",
         "CodeVersionNotificationResponse",
+        "ComponentSyncJobStatus",
+        "DriftResolveJobResponse",
         "DriftResolveRequest",
         "DriftResolveResponse",
         "FileDriftReport",

--- a/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
@@ -46,6 +46,8 @@ if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMoc
         "CodeSyncRefreshResponse",
         "CodeVersionNotification",
         "CodeVersionNotificationResponse",
+        "ComponentSyncJobStatus",
+        "DriftResolveJobResponse",
         "DriftResolveRequest",
         "DriftResolveResponse",
         "FileDriftReport",

--- a/autobot-slm-backend/tests/api/test_component_resolve_job.py
+++ b/autobot-slm-backend/tests/api/test_component_resolve_job.py
@@ -1,0 +1,322 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the async component drift/resolve job (#11303).
+
+Covers:
+  - _run_post_sync_steps(..., restart=False) defers restart, adds "restart deferred" step.
+  - _run_post_sync_steps(..., restart=True) (default) calls _restart_component_services.
+  - _run_component_resolve_job happy path: rsync ok + pip ok → job status="completed",
+    restart IS called, and the DB commit happens BEFORE the restart.
+  - _run_component_resolve_job rsync-failure path: status="failed", restart NOT called.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+# ---------------------------------------------------------------------------
+# Dev-host stub: provide minimal real Pydantic models for models.schemas so
+# the router can be imported without a full SLM venv.
+# Must happen before the api.code_sync import below.
+# ---------------------------------------------------------------------------
+if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMock):
+    from pydantic import BaseModel as _BM
+
+    def _pydantic_stub(name: str, **fields) -> type:
+        return type(name, (_BM,), {"__annotations__": {k: type(v) for k, v in fields.items()}, **fields})
+
+    _schemas = types.ModuleType("models.schemas")
+    for _cls in [
+        "CodeSyncStatusResponse",
+        "CodeSyncRefreshResponse",
+        "CodeVersionNotification",
+        "CodeVersionNotificationResponse",
+        "ComponentSyncJobStatus",
+        "DriftResolveJobResponse",
+        "DriftResolveRequest",
+        "DriftResolveResponse",
+        "FileDriftReport",
+        "FleetSyncJobStatus",
+        "FleetSyncNodeStatus",
+        "FleetSyncRequest",
+        "FleetSyncResponse",
+        "MarkSyncedResponse",
+        "NodeSyncRequest",
+        "NodeSyncResponse",
+        "PendingNodeResponse",
+        "PendingNodesResponse",
+        "ScheduleCreate",
+        "ScheduleResponse",
+        "ScheduleRunResponse",
+        "ScheduleUpdate",
+    ]:
+        setattr(_schemas, _cls, _pydantic_stub(_cls))
+    _models = sys.modules.get("models") or types.ModuleType("models")
+    _models.schemas = _schemas  # type: ignore[attr-defined]
+    sys.modules["models"] = _models
+    sys.modules["models.schemas"] = _schemas
+
+# Add autobot-slm-backend to path so api.code_sync imports resolve.
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+import asyncio  # noqa: E402  (re-import for clarity after path setup)
+
+from api.code_sync import (  # noqa: E402
+    _run_component_resolve_job,
+    _run_post_sync_steps,
+)
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build a db_service mock that captures row mutations
+# ---------------------------------------------------------------------------
+
+
+class _FakeRow:
+    """Minimal mutable object standing in for a ComponentSyncJob DB row."""
+
+    def __init__(self):
+        self.status = "running"
+        self.success = None
+        self.deps_changed = False
+        self.post_steps = None
+        self.message = None
+        self.completed_at = None
+
+
+def _make_db_service_mock(row: _FakeRow | None = None):
+    """Return a db_service mock whose session() is an async ctx-manager."""
+    db_service_mock = MagicMock()
+
+    fake_row = row
+
+    class _FakeSession:
+        def __init__(self):
+            self._committed = False
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            pass
+
+        async def execute(self, _stmt):
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = fake_row
+            return result
+
+        async def commit(self):
+            self._committed = True
+
+        def add(self, obj):
+            pass
+
+    db_service_mock.session.return_value = _FakeSession()
+    return db_service_mock
+
+
+# ---------------------------------------------------------------------------
+# _run_post_sync_steps — restart param
+# ---------------------------------------------------------------------------
+
+
+def test_run_post_sync_steps_restart_false_does_not_call_restart() -> None:
+    """restart=False must NOT invoke _restart_component_services for pip backends."""
+    restart_mock = AsyncMock()
+    with (
+        patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
+        patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()),
+        patch("api.code_sync._ensure_target_python_installed", AsyncMock()),
+        patch("api.code_sync._ensure_venv_python", AsyncMock()),
+        patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)),
+        patch("api.code_sync._run_alembic_migrations", AsyncMock()),
+        patch("api.code_sync._ensure_autobot_shared_symlink", AsyncMock()),
+        patch("api.code_sync._restart_component_services", restart_mock),
+    ):
+        _, steps, pip_ok = _run(
+            _run_post_sync_steps(
+                "autobot-slm-backend",
+                "/opt/autobot/code_source/autobot-slm-backend",
+                "/opt/autobot/autobot-slm-backend",
+                restart=False,
+            )
+        )
+
+    restart_mock.assert_not_called()
+    assert pip_ok is True
+    assert any("restart deferred" in s for s in steps), f"Expected 'restart deferred' in {steps}"
+
+
+def test_run_post_sync_steps_restart_true_calls_restart() -> None:
+    """restart=True (default) MUST call _restart_component_services for pip backends."""
+    restart_mock = AsyncMock()
+    with (
+        patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._deploy_constraints_dir", AsyncMock()),
+        patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()),
+        patch("api.code_sync._ensure_target_python_installed", AsyncMock()),
+        patch("api.code_sync._ensure_venv_python", AsyncMock()),
+        patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)),
+        patch("api.code_sync._run_alembic_migrations", AsyncMock()),
+        patch("api.code_sync._ensure_autobot_shared_symlink", AsyncMock()),
+        patch("api.code_sync._restart_component_services", restart_mock),
+    ):
+        _, steps, pip_ok = _run(
+            _run_post_sync_steps(
+                "autobot-slm-backend",
+                "/opt/autobot/code_source/autobot-slm-backend",
+                "/opt/autobot/autobot-slm-backend",
+            )
+        )
+
+    restart_mock.assert_called_once()
+    assert pip_ok is True
+    assert not any("restart deferred" in s for s in steps)
+
+
+def test_run_post_sync_steps_restart_false_frontend() -> None:
+    """restart=False defers restart for frontend components too."""
+    restart_mock = AsyncMock()
+    with (
+        patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._build_npm_frontend_for_component", AsyncMock()),
+        patch("api.code_sync._restart_component_services", restart_mock),
+    ):
+        _, steps, _ = _run(
+            _run_post_sync_steps(
+                "autobot-slm-frontend",
+                "/opt/autobot/code_source/autobot-slm-frontend",
+                "/opt/autobot/autobot-slm-frontend",
+                restart=False,
+            )
+        )
+
+    restart_mock.assert_not_called()
+    assert any("restart deferred" in s for s in steps)
+
+
+def test_run_post_sync_steps_restart_false_shared_library() -> None:
+    """restart=False defers restart for the autobot_shared library component."""
+    restart_mock = AsyncMock()
+    with (
+        patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._ensure_autobot_shared_symlink", AsyncMock()),
+        patch("api.code_sync._restart_component_services", restart_mock),
+    ):
+        _, steps, _ = _run(
+            _run_post_sync_steps(
+                "autobot_shared",
+                "/opt/autobot/code_source/autobot_shared",
+                "/opt/autobot/autobot_shared",
+                restart=False,
+            )
+        )
+
+    restart_mock.assert_not_called()
+    assert any("restart deferred" in s for s in steps)
+
+
+# ---------------------------------------------------------------------------
+# _run_component_resolve_job — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_run_component_resolve_job_happy_path() -> None:
+    """Happy path: rsync ok + pip ok → job committed as 'completed' BEFORE restart."""
+    row = _FakeRow()
+    db_mock = _make_db_service_mock(row)
+
+    restart_order: list[str] = []
+
+    class _TrackingSession:
+        """Session that records commit() timing vs restart calls."""
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            pass
+
+        async def execute(self, _stmt):
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = row
+            return result
+
+        async def commit(self):
+            restart_order.append("committed")
+
+        def add(self, _obj):
+            pass
+
+    db_mock.session.return_value = _TrackingSession()
+
+    async def _fake_restart(component, steps):
+        restart_order.append("restarted")
+
+    with (
+        patch("api.code_sync.get_default_source_dir", return_value="/src/autobot-slm-backend"),
+        patch("api.code_sync.get_default_deployed_dir", return_value="/opt/autobot/autobot-slm-backend"),
+        patch("api.code_sync._rsync_component_local", AsyncMock(return_value=(True, ""))),
+        patch(
+            "api.code_sync._run_post_sync_steps",
+            AsyncMock(return_value=(False, ["step1", "post-sync: restart deferred"], True)),
+        ),
+        patch("api.code_sync._restart_component_services", side_effect=_fake_restart),
+        patch("api.code_sync._running_tasks", {}),
+        patch("api.code_sync.db_service", db_mock, create=True),
+    ):
+        # Also patch the local import inside _run_component_resolve_job
+        with patch.dict("sys.modules", {"services.database": MagicMock(db_service=db_mock)}):
+            import importlib
+            import api.code_sync as _cs_mod
+
+            original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else None
+
+            # Directly patch the module-level reference that the function imports
+            old_db_service = getattr(_cs_mod, "db_service", None)
+            _run(_run_component_resolve_job("abc123", "autobot-slm-backend"))
+
+    # Commit must happen BEFORE restart
+    assert "committed" in restart_order, "DB was never committed"
+    assert "restarted" in restart_order, "restart was never called"
+    assert restart_order.index("committed") < restart_order.index("restarted"), (
+        f"DB commit must precede restart; order was {restart_order}"
+    )
+    assert row.status == "completed"
+    assert row.success is True
+
+
+def test_run_component_resolve_job_rsync_failure() -> None:
+    """rsync failure → job committed as 'failed'; restart NOT called."""
+    row = _FakeRow()
+    db_mock = _make_db_service_mock(row)
+
+    restart_mock = AsyncMock()
+
+    with (
+        patch("api.code_sync.get_default_source_dir", return_value="/src/autobot-slm-backend"),
+        patch("api.code_sync.get_default_deployed_dir", return_value="/opt/autobot/autobot-slm-backend"),
+        patch("api.code_sync._rsync_component_local", AsyncMock(return_value=(False, "rsync boom"))),
+        patch("api.code_sync._run_post_sync_steps", AsyncMock()),
+        patch("api.code_sync._restart_component_services", restart_mock),
+        patch("api.code_sync._running_tasks", {}),
+    ):
+        with patch.dict("sys.modules", {"services.database": MagicMock(db_service=db_mock)}):
+            _run(_run_component_resolve_job("def456", "autobot-slm-backend"))
+
+    assert row.status == "failed"
+    assert row.success is False
+    assert "rsync boom" in (row.message or "")
+    restart_mock.assert_not_called()

--- a/autobot-slm-backend/tests/api/test_component_resolve_job.py
+++ b/autobot-slm-backend/tests/api/test_component_resolve_job.py
@@ -18,7 +18,7 @@ import asyncio
 import sys
 import types
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # ---------------------------------------------------------------------------
 # Dev-host stub: provide minimal real Pydantic models for models.schemas so
@@ -279,21 +279,22 @@ def test_run_component_resolve_job_happy_path() -> None:
     ):
         # Also patch the local import inside _run_component_resolve_job
         with patch.dict("sys.modules", {"services.database": MagicMock(db_service=db_mock)}):
-            import importlib
+            pass
+
             import api.code_sync as _cs_mod
 
-            original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else None
+            __builtins__.__import__ if hasattr(__builtins__, "__import__") else None
 
             # Directly patch the module-level reference that the function imports
-            old_db_service = getattr(_cs_mod, "db_service", None)
+            getattr(_cs_mod, "db_service", None)
             _run(_run_component_resolve_job("abc123", "autobot-slm-backend"))
 
     # Commit must happen BEFORE restart
     assert "committed" in restart_order, "DB was never committed"
     assert "restarted" in restart_order, "restart was never called"
-    assert restart_order.index("committed") < restart_order.index("restarted"), (
-        f"DB commit must precede restart; order was {restart_order}"
-    )
+    assert restart_order.index("committed") < restart_order.index(
+        "restarted"
+    ), f"DB commit must precede restart; order was {restart_order}"
     assert row.status == "completed"
     assert row.success is True
 


### PR DESCRIPTION
## Thinking Path
`POST /drift/resolve` (`api/code_sync.py:434`) awaits the full rsync + `_run_post_sync_steps` (pip + alembic + **service restart**) inline. For the `autobot-slm-backend` component the final `_restart_component_services` restarts the SLM backend itself → the in-flight request dies and every endpoint returns 000 for 40-120s. Subprocess calls are already non-blocking, so it's the inline-restart + long request, not event-loop starvation.

This is **T1** of the #11303 decomposition — an **additive, non-breaking** backend foundation. The existing sync endpoint is untouched; the SLM frontend switch to polling is T2.

## What Changed
DB-backed job mirroring the `fleet_sync_jobs` pattern (added in #1707 for exactly this 'survive the self-restart' reason). Key design: the job is committed **completed to DB _before_ the restart**, so status is durable even when the restart kills the process.

- `ComponentSyncJob` model + `add_component_sync_jobs_table` migration (registered in `migrations/runner.py`; DDL matches model 1:1).
- `_run_post_sync_steps(..., restart: bool = True)` — new param guards the final `_restart_component_services` in all 3 branches (default `True` → every existing caller unchanged).
- `POST /drift/resolve-async` (202) → persists job (running), spawns `asyncio.create_task(_run_component_resolve_job)`, returns `{job_id, status}` immediately.
- `_run_component_resolve_job`: rsync → post-steps(restart=False) → **durable DB commit** → deferred restart; try/except/finally with error persistence + `_running_tasks` cleanup.
- `GET /drift/resolve/status/{job_id}` → job status + post_steps.
- `reconcile_stale_component_sync_jobs()` wired into `main.py` lifespan (mirrors the fleet reconciler) — flips orphaned 'running' jobs to 'failed' on startup.

## Verification
- `py_compile` all 7 changed .py files — OK
- `pytest tests/api/test_component_resolve_job.py test_code_sync_deploy_bugs.py test_code_sync_symlink_restore.py` — **43 passed** (6 new: restart-param on/off across pip/frontend/shared branches, commit-before-restart happy path, rsync-failure path)
- Migration DDL ↔ model columns cross-checked (10/10 + index); `migrate(db_url)` entrypoint matches runner invocation.

## Model Used
Opus 4.8

Refs #11303 (T1; T2 = SLM frontend polling)

Closes #11350