### PR TITLE
fix(deploy): single-node self-update deploys co-located backend/frontend (#11436)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -438,7 +438,12 @@
 # PLAY 2: Update All Other Infrastructure Nodes
 # =============================================================================
 - name: "Play 2 - Update Other Infrastructure Nodes"
-  hosts: infrastructure:!slm_server
+# 11436: no longer excludes slm_server — a co-located SLM node (single-node
+# install) joins `infrastructure` via the registry inventory only when it also
+# carries app roles, so pure SLM servers still skip this play while co-located
+# backend/frontend/worker components finally receive updates. Ordering is
+# preserved: Play 1 updates the SLM components first.
+  hosts: infrastructure
   gather_facts: false
   serial: 3
   # A failed node update (most critically a failed backend database

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -437,12 +437,12 @@
 # =============================================================================
 # PLAY 2: Update All Other Infrastructure Nodes
 # =============================================================================
-- name: "Play 2 - Update Other Infrastructure Nodes"
 # 11436: no longer excludes slm_server — a co-located SLM node (single-node
 # install) joins `infrastructure` via the registry inventory only when it also
 # carries app roles, so pure SLM servers still skip this play while co-located
 # backend/frontend/worker components finally receive updates. Ordering is
 # preserved: Play 1 updates the SLM components first.
+- name: "Play 2 - Update Other Infrastructure Nodes"
   hosts: infrastructure
   gather_facts: false
   serial: 3

--- a/autobot-slm-backend/services/inventory_builder.py
+++ b/autobot-slm-backend/services/inventory_builder.py
@@ -280,9 +280,14 @@ def build_registry_inventory(nodes: list[Any], local_ip_check: Any) -> dict:
         # Every node joins autobot + autobot_cluster (centralized logging, etc.)
         node_groups |= _UNIVERSAL_ALL
 
-        # Non-SLM nodes also join infrastructure + production_vms
+        # Non-SLM nodes join infrastructure + production_vms. #11436: an SLM
+        # node that ALSO carries app roles (single-node installs co-locate
+        # backend/frontend/workers on the SLM box) must join them too —
+        # otherwise the update playbook's Play 2 never matches that host and
+        # the co-located components silently stop receiving updates.
         is_slm = bool(node_groups & {"slm", "slm_server", "slm_nodes"})
-        if not is_slm:
+        app_groups = node_groups - {"slm", "slm_server", "slm_nodes"} - _UNIVERSAL_ALL
+        if not is_slm or app_groups:
             node_groups |= _UNIVERSAL_NON_SLM
 
         for g in node_groups:

--- a/autobot-slm-backend/services/inventory_builder.py
+++ b/autobot-slm-backend/services/inventory_builder.py
@@ -285,9 +285,16 @@ def build_registry_inventory(nodes: list[Any], local_ip_check: Any) -> dict:
         # backend/frontend/workers on the SLM box) must join them too —
         # otherwise the update playbook's Play 2 never matches that host and
         # the co-located components silently stop receiving updates.
+        # Co-location is classified at the ROLE-TOKEN level, not the group
+        # level: SLM-internal tokens (slm-database, slm-monitoring) map to
+        # non-SLM groups (redis/monitoring_vm), so group-based detection would
+        # wrongly promote a pure SLM manager into infrastructure (#11453).
         is_slm = bool(node_groups & {"slm", "slm_server", "slm_nodes"})
-        app_groups = node_groups - {"slm", "slm_server", "slm_nodes"} - _UNIVERSAL_ALL
-        if not is_slm or app_groups:
+        has_app_roles = any(
+            (t := tok.strip().lower()) and not t.startswith("slm-") and t != "slm_agent"
+            for tok in role_tokens
+        )
+        if not is_slm or has_app_roles:
             node_groups |= _UNIVERSAL_NON_SLM
 
         for g in node_groups:

--- a/autobot-slm-backend/services/inventory_builder_test.py
+++ b/autobot-slm-backend/services/inventory_builder_test.py
@@ -447,6 +447,27 @@ class TestColocatedSlmInfrastructure:
         inv = _build([_Node(node_id="00-SLM-Manager", ip_address="127.0.0.1", roles=["slm-manager"])])
         assert "00-SLM-Manager" not in inv["all"]["children"]["infrastructure"]["hosts"]
 
+    def test_production_pure_slm_role_set_stays_out_of_infrastructure(self):
+        """#11453 review: slm-database/slm-monitoring map to non-SLM groups
+        (redis/monitoring_vm) via exact match, so co-location must be detected
+        from role TOKENS — the full production SLM manager role set is still a
+        pure SLM node."""
+        inv = _build(
+            [
+                _Node(
+                    node_id="00-SLM-Manager",
+                    ip_address="127.0.0.1",
+                    roles=["slm-backend", "slm-frontend", "slm-database", "slm-monitoring", "slm-agent"],
+                )
+            ]
+        )
+        children = inv["all"]["children"]
+        assert "00-SLM-Manager" not in children["infrastructure"]["hosts"]
+        assert "00-SLM-Manager" not in children["production_vms"]["hosts"]
+        # its slm-internal groups are unaffected
+        assert "00-SLM-Manager" in children["slm_server"]["hosts"]
+        assert "00-SLM-Manager" in children["redis"]["hosts"]
+
     def test_colocated_slm_node_joins_infrastructure_and_app_groups(self):
         """#11436: an SLM node also carrying app roles (single-node install)
         joins infrastructure so update Play 2 deploys the co-located components."""

--- a/autobot-slm-backend/services/inventory_builder_test.py
+++ b/autobot-slm-backend/services/inventory_builder_test.py
@@ -434,3 +434,28 @@ def test_required_groups_covers_known_playbook_references():
     }
     missing = known - REQUIRED_GROUPS
     assert not missing, f"REQUIRED_GROUPS is missing known group refs: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# #11436: co-located SLM nodes must join infrastructure
