### PR TITLE
refactor(chat-workflow): uniform builtin routing table at the dispatch seam (#11489)

### DIFF
--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -407,6 +407,19 @@ BROWSER_TOOL_NAMES: frozenset[str] = frozenset(
     }
 )
 
+# Issue #7509: web research tools — direct internal dispatch via web_fetch.
+WEB_RESEARCH_TOOL_NAMES: frozenset[str] = frozenset(
+    {"scrape_url", "crawl_site", "map_site", "extract_structured_data"}
+)
+
+# GH#11489: builtin tools sharing the uniform dispatch gate (invalid-call
+# counter reset → Issue #4529 schema validation → handler). ``_builtin_route``
+# maps each name to its handler, so adding a tool here needs no new branch at
+# the ``_dispatch_tool_call`` seam.
+_UNIFORM_BUILTIN_TOOLS: frozenset[str] = (
+    BROWSER_TOOL_NAMES | WEB_RESEARCH_TOOL_NAMES | frozenset({"web_search", "execute_command"})
+)
+
 # GH#11160: maps a declared approval category (a work item's
 # ``requires_approval_before`` entry) to the tools that constitute that action. A
 # tool is approval-gated only when the work item declared its category; names
@@ -2665,50 +2678,10 @@ class ToolHandlerMixin:
                 yield msg
             return
 
-        # Issue #1368: Route browser tools to browser VM
-        if tool_name in BROWSER_TOOL_NAMES:
-            if ctx is not None:
-                ctx.consecutive_invalid_tool_calls = 0
-            # Issue #4529: Validate arguments against schema before dispatch.
-            validation_msg = _validate_builtin_tool_arguments(tool_name, tool_call)
-            if validation_msg is not None:
-                execution_results.append(
-                    {
-                        "tool": tool_name,
-                        "status": "schema_error",
-                        "error": validation_msg.content,
-                        "schema_validation_failed": True,
-                    }
-                )
-                yield validation_msg
-                return
-            async for msg in self._handle_browser_tool(tool_call, execution_results, session_id):
-                yield msg
-            return
-
-        # Issue #2306: web_search convenience tool wraps browser multi-step flow
-        if tool_name == "web_search":
-            if ctx is not None:
-                ctx.consecutive_invalid_tool_calls = 0
-            # Issue #4529: Validate arguments against schema before dispatch.
-            validation_msg = _validate_builtin_tool_arguments(tool_name, tool_call)
-            if validation_msg is not None:
-                execution_results.append(
-                    {
-                        "tool": tool_name,
-                        "status": "schema_error",
-                        "error": validation_msg.content,
-                        "schema_validation_failed": True,
-                    }
-                )
-                yield validation_msg
-                return
-            async for msg in self._handle_web_search_tool(tool_call, execution_results, session_id):
-                yield msg
-            return
-
-        # Issue #7509: Web research tools — direct internal dispatch.
-        if tool_name in ("scrape_url", "crawl_site", "map_site", "extract_structured_data"):
+        # GH#11489: every uniform builtin (browser #1368, web_search #2306, web
+        # research #7509, execute_command) passes one shared gate — invalid-call
+        # counter reset, then Issue #4529 schema validation — before its handler.
+        if tool_name in _UNIFORM_BUILTIN_TOOLS:
             if ctx is not None:
                 ctx.consecutive_invalid_tool_calls = 0
             validation_msg = _validate_builtin_tool_arguments(tool_name, tool_call)
@@ -2723,33 +2696,47 @@ class ToolHandlerMixin:
                 )
                 yield validation_msg
                 return
