### PR TITLE
fix(ci): replace add_done_callback lambda with functools.partial (#11472)

### DIFF
--- a/autobot_shared/redis_management/connection_manager.py
+++ b/autobot_shared/redis_management/connection_manager.py
@@ -20,6 +20,7 @@ Moved from autobot-backend/utils/ to autobot_shared/ (Issue #2313).
 """
 
 import asyncio
+import functools
 import logging
 import socket
 import time
@@ -888,7 +889,11 @@ class RedisConnectionManager:
                 # Always retrieve the exception even if every waiter was
                 # cancelled — avoids "Task exception was never retrieved" and
                 # preserves the failure reason in the logs (#11451).
-                task.add_done_callback(lambda t, _db=database_name: self._log_pool_task_failure(_db, t))
+                # functools.partial (not a lambda): Black collapses a short lambda
+                # onto one line, and mypy then rejects the single-line lambda-with-
+                # default with "Cannot infer type of lambda" — the two tools cannot
+                # both be satisfied with a lambda here (#11472). partial types cleanly.
+                task.add_done_callback(functools.partial(self._log_pool_task_failure, database_name))
                 self._async_pool_tasks[database_name] = task
         try:
             pool = await asyncio.shield(task)


### PR DESCRIPTION
## Thinking Path
The required **Code Quality** check has been red on `Dev_new_gui` for every PR at the `Type-check autobot_shared` step: `connection_manager.py:891: error: Cannot infer type of lambda [misc]`. Root cause is a Black↔mypy conflict — Black (`--line-length=120`) collapses the short pool-task-failure callback (#11451) onto one line, and mypy then rejects the single-line `lambda`-with-default. Any multi-line form is immediately re-collapsed by Black, so neither tool can be satisfied with a lambda. Line is byte-identical on base → pre-existing, blocks the whole queue.

## What Changed
- Replaced the lambda with `functools.partial(self._log_pool_task_failure, database_name)` (single-line, Black-clean, mypy-typeable). `add_done_callback(cb)` calls `cb(task)`; `_log_pool_task_failure(database_name, task)` matches — behaviour identical.
- Added `import functools`.

## Verification
- mypy before: `connection_manager.py:891: error: Cannot infer type of lambda`. After: **no error** on that line.
- black + py_compile clean.

## Model Used
Opus 4.8

Closes #11472