### PR TITLE
ci(ui): extend stylelint token guard to autobot-slm-frontend (#11515 Task 1.2)

### DIFF
--- a/.github/workflows/stylelint-tokens.yml
+++ b/.github/workflows/stylelint-tokens.yml
@@ -17,8 +17,11 @@ on:
     paths:
       - "autobot-frontend/**/*.vue"
       - "autobot-frontend/**/*.css"
-      # Self-validate when the guard or its config changes.
+      - "autobot-slm-frontend/**/*.vue"
+      - "autobot-slm-frontend/**/*.css"
+      # Self-validate when the guard or either config changes.
       - "autobot-frontend/.stylelintrc.json"
+      - "autobot-slm-frontend/.stylelintrc.json"
       - ".github/workflows/stylelint-tokens.yml"
 
 permissions:
@@ -45,7 +48,8 @@ jobs:
         run: |
           git fetch origin "$BASE_REF" --depth=1 || true
           git diff --name-only "origin/${BASE_REF}...HEAD" -- \
-            'autobot-frontend/**/*.vue' 'autobot-frontend/**/*.css' > changed-css.txt || true
+            'autobot-frontend/**/*.vue' 'autobot-frontend/**/*.css' \
+            'autobot-slm-frontend/**/*.vue' 'autobot-slm-frontend/**/*.css' > changed-css.txt || true
           count=$(wc -l < changed-css.txt | tr -d ' ')
           echo "count=${count:-0}" >> "$GITHUB_OUTPUT"
           echo "Changed CSS/Vue files: ${count:-0}"
@@ -55,5 +59,6 @@ jobs:
         run: |
           npm install --no-save --no-package-lock stylelint@^16 postcss-html@^1.6 >/dev/null 2>&1
           # Read the file list from disk (not interpolated) and pass via xargs so
-          # filenames can't inject shell. Config path is repo-relative and fixed.
-          xargs -a changed-css.txt npx stylelint --config autobot-frontend/.stylelintrc.json
+          # filenames can't inject shell. No --config: stylelint auto-resolves each
+          # file's nearest .stylelintrc (autobot-frontend/ or autobot-slm-frontend/).
+          xargs -a changed-css.txt npx stylelint

--- a/autobot-slm-frontend/.stylelintrc.json
+++ b/autobot-slm-frontend/.stylelintrc.json
@@ -1,0 +1,16 @@
+{
+  "overrides": [
+    {
+      "files": ["**/*.vue"],
+      "customSyntax": "postcss-html"
+    }
+  ],
+  "rules": {
+    "color-no-hex": [
+      true,
+      {
+        "message": "Hardcoded hex color — use a design token, e.g. var(--color-…) / var(--a11y-…) (tokenisation umbrella #11515). A var(--token, #fallback) fallback is still flagged here; migrate the raw value first."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Thinking Path
Umbrella #11515 Task 1.2 — the enforcement guard (Task 1.1) covered only `autobot-frontend`. Extend it to the SLM frontend so new hardcoded hex colors are surfaced there too.

## What Changed
- Added `autobot-slm-frontend/.stylelintrc.json` (same `color-no-hex` rule, SLM token hint).
- `stylelint-tokens.yml`: added SLM CSS/Vue trigger paths + diff globs; dropped the hardcoded `--config` so stylelint auto-resolves each file's nearest `.stylelintrc` (per-frontend config).
- Still non-blocking (`continue-on-error`), changed-files-only, `--no-save` install.

## Verification
- Workflow YAML + both `.stylelintrc.json` parse clean. Injection-safe (unchanged env/xargs pattern).

## Model Used
Opus 4.8

Refs #11515