### PR TITLE
fix(code-sync): status outdated_nodes uses live version signal (#11439)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -25,7 +25,7 @@ from urllib.parse import urlparse
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
-from sqlalchemy import func, select
+from sqlalchemy import func, select, or_ as sa_or
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
@@ -530,17 +530,32 @@ async def get_sync_status(
     total_result = await db.execute(select(func.count(Node.id)))
     total_nodes = total_result.scalar() or 0
 
-    # Issue #1605: count outdated + service-failed as needing attention
-    outdated_result = await db.execute(
-        select(func.count(Node.id)).where(
-            Node.code_status.in_(
-                [
-                    CodeStatus.OUTDATED.value,
-                    CodeStatus.CODE_CURRENT_SERVICE_FAILED.value,
-                ]
+    # Issue #1605: count outdated + service-failed as needing attention.
+    # #11439: currency uses the SAME live signal as has_update (#9996-B:
+    # code_version != latest), not the heartbeat-lagged code_status stamp —
+    # otherwise the endpoint could report has_update=true with
+    # outdated_nodes=0 (contradictory operator signal).
+    if latest_version:
+        outdated_result = await db.execute(
+            select(func.count(Node.id)).where(
+                sa_or(
+                    Node.code_version.is_(None),
+                    Node.code_version != latest_version,
+                    Node.code_status == CodeStatus.CODE_CURRENT_SERVICE_FAILED.value,
+                )
             )
         )
-    )
+    else:
+        outdated_result = await db.execute(
+            select(func.count(Node.id)).where(
+                Node.code_status.in_(
+                    [
+                        CodeStatus.OUTDATED.value,
+                        CodeStatus.CODE_CURRENT_SERVICE_FAILED.value,
+                    ]
+                )
+            )
+        )
     outdated_nodes = outdated_result.scalar() or 0
 
     # Check if local repo has updates

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -25,7 +25,9 @@ from urllib.parse import urlparse
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
-from sqlalchemy import func, select, or_ as sa_or
+from sqlalchemy import func
+from sqlalchemy import or_ as sa_or
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 

--- a/autobot-slm-backend/services/inventory_builder.py
+++ b/autobot-slm-backend/services/inventory_builder.py
@@ -291,8 +291,7 @@ def build_registry_inventory(nodes: list[Any], local_ip_check: Any) -> dict:
         # wrongly promote a pure SLM manager into infrastructure (#11453).
         is_slm = bool(node_groups & {"slm", "slm_server", "slm_nodes"})
         has_app_roles = any(
-            (t := tok.strip().lower()) and not t.startswith("slm-") and t != "slm_agent"
-            for tok in role_tokens
+            (t := tok.strip().lower()) and not t.startswith("slm-") and t != "slm_agent" for tok in role_tokens
         )
         if not is_slm or has_app_roles:
             node_groups |= _UNIVERSAL_NON_SLM

--- a/autobot-slm-backend/tests/api/test_sync_status_outdated_signal.py
+++ b/autobot-slm-backend/tests/api/test_sync_status_outdated_signal.py
@@ -1,0 +1,77 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11439: /code-sync/status outdated_nodes must use the live version signal
+(code_version != latest, #9996-B), not the heartbeat-lagged code_status stamp
+— otherwise has_update=true could coexist with outdated_nodes=0."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+import inspect  # noqa: E402
+import types  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+# Same shims as test_collect_outdated_node_ids.py (#10023): stub the
+# conflicting multipart package and swap benign dicts in for MagicMock schema
+# names so api.code_sync imports under the conftest stub regime.
+if "multipart" in sys.modules and not hasattr(sys.modules["multipart"], "multipart"):
+    sys.modules.pop("multipart", None)
+_mp_stub = types.ModuleType("multipart")
+_mp_stub.multipart = types.ModuleType("multipart.multipart")  # type: ignore[attr-defined]
+sys.modules.setdefault("multipart", _mp_stub)
+sys.modules.setdefault("multipart.multipart", _mp_stub.multipart)  # type: ignore[attr-defined]
+
+_SCHEMA_NAMES = (
+    "CodeSyncRefreshResponse",
+    "CodeSyncStatusResponse",
+    "CodeVersionNotification",
+    "CodeVersionNotificationResponse",
+    "DriftResolveRequest",
+    "DriftResolveResponse",
+    "FileDriftReport",
+    "FleetSyncJobStatus",
+    "FleetSyncNodeStatus",
+    "FleetSyncRequest",
+    "FleetSyncResponse",
+    "NodeSyncRequest",
+    "NodeSyncResponse",
+    "PendingNodeResponse",
+    "PendingNodesResponse",
+    "ScheduleCreate",
+    "ScheduleResponse",
+    "ScheduleRunResponse",
+    "ScheduleUpdate",
+    # #11303/#11447 additions missing from the sibling's list
+    "DriftResolveJobResponse",
+    "ComponentSyncJobStatus",
+    "UpdateAllRequest",
+    "UpdateAllStatusResponse",
+    "MarkSyncedResponse",
+)
+_schemas_stub = sys.modules.get("models.schemas")
+if isinstance(_schemas_stub, MagicMock):
+    for _name in _SCHEMA_NAMES:
+        setattr(_schemas_stub, _name, dict)
+
+
+def test_status_outdated_count_uses_version_signal_when_latest_known():
+    """The version-based branch must gate on latest_version and OR the
+    service-failed status (preserving #1605)."""
+    import api.code_sync as code_sync_mod
+
+    src = inspect.getsource(code_sync_mod.get_sync_status)
+    # version-based currency present and gated on latest_version
+    assert "if latest_version:" in src
+    assert "Node.code_version != latest_version" in src
+    assert "Node.code_version.is_(None)" in src
+    # #1605 service-failed still counted as needing attention
+    assert "CODE_CURRENT_SERVICE_FAILED" in src
+    # legacy status-stamp fallback retained when latest is unknown
+    assert "CodeStatus.OUTDATED.value" in src


### PR DESCRIPTION
## Thinking Path
Dogfooding observed `has_update: true` + `outdated_nodes: 0` from `/code-sync/status` — contradictory operator signal. Cause: the count keys on heartbeat-lagged `code_status` stamps while `has_update` compares live versions. Same class as #9996-B. (The refresh-message half of #11439 was already fixed by #11448.) Closes #11439.

## What Changed
`get_sync_status`: when `latest_version` is known, `outdated_nodes` counts `code_version != latest OR code_version IS NULL OR code_status == CODE_CURRENT_SERVICE_FAILED` (preserves #1605's needs-attention semantics); legacy stamp-based count retained as fallback when latest is unknown.
Test: source-level guard asserting the version-signal branch, the NULL case, the #1605 OR, and the fallback (with the conftest schema shims — extended the stale `_SCHEMA_NAMES` list with #11303 schemas).

## Verification
- New test passes; `ast.parse` clean. Endpoint-only change, no schema change.

## Model Used
Claude Fable 5 (1M context)
