### PR TITLE
fix(security): per-resource authz for workflow/heartbeat/task WS channels (#11396)

### DIFF
--- a/autobot-backend/api/live_events.py
+++ b/autobot-backend/api/live_events.py
@@ -30,6 +30,7 @@ from api.ws_security import enforce_ws_origin
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from events.bus import get_event_bus
+from services.workflow_permission_service import WorkflowPermissionService
 
 logger = get_logger(__name__)
 router = APIRouter()
@@ -89,6 +90,55 @@ async def _authorize_llc_channel(channel: str, user_payload: dict) -> bool:
         return False
 
 
+async def _authorize_resource_channel(channel: str, user_payload: dict) -> bool:
+    """Authorize ``workflow:``/``heartbeat:``/``task:`` subscriptions (#11396).
+
+    These prefixes previously had NO tenant check — any authenticated user could
+    subscribe to any id (cross-tenant leak, latent today since nothing publishes
+    to them yet). Per-resource owner resolution, admins bypass, fails closed:
+
+    - ``workflow:{id}`` — the caller must hold ``view`` permission on that
+      workflow (``WorkflowPermissionService.check_permission``, viewer+).
+    - ``heartbeat:{id}`` — resolve ``LLCHeartbeatRun.company_id`` and require
+      company membership (mirrors the ``board:`` resolver).
+    - ``task:{id}`` — no ownership store exists for task ids (and no publisher
+      or frontend consumer today), so non-admins are DENIED until one does.
+    """
+    if "admin" in user_payload.get("roles", []):
+        return True
+    user_id = str(user_payload.get("user_id") or user_payload.get("username") or "")
+    if not user_id:
+        return False
+    prefix, _, ident = channel.partition(":")
+    if not ident:
+        return False
+    if prefix == "task":
+        logger.warning("task-channel subscribe denied for %s: no task ownership store (#11396)", user_id)
+        return False
+    try:
+        from user_management.database import get_async_session_factory
+
+        async with get_async_session_factory()() as session:
+            if prefix == "workflow":
+                svc = WorkflowPermissionService(session)
+                return await svc.check_permission(user_id, ident, "view")
+            if prefix == "heartbeat":
+                from llc.models.heartbeat_run import LLCHeartbeatRun
+                from llc.services.membership_service import MembershipService
+                from sqlalchemy import select
+
+                run = (
+                    await session.execute(select(LLCHeartbeatRun).where(LLCHeartbeatRun.id == ident))
+                ).scalar_one_or_none()
+                if run is None:
+                    return False
+                return await MembershipService().is_member(session, str(run.company_id), user_id)
+    except Exception:
+        logger.exception("Resource channel authorization failed for %s", channel)
+        return False
+    return False
+
+
 async def _handle_subscribe(ws: WebSocket, channel: str, user_payload: dict | None) -> None:
     """Process a subscribe action from the client."""
     if user_payload and channel.startswith("agent:"):
@@ -102,6 +152,13 @@ async def _handle_subscribe(ws: WebSocket, channel: str, user_payload: dict | No
     elif user_payload and (channel.startswith("company:") or channel.startswith("board:")):
         # Tenant-scoped LLC channels: enforce company membership (#11386).
         if not await _authorize_llc_channel(channel, user_payload):
+            await _send_error(ws, f"Not authorized to subscribe to {channel}")
+            return
+    elif user_payload and (
+        channel.startswith("workflow:") or channel.startswith("heartbeat:") or channel.startswith("task:")
+    ):
+        # Per-resource owner resolution for the remaining scoped prefixes (#11396).
+        if not await _authorize_resource_channel(channel, user_payload):
             await _send_error(ws, f"Not authorized to subscribe to {channel}")
             return
     ok = await get_event_bus().subscribe_ws(ws, channel)

--- a/autobot-backend/api/live_events.py
+++ b/autobot-backend/api/live_events.py
@@ -123,9 +123,10 @@ async def _authorize_resource_channel(channel: str, user_payload: dict) -> bool:
                 svc = WorkflowPermissionService(session)
                 return await svc.check_permission(user_id, ident, "view")
             if prefix == "heartbeat":
+                from sqlalchemy import select
+
                 from llc.models.heartbeat_run import LLCHeartbeatRun
                 from llc.services.membership_service import MembershipService
-                from sqlalchemy import select
 
                 run = (
                     await session.execute(select(LLCHeartbeatRun).where(LLCHeartbeatRun.id == ident))

--- a/autobot-backend/api/test_live_events_authz.py
+++ b/autobot-backend/api/test_live_events_authz.py
@@ -88,3 +88,98 @@ async def test_board_not_found_denied() -> None:
 async def test_fails_closed_on_error() -> None:
     with patch("user_management.database.get_async_session_factory", MagicMock(side_effect=RuntimeError("db down"))):
         assert await _authorize_llc_channel("company:c1", {"user_id": "u1", "roles": []}) is False
+
+
+# ---------------------------------------------------------------------------
+# #11396 — per-resource authorization for workflow:/heartbeat:/task: channels
+# ---------------------------------------------------------------------------
+
+from api.live_events import _authorize_resource_channel  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_resource_admin_bypasses() -> None:
+    for ch in ("workflow:w1", "heartbeat:h1", "task:t1"):
+        assert await _authorize_resource_channel(ch, {"roles": ["admin"], "user_id": "u1"}) is True
+
+
+@pytest.mark.asyncio
+async def test_resource_missing_user_denied() -> None:
+    assert await _authorize_resource_channel("workflow:w1", {"roles": []}) is False
+
+
+@pytest.mark.asyncio
+async def test_resource_empty_ident_denied() -> None:
+    assert await _authorize_resource_channel("workflow:", {"user_id": "u1", "roles": []}) is False
+
+
+@pytest.mark.asyncio
+async def test_task_channel_denied_for_non_admin() -> None:
+    """No task ownership store exists — non-admins are denied fail-closed (#11396)."""
+    assert await _authorize_resource_channel("task:any-id", {"user_id": "u1", "roles": []}) is False
+
+
+@pytest.mark.asyncio
+async def test_workflow_permission_holder_allowed() -> None:
+    svc = MagicMock()
+    svc.check_permission = AsyncMock(return_value=True)
+    with (
+        _patch_session(),
+        patch("api.live_events.WorkflowPermissionService", MagicMock(return_value=svc)),
+    ):
+        assert await _authorize_resource_channel("workflow:w1", {"user_id": "u1", "roles": []}) is True
+    # checked with the "view" action against the claimed workflow id
+    assert svc.check_permission.call_args[0] == ("u1", "w1", "view")
+
+
+@pytest.mark.asyncio
+async def test_workflow_without_permission_denied() -> None:
+    svc = MagicMock()
+    svc.check_permission = AsyncMock(return_value=False)
+    with (
+        _patch_session(),
+        patch("api.live_events.WorkflowPermissionService", MagicMock(return_value=svc)),
+    ):
+        assert await _authorize_resource_channel("workflow:other", {"user_id": "u1", "roles": []}) is False
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_member_of_owning_company_allowed() -> None:
+    membership = MagicMock()
+    membership.is_member = AsyncMock(return_value=True)
+    run = MagicMock(company_id="c-owner")
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=run)))
+
+    @asynccontextmanager
+    async def _session_cm():
+        yield session
+
+    factory = MagicMock(return_value=_session_cm())
+    with (
+        patch("user_management.database.get_async_session_factory", MagicMock(return_value=factory)),
+        patch("llc.services.membership_service.MembershipService", MagicMock(return_value=membership)),
+    ):
+        assert await _authorize_resource_channel("heartbeat:h1", {"user_id": "u1", "roles": []}) is True
+    # membership checked against the run's owning company
+    assert membership.is_member.call_args[0][1] == "c-owner"
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_run_not_found_denied() -> None:
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None)))
+
+    @asynccontextmanager
+    async def _session_cm():
+        yield session
+
+    factory = MagicMock(return_value=_session_cm())
+    with patch("user_management.database.get_async_session_factory", MagicMock(return_value=factory)):
+        assert await _authorize_resource_channel("heartbeat:missing", {"user_id": "u1", "roles": []}) is False
+
+
+@pytest.mark.asyncio
+async def test_resource_fails_closed_on_error() -> None:
+    with patch("user_management.database.get_async_session_factory", MagicMock(side_effect=RuntimeError("db down"))):
+        assert await _authorize_resource_channel("workflow:w1", {"user_id": "u1", "roles": []}) is False


