### PR TITLE
ci(migrations): make Migration Gate always-report so it can be a required check (#11346)

### DIFF
--- a/.github/workflows/migration-gate.yml
+++ b/.github/workflows/migration-gate.yml
@@ -18,7 +18,7 @@ name: Migration Gate
 on:
   push:
     branches: [ main, Dev_new_gui ]
-    paths: &paths
+    paths:
       - 'autobot-backend/migrations/**'
       - 'autobot-backend/tests/migrations/**'
       - 'autobot-backend/user_management/models/**'
@@ -29,9 +29,13 @@ on:
       - 'autobot-slm-backend/ansible/setup-user-backend.yml'
       - 'autobot-slm-backend/ansible/playbooks/update-all-nodes.yml'
       - '.github/workflows/migration-gate.yml'
+  # NOTE (#11346): no pull_request.paths filter — this workflow ALWAYS runs on PRs
+  # so its required-check context ("migration-matrix") always reports a conclusion.
+  # A path-filtered required check that never triggers leaves the PR deadlocked on
+  # "Expected — Waiting for status". The real matrix is gated on the `changes` job
+  # below and self-skips (reporting success) when no migration-relevant path changes.
   pull_request:
     branches: [ main, Dev_new_gui ]
-    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -41,7 +45,37 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      migrations: ${{ steps.filter.outputs.migrations }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        id: filter
+        with:
+          filters: |
+            migrations:
+              - 'autobot-backend/migrations/**'
+              - 'autobot-backend/tests/migrations/**'
+              - 'autobot-backend/user_management/models/**'
+              - 'autobot-backend/llc/models/**'
+              - 'autobot-backend/canvas/models.py'
+              - 'autobot-backend/models/**'
+              - 'autobot-backend/initialization/lifespan.py'
+              - 'autobot-slm-backend/ansible/setup-user-backend.yml'
+              - 'autobot-slm-backend/ansible/playbooks/update-all-nodes.yml'
+              - '.github/workflows/migration-gate.yml'
+
   migration-matrix:
+    needs: changes
+    # Run the full matrix whenever a migration-relevant path changed. Using
+    # `!= 'false'` (rather than `== 'true'`) is fail-safe: any unexpected/empty
+    # filter output still runs the gate instead of silently skipping it. On PRs
+    # that touch no migration paths the job is skipped and reports success, so the
+    # required "migration-matrix" context always resolves.
+    if: needs.changes.outputs.migrations != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## Thinking Path
#11346 wants the Migration Gate to be a **required** status check on `Dev_new_gui` so a broken `alembic upgrade head` blocks merge (PR #11338 merged with the gate red because it wasn't required). Its second half — a lint enforcing `migrations.guards.pg_enum()` over generic `sa.Enum(` — is **already shipped** (`tests/migrations/test_guards.py::test_migrations_use_pg_enum_not_generic_sa_enum`, AST-based; passing).

The remaining blocker to requiring the gate: `migration-gate.yml` was **path-filtered on `pull_request`**, so the `migration-matrix` check only reported on migration-touching PRs. Making a path-filtered check required would **deadlock every other PR** on "Expected — Waiting for status" (only `--admin` could merge). This is the exact pitfall `verify-generated-types.yml` already documents and solves.

## What Changed
- `.github/workflows/migration-gate.yml`: mirror the proven `verify-generated-types.yml` pattern —
  - Dropped the `pull_request.paths` filter so the workflow **always runs on PRs** to `main`/`Dev_new_gui` and its `migration-matrix` context always reports a conclusion. (Kept the `push.paths` filter.)
  - Added a `changes` job (Detect changed paths, `dorny/paths-filter`) outputting `migrations`.
  - `migration-matrix` now `needs: changes` and runs `if: needs.changes.outputs.migrations != 'false'` — fail-safe (any unexpected/empty output still runs the gate). On PRs touching no migration paths the job **self-skips and reports success**, so the check is safe to require without deadlocking non-migration merges.

This PR is the enabling refactor. Once merged and confirmed to report on a non-migration PR, `migration-matrix` will be added to the `Dev_new_gui` required-status-checks set (the governance flip).

## Verification
- YAML validates; jobs = `changes`, `migration-matrix`; `pull_request` has no `paths`; `migration-matrix` has `needs: changes` + the fail-safe `if`.
- This PR touches `migration-gate.yml` (in the filter), so the real matrix runs here and proves the refactored workflow still executes the full gate.
- Post-merge check: a frontend/backend-only PR must show `migration-matrix` = *skipping* (success), confirming no deadlock before the required-checks flip.

## Model Used
Opus 4.8 (1M context)

Closes #11346