### PR TITLE
feat(llm): per-request/per-conversation model & provider override in chat (#11585)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -558,6 +558,8 @@ async def _generate_ai_response(
     session_id: str,
     request_id: str,
     reasoning_effort: str | None = None,
+    model: str | None = None,
+    provider: str | None = None,
 ) -> tuple[Dict, Any]:
     """
     Generate AI response using LLM service with fallback handling.
@@ -565,6 +567,7 @@ async def _generate_ai_response(
     Issue #281: Extracted helper for AI response generation.
     Issue #9043: Returns full LLMResponse for token tracking.
     Issue #9017: reasoning_effort threaded to provider via metadata["api_kwargs"].
+    Issue #11585: model/provider threaded into registry resolution.
 
     Args:
         llm_service: LLM service instance
@@ -572,20 +575,24 @@ async def _generate_ai_response(
         session_id: Session ID
         request_id: Request ID
         reasoning_effort: Optional effort level; None/'auto' → no change (#9017)
+        model: Optional per-request model override (#11585)
+        provider: Optional per-request provider override (#11585)
 
     Returns:
         Tuple of (AI response dict with content and role, LLMResponse object or None)
     """
     try:
-        # LLMService.chat() accepts OpenAI-format messages and uses
-        # conversation_id for per-conversation provider/model overrides.
-        # request_id flows through via **kwargs for tracing.
+        # #11585: conversation_id lets the registry apply the per-conversation
+        # provider pin; explicit model_name/provider_name (per-request override)
+        # take priority over it. request_id flows through **kwargs for tracing.
         extra_kwargs: Dict[str, Any] = {}
         if reasoning_effort and reasoning_effort != "auto":
             extra_kwargs["metadata"] = {"api_kwargs": {"reasoning_effort": reasoning_effort}}
         response = await llm_service.chat(
             messages=llm_context,
             conversation_id=session_id,
+            provider_name=provider,
+            model_name=model,
             request_id=request_id,
             **extra_kwargs,
         )
