### PR TITLE
fix(celery): idempotency guard, retry backoff, and dead-letter parking (#11586)

### DIFF
--- a/autobot-backend/initialization/endpoints.py
+++ b/autobot-backend/initialization/endpoints.py
@@ -210,6 +210,23 @@ def register_root_endpoints(app: FastAPI) -> None:
             "workers": cross["workers"],
         }
 
+    @app.get("/api/health/celery-dead-letter")
+    @with_error_handling(category=ErrorCategory.SYSTEM)
+    async def celery_dead_letter_health(limit: int = 20):
+        """Parked Celery tasks (retries exhausted) from the dead-letter list (#11586).
+
+        Returns the parked count plus the most recent entries recorded by
+        ``utils.celery_reliability.DeadLetterTask`` so terminally failed tasks
+        stay queryable after the Celery result TTL expires.
+        """
+        from utils.celery_reliability import get_dead_letter_status
+
+        status = await get_dead_letter_status(limit=limit)
+        return {
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            **status,
+        }
+
     @app.get("/api/version")
     @with_error_handling(category=ErrorCategory.SYSTEM)
     async def root_version():
@@ -230,7 +247,8 @@ def register_root_endpoints(app: FastAPI) -> None:
 
     logger.info(
         "Root endpoints registered: /api/health, /api/health/ai-stack, "
-        "/api/health/circuit-breakers, /api/version, /.well-known/agent.json"
+        "/api/health/circuit-breakers, /api/health/celery-dead-letter, "
+        "/api/version, /.well-known/agent.json"
     )
 
 

--- a/autobot-backend/llc/scheduler/project_disposal_sweep.py
+++ b/autobot-backend/llc/scheduler/project_disposal_sweep.py
@@ -30,11 +30,29 @@ from llc.models.enums import ApprovalStatus
 from llc.models.sprint import LLCProject
 from llc.services.project_disposal import dispose
 from user_management.database import get_async_session_factory
+from utils.celery_reliability import (
+    CELERY_MAX_RETRIES,
+    CELERY_RETRY_BACKOFF_MAX,
+    CELERY_TRANSIENT_ERRORS,
+    DeadLetterTask,
+)
 
 logger = logging.getLogger(__name__)
 
 
-@shared_task(name="llc.scheduler.project_disposal_sweep.run_disposal_sweep", bind=True, max_retries=3)
+# #11586: transient errors (ConnectionError/TimeoutError/OSError) retry with
+# jittered exponential backoff; validation errors fail fast; terminal failures
+# are parked in the Redis dead-letter list by DeadLetterTask.
+@shared_task(
+    name="llc.scheduler.project_disposal_sweep.run_disposal_sweep",
+    bind=True,
+    base=DeadLetterTask,
+    autoretry_for=CELERY_TRANSIENT_ERRORS,
+    retry_backoff=True,
+    retry_jitter=True,
+    retry_backoff_max=CELERY_RETRY_BACKOFF_MAX,
+    max_retries=CELERY_MAX_RETRIES,
+)
 def run_disposal_sweep(self: object) -> dict:  # type: ignore[type-arg]
     """Sync Celery entry point — disposes projects whose retention has elapsed."""
     try:

--- a/autobot-backend/llc/scheduler/sprint_autoclose.py
+++ b/autobot-backend/llc/scheduler/sprint_autoclose.py
@@ -22,6 +22,12 @@ import logging
 from celery import shared_task
 
 from user_management.database import get_async_session_factory
+from utils.celery_reliability import (
+    CELERY_MAX_RETRIES,
+    CELERY_RETRY_BACKOFF_MAX,
+    CELERY_TRANSIENT_ERRORS,
+    DeadLetterTask,
+)
 
 from ..services.sprint_autoclose import SprintAutoCloseService
 
@@ -30,7 +36,19 @@ logger = logging.getLogger(__name__)
 _svc = SprintAutoCloseService()
 
 
