### PR TITLE
fix(deploy): recover aiml deploy port dropped from #11425 (#11424)

### DIFF
--- a/autobot-slm-backend/ansible/README-PLAYBOOKS.md
+++ b/autobot-slm-backend/ansible/README-PLAYBOOKS.md
@@ -40,9 +40,11 @@ ansible-playbook update-all-nodes.yml --tags backend
 
 | Playbook | Purpose | Scope | Time |
 |----------|---------|-------|------|
-| `update-all-nodes.yml` | Code sync + **DB migrations** + restart (all nodes) | Fleet | ~2 min |
+| `update-all-nodes.yml` | Code sync + **DB migrations** + restart (all nodes) | Fleet | ~3–10 min¹ |
 | `update-all-nodes.yml --tags backend` | Backend code only | Single service | ~30s |
 | `provision-fleet-roles.yml` | Full re-provision | Fleet | ~45 min |
+
+¹ Includes the pre-restart migration sequence (pg_dump backup → baseline → `alembic upgrade head`); longer when migrations or dependency changes apply.
 
 ---
 

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -122,9 +122,20 @@
         label: "{{ item.name }}"
       changed_when: true
 
+    # AI Stack lives under a different path shape (nested docker dir), so it
+    # keeps its own archive task (ported from the retired top-level playbook,
+    # #11424 — the aiml deploy must not be lost in the canonical consolidation).
+    - name: "[PRE-FLIGHT] Create AI Stack archive"
+      shell: >-
+        git -c safe.directory={{ git_repo_root }} -C {{ git_repo_root }} archive {{ deploy_ref }}
+        -- autobot-infrastructure/shared/docker/ai-stack/
+        | gzip > {{ deploy_tmp }}/ai-stack.tar.gz
+      changed_when: true
+      tags: [always, ai-stack, aiml]
+
     - name: "[PRE-FLIGHT] Archives ready"
       debug:
-        msg: "7 deploy archives created from {{ deploy_ref }} ({{ deploy_info.stdout }})"
+        msg: "8 deploy archives created from {{ deploy_ref }} ({{ deploy_info.stdout }})"
 
     # --- Dependency change detection (#1603) ---
     - name: "[PRE-FLIGHT] Get previous commit (before pull)"
@@ -898,6 +909,41 @@
       when: >-
         'browser' in group_names
       tags: [browser, browser-worker, restart]
+
+    # ----- AI Stack (LangChain/LlamaIndex agent router + ChromaDB) -----
+    # Ported from the retired top-level update-all-nodes.yml (#11424) so the
+    # aiml node keeps receiving code updates through the canonical entrypoint.
+    - name: "[PLAY 2] AI Stack | Deploy ai_api_server and requirements"
+      unarchive:
+        src: "{{ deploy_tmp }}/ai-stack.tar.gz"
+        dest: /opt/autobot/autobot-ai-stack/
+        extra_opts: ['--strip-components=4']
+        owner: autobot
+        group: autobot
+      become: true
+      when: >-
+        'aiml' in group_names
+      tags: [ai-stack, aiml]
+
+    - name: "[PLAY 2] AI Stack | Restart autobot-ai-stack service"
+      systemd:
+        name: autobot-ai-stack
+        state: restarted
+      become: true
+      when: >-
+        'aiml' in group_names
+      failed_when: false
+      tags: [ai-stack, aiml, restart]
+
+    - name: "[PLAY 2] AI Stack | Restart autobot-chromadb service"
+      systemd:
+        name: autobot-chromadb
+        state: restarted
+      become: true
+      when: >-
+        'aiml' in group_names
+      failed_when: false
+      tags: [ai-stack, aiml, chromadb, restart]
 
     # ----- Shared (non-backend nodes) -----
     - name: "[PLAY 2] Shared | Deploy autobot_shared"


### PR DESCRIPTION
## Thinking Path
Follow-up to #11425: that PR was merged before the review-fix commit landed on the branch (the fix push arrived after merge + branch auto-delete — verified on Dev_new_gui: redirect present, aiml tasks absent). This recovers the dropped commit via cherry-pick.

## What Changed
- `playbooks/update-all-nodes.yml`: port the **aiml (AI-Stack/ChromaDB) deploy** from the retired top-level playbook — Play 0 ai-stack archive + Play 2 deploy/restart tasks (canonical style: group-gated, `failed_when: false` restarts). Without this, the redirect in #11425 would silently stop code updates to the aiml node — the exact capability drop the #11425 code review flagged.
- `README-PLAYBOOKS.md`: timing row corrected (+footnote) since updates now include the migration sequence.

## Verification
- Cherry-pick of reviewed commit `d202ce6dd` (implements the #11425 reviewer's recommendation verbatim).
- `ansible-playbook --syntax-check` passes for both entrypoints.
- `grep -c aiml playbooks/update-all-nodes.yml` → 9 (tasks present).

## Model Used
Claude Fable 5 (1M context)
