### PR TITLE
feat(testing): pytest llm_judge fixture wrapping the judges framework (#11521)

### DIFF
--- a/autobot-backend/llc/tests/test_agent_tools.py
+++ b/autobot-backend/llc/tests/test_agent_tools.py
@@ -94,9 +94,7 @@ async def test_create_task_calls_work_item_service_with_authed_actor():
     svc = MagicMock()
     svc.create = AsyncMock(return_value=item)
     with p, patch("llc.services.work_item_service.WorkItemService", return_value=svc):
-        out = await dispatch_llc_tool(
-            "create_task", {"title": "Write Q3 report", "priority": "high"}, _COMPANY, _USER
-        )
+        out = await dispatch_llc_tool("create_task", {"title": "Write Q3 report", "priority": "high"}, _COMPANY, _USER)
     assert out["status"] == "success" and out["entity_type"] == "work_item"
     assert svc.create.await_args.kwargs["company_id"] == _COMPANY
     assert svc.create.await_args.kwargs["title"] == "Write Q3 report"

--- a/autobot-backend/tests/conftest.py
+++ b/autobot-backend/tests/conftest.py
@@ -2,15 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Top-level conftest for the autobot-backend/tests/ directory.
+"""Conftest for the autobot-backend/tests/ directory.
 
-Registers shared test fixtures used across multiple test files under this
-directory, including the llm_judge fixture added in #11521.
+Re-exports shared fixtures so pytest discovers them for every test file under
+this directory.  A direct import is used instead of ``pytest_plugins`` because
+pytest ≥9 hard-fails on ``pytest_plugins`` in any non-root conftest whenever
+the conftest is loaded after configure — which depends on fragile testpath
+glob details (#11521 review).
 
 Heavy deps must NOT be imported at module scope here — see
-``tests/helpers/llm_judge_fixture.py`` for the lazy-import pattern.
+``tests/helpers/llm_judge_fixture.py`` for the lazy-import pattern (the module
+below imports only ``os``/``logging``/``pytest`` at module scope).
 """
 
-pytest_plugins = [
-    "tests.helpers.llm_judge_fixture",
-]
+from tests.helpers.llm_judge_fixture import llm_judge  # noqa: F401

--- a/autobot-backend/tests/conftest.py
+++ b/autobot-backend/tests/conftest.py
@@ -1,0 +1,16 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Top-level conftest for the autobot-backend/tests/ directory.
+
+Registers shared test fixtures used across multiple test files under this
+directory, including the llm_judge fixture added in #11521.
+
+Heavy deps must NOT be imported at module scope here — see
+``tests/helpers/llm_judge_fixture.py`` for the lazy-import pattern.
+"""
+
+pytest_plugins = [
+    "tests.helpers.llm_judge_fixture",
+]

--- a/autobot-backend/tests/helpers/README.md
+++ b/autobot-backend/tests/helpers/README.md
@@ -42,9 +42,45 @@ parameterization:
   placing fixtures in `conftest.py` unless they require non-trivial setup)
 - Production code disguised as a test utility (never)
 
+## LLM-judge quality assertions (#11521)
+
+`llm_judge_fixture.py` exposes the `llm_judge` pytest fixture, which wraps the
+existing `judges/` framework to let tests assert LLM output quality.
+
+### Quickstart
+
+```python
+@pytest.mark.llm_judge
+async def test_answer_quality(llm_judge) -> None:
+    await llm_judge.assert_llm(
+        output="Paris is the capital of France.",
+        criteria="The answer must be factually correct and relevant.",
+        min_score=0.8,
+        context="What is the capital of France?",
+    )
+```
+
+### Opt-in gate
+
+These tests **skip by default** and are never a CI dependency.  To run them
+locally against a configured Ollama or cloud provider:
+
+```bash
+AUTOBOT_LLM_JUDGE_TESTS=1 python -m pytest autobot-backend/tests/test_llm_judge_example.py -v
+```
+
+The fixture also skips when no provider environment variable is set
+(`AUTOBOT_OLLAMA_ENDPOINT`, `AUTOBOT_OPENAI_API_KEY`, etc.).
+
+### Minimum score threshold
+
+Override the default 0.7 threshold per call with `min_score=<float>`, or
+globally via the `AUTOBOT_LLM_JUDGE_MIN_SCORE` environment variable.
+
 ## See also
 
 - Root `autobot-backend/conftest.py` — shared pytest fixtures (auto-discoverable)
 - `docs/developer/PRIMITIVES.md` — repo-wide extraction rules
 - Issue #5437 — this directory's creation rationale
 - Issues #5431, #5432 — first consumers of this directory
+- Issue #11521 — llm_judge fixture origin

--- a/autobot-backend/tests/helpers/llm_judge_fixture.py
+++ b/autobot-backend/tests/helpers/llm_judge_fixture.py
@@ -31,12 +31,9 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING, Union
+from typing import Union
 
 import pytest
-
-if TYPE_CHECKING:
-    from judges import JudgmentDimension  # typing-time only — not imported at load
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +42,15 @@ _JUDGE_TESTS_ENV = "AUTOBOT_LLM_JUDGE_TESTS"
 
 # Configurable minimum score for the default threshold (env constant pattern).
 _DEFAULT_MIN_SCORE = float(os.environ.get("AUTOBOT_LLM_JUDGE_MIN_SCORE", "0.7"))
+
+# Dimensions evaluated when callers pass plain-string criteria.  Names are
+# resolved against JudgmentDimension lazily (the enum must not be imported at
+# collection time).  Override per-call by passing an explicit dimension list.
+STRING_CRITERIA_DIMENSIONS: tuple[str, ...] = ("RELEVANCE", "ACCURACY", "QUALITY")
+
+# The bare Ollama default — its presence alone does NOT prove a provider is
+# configured (it is often baked into .env files with no server running).
+_DEFAULT_OLLAMA_ENDPOINT = "http://localhost:11434"
 
 
 def _is_judge_tests_enabled() -> bool:
@@ -68,6 +74,9 @@ def _provider_configured() -> bool:
     ollama_ep = os.environ.get("AUTOBOT_OLLAMA_ENDPOINT", "")
     openai_key = os.environ.get("AUTOBOT_OPENAI_API_KEY", "")
     anthropic_key = os.environ.get("AUTOBOT_ANTHROPIC_API_KEY", "")
+    # The bare default endpoint is not evidence of a reachable provider.
+    if ollama_ep.rstrip("/") == _DEFAULT_OLLAMA_ENDPOINT:
+        ollama_ep = ""
     # Any explicit configuration counts.
     return bool(provider or ollama_ep or openai_key or anthropic_key)
 
@@ -116,7 +125,9 @@ class _LLMJudgeWrapper:
         from judges import JudgmentDimension as _Dim
 
         if isinstance(criteria, str):
-            dimensions = [_Dim.RELEVANCE, _Dim.ACCURACY, _Dim.QUALITY]
+            # String criteria are evaluated on the fixed STRING_CRITERIA_DIMENSIONS
+            # set — the string steers the judge's reasoning, not the dimension list.
+            dimensions = [getattr(_Dim, name) for name in STRING_CRITERIA_DIMENSIONS]
             judge_context = {"criteria_description": criteria, "context": context}
         else:
             dimensions = criteria
@@ -135,14 +146,12 @@ class _LLMJudgeWrapper:
                 f"Reasoning: {result.reasoning}",
             ]
             for cs in result.criterion_scores:
-                lines.append(
-                    f"  [{cs.dimension.value}] score={cs.score:.3f} — {cs.reasoning}"
-                )
+                lines.append(f"  [{cs.dimension.value}] score={cs.score:.3f} — {cs.reasoning}")
             raise AssertionError("\n".join(lines))
 
 
 @pytest.fixture
-async def llm_judge(request):
+async def llm_judge():
     """pytest fixture: provides ``_LLMJudgeWrapper`` for LLM-quality assertions.
 
     Auto-skips when:
@@ -153,9 +162,7 @@ async def llm_judge(request):
     in async test functions directly.
     """
     if not _is_judge_tests_enabled():
-        pytest.skip(
-            f"LLM judge tests disabled — set {_JUDGE_TESTS_ENV}=1 to enable"
-        )
+        pytest.skip(f"LLM judge tests disabled — set {_JUDGE_TESTS_ENV}=1 to enable")
 
     if not _provider_configured():
         pytest.skip(
@@ -163,9 +170,11 @@ async def llm_judge(request):
             "(set AUTOBOT_OLLAMA_ENDPOINT, AUTOBOT_OPENAI_API_KEY, etc.)"
         )
 
-    # Late import — judges/__init__.py imports llm_shared and autobot_shared
-    # chains that must NOT run at collection time.
-    from judges import BaseLLMJudge
+    # Late import — judges imports llm_shared and autobot_shared chains that
+    # must NOT run at collection time.  AgentResponseJudge is used because
+    # BaseLLMJudge._prepare_judgment_prompt is abstract (raises
+    # NotImplementedError → every judgment would error-score 0.0).
+    from judges.agent_response_judge import AgentResponseJudge
 
-    judge = BaseLLMJudge(judge_type="pytest_quality_judge")
+    judge = AgentResponseJudge()
     yield _LLMJudgeWrapper(judge)

--- a/autobot-backend/tests/helpers/llm_judge_fixture.py
+++ b/autobot-backend/tests/helpers/llm_judge_fixture.py
@@ -1,0 +1,171 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""pytest fixture: llm_judge
+
+Thin integration between the existing judges framework and pytest.
+
+Usage
+-----
+In any test::
+
+    @pytest.mark.llm_judge
+    async def test_answer_quality(llm_judge):
+        await llm_judge.assert_llm(
+            output="Paris is the capital of France.",
+            criteria="The answer must be factually correct and relevant.",
+            min_score=0.8,
+        )
+
+The fixture auto-skips when the opt-in env var ``AUTOBOT_LLM_JUDGE_TESTS=1``
+is absent OR when no LLM provider is reachable, so it is **never** a hard CI
+dependency.
+
+All judges imports happen **inside** the fixture function so that collection
+stays lightweight (this file is imported only via fixture lookup, not at
+collection time).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Union
+
+import pytest
+
+if TYPE_CHECKING:
+    from judges import JudgmentDimension  # typing-time only — not imported at load
+
+logger = logging.getLogger(__name__)
+
+# Environment opt-in gate — CI sets this to nothing; local dev sets it to "1".
+_JUDGE_TESTS_ENV = "AUTOBOT_LLM_JUDGE_TESTS"
+
+# Configurable minimum score for the default threshold (env constant pattern).
+_DEFAULT_MIN_SCORE = float(os.environ.get("AUTOBOT_LLM_JUDGE_MIN_SCORE", "0.7"))
+
+
+def _is_judge_tests_enabled() -> bool:
+    """Return True only when the opt-in env var is present and set to '1'."""
+    return os.environ.get(_JUDGE_TESTS_ENV, "").strip() == "1"
+
+
+def _provider_configured() -> bool:
+    """Return True when a non-empty LLM provider endpoint/key appears to be set.
+
+    Checks the SSOT config without importing heavy deps.  A provider is
+    considered configured when *any* of the following is non-empty/non-default:
+    - AUTOBOT_OLLAMA_ENDPOINT overrides the default value
+    - AUTOBOT_OPENAI_API_KEY is non-empty
+    - AUTOBOT_ANTHROPIC_API_KEY is non-empty
+    - AUTOBOT_LLM_PROVIDER is set to anything other than the bare default
+
+    This is a cheap heuristic — no socket connection is opened.
+    """
+    provider = os.environ.get("AUTOBOT_LLM_PROVIDER", "")
+    ollama_ep = os.environ.get("AUTOBOT_OLLAMA_ENDPOINT", "")
+    openai_key = os.environ.get("AUTOBOT_OPENAI_API_KEY", "")
+    anthropic_key = os.environ.get("AUTOBOT_ANTHROPIC_API_KEY", "")
+    # Any explicit configuration counts.
+    return bool(provider or ollama_ep or openai_key or anthropic_key)
+
+
+class _LLMJudgeWrapper:
+    """Thin wrapper that exposes ``assert_llm`` for use in tests.
+
+    Instantiation is deferred to the fixture so heavy deps are never imported
+    at module/collection time.
+    """
+
+    def __init__(self, judge) -> None:
+        self._judge = judge
+
+    async def assert_llm(
+        self,
+        output: str,
+        criteria: Union[str, list],
+        *,
+        min_score: float = _DEFAULT_MIN_SCORE,
+        context: str = "",
+    ) -> None:
+        """Assert that *output* meets *criteria* at the given minimum quality score.
+
+        Parameters
+        ----------
+        output:
+            The LLM-generated text to evaluate.
+        criteria:
+            Either a plain-English string describing what the output must satisfy
+            or a list of ``JudgmentDimension`` enum values to evaluate across.
+        min_score:
+            Minimum acceptable overall score (0–1).  Defaults to
+            ``AUTOBOT_LLM_JUDGE_MIN_SCORE`` env var or 0.7.
+        context:
+            Optional background text provided to the judge (e.g. the question
+            or retrieved documents for a RAG scenario).
+
+        Raises
+        ------
+        AssertionError
+            When the judge's overall score falls below *min_score*.  The error
+            message includes per-criterion reasoning from the judgment.
+        """
+        # Late import — keeps collection cost zero.
+        from judges import JudgmentDimension as _Dim
+
+        if isinstance(criteria, str):
+            dimensions = [_Dim.RELEVANCE, _Dim.ACCURACY, _Dim.QUALITY]
+            judge_context = {"criteria_description": criteria, "context": context}
+        else:
+            dimensions = criteria
+            judge_context = {"context": context}
+
+        result = await self._judge.make_judgment(
+            subject=output,
+            criteria=dimensions,
+            context=judge_context,
+        )
+
+        if result.overall_score < min_score:
+            lines = [
+                f"LLM judge score {result.overall_score:.3f} < required {min_score:.3f}",
+                f"Recommendation: {result.recommendation}",
+                f"Reasoning: {result.reasoning}",
+            ]
+            for cs in result.criterion_scores:
+                lines.append(
+                    f"  [{cs.dimension.value}] score={cs.score:.3f} — {cs.reasoning}"
+                )
+            raise AssertionError("\n".join(lines))
+
+
+@pytest.fixture
+async def llm_judge(request):
+    """pytest fixture: provides ``_LLMJudgeWrapper`` for LLM-quality assertions.
+
+    Auto-skips when:
+    - ``AUTOBOT_LLM_JUDGE_TESTS`` != "1"  (opt-in gate)
+    - No LLM provider environment variables are present
+
+    The fixture is async so callers can ``await llm_judge.assert_llm(...)``
+    in async test functions directly.
+    """
+    if not _is_judge_tests_enabled():
+        pytest.skip(
+            f"LLM judge tests disabled — set {_JUDGE_TESTS_ENV}=1 to enable"
+        )
+
+    if not _provider_configured():
+        pytest.skip(
+            "LLM judge tests skipped — no provider configured "
+            "(set AUTOBOT_OLLAMA_ENDPOINT, AUTOBOT_OPENAI_API_KEY, etc.)"
+        )
+
+    # Late import — judges/__init__.py imports llm_shared and autobot_shared
+    # chains that must NOT run at collection time.
+    from judges import BaseLLMJudge
+
+    judge = BaseLLMJudge(judge_type="pytest_quality_judge")
+    yield _LLMJudgeWrapper(judge)

--- a/autobot-backend/tests/test_llm_judge_example.py
+++ b/autobot-backend/tests/test_llm_judge_example.py
@@ -150,7 +150,6 @@ async def test_llm_judge_wrapper_raises_on_low_score() -> None:
 async def test_llm_judge_wrapper_includes_reasoning_in_error() -> None:
     """Failure message must include per-criterion reasoning for debuggability."""
     from judges import CriterionScore, JudgmentConfidence, JudgmentDimension
-
     from tests.helpers.llm_judge_fixture import _LLMJudgeWrapper
 
     criterion = CriterionScore(

--- a/autobot-backend/tests/test_llm_judge_example.py
+++ b/autobot-backend/tests/test_llm_judge_example.py
@@ -38,7 +38,8 @@ The unit tests in this file (``test_llm_judge_*_unit``) are NOT marked
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -105,7 +106,7 @@ def _make_judgment(overall_score: float, criterion_scores: list | None = None):
     return JudgmentResult(
         subject_id="test-subject",
         judge_type="pytest_quality_judge",
-        timestamp=MagicMock(),
+        timestamp=datetime.now(tz=timezone.utc),
         overall_score=overall_score,
         recommendation="APPROVE" if overall_score >= 0.7 else "REJECT",
         confidence=JudgmentConfidence.HIGH,
@@ -197,7 +198,12 @@ def test_provider_configured_no_env(monkeypatch) -> None:
     """Provider check returns False when no provider env vars are set."""
     from tests.helpers.llm_judge_fixture import _provider_configured
 
-    for key in ("AUTOBOT_LLM_PROVIDER", "AUTOBOT_OLLAMA_ENDPOINT", "AUTOBOT_OPENAI_API_KEY", "AUTOBOT_ANTHROPIC_API_KEY"):
+    for key in (
+        "AUTOBOT_LLM_PROVIDER",
+        "AUTOBOT_OLLAMA_ENDPOINT",
+        "AUTOBOT_OPENAI_API_KEY",
+        "AUTOBOT_ANTHROPIC_API_KEY",
+    ):
         monkeypatch.delenv(key, raising=False)
     assert not _provider_configured()
 
@@ -210,3 +216,33 @@ def test_provider_configured_with_openai_key(monkeypatch) -> None:
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("AUTOBOT_OPENAI_API_KEY", "sk-test")
     assert _provider_configured()
+
+
+def test_provider_configured_with_generic_provider(monkeypatch) -> None:
+    """Provider check returns True when AUTOBOT_LLM_PROVIDER is set."""
+    from tests.helpers.llm_judge_fixture import _provider_configured
+
+    for key in ("AUTOBOT_OLLAMA_ENDPOINT", "AUTOBOT_OPENAI_API_KEY", "AUTOBOT_ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("AUTOBOT_LLM_PROVIDER", "ollama")
+    assert _provider_configured()
+
+
+def test_provider_configured_with_custom_ollama_endpoint(monkeypatch) -> None:
+    """A non-default Ollama endpoint counts as configured."""
+    from tests.helpers.llm_judge_fixture import _provider_configured
+
+    for key in ("AUTOBOT_LLM_PROVIDER", "AUTOBOT_OPENAI_API_KEY", "AUTOBOT_ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("AUTOBOT_OLLAMA_ENDPOINT", "http://10.0.0.5:11434")
+    assert _provider_configured()
+
+
+def test_provider_configured_default_ollama_endpoint_excluded(monkeypatch) -> None:
+    """The bare default Ollama endpoint does NOT count as configured."""
+    from tests.helpers.llm_judge_fixture import _provider_configured
+
+    for key in ("AUTOBOT_LLM_PROVIDER", "AUTOBOT_OPENAI_API_KEY", "AUTOBOT_ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("AUTOBOT_OLLAMA_ENDPOINT", "http://localhost:11434")
+    assert not _provider_configured()

--- a/autobot-backend/tests/test_llm_judge_example.py
+++ b/autobot-backend/tests/test_llm_judge_example.py
@@ -1,0 +1,212 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Example tests for the llm_judge fixture.
+
+These tests demonstrate two usage patterns:
+
+1. **String criteria** (plain-English description — judge picks dimensions):
+
+       @pytest.mark.llm_judge
+       async def test_rag_answer_relevance(llm_judge):
+           await llm_judge.assert_llm(
+               output=ANSWER,
+               criteria="The answer must correctly identify Paris...",
+               context=QUESTION,
+           )
+
+2. **Explicit JudgmentDimension list** (evaluate specific axes):
+
+       @pytest.mark.llm_judge
+       async def test_answer_accuracy(llm_judge):
+           from judges import JudgmentDimension
+           await llm_judge.assert_llm(
+               output=ANSWER,
+               criteria=[JudgmentDimension.ACCURACY, JudgmentDimension.COMPLETENESS],
+           )
+
+Running
+-------
+These tests SKIP by default.  To run them locally against a configured provider::
+
+    AUTOBOT_LLM_JUDGE_TESTS=1 python -m pytest autobot-backend/tests/test_llm_judge_example.py -v
+
+The unit tests in this file (``test_llm_judge_*_unit``) are NOT marked
+``llm_judge`` and always run without a real LLM.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures are imported by pytest automatically via conftest.py plugin
+# loading; we declare the import here only for the unit-test helpers below.
+# ---------------------------------------------------------------------------
+
+# Canned RAG scenario
+_QUESTION = "What is the capital of France?"
+_CORRECT_ANSWER = "The capital of France is Paris, which has served as the country's capital since the 10th century."
+_IRRELEVANT_ANSWER = "Croissants are a popular French pastry often eaten at breakfast."
+
+# ---------------------------------------------------------------------------
+# Live LLM tests — skipped unless AUTOBOT_LLM_JUDGE_TESTS=1
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.llm_judge
+async def test_rag_answer_relevance(llm_judge) -> None:
+    """RAG answer about French capital should score high on relevance + accuracy."""
+    await llm_judge.assert_llm(
+        output=_CORRECT_ANSWER,
+        criteria="The answer must correctly identify Paris as the capital of France and be relevant to the question.",
+        context=_QUESTION,
+        min_score=0.7,
+    )
+
+
+@pytest.mark.llm_judge
+async def test_rag_answer_explicit_dimensions(llm_judge) -> None:
+    """Same scenario using explicit JudgmentDimension list instead of a string."""
+    from judges import JudgmentDimension
+
+    await llm_judge.assert_llm(
+        output=_CORRECT_ANSWER,
+        criteria=[JudgmentDimension.RELEVANCE, JudgmentDimension.ACCURACY],
+        context=_QUESTION,
+        min_score=0.7,
+    )
+
+
+@pytest.mark.llm_judge
+async def test_irrelevant_answer_fails(llm_judge) -> None:
+    """An irrelevant answer should be judged poorly and raise AssertionError."""
+    with pytest.raises(AssertionError, match="LLM judge score"):
+        await llm_judge.assert_llm(
+            output=_IRRELEVANT_ANSWER,
+            criteria="The answer must directly answer what the capital of France is.",
+            context=_QUESTION,
+            min_score=0.9,  # high bar — irrelevant answer should fail
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — always run, no real LLM required
+# ---------------------------------------------------------------------------
+
+
+def _make_judgment(overall_score: float, criterion_scores: list | None = None):
+    """Build a minimal JudgmentResult mock for unit tests."""
+    from judges import JudgmentConfidence, JudgmentResult
+
+    return JudgmentResult(
+        subject_id="test-subject",
+        judge_type="pytest_quality_judge",
+        timestamp=MagicMock(),
+        overall_score=overall_score,
+        recommendation="APPROVE" if overall_score >= 0.7 else "REJECT",
+        confidence=JudgmentConfidence.HIGH,
+        criterion_scores=criterion_scores or [],
+        reasoning="Unit test stub reasoning.",
+        alternatives_considered=[],
+        improvement_suggestions=[],
+        context_used={},
+        processing_time_ms=0.0,
+        llm_model_used="stub",
+    )
+
+
+@pytest.mark.asyncio
+async def test_llm_judge_wrapper_passes_on_high_score() -> None:
+    """_LLMJudgeWrapper.assert_llm must not raise when score >= min_score."""
+    from tests.helpers.llm_judge_fixture import _LLMJudgeWrapper
+
+    mock_judge = MagicMock()
+    mock_judge.make_judgment = AsyncMock(return_value=_make_judgment(0.85))
+    wrapper = _LLMJudgeWrapper(mock_judge)
+
+    # Should complete without exception.
+    await wrapper.assert_llm(output="Paris is the capital.", criteria="Correct answer.")
+
+
+@pytest.mark.asyncio
+async def test_llm_judge_wrapper_raises_on_low_score() -> None:
+    """_LLMJudgeWrapper.assert_llm must raise AssertionError when score < min_score."""
+    from tests.helpers.llm_judge_fixture import _LLMJudgeWrapper
+
+    mock_judge = MagicMock()
+    mock_judge.make_judgment = AsyncMock(return_value=_make_judgment(0.4))
+    wrapper = _LLMJudgeWrapper(mock_judge)
+
+    with pytest.raises(AssertionError, match="LLM judge score"):
+        await wrapper.assert_llm(output="Irrelevant text.", criteria="Must be relevant.", min_score=0.7)
+
+
+@pytest.mark.asyncio
+async def test_llm_judge_wrapper_includes_reasoning_in_error() -> None:
+    """Failure message must include per-criterion reasoning for debuggability."""
+    from judges import CriterionScore, JudgmentConfidence, JudgmentDimension
+
+    from tests.helpers.llm_judge_fixture import _LLMJudgeWrapper
+
+    criterion = CriterionScore(
+        dimension=JudgmentDimension.RELEVANCE,
+        score=0.3,
+        confidence=JudgmentConfidence.LOW,
+        reasoning="Response does not address the question.",
+        evidence=[],
+    )
+    mock_judge = MagicMock()
+    mock_judge.make_judgment = AsyncMock(return_value=_make_judgment(0.3, [criterion]))
+    wrapper = _LLMJudgeWrapper(mock_judge)
+
+    with pytest.raises(AssertionError) as exc_info:
+        await wrapper.assert_llm(output="Off-topic text.", criteria="Must be relevant.", min_score=0.7)
+
+    error_text = str(exc_info.value)
+    assert "relevance" in error_text.lower()
+    assert "does not address" in error_text
+
+
+def test_is_judge_tests_enabled_off_by_default() -> None:
+    """Gate env var must default to disabled (CI-safe)."""
+    import os
+
+    from tests.helpers.llm_judge_fixture import _is_judge_tests_enabled
+
+    env_backup = os.environ.pop("AUTOBOT_LLM_JUDGE_TESTS", None)
+    try:
+        assert not _is_judge_tests_enabled()
+    finally:
+        if env_backup is not None:
+            os.environ["AUTOBOT_LLM_JUDGE_TESTS"] = env_backup
+
+
+def test_is_judge_tests_enabled_when_set(monkeypatch) -> None:
+    """Gate returns True when env var is '1'."""
+    from tests.helpers.llm_judge_fixture import _is_judge_tests_enabled
+
+    monkeypatch.setenv("AUTOBOT_LLM_JUDGE_TESTS", "1")
+    assert _is_judge_tests_enabled()
+
+
+def test_provider_configured_no_env(monkeypatch) -> None:
+    """Provider check returns False when no provider env vars are set."""
+    from tests.helpers.llm_judge_fixture import _provider_configured
+
+    for key in ("AUTOBOT_LLM_PROVIDER", "AUTOBOT_OLLAMA_ENDPOINT", "AUTOBOT_OPENAI_API_KEY", "AUTOBOT_ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    assert not _provider_configured()
+
+
+def test_provider_configured_with_openai_key(monkeypatch) -> None:
+    """Provider check returns True when AUTOBOT_OPENAI_API_KEY is set."""
+    from tests.helpers.llm_judge_fixture import _provider_configured
+
+    for key in ("AUTOBOT_LLM_PROVIDER", "AUTOBOT_OLLAMA_ENDPOINT", "AUTOBOT_ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("AUTOBOT_OPENAI_API_KEY", "sk-test")
+    assert _provider_configured()

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,6 +19,7 @@ markers =
     real_kb: Tests that run against a real (in-memory) ChromaDB instance
     migration_gate: Alembic migration-path tests requiring a disposable Postgres (#10001/#10026)
     xdist_group: pytest-xdist group marker — tests with the same group run on the same worker
+    llm_judge: LLM-judged quality assertions — skipped unless AUTOBOT_LLM_JUDGE_TESTS=1 and a provider is configured (#11521)
 
 # Test discovery - colocated tests live next to source files (#734)
 testpaths =


### PR DESCRIPTION
Closes #11521. Part of umbrella #11518 (Task 4).

## Thinking Path
The judges framework (`judges/` — BaseLLMJudge, dimensions, confidence, history) existed only at runtime; tests could not make quality assertions about prompt/RAG output. Agent-platform research (umbrella #11518) identified test-runner-integrated LLM assertions as a proven pattern. This wraps the existing judges in a pytest fixture — no new judge logic.

## What Changed
- **New `tests/helpers/llm_judge_fixture.py`** — `llm_judge` fixture yielding a wrapper with `assert_llm(output, criteria, min_score=…, context=…)`; string criteria evaluate on `STRING_CRITERIA_DIMENSIONS` (RELEVANCE/ACCURACY/QUALITY, lazily resolved), or pass explicit `JudgmentDimension` lists; assertion failures include the judge's per-criterion reasoning. Uses `AgentResponseJudge` (concrete `_prepare_judgment_prompt`), not the abstract base.
- **Two-gate auto-skip** — requires `AUTOBOT_LLM_JUDGE_TESTS=1` AND provider env evidence (bare default Ollama endpoint excluded); never a CI dependency. Default threshold via `AUTOBOT_LLM_JUDGE_MIN_SCORE` (0.7).
- **`tests/conftest.py`** — re-exports the fixture via direct import, NOT `pytest_plugins` (pytest ≥9 hard-fails on `pytest_plugins` in non-root conftests depending on testpath glob details).
- **`pytest.ini`** — `llm_judge` marker registered.
- **Example + unit tests** — 3 live `@pytest.mark.llm_judge` tests (skip by default) and 10 always-run unit tests covering the wrapper pass/fail/reasoning paths and the provider-gate heuristics.
- **`tests/helpers/README.md`** — usage docs.

## Verification
- `pytest autobot-backend/tests/test_llm_judge_example.py` → **10 passed, 3 skipped** (live tests skip cleanly with no provider)
- Collection smoke: 3285 collected / 129 errors — identical 129 pre-existing errors as base (3272/129), +13 new tests
- `flake8 --config=.flake8` and `black --check -l 120` clean on changed files
- code-reviewer pass: 1 blocker (pytest_plugins fragility), 1 major (abstract judge → always 0.0 live), 5 minors — all fixed

## Model Used
Claude (Fable 5) orchestrating; Sonnet implementation agent; Sonnet code-reviewer agent.
