### PR TITLE
fix(deploy): gather minimal facts before slm_agent role import (version.json date_time) (#11480)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -370,6 +370,14 @@
     - name: "[PLAY 1] SLM Agent | Redeploy agent (code + secrets + restart) (#11480)"
       tags: [slm, slm-agent]
       block:
+        # #11480: the slm_agent role's version.json/service/config templates use
+        # ansible_facts['date_time'], but this play runs gather_facts:false — so
+        # the role failed at "Deploy version.json" (AnsibleUndefinedVariable:
+        # date_time) and the agent never redeployed. Gather the minimal fact set
+        # (includes date_time) just before the import.
+        - name: "[PLAY 1] SLM Agent | Gather minimal facts for role templates (#11480)"
+          ansible.builtin.setup:
+            gather_subset: ["min"]
         - name: "[PLAY 1] SLM Agent | Import slm_agent role"
           ansible.builtin.import_role:
             name: slm_agent
@@ -1103,6 +1111,9 @@
       when: slm_node_id is defined
       tags: [slm-agent]
       block:
+        - name: "[PLAY 2] SLM Agent | Gather minimal facts for role templates (#11480)"
+          ansible.builtin.setup:
+            gather_subset: ["min"]
         - name: "[PLAY 2] SLM Agent | Import slm_agent role"
           ansible.builtin.import_role:
             name: slm_agent


### PR DESCRIPTION
## Thinking Path
Live self-update (dogfooding #11450 agent verification) showed the agent redeploy failing — ansible.log:
```
TASK [slm_agent : SLM Agent | Deploy version.json]
fatal: [00-SLM-Manager]: FAILED! => AnsibleUndefinedVariable: 'dict object' has no attribute 'date_time'
TASK [[PLAY 1] SLM Agent | Warn on agent redeploy failure]  ← rescue swallows it
```
The `slm_agent` role's version.json/role.json/agent-config/service templates use `ansible_facts['date_time']`, but update-all's plays run `gather_facts: false`, so the fact is undefined → the role errors at version.json → the block's rescue warns → the agent never redeploys (agent.py stuck at old mtime, `agent-secrets.env` never written, heartbeats stay 401). Provisioning works because its plays gather facts. Fixes #11480 (completes the agent-redeploy path).

## What Changed
Add `ansible.builtin.setup: gather_subset: ["min"]` (min includes `date_time`) at the top of both agent blocks (Play 1 + Play 2) before the `slm_agent` role import. The role needs no other gathered facts — magic vars (`inventory_hostname`, `ansible_host`, `ansible_connection`) are always available regardless of gather_facts.

## Verification
- `ansible-playbook --syntax-check` OK; `yaml.safe_load_all` OK.
- Root cause is the exact live traceback above; `min` subset is the smallest set containing `date_time`.
- Post-merge: two self-updates (playbook-change lag, #11492) then confirm agent.py mtime advances, agent-secrets.env non-empty, heartbeats → 200, Service table populates.

## Model Used
Claude Fable 5 (1M context)
