### PR TITLE
feat(chat): code-execution agent mode v1 — governed compose tool, flag-off (#11568)

### DIFF
--- a/autobot-backend/chat_workflow/code_exec/__init__.py
+++ b/autobot-backend/chat_workflow/code_exec/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""code_exec — sandboxed Python composition tool (GH#11568)."""

--- a/autobot-backend/chat_workflow/code_exec/ast_guard.py
+++ b/autobot-backend/chat_workflow/code_exec/ast_guard.py
@@ -6,23 +6,52 @@
 
 Validates Python source before sandbox execution (hard gate):
 - import allowlist (top-level module names only)
-- exec/eval/compile/__import__/globals/vars/locals/breakpoint AND the reflective
-  accessors getattr/setattr/delattr/hasattr blocked as a bare Name reference ANYWHERE
-  (call, decorator, rebind, argument), not only as a call func — closes ``@eval``,
-  ``f = eval``, and ``g = getattr; g(...)`` aliasing escapes
+- builtin-call ALLOWLIST: a call to a bare Name that resolves to a Python builtin is
+  rejected unless the builtin is in ``SAFE_BUILTINS`` (pure-compute, no I/O, no
+  introspection). This is allowlist-not-blocklist, so new dangerous builtins (open,
+  input, type, memoryview, exit, help, ...) can never leak. Locally shadowed names
+  and injected tool names are exempt.
+- reflective accessors getattr/setattr/delattr/hasattr and eval/exec/compile/__import__/
+  globals/vars/locals/breakpoint blocked as a bare Name reference ANYWHERE (call,
+  decorator, rebind, argument) — closes ``@eval``, ``f = eval``, ``g = getattr; g(...)``
 - method-style ``obj.exec()``/``obj.eval()`` calls
 - ANY dunder attribute access (``.__class__``, ``.__bases__``, ``.__subclasses__``, ...)
 - subscripting ``__builtins__`` (or any dunder name)
 - forbidden_work token name references
+
+Protocol note: ``print``/``open``/``input`` are excluded from SAFE_BUILTINS on purpose —
+the broker RPC uses the script's stdout for requests and stdin for replies, so a user
+``print()`` corrupts the request stream and ``input()`` steals a broker reply.
 """
 
 import ast
+import builtins as _builtins
 import os
 from dataclasses import dataclass, field
 
 CODEEXEC_IMPORT_ALLOWLIST: frozenset[str] = frozenset(
     os.environ.get("AUTOBOT_CODEEXEC_IMPORT_ALLOWLIST", "autobot_tools,asyncio,json,re,math").split(",")
 )
+
+# Pure-compute, no-I/O, no-introspection builtins the script may call. Allowlist (not
+# blocklist) so dangerous builtins can never leak. Env-extendable, same pattern as the
+# import allowlist. Deliberately EXCLUDES: open/input/print (broker stdio channel),
+# type/object/super/vars/globals/locals/dir/id/hash/memoryview/compile/eval/exec/
+# __import__/exit/quit/help/getattr/setattr/delattr/hasattr/property/staticmethod/
+# classmethod (I/O or introspection reach).
+_DEFAULT_SAFE_BUILTINS = (
+    "len,range,enumerate,zip,sorted,reversed,sum,min,max,abs,round,all,any,map,filter,"
+    "str,int,float,bool,list,dict,set,tuple,frozenset,bytes,bytearray,repr,format,"
+    "isinstance,issubclass,ord,chr,divmod,pow,hex,oct,bin,slice"
+)
+SAFE_BUILTINS: frozenset[str] = frozenset(
+    b.strip()
+    for b in os.environ.get("AUTOBOT_CODEEXEC_BUILTINS_ALLOWLIST", _DEFAULT_SAFE_BUILTINS).split(",")
+    if b.strip()
+)
+
+# Every real Python builtin name — the universe the allowlist filters against.
+_ALL_BUILTINS: frozenset[str] = frozenset(dir(_builtins))
 
 # Names that grant reflective / eval-like reach into the runtime; unrepresentable in v1.
 # These are rejected as a bare Name load ANYWHERE (call func, decorator, RHS, arg),
@@ -49,6 +78,36 @@ def _is_dunder(name: str) -> bool:
     return len(name) > 4 and name.startswith("__") and name.endswith("__")
 
 
+def _collect_targets(target: ast.expr, names: set[str]) -> None:
+    """Add every Name id in an assignment *target* (incl. tuple/list unpacking)."""
+    if isinstance(target, ast.Name):
+        names.add(target.id)
+    elif isinstance(target, (ast.Tuple, ast.List)):
+        for elt in target.elts:
+            _collect_targets(elt, names)
+
+
+def _local_bindings(tree: ast.AST) -> frozenset[str]:
+    """Names the script binds itself (def/class/assign/import-as/params).
+
+    A bare-Name call to one of these is a user symbol, not a builtin, so it is exempt
+    from the builtin allowlist (e.g. the script may define its own ``def str(...)``).
+    """
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+            names.update(a.arg for a in getattr(node.args, "args", []))
+            names.update(a.arg for a in getattr(node.args, "posonlyargs", []))
+            names.update(a.arg for a in getattr(node.args, "kwonlyargs", []))
+        elif isinstance(node, ast.Assign):
+            for t in node.targets:
+                _collect_targets(t, names)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            names.update(a.asname or a.name.split(".")[0] for a in node.names)
+    return frozenset(names)
+
+
 def _check_import_node(node: ast.stmt) -> list[dict]:
     violations: list[dict] = []
     if isinstance(node, ast.Import):
@@ -63,16 +122,25 @@ def _check_import_node(node: ast.stmt) -> list[dict]:
     return violations
 
 
-def _check_call_node(node: ast.Call) -> list[dict]:
-    """Reject method-style ``obj.exec()``/``obj.eval()`` etc.
+def _check_call_node(node: ast.Call, exempt: frozenset[str]) -> list[dict]:
+    """Enforce the builtin-call allowlist and reject method-style ``obj.exec()``.
 
-    Bare-Name references to blocked builtins and reflective accessors are handled by
-    ``_check_name_node`` (which fires in the call-func position too); this only adds
-    the attribute-call form that has no bare Name to catch.
+    A call whose func is a bare Name resolving to a real Python builtin is rejected
+    unless that builtin is in ``SAFE_BUILTINS``. Names in *exempt* (local bindings +
+    injected tool names) are user/tool symbols, not builtins, and pass through.
+    Bare-Name references to blocked builtins/accessors are also caught by
+    ``_check_name_node``; this adds the allowlist gate and the attribute-call form.
     """
+    lineno = getattr(node, "lineno", 0)
     func = node.func
-    if isinstance(func, ast.Attribute) and func.attr in _BLOCKED_CALLS:
-        return [{"line": getattr(node, "lineno", 0), "message": f"forbidden call: .{func.attr!r}"}]
+    if isinstance(func, ast.Name):
+        name = func.id
+        if name in exempt or name in SAFE_BUILTINS:
+            return []
+        if name in _ALL_BUILTINS:
+            return [{"line": lineno, "message": f"forbidden builtin: {name!r} (not in SAFE_BUILTINS)"}]
+    elif isinstance(func, ast.Attribute) and func.attr in _BLOCKED_CALLS:
+        return [{"line": lineno, "message": f"forbidden call: .{func.attr!r}"}]
     return []
 
 
@@ -91,42 +159,54 @@ def _check_subscript_node(node: ast.Subscript) -> list[dict]:
     return []
 
 
-def _check_name_node(node: ast.Name, forbidden_work_tokens: frozenset[str]) -> list[dict]:
-    """Reject a blocked-builtin, reflective-accessor, forbidden-token, or dunder name.
+def _check_name_node(node: ast.Name, forbidden_work_tokens: frozenset[str], exempt: frozenset[str]) -> list[dict]:
+    """Reject an unsafe-builtin, reflective-accessor, forbidden-token, or dunder name.
 
     Blocking these as a bare Name (not just a call func) closes decorator (``@eval``),
-    rebind (``f = eval``), and accessor-aliasing (``g = getattr; g(...)``) escapes.
-    The clean shims never reference eval/exec/getattr/hasattr/etc. at all.
+    rebind (``f = eval``, ``g = getattr``), and bare-reference (``super``) escapes.
+    A Name resolving to a real builtin that is NOT in SAFE_BUILTINS and NOT locally
+    bound / injected is rejected — the allowlist applies to references, not just calls.
     """
+    name = node.id
     lineno = getattr(node, "lineno", 0)
-    if node.id in _BLOCKED_CALLS:
-        return [{"line": lineno, "message": f"forbidden builtin reference: {node.id!r}"}]
-    if node.id in _GETSET_ATTR:
-        return [{"line": lineno, "message": f"reflective accessor reference: {node.id!r}"}]
-    if node.id in forbidden_work_tokens:
-        return [{"line": lineno, "message": f"forbidden token reference: {node.id!r}"}]
-    if _is_dunder(node.id):
-        return [{"line": lineno, "message": f"dunder name reference: {node.id!r}"}]
+    if name in _GETSET_ATTR:
+        return [{"line": lineno, "message": f"reflective accessor reference: {name!r}"}]
+    if name in forbidden_work_tokens:
+        return [{"line": lineno, "message": f"forbidden token reference: {name!r}"}]
+    if _is_dunder(name):
+        return [{"line": lineno, "message": f"dunder name reference: {name!r}"}]
+    if name in _ALL_BUILTINS and name not in SAFE_BUILTINS and name not in exempt:
+        return [{"line": lineno, "message": f"forbidden builtin reference: {name!r} (not in SAFE_BUILTINS)"}]
     return []
 
 
-def check_script(script: str, forbidden_work_tokens: frozenset[str]) -> ASTGuardResult:
-    """Parse and safety-scan *script*; return ASTGuardResult (hard gate)."""
+def check_script(
+    script: str,
+    forbidden_work_tokens: frozenset[str],
+    injected_tools: "frozenset[str] | None" = None,
+) -> ASTGuardResult:
+    """Parse and safety-scan *script*; return ASTGuardResult (hard gate).
+
+    *injected_tools* are the shim names available to the script (e.g. ``web_search``);
+    together with the script's own local bindings they are exempt from the builtin
+    allowlist so a tool/user symbol shadowing is never mistaken for a builtin.
+    """
     try:
         tree = ast.parse(script)
     except SyntaxError as exc:
         return ASTGuardResult(ok=False, violations=[{"line": 0, "message": f"SyntaxError: {exc}"}])
 
+    exempt = _local_bindings(tree) | (injected_tools or frozenset())
     violations: list[dict] = []
     for node in ast.walk(tree):
         if isinstance(node, (ast.Import, ast.ImportFrom)):
             violations.extend(_check_import_node(node))
         elif isinstance(node, ast.Call):
-            violations.extend(_check_call_node(node))
+            violations.extend(_check_call_node(node, exempt))
         elif isinstance(node, ast.Attribute):
             violations.extend(_check_attribute_node(node))
         elif isinstance(node, ast.Subscript):
             violations.extend(_check_subscript_node(node))
         elif isinstance(node, ast.Name):
-            violations.extend(_check_name_node(node, forbidden_work_tokens))
+            violations.extend(_check_name_node(node, forbidden_work_tokens, exempt))
     return ASTGuardResult(ok=len(violations) == 0, violations=violations)

--- a/autobot-backend/chat_workflow/code_exec/ast_guard.py
+++ b/autobot-backend/chat_workflow/code_exec/ast_guard.py
@@ -1,0 +1,85 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""AST-based safety guard for the compose tool's user scripts (GH#11568).
+
+Validates Python source before sandbox execution:
+- import allowlist
+- exec/eval/compile/__import__ call block
+- getattr/setattr smuggling block
+- forbidden_work token name check
+"""
+
+import ast
+import os
+from dataclasses import dataclass, field
+
+CODEEXEC_IMPORT_ALLOWLIST: frozenset[str] = frozenset(
+    os.environ.get("AUTOBOT_CODEEXEC_IMPORT_ALLOWLIST", "autobot_tools,asyncio,json,re,math").split(",")
+)
+
+_BLOCKED_CALLS: frozenset[str] = frozenset({"exec", "eval", "compile", "__import__"})
+_GETSET_ATTR: frozenset[str] = frozenset({"getattr", "setattr"})
+
+
+@dataclass
+class ASTGuardResult:
+    """Result of an AST safety scan."""
+
+    ok: bool
+    violations: list[dict] = field(default_factory=list)
+
+
+def _check_import_node(node: ast.stmt) -> list[dict]:
+    violations: list[dict] = []
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            top = alias.name.split(".")[0]
+            if top not in CODEEXEC_IMPORT_ALLOWLIST:
+                violations.append({"line": node.lineno, "message": f"forbidden import: {top!r}"})
+    elif isinstance(node, ast.ImportFrom):
+        top = (node.module or "").split(".")[0]
+        if top not in CODEEXEC_IMPORT_ALLOWLIST:
+            violations.append({"line": node.lineno, "message": f"forbidden import: {top!r}"})
+    return violations
+
+
+def _check_call_node(node: ast.Call) -> list[dict]:
+    violations: list[dict] = []
+    lineno = node.lineno if hasattr(node, "lineno") else 0
+    if isinstance(node.func, ast.Name):
+        if node.func.id in _BLOCKED_CALLS:
+            violations.append({"line": lineno, "message": f"forbidden call: {node.func.id!r}"})
+        if node.func.id in _GETSET_ATTR and node.args and isinstance(node.args[0], ast.Name):
+            if node.args[0].id == "autobot_tools":
+                violations.append({"line": lineno, "message": f"attribute smuggling via {node.func.id!r}"})
+    elif isinstance(node.func, ast.Attribute):
+        if node.func.attr in _BLOCKED_CALLS:
+            violations.append({"line": lineno, "message": f"forbidden call: .{node.func.attr!r}"})
+    return violations
+
+
+def _check_name_node(node: ast.Name, forbidden_work_tokens: frozenset[str]) -> list[dict]:
+    if node.id in forbidden_work_tokens:
+        lineno = node.lineno if hasattr(node, "lineno") else 0
+        return [{"line": lineno, "message": f"forbidden token reference: {node.id!r}"}]
+    return []
+
+
+def check_script(script: str, forbidden_work_tokens: frozenset[str]) -> ASTGuardResult:
+    """Parse and safety-scan *script*; return ASTGuardResult."""
+    try:
+        tree = ast.parse(script)
+    except SyntaxError as exc:
+        return ASTGuardResult(ok=False, violations=[{"line": 0, "message": f"SyntaxError: {exc}"}])
+
+    violations: list[dict] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            violations.extend(_check_import_node(node))
+        elif isinstance(node, ast.Call):
+            violations.extend(_check_call_node(node))
+        elif isinstance(node, ast.Name):
+            violations.extend(_check_name_node(node, forbidden_work_tokens))
+    return ASTGuardResult(ok=len(violations) == 0, violations=violations)

--- a/autobot-backend/chat_workflow/code_exec/ast_guard.py
+++ b/autobot-backend/chat_workflow/code_exec/ast_guard.py
@@ -4,11 +4,13 @@
 # Author: mrveiss
 """AST-based safety guard for the compose tool's user scripts (GH#11568).
 
-Validates Python source before sandbox execution:
-- import allowlist
-- exec/eval/compile/__import__ call block
-- getattr/setattr smuggling block
-- forbidden_work token name check
+Validates Python source before sandbox execution (hard gate):
+- import allowlist (top-level module names only)
+- exec/eval/compile/__import__/globals/vars/locals/breakpoint call block
+- getattr/setattr smuggling on the autobot_tools module (incl. import aliases)
+- ANY dunder attribute access (``.__class__``, ``.__bases__``, ``.__subclasses__``, ...)
+- subscripting ``__builtins__``
+- forbidden_work token name references
 """
 
 import ast
@@ -19,8 +21,12 @@ CODEEXEC_IMPORT_ALLOWLIST: frozenset[str] = frozenset(
     os.environ.get("AUTOBOT_CODEEXEC_IMPORT_ALLOWLIST", "autobot_tools,asyncio,json,re,math").split(",")
 )
 
-_BLOCKED_CALLS: frozenset[str] = frozenset({"exec", "eval", "compile", "__import__"})
-_GETSET_ATTR: frozenset[str] = frozenset({"getattr", "setattr"})
+# Names that grant reflective / eval-like reach into the runtime; unrepresentable in v1.
+_BLOCKED_CALLS: frozenset[str] = frozenset(
+    {"exec", "eval", "compile", "__import__", "globals", "vars", "locals", "breakpoint"}
+)
+_GETSET_ATTR: frozenset[str] = frozenset({"getattr", "setattr", "delattr"})
+_TOOLS_MODULE = "autobot_tools"
 
 
 @dataclass
@@ -29,6 +35,24 @@ class ASTGuardResult:
 
     ok: bool
     violations: list[dict] = field(default_factory=list)
+
+
+def _is_dunder(name: str) -> bool:
+    """True for a Python dunder identifier (starts AND ends with ``__``)."""
+    return len(name) > 4 and name.startswith("__") and name.endswith("__")
+
+
+def _tools_aliases(tree: ast.AST) -> frozenset[str]:
+    """Local names bound to the autobot_tools module (``import autobot_tools as t``)."""
+    aliases = {_TOOLS_MODULE}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".")[0] == _TOOLS_MODULE:
+                    aliases.add(alias.asname or alias.name.split(".")[0])
+        elif isinstance(node, ast.Assign) and isinstance(node.value, ast.Name) and node.value.id in aliases:
+            aliases.update(t.id for t in node.targets if isinstance(t, ast.Name))
+    return frozenset(aliases)
 
 
 def _check_import_node(node: ast.stmt) -> list[dict]:
@@ -45,41 +69,67 @@ def _check_import_node(node: ast.stmt) -> list[dict]:
     return violations
 
 
-def _check_call_node(node: ast.Call) -> list[dict]:
+def _arg_targets_tools(arg: ast.expr, tools_aliases: frozenset[str]) -> bool:
+    """True when *arg* references the tools module (a bound Name, or any Attribute)."""
+    if isinstance(arg, ast.Name):
+        return arg.id in tools_aliases
+    return isinstance(arg, ast.Attribute)
+
+
+def _check_call_node(node: ast.Call, tools_aliases: frozenset[str]) -> list[dict]:
     violations: list[dict] = []
-    lineno = node.lineno if hasattr(node, "lineno") else 0
-    if isinstance(node.func, ast.Name):
-        if node.func.id in _BLOCKED_CALLS:
-            violations.append({"line": lineno, "message": f"forbidden call: {node.func.id!r}"})
-        if node.func.id in _GETSET_ATTR and node.args and isinstance(node.args[0], ast.Name):
-            if node.args[0].id == "autobot_tools":
-                violations.append({"line": lineno, "message": f"attribute smuggling via {node.func.id!r}"})
-    elif isinstance(node.func, ast.Attribute):
-        if node.func.attr in _BLOCKED_CALLS:
-            violations.append({"line": lineno, "message": f"forbidden call: .{node.func.attr!r}"})
+    lineno = getattr(node, "lineno", 0)
+    func = node.func
+    if isinstance(func, ast.Name):
+        if func.id in _BLOCKED_CALLS:
+            violations.append({"line": lineno, "message": f"forbidden call: {func.id!r}"})
+        if func.id in _GETSET_ATTR and node.args and _arg_targets_tools(node.args[0], tools_aliases):
+            violations.append({"line": lineno, "message": f"attribute smuggling via {func.id!r}"})
+    elif isinstance(func, ast.Attribute) and func.attr in _BLOCKED_CALLS:
+        violations.append({"line": lineno, "message": f"forbidden call: .{func.attr!r}"})
     return violations
 
 
+def _check_attribute_node(node: ast.Attribute) -> list[dict]:
+    """Reject any dunder attribute access (blocks __class__/__bases__/__subclasses__)."""
+    if _is_dunder(node.attr):
+        return [{"line": getattr(node, "lineno", 0), "message": f"dunder attribute access: .{node.attr}"}]
+    return []
+
+
+def _check_subscript_node(node: ast.Subscript) -> list[dict]:
+    """Reject ``__builtins__[...]`` and subscripting any dunder name."""
+    value = node.value
+    if isinstance(value, ast.Name) and _is_dunder(value.id):
+        return [{"line": getattr(node, "lineno", 0), "message": f"subscript of dunder name: {value.id}"}]
+    return []
+
+
 def _check_name_node(node: ast.Name, forbidden_work_tokens: frozenset[str]) -> list[dict]:
-    if node.id in forbidden_work_tokens:
-        lineno = node.lineno if hasattr(node, "lineno") else 0
-        return [{"line": lineno, "message": f"forbidden token reference: {node.id!r}"}]
+    if node.id in forbidden_work_tokens or _is_dunder(node.id):
+        reason = "forbidden token reference" if node.id in forbidden_work_tokens else "dunder name reference"
+        return [{"line": getattr(node, "lineno", 0), "message": f"{reason}: {node.id!r}"}]
     return []
 
 
 def check_script(script: str, forbidden_work_tokens: frozenset[str]) -> ASTGuardResult:
-    """Parse and safety-scan *script*; return ASTGuardResult."""
+    """Parse and safety-scan *script*; return ASTGuardResult (hard gate)."""
     try:
         tree = ast.parse(script)
     except SyntaxError as exc:
         return ASTGuardResult(ok=False, violations=[{"line": 0, "message": f"SyntaxError: {exc}"}])
 
+    tools_aliases = _tools_aliases(tree)
     violations: list[dict] = []
     for node in ast.walk(tree):
         if isinstance(node, (ast.Import, ast.ImportFrom)):
             violations.extend(_check_import_node(node))
         elif isinstance(node, ast.Call):
-            violations.extend(_check_call_node(node))
+            violations.extend(_check_call_node(node, tools_aliases))
+        elif isinstance(node, ast.Attribute):
+            violations.extend(_check_attribute_node(node))
+        elif isinstance(node, ast.Subscript):
+            violations.extend(_check_subscript_node(node))
         elif isinstance(node, ast.Name):
             violations.extend(_check_name_node(node, forbidden_work_tokens))
     return ASTGuardResult(ok=len(violations) == 0, violations=violations)

--- a/autobot-backend/chat_workflow/code_exec/ast_guard.py
+++ b/autobot-backend/chat_workflow/code_exec/ast_guard.py
@@ -6,10 +6,13 @@
 
 Validates Python source before sandbox execution (hard gate):
 - import allowlist (top-level module names only)
-- exec/eval/compile/__import__/globals/vars/locals/breakpoint call block
-- getattr/setattr smuggling on the autobot_tools module (incl. import aliases)
+- exec/eval/compile/__import__/globals/vars/locals/breakpoint AND the reflective
+  accessors getattr/setattr/delattr/hasattr blocked as a bare Name reference ANYWHERE
+  (call, decorator, rebind, argument), not only as a call func — closes ``@eval``,
+  ``f = eval``, and ``g = getattr; g(...)`` aliasing escapes
+- method-style ``obj.exec()``/``obj.eval()`` calls
 - ANY dunder attribute access (``.__class__``, ``.__bases__``, ``.__subclasses__``, ...)
-- subscripting ``__builtins__``
+- subscripting ``__builtins__`` (or any dunder name)
 - forbidden_work token name references
 """
 
@@ -22,11 +25,15 @@ CODEEXEC_IMPORT_ALLOWLIST: frozenset[str] = frozenset(
 )
 
 # Names that grant reflective / eval-like reach into the runtime; unrepresentable in v1.
+# These are rejected as a bare Name load ANYWHERE (call func, decorator, RHS, arg),
+# not only when directly called — ``@eval`` and ``f = eval`` are equally unsafe.
 _BLOCKED_CALLS: frozenset[str] = frozenset(
     {"exec", "eval", "compile", "__import__", "globals", "vars", "locals", "breakpoint"}
 )
-_GETSET_ATTR: frozenset[str] = frozenset({"getattr", "setattr", "delattr"})
-_TOOLS_MODULE = "autobot_tools"
+# Reflective attribute accessors — rejected as bare Name references anywhere. They are
+# never needed by the clean read-only shims, and permitting them re-opens computed-name,
+# dunder-target, and accessor-aliasing (``g = getattr``) smuggling paths.
+_GETSET_ATTR: frozenset[str] = frozenset({"getattr", "setattr", "delattr", "hasattr"})
 
 
 @dataclass
@@ -40,19 +47,6 @@ class ASTGuardResult:
 def _is_dunder(name: str) -> bool:
     """True for a Python dunder identifier (starts AND ends with ``__``)."""
     return len(name) > 4 and name.startswith("__") and name.endswith("__")
-
-
-def _tools_aliases(tree: ast.AST) -> frozenset[str]:
-    """Local names bound to the autobot_tools module (``import autobot_tools as t``)."""
-    aliases = {_TOOLS_MODULE}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                if alias.name.split(".")[0] == _TOOLS_MODULE:
-                    aliases.add(alias.asname or alias.name.split(".")[0])
-        elif isinstance(node, ast.Assign) and isinstance(node.value, ast.Name) and node.value.id in aliases:
-            aliases.update(t.id for t in node.targets if isinstance(t, ast.Name))
-    return frozenset(aliases)
 
 
 def _check_import_node(node: ast.stmt) -> list[dict]:
@@ -69,25 +63,17 @@ def _check_import_node(node: ast.stmt) -> list[dict]:
     return violations
 
 
-def _arg_targets_tools(arg: ast.expr, tools_aliases: frozenset[str]) -> bool:
-    """True when *arg* references the tools module (a bound Name, or any Attribute)."""
-    if isinstance(arg, ast.Name):
-        return arg.id in tools_aliases
-    return isinstance(arg, ast.Attribute)
+def _check_call_node(node: ast.Call) -> list[dict]:
+    """Reject method-style ``obj.exec()``/``obj.eval()`` etc.
 
-
-def _check_call_node(node: ast.Call, tools_aliases: frozenset[str]) -> list[dict]:
-    violations: list[dict] = []
-    lineno = getattr(node, "lineno", 0)
+    Bare-Name references to blocked builtins and reflective accessors are handled by
+    ``_check_name_node`` (which fires in the call-func position too); this only adds
+    the attribute-call form that has no bare Name to catch.
+    """
     func = node.func
-    if isinstance(func, ast.Name):
-        if func.id in _BLOCKED_CALLS:
-            violations.append({"line": lineno, "message": f"forbidden call: {func.id!r}"})
-        if func.id in _GETSET_ATTR and node.args and _arg_targets_tools(node.args[0], tools_aliases):
-            violations.append({"line": lineno, "message": f"attribute smuggling via {func.id!r}"})
-    elif isinstance(func, ast.Attribute) and func.attr in _BLOCKED_CALLS:
-        violations.append({"line": lineno, "message": f"forbidden call: .{func.attr!r}"})
-    return violations
+    if isinstance(func, ast.Attribute) and func.attr in _BLOCKED_CALLS:
+        return [{"line": getattr(node, "lineno", 0), "message": f"forbidden call: .{func.attr!r}"}]
+    return []
 
 
 def _check_attribute_node(node: ast.Attribute) -> list[dict]:
@@ -106,9 +92,21 @@ def _check_subscript_node(node: ast.Subscript) -> list[dict]:
 
 
 def _check_name_node(node: ast.Name, forbidden_work_tokens: frozenset[str]) -> list[dict]:
-    if node.id in forbidden_work_tokens or _is_dunder(node.id):
-        reason = "forbidden token reference" if node.id in forbidden_work_tokens else "dunder name reference"
-        return [{"line": getattr(node, "lineno", 0), "message": f"{reason}: {node.id!r}"}]
+    """Reject a blocked-builtin, reflective-accessor, forbidden-token, or dunder name.
+
+    Blocking these as a bare Name (not just a call func) closes decorator (``@eval``),
+    rebind (``f = eval``), and accessor-aliasing (``g = getattr; g(...)``) escapes.
+    The clean shims never reference eval/exec/getattr/hasattr/etc. at all.
+    """
+    lineno = getattr(node, "lineno", 0)
+    if node.id in _BLOCKED_CALLS:
+        return [{"line": lineno, "message": f"forbidden builtin reference: {node.id!r}"}]
+    if node.id in _GETSET_ATTR:
+        return [{"line": lineno, "message": f"reflective accessor reference: {node.id!r}"}]
+    if node.id in forbidden_work_tokens:
+        return [{"line": lineno, "message": f"forbidden token reference: {node.id!r}"}]
+    if _is_dunder(node.id):
+        return [{"line": lineno, "message": f"dunder name reference: {node.id!r}"}]
     return []
 
 
@@ -119,13 +117,12 @@ def check_script(script: str, forbidden_work_tokens: frozenset[str]) -> ASTGuard
     except SyntaxError as exc:
         return ASTGuardResult(ok=False, violations=[{"line": 0, "message": f"SyntaxError: {exc}"}])
 
-    tools_aliases = _tools_aliases(tree)
     violations: list[dict] = []
     for node in ast.walk(tree):
         if isinstance(node, (ast.Import, ast.ImportFrom)):
             violations.extend(_check_import_node(node))
         elif isinstance(node, ast.Call):
-            violations.extend(_check_call_node(node, tools_aliases))
+            violations.extend(_check_call_node(node))
         elif isinstance(node, ast.Attribute):
             violations.extend(_check_attribute_node(node))
         elif isinstance(node, ast.Subscript):

--- a/autobot-backend/chat_workflow/code_exec/broker.py
+++ b/autobot-backend/chat_workflow/code_exec/broker.py
@@ -1,0 +1,92 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Server-side stdio broker for the compose tool (GH#11568).
+
+Routes JSON-RPC tool calls emitted by the sandboxed script back through the
+AutoBot tool dispatcher, enforcing the injectable-tool allowlist and a call-
+count budget cap.
+"""
+
+import asyncio
+import hashlib
+import json
+import logging
+
+from autobot_shared.env_utils import env_int
+
+logger = logging.getLogger(__name__)
+
+CODEEXEC_MAX_TOOL_CALLS: int = env_int("AUTOBOT_CODEEXEC_MAX_TOOL_CALLS", default=50)
+
+
+class CodeExecBroker:
+    """Routes shim RPC calls from a sandboxed script to real AutoBot tools."""
+
+    def __init__(
+        self,
+        dispatch_fn,
+        tools: list[str],
+        forbidden: frozenset[str],
+        run_id: str,
+        security_event_key: str,
+    ) -> None:
+        self._dispatch = dispatch_fn
+        self._tools = set(tools)
+        self._forbidden = forbidden
+        self._run_id = run_id
+        self._security_key = security_event_key
+        self._call_count = 0
+
+    async def handle_line(self, line: str) -> str:
+        """Process one JSON-RPC line; return a JSON reply string."""
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError as exc:
+            return json.dumps({"id": None, "ok": False, "error": f"bad JSON: {exc}"})
+
+        req_id = req.get("id")
+        tool = req.get("tool", "")
+        params = req.get("params", {})
+
+        if tool not in self._tools:
+            return json.dumps({"id": req_id, "ok": False, "error": f"tool not injectable: {tool!r}"})
+        if tool in self._forbidden:
+            return json.dumps({"id": req_id, "ok": False, "error": f"tool forbidden: {tool!r}"})
+        if self._call_count >= CODEEXEC_MAX_TOOL_CALLS:
+            return json.dumps({"id": req_id, "ok": False, "error": "tool call budget exhausted"})
+
+        try:
+            result = await self._dispatch(tool, params)
+            self._call_count += 1
+            params_hash = hashlib.sha256(json.dumps(params, sort_keys=True).encode()).hexdigest()[:12]
+            asyncio.create_task(self._emit_audit(tool, params_hash, ok=True))
+            return json.dumps({"id": req_id, "ok": True, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            return json.dumps({"id": req_id, "ok": False, "error": str(exc)})
+
+    async def _emit_audit(self, tool: str, params_hash: str, ok: bool) -> None:
+        try:
+            from autobot_shared.redis_client import get_redis_client  # lazy import
+
+            rc = get_redis_client(async_client=True)
+            await rc.xadd(
+                self._security_key,
+                {"run_id": self._run_id, "tool": tool, "params_hash": params_hash, "ok": str(ok)},
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("code_exec audit emit failed: %s", exc)
+
+    async def _emit_progress(self, session_channel: str, tool: str) -> None:
+        try:
+            from events.bus import PersistStrategy, get_event_bus  # lazy import
+
+            await get_event_bus().publish(
+                session_channel,
+                "code_exec_progress",
+                {"tool": tool, "call_count": self._call_count},
+                persist=PersistStrategy.MEMORY,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("code_exec progress emit failed: %s", exc)

--- a/autobot-backend/chat_workflow/code_exec/broker.py
+++ b/autobot-backend/chat_workflow/code_exec/broker.py
@@ -41,11 +41,20 @@ class CodeExecBroker:
         self._security_key = security_event_key
         self._progress_channel = progress_channel or f"workflow:{run_id}"
         self._call_count = 0
+        self._budget_lock = asyncio.Lock()
 
     @property
     def budget_exhausted(self) -> bool:
         """True once the per-run tool-call budget has been hit (GH#11568)."""
         return self._call_count >= CODEEXEC_MAX_TOOL_CALLS
+
+    async def _reserve_budget(self) -> bool:
+        """Atomically claim one budget slot; False when exhausted (GH#11568 MINOR-3)."""
+        async with self._budget_lock:
+            if self._call_count >= CODEEXEC_MAX_TOOL_CALLS:
+                return False
+            self._call_count += 1
+            return True
 
     async def handle_line(self, line: str) -> str:
         """Process one JSON-RPC line; return a JSON reply string."""
@@ -62,16 +71,15 @@ class CodeExecBroker:
             return json.dumps({"id": req_id, "ok": False, "error": f"tool not injectable: {tool!r}"})
         if tool in self._forbidden:
             return json.dumps({"id": req_id, "ok": False, "error": f"tool forbidden: {tool!r}"})
-        if self.budget_exhausted:
+        if not await self._reserve_budget():
             return json.dumps({"id": req_id, "ok": False, "error": "tool call budget exhausted"})
 
         return await self._dispatch_and_reply(req_id, tool, params)
 
     async def _dispatch_and_reply(self, req_id: Any, tool: str, params: dict) -> str:
-        """Dispatch one validated call, emit audit + progress, return reply JSON."""
+        """Dispatch one already-budgeted call, emit audit + progress, return reply JSON."""
         try:
             result = await self._dispatch(tool, params)
-            self._call_count += 1
             params_hash = hashlib.sha256(json.dumps(params, sort_keys=True).encode()).hexdigest()[:12]
             asyncio.create_task(self._emit_audit(tool, params_hash, ok=True))
             asyncio.create_task(self._emit_progress(self._progress_channel, tool))
@@ -93,14 +101,33 @@ class CodeExecBroker:
             logger.warning("code_exec audit emit failed: %s", exc)
 
     async def _emit_progress(self, session_channel: str, tool: str) -> None:
+        """Publish a throttled progress event to BOTH event buses (design §4)."""
+        payload = {"tool": tool, "call_count": self._call_count, "run_id": self._run_id}
+        await self._emit_progress_live(session_channel, payload)
+        await self._emit_progress_stream(tool)
+
+    async def _emit_progress_live(self, session_channel: str, payload: dict) -> None:
+        """LiveEventManager (WebSocket fan-out) via the EventBus facade."""
         try:
             from events.bus import PersistStrategy, get_event_bus  # lazy import
 
             await get_event_bus().publish(
-                session_channel,
-                "code_exec_progress",
-                {"tool": tool, "call_count": self._call_count},
-                persist=PersistStrategy.MEMORY,
+                session_channel, "code_exec_progress", payload, persist=PersistStrategy.MEMORY
             )
         except Exception as exc:  # noqa: BLE001
-            logger.warning("code_exec progress emit failed: %s", exc)
+            logger.warning("code_exec live progress emit failed: %s", exc)
+
+    async def _emit_progress_stream(self, tool: str) -> None:
+        """RedisEventStreamManager (durable, task-scoped) — the second bus."""
+        try:
+            from events import AgentEvent, EventType, RedisEventStreamManager  # lazy import
+
+            event = AgentEvent(
+                event_type=EventType.ACTION,
+                content={"tool": tool, "call_count": self._call_count, "kind": "code_exec_progress"},
+                source="tool",
+                task_id=self._run_id,
+            )
+            await RedisEventStreamManager().publish(event)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("code_exec stream progress emit failed: %s", exc)

--- a/autobot-backend/chat_workflow/code_exec/broker.py
+++ b/autobot-backend/chat_workflow/code_exec/broker.py
@@ -13,6 +13,7 @@ import asyncio
 import hashlib
 import json
 import logging
+from typing import Any
 
 from autobot_shared.env_utils import env_int
 
@@ -31,13 +32,20 @@ class CodeExecBroker:
         forbidden: frozenset[str],
         run_id: str,
         security_event_key: str,
+        progress_channel: str = "",
     ) -> None:
         self._dispatch = dispatch_fn
         self._tools = set(tools)
         self._forbidden = forbidden
         self._run_id = run_id
         self._security_key = security_event_key
+        self._progress_channel = progress_channel or f"workflow:{run_id}"
         self._call_count = 0
+
+    @property
+    def budget_exhausted(self) -> bool:
+        """True once the per-run tool-call budget has been hit (GH#11568)."""
+        return self._call_count >= CODEEXEC_MAX_TOOL_CALLS
 
     async def handle_line(self, line: str) -> str:
         """Process one JSON-RPC line; return a JSON reply string."""
@@ -54,16 +62,22 @@ class CodeExecBroker:
             return json.dumps({"id": req_id, "ok": False, "error": f"tool not injectable: {tool!r}"})
         if tool in self._forbidden:
             return json.dumps({"id": req_id, "ok": False, "error": f"tool forbidden: {tool!r}"})
-        if self._call_count >= CODEEXEC_MAX_TOOL_CALLS:
+        if self.budget_exhausted:
             return json.dumps({"id": req_id, "ok": False, "error": "tool call budget exhausted"})
 
+        return await self._dispatch_and_reply(req_id, tool, params)
+
+    async def _dispatch_and_reply(self, req_id: Any, tool: str, params: dict) -> str:
+        """Dispatch one validated call, emit audit + progress, return reply JSON."""
         try:
             result = await self._dispatch(tool, params)
             self._call_count += 1
             params_hash = hashlib.sha256(json.dumps(params, sort_keys=True).encode()).hexdigest()[:12]
             asyncio.create_task(self._emit_audit(tool, params_hash, ok=True))
+            asyncio.create_task(self._emit_progress(self._progress_channel, tool))
             return json.dumps({"id": req_id, "ok": True, "result": result})
         except Exception as exc:  # noqa: BLE001
+            asyncio.create_task(self._emit_audit(tool, "", ok=False))
             return json.dumps({"id": req_id, "ok": False, "error": str(exc)})
 
     async def _emit_audit(self, tool: str, params_hash: str, ok: bool) -> None:

--- a/autobot-backend/chat_workflow/code_exec/shim_codegen.py
+++ b/autobot-backend/chat_workflow/code_exec/shim_codegen.py
@@ -1,0 +1,54 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shim module codegen for the compose tool (GH#11568).
+
+Generates the ``autobot_tools`` Python module that is prepended to user scripts.
+Each shim function calls the server-side broker via JSON-RPC over stdio.
+"""
+
+import os
+
+CODEEXEC_INJECTABLE_TOOLS: frozenset[str] = frozenset(
+    os.environ.get(
+        "AUTOBOT_CODEEXEC_INJECTABLE_TOOLS",
+        "web_search,scrape_url,map_site,extract_structured_data",
+    ).split(",")
+)
+
+
+def injectable_tool_set(allowed_work: list[str], forbidden_work: frozenset[str]) -> list[str]:
+    """Return sorted list of injectable tool names for this agent.
+
+    If *allowed_work* is non-empty (profile-bound agent), intersect with CODEEXEC_INJECTABLE_TOOLS.
+    If empty (main chat agent), use all CODEEXEC_INJECTABLE_TOOLS minus forbidden.
+    """
+    base = CODEEXEC_INJECTABLE_TOOLS - forbidden_work
+    if allowed_work:
+        return sorted(base & set(allowed_work))
+    return sorted(base)
+
+
+def _shim_for(tool: str) -> str:
+    return (
+        f"async def {tool}(**kwargs):\n"
+        f'    """Call the {tool} tool via the broker."""\n'
+        f'    req = json.dumps({{"id": "{tool}", "tool": "{tool}", "params": kwargs}})\n'
+        "    sys.stdout.write(req + \"\\n\")\n"
+        "    sys.stdout.flush()\n"
+        "    line = await asyncio.get_event_loop().run_in_executor(None, sys.stdin.readline)\n"
+        "    reply = json.loads(line)\n"
+        '    if not reply.get("ok"):\n'
+        '        raise RuntimeError(reply.get("error", "tool call failed"))\n'
+        '    return reply.get("result")\n'
+    )
+
+
+def generate_shim_module(tools: list[str]) -> str:
+    """Return Python source for the ``autobot_tools`` shim module."""
+    header = (
+        '"""autobot_tools — generated RPC shims. Do not edit."""\n'
+        "import asyncio, json, sys\n\n"
+    )
+    return header + "\n".join(_shim_for(t) for t in tools)

--- a/autobot-backend/chat_workflow/code_exec/shim_codegen.py
+++ b/autobot-backend/chat_workflow/code_exec/shim_codegen.py
@@ -5,7 +5,8 @@
 """Shim module codegen for the compose tool (GH#11568).
 
 Generates the ``autobot_tools`` Python module that is prepended to user scripts.
-Each shim function calls the server-side broker via JSON-RPC over stdio.
+Each shim function calls the server-side broker via JSON-RPC over stdio, using a
+per-call monotonic id so concurrent same-tool calls correlate their replies.
 """
 
 import os
@@ -17,14 +18,36 @@ CODEEXEC_INJECTABLE_TOOLS: frozenset[str] = frozenset(
     ).split(",")
 )
 
+# GH#11568 MAJOR-3: tools that must NEVER be injectable, regardless of the env
+# allowlist. Subtracted unconditionally so an operator who widens
+# AUTOBOT_CODEEXEC_INJECTABLE_TOOLS can never shim compose/delegate/execute_command.
+SENSITIVE_TOOLS: frozenset[str] = frozenset(
+    {
+        "execute_command",
+        "compose",
+        "delegate",
+        "deploy",
+        "git_push",
+        "navigate",
+        "click",
+        "fill",
+        "select",
+        "evaluate",
+        "write_file",
+        "edit_file",
+        "delete_file",
+    }
+)
+
 
 def injectable_tool_set(allowed_work: list[str], forbidden_work: frozenset[str]) -> list[str]:
-    """Return sorted list of injectable tool names for this agent.
+    """Return the sorted injectable tool names for this agent.
 
-    If *allowed_work* is non-empty (profile-bound agent), intersect with CODEEXEC_INJECTABLE_TOOLS.
-    If empty (main chat agent), use all CODEEXEC_INJECTABLE_TOOLS minus forbidden.
+    Intersects the declarative allowlist with ``allowed_work`` (when the agent is
+    profile-bound), removes ``forbidden_work``, and ALWAYS removes SENSITIVE_TOOLS
+    so sensitive tools can never be injected even if added to the env allowlist.
     """
-    base = CODEEXEC_INJECTABLE_TOOLS - forbidden_work
+    base = (CODEEXEC_INJECTABLE_TOOLS - forbidden_work) - SENSITIVE_TOOLS
     if allowed_work:
         return sorted(base & set(allowed_work))
     return sorted(base)
@@ -34,18 +57,36 @@ def _shim_for(tool: str) -> str:
     return (
         f"async def {tool}(**kwargs):\n"
         f'    """Call the {tool} tool via the broker."""\n'
-        f'    req = json.dumps({{"id": "{tool}", "tool": "{tool}", "params": kwargs}})\n'
+        f'    return await _rpc_call("{tool}", kwargs)\n'
+    )
+
+
+def _rpc_helper() -> str:
+    """Shared RPC helper: per-call monotonic id + reply correlation on that id."""
+    return (
+        "_call_seq = 0\n"
+        "_pending = {}\n\n"
+        "def _next_id():\n"
+        "    global _call_seq\n"
+        "    _call_seq += 1\n"
+        "    return _call_seq\n\n"
+        "async def _rpc_call(tool, params):\n"
+        "    call_id = _next_id()\n"
+        '    req = json.dumps({"id": call_id, "tool": tool, "params": params})\n'
         '    sys.stdout.write(req + "\\n")\n'
         "    sys.stdout.flush()\n"
-        "    line = await asyncio.get_event_loop().run_in_executor(None, sys.stdin.readline)\n"
-        "    reply = json.loads(line)\n"
+        "    while call_id not in _pending:\n"
+        "        line = await asyncio.get_event_loop().run_in_executor(None, sys.stdin.readline)\n"
+        "        reply = json.loads(line)\n"
+        '        _pending[reply.get("id")] = reply\n'
+        "    reply = _pending.pop(call_id)\n"
         '    if not reply.get("ok"):\n'
         '        raise RuntimeError(reply.get("error", "tool call failed"))\n'
-        '    return reply.get("result")\n'
+        '    return reply.get("result")\n\n'
     )
 
 
 def generate_shim_module(tools: list[str]) -> str:
     """Return Python source for the ``autobot_tools`` shim module."""
     header = '"""autobot_tools — generated RPC shims. Do not edit."""\n' "import asyncio, json, sys\n\n"
-    return header + "\n".join(_shim_for(t) for t in tools)
+    return header + _rpc_helper() + "\n".join(_shim_for(t) for t in tools)

--- a/autobot-backend/chat_workflow/code_exec/shim_codegen.py
+++ b/autobot-backend/chat_workflow/code_exec/shim_codegen.py
@@ -35,7 +35,7 @@ def _shim_for(tool: str) -> str:
         f"async def {tool}(**kwargs):\n"
         f'    """Call the {tool} tool via the broker."""\n'
         f'    req = json.dumps({{"id": "{tool}", "tool": "{tool}", "params": kwargs}})\n'
-        "    sys.stdout.write(req + \"\\n\")\n"
+        '    sys.stdout.write(req + "\\n")\n'
         "    sys.stdout.flush()\n"
         "    line = await asyncio.get_event_loop().run_in_executor(None, sys.stdin.readline)\n"
         "    reply = json.loads(line)\n"
@@ -47,8 +47,5 @@ def _shim_for(tool: str) -> str:
 
 def generate_shim_module(tools: list[str]) -> str:
     """Return Python source for the ``autobot_tools`` shim module."""
-    header = (
-        '"""autobot_tools — generated RPC shims. Do not edit."""\n'
-        "import asyncio, json, sys\n\n"
-    )
+    header = '"""autobot_tools — generated RPC shims. Do not edit."""\n' "import asyncio, json, sys\n\n"
     return header + "\n".join(_shim_for(t) for t in tools)

--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -617,13 +617,14 @@ class LLMHandlerMixin:
         resolved_lang = self._resolve_language(language)
         lang_instruction = self._get_language_instruction(resolved_lang)
         llc_tools = self._get_llc_tool_prompt() if company_id else ""
+        compose_teaching = self._get_compose_tool_prompt()
         try:
             prompt = get_prompt("chat.system_prompt_simple")
             logger.debug("[ChatWorkflowManager] Loaded simplified system prompt")
-            return preamble + prompt + llc_tools + lang_instruction
+            return preamble + prompt + llc_tools + compose_teaching + lang_instruction
         except Exception as e:
             logger.error("Failed to load system prompt from file: %s", e)
-            return preamble + llc_tools + """You are AutoBot. Execute commands using:
+            return preamble + llc_tools + compose_teaching + """You are AutoBot. Execute commands using:
 <TOOL_CALL name="execute_command" params='{"command":"cmd"}'>desc</TOOL_CALL>
 
 NEVER teach commands - ALWAYS execute them.""" + lang_instruction
@@ -637,6 +638,24 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
             return LLC_TOOL_PROMPT
         except Exception:  # noqa: BLE001 — LLC optional; never break general chat
             return ""
+
+    @staticmethod
+    def _get_compose_tool_prompt() -> str:
+        """Compose tool teaching injected when CODEEXEC_ENABLED (GH#11568)."""
+        try:
+            from chat_workflow.tool_handler import CODEEXEC_ENABLED
+
+            if not CODEEXEC_ENABLED:
+                return ""
+        except Exception:  # noqa: BLE001
+            return ""
+        return (
+            "\n\n## compose tool\n"
+            "Use `compose` to run a sandboxed Python script that can call read-only AutoBot tools "
+            "via the `autobot_tools` module (e.g. `await autobot_tools.web_search(query=...)`). "
+            "Scripts must only import from the allowlist (autobot_tools, asyncio, json, re, math). "
+            "Do NOT use exec, eval, compile, or __import__.\n"
+        )
 
     def _build_conversation_context(self, session: WorkflowSession) -> str:
         """Build conversation context from recent history.

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -370,7 +370,9 @@ COMPOSE_TOOL_SCHEMA: dict = {
     "properties": {
         "program": {
             "type": "string",
-            "description": "Python program to execute. Import autobot_tools and call tool functions as async coroutines.",
+            "description": (
+                "Python program to execute. Import autobot_tools and call tool " "functions as async coroutines."
+            ),
         },
         "description": {
             "type": "string",
@@ -2912,20 +2914,74 @@ class ToolHandlerMixin:
             metadata={"tool_name": "compose", "ast_violations": verdict.violations},
         )
 
-    def _approve_compose(self, tool_call: dict) -> "WorkflowMessage | None":
-        """Return approval_required WorkflowMessage when auto-approve is off, else None."""
+    async def _approve_compose(
+        self, program: str, shim_snapshot: list[str], session_id: str
+    ) -> "WorkflowMessage | None":
+        """Create a WORKFLOW_GATE approval when auto-approve is off (GH#11568).
+
+        Returns an approval_required WorkflowMessage carrying the persisted
+        approval id, or ``None`` when the read-only auto-approve posture applies.
+        """
         if CODEEXEC_AUTOAPPROVE_READONLY:
             return None
+        approval_id = await self._persist_compose_approval(program, shim_snapshot, session_id)
         return WorkflowMessage(
             type="approval_required",
             content="compose script requires approval before execution",
-            metadata={"tool": "compose", "approval_required": True},
+            metadata={
+                "tool": "compose",
+                "approval_required": True,
+                "approval_id": approval_id,
+                "shim_snapshot": shim_snapshot,
+            },
         )
 
+    async def _persist_compose_approval(self, program: str, shim_snapshot: list[str], session_id: str) -> "str | None":
+        """Persist a WORKFLOW_GATE Approval carrying program + shims + budgets (GH#11568)."""
+        from chat_workflow.code_exec.broker import CODEEXEC_MAX_TOOL_CALLS
+        from models.approval import ApprovalType
+        from secure_sandbox_executor import CODEEXEC_TIMEOUT_SECONDS
+        from services.approval_gate_service import ApprovalGateService
+        from user_management.database import get_async_session_factory
+
+        context = {
+            "program": program,
+            "shim_snapshot": shim_snapshot,
+            "budgets": {"max_tool_calls": CODEEXEC_MAX_TOOL_CALLS, "timeout_seconds": CODEEXEC_TIMEOUT_SECONDS},
+        }
+        session_factory = get_async_session_factory()
+        async with session_factory() as db:
+            approval = await ApprovalGateService(db).create_approval(
+                title="compose script execution",
+                approval_type=ApprovalType.WORKFLOW_GATE.value,
+                requested_by_agent="chat_agent",
+                description="Sandboxed Python compose script awaiting approval.",
+                workflow_id=session_id,
+                workflow_step="compose",
+                context=context,
+            )
+            return str(approval.id)
+
+    def _build_compose_dispatch(self, session_id: str, ctx: "LLMIterationContext | None"):
+        """Return an async dispatch callable routing shim calls through the seam (GH#11568)."""
+
+        async def _dispatch(tool: str, params: dict) -> Any:
+            sub_results: list[dict[str, Any]] = []
+            sub_call = {"name": tool, "params": params}
+            async for _ in self._dispatch_tool_call(sub_call, session_id, session_id, "", "", sub_results, [], ctx=ctx):
+                pass
+            last = sub_results[-1] if sub_results else {}
+            if last.get("status") == "error":
+                raise RepairableException(last.get("error", "tool dispatch failed"))
+            return last.get("output", last)
+
+        return _dispatch
+
     async def _execute_compose(
-        self, program: str, agent_id: "str | None", run_id: str
+        self, program: str, agent_id: "str | None", run_id: str, session_id: str, ctx: "LLMIterationContext | None"
     ) -> "WorkflowMessage":
-        """Run the script inside the sandbox; return result WorkflowMessage."""
+        """Run the script inside the sandbox via a live broker; return result msg."""
+        from chat_workflow.code_exec.broker import CodeExecBroker
         from chat_workflow.code_exec.shim_codegen import generate_shim_module, injectable_tool_set
         from orchestration.agent_registry import resolve_forbidden_tools
         from secure_sandbox_executor import CODEEXEC_TIMEOUT_SECONDS, SecureSandboxExecutor  # lazy
@@ -2933,8 +2989,20 @@ class ToolHandlerMixin:
         forbidden = resolve_forbidden_tools(agent_id)
         tools = injectable_tool_set([], forbidden)
         shim_src = generate_shim_module(tools)
+        broker = CodeExecBroker(
+            self._build_compose_dispatch(session_id, ctx),
+            tools,
+            forbidden,
+            run_id,
+            f"autobot:codeexec:security:events:{run_id}",
+            progress_channel=f"workflow:{session_id}",
+        )
         executor = SecureSandboxExecutor()
-        result = await executor.execute_with_stdio_broker(program, shim_src, CODEEXEC_TIMEOUT_SECONDS, run_id)
+        result = await executor.execute_with_stdio_broker(program, shim_src, broker, CODEEXEC_TIMEOUT_SECONDS, run_id)
+        return self._compose_result_message(result, run_id)
+
+    def _compose_result_message(self, result: Any, run_id: str) -> "WorkflowMessage":
+        """Build the tool_result WorkflowMessage from a SandboxResult (GH#11568)."""
         if result.success:
             return WorkflowMessage(
                 type="tool_result",
@@ -2948,6 +3016,23 @@ class ToolHandlerMixin:
             metadata={"tool_name": "compose", "run_id": run_id, "failed": True},
         )
 
+    def _compose_shim_snapshot(self, agent_id: "str | None") -> list[str]:
+        """Injectable-tool snapshot for this agent (allowlist ∩ allowed − forbidden)."""
+        from chat_workflow.code_exec.shim_codegen import injectable_tool_set
+        from orchestration.agent_registry import resolve_forbidden_tools
+
+        return injectable_tool_set([], resolve_forbidden_tools(agent_id))
+
+    def _reject_delegated_compose(self, agent_id: "str | None") -> "WorkflowMessage | None":
+        """Main-chat-only: reject compose for any profile-bound (delegated) agent (GH#11568)."""
+        if agent_id is None:
+            return None
+        return WorkflowMessage(
+            type="tool_result",
+            content="compose is not available for delegated subagents",
+            metadata={"tool_name": "compose"},
+        )
+
     async def _handle_compose_tool(
         self,
         tool_call: dict[str, Any],
@@ -2955,18 +3040,14 @@ class ToolHandlerMixin:
         execution_results: list[dict[str, Any]],
         ctx: "LLMIterationContext | None",
     ):
-        """Handle the compose tool call (GH#11568)."""
+        """Handle the compose tool call — main chat agent only (GH#11568)."""
         import uuid
 
-        params = tool_call.get("params", {})
-        program: str = params.get("program", "")
+        program: str = tool_call.get("params", {}).get("program", "")
         agent_id: str | None = ctx.agent_context.agent_id if (ctx and ctx.agent_context) else None
-        if agent_id is not None:
-            yield WorkflowMessage(
-                type="tool_result",
-                content="compose is not available for delegated subagents",
-                metadata={"tool_name": "compose"},
-            )
+        subagent_msg = self._reject_delegated_compose(agent_id)
+        if subagent_msg is not None:
+            yield subagent_msg
             return
 
         guard_msg = self._guard_compose(program, agent_id)
@@ -2975,13 +3056,15 @@ class ToolHandlerMixin:
             yield guard_msg
             return
 
-        approval_msg = self._approve_compose(tool_call)
+        shim_snapshot = self._compose_shim_snapshot(agent_id)
+        approval_msg = await self._approve_compose(program, shim_snapshot, session_id)
         if approval_msg is not None:
+            execution_results.append({"tool": "compose", "status": "pending_approval"})
             yield approval_msg
             return
 
         run_id = str(uuid.uuid4())
-        result_msg = await self._execute_compose(program, agent_id, run_id)
+        result_msg = await self._execute_compose(program, agent_id, run_id, session_id, ctx)
         execution_results.append({"tool": "compose", "status": "executed", "run_id": run_id})
         yield result_msg
 

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -15,7 +15,9 @@ import ast
 import asyncio
 import html
 import json
+import os
 import re
+import uuid
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from async_chat_workflow import WorkflowMessage
@@ -46,6 +48,18 @@ logger = get_logger(__name__)
 CODEEXEC_ENABLED: bool = env_flag("AUTOBOT_CODEEXEC_ENABLED", default=False)
 CODEEXEC_AUTOAPPROVE_READONLY: bool = env_flag("AUTOBOT_CODEEXEC_AUTOAPPROVE_READONLY", default=True)
 CODEEXEC_MAX_SCRIPT_RETRIES: int = env_int("AUTOBOT_CODEEXEC_MAX_SCRIPT_RETRIES", default=1)
+# GH#11568 BLOCKER-4: the read-only tool set eligible for auto-approval (design §3.1).
+# Auto-approve fires ONLY when every shimmed tool is in this set. Env-overridable so it
+# tracks the injectable default; sensitive tools are structurally excluded upstream.
+CODEEXEC_READONLY_TOOLS: frozenset[str] = frozenset(
+    os.environ.get(
+        "AUTOBOT_CODEEXEC_READONLY_TOOLS",
+        "web_search,scrape_url,map_site,extract_structured_data",
+    ).split(",")
+)
+# Approval-wait polling knobs (mirrors terminal-command approval loop).
+CODEEXEC_APPROVAL_WAIT_SECONDS: int = env_int("AUTOBOT_CODEEXEC_APPROVAL_WAIT_SECONDS", default=1800)
+CODEEXEC_APPROVAL_POLL_SECONDS: int = env_int("AUTOBOT_CODEEXEC_APPROVAL_POLL_SECONDS", default=2)
 
 # Issue #4482: Default retry count for schema self-correction loop.
 _DEFAULT_SCHEMA_RETRIES = 3
@@ -2914,27 +2928,44 @@ class ToolHandlerMixin:
             metadata={"tool_name": "compose", "ast_violations": verdict.violations},
         )
 
-    async def _approve_compose(
-        self, program: str, shim_snapshot: list[str], session_id: str
-    ) -> "WorkflowMessage | None":
-        """Create a WORKFLOW_GATE approval when auto-approve is off (GH#11568).
+    @staticmethod
+    def _compose_auto_approvable(shim_snapshot: list[str]) -> bool:
+        """Auto-approve only when the flag is on AND all shims are read-only (design §3.1)."""
+        return CODEEXEC_AUTOAPPROVE_READONLY and set(shim_snapshot) <= CODEEXEC_READONLY_TOOLS
 
-        Returns an approval_required WorkflowMessage carrying the persisted
-        approval id, or ``None`` when the read-only auto-approve posture applies.
+    async def _approve_compose(self, program: str, shim_snapshot: list[str], session_id: str) -> "str | None":
+        """Return an approval id requiring a gate, or ``None`` to auto-approve (GH#11568).
+
+        Auto-approval requires the flag AND a fully read-only shim set; any
+        non-read-only shim forces the WORKFLOW_GATE even with the flag on.
         """
-        if CODEEXEC_AUTOAPPROVE_READONLY:
+        if self._compose_auto_approvable(shim_snapshot):
             return None
-        approval_id = await self._persist_compose_approval(program, shim_snapshot, session_id)
-        return WorkflowMessage(
-            type="approval_required",
-            content="compose script requires approval before execution",
-            metadata={
-                "tool": "compose",
-                "approval_required": True,
-                "approval_id": approval_id,
-                "shim_snapshot": shim_snapshot,
-            },
-        )
+        return await self._persist_compose_approval(program, shim_snapshot, session_id)
+
+    async def _poll_compose_approval(self, approval_id: str) -> str:
+        """Poll the WORKFLOW_GATE until decided; return its terminal status (GH#11568 MINOR-2).
+
+        Mirrors the terminal-command approval loop: a bounded poll on the persisted
+        gate. Returns ``approved``/``rejected``/``revision_requested``, or
+        ``timeout`` when no decision lands within the wait budget.
+        """
+        import uuid as _uuid
+
+        from services.approval_gate_service import ApprovalGateService
+        from user_management.database import get_async_session_factory
+
+        elapsed = 0
+        session_factory = get_async_session_factory()
+        while elapsed < CODEEXEC_APPROVAL_WAIT_SECONDS:
+            async with session_factory() as db:
+                approval = await ApprovalGateService(db).get(_uuid.UUID(approval_id))
+            status = getattr(approval, "status", None)
+            if status and status != "pending":
+                return status
+            await asyncio.sleep(CODEEXEC_APPROVAL_POLL_SECONDS)
+            elapsed += CODEEXEC_APPROVAL_POLL_SECONDS
+        return "timeout"
 
     async def _persist_compose_approval(self, program: str, shim_snapshot: list[str], session_id: str) -> "str | None":
         """Persist a WORKFLOW_GATE Approval carrying program + shims + budgets (GH#11568)."""
@@ -3033,6 +3064,27 @@ class ToolHandlerMixin:
             metadata={"tool_name": "compose"},
         )
 
+    def _compose_gate_request_msg(self, approval_id: str, shim_snapshot: list[str]) -> "WorkflowMessage":
+        """Build the WORKFLOW_GATE approval-required notification (GH#11568)."""
+        return WorkflowMessage(
+            type="approval_required",
+            content="compose script requires approval before execution",
+            metadata={
+                "tool": "compose",
+                "approval_required": True,
+                "approval_id": approval_id,
+                "shim_snapshot": shim_snapshot,
+            },
+        )
+
+    def _compose_gate_refusal_msg(self, status: str) -> "WorkflowMessage":
+        """Terminal refusal message for a non-approved gate (GH#11568)."""
+        return WorkflowMessage(
+            type="tool_result",
+            content=f"compose execution not approved (gate status: {status}).",
+            metadata={"tool_name": "compose", "approval_status": status, "denied": True},
+        )
+
     async def _handle_compose_tool(
         self,
         tool_call: dict[str, Any],
@@ -3041,8 +3093,6 @@ class ToolHandlerMixin:
         ctx: "LLMIterationContext | None",
     ):
         """Handle the compose tool call — main chat agent only (GH#11568)."""
-        import uuid
-
         program: str = tool_call.get("params", {}).get("program", "")
         agent_id: str | None = ctx.agent_context.agent_id if (ctx and ctx.agent_context) else None
         subagent_msg = self._reject_delegated_compose(agent_id)
@@ -3057,11 +3107,14 @@ class ToolHandlerMixin:
             return
 
         shim_snapshot = self._compose_shim_snapshot(agent_id)
-        approval_msg = await self._approve_compose(program, shim_snapshot, session_id)
-        if approval_msg is not None:
-            execution_results.append({"tool": "compose", "status": "pending_approval"})
-            yield approval_msg
-            return
+        approval_id = await self._approve_compose(program, shim_snapshot, session_id)
+        if approval_id is not None:
+            yield self._compose_gate_request_msg(approval_id, shim_snapshot)
+            status = await self._poll_compose_approval(approval_id)
+            if status != "approved":
+                execution_results.append({"tool": "compose", "status": "gated", "approval_status": status})
+                yield self._compose_gate_refusal_msg(status)
+                return
 
         run_id = str(uuid.uuid4())
         result_msg = await self._execute_compose(program, agent_id, run_id, session_id, ctx)

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -19,6 +19,7 @@ import re
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from async_chat_workflow import WorkflowMessage
+from autobot_shared.env_utils import env_flag, env_int
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.tool_catalogue import APPROVAL_CATEGORY_TOOLS, match_tool_name
 from llc.agent_tools import LLC_TOOL_NAMES, LLC_TOOL_SCHEMAS, LLCToolError, dispatch_llc_tool
@@ -40,6 +41,11 @@ from chat_workflow.session_handler import (
 )
 
 logger = get_logger(__name__)
+
+# GH#11568: compose tool feature flag and tuning constants.
+CODEEXEC_ENABLED: bool = env_flag("AUTOBOT_CODEEXEC_ENABLED", default=False)
+CODEEXEC_AUTOAPPROVE_READONLY: bool = env_flag("AUTOBOT_CODEEXEC_AUTOAPPROVE_READONLY", default=True)
+CODEEXEC_MAX_SCRIPT_RETRIES: int = env_int("AUTOBOT_CODEEXEC_MAX_SCRIPT_RETRIES", default=1)
 
 # Issue #4482: Default retry count for schema self-correction loop.
 _DEFAULT_SCHEMA_RETRIES = 3
@@ -357,6 +363,25 @@ _BUILTIN_TOOL_SCHEMAS: dict[str, dict] = {
     # existing llc/services. Merged below so they validate like any built-in.
     **LLC_TOOL_SCHEMAS,
 }
+
+# GH#11568: compose tool — sandboxed Python script with injectable RPC shims.
+COMPOSE_TOOL_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "program": {
+            "type": "string",
+            "description": "Python program to execute. Import autobot_tools and call tool functions as async coroutines.",
+        },
+        "description": {
+            "type": "string",
+            "description": "Human-readable description of what this program does.",
+        },
+    },
+    "required": ["program"],
+}
+
+if CODEEXEC_ENABLED:
+    _BUILTIN_TOOL_SCHEMAS["compose"] = COMPOSE_TOOL_SCHEMA
 
 
 def _validate_builtin_tool_arguments(tool_name: str, tool_call: dict[str, Any]) -> WorkflowMessage | None:
@@ -2701,6 +2726,14 @@ class ToolHandlerMixin:
             yield approval_msg
             return
 
+        # GH#11568: sandboxed Python composition tool (main-chat only).
+        if tool_name == "compose" and CODEEXEC_ENABLED:
+            if ctx is not None:
+                ctx.consecutive_invalid_tool_calls = 0
+            async for msg in self._handle_compose_tool(tool_call, session_id, execution_results, ctx):
+                yield msg
+            return
+
         if tool_name == "respond":
             if ctx is not None:
                 ctx.consecutive_invalid_tool_calls = 0
@@ -2858,6 +2891,99 @@ class ToolHandlerMixin:
             additional_response_parts,
         ):
             yield msg
+
+    # ------------------------------------------------------------------ #
+    # GH#11568: compose tool handlers                                     #
+    # ------------------------------------------------------------------ #
+
+    def _guard_compose(self, program: str, agent_id: "str | None") -> "WorkflowMessage | None":
+        """Run AST guard; return error WorkflowMessage on violation, else None."""
+        from chat_workflow.code_exec.ast_guard import check_script
+        from orchestration.agent_registry import resolve_forbidden_tools
+
+        forbidden = resolve_forbidden_tools(agent_id)
+        verdict = check_script(program, frozenset(forbidden))
+        if verdict.ok:
+            return None
+        lines = "; ".join(f"line {v['line']}: {v['message']}" for v in verdict.violations)
+        return WorkflowMessage(
+            type="tool_result",
+            content=f"compose script rejected by AST guard: {lines}",
+            metadata={"tool_name": "compose", "ast_violations": verdict.violations},
+        )
+
+    def _approve_compose(self, tool_call: dict) -> "WorkflowMessage | None":
+        """Return approval_required WorkflowMessage when auto-approve is off, else None."""
+        if CODEEXEC_AUTOAPPROVE_READONLY:
+            return None
+        return WorkflowMessage(
+            type="approval_required",
+            content="compose script requires approval before execution",
+            metadata={"tool": "compose", "approval_required": True},
+        )
+
+    async def _execute_compose(
+        self, program: str, agent_id: "str | None", run_id: str
+    ) -> "WorkflowMessage":
+        """Run the script inside the sandbox; return result WorkflowMessage."""
+        from chat_workflow.code_exec.shim_codegen import generate_shim_module, injectable_tool_set
+        from orchestration.agent_registry import resolve_forbidden_tools
+        from secure_sandbox_executor import CODEEXEC_TIMEOUT_SECONDS, SecureSandboxExecutor  # lazy
+
+        forbidden = resolve_forbidden_tools(agent_id)
+        tools = injectable_tool_set([], forbidden)
+        shim_src = generate_shim_module(tools)
+        executor = SecureSandboxExecutor()
+        result = await executor.execute_with_stdio_broker(program, shim_src, CODEEXEC_TIMEOUT_SECONDS, run_id)
+        if result.success:
+            return WorkflowMessage(
+                type="tool_result",
+                content=result.stdout or "(no output)",
+                metadata={"tool_name": "compose", "run_id": run_id},
+            )
+        content = f"compose execution failed (exit {result.exit_code}): {result.stderr or result.stdout}"
+        return WorkflowMessage(
+            type="tool_result",
+            content=content,
+            metadata={"tool_name": "compose", "run_id": run_id, "failed": True},
+        )
+
+    async def _handle_compose_tool(
+        self,
+        tool_call: dict[str, Any],
+        session_id: str,
+        execution_results: list[dict[str, Any]],
+        ctx: "LLMIterationContext | None",
+    ):
+        """Handle the compose tool call (GH#11568)."""
+        import uuid
+
+        params = tool_call.get("params", {})
+        program: str = params.get("program", "")
+        agent_id: str | None = ctx.agent_context.agent_id if (ctx and ctx.agent_context) else None
+        if agent_id is not None:
+            yield WorkflowMessage(
+                type="tool_result",
+                content="compose is not available for delegated subagents",
+                metadata={"tool_name": "compose"},
+            )
+            return
+
+        guard_msg = self._guard_compose(program, agent_id)
+        if guard_msg is not None:
+            execution_results.append({"tool": "compose", "status": "ast_rejected"})
+            yield guard_msg
+            return
+
+        approval_msg = self._approve_compose(tool_call)
+        if approval_msg is not None:
+            yield approval_msg
+            return
+
+        run_id = str(uuid.uuid4())
+        result_msg = await self._execute_compose(program, agent_id, run_id)
+        execution_results.append({"tool": "compose", "status": "executed", "run_id": run_id})
+        yield result_msg
 
     async def _process_tool_calls(
         self,

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -2915,10 +2915,12 @@ class ToolHandlerMixin:
     def _guard_compose(self, program: str, agent_id: "str | None") -> "WorkflowMessage | None":
         """Run AST guard; return error WorkflowMessage on violation, else None."""
         from chat_workflow.code_exec.ast_guard import check_script
+        from chat_workflow.code_exec.shim_codegen import injectable_tool_set
         from orchestration.agent_registry import resolve_forbidden_tools
 
         forbidden = resolve_forbidden_tools(agent_id)
-        verdict = check_script(program, frozenset(forbidden))
+        injected = frozenset(injectable_tool_set([], forbidden))
+        verdict = check_script(program, frozenset(forbidden), injected_tools=injected)
         if verdict.ok:
             return None
         lines = "; ".join(f"line {v['line']}: {v['message']}" for v in verdict.violations)

--- a/autobot-backend/secure_sandbox_executor.py
+++ b/autobot-backend/secure_sandbox_executor.py
@@ -429,22 +429,56 @@ class SecureSandboxExecutor:
             except Exception as e:
                 self.logger.debug("Failed to cleanup script file %s: %s", script_path, e)
 
+    def _codeexec_config(self, timeout: int) -> "SandboxConfig":
+        """Build the HIGH-security, no-network sandbox config for compose (GH#11568)."""
+        return SandboxConfig(
+            security_level=SandboxSecurityLevel.HIGH,
+            execution_mode=SandboxExecutionMode.SCRIPT,
+            enable_network=False,
+            timeout=timeout,
+        )
+
+    async def _pump_broker_io(self, container, broker: Any) -> None:
+        """Drive the shim RPC loop: read stdout lines, reply on stdin (GH#11568).
+
+        Each line the sandboxed script writes is a JSON-RPC request; the broker
+        validates and dispatches it, and the reply is written back to the
+        container's stdin. Budget exhaustion aborts the container via teardown.
+        """
+        sock = container.attach_socket(params={"stdin": 1, "stdout": 1, "stream": 1})
+        stream = getattr(sock, "_sock", sock)
+        buf = b""
+        while True:
+            chunk = await asyncio.to_thread(stream.recv, 4096)
+            if not chunk:
+                break
+            buf += chunk
+            while b"\n" in buf:
+                raw, buf = buf.split(b"\n", 1)
+                reply = await broker.handle_line(raw.decode("utf-8", errors="replace"))
+                await asyncio.to_thread(stream.sendall, (reply + "\n").encode("utf-8"))
+                if broker.budget_exhausted:
+                    await asyncio.to_thread(container.kill)
+                    return
+
     async def execute_with_stdio_broker(
         self,
         script_content: str,
         shim_src: str,
+        broker: Any,
         timeout: int,
         run_id: str,
     ) -> "SandboxResult":
-        """Execute *script_content* with the shim module prepended (GH#11568).
+        """Execute *script_content* driving shim RPC through *broker* (GH#11568).
 
-        The combined source (shim + user script) runs inside the sandbox at
-        HIGH security with no network.  For v1 the broker is driven by the
-        caller (tool_handler) which processes stdout JSON lines after execution.
+        The combined source (shim + user script) runs inside the sandbox at HIGH
+        security with no network; ``broker`` is the live server-side capability
+        channel that re-validates and dispatches every shim call (design §3).
 
         Args:
             script_content: User-supplied Python script.
             shim_src: Generated autobot_tools shim module source.
+            broker: CodeExecBroker driving the stdio RPC loop.
             timeout: Wall-clock execution limit in seconds.
             run_id: Correlation ID for audit/logging.
 
@@ -452,14 +486,27 @@ class SecureSandboxExecutor:
             SandboxResult from the sandbox executor.
         """
         combined = shim_src + "\n\n" + script_content
-        cfg = SandboxConfig(
-            security_level=SandboxSecurityLevel.HIGH,
-            execution_mode=SandboxExecutionMode.SCRIPT,
-            enable_network=False,
-            timeout=timeout,
-        )
+        cfg = self._codeexec_config(timeout)
         self.logger.debug("execute_with_stdio_broker run_id=%s timeout=%d", run_id, timeout)
-        return await self.execute_script(combined, "python", cfg)
+        return await self._run_broker_script(combined, cfg, broker)
+
+    async def _run_broker_script(self, combined: str, cfg: "SandboxConfig", broker: Any) -> "SandboxResult":
+        """Run the combined script with a duplex broker pump (GH#11568)."""
+        container_id = f"{self.container_prefix}{uuid.uuid4().hex[:8]}"
+        start_time = time.time()
+        try:
+            container_config = self._prepare_container_config(["/usr/bin/python3", "-c", combined], cfg)
+            container_config["stdin_open"] = True
+            container = self.docker_client.containers.create(**container_config)
+            self.active_containers[container_id] = container.id
+            container.start()
+            await self._pump_broker_io(container, broker)
+            return await self._run_container_and_collect_results(container, container_id, cfg, start_time)
+        except Exception as e:  # noqa: BLE001
+            self.logger.error("Broker script execution error: %s", e)
+            return self._create_execution_error_result(e, start_time, container_id)
+        finally:
+            await self._cleanup_container(container_id)
 
     def _validate_command(self, command: str | List[str], config: SandboxConfig) -> bool:
         """Validate command against security policies."""

--- a/autobot-backend/secure_sandbox_executor.py
+++ b/autobot-backend/secure_sandbox_executor.py
@@ -438,28 +438,59 @@ class SecureSandboxExecutor:
             timeout=timeout,
         )
 
+    @staticmethod
+    def _demux_frames(buf: bytes) -> "Tuple[bytes, bytes]":
+        """Strip Docker's 8-byte stdout/stderr multiplexing headers (GH#11568 BLOCKER-3).
+
+        A non-tty ``attach_socket`` yields framed output: an 8-byte header
+        ``[stream(1)][000][size BE(4)]`` followed by ``size`` payload bytes. This
+        returns ``(decoded_stdout_payload, remaining_incomplete_bytes)``.
+        """
+        out = b""
+        while len(buf) >= 8:
+            size = int.from_bytes(buf[4:8], "big")
+            if len(buf) < 8 + size:
+                break
+            stream_type = buf[0]
+            payload = buf[8 : 8 + size]
+            if stream_type == 1:  # stdout only; stderr(2) is diagnostics, not RPC
+                out += payload
+            buf = buf[8 + size :]
+        return out, buf
+
     async def _pump_broker_io(self, container, broker: Any) -> None:
         """Drive the shim RPC loop: read stdout lines, reply on stdin (GH#11568).
 
-        Each line the sandboxed script writes is a JSON-RPC request; the broker
-        validates and dispatches it, and the reply is written back to the
-        container's stdin. Budget exhaustion aborts the container via teardown.
+        Reads Docker's multiplexed frames from the attach socket, demuxes stdout,
+        line-splits JSON-RPC requests, and writes the broker's reply to stdin.
+        Budget exhaustion aborts the container via teardown.
         """
         sock = container.attach_socket(params={"stdin": 1, "stdout": 1, "stream": 1})
         stream = getattr(sock, "_sock", sock)
-        buf = b""
+        raw_buf = b""
+        line_buf = b""
         while True:
             chunk = await asyncio.to_thread(stream.recv, 4096)
             if not chunk:
                 break
-            buf += chunk
-            while b"\n" in buf:
-                raw, buf = buf.split(b"\n", 1)
-                reply = await broker.handle_line(raw.decode("utf-8", errors="replace"))
-                await asyncio.to_thread(stream.sendall, (reply + "\n").encode("utf-8"))
-                if broker.budget_exhausted:
-                    await asyncio.to_thread(container.kill)
-                    return
+            raw_buf += chunk
+            decoded, raw_buf = self._demux_frames(raw_buf)
+            line_buf += decoded
+            aborted = await self._drain_lines(stream, broker, line_buf, container)
+            line_buf = aborted[1]
+            if aborted[0]:
+                return
+
+    async def _drain_lines(self, stream, broker: Any, line_buf: bytes, container) -> "Tuple[bool, bytes]":
+        """Process complete JSON lines in *line_buf*; return (aborted, remaining)."""
+        while b"\n" in line_buf:
+            raw, line_buf = line_buf.split(b"\n", 1)
+            reply = await broker.handle_line(raw.decode("utf-8", errors="replace"))
+            await asyncio.to_thread(stream.sendall, (reply + "\n").encode("utf-8"))
+            if broker.budget_exhausted:
+                await asyncio.to_thread(container.kill)
+                return True, line_buf
+        return False, line_buf
 
     async def execute_with_stdio_broker(
         self,
@@ -473,14 +504,8 @@ class SecureSandboxExecutor:
 
         The combined source (shim + user script) runs inside the sandbox at HIGH
         security with no network; ``broker`` is the live server-side capability
-        channel that re-validates and dispatches every shim call (design §3).
-
-        Args:
-            script_content: User-supplied Python script.
-            shim_src: Generated autobot_tools shim module source.
-            broker: CodeExecBroker driving the stdio RPC loop.
-            timeout: Wall-clock execution limit in seconds.
-            run_id: Correlation ID for audit/logging.
+        channel that re-validates and dispatches every shim call (design §3). The
+        source is delivered via a mounted file (not argv) to avoid ARG_MAX limits.
 
         Returns:
             SandboxResult from the sandbox executor.
@@ -490,23 +515,63 @@ class SecureSandboxExecutor:
         self.logger.debug("execute_with_stdio_broker run_id=%s timeout=%d", run_id, timeout)
         return await self._run_broker_script(combined, cfg, broker)
 
+    def _write_script_file(self, combined: str) -> str:
+        """Persist the combined source to a host temp file for read-only mounting."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False, encoding="utf-8") as f:
+            f.write(combined)
+            return f.name
+
     async def _run_broker_script(self, combined: str, cfg: "SandboxConfig", broker: Any) -> "SandboxResult":
-        """Run the combined script with a duplex broker pump (GH#11568)."""
+        """Run the combined script (via mounted file) with a duplex broker pump (GH#11568)."""
         container_id = f"{self.container_prefix}{uuid.uuid4().hex[:8]}"
         start_time = time.time()
+        script_path = self._write_script_file(combined)
+        guest_path = "/sandbox/compose_script.py"
         try:
-            container_config = self._prepare_container_config(["/usr/bin/python3", "-c", combined], cfg)
-            container_config["stdin_open"] = True
-            container = self.docker_client.containers.create(**container_config)
+            cc = self._prepare_container_config(["/usr/bin/python3", guest_path], cfg)
+            cc["stdin_open"] = True
+            cc.setdefault("volumes", {})[script_path] = {"bind": guest_path, "mode": "ro"}
+            container = self.docker_client.containers.create(**cc)
             self.active_containers[container_id] = container.id
             container.start()
             await self._pump_broker_io(container, broker)
-            return await self._run_container_and_collect_results(container, container_id, cfg, start_time)
+            return await self._collect_broker_results(container, container_id, cfg, start_time)
         except Exception as e:  # noqa: BLE001
             self.logger.error("Broker script execution error: %s", e)
             return self._create_execution_error_result(e, start_time, container_id)
         finally:
             await self._cleanup_container(container_id)
+            await asyncio.to_thread(self._safe_unlink, script_path)
+
+    @staticmethod
+    def _safe_unlink(path: str) -> None:
+        """Best-effort removal of a host temp file."""
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+    async def _collect_broker_results(
+        self, container, container_id: str, cfg: "SandboxConfig", start_time: float
+    ) -> "SandboxResult":
+        """Wait for an already-started broker container, then collect results (GH#11568 BLOCKER-2).
+
+        Unlike ``_run_container_and_collect_results`` this never calls ``start()``
+        again (the pump already started the container) — avoiding a 409 Conflict.
+        """
+        try:
+            exit_code = await asyncio.to_thread(lambda: container.wait(timeout=cfg.timeout)["StatusCode"])
+        except Exception:  # noqa: BLE001
+            await asyncio.to_thread(container.kill)
+            exit_code = -9
+        logs = await asyncio.to_thread(lambda: container.logs(stdout=True, stderr=True, stream=False))
+        stdout_logs, stderr_logs = self._parse_logs(logs)
+        security_events = await self._collect_security_events(container_id)
+        result = self._build_sandbox_result(
+            exit_code, stdout_logs, stderr_logs, time.time() - start_time, container_id, security_events, {}, cfg
+        )
+        await self._log_execution_metrics(container_id, result)
+        return result
 
     def _validate_command(self, command: str | List[str], config: SandboxConfig) -> bool:
         """Validate command against security policies."""

--- a/autobot-backend/secure_sandbox_executor.py
+++ b/autobot-backend/secure_sandbox_executor.py
@@ -42,6 +42,7 @@ except ImportError:
         """Stub raised when docker SDK is not installed."""
 
 
+from autobot_shared.env_utils import env_int
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.singleton_factory import lazy_optional_singleton
@@ -49,6 +50,9 @@ from autobot_shared.ssot_config import config as _ssot_config
 from constants.ttl_constants import TTL_1_HOUR
 
 logger = get_logger(__name__)
+
+# GH#11568: default timeout for compose-tool sandbox execution.
+CODEEXEC_TIMEOUT_SECONDS: int = env_int("AUTOBOT_CODEEXEC_TIMEOUT_SECONDS", default=120)
 
 
 class SandboxSecurityLevel(Enum):
@@ -424,6 +428,38 @@ class SecureSandboxExecutor:
                 await asyncio.to_thread(os.unlink, script_path)
             except Exception as e:
                 self.logger.debug("Failed to cleanup script file %s: %s", script_path, e)
+
+    async def execute_with_stdio_broker(
+        self,
+        script_content: str,
+        shim_src: str,
+        timeout: int,
+        run_id: str,
+    ) -> "SandboxResult":
+        """Execute *script_content* with the shim module prepended (GH#11568).
+
+        The combined source (shim + user script) runs inside the sandbox at
+        HIGH security with no network.  For v1 the broker is driven by the
+        caller (tool_handler) which processes stdout JSON lines after execution.
+
+        Args:
+            script_content: User-supplied Python script.
+            shim_src: Generated autobot_tools shim module source.
+            timeout: Wall-clock execution limit in seconds.
+            run_id: Correlation ID for audit/logging.
+
+        Returns:
+            SandboxResult from the sandbox executor.
+        """
+        combined = shim_src + "\n\n" + script_content
+        cfg = SandboxConfig(
+            security_level=SandboxSecurityLevel.HIGH,
+            execution_mode=SandboxExecutionMode.SCRIPT,
+            enable_network=False,
+            timeout=timeout,
+        )
+        self.logger.debug("execute_with_stdio_broker run_id=%s timeout=%d", run_id, timeout)
+        return await self.execute_script(combined, "python", cfg)
 
     def _validate_command(self, command: str | List[str], config: SandboxConfig) -> bool:
         """Validate command against security policies."""

--- a/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for chat_workflow.code_exec package (GH#11568)."""
 
+import asyncio
 import json
 import pathlib
 import sys
@@ -172,12 +173,27 @@ async def test_broker_budget_cap():
 
 
 def test_compose_absent_from_schemas_when_flag_off():
-    """When CODEEXEC_ENABLED is False, 'compose' must not be in _BUILTIN_TOOL_SCHEMAS."""
+    """Flag-off zero-change: 'compose' absent from schemas AND uniform routing."""
     import chat_workflow.tool_handler as th
 
-    # Re-read current value; if flag is off by default this should hold
-    if not th.CODEEXEC_ENABLED:
-        assert "compose" not in th._BUILTIN_TOOL_SCHEMAS
+    assert th.CODEEXEC_ENABLED is False  # default posture
+    assert "compose" not in th._BUILTIN_TOOL_SCHEMAS
+    assert "compose" not in th._UNIFORM_BUILTIN_TOOLS
+
+
+def test_compose_schema_registration_helper_matches_flag():
+    """The COMPOSE_TOOL_SCHEMA is only merged into _BUILTIN_TOOL_SCHEMAS under the flag."""
+    import chat_workflow.tool_handler as th
+
+    # Directly exercise the registration predicate the module uses at import time.
+    schemas = dict(th._BUILTIN_TOOL_SCHEMAS)
+    if th.CODEEXEC_ENABLED:
+        schemas["compose"] = th.COMPOSE_TOOL_SCHEMA
+        assert schemas["compose"]["required"] == ["program"]
+    else:
+        assert "compose" not in schemas
+    # The schema constant always exists (definition is unconditional); only registration is gated.
+    assert th.COMPOSE_TOOL_SCHEMA["properties"]["program"]["type"] == "string"
 
 
 # ---------------------------------------------------------------------------
@@ -228,19 +244,123 @@ async def test_compose_ast_violation_rejected():
 
 @pytest.mark.asyncio
 async def test_compose_approval_gate_creates_record():
-    """When CODEEXEC_AUTOAPPROVE_READONLY is False, compose yields approval_required."""
+    """When auto-approve is off, compose persists a WORKFLOW_GATE record and yields approval_required."""
     import chat_workflow.tool_handler as th
 
     handler = object.__new__(th.ToolHandlerMixin)
-    # A syntactically valid program that passes AST guard
     program = "import asyncio\nresult = 1\n"
     tool_call = {"name": "compose", "params": {"program": program}}
     msgs = []
+    handler._persist_compose_approval = AsyncMock(return_value="approval-uuid-1")
+
     with patch.object(th, "CODEEXEC_AUTOAPPROVE_READONLY", False):
         async for msg in handler._handle_compose_tool(tool_call, "s1", [], _FakeCtx()):
             msgs.append(msg)
-    assert msgs
+
     assert any(m.type == "approval_required" for m in msgs)
+    # AC: the persist path receives program text + shim snapshot to record on the gate.
+    handler._persist_compose_approval.assert_awaited_once()
+    call_args = handler._persist_compose_approval.await_args.args
+    assert call_args[0] == program
+    assert isinstance(call_args[1], list)
+
+
+@pytest.mark.asyncio
+async def test_persist_compose_approval_builds_workflow_gate_context():
+    """_persist_compose_approval must create a WORKFLOW_GATE Approval carrying program+shims+budgets."""
+    import chat_workflow.tool_handler as th
+
+    handler = object.__new__(th.ToolHandlerMixin)
+    created: dict = {}
+
+    class _FakeApproval:
+        id = "approval-uuid-2"
+
+    class _FakeSvc:
+        def __init__(self, _db):
+            pass
+
+        async def create_approval(self, **kwargs):
+            created.update(kwargs)
+            return _FakeApproval()
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    import services.approval_gate_service as svc_mod
+    import user_management.database as db_mod
+
+    with (
+        patch.object(svc_mod, "ApprovalGateService", _FakeSvc),
+        patch.object(db_mod, "get_async_session_factory", return_value=lambda: _FakeSession()),
+    ):
+        approval_id = await handler._persist_compose_approval("result = 1", ["web_search"], "s9")
+
+    assert approval_id == "approval-uuid-2"
+    assert created["approval_type"] == "workflow_gate"
+    assert created["context"]["program"] == "result = 1"
+    assert created["context"]["shim_snapshot"] == ["web_search"]
+    assert "max_tool_calls" in created["context"]["budgets"]
+    assert "timeout_seconds" in created["context"]["budgets"]
+
+
+@pytest.mark.asyncio
+async def test_broker_progress_emitted_dual_bus():
+    """A successful shim call emits an audit event AND an EventBus progress event (dual-bus)."""
+    from chat_workflow.code_exec.broker import CodeExecBroker
+
+    broker = CodeExecBroker(
+        dispatch_fn=AsyncMock(return_value="ok"),
+        tools=["web_search"],
+        forbidden=frozenset(),
+        run_id="run-prog",
+        security_event_key="autobot:codeexec:audit",
+    )
+    broker._emit_audit = AsyncMock()
+    broker._emit_progress = AsyncMock()
+    reply = json.loads(await broker.handle_line(json.dumps({"id": "p", "tool": "web_search", "params": {}})))
+    assert reply["ok"] is True
+    await asyncio.sleep(0)  # let create_task fire
+    broker._emit_progress.assert_awaited()
+    broker._emit_audit.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_compose_wires_broker_into_executor():
+    """_execute_compose must build a CodeExecBroker and pass it to the executor (production caller)."""
+    import chat_workflow.tool_handler as th
+    from secure_sandbox_executor import SandboxResult
+
+    handler = object.__new__(th.ToolHandlerMixin)
+    fake_result = SandboxResult(
+        success=True,
+        exit_code=0,
+        stdout="done\n",
+        stderr="",
+        execution_time=0.1,
+        container_id="c",
+        security_events=[],
+        resource_usage={},
+        metadata={},
+    )
+    passed = {}
+
+    async def _fake_exec(program, shim_src, broker, timeout, run_id):
+        passed["broker"] = broker
+        return fake_result
+
+    fake_executor = MagicMock()
+    fake_executor.execute_with_stdio_broker = _fake_exec
+    with patch("secure_sandbox_executor.SecureSandboxExecutor", return_value=fake_executor):
+        msg = await handler._execute_compose("result = 1", None, "rid", "s1", _FakeCtx())
+    from chat_workflow.code_exec.broker import CodeExecBroker
+
+    assert isinstance(passed["broker"], CodeExecBroker)
+    assert "done" in msg.content
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
@@ -59,13 +59,13 @@ def test_ast_guard_blocked_exec():
 
 
 def test_ast_guard_blocked_getattr_smuggling():
-    """getattr(autobot_tools, computed_name) must be rejected."""
+    """getattr against the tools module must be rejected (reflective accessor blocked)."""
     from chat_workflow.code_exec.ast_guard import check_script
 
     script = "import autobot_tools\nfn = getattr(autobot_tools, 'web_search')\n"
     result = check_script(script, frozenset())
     assert not result.ok
-    assert any("smuggling" in v["message"] for v in result.violations)
+    assert any("getattr" in v["message"] for v in result.violations)
 
 
 def test_ast_guard_blocked_forbidden_token():
@@ -413,6 +413,15 @@ _ESCAPE_CORPUS = [
     "locals()",
     "import autobot_tools as t\nfn = getattr(t, 'web_search')\n",
     "x = ().__reduce__()",
+    # LEAK-1: computed / concatenated attribute name reaching a dunder via getattr.
+    "getattr(object(), '__cl' + 'ass__')",
+    "g = getattr\ng(object(), '__class__')",
+    # LEAK-2: eval/exec/... as a bare Name (decorator, rebind), not a call func.
+    "@eval\ndef f():\n    pass\n",
+    "f = eval\nf('1')",
+    # LEAK-3: delattr smuggling + hasattr with a dunder/computed name.
+    "delattr(object, 'x')",
+    "hasattr(o, '__class__')",
 ]
 
 
@@ -426,18 +435,25 @@ def test_ast_guard_rejects_escape_corpus(script):
     assert result.violations
 
 
-def test_ast_guard_accepts_clean_script():
-    """A legitimate multi-tool script still passes after the gap fixes."""
-    from chat_workflow.code_exec.ast_guard import check_script
-
-    script = (
+_CLEAN_CORPUS = [
+    (
         "import autobot_tools\n"
         "import asyncio\n"
         "async def main():\n"
         "    r = await autobot_tools.web_search(query='x')\n"
         "    return r\n"
-    )
-    assert check_script(script, frozenset()).ok
+    ),
+    ("import asyncio, json\n" "async def run():\n" "    r = await scrape_url(url='x')\n" "    return json.dumps(r)\n"),
+]
+
+
+@pytest.mark.parametrize("script", _CLEAN_CORPUS)
+def test_ast_guard_accepts_clean_scripts(script):
+    """Legitimate multi-tool scripts still pass after the gap fixes."""
+    from chat_workflow.code_exec.ast_guard import check_script
+
+    result = check_script(script, frozenset())
+    assert result.ok, f"clean script wrongly rejected: {result.violations}"
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
@@ -252,6 +252,7 @@ async def test_compose_approval_gate_creates_record():
     tool_call = {"name": "compose", "params": {"program": program}}
     msgs = []
     handler._persist_compose_approval = AsyncMock(return_value="approval-uuid-1")
+    handler._poll_compose_approval = AsyncMock(return_value="rejected")
 
     with patch.object(th, "CODEEXEC_AUTOAPPROVE_READONLY", False):
         async for msg in handler._handle_compose_tool(tool_call, "s1", [], _FakeCtx()):
@@ -396,3 +397,329 @@ async def test_compose_e2e_with_fake_executor():
     assert msgs
     result_msg = msgs[-1]
     assert "42" in result_msg.content
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER-1: AST guard escape-gap corpus (each must be REJECTED)
+# ---------------------------------------------------------------------------
+
+_ESCAPE_CORPUS = [
+    "().__class__.__bases__[0].__subclasses__()",
+    'getattr(__builtins__, "exec")()',
+    '__builtins__["open"]("x")',
+    "breakpoint()",
+    'globals()["__builtins__"]',
+    "vars()",
+    "locals()",
+    "import autobot_tools as t\nfn = getattr(t, 'web_search')\n",
+    "x = ().__reduce__()",
+]
+
+
+@pytest.mark.parametrize("script", _ESCAPE_CORPUS)
+def test_ast_guard_rejects_escape_corpus(script):
+    """Each known escape technique must be rejected by the hard gate."""
+    from chat_workflow.code_exec.ast_guard import check_script
+
+    result = check_script(script, frozenset())
+    assert not result.ok, f"escape NOT rejected: {script!r}"
+    assert result.violations
+
+
+def test_ast_guard_accepts_clean_script():
+    """A legitimate multi-tool script still passes after the gap fixes."""
+    from chat_workflow.code_exec.ast_guard import check_script
+
+    script = (
+        "import autobot_tools\n"
+        "import asyncio\n"
+        "async def main():\n"
+        "    r = await autobot_tools.web_search(query='x')\n"
+        "    return r\n"
+    )
+    assert check_script(script, frozenset()).ok
+
+
+# ---------------------------------------------------------------------------
+# MAJOR-3: sensitive tools can never be injected via the env allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_injectable_excludes_sensitive_even_when_env_widened():
+    """compose/delegate/execute_command are excluded even if added to the env allowlist."""
+    from chat_workflow.code_exec import shim_codegen
+
+    widened = frozenset({"web_search", "compose", "delegate", "execute_command"})
+    with patch.object(shim_codegen, "CODEEXEC_INJECTABLE_TOOLS", widened):
+        result = shim_codegen.injectable_tool_set([], frozenset())
+    assert "compose" not in result
+    assert "delegate" not in result
+    assert "execute_command" not in result
+    assert "web_search" in result
+
+
+# ---------------------------------------------------------------------------
+# MAJOR-1: shim RPC uses per-call ids so concurrent calls correlate
+# ---------------------------------------------------------------------------
+
+
+def test_shim_codegen_uses_per_call_ids_not_tool_name():
+    """The shim must not hardcode the tool name as the RPC id."""
+    from chat_workflow.code_exec.shim_codegen import generate_shim_module
+
+    src = generate_shim_module(["web_search"])
+    assert "_next_id" in src
+    assert '"id": "web_search"' not in src  # not a constant id
+
+
+def test_shim_emits_monotonic_ids_and_correlates():
+    """The shim emits a distinct id per call and dispatches replies to a pending map.
+
+    Runs the generated ``_rpc_call`` against a synchronous stub stdio to prove the
+    id monotonically increments and that out-of-order replies land on the right id
+    — the correlation mechanism — without the executor-thread event-loop coupling
+    that only exists inside the real sandbox.
+    """
+    from chat_workflow.code_exec.shim_codegen import generate_shim_module
+
+    ns: dict = {}
+    exec(generate_shim_module(["web_search"]), ns)  # nosec B102 — generated trusted shim under test
+    assert ns["_next_id"]() == 1
+    assert ns["_next_id"]() == 2  # monotonic, not a constant tool-name id
+    # Correlation: a reply keyed by id is retrievable by that id, out of arrival order.
+    ns["_pending"][2] = {"id": 2, "ok": True, "result": "B"}
+    ns["_pending"][1] = {"id": 1, "ok": True, "result": "A"}
+    assert ns["_pending"].pop(1)["result"] == "A"
+    assert ns["_pending"].pop(2)["result"] == "B"
+
+
+@pytest.mark.asyncio
+async def test_broker_echoes_request_id():
+    """The broker must echo the incoming request id so the shim can correlate replies."""
+    from chat_workflow.code_exec.broker import CodeExecBroker
+
+    b = CodeExecBroker(
+        dispatch_fn=AsyncMock(return_value="r"),
+        tools=["web_search"],
+        forbidden=frozenset(),
+        run_id="r",
+        security_event_key="k",
+    )
+    b._emit_audit = AsyncMock()
+    b._emit_progress = AsyncMock()
+    reply = json.loads(await b.handle_line(json.dumps({"id": 7, "tool": "web_search", "params": {}})))
+    assert reply["id"] == 7
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER-2/3: executor start-once and multiplexed-frame demux
+# ---------------------------------------------------------------------------
+
+
+def test_demux_frames_strips_docker_headers():
+    """_demux_frames must strip the 8-byte stdout frame header and drop stderr frames."""
+    from secure_sandbox_executor import SecureSandboxExecutor
+
+    payload = b'{"id": 1}\n'
+    stdout_frame = bytes([1, 0, 0, 0]) + len(payload).to_bytes(4, "big") + payload
+    stderr_frame = bytes([2, 0, 0, 0]) + (3).to_bytes(4, "big") + b"err"
+    decoded, remaining = SecureSandboxExecutor._demux_frames(stdout_frame + stderr_frame)
+    assert decoded == payload
+    assert remaining == b""
+
+
+def test_demux_frames_holds_incomplete_frame():
+    """A partial frame is returned as remaining bytes, not decoded."""
+    from secure_sandbox_executor import SecureSandboxExecutor
+
+    partial = bytes([1, 0, 0, 0]) + (10).to_bytes(4, "big") + b"onl"  # claims 10, has 3
+    decoded, remaining = SecureSandboxExecutor._demux_frames(partial)
+    assert decoded == b""
+    assert remaining == partial
+
+
+@pytest.mark.asyncio
+async def test_run_broker_script_mounts_large_script_via_file_not_argv():
+    """MAJOR-2: a large script is delivered by mounted file, not argv (no ARG_MAX)."""
+    from secure_sandbox_executor import SandboxSecurityLevel, SecureSandboxExecutor
+
+    ex = object.__new__(SecureSandboxExecutor)
+    ex.logger = MagicMock()
+    ex.container_prefix = "t-"
+    ex.active_containers = {}
+    container = MagicMock()
+    container.wait.return_value = {"StatusCode": 0}
+    container.logs.return_value = b""
+    docker_client = MagicMock()
+    docker_client.containers.create.return_value = container
+    ex.docker_client = docker_client
+
+    captured = {}
+
+    def _prep(cmd, cfg):
+        captured["cmd"] = cmd
+        return {"image": "x"}
+
+    ex._prepare_container_config = _prep
+    ex._parse_logs = lambda logs: ("", "")
+    ex._collect_security_events = AsyncMock(return_value=[])
+    ex._build_sandbox_result = SecureSandboxExecutor._build_sandbox_result.__get__(ex)
+    ex._log_execution_metrics = AsyncMock()
+    ex._cleanup_container = AsyncMock()
+    ex._pump_broker_io = AsyncMock()
+
+    big = "x = 1  # padding\n" * 20000  # ~300 KB, well over a typical ARG_MAX
+    cfg = SecureSandboxExecutor._codeexec_config(ex, 30)
+    cfg.security_level = SandboxSecurityLevel.HIGH
+    await ex._run_broker_script(big, cfg, MagicMock())
+    # The command runs a file path, never embeds the source as an argv token.
+    assert captured["cmd"][:2] == ["/usr/bin/python3", "/sandbox/compose_script.py"]
+    assert not any(len(str(tok)) > 4096 for tok in captured["cmd"])
+
+
+@pytest.mark.asyncio
+async def test_run_broker_script_starts_container_once():
+    """BLOCKER-2: the broker path must call container.start() exactly once (no 409)."""
+    from secure_sandbox_executor import SandboxSecurityLevel, SecureSandboxExecutor
+
+    ex = object.__new__(SecureSandboxExecutor)
+    ex.logger = MagicMock()
+    ex.container_prefix = "t-"
+    ex.active_containers = {}
+
+    container = MagicMock()
+    container.wait.return_value = {"StatusCode": 0}
+    container.logs.return_value = b""
+    docker_client = MagicMock()
+    docker_client.containers.create.return_value = container
+    ex.docker_client = docker_client
+
+    ex._prepare_container_config = lambda cmd, cfg: {"image": "x"}
+    ex._parse_logs = lambda logs: ("out", "")
+    ex._collect_security_events = AsyncMock(return_value=[])
+    ex._build_sandbox_result = SecureSandboxExecutor._build_sandbox_result.__get__(ex)
+    ex._log_execution_metrics = AsyncMock()
+    ex._cleanup_container = AsyncMock()
+    ex._pump_broker_io = AsyncMock()
+
+    cfg = SecureSandboxExecutor._codeexec_config(ex, 30)
+    cfg.security_level = SandboxSecurityLevel.HIGH
+    await ex._run_broker_script("print(1)", cfg, MagicMock())
+    assert container.start.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER-4: non-read-only shim forces the gate even with the flag on
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compose_non_readonly_shim_forces_gate_despite_flag():
+    """A non-read-only tool in the shim snapshot forces approval even when auto-approve is on."""
+    import chat_workflow.tool_handler as th
+
+    handler = object.__new__(th.ToolHandlerMixin)
+    handler._persist_compose_approval = AsyncMock(return_value="gate-1")
+    handler._poll_compose_approval = AsyncMock(return_value="rejected")
+    handler._compose_shim_snapshot = lambda agent_id: ["web_search", "write_file"]
+    tool_call = {"name": "compose", "params": {"program": "import asyncio\n"}}
+
+    msgs = []
+    with patch.object(th, "CODEEXEC_AUTOAPPROVE_READONLY", True):
+        async for msg in handler._handle_compose_tool(tool_call, "s1", [], _FakeCtx()):
+            msgs.append(msg)
+
+    handler._persist_compose_approval.assert_awaited_once()  # gate created despite flag
+    assert any(m.type == "approval_required" for m in msgs)
+
+
+def test_compose_auto_approvable_only_for_readonly_set():
+    """_compose_auto_approvable is True only when all shims are read-only AND flag on."""
+    import chat_workflow.tool_handler as th
+
+    handler = object.__new__(th.ToolHandlerMixin)
+    with patch.object(th, "CODEEXEC_AUTOAPPROVE_READONLY", True):
+        assert handler._compose_auto_approvable(["web_search"]) is True
+        assert handler._compose_auto_approvable(["web_search", "write_file"]) is False
+    with patch.object(th, "CODEEXEC_AUTOAPPROVE_READONLY", False):
+        assert handler._compose_auto_approvable(["web_search"]) is False
+
+
+# ---------------------------------------------------------------------------
+# MINOR-2: approved gate resumes execution; denied gate returns a refusal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compose_gate_approved_resumes_execution():
+    """An APPROVED gate proceeds to _execute_compose."""
+    import chat_workflow.tool_handler as th
+
+    handler = object.__new__(th.ToolHandlerMixin)
+    handler._persist_compose_approval = AsyncMock(return_value="gate-2")
+    handler._poll_compose_approval = AsyncMock(return_value="approved")
+    handler._compose_shim_snapshot = lambda agent_id: ["write_file"]  # forces gate
+    handler._execute_compose = AsyncMock(
+        return_value=type("M", (), {"content": "ran", "type": "tool_result", "metadata": {}})()
+    )
+    tool_call = {"name": "compose", "params": {"program": "import asyncio\n"}}
+
+    msgs = []
+    with patch.object(th, "CODEEXEC_AUTOAPPROVE_READONLY", False):
+        async for msg in handler._handle_compose_tool(tool_call, "s1", [], _FakeCtx()):
+            msgs.append(msg)
+
+    handler._execute_compose.assert_awaited_once()
+    assert msgs[-1].content == "ran"
+
+
+@pytest.mark.asyncio
+async def test_compose_gate_denied_returns_refusal_and_skips_execution():
+    """A DENIED gate returns a refusal and never calls _execute_compose."""
+    import chat_workflow.tool_handler as th
+
+    handler = object.__new__(th.ToolHandlerMixin)
+    handler._persist_compose_approval = AsyncMock(return_value="gate-3")
+    handler._poll_compose_approval = AsyncMock(return_value="rejected")
+    handler._compose_shim_snapshot = lambda agent_id: ["write_file"]
+    handler._execute_compose = AsyncMock()
+    tool_call = {"name": "compose", "params": {"program": "import asyncio\n"}}
+
+    msgs = []
+    with patch.object(th, "CODEEXEC_AUTOAPPROVE_READONLY", False):
+        async for msg in handler._handle_compose_tool(tool_call, "s1", [], _FakeCtx()):
+            msgs.append(msg)
+
+    handler._execute_compose.assert_not_awaited()
+    assert any("not approved" in m.content for m in msgs)
+
+
+# ---------------------------------------------------------------------------
+# MINOR-3: budget cannot overshoot under concurrent reservation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_broker_budget_no_overshoot_concurrent():
+    """Concurrent handle_line calls must not exceed the budget cap."""
+    from chat_workflow.code_exec import broker as broker_mod
+    from chat_workflow.code_exec.broker import CodeExecBroker
+
+    async def _slow_dispatch(tool, params):
+        await asyncio.sleep(0)
+        return "ok"
+
+    with patch.object(broker_mod, "CODEEXEC_MAX_TOOL_CALLS", 3):
+        b = CodeExecBroker(
+            dispatch_fn=_slow_dispatch,
+            tools=["web_search"],
+            forbidden=frozenset(),
+            run_id="r",
+            security_event_key="k",
+        )
+        b._emit_audit = AsyncMock()
+        b._emit_progress = AsyncMock()
+        lines = [json.dumps({"id": i, "tool": "web_search", "params": {}}) for i in range(10)]
+        replies = await asyncio.gather(*(b.handle_line(x) for x in lines))
+    ok_count = sum(1 for r in replies if json.loads(r)["ok"])
+    assert ok_count == 3  # never overshoots the cap

--- a/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
@@ -1,0 +1,278 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for chat_workflow.code_exec package (GH#11568)."""
+
+import json
+import pathlib
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Ensure the backend is on sys.path
+_BACKEND = pathlib.Path(__file__).parent.parent.parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+# ---------------------------------------------------------------------------
+# AST guard tests
+# ---------------------------------------------------------------------------
+
+
+def test_ast_guard_allowed_script():
+    """Script using only allowlisted imports passes."""
+    from chat_workflow.code_exec.ast_guard import check_script
+
+    script = "import asyncio\nimport json\nresult = json.dumps({'x': 1})\n"
+    result = check_script(script, frozenset())
+    assert result.ok
+    assert result.violations == []
+
+
+def test_ast_guard_blocked_import():
+    """import os is not in the allowlist and must be rejected."""
+    from chat_workflow.code_exec.ast_guard import check_script
+
+    result = check_script("import os\n", frozenset())
+    assert not result.ok
+    assert any("forbidden import" in v["message"] for v in result.violations)
+
+
+def test_ast_guard_blocked_eval():
+    """eval() call must be rejected."""
+    from chat_workflow.code_exec.ast_guard import check_script
+
+    result = check_script("import json\nx = eval('1+1')\n", frozenset())
+    assert not result.ok
+    assert any("eval" in v["message"] for v in result.violations)
+
+
+def test_ast_guard_blocked_exec():
+    """exec() call must be rejected."""
+    from chat_workflow.code_exec.ast_guard import check_script
+
+    result = check_script("exec('print(1)')\n", frozenset())
+    assert not result.ok
+    assert any("exec" in v["message"] for v in result.violations)
+
+
+def test_ast_guard_blocked_getattr_smuggling():
+    """getattr(autobot_tools, computed_name) must be rejected."""
+    from chat_workflow.code_exec.ast_guard import check_script
+
+    script = "import autobot_tools\nfn = getattr(autobot_tools, 'web_search')\n"
+    result = check_script(script, frozenset())
+    assert not result.ok
+    assert any("smuggling" in v["message"] for v in result.violations)
+
+
+def test_ast_guard_blocked_forbidden_token():
+    """A name that matches a forbidden_work token must be rejected."""
+    from chat_workflow.code_exec.ast_guard import check_script
+
+    result = check_script("x = bash_run\n", frozenset({"bash_run"}))
+    assert not result.ok
+    assert any("forbidden token" in v["message"] for v in result.violations)
+
+
+def test_ast_guard_syntax_error():
+    """Malformed Python must produce a SyntaxError violation."""
+    from chat_workflow.code_exec.ast_guard import check_script
+
+    result = check_script("def broken(:\n    pass\n", frozenset())
+    assert not result.ok
+    assert any("SyntaxError" in v["message"] for v in result.violations)
+
+
+# ---------------------------------------------------------------------------
+# Shim codegen tests
+# ---------------------------------------------------------------------------
+
+
+def test_shim_codegen_generates_functions():
+    """generate_shim_module must produce async def for each tool."""
+    from chat_workflow.code_exec.shim_codegen import generate_shim_module
+
+    src = generate_shim_module(["web_search", "scrape_url"])
+    assert "async def web_search" in src
+    assert "async def scrape_url" in src
+
+
+def test_injectable_tool_set_empty_allowed():
+    """When allowed_work is empty, all CODEEXEC_INJECTABLE_TOOLS minus forbidden are returned."""
+    from chat_workflow.code_exec.shim_codegen import CODEEXEC_INJECTABLE_TOOLS, injectable_tool_set
+
+    result = injectable_tool_set([], frozenset())
+    assert set(result) == CODEEXEC_INJECTABLE_TOOLS
+
+
+def test_injectable_tool_set_forbidden_excluded():
+    """Forbidden tools must not appear in the injectable set."""
+    from chat_workflow.code_exec.shim_codegen import injectable_tool_set
+
+    result = injectable_tool_set([], frozenset({"web_search"}))
+    assert "web_search" not in result
+
+
+# ---------------------------------------------------------------------------
+# Broker enforcement tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_broker_rejects_non_shimmed_tool():
+    """handle_line must return ok=False for a tool not in the injectable list."""
+    from chat_workflow.code_exec.broker import CodeExecBroker
+
+    dispatch = AsyncMock(return_value="result")
+    broker = CodeExecBroker(
+        dispatch_fn=dispatch,
+        tools=["web_search"],
+        forbidden=frozenset(),
+        run_id="test-run",
+        security_event_key="autobot:codeexec:audit",
+    )
+    line = json.dumps({"id": "x", "tool": "execute_command", "params": {}})
+    reply = json.loads(await broker.handle_line(line))
+    assert reply["ok"] is False
+    assert "not injectable" in reply["error"]
+
+
+@pytest.mark.asyncio
+async def test_broker_budget_cap():
+    """After CODEEXEC_MAX_TOOL_CALLS calls the next call must be rejected."""
+    from chat_workflow.code_exec import broker as broker_mod
+    from chat_workflow.code_exec.broker import CodeExecBroker
+
+    dispatch = AsyncMock(return_value="result")
+    with patch.object(broker_mod, "CODEEXEC_MAX_TOOL_CALLS", 2):
+        b = CodeExecBroker(
+            dispatch_fn=dispatch,
+            tools=["web_search"],
+            forbidden=frozenset(),
+            run_id="run-cap",
+            security_event_key="autobot:codeexec:audit",
+        )
+        # Patch _emit_audit to avoid Redis calls
+        b._emit_audit = AsyncMock()
+        for _ in range(2):
+            line = json.dumps({"id": "x", "tool": "web_search", "params": {}})
+            reply = json.loads(await b.handle_line(line))
+            assert reply["ok"] is True
+        # Third call must be rejected
+        reply = json.loads(await b.handle_line(json.dumps({"id": "y", "tool": "web_search", "params": {}})))
+        assert reply["ok"] is False
+        assert "budget" in reply["error"]
+
+
+# ---------------------------------------------------------------------------
+# Compose flag-off test
+# ---------------------------------------------------------------------------
+
+
+def test_compose_absent_from_schemas_when_flag_off():
+    """When CODEEXEC_ENABLED is False, 'compose' must not be in _BUILTIN_TOOL_SCHEMAS."""
+    import chat_workflow.tool_handler as th
+
+    # Re-read current value; if flag is off by default this should hold
+    if not th.CODEEXEC_ENABLED:
+        assert "compose" not in th._BUILTIN_TOOL_SCHEMAS
+
+
+# ---------------------------------------------------------------------------
+# _handle_compose_tool tests (with fakes / patches)
+# ---------------------------------------------------------------------------
+
+
+class _FakeCtx:
+    agent_context = None
+    consecutive_invalid_tool_calls = 0
+
+
+class _FakeCtxWithAgent:
+    class _AC:
+        agent_id = "research_agent"
+
+    agent_context = _AC()
+    consecutive_invalid_tool_calls = 0
+
+
+@pytest.mark.asyncio
+async def test_compose_delegated_subagent_rejected():
+    """compose must yield error when ctx has an agent_context (delegated subagent)."""
+    import chat_workflow.tool_handler as th
+
+    handler = object.__new__(th.ToolHandlerMixin)
+    msgs = []
+    tool_call = {"name": "compose", "params": {"program": "x = 1"}}
+    async for msg in handler._handle_compose_tool(tool_call, "s1", [], _FakeCtxWithAgent()):
+        msgs.append(msg)
+    assert msgs
+    assert "not available" in msgs[0].content
+
+
+@pytest.mark.asyncio
+async def test_compose_ast_violation_rejected():
+    """compose must yield a tool_result error when AST guard fires."""
+    import chat_workflow.tool_handler as th
+
+    handler = object.__new__(th.ToolHandlerMixin)
+    tool_call = {"name": "compose", "params": {"program": "import os"}}
+    msgs = []
+    async for msg in handler._handle_compose_tool(tool_call, "s1", [], _FakeCtx()):
+        msgs.append(msg)
+    assert msgs
+    assert "AST guard" in msgs[0].content or "rejected" in msgs[0].content
+
+
+@pytest.mark.asyncio
+async def test_compose_approval_gate_creates_record():
+    """When CODEEXEC_AUTOAPPROVE_READONLY is False, compose yields approval_required."""
+    import chat_workflow.tool_handler as th
+
+    handler = object.__new__(th.ToolHandlerMixin)
+    # A syntactically valid program that passes AST guard
+    program = "import asyncio\nresult = 1\n"
+    tool_call = {"name": "compose", "params": {"program": program}}
+    msgs = []
+    with patch.object(th, "CODEEXEC_AUTOAPPROVE_READONLY", False):
+        async for msg in handler._handle_compose_tool(tool_call, "s1", [], _FakeCtx()):
+            msgs.append(msg)
+    assert msgs
+    assert any(m.type == "approval_required" for m in msgs)
+
+
+@pytest.mark.asyncio
+async def test_compose_e2e_with_fake_executor():
+    """End-to-end: fake SecureSandboxExecutor returns success; result WorkflowMessage carries stdout."""
+    import chat_workflow.tool_handler as th
+    from secure_sandbox_executor import SandboxResult
+
+    handler = object.__new__(th.ToolHandlerMixin)
+    program = "import asyncio\nresult = 42\n"
+    tool_call = {"name": "compose", "params": {"program": program}}
+
+    fake_result = SandboxResult(
+        success=True,
+        exit_code=0,
+        stdout="42\n",
+        stderr="",
+        execution_time=0.1,
+        container_id="fake-container",
+        security_events=[],
+        resource_usage={},
+        metadata={},
+    )
+    fake_executor_instance = MagicMock()
+    fake_executor_instance.execute_with_stdio_broker = AsyncMock(return_value=fake_result)
+
+    msgs = []
+    with patch("chat_workflow.tool_handler.CODEEXEC_AUTOAPPROVE_READONLY", True):
+        with patch("secure_sandbox_executor.SecureSandboxExecutor", return_value=fake_executor_instance):
+            async for msg in handler._handle_compose_tool(tool_call, "s1", [], _FakeCtx()):
+                msgs.append(msg)
+
+    assert msgs
+    result_msg = msgs[-1]
+    assert "42" in result_msg.content

--- a/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
@@ -422,6 +422,19 @@ _ESCAPE_CORPUS = [
     # LEAK-3: delattr smuggling + hasattr with a dunder/computed name.
     "delattr(object, 'x')",
     "hasattr(o, '__class__')",
+    # Builtin-ALLOWLIST wave: dangerous builtins caught by allowlist, not blocklist.
+    # print/open/input MUST reject — the broker RPC uses the script's stdout for
+    # requests and stdin for replies, so print() corrupts the request stream and
+    # input() steals a broker reply (protocol integrity, not just sandboxing).
+    "open('/etc/passwd')",
+    "input()",
+    "print('x')",
+    "type('X',(object,),{})",
+    "memoryview(b'x')",
+    "id(o)",
+    "dir()",
+    "object()",
+    "super",
 ]
 
 
@@ -444,6 +457,13 @@ _CLEAN_CORPUS = [
         "    return r\n"
     ),
     ("import asyncio, json\n" "async def run():\n" "    r = await scrape_url(url='x')\n" "    return json.dumps(r)\n"),
+    # Uses SAFE_BUILTINS range/len + math + a comprehension — must pass.
+    (
+        "import math\n"
+        "vals = extract_structured_data(url='u', schema={})\n"
+        "n = math.floor(1.5)\n"
+        "items = [x for x in range(len(vals))]\n"
+    ),
 ]
 
 
@@ -454,6 +474,29 @@ def test_ast_guard_accepts_clean_scripts(script):
 
     result = check_script(script, frozenset())
     assert result.ok, f"clean script wrongly rejected: {result.violations}"
+
+
+def test_ast_guard_allows_locally_shadowed_builtin_name():
+    """A user-defined function shadowing a builtin name is not a builtin violation."""
+    from chat_workflow.code_exec.ast_guard import check_script
+
+    script = "def helper(x):\n    return x + 1\n" "result = helper(1)\n"
+    assert check_script(script, frozenset()).ok
+
+
+def test_ast_guard_builtins_allowlist_is_env_extendable():
+    """AUTOBOT_CODEEXEC_BUILTINS_ALLOWLIST content is honored (env-extendable constant)."""
+    import importlib
+
+    import chat_workflow.code_exec.ast_guard as guard
+
+    # 'print' is excluded by default; a reload with it whitelisted must accept it.
+    with patch.dict("os.environ", {"AUTOBOT_CODEEXEC_BUILTINS_ALLOWLIST": "len,range,print"}):
+        reloaded = importlib.reload(guard)
+        try:
+            assert reloaded.check_script("print('x')", frozenset()).ok
+        finally:
+            importlib.reload(guard)  # restore default module state for other tests
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #11568. Implements the owner-approved design `docs/architecture/designs/CODE_EXECUTION_AGENT_MODE_DESIGN.md` (umbrella #11518 T6 follow-through).

## Thinking Path
Code-execution agent mode: the LLM writes one Python script that calls many tools in a Docker sandbox (one inference vs N tool-call roundtrips). The whole risk is the governance/sandbox layer, so this shipped behind `AUTOBOT_CODEEXEC_ENABLED` (default **false** — zero behavior change until flipped) and went through an adversarial security review plus four rounds of independent AST-guard probing.

## What Changed
- **`chat_workflow/code_exec/`**: `ast_guard.py` (static gate), `shim_codegen.py` (generates the `autobot_tools` JSON-RPC module for the injectable tool set), `broker.py` (server-side capability channel — re-validates every call, atomic budget, dual-bus progress + Redis audit).
- **`secure_sandbox_executor.py`**: `execute_with_stdio_broker` at HIGH/no-network; Docker frame demux; single container start; script mounted as a file (no ARG_MAX).
- **`tool_handler.py`**: `compose` tool gated on the flag; `_dispatch_tool_call` branch; whole-script WORKFLOW_GATE approval with an approval-awaited continuation; auto-approve only when all shims ∈ `CODEEXEC_READONLY_TOOLS`; main-chat-agent-only.
- **`llm_handler.py`**: compose prompt teaching, gated on the flag.

## Governance (design §3) — three layers
1. **Unrepresentable**: sensitive tools (`execute_command`/`compose`/`delegate`/…) unconditionally subtracted from the injectable set — env-widening can't inject them.
2. **AST guard (allowlist model)**: imports allowlisted; dunder attribute access blocked; reflective accessors (`getattr/setattr/delattr/hasattr`) blocked; builtins **allowlisted** to a pure-compute `SAFE_BUILTINS` set (so `open`/`input`/`print`/`type`/`eval`/`__import__`/… reject by construction — new dangerous builtins can never leak). `print`/`open`/`input` excluded specifically because the broker RPC owns the script's stdout/stdin.
3. **Broker**: re-validates every shim call server-side against allowlist + forbidden_work + budget, so an AST bypass still can't reach a forbidden tool.

## Verification
- `pytest test_code_exec.py` → **63 passed**; regression `-k "dispatch or tool_handler or delegat or compose"` → **74 passed, 0 regressions**
- Security review (adversarial, security-first): 4 blockers + 3 majors + minors — all fixed, each with a named regression test (container-start-once, Docker frame demux, readonly auto-approve gate, approval continuation, per-call RPC ids, sensitive-tool exclusion, atomic budget).
- **Four independent AST-guard probes** beyond the agent's corpus (≈90 attack patterns total): escapes found and closed across mro/dunder chains, `__builtins__` access, module-alias smuggling, computed-getattr, `eval` as decorator/name, `delattr`, and the full dangerous-builtin class (`open`/`input`/`print`/`type`/…). Final probe: 36/37 rejected; the 1 accept (`bytearray().fromhex`) is a benign method call reaching nothing. Clean scripts incl. builtin-shadowing all pass.
- flake8 `--config=.flake8` + black `-l 120` clean.

## Follow-up (validation gate before flipping the flag)
Real Docker stdio piping (`_pump_broker_io`/`attach_socket`) is exercised only in production; tests use the design's fake-runner. Needs an on-box integration smoke against the `autobot/secure-sandbox` image before `AUTOBOT_CODEEXEC_ENABLED` is ever set true — filing as a follow-up.

## Model Used
Claude (Fable 5) orchestrating + adversarial AST probing; Sonnet implementation agent; Sonnet security code-reviewer.
