### PR TITLE
docs(agent_loop): document AgentLoop as not-wired-in-production (#11221)

### DIFF
--- a/autobot-backend/agent_loop/__init__.py
+++ b/autobot-backend/agent_loop/__init__.py
@@ -8,6 +8,12 @@ Agent Loop Module
 Implements the Manus-inspired 6-step agent loop pattern for structured
 task execution with event stream integration.
 
+NOT WIRED IN PRODUCTION (#11221): ``AgentLoop`` is never instantiated by any
+production caller — the live tool seam is ``chat_workflow._dispatch_tool_call``.
+Submodules here (belief_state, extractors, guards) ARE reused by other
+subsystems, but the loop orchestrator itself is dormant, so anything wired only
+into it is inert. See ``AgentLoop``'s docstring for details.
+
 The Agent Loop:
     1. ANALYZE EVENTS    → Understand state from event stream
     2. SELECT TOOLS      → Choose based on plan + knowledge

--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -113,6 +113,20 @@ class AgentLoop:
 
     Implements the Manus-inspired 6-step iteration pattern with
     event stream integration, planning, and parallel tool execution.
+
+    PRODUCTION STATUS (#11221): this class is **not instantiated anywhere in
+    production** — the only references to ``AgentLoop`` are this module and the
+    re-export/docstring in ``agent_loop/__init__.py``. The live tool-execution
+    seam is ``chat_workflow`` (``_dispatch_tool_call``), not this loop. Reusable
+    building blocks under ``agent_loop/`` (belief_state, extractors, guards) are
+    imported directly by other subsystems, but the loop *orchestrator* below is
+    dormant.
+
+    Consequence: any capability wired ONLY into this loop (e.g. the guard stack,
+    which is additionally inert until the loop is given an ``agent_id``) has no
+    runtime effect until a production caller instantiates ``AgentLoop``. Treat
+    this as a library of parts + a reference implementation, not a live code
+    path, when reasoning about what actually runs.
     """
 
     def __init__(


### PR DESCRIPTION
## Thinking Path
Per the decision on #11221 (document, not wire/port): `AgentLoop` is never instantiated by any production caller — the only references are its own module and the re-export in `agent_loop/__init__.py`. The live tool-execution seam is `chat_workflow._dispatch_tool_call`.

## What Changed
Added a **PRODUCTION STATUS** note to the `AgentLoop` class docstring and a package-level note in `agent_loop/__init__.py`: the loop orchestrator is dormant; its submodules (belief_state, extractors, guards) are reused elsewhere, but anything wired *only* into the loop (e.g. the guard stack, itself inert until the loop has an `agent_id`) has no runtime effect. Docs-only — zero behavior change.

## Verification
- `py_compile` OK; `black --line-length=120` clean.
- Confirmed no prod instantiation: `grep AgentLoop(` → only `agent_loop/__init__.py` docstring + own module.

## Model Used
Opus 4.8

Closes #11221