### PR TITLE
fix(deploy): update-all redeploys the slm-agent (code + secrets) (#11480)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -22,7 +22,14 @@
 #   npu, npu-worker      - NPU worker deploy + restart tasks
 #   browser, browser-worker - browser worker deploy + restart tasks
 #   slm, slm-backend, slm-frontend - SLM node deploy + build + restart tasks
+#   slm-agent            - slm_agent role redeploy (code + secrets + restart) (#11480)
 #   shared               - autobot_shared deploy tasks (all nodes)
+#
+# NOTE (#11480): the slm-agent redeploy imports the slm_agent role, whose restart
+# runs via a handler and whose pip install is tagged `packages` (not `deps`).
+# So `--skip-tags restart` / `--skip-tags deps` do NOT skip the agent restart or
+# its dep install — a code-only push still restarts the agent. Use
+# `--skip-tags slm-agent` to exclude agent redeploy entirely.
 
 # =============================================================================
 # PLAY 0: Pre-flight Git Safety Check & Create Deploy Archives
@@ -1079,6 +1086,9 @@
     # remote nodes too. block/rescue keeps a single node's agent failure from
     # aborting the whole fleet update (Play 2 has any_errors_fatal: true) —
     # consistent with the failed_when:false used by the other Play 2 tasks.
+    # Note: a co-located SLM manager is in both slm_server (Play 1) and
+    # infrastructure (Play 2, #11436), so it runs this idempotent role twice
+    # per update (harmless — converges to the same state, one extra restart).
     - name: "[PLAY 2] SLM Agent | Redeploy agent (code + secrets + restart) (#11480)"
       when: slm_node_id is defined
       tags: [slm-agent]

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -427,12 +427,33 @@
       when: slm_login_play1.status == 200
       tags: [always]
 
+    # #11480: redeploy the slm-agent (code + agent-secrets.env + restart) on
+    # every update. Previously the routine update path only copied autobot_shared
+    # into the agent dir, so agent-side fixes (e.g. #11450 heartbeat auth) never
+    # reached nodes through self-update — only the separate deploy-slm-agent.yml.
+    # Idempotent role; slm_server has no any_errors_fatal so a failure here fails
+    # only this host (the SLM manager), matching the rest of Play 1.
+    - name: "[PLAY 1] SLM Agent | Redeploy agent (code + secrets + restart) (#11480)"
+      tags: [slm, slm-agent]
+      block:
+        - name: "[PLAY 1] SLM Agent | Import slm_agent role"
+          ansible.builtin.import_role:
+            name: slm_agent
+      rescue:
+        - name: "[PLAY 1] SLM Agent | Warn on agent redeploy failure"
+          ansible.builtin.debug:
+            msg: >-
+              WARNING: slm_agent redeploy failed on {{ inventory_hostname }} —
+              agent may run stale code / miss agent-secrets.env (#11480). Backend
+              + frontend already deployed; continuing.
+
     - name: "[PLAY 1] SLM Update Complete"
       debug:
         msg:
           - "SLM Server updated"
           - "  Backend deployed + restarted"
           - "  Frontend built + nginx restarted"
+          - "  SLM agent redeployed (#11480)"
 
 # =============================================================================
 # PLAY 2: Update All Other Infrastructure Nodes
@@ -1053,6 +1074,25 @@
       become: true
       when: slm_node_id is defined
       tags: [slm-agent, shared]
+
+    # #11480: redeploy the slm-agent (code + agent-secrets.env + restart) on
+    # remote nodes too. block/rescue keeps a single node's agent failure from
+    # aborting the whole fleet update (Play 2 has any_errors_fatal: true) —
+    # consistent with the failed_when:false used by the other Play 2 tasks.
+    - name: "[PLAY 2] SLM Agent | Redeploy agent (code + secrets + restart) (#11480)"
+      when: slm_node_id is defined
+      tags: [slm-agent]
+      block:
+        - name: "[PLAY 2] SLM Agent | Import slm_agent role"
+          ansible.builtin.import_role:
+            name: slm_agent
+      rescue:
+        - name: "[PLAY 2] SLM Agent | Warn on agent redeploy failure"
+          ansible.builtin.debug:
+            msg: >-
+              WARNING: slm_agent redeploy failed on {{ inventory_hostname }} —
+              agent may run stale code / miss agent-secrets.env (#11480).
+              Continuing fleet update.
 
     # Issue #9565: slm-backend needs autobot_shared in PYTHONPATH
     - name: "[PLAY 2] SLM Backend | Create autobot_shared symlink for backend imports"

--- a/autobot-slm-backend/ansible/roles/slm_agent/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/tasks/main.yml
@@ -237,12 +237,46 @@
 # #11450: the agent authenticates its heartbeat/events/code-sync/roles calls
 # with the shared AUTOBOT_INTERNAL_API_KEY. Write it to a 0600 EnvironmentFile
 # (loaded by the unit) rather than baking the secret into the world-readable
-# .service unit. Works on remote nodes too (they have no slm-secrets.env).
+# .service unit.
+#
+# #11480 review: the `autobot_internal_api_key` var is NOT supplied on the
+# self-update / provision-fleet / deploy-slm-agent import paths, so relying on
+# it alone wrote the file EMPTY and the agent still 401'd. Resolve the key from,
+# in order: the ansible var (provision extra_var) → the node's own
+# slm-secrets.env → autobot-backend.env (both already carry the key, #10263/
+# #10492). Remote agent-only nodes without either file get an empty key and the
+# agent logs the #11450 401 hint until the key is provisioned.
+- name: "SLM Agent | Read AUTOBOT_INTERNAL_API_KEY from node secrets (fallback when var unset) (#11480)"
+  ansible.builtin.shell: >-
+    set -o pipefail;
+    for f in /etc/autobot/slm-secrets.env /etc/autobot/autobot-backend.env; do
+      if [ -r "$f" ]; then
+        v=$(grep -m1 '^AUTOBOT_INTERNAL_API_KEY=' "$f" | cut -d= -f2-);
+        if [ -n "$v" ]; then printf '%s' "$v"; exit 0; fi;
+      fi;
+    done
+  args:
+    executable: /bin/bash
+  become: true
+  register: _agent_key_from_node
+  changed_when: false
+  failed_when: false
+  no_log: true
+  tags: ['slm_agent', 'systemd', 'secrets']
+
+- name: "SLM Agent | Resolve effective internal API key (var wins, else node file) (#11480)"
+  ansible.builtin.set_fact:
+    _agent_internal_api_key: >-
+      {{ autobot_internal_api_key | default('') | trim
+         or (_agent_key_from_node.stdout | default('') | trim) }}
+  no_log: true
+  tags: ['slm_agent', 'systemd', 'secrets']
+
 - name: "SLM Agent | Deploy agent secrets EnvironmentFile (#11450)"
   ansible.builtin.copy:
     content: |
       # Managed by Ansible - do not edit manually
-      AUTOBOT_INTERNAL_API_KEY={{ autobot_internal_api_key | default('') }}
+      AUTOBOT_INTERNAL_API_KEY={{ _agent_internal_api_key }}
     dest: "{{ slm_agent_data_dir }}/agent-secrets.env"
     owner: "{{ slm_agent_user }}"
     group: "{{ slm_agent_group }}"
@@ -250,6 +284,15 @@
   become: true
   no_log: true
   notify: Restart SLM agent
+  tags: ['slm_agent', 'systemd', 'secrets']
+
+- name: "SLM Agent | Warn when no internal API key could be resolved (#11480)"
+  ansible.builtin.debug:
+    msg: >-
+      WARNING: no AUTOBOT_INTERNAL_API_KEY resolved for {{ inventory_hostname }}
+      (no var, no slm-secrets.env / autobot-backend.env) — agent heartbeats will
+      401 until the key is provisioned (#11450).
+  when: not (_agent_internal_api_key | trim)
   tags: ['slm_agent', 'systemd', 'secrets']
 
 - name: "SLM Agent | Deploy systemd service unit"


### PR DESCRIPTION
## Thinking Path
Dogfooding the built-in update to verify #11450 exposed this: `code-sync self-update` runs `update-all-nodes.yml`, which **never redeploys the slm-agent** — it only copies `autobot_shared` into the agent dir. So the #11450 agent-side fix (agent must send `X-Internal-API-Key` from a new 0600 `agent-secrets.env`) couldn't reach the node via the normal update. `deploy-slm-agent.yml` does it but isn't registered in the infrastructure playbook API, and `provision-fleet` runs the *whole* fleet with no tag scoping. Net: no built-in, scoped path updates the agent. Fixes #11480 (and unblocks #11450's live deploy).

## What Changed
`update-all-nodes.yml`: import the idempotent `slm_agent` role in **Play 1** (slm_server, co-located agent) and **Play 2** (remote nodes, gated on `slm_node_id is defined`). Both wrapped in `block/rescue` → an agent-deploy failure logs a warning and continues instead of aborting (Play 2 has `any_errors_fatal: true`; in Play 1 the backend/frontend are already deployed by that point). The role writes agent code + the 0600 `agent-secrets.env` and restarts the agent.

## Verification
- `ansible-playbook --syntax-check` passes with the repo roles_path (same as `provision-fleet-roles.yml`, which already imports `slm_agent`); `yaml.safe_load_all` OK.
- Reuses the existing role (no duplicated tasks). Post-merge I'll re-run `self-update` and confirm the agent's heartbeats flip to 200 and the fleet Service table + Services view populate — completing #11450's end-to-end verification.

## Model Used
Claude Fable 5 (1M context)
