### PR TITLE
fix(chat): thread request context into graph iteration context so company-scoped tools work (#11552)

### DIFF
--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -418,6 +418,12 @@ def _build_llm_iteration_context(state: ChatState):
         system_prompt=state["llm_params"].get("system_prompt"),
         initial_prompt=initial_prompt,
         message=state["user_message"],
+        # #11552: thread the request context (company_id, user_id, …) into the
+        # iteration context so the tool-dispatch seam is company-scoped in the
+        # GRAPH path too. The legacy _create_llm_iteration_context already passes
+        # context=; without it here, ctx.context was {} and company-scoped tools
+        # (e.g. LLC create_task, #11501) could never resolve company_id.
+        context=dict(state.get("context", {}) or {}),
         agent_context=agent_context,
         work_item_id=work_item_id,
         requires_approval_before=approval_cats,

--- a/autobot-backend/tests/unit/chat_workflow/test_graph_context_threading.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_graph_context_threading.py
@@ -19,7 +19,7 @@ import pytest
 def _build():
     try:
         from chat_workflow.graph import _build_llm_iteration_context
-    except Exception as exc:  # noqa: BLE001 — env-dependent import chain
+    except ImportError as exc:  # env-dependent chain; a real regression still fails
         pytest.skip(f"chat_workflow not importable here: {exc}")
     return _build_llm_iteration_context
 
@@ -55,3 +55,14 @@ def test_missing_context_is_empty_not_crash():
     assert ctx.context == {}
     ctx2 = build(_state(None))
     assert ctx2.context == {}
+
+
+def test_shallow_copy_isolates_graph_state():
+    """#11552 review: the seam mutates ctx.context in place (delegations,
+    fact-forcing scratch) — that must NOT corrupt the persisted graph
+    state["context"]."""
+    build = _build()
+    state = _state({"company_id": "co-1"})
+    ctx = build(state)
+    ctx.context["delegations_this_turn"] = 3  # simulate an in-seam write
+    assert "delegations_this_turn" not in state["context"]  # original untouched

--- a/autobot-backend/tests/unit/chat_workflow/test_graph_context_threading.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_graph_context_threading.py
@@ -1,0 +1,57 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#11552: the graph's _build_llm_iteration_context must thread the request
+context (company_id/user_id) into ctx.context, so company-scoped tools (e.g.
+the LLC CEO-chat tools, #11501) can resolve company_id in the GRAPH path — the
+legacy _create_llm_iteration_context already did; the graph path dropped it.
+
+Imports the real helper; skips where the heavy chat_workflow chain can't load
+(runs in CI).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _build():
+    try:
+        from chat_workflow.graph import _build_llm_iteration_context
+    except Exception as exc:  # noqa: BLE001 — env-dependent import chain
+        pytest.skip(f"chat_workflow not importable here: {exc}")
+    return _build_llm_iteration_context
+
+
+def _state(context):
+    return {
+        "session_id": "t1",
+        "terminal_session_id": "term1",
+        "user_message": "Create a task",
+        "context": context,
+        "llm_params": {
+            "ollama_endpoint": "http://x/api/generate",
+            "selected_model": "m",
+            "system_prompt": "s",
+            "initial_prompt": "p",
+        },
+        "used_knowledge": False,
+        "rag_citations": [],
+        "execution_history": [],
+    }
+
+
+def test_context_threaded_into_iteration_context():
+    build = _build()
+    ctx = build(_state({"company_id": "co-123", "user_id": "u-9"}))
+    assert ctx.context.get("company_id") == "co-123"
+    assert ctx.context.get("user_id") == "u-9"
+
+
+def test_missing_context_is_empty_not_crash():
+    build = _build()
+    ctx = build(_state({}))
+    assert ctx.context == {}
+    ctx2 = build(_state(None))
+    assert ctx2.context == {}


### PR DESCRIPTION
## Thinking Path
CEO-chat #11501 T4 live E2E: the board LLM emitted `create_task` tool calls but no work item was ever created. Root-caused by reading the graph path: `chat_workflow/graph.py::_build_llm_iteration_context` rebuilds `LLMIterationContext` from graph state but **omits `context=`**, so `ctx.context` was `{}` in the LangGraph path. The LLC tools (#11501 T1) read `ctx.context["company_id"]` → got `None` → `LLCToolError` → the tool never executed. The legacy `_create_llm_iteration_context` (manager.py:2964) already passes `context=merged_context`; the graph path silently dropped it. Fixes #11552.

## What Changed
`_build_llm_iteration_context`: pass `context=dict(state.get("context", {}) or {})` into `LLMIterationContext(...)`, mirroring the legacy builder. Now `company_id`/`user_id` reach the tool-dispatch seam in the graph path (which is what `process_message_stream` / CEO chat use).

## Verification
- `ast.parse` clean; flake8 clean.
- Unit test (`test_graph_context_threading.py`): `ctx.context` carries `company_id`/`user_id`; empty-not-crash when absent. Imports the real helper (skips where the heavy chat_workflow chain can't load locally; runs in CI).
- Post-merge: redeploy autobot-backend (built-in resolve) + re-run the CEO-chat E2E — a board "create a task …" should now create a work item.

## Model Used
Claude Fable 5 (1M context)