### PR DESCRIPTION
## Thinking Path
The `/ws/live` bus only authorized `agent:`/`company:`/`board:` channels (#11386). The remaining scoped prefixes — `task:`, `workflow:`, `heartbeat:` — were subscribable by **any authenticated user** with no tenant check → cross-tenant event leak (latent today since nothing publishes to them yet, but a real hole). Per the owner decision on #11396: build a per-resource owner resolver (not admin-only).

## What Changed
`_authorize_resource_channel` — admins bypass, fails closed:
- **`workflow:{id}`** → `WorkflowPermissionService.check_permission(user, id, "view")` (viewer+; the existing per-workflow RBAC table).
- **`heartbeat:{id}`** → resolve `LLCHeartbeatRun.company_id` then `MembershipService.is_member` (mirrors the `board:` resolver).
- **`task:{id}`** → no task-ownership store exists (nor any publisher/frontend consumer today), so non-admins are **denied fail-closed** until one does — documented in the docstring, not silent.
- `WorkflowPermissionService` top-imported so it's patchable (the conftest rebuilds `services.*` `__path__`, which breaks lazy-import patches — caught two false-passing tests).

## Verification
- `pytest api/test_live_events_authz.py` — **17 passed** (8 existing #11386 + 9 new).
- **Mutation-checked:** forcing the workflow path to deny → 1 test fails; restore → 17 pass (authz is load-bearing, not vacuous).
- `py_compile` + `black` + `flake8 --config=.flake8` clean.

## Model Used
Fable 5

Closes #11396