### PR TITLE
fix(provision): browser role uses a+rX recurse, preserving chrome +x (#11470)

### DIFF
--- a/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
@@ -199,42 +199,18 @@
     - _chromium_binary.matched == 0
   tags: ['browser', 'packages']
 
-- name: "Browser | Find Playwright browser directories for permission fix (#5085)"
-  ansible.builtin.find:
-    paths: /var/lib/autobot/playwright-browsers
-    file_type: directory
-    recurse: true
-  register: _pb_dirs
-  become: true
-  when: _browser_worker_dir.stat.exists | default(false)
-  tags: ['browser', 'packages']
-
-- name: "Browser | Set Playwright browser directories world-executable (#5085)"
+# #5085: a root-run install produces browser files the `autobot` service user
+# cannot traverse/read. Symbolic a+rX adds read to all, plus traverse to dirs
+# and execute only to already-executable files — preserving the chrome binary's
+# +x. This single recurse=true task replaces the prior find+loop pair that set
+# directories 0755 then files 0644; the recursive 0644 stripped +x from the
+# chrome binary and its helpers, a latent brick (#11470). Matches the form the
+# update playbook adopted in #11468.
+- name: "Browser | Make Playwright browsers accessible to the service user (#5085)"
   ansible.builtin.file:
-    path: "{{ item.path }}"
-    state: directory
-    mode: "0755"
-  loop: "{{ _pb_dirs.files | default([]) }}"
-  become: true
-  when: _browser_worker_dir.stat.exists | default(false)
-  tags: ['browser', 'packages']
-
-- name: "Browser | Find Playwright browser data files for permission fix (#5085)"
-  ansible.builtin.find:
-    paths: /var/lib/autobot/playwright-browsers
-    file_type: file
+    path: /var/lib/autobot/playwright-browsers
+    mode: "a+rX"
     recurse: true
-  register: _pb_files
-  become: true
-  when: _browser_worker_dir.stat.exists | default(false)
-  tags: ['browser', 'packages']
-
-- name: "Browser | Set Playwright browser data files world-readable (#5085)"
-  ansible.builtin.file:
-    path: "{{ item.path }}"
-    state: file
-    mode: "0644"
-  loop: "{{ _pb_files.files | default([]) }}"
   become: true
   when: _browser_worker_dir.stat.exists | default(false)
   tags: ['browser', 'packages']


### PR DESCRIPTION
## Thinking Path
`ansible/roles/browser/tasks/main.yml` recursively set every file under `/var/lib/autobot/playwright-browsers` to `mode: "0644"` via a `find file_type: file` + loop — stripping `+x` from the `chrome` binary and its helper executables (a latent brick; production compensates via a root-run service). Discovered in #11468 review.

## What Changed
- Replaced the two find+loop chmod tasks (dirs `0755` / files `0644`) with a single `ansible.builtin.file: mode="a+rX" recurse=true`. Symbolic `X` adds execute only to directories and already-executable files → preserves the chrome binary's `+x` while keeping everything world-readable and dirs traversable.
- Same form the **update** playbook adopted in #11468 (PR #11468) — back-ported to the **provisioning** role for consistency.

## Verification
- YAML parses (29 tasks); no orphaned `_pb_dirs`/`_pb_files` references remain.
- Symbolic-mode reasoning matches the reviewed #11468 task verbatim (`mode: "a+rX"`, `recurse: true`).

## Model Used
Opus 4.8

Closes #11470