### PR TITLE
feat(skills): /adopt pipeline skill + audit-first gate in /research (#11576)

### DIFF
--- a/.claude/skills/adopt/SKILL.md
+++ b/.claude/skills/adopt/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: adopt
+description: End-to-end external-feature adoption pipeline — audit AutoBot first, research the source, file umbrella + child issues for confirmed gaps, implement each through merged PRs, report with evidence. Use when the user asks to adopt, port, or bring in features from an external repo/article, or to drive research through to merged code.
+---
+
+# Adopt External Features
+
+Pipeline: pre-flight → research → confirm → file → implement → evidence report. Each step gates the next. This skill orchestrates existing skills — it duplicates none of their content.
+
+## Input
+
+`/adopt <source> [focus areas]` — source is a URL, GitHub repo, or local file (same auto-detection as `/research`).
+
+## Steps
+
+1. **Pre-flight**
+   - Open PR count ≥5 → defer, report, stop
+   - Remove stale worktrees (`git worktree list` — merged branch but directory present)
+   - Confirm self-hosted runner is online before planning CI-dependent work
+2. **Research** — invoke the `research` skill on the source (Phase 1 → user gate → Phase 2). Its audit-first gate applies: nothing is adoptable without cited proof it doesn't already exist in AutoBot.
+3. **STOP — user confirms the adoption list.** No issues are filed and no code is written without explicit go-ahead on which gaps to adopt.
+4. **File issues** — one umbrella issue owning the adoption goal + one child issue per confirmed gap (use the `issue` skill; umbrella task-list format from global CLAUDE.md). Link each child to its Phase 2 evidence.
+5. **Implement each child** — use the `implement` skill per child: own worktree `.worktrees/issue-XXXX/`, tests, PR to `Dev_new_gui`, CI green, merge, close, worktree cleanup. Max 3 children in flight.
+6. **Evidence report** — final table, one row per child:
+
+   | Child issue | PR | Commit SHA | CI | Merged | Gaps |
+   |---|---|---|---|---|---|
+
+   A row may only read "done" with every artifact present. Missing artifact → flag it and resume the work; never report it complete.
+
+## Rules
+
+- Never skip step 3 — filing issues and writing code require explicit user approval
+- Subagent completion claims count only after artifact verification (`git log`, `gh pr view`) — no commits/PR means not done
+- Checkpoint Phase 1/2 output and the evidence table to a file incrementally (scratchpad or umbrella issue comment) so an interruption never loses the audit
+- Update the umbrella checklist after every child merges
+- Discovered off-task bugs → file discovery issues, per Core Rule 6

--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -141,6 +141,7 @@ Only after explicit user go-ahead. Read relevant AutoBot files guided by Phase 1
 ### What We Can Adopt
 - Specific patterns, techniques, or approaches from the source
 - For each: which AutoBot module/file it would apply to
+- For each: already-exists audit — the greps/files checked proving AutoBot lacks it (cite paths)
 - Effort estimate: trivial / moderate / significant
 
 ### What We Already Do Better
@@ -188,4 +189,5 @@ If source is too large for single analysis, summarize sections and focus on what
 - Phase 2 MUST NOT start without explicit user approval after Phase 1
 - Always cite specific files, functions, or sections when making claims
 - When comparing to AutoBot, read actual code — don't assume based on file names
+- **Audit-first gate:** no item enters "What We Can Adopt" without an already-exists audit (grep + read the candidate AutoBot modules, cite what was checked); capability already exists → it moves to "What We Already Do Better"; partially exists → describe only the missing delta
 - Keep each section concise — depth over breadth


### PR DESCRIPTION
Closes #11576

## Thinking Path

/insights (2026-07-11) flagged two recurring frictions across 11 sessions: adoptable-feature research repeatedly discovering the capability already existed after effort was spent, and no codified pipeline for the research→umbrella→implement→merge pattern used in 8+ sessions. Fix at the skill layer, not per-session prompting.

## What Changed

- `.claude/skills/research/SKILL.md` — Phase 2 audit-first gate: an item may only be listed as adoptable with a cited already-exists audit (grep + read of candidate AutoBot modules); existing capability moves to "What We Already Do Better", partial → only the missing delta
- `.claude/skills/adopt/SKILL.md` (new) — end-to-end adoption pipeline orchestrating existing skills (`research`, `issue`, `implement`): pre-flight (PR queue, stale worktrees, runner health) → research → explicit user gate → umbrella + child issues → per-child worktree implementation → evidence-table final report (issue/PR/SHA/CI per row, no artifacts = not done)

Out of scope (rejected in #11576): GitHub MCP server — conflicts with the established gh-CLI-first rule.

## Verification

Docs/skill-only change — no runtime surface. Markdown passes pre-commit hooks; skill frontmatter matches the existing skill format (`name` + `description`).

## Model Used

Claude Fable 5