### PR TITLE
feat(llm): persistent cross-worker provider degradation marking (#11519)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         python -m pip install -r requirements-ci.txt --prefer-binary
 
         echo "Installing testing dependencies..."
-        python -m pip install pytest pytest-asyncio pytest-cov pytest-xdist==3.8.0 flake8 black isort mypy bandit
+        python -m pip install pytest pytest-asyncio pytest-cov pytest-xdist==3.8.0 fakeredis flake8 black isort mypy bandit
 
     - name: Create necessary directories and config files
       run: |

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -340,6 +340,9 @@ if "llm_shared" not in sys.modules:
     _load_real_mod("llm_shared.models", _llm_root / "models.py")
     _load_real_mod("llm_shared.optimization.rate_limiter", _llm_root / "optimization" / "rate_limiter.py")
     _load_real_mod("llm_shared.fallback_chain", _llm_root / "fallback_chain.py")
+    # #11519: provider degradation store — load real BEFORE model_fallback_coordinator
+    # and provider_registry which import it at module level.
+    _load_real_mod("llm_shared.provider_degradation", _llm_root / "provider_degradation.py")
     _load_real_mod("llm_shared.model_fallback_coordinator", _llm_root / "model_fallback_coordinator.py")
     # #9017: reasoning_effort utility is imported by chat_workflow.manager at module level;
     # load the real file so tests that import manager don't hit the providers MagicMock stub.

--- a/autobot-backend/llc/tests/test_agent_tools.py
+++ b/autobot-backend/llc/tests/test_agent_tools.py
@@ -94,9 +94,7 @@ async def test_create_task_calls_work_item_service_with_authed_actor():
     svc = MagicMock()
     svc.create = AsyncMock(return_value=item)
     with p, patch("llc.services.work_item_service.WorkItemService", return_value=svc):
-        out = await dispatch_llc_tool(
-            "create_task", {"title": "Write Q3 report", "priority": "high"}, _COMPANY, _USER
-        )
+        out = await dispatch_llc_tool("create_task", {"title": "Write Q3 report", "priority": "high"}, _COMPANY, _USER)
     assert out["status"] == "success" and out["entity_type"] == "work_item"
     assert svc.create.await_args.kwargs["company_id"] == _COMPANY
     assert svc.create.await_args.kwargs["title"] == "Write Q3 report"

--- a/autobot-backend/llm_shared/model_fallback_coordinator.py
+++ b/autobot-backend/llm_shared/model_fallback_coordinator.py
@@ -104,6 +104,7 @@ class ModelFallbackCoordinator:
                     current_model=current_model,
                     attempt_count=attempt + 1,
                     chain_tried=chain_tried,
+                    degraded_skipped=request.metadata.get("degraded_skipped"),
                 )
                 if fallback_used:
                     logger.info(
@@ -169,6 +170,7 @@ class ModelFallbackCoordinator:
             attempt_count=len(chain_tried),
             chain_tried=chain_tried,
             exhausted=True,
+            degraded_skipped=request.metadata.get("degraded_skipped"),
         )
         return last_error_response
 

--- a/autobot-backend/llm_shared/model_fallback_coordinator.py
+++ b/autobot-backend/llm_shared/model_fallback_coordinator.py
@@ -33,6 +33,7 @@ from autobot_shared.singleton_factory import lazy_singleton
 from .fallback_chain import get_fallback_chain_manager
 from .models import LLMRequest, LLMResponse
 from .optimization.rate_limiter import RateLimitError
+from .provider_degradation import get_degradation_store
 
 if TYPE_CHECKING:
     from .provider_registry import ProviderRegistry
@@ -129,6 +130,12 @@ class ModelFallbackCoordinator:
                     )
                     break
 
+                # Mark the exhausted provider:model degraded so sibling workers
+                # skip it immediately (Issue #11519).
+                await get_degradation_store().mark_degraded(
+                    current_provider or "", current_model or None
+                )
+
                 fallback = get_fallback_chain_manager().get_next_fallback(current_model, current_provider)
                 if fallback is None:
                     logger.warning(
@@ -213,6 +220,7 @@ class ModelFallbackCoordinator:
         attempt_count: int,
         chain_tried: list[str],
         exhausted: bool = False,
+        degraded_skipped: list[str] | None = None,
     ) -> None:
         """Extend response.provider_metadata with fallback audit fields."""
         if response.provider_metadata is None:
@@ -227,6 +235,7 @@ class ModelFallbackCoordinator:
                 "attempt_count": attempt_count,
                 "fallback_chain_tried": chain_tried,
                 "fallback_exhausted": exhausted,
+                "degraded_skipped": degraded_skipped or [],
             }
         )
 

