### PR TITLE
fix(redis): fail fast on empty host + pool creation outside the global lock (#11449)

### DIFF
--- a/autobot_shared/redis_management/connection_manager.py
+++ b/autobot_shared/redis_management/connection_manager.py
@@ -848,6 +848,17 @@ class RedisConnectionManager:
             self._handle_sync_client_failure(database_name, e)
             return None
 
+    @staticmethod
+    def _log_pool_task_failure(database_name: str, task: "asyncio.Task") -> None:
+        """Done-callback: retrieve (and log) a failed pool-creation's exception
+        so asyncio never reports it as unretrieved, even when every waiter was
+        cancelled by its own deadline (#11451)."""
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.warning("Async pool creation for '%s' failed: %s", database_name, exc)
+
     async def _ensure_async_pool_exists(self, database_name: str) -> None:
         """
         Ensure async connection pool exists for database, creating if needed.
@@ -865,8 +876,21 @@ class RedisConnectionManager:
             if database_name in self._async_pools:
                 return
             task = self._async_pool_tasks.get(database_name)
+            if task is not None and task.done() and not task.cancelled() and task.exception() is None:
+                # A completed creation whose waiter hasn't written the registry
+                # yet — harvest its pool instead of spawning a duplicate that
+                # would lose the setdefault and leak its connection (#11451).
+                self._async_pools.setdefault(database_name, task.result())
+                self._async_pool_tasks.pop(database_name, None)
+                return
             if task is None or task.done():
                 task = asyncio.ensure_future(self._create_async_pool(database_name))
+                # Always retrieve the exception even if every waiter was
+                # cancelled — avoids "Task exception was never retrieved" and
+                # preserves the failure reason in the logs (#11451).
+                task.add_done_callback(
+                    lambda t, _db=database_name: self._log_pool_task_failure(_db, t)
+                )
                 self._async_pool_tasks[database_name] = task
         try:
             pool = await asyncio.shield(task)

--- a/autobot_shared/redis_management/connection_manager.py
+++ b/autobot_shared/redis_management/connection_manager.py
@@ -111,6 +111,15 @@ def _get_metrics_manager():
 logger = logging.getLogger(__name__)
 
 
+class RedisConfigurationError(ValueError):
+    """Invalid Redis configuration (e.g. empty host).
+
+    Deliberately NOT a ConnectionError: the retry mechanism must treat it as
+    non-retryable so a misconfiguration fails fast instead of burning the full
+    exponential-backoff budget against a host that can never exist (#11449).
+    """
+
+
 class RedisConnectionManager:
     """
     Centralized Redis connection manager with circuit breaker and health monitoring.
@@ -189,6 +198,10 @@ class RedisConnectionManager:
         self._states: Dict[str, ConnectionState] = {}
         self._init_lock = Lock()
         self._async_lock = asyncio.Lock()
+        # #11449: in-flight async pool creations. The lock only guards these
+        # dicts; the (slow, retrying) creation itself runs OUTSIDE the lock so
+        # one bad database/config cannot serialize every other caller.
+        self._async_pool_tasks: Dict[str, "asyncio.Task[async_redis.ConnectionPool]"] = {}
 
     def _init_circuit_breaker_state(self) -> None:
         """
@@ -698,7 +711,24 @@ class RedisConnectionManager:
                 max_retries=self._pool_config.max_retries,
             )
 
+        self._validate_config_host(database_name, config)
         return self._create_sync_pool_with_keepalive(database_name, config)
+
+    @staticmethod
+    def _validate_config_host(database_name: str, config: "RedisConfig") -> None:
+        """Reject blank Redis hosts before any connect attempt (#11449).
+
+        An empty host (e.g. unresolvable ``vm.redis`` in a process that cannot
+        import the backend ConfigRegistry) is a configuration error, not a
+        transient outage — retrying it burned ~60 s of exponential backoff per
+        caller during the 2026-07-10 SLM auth incident.
+        """
+        host = (config.host or "").strip()
+        if not host:
+            raise RedisConfigurationError(
+                f"Redis host for database '{database_name}' is empty — configuration "
+                "error (set REDIS_HOST / vm.redis); refusing to retry"
+            )
 
     async def _create_async_pool(self, database_name: str) -> async_redis.ConnectionPool:
         """
@@ -732,6 +762,7 @@ class RedisConnectionManager:
                 health_check_interval=int(self._pool_config.health_check_interval),
             )
 
+        self._validate_config_host(database_name, config)
         return await self._create_async_pool_with_retry(database_name, config)
 
     def _check_sync_client_preconditions(self, database_name: str) -> bool | None:
@@ -821,13 +852,33 @@ class RedisConnectionManager:
         """
         Ensure async connection pool exists for database, creating if needed.
 
-        Uses double-checked locking pattern for thread safety.
-        Issue #620.
+        Issue #620 (double-checked locking) + #11449: the lock now guards only
+        the pool/task registries — the creation itself (which may retry with
+        exponential backoff for tens of seconds) runs OUTSIDE the lock as a
+        shared task. Concurrent callers await the same in-flight creation, and
+        a caller cancelled by its own deadline (``asyncio.wait_for``) does not
+        cancel the creation for everyone else (``asyncio.shield``).
         """
-        if database_name not in self._async_pools:
+        if database_name in self._async_pools:
+            return
+        async with self._async_lock:
+            if database_name in self._async_pools:
+                return
+            task = self._async_pool_tasks.get(database_name)
+            if task is None or task.done():
+                task = asyncio.ensure_future(self._create_async_pool(database_name))
+                self._async_pool_tasks[database_name] = task
+        try:
+            pool = await asyncio.shield(task)
+        except BaseException:
             async with self._async_lock:
-                if database_name not in self._async_pools:
-                    self._async_pools[database_name] = await self._create_async_pool(database_name)
+                if self._async_pool_tasks.get(database_name) is task and task.done():
+                    self._async_pool_tasks.pop(database_name, None)
+            raise
+        async with self._async_lock:
+            self._async_pools.setdefault(database_name, pool)
+            if self._async_pool_tasks.get(database_name) is task:
+                self._async_pool_tasks.pop(database_name, None)
 
     async def _create_and_verify_async_client(self, database_name: str) -> async_redis.Redis:
         """

--- a/autobot_shared/redis_management/connection_manager_pool_test.py
+++ b/autobot_shared/redis_management/connection_manager_pool_test.py
@@ -49,8 +49,12 @@ class TestValidateConfigHost:
 
     def test_configuration_error_is_not_retryable_connection_error(self):
         """The retry mechanism keys on ConnectionError/TimeoutError — the
-        config error must not match, so it fails fast (#11449)."""
+        config error must match neither the builtin nor redis-py's
+        ConnectionError (which shadows the builtin in the module) (#11449)."""
+        from redis.exceptions import ConnectionError as _RedisCE
+
         assert not issubclass(RedisConfigurationError, ConnectionError)
+        assert not issubclass(RedisConfigurationError, _RedisCE)
         assert issubclass(RedisConfigurationError, ValueError)
 
 
@@ -126,3 +130,26 @@ class TestEnsureAsyncPoolLockScope:
         await m._ensure_async_pool_exists("main")  # retry succeeds
         assert m._async_pools["main"] is pool
         assert attempts["n"] == 2
+
+
+    @pytest.mark.asyncio
+    async def test_completed_task_is_harvested_not_respawned(self):
+        """A done-successful task whose waiter hasn't written the registry yet
+        must be harvested — not respawned as a duplicate pool (#11451)."""
+        m = _bare_manager()
+        pool = object()
+
+        async def _done_pool():
+            return pool
+
+        task = asyncio.ensure_future(_done_pool())
+        await task  # completed, but registry never written (waiter "not yet run")
+        m._async_pool_tasks["main"] = task
+
+        async def _must_not_run(name):  # pragma: no cover - failure path
+            raise AssertionError("duplicate creation spawned")
+
+        m._create_async_pool = _must_not_run
+        await m._ensure_async_pool_exists("main")
+        assert m._async_pools["main"] is pool
+        assert "main" not in m._async_pool_tasks

--- a/autobot_shared/redis_management/connection_manager_pool_test.py
+++ b/autobot_shared/redis_management/connection_manager_pool_test.py
@@ -1,0 +1,128 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for #11449: async pool creation must not serialize callers under the
+global lock, and an empty Redis host must fail fast as a configuration error
+instead of burning the exponential-backoff retry budget."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from autobot_shared.redis_management.connection_manager import (
+    RedisConfigurationError,
+    RedisConnectionManager,
+)
+
+
+def _bare_manager() -> RedisConnectionManager:
+    """Manager instance with only the pool-registry state initialised —
+    avoids the full config/circuit-breaker boot in __init__."""
+    m = object.__new__(RedisConnectionManager)
+    m._async_pools = {}
+    m._async_pool_tasks = {}
+    m._async_lock = asyncio.Lock()
+    return m
+
+
+class TestValidateConfigHost:
+    def test_empty_host_raises_configuration_error(self):
+        cfg = SimpleNamespace(host="")
+        with pytest.raises(RedisConfigurationError):
+            RedisConnectionManager._validate_config_host("main", cfg)
+
+    def test_blank_host_raises_configuration_error(self):
+        cfg = SimpleNamespace(host="   ")
+        with pytest.raises(RedisConfigurationError):
+            RedisConnectionManager._validate_config_host("main", cfg)
+
+    def test_none_host_raises_configuration_error(self):
+        cfg = SimpleNamespace(host=None)
+        with pytest.raises(RedisConfigurationError):
+            RedisConnectionManager._validate_config_host("main", cfg)
+
+    def test_valid_host_passes(self):
+        cfg = SimpleNamespace(host="127.0.0.1")
+        RedisConnectionManager._validate_config_host("main", cfg)  # no raise
+
+    def test_configuration_error_is_not_retryable_connection_error(self):
+        """The retry mechanism keys on ConnectionError/TimeoutError — the
+        config error must not match, so it fails fast (#11449)."""
+        assert not issubclass(RedisConfigurationError, ConnectionError)
+        assert issubclass(RedisConfigurationError, ValueError)
+
+
+class TestEnsureAsyncPoolLockScope:
+    @pytest.mark.asyncio
+    async def test_concurrent_callers_share_one_creation(self):
+        m = _bare_manager()
+        calls = {"n": 0}
+        pool = object()
+
+        async def _slow_create(name):
+            calls["n"] += 1
+            await asyncio.sleep(0.1)
+            return pool
+
+        m._create_async_pool = _slow_create
+        await asyncio.gather(*[m._ensure_async_pool_exists("main") for _ in range(5)])
+        assert calls["n"] == 1, "creation must run once for concurrent callers"
+        assert m._async_pools["main"] is pool
+        assert "main" not in m._async_pool_tasks
+
+    @pytest.mark.asyncio
+    async def test_deadline_cancelled_caller_does_not_kill_creation(self):
+        """A caller cancelled by its own asyncio.wait_for must not cancel the
+        shared creation for everyone else (shield semantics, #11449)."""
+        m = _bare_manager()
+        pool = object()
+
+        async def _slow_create(name):
+            await asyncio.sleep(0.2)
+            return pool
+
+        m._create_async_pool = _slow_create
+        patient = asyncio.ensure_future(m._ensure_async_pool_exists("main"))
+        await asyncio.sleep(0.01)  # let the creation task start
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(m._ensure_async_pool_exists("main"), timeout=0.05)
+        await patient  # the patient caller still completes
+        assert m._async_pools["main"] is pool
+
+    @pytest.mark.asyncio
+    async def test_lock_not_held_during_creation(self):
+        """While a slow creation is in flight, the registry lock must be free
+        (pre-#11449 it was held for the whole retry sequence)."""
+        m = _bare_manager()
+
+        async def _slow_create(name):
+            await asyncio.sleep(0.2)
+            return object()
+
+        m._create_async_pool = _slow_create
+        task = asyncio.ensure_future(m._ensure_async_pool_exists("main"))
+        await asyncio.sleep(0.05)  # creation is now in flight
+        assert not m._async_lock.locked(), "lock must not be held during creation"
+        await task
+
+    @pytest.mark.asyncio
+    async def test_failed_creation_propagates_and_allows_retry(self):
+        m = _bare_manager()
+        attempts = {"n": 0}
+        pool = object()
+
+        async def _flaky_create(name):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise RedisConfigurationError("empty host")
+            return pool
+
+        m._create_async_pool = _flaky_create
+        with pytest.raises(RedisConfigurationError):
+            await m._ensure_async_pool_exists("main")
+        assert "main" not in m._async_pools
+        await m._ensure_async_pool_exists("main")  # retry succeeds
+        assert m._async_pools["main"] is pool
+        assert attempts["n"] == 2


### PR DESCRIPTION
## Thinking Path
The 2026-07-10 SLM auth incident (#11443) was *enabled* by two shared-layer defects in `RedisConnectionManager` (diagnosed live via py3.14 `asyncio pstree`): an empty host was retried as if transient (~60s backoff budget), and pool creation ran **inside** the single global `asyncio.Lock`, serializing every `get_async_client` caller behind one bad database. #11443 hardened the one consumer (token denylist); this fixes the enabler for all consumers. Fixes #11449.

## What Changed
`autobot_shared/redis_management/connection_manager.py`:
- **`RedisConfigurationError(ValueError)`** + `_validate_config_host`: empty/blank host raises before any connect attempt (sync + async creation paths). ValueError is outside the retry mechanism's retryable tuple → fails fast, circuit breaker records the failure.
- **`_ensure_async_pool_exists` lock scope**: the lock now guards only the pool/task registries. Creation runs as a shared `asyncio.Task` outside the lock — concurrent callers await the same in-flight creation; `asyncio.shield` keeps one caller's own deadline (`wait_for`) from cancelling creation for the rest; a failed creation clears its slot so the next call can retry.

## Verification
- New `connection_manager_pool_test.py`: **9 passed** — empty/blank/None host raise; valid host passes; config error is not a retryable ConnectionError; 5 concurrent callers share ONE creation; deadline-cancelled caller doesn't kill creation; **lock is free while creation is in flight**; failure propagates and allows retry.
- `redis_management` suite: 25 passed, 1 pre-existing env-dependent failure (`celery_async_redis_test` uses `YOUR_REDIS_IP` placeholder; fails identically on the untouched base).
- Module imports clean.

## Model Used
Claude Fable 5 (1M context)
