### PR TITLE
fix(deploy): agent uses SLM slm-secrets.env key not managed-backend var (#11450 #11507)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/tasks/main.yml
@@ -264,11 +264,18 @@
   no_log: true
   tags: ['slm_agent', 'systemd', 'secrets']
 
-- name: "SLM Agent | Resolve effective internal API key (var wins, else node file) (#11480)"
+- name: "SLM Agent | Resolve effective internal API key (SLM slm-secrets.env wins) (#11450 #11507)"
   ansible.builtin.set_fact:
+    # The agent authenticates to the SLM backend, which loads slm-secrets.env —
+    # so the node file (read slm-secrets.env FIRST) is authoritative. The
+    # autobot_internal_api_key deploy var reflects the MANAGED backend's key,
+    # which has drifted from the SLM's on some installs (#11507) → using it gave
+    # the agent the wrong key and every heartbeat 401'd (#11450). Prefer the
+    # node file; fall back to the var only when no node secrets file exists
+    # (e.g. a remote agent-only node — tracked by the #11507 reconciliation).
     _agent_internal_api_key: >-
-      {{ autobot_internal_api_key | default('') | trim
-         or (_agent_key_from_node.stdout | default('') | trim) }}
+      {{ (_agent_key_from_node.stdout | default('') | trim)
+         or (autobot_internal_api_key | default('') | trim) }}
   no_log: true
   tags: ['slm_agent', 'systemd', 'secrets']
 


### PR DESCRIPTION
## Thinking Path
Completing #11450's live e2e: after all deploy fixes, the agent finally redeployed but every heartbeat still **401'd**. Root cause (on-box): the role wrote the agent the **managed backend's** internal key (`7b77b4…`, from the `autobot_internal_api_key` deploy var) but the agent authenticates to the **SLM backend**, which loads `slm-secrets.env` (`023ef2…`). The two keys have **drifted** (#11507). Fixes #11450 (redeploy-safe); root drift tracked in #11507.

## What Changed
`slm_agent` role key resolution now prefers the node's `slm-secrets.env` (the SLM backend's own key, read first) over the `autobot_internal_api_key` var, falling back to the var only when no node secrets file exists.

## Verification
- On-box proof: writing the `slm-secrets.env` key into `agent-secrets.env` → **0× 401**, agent "Synced 11 events", `/fleet/services` **0 → 106** (Services view now populates).
- `curl` heartbeat: slm-secrets.env key → **200**, autobot-backend.env key → **401** (confirms which key the SLM validates).
- yaml lint OK.

## Model Used
Claude Fable 5 (1M context)
