### PR TITLE
fix(ansible): gate unhealthy deploys + scheduled Postgres backups

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/health-check.yml
+++ b/autobot-slm-backend/ansible/playbooks/health-check.yml
@@ -89,6 +89,9 @@
       when: item != inventory_hostname
       register: network_tests
       changed_when: false
+      # OPTIONAL: cross-host reachability. On a single-box/partial inventory a
+      # peer VM may legitimately be absent/unreachable — this must not gate the
+      # deploy. Result is surfaced in the debug summary below.
       failed_when: false
       tags: [network]
 
@@ -103,6 +106,8 @@
       command: nslookup google.com
       register: dns_test
       changed_when: false
+      # OPTIONAL: outbound internet resolution is informational and unrelated to
+      # in-cluster service health (air-gapped boxes have none). Surfaced below.
       failed_when: false
       tags: [network]
 
@@ -119,6 +124,11 @@
       systemd:
         name: nginx
       register: nginx_status
+      # GATE: an inactive/failed unit is an unhealthy deploy — fail loud.
+      failed_when: >-
+        nginx_status is defined and nginx_status.status is defined
+        and nginx_status.status.ActiveState is defined
+        and nginx_status.status.ActiveState != 'active'
       when: is_frontend | bool
       tags: [frontend, services]
 
@@ -154,6 +164,11 @@
       systemd:
         name: autobot-backend
       register: backend_service_status
+      # GATE: an inactive/failed unit is an unhealthy deploy — fail loud.
+      failed_when: >-
+        backend_service_status is defined and backend_service_status.status is defined
+        and backend_service_status.status.ActiveState is defined
+        and backend_service_status.status.ActiveState != 'active'
       when: is_backend | bool
       tags: [backend, services]
 
@@ -192,6 +207,11 @@
       systemd:
         name: redis-stack-server
       register: redis_service_status
+      # GATE: an inactive/failed unit is an unhealthy deploy — fail loud.
+      failed_when: >-
+        redis_service_status is defined and redis_service_status.status is defined
+        and redis_service_status.status.ActiveState is defined
+        and redis_service_status.status.ActiveState != 'active'
       when: is_database | bool
       tags: [database, services]
 
@@ -232,6 +252,9 @@
         method: GET
         timeout: 10
       register: redisinsight_test
+      # OPTIONAL: RedisInsight is a developer GUI, not a data-plane service.
+      # Its absence must not gate the deploy; Redis health is gated by the
+      # redis-stack-server unit + PING checks above.
       failed_when: false
       when: is_database | bool
       tags: [database, services]
@@ -244,6 +267,11 @@
       systemd:
         name: autobot-ai-stack
       register: ai_stack_service_status
+      # GATE: an inactive/failed unit is an unhealthy deploy — fail loud.
+      failed_when: >-
+        ai_stack_service_status is defined and ai_stack_service_status.status is defined
+        and ai_stack_service_status.status.ActiveState is defined
+        and ai_stack_service_status.status.ActiveState != 'active'
       when: is_ai_stack | bool
       tags: [ai_stack, services]
 
@@ -261,6 +289,11 @@
       systemd:
         name: autobot-chromadb
       register: chromadb_service_status
+      # GATE: an inactive/failed unit is an unhealthy deploy — fail loud.
+      failed_when: >-
+        chromadb_service_status is defined and chromadb_service_status.status is defined
+        and chromadb_service_status.status.ActiveState is defined
+        and chromadb_service_status.status.ActiveState != 'active'
       when: is_ai_stack | bool
       tags: [ai_stack, services, chromadb]
 
@@ -296,6 +329,11 @@
       systemd:
         name: autobot-npu-worker
       register: npu_worker_service_status
+      # GATE: an inactive/failed unit is an unhealthy deploy — fail loud.
+      failed_when: >-
+        npu_worker_service_status is defined and npu_worker_service_status.status is defined
+        and npu_worker_service_status.status.ActiveState is defined
+        and npu_worker_service_status.status.ActiveState != 'active'
       when: is_npu | bool
       tags: [npu, services]
 
@@ -356,6 +394,11 @@
       systemd:
         name: autobot-slm-backend
       register: slm_service_status
