### PR TITLE
fix(tests): retarget drifted judge-integration tests to services.workflow_automation (#10880)

### DIFF
--- a/autobot-backend/api/api_endpoint_migrations_test.py
+++ b/autobot-backend/api/api_endpoint_migrations_test.py
@@ -29314,8 +29314,14 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
         """Verify migration preserves LLM judges integration for workflow evaluation"""
         from api import workflow_automation
 
-        # Verify judges availability flag exists
-        self.assertTrue(hasattr(workflow_automation, "JUDGES_AVAILABLE"))
+        # Issue #10880: JUDGES_AVAILABLE was removed; judge availability now
+        # lives in services.workflow_automation.step_evaluator via a try/except
+        # import inside WorkflowStepEvaluator._initialize_judges. Verify the
+        # shim still exposes the manager and the availability mechanism moved
+        # to the step evaluator.
+        from services.workflow_automation.step_evaluator import WorkflowStepEvaluator
+
+        self.assertTrue(hasattr(WorkflowStepEvaluator, "_initialize_judges"))
 
         # Verify WorkflowAutomationManager class exists
         self.assertTrue(hasattr(workflow_automation, "WorkflowAutomationManager"))

--- a/autobot-backend/judges/judge_integration_test.py
+++ b/autobot-backend/judges/judge_integration_test.py
@@ -4,6 +4,20 @@
 Integration tests for LLM-as-Judge framework
 
 Tests integration with workflow automation, validation dashboard, and other system components.
+
+Issue #10880: Judge integration retargeted to services.workflow_automation.
+Judges are now lazily imported inside
+services/workflow_automation/step_evaluator.py via
+``from judges.workflow_step_judge import WorkflowStepJudge`` (and friends).
+The module-level ``JUDGES_AVAILABLE`` flag and the
+``api.workflow_automation.WorkflowStepJudge`` / ``SecurityRiskJudge`` symbols no
+longer exist. Availability is expressed by a try/except import inside
+``WorkflowStepEvaluator._initialize_judges``. Because the judges are imported
+*inside a function*, the correct patch target is the **source** module
+(``judges.workflow_step_judge.WorkflowStepJudge`` etc.): patching the source
+affects the local import performed at evaluator construction time. To simulate
+"judges available" we patch the source to return a Mock; to simulate
+"judges unavailable" we patch the source to raise ImportError.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -12,6 +26,12 @@ import pytest
 from fastapi.testclient import TestClient
 
 from api.validation_dashboard import router as validation_router
+
+# Source patch targets — judges are imported lazily inside
+# WorkflowStepEvaluator._initialize_judges (#10880).
+WORKFLOW_STEP_JUDGE_SOURCE = "judges.workflow_step_judge.WorkflowStepJudge"
+SECURITY_RISK_JUDGE_SOURCE = "judges.security_risk_judge.SecurityRiskJudge"
+MULTI_AGENT_ARBITRATOR_SOURCE = "judges.multi_agent_arbitrator.MultiAgentArbitrator"
 
 
 class TestJudgeIntegration:
@@ -33,6 +53,9 @@ class TestJudgeIntegration:
         mock_judgment.reasoning = "Test reasoning"
         mock_judgment.criterion_scores = []
         mock_judgment.improvement_suggestions = ["Test suggestion"]
+        # llm_model_used must be a real string so the evaluator's fail-open
+        # error check (j.llm_model_used == "error") does not trip (#10880).
+        mock_judgment.llm_model_used = "test-model"
 
         workflow_judge.evaluate_workflow_step.return_value = mock_judgment
         response_judge.evaluate_agent_response.return_value = mock_judgment
@@ -107,13 +130,18 @@ class TestJudgeIntegration:
     @patch("api.validation_dashboard.get_validation_judges")
     def test_judge_status_api(self, mock_get_judges, mock_judges, test_client):
         """Test judge status API endpoint"""
-        # Mock performance metrics
+        # get_performance_metrics is a *synchronous* method on real judges; the
+        # /judge_status endpoint calls it without await. Because the mock judges
+        # are AsyncMock, we must override this attribute with a sync MagicMock so
+        # it returns a dict (not a coroutine) for JSON serialization (#10880).
         for judge_name, judge in mock_judges.items():
-            judge.get_performance_metrics.return_value = {
-                "total_judgments": 10,
-                "average_score": 0.75,
-                "average_processing_time_ms": 150.0,
-            }
+            judge.get_performance_metrics = MagicMock(
+                return_value={
+                    "total_judgments": 10,
+                    "average_score": 0.75,
+                    "average_processing_time_ms": 150.0,
+                }
+            )
 
         mock_get_judges.return_value = mock_judges
 
@@ -124,6 +152,7 @@ class TestJudgeIntegration:
         assert data["status"] == "healthy"
         assert len(data["available_judges"]) == 4
         assert "workflow_step_judge" in data["judge_metrics"]
+        assert data["judge_metrics"]["workflow_step_judge"]["total_judgments"] == 10
 
     @patch("api.validation_dashboard.get_validation_judges")
     def test_judge_unavailable(self, mock_get_judges, test_client):
@@ -137,77 +166,62 @@ class TestJudgeIntegration:
         assert "not available" in response.json()["detail"]
 
     def test_workflow_automation_judge_integration(self, mock_judges):
-        """Test integration with workflow automation system"""
+        """Test integration with workflow automation judge evaluator.
+
+        Issue #10880: Judge wiring moved from WorkflowAutomationManager to
+        WorkflowStepEvaluator. Judges are lazily imported from their source
+        modules inside _initialize_judges, so we patch the source symbols.
+        """
         with (
-            patch("api.workflow_automation.JUDGES_AVAILABLE", True),
-            patch(
-                "api.workflow_automation.WorkflowStepJudge",
-                return_value=mock_judges["workflow_step_judge"],
-            ),
-            patch(
-                "api.workflow_automation.SecurityRiskJudge",
-                return_value=mock_judges["security_risk_judge"],
-            ),
+            patch(WORKFLOW_STEP_JUDGE_SOURCE, return_value=mock_judges["workflow_step_judge"]),
+            patch(SECURITY_RISK_JUDGE_SOURCE, return_value=mock_judges["security_risk_judge"]),
+            patch(MULTI_AGENT_ARBITRATOR_SOURCE, return_value=mock_judges["multi_agent_arbitrator"]),
         ):
-            from api.workflow_automation import WorkflowAutomationManager
+            from services.workflow_automation.step_evaluator import WorkflowStepEvaluator
 
-            manager = WorkflowAutomationManager()
+            evaluator = WorkflowStepEvaluator()
 
-            assert manager.judges_enabled is True
-            assert manager.workflow_step_judge is not None
-            assert manager.security_risk_judge is not None
+            assert evaluator.judges_enabled is True
+            assert evaluator.workflow_step_judge is mock_judges["workflow_step_judge"]
+            assert evaluator.security_risk_judge is mock_judges["security_risk_judge"]
 
     @pytest.mark.asyncio
     async def test_workflow_step_evaluation_integration(self, mock_judges):
-        """Test workflow step evaluation in automation manager"""
+        """Test workflow step evaluation in the step evaluator (#10880)."""
         with (
-            patch("api.workflow_automation.JUDGES_AVAILABLE", True),
-            patch(
-                "api.workflow_automation.WorkflowStepJudge",
-                return_value=mock_judges["workflow_step_judge"],
-            ),
-            patch(
-                "api.workflow_automation.SecurityRiskJudge",
-                return_value=mock_judges["security_risk_judge"],
-            ),
+            patch(WORKFLOW_STEP_JUDGE_SOURCE, return_value=mock_judges["workflow_step_judge"]),
+            patch(SECURITY_RISK_JUDGE_SOURCE, return_value=mock_judges["security_risk_judge"]),
+            patch(MULTI_AGENT_ARBITRATOR_SOURCE, return_value=mock_judges["multi_agent_arbitrator"]),
         ):
-            from api.workflow_automation import (
-                ActiveWorkflow,
-                WorkflowAutomationManager,
-                WorkflowStep,
-            )
+            from services.workflow_automation.models import ActiveWorkflow, WorkflowStep
+            from services.workflow_automation.step_evaluator import WorkflowStepEvaluator
 
-            manager = WorkflowAutomationManager()
-
-            # Create a test workflow with a step
-            workflow_id = "test_workflow"
+            evaluator = WorkflowStepEvaluator()
 
             test_step = WorkflowStep(step_id="test_step", command="echo 'test'", description="Test step")
 
             workflow = ActiveWorkflow(
-                workflow_id=workflow_id,
+                workflow_id="test_workflow",
                 name="Test Workflow",
                 description="Test",
                 session_id="test_session",
                 steps=[test_step],
             )
 
-            manager.active_workflows[workflow_id] = workflow
-
             # Test step evaluation
-            evaluation = await manager._evaluate_workflow_step(workflow_id, test_step)
+            evaluation = await evaluator.evaluate_step(workflow, test_step)
 
             assert evaluation["should_proceed"] is True
             assert "workflow_judgment" in evaluation
             assert "security_judgment" in evaluation
 
-            # Verify judges were called
+            # Verify judges were actually reached by the code path
             mock_judges["workflow_step_judge"].evaluate_workflow_step.assert_called_once()
             mock_judges["security_risk_judge"].evaluate_command_security.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_step_rejection_by_judge(self, mock_judges):
-        """Test workflow step rejection by LLM judge"""
+        """Test workflow step rejection by LLM judge (#10880)."""
         # Configure judges to reject the step
         reject_judgment = MagicMock()
         reject_judgment.overall_score = 0.3
@@ -216,31 +230,20 @@ class TestJudgeIntegration:
         reject_judgment.reasoning = "Command is too risky"
         reject_judgment.criterion_scores = []
         reject_judgment.improvement_suggestions = ["Use safer alternative"]
+        reject_judgment.llm_model_used = "test-model"
 
         mock_judges["workflow_step_judge"].evaluate_workflow_step.return_value = reject_judgment
         mock_judges["security_risk_judge"].evaluate_command_security.return_value = reject_judgment
 
         with (
-            patch("api.workflow_automation.JUDGES_AVAILABLE", True),
-            patch(
-                "api.workflow_automation.WorkflowStepJudge",
-                return_value=mock_judges["workflow_step_judge"],
-            ),
-            patch(
-                "api.workflow_automation.SecurityRiskJudge",
-                return_value=mock_judges["security_risk_judge"],
-            ),
+            patch(WORKFLOW_STEP_JUDGE_SOURCE, return_value=mock_judges["workflow_step_judge"]),
+            patch(SECURITY_RISK_JUDGE_SOURCE, return_value=mock_judges["security_risk_judge"]),
+            patch(MULTI_AGENT_ARBITRATOR_SOURCE, return_value=mock_judges["multi_agent_arbitrator"]),
         ):
-            from api.workflow_automation import (
-                ActiveWorkflow,
-                WorkflowAutomationManager,
-                WorkflowStep,
-            )
+            from services.workflow_automation.models import ActiveWorkflow, WorkflowStep
+            from services.workflow_automation.step_evaluator import WorkflowStepEvaluator
 
-            manager = WorkflowAutomationManager()
-
-            # Create test workflow
-            workflow_id = "test_workflow"
+            evaluator = WorkflowStepEvaluator()
 
             test_step = WorkflowStep(
                 step_id="risky_step",
@@ -249,61 +252,95 @@ class TestJudgeIntegration:
             )
 
             workflow = ActiveWorkflow(
-                workflow_id=workflow_id,
+                workflow_id="test_workflow",
                 name="Test Workflow",
                 description="Test",
                 session_id="test_session",
                 steps=[test_step],
             )
 
-            manager.active_workflows[workflow_id] = workflow
-
             # Test step evaluation - should reject
-            evaluation = await manager._evaluate_workflow_step(workflow_id, test_step)
+            evaluation = await evaluator.evaluate_step(workflow, test_step)
 
             assert evaluation["should_proceed"] is False
-            assert "too risky" in evaluation["reason"]
+            assert "Workflow evaluation: REJECT" in evaluation["reason"]
+
+            # Verify the rejecting judges were actually reached
+            mock_judges["workflow_step_judge"].evaluate_workflow_step.assert_called_once()
+            mock_judges["security_risk_judge"].evaluate_command_security.assert_called_once()
 
     def test_judge_error_handling(self, mock_judges):
-        """Test error handling in judge integration"""
-        from api.workflow_automation import WorkflowAutomationManager
+        """Test error handling in judge integration (#10880).
 
-        # Configure judge to raise exception
+        When the source judge import raises ImportError, the evaluator must
+        gracefully disable judges (fail-open) rather than crashing.
+        """
+        with (
+            patch(WORKFLOW_STEP_JUDGE_SOURCE, side_effect=ImportError("Judge unavailable")),
+            patch(SECURITY_RISK_JUDGE_SOURCE, return_value=mock_judges["security_risk_judge"]),
+            patch(MULTI_AGENT_ARBITRATOR_SOURCE, return_value=mock_judges["multi_agent_arbitrator"]),
+        ):
+            from services.workflow_automation.step_evaluator import WorkflowStepEvaluator
+
+            evaluator = WorkflowStepEvaluator()
+
+            # Import failure must not crash construction; judges disabled.
+            assert evaluator.judges_enabled is False
+            assert evaluator.workflow_step_judge is None
+
+    @pytest.mark.asyncio
+    async def test_judge_error_handling_runtime(self, mock_judges):
+        """A judge raising at evaluation time must not crash the evaluator.
+
+        Issue #10880: evaluate_step wraps judge calls in try/except and returns
+        a fail-open ``should_proceed=True`` response on unexpected errors.
+        """
         mock_judges["workflow_step_judge"].evaluate_workflow_step.side_effect = Exception("Judge error")
 
         with (
-            patch("api.workflow_automation.JUDGES_AVAILABLE", True),
-            patch(
-                "api.workflow_automation.WorkflowStepJudge",
-                return_value=mock_judges["workflow_step_judge"],
-            ),
-            patch(
-                "api.workflow_automation.SecurityRiskJudge",
-                return_value=mock_judges["security_risk_judge"],
-            ),
+            patch(WORKFLOW_STEP_JUDGE_SOURCE, return_value=mock_judges["workflow_step_judge"]),
+            patch(SECURITY_RISK_JUDGE_SOURCE, return_value=mock_judges["security_risk_judge"]),
+            patch(MULTI_AGENT_ARBITRATOR_SOURCE, return_value=mock_judges["multi_agent_arbitrator"]),
         ):
-            manager = WorkflowAutomationManager()
+            from services.workflow_automation.models import ActiveWorkflow, WorkflowStep
+            from services.workflow_automation.step_evaluator import WorkflowStepEvaluator
 
-            # Test that manager handles judge errors gracefully
-            assert manager.judges_enabled is True
+            evaluator = WorkflowStepEvaluator()
 
-            # Error in individual evaluation should not crash the system
+            test_step = WorkflowStep(step_id="err_step", command="echo err", description="err")
+            workflow = ActiveWorkflow(
+                workflow_id="test_workflow",
+                name="Test Workflow",
+                description="Test",
+                session_id="test_session",
+                steps=[test_step],
+            )
+
+            evaluation = await evaluator.evaluate_step(workflow, test_step)
+
+            # Fail-open: evaluation error does not crash, defaults to proceed.
+            assert evaluation["should_proceed"] is True
+            assert "Evaluation error" in evaluation["reason"]
+            mock_judges["workflow_step_judge"].evaluate_workflow_step.assert_called_once()
 
     def test_judge_performance_tracking(self, mock_judges):
         """Test that judge performance is tracked properly"""
-        # Add mock judgments to history
+        # get_performance_metrics is synchronous on real judges; override the
+        # AsyncMock attribute with a sync MagicMock returning a dict (#10880).
         for judge in mock_judges.values():
-            judge.get_performance_metrics.return_value = {
-                "total_judgments": 5,
-                "average_score": 0.8,
-                "average_confidence": "high",
-                "average_processing_time_ms": 120.0,
-                "recommendation_distribution": {
-                    "APPROVE": 3,
-                    "CONDITIONAL": 1,
-                    "REJECT": 1,
-                },
-            }
+            judge.get_performance_metrics = MagicMock(
+                return_value={
+                    "total_judgments": 5,
+                    "average_score": 0.8,
+                    "average_confidence": "high",
+                    "average_processing_time_ms": 120.0,
+                    "recommendation_distribution": {
+                        "APPROVE": 3,
+                        "CONDITIONAL": 1,
+                        "REJECT": 1,
+                    },
+                }
+            )
 
         # Test metrics collection
         for judge_name, judge in mock_judges.items():
@@ -314,7 +351,7 @@ class TestJudgeIntegration:
 
     @pytest.mark.asyncio
     async def test_multi_criteria_evaluation(self, mock_judges):
-        """Test that judges evaluate multiple criteria"""
+        """Test that judges evaluate multiple criteria (#10880)."""
         from judges import CriterionScore, JudgmentConfidence, JudgmentDimension
 
         # Create detailed criterion scores
@@ -342,30 +379,20 @@ class TestJudgeIntegration:
         detailed_judgment.reasoning = "Multi-criteria evaluation successful"
         detailed_judgment.criterion_scores = criterion_scores
         detailed_judgment.improvement_suggestions = []
+        detailed_judgment.llm_model_used = "test-model"
 
         mock_judges["workflow_step_judge"].evaluate_workflow_step.return_value = detailed_judgment
 
         # Test that all criteria are evaluated
         with (
-            patch("api.workflow_automation.JUDGES_AVAILABLE", True),
-            patch(
-                "api.workflow_automation.WorkflowStepJudge",
-                return_value=mock_judges["workflow_step_judge"],
-            ),
-            patch(
-                "api.workflow_automation.SecurityRiskJudge",
-                return_value=mock_judges["security_risk_judge"],
-            ),
+            patch(WORKFLOW_STEP_JUDGE_SOURCE, return_value=mock_judges["workflow_step_judge"]),
+            patch(SECURITY_RISK_JUDGE_SOURCE, return_value=mock_judges["security_risk_judge"]),
+            patch(MULTI_AGENT_ARBITRATOR_SOURCE, return_value=mock_judges["multi_agent_arbitrator"]),
         ):
-            from api.workflow_automation import (
-                ActiveWorkflow,
-                WorkflowAutomationManager,
-                WorkflowStep,
-            )
+            from services.workflow_automation.models import ActiveWorkflow, WorkflowStep
+            from services.workflow_automation.step_evaluator import WorkflowStepEvaluator
 
-            manager = WorkflowAutomationManager()
-
-            workflow_id = "test_workflow"
+            evaluator = WorkflowStepEvaluator()
 
             test_step = WorkflowStep(
                 step_id="multi_criteria_step",
@@ -374,20 +401,20 @@ class TestJudgeIntegration:
             )
 
             workflow = ActiveWorkflow(
-                workflow_id=workflow_id,
+                workflow_id="test_workflow",
                 name="Test Workflow",
                 description="Test",
                 session_id="test_session",
                 steps=[test_step],
             )
 
-            manager.active_workflows[workflow_id] = workflow
+            evaluation = await evaluator.evaluate_step(workflow, test_step)
 
-            evaluation = await manager._evaluate_workflow_step(workflow_id, test_step)
-
-            # Verify multi-criteria evaluation
+            # Verify multi-criteria evaluation reached the workflow judge and
+            # its overall score is surfaced in the result.
             workflow_judgment = evaluation["workflow_judgment"]
             assert workflow_judgment["overall_score"] == 0.85
+            mock_judges["workflow_step_judge"].evaluate_workflow_step.assert_called_once()
 
     def test_judge_configuration(self):
         """Test judge configuration and customization"""
@@ -410,24 +437,39 @@ class TestJudgeIntegration:
         assert security_judge.high_risk_threshold == 0.4
 
     def test_judge_context_preparation(self):
-        """Test that judges receive proper context"""
-        from api.workflow_automation import WorkflowAutomationManager
+        """Test that judges receive proper context (#10880).
 
-        with patch("api.workflow_automation.JUDGES_AVAILABLE", True):
-            WorkflowAutomationManager()
+        The evaluator prepares step data and workflow context via
+        _prepare_step_data / _prepare_workflow_context before invoking judges.
+        This verifies the workflow context is well-formed for judge consumption.
+        """
+        from services.workflow_automation.models import ActiveWorkflow, WorkflowStep
+        from services.workflow_automation.step_evaluator import WorkflowStepEvaluator
 
-            # Test context preparation for different scenarios
-            contexts = [
-                {"environment": "production", "user": "admin"},
-                {"environment": "development", "user": "developer"},
-                {"environment": "testing", "user": "tester"},
-            ]
+        with (patch(WORKFLOW_STEP_JUDGE_SOURCE, side_effect=ImportError("Judge unavailable")),):
+            evaluator = WorkflowStepEvaluator()
 
-            for context in contexts:
-                # Context should be properly formatted and passed to judges
-                assert isinstance(context, dict)
-                assert "environment" in context
-                assert "user" in context
+            test_step = WorkflowStep(step_id="ctx_step", command="ls", description="List")
+            workflow = ActiveWorkflow(
+                workflow_id="ctx_workflow",
+                name="Context Workflow",
+                description="Context test",
+                session_id="ctx_session",
+                steps=[test_step],
+            )
+
+            step_data = evaluator._prepare_step_data(test_step)
+            workflow_context = evaluator._prepare_workflow_context(workflow)
+
+            # Step data must carry the fields judges rely on.
+            assert step_data["step_id"] == "ctx_step"
+            assert step_data["command"] == "ls"
+            assert step_data["description"] == "List"
+
+            # Workflow context must be well-formed for judge consumption.
+            assert workflow_context["workflow_name"] == "Context Workflow"
+            assert workflow_context["total_steps"] == 1
+            assert workflow_context["session_id"] == "ctx_session"
 
     @pytest.mark.asyncio
     async def test_judge_batch_evaluation(self, mock_judges):


### PR DESCRIPTION
## Thinking Path
Two pre-existing failing test groups on a clean tree (#10880). The `relationship_extractor::TestAutoSelectsNlpForLargeInput` pair **already passes** on current base (fixed upstream). The remaining 8 `judges/judge_integration_test.py` failures are **test-drift**: they patch `api.workflow_automation.JUDGES_AVAILABLE` / `WorkflowStepJudge` / `SecurityRiskJudge`, which no longer exist there — `api/workflow_automation.py` is now a backward-compat shim and the judge wiring moved to `services/workflow_automation/step_evaluator.py::WorkflowStepEvaluator` (lazy `from judges.* import ...` inside `_initialize_judges`).

## What Changed
- Rewrote the 8 tests to patch the **real source** import locations (`judges.workflow_step_judge.WorkflowStepJudge`, etc. — which `step_evaluator` imports at lines 39-41) and to exercise `WorkflowStepEvaluator().evaluate_step(workflow, step)` / `.judges_enabled` instead of the removed manager internals. `JUDGES_AVAILABLE` toggles replaced with the real availability mechanism (import success vs `ImportError`).
- Split the vacuous `test_judge_error_handling` into an import-availability test + a real fail-open runtime test (13→14 tests).
- Fixed the stale `hasattr(workflow_automation, "JUDGES_AVAILABLE")` assertion in `api/api_endpoint_migrations_test.py` → asserts `WorkflowStepEvaluator._initialize_judges` + the retained shim export.

## Verification (assertions proven load-bearing)
- `pytest judges/judge_integration_test.py` — **14 passed** (was 8 failed / 5 passed).
- **Independent mutation check:** breaking one source patch target → **7 tests fail**; restoring → 14 pass. Patch targets confirmed to match `step_evaluator.py:39-41` exactly, so the mocks truly intercept the code path (not vacuous).
- `py_compile` + `black --line-length=120` + `flake8` clean.
- Discovery filed: #11409 (a separate rotted source-assert in the same #5359-frozen migrations module, left untouched to keep scope tight).

## Model Used
Opus 4.8 (test rewrite delegated to testing agent, independently re-verified)

Closes #10880