### PR TITLE
refactor(orchestration): agent_capabilities is a pure projection of the profile registry (#11251)

### DIFF
--- a/autobot-backend/orchestration/agent_registry.py
+++ b/autobot-backend/orchestration/agent_registry.py
@@ -103,6 +103,83 @@ def _create_coordination_agent() -> AgentProfile:
     )
 
 
+# #11251 Part 1: the orchestrator's capability-routing map keys on these ids.
+# Giving each a first-class AgentProfile lets orchestrator.agent_capabilities be a
+# pure projection of this registry (no parallel hardcoded capability dict). The
+# capabilities below MUST match the historical routing map exactly (no routing
+# regression); a test asserts the projection equals the previous literal.
+# Boundaries (decision: proper hardening): read/analysis/synthesis routing agents
+# forbid infra+shell; ``system_commands`` is the routing executor, allowed
+# infra/shell like ``system_agent``.
+_ROUTING_PROFILE_SPECS = [
+    (
+        "classification_agent",
+        "classifier",
+        {AgentCapability.ANALYSIS, AgentCapability.VALIDATION},
+        ["intent_classification", "input_validation"],
+    ),
+    (
+        "kb_librarian",
+        "librarian",
+        {AgentCapability.RESEARCH, AgentCapability.SYNTHESIS},
+        ["knowledge_retrieval", "context_synthesis"],
+    ),
+    (
+        "security_scanner",
+        "security",
+        {AgentCapability.SECURITY, AgentCapability.VALIDATION},
+        ["vulnerability_scan", "policy_validation"],
+    ),
+    (
+        "npu_code_search",
+        "search",
+        {AgentCapability.ANALYSIS, AgentCapability.OPTIMIZATION},
+        ["code_search", "npu_acceleration"],
+    ),
+    (
+        "development_speedup",
+        "optimizer",
+        {AgentCapability.ANALYSIS, AgentCapability.OPTIMIZATION},
+        ["dev_optimization"],
+    ),
+    (
+        "json_formatter",
+        "formatter",
+        {AgentCapability.VALIDATION, AgentCapability.SYNTHESIS},
+        ["json_formatting", "schema_validation"],
+    ),
+    ("llm_failsafe", "failsafe", {AgentCapability.SYNTHESIS}, ["fallback_synthesis"]),
+]
+
+# The full routing-agent id set (the 7 above + the executor + research_agent).
+ROUTING_AGENT_IDS = frozenset([spec[0] for spec in _ROUTING_PROFILE_SPECS] + ["system_commands", "research_agent"])
+
+
+def _create_routing_profiles() -> List[AgentProfile]:
+    """Build first-class profiles for the orchestrator routing ids (#11251 P1)."""
+    profiles = [
+        AgentProfile(
+            agent_id=agent_id,
+            agent_type=agent_type,
+            capabilities=set(caps),
+            specializations=list(specs),
+            forbidden_work=list(_INFRA_AND_SHELL_TOOLS),
+        )
+        for agent_id, agent_type, caps, specs in _ROUTING_PROFILE_SPECS
+    ]
+    # system_commands is the routing executor — allowed infra/shell (mirrors system_agent).
+    profiles.append(
+        AgentProfile(
+            agent_id="system_commands",
+            agent_type="executor",
+            capabilities={AgentCapability.EXECUTION, AgentCapability.MONITORING},
+            specializations=["command_execution", "system_monitoring"],
+            allowed_work=list(_INFRA_AND_SHELL_TOOLS),
+        )
+    )
+    return profiles
+
+
 def get_default_agents() -> List[AgentProfile]:
     """
     Get the list of default agent profiles.
@@ -110,8 +187,9 @@ def get_default_agents() -> List[AgentProfile]:
     Returns:
         List of pre-configured AgentProfile instances.
         Issue #620: Refactored to use helper functions for each agent.
+        #11251 P1: routing-map agents get first-class profiles too.
     """
