### PR TITLE
fix(llc): linked repo survives refresh — hydrate code_source in project list (#11406)

### DIFF
--- a/autobot-backend/llc/api/sprints.py
+++ b/autobot-backend/llc/api/sprints.py
@@ -290,19 +290,27 @@ def _enrich(model_cls, orm_obj, **extra):
 
 
 async def _enrich_projects(session: AsyncSession, projects: List[LLCProject]) -> List[ProjectResponse]:
-    """Attach open-work-item counts + the active sprint name to project cards."""
+    """Attach open-work-item counts, the active sprint name, and the linked
+    code-source summary to project cards.
+
+    #11406: code_source must be hydrated here (not only on attach / with-repos)
+    so a linked repo survives a plain project-list refetch — otherwise the card
+    reverts to the empty state on refresh.
+    """
     pids = [p.id for p in projects]
     open_counts = await _open_work_item_counts(session, pids)
     active = await _active_sprint_names(session, pids)
-    return [
-        _enrich(
+    enriched: List[ProjectResponse] = []
+    for p in projects:
+        resp = _enrich(
             ProjectResponse,
             p,
             open_work_item_count=open_counts.get(p.id, 0),
             active_sprint_name=active.get(p.id),
         )
-        for p in projects
-    ]
+        resp.code_source = await _project_source_summary(p.code_source_id)
+        enriched.append(resp)
+    return enriched
 
 
 async def _project_source_summary(code_source_id: Optional[str]) -> Optional[CodeSourceSummary]:

--- a/autobot-backend/llc/tests/test_sprints_enrichment.py
+++ b/autobot-backend/llc/tests/test_sprints_enrichment.py
@@ -158,6 +158,31 @@ def test_list_programs_attaches_project_count():
     assert resp.json()[0]["project_count"] == 7
 
 
+def test_list_company_projects_hydrates_code_source(monkeypatch):
+    """#11406: a linked repo must survive a plain project-list refetch — the
+    list path must hydrate `code_source`, not just the attach / with-repos paths."""
+    import llc.api.sprints as sprints_mod  # noqa: PLC0415
+
+    org = str(uuid.uuid4())
+    pr = _project(org)
+    pr.code_source_id = "src-1"
+
+    async def _fake_summary(code_source_id):
+        if not code_source_id:
+            return None
+        return sprints_mod.CodeSourceSummary(
+            id=code_source_id, repo="owner/repo", branch="main", clone_path="/tmp/x", status="ready"
+        )
+
+    monkeypatch.setattr(sprints_mod, "_project_source_summary", _fake_summary)
+    client = _client(org, [pr], [(pr.id, 0)], [])  # no open items, no active sprint
+    resp = client.get(f"/companies/{org}/projects")
+    assert resp.status_code == 200
+    body = resp.json()[0]
+    assert body["code_source"] is not None, "code_source must be hydrated on the list path (#11406)"
+    assert body["code_source"]["repo"] == "owner/repo"
+
+
 def test_list_company_projects_attaches_open_count_and_active_sprint():
     org = str(uuid.uuid4())
     pr1, pr2 = _project(org), _project(org)


### PR DESCRIPTION
## Thinking Path
Reported: attaching a repo to a Company OS project shows it, but on refresh the repo disappears. Traced: `code_source_id` IS persisted; the bug is DTO hydration on the list path. `_enrich_projects` (feeds `list_projects` + `list_company_projects`) attached only work-item counts + active sprint, never `code_source`. The attach endpoint and `list_projects_with_repos` hydrate it; the plain list did not → card's `v-if="p.code_source"` false on refetch → repo section vanishes.

## What Changed
`llc/api/sprints.py::_enrich_projects` now hydrates `resp.code_source = await _project_source_summary(p.code_source_id)` per project — fixing both list endpoints at the source. Test added in `test_sprints_enrichment.py` asserting the list path returns the nested `code_source`.

## Verification
- `pytest llc/tests/test_sprints_enrichment.py test_project_repo_api.py test_sprints_idor.py test_project_lifecycle_api.py` → **27 passed**.
- New test fails on the old code (code_source defaulted to None), passes with the fix.

## Model Used
Claude Opus 4.8 (1M context)
