### PR TITLE
fix(code-sync): /refresh message no longer implies a deploy happened

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -747,6 +747,19 @@ async def get_component_resolve_status(
     )
 
 
+def _refresh_message(has_update: bool) -> str:
+    """Message for POST /refresh (#11439).
+
+    ``/refresh`` only re-fetches version *metadata* (git fetch) — it does NOT deploy
+    code. The old "Version updated successfully" wording read as if a deploy had
+    happened, so operators could believe a pending fix was live when nothing had
+    been synced. Word it as a metadata refresh and surface whether an update awaits.
+    """
+    if has_update:
+        return "Version metadata refreshed — an update is available (run resolve/update to deploy it)"
+    return "Version metadata refreshed — already up to date"
+
+
 @router.post("/refresh", response_model=CodeSyncRefreshResponse)
 async def refresh_version(
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -778,7 +791,7 @@ async def refresh_version(
 
             return CodeSyncRefreshResponse(
                 success=True,
-                message="Version updated successfully",
+                message=_refresh_message(result["has_update"]),
                 latest_version=result["remote_commit"],
                 has_update=result["has_update"],
             )

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -1849,3 +1849,23 @@ def test_run_post_sync_steps_does_not_roll_back_on_slow_start() -> None:
 
     assert pip_ok is True, "deploy must succeed when health poll returns True"
     assert not rolled_back, "rollback must NOT fire on slow-but-successful start"
+
+
+# ---------------------------------------------------------------------------
+# #11439 — /refresh message must not imply a deploy happened
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_message_does_not_imply_deploy() -> None:
+    """#11439: POST /refresh only re-fetches version metadata (git fetch) — it does
+    not deploy. The message must not read 'Version updated successfully' and must
+    surface whether an update is pending, so operators don't believe a fix is live."""
+    from api.code_sync import _refresh_message
+
+    up = _refresh_message(True)
+    current = _refresh_message(False)
+    assert "updated successfully" not in up.lower()
+    assert "updated successfully" not in current.lower()
+    assert "refreshed" in up.lower() and "refreshed" in current.lower()
+    assert "available" in up.lower()  # signals a pending, undeployed update
+    assert "up to date" in current.lower()


### PR DESCRIPTION
Closes #11447 (part 1 of #11439).

## Thinking Path
`POST /api/code-sync/refresh` returned `message="Version updated successfully"` after `check_for_updates(fetch=True)` — but that only re-fetches version metadata (git fetch); it never deploys code. Operators reading "updated successfully" could believe a pending fix is live when nothing was synced (dangerous — a critical fix looks deployed).

## What Changed
`autobot-slm-backend/api/code_sync.py`:
- Added `_refresh_message(has_update)` (pure helper) and used it in `refresh_version`. It words the response as a *metadata* refresh and states whether an update is pending: "Version metadata refreshed — an update is available (run resolve/update to deploy it)" / "… — already up to date".

`autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py`:
- Added `test_refresh_message_does_not_imply_deploy`: asserts neither branch says "updated successfully", both say "refreshed", the update branch signals "available", and the no-update branch says "up to date".

## Verification
- `tests/api/test_code_sync_deploy_bugs.py`: **81 passed** (new test + 80 existing).
- `py_compile` + `black -l120` clean.

## Note
Part 2 of #11439 (`GET /status` reports `outdated_nodes:0` while `has_update:true`) is deferred: `outdated_nodes` counts `Node.code_status` enum flags, decoupled from the latest remote commit. Making it consistent needs an `OR Node.code_version != latest_version` clause (with a NULL-version-semantics decision) and changes fleet-status UI meaning — a moderate-risk follow-up, not bundled here.

## Model Used
Claude Opus 4.8