### PR TITLE
refactor(deps): extract assemble_postgres_url shared primitive (#11466)

### DIFF
--- a/autobot-backend/migrations/db_url.py
+++ b/autobot-backend/migrations/db_url.py
@@ -14,6 +14,8 @@ import os
 
 from sqlalchemy.engine import make_url
 
+from autobot_shared.db_url import assemble_postgres_url
+
 
 def get_url() -> str:
     """Get database URL from deployment config or environment."""
@@ -28,9 +30,15 @@ def get_url() -> str:
         deployment_config = get_deployment_config()
         return deployment_config.postgres_sync_url
     except Exception:
-        # Default fallback for development
-        db_host = os.environ.get("AUTOBOT_POSTGRES_HOST", "autobot-postgres")
-        return f"postgresql://autobot:autobot@{db_host}:5432/autobot"
+        # Default fallback for development: assemble from AUTOBOT_POSTGRES_HOST
+        # only; user/password/db are fixed to their dev values (#11466).
+        return assemble_postgres_url(
+            {"AUTOBOT_POSTGRES_HOST": os.environ.get("AUTOBOT_POSTGRES_HOST", "autobot-postgres")},
+            default_host="autobot-postgres",
+            default_user="autobot",
+            default_db="autobot",
+            password_default="autobot",  # nosec B106 — dev-env placeholder, not a real credential
+        )
 
 
 def as_async_url(url: str) -> str:

--- a/autobot-backend/services/tool_output_filter.py
+++ b/autobot-backend/services/tool_output_filter.py
@@ -268,7 +268,7 @@ def tee_and_hint(raw: str, slug: str, exit_code: int, mode: str = "failures") ->
         tee_path = _TEE_DIR / filename
         tee_path.write_text(raw, encoding="utf-8")
         return f"[full output saved: {tee_path}]"
-    except Exception as exc:
+    except Exception:
         return None
 
 

--- a/autobot-backend/tests/migrations/test_db_url.py
+++ b/autobot-backend/tests/migrations/test_db_url.py
@@ -1,0 +1,140 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression tests for migrations/db_url.py (#11466).
+
+Proves that the get_url() dev-fallback branch produces byte-identical output
+before and after the shared-helper refactor in #11466.
+
+These tests run WITHOUT a real Postgres or SQLAlchemy connection — they only
+exercise the URL string-assembly logic inside get_url() in isolation.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Path bootstrap: migrations/ is not on sys.path by default on the dev host.
+# ---------------------------------------------------------------------------
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+_MIGRATIONS_DIR = _BACKEND_ROOT / "migrations"
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+
+def _get_url_dev_fallback(host_override: str | None = None) -> str:
+    """Call get_url() with the deployment-config path failing (dev fallback)."""
+    env: dict = {}
+    if host_override is not None:
+        env["AUTOBOT_POSTGRES_HOST"] = host_override
+
+    with (
+        patch.dict(os.environ, env, clear=False),
+        patch(
+            "user_management.config.get_deployment_config",
+            side_effect=RuntimeError("no deployment config in test"),
+        ),
+    ):
+        from migrations.db_url import get_url
+
+        return get_url()
+
+
+# ---------------------------------------------------------------------------
+# #11466 — byte-identical dev-fallback regression
+# ---------------------------------------------------------------------------
+
+
+def test_get_url_dev_fallback_default_host() -> None:
+    """Dev fallback without AUTOBOT_POSTGRES_HOST produces the historic default URL.
+
+    Before (#11466): f"postgresql://autobot:autobot@autobot-postgres:5432/autobot"
+    """
+    env_backup = os.environ.pop("AUTOBOT_POSTGRES_HOST", None)
+    env_backup_db_url = os.environ.pop("AUTOBOT_DATABASE_URL", None)
+    try:
+        result = _get_url_dev_fallback()
+    finally:
+        if env_backup is not None:
+            os.environ["AUTOBOT_POSTGRES_HOST"] = env_backup
+        if env_backup_db_url is not None:
+            os.environ["AUTOBOT_DATABASE_URL"] = env_backup_db_url
+
+    assert result == "postgresql://autobot:autobot@autobot-postgres:5432/autobot"
+
+
+def test_get_url_dev_fallback_custom_host() -> None:
+    """Dev fallback with a custom AUTOBOT_POSTGRES_HOST substitutes the host only.
+
+    Before (#11466):
+        db_host = os.environ.get("AUTOBOT_POSTGRES_HOST", "autobot-postgres")
+        return f"postgresql://autobot:autobot@{db_host}:5432/autobot"
+    """
+    env_backup_db_url = os.environ.pop("AUTOBOT_DATABASE_URL", None)
+    try:
+        result = _get_url_dev_fallback(host_override="my-custom-pg")
+    finally:
+        if env_backup_db_url is not None:
+            os.environ["AUTOBOT_DATABASE_URL"] = env_backup_db_url
+
+    assert result == "postgresql://autobot:autobot@my-custom-pg:5432/autobot"
+
+
+def test_get_url_dev_fallback_does_not_pick_up_other_pg_vars() -> None:
+    """Dev fallback ignores AUTOBOT_POSTGRES_USER/PASSWORD/DB/PORT — those are
+    fixed to 'autobot' in the original code and must stay fixed after #11466.
+    """
+    env_backup = {
+        k: os.environ.pop(k)
+        for k in (
+            "AUTOBOT_POSTGRES_USER",
+            "AUTOBOT_POSTGRES_PASSWORD",
+            "AUTOBOT_POSTGRES_DB",
+            "AUTOBOT_POSTGRES_PORT",
+            "AUTOBOT_DATABASE_URL",
+        )
+        if k in os.environ
+    }
+    try:
+        os.environ["AUTOBOT_POSTGRES_USER"] = "injected_user"
+        os.environ["AUTOBOT_POSTGRES_PASSWORD"] = "injected_pw"
+        os.environ["AUTOBOT_POSTGRES_DB"] = "injected_db"
+        os.environ["AUTOBOT_POSTGRES_PORT"] = "9999"
+        result = _get_url_dev_fallback()
+    finally:
+        os.environ.pop("AUTOBOT_POSTGRES_USER", None)
+        os.environ.pop("AUTOBOT_POSTGRES_PASSWORD", None)
+        os.environ.pop("AUTOBOT_POSTGRES_DB", None)
+        os.environ.pop("AUTOBOT_POSTGRES_PORT", None)
+        os.environ.update(env_backup)
+
+    # User/password/db/port must remain the hardcoded dev values
+    assert "autobot:autobot@" in result
+    assert ":5432/" in result
+    assert result.endswith("/autobot")
+    assert "injected" not in result
+
+
+def test_get_url_prefers_autobot_database_url_env_var() -> None:
+    """AUTOBOT_DATABASE_URL in os.environ short-circuits before the dev fallback."""
+    env_backup = os.environ.pop("AUTOBOT_DATABASE_URL", None)
+    try:
+        os.environ["AUTOBOT_DATABASE_URL"] = "postgresql://explicit:url@pghost/pgdb"
+        from importlib import reload
+
+        import migrations.db_url as _mod
+
+        reload(_mod)
+        result = _mod.get_url()
+    finally:
+        if env_backup is not None:
+            os.environ["AUTOBOT_DATABASE_URL"] = env_backup
+        else:
+            os.environ.pop("AUTOBOT_DATABASE_URL", None)
+
+    assert result == "postgresql://explicit:url@pghost/pgdb"

--- a/autobot-backend/tests/services/test_tool_output_filter.py
+++ b/autobot-backend/tests/services/test_tool_output_filter.py
@@ -738,7 +738,7 @@ def test_filter_savings_not_inflated_by_tee_hint(tmp_path, monkeypatch):
 
 
 def test_cap_unmatched_output_under_cap_untouched():
-    import services.tool_output_filter as mod
+    pass
 
     small_output = "just a normal short unmatched output\n"
     result = cap_unmatched_output("some-unknown-tool", small_output, exit_code=0)

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -63,6 +63,7 @@ from models.schemas import (
 from services.auth import get_current_user
 from services.code_distributor import get_code_distributor
 from services.database import get_db
+from autobot_shared.db_url import assemble_postgres_url
 from services.deploy_artifacts import rsync_artifact_excludes
 from services.drift_checker import (
     ALLOWED_COMPONENTS,
@@ -1487,14 +1488,22 @@ def _prune_old_backups(backup_dir: Path, component: str, max_keep: int) -> None:
             logger.warning("pg_dump prune: failed to remove %s: %s", old, exc)
 
 
+_PG_COMPONENT_KEYS = (
+    "AUTOBOT_POSTGRES_HOST",
+    "AUTOBOT_POSTGRES_PORT",
+    "AUTOBOT_POSTGRES_USER",
+    "AUTOBOT_POSTGRES_PASSWORD",
+    "AUTOBOT_POSTGRES_DB",
+)
+
+
 def _resolve_pg_db_url(env_vars: Dict[str, str]) -> str:
-    """Resolve the Postgres connection URL from env vars (#11431).
+    """Resolve the Postgres connection URL from env vars (#11431, #11466).
 
     Resolution order (mirrors migrations/db_url.py and alembic env.py):
       1. AUTOBOT_DATABASE_URL  — explicit full URL (set by db-credentials.env.j2)
       2. DATABASE_URL          — bare alias some deployments use
-      3. AUTOBOT_POSTGRES_*   — component vars from backend.env.j2
-      4. os.environ fallbacks — in case the process already has them
+      3. AUTOBOT_POSTGRES_*   — component vars from backend.env.j2 / os.environ
 
     Returns an empty string when no DB config can be found at all, which the
     caller treats as "proceed with warning" rather than "abort deploy".
@@ -1507,16 +1516,15 @@ def _resolve_pg_db_url(env_vars: Dict[str, str]) -> str:
     url = env_vars.get("DATABASE_URL") or os.environ.get("DATABASE_URL", "")
     if url:
         return url
-    # 3. Assemble from AUTOBOT_POSTGRES_* component vars (backend.env.j2 style)
-    host = env_vars.get("AUTOBOT_POSTGRES_HOST") or os.environ.get("AUTOBOT_POSTGRES_HOST", "")
-    if host:
-        port = env_vars.get("AUTOBOT_POSTGRES_PORT") or os.environ.get("AUTOBOT_POSTGRES_PORT", "5432")
-        user = env_vars.get("AUTOBOT_POSTGRES_USER") or os.environ.get("AUTOBOT_POSTGRES_USER", "autobot_app")
-        pw = env_vars.get("AUTOBOT_POSTGRES_PASSWORD") or os.environ.get("AUTOBOT_POSTGRES_PASSWORD", "")
-        db = env_vars.get("AUTOBOT_POSTGRES_DB") or os.environ.get("AUTOBOT_POSTGRES_DB", "autobot_users")
-        auth = f"{user}:{pw}@" if pw else f"{user}@"
-        return f"postgresql://{auth}{host}:{port}/{db}"
-    return ""
+    # 3. Assemble from AUTOBOT_POSTGRES_* component vars (backend.env.j2 style).
+    # Merge env_vars (higher precedence) over os.environ; filter empty strings so
+    # assemble_postgres_url falls back to its per-key defaults correctly (#11466).
+    merged = {k: v for k in _PG_COMPONENT_KEYS if (v := env_vars.get(k) or os.environ.get(k, ""))}
+    return assemble_postgres_url(
+        merged,
+        default_user="autobot_app",
+        default_db="autobot_users",
+    )
 
 
 async def _pg_dump_before_migration(component: str, deployed_dir: str, steps: List[str]) -> Optional[str]:

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -31,6 +31,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
+from autobot_shared.db_url import assemble_postgres_url
 from config import settings
 from models.database import CodeSource, CodeStatus
 from models.database import ComponentSyncJob as ComponentSyncJobModel
@@ -63,7 +64,6 @@ from models.schemas import (
 from services.auth import get_current_user
 from services.code_distributor import get_code_distributor
 from services.database import get_db
-from autobot_shared.db_url import assemble_postgres_url
 from services.deploy_artifacts import rsync_artifact_excludes
 from services.drift_checker import (
     ALLOWED_COMPONENTS,

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -1879,3 +1879,132 @@ def test_refresh_message_does_not_imply_deploy() -> None:
     assert "refreshed" in up.lower() and "refreshed" in current.lower()
     assert "available" in up.lower()  # signals a pending, undeployed update
     assert "up to date" in current.lower()
+
+
+# ---------------------------------------------------------------------------
+# #11466 — _resolve_pg_db_url: byte-identical output after shared-helper refactor
+# ---------------------------------------------------------------------------
+#
+# These tests prove the refactored _resolve_pg_db_url produces EXACTLY the
+# same strings as the inline version it replaced, for every significant input
+# combination.  The "before" values are the literal strings from the original
+# inline assembly removed in #11466.
+
+
+def test_resolve_pg_db_url_byte_identical_autobot_database_url_in_env_vars() -> None:
+    """AUTOBOT_DATABASE_URL in env_vars → returned as-is (unchanged)."""
+    env_vars = {"AUTOBOT_DATABASE_URL": "postgresql://u:p@host:5432/db"}
+    result = _resolve_pg_db_url(env_vars)
+    assert result == "postgresql://u:p@host:5432/db"
+
+
+def test_resolve_pg_db_url_byte_identical_autobot_database_url_in_os_environ() -> None:
+    """AUTOBOT_DATABASE_URL in os.environ → returned as-is (unchanged)."""
+    env_backup = os.environ.pop("AUTOBOT_DATABASE_URL", None)
+    try:
+        os.environ["AUTOBOT_DATABASE_URL"] = "postgresql://env_u:env_p@envhost/envdb"
+        result = _resolve_pg_db_url({})
+    finally:
+        if env_backup is not None:
+            os.environ["AUTOBOT_DATABASE_URL"] = env_backup
+        else:
+            os.environ.pop("AUTOBOT_DATABASE_URL", None)
+    assert result == "postgresql://env_u:env_p@envhost/envdb"
+
+
+def test_resolve_pg_db_url_byte_identical_database_url_fallback() -> None:
+    """DATABASE_URL in env_vars → returned as-is (unchanged)."""
+    env_vars = {"DATABASE_URL": "postgresql://u2:p2@host2/db2"}
+    result = _resolve_pg_db_url(env_vars)
+    assert result == "postgresql://u2:p2@host2/db2"
+
+
+def test_resolve_pg_db_url_byte_identical_component_vars_no_password() -> None:
+    """AUTOBOT_POSTGRES_* without password → 'user@host:port/db' (no colon before @).
+
+    Before (#11466 inline code):
+        auth = f"{user}@"  # pw is falsy
+        return f"postgresql://{auth}{host}:{port}/{db}"
+    """
+    env_vars = {
+        "AUTOBOT_POSTGRES_HOST": "pg-host",
+        "AUTOBOT_POSTGRES_PORT": "5432",
+        "AUTOBOT_POSTGRES_USER": "autobot_app",
+        "AUTOBOT_POSTGRES_DB": "autobot_users",
+    }
+    result = _resolve_pg_db_url(env_vars)
+    assert result == "postgresql://autobot_app@pg-host:5432/autobot_users"
+
+
+def test_resolve_pg_db_url_byte_identical_component_vars_with_password() -> None:
+    """AUTOBOT_POSTGRES_* with password → 'user:pw@host:port/db'.
+
+    Before (#11466 inline code):
+        auth = f"{user}:{pw}@"  # pw is truthy
+        return f"postgresql://{auth}{host}:{port}/{db}"
+    """
+    env_vars = {
+        "AUTOBOT_POSTGRES_HOST": "pg-host",
+        "AUTOBOT_POSTGRES_PORT": "5433",
+        "AUTOBOT_POSTGRES_USER": "svc",
+        "AUTOBOT_POSTGRES_PASSWORD": "s3cr3t",
+        "AUTOBOT_POSTGRES_DB": "autobot",
+    }
+    result = _resolve_pg_db_url(env_vars)
+    assert result == "postgresql://svc:s3cr3t@pg-host:5433/autobot"
+
+
+def test_resolve_pg_db_url_byte_identical_component_vars_defaults() -> None:
+    """When only HOST is set, defaults match the original hardcoded values.
+
+    Before (#11466 inline code):
+        user = ... os.environ.get("AUTOBOT_POSTGRES_USER", "autobot_app")
+        db   = ... os.environ.get("AUTOBOT_POSTGRES_DB",   "autobot_users")
+        port = ... os.environ.get("AUTOBOT_POSTGRES_PORT", "5432")
+    """
+    clear_keys = {
+        "AUTOBOT_POSTGRES_PORT",
+        "AUTOBOT_POSTGRES_USER",
+        "AUTOBOT_POSTGRES_PASSWORD",
+        "AUTOBOT_POSTGRES_DB",
+    }
+    env_backup = {k: os.environ.pop(k) for k in clear_keys if k in os.environ}
+    try:
+        result = _resolve_pg_db_url({"AUTOBOT_POSTGRES_HOST": "myhost"})
+    finally:
+        os.environ.update(env_backup)
+    assert result == "postgresql://autobot_app@myhost:5432/autobot_users"
+
+
+def test_resolve_pg_db_url_byte_identical_nothing_set_returns_empty() -> None:
+    """When nothing is configured, '' is returned (not None, not an exception).
+
+    Before (#11466 inline code):
+        return ""  # final line of the function
+    """
+    clear_keys = {
+        "AUTOBOT_DATABASE_URL",
+        "DATABASE_URL",
+        "AUTOBOT_POSTGRES_HOST",
+        "AUTOBOT_POSTGRES_PORT",
+        "AUTOBOT_POSTGRES_USER",
+        "AUTOBOT_POSTGRES_PASSWORD",
+        "AUTOBOT_POSTGRES_DB",
+    }
+    env_backup = {k: os.environ.pop(k) for k in clear_keys if k in os.environ}
+    try:
+        result = _resolve_pg_db_url({})
+    finally:
+        os.environ.update(env_backup)
+    assert result == ""
+
+
+def test_resolve_pg_db_url_env_vars_takes_precedence_over_os_environ() -> None:
+    """env_vars takes precedence over os.environ for AUTOBOT_POSTGRES_* keys."""
+    os.environ["AUTOBOT_POSTGRES_HOST"] = "os-environ-host"
+    try:
+        result = _resolve_pg_db_url({"AUTOBOT_POSTGRES_HOST": "env-vars-host"})
+    finally:
+        os.environ.pop("AUTOBOT_POSTGRES_HOST", None)
+    assert "env-vars-host" in result
+    assert "os-environ-host" not in result

--- a/autobot_shared/db_url.py
+++ b/autobot_shared/db_url.py
@@ -1,0 +1,65 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Canonical Postgres URL assembly helper (#11466).
+
+Extracts the AUTOBOT_POSTGRES_* component-var assembly that was duplicated
+between autobot-backend/migrations/db_url.py and
+autobot-slm-backend/api/code_sync.py into a single primitive.
+
+Only the string-assembly step is shared; each caller retains its own
+precedence logic (AUTOBOT_DATABASE_URL, deployment-config, etc.) and its
+own default values, which legitimately differ.
+
+Caller contract
+---------------
+*source* must contain only **non-empty** values for the AUTOBOT_POSTGRES_*
+keys.  Pass ``{k: v for k, v in raw.items() if v}`` (or equivalent) before
+calling when the raw mapping may contain empty strings — empty values are
+treated as absent by this function (they do NOT override the parameter
+defaults).
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def assemble_postgres_url(
+    source: Mapping[str, str],
+    *,
+    default_host: str = "",
+    default_port: str = "5432",
+    default_user: str = "autobot",
+    default_db: str = "autobot",
+    password_default: str = "",
+) -> str:
+    """Build a ``postgresql://`` URL from AUTOBOT_POSTGRES_* component vars.
+
+    Args:
+        source: Mapping with non-empty AUTOBOT_POSTGRES_* entries (empty
+            strings are treated as absent — see module docstring).
+        default_host: Fallback when ``AUTOBOT_POSTGRES_HOST`` is absent.
+            ``""`` (the default) causes ``""`` to be returned (no host).
+        default_port: Port fallback when ``AUTOBOT_POSTGRES_PORT`` is absent.
+        default_user: User fallback when ``AUTOBOT_POSTGRES_USER`` is absent.
+        default_db: DB name fallback when ``AUTOBOT_POSTGRES_DB`` is absent.
+        password_default: Password fallback when ``AUTOBOT_POSTGRES_PASSWORD``
+            is absent.  When the resolved password is ``""``, the auth segment
+            is ``user@`` instead of ``user:@``.
+
+    Returns:
+        ``postgresql://{user[:pw]}@{host}:{port}/{db}`` when a host is
+        present; ``""`` when ``host`` resolves to ``""`` and
+        ``default_host`` is also ``""``.
+    """
+    host = source.get("AUTOBOT_POSTGRES_HOST", default_host)
+    if not host:
+        return ""
+    port = source.get("AUTOBOT_POSTGRES_PORT", default_port)
+    user = source.get("AUTOBOT_POSTGRES_USER", default_user)
+    pw = source.get("AUTOBOT_POSTGRES_PASSWORD", password_default)
+    db = source.get("AUTOBOT_POSTGRES_DB", default_db)
+    auth = f"{user}:{pw}@" if pw else f"{user}@"
+    return f"postgresql://{auth}{host}:{port}/{db}"

--- a/autobot_shared/db_url_test.py
+++ b/autobot_shared/db_url_test.py
@@ -1,0 +1,170 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for autobot_shared.db_url.assemble_postgres_url (#11466).
+
+Regression suite proving the shared primitive produces the exact strings
+that both call sites previously assembled inline.
+"""
+
+from autobot_shared.db_url import assemble_postgres_url
+
+# ---------------------------------------------------------------------------
+# Core contract
+# ---------------------------------------------------------------------------
+
+
+def test_empty_source_no_default_host_returns_empty() -> None:
+    """When host is absent and default_host is '', return ''."""
+    assert assemble_postgres_url({}) == ""
+
+
+def test_host_present_no_password_omits_colon() -> None:
+    """Auth segment is 'user@' (not 'user:@') when password is empty."""
+    result = assemble_postgres_url(
+        {"AUTOBOT_POSTGRES_HOST": "db.example.com"},
+        default_user="myuser",
+        default_db="mydb",
+    )
+    assert result == "postgresql://myuser@db.example.com:5432/mydb"
+    assert ":@" not in result
+
+
+def test_host_present_with_password_includes_colon() -> None:
+    """Auth segment is 'user:pw@' when password is non-empty."""
+    result = assemble_postgres_url(
+        {
+            "AUTOBOT_POSTGRES_HOST": "db.example.com",
+            "AUTOBOT_POSTGRES_PASSWORD": "secret",
+        },
+        default_user="myuser",
+        default_db="mydb",
+    )
+    assert result == "postgresql://myuser:secret@db.example.com:5432/mydb"
+
+
+def test_custom_port_is_respected() -> None:
+    result = assemble_postgres_url(
+        {"AUTOBOT_POSTGRES_HOST": "pg", "AUTOBOT_POSTGRES_PORT": "5433"},
+        default_user="u",
+        default_db="d",
+    )
+    assert ":5433/" in result
+
+
+def test_custom_db_is_respected() -> None:
+    result = assemble_postgres_url(
+        {"AUTOBOT_POSTGRES_HOST": "pg", "AUTOBOT_POSTGRES_DB": "mydb"},
+        default_user="u",
+    )
+    assert result.endswith("/mydb")
+
+
+def test_default_host_is_used_when_absent() -> None:
+    result = assemble_postgres_url(
+        {},
+        default_host="autobot-postgres",
+        default_user="autobot",
+        default_db="autobot",
+        password_default="autobot",
+    )
+    assert result == "postgresql://autobot:autobot@autobot-postgres:5432/autobot"
+
+
+def test_password_default_applied_when_key_absent() -> None:
+    """password_default is used when AUTOBOT_POSTGRES_PASSWORD is not in source."""
+    result = assemble_postgres_url(
+        {"AUTOBOT_POSTGRES_HOST": "h"},
+        default_user="u",
+        default_db="d",
+        password_default="pw123",
+    )
+    assert "u:pw123@" in result
+
+
+# ---------------------------------------------------------------------------
+# Regression: migrations/db_url.py dev-fallback (call site A)
+# Exact string: postgresql://autobot:autobot@{host}:5432/autobot
+# ---------------------------------------------------------------------------
+
+
+def test_migrations_dev_fallback_default_host() -> None:
+    """Reproduces migrations/db_url.py dev-fallback with default host."""
+    result = assemble_postgres_url(
+        {},
+        default_host="autobot-postgres",
+        default_user="autobot",
+        default_db="autobot",
+        password_default="autobot",
+    )
+    assert result == "postgresql://autobot:autobot@autobot-postgres:5432/autobot"
+
+
+def test_migrations_dev_fallback_custom_host() -> None:
+    """Reproduces migrations/db_url.py dev-fallback with a custom host in source."""
+    result = assemble_postgres_url(
+        {"AUTOBOT_POSTGRES_HOST": "my-pg-host"},
+        default_host="autobot-postgres",
+        default_user="autobot",
+        default_db="autobot",
+        password_default="autobot",
+    )
+    assert result == "postgresql://autobot:autobot@my-pg-host:5432/autobot"
+
+
+# ---------------------------------------------------------------------------
+# Regression: code_sync._resolve_pg_db_url component-var assembly (call site B)
+# Defaults: user=autobot_app, pw='', db=autobot_users
+# ---------------------------------------------------------------------------
+
+
+def test_code_sync_assembly_no_password() -> None:
+    """Reproduces _resolve_pg_db_url assembly without a password."""
+    result = assemble_postgres_url(
+        {"AUTOBOT_POSTGRES_HOST": "10.0.0.5"},
+        default_user="autobot_app",
+        default_db="autobot_users",
+    )
+    assert result == "postgresql://autobot_app@10.0.0.5:5432/autobot_users"
+
+
+def test_code_sync_assembly_with_password() -> None:
+    """Reproduces _resolve_pg_db_url assembly with a password."""
+    result = assemble_postgres_url(
+        {
+            "AUTOBOT_POSTGRES_HOST": "10.0.0.5",
+            "AUTOBOT_POSTGRES_USER": "svc_user",
+            "AUTOBOT_POSTGRES_PASSWORD": "s3cr3t",
+            "AUTOBOT_POSTGRES_PORT": "5433",
+            "AUTOBOT_POSTGRES_DB": "autobot",
+        },
+        default_user="autobot_app",
+        default_db="autobot_users",
+    )
+    assert result == "postgresql://svc_user:s3cr3t@10.0.0.5:5433/autobot"
+
+
+def test_code_sync_assembly_no_host_returns_empty() -> None:
+    """Returns '' when AUTOBOT_POSTGRES_HOST is absent (no default_host)."""
+    result = assemble_postgres_url(
+        {"AUTOBOT_POSTGRES_USER": "autobot_app"},
+        default_user="autobot_app",
+        default_db="autobot_users",
+    )
+    assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Empty-string handling (callers must filter before passing)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_string_host_in_source_returns_empty() -> None:
+    """An explicit empty string for host is treated as absent."""
+    result = assemble_postgres_url(
+        {"AUTOBOT_POSTGRES_HOST": ""},
+        default_user="u",
+        default_db="d",
+    )
+    assert result == ""


### PR DESCRIPTION
## Thinking Path

Two places assembled an identical `postgresql://{user[:pw]}@{host}:{port}/{db}` string from `AUTOBOT_POSTGRES_*` component vars: `migrations/db_url.py` (dev fallback) and `code_sync._resolve_pg_db_url` (pg_dump URL resolution). They differ legitimately in precedence order, fallback defaults, and empty-result behavior — only the string-assembly primitive is shared.

Key constraint: the `env_vars.get(k) or os.environ.get(k, "")` pattern in `_resolve_pg_db_url` uses truthy `or` semantics — an empty string falls through to the next source. The shared helper receives a pre-filtered Mapping (empty strings stripped) so its `.get(k, default)` correctly falls to the parameter default when a key is absent.

The `get_url()` dev fallback only reads `AUTOBOT_POSTGRES_HOST` from env (user/password/db/port are hardcoded to `"autobot"`). Passing only that key to the helper, with hardcoded defaults for the rest, preserves that exact behavior — no other `AUTOBOT_POSTGRES_*` vars bleed in.

## What Changed

**New** `autobot_shared/db_url.py`:
- `assemble_postgres_url(source, *, default_host, default_port, default_user, default_db, password_default) -> str` — builds `postgresql://[user[:pw]@]host:port/db` from a pre-filtered Mapping of `AUTOBOT_POSTGRES_*` vars; returns `""` when host is absent.

**Refactored** `autobot-backend/migrations/db_url.py`:
- `get_url()` dev-fallback delegates to `assemble_postgres_url` with a single-key source (`AUTOBOT_POSTGRES_HOST` only) and hardcoded `default_user/default_db/password_default="autobot"`. Precedence paths (`AUTOBOT_DATABASE_URL` and deployment config) are unchanged. `as_async_url()` is untouched.

**Refactored** `autobot-slm-backend/api/code_sync.py`:
- `_resolve_pg_db_url` delegates the assembly step to `assemble_postgres_url` after building `merged` — a dict of non-empty values from `env_vars.get(k) or os.environ.get(k, "")` for all five `AUTOBOT_POSTGRES_*` keys. Precedence steps 1 (`AUTOBOT_DATABASE_URL`) and 2 (`DATABASE_URL`) are unchanged. The `NO_BACKUP` sentinel logic in `_pg_dump_before_migration` is untouched.

**New tests**:
- `autobot_shared/db_url_test.py` — 13 tests for the shared primitive (host present/absent, password present/absent, custom port/db, both call-site regression strings).
- `autobot-backend/tests/migrations/test_db_url.py` — 4 tests proving `get_url()` dev-fallback is byte-identical before/after; also verifies other `AUTOBOT_POSTGRES_*` vars do NOT bleed into the fixed dev credentials.
- `autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py` — 8 new byte-identical regression tests for `_resolve_pg_db_url` covering: `AUTOBOT_DATABASE_URL` in env_vars; `AUTOBOT_DATABASE_URL` in os.environ; `DATABASE_URL` fallback; component vars with password; component vars without password; default values; nothing set returns `""`; env_vars precedence over os.environ.

## Verification

```
# autobot_shared primitive: 13 passed
PYTHONPATH=. pytest autobot_shared/db_url_test.py -v
# 13 passed in 0.07s

# code_sync regression suite: 89 passed (81 pre-existing + 8 new)
PYTHONPATH=autobot_shared:. pytest autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py -v
# 89 passed in 3.01s

# migrations/db_url regression suite: 4 passed (all new)
PYTHONPATH=autobot_shared:autobot-backend:. pytest autobot-backend/tests/migrations/test_db_url.py -v
# 4 passed in 0.16s

# Linting (all 5 changed .py files)
ruff check ...        # All checks passed
black --check --fast  # All files unchanged
bandit -c .bandit -r  # 0 issues (B106 nosec on dev-env placeholder password)
```

## Model Used

claude-sonnet-4-6

Closes #11466