### PR TITLE
harden(oauth): server-side single-use state + PKCE binding for provider-auth callback (#11297)

### DIFF
--- a/autobot-backend/api/provider_auth.py
+++ b/autobot-backend/api/provider_auth.py
@@ -12,7 +12,8 @@ vault (``services.envelope_secrets_service``).
 
 Routes
 ------
-POST /api/llm-auth/oauth/callback          — exchange authorization code + persist tokens
+POST /api/llm-auth/oauth/initiate          — mint PKCE+state, return provider authorize URL
+POST /api/llm-auth/oauth/callback          — state-bound single-use code exchange + persist tokens
 POST /api/llm-auth/device/initiate         — begin device-code flow
 POST /api/llm-auth/device/poll             — poll for device-code approval + persist
 GET  /api/llm-auth/status/{provider_name}  — check whether a provider has a stored token
@@ -21,16 +22,20 @@ DELETE /api/llm-auth/{provider_name}       — revoke / delete stored tokens
 
 from __future__ import annotations
 
+import json
+import os
 import time
-from typing import Any
+from typing import Any, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.knowledge_connector_oauth import _redis_getdel, _redis_setex
 from api.user_management.dependencies import get_db_session
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_redis_client
 from autobot_shared.url_safety import get_oauth_allowed_hosts, require_allowlisted_https
 from llm_shared.provider_auth import (
     _vault_read,
@@ -72,6 +77,15 @@ router = APIRouter(prefix="/llm-auth", tags=["llm-auth"])
 # all authenticated users can use the shared provider connection.
 _SYSTEM_VAULT = "system"
 
+# OAuth authorize state is single-use and short-lived — a security window, not a
+# cache (#11297). Overridable via env; keyed to the initiating admin in Redis.
+_OAUTH_STATE_TTL_SECONDS = int(os.getenv("AUTOBOT_PROVIDER_OAUTH_STATE_TTL_SECONDS", "600"))
+_OAUTH_STATE_PREFIX = "llm-auth:oauth:state:"
+
+
+def _state_key(state: str) -> str:
+    return "%s%s" % (_OAUTH_STATE_PREFIX, state)
+
 
 # ---------------------------------------------------------------------------
 # Schemas
@@ -79,13 +93,33 @@ _SYSTEM_VAULT = "system"
 
 
 class OAuthInitiateRequest(BaseModel):
+    """Body for POST /oauth/initiate — starts a server-driven PKCE auth-code flow."""
+
     provider_name: str
+    authorize_url: str
     token_url: str
     client_id: str
-    client_secret: str
+    redirect_uri: str
+    scopes: Optional[List[str]] = None
+
+
+class OAuthAuthorizeResponse(BaseModel):
+    """Return of /oauth/initiate — the provider URL to redirect to + the CSRF state."""
+
+    authorize_url: str
+    state: str
+
+
+class OAuthCallbackRequest(BaseModel):
+    """Body for POST /oauth/callback — bound to a server-minted, single-use state.
+
+    The verifier / token_url / client_id are taken from the stored state, never
+    from the client, so a lured admin cannot inject an attacker's credentials.
+    """
+
+    state: str
     code: str
     redirect_uri: str
-    code_verifier: str
 
 
 class OAuthInitiateResponse(BaseModel):
@@ -140,62 +174,135 @@ def _current_user_id(user: Any) -> str:
 # ---------------------------------------------------------------------------
 
 
+@router.post("/oauth/initiate", response_model=OAuthAuthorizeResponse)
+async def oauth_initiate(
+    req: OAuthInitiateRequest,
+    user: Any = Depends(get_current_user),
+    _admin: bool = Depends(check_admin_permission),
+) -> OAuthAuthorizeResponse:
+    """Begin a provider auth-code + PKCE flow; return the authorize URL + state.
+
+    The server mints the PKCE verifier/challenge and an unguessable ``state``,
+    stashes them in Redis (short TTL, keyed to the initiating admin), and returns
+    the provider authorize URL. The client never supplies the verifier — the
+    callback takes it from the stored state (#11297). Requires admin: the stored
+    credential is system-wide.
+    """
+    from knowledge.connectors.oauth_flow import (  # noqa: PLC0415
+        OAuthProvider,
+        build_authorize_url,
+        generate_pkce,
+        generate_state,
+    )
+
+    # SSRF-validate BOTH outbound URLs before we store or return them.
+    _validate_outbound_url(req.authorize_url)
+    _validate_outbound_url(req.token_url)
+
+    redis = get_redis_client(database="main")
+    if redis is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="OAuth state store unavailable")
+
+    verifier, challenge = generate_pkce()
+    state = generate_state()
+    scopes = tuple(req.scopes) if req.scopes else None
+    provider_cfg = OAuthProvider(
+        name=req.provider_name,
+        authorize_url=req.authorize_url,
+        token_url=req.token_url,
+        client_id_setting="",
+        client_secret_setting="",  # nosec B106 - setting NAME (empty), not a secret value
+        default_scopes=scopes or (),
+    )
+
+    payload = {
+        "verifier": verifier,
+        "admin_id": _current_user_id(user),
+        "provider_name": req.provider_name,
+        "token_url": req.token_url,
+        "client_id": req.client_id,
+    }
+    await _redis_setex(redis, _state_key(state), _OAUTH_STATE_TTL_SECONDS, json.dumps(payload, ensure_ascii=False))
+
+    authorize_url = build_authorize_url(provider_cfg, req.client_id, req.redirect_uri, state, challenge, scopes)
+    logger.info("OAuth authorize initiated for provider %s", req.provider_name)
+    return OAuthAuthorizeResponse(authorize_url=authorize_url, state=state)
+
+
 @router.post("/oauth/callback", response_model=OAuthInitiateResponse)
 async def oauth_callback(
-    req: OAuthInitiateRequest,
+    req: OAuthCallbackRequest,
     session: AsyncSession = Depends(get_db_session),
     user: Any = Depends(get_current_user),
     _admin: bool = Depends(check_admin_permission),
 ) -> OAuthInitiateResponse:
     """Exchange an OAuth authorization code for tokens and persist to vault.
 
-    The frontend redirects to this endpoint after the user completes the
-    provider sign-in page.  The backend performs the PKCE code exchange and
-    stores the resulting token pair in the system vault.
+    Authorized by a server-minted, **single-use** ``state`` (from /oauth/initiate):
+    the state is atomically consumed (GETDEL), must belong to the current admin,
+    and supplies the verifier / token_url / client_id — none of which the client
+    provides. This closes the CSRF / code-injection hole where a lured admin could
+    bind an attacker's account as the shared system credential (#11297).
 
     Requires admin — stored credential is system-wide (shared by all users).
     """
     from knowledge.connectors.oauth_flow import OAuthProvider, exchange_code  # noqa: PLC0415
 
-    # Validate outbound URL before any HTTP call — prevents SSRF via token_url.
-    _validate_outbound_url(req.token_url)
+    redis = get_redis_client(database="main")
+    if redis is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="OAuth state store unavailable")
 
