### PR TITLE
fix(ci): register services.deploy_artifacts in conftest stub list (#11459 fast-follow)

### DIFF
--- a/autobot-slm-backend/conftest.py
+++ b/autobot-slm-backend/conftest.py
@@ -109,6 +109,7 @@ for _m in [
     "services.database",
     "services.blue_green",
     "services.code_distributor",
+    "services.deploy_artifacts",
     "services.deployment",
     "services.drift_checker",
     "services.encryption",


### PR DESCRIPTION
## Thinking Path
#11459 (PR #11477) squash-merged **before** its conftest follow-up commit, leaving `Dev_new_gui` with `api/code_sync.py` importing `from services.deploy_artifacts import rsync_artifact_excludes` while `autobot-slm-backend/conftest.py`'s services-stub hand-list does not include the new module. co-located-smoke `authz-and-selection` now aborts on base for every PR (`ModuleNotFoundError: No module named 'services.deploy_artifacts'`).

## What Changed
- Added `services.deploy_artifacts` to the conftest services-stub list (one line).

## Verification
- `pytest autobot-slm-backend/tests/api/test_collect_outdated_node_ids.py` → **7 passed** (was 0 collected / 1 error).
- Sibling code_sync-importing tests (`test_sync_status_outdated_signal.py`, `test_component_resolve_job.py`) → 11 passed.

## Model Used
Opus 4.8

Closes #11481