-            async for msg in self._handle_web_research_tool(tool_name, tool_call, execution_results, session_id):
-                yield msg
-            return
-
-        if tool_name != "execute_command":
-            async for msg in self._dispatch_mcp_or_unknown(
-                tool_name, tool_call, execution_results, ctx, role, session_id
+            async for msg in self._builtin_route(
+                tool_name,
+                tool_call,
+                session_id,
+                terminal_session_id,
+                ollama_endpoint,
+                selected_model,
+                execution_results,
+                additional_response_parts,
             ):
                 yield msg
             return
 
-        if ctx is not None:
-            ctx.consecutive_invalid_tool_calls = 0
-        # Issue #4529: Validate arguments against schema before dispatch.
-        validation_msg = _validate_builtin_tool_arguments(tool_name, tool_call)
-        if validation_msg is not None:
-            execution_results.append(
-                {
-                    "tool": tool_name,
-                    "status": "schema_error",
-                    "error": validation_msg.content,
-                    "schema_validation_failed": True,
-                }
-            )
-            yield validation_msg
-            return
-        async for msg in self._dispatch_execute_command(
+        async for msg in self._dispatch_mcp_or_unknown(tool_name, tool_call, execution_results, ctx, role, session_id):
+            yield msg
+
+    def _builtin_route(
+        self,
+        tool_name: str,
+        tool_call: dict[str, Any],
+        session_id: str,
+        terminal_session_id: str,
+        ollama_endpoint: str,
+        selected_model: str,
+        execution_results: list[dict[str, Any]],
+        additional_response_parts: list[str],
+    ):
+        """Return the handler async-generator for a uniform builtin tool (GH#11489).
+
+        Membership SSOT is ``_UNIFORM_BUILTIN_TOOLS``; the caller has already run
+        the shared gate. Adding a builtin that follows the standard gate takes a
+        schema entry plus one row here — no new branch at the dispatch seam.
+        """
+        if tool_name in BROWSER_TOOL_NAMES:  # Issue #1368: route to browser VM
+            return self._handle_browser_tool(tool_call, execution_results, session_id)
+        if tool_name == "web_search":  # Issue #2306: multi-step browser flow
+            return self._handle_web_search_tool(tool_call, execution_results, session_id)
+        if tool_name in WEB_RESEARCH_TOOL_NAMES:  # Issue #7509
+            return self._handle_web_research_tool(tool_name, tool_call, execution_results, session_id)
+        # execute_command — the only remaining member of _UNIFORM_BUILTIN_TOOLS.
+        return self._dispatch_execute_command(
             tool_call,
             session_id,
             terminal_session_id,
@@ -2757,8 +2744,7 @@ class ToolHandlerMixin:
             selected_model,
             execution_results,
             additional_response_parts,
-        ):
-            yield msg
+        )
 
     async def _dispatch_mcp_or_unknown(
         self,

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -408,9 +408,7 @@ BROWSER_TOOL_NAMES: frozenset[str] = frozenset(
 )
 
 # Issue #7509: web research tools — direct internal dispatch via web_fetch.
-WEB_RESEARCH_TOOL_NAMES: frozenset[str] = frozenset(
-    {"scrape_url", "crawl_site", "map_site", "extract_structured_data"}
-)
+WEB_RESEARCH_TOOL_NAMES: frozenset[str] = frozenset({"scrape_url", "crawl_site", "map_site", "extract_structured_data"})
 
 # GH#11489: builtin tools sharing the uniform dispatch gate (invalid-call
 # counter reset → Issue #4529 schema validation → handler). ``_builtin_route``

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -16,7 +16,7 @@ import asyncio
 import html
 import json
 import re
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from async_chat_workflow import WorkflowMessage
 from autobot_shared.logging_manager import get_logger
@@ -2423,20 +2423,8 @@ class ToolHandlerMixin:
         execution_results: list[dict[str, Any]],
     ) -> WorkflowMessage:
         """Build error message for an unknown tool call (#2305, #2310)."""
-        # Issue #7509: Added web research tools to known_tools hint.
-        known_tools = sorted(
-            {
-                "respond",
-                "delegate",
-                "execute_command",
-                "web_search",
-                "scrape_url",
-                "crawl_site",
-                "map_site",
-                "extract_structured_data",
-            }
-            | BROWSER_TOOL_NAMES
-        )
+        # GH#11489: derive from the routing SSOT so the hint never drifts.
+        known_tools = sorted({"respond", "delegate"} | _UNIFORM_BUILTIN_TOOLS)
         if ctx is not None:
             ctx.consecutive_invalid_tool_calls += 1
         consecutive = ctx.consecutive_invalid_tool_calls if ctx is not None else 0
@@ -2628,7 +2616,9 @@ class ToolHandlerMixin:
         """Route a tool call to the appropriate handler. Issue #620/#2310/#2629.
 
         Yields WorkflowMessage for execution stages, or (break_loop, respond_content) tuple
-        for the respond tool. Helpers handle MCP, browser, web_search, and execute_command.
+        for the respond tool. Uniform builtins (GH#11489: browser, web_search, web
+        research, execute_command) share one gate and route via ``_builtin_route``;
+        everything else falls through to MCP/unknown handling.
         """
         tool_name = tool_call["name"]
 
@@ -2722,7 +2712,7 @@ class ToolHandlerMixin:
         selected_model: str,
         execution_results: list[dict[str, Any]],
         additional_response_parts: list[str],
-    ):
+    ) -> AsyncIterator[Any]:
         """Return the handler async-generator for a uniform builtin tool (GH#11489).
 
         Membership SSOT is ``_UNIFORM_BUILTIN_TOOLS``; the caller has already run
@@ -2735,16 +2725,19 @@ class ToolHandlerMixin:
             return self._handle_web_search_tool(tool_call, execution_results, session_id)
         if tool_name in WEB_RESEARCH_TOOL_NAMES:  # Issue #7509
             return self._handle_web_research_tool(tool_name, tool_call, execution_results, session_id)
-        # execute_command — the only remaining member of _UNIFORM_BUILTIN_TOOLS.
-        return self._dispatch_execute_command(
-            tool_call,
-            session_id,
-            terminal_session_id,
-            ollama_endpoint,
-            selected_model,
-            execution_results,
-            additional_response_parts,
-        )
+        if tool_name == "execute_command":
+            return self._dispatch_execute_command(
+                tool_call,
+                session_id,
+                terminal_session_id,
+                ollama_endpoint,
+                selected_model,
+                execution_results,
+                additional_response_parts,
+            )
+        # A member of _UNIFORM_BUILTIN_TOOLS without a route row is a wiring bug —
+        # fail loudly rather than falling through to a high-blast-radius handler.
+        raise ValueError(f"_builtin_route: no route for {tool_name!r}; add a row alongside _UNIFORM_BUILTIN_TOOLS")
 
     async def _dispatch_mcp_or_unknown(
         self,

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_builtin_route.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_builtin_route.py
@@ -69,9 +69,7 @@ async def _dispatch(mixin: ToolHandlerMixin, tool_call: dict, execution_results:
 
 def test_uniform_set_is_union_of_builtin_families() -> None:
     """Membership SSOT: browser + web research + web_search + execute_command."""
-    assert _UNIFORM_BUILTIN_TOOLS == (
-        BROWSER_TOOL_NAMES | WEB_RESEARCH_TOOL_NAMES | {"web_search", "execute_command"}
-    )
+    assert _UNIFORM_BUILTIN_TOOLS == (BROWSER_TOOL_NAMES | WEB_RESEARCH_TOOL_NAMES | {"web_search", "execute_command"})
     # respond/delegate are non-uniform (special return shapes) and must stay out.
     assert "respond" not in _UNIFORM_BUILTIN_TOOLS
     assert "delegate" not in _UNIFORM_BUILTIN_TOOLS
@@ -102,7 +100,7 @@ def test_route_table_covers_every_member(tool_name: str, handler_attr: str) -> N
     )
 
     assert generator is not None
-    (label, _args), = calls  # handler factory invoked exactly once
+    ((label, _args),) = calls  # handler factory invoked exactly once
     assert label == handler_attr
 
 
@@ -144,7 +142,7 @@ async def test_browser_tool_routes_to_browser_handler() -> None:
     messages = await _dispatch(mixin, {"name": "click", "params": {"selector": "#go"}}, [])
 
     assert messages == ["browser-msg"]
-    (label, args), = calls
+    ((label, args),) = calls
     assert label == "browser"
     assert args[0]["name"] == "click"  # tool_call first
     assert args[2] == "sess-1"  # session_id third — parity with old branch
@@ -158,7 +156,7 @@ async def test_web_search_routes_to_web_search_handler() -> None:
     messages = await _dispatch(mixin, {"name": "web_search", "params": {"query": "hello"}}, [])
 
     assert messages == ["web_search-msg"]
-    (label, args), = calls
+    ((label, args),) = calls
     assert args[0]["params"]["query"] == "hello"
     assert args[2] == "sess-1"
 
@@ -171,7 +169,7 @@ async def test_web_research_handler_receives_tool_name_first() -> None:
     messages = await _dispatch(mixin, {"name": "scrape_url", "params": {"url": "https://example.com"}}, [])
 
     assert messages == ["research-msg"]
-    (label, args), = calls
+    ((label, args),) = calls
     assert args[0] == "scrape_url"  # tool_name first — parity with old branch
     assert args[3] == "sess-1"
 
@@ -193,7 +191,7 @@ async def test_execute_command_routes_with_full_arg_set() -> None:
     ]
 
     assert messages == ["exec-msg"]
-    (label, args), = calls
+    ((label, args),) = calls
     assert args[1] == "sess-1"
     assert args[2] == "term-1"
     assert args[3] == "http://127.0.0.1:11434"
@@ -226,5 +224,5 @@ async def test_unknown_tool_falls_through_to_mcp() -> None:
     messages = await _dispatch(mixin, {"name": "totally_unknown_tool", "params": {}}, [])
 
     assert messages == ["mcp-msg"]
-    (label, args), = calls
+    ((label, args),) = calls
     assert args[0] == "totally_unknown_tool"

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_builtin_route.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_builtin_route.py
@@ -1,0 +1,163 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Uniform builtin routing table at the dispatch seam (GH#11489).
+
+``_dispatch_tool_call`` runs one shared gate (invalid-call counter reset →
+Issue #4529 schema validation) for every tool in ``_UNIFORM_BUILTIN_TOOLS``,
+then delegates via ``_builtin_route``. These tests pin behavior parity with
+the four hand-written branches the table replaced (browser #1368, web_search
+#2306, web research #7509, execute_command).
+"""
+
+import pytest
+
+from chat_workflow.tool_handler import (
+    _UNIFORM_BUILTIN_TOOLS,
+    BROWSER_TOOL_NAMES,
+    WEB_RESEARCH_TOOL_NAMES,
+    ToolHandlerMixin,
+)
+
+_DISPATCH_ARGS = {
+    "session_id": "sess-1",
+    "terminal_session_id": "term-1",
+    "ollama_endpoint": "http://127.0.0.1:11434",
+    "selected_model": "test-model",
+}
+
+
+def _mixin() -> ToolHandlerMixin:
+    mixin = ToolHandlerMixin.__new__(ToolHandlerMixin)
+    # Governance gates are covered by their own suites (GH#11145/11160/11177/11178);
+    # quiet them here so routing is exercised in isolation.
+    mixin._enforce_forbidden_work = lambda *a, **k: None
+    mixin._enforce_config_protection = lambda *a, **k: None
+    mixin._enforce_fact_forcing = lambda *a, **k: None
+    mixin._enforce_work_item_approval = lambda *a, **k: None
+    return mixin
+
+
+def _recording_handler(calls: list, label: str):
+    async def handler(*args, **kwargs):
+        calls.append((label, args))
+        yield f"{label}-msg"
+
+    return handler
+
+
+async def _dispatch(mixin: ToolHandlerMixin, tool_call: dict, execution_results: list) -> list:
+    return [
+        msg
+        async for msg in mixin._dispatch_tool_call(
+            tool_call,
+            execution_results=execution_results,
+            additional_response_parts=[],
+            **_DISPATCH_ARGS,
+        )
+    ]
+
+
+def test_uniform_set_is_union_of_builtin_families() -> None:
+    """Membership SSOT: browser + web research + web_search + execute_command."""
+    assert _UNIFORM_BUILTIN_TOOLS == (
+        BROWSER_TOOL_NAMES | WEB_RESEARCH_TOOL_NAMES | {"web_search", "execute_command"}
+    )
+    # respond/delegate are non-uniform (special return shapes) and must stay out.
+    assert "respond" not in _UNIFORM_BUILTIN_TOOLS
+    assert "delegate" not in _UNIFORM_BUILTIN_TOOLS
+
+
+@pytest.mark.asyncio
+async def test_browser_tool_routes_to_browser_handler() -> None:
+    mixin, calls = _mixin(), []
+    mixin._handle_browser_tool = _recording_handler(calls, "browser")
+
+    messages = await _dispatch(mixin, {"name": "click", "params": {"selector": "#go"}}, [])
+
+    assert messages == ["browser-msg"]
+    (label, args), = calls
+    assert label == "browser"
+    assert args[0]["name"] == "click"  # tool_call first
+    assert args[2] == "sess-1"  # session_id third — parity with old branch
+
+
+@pytest.mark.asyncio
+async def test_web_search_routes_to_web_search_handler() -> None:
+    mixin, calls = _mixin(), []
+    mixin._handle_web_search_tool = _recording_handler(calls, "web_search")
+
+    messages = await _dispatch(mixin, {"name": "web_search", "params": {"query": "hello"}}, [])
+
+    assert messages == ["web_search-msg"]
+    (label, args), = calls
+    assert args[0]["params"]["query"] == "hello"
+    assert args[2] == "sess-1"
+
+
+@pytest.mark.asyncio
+async def test_web_research_handler_receives_tool_name_first() -> None:
+    mixin, calls = _mixin(), []
+    mixin._handle_web_research_tool = _recording_handler(calls, "research")
+
+    messages = await _dispatch(mixin, {"name": "scrape_url", "params": {"url": "https://example.com"}}, [])
+
+    assert messages == ["research-msg"]
+    (label, args), = calls
+    assert args[0] == "scrape_url"  # tool_name first — parity with old branch
+    assert args[3] == "sess-1"
+
+
+@pytest.mark.asyncio
+async def test_execute_command_routes_with_full_arg_set() -> None:
+    mixin, calls = _mixin(), []
+    mixin._dispatch_execute_command = _recording_handler(calls, "exec")
+    extra_parts: list = []
+
+    messages = [
+        msg
+        async for msg in mixin._dispatch_tool_call(
+            {"name": "execute_command", "params": {"command": "ls"}},
+            execution_results=[],
+            additional_response_parts=extra_parts,
+            **_DISPATCH_ARGS,
+        )
+    ]
+
+    assert messages == ["exec-msg"]
+    (label, args), = calls
+    assert args[1] == "sess-1"
+    assert args[2] == "term-1"
+    assert args[3] == "http://127.0.0.1:11434"
+    assert args[4] == "test-model"
+    assert args[6] is extra_parts  # additional_response_parts threaded through
+
+
+@pytest.mark.asyncio
+async def test_schema_error_blocks_handler_and_records_result() -> None:
+    """Issue #4529 gate parity: invalid params never reach the handler."""
+    mixin, calls = _mixin(), []
+    mixin._handle_web_search_tool = _recording_handler(calls, "web_search")
+    execution_results: list = []
+
+    messages = await _dispatch(mixin, {"name": "web_search", "params": {}}, execution_results)
+
+    assert calls == []  # handler never invoked
+    assert len(messages) == 1
+    assert messages[0].metadata.get("schema_validation_failed") is True
+    (result,) = execution_results
+    assert result["status"] == "schema_error"
+    assert result["schema_validation_failed"] is True
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_falls_through_to_mcp() -> None:
+    mixin, calls = _mixin(), []
+    mixin._dispatch_mcp_or_unknown = _recording_handler(calls, "mcp")
+
+    messages = await _dispatch(mixin, {"name": "totally_unknown_tool", "params": {}}, [])
+
+    assert messages == ["mcp-msg"]
+    (label, args), = calls
+    assert args[0] == "totally_unknown_tool"

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_handler_builtin_route.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_handler_builtin_route.py
@@ -11,9 +11,12 @@ the four hand-written branches the table replaced (browser #1368, web_search
 #2306, web research #7509, execute_command).
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from chat_workflow.tool_handler import (
+    _BUILTIN_TOOL_SCHEMAS,
     _UNIFORM_BUILTIN_TOOLS,
     BROWSER_TOOL_NAMES,
     WEB_RESEARCH_TOOL_NAMES,
@@ -40,11 +43,16 @@ def _mixin() -> ToolHandlerMixin:
 
 
 def _recording_handler(calls: list, label: str):
-    async def handler(*args, **kwargs):
+    def factory(*args, **kwargs):
+        # Record at call time (async-generator bodies only run when drained).
         calls.append((label, args))
-        yield f"{label}-msg"
 
-    return handler
+        async def gen():
+            yield f"{label}-msg"
+
+        return gen()
+
+    return factory
 
 
 async def _dispatch(mixin: ToolHandlerMixin, tool_call: dict, execution_results: list) -> list:
@@ -67,6 +75,65 @@ def test_uniform_set_is_union_of_builtin_families() -> None:
     # respond/delegate are non-uniform (special return shapes) and must stay out.
     assert "respond" not in _UNIFORM_BUILTIN_TOOLS
     assert "delegate" not in _UNIFORM_BUILTIN_TOOLS
+
+
+def test_every_uniform_tool_has_a_schema() -> None:
+    """A schema-less member would silently skip Issue #4529 validation."""
+    missing = _UNIFORM_BUILTIN_TOOLS - set(_BUILTIN_TOOL_SCHEMAS)
+    assert not missing, f"uniform builtins without schemas: {sorted(missing)}"
+
+
+_ROUTE_EXPECTATIONS = [
+    *[(name, "_handle_browser_tool") for name in sorted(BROWSER_TOOL_NAMES)],
+    *[(name, "_handle_web_research_tool") for name in sorted(WEB_RESEARCH_TOOL_NAMES)],
+    ("web_search", "_handle_web_search_tool"),
+    ("execute_command", "_dispatch_execute_command"),
+]
+
+
+@pytest.mark.parametrize("tool_name,handler_attr", _ROUTE_EXPECTATIONS)
+def test_route_table_covers_every_member(tool_name: str, handler_attr: str) -> None:
+    """Every union member maps to its family handler — no silent fallback."""
+    mixin, calls = _mixin(), []
+    setattr(mixin, handler_attr, _recording_handler(calls, handler_attr))
+
+    generator = mixin._builtin_route(
+        tool_name, {"name": tool_name, "params": {}}, "sess-1", "term-1", "ep", "model", [], []
+    )
+
+    assert generator is not None
+    (label, _args), = calls  # handler factory invoked exactly once
+    assert label == handler_attr
+
+
+def test_builtin_route_raises_on_unrouted_member() -> None:
+    """Defensive tail: an unrouted name fails loudly, never execute_command."""
+    mixin = _mixin()
+    with pytest.raises(ValueError, match="no route for 'not_a_builtin'"):
+        mixin._builtin_route("not_a_builtin", {"name": "not_a_builtin"}, "s", "t", "e", "m", [], [])
+
+
+@pytest.mark.asyncio
+async def test_uniform_gate_resets_invalid_call_counter() -> None:
+    """The shared gate resets ctx.consecutive_invalid_tool_calls — parity with
+    the four replaced branches."""
+    mixin, calls = _mixin(), []
+    mixin._handle_web_search_tool = _recording_handler(calls, "web_search")
+    ctx = SimpleNamespace(consecutive_invalid_tool_calls=2)
+
+    messages = [
+        msg
+        async for msg in mixin._dispatch_tool_call(
+            {"name": "web_search", "params": {"query": "q"}},
+            execution_results=[],
+            additional_response_parts=[],
+            ctx=ctx,
+            **_DISPATCH_ARGS,
+        )
+    ]
+
+    assert messages == ["web_search-msg"]
+    assert ctx.consecutive_invalid_tool_calls == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #11489. Part of umbrella #11486 (Task 3).

## Thinking Path
The original issue proposed tutorial-style signature-derived tool schemas; premise deep-dive showed that doesn't fit — builtin schemas are hand-authored JSON Schema constants carrying model-facing enums/defaults/descriptions that type hints can't express, and handlers are async generators with session plumbing, not parameter-shaped functions (scope amendment posted on #11489). The real duplication was at the dispatch seam: four copy-pasted validate-and-route branches.

## What Changed
- `chat_workflow/tool_handler.py`:
  - New `WEB_RESEARCH_TOOL_NAMES` frozenset (was an inline tuple) and `_UNIFORM_BUILTIN_TOOLS` = `BROWSER_TOOL_NAMES ∪ WEB_RESEARCH_TOOL_NAMES ∪ {web_search, execute_command}` as the routing SSOT.
  - `_dispatch_tool_call`: the four branches (browser #1368, web_search #2306, web research #7509, execute_command) collapsed into one shared gate (invalid-call counter reset → Issue #4529 schema validation → handler) that delegates via new `_builtin_route`. Governance enforcers, respond/delegate special cases, and MCP fallback ordering unchanged. Net −68 lines at the seam.
  - `_builtin_route`: explicit row per family + defensive `raise ValueError` tail so a future union member without a route row fails loudly instead of falling through to command execution (review finding 1).
  - `_build_unknown_tool_error`: hardcoded `known_tools` set replaced with `{"respond","delegate"} | _UNIFORM_BUILTIN_TOOLS` (review finding 2 — same duplication class).
- New `tests/unit/chat_workflow/test_tool_handler_builtin_route.py` (26 tests): membership SSOT, schema-coverage invariant (every union member has a `_BUILTIN_TOOL_SCHEMAS` entry), parametrized route check over all 16 members, per-family arg-order parity, schema-error gate parity, ctx counter-reset parity, MCP fallthrough, defensive-tail raise.

Adding a future uniform builtin = schema entry + one route row; no new branch at the seam.

Reviewed by code-reviewer agent: no blocking findings; both non-blocking findings and all test-gap suggestions folded in.

## Verification
- `pytest autobot-backend/tests/unit/chat_workflow/ autobot-backend/tests/unit/tools/` → 134 passed (base branch: 108 passed; delta = exactly the 26 new tests, 0 failures either side)
- Reviewer verified at runtime: old `tool_name != "execute_command"` MCP ordering is exactly equivalent to the new membership check; handler arg orders byte-identical; no other code referenced the removed tuple
- flake8 clean

## Model Used
Claude Fable 5