### PR TITLE
fix(deploy): run python-provision playbook from ansible dir so roles_path resolves

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -985,6 +985,13 @@ _COMPONENT_PYTHON_TARGET: Dict[str, str] = {
 # ansible/playbooks/configure-python-provision-permissions.yml.
 _ANSIBLE_DIR: Path = Path(DEFAULT_REPO_PATH) / "autobot-slm-backend" / "ansible"
 _PROVISION_PYTHON_PLAYBOOK: Path = _ANSIBLE_DIR / "playbooks" / "provision-local-python.yml"
+# #11403: ansible resolves roles via roles_path in ansible.cfg, which it only reads
+# from its cwd (or via ANSIBLE_CONFIG). Run from an arbitrary cwd, roles_path
+# defaults to playbooks/roles/ and the python314 role (at ansible/roles/) is not
+# found → play fails. We pass cwd=_ANSIBLE_DIR — it survives sudo's env_reset,
+# whereas changing the command args would break the exact-match NOPASSWD sudoers
+# rule. ANSIBLE_CONFIG is also set as a fallback (honored only if sudoers keeps it).
+_ANSIBLE_CONFIG: Path = _ANSIBLE_DIR / "ansible.cfg"
 
 # Deployed path for the top-level constraints/ dir (#11322).
 # `autobot-backend/requirements.txt` uses `-c ../constraints/shared.txt` so the
@@ -1135,6 +1142,8 @@ async def _run_python_provision_playbook(target: str, steps: List[str]) -> bool:
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
+            cwd=str(_ANSIBLE_DIR),
+            env={**os.environ, "ANSIBLE_CONFIG": str(_ANSIBLE_CONFIG)},
         )
         stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=600.0)
         out = stdout.decode(errors="replace") if stdout else ""

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -1444,3 +1444,45 @@ def test_run_post_sync_steps_rolls_back_on_unhealthy(tmp_path) -> None:
 
     assert not pip_ok
     assert rolled_back, "rollback must be triggered when health poll fails after restart"
+
+
+# ---------------------------------------------------------------------------
+# #11403 — python provision runs with ansible.cfg discoverable (cwd + ANSIBLE_CONFIG)
+# ---------------------------------------------------------------------------
+
+
+def test_provision_playbook_runs_from_ansible_dir_with_config() -> None:
+    """#11403: ansible-playbook must run with the ansible dir as cwd (survives
+    sudo env_reset) and ANSIBLE_CONFIG set, so roles_path resolves the python314
+    role instead of defaulting to playbooks/roles/ (role-not-found)."""
+    from api.code_sync import (
+        _ANSIBLE_CONFIG,
+        _ANSIBLE_DIR,
+        _PROVISION_PYTHON_PLAYBOOK,
+        _run_python_provision_playbook,
+    )
+
+    captured: dict = {}
+
+    async def _fake_exec(*cmd, **kw):
+        captured["cmd"] = cmd
+        captured["kw"] = kw
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"PLAY RECAP ok=11 changed=1 failed=0", b""))
+        return proc
+
+    steps: list = []
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        ok = _run(_run_python_provision_playbook("python3.14", steps))
+
+    assert ok is True
+    kw = captured["kw"]
+    # cwd is the load-bearing fix (sudo preserves cwd; command args can't change)
+    assert kw.get("cwd") == str(_ANSIBLE_DIR)
+    env = kw.get("env") or {}
+    assert env.get("ANSIBLE_CONFIG") == str(_ANSIBLE_CONFIG)
+    # env must be merged from os.environ, else sudo/ansible-playbook aren't on PATH
+    assert "PATH" in env
+    # command args unchanged — must still match the exact NOPASSWD sudoers grant
+    assert captured["cmd"][:3] == ("sudo", "ansible-playbook", str(_PROVISION_PYTHON_PLAYBOOK))


### PR DESCRIPTION
Closes #11403.

## Thinking Path
py3.14 provisioning (#11347/#11374) fails at runtime: `ERROR! the role 'python314' was not found`. `_run_python_provision_playbook` (`autobot-slm-backend/api/code_sync.py`) invokes `sudo ansible-playbook <playbook> --tags python314 -i localhost, --connection local` with **no cwd and no `ANSIBLE_CONFIG`**. Ansible only reads `ansible/ansible.cfg` (which sets `roles_path = roles` → `ansible/roles/`) from its cwd or via `ANSIBLE_CONFIG`; run from elsewhere, `roles_path` defaults to `playbooks/roles/`, so the role at `ansible/roles/python314` isn't found.

**Why cwd, not just `ANSIBLE_CONFIG`:** the command runs under a **NOPASSWD sudoers grant** (`configure-python-provision-permissions.yml`) that matches the *exact* argument vector with no `SETENV`/`env_keep`. Sudo's default `env_reset` therefore **strips `ANSIBLE_CONFIG`**, and adding `--preserve-env`/changing args would break the exact-match rule (→ password prompt/hang). Setting the child's **cwd** to the ansible dir survives `env_reset` (sudo preserves cwd) and leaves the args untouched — ansible then reads `./ansible.cfg`.

## What Changed
`autobot-slm-backend/api/code_sync.py`:
- Added `_ANSIBLE_CONFIG = _ANSIBLE_DIR / "ansible.cfg"` constant (with a comment explaining the cwd-vs-env rationale).
- `_run_python_provision_playbook`'s `create_subprocess_exec` now passes `cwd=str(_ANSIBLE_DIR)` (the load-bearing fix) and `env={**os.environ, "ANSIBLE_CONFIG": str(_ANSIBLE_CONFIG)}` as a fallback (honored only if sudoers ever keeps it). Command args are unchanged, so the NOPASSWD grant still matches.

`tests/api/test_code_sync_deploy_bugs.py`:
- Added `test_provision_playbook_runs_from_ansible_dir_with_config` asserting the subprocess gets `cwd == _ANSIBLE_DIR`, `env["ANSIBLE_CONFIG"] == _ANSIBLE_CONFIG`, `PATH` preserved (env merged from `os.environ`), and the command still starts with the exact `sudo ansible-playbook <playbook>` triple (sudoers match).

## Verification
- `tests/api/test_code_sync_deploy_bugs.py`: **64 passed** (new test + 63 existing, zero regressions).
- `py_compile` + `black -l120` clean.
- Matches the issue's proven finding (running the playbook so ansible.cfg is discovered → `ok=11 changed=1 failed=0`), achieved without changing the sudoers-matched argument vector. Full end-to-end provisioning still requires the target box, but the config-discovery mechanism is unit-verified.

## Model Used
Claude Opus 4.8