### PR TITLE
fix(deploy): skip non-operational fleet nodes in update-all; partial status + real ansible error (#11511)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -3783,11 +3783,12 @@ class UpdateAllJob(BaseModel):
     """Full orchestration job state for update-all."""
 
     job_id: str
-    status: str = "pending"  # pending | running | completed | failed | already_current
+    status: str = "pending"  # pending | running | completed | failed | already_current | partial
     stages: List[UpdateAllStage] = []
     total_fleet_nodes: int = 0
     completed_fleet_nodes: int = 0
     failed_fleet_nodes: int = 0
+    skipped_fleet_nodes: int = 0  # non-operational nodes skipped (#11511)
     created_at: str = ""
     completed_at: Optional[str] = None
     failure_reason: Optional[str] = None
@@ -4118,6 +4119,41 @@ def _fail_fleet_stage(
     job.completed_at = _now_iso()
 
 
+_NON_OPERATIONAL_STATUSES = frozenset({"degraded", "offline", "error", "pending", "enrolling", "decommissioned"})
+
+
+def _is_node_operational(node: Node) -> bool:
+    """Return True only when a node is in a state where a deploy is safe (#11511).
+
+    Nodes that are degraded, have never sent a heartbeat, or whose status is
+    anything other than online/maintenance are not targeted — attempting an
+    Ansible deploy against them will always fail and should not affect the
+    overall job result.
+    """
+    if node.last_heartbeat is None:
+        return False
+    return node.status not in _NON_OPERATIONAL_STATUSES
+
+
+def _extract_ansible_fatal(output: str) -> str:
+    """Return the first meaningful ansible error line from playbook output (#11511).
+
+    Filters out [DEPRECATION WARNING] / [WARNING] noise so the reported
+    failure message reflects the real fatal: / FAILED! / msg: line rather
+    than an unrelated deprecation notice.  Falls back to the tail of the
+    output when no fatal line is found.
+    """
+    fatal_keywords = ("fatal:", "FAILED!", "msg:", "ERROR!")
+    skip_prefixes = ("[DEPRECATION WARNING]", "[WARNING]", "DEPRECATION WARNING")
+    for line in output.splitlines():
+        stripped = line.strip()
+        if any(stripped.startswith(pfx) for pfx in skip_prefixes):
+            continue
+        if any(kw in stripped for kw in fatal_keywords):
+            return stripped[:300]
+    return output.strip()[-300:] if output.strip() else "playbook failed (no output)"
+
+
 async def _sync_fleet_node(
     executor,
     node_id: str,
@@ -4128,6 +4164,8 @@ async def _sync_fleet_node(
     """Sync one fleet node. Returns True to continue loop, False to halt.
 
     M1: node-not-found halts (returns False, caller clears plan).
+    Non-operational nodes (degraded/no-heartbeat) are skipped without
+    failing the job (#11511).
     """
     from services.database import db_service
 
@@ -4147,6 +4185,15 @@ async def _sync_fleet_node(
         job.completed_fleet_nodes += 1
         return True
 
+    # Skip non-operational nodes rather than attempting a deploy that will fail (#11511).
+    if not _is_node_operational(node):
+        reason = (
+            f"status={node.status}, last_heartbeat={'none' if node.last_heartbeat is None else node.last_heartbeat}"
+        )
+        _stage_log(stage, f"Node {node_id} ({node.hostname}) skipped — not operational ({reason})")
+        job.skipped_fleet_nodes += 1
+        return True
+
     playbook_result = await executor.execute_playbook(
         playbook_name="update-all-nodes.yml",
         limit=["localhost", node_id],
@@ -4157,9 +4204,10 @@ async def _sync_fleet_node(
         _stage_log(stage, f"Node {node_id} updated successfully")
         return True
 
+    error_msg = _extract_ansible_fatal(playbook_result["output"])
     job.failed_fleet_nodes += 1
-    _stage_log(stage, f"Node {node_id} FAILED: {playbook_result['output'][:300]}")
-    _fail_fleet_stage(job, stage, f"Fleet node {node_id} playbook failed")
+    _stage_log(stage, f"Node {node_id} FAILED: {error_msg}")
+    _fail_fleet_stage(job, stage, f"Fleet node {node_id} playbook failed: {error_msg}")
     return False
 
 
@@ -4167,8 +4215,10 @@ async def _run_fleet_stage(job: UpdateAllJob, node_ids: List[str]) -> None:
     """Execute stage 4: sequential full update of each outdated fleet node.
 
     Runs nodes SEQUENTIALLY (playbook executor is a singleton resource).
-    Marks job completed/failed when done. Clears the resume plan.
+    Marks job completed/failed/partial when done. Clears the resume plan.
     M1: node-not-found is treated as stage failure (halts pipeline).
+    Non-operational nodes are skipped and counted in skipped_fleet_nodes
+    without failing the job (#11511).
     """
     stage = _get_stage(job, "fleet_nodes")
     stage.status = _StageStatus.RUNNING
@@ -4176,6 +4226,7 @@ async def _run_fleet_stage(job: UpdateAllJob, node_ids: List[str]) -> None:
     job.total_fleet_nodes = len(node_ids)
     job.completed_fleet_nodes = 0
     job.failed_fleet_nodes = 0
+    job.skipped_fleet_nodes = 0
 
     executor = get_playbook_executor()
     slm_own_ip = urlparse(settings.external_url).hostname or ""
@@ -4193,12 +4244,17 @@ async def _run_fleet_stage(job: UpdateAllJob, node_ids: List[str]) -> None:
             await _clear_resume_plan()
             return
 
+    skipped = job.skipped_fleet_nodes
+    summary = f"Updated {job.completed_fleet_nodes}/{job.total_fleet_nodes} nodes"
+    if skipped:
+        summary += f" ({skipped} skipped — not operational)"
+
     stage.status = _StageStatus.SUCCESS
-    stage.message = f"Updated {job.completed_fleet_nodes}/{job.total_fleet_nodes} nodes"
+    stage.message = summary
     stage.completed_at = _now_iso()
-    job.status = "completed"
+    job.status = "partial" if skipped else "completed"
     job.completed_at = _now_iso()
-    _stage_log(stage, f"Fleet stage complete: {job.completed_fleet_nodes}/{job.total_fleet_nodes}")
+    _stage_log(stage, f"Fleet stage complete: {summary}")
     await _clear_resume_plan()
 
 

--- a/autobot-slm-backend/tests/api/test_fleet_node_update_11511.py
+++ b/autobot-slm-backend/tests/api/test_fleet_node_update_11511.py
@@ -79,11 +79,11 @@ sys.path.insert(0, str(_BACKEND_ROOT))
 
 from api.code_sync import (  # noqa: E402
     UpdateAllJob,
-    _StageStatus,
     _extract_ansible_fatal,
     _is_node_operational,
     _make_stage,
     _run_fleet_stage,
+    _StageStatus,
     _sync_fleet_node,
 )
 

--- a/autobot-slm-backend/tests/api/test_fleet_node_update_11511.py
+++ b/autobot-slm-backend/tests/api/test_fleet_node_update_11511.py
@@ -1,0 +1,443 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for fleet-node update-all fixes (#11511).
+
+#11511 — three bugs in POST /code-sync/update-all fleet_nodes stage:
+
+  Bug 1: Non-operational nodes (degraded / never-heartbeated) caused the whole
+         job to be marked failed when their Ansible deploy predictably failed.
+         Fix: _is_node_operational() gate — skip such nodes with a 'skipped'
+         per-node result; the job reaches 'partial' (or 'completed') instead of
+         'failed'.
+
+  Bug 2: Per-node partial-success model was absent — a single node failure
+         erased the overall success of slm_self_update and healthy nodes.
+         Fix: skipped_fleet_nodes counter on UpdateAllJob; job status becomes
+         'partial' when skips occurred but no operational node failed.
+
+  Bug 3: failure message / log_lines reported [DEPRECATION WARNING] noise
+         instead of the real ansible fatal: line.
+         Fix: _extract_ansible_fatal() filters WARNING/DEPRECATION lines and
+         returns the first fatal: / FAILED! / msg: line (or the tail).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Dev-host stub: minimal Pydantic models so the router can be imported
+# without a full SLM venv.
+# ---------------------------------------------------------------------------
+if "models" not in sys.modules or isinstance(sys.modules.get("models"), MagicMock):
+    from pydantic import BaseModel as _BM
+
+    def _pydantic_stub(name: str, **fields) -> type:
+        return type(name, (_BM,), {"__annotations__": {k: type(v) for k, v in fields.items()}, **fields})
+
+    _schemas = types.ModuleType("models.schemas")
+    for _cls in [
+        "CodeSyncStatusResponse",
+        "CodeSyncRefreshResponse",
+        "CodeVersionNotification",
+        "CodeVersionNotificationResponse",
+        "ComponentSyncJobStatus",
+        "DriftResolveJobResponse",
+        "DriftResolveRequest",
+        "DriftResolveResponse",
+        "FileDriftReport",
+        "FleetSyncJobStatus",
+        "FleetSyncNodeStatus",
+        "FleetSyncRequest",
+        "FleetSyncResponse",
+        "MarkSyncedResponse",
+        "NodeSyncRequest",
+        "NodeSyncResponse",
+        "PendingNodeResponse",
+        "PendingNodesResponse",
+        "ScheduleCreate",
+        "ScheduleResponse",
+        "ScheduleRunResponse",
+        "ScheduleUpdate",
+    ]:
+        setattr(_schemas, _cls, _pydantic_stub(_cls))
+    _models = sys.modules.get("models") or types.ModuleType("models")
+    _models.schemas = _schemas  # type: ignore[attr-defined]
+    sys.modules["models"] = _models
+    sys.modules["models.schemas"] = _schemas
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+from api.code_sync import (  # noqa: E402
+    UpdateAllJob,
+    _StageStatus,
+    _extract_ansible_fatal,
+    _is_node_operational,
+    _make_stage,
+    _run_fleet_stage,
+    _sync_fleet_node,
+)
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# Node status string constants (mirror NodeStatus enum values).
+# Used instead of importing NodeStatus to avoid mock contamination in
+# tests that stub models.database indirectly.
+# ---------------------------------------------------------------------------
+_STATUS_ONLINE = "online"
+_STATUS_MAINTENANCE = "maintenance"
+_STATUS_DEGRADED = "degraded"
+_STATUS_OFFLINE = "offline"
+_STATUS_ERROR = "error"
+_STATUS_PENDING = "pending"
+_STATUS_ENROLLING = "enrolling"
+_STATUS_DECOMMISSIONED = "decommissioned"
+
+_NOW = datetime(2026, 7, 10, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _fake_node(
+    node_id: str = "node-abc",
+    hostname: str = "test-host",
+    ip_address: str = "10.0.0.2",
+    status: str = _STATUS_ONLINE,
+    last_heartbeat=None,
+) -> SimpleNamespace:
+    """Return a SimpleNamespace that mimics the Node fields _is_node_operational uses."""
+    return SimpleNamespace(
+        node_id=node_id,
+        hostname=hostname,
+        ip_address=ip_address,
+        status=status,
+        last_heartbeat=last_heartbeat,
+    )
+
+
+def _job_with_fleet_stage() -> UpdateAllJob:
+    """Return an UpdateAllJob pre-populated with all four pipeline stages."""
+    job = UpdateAllJob(job_id="test-job")
+    job.stages = [
+        _make_stage("github_fetch"),
+        _make_stage("code_source_pull"),
+        _make_stage("slm_self_update"),
+        _make_stage("fleet_nodes"),
+    ]
+    return job
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — _is_node_operational: skip criteria
+# ---------------------------------------------------------------------------
+
+
+def test_is_node_operational_online_with_heartbeat() -> None:
+    """An online node with a heartbeat is operational."""
+    n = _fake_node(status=_STATUS_ONLINE, last_heartbeat=_NOW)
+    assert _is_node_operational(n) is True
+
+
+def test_is_node_operational_maintenance_with_heartbeat() -> None:
+    """A maintenance node with a heartbeat is considered operational."""
+    n = _fake_node(status=_STATUS_MAINTENANCE, last_heartbeat=_NOW)
+    assert _is_node_operational(n) is True
+
+
+def test_is_node_operational_no_heartbeat_is_not_operational() -> None:
+    """A node with last_heartbeat=None is never operational (#11511 root cause)."""
+    n = _fake_node(status=_STATUS_ONLINE, last_heartbeat=None)
+    assert _is_node_operational(n) is False
+
+
+def test_is_node_operational_degraded_is_not_operational() -> None:
+    """A degraded node is not operational even with a heartbeat (#11511 root cause)."""
+    n = _fake_node(status=_STATUS_DEGRADED, last_heartbeat=_NOW)
+    assert _is_node_operational(n) is False
+
+
+def test_is_node_operational_offline_is_not_operational() -> None:
+    n = _fake_node(status=_STATUS_OFFLINE, last_heartbeat=_NOW)
+    assert _is_node_operational(n) is False
+
+
+def test_is_node_operational_error_is_not_operational() -> None:
+    n = _fake_node(status=_STATUS_ERROR, last_heartbeat=_NOW)
+    assert _is_node_operational(n) is False
+
+
+def test_is_node_operational_pending_is_not_operational() -> None:
+    n = _fake_node(status=_STATUS_PENDING, last_heartbeat=_NOW)
+    assert _is_node_operational(n) is False
+
+
+def test_is_node_operational_decommissioned_is_not_operational() -> None:
+    n = _fake_node(status=_STATUS_DECOMMISSIONED, last_heartbeat=_NOW)
+    assert _is_node_operational(n) is False
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 — _extract_ansible_fatal: real error, not warning noise
+# ---------------------------------------------------------------------------
+
+
+def test_extract_ansible_fatal_returns_fatal_line() -> None:
+    """The first 'fatal:' line is returned, not the deprecation warning."""
+    output = (
+        "[DEPRECATION WARNING]: DEFAULT_GATHER_SUBSET option, normalizing to 'all'\n"
+        "PLAY [Update all nodes] **\n"
+        "TASK [Gathering Facts] **\n"
+        'fatal: [vnc]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect"}\n'
+    )
+    result = _extract_ansible_fatal(output)
+    assert "fatal:" in result
+    assert "UNREACHABLE" in result
+    assert "DEPRECATION WARNING" not in result
+
+
+def test_extract_ansible_fatal_returns_failed_line() -> None:
+    """FAILED! lines are captured as real errors."""
+    output = "[WARNING]: some irrelevant warning\n" 'FAILED! => {"msg": "Permission denied"}\n'
+    result = _extract_ansible_fatal(output)
+    assert "FAILED!" in result
+    assert "Permission denied" in result
+
+
+def test_extract_ansible_fatal_skips_all_warning_lines() -> None:
+    """Only [DEPRECATION WARNING] / [WARNING] prefixed lines are filtered."""
+    output = "[DEPRECATION WARNING]: foo\n" "[WARNING]: bar\n" "DEPRECATION WARNING: baz\n" "fatal: [host]: FAILED!\n"
+    result = _extract_ansible_fatal(output)
+    assert "fatal:" in result
+    assert "WARNING" not in result
+
+
+def test_extract_ansible_fatal_falls_back_to_tail_when_no_fatal() -> None:
+    """When there is no fatal: line, the tail of the output is returned."""
+    output = "line1\nline2\nlast line"
+    result = _extract_ansible_fatal(output)
+    assert "last line" in result
+
+
+def test_extract_ansible_fatal_handles_empty_output() -> None:
+    """Empty/whitespace-only output yields a non-crashing fallback."""
+    result = _extract_ansible_fatal("")
+    assert result == "playbook failed (no output)"
+
+
+def test_extract_ansible_fatal_deprecation_only_falls_back_to_tail() -> None:
+    """When every line is a warning, falls back to last non-empty segment."""
+    output = "[DEPRECATION WARNING]: foo\n[WARNING]: bar\n"
+    result = _extract_ansible_fatal(output)
+    # Falls through to tail — must not crash
+    assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 + 2 — _sync_fleet_node: degraded node is skipped, not failed
+# ---------------------------------------------------------------------------
+
+
+def _make_db_service_for_node(node):
+    """Return a mock db_service that yields *node* for any node_id query."""
+    mock_db_result = MagicMock()
+    mock_db_result.scalar_one_or_none.return_value = node
+
+    mock_db_session = MagicMock()
+    mock_db_session.execute = AsyncMock(return_value=mock_db_result)
+
+    mock_db_ctx = MagicMock()
+    mock_db_ctx.__aenter__ = AsyncMock(return_value=mock_db_session)
+    mock_db_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    mock_db_svc = MagicMock()
+    mock_db_svc.session.return_value = mock_db_ctx
+    return mock_db_svc
+
+
+def test_sync_fleet_node_skips_degraded_node() -> None:
+    """A degraded node (no heartbeat) increments skipped, not failed (#11511)."""
+    degraded = _fake_node(
+        node_id="node-vnc",
+        hostname="VNC",
+        ip_address="172.16.168.26",
+        status=_STATUS_DEGRADED,
+        last_heartbeat=None,
+    )
+    job = _job_with_fleet_stage()
+    from api.code_sync import _get_stage
+
+    stage = _get_stage(job, "fleet_nodes")
+    stage.status = _StageStatus.RUNNING
+
+    mock_executor = MagicMock()
+    mock_db_svc = _make_db_service_for_node(degraded)
+
+    with patch("services.database.db_service", mock_db_svc, create=True):
+        cont = _run(_sync_fleet_node(mock_executor, "node-vnc", job, stage, "10.0.0.1"))
+
+    assert cont is True, "loop must continue after skipping a non-operational node"
+    assert job.skipped_fleet_nodes == 1
+    assert job.failed_fleet_nodes == 0
+    assert job.completed_fleet_nodes == 0
+    mock_executor.execute_playbook.assert_not_called()
+
+
+def test_sync_fleet_node_skips_never_heartbeated_node() -> None:
+    """A node that never sent a heartbeat is skipped regardless of status (#11511)."""
+    never_beat = _fake_node(
+        node_id="node-new",
+        status=_STATUS_ONLINE,
+        last_heartbeat=None,
+    )
+    job = _job_with_fleet_stage()
+    from api.code_sync import _get_stage
+
+    stage = _get_stage(job, "fleet_nodes")
+    stage.status = _StageStatus.RUNNING
+
+    mock_executor = MagicMock()
+    mock_db_svc = _make_db_service_for_node(never_beat)
+
+    with patch("services.database.db_service", mock_db_svc, create=True):
+        cont = _run(_sync_fleet_node(mock_executor, "node-new", job, stage, ""))
+
+    assert cont is True
+    assert job.skipped_fleet_nodes == 1
+    assert job.failed_fleet_nodes == 0
+    mock_executor.execute_playbook.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 — _run_fleet_stage: partial status when skips occur but no failure
+# ---------------------------------------------------------------------------
+
+
+def test_run_fleet_stage_partial_when_node_skipped() -> None:
+    """job.status='partial' when only non-operational nodes were in the list (#11511)."""
+    job = _job_with_fleet_stage()
+    mock_executor = MagicMock()
+    mock_executor.execute_playbook = AsyncMock(return_value={"success": True, "output": "", "returncode": 0})
+
+    async def _fake_sync(executor, node_id, job, stage, slm_own_ip):
+        job.skipped_fleet_nodes += 1
+        return True
+
+    with (
+        patch("api.code_sync._sync_fleet_node", side_effect=_fake_sync),
+        patch("api.code_sync.get_playbook_executor", return_value=mock_executor),
+        patch("api.code_sync.settings") as mock_settings,
+        patch("api.code_sync._clear_resume_plan", AsyncMock()),
+    ):
+        mock_settings.external_url = "http://10.0.0.1"
+        _run(_run_fleet_stage(job, ["node-vnc"]))
+
+    assert job.status == "partial", f"expected 'partial', got {job.status!r}"
+    assert job.skipped_fleet_nodes == 1
+    assert job.failed_fleet_nodes == 0
+    mock_executor.execute_playbook.assert_not_called()
+
+
+def test_run_fleet_stage_completed_when_no_skips_and_success() -> None:
+    """job.status='completed' when all nodes deployed successfully with no skips."""
+    job = _job_with_fleet_stage()
+    mock_executor = MagicMock()
+
+    async def _fake_sync(executor, node_id, job, stage, slm_own_ip):
+        job.completed_fleet_nodes += 1
+        return True
+
+    with (
+        patch("api.code_sync._sync_fleet_node", side_effect=_fake_sync),
+        patch("api.code_sync.get_playbook_executor", return_value=mock_executor),
+        patch("api.code_sync.settings") as mock_settings,
+        patch("api.code_sync._clear_resume_plan", AsyncMock()),
+    ):
+        mock_settings.external_url = "http://10.0.0.1"
+        _run(_run_fleet_stage(job, ["node-ok"]))
+
+    assert job.status == "completed", f"expected 'completed', got {job.status!r}"
+    assert job.skipped_fleet_nodes == 0
+    assert job.completed_fleet_nodes == 1
+
+
+def test_run_fleet_stage_failed_when_operational_node_fails() -> None:
+    """job.status='failed' when an operational node's playbook fails (#11511).
+
+    Also confirms that the failure_reason contains the real ansible error line,
+    not a deprecation warning (Bug 3 integration check).
+    """
+    bad_output = (
+        "[DEPRECATION WARNING]: DEFAULT_GATHER_SUBSET\n"
+        'fatal: [node-fail]: UNREACHABLE! => {"msg": "Connection refused"}\n'
+    )
+    job = _job_with_fleet_stage()
+    mock_executor = MagicMock()
+
+    async def _fake_sync(executor, node_id, job, stage, slm_own_ip):
+        from api.code_sync import _extract_ansible_fatal, _fail_fleet_stage
+
+        error_msg = _extract_ansible_fatal(bad_output)
+        job.failed_fleet_nodes += 1
+        _fail_fleet_stage(job, stage, f"Fleet node {node_id} playbook failed: {error_msg}")
+        return False
+
+    with (
+        patch("api.code_sync._sync_fleet_node", side_effect=_fake_sync),
+        patch("api.code_sync.get_playbook_executor", return_value=mock_executor),
+        patch("api.code_sync.settings") as mock_settings,
+        patch("api.code_sync._clear_resume_plan", AsyncMock()),
+    ):
+        mock_settings.external_url = "http://10.0.0.1"
+        _run(_run_fleet_stage(job, ["node-fail"]))
+
+    assert job.status == "failed", f"expected 'failed', got {job.status!r}"
+    assert job.failed_fleet_nodes == 1
+    assert job.failure_reason is not None
+    assert "DEPRECATION WARNING" not in job.failure_reason
+    assert "UNREACHABLE" in job.failure_reason or "fatal:" in job.failure_reason
+
+
+def test_run_fleet_stage_skips_degraded_continues_to_healthy() -> None:
+    """A degraded node is skipped; the healthy node after it is still deployed."""
+    job = _job_with_fleet_stage()
+
+    # Patch _sync_fleet_node directly and track calls by node_id
+    sync_calls: list[str] = []
+
+    async def _fake_sync(executor, node_id, job, stage, slm_own_ip):
+        sync_calls.append(node_id)
+        if node_id == "node-vnc":
+            job.skipped_fleet_nodes += 1
+            return True
+        if node_id == "node-ok":
+            job.completed_fleet_nodes += 1
+            return True
+        return False
+
+    mock_executor = MagicMock()
+
+    with (
+        patch("api.code_sync._sync_fleet_node", side_effect=_fake_sync),
+        patch("api.code_sync.get_playbook_executor", return_value=mock_executor),
+        patch("api.code_sync.settings") as mock_settings,
+        patch("api.code_sync._clear_resume_plan", AsyncMock()),
+    ):
+        mock_settings.external_url = "http://10.0.0.1"
+        _run(_run_fleet_stage(job, ["node-vnc", "node-ok"]))
+
+    assert "node-vnc" in sync_calls
+    assert "node-ok" in sync_calls
+    assert job.skipped_fleet_nodes == 1
+    assert job.completed_fleet_nodes == 1
+    assert job.status == "partial", f"expected 'partial' (1 skip + 1 success), got {job.status!r}"


### PR DESCRIPTION
## Thinking Path

The `POST /code-sync/update-all` pipeline's `fleet_nodes` stage had three bugs:

**Bug 1 (root cause of reported failure):** `_sync_fleet_node` checked node existence and skipped the SLM self-node, but had no check for node health. Node `b9a29e04` (`VNC`, `172.16.168.26`) has `status=degraded`, `last_heartbeat=null`, and `code_status=unknown` — it was enrolled but never operational. The Ansible deploy to it predictably fails (unreachable), and `_fail_fleet_stage` marked the whole job `failed`, erasing the successful `slm_self_update`.

**Bug 2 (partial success model):** There was no `skipped` concept. A single non-operational node failing caused the entire job to report `failed` even though all healthy nodes + SLM self-update succeeded. Fixed with `skipped_fleet_nodes` counter and `partial` job status.

**Bug 3 (wrong error reported):** `playbook_result['output'][:300]` in the failure log captured the `[DEPRECATION WARNING]: DEFAULT_GATHER_SUBSET` line (first 300 chars) instead of the real `fatal:` / `UNREACHABLE!` line. Added `_extract_ansible_fatal()` to filter warning noise.

## What Changed

**`autobot-slm-backend/api/code_sync.py`**

- Added `_NON_OPERATIONAL_STATUSES` frozenset (string literals, not enum refs to avoid mock contamination)
- Added `_is_node_operational(node)` — returns `False` when `last_heartbeat is None` OR `status` is in `{degraded, offline, error, pending, enrolling, decommissioned}`
- Added `_extract_ansible_fatal(output)` — scans playbook output line-by-line, skips `[DEPRECATION WARNING]`/`[WARNING]` prefixed lines, returns first `fatal:`/`FAILED!`/`msg:`/`ERROR!` line (falls back to tail when none found)
- `UpdateAllJob.skipped_fleet_nodes: int = 0` — new field with comment `(#11511)`
- `UpdateAllJob.status` docstring extended with `partial` state
- `_sync_fleet_node` — added operability gate after self-node skip: if `not _is_node_operational(node)`, increments `skipped_fleet_nodes` and returns `True` (loop continues). Also uses `_extract_ansible_fatal` instead of raw `output[:300]` in failure path.
- `_run_fleet_stage` — initialises `job.skipped_fleet_nodes = 0`; builds a `skipped` summary suffix; sets `job.status = "partial"` when `skipped > 0`, `"completed"` when none skipped.

**`autobot-slm-backend/tests/api/test_fleet_node_update_11511.py`** (new, 20 tests)

- `_is_node_operational`: 8 tests covering online+heartbeat (pass), maintenance+heartbeat (pass), `last_heartbeat=None` (fail), degraded/offline/error/pending/decommissioned with heartbeat (all fail)
- `_extract_ansible_fatal`: 6 tests covering fatal: extraction, FAILED! extraction, all-warning filtering, tail fallback, empty output, deprecation-only output
- `_sync_fleet_node`: 2 integration tests — degraded node skipped (executor not called, skipped_fleet_nodes=1), never-heartbeated node skipped
- `_run_fleet_stage`: 4 scenario tests — partial (skip only), completed (all success), failed (operational node fails with real error in failure_reason), skip-then-success (loop continues past degraded to healthy node)

## Verification

```
pytest tests/api/test_fleet_node_update_11511.py -v
# 20 passed in 0.60s

ruff check autobot-slm-backend/api/code_sync.py   # All checks passed
black --check autobot-slm-backend/api/code_sync.py # 1 file would be left unchanged
bandit -c .bandit -r autobot-slm-backend/api/code_sync.py  # No issues identified
```

Skip criteria: `last_heartbeat IS NULL` OR `status IN {degraded, offline, error, pending, enrolling, decommissioned}`.

Partial-success: `job.status = "partial"` when `skipped_fleet_nodes > 0` and no operational node failed; `"completed"` when no skips and all operational nodes succeeded; `"failed"` only when an operational node's playbook genuinely fails.

Real error surfacing: `_extract_ansible_fatal()` skips lines starting with `[DEPRECATION WARNING]`, `[WARNING]`, or `DEPRECATION WARNING` and returns the first `fatal:`/`FAILED!`/`msg:`/`ERROR!` line.

Closes #11511

## Model Used

claude-sonnet-4-6