### PR TITLE
fix(code-sync): exclude *.egg-info build artifacts from drift report

### DIFF
--- a/autobot-slm-backend/services/drift_checker.py
+++ b/autobot-slm-backend/services/drift_checker.py
@@ -89,6 +89,14 @@ _SKIP_DIRS = {
     "build",
 }
 
+# Directory-name SUFFIXES to skip — variable-prefixed build artifacts (e.g.
+# ``<pkg>.egg-info`` created by ``pip install`` in the deployed dir) that the
+# exact-match ``_SKIP_DIRS`` can't catch. Their contents (SOURCES.txt,
+# requires.txt, top_level.txt, dependency_links.txt) are deployment-generated and
+# never present in the git source tree, so they were reported as permanent false
+# drift (#11440), training operators to ignore the drift signal.
+_SKIP_DIR_SUFFIXES: tuple[str, ...] = (".egg-info",)
+
 # Paths that are deployment-generated and never present in the git source tree.
 # Exact-match paths and prefix patterns are checked against the POSIX relative
 # path of each file before it is added to the drift report (Issue #4610).
@@ -166,8 +174,9 @@ def _collect_checksums(
     active_extensions = extensions if extensions is not None else _INCLUDE_EXTENSIONS
     checksums: Dict[str, str] = {}
     for dirpath, dirnames, filenames in os.walk(root):
-        # Prune skip dirs in-place so os.walk does not descend into them.
-        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        # Prune skip dirs in-place so os.walk does not descend into them. Also
+        # prune variable-named build-artifact dirs like ``<pkg>.egg-info`` (#11440).
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS and not d.endswith(_SKIP_DIR_SUFFIXES)]
 
         for filename in filenames:
             filepath = Path(dirpath) / filename

--- a/autobot-slm-backend/tests/services/drift_checker_test.py
+++ b/autobot-slm-backend/tests/services/drift_checker_test.py
@@ -101,6 +101,28 @@ class TestComputeDriftExclusions:
             drifted, _ = compute_drift(str(src), str(dep))
             assert any(d["path"] == "services/code_sync.py" for d in drifted)
 
+    def test_egg_info_dir_not_reported_as_drift(self):
+        """#11440: <pkg>.egg-info build-artifact dirs (deployed-only, pip-generated)
+        are pruned from the walk, not reported as permanent false drift. Their
+        contents are .txt (an included extension), so without the suffix-skip they
+        would surface as deployed-only drift forever."""
+        with tempfile.TemporaryDirectory() as src_root, tempfile.TemporaryDirectory() as dep_root:
+            src = Path(src_root)
+            dep = Path(dep_root)
+
+            self._write(src, "main.py", b"import os")
+            self._write(dep, "main.py", b"import os")
+
+            # pip-install artifacts present ONLY in the deployed dir.
+            self._write(dep, "autobot_shared.egg-info/SOURCES.txt", b"main.py\n")
+            self._write(dep, "autobot_shared.egg-info/requires.txt", b"redis\n")
+            self._write(dep, "autobot_shared.egg-info/top_level.txt", b"autobot_shared\n")
+            self._write(dep, "autobot_shared.egg-info/dependency_links.txt", b"\n")
+
+            drifted, _ = compute_drift(str(src), str(dep))
+            paths = [d["path"] for d in drifted]
+            assert paths == [], f"egg-info artifacts must not be reported as drift, got: {paths}"
+
     def test_total_compared_excludes_expected_drift_paths(self):
         """total_compared must count only non-excluded paths (Issue #4631)."""
         with tempfile.TemporaryDirectory() as src_root, tempfile.TemporaryDirectory() as dep_root:


### PR DESCRIPTION
Closes #11440.

## Thinking Path
`GET /code-sync/drift?component=autobot_shared` permanently reported 4 `deployed_only` files — `autobot_shared.egg-info/{SOURCES.txt,dependency_links.txt,requires.txt,top_level.txt}` — pip-install artifacts created in the deployed dir, never in `code_source`. Permanent false-positive drift ("drift_detected: true" forever) trains operators to ignore the drift signal.

Root cause: the drift walk (`_collect_checksums`) prunes `_SKIP_DIRS`, but that's an **exact-name** set — the artifact dir is `<pkg>.egg-info` (variable prefix), so it isn't matched. And `_EXPECTED_DRIFT_PREFIXES=("autobot_shared/",)` doesn't cover `autobot_shared.egg-info/…` (dot, not slash). The files are `.txt` (an included extension), so they surfaced as drift.

## What Changed
`autobot-slm-backend/services/drift_checker.py`:
- Added `_SKIP_DIR_SUFFIXES = (".egg-info",)` and extended the walk's dir-pruning to also skip dirs whose name ends with one of those suffixes: `d not in _SKIP_DIRS and not d.endswith(_SKIP_DIR_SUFFIXES)`. This prunes `<pkg>.egg-info/` from **both** the source and deployed walks, so its contents never enter the comparison.

`autobot-slm-backend/tests/services/drift_checker_test.py`:
- Added `test_egg_info_dir_not_reported_as_drift`: writes the four deployed-only `autobot_shared.egg-info/*.txt` artifacts and asserts `compute_drift` reports **no** drift.

## Verification
- `tests/services/drift_checker_test.py`: **11 passed** (new test + 10 existing).
- Mutation-verified: with the suffix-skip removed, the new test fails with exactly `['autobot_shared.egg-info/SOURCES.txt', 'autobot_shared.egg-info/dependency_links.txt', 'autobot_shared.egg-info/requires.txt', 'autobot_shared.egg-info/top_level.txt']` — reproducing the reported false drift; restored → 11 pass.
- `py_compile` + `black -l120` clean.

## Model Used
Claude Opus 4.8