### PR TITLE
refactor(agents): rename the two colliding AgentRegistry classes (#11251 Part 2)

### DIFF
--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -148,7 +148,7 @@ class AgentLoop:
             think_tool: Optional think tool for reasoning
             config: Loop configuration
             agent_id: Optional agent identity (GH#11145). When set, the agent's
-                ``forbidden_work`` manifest is resolved from ``AgentRegistry`` and
+                ``forbidden_work`` manifest is resolved from ``AgentCapabilityRegistry`` and
                 applied to ``config.forbidden_tools`` so ``_check_forbidden`` hard-
                 blocks out-of-manifest tools. When unset (the default), the loop
                 runs as no particular agent and the manifest is empty (no change).
@@ -1438,7 +1438,7 @@ Duration: {self._current_context.get_duration_ms():.0f}ms{belief_summary}
         """Populate ``config.forbidden_tools`` from the agent's manifest (GH#11145).
 
         Reads ``forbidden_work`` off the agent's ``AgentProfile`` via
-        ``AgentRegistry`` and returns a config with those tools hard-blocked. When
+        ``AgentCapabilityRegistry`` and returns a config with those tools hard-blocked. When
         no ``agent_id`` is given, or the config already carries an explicit
         ``forbidden_tools`` set, or the agent has no boundary, the config is
         returned unchanged. Registry resolution never raises into the loop — a

--- a/autobot-backend/agents/agent_client.py
+++ b/autobot-backend/agents/agent_client.py
@@ -67,13 +67,13 @@ class AgentClientConfig:
         )
 
 
-class AgentRegistry:
+class AgentHealthRegistry:
     """Health-tracking registry for running BaseAgent instances.
 
     Scope (#6828): tracks which BaseAgent objects are reachable and alive,
     performing periodic health checks.  This is the **runtime-health** registry
     — it does not hold capability profiles or database state.  See also:
-    - orchestration.agent_registry.AgentRegistry — static profile/capability registry
+    - orchestration.agent_registry.AgentCapabilityRegistry — static profile/capability registry
     - services.agent_registry_service.AgentRegistryService — DB-backed CRUD
     - agents.agent_orchestration.distributed_management.DistributedAgentManager — dynamic/distributed
     """
@@ -209,7 +209,7 @@ class AgentClient:
     def __init__(self, config: AgentClientConfig | None = None):
         """Initialize unified agent client with registry and stats tracking."""
         self.config = config or AgentClientConfig()
-        self.registry = AgentRegistry()
+        self.registry = AgentHealthRegistry()
         self.container_agents: Dict[str, ContainerAgentProxy] = {}
 
         # Performance tracking

--- a/autobot-backend/agents/agent_orchestration/distributed_management.py
+++ b/autobot-backend/agents/agent_orchestration/distributed_management.py
@@ -44,8 +44,8 @@ class DistributedAgentManager:
     work-stealing (#2109, #4694).  This is the **distributed-runtime** registry
     — it handles multi-node agent membership and task reassignment.  It does
     not hold database state or static capability profiles.  See also:
-    - orchestration.agent_registry.AgentRegistry — static profile/capability registry
-    - agents.agent_client.AgentRegistry — health-tracking runtime registry
+    - orchestration.agent_registry.AgentCapabilityRegistry — static profile/capability registry
+    - agents.agent_client.AgentHealthRegistry — health-tracking runtime registry
     - services.agent_registry_service.AgentRegistryService — DB-backed CRUD
     """
 

--- a/autobot-backend/api/agent_org.py
+++ b/autobot-backend/api/agent_org.py
@@ -48,15 +48,15 @@ _ORCH_TYPE_MAP: Dict[str, str] = {
 
 
 def _fallback_agents_from_registry() -> List[Dict[str, Any]]:
-    """Build agent list from the in-memory AgentRegistry when PG is unavailable (#10511).
+    """Build agent list from the in-memory AgentCapabilityRegistry when PG is unavailable (#10511).
 
     Returns the same shape as ``AgentOrgService.get_agent_statuses()`` so the
     caller can treat both sources uniformly.
     """
     try:
-        from orchestration.agent_registry import AgentRegistry
+        from orchestration.agent_registry import AgentCapabilityRegistry
 
-        registry = AgentRegistry(initialize_defaults=True)
+        registry = AgentCapabilityRegistry(initialize_defaults=True)
         agents = []
         for profile in registry.get_all().values():
             agents.append(
@@ -120,7 +120,7 @@ async def get_agents_status(
     """Return all registered agents with runtime status (#10502, #10511).
 
     Uses the Postgres-backed ``AgentOrgService`` when a session is available,
-    with a defensive fallback to the in-memory ``AgentRegistry`` populated from
+    with a defensive fallback to the in-memory ``AgentCapabilityRegistry`` populated from
     ``DEFAULT_AGENT_CONFIGS`` so the Home dashboard "Agent Activity Monitor"
     returns 200 instead of 503.
     """

--- a/autobot-backend/orchestration/__init__.py
+++ b/autobot-backend/orchestration/__init__.py
@@ -40,7 +40,7 @@ This package contains:
 
 from autobot_shared.workflow import ExecutionStrategy
 
-from .agent_registry import AgentRegistry, get_default_agents
+from .agent_registry import AgentCapabilityRegistry, get_default_agents
 from .agent_router import AgentRouter, TaskAgentScorer
 from .blocked_plan_resumer import BlockedPlanResumer
 from .causal_error_recovery import CausalErrorRecovery, RecoveryPlan, get_recovery_recommender
@@ -139,7 +139,7 @@ __all__ = [
     "AgentTask",
     "WorkflowDependencies",
     # Agent management
-    "AgentRegistry",
+    "AgentCapabilityRegistry",
     "get_default_agents",
     # Agent routing / scoring (#6819)
     "TaskAgentScorer",

--- a/autobot-backend/orchestration/agent_registry.py
+++ b/autobot-backend/orchestration/agent_registry.py
@@ -130,14 +130,14 @@ def match_forbidden_tool(tool_name: str, forbidden: "frozenset[str]") -> "str | 
     return match_tool_name(tool_name, forbidden)
 
 
-class AgentRegistry:
+class AgentCapabilityRegistry:
     """Static profile registry for orchestration agent capabilities.
 
     Scope (#6828): holds in-memory AgentProfile + AgentCapability catalogue
     populated at orchestrator startup from DEFAULT_AGENT_CONFIGS.  This is
     the **what-can-each-agent-do** registry — it does not track live health or
     database persistence.  See also:
-    - agents.agent_client.AgentRegistry — health-tracking runtime registry
+    - agents.agent_client.AgentHealthRegistry — health-tracking runtime registry
     - services.agent_registry_service.AgentRegistryService — DB-backed CRUD
     - agents.agent_orchestration.distributed_management.DistributedAgentManager — dynamic/distributed
     """
@@ -358,7 +358,7 @@ class AgentRegistry:
 # seeded once from get_default_agents() (the same SSOT the orchestrator uses, so
 # no drift). Lets the production tool-dispatch seam resolve an agent's boundary
 # cheaply without constructing an Orchestrator on every tool call.
-_default_registry: "AgentRegistry | None" = None
+_default_registry: "AgentCapabilityRegistry | None" = None
 
 
 def resolve_forbidden_tools(agent_id: "str | None") -> "frozenset[str]":
@@ -372,5 +372,5 @@ def resolve_forbidden_tools(agent_id: "str | None") -> "frozenset[str]":
         return frozenset()
     global _default_registry  # noqa: PLW0603
     if _default_registry is None:
-        _default_registry = AgentRegistry(initialize_defaults=True)
+        _default_registry = AgentCapabilityRegistry(initialize_defaults=True)
     return _default_registry.forbidden_tools(agent_id)

--- a/autobot-backend/orchestration/capability_audit.py
+++ b/autobot-backend/orchestration/capability_audit.py
@@ -20,7 +20,7 @@ from typing import List
 from autobot_shared.logging_manager import get_logger
 from orchestration.agent_registry import (
     _INFRA_AND_SHELL_TOOLS,
-    AgentRegistry,
+    AgentCapabilityRegistry,
     get_default_agents,
     match_forbidden_tool,
 )
@@ -113,7 +113,7 @@ def audit_agent_manifests(profiles: List[AgentProfile]) -> List[AuditFinding]:
     return findings
 
 
-def audit_registry(registry: AgentRegistry) -> List[AuditFinding]:
+def audit_registry(registry: AgentCapabilityRegistry) -> List[AuditFinding]:
     """Audit every profile in a live registry (incl. dynamically-registered agents)."""
     return audit_agent_manifests(list(registry.get_all().values()))
 

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -47,10 +47,10 @@ from memory import LongTermMemoryManager
 from orchestration import (
     FALLBACK_TIERS,
     AgentCapability,
+    AgentCapabilityRegistry,
     AgentInteraction,
     AgentPerformance,
     AgentProfile,
-    AgentCapabilityRegistry,
     AgentRouter,
     AgentTask,
     CausalErrorRecovery,

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -50,7 +50,7 @@ from orchestration import (
     AgentInteraction,
     AgentPerformance,
     AgentProfile,
-    AgentRegistry,
+    AgentCapabilityRegistry,
     AgentRouter,
     AgentTask,
     CausalErrorRecovery,
@@ -107,7 +107,7 @@ except ImportError:
     KNOWLEDGE_BASE_AVAILABLE = False
     logger.warning("KnowledgeBase not available - auto-documentation features disabled")
 
-from agents.agent_client import AgentRegistry as _AgentClientRegistry
+from agents.agent_client import AgentHealthRegistry as _AgentClientRegistry
 from autobot_shared.status_enums import Priority as TaskPriority  # #7504 consolidation
 from autobot_shared.status_enums import WorkflowStatus  # #6973 consolidation
 from autobot_types import TaskComplexity
@@ -157,11 +157,11 @@ class Orchestrator(_DeprecatedRequestMixin):
 
     def _init_components(self) -> None:
         self.agent_registry: Dict[str, AgentProfile] = {}
-        # GH #6820: AgentRegistry — structured profile store with capability-based lookup.
+        # GH #6820: AgentCapabilityRegistry — structured profile store with capability-based lookup.
         # Runs alongside the plain-dict self.agent_registry for structured queries.
         # GH#11139: seeded by _initialize_default_agents() (called later in __init__)
         # via register(), so skip the built-in defaults to avoid double instantiation.
-        self._profile_registry = AgentRegistry(initialize_defaults=False)
+        self._profile_registry = AgentCapabilityRegistry(initialize_defaults=False)
         self.workflow_documentation: Dict[str, WorkflowDocumentation] = {}
         self.agent_interactions: List[AgentInteraction] = []
         self.knowledge_base = KnowledgeBase() if KNOWLEDGE_BASE_AVAILABLE else None

--- a/autobot-backend/services/agent_registry_service.py
+++ b/autobot-backend/services/agent_registry_service.py
@@ -27,8 +27,8 @@ class AgentRegistryService:
     **persistence** registry — canonical source of truth for agent metadata at
     startup/shutdown.  Does not track live health or in-process profile state.
     See also:
-    - orchestration.agent_registry.AgentRegistry — static profile/capability registry
-    - agents.agent_client.AgentRegistry — health-tracking runtime registry
+    - orchestration.agent_registry.AgentCapabilityRegistry — static profile/capability registry
+    - agents.agent_client.AgentHealthRegistry — health-tracking runtime registry
     - agents.agent_orchestration.distributed_management.DistributedAgentManager — dynamic/distributed
     """
 

--- a/autobot-backend/tests/agent_loop/test_forbidden_tools_wiring.py
+++ b/autobot-backend/tests/agent_loop/test_forbidden_tools_wiring.py
@@ -7,7 +7,7 @@ End-to-end wiring: AgentProfile.forbidden_work -> AgentLoopConfig.forbidden_tool
 
 #11139 delivered the enforcement primitive (``_check_forbidden``); this proves the
 connective tissue: constructing ``AgentLoop`` with an ``agent_id`` resolves that
-agent's ``forbidden_work`` manifest from ``AgentRegistry`` and hard-blocks the
+agent's ``forbidden_work`` manifest from ``AgentCapabilityRegistry`` and hard-blocks the
 forbidden tools through a real dispatch path.
 
 Acceptance criteria:

--- a/autobot-backend/tests/orchestration/test_agent_capability_manifest.py
+++ b/autobot-backend/tests/orchestration/test_agent_capability_manifest.py
@@ -9,11 +9,11 @@ Acceptance criteria:
   - AgentProfile carries allowed_work / forbidden_work (default empty).
   - Default profiles declare a least-privilege forbidden_work boundary for
     non-executor agents; the system (executor) agent has none.
-  - AgentRegistry exposes the boundary via forbidden_tools() / work_boundary()
+  - AgentCapabilityRegistry exposes the boundary via forbidden_tools() / work_boundary()
     as the single query point — unknown agents degrade to empty (no boundary).
 """
 
-from orchestration.agent_registry import AgentRegistry, get_default_agents
+from orchestration.agent_registry import AgentCapabilityRegistry, get_default_agents
 from orchestration.types import AgentCapability, AgentProfile
 
 
@@ -54,19 +54,19 @@ class TestDefaultProfilesBoundary:
 
 class TestAgentRegistryAccessors:
     def test_forbidden_tools_reads_manifest(self) -> None:
-        reg = AgentRegistry(initialize_defaults=True)
+        reg = AgentCapabilityRegistry(initialize_defaults=True)
         forbidden = reg.forbidden_tools("research_agent")
         assert isinstance(forbidden, frozenset)
         assert "bash" in forbidden and "terraform" in forbidden
 
     def test_work_boundary_returns_allowed_and_forbidden(self) -> None:
-        reg = AgentRegistry(initialize_defaults=True)
+        reg = AgentCapabilityRegistry(initialize_defaults=True)
         allowed, forbidden = reg.work_boundary("documentation_agent")
         assert "write_file" in allowed
         assert "docker" in forbidden
 
     def test_unknown_agent_degrades_to_empty(self) -> None:
-        reg = AgentRegistry(initialize_defaults=True)
+        reg = AgentCapabilityRegistry(initialize_defaults=True)
         assert reg.forbidden_tools("does-not-exist") == frozenset()
         assert reg.work_boundary("does-not-exist") == ([], [])
 
@@ -85,7 +85,7 @@ class TestRoutingOverlayNonRegressive:
         before_keys = set(agent_capabilities)
         before_research = set(agent_capabilities["research_agent"])
 
-        reg = AgentRegistry(initialize_defaults=True)
+        reg = AgentCapabilityRegistry(initialize_defaults=True)
         for agent_id, profile in reg.get_all().items():
             if agent_id in agent_capabilities:
                 agent_capabilities[agent_id] = set(profile.capabilities)

--- a/autobot-backend/tests/unit/test_agents_status_pg_optional.py
+++ b/autobot-backend/tests/unit/test_agents_status_pg_optional.py
@@ -135,8 +135,6 @@ class TestFallbackAgentsFromRegistry:
 # registry contract inline to stay isolated from the import chain.
 # ---------------------------------------------------------------------------
 
-import pytest  # noqa: E402
-
 
 class TestAdapterRegistryContract:
     """Verify the AdapterRegistry contract that _init_llm_adapters relies on (#10526).

--- a/autobot-backend/tests/unit/test_agents_status_pg_optional.py
+++ b/autobot-backend/tests/unit/test_agents_status_pg_optional.py
@@ -57,20 +57,20 @@ class TestFallbackAgentsFromRegistry:
             raise ImportError("Could not load api/agent_org.py")
 
         # We can't exec the full module without heavy stubs; instead test the logic
-        # inline by calling the AgentRegistry directly.
+        # inline by calling the AgentCapabilityRegistry directly.
         return None
 
     def test_fallback_returns_list(self):
         """_fallback_agents_from_registry must return a non-empty list."""
-        from orchestration.agent_registry import AgentRegistry
+        from orchestration.agent_registry import AgentCapabilityRegistry
 
-        registry = AgentRegistry(initialize_defaults=True)
+        registry = AgentCapabilityRegistry(initialize_defaults=True)
         agents = registry.get_all()
         assert len(agents) >= 4, "Expected at least 4 default agents"
 
     def test_fallback_shapes(self):
         """Every in-memory agent maps to an AgentStatusItem-compatible dict."""
-        from orchestration.agent_registry import AgentRegistry
+        from orchestration.agent_registry import AgentCapabilityRegistry
 
         _ORCH_TYPE_MAP = {
             "research": "analyzer",
@@ -79,7 +79,7 @@ class TestFallbackAgentsFromRegistry:
             "orchestrator": "orchestrator",
         }
 
-        registry = AgentRegistry(initialize_defaults=True)
+        registry = AgentCapabilityRegistry(initialize_defaults=True)
         required_keys = {
             "id",
             "name",
@@ -112,7 +112,7 @@ class TestFallbackAgentsFromRegistry:
 
     def test_orch_type_map_covers_defaults(self):
         """All default agent types appear in _ORCH_TYPE_MAP or fall back to 'worker'."""
-        from orchestration.agent_registry import AgentRegistry
+        from orchestration.agent_registry import AgentCapabilityRegistry
 
         _ORCH_TYPE_MAP = {
             "research": "analyzer",
@@ -122,7 +122,7 @@ class TestFallbackAgentsFromRegistry:
         }
         valid_types = {"analyzer", "executor", "orchestrator", "worker"}
 
-        registry = AgentRegistry(initialize_defaults=True)
+        registry = AgentCapabilityRegistry(initialize_defaults=True)
         for profile in registry.get_all().values():
             mapped = _ORCH_TYPE_MAP.get(profile.agent_type, "worker")
             assert mapped in valid_types, f"Unexpected type '{mapped}' for {profile.agent_id}"

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -16452,7 +16452,7 @@ export interface paths {
          * @description Return all registered agents with runtime status (#10502, #10511).
          *
          *     Uses the Postgres-backed ``AgentOrgService`` when a session is available,
-         *     with a defensive fallback to the in-memory ``AgentRegistry`` populated from
+         *     with a defensive fallback to the in-memory ``AgentCapabilityRegistry`` populated from
          *     ``DEFAULT_AGENT_CONFIGS`` so the Home dashboard "Agent Activity Monitor"
          *     returns 200 instead of 503.
          */


### PR DESCRIPTION
## Thinking Path
Per the owner decision on #11251 Part 2: two classes literally named `AgentRegistry` (health-tracking in `agents/agent_client.py` vs profile/capability store in `orchestration/agent_registry.py`) forced alias imports and obscured which was authoritative. Rename both.

## What Changed (pure rename, 12 files + F401 cleanup)
- `agents/agent_client.py` `AgentRegistry` → **`AgentHealthRegistry`**.
- `orchestration/agent_registry.py` `AgentRegistry` → **`AgentCapabilityRegistry`**.
- Updated every in-repo importer/type-hint/`__all__`/docstring cross-ref (orchestrator, orchestration/__init__, capability_audit, api/agent_org, agent_loop docstrings, agent_registry_service docstrings, + 3 tests). No back-compat alias re-created (that would recreate the collision). Left the `AgentRegistryProtocol` alias in `agent_evolution.py` and `AgentRegistryService` untouched.
- Dropped a pre-existing unused `import pytest` (F401) in a touched test so code-quality stays green.

## Verification
- Repo-wide `grep '\bAgentRegistry\b'` → only the intentional `AgentRegistryProtocol` comment remains; no stray class refs.
- Import smoke resolves the new names; `pytest` on the affected suites → **30 passed**; `py_compile` + `black` + `flake8 --config=.flake8` clean.
- Diff confirmed pure-rename (no behavior lines changed).

## Model Used
Opus 4.8 (mechanical rename delegated + independently grep/import/test-verified)

Refs #11251 (Part 2 done; Part 1 — routing-ids-win capability projection — is a separate follow-up)

Closes #11434 (Part 2 deliverable).