### PR TITLE
harden(eval): DoS caps + timeout + report escaping + path validation + CI signal (#11062)

### DIFF
--- a/.github/workflows/trajectory-eval.yml
+++ b/.github/workflows/trajectory-eval.yml
@@ -51,7 +51,9 @@ jobs:
       - name: Install backend dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install -r requirements-ci.txt --prefer-binary || true
+          # #11062: drop `|| true` so a genuine install crash surfaces (red step);
+          # the step's continue-on-error keeps the eval non-blocking regardless.
+          python -m pip install -r requirements-ci.txt --prefer-binary
           python -m pip install pytest pytest-asyncio --prefer-binary
 
       - name: Run harness unit tests
@@ -65,8 +67,10 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/autobot-backend
         run: |
+          # #11062: keep pipefail but drop `|| true` so a harness crash surfaces
+          # as a red step; continue-on-error on the step keeps it non-blocking.
           set -o pipefail
-          python -m eval.run --json trajectory-eval-report.json | tee trajectory-eval-report.md || true
+          python -m eval.run --json trajectory-eval-report.json | tee trajectory-eval-report.md
 
       - name: Upload eval report
         if: always()

--- a/autobot-backend/eval/report.py
+++ b/autobot-backend/eval/report.py
@@ -21,6 +21,17 @@ from typing import Any, Dict, List
 DEFAULT_SCORE_EPSILON = 0.05
 
 
+def _md_escape(value: Any) -> str:
+    """Neutralize untrusted fields before interpolating into the markdown report (#11062).
+
+    trajectory_id / task_class / detail originate from golden fixtures + candidate
+    output, so a crafted value could inject backticks, table pipes, or newlines
+    into the CI artifact. Collapse newlines and escape markdown-significant chars.
+    """
+    text = " ".join(str(value).split())
+    return text.replace("\\", "\\\\").replace("`", "\\`").replace("|", "\\|")
+
+
 @dataclass
 class TrajectoryOutcome:
     """Result of replaying one golden trajectory against the candidate."""
@@ -134,13 +145,13 @@ class RegressionReport:
         lines.append("| Task class | Regressions | Improvements | Unchanged |")
         lines.append("| --- | --- | --- | --- |")
         for name, d in sorted(self.per_class().items()):
-            lines.append(f"| {name} | {d.regressions} | {d.improvements} | {d.unchanged} |")
+            lines.append(f"| {_md_escape(name)} | {d.regressions} | {d.improvements} | {d.unchanged} |")
         lines.append("")
         for outcome in self.outcomes:
             verdict = outcome.classify(self.epsilon).upper()
             lines.append(
-                f"- [{verdict}] `{outcome.trajectory_id}` ({outcome.task_class}) "
+                f"- [{verdict}] `{_md_escape(outcome.trajectory_id)}` ({_md_escape(outcome.task_class)}) "
                 f"baseline={outcome.baseline_score:.2f} candidate={outcome.candidate_score:.2f}"
-                + (f" — {outcome.detail}" if outcome.detail else "")
+                + (f" — {_md_escape(outcome.detail)}" if outcome.detail else "")
             )
         return "\n".join(lines)

--- a/autobot-backend/eval/run.py
+++ b/autobot-backend/eval/run.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 from pathlib import Path
 
 from autobot_shared.async_compat import run_or_schedule
@@ -68,13 +69,31 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _resolve_output_path(json_path: str) -> Path | None:
+    """Resolve ``--json`` within the allowed output dir, refusing escapes (#11062).
+
+    An operator-supplied path could otherwise write outside the working tree
+    (``--json /etc/x`` or ``../../x``). Allowed root is ``EVAL_OUTPUT_DIR`` or the
+    current working directory. Returns the resolved path, or None if it escapes.
+    """
+    allowed = Path(os.environ.get("EVAL_OUTPUT_DIR", str(Path.cwd()))).resolve()
+    resolved = Path(json_path).resolve()
+    if resolved != allowed and allowed not in resolved.parents:
+        logger.error("Refusing to write JSON report outside %s: %s (#11062)", allowed, resolved)
+        return None
+    return resolved
+
+
 def _emit(report: RegressionReport, json_path: str) -> None:
     """Print the markdown report and optionally write JSON."""
     logger.info("%s", report.render_markdown())
     if json_path:
-        with open(json_path, "w", encoding="utf-8") as handle:
+        resolved = _resolve_output_path(json_path)
+        if resolved is None:
+            return
+        with open(resolved, "w", encoding="utf-8") as handle:
             json.dump(report.to_dict(), handle, indent=2)
-        logger.info("Wrote JSON report to %s", json_path)
+        logger.info("Wrote JSON report to %s", resolved)
 
 
 def main() -> int:

--- a/autobot-backend/eval/runner.py
+++ b/autobot-backend/eval/runner.py
@@ -22,6 +22,8 @@ replay, a subprocess transcript, or a mock in tests).
 
 from __future__ import annotations
 
+import asyncio
+import os
 from dataclasses import dataclass, field
 from typing import Awaitable, Callable, List
 
