### PR TITLE
feat(llc): CEO-chat work-object tools for the chat agent (#11501 T1)

### DIFF
--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -2227,13 +2227,17 @@ class ToolHandlerMixin:
         LLM can react to, rather than a crash.
         """
         params = tool_call.get("params", {}) or {}
-        company_id = (ctx.context.get("company_id") if ctx is not None and ctx.context else None)
+        _cctx = ctx.context if ctx is not None and ctx.context else {}
+        company_id = _cctx.get("company_id")
+        # #11501 review: actor for audit/authz comes from the authenticated chat
+        # context, never from LLM-supplied params.
+        user_id = _cctx.get("user_id")
         try:
-            result = await dispatch_llc_tool(tool_name, params, company_id)
+            result = await dispatch_llc_tool(tool_name, params, company_id, user_id)
             execution_results.append({"tool": tool_name, "status": "success", "output": result})
             entity = result.get("entity_type", "item")
             entity_id = result.get("entity_id")
-            summary = f"Created {entity}" + (f" [{entity_id}]" if entity_id else "")
+            summary = f"Done ({entity})" + (f" [{entity_id}]" if entity_id else "")
             yield WorkflowMessage(
                 type="command_output",
                 content=summary,

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator
 from async_chat_workflow import WorkflowMessage
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.tool_catalogue import APPROVAL_CATEGORY_TOOLS, match_tool_name
+from llc.agent_tools import LLC_TOOL_NAMES, LLC_TOOL_SCHEMAS, LLCToolError, dispatch_llc_tool
 from tools.code_interpreter import CODE_INTERPRETER_SCHEMA
 from utils.errors import RepairableException
 
@@ -351,6 +352,10 @@ _BUILTIN_TOOL_SCHEMAS: dict[str, dict] = {
     "extract_structured_data": EXTRACT_STRUCTURED_DATA_SCHEMA,
     # #10932: Unified content_reach gateway (5 source chains).
     "content_reach": CONTENT_REACH_SCHEMA,
+    # #11501: LLC board/CEO-chat work-object tools (create_task, update_goal,
+    # request_approval, record_decision). Company-scoped; dispatched to the
+    # existing llc/services. Merged below so they validate like any built-in.
+    **LLC_TOOL_SCHEMAS,
 }
 
 
@@ -2214,6 +2219,42 @@ class ToolHandlerMixin:
                 metadata={"tool": tool_name, "error": True},
             )
 
+    async def _handle_llc_tool(self, tool_name, tool_call, execution_results, ctx):
+        """Dispatch an LLC work-object tool company-scoped (#11501).
+
+        company_id comes from the chat request context (set by the CEO-chat
+        endpoint, T2). A missing/invalid context surfaces as a tool error the
+        LLM can react to, rather than a crash.
+        """
+        params = tool_call.get("params", {}) or {}
+        company_id = (ctx.context.get("company_id") if ctx is not None and ctx.context else None)
+        try:
+            result = await dispatch_llc_tool(tool_name, params, company_id)
+            execution_results.append({"tool": tool_name, "status": "success", "output": result})
+            entity = result.get("entity_type", "item")
+            entity_id = result.get("entity_id")
+            summary = f"Created {entity}" + (f" [{entity_id}]" if entity_id else "")
+            yield WorkflowMessage(
+                type="command_output",
+                content=summary,
+                metadata={"tool": tool_name, "status": "success", "result": result},
+            )
+        except LLCToolError as exc:
+            execution_results.append({"tool": tool_name, "status": "error", "error": str(exc)})
+            yield WorkflowMessage(
+                type="error",
+                content=f"{tool_name}: {exc}",
+                metadata={"tool": tool_name, "error": True},
+            )
+        except Exception as exc:  # noqa: BLE001 — surface any service error to the LLM, don't crash the turn
+            logger.error("[#11501] LLC tool %s failed: %s", tool_name, exc)
+            execution_results.append({"tool": tool_name, "status": "error", "error": str(exc)})
+            yield WorkflowMessage(
+                type="error",
+                content=f"{tool_name} failed: {exc}",
+                metadata={"tool": tool_name, "error": True},
+            )
+
     async def _exec_scrape_url(self, params: dict) -> str:
         """Fetch a URL and return markdown content. Issue #7509."""
         from web_fetch import RenderMode, WebFetcher
@@ -2663,6 +2704,29 @@ class ToolHandlerMixin:
             if ctx is not None:
                 ctx.consecutive_invalid_tool_calls = 0
             async for msg in self._handle_delegate_tool(tool_call, execution_results, ctx):
+                yield msg
+            return
+
+        # #11501: LLC board/CEO-chat work-object tools — company-scoped dispatch
+        # to the existing llc/services. Handled here (not via _builtin_route)
+        # because the handler needs ctx.context["company_id"], which the uniform
+        # route does not receive.
+        if tool_name in LLC_TOOL_NAMES:
+            if ctx is not None:
+                ctx.consecutive_invalid_tool_calls = 0
+            validation_msg = _validate_builtin_tool_arguments(tool_name, tool_call)
+            if validation_msg is not None:
+                execution_results.append(
+                    {
+                        "tool": tool_name,
+                        "status": "schema_error",
+                        "error": validation_msg.content,
+                        "schema_validation_failed": True,
+                    }
+                )
+                yield validation_msg
+                return
+            async for msg in self._handle_llc_tool(tool_name, tool_call, execution_results, ctx):
                 yield msg
             return
 

--- a/autobot-backend/llc/agent_tools.py
+++ b/autobot-backend/llc/agent_tools.py
@@ -102,7 +102,16 @@ def _session_factory():
     return get_async_session_factory()
 
 
-async def _create_task(session, company_id: str, params: Dict[str, Any]) -> Dict[str, Any]:
+def _enum_or_error(enum_cls, value, field: str):
+    """Coerce *value* to *enum_cls*, raising LLCToolError (not ValueError) on a
+    bad LLM-supplied value so it surfaces as a tool error, not a crash."""
+    try:
+        return enum_cls(value)
+    except ValueError:
+        raise LLCToolError(f"invalid {field}: {value!r}") from None
+
+
+async def _create_task(session, company_id: str, user_id: str | None, params: Dict[str, Any]) -> Dict[str, Any]:
     from .models.enums import WorkItemPriority, WorkItemType
     from .services.work_item_service import WorkItemService
 
@@ -112,46 +121,62 @@ async def _create_task(session, company_id: str, params: Dict[str, Any]) -> Dict
     item = await WorkItemService().create(
         session,
         company_id=company_id,
-        type=WorkItemType(params.get("type", "task")),
+        type=_enum_or_error(WorkItemType, params.get("type", "task"), "type"),
         title=title,
         description=params.get("description"),
-        priority=WorkItemPriority(params.get("priority", "medium")),
+        priority=_enum_or_error(WorkItemPriority, params.get("priority", "medium"), "priority"),
+        # #11501 review: audit actor comes from the authenticated session, never
+        # from LLM-supplied params.
+        created_by_user_id=user_id,
     )
     return {"entity_type": "work_item", "entity_id": str(item.id), "title": title}
 
 
-async def _update_goal(session, company_id: str, params: Dict[str, Any]) -> Dict[str, Any]:
+async def _update_goal(session, company_id: str, user_id: str | None, params: Dict[str, Any]) -> Dict[str, Any]:
     from .services.goal import GoalService
 
     goal_id = params.get("goal_id")
     if not goal_id:
         raise LLCToolError("update_goal requires 'goal_id'")
+    svc = GoalService()
+    # #11501 review (cross-tenant IDOR): the goal_id is LLM-supplied — verify the
+    # goal belongs to THIS company before mutating it, else a board message in
+    # one company could edit another company's goal.
+    existing = await svc.get(session, uuid.UUID(str(goal_id)))
+    if existing is None:
+        raise LLCToolError(f"goal {goal_id} not found")
+    if str(existing.company_id) != str(company_id):
+        raise LLCToolError("goal does not belong to this company")
     fields = {k: v for k, v in params.items() if k != "goal_id" and v is not None}
-    goal = await GoalService().update(session, goal_id=uuid.UUID(str(goal_id)), **fields)
+    goal = await svc.update(session, goal_id=uuid.UUID(str(goal_id)), **fields)
     if goal is None:
         raise LLCToolError(f"goal {goal_id} not found")
     return {"entity_type": "goal", "entity_id": str(goal_id), "updated": sorted(fields)}
 
 
-async def _request_approval(session, company_id: str, params: Dict[str, Any]) -> Dict[str, Any]:
+async def _request_approval(session, company_id: str, user_id: str | None, params: Dict[str, Any]) -> Dict[str, Any]:
     from .models.enums import ApprovalType
     from .services.approval import ApprovalService
 
     summary = (params.get("summary") or "").strip()
     if not summary:
         raise LLCToolError("request_approval requires a 'summary'")
-    requested_by = params.get("requested_by") or company_id
+    # #11501 review (audit spoofing): requested_by is the AUTHENTICATED user from
+    # the chat session — never an LLM-supplied param. No authed user → refuse
+    # rather than attribute the request to an arbitrary/forged id.
+    if not user_id:
+        raise LLCToolError("request_approval requires an authenticated user in the chat context")
     appr = await ApprovalService().request_approval(
         session,
         company_id=uuid.UUID(str(company_id)),
-        gate_type=ApprovalType(params.get("gate_type", "strategy")),
+        gate_type=_enum_or_error(ApprovalType, params.get("gate_type", "strategy"), "gate_type"),
         payload={"summary": summary},
-        requested_by=uuid.UUID(str(requested_by)),
+        requested_by=uuid.UUID(str(user_id)),
     )
     return {"entity_type": "approval", "entity_id": str(appr.id), "summary": summary}
 
 
-async def _record_decision(session, company_id: str, params: Dict[str, Any]) -> Dict[str, Any]:
+async def _record_decision(session, company_id: str, user_id: str | None, params: Dict[str, Any]) -> Dict[str, Any]:
     # A decision has no dedicated entity — the CEO-chat thread / decisions KB is
     # the record (T2 persists it). Echo it back so the agent can confirm.
     decision = (params.get("decision") or "").strip()
@@ -168,12 +193,19 @@ _HANDLERS = {
 }
 
 
-async def dispatch_llc_tool(tool_name: str, params: Dict[str, Any], company_id: str | None) -> Dict[str, Any]:
+async def dispatch_llc_tool(
+    tool_name: str,
+    params: Dict[str, Any],
+    company_id: str | None,
+    user_id: str | None = None,
+) -> Dict[str, Any]:
     """Execute an LLC work-object tool company-scoped. Returns a result dict.
 
     Opens its own DB session (shared async_sessionmaker) so the chat tool
-    dispatch path can call it without a FastAPI request. Raises LLCToolError on
-    invalid context/args (the caller surfaces it as a tool error to the LLM).
+    dispatch path can call it without a FastAPI request. *company_id* and
+    *user_id* come from the authenticated chat context — NEVER from LLM params
+    (audit/tenant integrity, #11501 review). Raises LLCToolError on invalid
+    context/args (the caller surfaces it as a tool error to the LLM).
     """
     if tool_name not in _HANDLERS:
         raise LLCToolError(f"unknown LLC tool '{tool_name}'")
@@ -182,6 +214,6 @@ async def dispatch_llc_tool(tool_name: str, params: Dict[str, Any], company_id: 
     handler = _HANDLERS[tool_name]
     async with _session_factory()() as session:
         async with session.begin():
-            result = await handler(session, company_id, params or {})
+            result = await handler(session, company_id, user_id, params or {})
     logger.info("LLC tool %s → %s (company=%s)", tool_name, result.get("entity_type"), company_id)
     return {"status": "success", **result}

--- a/autobot-backend/llc/agent_tools.py
+++ b/autobot-backend/llc/agent_tools.py
@@ -1,0 +1,187 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""LLC work-object tools for the chat agent (#11501 T1).
+
+Exposes the board/CEO-chat operations — create_task, update_goal,
+request_approval, record_decision — as chat-agent tools so the shared chat
+pipeline (chat_workflow) can resolve a board message into a real work object
+via tool-calling, replacing the bespoke phi3 intent-classifier that always
+fell back to "clarify" (KeyError('"intent"'), a double-.format of the JSON
+schema prompt).
+
+Each tool is company-scoped: the dispatcher takes the company_id resolved from
+the chat request context (LLMIterationContext.context["company_id"]) and opens
+its own DB session via the shared async_sessionmaker, so it works outside a
+FastAPI request. Reuses the existing llc/services — no duplicated persistence.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+# --- Tool schemas advertised to the LLM (function parameters) ---------------
+
+CREATE_TASK_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string", "description": "Short imperative title of the work item."},
+        "description": {"type": "string", "description": "Optional details / context."},
+        "type": {
+            "type": "string",
+            "enum": ["epic", "feature", "pbi", "task", "bug"],
+            "description": "Work item type. Default 'task'.",
+        },
+        "priority": {
+            "type": "string",
+            "enum": ["critical", "high", "medium", "low"],
+            "description": "Priority. Default 'medium'.",
+        },
+    },
+    "required": ["title"],
+}
+
+UPDATE_GOAL_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "goal_id": {"type": "string", "description": "UUID of the goal to update."},
+        "title": {"type": "string"},
+        "description": {"type": "string"},
+        "status": {"type": "string", "description": "New goal status."},
+        "due_date": {"type": "string", "description": "ISO-8601 date/datetime."},
+    },
+    "required": ["goal_id"],
+}
+
+REQUEST_APPROVAL_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "gate_type": {
+            "type": "string",
+            "enum": ["hire", "strategy", "budget_override", "sprint_close", "project_disposal", "finding_promotion"],
+            "description": "The approval gate. Default 'strategy'.",
+        },
+        "summary": {"type": "string", "description": "What is being requested and why."},
+    },
+    "required": ["summary"],
+}
+
+RECORD_DECISION_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "decision": {"type": "string", "description": "The decision being recorded."},
+        "rationale": {"type": "string", "description": "Optional rationale / context."},
+    },
+    "required": ["decision"],
+}
+
+LLC_TOOL_SCHEMAS: Dict[str, dict] = {
+    "create_task": CREATE_TASK_SCHEMA,
+    "update_goal": UPDATE_GOAL_SCHEMA,
+    "request_approval": REQUEST_APPROVAL_SCHEMA,
+    "record_decision": RECORD_DECISION_SCHEMA,
+}
+
+LLC_TOOL_NAMES = frozenset(LLC_TOOL_SCHEMAS)
+
+
+class LLCToolError(RuntimeError):
+    """Raised when an LLC tool cannot be dispatched (bad context/args)."""
+
+
+def _session_factory():
+    """Return the shared async_sessionmaker (lazily, to avoid import cycles)."""
+    from user_management.database import get_async_session_factory
+
+    return get_async_session_factory()
+
+
+async def _create_task(session, company_id: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    from .models.enums import WorkItemPriority, WorkItemType
+    from .services.work_item_service import WorkItemService
+
+    title = (params.get("title") or "").strip()
+    if not title:
+        raise LLCToolError("create_task requires a non-empty 'title'")
+    item = await WorkItemService().create(
+        session,
+        company_id=company_id,
+        type=WorkItemType(params.get("type", "task")),
+        title=title,
+        description=params.get("description"),
+        priority=WorkItemPriority(params.get("priority", "medium")),
+    )
+    return {"entity_type": "work_item", "entity_id": str(item.id), "title": title}
+
+
+async def _update_goal(session, company_id: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    from .services.goal import GoalService
+
+    goal_id = params.get("goal_id")
+    if not goal_id:
+        raise LLCToolError("update_goal requires 'goal_id'")
+    fields = {k: v for k, v in params.items() if k != "goal_id" and v is not None}
+    goal = await GoalService().update(session, goal_id=uuid.UUID(str(goal_id)), **fields)
+    if goal is None:
+        raise LLCToolError(f"goal {goal_id} not found")
+    return {"entity_type": "goal", "entity_id": str(goal_id), "updated": sorted(fields)}
+
+
+async def _request_approval(session, company_id: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    from .models.enums import ApprovalType
+    from .services.approval import ApprovalService
+
+    summary = (params.get("summary") or "").strip()
+    if not summary:
+        raise LLCToolError("request_approval requires a 'summary'")
+    requested_by = params.get("requested_by") or company_id
+    appr = await ApprovalService().request_approval(
+        session,
+        company_id=uuid.UUID(str(company_id)),
+        gate_type=ApprovalType(params.get("gate_type", "strategy")),
+        payload={"summary": summary},
+        requested_by=uuid.UUID(str(requested_by)),
+    )
+    return {"entity_type": "approval", "entity_id": str(appr.id), "summary": summary}
+
+
+async def _record_decision(session, company_id: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    # A decision has no dedicated entity — the CEO-chat thread / decisions KB is
+    # the record (T2 persists it). Echo it back so the agent can confirm.
+    decision = (params.get("decision") or "").strip()
+    if not decision:
+        raise LLCToolError("record_decision requires 'decision'")
+    return {"entity_type": "decision", "entity_id": None, "decision": decision}
+
+
+_HANDLERS = {
+    "create_task": _create_task,
+    "update_goal": _update_goal,
+    "request_approval": _request_approval,
+    "record_decision": _record_decision,
+}
+
+
+async def dispatch_llc_tool(tool_name: str, params: Dict[str, Any], company_id: str | None) -> Dict[str, Any]:
+    """Execute an LLC work-object tool company-scoped. Returns a result dict.
+
+    Opens its own DB session (shared async_sessionmaker) so the chat tool
+    dispatch path can call it without a FastAPI request. Raises LLCToolError on
+    invalid context/args (the caller surfaces it as a tool error to the LLM).
+    """
+    if tool_name not in _HANDLERS:
+        raise LLCToolError(f"unknown LLC tool '{tool_name}'")
+    if not company_id:
+        raise LLCToolError(f"{tool_name} requires a company context (no company_id in the chat request)")
+    handler = _HANDLERS[tool_name]
+    async with _session_factory()() as session:
+        async with session.begin():
+            result = await handler(session, company_id, params or {})
+    logger.info("LLC tool %s → %s (company=%s)", tool_name, result.get("entity_type"), company_id)
+    return {"status": "success", **result}

--- a/autobot-backend/llc/tests/test_agent_tools.py
+++ b/autobot-backend/llc/tests/test_agent_tools.py
@@ -21,6 +21,7 @@ from llc import agent_tools
 from llc.agent_tools import LLC_TOOL_NAMES, LLC_TOOL_SCHEMAS, LLCToolError, dispatch_llc_tool
 
 _COMPANY = str(uuid.uuid4())
+_USER = str(uuid.uuid4())
 
 
 def _patch_session():
@@ -87,16 +88,20 @@ async def test_unknown_tool_raises():
 
 
 @pytest.mark.asyncio
-async def test_create_task_calls_work_item_service():
+async def test_create_task_calls_work_item_service_with_authed_actor():
     p, session = _patch_session()
     item = MagicMock(id=uuid.uuid4())
     svc = MagicMock()
     svc.create = AsyncMock(return_value=item)
     with p, patch("llc.services.work_item_service.WorkItemService", return_value=svc):
-        out = await dispatch_llc_tool("create_task", {"title": "Write Q3 report", "priority": "high"}, _COMPANY)
+        out = await dispatch_llc_tool(
+            "create_task", {"title": "Write Q3 report", "priority": "high"}, _COMPANY, _USER
+        )
     assert out["status"] == "success" and out["entity_type"] == "work_item"
     assert svc.create.await_args.kwargs["company_id"] == _COMPANY
     assert svc.create.await_args.kwargs["title"] == "Write Q3 report"
+    # #11501 review: audit actor = authenticated user, not LLM params.
+    assert svc.create.await_args.kwargs["created_by_user_id"] == _USER
 
 
 @pytest.mark.asyncio
@@ -104,25 +109,79 @@ async def test_create_task_blank_title_is_tool_error():
     p, _ = _patch_session()
     with p:
         with pytest.raises(LLCToolError):
-            await dispatch_llc_tool("create_task", {"title": "   "}, _COMPANY)
+            await dispatch_llc_tool("create_task", {"title": "   "}, _COMPANY, _USER)
 
 
 @pytest.mark.asyncio
-async def test_request_approval_calls_service():
+async def test_request_approval_uses_authed_user_not_params():
     p, _ = _patch_session()
     appr = MagicMock(id=uuid.uuid4())
     svc = MagicMock()
     svc.request_approval = AsyncMock(return_value=appr)
+    forged = str(uuid.uuid4())
     with p, patch("llc.services.approval.ApprovalService", return_value=svc):
-        out = await dispatch_llc_tool("request_approval", {"summary": "Approve the new hire"}, _COMPANY)
+        out = await dispatch_llc_tool(
+            # LLM tries to forge requested_by — must be IGNORED (#11501 review).
+            "request_approval",
+            {"summary": "Approve the new hire", "requested_by": forged},
+            _COMPANY,
+            _USER,
+        )
     assert out["status"] == "success" and out["entity_type"] == "approval"
     assert svc.request_approval.await_args.kwargs["company_id"] == uuid.UUID(_COMPANY)
+    assert svc.request_approval.await_args.kwargs["requested_by"] == uuid.UUID(_USER)
+
+
+@pytest.mark.asyncio
+async def test_request_approval_without_authed_user_is_error():
+    p, _ = _patch_session()
+    with p:
+        with pytest.raises(LLCToolError):
+            await dispatch_llc_tool("request_approval", {"summary": "x"}, _COMPANY, None)
+
+
+@pytest.mark.asyncio
+async def test_update_goal_rejects_cross_tenant():
+    """#11501 review (IDOR): a goal owned by another company must not be updated."""
+    p, _ = _patch_session()
+    other_company_goal = MagicMock(company_id=str(uuid.uuid4()))
+    svc = MagicMock()
+    svc.get = AsyncMock(return_value=other_company_goal)
+    svc.update = AsyncMock()
+    with p, patch("llc.services.goal.GoalService", return_value=svc):
+        with pytest.raises(LLCToolError):
+            await dispatch_llc_tool("update_goal", {"goal_id": str(uuid.uuid4()), "status": "done"}, _COMPANY, _USER)
+    svc.update.assert_not_awaited()  # never mutated the foreign goal
+
+
+@pytest.mark.asyncio
+async def test_update_goal_same_tenant_updates():
+    p, _ = _patch_session()
+    gid = uuid.uuid4()
+    goal = MagicMock(company_id=_COMPANY)
+    svc = MagicMock()
+    svc.get = AsyncMock(return_value=goal)
+    svc.update = AsyncMock(return_value=goal)
+    with p, patch("llc.services.goal.GoalService", return_value=svc):
+        out = await dispatch_llc_tool("update_goal", {"goal_id": str(gid), "status": "done"}, _COMPANY, _USER)
+    assert out["status"] == "success" and out["entity_type"] == "goal"
+    assert svc.update.await_args.kwargs["goal_id"] == gid
+
+
+@pytest.mark.asyncio
+async def test_update_goal_not_found_is_error():
+    p, _ = _patch_session()
+    svc = MagicMock()
+    svc.get = AsyncMock(return_value=None)
+    with p, patch("llc.services.goal.GoalService", return_value=svc):
+        with pytest.raises(LLCToolError):
+            await dispatch_llc_tool("update_goal", {"goal_id": str(uuid.uuid4())}, _COMPANY, _USER)
 
 
 @pytest.mark.asyncio
 async def test_record_decision_needs_no_service():
     p, _ = _patch_session()
     with p:
-        out = await dispatch_llc_tool("record_decision", {"decision": "Ship v2 on Friday"}, _COMPANY)
+        out = await dispatch_llc_tool("record_decision", {"decision": "Ship v2 on Friday"}, _COMPANY, _USER)
     assert out["status"] == "success" and out["entity_type"] == "decision"
     assert out["decision"] == "Ship v2 on Friday"

--- a/autobot-backend/llc/tests/test_agent_tools.py
+++ b/autobot-backend/llc/tests/test_agent_tools.py
@@ -1,0 +1,128 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the LLC chat-agent tools (#11501 T1).
+
+dispatch_llc_tool routes create_task/update_goal/request_approval/
+record_decision to the existing llc/services, company-scoped, opening its own
+DB session. These tests mock the session factory + services so no DB is needed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llc import agent_tools
+from llc.agent_tools import LLC_TOOL_NAMES, LLC_TOOL_SCHEMAS, LLCToolError, dispatch_llc_tool
+
+_COMPANY = str(uuid.uuid4())
+
+
+def _patch_session():
+    """Patch _session_factory so `async with factory()() as s: async with s.begin()` works."""
+    session = MagicMock()
+
+    @asynccontextmanager
+    async def _begin():
+        yield
+
+    session.begin = _begin
+
+    @asynccontextmanager
+    async def _sess_cm():
+        yield session
+
+    factory = MagicMock(return_value=_sess_cm())
+    return patch.object(agent_tools, "_session_factory", return_value=factory), session
+
+
+# ---------------------------------------------------------------------------
+# schema surface
+# ---------------------------------------------------------------------------
+
+
+def test_four_tools_registered():
+    assert LLC_TOOL_NAMES == {"create_task", "update_goal", "request_approval", "record_decision"}
+    for schema in LLC_TOOL_SCHEMAS.values():
+        assert schema["type"] == "object" and "properties" in schema
+
+
+def test_schemas_merged_into_builtin_validation():
+    # #11501: LLC schemas must be validated like any built-in tool. Importing
+    # chat_workflow pulls the full chat pipeline (heavy); skip where that chain
+    # isn't importable in this env — it runs in CI where deps are present.
+    try:
+        from chat_workflow.tool_handler import _BUILTIN_TOOL_SCHEMAS
+    except Exception as exc:  # noqa: BLE001 — env-dependent import chain
+        pytest.skip(f"chat_workflow not importable here: {exc}")
+    for name in LLC_TOOL_NAMES:
+        assert name in _BUILTIN_TOOL_SCHEMAS
+
+
+# ---------------------------------------------------------------------------
+# company-context guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_company_id_raises():
+    with pytest.raises(LLCToolError):
+        await dispatch_llc_tool("create_task", {"title": "x"}, None)
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_raises():
+    with pytest.raises(LLCToolError):
+        await dispatch_llc_tool("nope", {}, _COMPANY)
+
+
+# ---------------------------------------------------------------------------
+# dispatch → service
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_task_calls_work_item_service():
+    p, session = _patch_session()
+    item = MagicMock(id=uuid.uuid4())
+    svc = MagicMock()
+    svc.create = AsyncMock(return_value=item)
+    with p, patch("llc.services.work_item_service.WorkItemService", return_value=svc):
+        out = await dispatch_llc_tool("create_task", {"title": "Write Q3 report", "priority": "high"}, _COMPANY)
+    assert out["status"] == "success" and out["entity_type"] == "work_item"
+    assert svc.create.await_args.kwargs["company_id"] == _COMPANY
+    assert svc.create.await_args.kwargs["title"] == "Write Q3 report"
+
+
+@pytest.mark.asyncio
+async def test_create_task_blank_title_is_tool_error():
+    p, _ = _patch_session()
+    with p:
+        with pytest.raises(LLCToolError):
+            await dispatch_llc_tool("create_task", {"title": "   "}, _COMPANY)
+
+
+@pytest.mark.asyncio
+async def test_request_approval_calls_service():
+    p, _ = _patch_session()
+    appr = MagicMock(id=uuid.uuid4())
+    svc = MagicMock()
+    svc.request_approval = AsyncMock(return_value=appr)
+    with p, patch("llc.services.approval.ApprovalService", return_value=svc):
+        out = await dispatch_llc_tool("request_approval", {"summary": "Approve the new hire"}, _COMPANY)
+    assert out["status"] == "success" and out["entity_type"] == "approval"
+    assert svc.request_approval.await_args.kwargs["company_id"] == uuid.UUID(_COMPANY)
+
+
+@pytest.mark.asyncio
+async def test_record_decision_needs_no_service():
+    p, _ = _patch_session()
+    with p:
+        out = await dispatch_llc_tool("record_decision", {"decision": "Ship v2 on Friday"}, _COMPANY)
+    assert out["status"] == "success" and out["entity_type"] == "decision"
+    assert out["decision"] == "Ship v2 on Friday"


### PR DESCRIPTION
## Thinking Path
CEO chat always replied "Could you clarify?" — root cause `KeyError('"intent"')` (the board JSON-schema prompt `.format()`-ed twice), so the bespoke phi3 intent-classifier threw every call → clarify fallback. Owner-approved direction: **reuse the main /chat agent + expose LLC ops as tools** (umbrella #11501). This PR is **T1** — the tools + dispatch wiring.

## What Changed
- **`llc/agent_tools.py`** (new): schemas + `dispatch_llc_tool(name, params, company_id)` for `create_task` / `update_goal` / `request_approval` / `record_decision`, routed to the existing `llc/services` (no duplicated persistence). Company-scoped; opens its own session via the shared `async_sessionmaker` (`get_async_session_factory`) so it works outside a FastAPI request. `LLCToolError` surfaces bad context/args to the LLM instead of crashing the turn.
- **`chat_workflow/tool_handler.py`**: LLC schemas merged into `_BUILTIN_TOOL_SCHEMAS` (validated like any built-in); a dispatch branch in `_dispatch_tool_call` (placed where `ctx` is in scope, so `company_id` comes from `ctx.context["company_id"]`) → new `_handle_llc_tool` async-generator handler, before the MCP fallback.
- **tests**: schema surface, missing-company guard, unknown-tool guard, dispatch→service (create_task/request_approval), blank-title tool-error, record_decision. 7 pass; 1 skips locally (heavy `chat_workflow` import) and runs in CI.

## Verification
- `pytest llc/tests/test_agent_tools.py` → 7 passed, 1 skipped; flake8 + isort clean; `ast.parse` on both edited files.

## Follow-ups (tracked in #11501)
- **T2**: CEO-chat send endpoint delegates to `chat_workflow.process_message_stream` with `company_id` in context + LLC tools advertised; retire `_resolve_via_llm`. (Also fixes the pre-existing dead `ApprovalService.create()` call.)
- **T3**: frontend `CeoChatView` reuses the `/chat` streaming UX. **T4**: E2E.

## Model Used
Claude Fable 5 (1M context)

## Security hardening (background security review + code review)
- **Cross-tenant IDOR fixed:** `update_goal` now fetches the goal and rejects if `goal.company_id != company_id` (never mutates a foreign company's goal).
- **Audit spoofing fixed:** `requested_by` / `created_by` come ONLY from the authenticated chat context (`ctx.context['user_id']`, threaded via `dispatch_llc_tool(..., user_id)`); LLM-supplied `requested_by` is ignored; `request_approval` refuses without an authed user.
- Enum coercion raises `LLCToolError` (not `ValueError`) on bad LLM values.
- Tests added: cross-tenant reject (update not awaited), forged-`requested_by` ignored, no-user refused, goal not-found, same-tenant update, audit actor on create. 11 pass, 1 CI-only skip.