### PR TITLE
ci: fast-fail guard for the websockets<16 langgraph cap (#11030)

### DIFF
--- a/.github/workflows/constraint-drift.yml
+++ b/.github/workflows/constraint-drift.yml
@@ -20,6 +20,7 @@ on:
       - '**/requirements*.txt'
       - 'constraints/shared.txt'
       - 'scripts/check_constraint_drift.py'
+      - 'scripts/check_websockets_cap.py'
       - '.github/workflows/constraint-drift.yml'
   push:
     branches: [Dev_new_gui]
@@ -27,6 +28,7 @@ on:
       - '**/requirements*.txt'
       - 'constraints/shared.txt'
       - 'scripts/check_constraint_drift.py'
+      - 'scripts/check_websockets_cap.py'
 
 permissions:
   contents: read
@@ -41,5 +43,14 @@ jobs:
         with:
           python-version: '3.14'
 
+      - name: Install guard dependencies
+        run: python3 -m pip install --quiet packaging
+
       - name: Check single-source constraint compliance
         run: python3 scripts/check_constraint_drift.py
+
+      # #11030: fail fast with a clear message if autobot-backend's websockets pin
+      # is bumped past the langgraph-sdk <16 cap (the opaque ResolutionImpossible
+      # that dependabot #10997 caused). Auto-relaxes if langgraph is dropped.
+      - name: Check websockets <16 cap (langgraph-sdk)
+        run: python3 scripts/check_websockets_cap.py

--- a/scripts/check_websockets_cap.py
+++ b/scripts/check_websockets_cap.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Guard: autobot-backend must keep ``websockets<16`` while langgraph caps it (#11030).
+
+``autobot-backend`` pulls ``langgraph`` -> ``langgraph-sdk 0.4.2`` which requires
+``websockets>=14,<16``. Dependabot #10997 bypassed the ``<16`` ignore rule in
+``dependabot.yml`` and bumped ``autobot-backend/requirements.txt`` to
+``websockets>=16,<17``, making the graph unresolvable -> ``ResolutionImpossible``
+in the backend Docker build -> smoke-test red on *every* open PR (reverted #11029).
+
+This guard fails FAST with a clear message instead of the opaque, multi-minute
+ResolutionImpossible — the durable protection requested in #11030 (option 2). It
+does NOT touch the shared constraint (option 1 would break ``autobot-slm-backend``,
+which legitimately pins ``websockets>=16,<17`` and does not use the shared
+constraint). When ``langgraph`` is ever dropped from the backend the cap is no
+longer required, so the guard auto-relaxes.
+
+Run from the repo root:  python3 scripts/check_websockets_cap.py
+Exit 0 = compliant; exit 1 = the cap is violated (or the file/pin is missing).
+
+Security: reads repo files only; no network, no untrusted-input interpolation.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+from packaging.requirements import Requirement
+
+_BACKEND_REQ = pathlib.Path("autobot-backend/requirements.txt")
+# The version that must remain excluded while the langgraph cap holds.
+_FORBIDDEN_VERSION = "16.0"
+_CAP_PKG = "websockets"
+_CAP_TRIGGER_PKG = "langgraph"  # cap is only needed while this backend dep is present
+
+
+def _requirement_for(pkg: str, path: pathlib.Path) -> Requirement | None:
+    """Return the parsed Requirement for ``pkg`` in ``path`` (bare name match), or None."""
+    if not path.exists():
+        return None
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line or line.startswith("-"):
+            continue
+        # Match a top-level requirement whose project name is exactly pkg.
+        if not re.match(rf"^{re.escape(pkg)}(\[|[<>=!~ ]|$)", line, re.IGNORECASE):
+            continue
+        try:
+            req = Requirement(line)
+        except Exception:
+            continue
+        if req.name.lower().replace("_", "-") == pkg.lower().replace("_", "-"):
+            return req
+    return None
+
+
+def main() -> int:
+    if not _BACKEND_REQ.exists():
+        print(f"ERROR: {_BACKEND_REQ} not found — run from the repo root.", file=sys.stderr)
+        return 1
+
+    langgraph = _requirement_for(_CAP_TRIGGER_PKG, _BACKEND_REQ)
+    if langgraph is None:
+        print(f"OK: {_CAP_TRIGGER_PKG} not present in {_BACKEND_REQ} — websockets cap no longer required.")
+        return 0
+
+    ws = _requirement_for(_CAP_PKG, _BACKEND_REQ)
+    if ws is None:
+        print(
+            f"ERROR: {_BACKEND_REQ} declares '{_CAP_TRIGGER_PKG}' but no explicit '{_CAP_PKG}' pin.\n"
+            f"       {_CAP_PKG} must be pinned '<16' (langgraph-sdk 0.4.2 requires <16). See #11030.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if ws.specifier.contains(_FORBIDDEN_VERSION, prereleases=True):
+        print(
+            f"ERROR: {_BACKEND_REQ} allows {_CAP_PKG} {ws.specifier} — this permits >={_FORBIDDEN_VERSION},\n"
+            f"       but {_CAP_TRIGGER_PKG} -> langgraph-sdk 0.4.2 requires websockets<16. Bumping past <16\n"
+            f"       makes the backend dependency graph unresolvable (ResolutionImpossible) and breaks the\n"
+            f"       Docker build on every PR (this happened via dependabot #10997; reverted #11029).\n"
+            f"       Keep '{_CAP_PKG}>=15.0,<16' until langgraph-sdk widens its cap. See #11030 / #10386.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"OK: {_CAP_PKG} {ws.specifier} in {_BACKEND_REQ} correctly excludes >={_FORBIDDEN_VERSION} (langgraph cap held)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_websockets_cap_test.py
+++ b/scripts/check_websockets_cap_test.py
@@ -1,0 +1,71 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the websockets<16 cap guard (#11030).
+
+The guard fails fast (exit 1, clear message) when autobot-backend's websockets
+pin is bumped past the langgraph-sdk <16 cap, and auto-relaxes (exit 0) when
+langgraph is removed. Exercised as a subprocess to mirror the CI invocation.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("packaging")
+
+_SCRIPT = Path(__file__).resolve().parent / "check_websockets_cap.py"
+
+_GOOD = "langgraph>=1.2.7,<2.0.0\nwebsockets>=15.0,<16\n"
+_BAD = "langgraph>=1.2.7,<2.0.0\nwebsockets>=16.0,<17\n"
+_NO_LANGGRAPH = "websockets>=16.0,<17\n"
+_MISSING_WS = "langgraph>=1.2.7,<2.0.0\n"
+
+
+def _run(tmp_path: Path, requirements_body: str) -> subprocess.CompletedProcess:
+    backend = tmp_path / "autobot-backend"
+    backend.mkdir(parents=True, exist_ok=True)
+    (backend / "requirements.txt").write_text(requirements_body, encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_compliant_pin_passes(tmp_path: Path) -> None:
+    res = _run(tmp_path, _GOOD)
+    assert res.returncode == 0, res.stderr
+    assert "correctly excludes" in res.stdout
+
+
+def test_bump_past_cap_fails_with_clear_message(tmp_path: Path) -> None:
+    res = _run(tmp_path, _BAD)
+    assert res.returncode == 1
+    assert "ResolutionImpossible" in res.stderr
+    assert "websockets<16" in res.stderr
+
+
+def test_auto_relaxes_when_langgraph_removed(tmp_path: Path) -> None:
+    res = _run(tmp_path, _NO_LANGGRAPH)
+    assert res.returncode == 0, res.stderr
+    assert "no longer required" in res.stdout
+
+
+def test_missing_websockets_pin_with_langgraph_fails(tmp_path: Path) -> None:
+    res = _run(tmp_path, _MISSING_WS)
+    assert res.returncode == 1
+    assert "no explicit 'websockets' pin" in res.stderr
+
+
+def test_repo_backend_requirements_currently_compliant() -> None:
+    """The live autobot-backend/requirements.txt must satisfy the guard."""
+    repo_root = _SCRIPT.resolve().parents[1]
+    res = subprocess.run([sys.executable, str(_SCRIPT)], cwd=repo_root, capture_output=True, text=True)
+    assert res.returncode == 0, f"live requirements violate the websockets cap:\n{res.stderr}"


### PR DESCRIPTION
## Thinking Path
`dependabot.yml` caps `websockets<16` (langgraph-sdk 0.4.2 needs `>=14,<16`), but dependabot PR #10997 still bumped `autobot-backend/requirements.txt` to `>=16,<17`, making the graph unresolvable → **`ResolutionImpossible` in the backend Docker build → smoke-test red on every open PR** (reverted #11029). The build failure is opaque and slow.

**Deep-dive (verified before implementing):** the issue's option 1 (add `websockets<16` to `constraints/shared.txt`) is **unsafe** — the constraint-drift guard is repo-wide, so it would force `autobot-slm-backend`'s line bare too, **breaking its legitimate independent `websockets>=16,<17` pin** (SLM has no langgraph and does not reference the shared constraint). That's why the issue is owner-gated. This PR implements the safe **option 2**.

## What Changed
- `scripts/check_websockets_cap.py` — asserts autobot-backend's websockets pin excludes `>=16` **while langgraph is present**; **auto-relaxes** (exit 0) if langgraph is ever dropped (covers option 3). Fails with a clear, actionable message.
- Wired into the existing `constraint-drift` workflow (+ path triggers + `pip install packaging`).
- `scripts/check_websockets_cap_test.py` — 5 tests.
- No pin/constraint changes → zero impact on SLM or resolution.

## Verification
- `pytest scripts/check_websockets_cap_test.py` — **5 passed** (good→pass; `>=16,<17`→exit 1 with ResolutionImpossible message; langgraph-removed→auto-relax; missing-pin→fail; **live requirements.txt compliant**).
- `py_compile` + `black --line-length=120` + `ruff` clean; workflow YAML validated; workflow `run:` steps use no untrusted input.
- Note: the required `smoke-test` still blocks a bad bump (build fails); this guard adds the fast, clear diagnosis the issue asked for.

## Model Used
Opus 4.8

Closes #11030