### PR TITLE
fix(code-sync): requeue restart-interrupted resolve jobs + 409 during pending restart (#11437)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -145,24 +145,25 @@ async def reconcile_stale_fleet_sync_jobs() -> int:
     return count
 
 
-async def reconcile_stale_component_sync_jobs() -> int:
-    """Mark stale 'running' component sync jobs as failed on startup (#11303).
+async def reconcile_stale_component_sync_jobs() -> Tuple[int, List[Tuple[str, str]]]:
+    """Reconcile stale component sync jobs on startup (#11303, #11437).
 
-    Called during SLM backend lifespan init.  Any job left in 'running' status
-    from a prior process crash (including a self-restart triggered by the job
-    itself) is marked 'failed' with an explanatory message.
+    Jobs left 'running' (or 'queued' — a requeue whose re-run never started)
+    by a prior process death are re-queued ONCE so their post-steps (incl. DB
+    migrations) are not silently skipped; a job interrupted twice is failed
+    permanently with success=False.
 
     Returns:
-        Number of stale jobs reconciled.
+        (number of stale jobs reconciled, list of (job_id, component) requeued).
     """
     from services.database import db_service
 
     async with db_service.session() as db:
-        result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.status == "running"))
+        result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.status.in_(["running", "queued"])))
         stale_jobs = result.scalars().all()
         count = len(stale_jobs)
 
-        requeued: List[tuple] = []
+        requeued: List[Tuple[str, str]] = []
         for job in stale_jobs:
             if job.message and job.message.startswith("requeued"):
                 # Second interruption — do not loop forever (#11437).
@@ -1819,6 +1820,12 @@ async def _restart_component_services(component: str, steps: List[str]) -> None:
             logger.warning("drift resolve: restart %s error: %s", service, exc)
             steps.append(f"restart {service}: error: {exc}")
 
+    # #11460 review: reaching this line means the self-restart did NOT land
+    # (systemctl restart of our own unit blocks until this process dies, so a
+    # successful self-restart never returns here). Disarm the guard, or every
+    # future resolve would 409 forever after a failed restart chain.
+    _restart_pending = False
+
 
 # =============================================================================
 # #11377 — Component snapshot / rollback helpers
@@ -1842,7 +1849,6 @@ def _prune_old_snapshots(snap_base: Path, component: str, max_keep: int) -> None
             logger.info("snapshot prune: removed %s", old)
         except OSError as exc:
             logger.warning("snapshot prune: failed to remove %s: %s", old, exc)
-
 
 async def _snapshot_component(component: str) -> Optional[str]:
     """Rsync the deployed dir to a timestamped backup before mutation (#11404).

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -159,7 +159,9 @@ async def reconcile_stale_component_sync_jobs() -> Tuple[int, List[Tuple[str, st
     from services.database import db_service
 
     async with db_service.session() as db:
-        result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.status.in_(["running", "queued"])))
+        result = await db.execute(
+            select(ComponentSyncJobModel).where(ComponentSyncJobModel.status.in_(["running", "queued"]))
+        )
         stale_jobs = result.scalars().all()
         count = len(stale_jobs)
 
@@ -1849,6 +1851,7 @@ def _prune_old_snapshots(snap_base: Path, component: str, max_keep: int) -> None
             logger.info("snapshot prune: removed %s", old)
         except OSError as exc:
             logger.warning("snapshot prune: failed to remove %s: %s", old, exc)
+
 
 async def _snapshot_component(component: str) -> Optional[str]:
     """Rsync the deployed dir to a timestamped backup before mutation (#11404).

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -162,19 +162,31 @@ async def reconcile_stale_component_sync_jobs() -> int:
         stale_jobs = result.scalars().all()
         count = len(stale_jobs)
 
+        requeued: List[tuple] = []
         for job in stale_jobs:
-            job.status = "failed"
-            job.completed_at = datetime.now(timezone.utc)
-            job.message = "reconciled: server restarted while job was running"
-            logger.warning(
-                "Reconciled stale component sync job %s " "(was 'running', marked 'failed')",
-                job.job_id,
-            )
+            if job.message and job.message.startswith("requeued"):
+                # Second interruption — do not loop forever (#11437).
+                job.status = "failed"
+                job.success = False
+                job.completed_at = datetime.now(timezone.utc)
+                job.message = "failed: interrupted twice by server restarts"
+                logger.warning("Component sync job %s interrupted twice — marked failed", job.job_id)
+            else:
+                # #11437: the interruption was a restart racing the job, not a
+                # job failure — re-queue it so post-steps (incl. migrations)
+                # actually run instead of being silently skipped.
+                job.status = "queued"
+                job.message = "requeued after server restart"
+                requeued.append((job.job_id, job.component))
+                logger.warning(
+                    "Reconciled stale component sync job %s (was 'running', re-queued)",
+                    job.job_id,
+                )
 
         if count:
             await db.commit()
 
-    return count
+    return count, requeued
 
 
 async def _run_component_resolve_job(job_id: str, component: str) -> None:
@@ -188,6 +200,13 @@ async def _run_component_resolve_job(job_id: str, component: str) -> None:
     from services.database import db_service
 
     try:
+        # Requeued jobs arrive as 'queued' — mark running for status pollers (#11437).
+        async with db_service.session() as db:
+            result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id))
+            job_row = result.scalar_one_or_none()
+            if job_row and job_row.status != "running":
+                job_row.status = "running"
+                await db.commit()
         try:
             source_dir = get_default_source_dir(component)
         except ValueError as exc:
@@ -611,6 +630,11 @@ async def resolve_drift(
             status_code=400,
             detail=f"Invalid component '{request.component}'. Must be one of: {sorted(ALLOWED_COMPONENTS)}",
         )
+    if _restart_is_pending():
+        raise HTTPException(
+            status_code=409,
+            detail="A service restart from a previous resolve is in flight — retry in a few seconds (#11437)",
+        )
 
     try:
         source_dir = get_default_source_dir(request.component)
@@ -690,6 +714,11 @@ async def resolve_drift_async(
         raise HTTPException(
             status_code=400,
             detail=f"Invalid component '{request.component}'. Must be one of: {sorted(ALLOWED_COMPONENTS)}",
+        )
+    if _restart_is_pending():
+        raise HTTPException(
+            status_code=409,
+            detail="A service restart from a previous resolve is in flight — retry in a few seconds (#11437)",
         )
 
     from services.database import db_service
@@ -1046,6 +1075,19 @@ _COMPONENT_BUILD_SCRIPT: Dict[str, str] = {
 }
 
 # Maps component name → systemd service names to restart after sync.
+# #11437: components whose restart set includes autobot-slm-backend itself.
+# While such a restart chain is in flight this process is about to die; new
+# resolve jobs accepted in that window get killed mid-run and (pre-#11437)
+# were reconciled to failed with their migrations silently skipped.
+_SELF_KILLING_COMPONENTS = frozenset({"autobot-slm-backend", "autobot_shared"})
+_restart_pending: bool = False
+
+
+def _restart_is_pending() -> bool:
+    """True while a self-killing restart chain is in flight (#11437)."""
+    return _restart_pending
+
+
 _COMPONENT_SERVICES: Dict[str, List[str]] = {
     "autobot-backend": ["autobot-backend"],
     "autobot-slm-backend": ["autobot-slm-backend"],
@@ -1746,6 +1788,11 @@ async def _restart_component_services(component: str, steps: List[str]) -> None:
 
     Appends human-readable step notes to *steps*.
     """
+    global _restart_pending
+    if component in _SELF_KILLING_COMPONENTS:
+        # #11437: this chain will restart autobot-slm-backend itself — reject
+        # new resolve jobs until the process dies (flag resets on boot).
+        _restart_pending = True
     services = _COMPONENT_SERVICES.get(component, [])
     for service in services:
         steps.append(f"restart: {service}")

--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -252,13 +252,18 @@ async def lifespan(app: FastAPI):
     except Exception:
         logger.exception("Failed to reconcile stale fleet sync jobs")
 
-    # Reconcile stale component sync jobs from prior crash (#11303)
+    # Reconcile stale component sync jobs from prior crash (#11303).
+    # #11437: jobs interrupted by a racing restart are re-queued (once) and
+    # re-run here so their post-steps (incl. DB migrations) are not skipped.
     try:
-        from api.code_sync import reconcile_stale_component_sync_jobs
+        from api.code_sync import _run_component_resolve_job, reconcile_stale_component_sync_jobs
 
-        reconciled_comp = await reconcile_stale_component_sync_jobs()
+        reconciled_comp, requeued_jobs = await reconcile_stale_component_sync_jobs()
         if reconciled_comp:
             logger.warning("Reconciled %d stale component sync job(s)", reconciled_comp)
+        for _job_id, _component in requeued_jobs:
+            logger.warning("Re-running interrupted component sync job %s (%s)", _job_id, _component)
+            asyncio.create_task(_run_component_resolve_job(_job_id, _component))
     except Exception:
         logger.exception("Failed to reconcile stale component sync jobs")
 

--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -261,9 +261,14 @@ async def lifespan(app: FastAPI):
         reconciled_comp, requeued_jobs = await reconcile_stale_component_sync_jobs()
         if reconciled_comp:
             logger.warning("Reconciled %d stale component sync job(s)", reconciled_comp)
+        import api.code_sync as _code_sync_mod
+
         for _job_id, _component in requeued_jobs:
             logger.warning("Re-running interrupted component sync job %s (%s)", _job_id, _component)
-            asyncio.create_task(_run_component_resolve_job(_job_id, _component))
+            _task = asyncio.create_task(_run_component_resolve_job(_job_id, _component))
+            # #11460 review: keep a strong reference (GC) + same #1928 task
+            # tracking the endpoint path uses; the runner's finally pops it.
+            _code_sync_mod._running_tasks[_job_id] = _task
     except Exception:
         logger.exception("Failed to reconcile stale component sync jobs")
 

--- a/autobot-slm-backend/tests/api/test_component_resolve_job.py
+++ b/autobot-slm-backend/tests/api/test_component_resolve_job.py
@@ -321,3 +321,86 @@ def test_run_component_resolve_job_rsync_failure() -> None:
     assert row.success is False
     assert "rsync boom" in (row.message or "")
     restart_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# #11437: requeue-once reconcile + pending-restart guard
+# ---------------------------------------------------------------------------
+
+
+def _make_reconcile_db_mock(rows):
+    """db_service mock whose session().execute returns scalars().all() == rows."""
+    db_service_mock = MagicMock()
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            pass
+
+        async def execute(self, _stmt):
+            result = MagicMock()
+            result.scalars.return_value.all.return_value = rows
+            return result
+
+        async def commit(self):
+            pass
+
+    db_service_mock.session.return_value = _FakeSession()
+    return db_service_mock
+
+
+def test_reconcile_requeues_first_interruption() -> None:
+    """A job interrupted by a racing restart is re-queued, not failed (#11437)."""
+    import api.code_sync as code_sync_mod
+
+    row = _FakeRow()
+    row.status = "running"
+    row.message = None
+    row.job_id = "job-1"
+    row.component = "autobot-backend"
+
+    with patch("services.database.db_service", _make_reconcile_db_mock([row])):
+        count, requeued = _run(code_sync_mod.reconcile_stale_component_sync_jobs())
+
+    assert count == 1
+    assert row.status == "queued"
+    assert row.message.startswith("requeued")
+    assert requeued == [("job-1", "autobot-backend")]
+
+
+def test_reconcile_fails_second_interruption() -> None:
+    """A job interrupted twice must not requeue forever (#11437)."""
+    import api.code_sync as code_sync_mod
+
+    row = _FakeRow()
+    row.status = "running"
+    row.message = "requeued after server restart"
+    row.job_id = "job-2"
+    row.component = "autobot-backend"
+
+    with patch("services.database.db_service", _make_reconcile_db_mock([row])):
+        count, requeued = _run(code_sync_mod.reconcile_stale_component_sync_jobs())
+
+    assert count == 1
+    assert row.status == "failed"
+    assert row.success is False
+    assert requeued == []
+
+
+def test_restart_pending_arms_only_for_self_killing_components() -> None:
+    """_restart_component_services arms the 409 guard only when the chain can
+    kill the SLM itself (#11437)."""
+    import api.code_sync as code_sync_mod
+
+    code_sync_mod._restart_pending = False
+    try:
+        with patch.dict(code_sync_mod._COMPONENT_SERVICES, {"autobot-backend": [], "autobot_shared": []}):
+            _run(code_sync_mod._restart_component_services("autobot-backend", []))
+            assert code_sync_mod._restart_is_pending() is False
+
+            _run(code_sync_mod._restart_component_services("autobot_shared", []))
+            assert code_sync_mod._restart_is_pending() is True
+    finally:
+        code_sync_mod._restart_pending = False

--- a/autobot-slm-backend/tests/api/test_component_resolve_job.py
+++ b/autobot-slm-backend/tests/api/test_component_resolve_job.py
@@ -391,16 +391,49 @@ def test_reconcile_fails_second_interruption() -> None:
 
 def test_restart_pending_arms_only_for_self_killing_components() -> None:
     """_restart_component_services arms the 409 guard only when the chain can
-    kill the SLM itself (#11437)."""
+    kill the SLM itself (#11437); observable DURING the chain (it disarms on
+    surviving completion, #11460)."""
+    import api.code_sync as code_sync_mod
+
+    seen: dict = {}
+
+    async def _fake_exec(*args, **kwargs):
+        # record the guard state at restart time (mid-chain)
+        seen[args[-1]] = code_sync_mod._restart_is_pending()
+        proc = MagicMock()
+
+        async def _communicate():
+            return (b"", b"")
+
+        proc.communicate = _communicate
+        proc.returncode = 0
+        return proc
+
+    code_sync_mod._restart_pending = False
+    try:
+        with patch.dict(
+            code_sync_mod._COMPONENT_SERVICES,
+            {"autobot-backend": ["autobot-backend"], "autobot_shared": ["autobot-celery"]},
+        ), patch.object(code_sync_mod.asyncio, "create_subprocess_exec", _fake_exec):
+            _run(code_sync_mod._restart_component_services("autobot-backend", []))
+            _run(code_sync_mod._restart_component_services("autobot_shared", []))
+    finally:
+        code_sync_mod._restart_pending = False
+
+    assert seen["autobot-backend"] is False, "non-self-killing chain must not arm"
+    assert seen["autobot-celery"] is True, "self-killing chain must arm mid-chain"
+
+
+def test_restart_pending_disarms_when_process_survives() -> None:
+    """#11460 review: a failed self-restart chain must not leave the 409 guard
+    armed forever — reaching the end of the chain alive disarms it."""
     import api.code_sync as code_sync_mod
 
     code_sync_mod._restart_pending = False
     try:
-        with patch.dict(code_sync_mod._COMPONENT_SERVICES, {"autobot-backend": [], "autobot_shared": []}):
-            _run(code_sync_mod._restart_component_services("autobot-backend", []))
-            assert code_sync_mod._restart_is_pending() is False
-
+        with patch.dict(code_sync_mod._COMPONENT_SERVICES, {"autobot_shared": []}):
             _run(code_sync_mod._restart_component_services("autobot_shared", []))
-            assert code_sync_mod._restart_is_pending() is True
+        # chain completed without killing us -> guard released
+        assert code_sync_mod._restart_is_pending() is False
     finally:
         code_sync_mod._restart_pending = False

--- a/autobot-slm-backend/tests/api/test_component_resolve_job.py
+++ b/autobot-slm-backend/tests/api/test_component_resolve_job.py
@@ -411,10 +411,13 @@ def test_restart_pending_arms_only_for_self_killing_components() -> None:
 
     code_sync_mod._restart_pending = False
     try:
-        with patch.dict(
-            code_sync_mod._COMPONENT_SERVICES,
-            {"autobot-backend": ["autobot-backend"], "autobot_shared": ["autobot-celery"]},
-        ), patch.object(code_sync_mod.asyncio, "create_subprocess_exec", _fake_exec):
+        with (
+            patch.dict(
+                code_sync_mod._COMPONENT_SERVICES,
+                {"autobot-backend": ["autobot-backend"], "autobot_shared": ["autobot-celery"]},
+            ),
+            patch.object(code_sync_mod.asyncio, "create_subprocess_exec", _fake_exec),
+        ):
             _run(code_sync_mod._restart_component_services("autobot-backend", []))
             _run(code_sync_mod._restart_component_services("autobot_shared", []))
     finally:

--- a/autobot_shared/redis_management/connection_manager.py
+++ b/autobot_shared/redis_management/connection_manager.py
@@ -888,9 +888,7 @@ class RedisConnectionManager:
                 # Always retrieve the exception even if every waiter was
                 # cancelled — avoids "Task exception was never retrieved" and
                 # preserves the failure reason in the logs (#11451).
-                task.add_done_callback(
-                    lambda t, _db=database_name: self._log_pool_task_failure(_db, t)
-                )
+                task.add_done_callback(lambda t, _db=database_name: self._log_pool_task_failure(_db, t))
                 self._async_pool_tasks[database_name] = task
         try:
             pool = await asyncio.shield(task)

--- a/autobot_shared/redis_management/connection_manager_pool_test.py
+++ b/autobot_shared/redis_management/connection_manager_pool_test.py
@@ -131,7 +131,6 @@ class TestEnsureAsyncPoolLockScope:
         assert m._async_pools["main"] is pool
         assert attempts["n"] == 2
 
-
     @pytest.mark.asyncio
     async def test_completed_task_is_harvested_not_respawned(self):
         """A done-successful task whose waiter hasn't written the registry yet


### PR DESCRIPTION
## Thinking Path
Live-observed failure (dogfooding 2026-07-10): resolve job accepted during a prior resolve's restart chain → killed mid-run → reconciled `failed`, `post_steps: []` — **migrations silently skipped, no retry**. Fixes #11437 with two complementary mechanisms plus review hardening (#11460 review).

## What Changed
`api/code_sync.py`:
- `_restart_component_services` arms `_restart_pending` before a chain that restarts the SLM itself (`autobot-slm-backend`, `autobot_shared`); both resolve endpoints return **409** while armed. **Disarms at chain end** — reaching it alive means the self-restart didn't land (review BLOCKING: otherwise a failed restart bricked the resolve API until manual restart).
- `reconcile_stale_component_sync_jobs` **re-queues** interrupted jobs once (second interruption → permanent fail, `success=False`); also sweeps stale `queued` rows so a requeue whose re-run never started can't become an invisible zombie. Returns `(count, requeued)`.
- `_run_component_resolve_job` marks requeued jobs `running` for pollers.
`main.py` lifespan: re-runs requeued jobs, tracked in `_running_tasks` (strong ref + #1928 parity).

## Verification
- 4 targeted tests pass (<1s): requeue-once; second-interruption permanent fail; guard arms mid-chain only for self-killing components (observed via mocked subprocess); guard disarms when the process survives the chain.
- Correction from review: the earlier claim that `test_component_resolve_job.py` "hangs" was wrong — it pays ~3min of real subprocess timeouts (pre-existing; filed as #11462).

## Model Used
Claude Fable 5 (1M context)