### PR TITLE
fix(deploy): Play 1 agent redeploy must run before the backend self-restart (#11480 #11492)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -361,6 +361,28 @@
       register: slm_build
       tags: [slm, slm-frontend]
 
+    # #11480/#11492: redeploy the slm-agent BEFORE the backend restart. The
+    # backend restart below kills this fire-and-forget playbook (KillMode=
+    # control-group, #11492), so anything after it never runs — the agent
+    # deploy must land here, and flush_handlers forces the role's restart
+    # handler to fire now (handlers otherwise run at play end, i.e. never).
+    # Idempotent role; block/rescue keeps a failure from aborting Play 1.
+    - name: "[PLAY 1] SLM Agent | Redeploy agent (code + secrets + restart) (#11480)"
+      tags: [slm, slm-agent]
+      block:
+        - name: "[PLAY 1] SLM Agent | Import slm_agent role"
+          ansible.builtin.import_role:
+            name: slm_agent
+        - name: "[PLAY 1] SLM Agent | Flush handlers so the agent restarts before the backend self-restart"
+          ansible.builtin.meta: flush_handlers
+      rescue:
+        - name: "[PLAY 1] SLM Agent | Warn on agent redeploy failure"
+          ansible.builtin.debug:
+            msg: >-
+              WARNING: slm_agent redeploy failed on {{ inventory_hostname }} —
+              agent may run stale code / miss agent-secrets.env (#11480).
+              Continuing to backend restart.
+
     - name: "[PLAY 1] SLM | Restart backend service"
       systemd:
         name: autobot-slm-backend
@@ -433,26 +455,6 @@
       ignore_errors: true
       when: slm_login_play1.status == 200
       tags: [always]
-
-    # #11480: redeploy the slm-agent (code + agent-secrets.env + restart) on
-    # every update. Previously the routine update path only copied autobot_shared
-    # into the agent dir, so agent-side fixes (e.g. #11450 heartbeat auth) never
-    # reached nodes through self-update — only the separate deploy-slm-agent.yml.
-    # Idempotent role; slm_server has no any_errors_fatal so a failure here fails
-    # only this host (the SLM manager), matching the rest of Play 1.
-    - name: "[PLAY 1] SLM Agent | Redeploy agent (code + secrets + restart) (#11480)"
-      tags: [slm, slm-agent]
-      block:
-        - name: "[PLAY 1] SLM Agent | Import slm_agent role"
-          ansible.builtin.import_role:
-            name: slm_agent
-      rescue:
-        - name: "[PLAY 1] SLM Agent | Warn on agent redeploy failure"
-          ansible.builtin.debug:
-            msg: >-
-              WARNING: slm_agent redeploy failed on {{ inventory_hostname }} —
-              agent may run stale code / miss agent-secrets.env (#11480). Backend
-              + frontend already deployed; continuing.
 
     - name: "[PLAY 1] SLM Update Complete"
       debug:

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -1091,6 +1091,9 @@
     # Note: a co-located SLM manager is in both slm_server (Play 1) and
     # infrastructure (Play 2, #11436), so it runs this idempotent role twice
     # per update (harmless — converges to the same state, one extra restart).
+    # No flush_handlers here (unlike Play 1): Play 2 reaches its play end so
+    # handlers flush normally; Play 1 needs the early flush because the backend
+    # self-restart kills the run before play end (#11492).
     - name: "[PLAY 2] SLM Agent | Redeploy agent (code + secrets + restart) (#11480)"
       when: slm_node_id is defined
       tags: [slm-agent]


### PR DESCRIPTION
## Thinking Path
Live dogfooding of #11480 showed the agent still wasn't deployed by self-update: `agent.py` mtime stuck at 2026-06-27, `agent-secrets.env` absent, heartbeats still 401. Root cause (#11492): the self-update ansible run is a fire-and-forget child of the SLM backend (`KillMode=control-group`), so Play 1's **"Restart backend service"** kills the playbook — and #11480 placed the agent redeploy *after* that restart, so it never ran. Fixes the #11480 regression; broader "everything after the backend restart is lost" tracked in #11492.

## What Changed
`update-all-nodes.yml` Play 1: moved the `slm_agent` role import to **immediately before** "Restart backend service", and added `meta: flush_handlers` inside the block so the role's restart handler fires **now** (handlers otherwise run at play end — after the fatal restart = never). block/rescue retained (warn, don't abort). Play 2's agent block is unchanged (only reachable on direct/full playbook runs, not self-update).

## Verification
- `ansible-playbook --syntax-check` OK; `yaml.safe_load_all` OK; agent block (line 370) now precedes the backend restart (line 386).
- Post-merge: re-run built-in `self-update` and confirm `agent.py` mtime advances, `agent-secrets.env` is non-empty, agent heartbeats flip to 200, and the fleet Service table + Services view populate — closing #11450 end-to-end.

## Model Used
Claude Fable 5 (1M context)