+# ---------------------------------------------------------------------------
+
+
+class TestColocatedSlmInfrastructure:
+    def test_pure_slm_node_stays_out_of_infrastructure(self):
+        """Pure SLM servers keep pre-#11436 behavior: update Play 2 skips them."""
+        inv = _build([_Node(node_id="00-SLM-Manager", ip_address="127.0.0.1", roles=["slm-manager"])])
+        assert "00-SLM-Manager" not in inv["all"]["children"]["infrastructure"]["hosts"]
+
+    def test_colocated_slm_node_joins_infrastructure_and_app_groups(self):
+        """#11436: an SLM node also carrying app roles (single-node install)
+        joins infrastructure so update Play 2 deploys the co-located components."""
+        inv = _build(
+            [_Node(node_id="00-SLM-Manager", ip_address="127.0.0.1", roles=["slm-manager", "backend", "frontend"])]
+        )
+        children = inv["all"]["children"]
+        assert "00-SLM-Manager" in children["infrastructure"]["hosts"]
+        assert "00-SLM-Manager" in children["backend"]["hosts"]
+        assert "00-SLM-Manager" in children["frontend"]["hosts"]
+        # still recognized as the SLM server for update Play 1
+        assert "00-SLM-Manager" in children["slm_server"]["hosts"]


### PR DESCRIPTION
## Thinking Path
Dogfooding the built-in updater (2026-07-10) showed self-update leaving co-located backend/frontend at old code: `build_registry_inventory` never adds SLM nodes to `infrastructure`, AND Play 2 targets `infrastructure:!slm_server` — double exclusion; on a single-node install the app components silently never update (the original enabler of the schema-drift class). Fixes #11436.

## What Changed
- `services/inventory_builder.py`: an SLM node that also carries app roles joins `infrastructure` (+production_vms etc.) alongside its app groups; **pure** SLM servers keep the old behavior (not in `infrastructure`).
- `ansible/playbooks/update-all-nodes.yml` Play 2: drop the now-redundant `!slm_server` (membership does the gating). Ordering preserved: Play 1 updates SLM components first; on multi-node fleets pure SLM nodes aren't in `infrastructure`, so Play 2 still skips them exactly as before.

## Verification
- `pytest services/inventory_builder_test.py` → **34 passed** (2 new: pure-SLM exclusion preserved; co-located node in infrastructure+backend+frontend+slm_server).
- `ansible-playbook --syntax-check playbooks/update-all-nodes.yml` → OK.

## Model Used
Claude Fable 5 (1M context)
