### PR TITLE
refactor(deploy): single canonical artifact-exclusion vocabulary (#11459)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -63,6 +63,7 @@ from models.schemas import (
 from services.auth import get_current_user
 from services.code_distributor import get_code_distributor
 from services.database import get_db
+from services.deploy_artifacts import rsync_artifact_excludes
 from services.drift_checker import (
     ALLOWED_COMPONENTS,
     build_drift_report,
@@ -233,7 +234,7 @@ async def _run_component_resolve_job(job_id: str, component: str) -> None:
         excludes_map = {comp: excl for comp, excl in _SLM_COMPONENTS}
         excludes = excludes_map.get(
             component,
-            ["__pycache__", "*.pyc", ".git", "node_modules", "dist", "venv", "*.log"],
+            [],  # artifacts excluded universally at the rsync chokepoint (#11459)
         )
 
         logger.info(
@@ -669,7 +670,7 @@ async def resolve_drift(
     excludes_map = {comp: excl for comp, excl in _SLM_COMPONENTS}
     excludes = excludes_map.get(
         request.component,
-        ["__pycache__", "*.pyc", ".git", "node_modules", "dist", "venv", "*.log"],
+        [],  # artifacts excluded universally at the rsync chokepoint (#11459)
     )
 
     logger.info(
@@ -907,19 +908,16 @@ async def get_pending_nodes(
     )
 
 
-_SLM_COMPONENTS = [
-    (
-        "autobot-slm-backend",
-        ["venv", "__pycache__", "*.pyc", ".git", "*.log"],
-    ),
-    (
-        "autobot-slm-frontend",
-        ["node_modules", "dist", ".git"],
-    ),
-    (
-        "autobot_shared",
-        ["__pycache__", "*.pyc", ".git"],
-    ),
+# Components synced by the SLM code-sync flow. Per-component exclude lists are
+# empty: every build/deploy artifact (__pycache__, *.pyc, .git, node_modules,
+# dist, build, venv/.venv, *.egg-info, *.log, …) is now excluded universally at
+# the rsync chokepoint from the canonical vocabulary (#11459,
+# services/deploy_artifacts.py). A component only needs an entry here if it must
+# exclude something that is NOT a standard artifact.
+_SLM_COMPONENTS: List[Tuple[str, List[str]]] = [
+    ("autobot-slm-backend", []),
+    ("autobot-slm-frontend", []),
+    ("autobot_shared", []),
 ]
 
 
@@ -933,8 +931,17 @@ _PROTECTED_EXCLUDES: List[str] = [".env", "data"]
 
 
 def _rsync_exclude_args(excludes: List[str]) -> List[str]:
-    """Build --exclude args from caller excludes plus protected paths (#9970)."""
-    merged = list(dict.fromkeys([*excludes, *_PROTECTED_EXCLUDES]))
+    """Build --exclude args from caller excludes, canonical build/deploy
+    artifacts, and protected runtime paths.
+
+    Canonical artifact excludes (#11459) are injected here — the single rsync
+    chokepoint — so every sync ignores exactly what the drift checker skips
+    (shared source: services/deploy_artifacts.py). This keeps rsync and drift in
+    lockstep: previously ``*.egg-info`` etc. were drift-skipped (#11440) but
+    still deleted-and-resynced, churning the deployed tree. Protected paths
+    (#9970) must survive every delete-style sync.
+    """
+    merged = list(dict.fromkeys([*excludes, *rsync_artifact_excludes(), *_PROTECTED_EXCLUDES]))
     return [f"--exclude={exc}" for exc in merged]
 
 

--- a/autobot-slm-backend/services/deploy_artifacts.py
+++ b/autobot-slm-backend/services/deploy_artifacts.py
@@ -1,0 +1,63 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Canonical build/deploy-artifact vocabulary (single source of truth).
+
+The set of "generated artifacts that are never part of the git source tree"
+was previously hard-coded in several places that drifted apart: the rsync
+`--exclude` lists in ``api/code_sync.py`` (4× inline) and the walk-prune sets in
+``services/drift_checker.py``. They disagreed — e.g. ``*.egg-info`` was skipped
+by the drift report (#11440) but still deleted-and-resynced by rsync — which is
+exactly the class of bug #11440 fixed for one path only.
+
+Both consumers now derive from this module so they stay in lockstep (#11459):
+
+* ``drift_checker`` prunes ``ARTIFACT_DIRS`` (exact dir names) and
+  ``ARTIFACT_DIR_SUFFIXES`` (variable-prefixed dirs like ``<pkg>.egg-info``)
+  from its file-tree walk.
+* ``code_sync`` feeds :func:`rsync_artifact_excludes` into the rsync
+  ``--exclude`` chokepoint so every deploy sync ignores the same artifacts.
+"""
+
+from __future__ import annotations
+
+# Exact directory names that are always build/deploy artifacts — never synced,
+# never drift-reported. VCS, Python/JS build caches, virtualenvs, bundler output.
+ARTIFACT_DIRS: frozenset[str] = frozenset(
+    {
+        "__pycache__",
+        ".git",
+        "venv",
+        ".venv",
+        "node_modules",
+        ".mypy_cache",
+        ".ruff_cache",
+        "dist",
+        "build",
+    }
+)
+
+# Directory-name SUFFIXES — variable-prefixed artifact dirs that an exact-name
+# match can't catch. ``<pkg>.egg-info`` is created by ``pip install`` in the
+# deployed dir; its contents (SOURCES.txt, requires.txt, top_level.txt,
+# dependency_links.txt) are deployment-generated and absent from the git source,
+# so they read as permanent false drift when not skipped (#11440).
+ARTIFACT_DIR_SUFFIXES: tuple[str, ...] = (".egg-info",)
+
+# File glob patterns that are always artifacts (compiled bytecode, logs).
+ARTIFACT_FILE_GLOBS: tuple[str, ...] = ("*.pyc", "*.log")
+
+
+def rsync_artifact_excludes() -> list[str]:
+    """rsync ``--exclude`` patterns covering every build/deploy artifact.
+
+    Directories by name, variable-prefixed dirs by ``*<suffix>`` glob, and file
+    globs — the full artifact vocabulary as rsync patterns. Sorted for stable,
+    reviewable ``--exclude`` ordering.
+    """
+    return [
+        *sorted(ARTIFACT_DIRS),
+        *(f"*{suffix}" for suffix in ARTIFACT_DIR_SUFFIXES),
+        *ARTIFACT_FILE_GLOBS,
+    ]

--- a/autobot-slm-backend/services/drift_checker.py
+++ b/autobot-slm-backend/services/drift_checker.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+from services.deploy_artifacts import ARTIFACT_DIR_SUFFIXES, ARTIFACT_DIRS
 from services.git_tracker import DEFAULT_REPO_PATH
 
 logger = logging.getLogger(__name__)
@@ -76,26 +77,13 @@ ALLOWED_COMPONENTS = frozenset(
     }
 )
 
-# Directory names to skip entirely during traversal.
-_SKIP_DIRS = {
-    "__pycache__",
-    ".git",
-    "venv",
-    ".venv",
-    "node_modules",
-    ".mypy_cache",
-    ".ruff_cache",
-    "dist",
-    "build",
-}
-
-# Directory-name SUFFIXES to skip — variable-prefixed build artifacts (e.g.
-# ``<pkg>.egg-info`` created by ``pip install`` in the deployed dir) that the
-# exact-match ``_SKIP_DIRS`` can't catch. Their contents (SOURCES.txt,
-# requires.txt, top_level.txt, dependency_links.txt) are deployment-generated and
-# never present in the git source tree, so they were reported as permanent false
-# drift (#11440), training operators to ignore the drift signal.
-_SKIP_DIR_SUFFIXES: tuple[str, ...] = (".egg-info",)
+# Directory names / suffixes to skip entirely during traversal. Sourced from the
+# canonical deploy-artifact vocabulary (#11459) so the drift walk and the
+# code_sync rsync excludes never disagree about what is an artifact — the
+# divergence that let ``*.egg-info`` be drift-skipped (#11440) yet still
+# rsync-churned. See services/deploy_artifacts.py for the shared definitions.
+_SKIP_DIRS = set(ARTIFACT_DIRS)
+_SKIP_DIR_SUFFIXES: tuple[str, ...] = ARTIFACT_DIR_SUFFIXES
 
 # Paths that are deployment-generated and never present in the git source tree.
 # Exact-match paths and prefix patterns are checked against the POSIX relative

--- a/autobot-slm-backend/tests/services/drift_checker_test.py
+++ b/autobot-slm-backend/tests/services/drift_checker_test.py
@@ -10,14 +10,37 @@ ansible/inventory/localhost.yml, and autobot_shared/* files) are excluded from
 the drift report even when their checksums differ between source and deployed.
 """
 
+import importlib.util
+import sys
 import tempfile
+import types
 from pathlib import Path
 
+_services_dir = Path(__file__).parent.parent.parent / "services"
+
+
+def _load_service_module(name: str, filename: str):
+    """Load a services/*.py module standalone, bypassing services/__init__.py."""
+    spec = importlib.util.spec_from_file_location(name, _services_dir / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# drift_checker imports ``services.deploy_artifacts`` (canonical artifact
+# vocabulary, #11459) and ``services.git_tracker`` at module scope. Register a
+# minimal ``services`` package whose __path__ is the real directory so those
+# submodule imports resolve from disk WITHOUT executing the heavy
+# services/__init__.py chain (fastapi/redis/etc.).
+if "services" not in sys.modules:
+    _services_pkg = types.ModuleType("services")
+    _services_pkg.__path__ = [str(_services_dir)]  # type: ignore[attr-defined]
+    sys.modules["services"] = _services_pkg
+if "services.deploy_artifacts" not in sys.modules:
+    sys.modules["services.deploy_artifacts"] = _load_service_module("services.deploy_artifacts", "deploy_artifacts.py")
+
 # Load drift_checker without triggering services/__init__.py import chain.
-_mod_path = Path(__file__).parent.parent.parent / "services" / "drift_checker.py"
-_spec = __import__("importlib.util").util.spec_from_file_location("drift_checker", _mod_path)
-drift_checker = __import__("importlib.util").util.module_from_spec(_spec)
-_spec.loader.exec_module(drift_checker)
+drift_checker = _load_service_module("drift_checker", "drift_checker.py")
 
 _is_expected_drift = drift_checker._is_expected_drift
 compute_drift = drift_checker.compute_drift

--- a/autobot-slm-backend/tests/services/drift_checker_test.py
+++ b/autobot-slm-backend/tests/services/drift_checker_test.py
@@ -38,6 +38,13 @@ if "services" not in sys.modules:
     sys.modules["services"] = _services_pkg
 if "services.deploy_artifacts" not in sys.modules:
     sys.modules["services.deploy_artifacts"] = _load_service_module("services.deploy_artifacts", "deploy_artifacts.py")
+if "services.git_tracker" not in sys.modules:
+    # git_tracker.py transitively imports models.database; drift_checker only
+    # needs its DEFAULT_REPO_PATH constant, so stub it to keep this load fully
+    # standalone (same template as test_deploy_artifacts_lockstep.py).
+    _git_tracker_stub = types.ModuleType("services.git_tracker")
+    _git_tracker_stub.DEFAULT_REPO_PATH = "/opt/autobot/code_source"  # type: ignore[attr-defined]
+    sys.modules["services.git_tracker"] = _git_tracker_stub
 
 # Load drift_checker without triggering services/__init__.py import chain.
 drift_checker = _load_service_module("drift_checker", "drift_checker.py")

--- a/autobot-slm-backend/tests/services/test_deploy_artifacts_lockstep.py
+++ b/autobot-slm-backend/tests/services/test_deploy_artifacts_lockstep.py
@@ -1,0 +1,86 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11459: the rsync-exclude builder and the drift checker must stay in lockstep.
+
+Both consume services/deploy_artifacts.py. These tests pin that contract so the
+two paths can never re-diverge the way they did on ``*.egg-info`` (drift-skipped
+in #11440 but still rsync-churned) — the exact failure #11459 consolidates.
+
+drift_checker.py is loaded via importlib the same way drift_checker_test.py does
+(without triggering the heavy services/__init__.py chain); deploy_artifacts.py is
+pure-stdlib and loads standalone. A stub ``services.git_tracker`` is registered
+so drift_checker's own top-level import resolves.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_SERVICES = Path(__file__).resolve().parents[2] / "services"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# deploy_artifacts is dependency-free — load it and register it so drift_checker's
+# ``from services.deploy_artifacts import ...`` resolves during standalone load.
+deploy_artifacts = _load("services.deploy_artifacts", _SERVICES / "deploy_artifacts.py")
+if "services" not in sys.modules:
+    _svc_pkg = types.ModuleType("services")
+    _svc_pkg.__path__ = [str(_SERVICES)]  # type: ignore[attr-defined]
+    sys.modules["services"] = _svc_pkg
+sys.modules["services.deploy_artifacts"] = deploy_artifacts
+if "services.git_tracker" not in sys.modules:
+    _gt = types.ModuleType("services.git_tracker")
+    _gt.DEFAULT_REPO_PATH = "/opt/autobot/code_source"  # type: ignore[attr-defined]
+    sys.modules["services.git_tracker"] = _gt
+
+drift_checker = _load("drift_checker", _SERVICES / "drift_checker.py")
+
+ARTIFACT_DIRS = deploy_artifacts.ARTIFACT_DIRS
+ARTIFACT_DIR_SUFFIXES = deploy_artifacts.ARTIFACT_DIR_SUFFIXES
+ARTIFACT_FILE_GLOBS = deploy_artifacts.ARTIFACT_FILE_GLOBS
+rsync_artifact_excludes = deploy_artifacts.rsync_artifact_excludes
+
+
+def test_rsync_excludes_cover_every_drift_skip_dir() -> None:
+    """Every dir the drift walk prunes must also be an rsync --exclude pattern.
+
+    If a dir is skipped by drift but synced by rsync (or vice-versa) the two
+    disagree about what an artifact is — the #11440 egg-info bug generalised.
+    """
+    excludes = set(rsync_artifact_excludes())
+    for skip_dir in drift_checker._SKIP_DIRS:
+        assert skip_dir in excludes, f"drift skips {skip_dir!r} but rsync would sync it"
+
+
+def test_egg_info_excluded_by_both_paths() -> None:
+    """*.egg-info is the concrete regression (#11440/#11459) — pin it in both."""
+    assert ".egg-info" in drift_checker._SKIP_DIR_SUFFIXES
+    assert "*.egg-info" in rsync_artifact_excludes()
+
+
+def test_drift_checker_derives_from_canonical_source() -> None:
+    """drift_checker must consume the shared vocabulary, not a private copy."""
+    assert drift_checker._SKIP_DIRS == set(ARTIFACT_DIRS)
+    assert drift_checker._SKIP_DIR_SUFFIXES == ARTIFACT_DIR_SUFFIXES
+
+
+def test_rsync_artifact_excludes_shape() -> None:
+    """The rsync pattern list covers dir names, suffix globs, and file globs."""
+    patterns = rsync_artifact_excludes()
+    assert "__pycache__" in patterns and "node_modules" in patterns
+    for suffix in ARTIFACT_DIR_SUFFIXES:
+        assert f"*{suffix}" in patterns
+    for glob in ARTIFACT_FILE_GLOBS:
+        assert glob in patterns
+    assert len(patterns) == len(set(patterns)), "no duplicate --exclude patterns"


### PR DESCRIPTION
## Thinking Path
The "build/deploy artifacts to ignore" set was hard-coded in multiple places that **already drifted apart**: rsync `--exclude` lists in `api/code_sync.py` (4× inline) and the walk-prune sets in `services/drift_checker.py`. Concretely, `*.egg-info` was drift-skipped (#11440) but still rsync deleted-and-resynced — churning the deployed tree every sync. Same failure mode #11440 fixed for one path only.

## What Changed
- **New `services/deploy_artifacts.py`** — canonical `ARTIFACT_DIRS` / `ARTIFACT_DIR_SUFFIXES` / `ARTIFACT_FILE_GLOBS` + `rsync_artifact_excludes()` (single source of truth).
- **`drift_checker`** consumes it for `_SKIP_DIRS` / `_SKIP_DIR_SUFFIXES` — values **identical** to before, so **zero behaviour change** for the drift report.
- **`code_sync`** injects `rsync_artifact_excludes()` at the single `_rsync_exclude_args` chokepoint, so every `--delete` sync now also ignores `*.egg-info` / `.mypy_cache` / `.ruff_cache` / `build` / `.venv`. This is **strictly a superset** of the old per-component excludes (all pure artifacts) → safer on a delete-style sync, never fewer. rsync and drift are now in lockstep.
- Emptied the now-redundant per-component + inline exclude lists (removes the 4× duplication).
- **Lockstep test** (`test_deploy_artifacts_lockstep.py`) pins the contract; `drift_checker_test.py`’s standalone importlib loader updated to provide the new dependency.

## Blast radius (deploy)
The only behavioural change is rsync now excluding **more** pure build artifacts. On `--delete` rsync, `--exclude` also protects the target copy from deletion — so a deployed `<pkg>.egg-info` is preserved (pip regenerates it) instead of deleted-then-resynced. No component ever needs to sync an artifact dir (frontend already excluded `dist`; nothing syncs `build`/`.git`/`venv`). `_PROTECTED_EXCLUDES` (`.env`, `data`, #9970) unchanged.

## Verification
- Lockstep test: **4 passed**. `drift_checker_test.py`: **11 passed** (standalone loader fixed). Both together: **15 passed**, no session pollution.
- drift `_SKIP_DIRS` verified byte-identical to the previous hardcoded set (no drift-report change).
- rsync excludes verified to now include `*.egg-info` + every artifact dir; no duplicate `--exclude` patterns.
- black + py_compile clean on all 5 files.

## Model Used
Opus 4.8

Closes #11459