### PR TITLE
feat(llc): Company OS UI tail — portability nav + agent terminate (#11357 #11358)

### DIFF
--- a/autobot-frontend/src/components/llc/LlcSidebar.vue
+++ b/autobot-frontend/src/components/llc/LlcSidebar.vue
@@ -51,6 +51,7 @@ const links = computed<SidebarLink[]>(() => {
     { labelKey: 'nav.llcCosts', to: { path: `/llc/companies/${id}/costs` } },
     { labelKey: 'nav.llcHeartbeat', to: { path: `/llc/companies/${id}/heartbeat` } },
     { labelKey: 'nav.llcCeoChat', to: { path: `/llc/companies/${id}/ceo-chat` } },
+    { labelKey: 'nav.llcPortability', to: { path: `/llc/companies/${id}/portability` } },
   ]
 })
 

--- a/autobot-frontend/src/composables/llc/llcStatus.ts
+++ b/autobot-frontend/src/composables/llc/llcStatus.ts
@@ -13,8 +13,10 @@
  * the unions below are the single source of truth for the frontend.
  */
 
-/** Display status for an LLC agent (org-chart node / dashboard agent grid). */
-export type AgentDisplayStatus = 'active' | 'idle' | 'error' | 'paused'
+/** Display status for an LLC agent (org-chart node / dashboard agent grid).
+ * 'terminated' is a permanent stop set by the controls terminate endpoint
+ * (backend agent_org_nodes.status). */
+export type AgentDisplayStatus = 'active' | 'idle' | 'error' | 'paused' | 'terminated'
 
 /** Display status for a heartbeat-run row. */
 export type RunDisplayStatus = 'running' | 'done' | 'failed'
@@ -28,6 +30,7 @@ export function agentStatusColor(status: string): string {
   if (status === 'active') return 'bg-green-500'
   if (status === 'idle') return 'bg-yellow-400'
   if (status === 'error') return 'bg-red-500'
+  if (status === 'terminated') return 'bg-gray-600'
   return 'bg-gray-400'
 }
 

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8159,7 +8159,10 @@
       "budget": "Budget",
       "assignedItems": "Assigned Items",
       "resumeAgent": "Resume Agent",
