### PR TITLE
test(slm): use RFC 5737 doc IP in fleet-node test — fix SSOT hardcoded-IP violation

### DIFF
--- a/autobot-slm-backend/tests/api/test_fleet_node_update_11511.py
+++ b/autobot-slm-backend/tests/api/test_fleet_node_update_11511.py
@@ -270,7 +270,7 @@ def test_sync_fleet_node_skips_degraded_node() -> None:
     degraded = _fake_node(
         node_id="node-vnc",
         hostname="VNC",
-        ip_address="172.16.168.26",
+        ip_address="203.0.113.26",  # RFC 5737 TEST-NET-3 doc IP (no real fleet IPs in tests — SSOT)
         status=_STATUS_DEGRADED,
         last_heartbeat=None,
     )


### PR DESCRIPTION
## Thinking Path
`SSOT Configuration Compliance` is red on `Dev_new_gui` because `test_fleet_node_update_11511.py:273` hardcodes `172.16.168.26` (the vnc node's real fleet IP, added by #11514). The scanner bans `172.16.168.x`, leaving a required check silently red for every PR.

## What Changed
Swapped the test fixture IP to `203.0.113.26` (RFC 5737 TEST-NET-3, reserved for docs/tests). The test asserts skip-on-degraded regardless of IP value — no behavior change.

## Verification
Single-line test-fixture change; the fleet-node skip tests are unaffected by the IP value. Restores SSOT compliance green on base.

## Model Used
Opus 4.8

Closes #11588