### PR TITLE
ci(ui): stylelint token guard for changed frontend CSS/Vue (#11515 Task 1)

### DIFF
--- a/.github/workflows/stylelint-tokens.yml
+++ b/.github/workflows/stylelint-tokens.yml
@@ -1,0 +1,56 @@
+name: Stylelint Token Guard
+
+# Tokenisation enforcement scaffold (#11515 Task 1). Reports hardcoded hex colors
+# in CHANGED frontend CSS/Vue files so new hardcoded values are visible in review.
+#
+# NON-BLOCKING for now (continue-on-error): the ~6k pre-existing violations mean a
+# hard gate would block every frontend PR until migration completes. This job
+# surfaces new offenders without failing the queue. Once the worst offenders are
+# migrated (#11515 Task 4) and the config is validated, flip continue-on-error off
+# and add this to branch protection (#11515 Task 1.3).
+#
+# stylelint is installed ad-hoc with --no-save so no package.json / package-lock
+# change is required (the repo lockfiles are not regenerable in the dev env).
+
+on:
+  pull_request:
+    paths:
+      - "autobot-frontend/**/*.vue"
+      - "autobot-frontend/**/*.css"
+
+permissions:
+  contents: read
+
+jobs:
+  stylelint-changed:
+    name: Stylelint (changed CSS/Vue)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Determine changed frontend CSS/Vue files
+        id: changed
+        env:
+          # Untrusted-ish inputs handled via env (never interpolated into the
+          # shell command directly) to avoid workflow command injection.
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch origin "$BASE_REF" --depth=1 || true
+          git diff --name-only "origin/${BASE_REF}...HEAD" -- \
+            'autobot-frontend/**/*.vue' 'autobot-frontend/**/*.css' > changed-css.txt || true
+          count=$(wc -l < changed-css.txt | tr -d ' ')
+          echo "count=${count:-0}" >> "$GITHUB_OUTPUT"
+          echo "Changed CSS/Vue files: ${count:-0}"
+          cat changed-css.txt || true
+      - name: Run stylelint on changed files (report-only)
+        if: steps.changed.outputs.count != '0'
+        run: |
+          npm install --no-save --no-package-lock stylelint@^16 postcss-html@^1.6 >/dev/null 2>&1
+          # Read the file list from disk (not interpolated) and pass via xargs so
+          # filenames can't inject shell. Config path is repo-relative and fixed.
+          xargs -a changed-css.txt npx stylelint --config autobot-frontend/.stylelintrc.json

--- a/.github/workflows/stylelint-tokens.yml
+++ b/.github/workflows/stylelint-tokens.yml
@@ -17,6 +17,9 @@ on:
     paths:
       - "autobot-frontend/**/*.vue"
       - "autobot-frontend/**/*.css"
+      # Self-validate when the guard or its config changes.
+      - "autobot-frontend/.stylelintrc.json"
+      - ".github/workflows/stylelint-tokens.yml"
 
 permissions:
   contents: read

--- a/autobot-frontend/.stylelintrc.json
+++ b/autobot-frontend/.stylelintrc.json
@@ -1,0 +1,16 @@
+{
+  "overrides": [
+    {
+      "files": ["**/*.vue"],
+      "customSyntax": "postcss-html"
+    }
+  ],
+  "rules": {
+    "color-no-hex": [
+      true,
+      {
+        "message": "Hardcoded hex color — use a design token, e.g. var(--color-…) (tokenisation umbrella #11515). A var(--token, #fallback) fallback is still flagged here; migrate the raw value first."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Thinking Path
First step of the tokenisation umbrella #11515 — an enforcement gate so new hardcoded values stop landing (the root cause of recurring UI drift). Designed around two hard constraints: (1) ~6k pre-existing violations mean a hard repo-wide gate would block every frontend PR; (2) the dev env has no working npm/lockfile regen, so I cannot add stylelint as a devDependency.

## What Changed
- **`autobot-frontend/.stylelintrc.json`** — `color-no-hex` rule (`postcss-html` syntax for `.vue`), with a message pointing at the tokenisation umbrella.
- **`.github/workflows/stylelint-tokens.yml`** — a **non-blocking** (`continue-on-error`) workflow that, on frontend CSS/Vue PRs, runs stylelint on the **changed files only** (ratchet). stylelint is installed ad-hoc via `npm install --no-save` (no `package.json`/lockfile change). Injection-safe: `github.base_ref` via `env`, changed-file list read from disk via `xargs`.

## Why non-blocking (for now)
It surfaces new hardcoded hex colors in review without failing the queue. Once the worst offenders are migrated (Task 4) and the config is validated in real CI, we flip `continue-on-error` off and add it to branch protection (Task 1.3).

## Verification
- Workflow YAML + `.stylelintrc.json` parse clean.
- Injection review: no untrusted input interpolated into `run:` (base_ref in `env:`, file list via `xargs -a`).
- Note: stylelint itself is CI-validated — the dev env cannot run npm to execute it locally.

## Follow-ups (umbrella)
- Task 1.2: same guard for `autobot-slm-frontend`. Task 1.3: flip to required. Px/sizing rule is a separate harder sub-task (needs 1px/border nuance).

## Model Used
Opus 4.8

Refs #11515