### PR TITLE
refactor(llc): reuse formatHelpers in 7 LLC views (#11365)

### DIFF
--- a/autobot-frontend/src/views/llc/ApprovalsInbox.vue
+++ b/autobot-frontend/src/views/llc/ApprovalsInbox.vue
@@ -143,6 +143,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
+import { formatDateTime } from '@/utils/formatHelpers'
 import { useUserStore } from '@/stores/useUserStore'
 import { useI18n } from 'vue-i18n'
 import { useNotificationBus } from '@/composables/useNotificationBus'
@@ -216,8 +217,7 @@ function formatType(val: string) {
 }
 
 function formatDate(iso: string | null) {
-  if (!iso) return '—'
-  return new Date(iso).toLocaleString()
+  return formatDateTime(iso) || '—'
 }
 
 function formatJson(payload: Record<string, unknown>) {

--- a/autobot-frontend/src/views/llc/BoardsView.vue
+++ b/autobot-frontend/src/views/llc/BoardsView.vue
@@ -35,6 +35,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
+import { formatDate as fmtDate } from '@/utils/formatHelpers'
 
 interface BoardSummary {
   id: string
@@ -57,9 +58,7 @@ const boards = ref<BoardSummary[]>([])
 const loading = ref(false)
 
 function formatDate(value: string): string {
-  const ms = Date.parse(value)
-  if (Number.isNaN(ms)) return '—'
-  return new Date(ms).toLocaleDateString()
+  return fmtDate(value) || '—'
 }
 
 async function loadBoards(): Promise<void> {

--- a/autobot-frontend/src/views/llc/CeoChatView.vue
+++ b/autobot-frontend/src/views/llc/CeoChatView.vue
@@ -118,6 +118,7 @@ import { ref, computed, nextTick, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
+import { formatDate as fmtDate, formatTime as fmtTime } from '@/utils/formatHelpers'
 import { useI18n } from 'vue-i18n'
 import { useNotificationBus } from '@/composables/useNotificationBus'
 import { BaseModal } from '@autobot/ui'
@@ -165,11 +166,11 @@ const creatingThread = ref(false)
 const messagesArea = ref<HTMLElement | null>(null)
 
 function formatDate(iso: string) {
-  return new Date(iso).toLocaleDateString()
+  return fmtDate(iso)
 }
 
 function formatTime(iso: string) {
-  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return fmtTime(iso)
 }
 
 async function scrollToBottom() {

--- a/autobot-frontend/src/views/llc/CostDashboard.vue
+++ b/autobot-frontend/src/views/llc/CostDashboard.vue
@@ -225,6 +225,7 @@ import { ref, computed, reactive, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
+import { formatDate as fmtDate } from '@/utils/formatHelpers'
 import { BaseModal } from '@autobot/ui'
 import { useI18n } from 'vue-i18n'
 
@@ -368,7 +369,7 @@ const dailyBars = computed(() => {
 })
 
 function formatDate(iso: string) {
-  return new Date(iso).toLocaleDateString()
+  return fmtDate(iso)
 }
 
 function exportCsv() {

--- a/autobot-frontend/src/views/llc/HeartbeatMonitor.vue
+++ b/autobot-frontend/src/views/llc/HeartbeatMonitor.vue
@@ -157,6 +157,7 @@ import { useApiClient } from '@/plugins/api'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
+import { formatDateTime, formatDuration as fmtDuration } from '@/utils/formatHelpers'
 import { useI18n } from 'vue-i18n'
 
 const props = defineProps<{ companyId?: string }>()
@@ -226,24 +227,15 @@ const downloadingFixture = ref<Set<string>>(new Set())
 const heartbeatAgents = computed(() => agents.value.filter(a => a.heartbeat_enabled))
 
 function formatDate(iso?: string) {
-  if (!iso) return '—'
-  return new Date(iso).toLocaleString()
+  return formatDateTime(iso) || '—'
 }
 
 function formatDuration(startedAt?: string) {
-  if (!startedAt) return '—'
-  const ms = Date.now() - new Date(startedAt).getTime()
-  if (ms < 0) return '—'
-  const s = Math.floor(ms / 1000)
-  if (s < 60) return `${s}s`
-  return `${Math.floor(s / 60)}m ${s % 60}s`
+  return startedAt ? fmtDuration(startedAt, null) : '—'
 }
 
 function computeDuration(start: string, end: string) {
-  const ms = new Date(end).getTime() - new Date(start).getTime()
-  const s = Math.floor(ms / 1000)
-  if (s < 60) return `${s}s`
-  return `${Math.floor(s / 60)}m ${s % 60}s`
+  return fmtDuration(start, end)
 }
 
 function formatJson(data?: Record<string, unknown>) {

--- a/autobot-frontend/src/views/llc/PortfolioBrowserView.vue
+++ b/autobot-frontend/src/views/llc/PortfolioBrowserView.vue
@@ -105,6 +105,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
+import { formatDate as fmtDate } from '@/utils/formatHelpers'
 import LlcBreadcrumb, { type BreadcrumbItem } from '@/components/llc/LlcBreadcrumb.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import BaseInput from '@/components/base/BaseInput.vue'
@@ -141,9 +142,7 @@ const form = ref({ name: '', description: '' })
 const breadcrumb = computed<BreadcrumbItem[]>(() => [{ label: t('llcBrowser.portfolios.title') }])
 
 function formatDate(value: string): string {
-  const ms = Date.parse(value)
-  if (Number.isNaN(ms)) return '—'
-  return new Date(ms).toLocaleDateString()
+  return fmtDate(value) || '—'
 }
 
 async function loadPortfolios(): Promise<void> {

--- a/autobot-frontend/src/views/llc/ProjectBrowserView.vue
+++ b/autobot-frontend/src/views/llc/ProjectBrowserView.vue
@@ -333,6 +333,7 @@ import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
+import { formatDate as fmtDate } from '@/utils/formatHelpers'
 import { useClipboard } from '@/composables/useClipboard'
 import Icon from '@/components/ui/Icon.vue'
 import LlcBreadcrumb, { type BreadcrumbItem } from '@/components/llc/LlcBreadcrumb.vue'
@@ -475,10 +476,7 @@ const breadcrumb = computed<BreadcrumbItem[]>(() => [
 ])
 
 function formatDate(value: string | null): string {
-  if (!value) return '—'
-  const ms = Date.parse(value)
-  if (Number.isNaN(ms)) return '—'
-  return new Date(ms).toLocaleDateString()
+  return fmtDate(value) || '—'
 }
 
 async function loadProjects(): Promise<void> {


### PR DESCRIPTION
## Thinking Path
`utils/formatHelpers.ts` already consolidates date/duration formatting (its docstring says so), but 10+ LLC views hand-rolled their own copies (#11365). Delegating removes the duplicated parse+`toLocale` logic.

## What Changed
Delegated the local formatters to `formatHelpers` in 7 views (kept function names + em-dash empty state, so templates and behavior are unchanged):
- ApprovalsInbox, HeartbeatMonitor → `formatDateTime` (date+time); HeartbeatMonitor duration fns → `formatDuration`
- BoardsView, ProjectBrowserView, PortfolioBrowserView, CostDashboard → `formatDate`
- CeoChatView → `formatDate` + `formatTime`

**Scope:** SprintBoardView / KanbanBoardView / CompanyDashboard are intentionally excluded — they're in-flight in #11394 (real-time WS); deduping them there/after merge avoids conflict churn.

## Verification
- `vue-tsc --noEmit -p tsconfig.app.json` → **0 errors**.
- No API/i18n changes; pure frontend refactor.

## Model Used
Claude Opus 4.8 (1M context)

Closes #11365