### PR TITLE
feat(ansible): bake interpreter install + sudoers into canonical deploy (#11374)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/deploy-full.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-full.yml
@@ -67,6 +67,42 @@
     deployment_phase: "base-system"
     phase_description: "Ubuntu base system, security, users, networking"
 
+# -------------------------------------------------------------------
+# Phase 1.5: Language runtimes (#11374)
+# Install the target Python interpreter on every group whose service roles
+# build a venv, BEFORE those roles run. python3.14 for backend + AI/ML;
+# python3.11 (OpenVINO) for NPU. The python314 role is idempotent (skips when
+# the interpreter is present) and fail-loud (verifies after install), so a
+# broken deadsnakes PPA fails the deploy here instead of leaving the wrong
+# interpreter for the venv step to trip over. Ordered AFTER deploy-base (needs
+# apt/user) and BEFORE deploy-backend.
+# -------------------------------------------------------------------
+- name: "Phase 1.5: Language runtimes (Python interpreters)"
+  hosts: backend:aiml
+  become: true
+  gather_facts: true
+  vars:
+    deployment_phase: "language-runtimes"
+    phase_description: "Install python3.14 interpreter before venv creation"
+  roles:
+    - role: python314
+      vars:
+        python_interpreter_version: "3.14"
+      tags: ['deps', 'python314', 'runtimes']
+
+- name: "Phase 1.5: Language runtimes (NPU python3.11)"
+  hosts: npu
+  become: true
+  gather_facts: true
+  vars:
+    deployment_phase: "language-runtimes-npu"
+    phase_description: "Install python3.11 (OpenVINO) interpreter before venv creation"
+  roles:
+    - role: python314
+      vars:
+        python_interpreter_version: "3.11"
+      tags: ['deps', 'python314', 'runtimes']
+
 # Phase 2: Database Infrastructure
 - name: "Phase 2: Database Infrastructure"
   import_playbook: deploy-database.yml
@@ -84,12 +120,39 @@
     deployment_phase: "service-auth"
     phase_description: "Generate and deploy service-to-service auth keys"
 
+# -------------------------------------------------------------------
+# Phase 2.6: Service-management sudoers bootstraps (#11374)
+# Bake the previously-manual-only sudoers grants into the canonical install so
+# there is zero manual step / misconfig risk. Both are idempotent and
+# visudo-validated. Runs after base (autobot user exists) + after the interpreter
+# is present, and BEFORE backend (which relies on these grants at runtime):
+#   - python-provision: lets the SLM code-sync path (re)install the interpreter
+#     via provision-local-python.yml without a password (targets slm_server).
+#   - redis-service: lets the autobot user manage redis-stack-server (database).
+# -------------------------------------------------------------------
+- name: "Phase 2.6: Python provision sudoers"
+  import_playbook: configure-python-provision-permissions.yml
+  vars:
+    deployment_phase: "python-provision-sudoers"
+    phase_description: "NOPASSWD grant for interpreter provisioning"
+
+- name: "Phase 2.6: Redis service-management sudoers"
+  import_playbook: configure-redis-service-management.yml
+  vars:
+    deployment_phase: "redis-service-sudoers"
+    phase_description: "NOPASSWD grant for redis-stack-server control"
+
 # Phase 3: Backend Services
 - name: "Phase 3: Backend Services"
-  import_playbook: deploy-backend.yml
+  hosts: backend
+  become: true
+  gather_facts: true
   vars:
     deployment_phase: "backend"
     phase_description: "FastAPI, Python services, log aggregation"
+  roles:
+    - role: backend_services
+      tags: ['backend']
 
 # Phase 4: AI/ML Services
 - name: "Phase 4: AI/ML Infrastructure"
@@ -100,17 +163,27 @@
 
 # Phase 5: Frontend Services
 - name: "Phase 5: Frontend Infrastructure"
-  import_playbook: deploy-frontend.yml
+  hosts: frontend
+  become: true
+  gather_facts: true
   vars:
     deployment_phase: "frontend"
     phase_description: "Vue.js frontend, nginx, DNS cache"
+  roles:
+    - role: frontend
+      tags: ['frontend']
 
 # Phase 6: Browser Automation
 - name: "Phase 6: Browser Automation"
-  import_playbook: deploy-browser.yml
+  hosts: browser
+  become: true
+  gather_facts: true
   vars:
     deployment_phase: "browser"
     phase_description: "Playwright, VNC server, desktop environment"
+  roles:
+    - role: browser
+      tags: ['browser']
 
 # Phase 7: Data Migration
 - name: "Phase 7: Data Migration"

--- a/autobot-slm-backend/ansible/roles/backend_services/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend_services/tasks/main.yml
@@ -23,6 +23,18 @@
     - /opt/autobot/config
     - /opt/autobot/venv
 
+# #11374: Install the target interpreter BEFORE any venv work. The
+# ensure_venv_version step below removes a wrong-version venv, and the
+# subsequent pip step recreates it with virtualenv_python: python3.14 —
+# both fail if python3.14 is absent (the live py3.12 drift). The python314
+# role is idempotent (checks `python3.14 --version` first) and fail-loud
+# (verifies the interpreter after install), so re-running is a no-op.
+- name: "Backend Services | Install target Python interpreter (python3.14)"
+  ansible.builtin.include_role:
+    name: python314
+  vars:
+    python_interpreter_version: "3.14"
+
 - name: "Backend Services | Enforce venv target Python version (env-drift fix)"
   ansible.builtin.include_role:
     name: python314

--- a/autobot-slm-backend/ansible/roles/npu-worker/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/npu-worker/tasks/main.yml
@@ -92,6 +92,17 @@
     - "{{ npu_log_dir }}"
     - "{{ npu_models_dir }}"
 
+# #11374: Install python3.11 (OpenVINO's supported interpreter) BEFORE any
+# venv work. `ensure_venv_version` removes a wrong-version venv and the
+# `python3.11 -m venv` step recreates it — both fail if python3.11 is absent.
+# The SAME python314 role installs it via the parametrized version var,
+# reusing the deadsnakes apt logic (no duplication). Idempotent + fail-loud.
+- name: NPU worker | Install target Python interpreter (python3.11)
+  ansible.builtin.include_role:
+    name: python314
+  vars:
+    python_interpreter_version: "3.11"
+
 - name: NPU worker | Enforce venv target Python version (env-drift fix)
   ansible.builtin.include_role:
     name: python314

--- a/autobot-slm-backend/ansible/roles/python314/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/python314/defaults/main.yml
@@ -1,7 +1,17 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
 ---
+# Target interpreter version installed from the deadsnakes PPA.
+# Defaults to 3.14 (the fleet standard for backends). Callers that need a
+# different interpreter (e.g. the NPU worker needs 3.11 for OpenVINO) override
+# python_interpreter_version; the package list and the interpreter binary name
+# are derived from it so the SAME role installs any deadsnakes-supported
+# version without duplicated apt logic (#11374).
+python_interpreter_version: "3.14"
+
+# Derived — do not set directly; override python_interpreter_version instead.
+python_interpreter_binary: "python{{ python_interpreter_version }}"
 python314_packages:
-  - python3.14
-  - python3.14-venv
-  - python3.14-dev
+  - "python{{ python_interpreter_version }}"
+  - "python{{ python_interpreter_version }}-venv"
+  - "python{{ python_interpreter_version }}-dev"

--- a/autobot-slm-backend/ansible/roles/python314/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/python314/tasks/main.yml
@@ -3,17 +3,18 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 #
-# Shared dependency role: Python 3.14 (deadsnakes PPA)
-# Installs Python 3.14 interpreter and venv support.
+# Shared dependency role: install a deadsnakes Python interpreter.
+# Version is parameterized via python_interpreter_version (default 3.14;
+# NPU overrides to 3.11). Installs the interpreter and venv support.
 # Venv creation and pip installs stay in service roles.
 ---
 
-- name: "python314 | Check if Python 3.14 is available"
+- name: "python314 | Check if Python {{ python_interpreter_version }} is available"
   ansible.builtin.command:
-    cmd: python3.14 --version
-  register: _py312_check
+    cmd: "{{ python_interpreter_binary }} --version"
+  register: _py_check
   changed_when: false
-  # (#2872) Intentional: python3.14 may not be installed yet;
+  # (#2872) Intentional: the interpreter may not be installed yet;
   # rc != 0 triggers the deadsnakes PPA installation below.
   failed_when: false
   tags: ['deps', 'python314']
@@ -23,7 +24,7 @@
     name: software-properties-common
     state: present
   become: true
-  when: _py312_check.rc != 0
+  when: _py_check.rc != 0
   tags: ['deps', 'python314']
 
 # #7218: idempotent repo-add — preserve device-shipped PPA if present
@@ -33,14 +34,14 @@
     apt_repo_match: "deadsnakes/ppa"
     apt_repo_spec: "ppa:deadsnakes/ppa"
     apt_repo_filename: "deadsnakes"
-    apt_repo_label: "deadsnakes (Python 3.14)"
-  when: _py312_check.rc != 0
+    apt_repo_label: "deadsnakes (Python {{ python_interpreter_version }})"
+  when: _py_check.rc != 0
   tags: ['deps', 'python314']
 
 # #6719: bounded shell apt-get update — see roles/nginx/tasks/main.yml.
-# Only fires when Python 3.14 is missing, but when it does it must tolerate
+# Only fires when the interpreter is missing, but when it does it must tolerate
 # flaky PPAs (the deadsnakes PPA was just added; if it's unreachable, the
-# next deploy retry will still need to install Python 3.14).
+# next deploy retry will still need to install the interpreter).
 - name: "python314 | Refresh apt cache (best-effort, bounded; #6719)"
   ansible.builtin.command:
     cmd: >-
@@ -50,19 +51,21 @@
   become: true
   changed_when: false
   failed_when: false
-  when: _py312_check.rc != 0
+  when: _py_check.rc != 0
   tags: ['deps', 'python314']
 
-- name: "python314 | Install Python 3.14"
+- name: "python314 | Install Python {{ python_interpreter_version }}"
   ansible.builtin.apt:
     name: "{{ python314_packages }}"
     state: present
   become: true
-  when: _py312_check.rc != 0
+  when: _py_check.rc != 0
   tags: ['deps', 'python314']
 
-- name: "python314 | Verify Python 3.14 is available"
+# Fail-loud: a broken PPA must fail the deploy here, not silently leave the
+# wrong interpreter for the venv step to trip over. No failed_when: false.
+- name: "python314 | Verify Python {{ python_interpreter_version }} is available"
   ansible.builtin.command:
-    cmd: python3.14 --version
+    cmd: "{{ python_interpreter_binary }} --version"
   changed_when: false
   tags: ['deps', 'python314']


### PR DESCRIPTION
## Thinking Path

The canonical install (`playbooks/deploy-full.yml`) never installed the Python interpreters that its venv steps depend on, and two sudoers bootstraps were imported by no orchestration playbook — both are manual, misconfig-prone steps. Baked every dependency install into the canonical procedure so it happens automatically, idempotently, from its proper source (deadsnakes PPA + existing visudo-validated playbooks), with zero manual steps.

Root cause of the live py3.12 drift: `backend_services` and `npu-worker` roles call `ensure_venv_version` (removes wrong-version venv) then recreate the venv with `python3.14`/`python3.11 -m venv` — but nothing installed those interpreters first, so on a drifted box the recreate fails and the wrong interpreter survives.

## What Changed

**`roles/python314/`** — parametrized by interpreter version so ONE role installs any deadsnakes version (no duplicated apt logic, CLAUDE Rule 2):
- `defaults/main.yml`: added `python_interpreter_version` (default `"3.14"`); `python_interpreter_binary` and `python314_packages` derived from it.
- `tasks/main.yml`: uses `python_interpreter_binary` throughout; version-agnostic task names/messages. The final verify task stays **fail-loud** (no `failed_when: false`) so a broken PPA fails the deploy instead of leaving the wrong interpreter.

**`roles/backend_services/tasks/main.yml`** — added `include_role: python314` (`version 3.14`) BEFORE `ensure_venv_version`. Idempotent (role skips when `python3.14 --version` succeeds).

**`roles/npu-worker/tasks/main.yml`** — added `include_role: python314` (`version 3.11`, OpenVINO's interpreter) BEFORE `ensure_venv_version` and the `python3.11 -m venv` step. Same role, different version var — no duplication.

**`playbooks/deploy-full.yml`**:
- **Phase 1.5 (new): Language runtimes** — applies `python314` role to `backend:aiml` (3.14) and `npu` (3.11). Ordered after `deploy-base` (needs apt/user) and before backend.
- **Phase 2.6 (new): sudoers bootstraps** — `import_playbook` of `configure-python-provision-permissions.yml` + `configure-redis-service-management.yml` (already idempotent + visudo-validated), after service-auth, before backend.
- Fixed 3 **pre-existing dangling `import_playbook` refs** (`deploy-backend.yml`/`deploy-frontend.yml`/`deploy-browser.yml` — files that never existed and made the whole file un-syntax-checkable) by converting them to inline plays applying the real `backend_services` / `frontend` / `browser` roles. Discovered along the way; fixing it was required to syntax-check the file.

`pre-flight-code-sync.yml` and the venv-version logic are untouched and stay first.

## py3.11 vs py3.14 parametrization

Chose to parametrize the `python314` role (Rule 2: reuse over duplication) rather than duplicate deadsnakes logic in `npu-worker`. Callers pass `python_interpreter_version` in their `include_role` `vars:` block (scoped per include); packages and the binary name derive from it. Backend/AI-ML pass `"3.14"`, NPU passes `"3.11"`. The role name stays `python314` to avoid a churny rename of every existing caller.

## Verification

`ansible-playbook --syntax-check` (all pass; `slm_server`/`browser` group-pattern + deprecation warnings are pre-existing/expected):
- `deploy-full.yml` — now passes (was previously a hard ERROR on missing `deploy-backend.yml`)
- `configure-python-provision-permissions.yml`, `configure-redis-service-management.yml`, `provision-local-python.yml`
- `provision_host.yml` (exercises `npu-worker` + parametrized `python314`)

`yamllint -d relaxed` on all 5 changed files: exit 0 (only pre-existing-style `line-length` warnings).

`ansible-lint` not installed in this environment.

## Model Used

Opus 4.8 (1M context)

Closes #11374