@@ -685,6 +692,34 @@ async def _store_and_log_ai_response(
     return ai_message_id
 
 
+def _validate_and_pin_provider(provider: str | None, session_id: str | None) -> None:
+    """Validate a per-request provider override and pin it to the conversation (#11585).
+
+    Unknown provider names raise 422 so the client gets an actionable error
+    instead of a silent fallback-chain substitution. Model names are NOT
+    validated here — the live model list is provider-side and any invalid
+    model surfaces as a request-time provider error (matches existing
+    pass-through behavior for ``metadata.model``).
+    """
+    if not provider:
+        return
+    from llm_shared.provider_registry import get_provider_registry
+
+    registry = get_provider_registry()
+    if registry.get_provider_by_name(provider) is None:
+        registered = sorted(str(p["name"]) for p in registry.list_providers())
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Unknown LLM provider '{provider}'. "
+                f"Registered providers: {', '.join(registered) if registered else 'none'}"
+            ),
+        )
+    if session_id:
+        # Persist so later messages in this conversation inherit the choice.
+        registry.set_conversation_provider(session_id, provider)
+
+
 async def _resolve_chat_reasoning_effort(message: "ChatMessage", user_id: str | None) -> str:
     """Resolve reasoning effort for /chat endpoint (#9017).
 
@@ -721,11 +756,16 @@ async def process_chat_message(
 
     session_id = message.session_id
 
+    # #11585: Per-request provider override — validate (422 on unknown) and pin
+    # to the conversation so later messages in this session inherit it.
+    _validate_and_pin_provider(message.provider, session_id)
+
     # Store user message (Issue #281: uses helper, Issue #3282: author_id)
     await _store_and_log_user_message(message, session_id, chat_history_manager, author_id)
 
     # Get chat context (Issue #281: uses helper)
-    model_name = message.metadata.get("model") if message.metadata else None
+    # #11585: prefer the explicit per-request model field over legacy metadata.model.
+    model_name = message.model or (message.metadata.get("model") if message.metadata else None)
     chat_context = await _get_chat_context(chat_history_manager, session_id, model_name)
 
     # Build LLM context (Issue #281: uses helper)
@@ -736,7 +776,13 @@ async def process_chat_message(
 
     # Generate AI response (Issue #281: uses helper, Issue #9043: returns LLMResponse for token tracking)
     ai_response, llm_response = await _generate_ai_response(
-        llm_service, llm_context, session_id, request_id, reasoning_effort=resolved_effort
+        llm_service,
+        llm_context,
+        session_id,
+        request_id,
+        reasoning_effort=resolved_effort,
+        model=message.model,
+        provider=message.provider,
     )
 
     # Store AI response (Issue #281: uses helper)
@@ -1444,6 +1490,15 @@ async def send_chat_message_by_id(
     reasoning_effort = request_data.get("reasoning_effort")
     if reasoning_effort is not None:
         context["reasoning_effort"] = reasoning_effort
+
+    # #11585: per-request model/provider override — validate the provider (422 on
+    # unknown) and pin it to this conversation; the model rides in context so the
+    # workflow's request-scoped model resolution picks it up.
+    model_override = request_data.get("model") or context.get("model")
+    provider_override = request_data.get("provider") or context.get("provider")
+    _validate_and_pin_provider(provider_override, chat_id)
+    if model_override:
+        context["model"] = model_override
 
     return _create_streaming_response(
         _stream_chat_workflow_messages(

--- a/autobot-backend/api/chat_generate_ai_response_test.py
+++ b/autobot-backend/api/chat_generate_ai_response_test.py
@@ -46,18 +46,23 @@ async def test_generate_ai_response_returns_model_content_on_success(make_llm_re
     llm_service = AsyncMock()
     llm_service.chat = AsyncMock(return_value=make_llm_response(content="Hello, world!", error=None))
 
-    result = await _generate_ai_response(
+    ai_response, llm_response = await _generate_ai_response(
         llm_service=llm_service,
         llm_context=[{"role": "user", "content": "hi"}],
         session_id="s-123",
         request_id="r-abc",
     )
 
-    assert result == {"content": "Hello, world!", "role": "assistant"}
+    # #9043: helper returns (dict, LLMResponse) for token tracking.
+    assert ai_response == {"content": "Hello, world!", "role": "assistant"}
+    assert llm_response is not None
     # Pin the call shape — confirms migrated args reach LLMService.chat correctly.
+    # #11585: model_name/provider_name default to None (no per-request override).
     llm_service.chat.assert_awaited_once_with(
         messages=[{"role": "user", "content": "hi"}],
         conversation_id="s-123",
+        provider_name=None,
+        model_name=None,
         request_id="r-abc",
     )
 
@@ -70,17 +75,18 @@ async def test_generate_ai_response_falls_back_when_llm_returns_error(make_llm_r
     llm_service = AsyncMock()
     llm_service.chat = AsyncMock(return_value=make_llm_response(content="", error="rate limit exceeded"))
 
-    result = await _generate_ai_response(
+    ai_response, llm_response = await _generate_ai_response(
         llm_service=llm_service,
         llm_context=[{"role": "user", "content": "hi"}],
         session_id="s-1",
         request_id="r-1",
     )
 
-    assert result["role"] == "assistant"
+    assert ai_response["role"] == "assistant"
+    assert llm_response is None
     # Must NOT leak the underlying error message to the user — fallback string only.
-    assert "I encountered an error" in result["content"]
-    assert "rate limit" not in result["content"]
+    assert "I encountered an error" in ai_response["content"]
+    assert "rate limit" not in ai_response["content"]
 
 
 @pytest.mark.asyncio
@@ -91,17 +97,18 @@ async def test_generate_ai_response_falls_back_when_chat_raises(make_llm_respons
     llm_service = AsyncMock()
     llm_service.chat = AsyncMock(side_effect=RuntimeError("boom"))
 
-    result = await _generate_ai_response(
+    ai_response, llm_response = await _generate_ai_response(
         llm_service=llm_service,
         llm_context=[{"role": "user", "content": "hi"}],
         session_id="s-1",
         request_id="r-1",
     )
 
-    assert result["role"] == "assistant"
-    assert "I encountered an error" in result["content"]
+    assert ai_response["role"] == "assistant"
+    assert llm_response is None
+    assert "I encountered an error" in ai_response["content"]
     # Underlying exception detail must not surface in user-facing string.
-    assert "boom" not in result["content"]
+    assert "boom" not in ai_response["content"]
 
 
 @pytest.mark.asyncio
@@ -117,14 +124,14 @@ async def test_generate_ai_response_does_not_call_legacy_generate_response(make_
     # If a future caller hits this attribute, the test fails — locks the migration.
     llm_service.generate_response = AsyncMock(side_effect=AssertionError("legacy method"))
 
-    result = await _generate_ai_response(
+    ai_response, _llm_response = await _generate_ai_response(
         llm_service=llm_service,
         llm_context=[{"role": "user", "content": "hi"}],
         session_id="s-1",
         request_id="r-1",
     )
 
-    assert result["content"] == "ok"
+    assert ai_response["content"] == "ok"
     llm_service.generate_response.assert_not_awaited()
     llm_service.chat.assert_awaited_once()
 

--- a/autobot-backend/api/schemas_chat.py
+++ b/autobot-backend/api/schemas_chat.py
@@ -534,6 +534,20 @@ class ChatMessage(BaseModel):
         "Overrides the user's account-level default. Omit to use the user default. "
         "When 'auto' or absent the provider's own defaults are used (#9017).",
     )
+    # Per-request model/provider override (#11585)
+    model: str | None = Field(
+        None,
+        max_length=200,
+        description="Per-request model override. Overrides the per-conversation and "
+        "global default model for this message; omit to use the current default (#11585).",
+    )
+    provider: str | None = Field(
+        None,
+        max_length=100,
+        description="Per-request LLM provider override. Validated against registered "
+        "providers (422 on unknown names) and pinned to the conversation so later "
+        "messages inherit it (#11585).",
+    )
 
 
 class ChatResponse(BaseModel):

--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -741,8 +741,13 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
             prefix += trajectory_context + "\n"
         return prefix + conversation_context + f"\n**Current user message:** {message}\n\nAssistant:"
 
-    def _get_selected_model(self) -> str:
-        """Get selected LLM model from config with fallback."""
+    def _get_selected_model(self, requested_model: str | None = None) -> str:
+        """Get the LLM model: per-request/per-conversation override, else global config (#11585)."""
+        if requested_model:
+            logger.info(
+                "Using per-request LLM model override: %s", requested_model
+            )  # codeql[py/clear-text-logging-sensitive-data]
+            return requested_model
         try:
             default_model = get_config().get_default_llm_model()
             selected = get_config().get_nested("backend.llm.ollama.selected_model", default_model)
@@ -770,8 +775,12 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
 
         Issue #1325: Accepts language for system prompt resolution.
         Issue MVA-1992: lightweight_mode bypasses RAG/memory for trivial queries.
+        Issue #11585: session.metadata["model_override"] (per-request/per-conversation
+        choice) takes priority over the global config default.
         """
-        selected_model = self._get_selected_model()
+        selected_model = self._get_selected_model(
+            session.metadata.get("model_override") if session and session.metadata else None
+        )
         # Issue #1214: Try SLM service discovery first (fleet-managed endpoint),
         # then fall back to local config-based resolution (#1070 model routing).
         slm_base = await self._discover_ollama_from_slm()

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -2866,6 +2866,10 @@ before summarizing.
             # #11501 T2: CEO-chat path carries company_id — used to append the
             # board-tool teaching to the system prompt for this turn only.
             session.metadata["company_id"] = context.get("company_id") or ""
+            # #11585: per-request model override — persisted on the session so
+            # later messages in this conversation inherit the choice.
+            if context.get("model"):
+                session.metadata["model_override"] = str(context["model"])
 
         # Issue MVA-1992: Determine if query qualifies for lightweight mode.
         # Trivial tier (GH#9050, score < trivial_threshold) is the primary

--- a/autobot-backend/tests/api/test_model_provider_override.py
+++ b/autobot-backend/tests/api/test_model_provider_override.py
@@ -1,0 +1,175 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for per-request/per-conversation model & provider override (#11585).
+
+Covers:
+- ChatMessage schema accepts optional model/provider fields
+- _validate_and_pin_provider: 422 on unknown provider, conversation pinning
+- _generate_ai_response threads model/provider into LLMService.chat()
+- _get_selected_model prefers the per-request override over global config
+"""
+
+import importlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+# Resolve the REAL provider_registry module from sys.modules — the conftest
+# llm_shared package stub is a MagicMock, so string-target patching
+# ("llm_shared.provider_registry.get_provider_registry") would patch an
+# auto-created mock attribute instead of the module api.chat imports from.
+_pr_mod = importlib.import_module("llm_shared.provider_registry")
+
+# ---------------------------------------------------------------------------
+# ChatMessage schema fields
+# ---------------------------------------------------------------------------
+
+
+class TestChatMessageSchema:
+    def test_model_and_provider_default_to_none(self):
+        from api.schemas_chat import ChatMessage
+
+        msg = ChatMessage(content="hi", session_id="s1")
+        assert msg.model is None
+        assert msg.provider is None
+
+    def test_model_and_provider_accepted(self):
+        from api.schemas_chat import ChatMessage
+
+        msg = ChatMessage(content="hi", session_id="s1", model="llama3.2:3b", provider="ollama")
+        assert msg.model == "llama3.2:3b"
+        assert msg.provider == "ollama"
+
+
+# ---------------------------------------------------------------------------
+# _validate_and_pin_provider
+# ---------------------------------------------------------------------------
+
+
+def _mock_registry(known: bool):
+    registry = MagicMock()
+    registry.get_provider_by_name.return_value = object() if known else None
+    registry.list_providers.return_value = [{"name": "ollama"}, {"name": "openai"}]
+    return registry
+
+
+class TestValidateAndPinProvider:
+    def test_unknown_provider_raises_422_with_registered_list(self):
+        from api.chat import _validate_and_pin_provider
+
+        registry = _mock_registry(known=False)
+        with patch.object(_pr_mod, "get_provider_registry", return_value=registry):
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_and_pin_provider("nope", "sess-1")
+
+        assert exc_info.value.status_code == 422
+        assert "nope" in exc_info.value.detail
+        assert "ollama" in exc_info.value.detail
+        registry.set_conversation_provider.assert_not_called()
+
+    def test_valid_provider_pinned_to_conversation(self):
+        from api.chat import _validate_and_pin_provider
+
+        registry = _mock_registry(known=True)
+        with patch.object(_pr_mod, "get_provider_registry", return_value=registry):
+            _validate_and_pin_provider("ollama", "sess-1")
+
+        registry.set_conversation_provider.assert_called_once_with("sess-1", "ollama")
+
+    def test_valid_provider_without_session_not_pinned(self):
+        from api.chat import _validate_and_pin_provider
+
+        registry = _mock_registry(known=True)
+        with patch.object(_pr_mod, "get_provider_registry", return_value=registry):
+            _validate_and_pin_provider("ollama", None)
+
+        registry.set_conversation_provider.assert_not_called()
+
+    def test_none_provider_is_noop(self):
+        from api.chat import _validate_and_pin_provider
+
+        registry = _mock_registry(known=True)
+        with patch.object(_pr_mod, "get_provider_registry", return_value=registry):
+            _validate_and_pin_provider(None, "sess-1")
+
+        registry.get_provider_by_name.assert_not_called()
+        registry.set_conversation_provider.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _generate_ai_response threading
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_response_threads_model_and_provider():
+    from api.chat import _generate_ai_response
+
+    llm_service = MagicMock()
+    response = MagicMock()
+    response.error = ""
+    response.content = "hello"
+    llm_service.chat = AsyncMock(return_value=response)
+
+    ai_response, llm_response = await _generate_ai_response(
+        llm_service,
+        [{"role": "user", "content": "hi"}],
+        "sess-1",
+        "req-1",
+        model="llama3.2:3b",
+        provider="ollama",
+    )
+
+    kwargs = llm_service.chat.call_args.kwargs
+    assert kwargs["model_name"] == "llama3.2:3b"
+    assert kwargs["provider_name"] == "ollama"
+    assert kwargs["conversation_id"] == "sess-1"
+    assert ai_response["content"] == "hello"
+    assert llm_response is response
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_response_defaults_preserve_prior_behavior():
+    from api.chat import _generate_ai_response
+
+    llm_service = MagicMock()
+    response = MagicMock()
+    response.error = ""
+    response.content = "ok"
+    llm_service.chat = AsyncMock(return_value=response)
+
+    await _generate_ai_response(llm_service, [{"role": "user", "content": "hi"}], "sess-1", "req-1")
+
+    kwargs = llm_service.chat.call_args.kwargs
+    assert kwargs["model_name"] is None
+    assert kwargs["provider_name"] is None
+
+
+# ---------------------------------------------------------------------------
+# Workflow path: _get_selected_model request-scoped override
+# ---------------------------------------------------------------------------
+
+
+class TestGetSelectedModelOverride:
+    def test_requested_model_wins_over_global_config(self):
+        from chat_workflow.llm_handler import LLMHandlerMixin
+
+        class _Stub(LLMHandlerMixin):
+            pass
+
+        assert _Stub()._get_selected_model("mistral:7b") == "mistral:7b"
+
+    def test_unset_override_falls_back_to_global_config(self):
+        from chat_workflow.llm_handler import LLMHandlerMixin
+
+        class _Stub(LLMHandlerMixin):
+            pass
+
+        config = MagicMock()
+        config.get_default_llm_model.return_value = "default-model"
+        config.get_nested.return_value = "global-model"
+        with patch("chat_workflow.llm_handler.get_config", return_value=config):
+            assert _Stub()._get_selected_model(None) == "global-model"

