### PR TITLE
fix(slm): restore agent control plane — internal-key gate on machine endpoints (#11450)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
@@ -120,6 +120,16 @@ class SLMAgent:
         self.node_id = node_id or os.environ.get("SLM_NODE_ID")
         self.running = False
 
+        # #11450: machine-to-machine auth. The SLM control-plane routers
+        # (nodes/events/code-sync/roles) accept either a service.management
+        # user JWT (humans) or this shared internal key (the agent), sent on
+        # every request via the session default headers. Empty -> the server
+        # rejects our heartbeats 401 and the fleet Service table never
+        # populates, so warn loudly.
+        self._internal_api_key = os.environ.get("AUTOBOT_INTERNAL_API_KEY", "")
+        if not self._internal_api_key:
+            logger.warning("AUTOBOT_INTERNAL_API_KEY not set — heartbeats will be rejected 401 (#11450)")
+
         # Issue #741: Initialize version manager
         self.version_manager = get_agent_version()
         self._pending_update = False
@@ -433,8 +443,10 @@ class SLMAgent:
         # Notify systemd that we're ready
         sd_notify("READY=1")
 
-        # Single session for the lifetime of the agent (#9086)
-        async with aiohttp.ClientSession() as session:
+        # Single session for the lifetime of the agent (#9086). The internal
+        # API key rides as a default header on every request (#11450).
+        _default_headers = {"X-Internal-API-Key": self._internal_api_key} if self._internal_api_key else {}
+        async with aiohttp.ClientSession(headers=_default_headers) as session:
             self._session = session
 
             # Issue #741: Start notification server if enabled (code-source nodes)

--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
@@ -331,6 +331,17 @@ class SLMAgent:
                         new_backoff,
                     )
                     return False
