### PR TITLE
fix(llc): theme-adaptive categorical badge tokens for dark/ember (#10868)

### DIFF
--- a/autobot-frontend/src/assets/css/themes/_template.css
+++ b/autobot-frontend/src/assets/css/themes/_template.css
@@ -105,4 +105,64 @@
   --card-border: var(--border-subtle);
   --btn-radius: var(--radius-md);
   --input-radius: var(--radius-md);
+
+  /* ============================================
+   * LLC CATEGORICAL BADGE PALETTE — GH#10868
+   * Per-category bg/fg chip pairs for LLC board/detail badges.
+   * A new theme MUST define every token below (light-ish placeholders
+   * shown here). Keep each category's hue identity; ensure the fg/bg
+   * pair meets WCAG AA (~4.5:1) on the target surface.
+   * ============================================ */
+
+  /* Work-item type */
+  --badge-type-epic-bg: #ddd6fe;      --badge-type-epic-fg: #5b21b6;
+  --badge-type-feature-bg: #bfdbfe;   --badge-type-feature-fg: #1d4ed8;
+  --badge-type-pbi-bg: #d1fae5;       --badge-type-pbi-fg: #065f46;
+  --badge-type-task-bg: #e0f2fe;      --badge-type-task-fg: #0369a1;
+  --badge-type-bug-bg: #fee2e2;       --badge-type-bug-fg: #991b1b;
+  --badge-type-spike-bg: #fef3c7;     --badge-type-spike-fg: #92400e;
+  --badge-type-subtask-bg: #f3f4f6;   --badge-type-subtask-fg: #374151;
+  --badge-type-risk-bg: #fce7f3;      --badge-type-risk-fg: #9d174d;
+
+  /* Work-item status */
+  --badge-status-backlog-bg: #f3f4f6;     --badge-status-backlog-fg: #374151;
+  --badge-status-ready-bg: #e0f2fe;       --badge-status-ready-fg: #0369a1;
+  --badge-status-in_progress-bg: #ddd6fe; --badge-status-in_progress-fg: #5b21b6;
+  --badge-status-in_review-bg: #fef9c3;   --badge-status-in_review-fg: #713f12;
+  --badge-status-done-bg: #d1fae5;        --badge-status-done-fg: #065f46;
+  --badge-status-blocked-bg: #fee2e2;     --badge-status-blocked-fg: #991b1b;
+  --badge-status-cancelled-bg: #f3f4f6;   --badge-status-cancelled-fg: #9ca3af;
+
+  /* Work-item priority pill */
+  --badge-priority-critical-bg: #fee2e2;  --badge-priority-critical-fg: #991b1b;
+  --badge-priority-high-bg: #ffedd5;      --badge-priority-high-fg: #9a3412;
+  --badge-priority-medium-bg: #fef9c3;    --badge-priority-medium-fg: #713f12;
+  --badge-priority-low-bg: #f0fdf4;       --badge-priority-low-fg: #14532d;
+
+  /* Priority dot (solid fill indicators) */
+  --badge-dot-critical: #ef4444;
+  --badge-dot-high: #f97316;
+  --badge-dot-medium: #eab308;
+  --badge-dot-low: #22c55e;
+
+  /* Approval request type (ApprovalsInbox) */
+  --badge-approval-budget_increase-bg: #fef3c7; --badge-approval-budget_increase-fg: #92400e;
+  --badge-approval-agent_spawn-bg: #ddd6fe;     --badge-approval-agent_spawn-fg: #5b21b6;
+  --badge-approval-external_api-bg: #bfdbfe;    --badge-approval-external_api-fg: #1d4ed8;
+  --badge-approval-code_deploy-bg: #fee2e2;     --badge-approval-code_deploy-fg: #991b1b;
+  --badge-approval-data_access-bg: #d1fae5;     --badge-approval-data_access-fg: #065f46;
+  --badge-approval-policy_change-bg: #fce7f3;   --badge-approval-policy_change-fg: #9d174d;
+  --badge-approval-contract_sign-bg: #ffedd5;   --badge-approval-contract_sign-fg: #9a3412;
+  --badge-approval-hiring-bg: #e0f2fe;          --badge-approval-hiring-fg: #0369a1;
+
+  /* Approval decision status (ApprovalsInbox) */
+  --badge-approval-approved-bg: #d1fae5;          --badge-approval-approved-fg: #065f46;
+  --badge-approval-rejected-bg: #fee2e2;          --badge-approval-rejected-fg: #991b1b;
+  --badge-approval-changes_requested-bg: #fef3c7; --badge-approval-changes_requested-fg: #92400e;
+
+  /* Sprint status (SprintBoardView) */
+  --badge-sprint-planning-bg: #fef9c3;  --badge-sprint-planning-fg: #713f12;
+  --badge-sprint-active-bg: #d1fae5;    --badge-sprint-active-fg: #065f46;
+  --badge-sprint-review-bg: #ddd6fe;    --badge-sprint-review-fg: #5b21b6;
+  --badge-sprint-closed-bg: #f3f4f6;    --badge-sprint-closed-fg: #374151;
 }