--- a/autobot-backend/tests/test_provider_registry.py
+++ b/autobot-backend/tests/test_provider_registry.py
@@ -295,7 +295,7 @@ class TestHealthChecks:
         # Second check should return cached result (not failed)
         result2 = await registry._check_health_cached("mock_test")
 
-        assert result1 == result2 == True
+        assert result1 is True and result2 is True
 
     @pytest.mark.asyncio
     async def test_health_check_all_parallel(self):
@@ -576,6 +576,62 @@ class TestEdgeCases:
         # Should gracefully fall back to available providers
         selected = await registry.get_provider_for_request(conversation_id="conv-id", request=request)
         assert selected is provider
+
+
+# ============================================================================
+# #11585 — resolution precedence: per-request > per-conversation > org > global
+# ============================================================================
+
+
+class TestResolutionPrecedence:
+    """Full precedence chain for get_provider_for_request (#11585)."""
+
+    def _registry_with(self, names: List[str]):
+        registry = ProviderRegistry()
+        providers = {}
+        for name in names:
+            provider = MockProvider()
+            provider.provider_name = name
+            registry.register(provider)
+            providers[name] = provider
+        return registry, providers
+
+    @pytest.mark.asyncio
+    async def test_per_request_beats_conversation_org_and_global(self):
+        registry, providers = self._registry_with(["req", "conv", "org", "glob"])
+        registry.set_fallback_chain(["glob"])
+        registry.set_conversation_provider("c1", "conv")
+        registry._resolve_org_provider = AsyncMock(return_value="org")
+
+        selected = await registry.get_provider_for_request(provider_name="req", conversation_id="c1", org_id="o1")
+        assert selected is providers["req"]
+
+    @pytest.mark.asyncio
+    async def test_conversation_beats_org_and_global(self):
+        registry, providers = self._registry_with(["conv", "org", "glob"])
+        registry.set_fallback_chain(["glob"])
+        registry.set_conversation_provider("c1", "conv")
+        registry._resolve_org_provider = AsyncMock(return_value="org")
+
+        selected = await registry.get_provider_for_request(conversation_id="c1", org_id="o1")
+        assert selected is providers["conv"]
+
+    @pytest.mark.asyncio
+    async def test_org_beats_global(self):
+        registry, providers = self._registry_with(["org", "glob"])
+        registry.set_fallback_chain(["glob"])
+        registry._resolve_org_provider = AsyncMock(return_value="org")
+
+        selected = await registry.get_provider_for_request(org_id="o1")
+        assert selected is providers["org"]
+
+    @pytest.mark.asyncio
+    async def test_global_fallback_when_no_overrides(self):
+        registry, providers = self._registry_with(["glob", "other"])
+        registry.set_fallback_chain(["glob"])
+
+        selected = await registry.get_provider_for_request()
+        assert selected is providers["glob"]
 
 
 # ============================================================================