-    return [
+    return _create_routing_profiles() + [
         _create_research_agent(),
         _create_documentation_agent(),
         _create_system_agent(),

--- a/autobot-backend/orchestration/routing_projection_test.py
+++ b/autobot-backend/orchestration/routing_projection_test.py
@@ -1,0 +1,66 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11251 Part 1: orchestrator routing capabilities are a projection of the
+profile registry (routing ids win) — with NO routing-candidate regression."""
+
+from orchestration.agent_registry import ROUTING_AGENT_IDS, get_default_agents
+from orchestration.types import AgentCapability
+
+# The exact routing map that lived as a hardcoded dict in orchestrator.py before
+# #11251 P1. The projection MUST reproduce this verbatim (no routing regression).
+_LEGACY_ROUTING_MAP = {
+    "research_agent": {AgentCapability.RESEARCH, AgentCapability.ANALYSIS},
+    "classification_agent": {AgentCapability.ANALYSIS, AgentCapability.VALIDATION},
+    "kb_librarian": {AgentCapability.RESEARCH, AgentCapability.SYNTHESIS},
+    "system_commands": {AgentCapability.EXECUTION, AgentCapability.MONITORING},
+    "security_scanner": {AgentCapability.SECURITY, AgentCapability.VALIDATION},
+    "npu_code_search": {AgentCapability.ANALYSIS, AgentCapability.OPTIMIZATION},
+    "development_speedup": {AgentCapability.ANALYSIS, AgentCapability.OPTIMIZATION},
+    "json_formatter": {AgentCapability.VALIDATION, AgentCapability.SYNTHESIS},
+    "llm_failsafe": {AgentCapability.SYNTHESIS},
+}
+
+
+def _project() -> dict:
+    return {p.agent_id: set(p.capabilities) for p in get_default_agents() if p.agent_id in ROUTING_AGENT_IDS}
+
+
+def test_projection_equals_legacy_routing_map_exactly():
+    """No routing-candidate regression: the profile projection == the old literal."""
+    assert _project() == _LEGACY_ROUTING_MAP
+
+
+def test_every_routing_id_has_a_profile():
+    ids = {p.agent_id for p in get_default_agents()}
+    assert ROUTING_AGENT_IDS <= ids, f"missing routing profiles: {ROUTING_AGENT_IDS - ids}"
+
+
+def test_non_routing_profiles_excluded_from_projection():
+    """Orphan profiles (documentation/system/coordination) must NOT enter routing."""
+    projected = set(_project())
+    assert projected == set(ROUTING_AGENT_IDS)
+    assert "documentation_agent" not in projected
+    assert "coordination_agent" not in projected
+    assert "system_agent" not in projected
+
+
+def test_routing_profiles_carry_forbidden_boundaries():
+    """Decision: proper hardening. Read/analysis/synthesis routing agents forbid
+    infra+shell; the executor (system_commands) is allowed infra/shell."""
+    by_id = {p.agent_id: p for p in get_default_agents()}
+    # bounded agents
+    for aid in (
+        "kb_librarian",
+        "classification_agent",
+        "security_scanner",
+        "npu_code_search",
+        "development_speedup",
+        "json_formatter",
+        "llm_failsafe",
+    ):
+        assert by_id[aid].forbidden_work, f"{aid} must carry a forbidden_work boundary"
+    # the executor is deliberately unbounded (allowed infra/shell), like system_agent
+    assert not by_id["system_commands"].forbidden_work
+    assert by_id["system_commands"].allowed_work

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -184,32 +184,19 @@ class Orchestrator(_DeprecatedRequestMixin):
 
     def _init_strategy_components(self) -> None:
         """Initialize multi-agent strategy components. Renamed from _init_multi_agent_state (#5058)."""
-        # Agent capabilities registry (task-routing layer distinct from agent_registry)
+        # #11251 Part 1: the routing capability map is now a PURE PROJECTION of the
+        # canonical AgentProfile registry (routing ids win) — no parallel hardcoded
+        # dict to drift against. Every routing id (ROUTING_AGENT_IDS) has a
+        # first-class profile in get_default_agents(); we project their capabilities
+        # and drop non-routing profiles. A test asserts this equals the previous
+        # literal so the routing candidate set is unchanged.
+        from orchestration.agent_registry import ROUTING_AGENT_IDS
+
         self.agent_capabilities: Dict[str, Set] = {
-            "research_agent": {AgentCapability.RESEARCH, AgentCapability.ANALYSIS},
-            "classification_agent": {
-                AgentCapability.ANALYSIS,
-                AgentCapability.VALIDATION,
-            },
-            "kb_librarian": {AgentCapability.RESEARCH, AgentCapability.SYNTHESIS},
-            "system_commands": {AgentCapability.EXECUTION, AgentCapability.MONITORING},
-            "security_scanner": {AgentCapability.SECURITY, AgentCapability.VALIDATION},
-            "npu_code_search": {AgentCapability.ANALYSIS, AgentCapability.OPTIMIZATION},
-            "development_speedup": {
-                AgentCapability.ANALYSIS,
-                AgentCapability.OPTIMIZATION,
-            },
-            "json_formatter": {AgentCapability.VALIDATION, AgentCapability.SYNTHESIS},
-            "llm_failsafe": {AgentCapability.SYNTHESIS},
+            profile.agent_id: set(profile.capabilities)
+            for profile in get_default_agents()
+            if profile.agent_id in ROUTING_AGENT_IDS
         }
-        # GH#11139: the registered agent profiles are the capability manifest SSOT.
-        # Overlay their capabilities onto the routing map so any agent that also has
-        # a profile has ONE source of truth for its capabilities (no drift between
-        # this literal and the profile registry). Only overlays existing keys, so
-        # the routing candidate set is unchanged.
-        for agent_id, profile in self._profile_registry.get_all().items():
-            if agent_id in self.agent_capabilities:
-                self.agent_capabilities[agent_id] = set(profile.capabilities)
 
         # Workflow tracking
         self.active_workflows: Dict[str, WorkflowPlan] = {}


### PR DESCRIPTION
## Thinking Path
Umbrella #11251 wanted the agent-id namespace unified so the orchestrator's routing capability map and the `AgentProfile` registry stop drifting. Part 2 (#11430) deduped the two colliding `AgentRegistry` classes. This is **Part 1**: kill the parallel hardcoded `agent_capabilities` dict in `orchestrator.py` and make it a pure projection of the canonical `AgentProfile` registry — routing ids win.

Root cause of the drift risk: `orchestrator._init_strategy_components()` held a literal 9-entry `{agent_id: {capabilities}}` dict with no link to `get_default_agents()`. Any profile capability change silently diverged from routing.

## What Changed
- `orchestration/agent_registry.py`: gave the 7 routing-only ids (`classification_agent`, `kb_librarian`, `security_scanner`, `npu_code_search`, `development_speedup`, `json_formatter`, `llm_failsafe`) first-class `AgentProfile`s via `_ROUTING_PROFILE_SPECS` + `_create_routing_profiles()`. Added `ROUTING_AGENT_IDS` (the 7 + `system_commands` executor + `research_agent`). `get_default_agents()` now emits routing profiles too.
- Security boundaries (proper hardening): every read/analysis/synthesis routing agent carries `forbidden_work=INFRA_AND_SHELL_TOOLS`; `system_commands` is the routing **executor** — `allowed_work` infra/shell, no forbidden boundary (mirrors `system_agent`).
- `orchestrator.py`: replaced the hardcoded dict with a projection — `{p.agent_id: set(p.capabilities) for p in get_default_agents() if p.agent_id in ROUTING_AGENT_IDS}`. No `_v2`, no dormant overlay.
- `orchestration/routing_projection_test.py` (new): 4 tests, incl. `test_projection_equals_legacy_routing_map_exactly` pinning the projection to the pre-refactor literal (**zero routing-candidate regression**), orphan-exclusion, and boundary assertions.

## Verification
- `pytest orchestration/routing_projection_test.py orchestration/capability_audit_test.py tests/orchestration/test_agent_capability_manifest.py -q` → **19 passed**
- Projection == legacy 9-entry map exactly (asserted) → routing behavior unchanged
- `flake8 --config=.flake8` on all 3 files → clean; `black --line-length=120` applied
- Import smoke: 9 routing agents projected from 12 profiles; orphans (documentation/system/coordination) excluded

## Model Used
Opus 4.8 (1M context)

Closes #11251