+      # GATE: an inactive/failed unit is an unhealthy deploy — fail loud.
+      failed_when: >-
+        slm_service_status is defined and slm_service_status.status is defined
+        and slm_service_status.status.ActiveState is defined
+        and slm_service_status.status.ActiveState != 'active'
       when: is_slm | bool
       tags: [slm, services]
 
@@ -364,8 +407,8 @@
         url: "http://127.0.0.1:8000/api/health"
         method: GET
         timeout: 15
+        status_code: 200  # GATE: any non-200 (or unreachable) fails the play
       register: slm_health_test
-      failed_when: false
       when: is_slm | bool
       tags: [slm, services]
 
@@ -373,6 +416,11 @@
       systemd:
         name: nginx
       register: slm_nginx_status
+      # GATE: an inactive/failed unit is an unhealthy deploy — fail loud.
+      failed_when: >-
+        slm_nginx_status is defined and slm_nginx_status.status is defined
+        and slm_nginx_status.status.ActiveState is defined
+        and slm_nginx_status.status.ActiveState != 'active'
       when: is_slm | bool
       tags: [slm, services]
 
@@ -384,6 +432,11 @@
       systemd:
         name: autobot-vnc-server
       register: vnc_service_status
+      # GATE: an inactive/failed unit is an unhealthy deploy — fail loud.
+      failed_when: >-
+        vnc_service_status is defined and vnc_service_status.status is defined
+        and vnc_service_status.status.ActiveState is defined
+        and vnc_service_status.status.ActiveState != 'active'
       when: is_browser | bool
       tags: [browser, services]
 
@@ -391,6 +444,11 @@
       systemd:
         name: autobot-playwright
       register: playwright_service_status
+      # GATE: an inactive/failed unit is an unhealthy deploy — fail loud.
+      failed_when: >-
+        playwright_service_status is defined and playwright_service_status.status is defined
+        and playwright_service_status.status.ActiveState is defined
+        and playwright_service_status.status.ActiveState != 'active'
       when: is_browser | bool
       tags: [browser, services]
 
@@ -460,6 +518,8 @@
       shell: journalctl --since "1 hour ago" --priority=err --no-pager --lines=10
       register: system_errors
       changed_when: false
+      # OPTIONAL: log scan is diagnostic (non-zero exit == "no matching lines"),
+      # not a service-up check. Surfaced in the summary below.
       failed_when: false
       tags: [logs]
 
@@ -473,6 +533,7 @@
       shell: journalctl -u autobot-* --since "1 hour ago" --no-pager --lines=5
       register: autobot_logs
       changed_when: false
+      # OPTIONAL: diagnostic log tail, not a service-up check.
       failed_when: false
       tags: [logs]
 
@@ -504,6 +565,48 @@
           - "Services: {{ vm_health_summary.services_status }}"
       tags: always
 
