### PR TITLE
harden(workspace): reap stale container by name before recreate — avoid 409 collision (#11549)

### DIFF
--- a/autobot-backend/services/docker_task_workspace.py
+++ b/autobot-backend/services/docker_task_workspace.py
@@ -384,12 +384,31 @@ class TaskWorkspaceManager:
 
     def _start_container_sync(self, task_id: str, volume_name: str, image: str) -> str:
         """Start the workspace container applying full sandbox security constraints."""
+        name = f"{_CONTAINER_PREFIX}{task_id}"
+        # GH#11059: the container name is deterministic, so a stale container from a
+        # crashed/partially-cleaned prior run — or a restore racing an incomplete
+        # force-stop — makes ``run(name=…)`` fail with 409 Conflict. Reap any
+        # pre-existing container with this name first (idempotent). Lookups are
+        # always by container id, never name, so this reconcile is safe.
+        self._reap_container_by_name(name)
         container = self._docker.containers.run(
             image=image,
-            name=f"{_CONTAINER_PREFIX}{task_id}",
+            name=name,
             **_apply_sandbox_security(task_id, volume_name),
         )
         return container.id
+
+    def _reap_container_by_name(self, name: str) -> None:
+        """Force-remove a pre-existing container with *name*, if any (GH#11059)."""
+        try:
+            existing = self._docker.containers.get(name)
+        except NotFound:
+            return
+        try:
+            existing.remove(force=True)
+            logger.warning("workspace: reaped stale container name=%s before recreate (GH#11059)", name)
+        except (NotFound, APIError):
+            pass
 
     def _exec_sync(self, container_id: str, cmd: list[str]) -> dict[str, Any]:
         try:

--- a/autobot-backend/tests/test_task_workspace.py
+++ b/autobot-backend/tests/test_task_workspace.py
@@ -293,6 +293,31 @@ async def test_create_is_idempotent(manager, mock_redis, mock_docker):
     mock_docker.containers.run.assert_not_called()
 
 
+def test_start_reaps_stale_container_before_recreate(manager, mock_docker):
+    """GH#11059: a leftover container with the deterministic name is force-removed
+    before recreate, so run() cannot hit a 409 name conflict."""
+    stale = MagicMock()
+    stale.remove = MagicMock()
+    mock_docker.containers.get.return_value = stale
+
+    cid = manager._start_container_sync("task-collide", "vol-collide", "alpine:3.18")
+
+    mock_docker.containers.get.assert_called_once_with("autobot-workspace-task-collide")
+    stale.remove.assert_called_once_with(force=True)
+    mock_docker.containers.run.assert_called_once()
+    assert cid == "abc123def456"
+
+
+def test_start_no_stale_container_skips_reap(manager, mock_docker):
+    """GH#11059: no pre-existing container → nothing to reap; run() still proceeds."""
+    mock_docker.containers.get.side_effect = dtw.NotFound("no such container")
+
+    cid = manager._start_container_sync("task-fresh", "vol-fresh", "alpine:3.18")
+
+    mock_docker.containers.run.assert_called_once()
+    assert cid == "abc123def456"
+
+
 # ---------------------------------------------------------------------------
 # TaskWorkspaceManager.exec_command
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Thinking Path
From #11059 (umbrella #11058): `_start_container_sync` creates the workspace container with a **deterministic** name `f"{_CONTAINER_PREFIX}{task_id}"`. `restore()` force-stops the old container (`_stop_container_sync`, which swallows `NotFound`/`APIError`) then immediately recreates with the same name — so if the stop/remove silently failed, or a stale container survived a crash, `containers.run(name=…)` fails with **409 Conflict** and the task's workspace can no longer be recreated.

Container lookups are always by `container_id` (never by name), so the name is purely cosmetic — safe to reconcile.

## What Changed (`services/docker_task_workspace.py`)
- Before `run(name=…)`, `_start_container_sync` calls the new `_reap_container_by_name(name)`: `containers.get(name)` → `remove(force=True)` (tolerating `NotFound`/`APIError`), logging a warning when a stale container is reaped. Idempotent, so create/restore always get a clean name.

## Verification
- `pytest tests/test_task_workspace.py` → **42 passed** (40 existing + 2 new).
- New tests (via the existing `mock_docker` fixture): stale container present → `remove(force=True)` called with the exact name then `run` proceeds; no stale (`get` raises `NotFound`) → `run` proceeds, nothing reaped.
- **Mutation-verified**: dropping the `_reap_container_by_name` call fails the stale-reap test.
- `flake8` clean; `black` applied. Pure-logic change — no schema / `api.ts` impact.

## Model Used
Opus 4.8 (1M context)

Closes #11549