+                if response.status == 401:
+                    # #11450: 401 means our X-Internal-API-Key is missing or
+                    # doesn't match the server's AUTOBOT_INTERNAL_API_KEY (e.g.
+                    # a partial re-provision). Point at the fix explicitly —
+                    # a bare "rejected 401" cost real diagnosis time.
+                    logger.warning(
+                        "Heartbeat 401: X-Internal-API-Key %s the server's — "
+                        "re-run deploy-slm-agent.yml to refresh agent-secrets.env (#11450)",
+                        "missing" if not self._internal_api_key else "does not match",
+                    )
+                    return False
                 logger.warning(
                     "Heartbeat rejected: %s %s",
                     response.status,

--- a/autobot-slm-backend/ansible/roles/slm_agent/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/tasks/main.yml
@@ -234,6 +234,24 @@
   become: true
   tags: ['slm_agent', 'deploy', 'role-meta']
 
+# #11450: the agent authenticates its heartbeat/events/code-sync/roles calls
+# with the shared AUTOBOT_INTERNAL_API_KEY. Write it to a 0600 EnvironmentFile
+# (loaded by the unit) rather than baking the secret into the world-readable
+# .service unit. Works on remote nodes too (they have no slm-secrets.env).
+- name: "SLM Agent | Deploy agent secrets EnvironmentFile (#11450)"
+  ansible.builtin.copy:
+    content: |
+      # Managed by Ansible - do not edit manually
+      AUTOBOT_INTERNAL_API_KEY={{ autobot_internal_api_key | default('') }}
+    dest: "{{ slm_agent_data_dir }}/agent-secrets.env"
+    owner: "{{ slm_agent_user }}"
+    group: "{{ slm_agent_group }}"
+    mode: '0600'
+  become: true
+  no_log: true
+  notify: Restart SLM agent
+  tags: ['slm_agent', 'systemd', 'secrets']
+
 - name: "SLM Agent | Deploy systemd service unit"
   template:
     src: slm-agent.service.j2

--- a/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
@@ -39,6 +39,10 @@ Environment=PYTHONUNBUFFERED=1
 # Issue #9226: Redis connection for autobot_shared imports
 Environment=REDIS_HOST={{ slm_agent_redis_host }}
 Environment=AUTOBOT_REDIS_HOST={{ slm_agent_redis_host }}
+# #11450: AUTOBOT_INTERNAL_API_KEY for machine-to-machine auth. Loaded from a
+# 0600 file (not baked into this world-readable unit). Optional (-) so a node
+# missing the file still starts (the agent warns and heartbeats 401 until fixed).
+EnvironmentFile=-{{ slm_agent_data_dir }}/agent-secrets.env
 
 # Agent execution — admin_url resolved from SLM_ADMIN_URL env var above,
 # not baked into CLI args, so re-provisioning updates it (#2833).

--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -74,7 +74,7 @@ from autobot_shared.integrity_manifest import verify_integrity_at_startup
 from config import settings
 from middleware import ApiRequestCounterMiddleware, SecurityHeadersMiddleware
 from services.a2a_card_fetcher import start_card_refresh_task
-from services.auth import require_service_management
+from services.auth import require_service_management, require_service_management_or_internal
 from services.compose_fleet import (
     _SLM_MGMT_IP,
     _compose_nodes_enabled,
@@ -607,6 +607,13 @@ app.add_middleware(ApiRequestCounterMiddleware)
 # do not have this permission and receive 403.  Admin and Operator do.
 _SM = [Depends(require_service_management)]
 
+# #11450: routers that ALSO carry machine-to-machine agent-ingest endpoints
+# (heartbeat/enroll, roles/definitions, code-sync/notify, events/sync). The
+# node agent presents AUTOBOT_INTERNAL_API_KEY (no user JWT), so these mount
+# with a gate that accepts the internal key OR a service.management user —
+# preserving #10198's human-surface gate while un-breaking the agent plane.
+_SM_OR_AGENT = [Depends(require_service_management_or_internal)]
+
 app.include_router(health_router, prefix="/api")
 app.include_router(auth_router, prefix="/api")
 app.include_router(websocket_router, prefix="/api")
@@ -620,7 +627,7 @@ app.include_router(scim_router)
 # --- Service-management–gated routers ---
 app.include_router(browser_router, prefix="/api", dependencies=_SM)
 app.include_router(agents_router, prefix="/api", dependencies=_SM)
-app.include_router(nodes_router, prefix="/api", dependencies=_SM)
+app.include_router(nodes_router, prefix="/api", dependencies=_SM_OR_AGENT)
 app.include_router(nodes_execution_router, prefix="/api", dependencies=_SM)  # Issue #3406
 app.include_router(services_router, prefix="/api", dependencies=_SM)
 app.include_router(fleet_services_router, prefix="/api", dependencies=_SM)
@@ -633,7 +640,7 @@ app.include_router(maintenance_router, prefix="/api", dependencies=_SM)
 app.include_router(monitoring_router, prefix="/api", dependencies=_SM)
 app.include_router(performance_router, prefix="/api", dependencies=_SM)
 app.include_router(errors_router, prefix="/api", dependencies=_SM)
-app.include_router(events_router, prefix="/api", dependencies=_SM)
+app.include_router(events_router, prefix="/api", dependencies=_SM_OR_AGENT)
 app.include_router(external_agents_router, prefix="/api", dependencies=_SM)
 app.include_router(node_rdp_router, prefix="/api", dependencies=_SM)
 app.include_router(rdp_router, prefix="/api", dependencies=_SM)
@@ -643,8 +650,8 @@ app.include_router(node_tls_router, prefix="/api", dependencies=_SM)
 app.include_router(tls_router, prefix="/api", dependencies=_SM)
 app.include_router(secrets_router, prefix="/api", dependencies=_SM)
 app.include_router(security_router, prefix="/api", dependencies=_SM)
-app.include_router(code_sync_router, prefix="/api", dependencies=_SM)
-app.include_router(roles_router, prefix="/api", dependencies=_SM)
+app.include_router(code_sync_router, prefix="/api", dependencies=_SM_OR_AGENT)
+app.include_router(roles_router, prefix="/api", dependencies=_SM_OR_AGENT)
 app.include_router(code_source_router, prefix="/api", dependencies=_SM)
 app.include_router(personality_proxy_router, prefix="/api", dependencies=_SM)  # Issue #1145
 app.include_router(voice_proxy_router, prefix="/api", dependencies=_SM)  # Voice proxy for personality voice assignment

--- a/autobot-slm-backend/services/auth.py
+++ b/autobot-slm-backend/services/auth.py
@@ -27,6 +27,7 @@ rejected before PyJWT is invoked.
 """
 
 import logging
+import os
 import secrets
 from datetime import timedelta
 from typing import Callable
@@ -220,23 +221,79 @@ def require_permission(permission: Permission) -> Callable:
     """
 
     async def _check(current_user: dict = Depends(get_current_user)) -> dict:
-        role_str = current_user.get("role")
-        if role_str:
-            try:
-                role = Role(role_str)
-            except ValueError:
-                role = Role.USER
-        else:
-            role = Role.ADMIN if current_user.get("admin", False) else Role.USER
-
-        if permission not in ROLE_PERMISSIONS.get(role, []):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Permission denied: {permission.value} required",
-            )
-        return current_user
+        return _require_permission_or_403(current_user, permission)
 
     return _check
+
+
+def _resolve_role(current_user: dict) -> Role:
+    """Derive the caller's Role from the JWT 'role' field or legacy admin flag."""
+    role_str = current_user.get("role")
+    if role_str:
+        try:
+            return Role(role_str)
+        except ValueError:
+            return Role.USER
+    return Role.ADMIN if current_user.get("admin", False) else Role.USER
+
+
+def _require_permission_or_403(current_user: dict, permission: Permission) -> dict:
+    """Raise 403 unless *current_user*'s role grants *permission*; else return it."""
+    if permission not in ROLE_PERMISSIONS.get(_resolve_role(current_user), []):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Permission denied: {permission.value} required",
+        )
+    return current_user
+
+
+# Optional bearer: unlike ``security`` (auto_error=True), this returns None
+# instead of 401 when no Authorization header is present, so a machine caller
+# authenticating via the internal API key is not rejected first (#11450).
+_optional_security = HTTPBearer(auto_error=False)
+
+
+def verify_internal_api_key(provided: str | None) -> bool:
+    """Constant-time check of the trusted internal-service API key (#11450).
+
+    Mirrors autobot-backend ``auth_middleware.verify_internal_api_key`` (#1145):
+    the slm-agent and sibling services authenticate machine-to-machine with the
+    shared ``AUTOBOT_INTERNAL_API_KEY`` (#10263/#10492), never a user JWT.
+    Returns True only when the key is configured AND *provided* matches exactly;
+    ``secrets.compare_digest`` prevents timing inference and a None can't match.
+    """
+    expected = os.getenv("AUTOBOT_INTERNAL_API_KEY", "")
+    if not expected or not provided:
+        return False
+    return secrets.compare_digest(provided, expected)
+
+
+async def require_service_management_or_internal(
+    x_internal_api_key: str | None = Header(None, alias="X-Internal-API-Key"),
+    credentials: HTTPAuthorizationCredentials | None = Depends(_optional_security),
+) -> dict:
+    """Router gate for endpoints reachable by BOTH humans and the node agent.
+
+    #10198 gated the whole nodes/events/code-sync/roles routers behind the
+    *human* service.management permission, which also 401'd the machine-to-
+    machine agent-ingest endpoints (heartbeat/enroll/roles-definitions/code-sync
+    -notify/events-sync) — the agent carries no user JWT, so heartbeats were
+    rejected and the fleet Service table never populated (#11450).
+
+    Machine callers presenting a valid ``AUTOBOT_INTERNAL_API_KEY`` bypass the
+    user check; every other caller must be an authenticated user holding
+    service.management — preserving #10198's human-surface gate exactly.
+    """
+    if verify_internal_api_key(x_internal_api_key):
+        return {"internal_service": True, "role": "service"}
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    current_user = await get_current_user(credentials)
+    return _require_permission_or_403(current_user, Permission.SERVICE_MANAGEMENT)
 
 
 async def require_admin(current_user: dict = Depends(get_current_user)) -> dict:

