### PR TITLE
feat(slm-ui): add spacing/radius/font/shadow/z-index token scales (#11515 Task 2.3)

### DIFF
--- a/autobot-slm-frontend/src/assets/styles/main.css
+++ b/autobot-slm-frontend/src/assets/styles/main.css
@@ -160,6 +160,62 @@
   --info-bg: color-mix(in srgb, var(--color-primary-500) 14%, var(--a11y-bg));
 }
 
+/* ─── Sizing scales (#11515 Task 2.3) ─────────────────────────────
+ * SLM previously had NO spacing / radius / font-size / shadow / z-index tokens,
+ * so components hardcoded px everywhere. Add the same scales the user frontend
+ * uses (autobot-frontend design-tokens.css) so both frontends are consistent and
+ * SLM components can migrate hardcoded px onto tokens (Task 4). */
+:root {
+  /* Spacing (0.25rem step) + semantic aliases */
+  --spacing-0: 0;
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-3: 0.75rem;
+  --spacing-4: 1rem;
+  --spacing-5: 1.25rem;
+  --spacing-6: 1.5rem;
+  --spacing-8: 2rem;
+  --spacing-10: 2.5rem;
+  --spacing-12: 3rem;
+  --spacing-16: 4rem;
+  --spacing-xs: var(--spacing-1);
+  --spacing-sm: var(--spacing-2);
+  --spacing-md: var(--spacing-4);
+  --spacing-lg: var(--spacing-6);
+  --spacing-xl: var(--spacing-8);
+  --spacing-2xl: var(--spacing-12);
+  /* Border radius */
+  --radius-none: 0;
+  --radius-sm: 0.125rem;
+  --radius-default: 0.25rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+  --radius-xl: 0.75rem;
+  --radius-2xl: 1rem;
+  --radius-full: 9999px;
+  /* Font sizes */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  /* Elevation */
+  --shadow-sm: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+  /* Z-index scale */
+  --z-dropdown: 100;
+  --z-sticky: 200;
+  --z-fixed: 300;
+  --z-modal-backdrop: 900;
+  --z-modal: 1000;
+  --z-popover: 1100;
+  --z-tooltip: 1200;
+  --z-toast: 1300;
+}
+
 /* ─── High Contrast Mode (Issue #754) ────────────────────────── */
 
 :root[data-theme='high-contrast'] {


### PR DESCRIPTION
## Thinking Path
Umbrella #11515 Task 2.3. The SLM frontend had **no** sizing tokens (no `--spacing-*`, `--radius-*`, `--text-*`, `--shadow-*`, `--z-*`) — the audit found ~295 hardcoded px across SLM components with nothing to migrate them onto. (Task 2.2, adopting `@autobot/ui` as an SLM dependency, is deferred — it needs a `package.json`/lockfile change the dev env cannot regenerate; the scales here are the local-verifiable equivalent.)

## What Changed
- Added the sizing scales to `autobot-slm-frontend/src/assets/styles/main.css`, **mirroring the exact values the user frontend uses** (`autobot-frontend/design-tokens.css`): spacing (0–16 + `xs/sm/md/lg/xl/2xl` aliases), radius (`sm`..`2xl`, `full`), font-size (`xs`..`3xl`), shadow (`sm/md/lg`), z-index (dropdown..toast).
- Purely additive — no existing token/style changed. Gives Task 4 migrations a token vocabulary and keeps the two frontends’ scales consistent.

## Verification
- CSS braces balanced; spot-checked values equal the user frontend (`--spacing-4: 1rem`, `--radius-md: 0.375rem`, `--text-sm: 0.875rem`, `--z-modal: 1000`).

## Model Used
Opus 4.8

Refs #11515