### PR TITLE
feat(plugins): enforce config_schema at load/update + schema-driven config forms (#11522)

### DIFF
--- a/autobot-backend/plugin_manager.py
+++ b/autobot-backend/plugin_manager.py
@@ -28,8 +28,8 @@ from autobot_shared.plugin_sdk import (
     PluginRegistry,
     TrustTier,
 )
-from autobot_shared.plugin_sdk.loader import validate_plugin_config
 from autobot_shared.plugin_sdk.base import PluginLoadError
+from autobot_shared.plugin_sdk.loader import validate_plugin_config
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.ssot_config import config
 from plugin_install import install_from_git, install_from_zip

--- a/autobot-backend/plugin_manager.py
+++ b/autobot-backend/plugin_manager.py
@@ -28,7 +28,7 @@ from autobot_shared.plugin_sdk import (
     PluginRegistry,
     TrustTier,
 )
-from autobot_shared.plugin_sdk.loader import _validate_config_against_schema, _validate_config_schema
+from autobot_shared.plugin_sdk.loader import validate_plugin_config
 from autobot_shared.plugin_sdk.base import PluginLoadError
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.ssot_config import config
@@ -494,8 +494,7 @@ async def update_plugin_config(
     schema = plugin.manifest.config_schema
     if schema:
         try:
-            _validate_config_schema(plugin_name, schema)
-            _validate_config_against_schema(plugin_name, config_update.config, schema)
+            validate_plugin_config(plugin_name, config_update.config, schema)
         except PluginLoadError as exc:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/autobot-backend/plugin_manager.py
+++ b/autobot-backend/plugin_manager.py
@@ -28,6 +28,8 @@ from autobot_shared.plugin_sdk import (
     PluginRegistry,
     TrustTier,
 )
+from autobot_shared.plugin_sdk.loader import _validate_config_against_schema, _validate_config_schema
+from autobot_shared.plugin_sdk.base import PluginLoadError
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.ssot_config import config
 from plugin_install import install_from_git, install_from_zip
@@ -487,6 +489,18 @@ async def update_plugin_config(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Plugin not found: {plugin_name}",
         )
+
+    # GH#11522: validate new config against the manifest's config_schema (if any)
+    schema = plugin.manifest.config_schema
+    if schema:
+        try:
+            _validate_config_schema(plugin_name, schema)
+            _validate_config_against_schema(plugin_name, config_update.config, schema)
+        except PluginLoadError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(exc),
+            ) from exc
 
     # Update plugin config
     plugin.config = config_update.config

--- a/autobot-frontend/src/components/plugins/SchemaForm.vue
+++ b/autobot-frontend/src/components/plugins/SchemaForm.vue
@@ -45,7 +45,7 @@
           :id="`sf-${key}`"
           class="field-select"
           :value="String(localValue[key] ?? fieldSchema.default ?? '')"
-          @change="onSelect(key, ($event.target as HTMLSelectElement).value)"
+          @change="onSelect(key, fieldSchema, ($event.target as HTMLSelectElement).value)"
         >
           <option value="" disabled>{{ t('components.schemaForm.selectPlaceholder') }}</option>
           <option
@@ -85,7 +85,7 @@
             type="text"
             class="field-input tags-input"
             :placeholder="t('components.schemaForm.addTagPlaceholder')"
-            @keydown.enter.prevent="addTag(key, ($event.target as HTMLInputElement).value); ($event.target as HTMLInputElement).value = ''"
+            @keydown.enter.prevent="addTag(key, fieldSchema, ($event.target as HTMLInputElement).value); ($event.target as HTMLInputElement).value = ''"
           />
         </div>
 
@@ -222,21 +222,33 @@ function onCheckbox(key: string, checked: boolean) {
   emit_(key, checked)
 }
 
-function onSelect(key: string, value: string) {
-  emit_(key, value)
+function onSelect(key: string, s: JsonSchemaProperty, value: string) {
+  // Recover the original (possibly non-string) enum member: the DOM only
+  // gives us strings, but the schema may declare numeric/boolean enums.
+  const original = (s.enum ?? []).find((o) => String(o) === value)
+  emit_(key, original !== undefined ? original : value)
 }
 
-function arrayValue(key: string): string[] {
+function coerceScalar(v: string, type?: string): unknown {
+  if (type === 'number' || type === 'integer') {
+    const n = Number(v)
+    return Number.isNaN(n) ? v : n
+  }
+  if (type === 'boolean') return v === 'true'
+  return v
+}
+
+function arrayValue(key: string): unknown[] {
   const v = localValue.value[key]
-  if (Array.isArray(v)) return v as string[]
+  if (Array.isArray(v)) return v as unknown[]
   return []
 }
 
-function addTag(key: string, tag: string) {
+function addTag(key: string, s: JsonSchemaProperty, tag: string) {
   const trimmed = tag.trim()
   if (!trimmed) return
   const current = arrayValue(key)
-  emit_(key, [...current, trimmed])
+  emit_(key, [...current, coerceScalar(trimmed, s.items?.type)])
 }
 
 function removeTag(key: string, idx: number) {

--- a/autobot-frontend/src/components/plugins/SchemaForm.vue
+++ b/autobot-frontend/src/components/plugins/SchemaForm.vue
@@ -1,0 +1,394 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2025-2026 mrveiss -->
+<!-- Author: mrveiss -->
+<!--
+  SchemaForm Component
+  Issue #11522 - Schema-driven config form renderer for plugin and skill config.
+
+  Renders a form from a JSON Schema `properties` map.
+  Supports: string, number/integer, boolean, enum (select), array of scalars (tag input).
+  Honors: default, required, description, title.
+  Emits update:modelValue (v-model compatible).
+  Falls back to raw-JSON textarea for unsupported shapes (nested objects without
+  renderable properties, or schemas without a `properties` key).
+-->
+<template>
+  <div class="schema-form">
+    <template v-if="hasRenderableFields">
+      <div
+        v-for="[key, fieldSchema] in renderableFields"
+        :key="key"
+        class="schema-field"
+      >
+        <label :for="`sf-${key}`" class="field-label">
+          {{ fieldLabel(key, fieldSchema) }}
+          <span v-if="isRequired(key)" class="required-mark" :aria-label="t('components.schemaForm.requiredMark')">*</span>
+        </label>
+
+        <p v-if="fieldSchema.description" class="field-description">
+          {{ fieldSchema.description }}
+        </p>
+
+        <!-- Boolean toggle -->
+        <input
+          v-if="fieldSchema.type === 'boolean'"
+          :id="`sf-${key}`"
+          type="checkbox"
+          :checked="Boolean(localValue[key] ?? fieldSchema.default ?? false)"
+          class="field-checkbox"
+          @change="onCheckbox(key, ($event.target as HTMLInputElement).checked)"
+        />
+
+        <!-- Enum select -->
+        <select
+          v-else-if="fieldSchema.enum"
+          :id="`sf-${key}`"
+          class="field-select"
+          :value="String(localValue[key] ?? fieldSchema.default ?? '')"
+          @change="onSelect(key, ($event.target as HTMLSelectElement).value)"
+        >
+          <option value="" disabled>{{ t('components.schemaForm.selectPlaceholder') }}</option>
+          <option
+            v-for="opt in fieldSchema.enum"
+            :key="String(opt)"
+            :value="String(opt)"
+          >
+            {{ String(opt) }}
+          </option>
+        </select>
+
+        <!-- Number / integer -->
+        <input
+          v-else-if="fieldSchema.type === 'number' || fieldSchema.type === 'integer'"
+          :id="`sf-${key}`"
+          type="number"
+          class="field-input"
+          :value="localValue[key] ?? fieldSchema.default ?? ''"
+          :required="isRequired(key)"
+          @input="onNumber(key, ($event.target as HTMLInputElement).value)"
+        />
+
+        <!-- Array of scalars (tag input) -->
+        <div v-else-if="fieldSchema.type === 'array'" class="field-tags">
+          <div class="tags-list">
+            <span
+              v-for="(tag, idx) in arrayValue(key)"
+              :key="idx"
+              class="tag"
+            >
+              {{ tag }}
+              <button type="button" class="tag-remove" @click="removeTag(key, idx)" :aria-label="t('components.schemaForm.removeTag')">×</button>
+            </span>
+          </div>
+          <input
+            :id="`sf-${key}`"
+            type="text"
+            class="field-input tags-input"
+            :placeholder="t('components.schemaForm.addTagPlaceholder')"
+            @keydown.enter.prevent="addTag(key, ($event.target as HTMLInputElement).value); ($event.target as HTMLInputElement).value = ''"
+          />
+        </div>
+
+        <!-- String (default) -->
+        <input
+          v-else
+          :id="`sf-${key}`"
+          type="text"
+          class="field-input"
+          :value="String(localValue[key] ?? fieldSchema.default ?? '')"
+          :required="isRequired(key)"
+          @input="onText(key, ($event.target as HTMLInputElement).value)"
+        />
+      </div>
+    </template>
+
+    <!-- Fallback: raw JSON textarea for schemas SchemaForm can't render -->
+    <template v-else>
+      <p class="fallback-hint">{{ t('components.schemaForm.rawJsonFallback') }}</p>
+      <textarea
+        class="field-json"
+        :value="rawJson"
+        rows="6"
+        spellcheck="false"
+        :aria-label="t('components.schemaForm.rawJsonLabel')"
+        @input="onRawJson(($event.target as HTMLTextAreaElement).value)"
+      />
+      <p v-if="jsonError" class="json-error">{{ jsonError }}</p>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('SchemaForm')
+const { t } = useI18n()
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface JsonSchemaProperty {
+  type?: string
+  title?: string
+  description?: string
+  default?: unknown
+  enum?: unknown[]
+  items?: { type?: string }
+}
+
+export interface JsonSchema {
+  type?: string
+  properties?: Record<string, JsonSchemaProperty>
+  required?: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Props / Emits
+// ---------------------------------------------------------------------------
+
+const props = defineProps<{
+  schema: JsonSchema
+  modelValue: Record<string, unknown>
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: Record<string, unknown>]
+}>()
+
+// ---------------------------------------------------------------------------
+// Local reactive state
+// ---------------------------------------------------------------------------
+
+const localValue = ref<Record<string, unknown>>({ ...props.modelValue })
+
+watch(
+  () => props.modelValue,
+  (v: Record<string, unknown>) => {
+    localValue.value = { ...v }
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Schema analysis
+// ---------------------------------------------------------------------------
+
+const renderableFields = computed<[string, JsonSchemaProperty][]>(() => {
+  const props_ = props.schema?.properties ?? {}
+  return (Object.entries(props_) as [string, JsonSchemaProperty][]).filter(([, s]) => isRenderable(s))
+})
+
+const hasRenderableFields = computed(() => renderableFields.value.length > 0)
+
+function isRenderable(s: JsonSchemaProperty): boolean {
+  if (s.enum) return true
+  const type = s.type
+  if (!type) return false
+  if (['string', 'number', 'integer', 'boolean'].includes(type)) return true
+  if (type === 'array') return true
+  return false
+}
+
+function isRequired(key: string): boolean {
+  return (props.schema.required ?? []).includes(key)
+}
+
+function fieldLabel(key: string, s: JsonSchemaProperty): string {
+  return s.title ?? key
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function emit_(key: string, value: unknown) {
+  const next = { ...localValue.value, [key]: value }
+  localValue.value = next
+  emit('update:modelValue', next)
+}
+
+function onText(key: string, value: string) {
+  emit_(key, value)
+}
+
+function onNumber(key: string, value: string) {
+  const parsed = value === '' ? undefined : Number(value)
+  emit_(key, parsed)
+}
+
+function onCheckbox(key: string, checked: boolean) {
+  emit_(key, checked)
+}
+
+function onSelect(key: string, value: string) {
+  emit_(key, value)
+}
+
+function arrayValue(key: string): string[] {
+  const v = localValue.value[key]
+  if (Array.isArray(v)) return v as string[]
+  return []
+}
+
+function addTag(key: string, tag: string) {
+  const trimmed = tag.trim()
+  if (!trimmed) return
+  const current = arrayValue(key)
+  emit_(key, [...current, trimmed])
+}
+
+function removeTag(key: string, idx: number) {
+  const current = arrayValue(key)
+  const next = current.filter((_, i) => i !== idx)
+  emit_(key, next)
+}
+
+// ---------------------------------------------------------------------------
+// Raw-JSON fallback
+// ---------------------------------------------------------------------------
+
+const rawJson = ref(JSON.stringify(props.modelValue, null, 2))
+const jsonError = ref('')
+
+watch(
+  () => props.modelValue,
+  (v: Record<string, unknown>) => {
+    rawJson.value = JSON.stringify(v, null, 2)
+    jsonError.value = ''
+  },
+)
+
+function onRawJson(text: string) {
+  rawJson.value = text
+  try {
+    const parsed = JSON.parse(text)
+    jsonError.value = ''
+    emit('update:modelValue', parsed)
+    localValue.value = parsed
+  } catch {
+    jsonError.value = t('components.schemaForm.invalidJson')
+    logger.warn('SchemaForm raw JSON parse error')
+  }
+}
+</script>
+
+<style scoped>
+.schema-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md, 1rem);
+}
+
+.schema-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs, 0.25rem);
+}
+
+.field-label {
+  font-size: var(--text-sm, 0.875rem);
+  font-weight: 600;
+  color: var(--text-primary, #111);
+}
+
+.required-mark {
+  color: var(--color-error, #ef4444);
+  margin-left: 2px;
+}
+
+.field-description {
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--text-secondary, #6b7280);
+  margin: 0;
+}
+
+.field-input,
+.field-select,
+.field-json {
+  width: 100%;
+  background: var(--bg-secondary, #f9fafb);
+  border: 1px solid var(--border-default, #e5e7eb);
+  border-radius: var(--radius-md, 0.375rem);
+  padding: var(--spacing-xs, 0.25rem) var(--spacing-sm, 0.5rem);
+  font-size: var(--text-sm, 0.875rem);
+  color: var(--text-primary, #111);
+  box-sizing: border-box;
+}
+
+.field-input:focus,
+.field-select:focus,
+.field-json:focus {
+  outline: none;
+  border-color: var(--color-primary, #6366f1);
+}
+
+.field-checkbox {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--color-primary, #6366f1);
+  cursor: pointer;
+}
+
+.field-tags {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs, 0.25rem);
+}
+
+.tags-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-1, 0.25rem);
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--bg-tertiary, #f3f4f6);
+  border: 1px solid var(--border-default, #e5e7eb);
+  border-radius: var(--radius-default, 0.25rem);
+  padding: 2px var(--spacing-1-5, 0.375rem);
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--text-secondary, #6b7280);
+}
+
+.tag-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-secondary, #9ca3af);
+  padding: 0;
+  font-size: 0.875rem;
+  line-height: 1;
+}
+
+.tag-remove:hover {
+  color: var(--color-error, #ef4444);
+}
+
+.tags-input {
+  margin-top: var(--spacing-xs, 0.25rem);
+}
+
+.fallback-hint {
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--text-secondary, #6b7280);
+  margin: 0;
+  font-style: italic;
+}
+
+.field-json {
+  font-family: var(--font-mono, monospace);
+  font-size: var(--text-xs, 0.75rem);
+  resize: vertical;
+}
+
+.json-error {
+  font-size: var(--text-sm, 0.875rem);
+  color: var(--color-error, #ef4444);
+  margin: 0;
+}
+</style>

--- a/autobot-frontend/src/components/plugins/__tests__/SchemaForm.test.ts
+++ b/autobot-frontend/src/components/plugins/__tests__/SchemaForm.test.ts
@@ -228,16 +228,79 @@ describe('SchemaForm', () => {
   })
 
   // ----------------------------------------------------------
+  describe('enum typed values (B-1)', () => {
+    it('emits the original numeric enum member, not its string form', async () => {
+      const { container, emitted } = mountSchemaForm(
+        {
+          type: 'object',
+          properties: { level: { type: 'integer', title: 'Level', enum: [1, 2, 3] } },
+        },
+        { level: 1 },
+      )
+      const select = container.querySelector('.field-select') as HTMLSelectElement
+      await fireEvent.update(select, '2')
+      const events = emitted()['update:modelValue']
+      expect(events?.at(-1)?.[0]).toEqual({ level: 2 })
+    })
+  })
+
+  // ----------------------------------------------------------
   describe('array (tag list) field', () => {
     it('renders tag list and add input for type=array', () => {
-      const { container } = mountSchemaForm({
-        type: 'object',
-        properties: {
-          tags: { type: 'array', title: 'Tags' },
+      const { container } = mountSchemaForm(
+        {
+          type: 'object',
+          properties: {
+            tags: { type: 'array', title: 'Tags' },
+          },
         },
-        modelValue: { tags: ['alpha', 'beta'] },
-      })
+        { tags: ['alpha', 'beta'] },
+      )
       expect(container.querySelector('.field-tags')).toBeTruthy()
+    })
+
+    it('emits update:modelValue with appended tag on enter', async () => {
+      const { container, emitted } = mountSchemaForm(
+        {
+          type: 'object',
+          properties: { tags: { type: 'array', title: 'Tags' } },
+        },
+        { tags: ['alpha'] },
+      )
+      const input = container.querySelector('.tags-input') as HTMLInputElement
+      input.value = 'beta'
+      await fireEvent.keyDown(input, { key: 'Enter' })
+      const events = emitted()['update:modelValue']
+      expect(events?.at(-1)?.[0]).toEqual({ tags: ['alpha', 'beta'] })
+    })
+
+    it('emits update:modelValue without the removed tag', async () => {
+      const { container, emitted } = mountSchemaForm(
+        {
+          type: 'object',
+          properties: { tags: { type: 'array', title: 'Tags' } },
+        },
+        { tags: ['alpha', 'beta'] },
+      )
+      const removeButtons = container.querySelectorAll('.tag-remove')
+      await fireEvent.click(removeButtons[0])
+      const events = emitted()['update:modelValue']
+      expect(events?.at(-1)?.[0]).toEqual({ tags: ['beta'] })
+    })
+
+    it('coerces added tags to numbers when items.type is integer (B-1)', async () => {
+      const { container, emitted } = mountSchemaForm(
+        {
+          type: 'object',
+          properties: { ports: { type: 'array', title: 'Ports', items: { type: 'integer' } } },
+        },
+        { ports: [8080] },
+      )
+      const input = container.querySelector('.tags-input') as HTMLInputElement
+      input.value = '9090'
+      await fireEvent.keyDown(input, { key: 'Enter' })
+      const events = emitted()['update:modelValue']
+      expect(events?.at(-1)?.[0]).toEqual({ ports: [8080, 9090] })
     })
 
     it('shows existing tags from modelValue', () => {

--- a/autobot-frontend/src/components/plugins/__tests__/SchemaForm.test.ts
+++ b/autobot-frontend/src/components/plugins/__tests__/SchemaForm.test.ts
@@ -1,0 +1,312 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * SchemaForm component tests
+ * Issue #11522 - schema-driven config form
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent, screen } from '@testing-library/vue'
+import { createI18n } from 'vue-i18n'
+import SchemaForm from '../SchemaForm.vue'
+
+// ---- minimal i18n ----
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: {
+    en: {
+      components: {
+        schemaForm: {
+          requiredMark: 'required',
+          selectPlaceholder: 'Select an option',
+          removeTag: 'Remove tag',
+          addTagPlaceholder: 'Press Enter to add',
+          rawJsonFallback: 'Schema contains nested objects. Edit as raw JSON:',
+          rawJsonLabel: 'Plugin configuration (JSON)',
+          invalidJson: 'Invalid JSON — please fix before saving.',
+        },
+      },
+    },
+  },
+})
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+function mountSchemaForm(schema: object, modelValue: Record<string, unknown> = {}) {
+  const modelRef = { value: modelValue }
+  const result = render(SchemaForm, {
+    props: {
+      schema,
+      modelValue,
+    },
+    global: {
+      plugins: [i18n],
+    },
+  })
+  return result
+}
+
+// ============================================================
+describe('SchemaForm', () => {
+  // ----------------------------------------------------------
+  describe('string field', () => {
+    it('renders a text input for type=string', () => {
+      const { getByRole } = mountSchemaForm({
+        type: 'object',
+        properties: {
+          host: { type: 'string', title: 'Host', description: 'Server host' },
+        },
+      })
+      const input = getByRole('textbox', { name: /host/i })
+      expect(input).toBeTruthy()
+    })
+
+    it('shows default value in text input', () => {
+      const { getByRole } = mountSchemaForm(
+        {
+          type: 'object',
+          properties: {
+            name: { type: 'string', default: 'AutoBot', title: 'Name' },
+          },
+        },
+        {},
+      )
+      const input = getByRole('textbox') as HTMLInputElement
+      expect(input.value).toBe('AutoBot')
+    })
+
+    it('emits update:modelValue on text input change', async () => {
+      const handlers: Array<Record<string, unknown>> = []
+      const { getByRole, emitted } = render(SchemaForm, {
+        props: {
+          schema: {
+            type: 'object',
+            properties: { host: { type: 'string', title: 'Host' } },
+          },
+          modelValue: {},
+        },
+        global: { plugins: [i18n] },
+      })
+      const input = getByRole('textbox')
+      await fireEvent.input(input, { target: { value: 'localhost' } })
+      const emits = emitted()['update:modelValue'] as Array<[Record<string, unknown>]>
+      expect(emits).toBeTruthy()
+      expect(emits[emits.length - 1][0]).toEqual({ host: 'localhost' })
+    })
+  })
+
+  // ----------------------------------------------------------
+  describe('number / integer field', () => {
+    it('renders a number input for type=number', () => {
+      const { container } = mountSchemaForm({
+        type: 'object',
+        properties: {
+          port: { type: 'number', title: 'Port' },
+        },
+      })
+      const input = container.querySelector('input[type="number"]')
+      expect(input).toBeTruthy()
+    })
+
+    it('renders a number input for type=integer', () => {
+      const { container } = mountSchemaForm({
+        type: 'object',
+        properties: {
+          count: { type: 'integer', title: 'Count' },
+        },
+      })
+      const input = container.querySelector('input[type="number"]')
+      expect(input).toBeTruthy()
+    })
+
+    it('emits numeric value on change', async () => {
+      const { container, emitted } = render(SchemaForm, {
+        props: {
+          schema: { type: 'object', properties: { port: { type: 'integer', title: 'Port' } } },
+          modelValue: {},
+        },
+        global: { plugins: [i18n] },
+      })
+      const input = container.querySelector('input[type="number"]') as HTMLInputElement
+      await fireEvent.input(input, { target: { value: '8080' } })
+      const emits = emitted()['update:modelValue'] as Array<[Record<string, unknown>]>
+      expect(emits[emits.length - 1][0]).toEqual({ port: 8080 })
+    })
+  })
+
+  // ----------------------------------------------------------
+  describe('boolean field', () => {
+    it('renders a checkbox for type=boolean', () => {
+      const { container } = mountSchemaForm({
+        type: 'object',
+        properties: {
+          enabled: { type: 'boolean', title: 'Enabled' },
+        },
+      })
+      const checkbox = container.querySelector('input[type="checkbox"]')
+      expect(checkbox).toBeTruthy()
+    })
+
+    it('reflects default=true in checkbox', () => {
+      const { container } = mountSchemaForm({
+        type: 'object',
+        properties: {
+          enabled: { type: 'boolean', default: true, title: 'Enabled' },
+        },
+      })
+      const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement
+      expect(checkbox.checked).toBe(true)
+    })
+
+    it('emits boolean value on toggle', async () => {
+      const { container, emitted } = render(SchemaForm, {
+        props: {
+          schema: { type: 'object', properties: { enabled: { type: 'boolean', title: 'Enabled' } } },
+          modelValue: { enabled: false },
+        },
+        global: { plugins: [i18n] },
+      })
+      const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement
+      await fireEvent.change(checkbox, { target: { checked: true } })
+      const emits = emitted()['update:modelValue'] as Array<[Record<string, unknown>]>
+      expect(emits[emits.length - 1][0]).toEqual({ enabled: true })
+    })
+  })
+
+  // ----------------------------------------------------------
+  describe('enum / select field', () => {
+    it('renders a select for enum', () => {
+      const { container } = mountSchemaForm({
+        type: 'object',
+        properties: {
+          mode: { enum: ['fast', 'slow'], title: 'Mode' },
+        },
+      })
+      const select = container.querySelector('select')
+      expect(select).toBeTruthy()
+    })
+
+    it('shows each enum value as an option', () => {
+      const { container } = mountSchemaForm({
+        type: 'object',
+        properties: {
+          mode: { enum: ['fast', 'slow', 'medium'], title: 'Mode' },
+        },
+      })
+      const options = container.querySelectorAll('option')
+      const values = Array.from(options).map((o) => o.value)
+      expect(values).toContain('fast')
+      expect(values).toContain('slow')
+      expect(values).toContain('medium')
+    })
+
+    it('emits selected value on change', async () => {
+      const { container, emitted } = render(SchemaForm, {
+        props: {
+          schema: { type: 'object', properties: { mode: { enum: ['fast', 'slow'], title: 'Mode' } } },
+          modelValue: {},
+        },
+        global: { plugins: [i18n] },
+      })
+      const select = container.querySelector('select') as HTMLSelectElement
+      await fireEvent.change(select, { target: { value: 'slow' } })
+      const emits = emitted()['update:modelValue'] as Array<[Record<string, unknown>]>
+      expect(emits[emits.length - 1][0]).toEqual({ mode: 'slow' })
+    })
+  })
+
+  // ----------------------------------------------------------
+  describe('array (tag list) field', () => {
+    it('renders tag list and add input for type=array', () => {
+      const { container } = mountSchemaForm({
+        type: 'object',
+        properties: {
+          tags: { type: 'array', title: 'Tags' },
+        },
+        modelValue: { tags: ['alpha', 'beta'] },
+      })
+      expect(container.querySelector('.field-tags')).toBeTruthy()
+    })
+
+    it('shows existing tags from modelValue', () => {
+      const { container } = mountSchemaForm(
+        {
+          type: 'object',
+          properties: { tags: { type: 'array', title: 'Tags' } },
+        },
+        { tags: ['alpha', 'beta'] },
+      )
+      const tags = container.querySelectorAll('.tag')
+      expect(tags.length).toBe(2)
+    })
+  })
+
+  // ----------------------------------------------------------
+  describe('required field marker', () => {
+    it('shows required marker for required fields', () => {
+      const { container } = mountSchemaForm({
+        type: 'object',
+        properties: { host: { type: 'string', title: 'Host' } },
+        required: ['host'],
+      })
+      const mark = container.querySelector('.required-mark')
+      expect(mark).toBeTruthy()
+    })
+
+    it('does not show required marker for optional fields', () => {
+      const { container } = mountSchemaForm({
+        type: 'object',
+        properties: { host: { type: 'string', title: 'Host' } },
+      })
+      const mark = container.querySelector('.required-mark')
+      expect(mark).toBeNull()
+    })
+  })
+
+  // ----------------------------------------------------------
+  describe('description (help text)', () => {
+    it('renders field description when provided', () => {
+      const { getByText } = mountSchemaForm({
+        type: 'object',
+        properties: {
+          url: { type: 'string', title: 'URL', description: 'Base API URL' },
+        },
+      })
+      expect(getByText('Base API URL')).toBeTruthy()
+    })
+  })
+
+  // ----------------------------------------------------------
+  describe('raw JSON fallback', () => {
+    it('renders textarea fallback when schema has no renderable properties', () => {
+      const { container } = mountSchemaForm({
+        type: 'object',
+        properties: {
+          nested: { type: 'object', title: 'Nested' },
+        },
+      })
+      const textarea = container.querySelector('textarea')
+      expect(textarea).toBeTruthy()
+    })
+
+    it('renders textarea when schema has no properties', () => {
+      const { container } = mountSchemaForm({
+        type: 'object',
+      })
+      const textarea = container.querySelector('textarea')
+      expect(textarea).toBeTruthy()
+    })
+  })
+})

--- a/autobot-frontend/src/composables/usePlugins.ts
+++ b/autobot-frontend/src/composables/usePlugins.ts
@@ -29,6 +29,7 @@ export interface PluginInfo {
   status: 'unloaded' | 'loaded' | 'enabled' | 'disabled' | 'error'
   hooks: string[]
   trust_tier?: 'official' | 'verified' | 'community' | 'unverified'
+  config_schema?: Record<string, unknown>
 }
 
 export interface PluginManifest {

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8678,5 +8678,16 @@
       "refresh": "تحديث",
       "noSources": "لا توجد مصادر محتوى مهيأة"
     }
+  },
+  "components": {
+    "schemaForm": {
+      "requiredMark": "مطلوب",
+      "selectPlaceholder": "اختر خياراً",
+      "removeTag": "إزالة العلامة",
+      "addTagPlaceholder": "اضغط Enter للإضافة",
+      "rawJsonFallback": "يحتوي المخطط على كائنات متداخلة. تحرير كـ JSON خام:",
+      "rawJsonLabel": "تكوين المكوّن الإضافي (JSON)",
+      "invalidJson": "JSON غير صالح — يُرجى التصحيح قبل الحفظ."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8678,5 +8678,16 @@
       "refresh": "Aktualisieren",
       "noSources": "Keine Inhaltsquellen konfiguriert"
     }
+  },
+  "components": {
+    "schemaForm": {
+      "requiredMark": "erforderlich",
+      "selectPlaceholder": "Option wählen",
+      "removeTag": "Tag entfernen",
+      "addTagPlaceholder": "Enter drücken zum Hinzufügen",
+      "rawJsonFallback": "Schema enthält verschachtelte Objekte. Als JSON bearbeiten:",
+      "rawJsonLabel": "Plugin-Konfiguration (JSON)",
+      "invalidJson": "Ungültiges JSON — bitte vor dem Speichern korrigieren."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8678,5 +8678,16 @@
       "refresh": "Refresh",
       "noSources": "No content sources configured"
     }
+  },
+  "components": {
+    "schemaForm": {
+      "requiredMark": "required",
+      "selectPlaceholder": "Select an option",
+      "removeTag": "Remove tag",
+      "addTagPlaceholder": "Press Enter to add",
+      "rawJsonFallback": "Schema contains nested objects. Edit as raw JSON:",
+      "rawJsonLabel": "Plugin configuration (JSON)",
+      "invalidJson": "Invalid JSON — please fix before saving."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8678,5 +8678,16 @@
       "refresh": "Actualizar",
       "noSources": "No hay fuentes de contenido configuradas"
     }
+  },
+  "components": {
+    "schemaForm": {
+      "requiredMark": "requerido",
+      "selectPlaceholder": "Seleccionar una opción",
+      "removeTag": "Eliminar etiqueta",
+      "addTagPlaceholder": "Presiona Enter para añadir",
+      "rawJsonFallback": "El esquema contiene objetos anidados. Edite como JSON sin formato:",
+      "rawJsonLabel": "Configuración del plugin (JSON)",
+      "invalidJson": "JSON inválido — corrija antes de guardar."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8678,5 +8678,16 @@
       "refresh": "بازنشانی",
       "noSources": "هیچ منبع محتوایی پیکربندی نشده است"
     }
+  },
+  "components": {
+    "schemaForm": {
+      "requiredMark": "الزامی",
+      "selectPlaceholder": "یک گزینه انتخاب کنید",
+      "removeTag": "حذف برچسب",
+      "addTagPlaceholder": "Enter را برای افزودن فشار دهید",
+      "rawJsonFallback": "طرحواره حاوی اشیاء تودرتو است. به عنوان JSON خام ویرایش کنید:",
+      "rawJsonLabel": "پیکربندی افزونه (JSON)",
+      "invalidJson": "JSON نامعتبر است — لطفاً قبل از ذخیره اصلاح کنید."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8678,5 +8678,16 @@
       "refresh": "Actualiser",
       "noSources": "Aucune source de contenu configurée"
     }
+  },
+  "components": {
+    "schemaForm": {
+      "requiredMark": "requis",
+      "selectPlaceholder": "Sélectionner une option",
+      "removeTag": "Supprimer l'étiquette",
+      "addTagPlaceholder": "Appuyer sur Entrée pour ajouter",
+      "rawJsonFallback": "Le schéma contient des objets imbriqués. Modifier en JSON brut :",
+      "rawJsonLabel": "Configuration du plugin (JSON)",
+      "invalidJson": "JSON invalide — veuillez corriger avant d'enregistrer."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8678,5 +8678,16 @@
       "refresh": "רענן",
       "noSources": "לא הוגדרו מקורות תוכן"
     }
+  },
+  "components": {
+    "schemaForm": {
+      "requiredMark": "חובה",
+      "selectPlaceholder": "בחר אפשרות",
+      "removeTag": "הסר תגית",
+      "addTagPlaceholder": "לחץ Enter להוסיף",
+      "rawJsonFallback": "הסכמה מכילה אובייקטים מקוננים. ערוך כ-JSON גולמי:",
+      "rawJsonLabel": "תצורת תוסף (JSON)",
+      "invalidJson": "JSON לא תקין — נא לתקן לפני השמירה."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8678,5 +8678,16 @@
       "refresh": "Atsvaidzināt",
       "noSources": "Nav konfigurētu satura avotu"
     }
+  },
+  "components": {
+    "schemaForm": {
+      "requiredMark": "obligāts",
+      "selectPlaceholder": "Izvēlieties opciju",
+      "removeTag": "Noņemt atzīmi",
+      "addTagPlaceholder": "Nospiediet Enter, lai pievienotu",
+      "rawJsonFallback": "Shēma satur ligzdotus objektus. Rediģēt kā neapstrādātu JSON:",
+      "rawJsonLabel": "Spraudņa konfigurācija (JSON)",
+      "invalidJson": "Nederīgs JSON — lūdzu labojiet pirms saglabāšanas."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8678,5 +8678,16 @@
       "refresh": "Odśwież",
       "noSources": "Brak skonfigurowanych źródeł treści"
     }
+  },
+  "components": {
+    "schemaForm": {
+      "requiredMark": "wymagane",
+      "selectPlaceholder": "Wybierz opcję",
+      "removeTag": "Usuń tag",
+      "addTagPlaceholder": "Naciśnij Enter aby dodać",
+      "rawJsonFallback": "Schemat zawiera zagnieżdżone obiekty. Edytuj jako surowy JSON:",
+      "rawJsonLabel": "Konfiguracja wtyczki (JSON)",
+      "invalidJson": "Nieprawidłowy JSON — popraw przed zapisaniem."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8678,5 +8678,16 @@
       "refresh": "Atualizar",
       "noSources": "Nenhuma fonte de conteúdo configurada"
     }
+  },
+  "components": {
+    "schemaForm": {
+      "requiredMark": "obrigatório",
+      "selectPlaceholder": "Selecionar uma opção",
+      "removeTag": "Remover etiqueta",
+      "addTagPlaceholder": "Pressione Enter para adicionar",
+      "rawJsonFallback": "O esquema contém objetos aninhados. Edite como JSON puro:",
+      "rawJsonLabel": "Configuração do plugin (JSON)",
+      "invalidJson": "JSON inválido — corrija antes de salvar."
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8678,5 +8678,16 @@
       "refresh": "تازہ کریں",
       "noSources": "کوئی مواد کا ذریعہ ترتیب نہیں دیا گیا"
     }
+  },
+  "components": {
+    "schemaForm": {
+      "requiredMark": "ضروری",
+      "selectPlaceholder": "ایک آپشن منتخب کریں",
+      "removeTag": "ٹیگ ہٹائیں",
+      "addTagPlaceholder": "شامل کرنے کے لیے Enter دبائیں",
+      "rawJsonFallback": "اسکیما میں نیسٹڈ اشیاء ہیں۔ خام JSON کے طور پر ترمیم کریں:",
+      "rawJsonLabel": "پلگ ان کنفیگریشن (JSON)",
+      "invalidJson": "JSON غلط ہے — براہ کرم محفوظ کرنے سے پہلے درست کریں۔"
+    }
   }
 }

--- a/autobot-frontend/src/views/PluginsView.vue
+++ b/autobot-frontend/src/views/PluginsView.vue
@@ -397,7 +397,16 @@
             <div v-if="configLoading" class="config-loading">{{ $t('views.plugins.loadingConfig') }}</div>
 
             <div v-else-if="editingConfig">
+              <!-- Schema-driven form when manifest provides a config_schema (#11522) -->
+              <SchemaForm
+                v-if="selectedPlugin?.config_schema && hasSchemaProperties(selectedPlugin.config_schema)"
+                :schema="(selectedPlugin.config_schema as JsonSchema)"
+                :model-value="schemaFormValue"
+                @update:model-value="onSchemaFormUpdate"
+              />
+              <!-- Fallback: raw JSON textarea -->
               <textarea
+                v-else
                 v-model="configText"
                 class="config-editor"
                 rows="8"
@@ -444,6 +453,7 @@
 <script setup lang="ts">
 // Issue #929 - Plugin Manager UI
 // Issue #1359: i18n string extraction
+// Issue #11522: schema-driven config form
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -456,6 +466,7 @@ import PluginInstallModal from '@/components/plugins/PluginInstallModal.vue'
 import CapabilityApprovalDialog from '@/components/plugins/CapabilityApprovalDialog.vue'
 import CapabilityAuditLog from '@/components/plugins/CapabilityAuditLog.vue'
 import TrustTierBadge from '@/components/plugins/TrustTierBadge.vue'
+import SchemaForm, { type JsonSchema } from '@/components/plugins/SchemaForm.vue'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -505,6 +516,19 @@ const configLoading = ref(false)
 const editingConfig = ref(false)
 const configText = ref('')
 const configError = ref('')
+// Issue #11522: schema form reactive value
+const schemaFormValue = ref<Record<string, unknown>>({})
+
+function hasSchemaProperties(schema: Record<string, unknown>): boolean {
+  const props = (schema as JsonSchema).properties
+  return typeof props === 'object' && props !== null && Object.keys(props).length > 0
+}
+
+function onSchemaFormUpdate(value: Record<string, unknown>) {
+  schemaFormValue.value = value
+  // Keep configText in sync so saveConfig works regardless of which branch is shown
+  configText.value = JSON.stringify(value, null, 2)
+}
 
 // Plugins that are in discover but not already in installed list
 const uninstalledPlugins = computed<PluginManifest[]>(() => {
@@ -621,7 +645,9 @@ function closeDetail() {
 }
 
 function startEditConfig() {
-  configText.value = JSON.stringify(pluginConfig.value ?? {}, null, 2)
+  const current = pluginConfig.value ?? {}
+  configText.value = JSON.stringify(current, null, 2)
+  schemaFormValue.value = { ...current }
   configError.value = ''
   editingConfig.value = true
 }
@@ -634,13 +660,21 @@ function cancelEditConfig() {
 async function saveConfig() {
   if (!selectedPlugin.value) return
   configError.value = ''
+
+  // Schema-form branch: schemaFormValue is already up-to-date via onSchemaFormUpdate
+  const schema = selectedPlugin.value.config_schema
   let parsed: Record<string, unknown>
-  try {
-    parsed = JSON.parse(configText.value)
-  } catch {
-    configError.value = t('views.plugins.invalidJson')
-    return
+  if (schema && hasSchemaProperties(schema)) {
+    parsed = schemaFormValue.value
+  } else {
+    try {
+      parsed = JSON.parse(configText.value)
+    } catch {
+      configError.value = t('views.plugins.invalidJson')
+      return
+    }
   }
+
   const ok = await updatePluginConfig(selectedPlugin.value.name, parsed)
   if (ok) {
     pluginConfig.value = parsed

--- a/autobot_shared/plugin_sdk/base.py
+++ b/autobot_shared/plugin_sdk/base.py
@@ -219,6 +219,7 @@ class BasePlugin(ABC):
             "author": self.manifest.author,
             "status": self.status.value,
             "hooks": self.manifest.hooks,
+            "config_schema": self.manifest.config_schema,
         }
 
 

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -11,6 +11,7 @@ Issue #730 - Plugin SDK for extensible tool architecture.
 Issue #6970 - Validate declared hooks against HOOK_REGISTRY on load.
 Issue #6971 - Raise PluginLoadError for missing required env vars.
 Issue #10294 - File-path fallback for hyphenated core-plugin directories.
+Issue #11522 - Validate config_schema (JSON Schema Draft 2020-12) and config at load.
 """
 
 import importlib
@@ -20,13 +21,49 @@ import logging
 import os
 from pathlib import Path
 from types import ModuleType
-from typing import Dict, List, Tuple, Type
+from typing import Any, Dict, List, Tuple, Type
+
+import jsonschema
 
 from .base import BasePlugin, PluginLoadError, PluginManifest, PluginRegistry, PluginStatus
 from .hooks import validate_hook_names
 from .registry import get_registry
 
 logger = logging.getLogger(__name__)
+
+_DRAFT_202012_VALIDATOR = jsonschema.Draft202012Validator
+
+
+def _validate_config_schema(plugin_name: str, config_schema: Dict[str, Any]) -> None:
+    """Raise PluginLoadError if config_schema is not a valid JSON Schema Draft 2020-12.
+
+    Issue #11522 — structural validation at load time.
+    """
+    try:
+        _DRAFT_202012_VALIDATOR.check_schema(config_schema)
+    except jsonschema.SchemaError as exc:
+        raise PluginLoadError(
+            f"Plugin '{plugin_name}': config_schema is not valid JSON Schema " f"(Draft 2020-12): {exc.message}"
+        ) from exc
+
+
+def _validate_config_against_schema(
+    plugin_name: str,
+    config: Dict[str, Any],
+    config_schema: Dict[str, Any],
+) -> None:
+    """Raise PluginLoadError if config does not conform to config_schema.
+
+    Issue #11522 — field-level error detail on non-conforming config.
+    """
+    validator = _DRAFT_202012_VALIDATOR(config_schema)
+    errors = sorted(validator.iter_errors(config), key=lambda e: list(e.path))
+    if not errors:
+        return
+    field_messages = [f"  - {'.'.join(str(p) for p in err.path) or '<root>'}: {err.message}" for err in errors]
+    raise PluginLoadError(
+        f"Plugin '{plugin_name}': config does not conform to config_schema:\n" + "\n".join(field_messages)
+    )
 
 
 class PluginLoader:
@@ -122,6 +159,12 @@ class PluginLoader:
                     manifest.name,
                     missing_optional,
                 )
+
+            # GH#11522: validate config_schema and supplied config at load time
+            if manifest.config_schema:
+                _validate_config_schema(manifest.name, manifest.config_schema)
+                if config:
+                    _validate_config_against_schema(manifest.name, config, manifest.config_schema)
 
             # Import plugin module — pass on-disk directory for file-path fallback (#10294)
             plugin_dir = self._manifest_dirs.get(manifest.name)

--- a/autobot_shared/plugin_sdk/loader.py
+++ b/autobot_shared/plugin_sdk/loader.py
@@ -57,13 +57,38 @@ def _validate_config_against_schema(
     Issue #11522 — field-level error detail on non-conforming config.
     """
     validator = _DRAFT_202012_VALIDATOR(config_schema)
-    errors = sorted(validator.iter_errors(config), key=lambda e: list(e.path))
+    errors = list(validator.iter_errors(config))
     if not errors:
         return
-    field_messages = [f"  - {'.'.join(str(p) for p in err.path) or '<root>'}: {err.message}" for err in errors]
+
+    # Value-free, field-level messages: name the field and the violated
+    # constraint but never echo the submitted value (#11522 review m-4) —
+    # these strings surface in HTTP 422 responses via validate_plugin_config.
+    def _fmt(err: jsonschema.ValidationError) -> str:
+        path = ".".join(str(p) for p in err.path) or "<root>"
+        if err.validator == "required":
+            # 'required' messages name schema-declared fields, never submitted
+            # values — keep them for actionable diagnostics.
+            return f"  - {path}: {err.message}"
+        return f"  - {path}: violates '{err.validator}' constraint"
+
+    field_messages = [_fmt(err) for err in errors]
     raise PluginLoadError(
         f"Plugin '{plugin_name}': config does not conform to config_schema:\n" + "\n".join(field_messages)
     )
+
+
+def validate_plugin_config(plugin_name: str, config: Dict[str, Any], config_schema: Dict[str, Any]) -> None:
+    """Public seam: validate a plugin *config* against its *config_schema*.
+
+    For use outside the SDK (e.g. the plugin-manager API config-update path).
+    The schema itself is already structurally validated at plugin load time,
+    so only config conformance is checked here.  Raises PluginLoadError with
+    field-level, value-free messages.
+    """
+    if not config_schema:
+        return
+    _validate_config_against_schema(plugin_name, config, config_schema)
 
 
 class PluginLoader:

--- a/autobot_shared/plugin_sdk/plugin_sdk_test.py
+++ b/autobot_shared/plugin_sdk/plugin_sdk_test.py
@@ -774,3 +774,143 @@ async def test_load_plugin_returns_none_and_logs_when_required_env_missing(monke
 
     assert result is None
     assert "TEST_REQ_LOAD_FAIL_V2" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# GH#11522 — config_schema validation helpers
+# ---------------------------------------------------------------------------
+
+
+def test_validate_config_schema_accepts_valid_draft202012() -> None:
+    from plugin_sdk.loader import _validate_config_schema
+
+    _validate_config_schema("p", {"type": "object", "properties": {"host": {"type": "string"}}})
+
+
+def test_validate_config_schema_accepts_empty_schema() -> None:
+    from plugin_sdk.loader import _validate_config_schema
+
+    _validate_config_schema("p", {})
+
+
+def test_validate_config_schema_rejects_invalid_type() -> None:
+    from plugin_sdk.loader import _validate_config_schema
+
+    with pytest.raises(PluginLoadError, match="not valid JSON Schema"):
+        _validate_config_schema("p", {"type": "totally_invalid_type"})
+
+
+def test_validate_config_against_schema_accepts_conforming() -> None:
+    from plugin_sdk.loader import _validate_config_against_schema
+
+    schema = {
+        "type": "object",
+        "properties": {"host": {"type": "string"}, "port": {"type": "integer"}},
+        "required": ["host"],
+    }
+    _validate_config_against_schema("p", {"host": "localhost", "port": 8080}, schema)
+
+
+def test_validate_config_against_schema_rejects_wrong_type() -> None:
+    from plugin_sdk.loader import _validate_config_against_schema
+
+    schema = {"type": "object", "properties": {"port": {"type": "integer"}}}
+    with pytest.raises(PluginLoadError, match="does not conform to config_schema"):
+        _validate_config_against_schema("p", {"port": "not-an-int"}, schema)
+
+
+def test_validate_config_against_schema_field_level_detail() -> None:
+    """Error message must name the offending field."""
+    from plugin_sdk.loader import _validate_config_against_schema
+
+    schema = {
+        "type": "object",
+        "properties": {"timeout": {"type": "integer"}},
+        "required": ["timeout"],
+    }
+    with pytest.raises(PluginLoadError, match="timeout"):
+        _validate_config_against_schema("p", {}, schema)
+
+
+def test_validate_config_against_schema_missing_required() -> None:
+    from plugin_sdk.loader import _validate_config_against_schema
+
+    schema = {
+        "type": "object",
+        "properties": {"host": {"type": "string"}},
+        "required": ["host"],
+    }
+    with pytest.raises(PluginLoadError):
+        _validate_config_against_schema("p", {}, schema)
+
+
+# ---------------------------------------------------------------------------
+# GH#11522 — load_plugin enforces config_schema at load time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_plugin_invalid_schema_returns_none_and_logs(monkeypatch, caplog) -> None:
+    """A manifest with an invalid config_schema returns None (outer handler swallows PluginLoadError)."""
+    from plugin_sdk.loader import PluginLoader
+
+    PluginRegistry().clear()
+    loader = PluginLoader([])
+    manifest = _make_manifest(
+        name="bad-schema-plugin",
+        config_schema={"type": "totally_invalid_type"},
+    )
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep, d=None: _ConcretePlugin)
+
+    with caplog.at_level("ERROR"):
+        result = await loader.load_plugin(manifest)
+
+    assert result is None
+    assert "not valid JSON Schema" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_load_plugin_nonconforming_config_returns_none_and_logs(monkeypatch, caplog) -> None:
+    """A non-conforming config returns None and logs the field-level error."""
+    from plugin_sdk.loader import PluginLoader
+
+    PluginRegistry().clear()
+    loader = PluginLoader([])
+    schema = {"type": "object", "properties": {"host": {"type": "string"}}, "required": ["host"]}
+    manifest = _make_manifest(name="schema-plugin", config_schema=schema)
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep, d=None: _ConcretePlugin)
+
+    with caplog.at_level("ERROR"):
+        result = await loader.load_plugin(manifest, config={"host": 999})
+
+    assert result is None
+    assert "does not conform to config_schema" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_load_plugin_conforming_config_loads(monkeypatch) -> None:
+    """A valid schema + conforming config loads successfully."""
+    from plugin_sdk.loader import PluginLoader
+
+    PluginRegistry().clear()
+    schema = {"type": "object", "properties": {"host": {"type": "string"}}, "required": ["host"]}
+    loader = PluginLoader([])
+    manifest = _make_manifest(name="ok-schema-plugin", config_schema=schema)
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep, d=None: _ConcretePlugin)
+
+    plugin = await loader.load_plugin(manifest, config={"host": "localhost"})
+    assert plugin is not None
+
+
+@pytest.mark.asyncio
+async def test_load_plugin_empty_schema_any_config_loads(monkeypatch) -> None:
+    """An absent config_schema keeps today's behaviour (no validation)."""
+    from plugin_sdk.loader import PluginLoader
+
+    PluginRegistry().clear()
+    loader = PluginLoader([])
+    manifest = _make_manifest(name="noschema-plugin")
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep, d=None: _ConcretePlugin)
+
+    plugin = await loader.load_plugin(manifest, config={"anything": True})
+    assert plugin is not None

--- a/autobot_shared/plugin_sdk/plugin_sdk_test.py
+++ b/autobot_shared/plugin_sdk/plugin_sdk_test.py
@@ -914,3 +914,28 @@ async def test_load_plugin_empty_schema_any_config_loads(monkeypatch) -> None:
 
     plugin = await loader.load_plugin(manifest, config={"anything": True})
     assert plugin is not None
+
+
+def test_validate_config_valid_schema_with_unrenderable_properties() -> None:
+    """A valid schema whose properties are nested objects (unrenderable by the
+    UI form) must still pass load-time validation — renderability is a
+    frontend concern, not a load gate (#11522 review m-6)."""
+    from plugin_sdk.loader import _validate_config_against_schema, _validate_config_schema
+
+    schema = {
+        "type": "object",
+        "properties": {"nested": {"type": "object", "properties": {"inner": {"type": "string"}}}},
+    }
+    _validate_config_schema("p", schema)  # must not raise
+    _validate_config_against_schema("p", {"nested": {"inner": "ok"}}, schema)  # must not raise
+
+
+def test_validate_plugin_config_public_wrapper() -> None:
+    """Public wrapper validates config and skips cleanly on empty schema."""
+    from plugin_sdk.loader import validate_plugin_config
+
+    validate_plugin_config("p", {"anything": 1}, {})  # empty schema → no-op
+    schema = {"type": "object", "properties": {"timeout": {"type": "integer"}}}
+    validate_plugin_config("p", {"timeout": 5}, schema)  # conforming → no raise
+    with pytest.raises(PluginLoadError, match="timeout"):
+        validate_plugin_config("p", {"timeout": "not-an-int"}, schema)

--- a/autobot_shared/plugin_sdk/plugin_sdk_test.py
+++ b/autobot_shared/plugin_sdk/plugin_sdk_test.py
@@ -468,7 +468,7 @@ async def test_load_plugin_returns_none_when_required_env_missing(monkeypatch, c
         ]
     )
 
-    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep: _ConcretePlugin)
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep, plugin_dir=None: _ConcretePlugin)
 
     with caplog.at_level("ERROR"):
         result = await loader.load_plugin(manifest)
@@ -497,7 +497,7 @@ async def test_load_plugin_succeeds_with_optional_env_missing(monkeypatch, caplo
         ],
     )
 
-    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep: _ConcretePlugin)
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep, plugin_dir=None: _ConcretePlugin)
 
     with caplog.at_level("INFO"):
         plugin = await loader.load_plugin(manifest)
@@ -526,7 +526,7 @@ async def test_load_plugin_succeeds_when_all_required_env_set(monkeypatch) -> No
         ],
     )
 
-    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep: _ConcretePlugin)
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep, plugin_dir=None: _ConcretePlugin)
 
     plugin = await loader.load_plugin(manifest)
     assert plugin is not None
@@ -566,7 +566,7 @@ async def test_get_env_status_returns_correct_shape(monkeypatch) -> None:
             },
         ],
     )
