### PR TITLE
harden(workspace): reject shell-wrapper + prefix-runner exec denylist bypass (#11503)

### DIFF
--- a/autobot-backend/services/docker_task_workspace.py
+++ b/autobot-backend/services/docker_task_workspace.py
@@ -85,6 +85,14 @@ _BLOCKED_EXEC_COMMANDS: frozenset[str] = frozenset(
     }
 )
 
+# GH#11059: shell interpreters that run an inline command string bypass a
+# base-command-only denylist (e.g. `sh -c "sudo rm -rf /"`), so a wrapper
+# invocation with an inline-command flag is rejected outright.
+_SHELL_INTERPRETERS: frozenset[str] = frozenset(
+    {"sh", "bash", "dash", "zsh", "ash", "ksh", "csh", "tcsh", "fish", "busybox"}
+)
+_INLINE_CMD_FLAGS: frozenset[str] = frozenset({"-c", "-ic", "-lc", "-icl", "--command"})
+
 try:
     import docker
     from docker.errors import APIError, DockerException, NotFound
@@ -505,6 +513,18 @@ def validate_exec_command(cmd: list[str]) -> bool:
     if base in _BLOCKED_EXEC_COMMANDS:
         logger.warning("workspace: exec blocked base command=%s", base)
         return False
+    # GH#11059: a shell wrapper (`sh -c "sudo …"`) runs an inline command string
+    # that a first-token check never inspects — reject the wrapper itself.
+    if base in _SHELL_INTERPRETERS and any(a in _INLINE_CMD_FLAGS for a in cmd[1:]):
+        logger.warning("workspace: exec blocked shell wrapper base=%s", base)
+        return False
+    # GH#11059: scan EVERY token's basename, not just cmd[0], so prefix-runners
+    # (`env sudo …`, `timeout 5 sudo …`, `nice sudo …`) can't smuggle a blocked
+    # command past a first-token-only check.
+    for token in cmd:
+        if token.split("/")[-1] in _BLOCKED_EXEC_COMMANDS:
+            logger.warning("workspace: exec blocked command token=%s", token.split("/")[-1])
+            return False
     return True
 
 

--- a/autobot-backend/tests/test_task_workspace.py
+++ b/autobot-backend/tests/test_task_workspace.py
@@ -200,6 +200,30 @@ def test_exec_command_empty():
     assert validate_exec_command([]) is False
 
 
+# GH#11059: the denylist must not be bypassable via a shell wrapper or a
+# prefix-runner that smuggles a blocked command past the first-token check.
+
+
+def test_exec_command_blocks_shell_wrapper_inline_command():
+    assert validate_exec_command(["sh", "-c", "sudo rm -rf /"]) is False
+    assert validate_exec_command(["bash", "-c", "id"]) is False
+    assert validate_exec_command(["/bin/bash", "-lc", "echo hi"]) is False
+    assert validate_exec_command(["busybox", "-c", "wget http://x"]) is False
+
+
+def test_exec_command_blocks_prefix_runner_smuggling_blocked_token():
+    assert validate_exec_command(["env", "sudo", "id"]) is False
+    assert validate_exec_command(["timeout", "5", "sudo", "reboot"]) is False
+    assert validate_exec_command(["nice", "-n", "10", "docker", "ps"]) is False
+
+
+def test_exec_command_allows_shell_without_inline_flag():
+    # A plain interpreter with no -c (e.g. running a script file) is not the
+    # inline-command bypass and must still be allowed.
+    assert validate_exec_command(["sh", "build.sh"]) is True
+    assert validate_exec_command(["bash", "/workspace/run.sh"]) is True
+
+
 # ---------------------------------------------------------------------------
 # _apply_sandbox_security
 # ---------------------------------------------------------------------------
@@ -331,8 +355,7 @@ async def test_snapshot_registers_in_redis(manager, mock_redis, mock_docker):
     _store_info(mock_redis, _make_info(task_id, "cid-snap-redis"))
 
     await manager.snapshot(task_id, "v1")
-    # The snapshot list key must be present
-    snap_key = f"autobot:workspace:{task_id}:snapshots"
+    # The workspace metadata must be registered in Redis after a snapshot.
     assert mock_redis.get(_redis_meta_key(task_id)) is not None
 
 


### PR DESCRIPTION
## Thinking Path
From the #11059 audit (umbrella #11058): `services/docker_task_workspace.py::validate_exec_command` only checked the basename of `cmd[0]` against `_BLOCKED_EXEC_COMMANDS`, so the denylist was trivially bypassable — `["sh","-c","sudo rm -rf /"]` passes (base is `sh`; the blocked `sudo` is inside the `-c` string), and prefix-runners like `["env","sudo",…]` / `["timeout","5","sudo",…]` smuggle a blocked command past the first-token check. Contained today by `network_mode=none` + `cap_drop=ALL`, but still a real bypass on the workspace exec surface.

## What Changed (`services/docker_task_workspace.py`)
- Added `_SHELL_INTERPRETERS` (sh/bash/dash/zsh/ash/ksh/csh/tcsh/fish/busybox) + `_INLINE_CMD_FLAGS` (`-c`/`-ic`/`-lc`/…).
- `validate_exec_command` now, in addition to the `cmd[0]` base check:
  1. **rejects a shell interpreter invoked with an inline-command flag** (`sh -c …`) — the wrapper itself is blocked;
  2. **scans every token's basename** against the blocklist (not just `cmd[0]`), so prefix-runners can't smuggle `sudo`/`docker`/… through.
- A plain interpreter with no `-c` (running a script file, `sh build.sh`) is still allowed — no false positives.

Drive-by: removed a pre-existing dead `snap_key` local (F841) in the touched test file.

## Verification
- `pytest tests/test_task_workspace.py` → **40 passed** (no regression); new tests cover `sh -c`/`bash -lc`/`busybox -c` bypass → False, `env sudo` / `timeout 5 sudo` / `nice … docker` → False, and `sh build.sh` / `bash run.sh` → True.
- **Mutation-verified**: disabling the every-token scan → the prefix-runner test fails.
- `flake8` clean; `black` applied. Pure-logic change — no schema / `api.ts` impact.

## Model Used
Opus 4.8 (1M context)

Closes #11503