+    # ==========================================
+    # REQUIRED-SERVICE GATE (fail the deploy on any unhealthy required service)
+    # ==========================================
+    #
+    # The per-task `failed_when`/`status_code` checks above already abort the
+    # play the moment a required service is down. This block is a belt-and-braces
+    # final assertion so a green health-check run PROVABLY means every required
+    # service on this host reported healthy — a broken deploy can no longer be
+    # reported as success (#11382). Each check is guarded `is defined and not
+    # skipped` so it only asserts on services that actually apply to this host.
+    - name: "GATE | Assert all required services on this host are healthy"
+      ansible.builtin.assert:
+        that:
+          # systemd units must be active
+          - "nginx_status is not defined or nginx_status is skipped or nginx_status.status.ActiveState == 'active'"
+          - "backend_service_status is not defined or backend_service_status is skipped or backend_service_status.status.ActiveState == 'active'"
+          - "redis_service_status is not defined or redis_service_status is skipped or redis_service_status.status.ActiveState == 'active'"
+          - "ai_stack_service_status is not defined or ai_stack_service_status is skipped or ai_stack_service_status.status.ActiveState == 'active'"
+          - "chromadb_service_status is not defined or chromadb_service_status is skipped or chromadb_service_status.status.ActiveState == 'active'"
+          - "npu_worker_service_status is not defined or npu_worker_service_status is skipped or npu_worker_service_status.status.ActiveState == 'active'"
+          - "slm_service_status is not defined or slm_service_status is skipped or slm_service_status.status.ActiveState == 'active'"
+          - "slm_nginx_status is not defined or slm_nginx_status is skipped or slm_nginx_status.status.ActiveState == 'active'"
+          - "vnc_service_status is not defined or vnc_service_status is skipped or vnc_service_status.status.ActiveState == 'active'"
+          - "playwright_service_status is not defined or playwright_service_status is skipped or playwright_service_status.status.ActiveState == 'active'"
+          # HTTP health endpoints must have returned 200
+          - "frontend_http_test is not defined or frontend_http_test is skipped or frontend_http_test.status == 200"
+          - "backend_health_test is not defined or backend_health_test is skipped or backend_health_test.status == 200"
+          - "backend_status_test is not defined or backend_status_test is skipped or backend_status_test.status == 200"
+          - "ai_stack_health_test is not defined or ai_stack_health_test is skipped or ai_stack_health_test.status == 200"
+          - "chromadb_health_test is not defined or chromadb_health_test is skipped or chromadb_health_test.status == 200"
+          - "npu_worker_health_test is not defined or npu_worker_health_test is skipped or npu_worker_health_test.status == 200"
+          - "slm_health_test is not defined or slm_health_test is skipped or slm_health_test.status == 200"
+          - "playwright_health_test is not defined or playwright_health_test is skipped or playwright_health_test.status == 200"
+          # Redis must answer PING
+          - "redis_ping_test is not defined or redis_ping_test is skipped or 'PONG' in (redis_ping_test.stdout | default(''))"
+        fail_msg: >-
+          UNHEALTHY DEPLOY on {{ inventory_hostname }} ({{ group_names | join(', ') }}):
+          one or more required services are down or returned a non-healthy status.
+          Inspect the task output above and `journalctl -u autobot-*` on this host.
+        success_msg: "All required services on {{ inventory_hostname }} are healthy."
+      tags: [always, gate]
+
 # ==========================================
 # INTEGRATION TESTS
 # ==========================================
@@ -528,6 +631,10 @@
         method: GET
         timeout: 15
       register: frontend_backend_test
+      # Non-fatal here so every integration probe runs and is reported
+      # together; the aggregate GATE assertion in the final-report play
+      # fails the run if any probe that actually targeted a present host
+      # did not return 200 (#11382).
       failed_when: false
       when: _frontend_host | length > 0
       tags: [integration]
@@ -539,6 +646,10 @@
         timeout: 15
         validate_certs: false
       register: backend_database_test
+      # Non-fatal here so every integration probe runs and is reported
+      # together; the aggregate GATE assertion in the final-report play
+      # fails the run if any probe that actually targeted a present host
+      # did not return 200 (#11382).
       failed_when: false
       when: _backend_host | length > 0
       tags: [integration]
@@ -550,6 +661,10 @@
         timeout: 30
         validate_certs: false
       register: backend_ai_test
+      # Non-fatal here so every integration probe runs and is reported
+      # together; the aggregate GATE assertion in the final-report play
+      # fails the run if any probe that actually targeted a present host
+      # did not return 200 (#11382).
       failed_when: false
       when: _backend_host | length > 0
       tags: [integration]
@@ -560,6 +675,10 @@
         method: GET
         timeout: 15
       register: npu_connectivity_test
+      # Non-fatal here so every integration probe runs and is reported
+      # together; the aggregate GATE assertion in the final-report play
+      # fails the run if any probe that actually targeted a present host
+      # did not return 200 (#11382).
       failed_when: false
       when: _npu_host | length > 0
       tags: [integration]
@@ -601,6 +720,28 @@
           ai_vm: "{{ hostvars[_ai_host[0]]['vm_health_summary'] | default({'services_status': 'Unknown'}) if _ai_host | length > 0 else {'services_status': 'No host'} }}"
           npu_vm: "{{ hostvars[_npu_host[0]]['vm_health_summary'] | default({'services_status': 'Unknown'}) if _npu_host | length > 0 else {'services_status': 'No host'} }}"
           browser_vm: "{{ hostvars[_browser_host[0]]['vm_health_summary'] | default({'services_status': 'Unknown'}) if _browser_host | length > 0 else {'services_status': 'No host'} }}"