-    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep: _ConcretePlugin)
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep, plugin_dir=None: _ConcretePlugin)
     await loader.load_plugin(manifest)
 
     status = loader.get_env_status("status-shape-plugin")
@@ -619,7 +619,7 @@ async def test_get_env_status_never_returns_value(monkeypatch) -> None:
             }
         ],
     )
-    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep: _ConcretePlugin)
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep, plugin_dir=None: _ConcretePlugin)
     await loader.load_plugin(manifest)
 
     status = loader.get_env_status("leak-check-plugin")
@@ -692,7 +692,7 @@ async def test_load_plugin_validates_hook_names(monkeypatch) -> None:
     PluginRegistry().clear()
     loader = PluginLoader([])
     manifest = _make_manifest(name="hook-warn-plugin", hooks=["totally_invalid_hook"])
-    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep: _ConcretePlugin)
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep, plugin_dir=None: _ConcretePlugin)
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
@@ -710,7 +710,7 @@ async def test_load_plugin_no_warning_for_known_hooks(monkeypatch) -> None:
     PluginRegistry().clear()
     loader = PluginLoader([])
     manifest = _make_manifest(name="hook-ok-plugin", hooks=[Hook.ON_STARTUP.value])
-    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep: _ConcretePlugin)
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep, plugin_dir=None: _ConcretePlugin)
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
@@ -743,7 +743,7 @@ async def test_load_plugin_raises_plugin_load_error_when_required_env_missing(mo
         name="ple-test-plugin",
         required_env=[{"name": "TEST_PLE_VAR", "description": "x", "required": True}],
     )
