### PR TITLE
fix(llc): surface work-item create errors instead of silent failure (#11411)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8109,7 +8109,9 @@
       "sprintId": "Sprint ID",
       "sprintIdPlaceholder": "Sprint UUID",
       "assigning": "Assigning...",
-      "assign": "Assign"
+      "assign": "Assign",
+      "createError": "Couldn't create the work item. Please try again.",
+      "createErrorDetail": "Couldn't create the work item: {detail}"
     },
     "workItem": {
       "priority": "Priority",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8109,7 +8109,9 @@
       "sprintId": "Sprint-ID",
       "sprintIdPlaceholder": "Sprint-UUID",
       "assigning": "Wird zugewiesen...",
-      "assign": "Zuweisen"
+      "assign": "Zuweisen",
+      "createError": "Couldn't create the work item. Please try again.",
+      "createErrorDetail": "Couldn't create the work item: {detail}"
     },
     "workItem": {
       "priority": "Priorität",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8098,7 +8098,9 @@
       "sprintId": "Sprint ID",
       "sprintIdPlaceholder": "Sprint UUID",
       "assigning": "Assigning...",
-      "assign": "Assign"
+      "assign": "Assign",
+      "createError": "Couldn't create the work item. Please try again.",
+      "createErrorDetail": "Couldn't create the work item: {detail}"
     },
     "workItem": {
       "priority": "Priority",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8109,7 +8109,9 @@
       "sprintId": "ID de sprint",
       "sprintIdPlaceholder": "UUID de sprint",
       "assigning": "Asignando...",
-      "assign": "Asignar"
+      "assign": "Asignar",
+      "createError": "Couldn't create the work item. Please try again.",
+      "createErrorDetail": "Couldn't create the work item: {detail}"
     },
     "workItem": {
       "priority": "Prioridad",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8109,7 +8109,9 @@
       "sprintId": "Sprint ID",
       "sprintIdPlaceholder": "Sprint UUID",
       "assigning": "Assigning...",
-      "assign": "Assign"
+      "assign": "Assign",
+      "createError": "Couldn't create the work item. Please try again.",
+      "createErrorDetail": "Couldn't create the work item: {detail}"
     },
     "workItem": {
       "priority": "Priority",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8109,7 +8109,9 @@
       "sprintId": "ID du sprint",
       "sprintIdPlaceholder": "UUID du sprint",
       "assigning": "Affectation...",
-      "assign": "Affecter"
+      "assign": "Affecter",
+      "createError": "Couldn't create the work item. Please try again.",
+      "createErrorDetail": "Couldn't create the work item: {detail}"
     },
     "workItem": {
       "priority": "Priorité",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8109,7 +8109,9 @@
       "sprintId": "Sprint ID",
       "sprintIdPlaceholder": "Sprint UUID",
       "assigning": "Assigning...",
-      "assign": "Assign"
+      "assign": "Assign",
+      "createError": "Couldn't create the work item. Please try again.",
+      "createErrorDetail": "Couldn't create the work item: {detail}"
     },
     "workItem": {
       "priority": "Priority",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8109,7 +8109,9 @@
       "sprintId": "Sprint ID",
       "sprintIdPlaceholder": "Sprint UUID",
       "assigning": "Assigning...",
-      "assign": "Assign"
+      "assign": "Assign",
+      "createError": "Couldn't create the work item. Please try again.",
+      "createErrorDetail": "Couldn't create the work item: {detail}"
     },
     "workItem": {
       "priority": "Priority",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8109,7 +8109,9 @@
       "sprintId": "Sprint ID",
       "sprintIdPlaceholder": "Sprint UUID",
       "assigning": "Assigning...",
-      "assign": "Assign"
+      "assign": "Assign",
+      "createError": "Couldn't create the work item. Please try again.",
+      "createErrorDetail": "Couldn't create the work item: {detail}"
     },
     "workItem": {
       "priority": "Priority",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8109,7 +8109,9 @@
       "sprintId": "ID do sprint",
       "sprintIdPlaceholder": "UUID do sprint",
       "assigning": "Atribuindo...",
-      "assign": "Atribuir"
+      "assign": "Atribuir",
+      "createError": "Couldn't create the work item. Please try again.",
+      "createErrorDetail": "Couldn't create the work item: {detail}"
     },
     "workItem": {
       "priority": "Prioridade",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8109,7 +8109,9 @@
       "sprintId": "Sprint ID",
       "sprintIdPlaceholder": "Sprint UUID",
       "assigning": "Assigning...",
-      "assign": "Assign"
+      "assign": "Assign",
+      "createError": "Couldn't create the work item. Please try again.",
+      "createErrorDetail": "Couldn't create the work item: {detail}"
     },
     "workItem": {
       "priority": "Priority",

--- a/autobot-frontend/src/views/llc/BacklogView.vue
+++ b/autobot-frontend/src/views/llc/BacklogView.vue
@@ -177,6 +177,8 @@
           </div>
         </div>
 
+        <p v-if="createError" class="create-error" role="alert">{{ createError }}</p>
+
         <div class="modal-actions">
           <button class="btn-secondary" @click="showCreateForm = false">{{ t('common.cancel') }}</button>
           <button class="btn-primary" :disabled="!newItem.title || isCreating" @click="createItem">
@@ -260,6 +262,7 @@ const filters = ref({ type: '', status: '', priority: '', search: '' })
 
 const showCreateForm = ref(false)
 const isCreating = ref(false)
+const createError = ref('')
 const newItem = ref({ title: '', type: 'pbi', priority: 'medium', story_points: null as number | null, description: '' })
 const isSuggestingAC = ref(false)
 const suggestedACs = ref<{ text: string; selected: boolean }[]>([])
@@ -373,6 +376,7 @@ async function suggestAC() {
 async function createItem() {
   if (!newItem.value.title) return
   isCreating.value = true
+  createError.value = ''
   try {
     const ac = suggestedACs.value.filter(a => a.selected).map(a => a.text)
     const created = await api.post<WorkItem>(`/api/llc/work-items`, {
@@ -385,7 +389,12 @@ async function createItem() {
     newItem.value = { title: '', type: 'pbi', priority: 'medium', story_points: null, description: '' }
     suggestedACs.value = []
   } catch (err) {
+    // Surface the backend reason instead of a silent console-only log (#11411).
     logger.error('Create work item failed', err)
+    const detail = err instanceof Error ? err.message : ''
+    createError.value = detail
+      ? t('llc.backlog.createErrorDetail', { detail })
+      : t('llc.backlog.createError')
   } finally {
     isCreating.value = false
   }
@@ -688,6 +697,12 @@ onMounted(fetchBacklog)
   display: flex;
   justify-content: flex-end;
   gap: 0.5rem;
+}
+
+.create-error {
+  margin: 0 0 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--color-danger, #b91c1c);
 }
 
 .btn-primary {


### PR DESCRIPTION
## Thinking Path
Reported "unable to create work items." The create path is robust in code (schema/enum/service all match), so the failure is runtime-specific — but `createItem` swallowed the error (console-only `logger.error`), so the operator saw a silent no-op with no reason. The sibling `submitAttach` already surfaces backend errors; create didn't.

## What Changed
`BacklogView.vue`: added a `createError` ref, rendered in the create modal (`role="alert"`), populated in the catch from the backend detail (mirrors `submitAttach`). Reset on each attempt. i18n `llc.backlog.createError` + `createErrorDetail` across all 11 locales + a `.create-error` style.

## Verification
- `check:i18n` + `check:locales` green (11 locales). `vue-tsc` 0 errors.

## Note
This surfaces the real failure reason so the underlying backend cause (if any — e.g. non-UUID company_id → 400, or deployed-DB schema drift → 500) can be pinpointed and fixed as a fast-follow with the now-visible status.

## Model Used
Claude Opus 4.8 (1M context)
