### PR TITLE
fix(deploy): skip npm ci when lockfile unchanged; surface build failure (#11351)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -10,6 +10,7 @@ Provides endpoints for code version tracking and sync operations.
 
 import asyncio
 import functools
+import hashlib
 import logging
 import os
 import uuid
@@ -781,6 +782,17 @@ _COMPONENT_FRONTEND_DIRS: Dict[str, str] = {
     "autobot-slm-frontend": "/opt/autobot/autobot-slm-frontend",
 }
 
+# Timeout (seconds) for `npm ci` (dependency install).  Windows-generated
+# package-lock.json on WSL can be slow; 300 s default matches pip (#11351).
+_NPM_INSTALL_TIMEOUT: float = float(os.environ.get("AUTOBOT_NPM_INSTALL_TIMEOUT", "300"))
+
+# Timeout (seconds) for `npm run <build>` (vite build step) (#11351).
+_NPM_BUILD_TIMEOUT: float = float(os.environ.get("AUTOBOT_NPM_BUILD_TIMEOUT", "300"))
+
+# Marker file stored inside node_modules after a successful npm ci.  Holds the
+# sha256 hex-digest of the package-lock.json that was installed (#11351).
+_NPM_LOCK_HASH_MARKER: str = ".autobot-lock-hash"
+
 # npm build script per frontend component. The SLM frontend is co-located under
 # /slm and MUST bake VITE_API_URL=/slm (via `build:slm`), or its API calls hit
 # the root user backend instead of /slm/api — breaking login and every action
@@ -1164,15 +1176,43 @@ async def _run_alembic_migrations(component: str, deployed_dir: str, steps: List
         steps.append(f"alembic: upgrade error: {exc}")
 
 
-async def _build_npm_frontend_for_component(component: str, steps: List[str]) -> None:
-    """Run npm ci + npm run build for a frontend component (#9982).
+def _lockfile_hash(frontend_dir: str) -> Optional[str]:
+    """Return the sha256 hex-digest of <frontend_dir>/package-lock.json, or None if absent."""
+    lock_path = Path(frontend_dir) / "package-lock.json"
+    if not lock_path.exists():
+        return None
+    return hashlib.sha256(lock_path.read_bytes()).hexdigest()
 
-    Appends human-readable step notes to *steps*.
+
+def _lockfile_unchanged(frontend_dir: str) -> bool:
+    """Return True when node_modules exists and its lock-hash marker matches the current lockfile.
+
+    False means a fresh ``npm ci`` is needed (node_modules missing, marker absent,
+    or package-lock.json changed since the last successful install).
     """
-    frontend_dir = _COMPONENT_FRONTEND_DIRS.get(component)
-    if frontend_dir is None:
-        return
-    steps.append(f"npm: building {frontend_dir}")
+    node_modules = Path(frontend_dir) / "node_modules"
+    if not node_modules.is_dir():
+        return False
+    marker = node_modules / _NPM_LOCK_HASH_MARKER
+    if not marker.exists():
+        return False
+    stored = marker.read_text(encoding="utf-8").strip()
+    current = _lockfile_hash(frontend_dir)
+    return current is not None and stored == current
+
+
+async def _npm_install_if_needed(frontend_dir: str, component: str, steps: List[str]) -> bool:
+    """Run ``npm ci --prefix <frontend_dir>`` only when the lockfile changed or node_modules is missing.
+
+    Writes a sha256 marker to node_modules/.autobot-lock-hash after success so
+    subsequent runs with an unchanged lockfile skip the install entirely (#11351).
+    Returns True on success (or skip), False on failure.
+    """
+    if _lockfile_unchanged(frontend_dir):
+        steps.append("npm ci: skipped (node_modules up-to-date)")
+        logger.info("drift resolve: npm ci skipped for %s — lockfile unchanged", component)
+        return True
+    steps.append(f"npm ci: installing deps in {frontend_dir}")
     try:
         proc = await asyncio.create_subprocess_exec(
             "npm",
@@ -1182,14 +1222,45 @@ async def _build_npm_frontend_for_component(component: str, steps: List[str]) ->
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
         )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=300.0)
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_NPM_INSTALL_TIMEOUT)
         if proc.returncode != 0:
             out = stdout.decode(errors="replace")[:300] if stdout else ""
             logger.warning("drift resolve: npm ci failed (%d) for %s: %s", proc.returncode, component, out)
             steps.append(f"npm ci: failed (rc={proc.returncode}): {out[:150]}")
-            return
+            return False
+    except asyncio.TimeoutError:
+        logger.error("drift resolve: npm ci timed out for %s (%.0fs)", component, _NPM_INSTALL_TIMEOUT)
+        steps.append(f"npm ci: timed out after {_NPM_INSTALL_TIMEOUT:.0f}s")
+        return False
+    except Exception as exc:
+        logger.warning("drift resolve: npm ci error for %s: %s", component, exc)
+        steps.append(f"npm ci: error: {exc}")
+        return False
+    # Persist the lockfile hash so the next run can skip reinstall.
+    current_hash = _lockfile_hash(frontend_dir)
+    if current_hash:
+        marker = Path(frontend_dir) / "node_modules" / _NPM_LOCK_HASH_MARKER
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(current_hash, encoding="utf-8")
+    steps.append("npm ci: succeeded")
+    return True
 
-        build_script = _COMPONENT_BUILD_SCRIPT.get(component, "build")
+
+async def _build_npm_frontend_for_component(component: str, steps: List[str]) -> bool:
+    """Install deps (if needed) then run the npm build script for a frontend component (#9982, #11351).
+
+    Returns True when the build succeeds, False on any failure.
+    Appends human-readable step notes to *steps*.
+    """
+    frontend_dir = _COMPONENT_FRONTEND_DIRS.get(component)
+    if frontend_dir is None:
+        return True
+    steps.append(f"npm: building {frontend_dir}")
+    install_ok = await _npm_install_if_needed(frontend_dir, component, steps)
+    if not install_ok:
+        return False
+    build_script = _COMPONENT_BUILD_SCRIPT.get(component, "build")
+    try:
         proc = await asyncio.create_subprocess_exec(
             "npm",
             "run",
@@ -1199,20 +1270,23 @@ async def _build_npm_frontend_for_component(component: str, steps: List[str]) ->
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
         )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=300.0)
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_NPM_BUILD_TIMEOUT)
         if proc.returncode == 0:
             logger.info("drift resolve: npm build (%s) succeeded for %s", build_script, component)
             steps.append("npm build: succeeded")
-        else:
-            out = stdout.decode(errors="replace")[:300] if stdout else ""
-            logger.warning("drift resolve: npm build failed (%d) for %s: %s", proc.returncode, component, out)
-            steps.append(f"npm build: failed (rc={proc.returncode}): {out[:150]}")
+            return True
+        out = stdout.decode(errors="replace")[:300] if stdout else ""
+        logger.warning("drift resolve: npm build failed (%d) for %s: %s", proc.returncode, component, out)
+        steps.append(f"npm build: failed (rc={proc.returncode}): {out[:150]}")
+        return False
     except asyncio.TimeoutError:
-        logger.error("drift resolve: npm build timed out for %s", component)
-        steps.append("npm build: timed out after 300s")
+        logger.error("drift resolve: npm build timed out for %s (%.0fs)", component, _NPM_BUILD_TIMEOUT)
+        steps.append(f"npm build: timed out after {_NPM_BUILD_TIMEOUT:.0f}s")
+        return False
     except Exception as exc:
         logger.warning("drift resolve: npm build error for %s: %s", component, exc)
         steps.append(f"npm build: error: {exc}")
+        return False
 
 
 async def _restart_component_services(component: str, steps: List[str]) -> None:
@@ -1315,14 +1389,15 @@ async def _run_post_sync_steps(
     """Run dep-install / rebuild / restart after a per-component rsync (#9982).
 
     Returns (deps_changed, steps_log, pip_ok).
-    pip_ok is False when pip exits non-zero so resolve_drift can surface the
-    failure via success=False rather than silently returning success=True (#11322).
+    pip_ok is False when pip or npm exits non-zero so resolve_drift can surface
+    the failure via success=False rather than silently returning success=True
+    (#11322, #11351).
 
     Component routing:
       - Python backend (autobot-backend, autobot-slm-backend):
           constraints deploy (#11322) + venv version check (#11323) +
           pip install + symlink restore (#10912) + alembic + restart
-      - Frontend (autobot-frontend, autobot-slm-frontend): npm ci + build + nginx reload
+      - Frontend (autobot-frontend, autobot-slm-frontend): npm ci (conditional) + build + nginx reload
       - autobot_shared: restore BOTH backends' symlinks (#10912) + restart dependents
     """
     steps: List[str] = []
@@ -1357,7 +1432,9 @@ async def _run_post_sync_steps(
         await _ensure_autobot_shared_symlink(component, steps)
         await _restart_component_services(component, steps)
     elif component in _COMPONENT_FRONTEND_DIRS:
-        await _build_npm_frontend_for_component(component, steps)
+        npm_ok = await _build_npm_frontend_for_component(component, steps)
+        if not npm_ok:
+            pip_ok = False
         await _restart_component_services(component, steps)
     elif component in _COMPONENT_SERVICES:
         # Library component (autobot_shared): no build step, but every service

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -72,12 +72,17 @@ import asyncio  # noqa: E402
 from api.code_sync import (  # noqa: E402
     _COMPONENT_PYTHON_TARGET,
     _CONSTRAINTS_SOURCE_SUBDIR,
+    _NPM_LOCK_HASH_MARKER,
     _REPO_ROOT_REQUIREMENT_FILES,
+    _build_npm_frontend_for_component,
     _deploy_constraints_dir,
     _deploy_repo_root_requirements,
     _ensure_target_python_installed,
     _ensure_venv_python,
     _install_pip_deps_for_component,
+    _lockfile_hash,
+    _lockfile_unchanged,
+    _npm_install_if_needed,
     _run_post_sync_steps,
 )
 
@@ -629,3 +634,281 @@ def test_run_post_sync_steps_provisions_python_before_venv() -> None:
         _run(_run_post_sync_steps("autobot-backend", "/src/autobot-backend", "/opt/autobot/autobot-backend"))
 
     assert order == ["provision", "venv"], f"expected provision before venv, got {order}"
+
+
+# ---------------------------------------------------------------------------
+# #11351 — conditional npm ci: lockfile-hash skip logic
+# ---------------------------------------------------------------------------
+
+
+def test_lockfile_hash_returns_none_when_missing(tmp_path) -> None:
+    """_lockfile_hash returns None when package-lock.json is absent."""
+    assert _lockfile_hash(str(tmp_path)) is None
+
+
+def test_lockfile_hash_returns_hex_digest(tmp_path) -> None:
+    """_lockfile_hash returns a 64-char hex string for an existing lockfile."""
+    (tmp_path / "package-lock.json").write_bytes(b'{"lockfileVersion":3}')
+    result = _lockfile_hash(str(tmp_path))
+    assert result is not None
+    assert len(result) == 64
+    assert all(c in "0123456789abcdef" for c in result)
+
+
+def test_lockfile_unchanged_false_when_node_modules_missing(tmp_path) -> None:
+    """Returns False when node_modules directory does not exist."""
+    (tmp_path / "package-lock.json").write_bytes(b"{}")
+    assert _lockfile_unchanged(str(tmp_path)) is False
+
+
+def test_lockfile_unchanged_false_when_marker_absent(tmp_path) -> None:
+    """Returns False when node_modules exists but the hash marker file is missing."""
+    (tmp_path / "package-lock.json").write_bytes(b"{}")
+    (tmp_path / "node_modules").mkdir()
+    assert _lockfile_unchanged(str(tmp_path)) is False
+
+
+def test_lockfile_unchanged_false_when_hash_differs(tmp_path) -> None:
+    """Returns False when the stored hash doesn't match the current lockfile."""
+    lock = tmp_path / "package-lock.json"
+    lock.write_bytes(b'{"lockfileVersion":3}')
+    nm = tmp_path / "node_modules"
+    nm.mkdir()
+    (nm / _NPM_LOCK_HASH_MARKER).write_text("deadbeef" * 8, encoding="utf-8")
+    assert _lockfile_unchanged(str(tmp_path)) is False
+
+
+def test_lockfile_unchanged_true_when_hash_matches(tmp_path) -> None:
+    """Returns True when node_modules exists and the stored hash matches the lockfile."""
+    import hashlib
+
+    content = b'{"lockfileVersion":3}'
+    lock = tmp_path / "package-lock.json"
+    lock.write_bytes(content)
+    nm = tmp_path / "node_modules"
+    nm.mkdir()
+    (nm / _NPM_LOCK_HASH_MARKER).write_text(hashlib.sha256(content).hexdigest(), encoding="utf-8")
+    assert _lockfile_unchanged(str(tmp_path)) is True
+
+
+# ---------------------------------------------------------------------------
+# #11351 — _npm_install_if_needed: skip, run, failure
+# ---------------------------------------------------------------------------
+
+
+def test_npm_install_skipped_when_lockfile_unchanged(tmp_path) -> None:
+    """npm ci is NOT invoked when _lockfile_unchanged returns True."""
+    import hashlib
+
+    content = b'{"lockfileVersion":3}'
+    (tmp_path / "package-lock.json").write_bytes(content)
+    nm = tmp_path / "node_modules"
+    nm.mkdir()
+    (nm / _NPM_LOCK_HASH_MARKER).write_text(hashlib.sha256(content).hexdigest(), encoding="utf-8")
+
+    steps: list[str] = []
+    executed: list[str] = []
+
+    async def _fake_exec(*cmd, **kw):
+        executed.extend(cmd)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        result = _run(_npm_install_if_needed(str(tmp_path), "autobot-slm-frontend", steps))
+
+    assert result is True
+    assert not executed, "npm ci must not run when lockfile is unchanged"
+    assert any("skipped" in s for s in steps)
+
+
+def test_npm_install_runs_when_node_modules_missing(tmp_path) -> None:
+    """npm ci IS invoked when node_modules doesn't exist."""
+    (tmp_path / "package-lock.json").write_bytes(b'{"lockfileVersion":3}')
+    # node_modules intentionally absent
+
+    steps: list[str] = []
+    executed: list[str] = []
+
+    async def _fake_exec(*cmd, **kw):
+        executed.extend(cmd)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        result = _run(_npm_install_if_needed(str(tmp_path), "autobot-slm-frontend", steps))
+
+    assert result is True
+    assert "npm" in executed and "ci" in executed
+    assert any("succeeded" in s for s in steps)
+
+
+def test_npm_install_runs_when_lockfile_changed(tmp_path) -> None:
+    """npm ci IS invoked when the stored hash doesn't match the current lockfile."""
+    (tmp_path / "package-lock.json").write_bytes(b'{"lockfileVersion":3,"new-dep":true}')
+    nm = tmp_path / "node_modules"
+    nm.mkdir()
+    (nm / _NPM_LOCK_HASH_MARKER).write_text("stale_hash" * 6, encoding="utf-8")
+
+    steps: list[str] = []
+    executed: list[str] = []
+
+    async def _fake_exec(*cmd, **kw):
+        executed.extend(cmd)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        result = _run(_npm_install_if_needed(str(tmp_path), "autobot-slm-frontend", steps))
+
+    assert result is True
+    assert "npm" in executed and "ci" in executed
+
+
+def test_npm_install_writes_marker_on_success(tmp_path) -> None:
+    """After a successful npm ci the hash marker is written to node_modules/."""
+    import hashlib
+
+    content = b'{"lockfileVersion":3}'
+    (tmp_path / "package-lock.json").write_bytes(content)
+    # node_modules absent — will be created by the real npm, but we just need
+    # the marker write to happen; fake the dir creation here.
+    nm = tmp_path / "node_modules"
+    nm.mkdir()
+
+    async def _fake_exec(*cmd, **kw):
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        _run(_npm_install_if_needed(str(tmp_path), "autobot-slm-frontend", []))
+
+    marker = nm / _NPM_LOCK_HASH_MARKER
+    assert marker.exists()
+    assert marker.read_text(encoding="utf-8") == hashlib.sha256(content).hexdigest()
+
+
+def test_npm_install_returns_false_on_nonzero_rc(tmp_path) -> None:
+    """_npm_install_if_needed returns False when npm ci exits non-zero."""
+    (tmp_path / "package-lock.json").write_bytes(b"{}")
+
+    steps: list[str] = []
+
+    async def _fake_exec(*cmd, **kw):
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.communicate = AsyncMock(return_value=(b"ERESOLVE", b""))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        result = _run(_npm_install_if_needed(str(tmp_path), "autobot-slm-frontend", steps))
+
+    assert result is False
+    assert any("failed" in s for s in steps)
+
+
+# ---------------------------------------------------------------------------
+# #11351 — _build_npm_frontend_for_component: skip install → build still runs
+# ---------------------------------------------------------------------------
+
+
+def test_build_skips_install_and_runs_build(tmp_path) -> None:
+    """When lockfile is unchanged, npm ci is skipped but npm run build still runs."""
+    import hashlib
+
+    content = b'{"lockfileVersion":3}'
+    (tmp_path / "package-lock.json").write_bytes(content)
+    nm = tmp_path / "node_modules"
+    nm.mkdir()
+    (nm / _NPM_LOCK_HASH_MARKER).write_text(hashlib.sha256(content).hexdigest(), encoding="utf-8")
+
+    steps: list[str] = []
+    build_called: list[bool] = []
+
+    async def _fake_exec(*cmd, **kw):
+        if "run" in cmd:
+            build_called.append(True)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with (
+        patch("api.code_sync._COMPONENT_FRONTEND_DIRS", {"autobot-slm-frontend": str(tmp_path)}),
+        patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+    ):
+        result = _run(_build_npm_frontend_for_component("autobot-slm-frontend", steps))
+
+    assert result is True
+    assert build_called, "npm run build must still execute even when npm ci is skipped"
+    assert any("skipped" in s for s in steps)
+    assert any("succeeded" in s for s in steps)
+
+
+def test_build_returns_false_on_npm_ci_failure(tmp_path) -> None:
+    """When npm ci fails, the build is aborted and False is returned."""
+    (tmp_path / "package-lock.json").write_bytes(b"{}")
+
+    steps: list[str] = []
+
+    async def _fake_exec(*cmd, **kw):
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.communicate = AsyncMock(return_value=(b"err", b""))
+        return proc
+
+    with (
+        patch("api.code_sync._COMPONENT_FRONTEND_DIRS", {"autobot-slm-frontend": str(tmp_path)}),
+        patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+    ):
+        result = _run(_build_npm_frontend_for_component("autobot-slm-frontend", steps))
+
+    assert result is False
+    assert any("failed" in s for s in steps)
+
+
+# ---------------------------------------------------------------------------
+# #11351 — _run_post_sync_steps surfaces npm build failure via pip_ok=False
+# ---------------------------------------------------------------------------
+
+
+def test_run_post_sync_steps_pip_ok_false_on_npm_failure() -> None:
+    """When npm build returns False, _run_post_sync_steps returns pip_ok=False."""
+    with (
+        patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._build_npm_frontend_for_component", AsyncMock(return_value=False)),
+        patch("api.code_sync._restart_component_services", AsyncMock()),
+    ):
+        _, _, pip_ok = _run(
+            _run_post_sync_steps(
+                "autobot-slm-frontend",
+                "/src/autobot-slm-frontend",
+                "/opt/autobot/autobot-slm-frontend",
+            )
+        )
+    assert pip_ok is False
+
+
+def test_run_post_sync_steps_pip_ok_true_on_npm_success() -> None:
+    """When npm build returns True, _run_post_sync_steps returns pip_ok=True."""
+    with (
+        patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)),
+        patch("api.code_sync._build_npm_frontend_for_component", AsyncMock(return_value=True)),
+        patch("api.code_sync._restart_component_services", AsyncMock()),
+    ):
+        _, _, pip_ok = _run(
+            _run_post_sync_steps(
+                "autobot-slm-frontend",
+                "/src/autobot-slm-frontend",
+                "/opt/autobot/autobot-slm-frontend",
+            )
+        )
+    assert pip_ok is True


### PR DESCRIPTION
## Thinking Path

The `drift/resolve` request was dying with HTTP 000 (~216 s timeout) because
`_build_npm_frontend_for_component` always ran `npm ci --prefix <dir>` unconditionally.
`npm ci` wipes and reinstalls all 345 packages from scratch every time — on this WSL
host where `package-lock.json` was Windows-generated, that step stalls indefinitely.
The Vite build step never ran, so merged frontend fixes never went live.

Root cause: no skip guard. The fix is to cache the sha256 of `package-lock.json` in
`node_modules/.autobot-lock-hash` after a successful install and compare on next run.
If the hash matches, skip `npm ci` entirely. A genuinely changed lockfile still
triggers a fresh reinstall.

Also: `_build_npm_frontend_for_component` previously returned `None` (void), so build
failures were swallowed — the resolve returned `success=True` even when Vite failed.
Making it return `bool` and folding that into `pip_ok` in `_run_post_sync_steps`
surfaces failures consistently with how pip failures are already handled.

## What Changed

**`autobot-slm-backend/api/code_sync.py`**

New module-level constants (env-var sourced, not hardcoded):
- `_NPM_INSTALL_TIMEOUT` — from `AUTOBOT_NPM_INSTALL_TIMEOUT` (default 300 s)
- `_NPM_BUILD_TIMEOUT` — from `AUTOBOT_NPM_BUILD_TIMEOUT` (default 300 s)
- `_NPM_LOCK_HASH_MARKER` — marker filename (`".autobot-lock-hash"`)

New helpers (all ≤30 executable lines):
- `_lockfile_hash(frontend_dir)` — sha256 hex of `package-lock.json`, or `None`
- `_lockfile_unchanged(frontend_dir)` — `True` when node_modules exists and stored
  hash matches current lockfile; `False` triggers a fresh `npm ci`
- `_npm_install_if_needed(frontend_dir, component, steps)` — runs `npm ci` only
  when needed; on success writes hash marker to `node_modules/.autobot-lock-hash`
  with `mkdir(parents=True, exist_ok=True)` so it works even when node_modules
  was just created by npm

Refactored:
- `_build_npm_frontend_for_component` now returns `bool` (was `None`) and delegates
  install to `_npm_install_if_needed`
- `_run_post_sync_steps` folds npm build failure into `pip_ok=False` so
  `resolve_drift` returns `success=False` instead of silently succeeding

**`autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py`**

15 new tests covering:
- `_lockfile_hash`: absent lockfile → `None`; present → 64-char hex
- `_lockfile_unchanged`: node_modules missing → False; marker absent → False;
  hash differs → False; hash matches → True
- `_npm_install_if_needed`: skip when unchanged; run when node_modules missing;
  run when lockfile changed; marker written on success; returns False on non-zero rc
- `_build_npm_frontend_for_component`: skips install but still runs build; returns
  False on npm ci failure
- `_run_post_sync_steps`: `pip_ok=False` when npm fails; `pip_ok=True` when npm succeeds

## Verification

```
black --check autobot-slm-backend/api/code_sync.py   → unchanged
ruff check autobot-slm-backend/api/code_sync.py       → All checks passed!
pytest tests/api/test_code_sync_deploy_bugs.py -v     → 41 passed in 1.29s
```

Closes #11351

## Model Used

claude-sonnet-4-6