--- a/autobot-slm-backend/slm/agent/agent.py
+++ b/autobot-slm-backend/slm/agent/agent.py
@@ -120,6 +120,16 @@ class SLMAgent:
         self.node_id = node_id or os.environ.get("SLM_NODE_ID")
         self.running = False
 
+        # #11450: machine-to-machine auth. The SLM control-plane routers
+        # (nodes/events/code-sync/roles) accept either a service.management
+        # user JWT (humans) or this shared internal key (the agent), sent on
+        # every request via the session default headers. Empty -> the server
+        # rejects our heartbeats 401 and the fleet Service table never
+        # populates, so warn loudly.
+        self._internal_api_key = os.environ.get("AUTOBOT_INTERNAL_API_KEY", "")
+        if not self._internal_api_key:
+            logger.warning("AUTOBOT_INTERNAL_API_KEY not set — heartbeats will be rejected 401 (#11450)")
+
         # Issue #741: Initialize version manager
         self.version_manager = get_agent_version()
         self._pending_update = False
@@ -433,8 +443,10 @@ class SLMAgent:
         # Notify systemd that we're ready
         sd_notify("READY=1")
 
-        # Single session for the lifetime of the agent (#9086)
-        async with aiohttp.ClientSession() as session:
+        # Single session for the lifetime of the agent (#9086). The internal
+        # API key rides as a default header on every request (#11450).
+        _default_headers = {"X-Internal-API-Key": self._internal_api_key} if self._internal_api_key else {}
+        async with aiohttp.ClientSession(headers=_default_headers) as session:
             self._session = session
 
             # Issue #741: Start notification server if enabled (code-source nodes)

