### PR TITLE
fix(ui): HeartbeatMonitor status colors use semantic tokens; ember aliases --color-error (#11457)

### DIFF
--- a/autobot-frontend/src/assets/css/themes/ember.css
+++ b/autobot-frontend/src/assets/css/themes/ember.css
@@ -132,6 +132,10 @@
   --color-success-bg: var(--green-bg);
   --color-danger: var(--red-500);
   --color-danger-bg: var(--red-bg);
+  /* #11457: alias the functional error token to ember's danger red so
+     --color-error resolves to ember's palette instead of the base #ef4444. */
+  --color-error: var(--color-danger);
+  --color-error-bg: var(--color-danger-bg);
   --color-info: var(--wine-500);
   --color-info-bg: #f3e2ea;
 
@@ -258,6 +262,9 @@
   --color-success-bg: var(--green-bg-dk);
   --color-danger: var(--red-300);
   --color-danger-bg: var(--red-bg-dk);
+  /* #11457: dark-ember functional error aliases the dark danger red. */
+  --color-error: var(--color-danger);
+  --color-error-bg: var(--color-danger-bg);
   --color-info: var(--wine-300);
   --color-info-bg: #2e1822;
 

--- a/autobot-frontend/src/assets/css/themes/ember.css
+++ b/autobot-frontend/src/assets/css/themes/ember.css
@@ -132,10 +132,13 @@
   --color-success-bg: var(--green-bg);
   --color-danger: var(--red-500);
   --color-danger-bg: var(--red-bg);
-  /* #11457: alias the functional error token to ember's danger red so
-     --color-error resolves to ember's palette instead of the base #ef4444. */
+  /* #11457: alias the functional error/warning tokens to ember's own palette so
+     they resolve to ember hues instead of the base #ef4444 / #f59e0b. Warning maps
+     to ember's gold (its --color-highlight / --badge-dot-medium signal) so all four
+     functional statuses are ember-native (no queued-vs-failed palette split). */
   --color-error: var(--color-danger);
   --color-error-bg: var(--color-danger-bg);
+  --color-warning: var(--gold-500);
   --color-info: var(--wine-500);
   --color-info-bg: #f3e2ea;
 
@@ -262,9 +265,11 @@
   --color-success-bg: var(--green-bg-dk);
   --color-danger: var(--red-300);
   --color-danger-bg: var(--red-bg-dk);
-  /* #11457: dark-ember functional error aliases the dark danger red. */
+  /* #11457: dark-ember functional error/warning alias ember's dark palette
+     (danger red + gold) so all four functional statuses are ember-native. */
   --color-error: var(--color-danger);
   --color-error-bg: var(--color-danger-bg);
+  --color-warning: var(--gold-400);
   --color-info: var(--wine-300);
   --color-info-bg: #2e1822;
 

--- a/autobot-frontend/src/views/llc/HeartbeatMonitor.vue
+++ b/autobot-frontend/src/views/llc/HeartbeatMonitor.vue
@@ -498,16 +498,20 @@ onUnmounted(() => {
   text-transform: capitalize;
 }
 
-.status-succeeded { color: #10b981; }
-.status-succeeded.status-dot { background: #10b981; }
-.status-running { color: #3b82f6; }
-.status-running.status-dot { background: #3b82f6; }
-.status-queued { color: #f59e0b; }
-.status-queued.status-dot { background: #f59e0b; }
-.status-failed { color: #ef4444; }
-.status-failed.status-dot { background: #ef4444; }
-.status-timed_out { color: #ef4444; }
-.status-timed_out.status-dot { background: #ef4444; }
+/* #11457: functional-status colors map to the semantic tokens so they adapt to
+   dark/ember instead of being hardcoded light hexes. The fallbacks equal the base
+   (light) token values, so light/dark render identically and ember picks up its
+   own palette (success/info are themed; error resolves via the ember alias). */
+.status-succeeded { color: var(--color-success, #10b981); }
+.status-succeeded.status-dot { background: var(--color-success, #10b981); }
+.status-running { color: var(--color-info, #3b82f6); }
+.status-running.status-dot { background: var(--color-info, #3b82f6); }
+.status-queued { color: var(--color-warning, #f59e0b); }
+.status-queued.status-dot { background: var(--color-warning, #f59e0b); }
+.status-failed { color: var(--color-error, #ef4444); }
+.status-failed.status-dot { background: var(--color-error, #ef4444); }
+.status-timed_out { color: var(--color-error, #ef4444); }
+.status-timed_out.status-dot { background: var(--color-error, #ef4444); }
 .status-unknown { color: var(--text-secondary, #9ca3af); }
 .status-unknown.status-dot { background: var(--border-default, #d1d5db); }
 


### PR DESCRIPTION
## Thinking Path
`HeartbeatMonitor.vue` hardcoded light-mode-only functional-status hexes that never adapted to dark/ember. Map them to the semantic tokens `--color-{success,info,warning,error}`. Scoping: `--color-error`/`--color-warning` ARE defined in base `:root` (design-tokens.css / theme.css), so light/dark resolve fine; the only real gap is ember, which defined `--color-danger` but not `--color-error`/`--color-warning`.

## What Changed
1. **HeartbeatMonitor** — mapped the 4 status hex groups to `var(--color-*, <base-hex>)`. Base-hex fallbacks equal the light token values → **light/dark render pixel-identical**; ember picks up its themed hues.
2. **ember.css (both light + dark blocks)** — aliased `--color-error`→`--color-danger` and `--color-warning`→`--gold-500/400` (ember’s highlight/attention gold), so all four functional statuses resolve to ember-native hues (no queued-vs-failed palette split).

## Blast radius (verified by review, accepted)
Adding `--color-error` to ember shifts every ember consumer of `var(--color-error)` — **216 files / 911 occurrences** — from the base `#ef4444` to ember’s danger red (`#cb3326` light / `#ff6f5e` dark). Before this change they all fell through to `:root` `#ef4444` (ember never defined the token), so this is a cross-cutting **alignment to ember’s intended palette**, not a regression (reviewer confirmed the cascade + that no rule relied on the base red). `--color-warning` similarly aligns to ember gold. Light/dark themes untouched.

## Verification
- HeartbeatMonitor: no hardcoded functional hexes remain; fallbacks equal prior hexes (light/dark identical). CSS-only — vue-tsc/templates unaffected.
- `--color-error`/`--color-warning` now defined in both ember theme blocks; `--gold-500/400` + `--color-danger` chains resolve to real primitives.
- Code-reviewed: verdict "correct alignment, not a regression"; no blockers.

## Model Used
Opus 4.8

Closes #11457