### PR TITLE
feat(llm): canonical schema-typed extraction helper structured_ops + consolidate call sites (#11520)

### DIFF
--- a/autobot-backend/agents/knowledge_extraction_agent.py
+++ b/autobot-backend/agents/knowledge_extraction_agent.py
@@ -12,7 +12,6 @@ management.
 """
 
 import asyncio
-import json
 import re
 import time
 from datetime import datetime, timezone
@@ -464,27 +463,34 @@ Return the results as a JSON array of facts. Example format:
         return True
 
     async def _get_llm_facts_response(self, content: str, context: str | None) -> List[Dict[str, Any]] | None:
-        """Get raw facts from LLM response. Returns None on error."""
+        """Get raw facts from LLM response. Returns None on error.
+
+        Issue #11520: delegates JSON parsing, fence-stripping, and retry to
+        ``llm_shared.structured_ops.extract`` with an inline JSON Schema so the
+        helper handles all retry-on-invalid logic uniformly.
+        """
+        from llm_shared.structured_ops import ExtractionError, extract
+
+        # Minimal JSON Schema envelope that matches the existing response format.
+        facts_envelope_schema: Dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "facts": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                }
+            },
+            "required": ["facts"],
+        }
+
         prompt = self._build_extraction_prompt(content, context)
-        response = await self.llm_interface.chat(
-            [{"role": "user", "content": prompt}],
-            llm_type=LLMType.EXTRACTION,
-            structured_output=True,
-        )
-
-        if not response or response.error:
-            error_msg = response.error if response else "No response"
-            logger.warning("No response from LLM for fact extraction: %s", error_msg)
-            return None
-
         try:
-            facts_data = json.loads(response.content)
-            if "facts" not in facts_data:
-                logger.warning("LLM response missing 'facts' field")
-                return None
-            return facts_data["facts"]
-        except json.JSONDecodeError as e:
-            logger.error("Failed to parse LLM response as JSON: %s", e)
+            result: Dict[str, Any] = await extract(  # type: ignore[assignment]
+                prompt, facts_envelope_schema, llm_type=LLMType.EXTRACTION, chunking="never"
+            )
+            return result.get("facts")
+        except ExtractionError as exc:
+            logger.error("Fact extraction LLM call failed: %s", exc)
             return None
 
     def _enhance_fact_data(self, fact_data: Dict[str, Any], content: str) -> None:

--- a/autobot-backend/agents/knowledge_extraction_agent.py
+++ b/autobot-backend/agents/knowledge_extraction_agent.py
@@ -486,7 +486,11 @@ Return the results as a JSON array of facts. Example format:
         prompt = self._build_extraction_prompt(content, context)
         try:
             result: Dict[str, Any] = await extract(  # type: ignore[assignment]
-                prompt, facts_envelope_schema, llm_type=LLMType.EXTRACTION, chunking="never"
+                prompt,
+                facts_envelope_schema,
+                llm_type=LLMType.EXTRACTION,
+                chunking="never",
+                llm_service=self.llm_interface,
             )
             return result.get("facts")
         except ExtractionError as exc:

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -338,6 +338,10 @@ if "llm_shared" not in sys.modules:
 
     _load_real_mod("llm_shared.types", _llm_root / "types.py")
     _load_real_mod("llm_shared.models", _llm_root / "models.py")
+    # #11520: canonical JSON parser and schema-typed extraction helper — lightweight,
+    # no heavy deps; load real so tests importing them don't hit the stub.
+    _load_real_mod("llm_shared.json_utils", _llm_root / "json_utils.py")
+    _load_real_mod("llm_shared.structured_ops", _llm_root / "structured_ops.py")
     _load_real_mod("llm_shared.optimization.rate_limiter", _llm_root / "optimization" / "rate_limiter.py")
     _load_real_mod("llm_shared.fallback_chain", _llm_root / "fallback_chain.py")
     _load_real_mod("llm_shared.model_fallback_coordinator", _llm_root / "model_fallback_coordinator.py")

--- a/autobot-backend/judges/__init__.py
+++ b/autobot-backend/judges/__init__.py
@@ -16,34 +16,16 @@ Key Principles:
 - Feedback loops for continuous improvement
 """
 
-import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from llm_shared.json_utils import extract_json_object as _extract_json_object  # Issue #11520
 from llm_shared.types import LLMType
 
 logger = get_logger(__name__)
-
-
-def _extract_json_object(raw_text: str) -> Dict[str, Any]:
-    """Parse a JSON object from an LLM response, tolerating markdown code fences (#10672).
-
-    structured_output=True makes supporting providers emit valid JSON; providers
-    that ignore it may still wrap the object in a ```json fence, so strip that
-    before parsing. Raises json.JSONDecodeError on genuinely unparseable text.
-    """
-    try:
-        return json.loads(raw_text)
-    except json.JSONDecodeError:
-        if "```" in raw_text:
-            block = raw_text.split("```", 2)[1]
-            if block.lstrip().lower().startswith("json"):
-                block = block.lstrip()[4:]
-            return json.loads(block.strip())
-        raise
 
 
 class JudgmentConfidence(Enum):

--- a/autobot-backend/llc/tests/test_agent_tools.py
+++ b/autobot-backend/llc/tests/test_agent_tools.py
@@ -94,9 +94,7 @@ async def test_create_task_calls_work_item_service_with_authed_actor():
     svc = MagicMock()
     svc.create = AsyncMock(return_value=item)
     with p, patch("llc.services.work_item_service.WorkItemService", return_value=svc):
-        out = await dispatch_llc_tool(
-            "create_task", {"title": "Write Q3 report", "priority": "high"}, _COMPANY, _USER
-        )
+        out = await dispatch_llc_tool("create_task", {"title": "Write Q3 report", "priority": "high"}, _COMPANY, _USER)
     assert out["status"] == "success" and out["entity_type"] == "work_item"
     assert svc.create.await_args.kwargs["company_id"] == _COMPANY
     assert svc.create.await_args.kwargs["title"] == "Write Q3 report"

--- a/autobot-backend/llm_shared/json_utils.py
+++ b/autobot-backend/llm_shared/json_utils.py
@@ -1,0 +1,44 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+llm_shared.json_utils — Shared JSON parsing helpers for LLM responses.
+
+Issue #11520: Extracted from judges/__init__.py `_extract_json_object` so
+every LLM call site in the codebase shares a single fence-tolerant parser.
+judges/__init__.py now imports from here instead of defining its own copy.
+"""
+
+import json
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def extract_json_object(raw_text: str) -> Dict[str, Any]:
+    """Parse a JSON object from an LLM response, tolerating markdown code fences (#10672).
+
+    structured_output=True makes supporting providers emit valid JSON; providers
+    that ignore it may still wrap the object in a ```json fence, so strip that
+    before parsing. Raises json.JSONDecodeError on genuinely unparseable text.
+
+    Args:
+        raw_text: Raw LLM response content, possibly wrapped in markdown fences.
+
+    Returns:
+        Parsed JSON as a Python dict.
+
+    Raises:
+        json.JSONDecodeError: If the text cannot be parsed as JSON.
+    """
+    try:
+        return json.loads(raw_text)
+    except json.JSONDecodeError:
+        if "```" in raw_text:
+            block = raw_text.split("```", 2)[1]
+            if block.lstrip().lower().startswith("json"):
+                block = block.lstrip()[4:]
+            return json.loads(block.strip())
+        raise

--- a/autobot-backend/llm_shared/structured_ops.py
+++ b/autobot-backend/llm_shared/structured_ops.py
@@ -137,12 +137,19 @@ def _schema_to_repr(schema: type[pydantic.BaseModel] | dict) -> str:
     return json.dumps(schema.model_json_schema(), ensure_ascii=False)
 
 
-async def _call_llm(prompt: str, llm_type: LLMType) -> str:
-    """Call the shared LLM service and return the raw content string."""
-    from services.llm_service import get_llm_service
+async def _call_llm(prompt: str, llm_type: LLMType, llm_service: Any = None) -> str:
+    """Call the LLM and return the raw content string.
 
-    svc = get_llm_service()
-    response = await svc.chat(
+    *llm_service* lets callers inject their own configured interface (any
+    object with the ``LLMService.chat`` signature) so per-agent SSOT
+    provider/endpoint/model routing is preserved; defaults to the shared
+    service singleton.
+    """
+    if llm_service is None:
+        from services.llm_service import get_llm_service
+
+        llm_service = get_llm_service()
+    response = await llm_service.chat(
         messages=[{"role": "user", "content": prompt}],
         llm_type=llm_type,
         structured_output=True,
@@ -157,6 +164,7 @@ async def _extract_single(
     schema: type[pydantic.BaseModel] | dict,
     llm_type: LLMType,
     max_retries: int,
+    llm_service: Any = None,
 ) -> pydantic.BaseModel | dict:
     """Run the extraction + validation loop for a single text block.
 
@@ -179,7 +187,7 @@ async def _extract_single(
                 last_error,
             )
 
-        raw = await _call_llm(prompt, llm_type)
+        raw = await _call_llm(prompt, llm_type, llm_service)
 
         # --- Parse ---
         try:
@@ -260,6 +268,7 @@ async def extract(
     llm_type: LLMType = LLMType.EXTRACTION,
     max_retries: int = EXTRACT_MAX_RETRIES,
     chunking: str = "auto",
+    llm_service: Any = None,
 ) -> Union[pydantic.BaseModel, dict]:
     """Extract structured data from *text* conforming to *schema*.
 
@@ -274,6 +283,9 @@ async def extract(
         chunking:    ``"auto"`` (default): chunk text when it exceeds
                      ``EXTRACT_CHUNK_THRESHOLD_CHARS`` chars.
                      ``"never"``: always treat the full text as one block.
+        llm_service: Optional pre-configured LLM interface (``LLMService.chat``
+                     signature).  Callers with per-agent SSOT routing must pass
+                     their own interface; defaults to the shared singleton.
 
     Returns:
         A ``pydantic.BaseModel`` instance when *schema* is a model class, or
@@ -290,7 +302,7 @@ async def extract(
     should_chunk = chunking == "auto" and len(text) > EXTRACT_CHUNK_THRESHOLD_CHARS
 
     if not should_chunk:
-        return await _extract_single(text, schema, llm_type, max_retries)
+        return await _extract_single(text, schema, llm_type, max_retries, llm_service)
 
     # --- Chunked path ---
     logger.info(
@@ -310,21 +322,25 @@ async def extract(
         chunk_texts = [text]
 
     if len(chunk_texts) <= 1:
-        return await _extract_single(text, schema, llm_type, max_retries)
+        return await _extract_single(text, schema, llm_type, max_retries, llm_service)
 
     logger.info("structured_ops.extract: processing %d chunks", len(chunk_texts))
     results: list[Any] = []
     for i, chunk_text in enumerate(chunk_texts, 1):
         logger.debug("structured_ops.extract: chunk %d/%d", i, len(chunk_texts))
-        chunk_result = await _extract_single(chunk_text, schema, llm_type, max_retries)
+        chunk_result = await _extract_single(chunk_text, schema, llm_type, max_retries, llm_service)
         results.append(chunk_result)
 
     # Merge all chunk results into a single output.
     merged = _merge_results(results)
 
     # If caller passed a Pydantic model, re-validate the merged dict.
-    if not isinstance(schema, dict):
-        return _validate_pydantic(merged, schema)
-
-    _validate_json_schema(merged, schema)
+    # Wrapped so the public ExtractionError-only contract holds even when the
+    # merged result fails validation (#11520 review B1).
+    try:
+        if not isinstance(schema, dict):
+            return _validate_pydantic(merged, schema)
+        _validate_json_schema(merged, schema)
+    except Exception as exc:
+        raise ExtractionError(f"Merged chunk result failed schema validation: {exc}") from exc
     return merged

--- a/autobot-backend/llm_shared/structured_ops.py
+++ b/autobot-backend/llm_shared/structured_ops.py
@@ -165,10 +165,7 @@ async def _extract_single(
     prompt for attempt N+1.
     """
     schema_repr = _schema_to_repr(schema)
-    base_prompt = (
-        f"{_build_system_prompt(schema_repr)}\n\n"
-        f"Text to extract from:\n\n{text}"
-    )
+    base_prompt = f"{_build_system_prompt(schema_repr)}\n\n" f"Text to extract from:\n\n{text}"
     prompt = base_prompt
     last_error: str = ""
 
@@ -191,9 +188,7 @@ async def _extract_single(
             last_error = f"JSONDecodeError: {exc}"
             logger.warning("structured_ops: JSON parse failed (attempt %d): %s", attempt, exc)
             if attempt >= max_retries:
-                raise ExtractionError(
-                    f"LLM returned non-JSON output after {max_retries} attempts: {exc}"
-                ) from exc
+                raise ExtractionError(f"LLM returned non-JSON output after {max_retries} attempts: {exc}") from exc
             continue
 
         # --- Validate ---
@@ -205,13 +200,9 @@ async def _extract_single(
                 return _validate_pydantic(data, schema)
         except Exception as exc:
             last_error = str(exc)
-            logger.warning(
-                "structured_ops: validation failed (attempt %d): %s", attempt, exc
-            )
+            logger.warning("structured_ops: validation failed (attempt %d): %s", attempt, exc)
             if attempt >= max_retries:
-                raise ExtractionError(
-                    f"Schema validation failed after {max_retries} attempts: {exc}"
-                ) from exc
+                raise ExtractionError(f"Schema validation failed after {max_retries} attempts: {exc}") from exc
 
     # Should be unreachable — loop always returns or raises above.
     raise ExtractionError("extract: exhausted all attempts without result")  # pragma: no cover
@@ -296,10 +287,7 @@ async def extract(
         * Scalar/object fields: last non-null/non-empty chunk value wins.
         * List/array fields: concatenated; exact string duplicates removed.
     """
-    should_chunk = (
-        chunking == "auto"
-        and len(text) > EXTRACT_CHUNK_THRESHOLD_CHARS
-    )
+    should_chunk = chunking == "auto" and len(text) > EXTRACT_CHUNK_THRESHOLD_CHARS
 
     if not should_chunk:
         return await _extract_single(text, schema, llm_type, max_retries)
@@ -318,17 +306,13 @@ async def extract(
         chunk_texts = [c.content for c in chunks] if chunks else [text]
     except Exception as exc:
         # Graceful degradation: chunking unavailable, run on full text.
-        logger.warning(
-            "structured_ops.extract: chunking failed (%s) — using full text", exc
-        )
+        logger.warning("structured_ops.extract: chunking failed (%s) — using full text", exc)
         chunk_texts = [text]
 
     if len(chunk_texts) <= 1:
         return await _extract_single(text, schema, llm_type, max_retries)
 
-    logger.info(
-        "structured_ops.extract: processing %d chunks", len(chunk_texts)
-    )
+    logger.info("structured_ops.extract: processing %d chunks", len(chunk_texts))
     results: list[Any] = []
     for i, chunk_text in enumerate(chunk_texts, 1):
         logger.debug("structured_ops.extract: chunk %d/%d", i, len(chunk_texts))

--- a/autobot-backend/llm_shared/structured_ops.py
+++ b/autobot-backend/llm_shared/structured_ops.py
@@ -1,0 +1,346 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+llm_shared.structured_ops — Canonical schema-typed LLM extraction helper.
+
+Issue #11520: Consolidates three hand-rolled extraction paths that each
+re-implemented JSON parsing, retries, and chunking:
+    - web_fetch/extractors.py  (JSON Schema / dict)
+    - agents/knowledge_extraction_agent.py  (JSON dict → AtomicFact objects)
+    - api/entity_extraction.py  (delegates to graph_entity_extractor)
+
+Public API
+----------
+    async def extract(
+        text: str,
+        schema: type[BaseModel] | dict,
+        *,
+        llm_type: LLMType = LLMType.EXTRACTION,
+        max_retries: int = EXTRACT_MAX_RETRIES,
+        chunking: str = "auto",
+    ) -> BaseModel | dict
+
+Schema types
+~~~~~~~~~~~~
+* ``pydantic.BaseModel`` subclass → the helper validates the parsed JSON and
+  returns a model instance.
+* ``dict`` (JSON Schema) → validated via ``jsonschema.Draft202012Validator``;
+  returns a plain ``dict``.
+
+Chunking
+~~~~~~~~
+When ``chunking="auto"`` (default) and the input exceeds
+``EXTRACT_CHUNK_THRESHOLD_CHARS`` characters the text is split via the existing
+``utils.semantic_chunker.get_semantic_chunker()`` factory.  Each chunk is
+extracted independently and merged as follows:
+
+  * Object schemas: non-null field values from later chunks overwrite nulls /
+    absences from earlier chunks (last-non-null wins).
+  * List/array fields: concatenated across chunks, deduplicating exact
+    string duplicates.
+
+The merge strategy is deliberately simple and documented here; call sites that
+need custom merge logic should call ``extract()`` per chunk themselves.
+
+Retries
+~~~~~~~
+On ``json.JSONDecodeError`` or schema validation failure the error message is
+fed back to the LLM in a retry prompt so the model can self-correct.  After
+``max_retries`` attempts a ``ExtractionError`` is raised — errors are never
+swallowed.
+
+Import safety
+~~~~~~~~~~~~~
+``llm_shared`` must never import from ``judges``.  The fence-tolerant JSON
+parser lives in ``llm_shared.json_utils`` and is imported from there by both
+this module and ``judges/__init__.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Union
+
+import pydantic
+
+from llm_shared.json_utils import extract_json_object
+from llm_shared.types import LLMType
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level env-configurable constants (never hard-coded)
+# ---------------------------------------------------------------------------
+
+#: Maximum number of LLM call attempts before raising ExtractionError.
+EXTRACT_MAX_RETRIES: int = int(os.environ.get("AUTOBOT_EXTRACT_MAX_RETRIES", "3"))
+
+#: Inputs larger than this many characters trigger auto-chunking.
+EXTRACT_CHUNK_THRESHOLD_CHARS: int = int(os.environ.get("AUTOBOT_EXTRACT_CHUNK_THRESHOLD", "8000"))
+
+
+# ---------------------------------------------------------------------------
+# Public exception
+# ---------------------------------------------------------------------------
+
+
+class ExtractionError(RuntimeError):
+    """Raised after all retry attempts are exhausted without a valid result."""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_system_prompt(schema_repr: str) -> str:
+    """Return the system prompt for schema-driven extraction."""
+    return (
+        "You are a structured data extraction assistant. "
+        "Extract information from the provided text and return ONLY a valid JSON object "
+        f"that conforms to this schema:\n\n{schema_repr}\n\n"
+        "Respond with only the JSON object, no explanation or markdown fences."
+    )
+
+
+def _build_retry_prompt(previous_prompt: str, error_msg: str) -> str:
+    """Return a follow-up prompt that feeds the validation error back to the LLM."""
+    return (
+        f"{previous_prompt}\n\n"
+        f"Your previous response was invalid: {error_msg}\n"
+        "Please fix the JSON and try again. Return ONLY a valid JSON object."
+    )
+
+
+def _validate_pydantic(data: dict, schema: type[pydantic.BaseModel]) -> pydantic.BaseModel:
+    """Validate dict against a Pydantic model. Raises ValidationError on failure."""
+    return schema.model_validate(data)
+
+
+def _validate_json_schema(data: dict, schema: dict) -> None:
+    """Validate dict against JSON Schema (Draft 2020-12). Raises ValidationError."""
+    import jsonschema
+
+    validator = jsonschema.Draft202012Validator(schema)
+    validator.validate(data)
+
+
+def _schema_to_repr(schema: type[pydantic.BaseModel] | dict) -> str:
+    """Serialise the schema for inclusion in the LLM prompt."""
+    if isinstance(schema, dict):
+        return json.dumps(schema, ensure_ascii=False)
+    # Pydantic model class
+    return json.dumps(schema.model_json_schema(), ensure_ascii=False)
+
+
+async def _call_llm(prompt: str, llm_type: LLMType) -> str:
+    """Call the shared LLM service and return the raw content string."""
+    from services.llm_service import get_llm_service
+
+    svc = get_llm_service()
+    response = await svc.chat(
+        messages=[{"role": "user", "content": prompt}],
+        llm_type=llm_type,
+        structured_output=True,
+    )
+    if response.error:
+        raise ExtractionError(f"LLM call failed: {response.error}")
+    return response.content
+
+
+async def _extract_single(
+    text: str,
+    schema: type[pydantic.BaseModel] | dict,
+    llm_type: LLMType,
+    max_retries: int,
+) -> pydantic.BaseModel | dict:
+    """Run the extraction + validation loop for a single text block.
+
+    On each attempt the full prompt is rebuilt so the model always has the
+    schema in view. The validation error from attempt N is prepended in the
+    prompt for attempt N+1.
+    """
+    schema_repr = _schema_to_repr(schema)
+    base_prompt = (
+        f"{_build_system_prompt(schema_repr)}\n\n"
+        f"Text to extract from:\n\n{text}"
+    )
+    prompt = base_prompt
+    last_error: str = ""
+
+    for attempt in range(1, max_retries + 1):
+        if attempt > 1:
+            prompt = _build_retry_prompt(base_prompt, last_error)
+            logger.debug(
+                "structured_ops.extract: retry %d/%d after error: %s",
+                attempt,
+                max_retries,
+                last_error,
+            )
+
+        raw = await _call_llm(prompt, llm_type)
+
+        # --- Parse ---
+        try:
+            data = extract_json_object(raw)
+        except json.JSONDecodeError as exc:
+            last_error = f"JSONDecodeError: {exc}"
+            logger.warning("structured_ops: JSON parse failed (attempt %d): %s", attempt, exc)
+            if attempt >= max_retries:
+                raise ExtractionError(
+                    f"LLM returned non-JSON output after {max_retries} attempts: {exc}"
+                ) from exc
+            continue
+
+        # --- Validate ---
+        try:
+            if isinstance(schema, dict):
+                _validate_json_schema(data, schema)
+                return data
+            else:
+                return _validate_pydantic(data, schema)
+        except Exception as exc:
+            last_error = str(exc)
+            logger.warning(
+                "structured_ops: validation failed (attempt %d): %s", attempt, exc
+            )
+            if attempt >= max_retries:
+                raise ExtractionError(
+                    f"Schema validation failed after {max_retries} attempts: {exc}"
+                ) from exc
+
+    # Should be unreachable — loop always returns or raises above.
+    raise ExtractionError("extract: exhausted all attempts without result")  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# Chunk-merge helpers
+# ---------------------------------------------------------------------------
+
+
+def _merge_dicts(base: dict, update: dict) -> dict:
+    """Merge *update* into *base* using last-non-null-wins for scalars and
+    concatenation for lists.
+
+    Rules (documented in module docstring):
+    * Scalar/object fields: value from *update* wins when it is not None / "".
+    * List/array fields: concatenated; exact string duplicates are removed.
+    """
+    result = dict(base)
+    for key, value in update.items():
+        existing = result.get(key)
+        if isinstance(existing, list) and isinstance(value, list):
+            # Concatenate lists, removing exact string duplicates.
+            seen: set = set()
+            merged: list = []
+            for item in existing + value:
+                dedup_key = item if isinstance(item, str) else id(item)
+                if dedup_key not in seen:
+                    seen.add(dedup_key)
+                    merged.append(item)
+            result[key] = merged
+        elif value is not None and value != "" and value != []:
+            result[key] = value
+    return result
+
+
+def _merge_results(results: list[Any]) -> dict:
+    """Merge a list of per-chunk dict results into a single dict."""
+    merged: dict = {}
+    for r in results:
+        chunk_dict = r if isinstance(r, dict) else r.model_dump()
+        merged = _merge_dicts(merged, chunk_dict)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def extract(
+    text: str,
+    schema: Union[type[pydantic.BaseModel], dict],
+    *,
+    llm_type: LLMType = LLMType.EXTRACTION,
+    max_retries: int = EXTRACT_MAX_RETRIES,
+    chunking: str = "auto",
+) -> Union[pydantic.BaseModel, dict]:
+    """Extract structured data from *text* conforming to *schema*.
+
+    Args:
+        text:        Input text to extract from.
+        schema:      Either a ``pydantic.BaseModel`` subclass (returns an
+                     instance) or a ``dict`` (JSON Schema — returns a dict).
+        llm_type:    LLMType routing key; defaults to ``LLMType.EXTRACTION``.
+        max_retries: Maximum LLM call attempts per chunk before raising
+                     ``ExtractionError``.  Env override:
+                     ``AUTOBOT_EXTRACT_MAX_RETRIES`` (default 3).
+        chunking:    ``"auto"`` (default): chunk text when it exceeds
+                     ``EXTRACT_CHUNK_THRESHOLD_CHARS`` chars.
+                     ``"never"``: always treat the full text as one block.
+
+    Returns:
+        A ``pydantic.BaseModel`` instance when *schema* is a model class, or
+        a ``dict`` when *schema* is a JSON Schema dict.
+
+    Raises:
+        ExtractionError: After all retry attempts are exhausted without a
+                         valid result.  Never swallows errors.
+
+    Merge rules (chunked path, dict output):
+        * Scalar/object fields: last non-null/non-empty chunk value wins.
+        * List/array fields: concatenated; exact string duplicates removed.
+    """
+    should_chunk = (
+        chunking == "auto"
+        and len(text) > EXTRACT_CHUNK_THRESHOLD_CHARS
+    )
+
+    if not should_chunk:
+        return await _extract_single(text, schema, llm_type, max_retries)
+
+    # --- Chunked path ---
+    logger.info(
+        "structured_ops.extract: text length %d > threshold %d — chunking",
+        len(text),
+        EXTRACT_CHUNK_THRESHOLD_CHARS,
+    )
+    try:
+        from utils.semantic_chunker import get_semantic_chunker
+
+        chunker = get_semantic_chunker()
+        chunks = await chunker.chunk_text(text)
+        chunk_texts = [c.content for c in chunks] if chunks else [text]
+    except Exception as exc:
+        # Graceful degradation: chunking unavailable, run on full text.
+        logger.warning(
+            "structured_ops.extract: chunking failed (%s) — using full text", exc
+        )
+        chunk_texts = [text]
+
+    if len(chunk_texts) <= 1:
+        return await _extract_single(text, schema, llm_type, max_retries)
+
+    logger.info(
+        "structured_ops.extract: processing %d chunks", len(chunk_texts)
+    )
+    results: list[Any] = []
+    for i, chunk_text in enumerate(chunk_texts, 1):
+        logger.debug("structured_ops.extract: chunk %d/%d", i, len(chunk_texts))
+        chunk_result = await _extract_single(chunk_text, schema, llm_type, max_retries)
+        results.append(chunk_result)
+
+    # Merge all chunk results into a single output.
+    merged = _merge_results(results)
+
+    # If caller passed a Pydantic model, re-validate the merged dict.
+    if not isinstance(schema, dict):
+        return _validate_pydantic(merged, schema)
+
+    _validate_json_schema(merged, schema)
+    return merged

--- a/autobot-backend/llm_shared/structured_ops_test.py
+++ b/autobot-backend/llm_shared/structured_ops_test.py
@@ -1,0 +1,343 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit tests for llm_shared.structured_ops (Issue #11520).
+
+Covers:
+- Pydantic model schema path (returns model instance)
+- dict (JSON Schema) path (returns plain dict)
+- Fence-wrapped JSON parsing via json_utils
+- Invalid-JSON retry then raise after max retries
+- Oversized-document chunking + merge with a mocked LLM
+- ExtractionError surfaces after max retries (no swallowed errors)
+
+Patching note: ``_call_llm`` resolves ``get_llm_service`` via a local import
+from ``services.llm_service``.  In the test environment ``services.llm_service``
+is a MagicMock stub (conftest.py); we set ``get_llm_service`` on that stub
+directly so the import-inside-function path picks it up correctly.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_llm_response(content: str, error: str | None = None) -> MagicMock:
+    resp = MagicMock()
+    resp.content = content
+    resp.error = error
+    return resp
+
+
+def _mock_llm_service(return_values: list[str]) -> MagicMock:
+    svc = MagicMock()
+    responses = [_make_llm_response(v) for v in return_values]
+    svc.chat = AsyncMock(side_effect=responses)
+    return svc
+
+
+@contextmanager
+def _patch_llm_service(svc: MagicMock):
+    """Inject *svc* as the return value of ``services.llm_service.get_llm_service``.
+
+    ``_call_llm`` resolves the service factory via a fresh import inside the
+    function body, so the patch target is the attribute on the stub module that
+    conftest already placed in ``sys.modules["services.llm_service"]``.
+    """
+    llm_svc_mod = sys.modules["services.llm_service"]
+    original = getattr(llm_svc_mod, "get_llm_service", None)
+    llm_svc_mod.get_llm_service = MagicMock(return_value=svc)
+    try:
+        yield
+    finally:
+        if original is None:
+            try:
+                del llm_svc_mod.get_llm_service
+            except AttributeError:
+                pass
+        else:
+            llm_svc_mod.get_llm_service = original
+
+
+# ---------------------------------------------------------------------------
+# json_utils.extract_json_object
+# ---------------------------------------------------------------------------
+
+
+def test_extract_json_plain() -> None:
+    from .json_utils import extract_json_object
+
+    assert extract_json_object('{"a": 1}') == {"a": 1}
+
+
+def test_extract_json_fence() -> None:
+    from .json_utils import extract_json_object
+
+    raw = "```json\n{\"b\": 2}\n```"
+    assert extract_json_object(raw) == {"b": 2}
+
+
+def test_extract_json_unnamed_fence() -> None:
+    from .json_utils import extract_json_object
+
+    raw = "```\n{\"c\": 3}\n```"
+    assert extract_json_object(raw) == {"c": 3}
+
+
+def test_extract_json_raises_on_garbage() -> None:
+    from .json_utils import extract_json_object
+
+    with pytest.raises(json.JSONDecodeError):
+        extract_json_object("not json at all")
+
+
+# ---------------------------------------------------------------------------
+# structured_ops.extract — dict schema path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_dict_schema_happy_path() -> None:
+    """Returns a plain dict when schema is a JSON Schema dict."""
+    from .structured_ops import extract
+
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    }
+    svc = _mock_llm_service(['{"name": "widget"}'])
+
+    with _patch_llm_service(svc):
+        result = await extract("some text", schema)
+
+    assert isinstance(result, dict)
+    assert result["name"] == "widget"
+
+
+@pytest.mark.asyncio
+async def test_extract_dict_schema_fence_json() -> None:
+    """Fence-wrapped JSON is accepted via extract_json_object."""
+    from .structured_ops import extract
+
+    schema = {"type": "object", "properties": {"x": {"type": "integer"}}}
+    raw = '```json\n{"x": 42}\n```'
+    svc = _mock_llm_service([raw])
+
+    with _patch_llm_service(svc):
+        result = await extract("text", schema)
+
+    assert result["x"] == 42  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# structured_ops.extract — Pydantic schema path
+# ---------------------------------------------------------------------------
+
+
+class _SampleModel(BaseModel):
+    title: str
+    count: int = 0
+
+
+@pytest.mark.asyncio
+async def test_extract_pydantic_schema_happy_path() -> None:
+    """Returns a Pydantic model instance when schema is a model class."""
+    from .structured_ops import extract
+
+    svc = _mock_llm_service(['{"title": "Test", "count": 5}'])
+
+    with _patch_llm_service(svc):
+        result = await extract("some text", _SampleModel)
+
+    assert isinstance(result, _SampleModel)
+    assert result.title == "Test"
+    assert result.count == 5
+
+
+@pytest.mark.asyncio
+async def test_extract_pydantic_fence_json() -> None:
+    """Pydantic path also tolerates fence-wrapped JSON."""
+    from .structured_ops import extract
+
+    raw = '```json\n{"title": "Hello", "count": 1}\n```'
+    svc = _mock_llm_service([raw])
+
+    with _patch_llm_service(svc):
+        result = await extract("text", _SampleModel)
+
+    assert isinstance(result, _SampleModel)
+    assert result.title == "Hello"
+
+
+# ---------------------------------------------------------------------------
+# Retry on invalid JSON / validation failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_on_bad_json_then_succeeds() -> None:
+    """First response is bad JSON; second attempt succeeds."""
+    from .structured_ops import extract
+
+    schema = {"type": "object", "properties": {"k": {"type": "string"}}}
+    svc = _mock_llm_service(["not json!", '{"k": "ok"}'])
+
+    with _patch_llm_service(svc):
+        result = await extract("text", schema, max_retries=3)
+
+    assert result["k"] == "ok"  # type: ignore[index]
+    assert svc.chat.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_raises_after_max_retries() -> None:
+    """ExtractionError is raised (never swallowed) when all retries fail."""
+    from .structured_ops import ExtractionError, extract
+
+    schema = {"type": "object", "properties": {"k": {"type": "string"}}}
+    svc = _mock_llm_service(["bad", "also bad", "still bad"])
+
+    with _patch_llm_service(svc):
+        with pytest.raises(ExtractionError):
+            await extract("text", schema, max_retries=3)
+
+    assert svc.chat.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_validation_error_triggers_retry() -> None:
+    """Schema validation failure on first attempt triggers a retry."""
+    from .structured_ops import extract
+
+    schema = {
+        "type": "object",
+        "properties": {"score": {"type": "number", "minimum": 0}},
+        "required": ["score"],
+    }
+    svc = _mock_llm_service(['{"score": "not-a-number"}', '{"score": 0.9}'])
+
+    with _patch_llm_service(svc):
+        result = await extract("text", schema, max_retries=3)
+
+    assert result["score"] == 0.9  # type: ignore[index]
+    assert svc.chat.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Chunking + merge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chunk_merge_combines_fields() -> None:
+    """Oversized input is split; per-chunk dicts are merged (last-non-null wins)."""
+    from .structured_ops import extract
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "tags": {"type": "array", "items": {"type": "string"}},
+        },
+    }
+
+    chunk1_resp = '{"title": "First Title", "tags": ["a", "b"]}'
+    chunk2_resp = '{"title": "Better Title", "tags": ["b", "c"]}'
+    svc = _mock_llm_service([chunk1_resp, chunk2_resp])
+
+    chunk_a = MagicMock()
+    chunk_a.content = "chunk text one"
+    chunk_b = MagicMock()
+    chunk_b.content = "chunk text two"
+    fake_chunker = AsyncMock()
+    fake_chunker.chunk_text = AsyncMock(return_value=[chunk_a, chunk_b])
+
+    ops_mod = sys.modules["llm_shared.structured_ops"]
+    # get_semantic_chunker is a local import inside extract(); ensure the stub
+    # module exists in sys.modules then set the attribute before extract() runs.
+    import types as _types
+    if "utils" not in sys.modules:
+        sys.modules["utils"] = _types.ModuleType("utils")
+    if "utils.semantic_chunker" not in sys.modules:
+        sys.modules["utils.semantic_chunker"] = _types.ModuleType("utils.semantic_chunker")
+    chunker_mod = sys.modules["utils.semantic_chunker"]
+    original_gsc = getattr(chunker_mod, "get_semantic_chunker", None)
+    chunker_mod.get_semantic_chunker = MagicMock(return_value=fake_chunker)
+    try:
+        with (
+            _patch_llm_service(svc),
+            patch.object(ops_mod, "EXTRACT_CHUNK_THRESHOLD_CHARS", 5),
+        ):
+            result = await extract("a" * 10, schema, chunking="auto")
+    finally:
+        if original_gsc is None:
+            try:
+                del chunker_mod.get_semantic_chunker
+            except AttributeError:
+                pass
+        else:
+            chunker_mod.get_semantic_chunker = original_gsc
+
+    assert result["title"] == "Better Title"  # type: ignore[index]
+    assert set(result["tags"]) == {"a", "b", "c"}  # type: ignore[index]
+
+
+@pytest.mark.asyncio
+async def test_chunking_never_skips_chunker() -> None:
+    """chunking='never' bypasses the chunker even for oversized input."""
+    from .structured_ops import extract
+
+    schema = {"type": "object"}
+    svc = _mock_llm_service(["{}"])
+
+    ops_mod = sys.modules["llm_shared.structured_ops"]
+    with (
+        _patch_llm_service(svc),
+        patch.object(ops_mod, "EXTRACT_CHUNK_THRESHOLD_CHARS", 0),
+    ):
+        result = await extract("some text", schema, chunking="never")
+
+    assert isinstance(result, dict)
+    assert svc.chat.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# _merge_dicts helper
+# ---------------------------------------------------------------------------
+
+
+def test_merge_dicts_scalar_last_non_null_wins() -> None:
+    from .structured_ops import _merge_dicts
+
+    merged = _merge_dicts({"a": "old", "b": None}, {"a": "new", "b": "value"})
+    assert merged["a"] == "new"
+    assert merged["b"] == "value"
+
+
+def test_merge_dicts_null_does_not_overwrite() -> None:
+    from .structured_ops import _merge_dicts
+
+    merged = _merge_dicts({"a": "keep"}, {"a": None})
+    assert merged["a"] == "keep"
+
+
+def test_merge_dicts_list_concatenation_dedup() -> None:
+    from .structured_ops import _merge_dicts
+
+    merged = _merge_dicts({"tags": ["a", "b"]}, {"tags": ["b", "c"]})
+    assert set(merged["tags"]) == {"a", "b", "c"}
+    assert merged["tags"].count("b") == 1

--- a/autobot-backend/llm_shared/structured_ops_test.py
+++ b/autobot-backend/llm_shared/structured_ops_test.py
@@ -29,7 +29,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic import BaseModel
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -86,14 +85,14 @@ def test_extract_json_plain() -> None:
 def test_extract_json_fence() -> None:
     from .json_utils import extract_json_object
 
-    raw = "```json\n{\"b\": 2}\n```"
+    raw = '```json\n{"b": 2}\n```'
     assert extract_json_object(raw) == {"b": 2}
 
 
 def test_extract_json_unnamed_fence() -> None:
     from .json_utils import extract_json_object
 
-    raw = "```\n{\"c\": 3}\n```"
+    raw = '```\n{"c": 3}\n```'
     assert extract_json_object(raw) == {"c": 3}
 
 
@@ -201,6 +200,10 @@ async def test_retry_on_bad_json_then_succeeds() -> None:
 
     assert result["k"] == "ok"  # type: ignore[index]
     assert svc.chat.call_count == 2
+    # The retry prompt must feed the parse error back to the model (M2).
+    second_prompt = svc.chat.call_args_list[1].kwargs["messages"][0]["content"]
+    assert "JSONDecodeError" in second_prompt
+    assert "previous response was invalid" in second_prompt
 
 
 @pytest.mark.asyncio
@@ -235,6 +238,10 @@ async def test_validation_error_triggers_retry() -> None:
 
     assert result["score"] == 0.9  # type: ignore[index]
     assert svc.chat.call_count == 2
+    # The retry prompt must feed the validation error back to the model (M2).
+    second_prompt = svc.chat.call_args_list[1].kwargs["messages"][0]["content"]
+    assert "not-a-number" in second_prompt
+    assert "previous response was invalid" in second_prompt
 
 
 # ---------------------------------------------------------------------------
@@ -270,6 +277,7 @@ async def test_chunk_merge_combines_fields() -> None:
     # get_semantic_chunker is a local import inside extract(); ensure the stub
     # module exists in sys.modules then set the attribute before extract() runs.
     import types as _types
+
     if "utils" not in sys.modules:
         sys.modules["utils"] = _types.ModuleType("utils")
     if "utils.semantic_chunker" not in sys.modules:
@@ -282,6 +290,9 @@ async def test_chunk_merge_combines_fields() -> None:
             _patch_llm_service(svc),
             patch.object(ops_mod, "EXTRACT_CHUNK_THRESHOLD_CHARS", 5),
         ):
+            # The chunker is fully mocked, so the input content is irrelevant —
+            # only its length matters (> patched threshold of 5) to trigger the
+            # chunked code path.
             result = await extract("a" * 10, schema, chunking="auto")
     finally:
         if original_gsc is None:
@@ -341,3 +352,24 @@ def test_merge_dicts_list_concatenation_dedup() -> None:
     merged = _merge_dicts({"tags": ["a", "b"]}, {"tags": ["b", "c"]})
     assert set(merged["tags"]) == {"a", "b", "c"}
     assert merged["tags"].count("b") == 1
+
+
+@pytest.mark.asyncio
+async def test_injected_llm_service_is_used_not_singleton() -> None:
+    """extract(llm_service=...) must call the injected interface (#11520 M1).
+
+    Guards per-agent SSOT provider/endpoint/model routing: callers with their
+    own configured interface (e.g. KnowledgeExtractionAgent.llm_interface)
+    must not silently fall back to the global service singleton.
+    """
+    from .structured_ops import extract
+
+    schema = {"type": "object", "properties": {"k": {"type": "string"}}}
+    injected = _mock_llm_service(['{"k": "from-injected"}'])
+
+    # No _patch_llm_service here: if extract() ignored the injected service it
+    # would import the real singleton and fail loudly in the stub test env.
+    result = await extract("text", schema, llm_service=injected)
+
+    assert result["k"] == "from-injected"  # type: ignore[index]
+    assert injected.chat.call_count == 1

--- a/autobot-backend/tests/unit/web_fetch/test_extractors.py
+++ b/autobot-backend/tests/unit/web_fetch/test_extractors.py
@@ -3,14 +3,22 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 """Tests for web_fetch.extractors — HTML-to-Markdown, SPA detection, title extraction,
-and schema-driven structured data extraction (Issue #7405)."""
+and schema-driven structured data extraction (Issue #7405).
 
+Issue #11520: _build_extraction_prompt and _call_llm_for_extraction were
+consolidated into llm_shared.structured_ops.extract; extract_url now delegates
+there.  Tests for those internal helpers were moved/updated accordingly:
+  - _build_extraction_prompt → covered by structured_ops_test.py
+  - _call_llm_for_extraction → absorbed into structured_ops._extract_single
+  - extract_url tests now patch llm_shared.structured_ops.extract directly.
+"""
+
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from web_fetch.extractors import (
-    _build_extraction_prompt,
     _extract_title,
     _html_to_markdown_via_markdownify,
     _html_to_plain_text_via_bs4,
@@ -227,41 +235,17 @@ class TestStripScriptBlocks:
         assert "b()" not in result
         assert "text" in result
 
-    def test_script_injection_page_does_not_bleed_into_prompt(self) -> None:
-        """Fixture: <script>alert(1)</script> in page must not reach LLM prompt."""
+    def test_script_injection_stripped_before_extraction(self) -> None:
+        """_strip_script_blocks removes script content; safe to pass to LLM."""
         malicious_md = "<html><body><script>alert(1)</script><p>Real content</p></body></html>"
         safe = _strip_script_blocks(malicious_md)
-        prompt = _build_extraction_prompt(safe, {"type": "object"})
-        assert "alert(1)" not in prompt
-
-
-# ---------------------------------------------------------------------------
-# Issue #7405 — _build_extraction_prompt
-# ---------------------------------------------------------------------------
-
-
-class TestBuildExtractionPrompt:
-    def test_schema_is_json_serialised(self) -> None:
-        schema = {"type": "object", "properties": {"name": {"type": "string"}}}
-        prompt = _build_extraction_prompt("page content", schema)
-        import json
-
-        assert json.dumps(schema, ensure_ascii=False) in prompt
-
-    def test_markdown_content_included(self) -> None:
-        prompt = _build_extraction_prompt("My page text", {"type": "object"})
-        assert "My page text" in prompt
-
-    def test_raw_schema_string_not_interpolated(self) -> None:
-        # Schema dict with special chars — must be serialised, not raw
-        schema = {"type": "object", "description": 'say "hello"'}
-        prompt = _build_extraction_prompt("content", schema)
-        # The escaped JSON form should be in the prompt, not the raw Python repr
-        assert '"say \\"hello\\""' in prompt or 'say "hello"' in prompt
+        assert "alert(1)" not in safe
+        assert "Real content" in safe
 
 
 # ---------------------------------------------------------------------------
 # Issue #7405 — extract_url (integration-level unit tests with mocks)
+# Issue #11520 — now delegates to llm_shared.structured_ops.extract
 # ---------------------------------------------------------------------------
 
 
@@ -278,6 +262,16 @@ def _make_fetch_result(
     return r
 
 
+def _make_firewall_verdict(blocked: bool = False, content: str = "# Hello") -> MagicMock:
+    """Return a mock firewall verdict that passes through by default."""
+    v = MagicMock()
+    v.blocked = blocked
+    v.content = content
+    v.risk = MagicMock()
+    v.risk.value = "none"
+    return v
+
+
 @pytest.mark.asyncio
 async def test_extract_url_success() -> None:
     """extract_url returns {url, data, schema_valid:True} on happy path."""
@@ -285,11 +279,18 @@ async def test_extract_url_success() -> None:
 
     mock_result = _make_fetch_result(markdown="Product: Widget, Price: 9.99")
     schema = {"type": "object", "properties": {"product": {"type": "string"}, "price": {"type": "number"}}}
-    llm_json = '{"product": "Widget", "price": 9.99}'
+    extracted_data = {"product": "Widget", "price": 9.99}
+    ops_mod = sys.modules["llm_shared.structured_ops"]
 
     with (
         patch("web_fetch.WebFetcher.fetch", new_callable=AsyncMock, return_value=mock_result),
-        patch("web_fetch.extractors._call_llm_for_extraction", new_callable=AsyncMock, return_value=llm_json),
+        patch(
+            "security.content_firewall.get_content_firewall",
+            return_value=MagicMock(
+                inspect=AsyncMock(return_value=_make_firewall_verdict(content=mock_result.markdown))
+            ),
+        ),
+        patch.object(ops_mod, "extract", new_callable=AsyncMock, return_value=extracted_data),
     ):
         result = await extract_url("https://ex.com", schema)
 
@@ -312,32 +313,55 @@ async def test_extract_url_fetch_failure_raises_runtime_error() -> None:
 
 @pytest.mark.asyncio
 async def test_extract_url_schema_validation_failure_raises_value_error() -> None:
-    """extract_url raises ValueError when LLM output fails JSON Schema validation."""
+    """extract_url raises ValueError when extraction fails (ExtractionError → ValueError)."""
+    from llm_shared.structured_ops import ExtractionError
     from web_fetch.extractors import extract_url
 
     mock_result = _make_fetch_result()
-    schema = {"type": "object", "properties": {"count": {"type": "integer"}}, "required": ["count"]}
-    # LLM returns wrong type for 'count'
-    llm_json = '{"count": "not-an-integer"}'
+    ops_mod = sys.modules["llm_shared.structured_ops"]
 
     with (
         patch("web_fetch.WebFetcher.fetch", new_callable=AsyncMock, return_value=mock_result),
-        patch("web_fetch.extractors._call_llm_for_extraction", new_callable=AsyncMock, return_value=llm_json),
+        patch(
+            "security.content_firewall.get_content_firewall",
+            return_value=MagicMock(
+                inspect=AsyncMock(return_value=_make_firewall_verdict(content=mock_result.markdown))
+            ),
+        ),
+        patch.object(
+            ops_mod,
+            "extract",
+            new_callable=AsyncMock,
+            side_effect=ExtractionError("schema validation failed after 3 attempts"),
+        ),
     ):
         with pytest.raises(ValueError):
-            await extract_url("https://ex.com", schema)
+            await extract_url("https://ex.com", {"type": "object", "properties": {"count": {"type": "integer"}}})
 
 
 @pytest.mark.asyncio
 async def test_extract_url_non_json_llm_output_raises_value_error() -> None:
-    """extract_url raises ValueError when LLM returns non-JSON."""
+    """extract_url raises ValueError when extraction fails (e.g. non-JSON after retries)."""
+    from llm_shared.structured_ops import ExtractionError
     from web_fetch.extractors import extract_url
 
     mock_result = _make_fetch_result()
+    ops_mod = sys.modules["llm_shared.structured_ops"]
 
     with (
         patch("web_fetch.WebFetcher.fetch", new_callable=AsyncMock, return_value=mock_result),
-        patch("web_fetch.extractors._call_llm_for_extraction", new_callable=AsyncMock, return_value="not json at all"),
+        patch(
+            "security.content_firewall.get_content_firewall",
+            return_value=MagicMock(
+                inspect=AsyncMock(return_value=_make_firewall_verdict(content=mock_result.markdown))
+            ),
+        ),
+        patch.object(
+            ops_mod,
+            "extract",
+            new_callable=AsyncMock,
+            side_effect=ExtractionError("LLM returned non-JSON output after 3 attempts"),
+        ),
     ):
         with pytest.raises(ValueError, match="non-JSON"):
             await extract_url("https://ex.com", {"type": "object"})
@@ -350,19 +374,27 @@ async def test_extract_url_strips_scripts_before_llm() -> None:
 
     script_page = "<script>steal_cookies()</script>\n# Product: Widget"
     mock_result = _make_fetch_result(markdown=script_page)
-    captured_prompt: list = []
+    captured_text: list = []
 
-    async def capture_llm(prompt: str) -> str:
-        captured_prompt.append(prompt)
-        return '{"product": "Widget"}'
+    async def capture_extract(text: str, schema, **kwargs) -> dict:
+        captured_text.append(text)
+        return {"product": "Widget"}
 
     schema = {"type": "object", "properties": {"product": {"type": "string"}}}
+    safe_page = "# Product: Widget"
+    ops_mod = sys.modules["llm_shared.structured_ops"]
 
     with (
         patch("web_fetch.WebFetcher.fetch", new_callable=AsyncMock, return_value=mock_result),
-        patch("web_fetch.extractors._call_llm_for_extraction", side_effect=capture_llm),
+        patch(
+            "security.content_firewall.get_content_firewall",
+            return_value=MagicMock(
+                inspect=AsyncMock(return_value=_make_firewall_verdict(content=safe_page))
+            ),
+        ),
+        patch.object(ops_mod, "extract", side_effect=capture_extract),
     ):
         await extract_url("https://ex.com", schema)
 
-    assert captured_prompt, "LLM was never called"
-    assert "steal_cookies" not in captured_prompt[0]
+    assert captured_text, "extract() was never called"
+    assert "steal_cookies" not in captured_text[0]

--- a/autobot-backend/tests/unit/web_fetch/test_extractors.py
+++ b/autobot-backend/tests/unit/web_fetch/test_extractors.py
@@ -388,9 +388,7 @@ async def test_extract_url_strips_scripts_before_llm() -> None:
         patch("web_fetch.WebFetcher.fetch", new_callable=AsyncMock, return_value=mock_result),
         patch(
             "security.content_firewall.get_content_firewall",
-            return_value=MagicMock(
-                inspect=AsyncMock(return_value=_make_firewall_verdict(content=safe_page))
-            ),
+            return_value=MagicMock(inspect=AsyncMock(return_value=_make_firewall_verdict(content=safe_page))),
         ),
         patch.object(ops_mod, "extract", side_effect=capture_extract),
     ):

--- a/autobot-backend/web_fetch/extractors.py
+++ b/autobot-backend/web_fetch/extractors.py
@@ -158,6 +158,11 @@ async def extract_url(
     Delegates the LLM call, JSON parsing, retry logic, and schema validation to
     ``llm_shared.structured_ops.extract`` (Issue #11520).
 
+    Deliberate behavior change vs the pre-#11520 implementation: LLM output
+    wrapped in markdown code fences is now tolerated (previously a hard parse
+    failure), and invalid JSON triggers up to ``EXTRACT_MAX_RETRIES`` retries
+    with the error fed back to the model.
+
     Args:
         url:    Absolute URL to fetch.
         schema: JSON Schema (draft 2020-12) dict describing the desired output.

--- a/autobot-backend/web_fetch/extractors.py
+++ b/autobot-backend/web_fetch/extractors.py
@@ -14,7 +14,6 @@ guards or Jina logic — those live in media/link/pipeline.py.
 
 from __future__ import annotations
 
-import json
 import re
 from typing import Any, Dict, Tuple
 
@@ -149,56 +148,15 @@ def _strip_script_blocks(markdown: str) -> str:
     return _SCRIPT_BLOCK_RE.sub("", markdown).strip()
 
 
-def _build_extraction_prompt(markdown: str, schema: Dict[str, Any]) -> str:
-    """Build the LLM prompt for schema-driven extraction.
-
-    The schema dict is JSON-serialised — never interpolated as raw string —
-    to prevent schema-injection attacks.
-    """
-    schema_json = json.dumps(schema, ensure_ascii=False)
-    return (
-        "Extract structured data from the following web page content.\n"
-        "Return ONLY a valid JSON object that conforms to this JSON Schema:\n\n"
-        f"```json\n{schema_json}\n```\n\n"
-        "Page content:\n\n"
-        f"{markdown}\n\n"
-        "Respond with only the JSON object, no explanation or markdown fences."
-    )
-
-
-async def _call_llm_for_extraction(prompt: str) -> str:
-    """Call the LLM gateway with structured-output mode and return raw content."""
-    from llm_shared.types import LLMType
-    from services.llm_service import get_llm_service
-
-    svc = get_llm_service()
-    response = await svc.chat(
-        messages=[{"role": "user", "content": prompt}],
-        llm_type=LLMType.EXTRACTION,
-        structured_output=True,
-    )
-    if response.error:
-        raise RuntimeError(f"LLM extraction failed: {response.error}")
-    return response.content
-
-
-def _validate_against_schema(data: Dict[str, Any], schema: Dict[str, Any]) -> None:
-    """Validate *data* against *schema* using Draft202012Validator.
-
-    Raises jsonschema.ValidationError on failure.
-    """
-    import jsonschema
-
-    validator = jsonschema.Draft202012Validator(schema)
-    validator.validate(data)
-
-
 async def extract_url(
     url: str,
     schema: Dict[str, Any],
     render: str = "auto",
 ) -> Dict[str, Any]:
     """Fetch *url*, strip script blocks, call LLM to extract structured data.
+
+    Delegates the LLM call, JSON parsing, retry logic, and schema validation to
+    ``llm_shared.structured_ops.extract`` (Issue #11520).
 
     Args:
         url:    Absolute URL to fetch.
@@ -212,6 +170,7 @@ async def extract_url(
         RuntimeError:  Fetch failed (caller maps to 502).
         ValueError:    LLM returned invalid JSON or data fails schema (caller maps to 422).
     """
+    from llm_shared.structured_ops import ExtractionError, extract
     from web_fetch import FetchResult, RenderMode, WebFetcher
 
     render_mode = RenderMode(render)
@@ -229,17 +188,9 @@ async def extract_url(
         raise RuntimeError(f"web_content_blocked_by_firewall: risk={fw_verdict.risk.value}")
     safe_markdown = fw_verdict.content
 
-    prompt = _build_extraction_prompt(safe_markdown, schema)
-    raw = await _call_llm_for_extraction(prompt)
-
     try:
-        data = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"LLM returned non-JSON output: {exc}") from exc
-
-    try:
-        _validate_against_schema(data, schema)
-    except Exception as exc:
+        data = await extract(safe_markdown, schema)
+    except ExtractionError as exc:
         raise ValueError(str(exc)) from exc
 
     return {"url": result.url, "data": data, "schema_valid": True}


### PR DESCRIPTION
Closes #11520. Part of umbrella #11518 (Task 2).

## Thinking Path
Schema-typed LLM extraction was implemented three times with drift (web_fetch, knowledge_extraction_agent, judges' JSON parsing) — each hand-rolling prompting, parsing, and retries, none handling oversized input uniformly. Agent-platform research (umbrella #11518) identified a single typed `extract(text, schema)` helper as the consolidation pattern. Canonical-coding: extend/reuse, no new frameworks.

## What Changed
- **New `llm_shared/json_utils.py`** — fence-tolerant `extract_json_object()`; the judges' local `_extract_json_object` is deleted and imports from here (one canonical implementation).
- **New `llm_shared/structured_ops.py`** — `async extract(text, schema, *, llm_type, max_retries, chunking, llm_service)`:
  - accepts a Pydantic model class (returns instance) or JSON Schema dict (Draft 2020-12, returns dict)
  - retry-on-invalid with the parse/validation error fed back into the retry prompt; `ExtractionError` after `AUTOBOT_EXTRACT_MAX_RETRIES` (default 3) — including the chunk-merge re-validation path (review B1)
  - auto-chunking above `AUTOBOT_EXTRACT_CHUNK_THRESHOLD` chars via the existing semantic chunker; documented merge rules (last-non-null scalars, concatenated deduped lists)
  - injectable `llm_service` so per-agent SSOT provider/endpoint/model routing is preserved (review M1) — defaults to the shared singleton
- **Refactored call sites** (behavior preserved): `web_fetch/extractors.py` (`extract_url` delegates; deliberate improvement: fenced output now tolerated + retried, documented in docstring), `agents/knowledge_extraction_agent.py` (delegates, passing `llm_service=self.llm_interface`), `judges/__init__.py` (shared parser import).
- **Not touched, verified**: `api/entity_extraction.py` / `graph_entity_extractor.py` contain no hand-rolled LLM JSON parsing — all their LLM work flows through `KnowledgeExtractionAgent`, which is now on the helper (reviewer-verified).
- conftest real-loads `json_utils` + `structured_ops` in dependency order.

## Verification
- `pytest structured_ops_test.py tests/unit/web_fetch/test_extractors.py tests/unit/api/test_knowledge_extract.py` → **66 passed** (17 new unit tests incl. retry-feedback prompt assertions and injected-service regression test)
- `flake8 --config=.flake8` + `black --check -l 120` clean on changed files
- code-reviewer pass: 1 blocker (exception-type leak on merge path), 2 majors (routing bypass; weak retry tests), 3 minors — all fixed; import graph verified acyclic; conftest ordering verified

## Model Used
Claude (Fable 5) orchestrating; Sonnet implementation agent; Sonnet code-reviewer agent.
