### PR TITLE
docs(claude): dedup CLAUDE.md vs global instructions (#11590)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,5 +60,6 @@ Correctness → Speed → Maintainability. No wasted motion. No speculative work
 - **PR template headings:** `Thinking Path` · `What Changed` · `Verification` · `Model Used`
 - **PR queue limit:** ≥5 open PRs → defer implementation and notify
 - **Codebase is source of truth:** never edit `/opt/autobot/` or `/var/log/autobot/`
+- **System updates (test AND prod):** ONLY via the builtin updater a user reaches at `/slm/maintenance/updates/code-sync` (code-sync API / self-update); if the builtin can't do it, fix that gap (issue + PR) — never side-channel via ad-hoc ansible/shell
 - **One issue per session** — don't auto-start others after completing one
 - **Model tiers:** Haiku (`claude-haiku-4-5-20251001`) for status/labels/simple transitions; Sonnet for implementation and reviews

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,15 @@
 # AutoBot Development Instructions
 
 > **Rules:** [`docs/developer/CLAUDE_RULES.md`](docs/developer/CLAUDE_RULES.md) — read when starting a new task
-> **Workflow:** [`docs/developer/CLAUDE_WORKFLOW.md`](docs/developer/CLAUDE_WORKFLOW.md) — read when needed
+> **Workflow:** [`docs/developer/CLAUDE_WORKFLOW.md`](docs/developer/CLAUDE_WORKFLOW.md) — labels, gh workarounds, CI diagnosis, pre-merge gates
 > **Git & Worktrees:** [`docs/developer/CLAUDE_GIT.md`](docs/developer/CLAUDE_GIT.md) — branching, safety, push recovery
 > **Batch & Agents:** [`docs/developer/CLAUDE_BATCH.md`](docs/developer/CLAUDE_BATCH.md) — parallel work, sub-agent rules
 > **Code Review:** [`docs/developer/CLAUDE_REVIEW.md`](docs/developer/CLAUDE_REVIEW.md) — review methodology, merge checklist
 > **Issue Closure:** [`docs/developer/CLAUDE_CLOSURE.md`](docs/developer/CLAUDE_CLOSURE.md) — closure gate, discovery issues
 > **Reference:** [`docs/developer/AUTOBOT_REFERENCE.md`](docs/developer/AUTOBOT_REFERENCE.md)
 > **Architecture exceptions:** [`docs/developer/ARCHITECTURE_EXCEPTIONS.md`](docs/developer/ARCHITECTURE_EXCEPTIONS.md)
+
+Read a pointed doc only when its topic triggers. Universal rules (worktree mandate, issue decomposition, verification/evidence, CI diagnosis, no temp fixes) live in the global instructions and the docs above — not repeated here.
 
 ---
 
@@ -22,15 +24,9 @@ Correctness → Speed → Maintainability. No wasted motion. No speculative work
 
 ---
 
-## Quick Reference
+## Core Rules
 
 **Every task must:** link to GitHub issue · search Memory MCP first · break into subtasks · use code-reviewer · update issue throughout · verify before closing.
-
-**Stop if any fails:** work tied to issue? subtasks added? root cause (not workaround)?
-
----
-
-## Core Rules
 
 1. **Check Before Writing** — search existing code/docs/PRs before creating anything
 2. **Reuse** — import from `autobot_shared/`; never duplicate or hardcode
@@ -62,17 +58,7 @@ Correctness → Speed → Maintainability. No wasted motion. No speculative work
 - **Never `--no-verify`** — PostToolUse hook auto-formats `.py`
 - **Protected branches:** `main`/`master` blocked by pre-commit hook → use `issue-*` or `hotfix-*`
 - **PR template headings:** `Thinking Path` · `What Changed` · `Verification` · `Model Used`
-- **PR queue limit:** check open PR count before starting implementation; if ≥5, defer and notify
-- **CI diagnosis:** queued checks on self-hosted runners are NOT stuck — confirm failure before acting
-- **Posting comments:** write literal markdown — never raw JSON or a file path
-- **Worktrees:** `.worktrees/issue-XXXX/` for all parallel work → read [`CLAUDE_GIT.md`](docs/developer/CLAUDE_GIT.md)
+- **PR queue limit:** ≥5 open PRs → defer implementation and notify
 - **Codebase is source of truth:** never edit `/opt/autobot/` or `/var/log/autobot/`
 - **One issue per session** — don't auto-start others after completing one
-- **No temp fixes:** zero tolerance for workarounds, TODO comments, swallowed errors
-
----
-
-## Model Tier Routing
-
-- **Haiku** (`claude-haiku-4-5-20251001`): heartbeat status checks, label updates, simple transitions
-- **Sonnet**: deep reviews, multi-file fixes, feature implementation, extended reasoning
+- **Model tiers:** Haiku (`claude-haiku-4-5-20251001`) for status/labels/simple transitions; Sonnet for implementation and reviews

--- a/docs/developer/CLAUDE_WORKFLOW.md
+++ b/docs/developer/CLAUDE_WORKFLOW.md
@@ -160,6 +160,10 @@ Subagents cannot autonomously acquire Bash permission. Run batch file-manipulati
 
 **Always close the issue after implementation.** PRs targeting `Dev_new_gui` will NOT auto-close issues — verify with `gh issue view`.
 
+**CI diagnosis:** queued checks on self-hosted runners are NOT stuck — confirm failure before acting.
+
+**Posting comments:** write literal markdown — never raw JSON or a file path.
+
 **GitHub CLI Workarounds:**
 
 - **`gh pr edit --body` silently fails** when the repo has classic Projects attached. The command exits non-zero and leaves the body unchanged. Error output:


### PR DESCRIPTION
Closes #11590

## Thinking Path

Token-usage optimization: CLAUDE.md loads every session. Several bullets duplicated the user-global instructions verbatim (Lean Instructions Principle forbids cross-file duplication). Two rules (CI diagnosis, posting comments) existed ONLY in CLAUDE.md, so they were moved into the pointed doc rather than deleted — repo-side consumers keep every rule.

## What Changed

- `CLAUDE.md` 4322 → 3968 bytes: removed bullets duplicated by global instructions (CI diagnosis, posting comments, no-temp-fixes, worktrees pointer); merged Quick Reference into Core Rules; collapsed Model Tier Routing to one line; added an explicit "read pointed docs only when the topic triggers" note
- `docs/developer/CLAUDE_WORKFLOW.md`: gained the CI-diagnosis and posting-comments rules under GitHub Workflow (previously only in CLAUDE.md)
- Core Rules 1–6 numbering preserved (referenced by skills/memory)

Companion change outside the repo: global `~/.claude/CLAUDE.md` cut 5292 → 3180 bytes (−40%) by moving worktree/decomposition detail to `~/.claude/docs/` on-demand docs.

## Verification

- Every removed bullet verified present in global instructions or a pointed doc (`grep` per rule; CI-diagnosis/posting-comments had 0 hits in docs → moved, not dropped)
- `wc -c` before/after: 4322 → 3968 (project), 5292 → 3180 (global)

## Model Used

Claude Fable 5