### PR TITLE
fix(llm): circuit-break all providers at the BaseProvider seam (#11488)

### DIFF
--- a/autobot-backend/circuit_breaker.py
+++ b/autobot-backend/circuit_breaker.py
@@ -44,7 +44,8 @@ class CircuitBreakerConfig:
     failure_threshold: int = CircuitBreakerDefaults.DEFAULT_FAILURE_THRESHOLD
     recovery_timeout: float = CircuitBreakerDefaults.DEFAULT_RECOVERY_TIMEOUT
     success_threshold: int = CircuitBreakerDefaults.DEFAULT_SUCCESS_THRESHOLD
-    timeout: float = CircuitBreakerDefaults.DEFAULT_TIMEOUT
+    # None disables the breaker-level asyncio.wait_for (caller/SDK owns latency). GH#11488.
+    timeout: float | None = CircuitBreakerDefaults.DEFAULT_TIMEOUT
 
     # Exceptions that should trigger circuit breaker
     monitored_exceptions: tuple = (

--- a/autobot-backend/llm_shared/base_provider.py
+++ b/autobot-backend/llm_shared/base_provider.py
@@ -18,14 +18,30 @@ from abc import ABC, abstractmethod
 from typing import Any, AsyncIterator, Dict, List, Optional
 
 from autobot_shared.logging_manager import get_logger
+from circuit_breaker import CircuitBreakerConfig, CircuitBreakerOpenError, get_circuit_breaker_manager
+from constants import CircuitBreakerDefaults
 
 from .cross_worker_rate_limiter import get_llm_rate_limiter
 from .models import LLMRequest, LLMResponse
 from .observability import registry as obs_registry
 from .provider_auth import ApiKeyAuth, ProviderAuthError, ProviderAuthStrategy
-from .rate_limit_backoff import get_backoff_handler, raise_if_rate_limited
+from .rate_limit_backoff import extract_rate_limit_info, get_backoff_handler, raise_if_rate_limited
 
 logger = get_logger(__name__)
+
+
+class _CompletionErrorSignal(Exception):
+    """Internal: carries an error LLMResponse through the circuit breaker.
+
+    ``_chat_completion_impl`` must not raise (errors travel via
+    ``LLMResponse.error``), so the breaker cannot observe failures directly.
+    Raising this inside the breaker-guarded call records the failure; the
+    caller unwraps and returns the original response (#11488).
+    """
+
+    def __init__(self, response: LLMResponse) -> None:
+        super().__init__(response.error or "provider completion failed")
+        self.response = response
 
 
 class BaseProvider(ABC):
@@ -83,6 +99,7 @@ class BaseProvider(ABC):
         Wraps ``_chat_completion_impl`` with:
         - Issue #8170: cross-worker Redis rate limiter (proactive token acquire)
         - GH#8502: exponential backoff + auto-resume on provider rate-limit / quota reset
+        - GH#11488: per-provider circuit breaker (fail fast while a provider is down)
         - Observer fan-out (GH#6593)
 
         Errors are returned via ``LLMResponse.error`` so the registry can
@@ -97,7 +114,7 @@ class BaseProvider(ABC):
             async with get_llm_rate_limiter().acquire(provider_key):
                 start = time.monotonic()
                 try:
-                    response = await self._chat_completion_impl(request)
+                    response = await self._guarded_completion(request)
                     latency_ms = (time.monotonic() - start) * 1000
                     try:
                         asyncio.get_running_loop().create_task(obs_registry.notify_response(response, latency_ms, 0.0))
@@ -119,6 +136,60 @@ class BaseProvider(ABC):
             # Backoff exhausted — return the last error response if we have one,
             # otherwise let the exception propagate to the registry for fallback.
             raise
+
+    def _completion_circuit_breaker(self):
+        """Return this provider's completion circuit breaker (GH#11488).
+
+        Name-keyed on ``{provider_name}_service`` so all instances of a
+        provider share one breaker. Config uses the SSOT LLM defaults.
+        """
+        breaker_config = CircuitBreakerConfig(
+            failure_threshold=CircuitBreakerDefaults.LLM_FAILURE_THRESHOLD,
+            recovery_timeout=CircuitBreakerDefaults.LLM_RECOVERY_TIMEOUT,
+            timeout=CircuitBreakerDefaults.LLM_TIMEOUT,
+        )
+        name = f"{self.provider_name or 'default'}_service"
+        return get_circuit_breaker_manager().get_circuit_breaker(name, breaker_config)
+
+    def _breaker_error_response(self, request: LLMRequest, error: str, start: float) -> LLMResponse:
+        """Build the error LLMResponse for breaker-open / breaker-timeout outcomes."""
+        self._total_errors += 1
+        return LLMResponse(
+            content="",
+            model=request.model_name or "",
+            provider=self.provider_name,
+            processing_time=time.monotonic() - start,
+            request_id=request.request_id,
+            error=error,
+        )
+
+    async def _guarded_completion(self, request: LLMRequest) -> LLMResponse:
+        """Run ``_chat_completion_impl`` through the provider circuit breaker (GH#11488).
+
+        Error responses count as breaker failures — except rate limits, which
+        the backoff handler owns (GH#8502) and which prove the provider is up.
+        An open breaker fails fast with an error response so the registry can
+        fall back without paying per-request timeout latency.
+        """
+        breaker = self._completion_circuit_breaker()
+        start = time.monotonic()
+
+        async def _run() -> LLMResponse:
+            response = await self._chat_completion_impl(request)
+            is_rate_limited, _ = extract_rate_limit_info(response)
+            if response.error and not is_rate_limited:
+                raise _CompletionErrorSignal(response)
+            return response
+
+        try:
+            return await breaker.call_async(_run)
+        except _CompletionErrorSignal as signal:
+            return signal.response
+        except CircuitBreakerOpenError as exc:
+            logger.warning("Provider %s circuit breaker open; failing fast", self.provider_name)
+            return self._breaker_error_response(request, f"circuit breaker open: {exc}", start)
+        except TimeoutError as exc:
+            return self._breaker_error_response(request, str(exc), start)
 
     @abstractmethod
     async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:

--- a/autobot-backend/llm_shared/base_provider.py
+++ b/autobot-backend/llm_shared/base_provider.py
@@ -18,7 +18,12 @@ from abc import ABC, abstractmethod
 from typing import Any, AsyncIterator, Dict, List, Optional
 
 from autobot_shared.logging_manager import get_logger
-from circuit_breaker import CircuitBreakerConfig, CircuitBreakerOpenError, get_circuit_breaker_manager
+from circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerConfig,
+    CircuitBreakerOpenError,
+    get_circuit_breaker_manager,
+)
 from constants import CircuitBreakerDefaults
 
 from .cross_worker_rate_limiter import get_llm_rate_limiter
@@ -28,6 +33,16 @@ from .provider_auth import ApiKeyAuth, ProviderAuthError, ProviderAuthStrategy
 from .rate_limit_backoff import extract_rate_limit_info, get_backoff_handler, raise_if_rate_limited
 
 logger = get_logger(__name__)
+
+# GH#11488: one breaker config for all provider completion breakers. ``timeout=None``
+# is deliberate — the breaker owns availability accounting only; latency budgets
+# belong to each provider/SDK (some use unbounded reads for long local generations,
+# and ``LLMRequest.timeout`` may legitimately exceed any fixed constant here).
+_LLM_BREAKER_CONFIG = CircuitBreakerConfig(
+    failure_threshold=CircuitBreakerDefaults.LLM_FAILURE_THRESHOLD,
+    recovery_timeout=CircuitBreakerDefaults.LLM_RECOVERY_TIMEOUT,
+    timeout=None,
+)
 
 
 class _CompletionErrorSignal(Exception):
@@ -137,22 +152,18 @@ class BaseProvider(ABC):
             # otherwise let the exception propagate to the registry for fallback.
             raise
 
-    def _completion_circuit_breaker(self):
+    def _completion_circuit_breaker(self) -> "CircuitBreaker":
         """Return this provider's completion circuit breaker (GH#11488).
 
         Name-keyed on ``{provider_name}_service`` so all instances of a
-        provider share one breaker. Config uses the SSOT LLM defaults.
+        provider share one breaker (config binds on first registration).
         """
-        breaker_config = CircuitBreakerConfig(
-            failure_threshold=CircuitBreakerDefaults.LLM_FAILURE_THRESHOLD,
-            recovery_timeout=CircuitBreakerDefaults.LLM_RECOVERY_TIMEOUT,
-            timeout=CircuitBreakerDefaults.LLM_TIMEOUT,
-        )
         name = f"{self.provider_name or 'default'}_service"
-        return get_circuit_breaker_manager().get_circuit_breaker(name, breaker_config)
+        return get_circuit_breaker_manager().get_circuit_breaker(name, _LLM_BREAKER_CONFIG)
 
     def _breaker_error_response(self, request: LLMRequest, error: str, start: float) -> LLMResponse:
         """Build the error LLMResponse for breaker-open / breaker-timeout outcomes."""
+        self._total_requests += 1  # blocked attempts still count as requests
         self._total_errors += 1
         return LLMResponse(
             content="",
@@ -168,8 +179,10 @@ class BaseProvider(ABC):
 
         Error responses count as breaker failures — except rate limits, which
         the backoff handler owns (GH#8502) and which prove the provider is up.
-        An open breaker fails fast with an error response so the registry can
-        fall back without paying per-request timeout latency.
+        An open breaker fails fast with an error response, sparing the caller
+        the provider's connect/latency cost while it is down. (The response
+        surfaces like any provider error; registry-level avoidance of
+        breaker-open providers is tracked separately.)
         """
         breaker = self._completion_circuit_breaker()
         start = time.monotonic()

--- a/autobot-backend/llm_shared/base_provider_breaker_test.py
+++ b/autobot-backend/llm_shared/base_provider_breaker_test.py
@@ -157,8 +157,6 @@ class TestNoMethodLevelBreaker:
         providers_dir = Path(__file__).parent / "providers"
         pattern = re.compile(r"@circuit_breaker_async[\s\S]{0,300}?async def _chat_completion_impl")
         offenders = [
-            path.name
-            for path in sorted(providers_dir.glob("*.py"))
-            if pattern.search(path.read_text(encoding="utf-8"))
+            path.name for path in sorted(providers_dir.glob("*.py")) if pattern.search(path.read_text(encoding="utf-8"))
         ]
         assert not offenders, f"method-level breaker on _chat_completion_impl in: {offenders}"

--- a/autobot-backend/llm_shared/base_provider_breaker_test.py
+++ b/autobot-backend/llm_shared/base_provider_breaker_test.py
@@ -16,10 +16,22 @@ import re
 from pathlib import Path
 from typing import AsyncIterator, List
 
+import pytest
+
+from circuit_breaker import get_circuit_breaker_manager
 from constants import CircuitBreakerDefaults
 
 from .base_provider import BaseProvider
 from .models import LLMRequest, LLMResponse
+
+
+@pytest.fixture(autouse=True)
+def _clean_test_breakers():
+    """Drop cbtest-* breakers from the process-wide manager after each test."""
+    yield
+    manager = get_circuit_breaker_manager()
+    for name in [n for n in manager.circuit_breakers if n.startswith("cbtest-")]:
+        del manager.circuit_breakers[name]
 
 
 def _request() -> LLMRequest:
@@ -108,6 +120,29 @@ class TestGuardedCompletion:
 
         # threshold-1 failures, a success, then one failure — breaker never opened.
         assert provider.impl_calls == len(script)
+
+
+class TestChatCompletionPipeline:
+    """The breaker-open error response survives the full chat_completion stack
+    (rate limiter → backoff handler → guarded completion) without being
+    retried or misread as a rate limit."""
+
+    async def test_open_breaker_fails_fast_through_chat_completion(self):
+        threshold = CircuitBreakerDefaults.LLM_FAILURE_THRESHOLD
+        provider = _ScriptedProvider(
+            "cbtest-pipeline",
+            [_err("cbtest-pipeline")] * threshold + [_ok("cbtest-pipeline")],
+        )
+
+        for _ in range(threshold):
+            response = await provider.chat_completion(_request())
+            assert response.error == "connection refused"
+
+        blocked = await provider.chat_completion(_request())
+        assert "circuit breaker open" in blocked.error
+        assert provider.impl_calls == threshold  # impl never reached while open
+        stats = provider.get_stats()
+        assert stats["error_rate"] <= 1.0
 
 
 class TestNoMethodLevelBreaker:

--- a/autobot-backend/llm_shared/base_provider_breaker_test.py
+++ b/autobot-backend/llm_shared/base_provider_breaker_test.py
@@ -1,0 +1,129 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Tests for the BaseProvider completion circuit breaker (GH#11488).
+
+``_chat_completion_impl`` must not raise (errors travel via
+``LLMResponse.error``), so breaker accounting happens in
+``BaseProvider._guarded_completion``: error responses count as failures,
+rate-limit errors are exempt (owned by the GH#8502 backoff handler), and an
+open breaker fails fast without invoking the provider.
+"""
+
+import re
+from pathlib import Path
+from typing import AsyncIterator, List
+
+from constants import CircuitBreakerDefaults
+
+from .base_provider import BaseProvider
+from .models import LLMRequest, LLMResponse
+
+
+def _request() -> LLMRequest:
+    return LLMRequest(messages=[{"role": "user", "content": "hi"}])
+
+
+class _ScriptedProvider(BaseProvider):
+    """Provider whose _chat_completion_impl replays a scripted response list."""
+
+    def __init__(self, name: str, responses: List[LLMResponse]) -> None:
+        super().__init__({})
+        self.provider_name = name
+        self._responses = list(responses)
+        self.impl_calls = 0
+
+    async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
+        self.impl_calls += 1
+        return self._responses.pop(0)
+
+    async def stream_completion(self, request: LLMRequest) -> AsyncIterator[str]:
+        yield ""
+
+    async def is_available(self) -> bool:
+        return True
+
+    async def list_models(self) -> List[str]:
+        return []
+
+
+def _ok(provider: str) -> LLMResponse:
+    return LLMResponse(content="ok", provider=provider)
+
+
+def _err(provider: str, error: str = "connection refused") -> LLMResponse:
+    return LLMResponse(content="", provider=provider, error=error)
+
+
+class TestGuardedCompletion:
+    """Breaker accounting through _guarded_completion."""
+
+    async def test_success_passes_through(self):
+        provider = _ScriptedProvider("cbtest-success", [_ok("cbtest-success")])
+        response = await provider._guarded_completion(_request())
+        assert response.error is None
+        assert response.content == "ok"
+        assert provider.impl_calls == 1
+
+    async def test_error_responses_open_breaker_and_fail_fast(self):
+        threshold = CircuitBreakerDefaults.LLM_FAILURE_THRESHOLD
+        provider = _ScriptedProvider(
+            "cbtest-open",
+            [_err("cbtest-open")] * threshold + [_ok("cbtest-open")],
+        )
+
+        for _ in range(threshold):
+            response = await provider._guarded_completion(_request())
+            assert response.error == "connection refused"  # original error preserved
+
+        # Breaker is now open: fail fast, provider impl NOT invoked.
+        blocked = await provider._guarded_completion(_request())
+        assert blocked.error is not None
+        assert "circuit breaker open" in blocked.error
+        assert provider.impl_calls == threshold
+
+    async def test_rate_limit_errors_do_not_trip_breaker(self):
+        threshold = CircuitBreakerDefaults.LLM_FAILURE_THRESHOLD
+        rate_limited = [_err("cbtest-ratelimit", "HTTP 429: rate limit exceeded")] * (threshold + 1)
+        provider = _ScriptedProvider("cbtest-ratelimit", rate_limited + [_ok("cbtest-ratelimit")])
+
+        for _ in range(threshold + 1):
+            response = await provider._guarded_completion(_request())
+            assert "rate limit" in response.error
+
+        # Still closed: the next call reaches the provider implementation.
+        response = await provider._guarded_completion(_request())
+        assert response.error is None
+        assert provider.impl_calls == threshold + 2
+
+    async def test_success_resets_failure_count(self):
+        threshold = CircuitBreakerDefaults.LLM_FAILURE_THRESHOLD
+        script = [_err("cbtest-reset")] * (threshold - 1) + [_ok("cbtest-reset")] + [_err("cbtest-reset")]
+        provider = _ScriptedProvider("cbtest-reset", script)
+
+        for _ in range(len(script)):
+            await provider._guarded_completion(_request())
+
+        # threshold-1 failures, a success, then one failure — breaker never opened.
+        assert provider.impl_calls == len(script)
+
+
+class TestNoMethodLevelBreaker:
+    """GH#11488: ``_chat_completion_impl`` must not carry a breaker decorator.
+
+    The method returns errors via ``LLMResponse.error`` instead of raising, so
+    a method-level ``@circuit_breaker_async`` never records real failures —
+    and now it would double-wrap ``BaseProvider._guarded_completion``.
+    """
+
+    def test_no_breaker_decorator_on_chat_completion_impl(self):
+        providers_dir = Path(__file__).parent / "providers"
+        pattern = re.compile(r"@circuit_breaker_async[\s\S]{0,300}?async def _chat_completion_impl")
+        offenders = [
+            path.name
+            for path in sorted(providers_dir.glob("*.py"))
+            if pattern.search(path.read_text(encoding="utf-8"))
+        ]
+        assert not offenders, f"method-level breaker on _chat_completion_impl in: {offenders}"

--- a/autobot-backend/llm_shared/providers/ollama.py
+++ b/autobot-backend/llm_shared/providers/ollama.py
@@ -20,8 +20,6 @@ import aiohttp
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import get_ollama_url
-from circuit_breaker import circuit_breaker_async
-from config.manager import get_config_manager
 from constants.api_constants import PATH_OLLAMA_CHAT
 
 from ..models import LLMRequest, LLMResponse, LLMSettings, ToolCall
@@ -29,7 +27,6 @@ from ..observability import registry as obs_registry
 from ..streaming import StreamingManager
 
 logger = get_logger(__name__)
-config = get_config_manager()
 
 _OLLAMA_TOOL_CAPABLE_MODELS: frozenset[str] = frozenset(
     {
@@ -481,12 +478,9 @@ class OllamaProvider:
 
         return url, headers, model, use_streaming, data, span_attrs
 
-    @circuit_breaker_async(
-        "ollama_service",
-        failure_threshold=config.get("circuit_breaker.ollama.failure_threshold", 3),
-        recovery_timeout=config.get_timeout("circuit_breaker", "recovery"),
-        timeout=config.get_timeout("llm", "default"),
-    )
+    # GH#11488: the "ollama_service" breaker decorator moved to the
+    # BaseProvider._guarded_completion seam (sole production caller is
+    # ollama_provider.py) — decorating here too double-counted every failure.
     async def chat_completion(self, request: LLMRequest) -> LLMResponse:
         """
         Enhanced Ollama chat completion with improved streaming.

--- a/autobot-backend/llm_shared/providers/ollama_provider.py
+++ b/autobot-backend/llm_shared/providers/ollama_provider.py
@@ -91,8 +91,9 @@ class OllamaProvider(BaseProvider):
             if chat_template:
                 # Issue #4525: when a chat_template is set, render messages to a
                 # prompt string and POST to /api/generate directly.
-                # Issue #6770: route through the shared "ollama_service" circuit breaker
-                # so total_calls is incremented (same breaker as the delegate path).
+                # GH#11488: breaker accounting (Issue #6770) now lives at the
+                # BaseProvider._guarded_completion seam — wrapping the same
+                # "ollama_service" breaker here again double-counted failures.
                 base_url = self._resolve_base_url()
                 model = request.model_name or self._get_setting("default_model", "")
                 raw_messages = [
@@ -113,10 +114,6 @@ class OllamaProvider(BaseProvider):
                 if request.max_tokens:
                     payload["options"]["num_predict"] = request.max_tokens
 
-                from circuit_breaker import get_circuit_breaker_manager
-
-                cb = get_circuit_breaker_manager().get_circuit_breaker("ollama_service")
-
                 async def _generate() -> Dict[str, Any]:
                     http_client = get_http_client()
                     timeout = aiohttp.ClientTimeout(total=None, connect=5.0, sock_read=None)
@@ -131,7 +128,7 @@ class OllamaProvider(BaseProvider):
                             raise RuntimeError(f"Ollama generate returned HTTP {resp.status}: {body}")
                         return await resp.json()
 
-                data = await cb.call_async(_generate)
+                data = await _generate()
                 content = data.get("response", "")
                 usage = {
                     "prompt_tokens": data.get("prompt_eval_count", 0),

--- a/autobot-backend/llm_shared/providers/openai.py
+++ b/autobot-backend/llm_shared/providers/openai.py
@@ -23,7 +23,6 @@ from typing import Any, AsyncIterator, Dict, List
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
-from circuit_breaker import circuit_breaker_async
 from constants.model_constants import OPENAI_O1_MINI  # used in _OPENAI_MODELS list
 from constants.model_constants import (
     OPENAI_GPT4,
@@ -103,12 +102,13 @@ class OpenAIProvider(BaseProvider):
         self._client = openai.AsyncOpenAI(**kwargs)
         return self._client
 
-    @circuit_breaker_async("openai_service")
     async def _chat_completion_impl(self, request: LLMRequest) -> LLMResponse:
         """Execute a non-streaming chat completion via OpenAI.
 
-        Protected by the openai_service circuit breaker.  Errors are returned
-        via ``LLMResponse.error`` so the registry can perform fallback.
+        Circuit-breaker protection lives in ``BaseProvider._guarded_completion``
+        (GH#11488) — the old per-method decorator never saw failures because
+        errors are returned via ``LLMResponse.error``, and its 30s default
+        timeout killed healthy long completions.
         """
         self._total_requests += 1
         start = time.time()


### PR DESCRIPTION
Closes #11488. Part of umbrella #11486 (Task 2).

## Thinking Path
Providers' `_chat_completion_impl` must not raise (errors travel via `LLMResponse.error` per the documented contract), so the existing per-method `@circuit_breaker_async` on openai.py never observed a single real failure — its only effect was a 30s `asyncio.wait_for` that killed healthy long completions and counted them as failures. Copying that decorator to the other nine providers (the original issue text) would have replicated a broken pattern. Root cause fix instead: integrate the breaker once at the `BaseProvider.chat_completion` seam, where every provider's completion already flows, keyed on `response.error`.

## What Changed
- `llm_shared/base_provider.py`: new `_guarded_completion` runs `_chat_completion_impl` through a per-provider breaker (`{provider}_service`, SSOT LLM thresholds). Error responses count as failures via an internal `_CompletionErrorSignal`; rate-limit errors are exempt (owned by the GH#8502 backoff handler — they prove the provider is up); breaker-open fails fast with an error response so callers see a normal provider error. `timeout=None` deliberately — the breaker owns availability accounting only; latency budgets belong to each SDK (some use unbounded reads; `LLMRequest.timeout` may exceed any fixed constant).
- `llm_shared/providers/openai.py`: removed the inert/harmful method-level decorator.
- `llm_shared/providers/ollama.py` + `ollama_provider.py`: removed both inner `ollama_service` breaker usages (review finding B1 — with the seam added they double-counted, opening the breaker after 2 real failures instead of 3). The seam is now the single accountant; the legacy client's only production caller is the seam adapter.
- `circuit_breaker.py`: `CircuitBreakerConfig.timeout` widened to `float | None` (None disables the breaker-level `wait_for`).
- New `llm_shared/base_provider_breaker_test.py` (6 tests): failure counting/opening/fail-fast, rate-limit exemption, success reset, full `chat_completion` pipeline with open breaker, and a source-conformance guard against re-adding method-level breaker decorators on `_chat_completion_impl`.

Reviewed by code-reviewer agent; blocking finding B1 fixed, N1 (timeout) fixed, N2/N4 filed as follow-up #11498.

## Verification
- `pytest autobot-backend/llm_shared/base_provider_breaker_test.py` → 6 passed
- `pytest autobot-backend/llm_shared/ --continue-on-collection-errors` → 101 passed / 77 failed / 14 collection errors — failure set diffed against base branch: **identical** (pre-existing, missing optional deps on dev box); +6 passed are the new tests
- `pytest autobot-backend/circuit_breaker_test.py autobot-backend/tests/resilience/test_circuit_breaker.py` → 42 passed / 3 failed, identical on base (pre-existing)
- flake8 clean on all touched files

## Model Used
Claude Fable 5