--- a/autobot-slm-backend/slm/agent/agent.py
+++ b/autobot-slm-backend/slm/agent/agent.py
@@ -331,6 +331,17 @@ class SLMAgent:
                         new_backoff,
                     )
                     return False
+                if response.status == 401:
+                    # #11450: 401 means our X-Internal-API-Key is missing or
+                    # doesn't match the server's AUTOBOT_INTERNAL_API_KEY (e.g.
+                    # a partial re-provision). Point at the fix explicitly —
+                    # a bare "rejected 401" cost real diagnosis time.
+                    logger.warning(
+                        "Heartbeat 401: X-Internal-API-Key %s the server's — "
+                        "re-run deploy-slm-agent.yml to refresh agent-secrets.env (#11450)",
+                        "missing" if not self._internal_api_key else "does not match",
+                    )
+                    return False
                 logger.warning(
                     "Heartbeat rejected: %s %s",
                     response.status,

--- a/autobot-slm-backend/tests/services/test_internal_api_key_gate.py
+++ b/autobot-slm-backend/tests/services/test_internal_api_key_gate.py
@@ -18,7 +18,6 @@ assert their branch behaviour; keep them in lock-step with the source.
 from __future__ import annotations
 
 import importlib
-import os
 import secrets
 
 import pytest

--- a/autobot-slm-backend/tests/services/test_internal_api_key_gate.py
+++ b/autobot-slm-backend/tests/services/test_internal_api_key_gate.py
@@ -17,7 +17,11 @@ assert their branch behaviour; keep them in lock-step with the source.
 
 from __future__ import annotations
 
+import importlib
+import os
 import secrets
+
+import pytest
 
 
 # --- verbatim mirror of services.auth.verify_internal_api_key -------------
@@ -94,3 +98,41 @@ def test_gate_wrong_key_falls_through_to_user_permission():
         raise AssertionError("expected 403")
     except _Denied as e:
         assert e.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Drift guard: exercise the REAL services.auth.verify_internal_api_key when the
+# import chain is loadable (CI). Skips where the config chain can't load (this
+# sandbox reads /etc/autobot and conftest MagicMock-stubs `services`), so the
+# replicated tests above always run and this adds real-code coverage in CI.
+# ---------------------------------------------------------------------------
+
+
+def _load_real_auth():
+    import sys
+    import types
+
+    if "multipart" in sys.modules and not hasattr(sys.modules["multipart"], "multipart"):
+        sys.modules.pop("multipart", None)
+    _mp = types.ModuleType("multipart")
+    _mp.multipart = types.ModuleType("multipart.multipart")  # type: ignore[attr-defined]
+    sys.modules.setdefault("multipart", _mp)
+    sys.modules.setdefault("multipart.multipart", _mp.multipart)  # type: ignore[attr-defined]
+    mod = importlib.import_module("services.auth")
+    fn = getattr(mod, "verify_internal_api_key", None)
+    if not callable(fn) or type(fn).__name__ == "MagicMock":
+        raise RuntimeError("services.auth not real-loadable in this env")
+    return fn
+
+
+def test_real_verify_internal_api_key_matches_replica(monkeypatch):
+    try:
+        real = _load_real_auth()
+    except Exception as exc:  # noqa: BLE001 — env-dependent import chain
+        pytest.skip(f"services.auth not importable here: {exc}")
+    monkeypatch.setenv("AUTOBOT_INTERNAL_API_KEY", _KEY)
+    assert real(_KEY) is True
+    assert real("b" * 64) is False
+    assert real(None) is False
+    monkeypatch.delenv("AUTOBOT_INTERNAL_API_KEY", raising=False)
+    assert real(_KEY) is False

--- a/autobot-slm-backend/tests/services/test_internal_api_key_gate.py
+++ b/autobot-slm-backend/tests/services/test_internal_api_key_gate.py
@@ -1,0 +1,96 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11450: machine-to-machine gate for the agent control plane.
+
+`require_service_management_or_internal` must let the node agent through on a
+valid AUTOBOT_INTERNAL_API_KEY (no user JWT), while 401'ing anonymous callers
+and otherwise falling back to the human service.management permission.
+
+services/auth.py imports the full FastAPI + config chain (which reads
+/etc/autobot secrets and is stubbed to a MagicMock by conftest — see the same
+constraint in tests/api/test_require_permission.py). These tests therefore
+replicate the two pure decision helpers verbatim from services/auth.py and
+assert their branch behaviour; keep them in lock-step with the source.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+
+# --- verbatim mirror of services.auth.verify_internal_api_key -------------
+def _verify_internal_api_key(provided: str | None, expected: str) -> bool:
+    if not expected or not provided:
+        return False
+    return secrets.compare_digest(provided, expected)
+
+
+# --- verbatim mirror of the gate's decision (internal key OR user perm) ----
+class _Denied(Exception):
+    def __init__(self, code: int):
+        self.status_code = code
+
+
+def _gate(x_internal_api_key, credentials, expected, user_has_perm):
+    if _verify_internal_api_key(x_internal_api_key, expected):
+        return {"internal_service": True, "role": "service"}
+    if credentials is None:
+        raise _Denied(401)
+    if not user_has_perm:
+        raise _Denied(403)
+    return {"user": True}
+
+
+_KEY = "a" * 64
+
+
+# ---------------------------------------------------------------------------
+# key check
+# ---------------------------------------------------------------------------
+
+
+def test_verify_rejects_when_key_unset():
+    assert _verify_internal_api_key(_KEY, "") is False
+
+
+def test_verify_rejects_none_even_when_configured():
+    assert _verify_internal_api_key(None, _KEY) is False
+
+
+def test_verify_rejects_wrong_key():
+    assert _verify_internal_api_key("b" * 64, _KEY) is False
+
+
+def test_verify_accepts_matching_key():
+    assert _verify_internal_api_key(_KEY, _KEY) is True
+
+
+# ---------------------------------------------------------------------------
+# gate decision
+# ---------------------------------------------------------------------------
+
+
+def test_gate_accepts_valid_internal_key():
+    out = _gate(_KEY, None, _KEY, user_has_perm=False)
+    assert out["internal_service"] is True  # bypasses user check entirely
+
+
+def test_gate_rejects_anonymous_without_key_or_bearer():
+    try:
+        _gate(None, None, _KEY, user_has_perm=False)
+        raise AssertionError("expected 401")
+    except _Denied as e:
+        assert e.status_code == 401
+
+
+def test_gate_wrong_key_falls_through_to_user_permission():
+    # wrong key + a permitted user -> allowed via the human path
+    assert _gate("b" * 64, object(), _KEY, user_has_perm=True) == {"user": True}
+    # wrong key + a user lacking the permission -> 403 (human gate preserved)
+    try:
+        _gate("b" * 64, object(), _KEY, user_has_perm=False)
+        raise AssertionError("expected 403")
+    except _Denied as e:
+        assert e.status_code == 403


### PR DESCRIPTION
## Thinking Path
Traced live on the SLM host: the Services view shows 0 services because the slm-agent's heartbeats are **rejected 401** every 30s (`journalctl -u slm-agent`). Heartbeats populate the `Service` table (reconciler `_upsert_service`), so rejection → empty table → "No services found". Fleet Health shows 1/1 only because `_ensure_local_node` seeds `status=ONLINE` at startup.

**Root cause:** #10198 mounted the whole `nodes`/`events`/`code_sync`/`roles` routers behind `require_service_management` (a *human* permission). That swept in the machine-to-machine agent-ingest endpoints. The agent carries no user JWT (mTLS is the planned transport auth, #725), so `HTTPBearer(auto_error)` rejects it. Live probe: heartbeat/roles-defs/code-sync-notify/events-sync all **401**; only `/health` 200. This broke the entire agent↔server plane on every install, not just single-node. Closes #11450.

**Chosen auth model (user-approved):** reuse the existing internal API key (#10263/#10492) — machine callers present `AUTOBOT_INTERNAL_API_KEY`; humans still need `service.management`.

## What Changed
- **`services/auth.py`**: `verify_internal_api_key` (constant-time `compare_digest`, mirrors autobot-backend `auth_middleware` #1145) + `require_service_management_or_internal` gate (internal key bypasses user check; else 401 if anonymous, else the existing `service.management` check). Extracted `_resolve_role` / `_require_permission_or_403` so `require_permission` reuses the same logic (no duplication).
- **`main.py`**: `nodes`/`events`/`code_sync`/`roles` routers mount with the combined gate (`_SM_OR_AGENT`); all other SLM routers keep `_SM` unchanged.
- **`slm/agent/agent.py`** (+ ansible role copy, kept in lock-step): sends `X-Internal-API-Key` from `AUTOBOT_INTERNAL_API_KEY` as a session default header; warns if unset.
- **`slm_agent` role**: writes a **0600** `agent-secrets.env` (secret NOT baked into the world-readable unit) and loads it via `EnvironmentFile=-`; works on remote nodes (no `slm-secrets.env` there).
- **tests**: internal-key check (unset/None/wrong/match) + gate branches (key-bypass / anonymous-401 / wrong-key→permission-403 fallthrough). 7 pass.

## Verification
- 7 unit tests pass; isort/black/flake8 clean; ansible tasks YAML valid.
- Post-merge I will deploy via the built-in code-sync + re-run the slm_agent role (writes agent-secrets.env), then confirm heartbeats flip 200 and the Services view populates, and re-check the Redis panel (`/api/redis-service/status`).

## Follow-ups
- The internal key now also satisfies those four routers' human routes — acceptable (trusted server secret). mTLS (#725) remains the long-term transport-auth hardening.

## Model Used
Claude Fable 5 (1M context)