+
+    # ==========================================
+    # INTEGRATION GATE (fail the deploy on any broken cross-service path)
+    # ==========================================
+    # The integration probes are non-fatal individually so they all run; this
+    # assertion aggregates them and fails the run if any probe that ACTUALLY
+    # targeted a present host did not return 200. A probe that was skipped
+    # (group absent on this inventory) has no `.status` and is not asserted —
+    # single-box/partial deploys are not penalised for missing peers (#11382).
+    - name: "GATE | Assert cross-service integration paths are healthy"
+      ansible.builtin.assert:
+        that:
+          - "hostvars['localhost']['frontend_backend_test'] is not defined or hostvars['localhost']['frontend_backend_test'] is skipped or hostvars['localhost']['frontend_backend_test'].status | default(0) == 200"
+          - "hostvars['localhost']['backend_database_test'] is not defined or hostvars['localhost']['backend_database_test'] is skipped or hostvars['localhost']['backend_database_test'].status | default(0) == 200"
+          - "hostvars['localhost']['backend_ai_test'] is not defined or hostvars['localhost']['backend_ai_test'] is skipped or hostvars['localhost']['backend_ai_test'].status | default(0) == 200"
+          - "hostvars['localhost']['npu_connectivity_test'] is not defined or hostvars['localhost']['npu_connectivity_test'] is skipped or hostvars['localhost']['npu_connectivity_test'].status | default(0) == 200"
+        fail_msg: >-
+          UNHEALTHY DEPLOY: one or more cross-service integration paths failed
+          (frontend->backend, backend->database, backend->AI, or NPU worker).
+          See the "Integration Test Results" output above.
+        success_msg: "All targeted cross-service integration paths returned 200."
+      tags: [always, gate, integration]
 
     - name: Generate final health report
       debug:

--- a/autobot-slm-backend/ansible/roles/postgresql/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/postgresql/defaults/main.yml
@@ -79,3 +79,24 @@ autobot_group: "autobot"
 # Health check (retry-based polling instead of fixed timeout)
 postgresql_health_check_retries: 60  # Max attempts (60 × 5s = 300s)
 postgresql_health_check_delay: 5     # Seconds between retries
+
+# ==========================================
+# Scheduled backups (systemd timer + pg_dumpall) — #11383
+# ==========================================
+# Master switch. Set false to skip backup provisioning entirely (idempotent).
+postgresql_backup_enabled: true
+
+# Destination for compressed cluster dumps. Owned by the AutoBot service user.
+postgresql_backup_dir: "/var/backups/autobot/postgresql"
+
+# systemd OnCalendar schedule (see `man systemd.time`). Default: daily 02:30.
+postgresql_backup_on_calendar: "*-*-* 02:30:00"
+
+# Spread load / avoid thundering-herd when many nodes share a schedule.
+postgresql_backup_randomized_delay_sec: 900
+
+# Keep dumps for this many days; older *.sql.gz files are pruned each run.
+postgresql_backup_retention_days: 14
+
+# Filename prefix for each dump (timestamp is appended).
+postgresql_backup_prefix: "postgresql-all"

