### PR TITLE
feat(attribution): add SourceType.FORUM + SourceReliability.COMMUNITY tiers (#11079)

### DIFF
--- a/autobot-backend/content_reach/sources/reddit.py
+++ b/autobot-backend/content_reach/sources/reddit.py
@@ -109,7 +109,7 @@ class RedditJsonBackend(ContentBackend):
             backend_used=self.name,
             text="\n".join(text_lines),
             structured={"posts": posts},
-            reliability=SourceReliability.MEDIUM,
+            reliability=SourceReliability.COMMUNITY,  # #11079: crowd-sourced
         )
 
 
@@ -123,7 +123,7 @@ class HnAlgoliaBackend(ContentBackend):
     """
 
     name = "hn_algolia"
-    source_type = SourceType.REDDIT
+    source_type = SourceType.FORUM  # #11079: Hacker News is a forum, not Reddit
 
     def __init__(self, client: httpx.AsyncClient | None = None) -> None:
         self._client = client
@@ -171,11 +171,11 @@ class HnAlgoliaBackend(ContentBackend):
 
         return ContentResult(
             success=True,
-            source_type=SourceType.REDDIT,
+            source_type=SourceType.FORUM,  # #11079: HN is a forum, not Reddit
             backend_used=self.name,
             text="\n".join(text_lines),
             structured={"hits": hits},
-            reliability=SourceReliability.MEDIUM,
+            reliability=SourceReliability.COMMUNITY,  # #11079: crowd-sourced
         )
 
 

--- a/autobot-backend/source_attribution.py
+++ b/autobot-backend/source_attribution.py
@@ -37,6 +37,7 @@ class SourceType(Enum):
     REDDIT = "reddit"  # #10932 content reach
     WEB_PAGE = "web_page"  # #10932 content reach
     SOCIAL = "social"  # #10932 content reach
+    FORUM = "forum"  # #11079: forum/discussion boards (e.g. Hacker News) — not Reddit-specific
 
 
 class SourceReliability(Enum):
@@ -45,6 +46,7 @@ class SourceReliability(Enum):
     VERIFIED = "verified"  # System state, tool output
     HIGH = "high"  # KB, official docs
     MEDIUM = "medium"  # Web search, API responses
+    COMMUNITY = "community"  # #11079: crowd-sourced (reddit/forum/social) — below MEDIUM, above LOW
     LOW = "low"  # User input, unverified sources
     UNKNOWN = "unknown"  # Cannot determine reliability
 
@@ -86,6 +88,7 @@ class Source:
             SourceType.REDDIT: "👽",
             SourceType.WEB_PAGE: "🌐",
             SourceType.SOCIAL: "💬",
+            SourceType.FORUM: "💬",
         }
 
         icon = source_icon.get(self.type, "📋")

--- a/autobot-backend/tests/content_reach/sources/test_reddit.py
+++ b/autobot-backend/tests/content_reach/sources/test_reddit.py
@@ -175,8 +175,8 @@ async def test_reddit_empty_children_raises_backend_error():
 
 
 @pytest.mark.asyncio
-async def test_reddit_result_reliability_medium():
-    """RedditJsonBackend result has reliability MEDIUM."""
+async def test_reddit_result_reliability_community():
+    """RedditJsonBackend result is COMMUNITY reliability (#11079: crowd-sourced)."""
     from content_reach.sources.reddit import RedditJsonBackend
 
     mock_client, _ = _make_async_mock_client(200, _REDDIT_SEARCH_JSON)
@@ -184,7 +184,7 @@ async def test_reddit_result_reliability_medium():
     request = ContentRequest(query="python tips", limit=2)
     result = await backend.fetch(request)
 
-    assert result.reliability is SourceReliability.MEDIUM
+    assert result.reliability is SourceReliability.COMMUNITY
 
 
 # ---------------------------------------------------------------------------
@@ -203,7 +203,7 @@ async def test_hn_maps_hits():
     result = await backend.fetch(request)
 
     assert result.success is True
-    assert result.source_type is SourceType.REDDIT
+    assert result.source_type is SourceType.FORUM  # #11079: HN is a forum, not Reddit
     hits = result.structured["hits"]
     assert len(hits) == 2
     # First hit: has url field
@@ -230,8 +230,8 @@ async def test_hn_forwards_limit():
 
 
 @pytest.mark.asyncio
-async def test_hn_result_reliability_medium():
-    """HnAlgoliaBackend result has reliability MEDIUM."""
+async def test_hn_result_reliability_community():
+    """HnAlgoliaBackend result is COMMUNITY reliability (#11079: crowd-sourced)."""
     from content_reach.sources.reddit import HnAlgoliaBackend
 
     mock_client, _ = _make_async_mock_client(200, _HN_ALGOLIA_JSON)
@@ -239,7 +239,7 @@ async def test_hn_result_reliability_medium():
     request = ContentRequest(query="python asyncio")
     result = await backend.fetch(request)
 
-    assert result.reliability is SourceReliability.MEDIUM
+    assert result.reliability is SourceReliability.COMMUNITY
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path
Per the owner decision on #11079 (add FORUM source type + reliability weighting). Two enum-precision gaps from #10932 (an earlier attempt was reverted as unreviewed scope creep on the shared `source_attribution` enum — now owner-approved):
- `HnAlgoliaBackend` shoehorned Hacker News under `SourceType.REDDIT` — HN is a forum, not Reddit.
- Reddit/HN community content was tiered `MEDIUM` (same as web/API), with no distinct crowd-sourced tier.

## What Changed
- `SourceType.FORUM` — HN now attributes as FORUM (class attr + result).
- `SourceReliability.COMMUNITY` — sits between MEDIUM and LOW; RedditJson + HnAlgolia results now use it.
- `format_citation` icon map gains a FORUM entry (already had a `.get(default)` fallback).
- Reddit source-*group* definition stays `REDDIT` (only the HN backend's per-result type changed).

## Verification (safe on a shared enum)
- Grep-confirmed **no exhaustive `match/case`** over SourceType/SourceReliability, so new members break nothing.
- These enums are **not in any API response schema** → `forum`/`community` absent from api.ts, no `verify-generated-types` impact.
- `pytest tests/content_reach/{sources/test_reddit,test_registry,test_bootstrap}` — **34 passed** (updated HN→FORUM/COMMUNITY, RedditJson→COMMUNITY assertions).
- `py_compile` + `black` + `flake8` clean.

## Model Used
Opus 4.8

Closes #11079