### PR TITLE
feat(llc): CEO chat delegates to the shared chat agent + retire broken resolver (#11501 T2)

### DIFF
--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -605,25 +605,38 @@ class LLMHandlerMixin:
         """
         return get_language_instruction(language_code)
 
-    def _get_system_prompt(self, language=None) -> str:
+    def _get_system_prompt(self, language=None, company_id=None) -> str:
         """Get system prompt with optional personality preamble.
 
         Issue #964: Personality preamble prepended when a profile is active.
         Issue #1325: Appends language instruction when non-English.
+        #11501 T2: appends board/company tool teaching when *company_id* is set
+        (the CEO-chat path), so those tools are advertised only there.
         """
         preamble = self._get_personality_preamble()
         resolved_lang = self._resolve_language(language)
         lang_instruction = self._get_language_instruction(resolved_lang)
+        llc_tools = self._get_llc_tool_prompt() if company_id else ""
         try:
             prompt = get_prompt("chat.system_prompt_simple")
             logger.debug("[ChatWorkflowManager] Loaded simplified system prompt")
-            return preamble + prompt + lang_instruction
+            return preamble + prompt + llc_tools + lang_instruction
         except Exception as e:
             logger.error("Failed to load system prompt from file: %s", e)
-            return preamble + """You are AutoBot. Execute commands using:
+            return preamble + llc_tools + """You are AutoBot. Execute commands using:
 <TOOL_CALL name="execute_command" params='{"command":"cmd"}'>desc</TOOL_CALL>
 
 NEVER teach commands - ALWAYS execute them.""" + lang_instruction
+
+    @staticmethod
+    def _get_llc_tool_prompt() -> str:
+        """Board/company tool teaching for the CEO-chat path (#11501 T2)."""
+        try:
+            from llc.agent_tools import LLC_TOOL_PROMPT
+
+            return LLC_TOOL_PROMPT
+        except Exception:  # noqa: BLE001 — LLC optional; never break general chat
+            return ""
 
     def _build_conversation_context(self, session: WorkflowSession) -> str:
         """Build conversation context from recent history.
@@ -756,7 +769,10 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
             {"message": message, "use_knowledge": use_knowledge, "language": language},
         )
 
-        system_prompt = self._get_system_prompt(language=language)
+        system_prompt = self._get_system_prompt(
+            language=language,
+            company_id=(session.metadata.get("company_id") if session and session.metadata else None),
+        )
         # Issue #5066: Tiered L0-L3 context wake-up (A/B against legacy path).
         # When TIERED_CONTEXT_ENABLED=true the TieredContextBuilder owns all
         # context prepending (L0 identity + L1 essential story + L2/L3 on-demand).

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -2861,6 +2861,9 @@ before summarizing.
         if context:
             session.metadata["user_id"] = context.get("user_id") or ""
             session.metadata["tenant_id"] = context.get("tenant_id") or context.get("org_id") or ""
+            # #11501 T2: CEO-chat path carries company_id — used to append the
+            # board-tool teaching to the system prompt for this turn only.
+            session.metadata["company_id"] = context.get("company_id") or ""
 
         # Issue MVA-1992: Determine if query qualifies for lightweight mode.
         # Trivial tier (GH#9050, score < trivial_threshold) is the primary

--- a/autobot-backend/llc/agent_tools.py
+++ b/autobot-backend/llc/agent_tools.py
@@ -95,6 +95,32 @@ class LLCToolError(RuntimeError):
     """Raised when an LLC tool cannot be dispatched (bad context/args)."""
 
 
+# --- System-prompt teaching for the chat agent (#11501 T2) ------------------
+# The chat agent learns tools from the system prompt (<TOOL_CALL> syntax), not
+# function-calling schemas. This snippet is appended to the system prompt only
+# for the CEO-chat path (context carries company_id), so board tools are never
+# advertised in general chat.
+LLC_TOOL_PROMPT = """
+## Board / Company operations
+
+You are the company's board interface. When the message calls for it, act on it
+by emitting ONE of these tool calls (same <TOOL_CALL> syntax as other tools) —
+do NOT ask for clarification if the intent is clear. Example params shown; keep
+titles/summaries concise:
+
+- create_task — params: {"title":"...","priority":"high|medium|low","description":"..."}
+- update_goal — params: {"goal_id":"<uuid-from-context>","status":"...","title":"..."}
+- request_approval — params: {"gate_type":"strategy","summary":"..."}
+- record_decision — params: {"decision":"...","rationale":"..."}
+
+For example:
+<TOOL_CALL name="create_task" params='{"title":"Write the Q3 report"}'>Create task</TOOL_CALL>
+
+After the tool result, use the `respond` tool to confirm what you did in one
+sentence. Only ask the user to clarify if the request is genuinely ambiguous.
+"""
+
+
 def _session_factory():
     """Return the shared async_sessionmaker (lazily, to avoid import cycles)."""
     from user_management.database import get_async_session_factory

--- a/autobot-backend/llc/services/ceo_chat.py
+++ b/autobot-backend/llc/services/ceo_chat.py
@@ -4,19 +4,19 @@
 # Author: mrveiss
 """CEO Chat service — company-scoped chat resolving to work objects (GH#8233).
 
-CeoChatService.send() flow:
-  1. RAG-query ``company:{company_id}`` KB collection with message text (top 5).
-  2. Call LLM via ``llm_shared`` with board-interface system prompt.
-  3. Interpret structured JSON response → call appropriate LLC service.
-  4. Persist resolution in ``resolved_entity_type`` + ``resolved_entity_id``.
-  5. Return system reply message with link to the resolved entity.
+#11501 T2: CeoChatService.send() now delegates to the shared chat pipeline
+(chat_workflow) instead of a bespoke intent-classifier. The board LLM gets the
+same experience as /chat and creates work objects by calling the LLC tools
+(create_task / update_goal / request_approval / record_decision), which are
+taught in the system prompt only when the request context carries a company_id.
 
-Resolution intents:
-  create_task        → WorkItemService.create()
-  update_goal        → GoalService.update()
-  request_approval   → ApprovalService.create()
-  record_decision    → stored as thread annotation (resolved_entity_type="decision")
-  clarify            → no entity created; asks for more info
+Flow:
+  1. Persist the human message.
+  2. RAG-query the company + decisions KB for grounding (top 5 chunks).
+  3. Delegate to ChatWorkflowManager.process_message_stream with
+     {company_id, user_id} context; the LLC tools execute company-scoped.
+  4. Persist the streamed reply; set resolved_entity_type/id from the tool
+     result when the LLM created an entity.
 """
 
 import logging
@@ -105,15 +105,15 @@ class CeoChatService(LLCServiceBase):
         *,
         company_name: str = "the company",
     ) -> LLCCeoChatMessage:
-        """Process a human message and return the system reply.
+        """Process a human board message and return the system reply (#11501 T2).
 
         Steps:
           1. Persist the human message.
-          2. RAG-query the company KB for context.
-          3. Call LLM to resolve the intent.
-          4. Call the appropriate LLC service for non-clarify intents.
-          5. Update thread resolution fields.
-          6. Persist and return the system reply message.
+          2. RAG-query the company + decisions KB for grounding.
+          3-6. Delegate to the shared chat pipeline (_run_pipeline): the board
+             LLM answers and creates work objects via the LLC tools, then the
+             reply is persisted and the thread resolution updated if an entity
+             was created. company_name grounds the prompt.
         """
         # 1. Persist the incoming human message
         human_msg = LLCCeoChatMessage(
@@ -143,6 +143,7 @@ class CeoChatService(LLCServiceBase):
             company_id=company_id,
             user_id=user_id,
             kb_chunks=kb_chunks,
+            company_name=company_name,
         )
 
         if entity_type and entity_id:
@@ -170,21 +171,28 @@ class CeoChatService(LLCServiceBase):
         company_id: str,
         user_id: Optional[str],
         kb_chunks: List[str],
+        company_name: str = "the company",
     ) -> tuple[str, Optional[str], Optional[str]]:
         """Run the board message through the shared chat pipeline (#11501 T2).
 
         Returns (reply_text, entity_type, entity_id). company_id/user_id go in
         the context so the LLC tools (create_task/...) execute company-scoped;
-        the thread_id is the chat session_id. Company-KB chunks are prepended as
-        grounding. Reply is the last ``response`` message; the created entity (if
-        any) is read from the LLC tool-result metadata.
+        the thread_id is the chat session_id. Company name + KB chunks are
+        prepended as grounding. The created entity (if any) is read from the LLC
+        tool-result metadata.
+
+        Reply assembly (#11525 review): streaming ``response`` chunks are
+        cumulative snapshots keyed by message id, so we keep the latest content
+        per id and join distinct segments in order — robust whether the model
+        ends with a single ``respond`` message or interleaves prose + thoughts.
         """
-        grounded = message
+        grounded = f"[Company: {company_name}]\n"
         if kb_chunks:
-            grounded = "Company context:\n" + "\n".join(kb_chunks[:5]) + "\n\n---\n\n" + message
+            grounded += "Company context:\n" + "\n".join(kb_chunks[:5]) + "\n\n---\n\n"
+        grounded += message
         context = {"company_id": company_id, "user_id": user_id or ""}
 
-        reply_parts: List[str] = []
+        responses: "dict[str, str]" = {}  # message-id → latest full content, in order
         entity_type: Optional[str] = None
         entity_id: Optional[str] = None
         manager = _get_workflow_manager()
@@ -193,13 +201,14 @@ class CeoChatService(LLCServiceBase):
             content = getattr(msg, "content", "") or ""
             meta = getattr(msg, "metadata", None) or {}
             if mtype == "response" and content:
-                reply_parts.append(content)
+                mid = getattr(msg, "id", None) or f"_seg{len(responses)}"
+                responses[mid] = content  # snapshots replace; new segments append
             result = meta.get("result") if isinstance(meta, dict) else None
             if isinstance(result, dict) and result.get("entity_type") and result.get("entity_id"):
                 entity_type = result["entity_type"]
                 entity_id = result["entity_id"]
 
-        reply = reply_parts[-1] if reply_parts else "Done."
+        reply = "\n\n".join(v for v in responses.values() if v).strip() or "Done."
         return reply, entity_type, entity_id
 
     # --------------------------------------------------------------- Helpers

--- a/autobot-backend/llc/services/ceo_chat.py
+++ b/autobot-backend/llc/services/ceo_chat.py
@@ -19,45 +19,34 @@ Resolution intents:
   clarify            → no entity created; asks for more info
 """
 
-import json
 import logging
-import re
-import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
-
-import services.llm_service as _llm_service_mod
-from autobot_shared.ssot_config import config as _cfg
-from llm_shared.types import LLMType
 
 from ..models.ceo_chat import LLCCeoChatMessage, LLCCeoChatThread
 from .base import LLCServiceBase
 
 logger = logging.getLogger(__name__)
 
-_BOARD_SYSTEM_PROMPT = (
-    "You are the board interface for {company_name}. "
-    "Your goal is to resolve this message into one of: "
-    "[create_task, update_goal, request_approval, record_decision, clarify]. "
-    "Return structured JSON with keys: "
-    '{{"intent": "<one of the above>", "summary": "<brief>", "entity": {{<relevant fields>}}}}. '
-    "Respond ONLY with valid JSON. Do NOT include any explanation, markdown, or thinking text."
-)
-
-_BOARD_RETRY_PROMPT = (
-    "Your previous response could not be parsed as JSON. "
-    "You MUST reply with ONLY a raw JSON object — no markdown, no explanation. "
-    'Example: {"intent":"create_task","summary":"Write Q3 report","entity":{"title":"Q3 report"}}'
-)
-
-_VALID_INTENTS = frozenset({"create_task", "update_goal", "request_approval", "record_decision", "clarify"})
-_THINK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
-_CEO_CHAT_TIMEOUT = 30  # seconds — fast model; qwen3.5:9b was hanging >60s
+# #11501 T2: the bespoke phi3 intent-classifier (prompts, JSON extraction,
+# intent dispatch) is retired — the board LLM now uses the shared chat pipeline
+# + LLC tools. See CeoChatService._run_pipeline.
 
 _AUTHOR_HUMAN = "human"
 _AUTHOR_SYSTEM = "system"
+
+
+def _get_workflow_manager():
+    """Return the shared chat-workflow manager (#11501 T2).
+
+    Wrapped so the heavy chat_workflow import is lazy and tests can patch this
+    without importing the full pipeline.
+    """
+    from chat_workflow import get_chat_workflow_manager
+
+    return get_chat_workflow_manager()
 
 
 class CeoChatService(LLCServiceBase):
@@ -143,34 +132,26 @@ class CeoChatService(LLCServiceBase):
         decision_chunks = await self._query_decisions(company_id, message)
         kb_chunks = kb_chunks + decision_chunks
 
-        # 3. LLM resolution
-        resolution = await self._resolve_via_llm(
+        # 3-6. Delegate to the shared chat pipeline (#11501 T2). The board LLM
+        # gets the same /chat experience and creates work objects via the LLC
+        # tools (create_task/update_goal/request_approval/record_decision),
+        # company-scoped from context. Retires the bespoke phi3 intent-classifier
+        # that always fell back to "clarify" (KeyError('"intent"')).
+        reply_body, entity_type, entity_id = await self._run_pipeline(
+            thread_id=thread_id,
             message=message,
-            kb_chunks=kb_chunks,
-            company_name=company_name,
-            conversation_id=thread_id,
-        )
-
-        # 4. Act on resolved intent (company_id resolved above in step 2)
-        entity_type, entity_id = await self._dispatch_intent(
-            session=session,
             company_id=company_id,
-            resolution=resolution,
+            user_id=user_id,
+            kb_chunks=kb_chunks,
         )
 
-        # 5. Update thread resolution fields when we created/updated an entity
         if entity_type and entity_id:
             await session.execute(
                 update(LLCCeoChatThread)
                 .where(LLCCeoChatThread.id == thread_id)
-                .values(
-                    resolved_entity_type=entity_type,
-                    resolved_entity_id=entity_id,
-                )
+                .values(resolved_entity_type=entity_type, resolved_entity_id=entity_id)
             )
 
-        # 6. Build and persist system reply
-        reply_body = self._build_reply(resolution, entity_type, entity_id)
         system_msg = LLCCeoChatMessage(
             thread_id=thread_id,
             author_type=_AUTHOR_SYSTEM,
@@ -180,6 +161,46 @@ class CeoChatService(LLCServiceBase):
         session.add(system_msg)
         await session.flush()
         return system_msg
+
+    async def _run_pipeline(
+        self,
+        *,
+        thread_id: str,
+        message: str,
+        company_id: str,
+        user_id: Optional[str],
+        kb_chunks: List[str],
+    ) -> tuple[str, Optional[str], Optional[str]]:
+        """Run the board message through the shared chat pipeline (#11501 T2).
+
+        Returns (reply_text, entity_type, entity_id). company_id/user_id go in
+        the context so the LLC tools (create_task/...) execute company-scoped;
+        the thread_id is the chat session_id. Company-KB chunks are prepended as
+        grounding. Reply is the last ``response`` message; the created entity (if
+        any) is read from the LLC tool-result metadata.
+        """
+        grounded = message
+        if kb_chunks:
+            grounded = "Company context:\n" + "\n".join(kb_chunks[:5]) + "\n\n---\n\n" + message
+        context = {"company_id": company_id, "user_id": user_id or ""}
+
+        reply_parts: List[str] = []
+        entity_type: Optional[str] = None
+        entity_id: Optional[str] = None
+        manager = _get_workflow_manager()
+        async for msg in manager.process_message_stream(thread_id, grounded, context):
+            mtype = getattr(msg, "type", None)
+            content = getattr(msg, "content", "") or ""
+            meta = getattr(msg, "metadata", None) or {}
+            if mtype == "response" and content:
+                reply_parts.append(content)
+            result = meta.get("result") if isinstance(meta, dict) else None
+            if isinstance(result, dict) and result.get("entity_type") and result.get("entity_id"):
+                entity_type = result["entity_type"]
+                entity_id = result["entity_id"]
+
+        reply = reply_parts[-1] if reply_parts else "Done."
+        return reply, entity_type, entity_id
 
     # --------------------------------------------------------------- Helpers
 
@@ -218,172 +239,3 @@ class CeoChatService(LLCServiceBase):
         except Exception as exc:
             logger.warning("Decisions RAG query failed for company %s: %s", company_id, exc)
             return []
-
-    @staticmethod
-    def _extract_json(raw: str) -> Dict[str, Any]:
-        """Strip think blocks + prose and extract the first balanced JSON object."""
-        # Remove <think>…</think> reasoning blocks emitted by some models.
-        cleaned = _THINK_RE.sub("", raw).strip()
-        # Strip markdown fences.
-        cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.MULTILINE)
-        cleaned = re.sub(r"\s*```$", "", cleaned, flags=re.MULTILINE).strip()
-        # Find the first balanced { … } block.
-        start = cleaned.find("{")
-        if start == -1:
-            raise ValueError("No JSON object found in LLM response")
-        depth, end = 0, -1
-        for i, ch in enumerate(cleaned[start:], start):
-            if ch == "{":
-                depth += 1
-            elif ch == "}":
-                depth -= 1
-                if depth == 0:
-                    end = i
-                    break
-        if end == -1:
-            raise ValueError("Unbalanced JSON braces in LLM response")
-        return json.loads(cleaned[start : end + 1])
-
-    async def _resolve_via_llm(
-        self,
-        *,
-        message: str,
-        kb_chunks: List[str],
-        company_name: str,
-        conversation_id: str,
-    ) -> Dict[str, Any]:
-        """Call the LLM and return parsed resolution dict.
-
-        Uses a fast non-thinking model (light_processing_model, default phi3:mini)
-        with Ollama JSON mode (structured_output=True) so responses are reliably
-        machine-parseable.  Falls back to clarify only after one retry.
-        """
-        try:
-            svc = _llm_service_mod.get_llm_service()
-            fast_model: str = _cfg.light_processing_model  # phi3:mini by default
-            context = "\n".join(kb_chunks) if kb_chunks else ""
-            system_prompt = _BOARD_SYSTEM_PROMPT.format(company_name=company_name)
-
-            messages: List[Dict[str, str]] = [
-                {
-                    "role": "system",
-                    "content": f"{system_prompt}\n\nContext:\n{context}" if context else system_prompt,
-                },
-                {"role": "user", "content": message},
-            ]
-
-            async def _call(msgs: List[Dict[str, str]]) -> str:
-                resp = await svc.chat(
-                    messages=msgs,
-                    conversation_id=conversation_id,
-                    llm_type=LLMType.EXTRACTION,
-                    model_name=fast_model,
-                    structured_output=True,  # → Ollama format:"json"
-                    timeout=_CEO_CHAT_TIMEOUT,
-                    use_cache=False,  # don't serve stale/empty cached failures
-                )
-                if resp.error:
-                    raise RuntimeError(f"LLM provider error: {resp.error}")
-                return (resp.content or "").strip()
-
-            # First attempt.
-            raw = await _call(messages)
-            try:
-                parsed = self._extract_json(raw)
-            except (ValueError, json.JSONDecodeError):
-                # Retry once with an explicit reminder to return only JSON.
-                logger.debug("CEO chat JSON parse failed on first attempt, retrying")
-                messages.append({"role": "assistant", "content": raw})
-                messages.append({"role": "user", "content": _BOARD_RETRY_PROMPT})
-                raw = await _call(messages)
-                parsed = self._extract_json(raw)
-
-            intent = parsed.get("intent", "clarify")
-            if intent not in _VALID_INTENTS:
-                logger.warning("CEO chat: unknown intent %r — treating as clarify", intent)
-                parsed["intent"] = "clarify"
-            return parsed
-
-        except Exception as exc:
-            logger.warning("LLM resolution failed: %s", exc)
-            return {"intent": "clarify", "summary": "I couldn't understand that — could you rephrase?", "entity": {}}
-
-    async def _dispatch_intent(
-        self,
-        *,
-        session: AsyncSession,
-        company_id: str,
-        resolution: Dict[str, Any],
-    ) -> tuple[Optional[str], Optional[uuid.UUID]]:
-        """Call the appropriate LLC service and return (entity_type, entity_id)."""
-        intent = resolution.get("intent", "clarify")
-        entity_data = resolution.get("entity", {})
-
-        try:
-            if intent == "create_task":
-                from ..models.enums import WorkItemPriority, WorkItemType
-                from .work_item_service import WorkItemService
-
-                item_svc = WorkItemService()
-                item = await item_svc.create(
-                    session,
-                    company_id=company_id,
-                    type=WorkItemType.TASK,
-                    title=entity_data.get("title", resolution.get("summary", "CEO Chat Task")),
-                    description=entity_data.get("description"),
-                    priority=WorkItemPriority(entity_data.get("priority", "medium")),
-                )
-                return "work_item", item.id
-
-            if intent == "update_goal":
-                goal_id = entity_data.get("goal_id")
-                if goal_id:
-                    from .goal import GoalService
-
-                    goal_svc = GoalService()
-                    updates = {k: v for k, v in entity_data.items() if k != "goal_id"}
-                    await goal_svc.update(session, goal_id=goal_id, **updates)
-                    return "goal", uuid.UUID(goal_id)
-
-            if intent == "request_approval":
-                from ..models.enums import ApprovalType
-                from .approval import ApprovalService
-
-                appr_svc = ApprovalService()
-                appr = await appr_svc.create(
-                    session,
-                    company_id=company_id,
-                    type=ApprovalType(entity_data.get("type", "general")),
-                    requested_by_agent_id=entity_data.get("agent_id", str(uuid.uuid4())),
-                    payload=entity_data,
-                )
-                return "approval", appr.id
-
-            if intent == "record_decision":
-                # No external service call — the thread itself is the record.
-                return "decision", None
-
-        except Exception as exc:
-            logger.warning("Intent dispatch failed for intent=%s: %s", intent, exc)
-
-        return None, None
-
-    @staticmethod
-    def _build_reply(
-        resolution: Dict[str, Any],
-        entity_type: Optional[str],
-        entity_id: Optional[uuid.UUID],
-    ) -> str:
-        intent = resolution.get("intent", "clarify")
-        summary = resolution.get("summary", "")
-
-        if intent == "clarify":
-            return f"Could you clarify? {summary}"
-
-        if not entity_type:
-            return f"Resolved as '{intent}': {summary} (no entity created due to missing context)."
-
-        if entity_id:
-            return f"Resolved as '{intent}': {summary}. Created {entity_type} [{entity_id}]."
-
-        return f"Resolved as '{intent}': {summary}. Recorded as {entity_type}."

--- a/autobot-backend/llc/tests/test_agent_tools.py
+++ b/autobot-backend/llc/tests/test_agent_tools.py
@@ -94,9 +94,7 @@ async def test_create_task_calls_work_item_service_with_authed_actor():
     svc = MagicMock()
     svc.create = AsyncMock(return_value=item)
     with p, patch("llc.services.work_item_service.WorkItemService", return_value=svc):
-        out = await dispatch_llc_tool(
-            "create_task", {"title": "Write Q3 report", "priority": "high"}, _COMPANY, _USER
-        )
+        out = await dispatch_llc_tool("create_task", {"title": "Write Q3 report", "priority": "high"}, _COMPANY, _USER)
     assert out["status"] == "success" and out["entity_type"] == "work_item"
     assert svc.create.await_args.kwargs["company_id"] == _COMPANY
     assert svc.create.await_args.kwargs["title"] == "Write Q3 report"

--- a/autobot-backend/llc/tests/test_ceo_chat.py
+++ b/autobot-backend/llc/tests/test_ceo_chat.py
@@ -117,144 +117,100 @@ async def test_list_threads(svc: CeoChatService) -> None:
     assert len(found) == 3
 
 
-# --------------------------------- send — RAG + LLM mocked
+# --------------------------------- send — delegates to the chat pipeline (#11501 T2)
+
+
+class _Msg:
+    """Minimal stand-in for a WorkflowMessage from the pipeline stream."""
+
+    def __init__(self, type="response", content="", metadata=None):
+        self.type = type
+        self.content = content
+        self.metadata = metadata or {}
 
 
 @pytest.mark.asyncio
-async def test_send_clarify_intent(svc: CeoChatService) -> None:
-    """send() with LLM returning 'clarify' stores no entity and returns system msg."""
+async def test_send_delegates_to_pipeline_and_persists(svc: CeoChatService) -> None:
+    """send() persists the human msg, delegates to _run_pipeline, and persists
+    the pipeline reply as the system message; updates thread on entity."""
     thread_id = str(uuid.uuid4())
-    session = AsyncMock()
-    session.flush = AsyncMock()
-    # get_thread call
     thread = _make_thread()
     thread.company_id = "co1"
-
+    session = AsyncMock()
+    session.flush = AsyncMock()
     with (
         patch.object(svc, "_rag_query", new=AsyncMock(return_value=[])),
-        patch.object(
-            svc,
-            "_resolve_via_llm",
-            new=AsyncMock(return_value={"intent": "clarify", "summary": "Need more info", "entity": {}}),
-        ),
+        patch.object(svc, "_query_decisions", new=AsyncMock(return_value=[])),
         patch.object(svc, "get_thread", new=AsyncMock(return_value=thread)),
+        patch.object(svc, "_run_pipeline", new=AsyncMock(return_value=("Created the task.", "work_item", "wi-1"))),
     ):
-        msg = await svc.send(session, thread_id=thread_id, message="hello", user_id=None)
-
+        msg = await svc.send(session, thread_id=thread_id, message="Create a Q3 task", user_id="u1")
     assert msg.author_type == "system"
-    assert "clarify" in msg.body.lower() or "could you" in msg.body.lower()
-    # Two flush calls: one for human_msg, one for system_msg
-    assert session.flush.await_count == 2
+    assert msg.body == "Created the task."
+    assert session.flush.await_count == 2  # human + system
+    session.execute.assert_awaited()  # thread resolution updated (entity present)
 
 
 @pytest.mark.asyncio
-async def test_send_create_task_intent(svc: CeoChatService) -> None:
-    """send() with 'create_task' intent delegates to WorkItemService."""
+async def test_send_no_entity_skips_thread_update(svc: CeoChatService) -> None:
     thread_id = str(uuid.uuid4())
     thread = _make_thread()
     thread.company_id = "co1"
-
-    fake_item = MagicMock()
-    fake_item.id = uuid.uuid4()
-
     session = AsyncMock()
     session.flush = AsyncMock()
-
-    with (
-        patch.object(svc, "_rag_query", new=AsyncMock(return_value=["some context"])),
-        patch.object(
-            svc,
-            "_resolve_via_llm",
-            new=AsyncMock(
-                return_value={
-                    "intent": "create_task",
-                    "summary": "Create Q3 roadmap task",
-                    "entity": {"title": "Q3 Roadmap"},
-                }
-            ),
-        ),
-        patch.object(svc, "get_thread", new=AsyncMock(return_value=thread)),
-        patch.object(svc, "_dispatch_intent", new=AsyncMock(return_value=("work_item", fake_item.id))),
-    ):
-        msg = await svc.send(session, thread_id=thread_id, message="Create a Q3 roadmap task", user_id=None)
-
-    assert msg.author_type == "system"
-    assert "work_item" in msg.body or "Resolved" in msg.body
-
-
-@pytest.mark.asyncio
-async def test_send_record_decision_intent(svc: CeoChatService) -> None:
-    """send() with 'record_decision' creates no external entity."""
-    thread_id = str(uuid.uuid4())
-    thread = _make_thread()
-    thread.company_id = "co1"
-
-    session = AsyncMock()
-    session.flush = AsyncMock()
-
     with (
         patch.object(svc, "_rag_query", new=AsyncMock(return_value=[])),
-        patch.object(
-            svc,
-            "_resolve_via_llm",
-            new=AsyncMock(return_value={"intent": "record_decision", "summary": "Approved budget", "entity": {}}),
-        ),
+        patch.object(svc, "_query_decisions", new=AsyncMock(return_value=[])),
         patch.object(svc, "get_thread", new=AsyncMock(return_value=thread)),
+        patch.object(svc, "_run_pipeline", new=AsyncMock(return_value=("Here's some info.", None, None))),
     ):
-        msg = await svc.send(session, thread_id=thread_id, message="We approved the budget", user_id=None)
-
-    assert msg.author_type == "system"
-    assert "decision" in msg.body.lower() or "Recorded" in msg.body
-
-
-# --------------------------------- build_reply
+        msg = await svc.send(session, thread_id=thread_id, message="what's our runway?", user_id="u1")
+    assert msg.body == "Here's some info."
+    session.execute.assert_not_awaited()  # no entity → no resolution update
 
 
-def test_build_reply_clarify() -> None:
-    body = CeoChatService._build_reply({"intent": "clarify", "summary": "Need more info", "entity": {}}, None, None)
-    assert "clarify" in body.lower() or "could you" in body.lower()
+@pytest.mark.asyncio
+async def test_run_pipeline_collects_reply_and_entity(svc: CeoChatService) -> None:
+    """_run_pipeline returns the last 'response' content + the LLC tool entity,
+    and passes company_id/user_id in the context."""
+
+    async def _fake_stream(session_id, message, context):
+        assert context["company_id"] == "co1" and context["user_id"] == "u1"
+        assert session_id == "t1"
+        yield _Msg("thought", "thinking...")
+        yield _Msg("command_output", "Done", {"result": {"entity_type": "work_item", "entity_id": "wi-9"}})
+        yield _Msg("response", "Created the Q3 task for you.")
+
+    fake_mgr = MagicMock()
+    fake_mgr.process_message_stream = _fake_stream
+    with patch("llc.services.ceo_chat._get_workflow_manager", return_value=fake_mgr):
+        reply, etype, eid = await svc._run_pipeline(
+            thread_id="t1", message="Create a Q3 task", company_id="co1", user_id="u1", kb_chunks=["ctx"]
+        )
+    assert reply == "Created the Q3 task for you."
+    assert etype == "work_item" and eid == "wi-9"
 
 
-def test_build_reply_create_task_with_entity() -> None:
-    eid = uuid.uuid4()
-    body = CeoChatService._build_reply(
-        {"intent": "create_task", "summary": "Created task", "entity": {}},
-        "work_item",
-        eid,
-    )
-    assert str(eid) in body
-    assert "work_item" in body
+@pytest.mark.asyncio
+async def test_run_pipeline_default_reply_when_no_response(svc: CeoChatService) -> None:
+    async def _fake_stream(session_id, message, context):
+        yield _Msg("thought", "hmm")
+
+    fake_mgr = MagicMock()
+    fake_mgr.process_message_stream = _fake_stream
+    with patch("llc.services.ceo_chat._get_workflow_manager", return_value=fake_mgr):
+        reply, etype, eid = await svc._run_pipeline(
+            thread_id="t1", message="hi", company_id="co1", user_id=None, kb_chunks=[]
+        )
+    assert reply == "Done." and etype is None and eid is None
 
 
-def test_build_reply_no_entity_created() -> None:
-    body = CeoChatService._build_reply(
-        {"intent": "create_task", "summary": "Failed to create task", "entity": {}},
-        None,
-        None,
-    )
-    assert "no entity" in body.lower()
-
-
-def test_build_reply_decision_no_entity_id() -> None:
-    body = CeoChatService._build_reply(
-        {"intent": "record_decision", "summary": "Approved budget", "entity": {}},
-        "decision",
-        None,
-    )
-    assert "decision" in body.lower()
-
-
-# --------------------------------- RAG helper
+# --------------------------------- _rag_query graceful failure (preserved)
 
 
 @pytest.mark.asyncio
 async def test_rag_query_graceful_failure(svc: CeoChatService) -> None:
-    """_rag_query returns [] when ChromaDB is unavailable.
-
-    The source does a local ``from utils.async_chromadb_client import ...``
-    inside the try block, so we simulate unavailability by temporarily removing
-    the module from sys.modules so the import raises ImportError.
-    """
+    """_rag_query returns [] when ChromaDB is unavailable."""
     import sys
 
     sentinel = object()
@@ -268,144 +224,3 @@ async def test_rag_query_graceful_failure(svc: CeoChatService) -> None:
         else:
             sys.modules["utils.async_chromadb_client"] = orig
     assert result == []
-
-
-# --------------------------------- LLM helper — malformed JSON
-
-
-@pytest.mark.asyncio
-async def test_resolve_via_llm_malformed_json(svc: CeoChatService) -> None:
-    """_resolve_via_llm falls back to 'clarify' on malformed LLM output (both attempts)."""
-    mock_response = MagicMock()
-    mock_response.content = "NOT JSON"
-    mock_response.error = None
-    mock_svc = MagicMock()
-    mock_svc.chat = AsyncMock(return_value=mock_response)
-
-    with patch("llc.services.ceo_chat._llm_service_mod.get_llm_service", return_value=mock_svc):
-        resolution = await svc._resolve_via_llm(
-            message="hello",
-            kb_chunks=[],
-            company_name="ACME",
-            conversation_id="t1",
-        )
-
-    assert resolution["intent"] == "clarify"
-    # Friendly message — not a raw exception string.
-    assert "exception" not in resolution["summary"].lower()
-    assert resolution["summary"]
-
-
-# --------------------------------- _extract_json parser
-
-
-def test_extract_json_clean() -> None:
-    raw = '{"intent":"create_task","summary":"ok","entity":{}}'
-    result = CeoChatService._extract_json(raw)
-    assert result["intent"] == "create_task"
-
-
-def test_extract_json_think_block_stripped() -> None:
-    raw = "<think>I should parse this carefully.</think>\n" '{"intent":"create_task","summary":"ok","entity":{}}'
-    result = CeoChatService._extract_json(raw)
-    assert result["intent"] == "create_task"
-
-
-def test_extract_json_prose_wrapper() -> None:
-    raw = (
-        'Here is my answer:\n```json\n{"intent":"update_goal","summary":"raise target","entity":{"goal_id":"g1"}}\n```'
-    )
-    result = CeoChatService._extract_json(raw)
-    assert result["intent"] == "update_goal"
-
-
-def test_extract_json_think_plus_prose() -> None:
-    """Models that emit <think> blocks AND wrap in prose are handled correctly."""
-    raw = (
-        "<think>Let me think step by step.</think>\n"
-        "Sure! Here is the JSON:\n"
-        '{"intent":"record_decision","summary":"approved","entity":{}}\n'
-        "That should be all."
-    )
-    result = CeoChatService._extract_json(raw)
-    assert result["intent"] == "record_decision"
-
-
-def test_extract_json_no_object_raises() -> None:
-    import pytest as _pytest
-
-    with _pytest.raises((ValueError, Exception)):
-        CeoChatService._extract_json("no json here at all")
-
-
-# --------------------------------- _resolve_via_llm retry path
-
-
-@pytest.mark.asyncio
-async def test_resolve_via_llm_recovers_on_retry(svc: CeoChatService) -> None:
-    """First response has think block + prose; second attempt returns clean JSON."""
-    first = MagicMock()
-    first.content = "<think>thinking…</think>\nHere you go: some prose before the JSON"
-    first.error = None
-
-    second = MagicMock()
-    second.content = '{"intent":"create_task","summary":"Write Q3 report","entity":{"title":"Q3 report"}}'
-    second.error = None
-
-    mock_svc = MagicMock()
-    mock_svc.chat = AsyncMock(side_effect=[first, second])
-
-    with patch("llc.services.ceo_chat._llm_service_mod.get_llm_service", return_value=mock_svc):
-        result = await svc._resolve_via_llm(
-            message="Create a task to write the Q3 report",
-            kb_chunks=[],
-            company_name="TestCo",
-            conversation_id="verify",
-        )
-
-    assert result["intent"] == "create_task"
-    assert mock_svc.chat.await_count == 2
-
-
-@pytest.mark.asyncio
-async def test_resolve_via_llm_think_block_recovered_first_pass(svc: CeoChatService) -> None:
-    """Think block on first response — parser should extract JSON without needing retry."""
-    resp = MagicMock()
-    resp.content = (
-        "<think>I should figure out the intent.</think>"
-        '{"intent":"create_task","summary":"Draft Q3 report","entity":{"title":"Q3 report"}}'
-    )
-    resp.error = None
-    mock_svc = MagicMock()
-    mock_svc.chat = AsyncMock(return_value=resp)
-
-    with patch("llc.services.ceo_chat._llm_service_mod.get_llm_service", return_value=mock_svc):
-        result = await svc._resolve_via_llm(
-            message="Create a task to write the Q3 report",
-            kb_chunks=[],
-            company_name="TestCo",
-            conversation_id="verify",
-        )
-
-    assert result["intent"] == "create_task"
-    # Only one LLM call needed — parser succeeded first pass.
-    assert mock_svc.chat.await_count == 1
-
-
-@pytest.mark.asyncio
-async def test_resolve_via_llm_unknown_intent_becomes_clarify(svc: CeoChatService) -> None:
-    resp = MagicMock()
-    resp.content = '{"intent":"do_something_weird","summary":"x","entity":{}}'
-    resp.error = None
-    mock_svc = MagicMock()
-    mock_svc.chat = AsyncMock(return_value=resp)
-
-    with patch("llc.services.ceo_chat._llm_service_mod.get_llm_service", return_value=mock_svc):
-        result = await svc._resolve_via_llm(
-            message="Do something weird",
-            kb_chunks=[],
-            company_name="Acme",
-            conversation_id="t",
-        )
-
-    assert result["intent"] == "clarify"

--- a/autobot-backend/llc/tests/test_ceo_chat.py
+++ b/autobot-backend/llc/tests/test_ceo_chat.py
@@ -224,3 +224,46 @@ async def test_rag_query_graceful_failure(svc: CeoChatService) -> None:
         else:
             sys.modules["utils.async_chromadb_client"] = orig
     assert result == []
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_joins_multi_segment_responses(svc: CeoChatService) -> None:
+    """#11525 review: prose answer interrupted by a thought yields two response
+    segments (distinct ids) — both must survive, not just the last."""
+
+    async def _stream(session_id, message, context):
+        a = _Msg("response", "Our runway is 14 months.", {})
+        a.id = "seg1"
+        b = _Msg("response", "We should raise in Q3.", {})
+        b.id = "seg2"
+        yield a
+        yield b
+
+    fake_mgr = MagicMock()
+    fake_mgr.process_message_stream = _stream
+    with patch("llc.services.ceo_chat._get_workflow_manager", return_value=fake_mgr):
+        reply, _, _ = await svc._run_pipeline(
+            thread_id="t1", message="runway?", company_id="co1", user_id="u1", kb_chunks=[]
+        )
+    assert "14 months" in reply and "raise in Q3" in reply  # both segments preserved
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_snapshots_same_id_take_latest(svc: CeoChatService) -> None:
+    """Cumulative streaming snapshots share an id — keep the latest (full) one."""
+
+    async def _stream(session_id, message, context):
+        a = _Msg("response", "Created", {})
+        a.id = "r1"
+        b = _Msg("response", "Created the Q3 task.", {})
+        b.id = "r1"
+        yield a
+        yield b
+
+    fake_mgr = MagicMock()
+    fake_mgr.process_message_stream = _stream
+    with patch("llc.services.ceo_chat._get_workflow_manager", return_value=fake_mgr):
+        reply, _, _ = await svc._run_pipeline(
+            thread_id="t1", message="task", company_id="co1", user_id="u1", kb_chunks=[]
+        )
+    assert reply == "Created the Q3 task."  # snapshot replaced, not duplicated


### PR DESCRIPTION
## Thinking Path
T1 gave the chat agent the LLC tools. T2 makes CEO chat actually use them: it now delegates to the SAME pipeline as `/chat` and retires the broken phi3 intent-classifier (`KeyError('"intent"')` double-`.format` → always "clarify"). Owner-approved approach: context-scoped prompt hook (tools taught only on the CEO-chat path). Fixes the user-reported CEO-chat bug; #11501 T2.

## What Changed
- **`llc/services/ceo_chat.py`**: `send()` → `_run_pipeline()` which calls `ChatWorkflowManager.process_message_stream(thread_id, message, {company_id, user_id})`, collects the final `response` text + the LLC tool-result entity (from message metadata), persists the reply, updates thread resolution. Company-KB/decisions RAG kept as grounding (prepended). **Deleted** `_resolve_via_llm`, `_dispatch_intent`, `_build_reply`, `_extract_json`, `_BOARD_SYSTEM_PROMPT`, `_BOARD_RETRY_PROMPT`, `_VALID_INTENTS`, `_THINK_RE` + now-unused imports (also kills the dead `ApprovalService.create()` call). `_get_workflow_manager()` indirection keeps the import lazy + patchable.
- **context-scoped tool teaching**: `manager` stores `company_id` in `session.metadata`; `llm_handler._get_system_prompt(company_id=...)` appends `LLC_TOOL_PROMPT` **only when company_id is set** — board tools are never advertised in general chat (no scope leakage).
- **`llc/agent_tools.py`**: `LLC_TOOL_PROMPT` (the `<TOOL_CALL>` teaching for the 4 tools).
- **tests**: pipeline delegation + persistence, no-entity path, `_run_pipeline` reply+entity collection with company_id/user_id assertion, default reply, RAG graceful-failure. 10 ceo_chat + 11 agent_tools pass.

## Verification
- `pytest llc/tests/test_ceo_chat.py llc/tests/test_agent_tools.py` → 21 passed, 1 skipped; flake8 + isort clean; `ast.parse` on all 4 edited modules.

## Follow-ups (#11501)
- **T3**: frontend `CeoChatView` reuses the `/chat` streaming UX. **T4**: live E2E on the box (message → work item created + natural reply).

## Model Used
Claude Fable 5 (1M context)
