### PR TITLE
fix(deploy): provision py3.14 against inline localhost inventory, not --limit (#11352)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/configure-python-provision-permissions.yml
+++ b/autobot-slm-backend/ansible/playbooks/configure-python-provision-permissions.yml
@@ -29,7 +29,6 @@
     # builds in _ensure_target_python_installed.
     ansible_playbook_bin: "/usr/bin/ansible-playbook"
     provision_playbook: "/opt/autobot/code_source/autobot-slm-backend/ansible/playbooks/provision-local-python.yml"
-    provision_inventory: "/opt/autobot/code_source/autobot-slm-backend/ansible/inventory.yml"
 
   pre_tasks:
     - name: Display configuration information
@@ -58,7 +57,7 @@
           # Created by: Ansible playbook configure-python-provision-permissions.yml
           # Date: {{ ansible_facts['date_time'].iso8601 }}
 
-          {{ autobot_user }} ALL=(root) NOPASSWD: {{ ansible_playbook_bin }} {{ provision_playbook }} --tags python314 --limit localhost -i {{ provision_inventory }} --connection local
+          {{ autobot_user }} ALL=(root) NOPASSWD: {{ ansible_playbook_bin }} {{ provision_playbook }} --tags python314 -i localhost, --connection local
         dest: "{{ sudoers_file }}.tmp"
         owner: root
         group: root
@@ -90,4 +89,4 @@
           - "Sudoers file: {{ sudoers_file }}"
           - "User: {{ autobot_user }}"
           - "The autobot user can now run the interpreter provisioning playbook:"
-          - "  sudo {{ ansible_playbook_bin }} {{ provision_playbook }} --tags python314 --limit localhost -i {{ provision_inventory }} --connection local"
+          - "  sudo {{ ansible_playbook_bin }} {{ provision_playbook }} --tags python314 -i localhost, --connection local"

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -760,7 +760,6 @@ _COMPONENT_PYTHON_TARGET: Dict[str, str] = {
 # ansible/playbooks/configure-python-provision-permissions.yml.
 _ANSIBLE_DIR: Path = Path(DEFAULT_REPO_PATH) / "autobot-slm-backend" / "ansible"
 _PROVISION_PYTHON_PLAYBOOK: Path = _ANSIBLE_DIR / "playbooks" / "provision-local-python.yml"
-_PROVISION_PYTHON_INVENTORY: Path = _ANSIBLE_DIR / "inventory.yml"
 
 # Deployed path for the top-level constraints/ dir (#11322).
 # `autobot-backend/requirements.txt` uses `-c ../constraints/shared.txt` so the
@@ -899,9 +898,12 @@ async def _run_python_provision_playbook(target: str, steps: List[str]) -> bool:
     configure-python-provision-permissions.yml. Returns True on rc==0.
     """
     # ARG LIST only — never a shell string. Matches the NOPASSWD sudoers grant.
+    # Use an inline localhost inventory ("localhost,") rather than the fleet
+    # inventory + "--limit localhost": the fleet inventory has no localhost host,
+    # so "--limit localhost" left ansible with no hosts to target (#11352). The
+    # playbook is `hosts: localhost` / `connection: local`.
     cmd = ["sudo", "ansible-playbook", str(_PROVISION_PYTHON_PLAYBOOK)]
-    cmd += ["--tags", "python314", "--limit", "localhost"]
-    cmd += ["-i", str(_PROVISION_PYTHON_INVENTORY), "--connection", "local"]
+    cmd += ["--tags", "python314", "-i", "localhost,", "--connection", "local"]
     steps.append(f"python-provision: installing {target} via {_PROVISION_PYTHON_PLAYBOOK.name}")
     try:
         proc = await asyncio.create_subprocess_exec(

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -574,14 +574,11 @@ def test_ensure_target_python_uses_arg_list_and_target_from_map(tmp_path) -> Non
 
     playbook = tmp_path / "provision-local-python.yml"
     playbook.write_text("---\n", encoding="utf-8")
-    inventory = tmp_path / "inventory.yml"
-    inventory.write_text("all:\n", encoding="utf-8")
 
     # shutil.which: None first (trigger provision), path after install re-check.
     with (
         patch("shutil.which", side_effect=[None, "/usr/bin/python3.14"]),
         patch("api.code_sync._PROVISION_PYTHON_PLAYBOOK", playbook),
-        patch("api.code_sync._PROVISION_PYTHON_INVENTORY", inventory),
         patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
     ):
         _run(_ensure_target_python_installed("autobot-backend", steps))
@@ -591,6 +588,10 @@ def test_ensure_target_python_uses_arg_list_and_target_from_map(tmp_path) -> Non
     assert "--tags" in captured and "python314" in captured
     assert "--connection" in captured and "local" in captured
     assert str(playbook) in captured
+    # #11352: inline localhost inventory, NOT "--limit localhost" against the
+    # fleet inventory (which targeted no hosts).
+    assert "-i" in captured and "localhost," in captured
+    assert "--limit" not in captured
     assert any("now on PATH" in s for s in steps)
 
 


### PR DESCRIPTION
## Thinking Path
After #11347 wired py3.14 provisioning into code-sync, the live deploy showed `python-provision: FAILED (rc=1): ERROR! Specified inventory, host pattern and/or --limit leaves us with no hosts to target.` The playbook itself is correct (`hosts: localhost`, `connection: local`) — the invocation was wrong: `--limit localhost` combined with `-i <fleet inventory.yml>` (which has no localhost host) filtered the play down to zero hosts.

## What Changed
- `api/code_sync.py` `_run_python_provision_playbook`: invoke `ansible-playbook <playbook> --tags python314 -i localhost, --connection local` (inline localhost inventory) and drop `--limit localhost` + the fleet inventory. Removed the now-unused `_PROVISION_PYTHON_INVENTORY` constant.
- `ansible/playbooks/configure-python-provision-permissions.yml`: updated the NOPASSWD sudoers grant (and the summary echo) to match the new exact command; removed the unused `provision_inventory` var.
- Updated `test_ensure_target_python_uses_arg_list_and_target_from_map` to assert `-i localhost,` is used and `--limit` is absent.

## Verification
- `black --check` + `ruff check` on code_sync.py — clean.
- `ansible-playbook --syntax-check` on the permissions playbook — OK (pre-existing `slm_server` group-pattern warning, matches sibling playbooks).
- `pytest tests/api/test_code_sync_deploy_bugs.py` — 41 passed.

## Model Used
Opus 4.8

Closes #11352