--- a/autobot-backend/llm_shared/model_fallback_coordinator.py
+++ b/autobot-backend/llm_shared/model_fallback_coordinator.py
@@ -123,6 +123,20 @@ class ModelFallbackCoordinator:
                     provider=current_provider or "",
                     error=str(exc),
                 )
+                # Mark the exhausted provider:model degraded so sibling workers
+                # skip it immediately (Issue #11519).  Use the provider the
+                # registry actually resolved at dispatch time — the request may
+                # carry no provider at all.  Marking happens before the
+                # max-attempts break so the final provider is marked too.
+                failed_provider = request.metadata.get("selected_provider") or current_provider
+                if failed_provider:
+                    await get_degradation_store().mark_degraded(failed_provider, current_model or None)
+                else:
+                    logger.debug(
+                        "degradation: provider unresolved for model=%r — mark skipped",
+                        current_model,
+                    )
+
                 if attempt >= max_attempts:
                     logger.warning(
                         "quota-fallback: all %d fallback attempts exhausted for model=%r",
@@ -130,12 +144,6 @@ class ModelFallbackCoordinator:
                         primary_model,
                     )
                     break
-
-                # Mark the exhausted provider:model degraded so sibling workers
-                # skip it immediately (Issue #11519).
-                await get_degradation_store().mark_degraded(
-                    current_provider or "", current_model or None
-                )
 
                 fallback = get_fallback_chain_manager().get_next_fallback(current_model, current_provider)
                 if fallback is None:

