### PR TITLE
feat(skills): deterministic cross-source skill name-conflict detection (#11141)

### DIFF
--- a/autobot-backend/api/skills.py
+++ b/autobot-backend/api/skills.py
@@ -124,11 +124,17 @@ async def probe_skills(
     try:
         registry = get_skill_registry()
         skill_count = len(registry.list_skills()) if registry else 0
+        # #11141: surface cross-source name conflicts so operators can see when a
+        # source shadowed another (resolution is deterministic, not order-based).
+        conflicts = registry.get_conflicts() if registry else []
+        detail = f"{skill_count} skills loaded"
+        if conflicts:
+            detail += f"; {len(conflicts)} cross-source name conflict(s)"
         return ComponentHealth(
             name="skills",
             status="ok" if skill_count > 0 else "degraded",
-            detail=f"{skill_count} skills loaded",
-            data={"skill_count": skill_count},
+            detail=detail,
+            data={"skill_count": skill_count, "conflict_count": len(conflicts), "conflicts": conflicts},
         )
     except Exception as exc:
         return ComponentHealth(

--- a/autobot-backend/skills/manager.py
+++ b/autobot-backend/skills/manager.py
@@ -75,7 +75,7 @@ class SkillManager:
                 description=f"Hub skill {rec.name}",
                 category="hub",
             )
-            if self._registry.register_declarative(manifest):
+            if self._registry.register_declarative(manifest, source="hub"):
                 registered += 1
         if registered:
             logger.info("Re-registered %d custom/hub skill(s) at boot", registered)

--- a/autobot-backend/skills/registry.py
+++ b/autobot-backend/skills/registry.py
@@ -14,6 +14,7 @@ import importlib.util
 import os
 import pkgutil
 import threading
+from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Set, Type
 
 import yaml
@@ -25,6 +26,38 @@ from skills.base_skill import BaseSkill, DeclarativeSkill, SkillHealth, SkillMan
 from skills.dependency_resolver import check_missing_dependencies, resolve_dependencies
 
 logger = get_logger(__name__)
+
+# #11141: skills arrive from independent sources (builtin modules, SKILL.md
+# declaratives, the community hub, external git/http imports, sync backends).
+# On a name collision we must resolve DETERMINISTICALLY by source trust — never
+# by discovery order — so a SANDBOXED external import can never silently mask a
+# trusted builtin (nor vice-versa). Higher number = higher trust = wins.
+_SOURCE_PRIORITY: Dict[str, int] = {
+    "builtin": 100,
+    "custom": 50,
+    "hub": 30,
+    "external": 20,
+    "mcp": 20,
+    "sync": 20,
+}
+_DEFAULT_SOURCE_PRIORITY = 10
+
+
+def _source_priority(source: str) -> int:
+    """Trust rank for a skill source; unknown sources rank below all known ones."""
+    return _SOURCE_PRIORITY.get(source, _DEFAULT_SOURCE_PRIORITY)
+
+
+@dataclass
+class SkillConflict:
+    """A recorded cross-source skill name collision (#11141)."""
+
+    name: str
+    incumbent_source: str
+    incumbent_version: str
+    incoming_source: str
+    incoming_version: str
+    resolution: str  # "kept_incumbent" | "replaced_with_incoming"
 
 
 class SkillRegistry:
@@ -38,23 +71,78 @@ class SkillRegistry:
         self._skill_classes: Dict[str, Type[BaseSkill]] = {}
         self._lock = threading.Lock()
         self._routing_index: SkillRoutingIndex | None = None
+        # #11141: source of each registered skill + recorded cross-source conflicts.
+        self._sources: Dict[str, str] = {}
+        self._conflicts: List[SkillConflict] = []
 
-    def register(self, skill_class: Type[BaseSkill]) -> None:
+    def _resolve_name_conflict(self, name: str, incoming_source: str, incoming_version: str) -> bool:
+        """Record a name collision and decide the winner by source trust (#11141).
+
+        MUST be called while holding ``self._lock``. Returns True when the
+        incoming skill should REPLACE the incumbent (strictly higher-trust
+        source), False when the incumbent is kept. Either way the conflict is
+        recorded (visible via :meth:`get_conflicts`) instead of being silently
+        dropped. Ties keep the incumbent — a same-trust source never displaces
+        an already-registered skill.
+        """
+        incumbent_source = self._sources.get(name, "builtin")
+        try:
+            incumbent_version = self._skills[name].get_manifest().version
+        except Exception:
+            incumbent_version = "unknown"
+        # A same-source, same-version re-registration is an idempotent reload,
+        # not a cross-source conflict — keep the incumbent without recording.
+        if incoming_source == incumbent_source and incoming_version == incumbent_version:
+            return False
+        incoming_wins = _source_priority(incoming_source) > _source_priority(incumbent_source)
+        resolution = "replaced_with_incoming" if incoming_wins else "kept_incumbent"
+        self._conflicts.append(
+            SkillConflict(
+                name=name,
+                incumbent_source=incumbent_source,
+                incumbent_version=incumbent_version,
+                incoming_source=incoming_source,
+                incoming_version=incoming_version,
+                resolution=resolution,
+            )
+        )
+        logger.warning(
+            "Skill name conflict on '%s': incumbent %s v%s (%s) vs incoming %s v%s (%s) -> %s",
+            name,
+            incumbent_source,
+            incumbent_version,
+            incumbent_source,
+            incoming_source,
+            incoming_version,
+            incoming_source,
+            resolution,
+        )
+        return incoming_wins
+
+    def get_conflicts(self) -> List[Dict[str, Any]]:
+        """Structured cross-source skill name conflicts recorded so far (#11141)."""
+        with self._lock:
+            return [asdict(c) for c in self._conflicts]
+
+    def register(self, skill_class: Type[BaseSkill], source: str = "builtin") -> None:
         """Register a skill class and create its instance.
 
         Args:
             skill_class: A class extending BaseSkill.
+            source: Origin of the skill (``builtin``/``custom``/``hub``/``external``/
+                ``mcp``/``sync``). On a name collision the higher-trust source wins
+                deterministically and the conflict is recorded (#11141).
         """
         manifest = skill_class.get_manifest()
         name = manifest.name
         with self._lock:
-            if name in self._skills:
-                logger.warning("Skill '%s' already registered, skipping", name)
+            if name in self._skills and not self._resolve_name_conflict(name, source, manifest.version):
                 return
             instance = skill_class()
             self._skills[name] = instance
             self._skill_classes[name] = skill_class
-            logger.info("Registered skill: %s v%s", name, manifest.version)
+            self._sources[name] = source
+            logger.info("Registered skill: %s v%s (source=%s)", name, manifest.version, source)
         # #7431 ADR-006: publish skill_promoted so blocked plans waiting on
         # a matching capability can be re-routed and resumed via the
         # BlockedPlanResumer subscriber. Fire-and-forget; never raises if
@@ -62,19 +150,25 @@ class SkillRegistry:
         self._publish_skill_promoted(name, manifest.tools)
         self._rebuild_routing_index()
 
-    def register_declarative(self, manifest: "SkillManifest") -> bool:
+    def register_declarative(self, manifest: "SkillManifest", source: str = "builtin") -> bool:
         """Register a SKILL.md-style manifest as a DeclarativeSkill.
 
-        Returns True if newly registered, False if a skill of that name exists.
-        Used by builtin Pass-2 discovery and by boot-time custom-skill reload.
+        Returns True if newly registered or if it replaced a lower-trust
+        incumbent, False if an equal/higher-trust skill of that name was kept.
+        On a name collision the winner is chosen by source trust and the
+        conflict is recorded (#11141). Used by builtin Pass-2 discovery and by
+        boot-time custom/hub-skill reload.
         """
         with self._lock:
-            if manifest.name in self._skills:
+            if manifest.name in self._skills and not self._resolve_name_conflict(
+                manifest.name, source, manifest.version
+            ):
                 return False
             self._skills[manifest.name] = DeclarativeSkill(manifest)
+            self._sources[manifest.name] = source
         self._rebuild_routing_index()
         self._publish_skill_promoted(manifest.name, manifest.tools)
-        logger.info("Registered declarative skill: %s v%s", manifest.name, manifest.version)
+        logger.info("Registered declarative skill: %s v%s (source=%s)", manifest.name, manifest.version, source)
         return True
 
     def _rebuild_routing_index(self) -> None:

--- a/autobot-backend/skills/registry_conflict_test.py
+++ b/autobot-backend/skills/registry_conflict_test.py
@@ -1,0 +1,84 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Cross-source skill name-conflict detection + deterministic resolution (#11141).
+
+A sandboxed external/hub import must never silently mask a trusted builtin (nor
+vice-versa); the winner is decided by source trust, not discovery order, and
+every genuine collision is recorded (visible via ``get_conflicts``).
+"""
+
+from skills.base_skill import SkillManifest
+from skills.registry import SkillRegistry
+
+
+def _m(name: str, version: str = "1.0.0") -> SkillManifest:
+    return SkillManifest(name=name, version=version, description="d")
+
+
+def test_no_conflict_when_names_differ():
+    reg = SkillRegistry()
+    reg.register_declarative(_m("a"), source="builtin")
+    reg.register_declarative(_m("b"), source="hub")
+    assert reg.get_conflicts() == []
+
+
+def test_builtin_incumbent_kept_over_hub_incoming():
+    reg = SkillRegistry()
+    assert reg.register_declarative(_m("dup", "1.0.0"), source="builtin") is True
+    # Hub tries to register the same name later — must NOT win.
+    assert reg.register_declarative(_m("dup", "2.0.0"), source="hub") is False
+    conflicts = reg.get_conflicts()
+    assert len(conflicts) == 1
+    c = conflicts[0]
+    assert c["name"] == "dup"
+    assert c["incumbent_source"] == "builtin" and c["incoming_source"] == "hub"
+    assert c["resolution"] == "kept_incumbent"
+    # incumbent unchanged
+    assert reg.get_skill_detail("dup")["version"] == "1.0.0"
+
+
+def test_builtin_incoming_overrides_lower_trust_incumbent_regardless_of_order():
+    reg = SkillRegistry()
+    # Hub registers FIRST (discovery-order would keep it) ...
+    assert reg.register_declarative(_m("dup", "9.9.9"), source="hub") is True
+    # ... but a trusted builtin arriving later must deterministically win.
+    assert reg.register_declarative(_m("dup", "1.0.0"), source="builtin") is True
+    conflicts = reg.get_conflicts()
+    assert len(conflicts) == 1
+    assert conflicts[0]["resolution"] == "replaced_with_incoming"
+    assert conflicts[0]["incoming_source"] == "builtin"
+    assert reg.get_skill_detail("dup")["version"] == "1.0.0"  # builtin now wins
+
+
+def test_same_trust_tie_keeps_incumbent_and_records_conflict_when_version_differs():
+    reg = SkillRegistry()
+    reg.register_declarative(_m("dup", "1.0.0"), source="hub")
+    assert reg.register_declarative(_m("dup", "2.0.0"), source="hub") is False
+    conflicts = reg.get_conflicts()
+    assert len(conflicts) == 1
+    assert conflicts[0]["resolution"] == "kept_incumbent"
+    assert reg.get_skill_detail("dup")["version"] == "1.0.0"
+
+
+def test_idempotent_same_source_same_version_is_not_a_conflict():
+    reg = SkillRegistry()
+    reg.register_declarative(_m("dup", "1.0.0"), source="builtin")
+    assert reg.register_declarative(_m("dup", "1.0.0"), source="builtin") is False
+    assert reg.get_conflicts() == []  # pure reload, not a conflict
+
+
+def test_get_conflicts_returns_structured_dicts():
+    reg = SkillRegistry()
+    reg.register_declarative(_m("dup"), source="builtin")
+    reg.register_declarative(_m("dup", "2.0.0"), source="external")
+    (c,) = reg.get_conflicts()
+    assert set(c.keys()) == {
+        "name",
+        "incumbent_source",
+        "incumbent_version",
+        "incoming_source",
+        "incoming_version",
+        "resolution",
+    }


### PR DESCRIPTION
## Thinking Path
`SkillRegistry.register()`/`register_declarative()` silently first-write-wins on a name collision, so whichever source registered first won — non-deterministic by discovery order. A sandboxed hub/external import could silently mask a trusted builtin (or vice-versa) — a trust-boundary surprise.

## What Changed (backend, security-preserving)
- Source-trust priority (`builtin=100` > `custom` > `hub`/`external`/`mcp`/`sync`). On collision the **higher-trust source wins deterministically, regardless of registration order**; ties keep the incumbent; pure same-source+version reloads are no-ops.
- `SkillConflict` records genuine collisions (name, both sources, both versions, resolution); exposed via `get_conflicts()` and surfaced in the `/skills` health probe.
- `source` threaded at the hub caller (`manager.py`); builtin discovery uses the default. External/hub can **never** auto-win over a builtin — import security model preserved.

## Verification
- `pytest skills/registry_conflict_test.py skills/registry_register_declarative_test.py` — **8 passed** (6 new: names-differ, builtin-kept-over-hub, builtin-overrides-lower-trust-regardless-of-order, same-trust-tie, idempotent-not-conflict, structured-dicts; + existing declarative tests confirm backward-compat).
- `py_compile` + `black --line-length=120` + `flake8` clean.

## Model Used
Opus 4.8

Closes #11141
(Frontend surfacing in SkillsView.vue = follow-up T2.)