### PR TITLE
fix(llc): persist per-criterion acceptance-criteria completion (#10852)

### DIFF
--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -162,6 +162,9 @@ class WorkItemUpdate(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
     acceptance_criteria: Optional[List[str]] = None
+    # GH#10852: per-criterion completion, booleans parallel-indexed to
+    # acceptance_criteria; persists the WorkItemDetail checkboxes.
+    acceptance_criteria_done: Optional[List[bool]] = None
     priority: Optional[WorkItemPriority] = None
     story_points: Optional[int] = None
     labels: Optional[List[str]] = None
@@ -330,6 +333,7 @@ async def _item_to_dict(item: Any, session: AsyncSession) -> Dict[str, Any]:
         "title": item.title,
         "description": item.description,
         "acceptance_criteria": item.acceptance_criteria,
+        "acceptance_criteria_done": item.acceptance_criteria_done or [],  # GH#10852
         "status": item.status,
         "priority": item.priority,
         "story_points": item.story_points,

--- a/autobot-backend/llc/models/work_item.py
+++ b/autobot-backend/llc/models/work_item.py
@@ -67,6 +67,9 @@ class LLCWorkItem(Base):
     title: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     acceptance_criteria: Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
+    # GH#10852: per-criterion completion, booleans parallel-indexed to
+    # acceptance_criteria. NULL means no completion has been tracked yet.
+    acceptance_criteria_done: Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
     labels: Mapped[list] = mapped_column(JSONB, nullable=False, server_default=sa.text("'[]'::jsonb"))
 
     # GitHub PR linking (GH#9625)

--- a/autobot-backend/llc/services/work_item_service.py
+++ b/autobot-backend/llc/services/work_item_service.py
@@ -319,6 +319,7 @@ class WorkItemService(LLCServiceBase):
             "title",
             "description",
             "acceptance_criteria",
+            "acceptance_criteria_done",  # GH#10852
             "priority",
             "story_points",
             "labels",

--- a/autobot-backend/llc/tests/test_work_item_ac_completion.py
+++ b/autobot-backend/llc/tests/test_work_item_ac_completion.py
@@ -1,0 +1,83 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Per-criterion acceptance-criteria completion on LLC work items (GH#10852).
+
+The WorkItemDetail checkboxes were local-only display state (``saveAC()`` was a
+no-op), so toggles never persisted and were lost on reload. This proves the new
+``acceptance_criteria_done`` boolean list round-trips through the service update
+path and the API serialization contract.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc.services.work_item_service import WorkItemService
+
+
+@pytest.fixture
+def service():
+    return WorkItemService()
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.flush = AsyncMock()
+    session.add = MagicMock()
+    return session
+
+
+class TestUpdate:
+    async def test_update_persists_acceptance_criteria_done(self, service, mock_session):
+        item = MagicMock()
+        with patch.object(service, "get", new=AsyncMock(return_value=item)):
+            result = await service.update(
+                mock_session,
+                str(uuid.uuid4()),
+                acceptance_criteria_done=[True, False, True],
+            )
+        assert result is item
+        assert item.acceptance_criteria_done == [True, False, True]
+
+    async def test_update_accepts_empty_completion_list(self, service, mock_session):
+        """All-unchecked (or no criteria) sends an empty list, not None."""
+        item = MagicMock()
+        with patch.object(service, "get", new=AsyncMock(return_value=item)):
+            await service.update(mock_session, str(uuid.uuid4()), acceptance_criteria_done=[])
+        assert item.acceptance_criteria_done == []
+
+
+class TestSerialization:
+    async def test_item_to_dict_includes_acceptance_criteria_done(self):
+        from llc.api import work_items
+
+        item = MagicMock()
+        item.acceptance_criteria_done = [True, False]
+        item.requires_approval_before = []
+        item.linked_pr_urls = []
+        item.labels = []
+        session = AsyncMock()
+        with (
+            patch.object(work_items, "_assignee_display", new=AsyncMock(return_value=None)),
+            patch.object(work_items, "_relations_to_list", return_value=[]),
+        ):
+            result = await work_items._item_to_dict(item, session)
+        assert result["acceptance_criteria_done"] == [True, False]
+
+    async def test_item_to_dict_defaults_none_to_empty_list(self):
+        from llc.api import work_items
+
+        item = MagicMock()
+        item.acceptance_criteria_done = None  # never tracked
+        item.requires_approval_before = []
+        item.linked_pr_urls = []
+        item.labels = []
+        session = AsyncMock()
+        with (
+            patch.object(work_items, "_assignee_display", new=AsyncMock(return_value=None)),
+            patch.object(work_items, "_relations_to_list", return_value=[]),
+        ):
+            result = await work_items._item_to_dict(item, session)
+        assert result["acceptance_criteria_done"] == []

--- a/autobot-backend/migrations/versions/20260710_070_llc_ac_completion.py
+++ b/autobot-backend/migrations/versions/20260710_070_llc_ac_completion.py
@@ -1,0 +1,37 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Add acceptance_criteria_done to llc_work_items (GH#10852).
+
+Revision ID: 20260710_070
+Revises: 20260708_069
+Create Date: 2026-07-10 00:00:00.000000
+
+Adds a JSONB ``acceptance_criteria_done`` column to ``llc_work_items`` storing a
+list of booleans parallel-indexed to ``acceptance_criteria`` — the per-criterion
+completion state that the WorkItemDetail checkboxes toggle. Before this the
+checkboxes were local-only display state (``saveAC()`` was a no-op), so toggles
+never persisted and were lost on reload. Nullable (matching ``acceptance_criteria``);
+NULL means "no completion tracked yet" and existing rows keep their behaviour.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "20260710_070"
+down_revision: Union[str, None] = "20260708_069"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "llc_work_items",
+        sa.Column("acceptance_criteria_done", JSONB, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("llc_work_items", "acceptance_criteria_done")

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -98996,6 +98996,8 @@ export interface components {
             description?: string | null;
             /** Acceptance Criteria */
             acceptance_criteria?: string[] | null;
+            /** Acceptance Criteria Done */
+            acceptance_criteria_done?: boolean[] | null;
             priority?: components["schemas"]["WorkItemPriority"] | null;
             /** Story Points */
             story_points?: number | null;

--- a/autobot-frontend/src/views/llc/WorkItemDetail.vue
+++ b/autobot-frontend/src/views/llc/WorkItemDetail.vue
@@ -419,7 +419,10 @@ async function saveDesc() {
 }
 
 async function saveAC() {
-  // no-op: checkboxes are local display state; AC completion tracked via transition
+  // GH#10852: persist per-criterion completion (parallel-indexed to
+  // acceptance_criteria) so checkbox state survives reload.
+  const done = (localItem.value.acceptance_criteria ?? []).map((_, i) => checkedAC.value[i] ?? false)
+  await patchItem({ acceptance_criteria_done: done })
 }
 
 async function patchItem(patch: Partial<WorkItem>) {
@@ -540,7 +543,9 @@ watch(activeTab, (tab) => {
 
 onMounted(() => {
   localItem.value = { ...props.item }
-  checkedAC.value = (props.item.acceptance_criteria ?? []).map(() => false)
+  // GH#10852: hydrate from persisted per-criterion completion (default false).
+  const done = props.item.acceptance_criteria_done ?? []
+  checkedAC.value = (props.item.acceptance_criteria ?? []).map((_, i) => done[i] ?? false)
 })
 </script>
 

--- a/autobot-frontend/src/views/llc/workItemTypes.ts
+++ b/autobot-frontend/src/views/llc/workItemTypes.ts
@@ -48,5 +48,7 @@ export interface WorkItem {
   status: WorkItemStatus
   labels: string[]
   acceptance_criteria: string[]
+  // GH#10852: per-criterion completion, parallel-indexed to acceptance_criteria.
+  acceptance_criteria_done?: boolean[]
   linked_pr_urls?: string[]
 }

--- a/autobot-slm-backend/services/inventory_builder.py
+++ b/autobot-slm-backend/services/inventory_builder.py
@@ -291,8 +291,7 @@ def build_registry_inventory(nodes: list[Any], local_ip_check: Any) -> dict:
         # wrongly promote a pure SLM manager into infrastructure (#11453).
         is_slm = bool(node_groups & {"slm", "slm_server", "slm_nodes"})
         has_app_roles = any(
-            (t := tok.strip().lower()) and not t.startswith("slm-") and t != "slm_agent"
-            for tok in role_tokens
+            (t := tok.strip().lower()) and not t.startswith("slm-") and t != "slm_agent" for tok in role_tokens
         )
         if not is_slm or has_app_roles:
             node_groups |= _UNIVERSAL_NON_SLM

--- a/autobot_shared/redis_management/connection_manager.py
+++ b/autobot_shared/redis_management/connection_manager.py
@@ -888,9 +888,7 @@ class RedisConnectionManager:
                 # Always retrieve the exception even if every waiter was
                 # cancelled — avoids "Task exception was never retrieved" and
                 # preserves the failure reason in the logs (#11451).
-                task.add_done_callback(
-                    lambda t, _db=database_name: self._log_pool_task_failure(_db, t)
-                )
+                task.add_done_callback(lambda t, _db=database_name: self._log_pool_task_failure(_db, t))
                 self._async_pool_tasks[database_name] = task
         try:
             pool = await asyncio.shield(task)

--- a/autobot_shared/redis_management/connection_manager_pool_test.py
+++ b/autobot_shared/redis_management/connection_manager_pool_test.py
@@ -131,7 +131,6 @@ class TestEnsureAsyncPoolLockScope:
         assert m._async_pools["main"] is pool
         assert attempts["n"] == 2
 
-
     @pytest.mark.asyncio
     async def test_completed_task_is_harvested_not_respawned(self):
         """A done-successful task whose waiter hasn't written the registry yet


### PR DESCRIPTION
## Thinking Path
`WorkItemDetail.vue` acceptance-criteria checkboxes were local-only display state — `saveAC()` was a documented no-op, so toggling a box never persisted and the state was lost on reload. Users believed they were tracking AC completion but nothing saved.

Root cause: there was no backend field to hold per-criterion completion. The documented intent ("AC completion tracked via transition") only covers overall status, not individual criteria. Per *never delete a working affordance — wire it in*, the fix is option (a): **persist per-criterion completion**, not remove the checkboxes.

## What Changed
Additive, nullable `acceptance_criteria_done` (JSONB list of booleans, parallel-indexed to `acceptance_criteria`) end-to-end:
- **Migration** `20260710_070_llc_ac_completion` — adds nullable JSONB column (NULL = never tracked; existing rows unchanged).
- **Model** `llc/models/work_item.py` — `acceptance_criteria_done: Mapped[Optional[list]]`.
- **API** `llc/api/work_items.py` — field on `WorkItemUpdate`; `_item_to_dict` serializes it (NULL → `[]`).
- **Service** `llc/services/work_item_service.py` — added to the `update()` allow-list.
- **Frontend** `WorkItemDetail.vue` — `saveAC()` now PATCHes `acceptance_criteria_done` (aligned to current criteria); `onMounted` hydrates `checkedAC` from the persisted list. Type added to `workItemTypes.ts`; `api.ts` regenerated (only the new field).

## Verification
- `pytest llc/tests/test_work_item_ac_completion.py llc/tests/test_work_item_requires_approval.py llc/tests/test_work_item.py llc/tests/test_work_items_idor.py -q` → **60 passed**
- New tests prove: update round-trips `[True,False,True]`; empty list accepted; `_item_to_dict` includes the field and maps NULL→`[]`.
- Mutation check: removing `acceptance_criteria_done` from the service allow-list → the two update tests fail (ValueError) — assertions are load-bearing.
- `flake8 --config=.flake8` clean; `black --line-length=120` applied.
- `api.ts` diff is exactly the one new field (env-derived defaults left untouched, matching CI's authoritative py3.14 regen).

## Model Used
Opus 4.8 (1M context)

Closes #10852