### PR TITLE
fix(chat): tolerate missing closing '>' on </TOOL_CALL so tool calls execute (#11545)

### DIFF
--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -60,8 +60,10 @@ _TOOL_CALL_OPEN_RE = re.compile(r"<TOOL_\s+CALL")
 _TOOL_CALL_CLOSE_RE = re.compile(r"</TOOL_\s+CALL>")
 
 # Issue #727: Pattern to detect completed tool call tags (for hallucination prevention)
-# Matches </tool_call>, </TOOL_CALL>, and </TOOL_ CALL> (underscore variant) with optional whitespace
-_TOOL_CALL_COMPLETE_RE = re.compile(r"</\s*tool_?\s*call\s*>", re.IGNORECASE)
+# Matches </tool_call>, </TOOL_CALL>, and </TOOL_ CALL> (underscore variant).
+# #11545: the trailing `>` is optional — some models omit it (`</TOOL_CALL` +
+# newline); `\b` keeps `</tool_callable` from matching.
+_TOOL_CALL_COMPLETE_RE = re.compile(r"</\s*tool_?\s*call\b\s*>?", re.IGNORECASE)
 
 # Issue #716: Patterns for internal prompts that should not be shown to users
 # These are continuation instructions that LLM sometimes echoes back

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -446,8 +446,13 @@ def _approval_category_for(tool_name: str, declared: list[str]) -> str | None:
 
 # Issue #650: Pre-compiled regex for tool call parsing (performance optimization)
 # Handles both uppercase and lowercase TOOL_CALL tags with nested JSON in params
+# #11545: the closing `>` is optional — some chat models emit `</TOOL_CALL`
+# (newline/prose after) without it, which previously left the whole tool call
+# unparsed (raw tag leaked to the user, tool never executed). `\b` guards
+# against matching `</tool_callable…`. The opening tag's `>` (after params) is
+# still required.
 _TOOL_CALL_PATTERN = re.compile(
-    r'<tool_call\s+name="([^"]+)"\s+params=(["\'])(.+?)\2>([^<]*)</tool_call>',
+    r'<tool_call\s+name="([^"]+)"\s+params=(["\'])(.+?)\2>([^<]*)</tool_call\b\s*>?',
     re.IGNORECASE | re.DOTALL,
 )
 

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_call_missing_gt.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_call_missing_gt.py
@@ -55,3 +55,21 @@ def test_complete_re_detects_missing_gt_and_wellformed_but_not_callable():
     assert complete.search("</TOOL_CALL>") is not None
     assert complete.search("</TOOL_CALL\n") is not None  # #11545
     assert complete.search("</tool_callable>") is None
+
+
+def test_two_back_to_back_calls_parse_separately_first_missing_gt():
+    """#11545: two calls (first missing '>') must parse as 2 separate matches,
+    not merge — the risk from making '>' optional."""
+    pat, _ = _load_patterns()
+    text = _OPEN.replace('create_task', 'a') + "</TOOL_CALL\n" + \
+        "<TOOL_CALL name=\"b\" params='{\"y\":2}'>second</TOOL_CALL>"
+    matches = list(pat.finditer(text))
+    assert [m.group(1) for m in matches] == ["a", "b"]
+    assert matches[1].group(3) == '{"y":2}'  # second call's params intact
+
+
+def test_trailing_prose_with_tool_call_mention_not_captured():
+    pat, _ = _load_patterns()
+    text = _OPEN + "</TOOL_CALL\n\nLater I referenced </tool_call in prose."
+    m = pat.search(text)
+    assert m and m.group(4).strip() == "Create task"  # desc not polluted by later mention

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_call_missing_gt.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_call_missing_gt.py
@@ -24,7 +24,7 @@ def _load_patterns():
     return _TOOL_CALL_PATTERN, _TOOL_CALL_COMPLETE_RE
 
 
-_OPEN = "<TOOL_CALL name=\"create_task\" params='{\"title\":\"X\"}'>Create task"
+_OPEN = '<TOOL_CALL name="create_task" params=\'{"title":"X"}\'>Create task'
 _WELLFORMED = _OPEN + "</TOOL_CALL>"
 _MISSING_GT = _OPEN + "</TOOL_CALL\n\nHigh priority created"  # #11545: no closing '>'
 

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_call_missing_gt.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_call_missing_gt.py
@@ -1,0 +1,57 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11545: tool-call parsing must tolerate a missing closing '>' — some chat
+models emit `</TOOL_CALL` (newline/prose after) without it, which previously
+left the whole tool call unparsed (raw tag leaked, tool never executed).
+
+Imports the REAL compiled patterns; skips where the heavy chat_workflow import
+chain isn't available in this env (runs in CI).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _load_patterns():
+    try:
+        from chat_workflow.manager import _TOOL_CALL_COMPLETE_RE
+        from chat_workflow.tool_handler import _TOOL_CALL_PATTERN
+    except Exception as exc:  # noqa: BLE001 — env-dependent import chain
+        pytest.skip(f"chat_workflow not importable here: {exc}")
+    return _TOOL_CALL_PATTERN, _TOOL_CALL_COMPLETE_RE
+
+
+_OPEN = "<TOOL_CALL name=\"create_task\" params='{\"title\":\"X\"}'>Create task"
+_WELLFORMED = _OPEN + "</TOOL_CALL>"
+_MISSING_GT = _OPEN + "</TOOL_CALL\n\nHigh priority created"  # #11545: no closing '>'
+
+
+def test_pattern_parses_wellformed():
+    pat, _ = _load_patterns()
+    m = pat.search(_WELLFORMED)
+    assert m and m.group(1) == "create_task" and m.group(4).strip() == "Create task"
+
+
+def test_pattern_parses_missing_closing_gt():
+    """The #11545 fix: `</TOOL_CALL` without `>` still parses + extracts name."""
+    pat, _ = _load_patterns()
+    m = pat.search(_MISSING_GT)
+    assert m and m.group(1) == "create_task"
+
+
+def test_pattern_does_not_false_match_callable():
+    pat, _ = _load_patterns()
+    text = "<TOOL_CALL name=\"x\" params='{}'>d</tool_callable stuff"
+    # closing must be a real </tool_call> boundary, not `</tool_callable`
+    m = pat.search(text)
+    assert m is None
+
+
+def test_complete_re_detects_missing_gt_and_wellformed_but_not_callable():
+    _, complete = _load_patterns()
+    assert complete.search("</TOOL_CALL>") is not None
+    assert complete.search("</TOOL_CALL\n") is not None  # #11545
+    assert complete.search("</tool_callable>") is None

--- a/autobot-backend/tests/unit/chat_workflow/test_tool_call_missing_gt.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_tool_call_missing_gt.py
@@ -61,8 +61,11 @@ def test_two_back_to_back_calls_parse_separately_first_missing_gt():
     """#11545: two calls (first missing '>') must parse as 2 separate matches,
     not merge — the risk from making '>' optional."""
     pat, _ = _load_patterns()
-    text = _OPEN.replace('create_task', 'a') + "</TOOL_CALL\n" + \
-        "<TOOL_CALL name=\"b\" params='{\"y\":2}'>second</TOOL_CALL>"
+    text = (
+        _OPEN.replace("create_task", "a")
+        + "</TOOL_CALL\n"
+        + '<TOOL_CALL name="b" params=\'{"y":2}\'>second</TOOL_CALL>'
+    )
     matches = list(pat.finditer(text))
     assert [m.group(1) for m in matches] == ["a", "b"]
     assert matches[1].group(3) == '{"y":2}'  # second call's params intact


### PR DESCRIPTION
## Thinking Path
Live CEO-chat E2E (#11501 T2, on the box) proved the pipeline + tool-teaching work — the board LLM emitted `create_task` tool calls — but they were **never executed**: this chat model emits the closing tag **without the trailing `>`** (`</TOOL_CALL` + newline + prose), and both regexes require it, so the tag leaked into the reply and no work item was created (reproduced twice; `resolved_entity` null; backend log "TOOL_CALL tag found but regex didn't match"). Affects **all** pipeline tools for any model that drops the `>`. Fixes #11545.

## What Changed
- `chat_workflow/tool_handler.py:_TOOL_CALL_PATTERN` — closing `</tool_call>` → `</tool_call\b\s*>?` (trailing `>` optional).
- `chat_workflow/manager.py:_TOOL_CALL_COMPLETE_RE` — `</\s*tool_?\s*call\s*>` → `...\b\s*>?`.
- Both guarded by `\b` so `</tool_callable…` cannot false-match; the **opening** tag's `>` (after params) stays required.

## Verification
- New test (`tests/unit/chat_workflow/test_tool_call_missing_gt.py`, imports the REAL patterns): well-formed parses, missing-`>` parses (the fix), `callable` does not false-match, completion-RE detects `</TOOL_CALL>` and `</TOOL_CALL\n` but not `</tool_callable>`. 4 pass; flake8 clean.
- Post-merge: redeploy autobot-backend (built-in resolve) and re-run the CEO-chat E2E — board message should now create a work item + a clean reply (no raw tags).

## Model Used
Claude Fable 5 (1M context)
