### PR TITLE
fix(deploy): raise health-poll default 60s→180s for py3.14 cold start

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -1345,7 +1345,12 @@ _DB_BACKUP_KEEP: int = int(os.environ.get("AUTOBOT_DB_BACKUP_KEEP", "5"))
 
 # --- #11378: post-restart health polling ---------------------------------------
 # Total seconds to wait for a component to become healthy after restart.
-_HEALTH_POLL_TIMEOUT: float = float(os.environ.get("AUTOBOT_HEALTH_POLL_TIMEOUT", "60"))
+# Default 180s (#11413): a freshly-recreated py3.14 venv cold-starts slowly —
+# first-run bytecode compilation of the whole dependency tree can take >60s, so a
+# 60s window falsely reported a healthy service as unhealthy and tripped the
+# #11377 rollback. Env-overridable via AUTOBOT_HEALTH_POLL_TIMEOUT.
+_DEFAULT_HEALTH_POLL_TIMEOUT_S = "180"
+_HEALTH_POLL_TIMEOUT: float = float(os.environ.get("AUTOBOT_HEALTH_POLL_TIMEOUT", _DEFAULT_HEALTH_POLL_TIMEOUT_S))
 # Per-attempt connect timeout (seconds) when probing the health endpoint.
 _HEALTH_POLL_CONNECT_TIMEOUT: float = 3.0
 # Per-component health URLs (localhost only — never egress).

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -1352,6 +1352,16 @@ def test_health_poll_timeout_constant_positive() -> None:
     assert _HEALTH_POLL_TIMEOUT > 0
 
 
+def test_health_poll_default_allows_py314_cold_start() -> None:
+    """#11413: the default health-poll window must be >=180s so a freshly-recreated
+    py3.14 venv (slow first-run bytecode compilation, >60s) isn't falsely declared
+    unhealthy → false rollback. Asserts the env-independent default, not the
+    possibly-overridden runtime value."""
+    from api.code_sync import _DEFAULT_HEALTH_POLL_TIMEOUT_S
+
+    assert float(_DEFAULT_HEALTH_POLL_TIMEOUT_S) >= 180
+
+
 def test_wait_component_healthy_returns_true_on_healthy_response() -> None:
     """Returns True when the health endpoint responds 2xx (#11378)."""
     steps: list[str] = []


### PR DESCRIPTION
Closes #11418 (part 1 of #11413).

## Thinking Path
During a py3.14 convergence resync, the SLM backend was healthy but took ~60s+ to start — a freshly-recreated py3.14 venv cold-starts slowly (first-run bytecode compilation of the whole dependency tree). The #11378 post-restart health poll (`_HEALTH_POLL_TIMEOUT`, default 60s) expired first → falsely declared the service unhealthy → triggered the #11377 rollback on a **successful** deploy. It only survived because the rollback is currently a no-op (#11404) — had rollback worked, it would have reverted a good py3.14 convergence.

## What Changed
`autobot-slm-backend/api/code_sync.py`:
- Raised the default `_HEALTH_POLL_TIMEOUT` from `"60"` to a named `_DEFAULT_HEALTH_POLL_TIMEOUT_S = "180"`, still overridable via `AUTOBOT_HEALTH_POLL_TIMEOUT`. Comment explains the py3.14 cold-start rationale.

`tests/api/test_code_sync_deploy_bugs.py`:
- Added `test_health_poll_default_allows_py314_cold_start` asserting the **env-independent** default (`_DEFAULT_HEALTH_POLL_TIMEOUT_S`) is >=180, so the value can't silently regress below a safe cold-start window regardless of env.

## Verification
- `tests/api/test_code_sync_deploy_bugs.py`: **65 passed** (new test + 64 existing, incl. the existing health-poll tests, zero regressions).
- `py_compile` + `black -l120` clean.

## Note
Follow-ups on #11413 (not in this PR): (2) make the timeout adaptive — auto-extend when the venv was just recreated; (3) gate rollback on a genuine failure signal (service `failed`/crash-loop) rather than "not healthy within N seconds" — best landed alongside #11404 (which makes rollback actually functional).

## Model Used
Claude Opus 4.8