### PR TITLE
harden(workspace): cap unbounded WS shell output to prevent flood DoS

### DIFF
--- a/autobot-backend/api/task_workspace_ws.py
+++ b/autobot-backend/api/task_workspace_ws.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect, status
 from pydantic import BaseModel
@@ -57,6 +58,12 @@ from services.docker_task_workspace import (
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/workspace", tags=["task-workspace"])
+
+# GH#11059: bound the total bytes streamed from a workspace shell exec to the
+# client. Without this, a runaway command (e.g. `cat /dev/urandom`, `yes`) streams
+# unbounded data through the WebSocket, exhausting backend memory/bandwidth. The
+# cap is generous for interactive use and env-overridable.
+_WS_OUTPUT_CAP_BYTES: int = int(os.environ.get("AUTOBOT_WORKSPACE_WS_OUTPUT_CAP_MB", "25")) * 1024 * 1024
 
 
 # ---------------------------------------------------------------------------
@@ -325,11 +332,26 @@ async def workspace_shell(
 
 
 async def _pump_container_to_ws(sock: Any, websocket: WebSocket) -> None:
-    """Read raw bytes from Docker exec socket and forward as 'output' messages."""
+    """Read raw bytes from the Docker exec socket and forward as 'output' messages.
+
+    Bounds the total forwarded output (GH#11059): a runaway command can otherwise
+    stream unbounded data through the WebSocket, exhausting backend memory/bandwidth.
+    On reaching the cap the client is told and the pump stops (the shell session is
+    torn down by the caller's ``finally``).
+    """
+    total = 0
     try:
         while True:
             chunk = await asyncio.to_thread(_socket_read, sock, 4096)
             if not chunk:
+                break
+            total += len(chunk)
+            if total > _WS_OUTPUT_CAP_BYTES:
+                await _ws_send(
+                    websocket,
+                    "output",
+                    "\r\n[output limit reached — shell session closed to protect the server]\r\n",
+                )
                 break
             text = chunk.decode("utf-8", errors="replace")
             await _ws_send(websocket, "output", text)
@@ -376,8 +398,6 @@ def _authenticate_ws_admin(websocket: WebSocket) -> bool:
     A WebSocket exposes the same ``headers``/``cookies`` interface as a Request,
     so the standard auth middleware resolves the caller. Any error → deny.
     """
-    import os  # noqa: PLC0415
-
     # Dev/test escape hatch: when WS auth is explicitly disabled, allow the
     # connection. Production defaults to "1", so full auth is required.
     if os.environ.get("AUTOBOT_REQUIRE_WS_AUTH", "1") != "1":

--- a/autobot-backend/tests/test_task_workspace.py
+++ b/autobot-backend/tests/test_task_workspace.py
@@ -501,3 +501,32 @@ def test_authenticate_ws_admin_dev_bypass_when_disabled():
 
     with patch.dict("os.environ", {"AUTOBOT_REQUIRE_WS_AUTH": "0"}):
         assert mod._authenticate_ws_admin(SimpleNamespace(headers={})) is True
+
+
+@pytest.mark.asyncio
+async def test_pump_container_to_ws_caps_output():
+    """#11059: the shell-output pump stops after the byte cap, so a runaway command
+    (e.g. `cat /dev/urandom`) can't flood the backend / WebSocket with unbounded data."""
+    from unittest.mock import patch
+
+    import api.task_workspace_ws as mod
+
+    sent: list[str] = []
+
+    class _FakeWS:
+        async def send_text(self, s: str) -> None:
+            sent.append(s)
+
+    class _FakeSock:
+        # Never returns empty, so only the cap can terminate the pump.
+        def recv(self, n: int) -> bytes:
+            return b"x" * 64
+
+    with patch.object(mod, "_WS_OUTPUT_CAP_BYTES", 256):
+        await mod._pump_container_to_ws(_FakeSock(), _FakeWS())
+
+    assert sent, "pump should forward output then stop"
+    last = json.loads(sent[-1])
+    assert "output limit reached" in last["content"], "must notify the client on cap"
+    forwarded = sum(len(json.loads(s)["content"].encode("utf-8")) for s in sent[:-1])
+    assert forwarded <= 256 + 64, "forwarded bytes must stay within the cap (+ one chunk)"


### PR DESCRIPTION
Closes #11426 (one MED finding of umbrella #11059 / #11058 July-6 hardening wave).

## Thinking Path
`api/task_workspace_ws.py::_pump_container_to_ws` reads Docker-exec output and forwards it to the WebSocket client in an unbounded `while True` loop with no total-byte cap. A runaway command in a workspace shell (`cat /dev/urandom`, `yes`, an infinite log tail) streams unbounded data through the socket, exhausting backend memory/bandwidth — the "unbounded WS shell output DoS" finding in #11059.

## What Changed
`autobot-backend/api/task_workspace_ws.py`:
- Added `_WS_OUTPUT_CAP_BYTES` (module constant from `AUTOBOT_WORKSPACE_WS_OUTPUT_CAP_MB`, default **25 MB** — generous for interactive use, env-overridable).
- `_pump_container_to_ws` now tracks total forwarded bytes; on exceeding the cap it sends a one-line "output limit reached" notice and stops (the caller's `finally` tears down the shell session). No change to auth or exec semantics — purely a defensive bound.
- Hoisted the previously function-local `import os` to a module import (now used by the constant).

`autobot-backend/tests/test_task_workspace.py`:
- Added `test_pump_container_to_ws_caps_output`: a fake exec socket that never returns empty (so only the cap can stop the loop) + a fake WS; with the cap patched to 256 bytes, asserts the pump terminates, the final frame is the limit notice, and forwarded bytes stay within cap + one chunk.

## Verification
- `tests/test_task_workspace.py`: **37 passed** (new test + 36 existing, zero regressions).
- `py_compile` + `black -l120` clean.

## Note
The sibling idle-timeout part of this finding is intentionally deferred: a naive output-idle timeout would wrongly close a shell whose user is merely thinking (the pump sees only output, not input), so it needs input+output activity coordination. Other #11059 items (non-root container user, exec-denylist allowlist, task-owner scoping) remain open — each is its own focused PR per the wave's pattern.

## Model Used
Claude Opus 4.8