### PR TITLE
feat(slm-ui): shared view layout primitive (#11515 Task 3.1)

### DIFF
--- a/autobot-slm-frontend/src/assets/styles/main.css
+++ b/autobot-slm-frontend/src/assets/styles/main.css
@@ -448,3 +448,72 @@ p {
   white-space: nowrap;
   border: 0;
 }
+
+/* ─── Shared view layout primitive (#11515 Task 3) ────────────────
+ * A consistent page container + header for every SLM view, so views stop
+ * rolling their own padding / max-width / title styling (Tailwind p-6, ad-hoc
+ * `.*-view` classes). Token-driven: adapts to the active theme via --a11y-* and
+ * uses the sizing scales added in Task 2.3. Mirrors the user frontend's
+ * view.css so both frontends' views are structured the same way. Adopt by
+ * adding `view-container` (or `view-container-constrained`) to a view root and
+ * `view-header`/`view-title`/`view-description` to its heading (Task 3.2). */
+:root {
+  --content-max-width: 1400px;
+  --content-padding: var(--spacing-6);
+}
+
+.view-container {
+  padding: var(--content-padding);
+  color: var(--a11y-text);
+}
+
+/* Centred, width-capped content for wide dashboards. */
+.view-container-constrained {
+  max-width: var(--content-max-width);
+  margin-inline: auto;
+  padding: var(--content-padding);
+  color: var(--a11y-text);
+}
+
+.view-header {
+  margin-bottom: var(--spacing-6);
+}
+
+.view-title {
+  margin: 0 0 var(--spacing-2) 0;
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  color: var(--a11y-text);
+}
+
+.view-description {
+  margin: 0;
+  font-size: var(--text-base);
+  color: var(--a11y-text-muted);
+}
+
+/* Sub-nav tab row within a view. */
+.view-nav {
+  display: flex;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.view-nav-link {
+  padding: var(--spacing-2) var(--spacing-4);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--a11y-text-muted);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+}
+
+.view-nav-link:hover {
+  color: var(--a11y-text);
+}
+
+.view-nav-link.is-active {
+  color: var(--color-primary-500);
+  border-bottom-color: var(--color-primary-500);
+}


### PR DESCRIPTION
## Thinking Path
Umbrella #11515 Task 3.1. The SLM audit found **no shared layout primitive** — every SLM view rolls its own container (Tailwind `p-6`, ad-hoc `.*-view` classes), so padding / max-width / header styling are inconsistent across views. The user frontend already has this via `assets/styles/view.css`.

## What Changed
- Added a token-driven **view primitive** to `autobot-slm-frontend/.../main.css`, mirroring the user frontend’s `view.css`:
  - `.view-container` / `.view-container-constrained` — consistent padding + capped, centred max-width.
  - `.view-header` / `.view-title` / `.view-description` — consistent page heading.
  - `.view-nav` / `.view-nav-link` — consistent sub-nav tabs.
- All values are tokens: theme-adaptive `--a11y-*` for color/border + the Task 2.3 sizing scales. Two layout tokens added (`--content-max-width: 1400px`, `--content-padding`).

## Verification
- CSS braces balanced; all 12 referenced tokens confirmed defined in `main.css`.
- Purely additive — no existing view changed, so zero rendering risk until views adopt the classes.

## Follow-up
Task 3.2 migrates SLM views onto these classes (best done with visual verification, so kept separate from this additive primitive).

## Model Used
Opus 4.8

Refs #11515