--- a/autobot-slm-backend/ansible/roles/postgresql/tasks/backup.yml
+++ b/autobot-slm-backend/ansible/roles/postgresql/tasks/backup.yml
@@ -1,0 +1,73 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+#
+# PostgreSQL Scheduled Backups (#11383)
+# Provisions a systemd timer that runs `pg_dumpall` on a configurable schedule
+# to a configurable retention directory, pruning dumps older than the window.
+# Idempotent: re-running only rewrites managed files and re-asserts timer state.
+---
+
+- name: Ensure PostgreSQL backup directory exists
+  ansible.builtin.file:
+    path: "{{ postgresql_backup_dir }}"
+    state: directory
+    owner: "{{ autobot_user }}"
+    group: "{{ autobot_group }}"
+    mode: "0750"
+  become: true
+
+- name: Deploy PostgreSQL backup script
+  ansible.builtin.template:
+    src: autobot-pg-backup.sh.j2
+    dest: /usr/local/bin/autobot-pg-backup.sh
+    owner: root
+    group: root
+    mode: "0755"
+  become: true
+
+- name: Deploy PostgreSQL backup service unit
+  ansible.builtin.template:
+    src: autobot-pg-backup.service.j2
+    dest: /etc/systemd/system/autobot-pg-backup.service
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  notify: Reload systemd
+
+- name: Deploy PostgreSQL backup timer unit
+  ansible.builtin.template:
+    src: autobot-pg-backup.timer.j2
+    dest: /etc/systemd/system/autobot-pg-backup.timer
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  notify: Reload systemd
+
+- name: Flush handlers to reload systemd before enabling the timer
+  ansible.builtin.meta: flush_handlers
+
+- name: Enable and start PostgreSQL backup timer
+  ansible.builtin.systemd:
+    name: autobot-pg-backup.timer
+    state: started
+    enabled: true
+  become: true
+
+- name: Report PostgreSQL backup timer schedule
+  ansible.builtin.command:
+    cmd: systemctl list-timers autobot-pg-backup.timer --no-pager
+  register: _pg_backup_timer_status
+  changed_when: false
+
+- name: Display PostgreSQL backup timer status
+  ansible.builtin.debug:
+    msg:
+      - "PostgreSQL scheduled backups enabled"
+      - "Schedule: {{ postgresql_backup_on_calendar }}"
+      - "Destination: {{ postgresql_backup_dir }}"
+      - "Retention: {{ postgresql_backup_retention_days }} days"
+      - "{{ _pg_backup_timer_status.stdout_lines | default(['(timer output unavailable)']) }}"

--- a/autobot-slm-backend/ansible/roles/postgresql/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/postgresql/tasks/main.yml
@@ -23,3 +23,9 @@
   tags:
     - postgresql
     - databases
+- name: Include scheduled backup tasks
+  ansible.builtin.include_tasks: backup.yml
+  when: postgresql_backup_enabled | bool
+  tags:
+    - postgresql
+    - backup

--- a/autobot-slm-backend/ansible/roles/postgresql/templates/autobot-pg-backup.service.j2
+++ b/autobot-slm-backend/ansible/roles/postgresql/templates/autobot-pg-backup.service.j2
@@ -1,0 +1,18 @@
+# AutoBot PostgreSQL Scheduled Backup - Ansible Managed (#11383)
+# Oneshot cluster dump; triggered by autobot-pg-backup.timer.
+# Check status: systemctl status autobot-pg-backup.service
+[Unit]
+Description=AutoBot PostgreSQL cluster backup (pg_dumpall)
+After=postgresql.service
+Wants=postgresql.service
+
+[Service]
+Type=oneshot
+# Runs as root so `su - postgres` needs no password (matches pre-migration dump).
+User=root
+Group=root
+ExecStart=/usr/local/bin/autobot-pg-backup.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=autobot-pg-backup
+TimeoutStartSec=1800

--- a/autobot-slm-backend/ansible/roles/postgresql/templates/autobot-pg-backup.sh.j2
+++ b/autobot-slm-backend/ansible/roles/postgresql/templates/autobot-pg-backup.sh.j2
@@ -1,0 +1,34 @@
+#!/bin/bash
+# AutoBot PostgreSQL Scheduled Backup - Ansible Managed (#11383)
+# Do not edit manually — rendered from
+# roles/postgresql/templates/autobot-pg-backup.sh.j2
+#
+# Full-cluster dump via `su - postgres -c pg_dumpall` (run as root by the
+# oneshot service unit) so no password is embedded — matches the established
+# pre-migration backup pattern. Prunes dumps older than the retention window.
+set -euo pipefail
+
+BACKUP_DIR="{{ postgresql_backup_dir }}"
+PREFIX="{{ postgresql_backup_prefix }}"
+RETENTION_DAYS="{{ postgresql_backup_retention_days }}"
+OWNER="{{ autobot_user }}"
+GROUP="{{ autobot_group }}"
+
+timestamp="$(date +%Y%m%d-%H%M%S)"
+target="${BACKUP_DIR}/${PREFIX}-${timestamp}.sql.gz"
+tmp="${target}.partial"
+
+mkdir -p "${BACKUP_DIR}"
+
+# Dump to a .partial file first, then atomically rename, so an interrupted run
+# never leaves a half-written dump that prune/restore could pick up.
+su - postgres -c "pg_dumpall --clean --if-exists" | gzip > "${tmp}"
+mv "${tmp}" "${target}"
+chown "${OWNER}:${GROUP}" "${target}"
+chmod 0640 "${target}"
+
+echo "PostgreSQL cluster dump written: ${target}"
+
+# Prune dumps older than the retention window (mtime-based).
+find "${BACKUP_DIR}" -maxdepth 1 -type f -name "${PREFIX}-*.sql.gz" \
+  -mtime "+${RETENTION_DAYS}" -print -delete

