### PR TITLE
fix(a11y): thread translated close-label into all BaseModal call sites (#10890)

### DIFF
--- a/autobot-frontend/src/components/analytics/AddSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/AddSourceModal.vue
@@ -1,5 +1,6 @@
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     :model-value="visible"
     :title="isEditMode ? $t('analytics.sources.editSource') : $t('analytics.sources.addCodeSource')"
     size="sm"

--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -394,6 +394,7 @@
 
     <!-- Drill-Down Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       :model-value="!!drillDownCategory"
       :title="drillDownCategory ? `${formatCategoryName(drillDownCategory)} - ${$t('analytics.codeQuality.detailedView')}` : ''"
       size="md"

--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
@@ -304,6 +304,7 @@
 
     <!-- Patterns Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       :model-value="showPatterns"
       :title="$t('analytics.codeReview.reviewPatterns')"
       size="md"

--- a/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
+++ b/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
@@ -197,6 +197,7 @@
 
     <!-- Intent Detail Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       :model-value="!!selectedIntent"
       :title="selectedIntent?.intent_name ?? ''"
       size="sm"
@@ -260,11 +261,13 @@
  */
 import Icon from '@/components/ui/Icon.vue'
 import { BaseModal } from '@autobot/ui'
+import { useI18n } from 'vue-i18n'
 import { ref, onMounted, computed } from 'vue'
 import {
   useConversationFlowData,
   type IntentPattern,
 } from '@/composables/analytics/useConversationFlowData'
+const { t } = useI18n()
 
 // State
 const timeRange = ref(24)

--- a/autobot-frontend/src/components/analytics/LogPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LogPatternDashboard.vue
@@ -172,6 +172,7 @@
 
     <!-- Pattern Details Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       :model-value="!!selectedPattern"
       :title="selectedPattern ? $t('analytics.logPatterns.patternDetails', { id: selectedPattern.pattern_id }) : ''"
       size="md"

--- a/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
@@ -309,6 +309,7 @@
 
     <!-- Patterns Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       :model-value="showPatterns"
       :title="$t('analytics.performanceAnalysis.performancePatterns')"
       size="md"

--- a/autobot-frontend/src/components/analytics/ShareSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/ShareSourceModal.vue
@@ -1,5 +1,6 @@
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     :model-value="visible"
     :title="$t('analytics.sources.shareSource')"
     size="sm"

--- a/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
+++ b/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
@@ -374,6 +374,7 @@
 
     <!-- Item Details Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       :model-value="!!selectedItem"
       :title="$t('analytics.technicalDebt.debtItemDetails')"
       size="sm"
@@ -434,6 +435,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue';
 import { BaseModal } from '@autobot/ui'
+import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils';
 import { getCssVar } from '@/composables/useCssVars'
 import {
@@ -443,6 +445,7 @@ import {
   type TrendPoint,
   type DebtSummary,
 } from '@/composables/analytics/useTechnicalDebtData'
+const { t } = useI18n()
 
 // Create scoped logger for TechnicalDebtDashboard
 const logger = createLogger('TechnicalDebtDashboard');

--- a/autobot-frontend/src/components/analytics/code-intelligence/FileScanModal.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/FileScanModal.vue
@@ -5,6 +5,7 @@
 
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     :model-value="show"
     :title="$t('analytics.findings.fileScan.title')"
     size="sm"

--- a/autobot-frontend/src/components/browser/BrowserSessionManager.vue
+++ b/autobot-frontend/src/components/browser/BrowserSessionManager.vue
@@ -186,7 +186,7 @@
 
     <!-- Create Session Modal -->
     <BaseModal
-      :close-label="t('ui.modal.closeDialog')"
+      :close-label="$t('ui.modal.closeDialog')"
       v-model="showCreateModal"
       :title="$t('browser.sessionManager.createBrowserSession')"
       size="sm"

--- a/autobot-frontend/src/components/browser/BrowserSessionManager.vue
+++ b/autobot-frontend/src/components/browser/BrowserSessionManager.vue
@@ -186,6 +186,7 @@
 
     <!-- Create Session Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showCreateModal"
       :title="$t('browser.sessionManager.createBrowserSession')"
       size="sm"

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -518,6 +518,7 @@
 
   <!-- Edit Message Modal -->
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     v-model="showEditModal"
     :title="$t('chat.messages.editMessage')"
     size="md"

--- a/autobot-frontend/src/components/chat/ChatSidebar.vue
+++ b/autobot-frontend/src/components/chat/ChatSidebar.vue
@@ -366,6 +366,7 @@
 
   <!-- Edit Session Name Modal -->
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     v-model="showEditModal"
     :title="$t('chat.sidebar.editChatName')"
     size="md"

--- a/autobot-frontend/src/components/chat/DeleteConversationDialog.vue
+++ b/autobot-frontend/src/components/chat/DeleteConversationDialog.vue
@@ -1,5 +1,6 @@
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     :model-value="visible"
     :title="$t('chat.deleteDialog.title')"
     size="md"

--- a/autobot-frontend/src/components/chat/McpPromptPicker.vue
+++ b/autobot-frontend/src/components/chat/McpPromptPicker.vue
@@ -12,6 +12,7 @@
     </BaseButton>
 
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-if="showModal"
       :model-value="showModal"
       title="Prompt Templates"
@@ -149,8 +150,10 @@ import { ref, computed, watch } from 'vue'
 import { useApiClient } from '@/plugins/api'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { BaseModal } from '@autobot/ui'
+import { useI18n } from 'vue-i18n'
 import Icon from '@/components/ui/Icon.vue'
 import { createLogger } from '@/utils/debugUtils'
+const { t } = useI18n()
 
 const logger = createLogger('McpPromptPicker')
 const api = useApiClient()

--- a/autobot-frontend/src/components/chat/PresetManagementModal.vue
+++ b/autobot-frontend/src/components/chat/PresetManagementModal.vue
@@ -4,6 +4,7 @@
 
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     :model-value="modelValue"
     :title="$t('chat.presets.modalTitle')"
     size="md"
@@ -17,7 +18,9 @@
 
 <script setup lang="ts">
 import { BaseModal } from '@autobot/ui'
+import { useI18n } from 'vue-i18n'
 import PresetFormBody from '@/components/chat/PresetFormBody.vue'
+const { t } = useI18n()
 
 defineProps<{
   modelValue: boolean

--- a/autobot-frontend/src/components/chat/ShareConversationDialog.vue
+++ b/autobot-frontend/src/components/chat/ShareConversationDialog.vue
@@ -1,5 +1,6 @@
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     :model-value="visible"
     :title="$t('chat.share.title')"
     size="md"
@@ -221,12 +222,14 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { BaseModal } from '@autobot/ui'
+import { useI18n } from 'vue-i18n'
 import BaseButton from '@/components/base/BaseButton.vue'
 import ApiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import { useBatchSelection } from '@/composables/useBatchSelection'
 import Icon from '@/components/ui/Icon.vue'
+const { t } = useI18n()
 
 const logger = createLogger('ShareConversationDialog')
 

--- a/autobot-frontend/src/components/feature-flags/EndpointEnforcement.vue
+++ b/autobot-frontend/src/components/feature-flags/EndpointEnforcement.vue
@@ -71,6 +71,7 @@
 
     <!-- Add/Edit Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showAddModal"
       :title="editingEndpoint ? $t('featureFlags.enforcement.editOverride') : $t('featureFlags.enforcement.addEndpointOverride')"
       size="md"
@@ -127,6 +128,7 @@
 
     <!-- Remove Confirmation Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showRemoveModal"
       :title="$t('featureFlags.enforcement.removeOverride')"
       size="sm"

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -87,6 +87,7 @@
 
     <!-- System Category Documents Panel -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showCategoryDocuments"
       :title="`${formatCategoryName(selectedCategoryPath)} - Documents`"
       size="lg"
@@ -127,6 +128,7 @@
 
     <!-- Document Details Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showDocumentModal"
       :title="currentDocument?.title || currentDocument?.filename || $t('knowledge.categories.documentDetails')"
       size="lg"

--- a/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
@@ -290,6 +290,7 @@
 
     <!-- View/Edit Dialog -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showDialog"
       :title="dialogMode === 'view' ? $t('knowledge.entries.viewEntry') : $t('knowledge.entries.editEntry')"
       size="lg"

--- a/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
@@ -414,6 +414,7 @@ onBeforeUnmount(() => {
 
     <!-- History Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showHistoryModal"
       :title="$t('knowledge.promptEditor.versionHistory')"
       size="lg"

--- a/autobot-frontend/src/components/knowledge/McpResourceBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/McpResourceBrowser.vue
@@ -65,6 +65,7 @@
 
     <!-- Resource Viewer Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-if="viewingResource"
       :model-value="!!viewingResource"
       :title="viewingResource.name"
@@ -109,8 +110,10 @@ import { ref, computed, onMounted } from 'vue'
 import { useApiClient } from '@/plugins/api'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { BaseModal } from '@autobot/ui'
+import { useI18n } from 'vue-i18n'
 import Icon from '@/components/ui/Icon.vue'
 import { createLogger } from '@/utils/debugUtils'
+const { t } = useI18n()
 
 const logger = createLogger('McpResourceBrowser')
 const api = useApiClient()

--- a/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
+++ b/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
@@ -1,5 +1,6 @@
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     :model-value="isOpen"
     :title="$t('knowledge.share.title', { name: factTitle })"
     size="md"

--- a/autobot-frontend/src/components/knowledge/VectorizationProgressModal.vue
+++ b/autobot-frontend/src/components/knowledge/VectorizationProgressModal.vue
@@ -1,5 +1,6 @@
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     :model-value="show"
     :title="$t('knowledge.vectorization.progressTitle')"
     size="md"
@@ -129,6 +130,8 @@ import { computed } from 'vue'
 import VectorizationStatusBadge from './VectorizationStatusBadge.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import { BaseModal } from '@autobot/ui'
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
 
 interface DocumentState {
   documentId: string

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
@@ -577,6 +577,7 @@ function closeModal() {
 
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     :model-value="modelValue"
     :title="modalTitle"
     size="md"

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
@@ -265,6 +265,7 @@ onMounted(() => {
 
     <!-- History Modal — Issue #8149: replaced with ConnectorHistoryPanel -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showHistoryModal"
       :title="t('knowledge.connectors.syncHistoryTitle', { name: historyConnectorName })"
       size="md"

--- a/autobot-frontend/src/components/knowledge/modals/BulkEditModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/BulkEditModal.vue
@@ -230,6 +230,7 @@ watch(() => props.modelValue, (newValue) => {
 
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     v-model="isOpen"
     :title="modalTitle"
     size="md"

--- a/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
@@ -258,6 +258,7 @@ function selectIcon(icon: string): void {
 
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     v-model="isOpen"
     :title="t('knowledge.modals.categoryEdit.editTitle', { name: categoryTitle })"
     size="md"

--- a/autobot-frontend/src/components/knowledge/modals/DocumentExportModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/DocumentExportModal.vue
@@ -204,6 +204,7 @@ watch(() => props.modelValue, (isOpen) => {
 
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     v-model="isOpen"
     :title="modalTitle"
     size="sm"

--- a/autobot-frontend/src/components/llc/HandoffModal.vue
+++ b/autobot-frontend/src/components/llc/HandoffModal.vue
@@ -8,6 +8,7 @@
 -->
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     :model-value="true"
     :title="modalTitle"
     size="sm"

--- a/autobot-frontend/src/components/llc/HireAgentModal.vue
+++ b/autobot-frontend/src/components/llc/HireAgentModal.vue
@@ -7,6 +7,7 @@
 -->
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     :model-value="true"
     title="Hire Agent"
     size="sm"
@@ -58,7 +59,9 @@ import { ref } from 'vue'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import { BaseModal } from '@autobot/ui'
+import { useI18n } from 'vue-i18n'
 import AdapterTypeSelect from './AdapterTypeSelect.vue'
+const { t } = useI18n()
 
 const props = defineProps<{ companyId: string }>()
 const emit = defineEmits<{ close: []; hired: [] }>()

--- a/autobot-frontend/src/components/mobile/PairDeviceDialog.vue
+++ b/autobot-frontend/src/components/mobile/PairDeviceDialog.vue
@@ -5,9 +5,11 @@
 
 import { watch } from 'vue'
 import { BaseModal } from '@autobot/ui'
+import { useI18n } from 'vue-i18n'
 import Icon from '@/components/ui/Icon.vue'
 import { usePairingQR } from '@/composables/usePairingQR'
 import { createLogger } from '@/utils/debugUtils'
+const { t } = useI18n()
 
 const logger = createLogger('PairDeviceDialog')
 
@@ -54,6 +56,7 @@ watch(isPaired, (paired) => {
 
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     :model-value="modelValue"
     :title="$t('mobile.pairing.title')"
     size="md"

--- a/autobot-frontend/src/components/modals/TelemetryConsentModal.vue
+++ b/autobot-frontend/src/components/modals/TelemetryConsentModal.vue
@@ -9,6 +9,7 @@ Issue #9035: Operator-controlled local usage metrics (never transmitted)
 
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     v-model="isVisible"
     title="Local Usage Metrics"
     size="sm"
@@ -75,6 +76,8 @@ import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import Icon from '@/components/ui/Icon.vue'
 import { BaseModal } from '@autobot/ui'
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
 
 const logger = createLogger('TelemetryConsentModal')
 const api = useApiClient()

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -270,6 +270,7 @@
 
     <!-- Create/Edit Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       :modelValue="showCreateModal || showEditModal"
       @update:modelValue="val => !val && closeModals()"
       :title="modalTitle"
@@ -650,6 +651,7 @@
 
     <!-- View Secret Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showViewModal"
       :title="viewingSecret?.name || $t('security.secretsManager.viewDetails')"
       size="md"
@@ -728,6 +730,7 @@
 
     <!-- Transfer Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showTransferModal"
       :title="$t('security.secretsManager.transferTitle')"
       size="sm"
@@ -755,6 +758,7 @@
 
     <!-- Delete Confirmation Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showDeleteModal"
       :title="$t('security.secretsManager.deleteConfirmTitle')"
       size="sm"

--- a/autobot-frontend/src/components/services/RedisServiceControl.vue
+++ b/autobot-frontend/src/components/services/RedisServiceControl.vue
@@ -189,6 +189,7 @@
 
     <!-- Confirmation Dialog -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showConfirmDialog"
       :title="confirmDialog.title"
       size="md"

--- a/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
+++ b/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
@@ -1,5 +1,6 @@
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     :modelValue="modelValue"
     @update:modelValue="$emit('update:modelValue', $event)"
     :title="t('settings.apiKeys.wizardTitle')"

--- a/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
+++ b/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
@@ -181,6 +181,7 @@ function resetEdit(): void {
 
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     v-model="isOpen"
     :title="t('terminal.window.workflowStepConfirmation')"
     size="md"

--- a/autobot-frontend/src/components/terminal/TerminalModals.vue
+++ b/autobot-frontend/src/components/terminal/TerminalModals.vue
@@ -2,6 +2,7 @@
   <div>
     <!-- Connection Lost Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       :modelValue="showReconnectModal"
       @update:modelValue="val => !val && $emit('hide-reconnect-modal')"
       :title="$t('terminal.modals.connectionLost')"
@@ -42,6 +43,7 @@
 
     <!-- Command Confirmation Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       :modelValue="showCommandConfirmation"
       @update:modelValue="val => !val && cancelCommand()"
       :title="$t('terminal.modals.destructiveCommand')"
@@ -108,6 +110,7 @@
 
     <!-- Emergency Kill Confirmation Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       :modelValue="showKillConfirmation"
       @update:modelValue="val => !val && cancelKill()"
       :title="$t('terminal.modals.emergencyKillTitle')"
@@ -158,6 +161,7 @@
 
     <!-- Legacy Manual Step Confirmation Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       :modelValue="showLegacyModal"
       @update:modelValue="val => !val && handleTakeManualControl()"
       :title="$t('terminal.modals.workflowTitle')"
@@ -238,9 +242,11 @@
 import { ref } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 import BaseButton from '@/components/base/BaseButton.vue'
+import { BaseModal } from '@autobot/ui'
+import { useI18n } from 'vue-i18n'
 
 const logger = createLogger('TerminalModals')
-import { BaseModal } from '@autobot/ui'
+const { t } = useI18n()
 
 interface ProcessInfo {
   pid: number

--- a/autobot-frontend/src/components/transcriber/UploadModal.vue
+++ b/autobot-frontend/src/components/transcriber/UploadModal.vue
@@ -6,6 +6,8 @@ import { useTranscriberApi } from '@/composables/transcriber/useTranscriberApi'
 import type { Recording } from '@/composables/transcriber/useTranscriberApi'
 import { createLogger } from '@/utils/debugUtils'
 import { BaseModal } from '@autobot/ui'
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
 
 const logger = createLogger('UploadModal')
 const props = defineProps<{ projectId: number; open: boolean }>()
@@ -41,6 +43,7 @@ async function upload() {
 
 <template>
   <BaseModal
+    :close-label="t('ui.modal.closeDialog')"
     :model-value="open"
     title="Upload Recording"
     size="sm"

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -5555,7 +5555,7 @@
       "dismissAlert": "Dismiss alert"
     },
     "modal": {
-      "closeDialog": "Close dialog"
+      "closeDialog": "إغلاق مربع الحوار"
     },
     "commandPermission": {
       "title": "Command Permission Required",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -5555,7 +5555,7 @@
       "dismissAlert": "Dismiss alert"
     },
     "modal": {
-      "closeDialog": "Close dialog"
+      "closeDialog": "Dialog schließen"
     },
     "commandPermission": {
       "title": "Command Permission Required",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -5555,7 +5555,7 @@
       "dismissAlert": "Dismiss alert"
     },
     "modal": {
-      "closeDialog": "Close dialog"
+      "closeDialog": "Cerrar diálogo"
     },
     "commandPermission": {
       "title": "Command Permission Required",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -4819,7 +4819,7 @@
       "notifications": "Notifications"
     },
     "modal": {
-      "closeDialog": "Close dialog"
+      "closeDialog": "بستن کادر گفتگو"
     },
     "progressBar": {
       "timeRemaining": "{time} remaining"

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -5555,7 +5555,7 @@
       "dismissAlert": "Dismiss alert"
     },
     "modal": {
-      "closeDialog": "Close dialog"
+      "closeDialog": "Fermer la boîte de dialogue"
     },
     "commandPermission": {
       "title": "Command Permission Required",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -4819,7 +4819,7 @@
       "notifications": "Notifications"
     },
     "modal": {
-      "closeDialog": "Close dialog"
+      "closeDialog": "סגירת תיבת הדו-שיח"
     },
     "progressBar": {
       "timeRemaining": "{time} remaining"

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -5555,7 +5555,7 @@
       "dismissAlert": "Dismiss alert"
     },
     "modal": {
-      "closeDialog": "Close dialog"
+      "closeDialog": "Aizvērt dialoglodziņu"
     },
     "commandPermission": {
       "title": "Command Permission Required",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -5555,7 +5555,7 @@
       "dismissAlert": "Dismiss alert"
     },
     "modal": {
-      "closeDialog": "Close dialog"
+      "closeDialog": "Zamknij okno dialogowe"
     },
     "commandPermission": {
       "title": "Command Permission Required",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -5555,7 +5555,7 @@
       "dismissAlert": "Dismiss alert"
     },
     "modal": {
-      "closeDialog": "Close dialog"
+      "closeDialog": "Fechar caixa de diálogo"
     },
     "commandPermission": {
       "title": "Command Permission Required",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -4819,7 +4819,7 @@
       "notifications": "Notifications"
     },
     "modal": {
-      "closeDialog": "Close dialog"
+      "closeDialog": "ڈائیلاگ بند کریں"
     },
     "progressBar": {
       "timeRemaining": "{time} remaining"

--- a/autobot-frontend/src/views/AdminUsersView.vue
+++ b/autobot-frontend/src/views/AdminUsersView.vue
@@ -149,6 +149,7 @@
 
     <!-- Create User Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showCreateModal"
       title="Add User"
       size="sm"
@@ -185,6 +186,7 @@
 
     <!-- Assign Voice Bundle Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       :model-value="!!bundleTarget"
       title="Assign Voice Bundle"
       size="sm"
@@ -221,6 +223,7 @@
 
     <!-- Delete Confirm Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       :model-value="!!deleteTarget"
       title="Delete User"
       size="sm"
@@ -243,6 +246,7 @@ import { createLogger } from '@/utils/debugUtils'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import Icon from '@/components/ui/Icon.vue'
 import { BaseModal } from '@autobot/ui'
+import { useI18n } from 'vue-i18n'
 import {
   useAdminVoiceBundle,
   VOICE_BUNDLE_NAMES,
@@ -250,6 +254,7 @@ import {
 } from '@/composables/useVoiceBundle'
 import type { VoiceBundleName } from '@/composables/useVoiceBundle'
 
+const { t } = useI18n()
 const logger = createLogger('AdminUsersView')
 
 interface UserRecord {

--- a/autobot-frontend/src/views/AuditLogsView.vue
+++ b/autobot-frontend/src/views/AuditLogsView.vue
@@ -139,6 +139,7 @@
 
       <!-- Cleanup Modal -->
       <BaseModal
+        :close-label="t('ui.modal.closeDialog')"
         v-model="showCleanupModal"
         :title="$t('views.auditLogs.cleanupTitle')"
         size="sm"

--- a/autobot-frontend/src/views/llc/CeoChatView.vue
+++ b/autobot-frontend/src/views/llc/CeoChatView.vue
@@ -91,6 +91,7 @@
 
     <!-- New thread modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showNewThread"
       :title="$t('llc.ceoChat.newThreadTitle')"
       size="sm"

--- a/autobot-frontend/src/views/llc/CostDashboard.vue
+++ b/autobot-frontend/src/views/llc/CostDashboard.vue
@@ -76,6 +76,7 @@
 
     <!-- Budget settings modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       :model-value="settingsModal.visible"
       :title="$t('llc.cost.settingsTitle')"
       size="sm"

--- a/autobot-frontend/src/views/llc/MembersView.vue
+++ b/autobot-frontend/src/views/llc/MembersView.vue
@@ -75,6 +75,7 @@
 
     <!-- Add member modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showAddModal"
       :title="t('llcMembers.addModalTitle')"
       size="md"

--- a/autobot-frontend/src/views/llc/PortfolioBrowserView.vue
+++ b/autobot-frontend/src/views/llc/PortfolioBrowserView.vue
@@ -57,6 +57,7 @@
     </div>
 
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showCreate"
       :title="t('llcBrowser.portfolios.createTitle')"
       size="sm"

--- a/autobot-frontend/src/views/llc/ProgramBrowserView.vue
+++ b/autobot-frontend/src/views/llc/ProgramBrowserView.vue
@@ -54,6 +54,7 @@
     </div>
 
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showCreate"
       :title="t('llcBrowser.programs.createTitle')"
       size="sm"

--- a/autobot-frontend/src/views/llc/ProjectBrowserView.vue
+++ b/autobot-frontend/src/views/llc/ProjectBrowserView.vue
@@ -225,6 +225,7 @@
 
     <!-- Create project modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showCreate"
       :title="t('llcBrowser.projects.createTitle')"
       size="sm"
@@ -267,6 +268,7 @@
 
     <!-- GH#11129: Attach repo modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showAttach"
       :title="t('llcBrowser.repo.attachTitle')"
       size="sm"

--- a/autobot-frontend/src/views/secrets/LlmApiKeysView.vue
+++ b/autobot-frontend/src/views/secrets/LlmApiKeysView.vue
@@ -110,6 +110,7 @@
 
     <!-- Issue Key Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       v-model="showIssueModal"
       :title="t('llmKeys.issueKey')"
       size="md"
@@ -154,6 +155,7 @@
 
     <!-- Revoke Confirmation Modal -->
     <BaseModal
+      :close-label="t('ui.modal.closeDialog')"
       :model-value="!!revokeKeyId"
       :title="t('llmKeys.revokeConfirm.title')"
       size="sm"


### PR DESCRIPTION
## Thinking Path
The shared kit `@autobot/ui`'s `BaseModal` can't depend on `vue-i18n`, so its close-button `aria-label` is a `closeLabel` prop defaulting to English `'Close'`. All 47 call sites imported `BaseModal` directly and none passed a translated label → the screen-reader label was English-only (a11y i18n regression from #10750 C2c). Compounding it, the `ui.modal.closeDialog` key held the English placeholder in **all** 11 locales, so even threading it would have stayed English.

## What Changed (57 files)
- **i18n (10 locales)**: translated `ui.modal.closeDialog` in de/es/fr/pt/pl/lv/ar/fa/he/ur (en unchanged: "Close dialog"). RTL locales included.
- **47 BaseModal call sites**: added `:close-label="t('ui.modal.closeDialog')"` to every `<BaseModal>` tag.
- **13 of those files** lacked a local `t` binding (they used the global `$t` helper or none) — added `import { useI18n } from 'vue-i18n'` + `const { t } = useI18n()` so `t(...)` resolves.

## Verification (independently re-run)
- 47 files contain `<BaseModal`; **47** now contain `:close-label="t('ui.modal.closeDialog')"`. A multi-line-aware scan found **zero** `<BaseModal>` opening tags without a `:close-label`.
- Every file referencing `t('ui.modal.closeDialog')` has both a local `useI18n()` `t` binding **and** the `vue-i18n` import — **no undefined-`t`**; no duplicate `useI18n` bindings introduced. Import placement in the two auto-insert edge cases (`TerminalModals.vue`, `AdminUsersView.vue`) verified correct.
- All 11 locale files parse; each of the 10 non-English `ui.modal.closeDialog` values is the translated string; only that key changed (1 insertion / 1 deletion per locale).

## Model Used
Opus 4.8 (1M context) + frontend-engineer agent (implementation), independently verified.

Closes #10890