### PR TITLE
fix(slm-ui): define the semantic tokens SLM components reference (#11515 Task 2.1)

### DIFF
--- a/autobot-slm-frontend/src/assets/styles/main.css
+++ b/autobot-slm-frontend/src/assets/styles/main.css
@@ -117,6 +117,49 @@
   --a11y-sidebar-active: #0284c7;
 }
 
+/* ─── Semantic token aliases (#11515 Task 2.1) ────────────────────
+ * SLM components were written against user-frontend token names
+ * (--text-primary, --bg-secondary, --border-color, --color-primary, …)
+ * that were never defined here, so every `var(--text-primary, #fallback)`
+ * silently used its hardcoded fallback and ignored the theme. Map those
+ * names onto the real SLM tokens: the theme-adaptive --a11y-* set (redefined
+ * per :root / [data-theme='dark'] / [data-theme='high-contrast']) for
+ * surface/text/border, and the --color-*-500 scale for brand/status. var() is
+ * resolved at use-time, so these resolve to the ACTIVE theme's values. */
+:root {
+  /* Text */
+  --text-primary: var(--a11y-text);
+  --text-secondary: var(--a11y-text-muted);
+  --text-muted: var(--a11y-text-muted);
+  /* Surfaces */
+  --bg-primary: var(--a11y-bg);
+  --bg-secondary: var(--a11y-bg-surface);
+  --bg-tertiary: var(--a11y-bg-muted);
+  --bg-hover: var(--a11y-bg-muted);
+  /* Border */
+  --border-color: var(--a11y-border);
+  /* Brand / accent */
+  --color-primary: var(--color-primary-500);
+  --primary-color: var(--color-primary-500);
+  --primary: var(--color-primary-500);
+  --color-accent: var(--color-primary-500);
+  /* Status foregrounds */
+  --color-success: var(--color-success-500);
+  --success-color: var(--color-success-500);
+  --color-warning: var(--color-warning-500);
+  --warning-color: var(--color-warning-500);
+  --color-danger: var(--color-danger-500);
+  --danger-color: var(--color-danger-500);
+  --color-info: var(--color-primary-500);
+  --info-color: var(--color-primary-500);
+  /* Status backgrounds — tint the status hue over the active surface so they
+   * stay theme-aware (dark themes get a dark-tinted chip, not a light one). */
+  --success-bg: color-mix(in srgb, var(--color-success-500) 14%, var(--a11y-bg));
+  --warning-bg: color-mix(in srgb, var(--color-warning-500) 14%, var(--a11y-bg));
+  --danger-bg: color-mix(in srgb, var(--color-danger-500) 14%, var(--a11y-bg));
+  --info-bg: color-mix(in srgb, var(--color-primary-500) 14%, var(--a11y-bg));
+}
+
 /* ─── High Contrast Mode (Issue #754) ────────────────────────── */
 
 :root[data-theme='high-contrast'] {


### PR DESCRIPTION
## Thinking Path
Umbrella #11515 Task 2.1. The SLM audit found SLM `.vue` components reference a token vocabulary (`--text-primary`, `--bg-secondary`, `--border-color`, `--color-primary`, …) copied from the *user* frontend but **never defined** in SLM `main.css`. Each `var(--token, #fallback)` therefore silently used its hardcoded fallback and **ignored the active theme** — theming is broken in dark / high-contrast.

## What Changed
- Added a **compatibility-alias block** to `main.css` `:root` mapping every referenced-but-undefined name onto SLM’s real tokens:
  - text / surface / border → the theme-adaptive `--a11y-*` set (redefined per `:root` / `[data-theme=dark]` / `[data-theme=high-contrast]`).
  - brand / status foregrounds → the `--color-*-500` scale.
  - status backgrounds → `color-mix(... over var(--a11y-bg))` so chips stay theme-aware (dark themes get a dark-tinted chip).
- `var()` resolves at use-time, so each alias adapts to the live theme automatically.

## Verification
- CSS braces balanced; `color-mix` syntax valid.
- **Grep proof**: after the change, **zero** `var(--…)` references in SLM `.vue` files remain undefined in `main.css` (all resolve).
- Purely additive — no existing token value changed, so no regression to already-correct styling; the only behavioural change is that the ~24 previously-broken token names now follow the theme instead of a static fallback.

## Note
This fixes the *references*; migrating the remaining hardcoded hex/px in SLM components onto these tokens is Task 4 (batched by worst-offender).

## Model Used
Opus 4.8

Refs #11515