### PR TITLE
fix(knowledge): guard llama_index imports so knowledge.base/facts import without it (#11391)

### DIFF
--- a/autobot-backend/knowledge/base.py
+++ b/autobot-backend/knowledge/base.py
@@ -17,12 +17,16 @@ from pathlib import Path
 from typing import TYPE_CHECKING, List
 
 import redis
-from llama_index.core import Settings, VectorStoreIndex
-from llama_index.core.storage.storage_context import StorageContext
-from llama_index.embeddings.ollama import OllamaEmbedding as LlamaIndexOllamaEmbedding
-from llama_index.llms.ollama import Ollama as LlamaIndexOllamaLLM
-from llama_index.vector_stores.chroma import ChromaVectorStore
 from redis import asyncio as aioredis
+
+# llama_index is imported lazily inside the methods that use it (#11391) so that
+# merely importing knowledge.base does not require the (heavy, optional-in-tests)
+# llama_index family — its absence otherwise ModuleNotFound'd any import chain
+# reaching this module (e.g. test collection for concurrent_limiter). Sibling
+# knowledge mixins (index.py, facts.py, search.py, stats.py) already guard theirs.
+if TYPE_CHECKING:
+    from llama_index.core import VectorStoreIndex
+    from llama_index.vector_stores.chroma import ChromaVectorStore
 
 from autobot_shared.error_boundaries import error_boundary, get_error_boundary_manager
 from autobot_shared.logging_manager import get_logger
@@ -190,7 +194,11 @@ class KnowledgeBaseCore:
             timeout: Request timeout in seconds
             ssot_config: SSOT configuration object
         """
+        from llama_index.core import Settings
+
         if provider == "ollama":
+            from llama_index.llms.ollama import Ollama as LlamaIndexOllamaLLM
+
             Settings.llm = LlamaIndexOllamaLLM(
                 model=model,
                 request_timeout=timeout,
@@ -227,7 +235,11 @@ class KnowledgeBaseCore:
         Returns:
             int: Embedding dimensions for the configured provider
         """
+        from llama_index.core import Settings
+
         if provider == "ollama":
+            from llama_index.embeddings.ollama import OllamaEmbedding as LlamaIndexOllamaEmbedding
+
             Settings.embed_model = LlamaIndexOllamaEmbedding(
                 model_name=model_name,
                 base_url=endpoint,
@@ -382,6 +394,8 @@ class KnowledgeBaseCore:
         # LlamaIndex ChromaVectorStore requires the raw chromadb collection.
         # ChromaDBCollection._raw holds the underlying chromadb object.
         raw_collection = getattr(abc_collection, "_raw", abc_collection)
+        from llama_index.vector_stores.chroma import ChromaVectorStore
+
         self.vector_store = ChromaVectorStore(chroma_collection=raw_collection)
 
         # Issue #8391: Instantiate VectorWriteBuffer backed by this collection.
@@ -457,6 +471,9 @@ class KnowledgeBaseCore:
                 return
 
             logger.info("Creating initial vector index with ChromaDB...")
+
+            from llama_index.core import VectorStoreIndex
+            from llama_index.core.storage.storage_context import StorageContext
 
             # Create storage context with ChromaDB vector store
             storage_context = StorageContext.from_defaults(vector_store=self.vector_store)

--- a/autobot-backend/knowledge/facts.py
+++ b/autobot-backend/knowledge/facts.py
@@ -16,8 +16,6 @@ import uuid
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List
 
-from llama_index.core import Document
-
 from autobot_shared.logging_manager import get_logger
 
 if TYPE_CHECKING:
@@ -604,6 +602,8 @@ class FactsMixin:
         if write_buffer is not None:
             await write_buffer.write(fact_id, embedding, content, sanitized_metadata)
         else:
+            from llama_index.core import Document
+
             doc = Document(text=content, doc_id=fact_id, metadata=sanitized_metadata)
             doc.embedding = embedding
             await asyncio.to_thread(self.vector_store.add, [doc])
@@ -873,6 +873,8 @@ class FactsMixin:
         if write_buffer is not None:
             await write_buffer.write(fact_id, embedding, content, sanitized_metadata)
         else:
+            from llama_index.core import Document
+
             doc = Document(text=content, doc_id=fact_id, metadata=sanitized_metadata)
             doc.embedding = embedding
             await asyncio.to_thread(self.vector_store.add, [doc])

--- a/autobot-backend/tests/knowledge/test_llama_index_import_guarded.py
+++ b/autobot-backend/tests/knowledge/test_llama_index_import_guarded.py
@@ -1,0 +1,70 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression guard: knowledge modules must not eagerly import llama_index (#11391).
+
+`knowledge/base.py` and `knowledge/facts.py` used unguarded top-level
+`from llama_index...` imports, so any import chain reaching them (e.g.
+`workflow_automation -> orchestrator -> knowledge_base`) hard-failed with
+ModuleNotFoundError in an environment without the (heavy, optional-in-tests)
+llama_index family — which blocked scoped test collection such as
+`tests/services/test_concurrent_limiter.py`.
+
+llama_index must only be imported lazily (inside the functions that use it) or
+under `if TYPE_CHECKING:`. This test enforces that at the source level so it
+cannot silently regress, and also proves the modules import with llama_index
+absent.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+_GUARDED_MODULES = ["knowledge/base.py", "knowledge/facts.py"]
+
+
+def _module_level_llama_imports(source: str) -> list[str]:
+    """Return llama_index imports that sit at module scope and outside TYPE_CHECKING."""
+    tree = ast.parse(source)
+    offenders: list[str] = []
+
+    def _is_llama(node: ast.AST) -> bool:
+        if isinstance(node, ast.ImportFrom):
+            return bool(node.module and node.module.startswith("llama_index"))
+        if isinstance(node, ast.Import):
+            return any(a.name.startswith("llama_index") for a in node.names)
+        return False
+
+    for node in tree.body:  # module-level statements only
+        if _is_llama(node):
+            offenders.append(f"line {node.lineno}: top-level llama_index import")
+        # `if TYPE_CHECKING:` blocks are allowed to import llama_index.
+        if isinstance(node, ast.If):
+            continue  # type-checking / conditional guards are fine
+    return offenders
+
+
+@pytest.mark.parametrize("rel_path", _GUARDED_MODULES)
+def test_no_unguarded_top_level_llama_index_import(rel_path: str) -> None:
+    source = (_BACKEND_ROOT / rel_path).read_text(encoding="utf-8")
+    offenders = _module_level_llama_imports(source)
+    assert not offenders, f"{rel_path} must import llama_index lazily / under TYPE_CHECKING, found: {offenders}"
+
+
+def test_knowledge_base_imports_without_llama_index(monkeypatch) -> None:
+    """knowledge.base + knowledge.facts import even when llama_index is absent."""
+    saved = {k: v for k, v in sys.modules.items() if k.startswith("llama_index")}
+    for k in saved:
+        monkeypatch.delitem(sys.modules, k, raising=False)
+    # Force any `import llama_index.*` to raise ModuleNotFoundError.
+    monkeypatch.setitem(sys.modules, "llama_index", None)
+    for mod in ("knowledge.base", "knowledge.facts"):
+        monkeypatch.delitem(sys.modules, mod, raising=False)
+        importlib.import_module(mod)  # must not raise ModuleNotFoundError


### PR DESCRIPTION
## Thinking Path
`knowledge/base.py` (5 module-level `from llama_index...` imports) and `knowledge/facts.py` (`from llama_index.core import Document`) hard-imported the llama_index family at module scope. Any import chain reaching them — `workflow_automation → orchestrator → knowledge_base` — then `ModuleNotFoundError`'d in an env without llama_index, **blocking scoped test collection for `services/test_concurrent_limiter.py`**. The sibling knowledge mixins (`index.py`, `search.py`, `stats.py`) already guard theirs; base.py/facts.py were the inconsistent ones.

**Premise correction (verified before implementing):** the issue states llama_index is "not present in requirements" — it **is** (`requirements.txt:65-69`). The real bug is the *eager* import, not a missing dependency.

## What Changed
- Type-only symbols (`VectorStoreIndex`, `ChromaVectorStore`) → `if TYPE_CHECKING:` (annotations are strings via `from __future__ import annotations`).
- Runtime symbols (`Settings`, `StorageContext`, Ollama LLM/embedding, `ChromaVectorStore`, `Document`) → lazy imports inside the methods that use them — matching base.py's own existing OpenAI/Anthropic lazy pattern. No behavior change when llama_index is present.

## Verification (ran the actual failing case)
- **Reproduced** the block: with llama_index masked, `import knowledge.base` → `ModuleNotFoundError`.
- **After fix, with llama_index masked:** `knowledge.base`, `knowledge.facts`, `knowledge_base`, **and `services.workflow_automation.concurrent_limiter`** all import cleanly. (base.py alone was insufficient — facts.py was also in the chain; caught by verifying the full chain, not assuming.)
- `tests/knowledge/test_llama_index_import_guarded.py` — **3 passed** (AST guard: no top-level llama_index import in either file; runtime masked-import test).
- `test_concurrent_limiter.py` collects 10 tests; `py_compile` + `black --line-length=120` + `ruff` clean.

## Model Used
Opus 4.8

Closes #11391