### PR TITLE
harden(oauth): RFC-8628 server-side device-code poll limiter (completes #11061)

### DIFF
--- a/autobot-backend/api/provider_auth.py
+++ b/autobot-backend/api/provider_auth.py
@@ -22,6 +22,7 @@ DELETE /api/llm-auth/{provider_name}       — revoke / delete stored tokens
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import time
@@ -85,6 +86,29 @@ _OAUTH_STATE_PREFIX = "llm-auth:oauth:state:"
 
 def _state_key(state: str) -> str:
     return "%s%s" % (_OAUTH_STATE_PREFIX, state)
+
+
+# Device-code poll limiter (#11061): honor RFC-8628 server-side — reject polls
+# faster than the current interval, back off +5s on ``slow_down``, and cap total
+# attempts per device_code. All overridable via env.
+_DEVICE_POLL_MIN_INTERVAL = int(os.getenv("AUTOBOT_DEVICE_POLL_MIN_INTERVAL_SECONDS", "5"))
+_DEVICE_POLL_BACKOFF = int(os.getenv("AUTOBOT_DEVICE_POLL_BACKOFF_SECONDS", "5"))
+_DEVICE_POLL_MAX_ATTEMPTS = int(os.getenv("AUTOBOT_DEVICE_POLL_MAX_ATTEMPTS", "360"))
+_DEVICE_POLL_WINDOW = int(os.getenv("AUTOBOT_DEVICE_POLL_WINDOW_SECONDS", "1800"))
+_DEVICE_POLL_PREFIX = "llm-auth:device:poll:"
+
+
+def _device_poll_key(device_code: str) -> str:
+    # Hash the device_code so the raw grant secret never becomes a Redis key.
+    return "%s%s" % (_DEVICE_POLL_PREFIX, hashlib.sha256(device_code.encode("utf-8")).hexdigest())
+
+
+async def _redis_get(redis, key: str):
+    """Read a key without deleting it (sync- or async-client tolerant)."""
+    value = redis.get(key)
+    if hasattr(value, "__await__"):
+        value = await value
+    return value
 
 
 # ---------------------------------------------------------------------------
@@ -380,6 +404,27 @@ async def device_poll(
     # Validate outbound URL before any HTTP call — prevents SSRF via token_url.
     _validate_outbound_url(req.token_url)
 
+    # RFC-8628 server-side poll limiter (#11061): reject too-fast polls and cap
+    # total attempts BEFORE hitting the provider. Best-effort — skipped if Redis
+    # is unavailable so the flow still works in degraded mode.
+    redis = get_redis_client(database="main")
+    poll_key = _device_poll_key(req.device_code)
+    now = time.time()
+    poll_state = {"interval": _DEVICE_POLL_MIN_INTERVAL, "count": 0, "last_ts": 0.0}
+    if redis is not None:
+        raw = await _redis_get(redis, poll_key)
+        if raw:
+            poll_state = json.loads(raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw)
+        if poll_state["count"] >= _DEVICE_POLL_MAX_ATTEMPTS:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="device-code polling attempts exhausted"
+            )
+        if now - poll_state["last_ts"] < poll_state["interval"]:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="polling too fast; honor the device-code interval",
+            )
+
     payload = {
         "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
         "device_code": req.device_code,
@@ -399,6 +444,18 @@ async def device_poll(
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
 
     error = data.get("error")
+    # Update the limiter: on slow_down, back off (+5s, RFC-8628); on a still-pending
+    # grant persist the new state; on a terminal outcome clear it.
+    if redis is not None:
+        if error == "slow_down":
+            poll_state["interval"] += _DEVICE_POLL_BACKOFF
+        poll_state["count"] += 1
+        poll_state["last_ts"] = now
+        if error in ("authorization_pending", "slow_down"):
+            await _redis_setex(redis, poll_key, _DEVICE_POLL_WINDOW, json.dumps(poll_state))
+        else:
+            await _redis_getdel(redis, poll_key)
+
     if error in ("authorization_pending", "slow_down"):
         return OAuthInitiateResponse(provider_name=req.provider_name, stored=False)
     if error:

--- a/autobot-backend/api/tests/test_provider_auth_device_poll_limit.py
+++ b/autobot-backend/api/tests/test_provider_auth_device_poll_limit.py
@@ -1,0 +1,154 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""RFC-8628 server-side device-code poll limiter (#11061).
+
+Proves /device/poll rejects too-fast polls and exhausted attempts (429) before
+hitting the provider, and honors ``slow_down`` by backing the interval off +5s.
+"""
+
+import json
+import time
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api import provider_auth as mod
+from api.user_management.dependencies import get_db_session
+from auth_middleware import check_admin_permission, get_current_user
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def set(self, key, value, ex=None):
+        self.store[key] = value
+        return True
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def getdel(self, key):
+        return self.store.pop(key, None)
+
+    def delete(self, key):
+        return 1 if self.store.pop(key, None) is not None else 0
+
+
+class _FakeResp:
+    def __init__(self, data):
+        self._data = data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def json(self, content_type=None):
+        return self._data
+
+
+class _FakeSession:
+    """Stand-in for aiohttp.ClientSession returning a canned token response."""
+
+    _data = {"error": "authorization_pending"}
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    def post(self, *a, **k):
+        return _FakeResp(self._data)
+
+
+_ADMIN = types.SimpleNamespace(user_id="admin-1")
+_POLL = "/api/llm-auth/device/poll"
+
+
+@pytest.fixture
+def ctx(monkeypatch):
+    fake_redis = _FakeRedis()
+    monkeypatch.setattr(mod, "get_redis_client", lambda database="main": fake_redis)
+    monkeypatch.setattr(mod, "get_oauth_allowed_hosts", lambda: {"token.example.com"})
+    monkeypatch.setattr(mod, "_vault_write", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "build_token_data", lambda data, created_by: {"expires_at": 1.0})
+
+    app = FastAPI()
+    app.include_router(mod.router, prefix="/api")
+    app.dependency_overrides[get_current_user] = lambda: _ADMIN
+    app.dependency_overrides[check_admin_permission] = lambda: True
+    app.dependency_overrides[get_db_session] = lambda: AsyncMock()
+    return TestClient(app), fake_redis
+
+
+def _body(device_code="dev-code-1"):
+    return {
+        "provider_name": "acme",
+        "token_url": "https://token.example.com/token",
+        "client_id": "cid",
+        "device_code": device_code,
+    }
+
+
+def test_poll_too_fast_returns_429_before_provider_call(ctx):
+    tc, fake_redis = ctx
+    # A poll happened "just now" — the next one is inside the interval window.
+    fake_redis.store[mod._device_poll_key("dev-code-1")] = json.dumps(
+        {"interval": 5, "count": 1, "last_ts": time.time()}
+    )
+    resp = tc.post(_POLL, json=_body())
+    assert resp.status_code == 429
+    assert "too fast" in resp.json()["detail"]
+
+
+def test_poll_attempts_exhausted_returns_429(ctx):
+    tc, fake_redis = ctx
+    fake_redis.store[mod._device_poll_key("dev-code-1")] = json.dumps(
+        {"interval": 5, "count": mod._DEVICE_POLL_MAX_ATTEMPTS, "last_ts": 0.0}
+    )
+    resp = tc.post(_POLL, json=_body())
+    assert resp.status_code == 429
+    assert "exhausted" in resp.json()["detail"]
+
+
+def test_first_poll_allowed_and_persists_state(ctx, monkeypatch):
+    tc, fake_redis = ctx
+    monkeypatch.setattr("aiohttp.ClientSession", _FakeSession)
+    resp = tc.post(_POLL, json=_body())
+    assert resp.status_code == 200
+    assert resp.json()["stored"] is False  # authorization_pending
+    saved = json.loads(fake_redis.store[mod._device_poll_key("dev-code-1")])
+    assert saved["count"] == 1 and saved["last_ts"] > 0
+
+
+def test_slow_down_backs_off_interval(ctx, monkeypatch):
+    tc, fake_redis = ctx
+
+    class _SlowSession(_FakeSession):
+        _data = {"error": "slow_down"}
+
+    monkeypatch.setattr("aiohttp.ClientSession", _SlowSession)
+    # Pre-existing state whose window has elapsed so the poll is allowed through.
+    fake_redis.store[mod._device_poll_key("dev-code-1")] = json.dumps({"interval": 5, "count": 1, "last_ts": 0.0})
+    resp = tc.post(_POLL, json=_body())
+    assert resp.status_code == 200
+    saved = json.loads(fake_redis.store[mod._device_poll_key("dev-code-1")])
+    assert saved["interval"] == 5 + mod._DEVICE_POLL_BACKOFF  # backed off +5s
+    assert saved["count"] == 2
+
+
+def test_poll_key_hashes_device_code(ctx):
+    key = mod._device_poll_key("super-secret-code")
+    assert "super-secret-code" not in key
+    assert key.startswith("llm-auth:device:poll:")


### PR DESCRIPTION
## Thinking Path
Umbrella #11061 (from an adversarial audit of provider-auth OAuth) had several findings. Re-auditing the current tree, **all but one were already fixed**:
- ✅ **HIGH — OAuth callback state/PKCE binding**: shipped in #11297 (`/oauth/initiate` + single-use state + server-stored verifier).
- ✅ **HIGH — refresh/device SSRF bypass**: `llm_shared/provider_auth.py._refresh` now calls `require_allowlisted_https(self._token_url, get_oauth_allowed_hosts())` before the outbound POST (device path reuses this refresh logic).
- ✅ **MED — `/status/{provider_name}` admin-gate**: now depends on `check_admin_permission`.
- ✅ SSRF validation on `/device/poll` (`_validate_outbound_url`) already present.

The **one remaining acceptance item** was *device-poll rate-limiting* — that's this PR.

## What Changed (`api/provider_auth.py`)
Added an RFC-8628-compliant server-side poll limiter to `/device/poll`:
- Per-`device_code` Redis state (`llm-auth:device:poll:{sha256(device_code)}` — the raw grant secret is never a key), read **before** the provider call.
- **Reject too-fast polls** (429) when `now - last_ts < interval`, and **cap total attempts** (429 when `count ≥ AUTOBOT_DEVICE_POLL_MAX_ATTEMPTS`, default 360) — both *before* hitting the provider.
- **Honor `slow_down`**: back the interval off by +5s (`AUTOBOT_DEVICE_POLL_BACKOFF_SECONDS`) on each provider `slow_down`.
- State TTL `AUTOBOT_DEVICE_POLL_WINDOW_SECONDS` (default 1800s); cleared on a terminal outcome. Best-effort — degrades gracefully if Redis is down. All thresholds env-tunable (no hardcoded TTLs).

## Verification
- `pytest api/tests/test_provider_auth_device_poll_limit.py` → **5 passed**: too-fast → 429 (before any provider call), attempts-exhausted → 429, first poll allowed + state persisted, `slow_down` backs interval off +5s, device_code is hashed in the key.
- Existing #11297 state tests still pass (11 total in the module).
- **Mutation-verified**: neutering the too-fast check → the 429 test fails.
- `flake8` clean; `black` applied. No OpenAPI schema change (internal logic only) → `api.ts` unaffected.

## Model Used
Opus 4.8 (1M context)

Closes #11061