-      "pauseAgent": "Pause Agent"
+      "pauseAgent": "Pause Agent",
+      "terminateAgent": "Terminate Agent",
+      "confirmTerminate": "Terminate agent \"{name}\"? This permanently stops it with no recovery path.",
+      "terminatedNote": "This agent has been terminated."
     },
     "goals": {
       "title": "Goal Tree",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8159,7 +8159,10 @@
       "budget": "Budget",
       "assignedItems": "Zugewiesene Elemente",
       "resumeAgent": "Agent fortsetzen",
-      "pauseAgent": "Agent pausieren"
+      "pauseAgent": "Agent pausieren",
+      "terminateAgent": "Terminate Agent",
+      "confirmTerminate": "Terminate agent \"{name}\"? This permanently stops it with no recovery path.",
+      "terminatedNote": "This agent has been terminated."
     },
     "goals": {
       "title": "Zielbaum",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8148,7 +8148,10 @@
       "budget": "Budget",
       "assignedItems": "Assigned Items",
       "resumeAgent": "Resume Agent",
-      "pauseAgent": "Pause Agent"
+      "pauseAgent": "Pause Agent",
+      "terminateAgent": "Terminate Agent",
+      "confirmTerminate": "Terminate agent \"{name}\"? This permanently stops it with no recovery path.",
+      "terminatedNote": "This agent has been terminated."
     },
     "goals": {
       "title": "Goal Tree",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8159,7 +8159,10 @@
       "budget": "Presupuesto",
       "assignedItems": "Elementos asignados",
       "resumeAgent": "Reanudar agente",
-      "pauseAgent": "Pausar agente"
+      "pauseAgent": "Pausar agente",
+      "terminateAgent": "Terminate Agent",
+      "confirmTerminate": "Terminate agent \"{name}\"? This permanently stops it with no recovery path.",
+      "terminatedNote": "This agent has been terminated."
     },
     "goals": {
       "title": "Árbol de objetivos",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8159,7 +8159,10 @@
       "budget": "Budget",
       "assignedItems": "Assigned Items",
       "resumeAgent": "Resume Agent",
-      "pauseAgent": "Pause Agent"
+      "pauseAgent": "Pause Agent",
+      "terminateAgent": "Terminate Agent",
+      "confirmTerminate": "Terminate agent \"{name}\"? This permanently stops it with no recovery path.",
+      "terminatedNote": "This agent has been terminated."
     },
     "goals": {
       "title": "Goal Tree",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8159,7 +8159,10 @@
       "budget": "Budget",
       "assignedItems": "Éléments assignés",
       "resumeAgent": "Reprendre l'agent",
-      "pauseAgent": "Suspendre l'agent"
+      "pauseAgent": "Suspendre l'agent",
+      "terminateAgent": "Terminate Agent",
+      "confirmTerminate": "Terminate agent \"{name}\"? This permanently stops it with no recovery path.",
+      "terminatedNote": "This agent has been terminated."
     },
     "goals": {
       "title": "Arbre des objectifs",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8159,7 +8159,10 @@
       "budget": "Budget",
       "assignedItems": "Assigned Items",
       "resumeAgent": "Resume Agent",
-      "pauseAgent": "Pause Agent"
+      "pauseAgent": "Pause Agent",
+      "terminateAgent": "Terminate Agent",
+      "confirmTerminate": "Terminate agent \"{name}\"? This permanently stops it with no recovery path.",
+      "terminatedNote": "This agent has been terminated."
     },
     "goals": {
       "title": "Goal Tree",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8159,7 +8159,10 @@
       "budget": "Budget",
       "assignedItems": "Assigned Items",
       "resumeAgent": "Resume Agent",
-      "pauseAgent": "Pause Agent"
+      "pauseAgent": "Pause Agent",
+      "terminateAgent": "Terminate Agent",
+      "confirmTerminate": "Terminate agent \"{name}\"? This permanently stops it with no recovery path.",
+      "terminatedNote": "This agent has been terminated."
     },
     "goals": {
       "title": "Goal Tree",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8159,7 +8159,10 @@
       "budget": "Budget",
       "assignedItems": "Assigned Items",
       "resumeAgent": "Resume Agent",
-      "pauseAgent": "Pause Agent"
+      "pauseAgent": "Pause Agent",
+      "terminateAgent": "Terminate Agent",
+      "confirmTerminate": "Terminate agent \"{name}\"? This permanently stops it with no recovery path.",
+      "terminatedNote": "This agent has been terminated."
     },
     "goals": {
       "title": "Goal Tree",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8159,7 +8159,10 @@
       "budget": "Orçamento",
       "assignedItems": "Itens atribuídos",
       "resumeAgent": "Retomar agente",
-      "pauseAgent": "Pausar agente"
+      "pauseAgent": "Pausar agente",
+      "terminateAgent": "Terminate Agent",
+      "confirmTerminate": "Terminate agent \"{name}\"? This permanently stops it with no recovery path.",
+      "terminatedNote": "This agent has been terminated."
     },
     "goals": {
       "title": "Árvore de objetivos",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8159,7 +8159,10 @@
       "budget": "Budget",
       "assignedItems": "Assigned Items",
       "resumeAgent": "Resume Agent",
-      "pauseAgent": "Pause Agent"
+      "pauseAgent": "Pause Agent",
+      "terminateAgent": "Terminate Agent",
+      "confirmTerminate": "Terminate agent \"{name}\"? This permanently stops it with no recovery path.",
+      "terminatedNote": "This agent has been terminated."
     },
     "goals": {
       "title": "Goal Tree",

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -1188,6 +1188,7 @@ export const routes: RouteRecordRaw[] = [
       { path: 'heartbeat', name: 'llc-heartbeat', component: () => import('@/views/llc/HeartbeatMonitor.vue'), props: true, meta: { title: 'Heartbeat Monitor', requiresAuth: true } },
       { path: 'ceo-chat', name: 'llc-ceo-chat', component: () => import('@/views/llc/CeoChatView.vue'), props: true, meta: { title: 'CEO Chat', requiresAuth: true } },
       { path: 'members', name: 'llc-members', component: () => import('@/views/llc/MembersView.vue'), props: true, meta: { title: 'Members', requiresAuth: true } },
+      { path: 'portability', name: 'llc-company-portability', component: () => import('@/views/llc/CompanyPortabilityView.vue'), props: true, meta: { title: 'Portability', requiresAuth: true } },
       // GH#10750 (B3): in-layout variants of the formerly top-level dashboard/
       // goals/org-chart views so the LlcSidebar stays mounted on navigation.
       // The views resolve the active company from :companyId via

--- a/autobot-frontend/src/views/llc/OrgChart.vue
+++ b/autobot-frontend/src/views/llc/OrgChart.vue
@@ -23,6 +23,7 @@ const error = ref<string | null>(null)
 const selectedNode = ref<OrgNode | null>(null)
 const drawerOpen = ref(false)
 const showHire = ref(false) // GH#10219
+const terminating = ref(false) // in-flight guard — terminate is irreversible
 
 async function fetchTree() {
   isLoading.value = true
@@ -64,8 +65,9 @@ async function toggleAgentPause(node: OrgNode) {
 }
 
 async function terminateAgent(node: OrgNode) {
-  if (!companyId.value) return
+  if (!companyId.value || terminating.value) return
   if (!window.confirm(t('llc.orgChart.confirmTerminate', { name: node.name }))) return
+  terminating.value = true
   try {
     // Permanent stop — canonical /controls/agents/{id}/terminate endpoint.
     await api.post(`/api/llc/companies/${companyId.value}/controls/agents/${node.id}/terminate`, {})
@@ -73,6 +75,8 @@ async function terminateAgent(node: OrgNode) {
     closeDrawer()
   } catch (err: unknown) {
     logger.error('Terminate agent failed', err)
+  } finally {
+    terminating.value = false
   }
 }
 
@@ -199,7 +203,8 @@ onMounted(fetchTree)
             {{ selectedNode.status === 'paused' ? t('llc.orgChart.resumeAgent') : t('llc.orgChart.pauseAgent') }}
           </button>
           <button
-            class="w-full py-2 rounded-lg text-sm font-medium transition-colors bg-red-600 text-white hover:bg-red-700"
+            class="w-full py-2 rounded-lg text-sm font-medium transition-colors bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
+            :disabled="terminating"
             @click="terminateAgent(selectedNode)"
           >
             {{ t('llc.orgChart.terminateAgent') }}

--- a/autobot-frontend/src/views/llc/OrgChart.vue
+++ b/autobot-frontend/src/views/llc/OrgChart.vue
@@ -63,6 +63,19 @@ async function toggleAgentPause(node: OrgNode) {
   }
 }
 
+async function terminateAgent(node: OrgNode) {
+  if (!companyId.value) return
+  if (!window.confirm(t('llc.orgChart.confirmTerminate', { name: node.name }))) return
+  try {
+    // Permanent stop — canonical /controls/agents/{id}/terminate endpoint.
+    await api.post(`/api/llc/companies/${companyId.value}/controls/agents/${node.id}/terminate`, {})
+    await fetchTree() // reload from source of truth (backend sets status=terminated)
+    closeDrawer()
+  } catch (err: unknown) {
+    logger.error('Terminate agent failed', err)
+  }
+}
+
 function openDrawer(node: OrgNode) {
   selectedNode.value = node
   drawerOpen.value = true
@@ -175,7 +188,7 @@ onMounted(fetchTree)
             </div>
           </dl>
         </div>
-        <div class="px-5 py-4 border-t border-autobot-border">
+        <div v-if="selectedNode.status !== 'terminated'" class="px-5 py-4 border-t border-autobot-border space-y-2">
           <button
             class="w-full py-2 rounded-lg text-sm font-medium transition-colors"
             :class="selectedNode.status === 'paused'
@@ -185,6 +198,15 @@ onMounted(fetchTree)
           >
             {{ selectedNode.status === 'paused' ? t('llc.orgChart.resumeAgent') : t('llc.orgChart.pauseAgent') }}
           </button>
+          <button
+            class="w-full py-2 rounded-lg text-sm font-medium transition-colors bg-red-600 text-white hover:bg-red-700"
+            @click="terminateAgent(selectedNode)"
+          >
+            {{ t('llc.orgChart.terminateAgent') }}
+          </button>
+        </div>
+        <div v-else class="px-5 py-4 border-t border-autobot-border text-sm text-autobot-text-muted">
+          {{ t('llc.orgChart.terminatedNote') }}
         </div>
       </div>
     </transition>


### PR DESCRIPTION
## Thinking Path

Closes the final two Company OS UI-completion gaps from umbrella #11354, batched (both tiny, same theme):
- **#11357** — the export/import view (`CompanyPortabilityView`) was reachable only via the top-level deep-link `/llc/portability`, absent from the company sidebar. The view already reads `route.params.companyId` + a `companyId` prop, so it was *built* to be company-scoped but never given a scoped route.
- **#11358** — OrgChart exposed pause/resume (`/controls/agents/{id}/pause|resume`) but not the backend's `terminate` control.

## What Changed

**#11357**
- New company-scoped route `/llc/companies/:companyId/portability` (`llc-company-portability`, `props: true`) — keeps `LlcCompanyLayout`/sidebar mounted. Existing top-level route retained for back-compat.
- `nav.llcPortability` link in `LlcSidebar`.

**#11358**
- `terminateAgent()` in `OrgChart.vue`: confirm dialog → `POST /controls/agents/{id}/terminate` → `fetchTree()` (reload from source of truth) → close drawer.
- Red Terminate button in the agent drawer; pause/resume + terminate hidden and a terminated note shown once `status === 'terminated'`.
- `AgentDisplayStatus` gains `'terminated'` (backend `agent_org_nodes.status`) + a `bg-gray-600` dot in `agentStatusColor` — a first-class status, not a runtime type lie. No exhaustive consumers, so additive-safe.

**i18n:** `nav.llcPortability` + `llc.orgChart.{terminateAgent,confirmTerminate,terminatedNote}` across all 11 locales.

## Verification

- `scripts/audit_api_wiring.py --fail-on-unwired` → **exit 0** (authoritative build; 201 frontend paths; terminate endpoint resolves).
- `check:i18n` + `check:locales` → green (all 11 complete).
- `vue-tsc --noEmit -p tsconfig.app.json` → **0 errors** project-wide (confirms the `AgentDisplayStatus` change breaks nothing).

## Model Used

Claude Opus 4.8 (1M context)