--- a/autobot-backend/llm_shared/provider_degradation.py
+++ b/autobot-backend/llm_shared/provider_degradation.py
@@ -1,0 +1,144 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Persistent cross-worker provider degradation marking (Issue #11519).
+
+When a provider fails (rate-limit exhaustion, connection error), mark it
+degraded in Redis so ALL uvicorn workers skip it during the TTL window —
+mirroring the cross-worker pattern from cross_worker_rate_limiter.py (#8170).
+
+Key naming: ``autobot:llm:deg:{provider}`` or ``autobot:llm:deg:{provider}:{model}``
+
+TTL is read once at import time from the env var
+``AUTOBOT_PROVIDER_DEGRADATION_TTL_SECONDS`` (default 300 s).  Never
+hard-code the TTL inline.
+
+Graceful fallback: when Redis is unavailable the store switches to an
+in-process dict with expiry timestamps, preserving today's behavior.
+
+Usage::
+
+    from llm_shared.provider_degradation import get_degradation_store
+
+    store = get_degradation_store()
+    await store.mark_degraded("openai", "gpt-4o")
+    if await store.is_degraded("openai", "gpt-4o"):
+        ...
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Dict, Optional, Tuple
+
+from autobot_shared.env_utils import env_int
+from autobot_shared.singleton_factory import lazy_singleton
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level TTL constant — read from env, never hard-coded in call sites.
+# ---------------------------------------------------------------------------
+_DEGRADATION_TTL_SECONDS: int = env_int("AUTOBOT_PROVIDER_DEGRADATION_TTL_SECONDS", 300)
+
+_KEY_PREFIX = "autobot:llm:deg"
+
+
+def _make_key(provider: str, model: Optional[str]) -> str:
+    """Build a Redis key for a provider (optionally scoped to a model)."""
+    if model:
+        return f"{_KEY_PREFIX}:{provider}:{model}"
+    return f"{_KEY_PREFIX}:{provider}"
+
+
+class ProviderDegradationStore:
+    """
+    Redis-backed degradation store shared across all uvicorn workers.
+
+    Falls back to an in-process dict when Redis is unavailable, ensuring
+    a Redis outage never hard-blocks LLM calls.
+    """
+
+    def __init__(self) -> None:
+        # {key: expires_at_monotonic} — used only when Redis is unavailable.
+        self._local: Dict[str, float] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def mark_degraded(self, provider: str, model: Optional[str] = None) -> None:
+        """Mark *provider* (optionally *model*) degraded for the configured TTL."""
+        key = _make_key(provider, model)
+        try:
+            redis = await self._get_redis()
+            await redis.set(key, "1", ex=_DEGRADATION_TTL_SECONDS)
+            logger.info(
+                "degradation: marked %r degraded (TTL=%ds key=%s)",
+                provider if not model else f"{provider}:{model}",
+                _DEGRADATION_TTL_SECONDS,
+                key,
+            )
+        except Exception:
+            logger.debug(
+                "degradation: Redis unavailable — using in-process fallback for %s",
+                key,
+                exc_info=True,
+            )
+            self._local[key] = time.monotonic() + _DEGRADATION_TTL_SECONDS
+
+    async def is_degraded(self, provider: str, model: Optional[str] = None) -> bool:
+        """Return True if *provider* (or *provider*:*model*) is currently degraded."""
+        key = _make_key(provider, model)
+        try:
+            redis = await self._get_redis()
+            result = await redis.exists(key)
+            return bool(result)
+        except Exception:
+            logger.debug("degradation: Redis unavailable — checking in-process fallback")
+            expires_at = self._local.get(key)
+            if expires_at is None:
+                return False
+            if time.monotonic() < expires_at:
+                return True
+            # Expired — clean up.
+            del self._local[key]
+            return False
+
+    async def degraded_entries(self) -> list[str]:
+        """Return the list of currently-degraded keys (for observability)."""
+        try:
+            redis = await self._get_redis()
+            # SCAN is O(N) but safe because the keyspace is tiny.
+            keys: list[bytes | str] = []
+            async for key in redis.scan_iter(f"{_KEY_PREFIX}:*"):
+                keys.append(key)
+            return [k.decode() if isinstance(k, bytes) else k for k in keys]
+        except Exception:
+            now = time.monotonic()
+            return [k for k, exp in list(self._local.items()) if exp > now]
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    async def _get_redis(self):
+        from autobot_shared.redis_client import get_async_redis_client  # noqa: PLC0415
+
+        return await get_async_redis_client()
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+get_degradation_store = lazy_singleton(ProviderDegradationStore)
+
+__all__ = [
+    "ProviderDegradationStore",
+    "get_degradation_store",
+    "_DEGRADATION_TTL_SECONDS",
+]

--- a/autobot-backend/llm_shared/provider_degradation.py
+++ b/autobot-backend/llm_shared/provider_degradation.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional
 
 from autobot_shared.env_utils import env_int
 from autobot_shared.singleton_factory import lazy_singleton
@@ -140,5 +140,4 @@ get_degradation_store = lazy_singleton(ProviderDegradationStore)
 __all__ = [
     "ProviderDegradationStore",
     "get_degradation_store",
-    "_DEGRADATION_TTL_SECONDS",
 ]

--- a/autobot-backend/llm_shared/provider_registry.py
+++ b/autobot-backend/llm_shared/provider_registry.py
@@ -43,6 +43,7 @@ from llm_shared.models import LLMRequest
 from prepared_facts import ProviderRuntimeFact
 
 from .base_provider import BaseProvider
+from .provider_degradation import get_degradation_store
 
 logger = get_logger(__name__)
 
@@ -434,11 +435,38 @@ class ProviderRegistry:
                 candidates.append(name)
 
         primary = candidates[0] if candidates else None
+        model_name: str | None = request.model_name if request else None
+        degradation = get_degradation_store()
+
+        # Determine which candidates are currently degraded (Issue #11519).
+        # All candidates are checked up-front so we can detect the all-degraded
+        # edge case and fall through rather than returning None.
+        degraded_set: set[str] = set()
         for name in candidates:
+            if await degradation.is_degraded(name, model_name):
+                degraded_set.add(name)
+        all_degraded = len(candidates) > 0 and degraded_set == set(candidates)
+        if all_degraded and degraded_set:
+            logger.warning(
+                "degradation: all %d candidates degraded — proceeding anyway",
+                len(candidates),
+            )
+
+        degraded_skipped: list[str] = []
+        for name in candidates:
+            if name in degraded_set and not all_degraded:
+                logger.debug("degradation: skipping degraded provider %s", name)
+                degraded_skipped.append(name)
+                continue
             provider = await self.get_provider(name)
             if provider is not None:
                 if request is not None:
                     self.enrich_request(request, name)
+                    # Attach observability field so callers know what was skipped.
+                    if degraded_skipped:
+                        if request.metadata is None:
+                            request.metadata = {}
+                        request.metadata["degraded_skipped"] = degraded_skipped
                 if name != primary:
                     logger.debug(
                         "Fallback chain selected non-primary provider: %s (preferred: %s)",

--- a/autobot-backend/llm_shared/provider_registry.py
+++ b/autobot-backend/llm_shared/provider_registry.py
@@ -446,7 +446,7 @@ class ProviderRegistry:
             if await degradation.is_degraded(name, model_name):
                 degraded_set.add(name)
         all_degraded = len(candidates) > 0 and degraded_set == set(candidates)
-        if all_degraded and degraded_set:
+        if all_degraded:
             logger.warning(
                 "degradation: all %d candidates degraded — proceeding anyway",
                 len(candidates),
@@ -462,10 +462,12 @@ class ProviderRegistry:
             if provider is not None:
                 if request is not None:
                     self.enrich_request(request, name)
+                    # Record the resolved provider so the fallback coordinator
+                    # marks the provider actually used, not the (possibly
+                    # absent) one on the request (#11519).
+                    request.metadata["selected_provider"] = name
                     # Attach observability field so callers know what was skipped.
                     if degraded_skipped:
-                        if request.metadata is None:
-                            request.metadata = {}
                         request.metadata["degraded_skipped"] = degraded_skipped
                 if name != primary:
                     logger.debug(

--- a/autobot-backend/llm_shared/tests/test_provider_degradation.py
+++ b/autobot-backend/llm_shared/tests/test_provider_degradation.py
@@ -16,8 +16,8 @@ Coverage:
 from __future__ import annotations
 
 import time
-from typing import Optional
-from unittest.mock import AsyncMock, MagicMock, patch
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -50,6 +50,25 @@ def _make_store_with_fake_server(server):
 
     store._get_redis = _fake_redis  # type: ignore[method-assign]
     return store
+
+
+@contextmanager
+def _inject_globals(func, **replacements):
+    """Swap names in *func*'s own module globals for the duration of the block.
+
+    ``unittest.mock.patch("llm_shared.X.name")`` resolves the target through
+    ``sys.modules``, which the conftest stub machinery can leave pointing at a
+    MagicMock module while the real class lives in a separately loaded module
+    object — silently patching the wrong namespace.  Injecting through
+    ``func.__globals__`` always hits the dict the executing code reads.
+    """
+    g = func.__globals__
+    saved = {k: g[k] for k in replacements}
+    g.update(replacements)
+    try:
+        yield
+    finally:
+        g.update(saved)
 
 
 # ---------------------------------------------------------------------------
@@ -248,8 +267,10 @@ async def test_coordinator_marks_degraded_on_rate_limit():
     )
     mgr._chains["claude-opus-4"] = chain
 
-    with patch("llm_shared.model_fallback_coordinator.get_fallback_chain_manager", return_value=mgr), patch(
-        "llm_shared.model_fallback_coordinator.get_degradation_store", return_value=store_instance
+    with _inject_globals(
+        ModelFallbackCoordinator.execute_with_fallback,
+        get_fallback_chain_manager=lambda: mgr,
+        get_degradation_store=lambda: store_instance,
     ):
         result = await coordinator.execute_with_fallback(req, registry)
 
@@ -291,7 +312,10 @@ async def test_registry_skips_degraded_provider():
     registry.set_fallback_chain(["openai", "anthropic"])
 
     store_b = _make_store_with_fake_server(server)
-    with patch("llm_shared.provider_registry.get_degradation_store", return_value=store_b):
+    with _inject_globals(
+        ProviderRegistry.get_provider_for_request,
+        get_degradation_store=lambda: store_b,
+    ):
         chosen = await registry.get_provider_for_request()
 
     # Should skip openai (degraded) and return anthropic.
@@ -320,8 +344,162 @@ async def test_registry_all_degraded_proceeds():
     registry.set_fallback_chain(["openai"])
 
     store_b = _make_store_with_fake_server(server)
-    with patch("llm_shared.provider_registry.get_degradation_store", return_value=store_b):
+    with _inject_globals(
+        ProviderRegistry.get_provider_for_request,
+        get_degradation_store=lambda: store_b,
+    ):
         chosen = await registry.get_provider_for_request()
 
     # All-degraded → proceed anyway; openai is still returned.
     assert chosen is openai_prov
+
+
+# ---------------------------------------------------------------------------
+# Review follow-ups (#11519): exhaustion marking, provider resolution,
+# coordinator→registry end-to-end key match.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_coordinator_marks_final_provider_on_exhaustion():
+    """The provider failing on the LAST attempt is marked too (mark before break)."""
+    _require_fakeredis()
+    server = fakeredis_async.FakeServer()
+    store_instance = _make_store_with_fake_server(server)
+
+    from llm_shared.fallback_chain import FallbackChain, FallbackChainManager
+    from llm_shared.model_fallback_coordinator import ModelFallbackCoordinator
+    from llm_shared.models import LLMRequest, ProviderType
+    from llm_shared.optimization.rate_limiter import RateLimitError
+
+    coordinator = ModelFallbackCoordinator()
+    req = LLMRequest(messages=[{"role": "user", "content": "hi"}])
+    req.model_name = "claude-opus-4"
+    req.provider = ProviderType("anthropic")
+
+    async def _always_rate_limited(r):
+        raise RateLimitError("quota")
+
+    provider = MagicMock()
+    provider.chat_completion = _always_rate_limited
+    registry = MagicMock()
+    registry.get_provider_for_request = AsyncMock(return_value=provider)
+
+    mgr = FallbackChainManager.__new__(FallbackChainManager)
+    mgr._chains = {}
+    mgr._chains["claude-opus-4"] = FallbackChain(
+        primary_model="claude-opus-4",
+        fallback_models=["claude-sonnet-4"],
+        primary_provider="anthropic",
+        fallback_providers=["anthropic"],
+    )
+    mgr._chains["claude-sonnet-4"] = FallbackChain(
+        primary_model="claude-sonnet-4",
+        fallback_models=["claude-haiku-4"],
+        primary_provider="anthropic",
+        fallback_providers=["anthropic"],
+    )
+
+    with _inject_globals(
+        ModelFallbackCoordinator.execute_with_fallback,
+        get_fallback_chain_manager=lambda: mgr,
+        get_degradation_store=lambda: store_instance,
+    ):
+        result = await coordinator.execute_with_fallback(req, registry, max_attempts=1)
+
+    assert result.error  # exhausted
+    # BOTH the primary and the final (exhausted) fallback model are marked.
+    assert await store_instance.is_degraded("anthropic", "claude-opus-4") is True
+    assert await store_instance.is_degraded("anthropic", "claude-sonnet-4") is True
+
+
+@pytest.mark.asyncio
+async def test_coordinator_marks_registry_resolved_provider_when_request_has_none():
+    """A request without a provider still produces a matchable mark via selected_provider."""
+    _require_fakeredis()
+    server = fakeredis_async.FakeServer()
+    store_instance = _make_store_with_fake_server(server)
+
+    from llm_shared.fallback_chain import FallbackChainManager
+    from llm_shared.model_fallback_coordinator import ModelFallbackCoordinator
+    from llm_shared.models import LLMRequest
+    from llm_shared.optimization.rate_limiter import RateLimitError
+
+    coordinator = ModelFallbackCoordinator()
+    req = LLMRequest(messages=[{"role": "user", "content": "hi"}])
+    req.model_name = "gpt-4o"
+    assert req.provider is None
+
+    async def _rate_limited(r):
+        raise RateLimitError("quota")
+
+    provider = MagicMock()
+    provider.chat_completion = _rate_limited
+
+    async def _resolve(provider_name=None, request=None):
+        # Emulate the real registry stamping the resolved provider (#11519).
+        if request is not None:
+            request.metadata["selected_provider"] = "openai"
+        return provider
+
+    registry = MagicMock()
+    registry.get_provider_for_request = AsyncMock(side_effect=_resolve)
+
+    mgr = FallbackChainManager.__new__(FallbackChainManager)
+    mgr._chains = {}  # no fallback registered → break after first failure
+
+    with _inject_globals(
+        ModelFallbackCoordinator.execute_with_fallback,
+        get_fallback_chain_manager=lambda: mgr,
+        get_degradation_store=lambda: store_instance,
+    ):
+        result = await coordinator.execute_with_fallback(req, registry)
+
+    assert result.error
+    # The mark uses the registry-resolved provider, so the registry's own
+    # is_degraded("openai", "gpt-4o") check matches the key.
+    assert await store_instance.is_degraded("openai", "gpt-4o") is True
+    # No junk empty-provider key was written.
+    entries = await store_instance.degraded_entries()
+    assert all(":deg::" not in e for e in entries)
+
+
+@pytest.mark.asyncio
+async def test_registry_stamps_selected_provider_and_skips_model_scoped_mark():
+    """End-to-end: a model-scoped coordinator mark is honored by registry selection."""
+    _require_fakeredis()
+    server = fakeredis_async.FakeServer()
+    store_a = _make_store_with_fake_server(server)
+
+    # Coordinator-style mark from another worker: provider:model scoped.
+    await store_a.mark_degraded("openai", "gpt-4o")
+
+    from llm_shared.models import LLMRequest
+    from llm_shared.provider_registry import ProviderRegistry
+
+    registry = ProviderRegistry()
+    openai_prov = MagicMock()
+    openai_prov.provider_name = "openai"
+    openai_prov.is_available = AsyncMock(return_value=True)
+    anthropic_prov = MagicMock()
+    anthropic_prov.provider_name = "anthropic"
+    anthropic_prov.is_available = AsyncMock(return_value=True)
+    registry.register(openai_prov)
+    registry.register(anthropic_prov)
+    registry.set_fallback_chain(["openai", "anthropic"])
+
+    req = LLMRequest(messages=[{"role": "user", "content": "hi"}])
+    req.model_name = "gpt-4o"
+
+    store_b = _make_store_with_fake_server(server)
+    with _inject_globals(
+        ProviderRegistry.get_provider_for_request,
+        get_degradation_store=lambda: store_b,
+    ):
+        chosen = await registry.get_provider_for_request(request=req)
+
+    # Model-scoped mark on openai:gpt-4o → anthropic chosen.
+    assert chosen is anthropic_prov
+    # Resolved provider stamped for the coordinator's mark path.
+    assert req.metadata["selected_provider"] == "anthropic"
+    assert req.metadata["degraded_skipped"] == ["openai"]

--- a/autobot-backend/llm_shared/tests/test_provider_degradation.py
+++ b/autobot-backend/llm_shared/tests/test_provider_degradation.py
@@ -1,0 +1,327 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for ProviderDegradationStore (Issue #11519).
+
+Coverage:
+- mark → is_degraded returns True within TTL (Redis-backed via fakeredis).
+- Two store instances sharing a FakeServer simulate two workers sharing state.
+- TTL expiry restores the provider (time-travel via manual key deletion).
+- No-Redis fallback (mocked _get_redis raises): in-process dict tracks marks.
+- All-degraded chain in provider_registry still proceeds (no hard failure).
+- mark_degraded in coordinator sets the Redis key after fallback exhaustion.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+try:
+    import fakeredis.aioredis as fakeredis_async
+
+    _FAKEREDIS_AVAILABLE = True
+except ImportError:
+    _FAKEREDIS_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_fakeredis():
+    """Skip the test when fakeredis is not installed."""
+    if not _FAKEREDIS_AVAILABLE:
+        pytest.skip("fakeredis not installed — skipping Redis-backed tests")
+
+
+def _make_store_with_fake_server(server):
+    """Return a ProviderDegradationStore whose Redis calls hit *server*."""
+    from llm_shared.provider_degradation import ProviderDegradationStore
+
+    store = ProviderDegradationStore()
+
+    async def _fake_redis(*_args, **_kwargs):
+        return fakeredis_async.FakeRedis(server=server, decode_responses=True)
+
+    store._get_redis = _fake_redis  # type: ignore[method-assign]
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Redis-backed tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_then_is_degraded_redis():
+    """mark_degraded → is_degraded returns True within TTL (Redis path)."""
+    _require_fakeredis()
+    server = fakeredis_async.FakeServer()
+    store = _make_store_with_fake_server(server)
+
+    await store.mark_degraded("openai", "gpt-4o")
+
+    assert await store.is_degraded("openai", "gpt-4o") is True
+
+
+@pytest.mark.asyncio
+async def test_not_degraded_without_mark_redis():
+    """is_degraded returns False when no mark has been set."""
+    _require_fakeredis()
+    server = fakeredis_async.FakeServer()
+    store = _make_store_with_fake_server(server)
+
+    assert await store.is_degraded("anthropic", "claude-opus-4") is False
+
+
+@pytest.mark.asyncio
+async def test_provider_only_key_redis():
+    """Provider-only mark (no model) is correctly stored and retrieved."""
+    _require_fakeredis()
+    server = fakeredis_async.FakeServer()
+    store = _make_store_with_fake_server(server)
+
+    await store.mark_degraded("groq")
+
+    assert await store.is_degraded("groq") is True
+    # Model-scoped key must NOT match a provider-only mark.
+    assert await store.is_degraded("groq", "llama3") is False
+
+
+@pytest.mark.asyncio
+async def test_cross_worker_mark_visible_to_second_store():
+    """Two stores sharing a FakeServer (simulating two workers) share state."""
+    _require_fakeredis()
+    server = fakeredis_async.FakeServer()
+    worker_a = _make_store_with_fake_server(server)
+    worker_b = _make_store_with_fake_server(server)
+
+    await worker_a.mark_degraded("openai", "gpt-4o")
+
+    # Worker B must see worker A's mark without any direct call.
+    assert await worker_b.is_degraded("openai", "gpt-4o") is True
+
+
+@pytest.mark.asyncio
+async def test_ttl_expiry_restores_provider():
+    """After TTL expiry (simulated by deleting the key), is_degraded returns False."""
+    _require_fakeredis()
+    server = fakeredis_async.FakeServer()
+    store = _make_store_with_fake_server(server)
+
+    await store.mark_degraded("openai", "gpt-4o")
+    assert await store.is_degraded("openai", "gpt-4o") is True
+
+    # Simulate TTL expiry by directly deleting the key from Redis.
+    redis = await store._get_redis()
+    await redis.delete("autobot:llm:deg:openai:gpt-4o")
+
+    assert await store.is_degraded("openai", "gpt-4o") is False
+
+
+@pytest.mark.asyncio
+async def test_degraded_entries_returns_marked_keys():
+    """degraded_entries() lists all currently-marked keys."""
+    _require_fakeredis()
+    server = fakeredis_async.FakeServer()
+    store = _make_store_with_fake_server(server)
+
+    await store.mark_degraded("openai", "gpt-4o")
+    await store.mark_degraded("anthropic")
+
+    entries = await store.degraded_entries()
+    assert "autobot:llm:deg:openai:gpt-4o" in entries
+    assert "autobot:llm:deg:anthropic" in entries
+
+
+# ---------------------------------------------------------------------------
+# In-process fallback (no Redis)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_redis_fallback_mark_and_check():
+    """When Redis is unavailable, in-process dict tracks marks correctly."""
+    from llm_shared.provider_degradation import ProviderDegradationStore
+
+    store = ProviderDegradationStore()
+
+    async def _raise(*_args, **_kwargs):
+        raise ConnectionError("Redis unavailable")
+
+    store._get_redis = _raise  # type: ignore[method-assign]
+
+    await store.mark_degraded("openai", "gpt-4o")
+    assert await store.is_degraded("openai", "gpt-4o") is True
+
+
+@pytest.mark.asyncio
+async def test_no_redis_fallback_expiry():
+    """In-process fallback respects expiry timestamps (time-travel via monkeypatch)."""
+    from llm_shared.provider_degradation import ProviderDegradationStore
+
+    store = ProviderDegradationStore()
+
+    async def _raise(*_args, **_kwargs):
+        raise ConnectionError("Redis unavailable")
+
+    store._get_redis = _raise  # type: ignore[method-assign]
+
+    await store.mark_degraded("openai", "gpt-4o")
+    assert await store.is_degraded("openai", "gpt-4o") is True
+
+    # Force expiry by back-dating the timestamp.
+    store._local["autobot:llm:deg:openai:gpt-4o"] = time.monotonic() - 1.0
+    assert await store.is_degraded("openai", "gpt-4o") is False
+
+
+@pytest.mark.asyncio
+async def test_no_redis_degraded_entries_fallback():
+    """degraded_entries() uses in-process dict when Redis is unavailable."""
+    from llm_shared.provider_degradation import ProviderDegradationStore
+
+    store = ProviderDegradationStore()
+
+    async def _raise(*_args, **_kwargs):
+        raise ConnectionError("Redis unavailable")
+
+    store._get_redis = _raise  # type: ignore[method-assign]
+
+    await store.mark_degraded("openai", "gpt-4o")
+    entries = await store.degraded_entries()
+    assert "autobot:llm:deg:openai:gpt-4o" in entries
+
+
+# ---------------------------------------------------------------------------
+# ModelFallbackCoordinator integration: mark on exhaustion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_coordinator_marks_degraded_on_rate_limit():
+    """execute_with_fallback marks a provider degraded when rate-limited."""
+    _require_fakeredis()
+    server = fakeredis_async.FakeServer()
+    store_instance = _make_store_with_fake_server(server)
+
+    from llm_shared.fallback_chain import FallbackChain, FallbackChainManager
+    from llm_shared.model_fallback_coordinator import ModelFallbackCoordinator
+    from llm_shared.models import LLMRequest, LLMResponse
+    from llm_shared.optimization.rate_limiter import RateLimitError
+
+    coordinator = ModelFallbackCoordinator()
+
+    req = LLMRequest(messages=[{"role": "user", "content": "hi"}])
+    req.model_name = "claude-opus-4"
+    from llm_shared.models import ProviderType
+
+    req.provider = ProviderType("anthropic")
+
+    fallback_response = LLMResponse(content="ok", model="claude-sonnet-4", provider="anthropic")
+    call_count = [0]
+
+    async def _dispatch(r):
+        idx = call_count[0]
+        call_count[0] += 1
+        if idx == 0:
+            raise RateLimitError("quota")
+        return fallback_response
+
+    provider = MagicMock()
+    provider.chat_completion = _dispatch
+    provider.provider_name = "anthropic"
+    registry = MagicMock()
+    registry.get_provider_for_request = AsyncMock(return_value=provider)
+
+    mgr = FallbackChainManager.__new__(FallbackChainManager)
+    mgr._chains = {}
+    chain = FallbackChain(
+        primary_model="claude-opus-4",
+        fallback_models=["claude-sonnet-4"],
+        primary_provider="anthropic",
+        fallback_providers=["anthropic"],
+    )
+    mgr._chains["claude-opus-4"] = chain
+
+    with patch("llm_shared.model_fallback_coordinator.get_fallback_chain_manager", return_value=mgr), patch(
+        "llm_shared.model_fallback_coordinator.get_degradation_store", return_value=store_instance
+    ):
+        result = await coordinator.execute_with_fallback(req, registry)
+
+    assert result.content == "ok"
+    # The primary provider:model must now be marked degraded.
+    assert await store_instance.is_degraded("anthropic", "claude-opus-4") is True
+
+
+# ---------------------------------------------------------------------------
+# ProviderRegistry: skip degraded, all-degraded fallthrough
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registry_skips_degraded_provider():
+    """get_provider_for_request skips a degraded provider and picks the next."""
+    _require_fakeredis()
+    server = fakeredis_async.FakeServer()
+    store_a = _make_store_with_fake_server(server)
+
+    # Mark openai degraded from another "worker".
+    await store_a.mark_degraded("openai")
+
+    from llm_shared.provider_registry import ProviderRegistry
+
+    registry = ProviderRegistry()
+
+    # Register two providers; openai is degraded.
+    openai_prov = MagicMock()
+    openai_prov.provider_name = "openai"
+    openai_prov.is_available = AsyncMock(return_value=True)
+
+    anthropic_prov = MagicMock()
+    anthropic_prov.provider_name = "anthropic"
+    anthropic_prov.is_available = AsyncMock(return_value=True)
+
+    registry.register(openai_prov)
+    registry.register(anthropic_prov)
+    registry.set_fallback_chain(["openai", "anthropic"])
+
+    store_b = _make_store_with_fake_server(server)
+    with patch("llm_shared.provider_registry.get_degradation_store", return_value=store_b):
+        chosen = await registry.get_provider_for_request()
+
+    # Should skip openai (degraded) and return anthropic.
+    assert chosen is anthropic_prov
+
+
+@pytest.mark.asyncio
+async def test_registry_all_degraded_proceeds():
+    """When all providers are degraded, the registry still returns one (no hard fail)."""
+    _require_fakeredis()
+    server = fakeredis_async.FakeServer()
+    store_a = _make_store_with_fake_server(server)
+
+    await store_a.mark_degraded("openai")
+    await store_a.mark_degraded("anthropic")
+
+    from llm_shared.provider_registry import ProviderRegistry
+
+    registry = ProviderRegistry()
+
+    openai_prov = MagicMock()
+    openai_prov.provider_name = "openai"
+    openai_prov.is_available = AsyncMock(return_value=True)
+
+    registry.register(openai_prov)
+    registry.set_fallback_chain(["openai"])
+
+    store_b = _make_store_with_fake_server(server)
+    with patch("llm_shared.provider_registry.get_degradation_store", return_value=store_b):
+        chosen = await registry.get_provider_for_request()
+
+    # All-degraded → proceed anyway; openai is still returned.
+    assert chosen is openai_prov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@
 # even when pip resolves the -r chain in unexpected order.
 structlog>=26.1.0    # service_auth_enforcement, service_auth_logging, service_client
 aiosqlite>=0.22.1   # memory/storage/general_storage, memory/storage/task_storage, utils/async_database_pool
+fakeredis>=2.26    # llm_shared provider-degradation cross-worker tests (#11519)


### PR DESCRIPTION
Closes #11519. Part of umbrella #11518 (Task 1).

## Thinking Path
Provider health was a 30-second in-process cache: every uvicorn worker independently re-discovered a dead provider, and fallback state never crossed workers. Research on production agent-platform resilience patterns (umbrella #11518) identified persistent shared degradation marking as the gap. The cross-worker Redis pattern already proven by `cross_worker_rate_limiter.py` (#8170) is reused.

## What Changed
- **New `llm_shared/provider_degradation.py`** — `ProviderDegradationStore`: Redis-backed `provider[:model]` degradation marks with env-configurable TTL (`AUTOBOT_PROVIDER_DEGRADATION_TTL_SECONDS`, default 300 s); never-raise contract with in-process dict fallback when Redis is down.
- **`model_fallback_coordinator.py`** — marks the failing provider:model degraded on every rate-limit hop **including the final exhausted attempt**; resolves the provider via the registry-stamped `request.metadata["selected_provider"]` (requests often carry no provider); threads `degraded_skipped` into the fallback audit metadata.
- **`provider_registry.py`** — `get_provider_for_request` checks all candidates up-front, skips degraded ones, and falls through when ALL are degraded (never hard-fails on marks alone); stamps `selected_provider` for the coordinator's mark path.
- **`conftest.py`** — real-loads `provider_degradation` before its importers in the stub chain.
- **CI/dev deps** — `fakeredis` added to `ci.yml` test-install line and `requirements-dev.txt` so the 12 Redis-path tests execute (previously they skipped everywhere).
- **Tests** — 15 tests: cross-worker visibility via shared FakeServer, TTL expiry, no-Redis fallback, all-degraded fallthrough, exhaustion marking, provider-resolution end-to-end key match. Tests inject via `func.__globals__` because `unittest.mock.patch` on module paths is unreliable under the conftest stub machinery (details in the test helper docstring).

## Verification
- `pytest autobot-backend/llm_shared/tests/test_provider_degradation.py autobot-backend/llm_shared/model_fallback_coordinator_test.py autobot-backend/tests/test_provider_registry.py autobot-backend/llm_shared/base_provider_breaker_test.py` → **62 passed, 0 skipped** (fakeredis installed)
- `flake8 --config=.flake8` clean; `black --check -l 120` clean
- code-reviewer pass: 2 blockers (final-attempt not marked; unmatchable empty-provider key), 1 major (missing end-to-end key-match test), 3 minors — all fixed and covered by the 3 newest tests

## Model Used
Claude (Fable 5) orchestrating; Sonnet implementation agent; Sonnet code-reviewer agent.