-@shared_task(name="llc.scheduler.sprint_autoclose.run_daily_check", bind=True, max_retries=3)
+# #11586: transient errors (ConnectionError/TimeoutError/OSError) retry with
+# jittered exponential backoff; validation errors fail fast; terminal failures
+# are parked in the Redis dead-letter list by DeadLetterTask.
+@shared_task(
+    name="llc.scheduler.sprint_autoclose.run_daily_check",
+    bind=True,
+    base=DeadLetterTask,
+    autoretry_for=CELERY_TRANSIENT_ERRORS,
+    retry_backoff=True,
+    retry_jitter=True,
+    retry_backoff_max=CELERY_RETRY_BACKOFF_MAX,
+    max_retries=CELERY_MAX_RETRIES,
+)
 def run_daily_check(self: object) -> dict:  # type: ignore[type-arg]
     """Celery task — detects expired sprints and queues SPRINT_CLOSE approvals.
 

--- a/autobot-backend/tasks/system_tasks.py
+++ b/autobot-backend/tasks/system_tasks.py
@@ -13,11 +13,33 @@ Stubs maintained for backward compatibility with existing API endpoints.
 
 from autobot_shared.logging_manager import get_logger
 from celery_app import celery_app
+from utils.celery_reliability import (
+    CELERY_MAX_RETRIES,
+    CELERY_RETRY_BACKOFF_MAX,
+    CELERY_TRANSIENT_ERRORS,
+    DeadLetterTask,
+    idempotent_task,
+)
 
 logger = get_logger(__name__)
 
+# #11586: shared reliability options for the side-effectful queue tasks below
+# (deployments queue). Transient errors back off with jitter; validation errors
+# fail fast; terminal failures are parked by DeadLetterTask; duplicate broker
+# deliveries are skipped by @idempotent_task.
+_RELIABLE_TASK_OPTIONS = {
+    "bind": True,
+    "base": DeadLetterTask,
+    "autoretry_for": CELERY_TRANSIENT_ERRORS,
+    "retry_backoff": True,
+    "retry_jitter": True,
+    "retry_backoff_max": CELERY_RETRY_BACKOFF_MAX,
+    "max_retries": CELERY_MAX_RETRIES,
+}
 
-@celery_app.task(bind=True, name="tasks.initialize_rbac")
+
+@celery_app.task(name="tasks.initialize_rbac", **_RELIABLE_TASK_OPTIONS)
+@idempotent_task
 def initialize_rbac(self, create_admin: bool = False, admin_username: str = "admin"):
     """
     Initialize RBAC system using Ansible playbook (Issue #687).
@@ -39,7 +61,8 @@ def initialize_rbac(self, create_admin: bool = False, admin_username: str = "adm
     raise NotImplementedError("RBAC initialization moved to SLM server. Use SLM API for RBAC setup (#729).")
 
 
-@celery_app.task(bind=True, name="tasks.run_system_update")
+@celery_app.task(name="tasks.run_system_update", **_RELIABLE_TASK_OPTIONS)
+@idempotent_task
 def run_system_update(
     self,
     update_type: str = "dependencies",
@@ -69,7 +92,8 @@ def run_system_update(
     raise NotImplementedError("System updates moved to SLM server. Use SLM API for system updates (#729).")
 
 
-@celery_app.task(bind=True, name="tasks.check_available_updates")
+@celery_app.task(name="tasks.check_available_updates", **_RELIABLE_TASK_OPTIONS)
+@idempotent_task
 def check_available_updates(self):
     """
     Check for available updates without applying them (Issue #544).

--- a/autobot-backend/tasks/system_tasks_reliability_test.py
+++ b/autobot-backend/tasks/system_tasks_reliability_test.py
@@ -1,0 +1,69 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression tests: reliability options on side-effectful queue tasks (#11586).
+
+The tasks routed to the ``deployments``/``provisioning``/``services`` queues
+must carry the idempotency guard, the canonical transient-error retry policy
+(backoff + jitter, validation errors fail fast) and the dead-letter base so
+broker redelivery cannot duplicate side effects and terminal failures are
+parked instead of vanishing.
+
+Infrastructure stubs (celery_app, Redis, logging) come from conftest.py in
+this directory and the repository root — no live stack is needed.
+"""
+
+from __future__ import annotations
+
+
+def _reliable_tasks():
+    from tasks.system_tasks import check_available_updates, initialize_rbac, run_system_update
+
+    return [initialize_rbac, run_system_update, check_available_updates]
+
+
+def test_queue_tasks_use_dead_letter_base():
+    """Terminal failures must be parked via the DeadLetterTask base."""
+    from utils.celery_reliability import DeadLetterTask
+
+    for task in _reliable_tasks():
+        assert isinstance(task, DeadLetterTask), f"{task.name} missing DeadLetterTask base"
+
+
+def test_queue_tasks_retry_policy():
+    """Transient errors back off with jitter; retries are env-bounded."""
+    from utils.celery_reliability import (
+        CELERY_MAX_RETRIES,
+        CELERY_RETRY_BACKOFF_MAX,
+        CELERY_TRANSIENT_ERRORS,
+    )
+
+    for task in _reliable_tasks():
+        assert task.autoretry_for == CELERY_TRANSIENT_ERRORS, task.name
+        assert task.retry_backoff is True, task.name
+        assert task.retry_jitter is True, task.name
+        assert task.retry_backoff_max == CELERY_RETRY_BACKOFF_MAX, task.name
+        assert task.max_retries == CELERY_MAX_RETRIES, task.name
+
+
+def test_queue_tasks_never_retry_validation_errors():
+    """ValueError/TypeError must not be in the autoretry set (#7010 split)."""
+    for task in _reliable_tasks():
+        assert ValueError not in task.autoretry_for, task.name
+        assert TypeError not in task.autoretry_for, task.name
+
+
+def test_queue_tasks_are_idempotency_guarded(monkeypatch):
+    """Duplicate delivery of a claimed task_id must skip the task body."""
+    import utils.celery_reliability as cr
+
+    monkeypatch.setattr(cr, "_claim_task_id", lambda _task_id: False)
+
+    for task in _reliable_tasks():
+        result = task.apply(task_id="dup-guard-1").get()
+        assert result == {
+            "task_id": "dup-guard-1",
+            "status": "skipped",
+            "reason": "duplicate_delivery",
+        }, f"{task.name} executed despite an existing dedup claim"

--- a/autobot-backend/tests/initialization/test_health_celery_dead_letter.py
+++ b/autobot-backend/tests/initialization/test_health_celery_dead_letter.py
@@ -1,0 +1,53 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Wiring test for the /api/health/celery-dead-letter endpoint (#11586).
+
+Verifies the dead-letter health endpoint is registered by
+``register_root_endpoints`` (called from app_factory) and returns the parked
+count + recent entries produced by ``utils.celery_reliability``.
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _build_app() -> FastAPI:
+    from initialization.endpoints import register_root_endpoints
+
+    app = FastAPI()
+    register_root_endpoints(app)
+    return app
+
+
+def test_celery_dead_letter_route_registered():
+    """The endpoint must be present among the root health routes."""
+    app = _build_app()
+    paths = {getattr(route, "path", None) for route in app.routes}
+    assert "/api/health/celery-dead-letter" in paths
+
+
+def test_celery_dead_letter_endpoint_returns_status(monkeypatch):
+    """The endpoint must surface count + recent entries from the accessor."""
+    import utils.celery_reliability as cr
+
+    async def _fake_status(limit: int = 20):
+        return {
+            "available": True,
+            "parked": 2,
+            "recent": [{"task_id": "p-1", "status": "parked"}][:limit],
+        }
+
+    monkeypatch.setattr(cr, "get_dead_letter_status", _fake_status)
+
+    app = _build_app()
+    with TestClient(app) as client:
+        response = client.get("/api/health/celery-dead-letter")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["available"] is True
+    assert body["parked"] == 2
+    assert body["recent"][0]["task_id"] == "p-1"
+    assert "timestamp" in body

--- a/autobot-backend/tests/integration/test_celery_reliability.py
+++ b/autobot-backend/tests/integration/test_celery_reliability.py
@@ -1,0 +1,281 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Integration tests for Celery reliability helpers (#11586).
+
+Covers the three acceptance criteria:
+  (a) re-delivering an already-executed task_id is a no-op (idempotency guard)
+  (b) transient errors engage the retry path; validation errors fail fast
+  (c) retry-exhausted tasks land in the queryable Redis dead-letter list
+
+Uses fakeredis for isolation (same pattern as test_task_claim_race.py) and an
+in-process eager Celery app so no broker is required.
+"""
+
+import json
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Redis fixture: fakeredis for isolation (skip when not installed).
+# ---------------------------------------------------------------------------
+
+try:
+    import fakeredis
+    import fakeredis.aioredis as fakeredis_async
+
+    _FAKEREDIS_AVAILABLE = True
+except ImportError:
+    _FAKEREDIS_AVAILABLE = False
+
+from celery import Celery
+from celery.exceptions import Retry
+
+import utils.celery_reliability as cr
+from utils.celery_reliability import (
+    CELERY_TRANSIENT_ERRORS,
+    DEAD_LETTER_KEY,
+    DEDUP_KEY_PREFIX,
+    DeadLetterTask,
+    idempotent_task,
+)
+
+pytestmark = pytest.mark.skipif(not _FAKEREDIS_AVAILABLE, reason="fakeredis not installed")
+
+
+@pytest.fixture
+def fake_sync_redis(monkeypatch):
+    """Patch the sync Redis seam in celery_reliability with fakeredis."""
+    server = fakeredis.FakeServer()
+    client = fakeredis.FakeRedis(server=server, decode_responses=True)
+    monkeypatch.setattr(cr, "get_redis_client", lambda *_a, **_k: client)
+    return client
+
+
+@pytest.fixture
+def eager_app():
+    """In-process Celery app: eager execution, exceptions propagate."""
+    app = Celery("reliability-test", broker="memory://", backend="cache+memory://")
+    app.conf.task_always_eager = True
+    app.conf.task_eager_propagates = True
+    return app
+
+
+# ---------------------------------------------------------------------------
+# (a) Idempotency guard — duplicate delivery of the same task_id is a no-op
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_task_id_is_noop(fake_sync_redis, eager_app):
+    """Second delivery of an already-claimed task_id must not re-execute."""
+    calls = []
+
+    @eager_app.task(bind=True, name="test.reliability.side_effect")
+    @idempotent_task
+    def side_effect(self):
+        calls.append(1)
+        return {"status": "ok"}
+
+    first = side_effect.apply(task_id="dup-1").get()
+    second = side_effect.apply(task_id="dup-1").get()
+
+    assert first == {"status": "ok"}
+    assert len(calls) == 1, "duplicate delivery must not re-execute the task body"
+    assert second == {"task_id": "dup-1", "status": "skipped", "reason": "duplicate_delivery"}
+
+
+def test_dedup_claim_written_with_ttl(fake_sync_redis, eager_app):
+    """The dedup key must exist with a TTL after first execution."""
+
+    @eager_app.task(bind=True, name="test.reliability.claims")
+    @idempotent_task
+    def claims(self):
+        return {"status": "ok"}
+
+    claims.apply(task_id="ttl-1")
+
+    key = f"{DEDUP_KEY_PREFIX}ttl-1"
+    assert fake_sync_redis.get(key) == "1"
+    assert 0 < fake_sync_redis.ttl(key) <= cr.CELERY_DEDUP_TTL
+
+
+def test_distinct_task_ids_both_execute(fake_sync_redis, eager_app):
+    """Different task_ids are independent — no cross-task blocking."""
+    calls = []
+
+    @eager_app.task(bind=True, name="test.reliability.independent")
+    @idempotent_task
+    def independent(self):
+        calls.append(1)
+        return {"status": "ok"}
+
+    independent.apply(task_id="ind-1")
+    independent.apply(task_id="ind-2")
+
+    assert len(calls) == 2
+
+
+def test_retry_attempt_bypasses_dedup_guard(fake_sync_redis, eager_app):
+    """A retry (retries > 0) of a claimed task_id is a legitimate re-execution."""
+    calls = []
+
+    @eager_app.task(bind=True, name="test.reliability.retry_pass")
+    @idempotent_task
+    def retry_pass(self):
+        calls.append(1)
+        return {"status": "ok"}
+
+    retry_pass.apply(task_id="retry-1")  # first attempt claims the key
+    result = retry_pass.apply(task_id="retry-1", retries=1).get()
+
+    assert len(calls) == 2, "retries must bypass the dedup guard"
+    assert result == {"status": "ok"}
+
+
+def test_redis_unavailable_fails_open(monkeypatch, eager_app):
+    """Without Redis the guard must not block execution (fail-open)."""
+    monkeypatch.setattr(cr, "get_redis_client", lambda *_a, **_k: None)
+    calls = []
+
+    @eager_app.task(bind=True, name="test.reliability.failopen")
+    @idempotent_task
+    def failopen(self):
+        calls.append(1)
+        return {"status": "ok"}
+
+    failopen.apply(task_id="open-1")
+    failopen.apply(task_id="open-1")
+
+    assert len(calls) == 2, "Redis outage must not turn into a task outage"
+
+
+# ---------------------------------------------------------------------------
+# (b) Retry classification — transient retries, validation fails fast
+# ---------------------------------------------------------------------------
+
+
+def test_transient_error_engages_retry(fake_sync_redis, eager_app):
+    """ConnectionError must be converted into a Celery retry, not a failure."""
+
+    @eager_app.task(
+        bind=True,
+        base=DeadLetterTask,
+        name="test.reliability.transient",
+        autoretry_for=CELERY_TRANSIENT_ERRORS,
+        retry_backoff=True,
+        retry_jitter=True,
+        max_retries=3,
+    )
+    def transient(self):
+        raise ConnectionError("redis briefly unavailable")
+
+    with pytest.raises(Retry):
+        transient.apply(task_id="transient-1", throw=True)
+
+
+def test_validation_error_fails_fast(fake_sync_redis, eager_app):
+    """ValueError must propagate immediately without entering the retry path."""
+
+    @eager_app.task(
+        bind=True,
+        base=DeadLetterTask,
+        name="test.reliability.validation",
+        autoretry_for=CELERY_TRANSIENT_ERRORS,
+        retry_backoff=True,
+        retry_jitter=True,
+        max_retries=3,
+    )
+    def validation(self):
+        raise ValueError("bad input")
+
+    with pytest.raises(ValueError):
+        validation.apply(task_id="validation-1", throw=True)
+
+
+# ---------------------------------------------------------------------------
+# (c) Dead-letter parking — exhausted retries land in a queryable parked list
+# ---------------------------------------------------------------------------
+
+
+def test_exhausted_retries_park_dead_letter_entry(fake_sync_redis, eager_app):
+    """When retries are exhausted, the task must be parked with error detail."""
+
+    @eager_app.task(
+        bind=True,
+        base=DeadLetterTask,
+        name="test.reliability.exhaust",
+        autoretry_for=CELERY_TRANSIENT_ERRORS,
+        retry_backoff=True,
+        retry_jitter=True,
+        max_retries=2,
+    )
+    def exhaust(self, target: str):
+        raise ConnectionError("still down")
+
+    # retries == max_retries → autoretry re-raises the original exception and
+    # Celery invokes on_failure (throw=False mirrors worker-side handling).
+    result = exhaust.apply(args=("host-1",), task_id="exhaust-1", retries=2, throw=False)
+
+    assert result.state == "FAILURE"
+    entries = fake_sync_redis.lrange(DEAD_LETTER_KEY, 0, -1)
+    assert len(entries) == 1
+    entry = json.loads(entries[0])
+    assert entry["task_name"] == "test.reliability.exhaust"
+    assert entry["task_id"] == "exhaust-1"
+    assert entry["status"] == "parked"
+    assert "ConnectionError" in entry["error"]
+    assert "host-1" in entry["args_summary"]
+    assert entry["timestamp"]
+
+
+def test_dead_letter_list_is_bounded(fake_sync_redis, monkeypatch):
+    """The parked list must never exceed CELERY_DEAD_LETTER_MAX entries."""
+    monkeypatch.setattr(cr, "CELERY_DEAD_LETTER_MAX", 3)
+
+    for i in range(5):
+        cr.park_dead_letter("test.reliability.bound", f"bound-{i}", "args=() kwargs={}", "boom")
+
+    entries = fake_sync_redis.lrange(DEAD_LETTER_KEY, 0, -1)
+    assert len(entries) == 3
+    # LPUSH ordering: newest first — oldest entries were trimmed.
+    assert json.loads(entries[0])["task_id"] == "bound-4"
+    assert json.loads(entries[-1])["task_id"] == "bound-2"
+
+
+async def test_dead_letter_status_queryable(monkeypatch):
+    """get_dead_letter_status must expose count + recent entries (health API)."""
+    server = fakeredis_async.FakeServer()
+    aclient = fakeredis_async.FakeRedis(server=server, decode_responses=True)
+
+    async def _fake_async_client(*_a, **_k):
+        return aclient
+
+    monkeypatch.setattr(cr, "get_async_redis_client", _fake_async_client)
+
+    for i in range(3):
+        await aclient.lpush(
+            DEAD_LETTER_KEY,
+            json.dumps({"task_name": "test.t", "task_id": f"q-{i}", "status": "parked"}),
+        )
+
+    status = await cr.get_dead_letter_status(limit=2)
+
+    assert status["available"] is True
+    assert status["parked"] == 3
+    assert len(status["recent"]) == 2
+    assert status["recent"][0]["task_id"] == "q-2"
+    await aclient.aclose()
+
+
+async def test_dead_letter_status_without_redis(monkeypatch):
+    """Health accessor degrades gracefully when Redis is unavailable."""
+
+    async def _no_client(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(cr, "get_async_redis_client", _no_client)
+
+    status = await cr.get_dead_letter_status()
+
+    assert status == {"available": False, "parked": 0, "recent": []}

--- a/autobot-backend/utils/celery_reliability.py
+++ b/autobot-backend/utils/celery_reliability.py
@@ -1,0 +1,202 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Celery reliability helpers: idempotency guard, retry policy, dead-letter parking (#11586).
+
+Celery delivers at-least-once: with the 12 h broker visibility timeout set in
+``celery_app.py``, a worker crash (or visibility-timeout overrun) mid-task
+causes broker redelivery and the task body runs twice.  ``idempotent_task``
+claims ``celery:dedup:{task_id}`` with ``SET NX`` before the body executes so
+a redelivered duplicate becomes a logged no-op.
+
+``DeadLetterTask`` parks terminally failed tasks (retries exhausted or a
+non-retryable error) in a bounded Redis list so failures stay queryable via
+``GET /api/health/celery-dead-letter`` instead of vanishing when the Celery
+result TTL expires.
+
+``CELERY_TRANSIENT_ERRORS`` mirrors the canonical retryable vs non-retryable
+exception split in ``autobot_shared/retry_mechanism.py`` (#7010):
+ConnectionError/TimeoutError/OSError back off with jitter; validation errors
+(ValueError/TypeError) fail fast and are never retried.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+from functools import wraps
+from typing import Any, Callable, Dict
+
+from celery import Task
+
+from autobot_shared.redis_client import get_async_redis_client, get_redis_client
+from autobot_shared.ssot_config import config
+from autobot_shared.status_enums import TaskStatus
+
+logger = logging.getLogger(__name__)
+
+# Transient errors that trigger Celery autoretry — the retryable set from
+# autobot_shared/retry_mechanism.py (#7010). ValueError/TypeError are
+# intentionally absent so validation failures fail fast without retry.
+CELERY_TRANSIENT_ERRORS = (ConnectionError, TimeoutError, OSError)
+
+DEDUP_KEY_PREFIX = "celery:dedup:"
+DEAD_LETTER_KEY = "celery:dead_letter"
+_REDIS_DATABASE = "main"
+_ARGS_SUMMARY_MAX_CHARS = 400
+
+
+def _resolve_positive_int(field_name: str, env_var: str, default: int) -> int:
+    """Return a positive int from ``config.misc.<field_name>``, else *default*."""
+    try:
+        raw = getattr(config.misc, field_name)
+    except Exception:  # config unavailable (e.g. stubbed in tests)
+        return default
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning("%s=%r is not an integer; falling back to %d", env_var, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("%s=%d must be positive; falling back to %d", env_var, value, default)
+        return default
+    return value
+
+
+# Dedup claims must outlive the broker visibility timeout (43200 s default in
+# celery_app.py), otherwise a redelivery after claim expiry re-executes the task.
+CELERY_DEDUP_TTL = _resolve_positive_int("celery_dedup_ttl", "AUTOBOT_CELERY_DEDUP_TTL", 43200)
+CELERY_MAX_RETRIES = _resolve_positive_int("celery_max_retries", "AUTOBOT_CELERY_MAX_RETRIES", 3)
+CELERY_RETRY_BACKOFF_MAX = _resolve_positive_int("celery_retry_backoff_max", "AUTOBOT_CELERY_RETRY_BACKOFF_MAX", 600)
+CELERY_DEAD_LETTER_MAX = _resolve_positive_int("celery_dead_letter_max", "AUTOBOT_CELERY_DEAD_LETTER_MAX", 500)
+
+
+def _claim_task_id(task_id: str) -> bool:
+    """Atomically claim *task_id*; False means another delivery already ran it."""
+    try:
+        client = get_redis_client(database=_REDIS_DATABASE)
+        if client is None:
+            # Fail open: without Redis there is nothing to dedup against and
+            # blocking execution would turn a cache outage into a task outage.
+            return True
+        return bool(client.set(f"{DEDUP_KEY_PREFIX}{task_id}", "1", nx=True, ex=CELERY_DEDUP_TTL))
+    except Exception:
+        logger.warning(
+            "Idempotency claim failed for task %s — proceeding without dedup",
+            task_id,
+            exc_info=True,
+        )
+        return True
+
+
+def idempotent_task(func: Callable) -> Callable:
+    """Skip re-execution when the same task_id was already delivered (#11586).
+
+    Must sit *below* ``@celery_app.task(bind=True)`` so it wraps the task body.
+    Retries (``self.request.retries > 0``) bypass the guard: the first attempt
+    already holds the claim and a retry is a legitimate re-execution.
+    """
+
+    @wraps(func)
+    def wrapper(self: Task, *args: Any, **kwargs: Any) -> Any:
+        request = getattr(self, "request", None)
+        task_id = getattr(request, "id", None)
+        retries = getattr(request, "retries", 0) or 0
+        if task_id and retries == 0 and not _claim_task_id(task_id):
+            logger.warning(
+                "Duplicate delivery of task %s (%s) — skipping re-execution",
+                self.name,
+                task_id,
+            )
+            return {
+                "task_id": task_id,
+                "status": TaskStatus.SKIPPED.value,
+                "reason": "duplicate_delivery",
+            }
+        return func(self, *args, **kwargs)
+
+    return wrapper
+
+
+def _summarize_args(args: Any, kwargs: Any) -> str:
+    """Bounded repr of task args/kwargs for the dead-letter record."""
+    summary = f"args={args!r} kwargs={kwargs!r}"
+    if len(summary) > _ARGS_SUMMARY_MAX_CHARS:
+        summary = summary[:_ARGS_SUMMARY_MAX_CHARS] + "…"
+    return summary
+
+
+def park_dead_letter(task_name: str, task_id: str, args_summary: str, error: str) -> None:
+    """Record a terminally failed task in the bounded Redis dead-letter list."""
+    entry = {
+        "task_name": task_name,
+        "task_id": task_id,
+        "args_summary": args_summary,
+        "error": error,
+        "status": TaskStatus.PARKED.value,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    logger.error("Celery task parked in dead-letter queue: %s (%s) — %s", task_name, task_id, error)
+    try:
+        client = get_redis_client(database=_REDIS_DATABASE)
+        if client is None:
+            return
+        pipe = client.pipeline()
+        pipe.lpush(DEAD_LETTER_KEY, json.dumps(entry))
+        pipe.ltrim(DEAD_LETTER_KEY, 0, CELERY_DEAD_LETTER_MAX - 1)
+        pipe.execute()
+    except Exception:
+        logger.error(
+            "Failed to park dead-letter entry for task %s (%s)",
+            task_name,
+            task_id,
+            exc_info=True,
+        )
+
+
+class DeadLetterTask(Task):
+    """Celery base task that parks terminal failures for operator review (#11586)."""
+
+    def on_failure(self, exc: BaseException, task_id: str, args: Any, kwargs: Any, einfo: Any) -> None:
+        """Celery hook — fires once per task, after retries are exhausted."""
+        park_dead_letter(
+            task_name=self.name,
+            task_id=task_id,
+            args_summary=_summarize_args(args, kwargs),
+            error=f"{type(exc).__name__}: {exc}",
+        )
+        super().on_failure(exc, task_id, args, kwargs, einfo)
+
+
+async def get_dead_letter_status(limit: int = 20) -> Dict[str, Any]:
+    """Return the parked-task count plus the *limit* most recent entries."""
+    redis = await get_async_redis_client(database=_REDIS_DATABASE)
+    if redis is None:
+        return {"available": False, "parked": 0, "recent": []}
+    count = await redis.llen(DEAD_LETTER_KEY)
+    raw_entries = await redis.lrange(DEAD_LETTER_KEY, 0, max(limit, 1) - 1)
+    recent = []
+    for raw in raw_entries:
+        text = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+        try:
+            recent.append(json.loads(text))
+        except json.JSONDecodeError:
+            recent.append({"raw": text})
+    return {"available": True, "parked": count, "recent": recent}
+
+
+__all__ = [
+    "CELERY_DEAD_LETTER_MAX",
+    "CELERY_DEDUP_TTL",
+    "CELERY_MAX_RETRIES",
+    "CELERY_RETRY_BACKOFF_MAX",
+    "CELERY_TRANSIENT_ERRORS",
+    "DEAD_LETTER_KEY",
+    "DEDUP_KEY_PREFIX",
+    "DeadLetterTask",
+    "get_dead_letter_status",
+    "idempotent_task",
+    "park_dead_letter",
+]

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -94,6 +94,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/health/celery-dead-letter": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Celery Dead Letter Health
+         * @description Parked Celery tasks (retries exhausted) from the dead-letter list (#11586).
+         *
+         *     Returns the parked count plus the most recent entries recorded by
+         *     ``utils.celery_reliability.DeadLetterTask`` so terminally failed tasks
+         *     stay queryable after the Celery result TTL expires.
+         */
+        get: operations["celery_dead_letter_health_api_health_celery_dead_letter_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/version": {
         parameters: {
             query?: never;
@@ -100672,6 +100696,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    celery_dead_letter_health_api_health_celery_dead_letter_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1367,7 +1367,11 @@ class MiscConfig(BaseSettings):
         alias="AUTOBOT_CACHE_L2_TTL",
         description="L2 Redis LLM response cache TTL in seconds",
     )
+    celery_dead_letter_max: str = Field(default="", alias="AUTOBOT_CELERY_DEAD_LETTER_MAX")
+    celery_dedup_ttl: str = Field(default="", alias="AUTOBOT_CELERY_DEDUP_TTL")
+    celery_max_retries: str = Field(default="", alias="AUTOBOT_CELERY_MAX_RETRIES")
     celery_result_expires: str = Field(default="", alias="AUTOBOT_CELERY_RESULT_EXPIRES")
+    celery_retry_backoff_max: str = Field(default="", alias="AUTOBOT_CELERY_RETRY_BACKOFF_MAX")
     celery_visibility_timeout: int = Field(default=0, alias="AUTOBOT_CELERY_VISIBILITY_TIMEOUT")
     chats_directory: str = Field(default="", alias="AUTOBOT_CHATS_DIRECTORY")
     chat_history_file: str = Field(default="", alias="AUTOBOT_CHAT_HISTORY_FILE")

--- a/autobot_shared/status_enums.py
+++ b/autobot_shared/status_enums.py
@@ -49,11 +49,12 @@ class TaskStatus(Enum):
     BLOCKED = "blocked"
     WAITING = "waiting"
     TIMEOUT = "timeout"  # #6520: services/agent_analytics + subagent_manager use TIMEOUT
+    PARKED = "parked"  # #11586: dead-letter terminal state — retries exhausted, awaiting operator review
 
     @classmethod
     def is_terminal(cls, status: "TaskStatus") -> bool:
         """Check if status is a terminal state (no further transitions)."""
-        return status in {cls.COMPLETED, cls.FAILED, cls.CANCELLED}
+        return status in {cls.COMPLETED, cls.FAILED, cls.CANCELLED, cls.PARKED}
 
     @classmethod
     def is_active(cls, status: "TaskStatus") -> bool:


### PR DESCRIPTION
Closes #11586. Part of #11584 (Task 2).

## Thinking Path

Celery delivers at-least-once with a 12 h visibility timeout and had no dedup, no backoff on task decorators, and no dead-letter path — a worker crash mid-task meant duplicate re-execution of side-effectful tasks, and retry-exhausted failures vanished after the 24 h result TTL. The fix reuses the canonical retryable/non-retryable split from `autobot_shared/retry_mechanism.py` (#7010) and the canonical `TaskStatus` enum rather than inventing new taxonomies.

## What Changed

- **New `utils/celery_reliability.py`**: `@idempotent_task` (Redis `SET NX EX` on `celery:dedup:{task_id}`; retries bypass the guard; fails open on Redis outage), `DeadLetterTask` base (`on_failure` parks `{task_name, task_id, args_summary, error, timestamp}` to a bounded `celery:dead_letter` list), `get_dead_letter_status()`, env-backed constants (`AUTOBOT_CELERY_DEDUP_TTL` default 43200 s = visibility timeout, `_MAX_RETRIES`, `_RETRY_BACKOFF_MAX`, `_DEAD_LETTER_MAX`).
- **Applied** to the three registered deployments-queue tasks (`tasks.initialize_rbac`/`run_system_update`/`check_available_updates`) and both LLC beat tasks: `autoretry_for=(ConnectionError, TimeoutError, OSError)` + jittered backoff; ValueError/TypeError fail fast.
- **New `GET /api/health/celery-dead-letter`** on the existing root-endpoints registrar (parked count + recent entries).
- **`TaskStatus.PARKED`** added as a terminal state; SSOT config fields for the four env vars.

## Verification

- 17 new tests pass: duplicate task_id → no-op skip; transient error → `celery.exceptions.Retry`, ValueError → propagates without retry (verified empirically in eager mode); exhausted retries → parked entry queryable via the endpoint (fakeredis)
- Regression: `tasks/test_task_registration.py`, `llc/tests/test_sprint_close.py` (9/9) unchanged vs base
- `black --check` + `py_compile` clean

## Discoveries

- `tasks.deploy_host`/`provision_ssh_key`/`manage_service` in `celery_app.py:113-115` task_routes are **phantom** — no task definitions exist (moved to SLM per #729); only the three tasks above are registered on that queue.
- Pre-existing test failures verified identical on untouched base → filed #11604 (fakeredis Lua/evalsha + fixture drift) and #11606 (celery_app stub missing `_crontab_from_string`; analytics eager-state bleed).

## Model Used

Claude Fable 5 (orchestrator + implementation agent)