### PR TITLE
fix(llc): list full agent roster with human names from org chart

### DIFF
--- a/autobot-backend/llc/api/agents.py
+++ b/autobot-backend/llc/api/agents.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.user_management.dependencies import get_current_user, require_org_context
 from autobot_shared.logging_manager import get_logger
+from models.agent_org import AgentOrgNode
 from user_management.database import get_async_session
 from user_management.services import TenantContext
 
@@ -44,16 +45,20 @@ async def list_agents(
     _current_user: dict = Depends(get_current_user),
     ctx: TenantContext = Depends(require_org_context),
 ) -> List[Dict[str, Any]]:
-    """List LLC agents for the org with their latest heartbeat summary (GH#8549).
+    """List LLC agents for the org with their latest heartbeat summary (GH#8549, #11366).
 
-    Returns one row per distinct agent_id that has at least one heartbeat run
-    scoped to the caller's org.  Heartbeat-enabled status and last-run data are
-    derived from LLCHeartbeatRun rows.
+    Returns the full company roster from the org chart (``AgentOrgNode``) — every
+    agent, not just those with heartbeat history — each with its human-readable
+    name and its latest heartbeat run (LEFT JOIN) for status.  This lets assignee
+    pickers (Routines, Heartbeat monitor) list freshly-provisioned agents and show
+    names instead of opaque ids.
     """
     effective_company_id = company_id or str(ctx.org_id)
 
-    # Subquery: latest run per agent
-    subq = (
+    # Latest heartbeat run per agent, keyed by the logical agent_id *slug* — the
+    # dual-keyspace column shared by heartbeat/controls/budgets, NOT the UUID PK
+    # (joining on the wrong one silently returns 0 rows in Postgres; see AgentOrgNode).
+    latest_runs = (
         select(
             LLCHeartbeatRun.agent_id,
             func.max(LLCHeartbeatRun.created_at).label("latest_at"),
@@ -62,28 +67,44 @@ async def list_agents(
         .group_by(LLCHeartbeatRun.agent_id)
         .subquery()
     )
+
+    # Full roster from the org chart, LEFT JOINed to each agent's latest run.
     result = await session.execute(
-        select(LLCHeartbeatRun)
-        .join(
-            subq,
-            (LLCHeartbeatRun.agent_id == subq.c.agent_id) & (LLCHeartbeatRun.created_at == subq.c.latest_at),
+        select(AgentOrgNode, LLCHeartbeatRun)
+        .outerjoin(latest_runs, latest_runs.c.agent_id == AgentOrgNode.agent_id)
+        .outerjoin(
+            LLCHeartbeatRun,
+            (LLCHeartbeatRun.agent_id == latest_runs.c.agent_id)
+            & (LLCHeartbeatRun.created_at == latest_runs.c.latest_at),
         )
-        .order_by(LLCHeartbeatRun.agent_id)
+        .where(AgentOrgNode.company_id == effective_company_id)
+        .order_by(AgentOrgNode.name)
     )
-    rows = result.scalars().all()
 
     return [
         {
-            "id": run.agent_id,
-            "name": run.agent_id,
-            "heartbeat_enabled": True,
-            "last_heartbeat_at": run.started_at.isoformat() if run.started_at else None,
-            "last_run_status": run.status,
+            # Logical agent_id slug — kept as `id` for backward compatibility with
+            # the heartbeat monitor; also exposed explicitly as `agent_id`.
+            "id": node.agent_id,
+            "agent_id": node.agent_id,
+            # UUID PK — the keyspace work-item / routine assignees are stored in
+            # (llc_work_items.assignee_agent_id); assignee pickers POST this value.
+            "org_node_id": str(node.id),
+            "name": node.name,
+            "org_role": node.org_role,
+            "title": node.title,
+            "heartbeat_enabled": node.heartbeat_enabled,
+            "last_heartbeat_at": (
+                run.started_at.isoformat()
+                if run is not None and run.started_at
+                else (node.last_heartbeat_at.isoformat() if node.last_heartbeat_at else None)
+            ),
+            "last_run_status": run.status if run is not None else None,
             "current_run_started_at": (
-                run.started_at.isoformat() if run.status == "running" and run.started_at else None
+                run.started_at.isoformat() if run is not None and run.status == "running" and run.started_at else None
             ),
         }
-        for run in rows
+        for node, run in result.all()
     ]
 
 

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -50213,11 +50213,13 @@ export interface paths {
         };
         /**
          * List Agents
-         * @description List LLC agents for the org with their latest heartbeat summary (GH#8549).
+         * @description List LLC agents for the org with their latest heartbeat summary (GH#8549, #11366).
          *
-         *     Returns one row per distinct agent_id that has at least one heartbeat run
-         *     scoped to the caller's org.  Heartbeat-enabled status and last-run data are
-         *     derived from LLCHeartbeatRun rows.
+         *     Returns the full company roster from the org chart (``AgentOrgNode``) — every
+         *     agent, not just those with heartbeat history — each with its human-readable
+         *     name and its latest heartbeat run (LEFT JOIN) for status.  This lets assignee
+         *     pickers (Routines, Heartbeat monitor) list freshly-provisioned agents and show
+         *     names instead of opaque ids.
          */
         get: operations["list_agents_api_llc_agents_get"];
         put?: never;


### PR DESCRIPTION
Closes #11366.

## Thinking Path
`GET /api/llc/agents` (`llc/api/agents.py`) derived its list from `LLCHeartbeatRun` rows and returned `{id: agent_id, name: agent_id}`. Two bugs for any assignee picker (Routines #11355, Heartbeat monitor):
1. Agents with no heartbeat-run history never appeared — a freshly-provisioned agent couldn't be selected until it had run once.
2. `name` was the raw `agent_id` slug, so dropdowns showed an opaque id instead of a human name.

The full roster with human names lives in `AgentOrgNode` (org chart). Its docstring flags a **dual-keyspace trap**: `id` is the UUID PK (work-item/routine assignees), `agent_id` is the logical slug (heartbeat/controls/budgets) — joining heartbeat data on the wrong column silently returns 0 rows in Postgres.

## What Changed
`llc/api/agents.py` `list_agents`:
- Drive the query **`FROM AgentOrgNode`** (full company roster) instead of `LLCHeartbeatRun`, LEFT JOINing each agent's latest heartbeat run for status — so every agent appears, with or without run history.
- Join heartbeat data on the **slug `agent_id`** (both columns are `String(255)`), never the UUID PK — dual-keyspace-safe.
- Response keeps `id` = slug (backward-compatible with the heartbeat monitor, which uses it for `/agents/{id}/...` paths) and adds: `agent_id` (slug, explicit), `org_node_id` (UUID PK — the value routine/work-item assignee pickers must POST), human `name`, `org_role`, `title`. `heartbeat_enabled` now reflects the real per-agent flag (was hardcoded `True`); `last_run_status`/`current_run_started_at` come from the LEFT-joined run (null when never run).

## Verification
- Statement compiles under real SQLAlchemy 2.0 (Postgres dialect): **2 LEFT OUTER JOINs**, driven `FROM agent_org_nodes`, join predicates reference `agent_org_nodes.agent_id`/`llc_heartbeat_runs.agent_id` (slug — not the UUID PK), and select `agent_org_nodes.name`.
- `python -m py_compile` + `black -l120` clean; import ordered for isort.
- Existing list-endpoint consumers (`CompanyDashboard.vue`, `HeartbeatMonitor.vue`) use `.id` (slug, unchanged) for follow-up calls, so they keep working; they now render human names and the complete agent list. No backend caller relies on the old `name`=slug shape.
- Note: the Routines/Heartbeat assignee **pickers** (frontend #11355) should adopt `org_node_id` as the assignee value and `name` for display; this PR provides those fields. No local runtime DB test — the dev venv lacks SQLAlchemy and `AgentOrgNode` has a Postgres `JSONB` column SQLite can't create; CI container smoke-test exercises the real stack.

## Model Used
Claude Opus 4.8