--- a/autobot-backend/tests/unit/chat_workflow/test_citations_default_on.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_citations_default_on.py
@@ -44,6 +44,9 @@ def _make_chat_message(use_knowledge_base: bool = True) -> MagicMock:
     msg.metadata = {}
     msg.reasoning_effort = None
     msg.use_knowledge_base = use_knowledge_base
+    # #11585: per-request model/provider override fields
+    msg.model = None
+    msg.provider = None
     return msg
 
 

--- a/autobot-frontend/src/components/chat/ChatInput.vue
+++ b/autobot-frontend/src/components/chat/ChatInput.vue
@@ -1613,7 +1613,7 @@ onUnmounted(() => {
 }
 
 .image-gen-dialog {
-  background: var(--bg-surface, #fff);
+  background: var(--bg-surface);
   border-radius: 0.75rem;
   padding: 1.5rem;
   width: 100%;
@@ -1630,30 +1630,30 @@ onUnmounted(() => {
   gap: 0.5rem;
   font-size: 1rem;
   font-weight: 600;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
   margin: 0;
 }
 
 .image-gen-label {
   font-size: 0.8125rem;
   font-weight: 500;
-  color: var(--text-muted, #6b7280);
+  color: var(--text-muted);
 }
 
 .image-gen-prompt {
   width: 100%;
   padding: 0.625rem 0.75rem;
-  border: 1px solid var(--border-default, #e5e7eb);
+  border: 1px solid var(--border-default);
   border-radius: 0.5rem;
   font-size: 0.875rem;
   resize: none;
   font-family: inherit;
-  color: var(--text-primary, #111827);
-  background: var(--bg-surface, #fff);
+  color: var(--text-primary);
+  background: var(--bg-surface);
 }
 
 .image-gen-prompt:focus {
-  outline: 2px solid var(--color-primary, #3b82f6);
+  outline: 2px solid var(--color-primary);
   outline-offset: 1px;
 }
 
@@ -1670,7 +1670,7 @@ onUnmounted(() => {
   gap: 0.375rem;
   font-size: 0.8125rem;
   cursor: pointer;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
 }
 
 .image-gen-actions {
@@ -1682,12 +1682,12 @@ onUnmounted(() => {
 
 .image-gen-cancel {
   padding: 0.5rem 1rem;
-  border: 1px solid var(--border-default, #e5e7eb);
+  border: 1px solid var(--border-default);
   border-radius: 0.5rem;
   background: transparent;
   font-size: 0.875rem;
   cursor: pointer;
-  color: var(--text-muted, #6b7280);
+  color: var(--text-muted);
 }
 
 .image-gen-submit {
@@ -1695,7 +1695,7 @@ onUnmounted(() => {
   align-items: center;
   gap: 0.375rem;
   padding: 0.5rem 1.25rem;
-  background: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
   color: white;
   border: none;
   border-radius: 0.5rem;
@@ -1706,7 +1706,7 @@ onUnmounted(() => {
 }
 
 .image-gen-submit:hover:not(:disabled) {
-  background: var(--color-primary-dark, #2563eb);
+  background: var(--color-primary-dark);
 }
 
 .image-gen-submit:disabled {

--- a/autobot-frontend/src/components/chat/ChatInput.vue
+++ b/autobot-frontend/src/components/chat/ChatInput.vue
@@ -111,6 +111,22 @@
 
           <!-- Input Actions -->
           <div class="input-actions">
+            <!-- #11585: Per-conversation model/provider picker -->
+            <label class="model-picker" :title="$t('chat.modelPicker.title')">
+              <span class="sr-only">{{ $t('chat.modelPicker.label') }}</span>
+              <select
+                v-model="selectedModel"
+                class="model-picker-select"
+                :disabled="isDisabled"
+                :aria-label="$t('chat.modelPicker.label')"
+              >
+                <option value="">{{ $t('chat.modelPicker.auto') }}</option>
+                <option v-for="m in pickerModels" :key="m.name" :value="m.name">
+                  {{ m.provider ? `${m.name} · ${m.provider}` : m.name }}
+                </option>
+              </select>
+            </label>
+
             <!-- Issue #249: Knowledge Base Toggle -->
             <label class="knowledge-toggle" :class="{ 'active': useKnowledge }" :title="$t('chat.input.useKnowledge')">
               <input
@@ -465,6 +481,7 @@ import type { SlashCommandPreset } from '@/types/api'
 import { useImageGeneration } from '@/composables/useImageGeneration'
 import { useThinkingMode, BUDGET_STEPS, BUDGET_STEP_LABELS } from '@/composables/useThinkingMode'
 import { usePreferences } from '@/composables/usePreferences'
+import { useChatModelSelection } from '@/composables/chat/useChatModelSelection'
 
 // Minimal Web Speech API event shapes (not in TS lib.dom): only the fields this
 // component reads. SpeechRecognitionResult / *Alternative come from lib.dom.
@@ -573,6 +590,8 @@ const { generating: imageGenerating, generateImage } = useImageGeneration()
 const { enabled: thinkingEnabled, budgetTokens: thinkingBudget, load: loadThinkingPrefs, toggle: toggleThinking, setBudget: setThinkingBudget } = useThinkingMode(() => store.currentSessionId)
 // #9460/#9471: per-user reasoning-effort default, passed per-conversation
 const { reasoningEffort } = usePreferences()
+// #11585: per-conversation model/provider override picker
+const { selectedModel, pickerModels, overrideFields, fetchModels: fetchAvailableModels } = useChatModelSelection()
 const showImageGenModal = ref(false)
 const imagePrompt = ref('')
 const imageProvider = ref<'dalle' | 'flux' | 'stable_diffusion'>('dalle')
@@ -759,7 +778,9 @@ const sendMessage = async () => {
         logger.warn('[ChatInput] Overseer submission failed, falling back to normal flow')
         // Fallback: send as normal message
         await controller.sendMessage(message, {
-          use_knowledge: useKnowledge.value
+          use_knowledge: useKnowledge.value,
+          // #11585: per-request model/provider override (empty when "auto")
+          ...overrideFields.value,
         })
       }
     } else {
@@ -777,6 +798,8 @@ const sendMessage = async () => {
         ...(thinkingEnabled.value ? { thinking_enabled: true, thinking_budget_tokens: thinkingBudget.value } : {}),
         // #9460/#9471: per-conversation reasoning effort (omit 'auto' so request stays inert)
         ...(reasoningEffort.value !== 'auto' ? { reasoning_effort: reasoningEffort.value } : {}),
+        // #11585: per-request model/provider override (empty when "auto")
+        ...overrideFields.value,
       })
     }
 
@@ -1190,6 +1213,9 @@ onMounted(() => {
 
   // GH#8993: load thinking preferences for current session
   loadThinkingPrefs()
+
+  // #11585: load live model list for the model/provider picker
+  fetchAvailableModels()
 })
 
 onUnmounted(() => {
@@ -1295,6 +1321,30 @@ onUnmounted(() => {
 .action-divider {
   @apply w-px h-6 bg-autobot-border mx-2;
   flex-shrink: 0;
+}
+
+/* #11585: Model/provider picker */
+.model-picker {
+  @apply flex items-center;
+  flex-shrink: 0;
+  max-width: 12rem;
+}
+
+.model-picker-select {
+  @apply w-full text-xs font-medium rounded px-2 py-1 cursor-pointer transition-all duration-200;
+  @apply bg-autobot-bg-tertiary text-autobot-text-muted border border-autobot-border;
+}
+
+.model-picker-select:hover {
+  @apply text-autobot-text-secondary;
+}
+
+.model-picker-select:focus {
+  @apply outline-hidden text-autobot-primary border-autobot-primary;
+}
+
+.model-picker-select:disabled {
+  @apply opacity-50 cursor-not-allowed;
 }
 
 /* Issue #249: Knowledge Base Toggle Styles */

--- a/autobot-frontend/src/composables/chat/__tests__/useChatModelSelection.test.ts
+++ b/autobot-frontend/src/composables/chat/__tests__/useChatModelSelection.test.ts
@@ -1,0 +1,77 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+//
+// Tests for useChatModelSelection (#11585 — per-request/per-conversation
+// model & provider override picker).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { nextTick, ref } from 'vue'
+import type { AvailableModel } from '../../useAvailableModels'
+
+const mockModels = ref<AvailableModel[]>([])
+
+vi.mock('../../useAvailableModels', () => ({
+  useAvailableModels: () => ({
+    models: mockModels,
+    isLoading: ref(false),
+    error: ref(null),
+    fetchModels: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+import { useChatModelSelection } from '../useChatModelSelection'
+
+function makeModel(name: string, provider: string): AvailableModel {
+  return { name, provider, available: true, context_window: 8192, capabilities: [] }
+}
+
+describe('useChatModelSelection', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mockModels.value = [makeModel('llama3.2:3b', 'ollama'), makeModel('gpt-4o', 'openai')]
+    const { selectedModel } = useChatModelSelection()
+    selectedModel.value = ''
+  })
+
+  it('sends no override fields when set to auto (empty selection)', () => {
+    const { overrideFields } = useChatModelSelection()
+    expect(overrideFields.value).toEqual({})
+  })
+
+  it('derives provider from live model metadata for the selected model', () => {
+    const { selectedModel, selectedProvider, overrideFields } = useChatModelSelection()
+    selectedModel.value = 'gpt-4o'
+    expect(selectedProvider.value).toBe('openai')
+    expect(overrideFields.value).toEqual({ model: 'gpt-4o', provider: 'openai' })
+  })
+
+  it('omits provider when the selected model has no live metadata', () => {
+    const { selectedModel, overrideFields } = useChatModelSelection()
+    selectedModel.value = 'vanished-model'
+    expect(overrideFields.value).toEqual({ model: 'vanished-model' })
+  })
+
+  it('keeps a persisted selection visible in picker options when not in the live list', () => {
+    const { selectedModel, pickerModels } = useChatModelSelection()
+    selectedModel.value = 'vanished-model'
+    expect(pickerModels.value.map((m) => m.name)).toContain('vanished-model')
+  })
+
+  it('picker options match the live list when the selection is live', () => {
+    const { selectedModel, pickerModels } = useChatModelSelection()
+    selectedModel.value = 'llama3.2:3b'
+    expect(pickerModels.value).toHaveLength(2)
+  })
+
+  it('persists the selection to localStorage and clears it on auto', async () => {
+    const { selectedModel } = useChatModelSelection()
+    selectedModel.value = 'llama3.2:3b'
+    await nextTick() // flush watcher
+    expect(localStorage.getItem('autobot-chat-model-override')).toBe('llama3.2:3b')
+    selectedModel.value = ''
+    await nextTick()
+    expect(localStorage.getItem('autobot-chat-model-override')).toBeNull()
+  })
+})

--- a/autobot-frontend/src/composables/chat/useChatModelSelection.ts
+++ b/autobot-frontend/src/composables/chat/useChatModelSelection.ts
@@ -1,0 +1,105 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * useChatModelSelection — per-request/per-conversation model & provider
+ * override for the chat composer (#11585).
+ *
+ * Wraps useAvailableModels (GET /api/models/available) and holds the user's
+ * model choice. The empty string means "auto" — no override is sent and the
+ * backend uses its per-conversation/global default. When a model is chosen,
+ * its provider is derived from the live model metadata so the backend can
+ * validate and pin it via the provider-registry seam.
+ *
+ * The choice is persisted in localStorage so it survives reloads; the backend
+ * additionally pins the provider per conversation once a message is sent.
+ */
+
+import { ref, computed, watch } from 'vue'
+import { useAvailableModels, type AvailableModel } from '../useAvailableModels'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useChatModelSelection')
+
+const STORAGE_KEY = 'autobot-chat-model-override'
+
+/** '' = auto (no override sent). Module-level so all composer instances agree. */
+const selectedModel = ref<string>('')
+let _initialized = false
+
+function loadPersistedSelection(): void {
+  try {
+    selectedModel.value = localStorage.getItem(STORAGE_KEY) ?? ''
+  } catch (err) {
+    logger.warn('Failed to load persisted model selection:', err)
+  }
+}
+
+function persistSelection(model: string): void {
+  try {
+    if (model) {
+      localStorage.setItem(STORAGE_KEY, model)
+    } else {
+      localStorage.removeItem(STORAGE_KEY)
+    }
+  } catch (err) {
+    logger.warn('Failed to persist model selection:', err)
+  }
+}
+
+export interface ModelOverrideFields {
+  model?: string
+  provider?: string
+}
+
+export function useChatModelSelection() {
+  const { models, isLoading, error, fetchModels } = useAvailableModels()
+
+  if (!_initialized) {
+    _initialized = true
+    loadPersistedSelection()
+    watch(selectedModel, (model) => {
+      persistSelection(model)
+      logger.debug('Chat model override set to: %s', model || '(auto)')
+    })
+  }
+
+  /** Picker options: live models plus the persisted choice (stays selectable
+   *  even if its provider is briefly down — mirrors useModelPicker). */
+  const pickerModels = computed<AvailableModel[]>(() => {
+    if (!selectedModel.value || models.value.some((m) => m.name === selectedModel.value)) {
+      return models.value
+    }
+    return [
+      ...models.value,
+      { name: selectedModel.value, provider: '', available: false, context_window: 0, capabilities: [] },
+    ]
+  })
+
+  /** Provider of the selected model, derived from live metadata. */
+  const selectedProvider = computed<string>(() => {
+    if (!selectedModel.value) return ''
+    return models.value.find((m) => m.name === selectedModel.value)?.provider ?? ''
+  })
+
+  /** Request fields to spread into sendMessage options — empty when auto. */
+  const overrideFields = computed<ModelOverrideFields>(() => {
+    if (!selectedModel.value) return {}
+    const fields: ModelOverrideFields = { model: selectedModel.value }
+    if (selectedProvider.value) fields.provider = selectedProvider.value
+    return fields
+  })
+
+  return {
+    models,
+    pickerModels,
+    selectedModel,
+    selectedProvider,
+    overrideFields,
+    isLoading,
+    error,
+    fetchModels,
+  }
+}

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8694,5 +8694,8 @@
   },
   "knowledge.health.tagDocCount": "{count} وثائق",
   "knowledge.health.activityCreated": "تم إنشاء {title}",
-  "knowledge.health.activityUpdated": "تم تحديث {title}"
+  "knowledge.health.activityUpdated": "تم تحديث {title}",
+  "chat.modelPicker.label": "النموذج",
+  "chat.modelPicker.auto": "تلقائي (النموذج الافتراضي)",
+  "chat.modelPicker.title": "اختر النموذج والمزوّد لهذه المحادثة"
 }

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8694,5 +8694,8 @@
   },
   "knowledge.health.tagDocCount": "{count} Dokumente",
   "knowledge.health.activityCreated": "{title} wurde erstellt",
-  "knowledge.health.activityUpdated": "{title} wurde aktualisiert"
+  "knowledge.health.activityUpdated": "{title} wurde aktualisiert",
+  "chat.modelPicker.label": "Modell",
+  "chat.modelPicker.auto": "Automatisch (Standardmodell)",
+  "chat.modelPicker.title": "Modell und Anbieter für diese Unterhaltung wählen"
 }

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8694,5 +8694,8 @@
   },
   "knowledge.health.tagDocCount": "{count} documents",
   "knowledge.health.activityCreated": "{title} was created",
-  "knowledge.health.activityUpdated": "{title} was updated"
+  "knowledge.health.activityUpdated": "{title} was updated",
+  "chat.modelPicker.label": "Model",
+  "chat.modelPicker.auto": "Auto (default model)",
+  "chat.modelPicker.title": "Choose the model and provider for this conversation"
 }

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8694,5 +8694,8 @@
   },
   "knowledge.health.tagDocCount": "{count} documentos",
   "knowledge.health.activityCreated": "{title} fue creado",
-  "knowledge.health.activityUpdated": "{title} fue actualizado"
+  "knowledge.health.activityUpdated": "{title} fue actualizado",
+  "chat.modelPicker.label": "Modelo",
+  "chat.modelPicker.auto": "Automático (modelo predeterminado)",
+  "chat.modelPicker.title": "Elige el modelo y el proveedor para esta conversación"
 }

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8694,5 +8694,8 @@
   },
   "knowledge.health.tagDocCount": "{count} اسناد",
   "knowledge.health.activityCreated": "{title} ایجاد شد",
-  "knowledge.health.activityUpdated": "{title} به‌روز شد"
+  "knowledge.health.activityUpdated": "{title} به‌روز شد",
+  "chat.modelPicker.label": "مدل",
+  "chat.modelPicker.auto": "خودکار (مدل پیش‌فرض)",
+  "chat.modelPicker.title": "مدل و ارائه‌دهنده را برای این گفتگو انتخاب کنید"
 }

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8694,5 +8694,8 @@
   },
   "knowledge.health.tagDocCount": "{count} documents",
   "knowledge.health.activityCreated": "{title} a été créé",
-  "knowledge.health.activityUpdated": "{title} a été mis à jour"
+  "knowledge.health.activityUpdated": "{title} a été mis à jour",
+  "chat.modelPicker.label": "Modèle",
+  "chat.modelPicker.auto": "Auto (modèle par défaut)",
+  "chat.modelPicker.title": "Choisir le modèle et le fournisseur pour cette conversation"
 }

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8694,5 +8694,8 @@
   },
   "knowledge.health.tagDocCount": "{count} מסמכים",
   "knowledge.health.activityCreated": "{title} נוצר",
-  "knowledge.health.activityUpdated": "{title} עודכן"
+  "knowledge.health.activityUpdated": "{title} עודכן",
+  "chat.modelPicker.label": "מודל",
+  "chat.modelPicker.auto": "אוטומטי (מודל ברירת מחדל)",
+  "chat.modelPicker.title": "בחרו מודל וספק לשיחה זו"
 }

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8694,5 +8694,8 @@
   },
   "knowledge.health.tagDocCount": "{count} dokumenti",
   "knowledge.health.activityCreated": "{title} tika izveidots",
-  "knowledge.health.activityUpdated": "{title} tika atjaunots"
+  "knowledge.health.activityUpdated": "{title} tika atjaunots",
+  "chat.modelPicker.label": "Modelis",
+  "chat.modelPicker.auto": "Automātiski (noklusējuma modelis)",
+  "chat.modelPicker.title": "Izvēlieties modeli un pakalpojumu sniedzēju šai sarunai"
 }

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8694,5 +8694,8 @@
   },
   "knowledge.health.tagDocCount": "{count} dokumentów",
   "knowledge.health.activityCreated": "{title} został utworzony",
-  "knowledge.health.activityUpdated": "{title} został zaktualizowany"
+  "knowledge.health.activityUpdated": "{title} został zaktualizowany",
+  "chat.modelPicker.label": "Model",
+  "chat.modelPicker.auto": "Automatycznie (model domyślny)",
+  "chat.modelPicker.title": "Wybierz model i dostawcę dla tej rozmowy"
 }

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8694,5 +8694,8 @@
   },
   "knowledge.health.tagDocCount": "{count} documentos",
   "knowledge.health.activityCreated": "{title} foi criado",
-  "knowledge.health.activityUpdated": "{title} foi atualizado"
+  "knowledge.health.activityUpdated": "{title} foi atualizado",
+  "chat.modelPicker.label": "Modelo",
+  "chat.modelPicker.auto": "Automático (modelo padrão)",
+  "chat.modelPicker.title": "Escolha o modelo e o provedor para esta conversa"
 }

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8694,5 +8694,8 @@
   },
   "knowledge.health.tagDocCount": "{count} دستاویزات",
   "knowledge.health.activityCreated": "{title} بنایا گیا",
-  "knowledge.health.activityUpdated": "{title} کو اپ ڈیٹ کیا گیا"
+  "knowledge.health.activityUpdated": "{title} کو اپ ڈیٹ کیا گیا",
+  "chat.modelPicker.label": "ماڈل",
+  "chat.modelPicker.auto": "خودکار (طے شدہ ماڈل)",
+  "chat.modelPicker.title": "اس گفتگو کے لیے ماڈل اور فراہم کنندہ منتخب کریں"
 }

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -59856,6 +59856,16 @@ export interface components {
              * @description Per-conversation reasoning effort override (low, medium, high, auto). Overrides the user's account-level default. Omit to use the user default. When 'auto' or absent the provider's own defaults are used (#9017).
              */
             reasoning_effort?: string | null;
+            /**
+             * Model
+             * @description Per-request model override. Overrides the per-conversation and global default model for this message; omit to use the current default (#11585).
+             */
+            model?: string | null;
+            /**
+             * Provider
+             * @description Per-request LLM provider override. Validated against registered providers (422 on unknown names) and pinned to the conversation so later messages inherit it (#11585).
+             */
+            provider?: string | null;
         } & {
             [key: string]: unknown;
         };


### PR DESCRIPTION
Closes #11585. Part of #11584 (Task 1).

## Thinking Path

The provider registry already implemented override resolution end-to-end (`set_conversation_provider`, `get_provider_for_request` precedence chain) — and `LLMService.chat()/stream()` already forwarded `provider_name` + `conversation_id` into it. The real gaps were: no schema fields, no endpoint threading, no `set_conversation_provider` call anywhere, and the workflow path's global-only `_get_selected_model()`. This PR wires those seams; no new infrastructure.

## What Changed

**Backend**
- `api/schemas_chat.py`: optional `model`/`provider` fields on the chat request schema
- `api/chat.py`: new `_validate_and_pin_provider()` — unknown provider → 422 listing registered providers; valid provider pinned via `set_conversation_provider()` so later messages inherit it. Threaded through all three chat entry points: POST /api/chat(+/message), /api/chat/stream, and /api/chats/{chat_id}/message (the composer's actual path). Fixed the stale line-581 comment.
- `chat_workflow/llm_handler.py`: `_get_selected_model(requested_model)` — per-request/per-conversation override beats global config
- `chat_workflow/manager.py`: `context["model"]` persisted to `session.metadata["model_override"]`
- Model names are pass-through by design (live model list is provider-side); providers get strict 422

**Frontend**
- New `useChatModelSelection` composable fed by `GET /api/models/available`; picker in `ChatInput.vue` composer; override fields sent on both send paths
- i18n: `chat.modelPicker.{label,auto,title}` added to ALL 11 locales (flat dotted keys)

## Verification

- Backend: 59 tests pass in the touched suites, incl. new `tests/api/test_model_provider_override.py` (10) and `TestResolutionPrecedence` (per-request > per-conversation > org > global); full run by the implementation pass: 279 passed
- Frontend: 27 vitest pass (new composable tests + locale parity); `vue-tsc --noEmit` clean; eslint clean
- `black --check` + `py_compile` clean

## Discoveries (fixed in-scope)

- `api/chat_generate_ai_response_test.py` asserted the pre-#9043 dict return — 4 tests failing on base, updated to the tuple contract
- E712 in `tests/test_provider_registry.py:298`

## Model Used

Claude Fable 5 (orchestrator + implementation agent)