--- a/autobot-slm-backend/ansible/roles/postgresql/templates/autobot-pg-backup.timer.j2
+++ b/autobot-slm-backend/ansible/roles/postgresql/templates/autobot-pg-backup.timer.j2
@@ -1,0 +1,12 @@
+# AutoBot PostgreSQL Scheduled Backup Timer - Ansible Managed (#11383)
+# View schedule: systemctl list-timers autobot-pg-backup*
+[Unit]
+Description=AutoBot PostgreSQL backup timer ({{ postgresql_backup_on_calendar }})
+
+[Timer]
+OnCalendar={{ postgresql_backup_on_calendar }}
+RandomizedDelaySec={{ postgresql_backup_randomized_delay_sec }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes #11382
Closes #11383

Two independent deploy-safety improvements to the AutoBot Ansible tree, shipped together. Does not touch `deploy-full.yml` (owned by #11374 in a parallel session).

## Thinking Path

Two gaps make a broken deploy look successful and put Postgres data at risk:

1. **`health-check.yml` could not gate a deploy.** The `systemd` module does not fail on an inactive/failed unit — it just reports state — so every `systemd:` service check was effectively advisory. The final report interpolated `... else 'FAILED'` strings but never actually failed the play, and the SLM health endpoint carried `failed_when: false`. Net result: an unhealthy service prints `FAILED` and the run still exits 0.
2. **No scheduled Postgres backups exist.** `services/backup.py` and `roles/access_control/tasks/backup.yml` snapshot Redis only. Every `pg_dump`/`pg_dumpall` in the tree is one-shot (pre-migration safety dump, restore-verification test). No cron and no systemd timer runs a recurring dump — a host loss between migrations means unbounded loss of user-management / RBAC / Company-OS data.

## What Changed

**Part A — health-check.yml gates the deploy (#11382)**
- Added `failed_when` to every required `systemd` unit check (nginx, autobot-backend, redis-stack-server, autobot-ai-stack, autobot-chromadb, autobot-npu-worker, autobot-slm-backend, VNC, Playwright) so a non-`active` unit fails the play.
- SLM health endpoint now requires `status_code: 200` (removed its `failed_when: false`).
- Added two belt-and-braces GATE assertions: a per-host required-service assertion (`post_tasks`) and an aggregate cross-service integration assertion (final-report play). Each `that:` line is guarded `is not defined or ... is skipped or ...` so single-box / partial inventories are never penalised for absent peers.
- Kept `failed_when: false` **only** where legitimately optional — cross-host ping, DNS, RedisInsight GUI, journalctl diagnostics, cross-host integration probes — each now carrying a comment explaining why.

**Part B — scheduled Postgres backups (#11383)**
- New systemd timer + oneshot service in the `postgresql` role that runs `su - postgres -c "pg_dumpall --clean --if-exists" | gzip` (no embedded password — matches the established pre-migration dump), writes to a configurable retention dir, and prunes dumps older than the retention window. Dumps are written `.partial` then atomically renamed.
- Wired into the role's `main.yml` behind `postgresql_backup_enabled`, so `deploy-full` (via the postgresql role) provisions it automatically and idempotently.
- All schedule / dir / retention / prefix values live in role defaults — no hardcoding.

New files: `roles/postgresql/tasks/backup.yml`, `templates/autobot-pg-backup.{sh,service,timer}.j2`; defaults + `main.yml` wire-in.

## Verification

- `ansible-playbook --syntax-check` passes on `health-check.yml`, `deploy-slm-manager.yml`, `deploy-user-management-db.yml`, `provision-backend-db-single-box.yml` (only the expected empty-hosts / group-pattern warnings).
- `yamllint` (line-length relaxed to match the file's pre-existing style) reports no structural issues on all changed YAML.
- Jinja2 render of all three templates verified; the rendered backup script passes `bash -n`.
- No live Ansible run against any host — code only.

## Model Used

Claude Opus 4.8 (1M context)