### PR TITLE
fix(deploy): chown dist/ before npm build to clear root-owned EACCES (#11364)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -10,6 +10,7 @@ Provides endpoints for code version tracking and sync operations.
 
 import asyncio
 import functools
+import getpass
 import hashlib
 import logging
 import os
@@ -1248,6 +1249,41 @@ async def _npm_install_if_needed(frontend_dir: str, component: str, steps: List[
     return True
 
 
+async def _ensure_dist_writable(frontend_dir: str, steps: List[str]) -> None:
+    """Chown dist/ to the running service user so vite's emptyOutDir can rimraf it (#11364).
+
+    Root-owned files (from a prior Ansible build) cause EACCES; chown normalises
+    ownership without destroying the live bundle.  Service user = getpass.getuser()
+    (never hardcoded). Failure is non-fatal — step recorded, build still attempted.
+    """
+    dist_dir = Path(frontend_dir) / "dist"
+    if not dist_dir.exists():
+        steps.append("dist: no dist/ directory — ownership check skipped")
+        return
+    service_user = getpass.getuser()
+    owner_spec = f"{service_user}:{service_user}"
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "sudo",
+            "chown",
+            "-R",
+            owner_spec,
+            str(dist_dir),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        _, _ = await asyncio.wait_for(proc.communicate(), timeout=30.0)
+        if proc.returncode == 0:
+            logger.info("dist: chown -R %s %s ok", owner_spec, dist_dir)
+            steps.append("dist: normalized ownership")
+        else:
+            logger.warning("dist: chown -R %s %s rc=%d", owner_spec, dist_dir, proc.returncode)
+            steps.append(f"dist: chown failed (rc={proc.returncode}) — attempting build anyway")
+    except Exception as exc:
+        logger.warning("dist: chown error for %s: %s", dist_dir, exc)
+        steps.append(f"dist: chown error: {exc} — attempting build anyway")
+
+
 async def _build_npm_frontend_for_component(component: str, steps: List[str]) -> bool:
     """Install deps (if needed) then run the npm build script for a frontend component (#9982, #11351).
 
@@ -1258,6 +1294,7 @@ async def _build_npm_frontend_for_component(component: str, steps: List[str]) ->
     if frontend_dir is None:
         return True
     steps.append(f"npm: building {frontend_dir}")
+    await _ensure_dist_writable(frontend_dir, steps)
     install_ok = await _npm_install_if_needed(frontend_dir, component, steps)
     if not install_ok:
         return False

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -77,6 +77,7 @@ from api.code_sync import (  # noqa: E402
     _build_npm_frontend_for_component,
     _deploy_constraints_dir,
     _deploy_repo_root_requirements,
+    _ensure_dist_writable,
     _ensure_target_python_installed,
     _ensure_venv_python,
     _install_pip_deps_for_component,
@@ -913,3 +914,139 @@ def test_run_post_sync_steps_pip_ok_true_on_npm_success() -> None:
             )
         )
     assert pip_ok is True
+
+
+# ---------------------------------------------------------------------------
+# #11364 — _ensure_dist_writable: chown before npm build
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_dist_writable_skipped_when_dist_absent(tmp_path) -> None:
+    """No chown is run when dist/ does not exist."""
+    steps: list[str] = []
+    executed: list = []
+
+    async def _fake_exec(*cmd, **kw):
+        executed.extend(cmd)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        _run(_ensure_dist_writable(str(tmp_path), steps))
+
+    assert not executed, "sudo chown must not run when dist/ is absent"
+    assert any("skipped" in s for s in steps)
+
+
+def test_ensure_dist_writable_chowns_when_dist_exists(tmp_path) -> None:
+    """sudo chown -R <user>:<user> dist/ is invoked when dist/ exists."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.js").write_bytes(b"")
+
+    steps: list[str] = []
+    captured: list = []
+
+    async def _fake_exec(*cmd, **kw):
+        captured.extend(cmd)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with (
+        patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+        patch("getpass.getuser", return_value="autobot"),
+    ):
+        _run(_ensure_dist_writable(str(tmp_path), steps))
+
+    assert captured[:3] == ["sudo", "chown", "-R"], f"unexpected cmd prefix: {captured[:3]}"
+    assert "autobot:autobot" in captured
+    assert str(dist) in captured
+    assert any("normalized ownership" in s for s in steps)
+
+
+def test_ensure_dist_writable_uses_getpass_not_hardcoded(tmp_path) -> None:
+    """Service user comes from getpass.getuser(), not a hardcoded string."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+
+    steps: list[str] = []
+    captured: list = []
+
+    async def _fake_exec(*cmd, **kw):
+        captured.extend(cmd)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with (
+        patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+        patch("getpass.getuser", return_value="customsvcuser"),
+    ):
+        _run(_ensure_dist_writable(str(tmp_path), steps))
+
+    owner_arg = next((a for a in captured if "customsvcuser" in a), None)
+    assert owner_arg == "customsvcuser:customsvcuser", f"expected owner arg, got captured={captured}"
+
+
+def test_ensure_dist_writable_non_fatal_on_chown_failure(tmp_path) -> None:
+    """A non-zero chown rc appends a failure step but does NOT raise."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+
+    steps: list[str] = []
+
+    async def _fake_exec(*cmd, **kw):
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.communicate = AsyncMock(return_value=(b"permission denied", b""))
+        return proc
+
+    with (
+        patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+        patch("getpass.getuser", return_value="autobot"),
+    ):
+        _run(_ensure_dist_writable(str(tmp_path), steps))  # must not raise
+
+    assert any("attempting build anyway" in s for s in steps)
+
+
+def test_build_npm_calls_ensure_dist_writable_before_install(tmp_path) -> None:
+    """_ensure_dist_writable is called before _npm_install_if_needed in the build path."""
+    import hashlib
+
+    content = b'{"lockfileVersion":3}'
+    (tmp_path / "package-lock.json").write_bytes(content)
+    nm = tmp_path / "node_modules"
+    nm.mkdir()
+    (nm / _NPM_LOCK_HASH_MARKER).write_text(hashlib.sha256(content).hexdigest(), encoding="utf-8")
+
+    order: list[str] = []
+
+    async def _fake_writable(fd, steps):
+        order.append("ensure_dist_writable")
+
+    async def _fake_install(fd, comp, steps):
+        order.append("npm_install")
+        return True
+
+    async def _fake_exec(*cmd, **kw):
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with (
+        patch("api.code_sync._COMPONENT_FRONTEND_DIRS", {"autobot-slm-frontend": str(tmp_path)}),
+        patch("api.code_sync._ensure_dist_writable", side_effect=_fake_writable),
+        patch("api.code_sync._npm_install_if_needed", side_effect=_fake_install),
+        patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+    ):
+        result = _run(_build_npm_frontend_for_component("autobot-slm-frontend", []))
+
+    assert result is True
+    assert order[0] == "ensure_dist_writable", f"expected ensure_dist_writable first, got {order}"


### PR DESCRIPTION
## Thinking Path

Root cause: Vite's `emptyOutDir` calls `rimraf` on `dist/` before writing
new assets.  When a prior Ansible/root build left `dist/` owned by root, the
`rimraf` call fails immediately with `EACCES: permission denied, unlink
'.../dist/assets/APISettings-*.js'`.  The npm build then exits non-zero and
the frontend is never updated — the old bundle (or nothing) keeps being served.

Fix options considered:
- **`sudo rm -rf dist/` before build** — solves EACCES but creates a window
  where nginx has no assets to serve while vite builds.  Destructive.
- **`sudo chown -R <user> dist/`** — normalises ownership in-place; nginx
  continues serving the old bundle until vite atomically replaces it.
  Chosen because it is non-destructive and nginx-safe.

Service user: `getpass.getuser()` — the running process owner, never
hardcoded.  The autobot user already has `NOPASSWD: ALL` via
`setup-passwordless-sudo.yml` so no new sudoers entry is required.

## What Changed

**`autobot-slm-backend/api/code_sync.py`**
- Added `import getpass` (stdlib, no new dependency).
- Added `_ensure_dist_writable(frontend_dir, steps)` — 29-line async helper
  that runs `sudo chown -R <user>:<user> dist/` when `dist/` exists.  Non-
  fatal: on failure a step is recorded and the build proceeds anyway.
- Wired into `_build_npm_frontend_for_component()` immediately after the
  `steps.append(f"npm: building ...")` line, before `_npm_install_if_needed`.

**`autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py`**
- Imported `_ensure_dist_writable`.
- Added 5 new tests covering:
  - `dist/` absent → no chown invoked, skip step recorded
  - `dist/` present → `sudo chown -R autobot:autobot dist/` called with arg-list
  - `getpass.getuser()` is the source of the owner, not a hardcoded string
  - Non-zero chown rc is non-fatal (step recorded, no exception)
  - `_ensure_dist_writable` is called before `_npm_install_if_needed` in the
    build path

**No Ansible change required** — `setup-passwordless-sudo.yml` already grants
`NOPASSWD: ALL` to the autobot user on all nodes, so `sudo chown` works out
of the box.

## Verification

```
black --check autobot-slm-backend/api/code_sync.py  →  1 file left unchanged
ruff check  autobot-slm-backend/api/code_sync.py    →  All checks passed!

pytest tests/api/test_code_sync_deploy_bugs.py -v
46 passed in 1.86s  (41 pre-existing + 5 new)
```

## Model Used

claude-sonnet-4-6

Closes #11364