### PR TITLE
feat(llc): pending-approval count badge on Approvals sidebar link (#11387)

### DIFF
--- a/autobot-frontend/src/components/llc/LlcSidebar.vue
+++ b/autobot-frontend/src/components/llc/LlcSidebar.vue
@@ -13,20 +13,51 @@
   Sprint & Kanban boards need a :boardId and are reached via the Backlog.
 -->
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useLlcCompanyStore } from '@/stores/useLlcCompanyStore'
+import { useApiClient } from '@/plugins/api'
+import { useLiveEvents } from '@/composables/useLiveEvents'
+import { createLogger } from '@/utils/debugUtils'
 
 const route = useRoute()
 const router = useRouter()
 const { t } = useI18n()
 const companyStore = useLlcCompanyStore()
+const api = useApiClient()
+const live = useLiveEvents()
+const logger = createLogger('LlcSidebar')
 
 const companyId = computed(() => {
   const raw = route.params.companyId
   return (Array.isArray(raw) ? raw[0] : raw) ?? companyStore.selectedCompanyId
 })
+
+// FR-GOV-03: pending board-approval count badge on the Approvals link.
+const pendingApprovals = ref(0)
+
+async function fetchPendingCount(): Promise<void> {
+  const id = companyId.value
+  if (!id) return
+  try {
+    // GET /api/llc/approvals returns the pending list for a company.
+    const list = await api.get<unknown[]>(`/api/llc/approvals?company_id=${id}`)
+    pendingApprovals.value = Array.isArray(list) ? list.length : 0
+  } catch (err) {
+    logger.error('Failed to load pending approval count', err)
+  }
+}
+
+onMounted(() => {
+  void fetchPendingCount()
+  // Live refresh when an approval is created/resolved (auto-unsubscribes on unmount).
+  live.subscribe(`company:${companyId.value}`, (ev) => {
+    if (String(ev.event_type).includes('approval')) void fetchPendingCount()
+  })
+})
+
+watch(companyId, () => void fetchPendingCount())
 
 interface SidebarLink {
   labelKey: string
@@ -116,7 +147,14 @@ async function onCompanyChange(event: Event): Promise<void> {
         :class="{ active: isActive(link) }"
         :aria-current="isActive(link) ? 'page' : undefined"
       >
-        {{ t(link.labelKey) }}
+        <span class="llc-nav-label">{{ t(link.labelKey) }}</span>
+        <span
+          v-if="link.labelKey === 'nav.llcApprovals' && pendingApprovals > 0"
+          class="llc-nav-badge"
+          :aria-label="t('nav.llcApprovalsPending', { count: pendingApprovals })"
+        >
+          {{ pendingApprovals }}
+        </span>
       </RouterLink>
     </nav>
   </aside>
@@ -179,13 +217,29 @@ async function onCompanyChange(event: Event): Promise<void> {
 }
 
 .llc-nav-item {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
   padding: 0.4375rem 0.625rem;
   font-size: 0.875rem;
   border-radius: var(--radius-md, 8px);
   border-left: 2px solid transparent;
   color: var(--text-secondary, #4b5563);
   text-decoration: none;
+}
+
+.llc-nav-badge {
+  flex: none;
+  min-width: 1.25rem;
+  padding: 0 0.375rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  line-height: 1.25rem;
+  text-align: center;
+  border-radius: 999px;
+  background: var(--color-accent, #c4651a);
+  color: #fff;
 }
 
 .llc-nav-item:hover {

--- a/autobot-frontend/src/components/llc/LlcSidebar.vue
+++ b/autobot-frontend/src/components/llc/LlcSidebar.vue
@@ -13,7 +13,7 @@
   Sprint & Kanban boards need a :boardId and are reached via the Backlog.
 -->
 <script setup lang="ts">
-import { computed, ref, onMounted, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useLlcCompanyStore } from '@/stores/useLlcCompanyStore'
@@ -49,15 +49,23 @@ async function fetchPendingCount(): Promise<void> {
   }
 }
 
-onMounted(() => {
-  void fetchPendingCount()
-  // Live refresh when an approval is created/resolved (auto-unsubscribes on unmount).
-  live.subscribe(`company:${companyId.value}`, (ev) => {
-    if (String(ev.event_type).includes('approval')) void fetchPendingCount()
-  })
-})
-
-watch(companyId, () => void fetchPendingCount())
+// Track + rebind the live subscription across company switches: the sidebar
+// stays mounted (#10750 B3) and companyId is a computed, so re-subscribe on
+// change (immediate covers mount). useLiveEvents also auto-cleans on unmount.
+let unsubApprovals: (() => void) | null = null
+watch(
+  companyId,
+  (id) => {
+    void fetchPendingCount()
+    if (unsubApprovals) unsubApprovals()
+    unsubApprovals = id
+      ? live.subscribe(`company:${id}`, (ev) => {
+          if (String(ev.event_type).includes('approval')) void fetchPendingCount()
+        })
+      : null
+  },
+  { immediate: true },
+)
 
 interface SidebarLink {
   labelKey: string

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -7702,6 +7702,7 @@
     "llcPortfolios": "Portfolios",
     "llcTimeline": "Timeline",
     "llcApprovals": "Approvals",
+    "llcApprovalsPending": "{count} pending approvals",
     "llcCosts": "Costs & Budget",
     "llcHeartbeat": "Heartbeat",
     "llcRoutines": "Routines",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -7702,6 +7702,7 @@
     "llcPortfolios": "Portfolios",
     "llcTimeline": "Timeline",
     "llcApprovals": "Approvals",
+    "llcApprovalsPending": "{count} pending approvals",
     "llcCosts": "Costs & Budget",
     "llcHeartbeat": "Heartbeat",
     "llcRoutines": "Routines",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -7749,6 +7749,7 @@
     "llcPortfolios": "Portfolios",
     "llcTimeline": "Timeline",
     "llcApprovals": "Approvals",
+    "llcApprovalsPending": "{count} pending approvals",
     "llcCosts": "Costs & Budget",
     "llcHeartbeat": "Heartbeat",
     "llcRoutines": "Routines",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -7702,6 +7702,7 @@
     "llcPortfolios": "Portfolios",
     "llcTimeline": "Timeline",
     "llcApprovals": "Approvals",
+    "llcApprovalsPending": "{count} pending approvals",
     "llcCosts": "Costs & Budget",
     "llcHeartbeat": "Heartbeat",
     "llcRoutines": "Routines",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -182,6 +182,7 @@
     "llcPortfolios": "Portfolios",
     "llcTimeline": "Timeline",
     "llcApprovals": "Approvals",
+    "llcApprovalsPending": "{count} pending approvals",
     "llcCosts": "Costs & Budget",
     "llcHeartbeat": "Heartbeat",
     "llcRoutines": "Routines",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -7702,6 +7702,7 @@
     "llcPortfolios": "Portfolios",
     "llcTimeline": "Timeline",
     "llcApprovals": "Approvals",
+    "llcApprovalsPending": "{count} pending approvals",
     "llcCosts": "Costs & Budget",
     "llcHeartbeat": "Heartbeat",
     "llcRoutines": "Routines",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -182,6 +182,7 @@
     "llcPortfolios": "Portfolios",
     "llcTimeline": "Timeline",
     "llcApprovals": "Approvals",
+    "llcApprovalsPending": "{count} pending approvals",
     "llcCosts": "Costs & Budget",
     "llcHeartbeat": "Heartbeat",
     "llcRoutines": "Routines",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -7702,6 +7702,7 @@
     "llcPortfolios": "Portfolios",
     "llcTimeline": "Timeline",
     "llcApprovals": "Approvals",
+    "llcApprovalsPending": "{count} pending approvals",
     "llcCosts": "Costs & Budget",
     "llcHeartbeat": "Heartbeat",
     "llcRoutines": "Routines",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -7702,6 +7702,7 @@
     "llcPortfolios": "Portfolios",
     "llcTimeline": "Timeline",
     "llcApprovals": "Approvals",
+    "llcApprovalsPending": "{count} pending approvals",
     "llcCosts": "Costs & Budget",
     "llcHeartbeat": "Heartbeat",
     "llcRoutines": "Routines",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -7702,6 +7702,7 @@
     "llcPortfolios": "Portfolios",
     "llcTimeline": "Timeline",
     "llcApprovals": "Approvals",
+    "llcApprovalsPending": "{count} pending approvals",
     "llcCosts": "Costs & Budget",
     "llcHeartbeat": "Heartbeat",
     "llcRoutines": "Routines",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -182,6 +182,7 @@
     "llcPortfolios": "Portfolios",
     "llcTimeline": "Timeline",
     "llcApprovals": "Approvals",
+    "llcApprovalsPending": "{count} pending approvals",
     "llcCosts": "Costs & Budget",
     "llcHeartbeat": "Heartbeat",
     "llcRoutines": "Routines",


### PR DESCRIPTION
## Thinking Path
PRD FR-GOV-03 requires the Approvals sidebar link to show a pending-count badge; it was a plain link (#11387).

## What Changed
- `LlcSidebar.vue`: fetch pending count (`GET /api/llc/approvals?company_id=`), render a badge on the Approvals link, refresh live via `useLiveEvents` (channel `company:{id}`, on approval events), re-fetch on company switch. nav-item is now flex (label + badge).
- i18n: `nav.llcApprovalsPending` aria-label across all 11 locales.

## Verification
- `check:i18n` + `check:locales` green (11 locales). `vue-tsc` 0 errors.
- Endpoint reused (ApprovalsInbox already calls it) — no new backend surface.

## Model Used
Claude Opus 4.8 (1M context)

Closes #11387