### PR TITLE
test(code-sync): un-hang the deploy-safety fixtures so they can be gated (#11467)

### DIFF
--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -1460,6 +1460,7 @@ def test_wait_component_healthy_returns_true_on_healthy_response() -> None:
     with (
         patch("api.code_sync._COMPONENT_HEALTH_URLS", {"autobot-backend": "http://127.0.0.1:8001/api/health"}),
         patch("api.code_sync._HEALTH_POLL_TIMEOUT", 5.0),
+        patch("api.code_sync._FAST_HEALTH_POLL_TIMEOUT", 5.0),  # #11458/#11467: default slow_start uses the fast window
         patch("httpx.AsyncClient", return_value=_FakeClient()),
     ):
         result = _run(_wait_component_healthy("autobot-backend", steps))
@@ -1490,6 +1491,10 @@ def test_wait_component_healthy_returns_true_on_timeout_no_failure() -> None:
     with (
         patch("api.code_sync._COMPONENT_HEALTH_URLS", {"autobot-backend": "http://127.0.0.1:8001/api/health"}),
         patch("api.code_sync._HEALTH_POLL_TIMEOUT", 0.1),
+        # #11458 split the window into slow (venv-recreated) and fast (warm) — a
+        # default-slow_start call now uses _FAST_HEALTH_POLL_TIMEOUT, so pin both
+        # or the poll busy-spins the unpatched 60s fast window (#11467).
+        patch("api.code_sync._FAST_HEALTH_POLL_TIMEOUT", 0.1),
         patch("api.code_sync._HEALTH_POLL_CONNECT_TIMEOUT", 0.05),
         patch("asyncio.sleep", AsyncMock()),
         patch("httpx.AsyncClient", return_value=_FailClient()),
@@ -1752,6 +1757,10 @@ def test_wait_component_healthy_returns_true_on_timeout_without_systemd_failure(
     with (
         patch("api.code_sync._COMPONENT_HEALTH_URLS", {"autobot-backend": "http://127.0.0.1:8001/api/health"}),
         patch("api.code_sync._HEALTH_POLL_TIMEOUT", 0.1),
+        # #11458 split the window into slow (venv-recreated) and fast (warm) — a
+        # default-slow_start call now uses _FAST_HEALTH_POLL_TIMEOUT, so pin both
+        # or the poll busy-spins the unpatched 60s fast window (#11467).
+        patch("api.code_sync._FAST_HEALTH_POLL_TIMEOUT", 0.1),
         patch("api.code_sync._HEALTH_POLL_CONNECT_TIMEOUT", 0.05),
         patch("asyncio.sleep", AsyncMock()),
         patch("httpx.AsyncClient", return_value=_FailClient()),
@@ -1781,6 +1790,7 @@ def test_wait_component_healthy_returns_false_when_unit_failed_during_poll() -> 
     with (
         patch("api.code_sync._COMPONENT_HEALTH_URLS", {"autobot-backend": "http://127.0.0.1:8001/api/health"}),
         patch("api.code_sync._HEALTH_POLL_TIMEOUT", 5.0),
+        patch("api.code_sync._FAST_HEALTH_POLL_TIMEOUT", 5.0),  # #11458/#11467: default slow_start uses the fast window
         patch("api.code_sync._HEALTH_POLL_CONNECT_TIMEOUT", 0.05),
         patch("asyncio.sleep", AsyncMock()),
         patch("httpx.AsyncClient", return_value=_FailClient()),

--- a/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_symlink_restore.py
@@ -273,6 +273,10 @@ def test_pip_backend_emits_symlink_step(tmp_path) -> None:
             patch("api.code_sync._ensure_venv_python", AsyncMock()),
             patch("api.code_sync._run_alembic_migrations", AsyncMock()),
             patch("api.code_sync._restart_component_services", AsyncMock()),
+            # restart=True runs the post-restart health poll; without this mock it
+            # makes real httpx polls until the deadline — ~3 min of dead wait that
+            # reads as a hang (#11467, same class as #11462).
+            patch("api.code_sync._wait_component_healthy", AsyncMock(return_value=True)),
         ):
             _, steps, _ = _run(_run_post_sync_steps(component, f"/src/{component}", f"/opt/autobot/{component}"))
             steps_collected.extend(steps)


### PR DESCRIPTION
## Thinking Path
#11467: the deploy-safety trio merged green but regressed the live update path 3× (#11431/#11404/#11413), because the fixtures mocked away the real-deployment facts. The real-env regression tests were added (#11433) — but two code-sync test files could not actually run to completion, so they cannot be gated (a hanging test cannot be a required check).

## What Changed
- **`test_code_sync_deploy_bugs.py`** — four `_wait_component_healthy` tests patched only `_HEALTH_POLL_TIMEOUT`. #11458 split the window; a default-`slow_start` call now uses `_FAST_HEALTH_POLL_TIMEOUT` (left unpatched at 60s), so with `asyncio.sleep` mocked the poll **busy-spun the full 60s** (a regression from my own #11458). Pin **both** windows. → **81 passed in ~2.6s** (was >90s hang).
- **`test_code_sync_symlink_restore.py`** — the pip-backend `restart=True` test mocked the restart but not the post-restart `_wait_component_healthy` poll → real httpx polls to the deadline, ~3 min dead wait (pre-existing, same class as #11462). Mock the health poll. → **11 passed in ~2s** (was 180s hang).

## Verification
- `test_code_sync_deploy_bugs.py`: **81 passed** (~2.6s). `test_code_sync_symlink_restore.py`: **11 passed** (~2s). black + py_compile clean.
- The real-env regression coverage #11467 asked for already exists in these files (pg_dump from `AUTOBOT_POSTGRES_*`, snapshot/rollback on a non-git `tmp_path`, slow-start-not-rolled-back). This PR makes them **runnable** — the prerequisite to gating them.

## Follow-up (optional, not blocking)
A lightweight CI job that runs these files (now fast) as a required gate — so deploy-safety changes cannot regress un-noticed again. Left as a separate enhancement.

## Model Used
Opus 4.8

Closes #11467