@@ -29,6 +31,9 @@ from autobot_shared.logging_manager import get_logger
 from eval.report import RegressionReport, TrajectoryOutcome
 from eval.store import GoldenTrajectory
 from rlm.evaluator import ResponseQualityEvaluator
+
+# #11062: a hung/slow candidate must not stall the whole regression run.
+_REPLAY_TIMEOUT_S = float(os.environ.get("EVAL_REPLAY_TIMEOUT_S", "120"))
 
 logger = get_logger(__name__)
 
@@ -88,7 +93,23 @@ class TrajectoryReplayer:
         """Replay every golden against *candidate* and build the report."""
         outcomes: List[TrajectoryOutcome] = []
         for golden in goldens:
-            outcome = await self.replay_one(golden, candidate)
+            try:
+                outcome = await asyncio.wait_for(self.replay_one(golden, candidate), timeout=_REPLAY_TIMEOUT_S)
+            except asyncio.TimeoutError:
+                logger.error(
+                    "replay of %s timed out after %.0fs — recording as failure (#11062)",
+                    golden.trajectory_id,
+                    _REPLAY_TIMEOUT_S,
+                )
+                outcome = TrajectoryOutcome(
+                    trajectory_id=golden.trajectory_id,
+                    task_class=golden.task_class,
+                    baseline_score=golden.baseline_score,
+                    candidate_score=0.0,
+                    tools_ok=False,
+                    status_ok=False,
+                    detail=f"replay timed out after {_REPLAY_TIMEOUT_S:.0f}s",
+                )
             logger.info(
                 "replayed %s [%s] verdict=%s baseline=%.2f candidate=%.2f",
                 outcome.trajectory_id,

--- a/autobot-backend/eval/store.py
+++ b/autobot-backend/eval/store.py
@@ -22,11 +22,17 @@ in as a golden with only these three keys added — no new format invented.
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+
+# #11062: bound the golden loader so a runaway fixture dir cannot OOM/hang the
+# harness. Env-tunable; defaults are generous vs the current ~75 goldens.
+_MAX_GOLDEN_COUNT = int(os.environ.get("EVAL_MAX_GOLDEN_COUNT", "1000"))
+_MAX_GOLDEN_FILE_BYTES = int(os.environ.get("EVAL_MAX_GOLDEN_FILE_BYTES", str(1_000_000)))
 
 logger = get_logger(__name__)
 
@@ -85,6 +91,13 @@ def load_golden_set(directory: Path | None = None) -> List[GoldenTrajectory]:
     root = directory or GOLDEN_DIR
     goldens: List[GoldenTrajectory] = []
     for path in sorted(root.glob("*.json")):
+        if len(goldens) >= _MAX_GOLDEN_COUNT:
+            logger.warning("Golden cap %d reached; ignoring remaining files in %s (#11062)", _MAX_GOLDEN_COUNT, root)
+            break
+        size = path.stat().st_size
+        if size > _MAX_GOLDEN_FILE_BYTES:
+            logger.warning("Skipping oversized golden %s (%d > %d bytes) (#11062)", path, size, _MAX_GOLDEN_FILE_BYTES)
+            continue
         with open(path, encoding="utf-8") as handle:
             data = json.load(handle)
         goldens.append(GoldenTrajectory.from_fixture(data))

--- a/autobot-backend/eval/tests/test_hardening.py
+++ b/autobot-backend/eval/tests/test_hardening.py
@@ -1,0 +1,127 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Hardening tests for the golden-trajectory eval harness (#11062).
+
+Covers the DoS/robustness/hygiene fixes: bounded golden loader, per-replay
+timeout, markdown-escaped report interpolation, and validated JSON output path.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock
+
+from eval import run as run_mod
+from eval import store as store_mod
+from eval.report import RegressionReport, TrajectoryOutcome, _md_escape
+from eval.runner import CandidateResult, TrajectoryReplayer
+from eval.store import load_golden_set
+from rlm.evaluator import ResponseQualityEvaluator
+
+_FIXTURE = {
+    "trajectory_id": "t1",
+    "task_class": "code_fix",
+    "inputs": {"prompt": "p"},
+    "expected_tools": ["read_file"],
+    "baseline_score": 0.9,
+    "expected_status": "completed",
+    "expected_output_excerpt": "ok",
+}
+
+
+def _write_golden(directory, name: str, extra_bytes: int = 0) -> None:
+    data = dict(_FIXTURE, trajectory_id=name)
+    if extra_bytes:
+        data["expected_output_excerpt"] = "x" * extra_bytes
+    (directory / f"{name}.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+# --- bounded loader (#11062) ---
+
+
+def test_load_golden_set_respects_count_cap(tmp_path, monkeypatch):
+    for i in range(5):
+        _write_golden(tmp_path, f"g{i}")
+    monkeypatch.setattr(store_mod, "_MAX_GOLDEN_COUNT", 3)
+    assert len(load_golden_set(tmp_path)) == 3
+
+
+def test_load_golden_set_skips_oversized_files(tmp_path, monkeypatch):
+    _write_golden(tmp_path, "small")
+    _write_golden(tmp_path, "huge", extra_bytes=5000)
+    monkeypatch.setattr(store_mod, "_MAX_GOLDEN_FILE_BYTES", 1000)
+    ids = [g.trajectory_id for g in load_golden_set(tmp_path)]
+    assert ids == ["small"]  # huge skipped
+
+
+# --- per-replay timeout (#11062) ---
+
+
+def test_hanging_replay_recorded_as_failure(monkeypatch):
+    monkeypatch.setattr("eval.runner._REPLAY_TIMEOUT_S", 0.05)
+    evaluator = ResponseQualityEvaluator()
+    evaluator._call_llm = AsyncMock(return_value="SCORE: 0.9\nCRITIQUE: None\nHINT: None")
+    replayer = TrajectoryReplayer(evaluator=evaluator)
+
+    async def _hanging_candidate(golden):
+        await asyncio.sleep(10)
+        return CandidateResult(response_text="never", tool_sequence=[], final_status="completed")
+
+    from eval.store import GoldenTrajectory
+
+    golden = GoldenTrajectory(
+        trajectory_id="slow",
+        task_class="code_fix",
+        inputs={"prompt": "p"},
+        expected_tools=["read_file"],
+        baseline_score=0.9,
+        expected_status="completed",
+        expected_output_excerpt="ok",
+    )
+    rep = asyncio.run(replayer.run([golden], _hanging_candidate))
+    (outcome,) = rep.outcomes
+    assert outcome.trajectory_id == "slow"
+    assert outcome.candidate_score == 0.0 and outcome.tools_ok is False
+    assert "timed out" in outcome.detail
+
+
+# --- markdown escaping (#11062) ---
+
+
+def test_md_escape_neutralizes_markdown():
+    assert _md_escape("a`b|c\nd") == "a\\`b\\|c d"
+
+
+def test_render_markdown_escapes_crafted_detail():
+    rep = RegressionReport(
+        outcomes=[
+            TrajectoryOutcome(
+                trajectory_id="`evil`",
+                task_class="x|y",
+                baseline_score=0.9,
+                candidate_score=0.1,
+                tools_ok=False,
+                status_ok=True,
+                detail="inject `code` | pipe",
+            )
+        ]
+    )
+    md = rep.render_markdown()
+    assert "`evil`" not in md and "\\`evil\\`" in md
+    assert "inject `code`" not in md
+
+
+# --- output path validation (#11062) ---
+
+
+def test_resolve_output_path_allows_within_cwd(tmp_path, monkeypatch):
+    monkeypatch.setenv("EVAL_OUTPUT_DIR", str(tmp_path))
+    resolved = run_mod._resolve_output_path(str(tmp_path / "report.json"))
+    assert resolved == (tmp_path / "report.json").resolve()
+
+
+def test_resolve_output_path_refuses_escape(tmp_path, monkeypatch):
+    monkeypatch.setenv("EVAL_OUTPUT_DIR", str(tmp_path))
+    assert run_mod._resolve_output_path("/etc/passwd") is None
+    assert run_mod._resolve_output_path(str(tmp_path / ".." / "escape.json")) is None


### PR DESCRIPTION
## Thinking Path
Adversarial-audit findings on the golden-trajectory eval harness (`eval/*.py` + `trajectory-eval.yml`). Verified SAFE (no eval/exec/subprocess on trajectory data, no fork-secret exposure); residual issues are DoS/robustness/hygiene — all LOW, advisory/flagged paths.

## What Changed (5 fixes, one PR)
- **store.py** — bound the golden loader: cap count (`EVAL_MAX_GOLDEN_COUNT`) + skip oversized files (`EVAL_MAX_GOLDEN_FILE_BYTES`) so a runaway fixture dir can't OOM/hang the run.
- **runner.py** — `asyncio.wait_for` per replay (`EVAL_REPLAY_TIMEOUT_S`); a hung candidate is recorded as a failure outcome instead of stalling the whole run.
- **report.py** — `_md_escape` on `trajectory_id`/`task_class`/`detail` before markdown interpolation → crafted values can't inject backticks/pipes into the CI artifact.
- **run.py** — resolve + validate the `--json` output path within `EVAL_OUTPUT_DIR`/cwd; refuse write-outside-dir.
- **trajectory-eval.yml** — drop the extra `|| true` layer so genuine install/harness crashes surface as a red step (step keeps `continue-on-error` → still non-blocking; stays on `ubuntu-latest`).

## Verification
- `pytest eval/tests` — **13 passed** (7 new: count-cap, oversized-skip, hanging-replay→failure, md-escape, crafted-detail-not-injected, path-allowed, path-escape-refused; + 6 existing green).
- `py_compile` + `black` + `isort` + `flake8` clean; workflow YAML validated; workflow `run:` steps carry no untrusted input.

## Model Used
Opus 4.8

Closes #11062 (part of umbrella #11058)