### PR TITLE
fix(auth): bound denylist Redis access so SLM auth can't hang (#11443)

### DIFF
--- a/autobot-slm-backend/services/token_denylist.py
+++ b/autobot-slm-backend/services/token_denylist.py
@@ -16,9 +16,21 @@ function returns ``False``.  This is acceptable because:
 - A revoked token will expire naturally before long.
 - Denying all auth on Redis downtime would be worse than a brief window
   where a revoked token could be reused.
+
+Bounded access (#11443): ``get_redis_client`` does NOT return ``None``
+quickly when Redis is down or misconfigured — the shared connection
+manager retries pool creation for ~60 s while holding a global lock, which
+serialized every authenticated request behind a one-minute wait and made
+the whole SLM GUI appear dead.  The documented fail-open therefore has to
+be enforced HERE: every Redis interaction is wrapped in
+``asyncio.wait_for`` with a short deadline, and failures arm a short
+negative-cache so subsequent auths skip Redis entirely instead of paying
+the timeout each time.
 """
 
+import asyncio
 import logging
+import time
 
 from autobot_shared.redis_client import get_redis_client
 
@@ -26,10 +38,46 @@ logger = logging.getLogger(__name__)
 
 _DENYLIST_PREFIX = "slm:jwt:denylist:"
 
+# Hard deadline for any denylist Redis interaction (client acquisition +
+# command). Auth latency must never be hostage to Redis (#11443).
+_REDIS_DEADLINE_SECONDS = 1.5
+# After a failure, skip Redis for this long (fail-open window) instead of
+# re-paying the deadline on every authenticated request.
+_UNAVAILABLE_RETRY_SECONDS = 30.0
+
+# Monotonic timestamp until which Redis is considered unavailable (0 = OK).
+_unavailable_until: float = 0.0
+
 
 def _denylist_key(jti: str) -> str:
     """Return the Redis key for *jti*."""
     return f"{_DENYLIST_PREFIX}{jti}"
+
+
+def _redis_marked_unavailable() -> bool:
+    """True while the negative-cache window from a previous failure is active."""
+    return time.monotonic() < _unavailable_until
+
+
+def _mark_redis_unavailable(op: str, jti: str, exc: Exception | None) -> None:
+    """Arm the negative-cache window and log the degradation once per trip."""
+    global _unavailable_until
+    was_armed = _redis_marked_unavailable()
+    _unavailable_until = time.monotonic() + _UNAVAILABLE_RETRY_SECONDS
+    if not was_armed:
+        logger.warning(
+            "%s: Redis unavailable (%s); denylist fail-open for %.0fs (jti=%r)",
+            op,
+            exc.__class__.__name__ if exc else "no client",
+            _UNAVAILABLE_RETRY_SECONDS,
+            jti,
+        )
+
+
+def _mark_redis_available() -> None:
+    """Clear the negative-cache window after a successful interaction."""
+    global _unavailable_until
+    _unavailable_until = 0.0
 
 
 async def revoke_jti(jti: str, ttl_seconds: int) -> None:
@@ -37,26 +85,52 @@ async def revoke_jti(jti: str, ttl_seconds: int) -> None:
 
     The key auto-expires when the original token would have expired anyway,
     so no background cleanup is needed.  Silently no-ops if Redis is
-    unavailable (logs a warning).
+    unavailable (logs a warning) — bounded by the module deadline.
     """
-    redis = await get_redis_client(async_client=True)
-    if redis is None:
-        logger.warning("revoke_jti: Redis unavailable; jti=%r NOT revoked", jti)
-        return
     ttl = max(1, ttl_seconds)
-    await redis.set(_denylist_key(jti), "1", ex=ttl)
+
+    async def _do() -> bool:
+        redis = await get_redis_client(async_client=True)
+        if redis is None:
+            return False
+        await redis.set(_denylist_key(jti), "1", ex=ttl)
+        return True
+
+    try:
+        ok = await asyncio.wait_for(_do(), timeout=_REDIS_DEADLINE_SECONDS)
+    except (asyncio.TimeoutError, ConnectionError, OSError) as exc:
+        _mark_redis_unavailable("revoke_jti", jti, exc)
+        return
+    if not ok:
+        _mark_redis_unavailable("revoke_jti", jti, None)
+        return
+    _mark_redis_available()
     logger.info("revoke_jti: jti=%r revoked with ttl=%d", jti, ttl)
 
 
 async def is_jti_revoked(jti: str) -> bool:
     """Return ``True`` if *jti* is in the denylist.
 
-    Fail-open: returns ``False`` when Redis is unavailable.  The token's own
-    TTL still provides a time-bounded guard in that case.
+    Fail-open: returns ``False`` when Redis is unavailable, misconfigured,
+    or slower than the module deadline (#11443).  The token's own TTL still
+    provides a time-bounded guard in that case.
     """
-    redis = await get_redis_client(async_client=True)
-    if redis is None:
-        logger.warning("is_jti_revoked: Redis unavailable; treating jti=%r as NOT revoked (fail-open)", jti)
+    if _redis_marked_unavailable():
         return False
-    exists = await redis.exists(_denylist_key(jti))
-    return bool(exists)
+
+    async def _do() -> bool | None:
+        redis = await get_redis_client(async_client=True)
+        if redis is None:
+            return None
+        return bool(await redis.exists(_denylist_key(jti)))
+
+    try:
+        result = await asyncio.wait_for(_do(), timeout=_REDIS_DEADLINE_SECONDS)
+    except (asyncio.TimeoutError, ConnectionError, OSError) as exc:
+        _mark_redis_unavailable("is_jti_revoked", jti, exc)
+        return False
+    if result is None:
+        _mark_redis_unavailable("is_jti_revoked", jti, None)
+        return False
+    _mark_redis_available()
+    return result

--- a/autobot-slm-backend/tests/services/test_token_denylist.py
+++ b/autobot-slm-backend/tests/services/test_token_denylist.py
@@ -300,8 +300,9 @@ class TestBoundedRedisAccess:
         async def _hang(*a, **kw):
             await _asyncio.sleep(30)
 
-        with patch.object(_dl_mod, "_REDIS_DEADLINE_SECONDS", 0.05), patch.object(
-            _dl_mod, "get_redis_client", new=_hang
+        with (
+            patch.object(_dl_mod, "_REDIS_DEADLINE_SECONDS", 0.05),
+            patch.object(_dl_mod, "get_redis_client", new=_hang),
         ):
             loop = _asyncio.get_event_loop()
             start = loop.time()

--- a/autobot-slm-backend/tests/services/test_token_denylist.py
+++ b/autobot-slm-backend/tests/services/test_token_denylist.py
@@ -109,6 +109,15 @@ def _make_redis_mock(exists_return: int = 0) -> AsyncMock:
     return mock
 
 
+@pytest.fixture(autouse=True)
+def _reset_denylist_negative_cache():
+    """#11443: the module arms a negative-cache window after Redis failures;
+    reset it between tests so unavailable-path tests don't poison others."""
+    _dl_mod._unavailable_until = 0.0
+    yield
+    _dl_mod._unavailable_until = 0.0
+
+
 # ---------------------------------------------------------------------------
 # token_denylist: key format
 # ---------------------------------------------------------------------------
@@ -274,3 +283,51 @@ class TestDecodeTokenAsyncRevocation:
 
         assert result is not None
         assert result["sub"] == "eve"
+
+
+# ---------------------------------------------------------------------------
+# token_denylist: bounded Redis access + negative cache (#11443)
+# ---------------------------------------------------------------------------
+
+
+class TestBoundedRedisAccess:
+    @pytest.mark.asyncio
+    async def test_hanging_client_acquisition_is_cut_by_deadline(self):
+        """A hanging get_redis_client (retry-under-lock) must not hang auth:
+        the deadline cuts it and the check fails open (#11443)."""
+        import asyncio as _asyncio
+
+        async def _hang(*a, **kw):
+            await _asyncio.sleep(30)
+
+        with patch.object(_dl_mod, "_REDIS_DEADLINE_SECONDS", 0.05), patch.object(
+            _dl_mod, "get_redis_client", new=_hang
+        ):
+            loop = _asyncio.get_event_loop()
+            start = loop.time()
+            result = await is_jti_revoked("jti-hang")
+            elapsed = loop.time() - start
+
+        assert result is False
+        assert elapsed < 1.0, f"deadline did not bound the call ({elapsed:.2f}s)"
+
+    @pytest.mark.asyncio
+    async def test_failure_arms_negative_cache_skipping_redis(self):
+        """After a failure, subsequent checks skip Redis entirely for the
+        fail-open window instead of re-paying the deadline (#11443)."""
+        get_client = AsyncMock(return_value=None)
+        with patch.object(_dl_mod, "get_redis_client", get_client):
+            assert await is_jti_revoked("jti-a") is False  # arms the window
+            assert await is_jti_revoked("jti-b") is False  # short-circuits
+
+        get_client.assert_called_once()  # second call never touched Redis
+
+    @pytest.mark.asyncio
+    async def test_success_clears_negative_cache(self):
+        """A successful interaction clears the fail-open window."""
+        redis_mock = _make_redis_mock(exists_return=1)
+        get_client = AsyncMock(return_value=redis_mock)
+        _dl_mod._unavailable_until = 0.0
+        with patch.object(_dl_mod, "get_redis_client", get_client):
+            assert await is_jti_revoked("jti-ok") is True
+        assert _dl_mod._unavailable_until == 0.0


### PR DESCRIPTION
## Thinking Path
Live incident: SLM login ~60s, menus dead. Python 3.14 `asyncio pstree` on the running SLM showed every authed request queued on `RedisConnectionManager._ensure_async_pool_exists`'s Lock while `_create_async_pool_with_retry` burned 5 backoff attempts against an **empty Redis host** (`vm.redis` unresolvable in the SLM process). Trigger: #11422 (today) wired the JWT denylist into `decode_token_async`. The denylist is documented fail-open, but `get_redis_client` never returns None fast — the fail-open was unreachable. Fixes #11443.

## What Changed
`services/token_denylist.py`: every Redis interaction (client acquisition + command) wrapped in `asyncio.wait_for` with a 1.5s deadline; failures arm a 30s negative-cache (log once) so subsequent auths skip Redis instead of re-paying the deadline; success clears the window. `revoke_jti` gets the same bounding.
Tests (+3, +fixture): hanging client acquisition cut by deadline (<1s); failure arms negative-cache (second call never touches Redis); success clears the window; autouse fixture resets module state between tests.

## Verification
- `pytest tests/services/test_token_denylist.py tests/api/test_auth_logout.py` → **26 passed**.
- Root cause chain verified live on the affected host (pstree stacks + empty `REDIS_VM_IP` repro).

## Follow-ups (filed in #11443 body)
- autobot_shared: pool-creation retries under a global lock serialize all callers; empty host should fail fast as config error.
- SLM deployment: provide REDIS_HOST to the SLM unit env / make `vm.redis` resolvable in SLM context.

## Model Used
Claude Fable 5 (1M context)