-    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep: _ConcretePlugin)
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep, plugin_dir=None: _ConcretePlugin)
 
     # Bypass the outer try/except to observe the raw exception
     with pytest.raises(PluginLoadError, match="TEST_PLE_VAR"):
@@ -767,7 +767,7 @@ async def test_load_plugin_returns_none_and_logs_when_required_env_missing(monke
         name="ple-bc-plugin",
         required_env=[{"name": "TEST_REQ_LOAD_FAIL_V2", "description": "x", "required": True}],
     )
-    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep: _ConcretePlugin)
+    monkeypatch.setattr(loader, "_import_plugin_class", lambda ep, plugin_dir=None: _ConcretePlugin)
 
     with caplog.at_level("ERROR"):
         result = await loader.load_plugin(manifest)


### PR DESCRIPTION
Closes #11522. Part of umbrella #11518 (Task 3).

## Thinking Path
`PluginManifest.config_schema` was an opaque dict — never validated at load, never enforced on update, and unrendered in the UI (raw-JSON textarea only). Research (#11518) identified schema-drives-validation-and-UI as the closing pattern; per the umbrella non-goals this uses plain JSON Schema, no schema-library fork.

## What Changed
**Backend**
- `plugin_sdk/loader.py`: structural JSON-Schema validation (Draft 2020-12 `check_schema`) at plugin load + config-conformance validation; both raise `PluginLoadError` (load keeps returning None-with-error-log, matching existing missing-env behavior). New public `validate_plugin_config()` seam for non-SDK callers; error messages are field-level and value-free (submitted values never echoed into HTTP detail; `required` violations name the schema-declared missing fields).
- `plugin_manager.py`: `update_plugin_config` validates via the public seam → 422 with field-level detail.
- 14 new tests; also repaired 9 pre-existing plugin_sdk tests that monkeypatched `_import_plugin_class` with the wrong arity (never exercised before — in-scope Rule 6 fix).

**Frontend**
- New `components/plugins/SchemaForm.vue`: schema-driven form (string/number/integer/boolean/enum/array-of-scalars; required marker, defaults, description help text, title labels); typed emission — numeric/boolean enum members and array items are coerced back to their schema types, never stringified; internal raw-JSON fallback for unrenderable schemas.
- `PluginsView.vue`: SchemaForm wired into the plugin config editor; raw-JSON textarea retained as fallback.
- `usePlugins.ts`: `config_schema` on `PluginInfo`; `get_info()` now exposes it from the manifest.
- i18n keys added to all 11 locales (`components.schemaForm.*`); `npm run check:i18n` green.
- Skill-config UI adapter skipped per issue condition — no existing skill-config UI exists.

## Verification
- Backend: `pytest autobot_shared/plugin_sdk/plugin_sdk_test.py` → **64 passed** (was 57 passed + 5 broken pre-existing)
- Frontend: `npx vitest run SchemaForm.test.ts` → **23 passed** (incl. typed-enum and typed-array coercion regressions); `vue-tsc --noEmit -p tsconfig.app.json` → 0 errors (baseline 0)
- `flake8 --config=.flake8` + `black -l 120` clean
- code-reviewer pass: 1 blocker (enum/array stringification → guaranteed 422 on non-string schemas), 2 majors (private-import boundary; redundant per-request schema re-validation), 7 minors — blocker + majors + test minors fixed; m-7 (PluginInfo optionality) left as-is deliberately: mocks construct partial PluginInfo objects.

## Model Used
Claude (Fable 5) orchestrating; Sonnet implementation agent; Sonnet code-reviewer agent.
