### PR TITLE
fix(deploy): node-ownership covers co-located nodes; backend health probe runs on the node (#11455)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/fix-node-ownership.yml
+++ b/autobot-slm-backend/ansible/playbooks/fix-node-ownership.yml
@@ -8,8 +8,13 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 
+# #11455: target `infrastructure` (not `infrastructure:!slm_server`). A co-located
+# single-node host is in BOTH groups after #11436, so `!slm_server` wrongly
+# excluded it and its /opt/autobot ownership was never fixed. A pure SLM
+# controller is only in `slm_server` (not `infrastructure`), so it is still
+# excluded — matching update-all-nodes.yml Play 2's membership model.
 - name: "Fix AutoBot file ownership on all nodes"
-  hosts: infrastructure:!slm_server
+  hosts: infrastructure
   gather_facts: false
   serial: 3
 

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -744,13 +744,18 @@
         # TLS on 443. There is NO 8443 listener (#957/#10378). Probe the direct
         # backend on the loopback — it does not depend on nginx (deployed after
         # this task) and needs no cert validation (#10650).
+        #
+        # #11455: run ON the backend node (no delegate_to) so 127.0.0.1 is the
+        # node's own loopback. 8001 is bound to localhost, so it is unreachable
+        # from the controller — delegating to localhost only worked for a
+        # co-located single-node backend and spun 42×10s against the wrong host
+        # for any remote backend, aborting the rollout via any_errors_fatal.
         url: "http://127.0.0.1:8001/api/health"
         status_code: 200
       register: backend_health_check
       until: backend_health_check.status == 200
       retries: 42
       delay: 10
-      delegate_to: localhost
       when: "'backend' in group_names"
       tags: [backend, restart]
 


### PR DESCRIPTION
## Thinking Path
Two deploy-topology bugs found in #11453 review, both stemming from single-node/co-located assumptions that break the multi-node model established by #11436.

## What Changed
1. **`fix-node-ownership.yml`** — `hosts: infrastructure:!slm_server` → `hosts: infrastructure`. A co-located single-node host is in **both** groups after #11436, so `!slm_server` excluded it and its `/opt/autobot` ownership was never fixed. A pure SLM controller is only in `slm_server` (not `infrastructure`), so it stays excluded — matching `update-all-nodes.yml` Play 2.
2. **`update-all-nodes.yml` Play 2 backend health probe** — removed `delegate_to: localhost`. It probed `127.0.0.1:8001` on the **controller** loopback; uvicorn binds 8001 to localhost only (unreachable cross-host), so for any **remote** backend node it spun 42×10s against the wrong host and aborted the rollout via `any_errors_fatal`. Without the delegate the probe runs **on the backend node** against its own loopback — correct for co-located and remote.

## Blast radius (deploy)
- Part 1: a pure SLM controller is confirmed excluded (only in `slm_server`); co-located + managed infra nodes gain correct coverage. Ownership fix is idempotent `chown`.
- Part 2: co-located path unchanged (node == controller, same `127.0.0.1`); only remote backends change (now probe the right host). `8001` is localhost-bound so `{{ ansible_host }}:8001` from the controller would fail — running on the node is the only correct option.

## Verification
- Both playbooks parse as valid YAML.
- Confirmed Play 2 has `any_errors_fatal: true` (validates the rollout-abort failure mode).

## Model Used
Opus 4.8

Closes #11455