-    # Build a minimal OAuthProvider for the exchange helper.
+    # Single-use: atomically fetch-and-delete. Missing/expired/replayed → 400.
+    raw = await _redis_getdel(redis, _state_key(req.state))
+    if raw is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid or expired OAuth state")
+    stored = json.loads(raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw)
+
+    # Bind the completing admin to the initiating admin (defends against a lured admin).
+    if stored.get("admin_id") != _current_user_id(user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="OAuth state does not belong to the current admin"
+        )
+
+    token_url = stored["token_url"]
+    _validate_outbound_url(token_url)  # defensive re-check before the outbound call
+
     provider_cfg = OAuthProvider(
-        name=req.provider_name,
+        name=stored["provider_name"],
         authorize_url="",
-        token_url=req.token_url,
+        token_url=token_url,
         client_id_setting="",
         client_secret_setting="",  # nosec B106 - setting NAME (empty), not a secret value
     )
 
     try:
+        # Public-client PKCE: the verifier (server-stored) replaces a client secret.
         resp = await exchange_code(
             provider_cfg,
-            req.client_id,
-            req.client_secret,
+            stored["client_id"],
+            "",  # nosec B106 - PKCE public client: no client_secret
             req.code,
             req.redirect_uri,
-            req.code_verifier,
+            stored["verifier"],
         )
     except RuntimeError as exc:
-        # Log provider name only — never log code, client_secret, or token values.
-        logger.warning("OAuth code exchange failed for provider %s", req.provider_name)
+        # Log provider name only — never log code or token values.
+        logger.warning("OAuth code exchange failed for provider %s", stored.get("provider_name"))
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     token_data = build_token_data(resp, created_by=_current_user_id(user))
     await _vault_write(
         session,
-        provider_name=req.provider_name,
+        provider_name=stored["provider_name"],
         subject="global",
         owner_vault_str=_SYSTEM_VAULT,
         token_data=token_data,
         created_by_id=_current_user_id(user),
     )
     await session.commit()
