### PR TITLE
fix(ui): mobile .view-container uses tokenized header height, not hardcoded 60px (#10902)

### DIFF
--- a/autobot-frontend/src/assets/styles/view.css
+++ b/autobot-frontend/src/assets/styles/view.css
@@ -157,9 +157,11 @@
 
 @media (max-width: 768px) {
   .view-container {
-    /* Adjust for mobile header height if different */
-    min-height: calc(100vh - 60px);
-    max-height: calc(100vh - 60px);
+    /* GH#10902: the header height is tokenized (--header-height, 56px) and does
+       not change on mobile — stay in sync via --view-min-height instead of a
+       hardcoded 60px that mis-sizes the view against its bounded content region. */
+    min-height: var(--view-min-height);
+    max-height: var(--view-min-height);
   }
 
   .view-content {


### PR DESCRIPTION
## Thinking Path
#10902 asked to sweep shell-nested views for `100vh`/`h-screen`/`min-h-screen` that overflow App.vue's bounded `<main class="flex-1 min-h-0">` (viewport − header).

I audited **every** viewport-height usage in the frontend and classified each. Key finding: the acute "raw 100vh overflows the shell" bug has **no remaining instances** — the one genuine case (LogPatternDashboard) was fixed in #10901 and its `100vh→100%` change propagated. The issue's other "likely offenders" are all **false positives** — correct fixed-position contexts:
- `FunctionCallGraph.vue` (1961/1970/1975/1980) — all under `.function-call-graph.fullscreen` (`position: fixed` viewport overlay). Correct.
- `KnowledgeGraph.vue` (1980/1989/1993) — all under `.knowledge-graph.fullscreen` (`position: fixed`). Correct.
- `KnowledgeView.vue:496` (`100dvh`) — `.knowledge-sidebar.mobile-open` fixed drawer. Correct.
- `LoginForm`/`SharedChatView`/`CommandPalette`/`*.stories.ts` — standalone pages / overlays / Storybook. Correct (issue agreed).

The **one genuine residual**: the base `.view-container` (used by 17 shell-nested views) correctly sizes to `var(--view-min-height)` = `calc(100vh - var(--header-height))` = `calc(100vh - 56px)`, matching the bounded main. But its **mobile override hardcoded `calc(100vh - 60px)`** — 60px ≠ the tokenized 56px header — so on mobile every view was mis-sized by 4px vs its bounded region (dead-space / spurious scroll). The stale comment "if different" is wrong: the header is 56px on mobile too.

## What Changed
- `src/assets/styles/view.css` (mobile `@media (max-width: 768px)`): `.view-container` `min-height`/`max-height` `calc(100vh - 60px)` → `var(--view-min-height)`. Mobile now stays in sync with the tokenized header height and matches the desktop rule; removes the hardcoded viewport magic number.

## Verification
- Full inventory of `100vh`/`100dvh`/`h-screen`/`min-h-screen`/`calc(100vh-…)` across `src/**` — every remaining hit is root (`App.vue`, `base.css` body), a `position: fixed` overlay/fullscreen, a standalone page, a utility-class definition (`vue-notus.css`), a Storybook story, or a comment. **Zero raw shell-nested viewport-height offenders remain.**
- `--header-height: 56px` and `--view-min-height: calc(100vh - var(--header-height))` confirmed in `design-tokens.css`; the mobile override is now consistent with the base rule.
- CSS-only change; no TS/behavior impact.

## Model Used
Opus 4.8 (1M context)

Closes #10902