--- a/autobot-frontend/src/assets/css/themes/dark.css
+++ b/autobot-frontend/src/assets/css/themes/dark.css
@@ -113,6 +113,64 @@
   --color-agent-draft-border: #60A5FA;
   --color-agent-draft-bg: #1E3A5F;
   --color-user-edit-cursor: #34D399;
+
+  /* ============================================
+   * LLC CATEGORICAL BADGE PALETTE — GH#10868
+   * Dark-surface variants: deep desaturated backgrounds with light
+   * same-hue foregrounds (WCAG AA), preserving each category's hue.
+   * ============================================ */
+
+  /* Work-item type */
+  --badge-type-epic-bg: #362b6b;      --badge-type-epic-fg: #d6ccff;   /* violet */
+  --badge-type-feature-bg: #1e365f;   --badge-type-feature-fg: #bfd7ff; /* blue */
+  --badge-type-pbi-bg: #123b2c;       --badge-type-pbi-fg: #a7ecc9;    /* green */
+  --badge-type-task-bg: #0e3a52;      --badge-type-task-fg: #b3e2f7;   /* cyan */
+  --badge-type-bug-bg: #4a1d1d;       --badge-type-bug-fg: #ffc4c4;    /* red */
+  --badge-type-spike-bg: #4a3411;     --badge-type-spike-fg: #fbdf9b;  /* amber */
+  --badge-type-subtask-bg: #2f3742;   --badge-type-subtask-fg: #cdd6e2; /* slate */
+  --badge-type-risk-bg: #4a1f38;      --badge-type-risk-fg: #f9c0dd;   /* pink */
+
+  /* Work-item status */
+  --badge-status-backlog-bg: #2f3742;     --badge-status-backlog-fg: #cdd6e2;
+  --badge-status-ready-bg: #0e3a52;       --badge-status-ready-fg: #b3e2f7;
+  --badge-status-in_progress-bg: #362b6b; --badge-status-in_progress-fg: #d6ccff;
+  --badge-status-in_review-bg: #4a3d11;   --badge-status-in_review-fg: #f5e39b;
+  --badge-status-done-bg: #123b2c;        --badge-status-done-fg: #a7ecc9;
+  --badge-status-blocked-bg: #4a1d1d;     --badge-status-blocked-fg: #ffc4c4;
+  --badge-status-cancelled-bg: #2f3742;   --badge-status-cancelled-fg: #9aa5b3;
+
+  /* Work-item priority pill */
+  --badge-priority-critical-bg: #4a1d1d;  --badge-priority-critical-fg: #ffc4c4;
+  --badge-priority-high-bg: #4a2c11;      --badge-priority-high-fg: #ffcea1;
+  --badge-priority-medium-bg: #4a3d11;    --badge-priority-medium-fg: #f5e39b;
+  --badge-priority-low-bg: #163a1f;       --badge-priority-low-fg: #aeeabb;
+
+  /* Priority dot (solid fill indicators) — brighten for dark surface */
+  --badge-dot-critical: #f87171;
+  --badge-dot-high: #fb923c;
+  --badge-dot-medium: #facc15;
+  --badge-dot-low: #4ade80;
+
+  /* Approval request type (ApprovalsInbox) */
+  --badge-approval-budget_increase-bg: #4a3411; --badge-approval-budget_increase-fg: #fbdf9b;
+  --badge-approval-agent_spawn-bg: #362b6b;     --badge-approval-agent_spawn-fg: #d6ccff;
+  --badge-approval-external_api-bg: #1e365f;    --badge-approval-external_api-fg: #bfd7ff;
+  --badge-approval-code_deploy-bg: #4a1d1d;     --badge-approval-code_deploy-fg: #ffc4c4;
+  --badge-approval-data_access-bg: #123b2c;     --badge-approval-data_access-fg: #a7ecc9;
+  --badge-approval-policy_change-bg: #4a1f38;   --badge-approval-policy_change-fg: #f9c0dd;
+  --badge-approval-contract_sign-bg: #4a2c11;   --badge-approval-contract_sign-fg: #ffcea1;
+  --badge-approval-hiring-bg: #0e3a52;          --badge-approval-hiring-fg: #b3e2f7;
+
+  /* Approval decision status (ApprovalsInbox) */
+  --badge-approval-approved-bg: #123b2c;          --badge-approval-approved-fg: #a7ecc9;
+  --badge-approval-rejected-bg: #4a1d1d;          --badge-approval-rejected-fg: #ffc4c4;
+  --badge-approval-changes_requested-bg: #4a3411; --badge-approval-changes_requested-fg: #fbdf9b;
+
+  /* Sprint status (SprintBoardView) */
+  --badge-sprint-planning-bg: #4a3d11;  --badge-sprint-planning-fg: #f5e39b;
+  --badge-sprint-active-bg: #123b2c;    --badge-sprint-active-fg: #a7ecc9;
+  --badge-sprint-review-bg: #362b6b;    --badge-sprint-review-fg: #d6ccff;
+  --badge-sprint-closed-bg: #2f3742;    --badge-sprint-closed-fg: #cdd6e2;
 }
 
 /* ============================================

--- a/autobot-frontend/src/assets/css/themes/ember.css
+++ b/autobot-frontend/src/assets/css/themes/ember.css
@@ -145,6 +145,64 @@
   --shadow-sm: 0 1px 3px rgba(44, 28, 14, 0.08), 0 1px 2px rgba(44, 28, 14, 0.05);
   --shadow-md: 0 4px 12px rgba(44, 28, 14, 0.10), 0 2px 4px rgba(44, 28, 14, 0.05);
   --shadow-lg: 0 12px 32px rgba(44, 28, 14, 0.14), 0 4px 8px rgba(44, 28, 14, 0.06);
+
+  /* ============================================
+   * LLC CATEGORICAL BADGE PALETTE — GH#10868
+   * Ember light: warm apricot-linen tinted category chips, same hue
+   * identity as the base palette but shifted toward the ember warmth.
+   * ============================================ */
+
+  /* Work-item type */
+  --badge-type-epic-bg: #e6ddf5;      --badge-type-epic-fg: #59307a;
+  --badge-type-feature-bg: #d3ddf0;   --badge-type-feature-fg: #2a4a86;
+  --badge-type-pbi-bg: var(--green-bg); --badge-type-pbi-fg: #1c5a3f;
+  --badge-type-task-bg: #d7e6ee;      --badge-type-task-fg: #1c5670;
+  --badge-type-bug-bg: var(--red-bg); --badge-type-bug-fg: #8f2a20;
+  --badge-type-spike-bg: #f7e6c4;     --badge-type-spike-fg: #8a5410;
+  --badge-type-subtask-bg: var(--wax-100); --badge-type-subtask-fg: #4a3f30;
+  --badge-type-risk-bg: #f3dce6;      --badge-type-risk-fg: #8a2f57;
+
+  /* Work-item status */
+  --badge-status-backlog-bg: var(--wax-100);  --badge-status-backlog-fg: #4a3f30;
+  --badge-status-ready-bg: #d7e6ee;           --badge-status-ready-fg: #1c5670;
+  --badge-status-in_progress-bg: #e6ddf5;     --badge-status-in_progress-fg: #59307a;
+  --badge-status-in_review-bg: #f7ecc4;       --badge-status-in_review-fg: #7a5510;
+  --badge-status-done-bg: var(--green-bg);    --badge-status-done-fg: #1c5a3f;
+  --badge-status-blocked-bg: var(--red-bg);   --badge-status-blocked-fg: #8f2a20;
+  --badge-status-cancelled-bg: var(--wax-100); --badge-status-cancelled-fg: var(--wax-500);
+
+  /* Work-item priority pill */
+  --badge-priority-critical-bg: var(--red-bg); --badge-priority-critical-fg: #8f2a20;
+  --badge-priority-high-bg: #f8e0c6;           --badge-priority-high-fg: #a35214;
+  --badge-priority-medium-bg: #f7ecc4;         --badge-priority-medium-fg: #7a5510;
+  --badge-priority-low-bg: #e0efd8;            --badge-priority-low-fg: #35662a;
+
+  /* Priority dot (solid fill indicators) */
+  --badge-dot-critical: var(--red-500);
+  --badge-dot-high: var(--orange-500);
+  --badge-dot-medium: var(--gold-500);
+  --badge-dot-low: var(--green-500);
+
+  /* Approval request type (ApprovalsInbox) */
+  --badge-approval-budget_increase-bg: #f7e6c4; --badge-approval-budget_increase-fg: #8a5410;
+  --badge-approval-agent_spawn-bg: #e6ddf5;     --badge-approval-agent_spawn-fg: #59307a;
+  --badge-approval-external_api-bg: #d3ddf0;    --badge-approval-external_api-fg: #2a4a86;
+  --badge-approval-code_deploy-bg: var(--red-bg); --badge-approval-code_deploy-fg: #8f2a20;
+  --badge-approval-data_access-bg: var(--green-bg); --badge-approval-data_access-fg: #1c5a3f;
+  --badge-approval-policy_change-bg: #f3dce6;   --badge-approval-policy_change-fg: #8a2f57;
+  --badge-approval-contract_sign-bg: #f8e0c6;   --badge-approval-contract_sign-fg: #a35214;
+  --badge-approval-hiring-bg: #d7e6ee;          --badge-approval-hiring-fg: #1c5670;
+
+  /* Approval decision status (ApprovalsInbox) */
+  --badge-approval-approved-bg: var(--green-bg);  --badge-approval-approved-fg: #1c5a3f;
+  --badge-approval-rejected-bg: var(--red-bg);    --badge-approval-rejected-fg: #8f2a20;
+  --badge-approval-changes_requested-bg: #f7e6c4; --badge-approval-changes_requested-fg: #8a5410;
+
+  /* Sprint status (SprintBoardView) */
+  --badge-sprint-planning-bg: #f7ecc4;  --badge-sprint-planning-fg: #7a5510;
+  --badge-sprint-active-bg: var(--green-bg); --badge-sprint-active-fg: #1c5a3f;
+  --badge-sprint-review-bg: #e6ddf5;    --badge-sprint-review-fg: #59307a;
+  --badge-sprint-closed-bg: var(--wax-100); --badge-sprint-closed-fg: #4a3f30;
 }
 
 /* ----------------------------------------------------------------------------
@@ -212,6 +270,64 @@
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.55), 0 1px 2px rgba(0, 0, 0, 0.35);
   --shadow-md: 0 4px 14px rgba(0, 0, 0, 0.6), 0 2px 4px rgba(0, 0, 0, 0.35);
   --shadow-lg: 0 14px 36px rgba(0, 0, 0, 0.65), 0 4px 8px rgba(0, 0, 0, 0.45);
+
+  /* ============================================
+   * LLC CATEGORICAL BADGE PALETTE — GH#10868
+   * Ember dark: mulberry-cocoa warm dark backgrounds with light
+   * same-hue foregrounds, hue identity preserved (WCAG AA).
+   * ============================================ */
+
+  /* Work-item type */
+  --badge-type-epic-bg: #3a2c56;      --badge-type-epic-fg: #d9caf0;
+  --badge-type-feature-bg: #26324f;   --badge-type-feature-fg: #c3d5f2;
+  --badge-type-pbi-bg: var(--green-bg-dk); --badge-type-pbi-fg: #7fd0a6;
+  --badge-type-task-bg: #1d3646;      --badge-type-task-fg: #a9d7ea;
+  --badge-type-bug-bg: var(--red-bg-dk); --badge-type-bug-fg: #ff9d8f;
+  --badge-type-spike-bg: #48350f;     --badge-type-spike-fg: #f5cf7d;
+  --badge-type-subtask-bg: #352a3a;   --badge-type-subtask-fg: #cabbc2;
+  --badge-type-risk-bg: #46213a;      --badge-type-risk-fg: #eaa9c6;
+
+  /* Work-item status */
+  --badge-status-backlog-bg: #352a3a;     --badge-status-backlog-fg: #cabbc2;
+  --badge-status-ready-bg: #1d3646;       --badge-status-ready-fg: #a9d7ea;
+  --badge-status-in_progress-bg: #3a2c56; --badge-status-in_progress-fg: #d9caf0;
+  --badge-status-in_review-bg: #48350f;   --badge-status-in_review-fg: #f5cf7d;
+  --badge-status-done-bg: var(--green-bg-dk); --badge-status-done-fg: #7fd0a6;
+  --badge-status-blocked-bg: var(--red-bg-dk); --badge-status-blocked-fg: #ff9d8f;
+  --badge-status-cancelled-bg: #352a3a;   --badge-status-cancelled-fg: #a08f97;
+
+  /* Work-item priority pill */
+  --badge-priority-critical-bg: var(--red-bg-dk); --badge-priority-critical-fg: #ff9d8f;
+  --badge-priority-high-bg: #472c10;      --badge-priority-high-fg: #f5b877;
+  --badge-priority-medium-bg: #48350f;    --badge-priority-medium-fg: #f5cf7d;
+  --badge-priority-low-bg: #163422;       --badge-priority-low-fg: #7fd0a6;
+
+  /* Priority dot (solid fill indicators) */
+  --badge-dot-critical: var(--red-300);
+  --badge-dot-high: var(--orange-300);
+  --badge-dot-medium: var(--gold-400);
+  --badge-dot-low: var(--green-300);
+
+  /* Approval request type (ApprovalsInbox) */
+  --badge-approval-budget_increase-bg: #48350f; --badge-approval-budget_increase-fg: #f5cf7d;
+  --badge-approval-agent_spawn-bg: #3a2c56;     --badge-approval-agent_spawn-fg: #d9caf0;
+  --badge-approval-external_api-bg: #26324f;    --badge-approval-external_api-fg: #c3d5f2;
+  --badge-approval-code_deploy-bg: var(--red-bg-dk); --badge-approval-code_deploy-fg: #ff9d8f;
+  --badge-approval-data_access-bg: var(--green-bg-dk); --badge-approval-data_access-fg: #7fd0a6;
+  --badge-approval-policy_change-bg: #46213a;   --badge-approval-policy_change-fg: #eaa9c6;
+  --badge-approval-contract_sign-bg: #472c10;   --badge-approval-contract_sign-fg: #f5b877;
+  --badge-approval-hiring-bg: #1d3646;          --badge-approval-hiring-fg: #a9d7ea;
+
+  /* Approval decision status (ApprovalsInbox) */
+  --badge-approval-approved-bg: var(--green-bg-dk);  --badge-approval-approved-fg: #7fd0a6;
+  --badge-approval-rejected-bg: var(--red-bg-dk);    --badge-approval-rejected-fg: #ff9d8f;
+  --badge-approval-changes_requested-bg: #48350f; --badge-approval-changes_requested-fg: #f5cf7d;
+
+  /* Sprint status (SprintBoardView) */
+  --badge-sprint-planning-bg: #48350f;  --badge-sprint-planning-fg: #f5cf7d;
+  --badge-sprint-active-bg: var(--green-bg-dk); --badge-sprint-active-fg: #7fd0a6;
+  --badge-sprint-review-bg: #3a2c56;    --badge-sprint-review-fg: #d9caf0;
+  --badge-sprint-closed-bg: #352a3a;    --badge-sprint-closed-fg: #cabbc2;
 }
 
 /* ----------------------------------------------------------------------------

--- a/autobot-frontend/src/assets/css/themes/light.css
+++ b/autobot-frontend/src/assets/css/themes/light.css
@@ -133,6 +133,65 @@
   --color-agent-draft-border: #3B82F6;
   --color-agent-draft-bg: #EFF6FF;
   --color-user-edit-cursor: #059669;
+
+  /* ============================================
+   * LLC CATEGORICAL BADGE PALETTE — GH#10868
+   * Per-category badge bg/fg pairs, extracted verbatim from the
+   * previously hardcoded LLC view/component CSS so light mode is
+   * visually identical. Dark/ember define theme-appropriate variants.
+   * ============================================ */
+
+  /* Work-item type */
+  --badge-type-epic-bg: #ddd6fe;      --badge-type-epic-fg: #5b21b6;
+  --badge-type-feature-bg: #bfdbfe;   --badge-type-feature-fg: #1d4ed8;
+  --badge-type-pbi-bg: #d1fae5;       --badge-type-pbi-fg: #065f46;
+  --badge-type-task-bg: #e0f2fe;      --badge-type-task-fg: #0369a1;
+  --badge-type-bug-bg: #fee2e2;       --badge-type-bug-fg: #991b1b;
+  --badge-type-spike-bg: #fef3c7;     --badge-type-spike-fg: #92400e;
+  --badge-type-subtask-bg: #f3f4f6;   --badge-type-subtask-fg: #374151;
+  --badge-type-risk-bg: #fce7f3;      --badge-type-risk-fg: #9d174d;
+
+  /* Work-item status */
+  --badge-status-backlog-bg: #f3f4f6;     --badge-status-backlog-fg: #374151;
+  --badge-status-ready-bg: #e0f2fe;       --badge-status-ready-fg: #0369a1;
+  --badge-status-in_progress-bg: #ddd6fe; --badge-status-in_progress-fg: #5b21b6;
+  --badge-status-in_review-bg: #fef9c3;   --badge-status-in_review-fg: #713f12;
+  --badge-status-done-bg: #d1fae5;        --badge-status-done-fg: #065f46;
+  --badge-status-blocked-bg: #fee2e2;     --badge-status-blocked-fg: #991b1b;
+  --badge-status-cancelled-bg: #f3f4f6;   --badge-status-cancelled-fg: #9ca3af;
+
+  /* Work-item priority pill */
+  --badge-priority-critical-bg: #fee2e2;  --badge-priority-critical-fg: #991b1b;
+  --badge-priority-high-bg: #ffedd5;      --badge-priority-high-fg: #9a3412;
+  --badge-priority-medium-bg: #fef9c3;    --badge-priority-medium-fg: #713f12;
+  --badge-priority-low-bg: #f0fdf4;       --badge-priority-low-fg: #14532d;
+
+  /* Priority dot (solid fill indicators) */
+  --badge-dot-critical: #ef4444;
+  --badge-dot-high: #f97316;
+  --badge-dot-medium: #eab308;
+  --badge-dot-low: #22c55e;
+
+  /* Approval request type (ApprovalsInbox) */
+  --badge-approval-budget_increase-bg: #fef3c7; --badge-approval-budget_increase-fg: #92400e;
+  --badge-approval-agent_spawn-bg: #ddd6fe;     --badge-approval-agent_spawn-fg: #5b21b6;
+  --badge-approval-external_api-bg: #bfdbfe;    --badge-approval-external_api-fg: #1d4ed8;
+  --badge-approval-code_deploy-bg: #fee2e2;     --badge-approval-code_deploy-fg: #991b1b;
+  --badge-approval-data_access-bg: #d1fae5;     --badge-approval-data_access-fg: #065f46;
+  --badge-approval-policy_change-bg: #fce7f3;   --badge-approval-policy_change-fg: #9d174d;
+  --badge-approval-contract_sign-bg: #ffedd5;   --badge-approval-contract_sign-fg: #9a3412;
+  --badge-approval-hiring-bg: #e0f2fe;          --badge-approval-hiring-fg: #0369a1;
+
+  /* Approval decision status (ApprovalsInbox) */
+  --badge-approval-approved-bg: #d1fae5;          --badge-approval-approved-fg: #065f46;
+  --badge-approval-rejected-bg: #fee2e2;          --badge-approval-rejected-fg: #991b1b;
+  --badge-approval-changes_requested-bg: #fef3c7; --badge-approval-changes_requested-fg: #92400e;
+
+  /* Sprint status (SprintBoardView) */
+  --badge-sprint-planning-bg: #fef9c3;  --badge-sprint-planning-fg: #713f12;
+  --badge-sprint-active-bg: #d1fae5;    --badge-sprint-active-fg: #065f46;
+  --badge-sprint-review-bg: #ddd6fe;    --badge-sprint-review-fg: #5b21b6;
+  --badge-sprint-closed-bg: #f3f4f6;    --badge-sprint-closed-fg: #374151;
 }
 
 /* ============================================

--- a/autobot-frontend/src/components/llc/WorkItemBadge.vue
+++ b/autobot-frontend/src/components/llc/WorkItemBadge.vue
@@ -65,34 +65,34 @@ const colorClass = computed(() =>
 .wib-dot--sm { width: 0.5rem; height: 0.5rem; }
 .wib-dot--xs { width: 0.45rem; height: 0.45rem; }
 
-/* type palette (identical across all LLC boards) */
-.type-epic { background: #ddd6fe; color: #5b21b6; }
-.type-feature { background: #bfdbfe; color: #1d4ed8; }
-.type-pbi { background: #d1fae5; color: #065f46; }
-.type-task { background: #e0f2fe; color: #0369a1; }
-.type-bug { background: #fee2e2; color: #991b1b; }
-.type-spike { background: #fef3c7; color: #92400e; }
-.type-subtask { background: #f3f4f6; color: #374151; }
-.type-risk { background: #fce7f3; color: #9d174d; }
+/* type palette — theme-adaptive categorical tokens (GH#10868) */
+.type-epic { background: var(--badge-type-epic-bg); color: var(--badge-type-epic-fg); }
+.type-feature { background: var(--badge-type-feature-bg); color: var(--badge-type-feature-fg); }
+.type-pbi { background: var(--badge-type-pbi-bg); color: var(--badge-type-pbi-fg); }
+.type-task { background: var(--badge-type-task-bg); color: var(--badge-type-task-fg); }
+.type-bug { background: var(--badge-type-bug-bg); color: var(--badge-type-bug-fg); }
+.type-spike { background: var(--badge-type-spike-bg); color: var(--badge-type-spike-fg); }
+.type-subtask { background: var(--badge-type-subtask-bg); color: var(--badge-type-subtask-fg); }
+.type-risk { background: var(--badge-type-risk-bg); color: var(--badge-type-risk-fg); }
 
-/* work-item status palette (from WorkItemDetail) */
-.status-backlog { background: #f3f4f6; color: #374151; }
-.status-ready { background: #e0f2fe; color: #0369a1; }
-.status-in_progress { background: #ddd6fe; color: #5b21b6; }
-.status-in_review { background: #fef9c3; color: #713f12; }
-.status-done { background: #d1fae5; color: #065f46; }
-.status-blocked { background: #fee2e2; color: #991b1b; }
-.status-cancelled { background: #f3f4f6; color: #9ca3af; }
+/* work-item status palette — theme-adaptive (GH#10868) */
+.status-backlog { background: var(--badge-status-backlog-bg); color: var(--badge-status-backlog-fg); }
+.status-ready { background: var(--badge-status-ready-bg); color: var(--badge-status-ready-fg); }
+.status-in_progress { background: var(--badge-status-in_progress-bg); color: var(--badge-status-in_progress-fg); }
+.status-in_review { background: var(--badge-status-in_review-bg); color: var(--badge-status-in_review-fg); }
+.status-done { background: var(--badge-status-done-bg); color: var(--badge-status-done-fg); }
+.status-blocked { background: var(--badge-status-blocked-bg); color: var(--badge-status-blocked-fg); }
+.status-cancelled { background: var(--badge-status-cancelled-bg); color: var(--badge-status-cancelled-fg); }
 
-/* priority pill palette (Backlog / WorkItemDetail) */
-.priority-critical { background: #fee2e2; color: #991b1b; }
-.priority-high { background: #ffedd5; color: #9a3412; }
-.priority-medium { background: #fef9c3; color: #713f12; }
-.priority-low { background: #f0fdf4; color: #14532d; }
+/* priority pill palette — theme-adaptive (GH#10868) */
+.priority-critical { background: var(--badge-priority-critical-bg); color: var(--badge-priority-critical-fg); }
+.priority-high { background: var(--badge-priority-high-bg); color: var(--badge-priority-high-fg); }
+.priority-medium { background: var(--badge-priority-medium-bg); color: var(--badge-priority-medium-fg); }
+.priority-low { background: var(--badge-priority-low-bg); color: var(--badge-priority-low-fg); }
 
-/* priority dot palette (SprintBoard / Kanban — solid fills) */
-.dot-critical { background: #ef4444; }
-.dot-high { background: #f97316; }
-.dot-medium { background: #eab308; }
-.dot-low { background: #22c55e; }
+/* priority dot palette — solid fills, theme-adaptive (GH#10868) */
+.dot-critical { background: var(--badge-dot-critical); }
+.dot-high { background: var(--badge-dot-high); }
+.dot-medium { background: var(--badge-dot-medium); }
+.dot-low { background: var(--badge-dot-low); }
 </style>

--- a/autobot-frontend/src/views/llc/ApprovalsInbox.vue
+++ b/autobot-frontend/src/views/llc/ApprovalsInbox.vue
@@ -424,18 +424,19 @@ onUnmounted(() => {
   font-weight: 500;
 }
 
-.type-budget_increase { background: #fef3c7; color: #92400e; }
-.type-agent_spawn { background: #ddd6fe; color: #5b21b6; }
-.type-external_api { background: #bfdbfe; color: #1d4ed8; }
-.type-code_deploy { background: #fee2e2; color: #991b1b; }
-.type-data_access { background: #d1fae5; color: #065f46; }
-.type-policy_change { background: #fce7f3; color: #9d174d; }
-.type-contract_sign { background: #ffedd5; color: #9a3412; }
-.type-hiring { background: #e0f2fe; color: #0369a1; }
+/* approval type + decision palette — theme-adaptive (GH#10868) */
+.type-budget_increase { background: var(--badge-approval-budget_increase-bg); color: var(--badge-approval-budget_increase-fg); }
+.type-agent_spawn { background: var(--badge-approval-agent_spawn-bg); color: var(--badge-approval-agent_spawn-fg); }
+.type-external_api { background: var(--badge-approval-external_api-bg); color: var(--badge-approval-external_api-fg); }
+.type-code_deploy { background: var(--badge-approval-code_deploy-bg); color: var(--badge-approval-code_deploy-fg); }
+.type-data_access { background: var(--badge-approval-data_access-bg); color: var(--badge-approval-data_access-fg); }
+.type-policy_change { background: var(--badge-approval-policy_change-bg); color: var(--badge-approval-policy_change-fg); }
+.type-contract_sign { background: var(--badge-approval-contract_sign-bg); color: var(--badge-approval-contract_sign-fg); }
+.type-hiring { background: var(--badge-approval-hiring-bg); color: var(--badge-approval-hiring-fg); }
 
-.status-approved { background: #d1fae5; color: #065f46; }
-.status-rejected { background: #fee2e2; color: #991b1b; }
-.status-changes_requested { background: #fef3c7; color: #92400e; }
+.status-approved { background: var(--badge-approval-approved-bg); color: var(--badge-approval-approved-fg); }
+.status-rejected { background: var(--badge-approval-rejected-bg); color: var(--badge-approval-rejected-fg); }
+.status-changes_requested { background: var(--badge-approval-changes_requested-bg); color: var(--badge-approval-changes_requested-fg); }
 
 .toggle-payload {
   font-size: 0.8rem;

--- a/autobot-frontend/src/views/llc/SprintBoardView.vue
+++ b/autobot-frontend/src/views/llc/SprintBoardView.vue
@@ -298,10 +298,11 @@ onMounted(async () => {
   text-transform: capitalize;
 }
 
-.status-planning { background: #fef9c3; color: #713f12; }
-.status-active { background: #d1fae5; color: #065f46; }
-.status-review { background: #ddd6fe; color: #5b21b6; }
-.status-closed { background: #f3f4f6; color: #374151; }
+/* sprint status palette — theme-adaptive (GH#10868) */
+.status-planning { background: var(--badge-sprint-planning-bg); color: var(--badge-sprint-planning-fg); }
+.status-active { background: var(--badge-sprint-active-bg); color: var(--badge-sprint-active-fg); }
+.status-review { background: var(--badge-sprint-review-bg); color: var(--badge-sprint-review-fg); }
+.status-closed { background: var(--badge-sprint-closed-bg); color: var(--badge-sprint-closed-fg); }
 
 .sprint-stats {
   display: flex;


### PR DESCRIPTION
## Thinking Path
LLC board/detail views hardcoded **light-mode-only** categorical badge palettes in scoped CSS (`.type-epic { background:#ddd6fe }`, `.status-backlog { background:#f3f4f6 }`, `.priority-*`, `.dot-*`). On the dark/ember themes a light-gray badge rendered near-invisible on a dark surface. Root cause: no theme-adaptive categorical token layer existed — C1b (#10750) only did residual gray/hex→token cleanup and explicitly deferred this.

Fix: introduce a per-theme categorical token surface (`--badge-<group>-<key>-bg/-fg`) defined in every theme, and point the badge classes at it. Light values are the **exact** current hexes (zero visual regression); dark/ember carry contrast-adapted values preserving each category's hue identity.

## What Changed (7 files)
- **Themes** `light/dark/ember/_template.css` — 72 `--badge-*` tokens each: type (8×bg/fg), status (7×bg/fg), priority pill (4×bg/fg), priority dot (4), approval type (8×bg/fg), approval status (3×bg/fg), sprint status (4×bg/fg). Light = original hexes; dark = dark-surface-appropriate (e.g. `status-backlog-bg` `#f3f4f6`→`#2f3742`); ember = warm-tinted via its own primitives (`--green-bg`, `--wax-100`, `--red-bg`). Ember defines the set in both its light and dark blocks.
- **Views** `WorkItemBadge.vue`, `ApprovalsInbox.vue`, `SprintBoardView.vue` — every `.type-*`/`.status-*`/`.priority-*`/`.dot-*` palette → `var(--badge-*)`.

No JS `stateColors` refactor needed — `WorkItemBadge.colorClass` returns a class name, not a color; the LLC JS status helpers return theme-agnostic Tailwind utilities (out of scope).

## Verification (independently re-run, not just agent-reported)
- **Zero hardcoded badge hexes remain**: `grep -E '\.(type|status|priority|dot)-[a-z_]+\s*\{[^}]*#'` across the 3 views = **0**.
- **Token coverage**: 72 `var(--badge-*)` references; each defined in light/dark/ember/_template — **0 missing** in every theme.
- **Zero light regression**: parsed all **38** original badge blocks from `origin/Dev_new_gui` and compared each bg/fg hex to its light.css token — **0 mismatches**.
- **Real theme adaptivity**: **0 / 72** badge tokens are identical between light and dark — every badge adapts.

## Discovery (separate follow-up)
`HeartbeatMonitor.vue` (L501–510) hardcodes light-only *functional*-status colors (`.status-succeeded #10b981`, etc.) — a distinct single-color set mapping to functional semantic tokens whose surface is inconsistent across themes (`--color-error`/`--color-warning` vs ember's `--color-danger`). Out of scope; filing a follow-up.

## Model Used
Opus 4.8 (1M context) + frontend-engineer agent (implementation), independently verified.

Closes #10868