-    logger.info("OAuth token stored for provider %s", req.provider_name)
+    logger.info("OAuth token stored for provider %s", stored.get("provider_name"))
     return OAuthInitiateResponse(
-        provider_name=req.provider_name,
+        provider_name=stored["provider_name"],
         stored=True,
         expires_at=token_data.get("expires_at"),
     )

--- a/autobot-backend/api/tests/test_provider_auth_oauth_state.py
+++ b/autobot-backend/api/tests/test_provider_auth_oauth_state.py
@@ -1,0 +1,168 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""State-bound provider OAuth: /oauth/initiate + single-use /oauth/callback (#11297).
+
+Proves the callback is authorized by a server-minted, single-use ``state`` (not a
+client-supplied verifier): missing/replayed/expired state → 400, admin mismatch →
+403, and the happy path exchanges with the SERVER-STORED verifier.
+"""
+
+import json
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api import provider_auth as mod
+from api.user_management.dependencies import get_db_session
+from auth_middleware import check_admin_permission, get_current_user
+from knowledge.connectors import oauth_flow
+
+
+class _FakeRedis:
+    """Minimal in-memory redis supporting set(ex=) and getdel() (single-use)."""
+
+    def __init__(self):
+        self.store = {}
+
+    def set(self, key, value, ex=None):
+        self.store[key] = value
+        return True
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def getdel(self, key):
+        return self.store.pop(key, None)
+
+    def delete(self, key):
+        return 1 if self.store.pop(key, None) is not None else 0
+
+
+_ADMIN = types.SimpleNamespace(user_id="admin-1")
+_INITIATE = "/api/llm-auth/oauth/initiate"
+_CALLBACK = "/api/llm-auth/oauth/callback"
+
+
+@pytest.fixture
+def ctx(monkeypatch):
+    fake_redis = _FakeRedis()
+    monkeypatch.setattr(mod, "get_redis_client", lambda database="main": fake_redis)
+    # Allow the test provider hosts through the SSRF guard.
+    monkeypatch.setattr(mod, "get_oauth_allowed_hosts", lambda: {"auth.example.com", "token.example.com"})
+    # Persist step is exercised elsewhere; isolate the state/PKCE/admin logic.
+    monkeypatch.setattr(mod, "_vault_write", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "build_token_data", lambda resp, created_by: {"expires_at": 111.0})
+
+    app = FastAPI()
+    app.include_router(mod.router, prefix="/api")
+    app.dependency_overrides[get_current_user] = lambda: _ADMIN
+    app.dependency_overrides[check_admin_permission] = lambda: True
+    app.dependency_overrides[get_db_session] = lambda: AsyncMock()
+    return TestClient(app), fake_redis, app
+
+
+def _valid_initiate_body():
+    return {
+        "provider_name": "acme",
+        "authorize_url": "https://auth.example.com/authorize",
+        "token_url": "https://token.example.com/token",
+        "client_id": "cid-123",
+        "redirect_uri": "https://app.local/cb",
+        "scopes": ["read"],
+    }
+
+
+def test_initiate_stores_state_and_verifier_keyed_to_admin(ctx):
+    tc, fake_redis, _ = ctx
+    resp = tc.post(_INITIATE, json=_valid_initiate_body())
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["state"]
+    assert data["authorize_url"].startswith("https://auth.example.com/authorize?")
+    assert "code_challenge=" in data["authorize_url"] and "state=%s" % data["state"] in data["authorize_url"]
+    # Server-side state carries the verifier + initiating admin; verifier never leaves the server.
+    (stored_raw,) = fake_redis.store.values()
+    stored = json.loads(stored_raw)
+    assert stored["admin_id"] == "admin-1"
+    assert stored["verifier"] and stored["verifier"] not in data["authorize_url"]
+    assert stored["token_url"] == "https://token.example.com/token"
+    assert stored["client_id"] == "cid-123"
+
+
+def test_initiate_rejects_ssrf_token_url(ctx):
+    tc, _, _ = ctx
+    body = _valid_initiate_body()
+    body["token_url"] = "https://evil.example.net/token"  # not allow-listed
+    resp = tc.post(_INITIATE, json=body)
+    assert resp.status_code == 400
+
+
+def _prestore_state(fake_redis, state="st-1", admin_id="admin-1"):
+    fake_redis.store[mod._state_key(state)] = json.dumps(
+        {
+            "verifier": "server-verifier",
+            "admin_id": admin_id,
+            "provider_name": "acme",
+            "token_url": "https://token.example.com/token",
+            "client_id": "cid-123",
+        }
+    )
+    return state
+
+
+def test_callback_happy_path_uses_stored_verifier(ctx, monkeypatch):
+    tc, fake_redis, _ = ctx
+    captured = {}
+
+    async def fake_exchange(provider, client_id, client_secret, code, redirect_uri, code_verifier):
+        captured.update(client_id=client_id, client_secret=client_secret, code=code, verifier=code_verifier)
+        return {"access_token": "at", "refresh_token": "rt", "expires_in": 3600}
+
+    monkeypatch.setattr(oauth_flow, "exchange_code", fake_exchange)
+    state = _prestore_state(fake_redis)
+
+    resp = tc.post(_CALLBACK, json={"state": state, "code": "auth-code", "redirect_uri": "https://app.local/cb"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["stored"] is True
+    # Exchange used the SERVER-STORED verifier + client_id, and a PKCE public-client (no secret).
+    assert captured["verifier"] == "server-verifier"
+    assert captured["client_id"] == "cid-123"
+    assert captured["client_secret"] == ""
+    # State was consumed (single-use).
+    assert mod._state_key(state) not in fake_redis.store
+
+
+def test_callback_missing_state_400(ctx):
+    tc, _, _ = ctx
+    resp = tc.post(_CALLBACK, json={"state": "nope", "code": "c", "redirect_uri": "https://app.local/cb"})
+    assert resp.status_code == 400
+
+
+def test_callback_replayed_state_400(ctx, monkeypatch):
+    tc, fake_redis, _ = ctx
+
+    async def fake_exchange(*a, **k):
+        return {"access_token": "at", "expires_in": 3600}
+
+    monkeypatch.setattr(oauth_flow, "exchange_code", fake_exchange)
+    state = _prestore_state(fake_redis)
+    first = tc.post(_CALLBACK, json={"state": state, "code": "c", "redirect_uri": "https://app.local/cb"})
+    assert first.status_code == 200
+    # Replay the same (now-consumed) state → rejected.
+    replay = tc.post(_CALLBACK, json={"state": state, "code": "c", "redirect_uri": "https://app.local/cb"})
+    assert replay.status_code == 400
+
+
+def test_callback_admin_mismatch_403(ctx):
+    tc, fake_redis, _ = ctx
+    # State minted by a DIFFERENT admin than the caller (_ADMIN = admin-1).
+    state = _prestore_state(fake_redis, admin_id="admin-999")
+    resp = tc.post(_CALLBACK, json={"state": state, "code": "c", "redirect_uri": "https://app.local/cb"})
+    assert resp.status_code == 403
+    # A rejected mismatch still consumed the single-use state (no reuse window).
+    assert mod._state_key(state) not in fake_redis.store

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -29760,6 +29760,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/llm-auth/oauth/initiate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Oauth Initiate
+         * @description Begin a provider auth-code + PKCE flow; return the authorize URL + state.
+         *
+         *     The server mints the PKCE verifier/challenge and an unguessable ``state``,
+         *     stashes them in Redis (short TTL, keyed to the initiating admin), and returns
+         *     the provider authorize URL. The client never supplies the verifier — the
+         *     callback takes it from the stored state (#11297). Requires admin: the stored
+         *     credential is system-wide.
+         */
+        post: operations["oauth_initiate_api_llm_auth_oauth_initiate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/llm-auth/oauth/callback": {
         parameters: {
             query?: never;
@@ -29773,9 +29799,11 @@ export interface paths {
          * Oauth Callback
          * @description Exchange an OAuth authorization code for tokens and persist to vault.
          *
-         *     The frontend redirects to this endpoint after the user completes the
-         *     provider sign-in page.  The backend performs the PKCE code exchange and
-         *     stores the resulting token pair in the system vault.
+         *     Authorized by a server-minted, **single-use** ``state`` (from /oauth/initiate):
+         *     the state is atomically consumed (GETDEL), must belong to the current admin,
+         *     and supplies the verifier / token_url / client_id — none of which the client
+         *     provides. This closes the CSRF / code-injection hole where a lured admin could
+         *     bind an attacker's account as the shared system credential (#11297).
          *
          *     Requires admin — stored credential is system-wide (shared by all users).
          */
@@ -82783,22 +82811,52 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** OAuthInitiateRequest */
-        OAuthInitiateRequest: {
-            /** Provider Name */
-            provider_name: string;
-            /** Token Url */
-            token_url: string;
-            /** Client Id */
-            client_id: string;
-            /** Client Secret */
-            client_secret: string;
+        /**
+         * OAuthAuthorizeResponse
+         * @description Return of /oauth/initiate — the provider URL to redirect to + the CSRF state.
+         */
+        OAuthAuthorizeResponse: {
+            /** Authorize Url */
+            authorize_url: string;
+            /** State */
+            state: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * OAuthCallbackRequest
+         * @description Body for POST /oauth/callback — bound to a server-minted, single-use state.
+         *
+         *     The verifier / token_url / client_id are taken from the stored state, never
+         *     from the client, so a lured admin cannot inject an attacker's credentials.
+         */
+        OAuthCallbackRequest: {
+            /** State */
+            state: string;
             /** Code */
             code: string;
             /** Redirect Uri */
             redirect_uri: string;
-            /** Code Verifier */
-            code_verifier: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * OAuthInitiateRequest
+         * @description Body for POST /oauth/initiate — starts a server-driven PKCE auth-code flow.
+         */
+        OAuthInitiateRequest: {
+            /** Provider Name */
+            provider_name: string;
+            /** Authorize Url */
+            authorize_url: string;
+            /** Token Url */
+            token_url: string;
+            /** Client Id */
+            client_id: string;
+            /** Redirect Uri */
+            redirect_uri: string;
+            /** Scopes */
+            scopes?: string[] | null;
         } & {
             [key: string]: unknown;
         };
@@ -139020,7 +139078,7 @@ export interface operations {
             };
         };
     };
-    oauth_callback_api_llm_auth_oauth_callback_post: {
+    oauth_initiate_api_llm_auth_oauth_initiate_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -139030,6 +139088,39 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["OAuthInitiateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OAuthAuthorizeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    oauth_callback_api_llm_auth_oauth_callback_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OAuthCallbackRequest"];
             };
         };
         responses: {


### PR DESCRIPTION
## Thinking Path
`/api/llm-auth/oauth/callback` trusted a **client-supplied** `code_verifier` and had **no `state`** — there was no `/oauth/initiate`, and `generate_state`/`generate_pkce` were never called. A lured admin hitting a crafted callback could bind an attacker's account as the shared system credential (CSRF / code injection). Admin-gated, but exploitable via a lured admin (the headline HIGH of #11061 / umbrella #11058).

This mirrors the **already-hardened knowledge-connector OAuth flow** (`api/knowledge_connector_oauth.py`): server-minted single-use state + PKCE, consumed via GETDEL. I reused its `_redis_setex`/`_redis_getdel` helpers (no duplication).

The LLM-provider OAuth flow has **no live frontend caller** (`ConnectorOAuthButton.vue` drives the separate knowledge-connector endpoint), so the callback-contract change breaks nothing today; the frontend is a genuinely separate task (per the issue).

## What Changed (`api/provider_auth.py`)
- **New `POST /oauth/initiate`** (admin-gated): SSRF-validates `authorize_url` + `token_url`, mints `generate_pkce()` + `generate_state()`, stores `{verifier, admin_id, provider_name, token_url, client_id}` in Redis at `llm-auth:oauth:state:{state}` (TTL from `AUTOBOT_PROVIDER_OAUTH_STATE_TTL_SECONDS`, default 600s), returns `{authorize_url, state}`. The verifier never leaves the server.
- **`/oauth/callback` is now state-bound** (`OAuthCallbackRequest{state, code, redirect_uri}` — client no longer sends verifier/token_url/client_id/client_secret): atomically `GETDEL`s the state (single-use → missing/expired/replayed = 400), asserts stored `admin_id == current admin` (else 403), re-validates the stored `token_url` (SSRF), and exchanges with the **server-stored** verifier/token_url/client_id as a PKCE public client (empty secret).
- Schemas: repurposed the mis-named `OAuthInitiateRequest` for the real initiate; added `OAuthAuthorizeResponse` + `OAuthCallbackRequest` (no `_v2` suffixes).

## Verification
- `pytest api/tests/test_provider_auth_oauth_state.py` → **6 passed**: initiate stores state+verifier keyed to admin; initiate rejects SSRF `token_url`; callback happy-path uses the **server-stored** verifier (asserted) + PKCE public client; missing/replayed state → 400; admin mismatch → 403 (and still consumes the state — no reuse window).
- **Mutation-verified**: neutering the admin-match check → the 403 test fails; changing GETDEL→GET (drop single-use) → the replay test fails. Assertions are load-bearing.
- `flake8 --config=.flake8` clean; `black` applied; router imports cleanly (no circular import).
- `api.ts` will be regenerated from the authoritative py3.14 OpenAPI (schema-only; no live frontend caller yet).

## Model Used
Opus 4.8 (1M context)

Closes #11297