### PR TITLE
refactor(knowledge): wire six orphaned stats subpanels into KnowledgeHealthAnalytics (#11562)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgeHealthAnalytics.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeHealthAnalytics.vue
@@ -60,7 +60,6 @@ import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useKnowledgeStore } from '@/stores/useKnowledgeStore'
 import type { KnowledgeDocument } from '@/stores/useKnowledgeStore'
-import { useKnowledgeStats } from '@/composables/knowledge/useKnowledgeStats'
 import { useKnowledgeController } from '@/models/controllers/index'
 import DocumentChangeFeed from '@/components/knowledge/DocumentChangeFeed.vue'
 import { formatFileSize } from '@/utils/formatHelpers'
@@ -109,9 +108,6 @@ try {
     getDetailedStats: async () => ({})
   }
 }
-
-// Composable: category facts fetching
-const { refreshCategoryFacts } = useKnowledgeStats()
 
 // State
 const recentActivities = ref<Activity[]>([])
@@ -315,16 +311,10 @@ const capitalize = (str: string): string => {
   return str && str.length > 0 ? str.charAt(0).toUpperCase() + str.slice(1) : str || ''
 }
 
-// Load stats on mount: unified refreshStats + refreshCategoryFacts
+// Load stats on mount (category fact counts are fetched by VectorStatsSection
+// on its own useKnowledgeStats instance — the composable state is per-instance)
 onMounted(async () => {
-  // Fetch stats (controller + store) and populate recent activities
   await refreshStats()
-
-  // Fetch category fact counts for the distribution chart (owned by VectorStatsSection)
-  const factsResult = await refreshCategoryFacts()
-  if (factsResult === null) {
-    logger.warn('Failed to fetch category facts, continuing with basic stats')
-  }
 })
 </script>
 

--- a/autobot-frontend/src/components/knowledge/KnowledgeHealthAnalytics.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeHealthAnalytics.vue
@@ -10,30 +10,7 @@
     </div>
 
     <!-- Vector Categories Distribution Chart -->
-    <div v-if="vectorStats" class="vector-chart-section">
-      <h4><Icon name="chart-pie" /> {{ $t('knowledge.stats.vectorDistribution') }}</h4>
-      <div class="vector-categories-chart">
-        <div
-          v-for="(category, idx) in vectorStats.categories"
-          :key="idx"
-          class="category-bar"
-        >
-          <div class="category-info">
-            <span class="category-name">{{ formatCategoryName(category) }}</span>
-            <span class="category-count">{{ $t('knowledge.stats.factsCount', { count: getCategoryFactCount(category) }) }}</span>
-          </div>
-          <div class="category-progress">
-            <div
-              class="category-fill"
-              :style="{
-                width: getCategoryPercentage(category) + '%',
-                backgroundColor: getCategoryColor(idx)
-              }"
-            ></div>
-          </div>
-        </div>
-      </div>
-    </div>
+    <VectorStatsSection />
 
     <!-- Document Change Feed Section (PROMINENT) -->
     <div class="change-feed-section-wrapper">
@@ -45,188 +22,58 @@
     </div>
 
     <!-- Compact Overview Row -->
-    <div class="stats-overview" role="region" :aria-label="$t('knowledge.stats.overviewAriaLabel')">
-      <BasePanel variant="elevated" size="sm" role="article" aria-labelledby="analytics-documents-title">
-        <div class="stat-icon documents" aria-hidden="true">
-          <Icon name="file-alt" />
-        </div>
-        <div class="stat-content">
-          <h4 id="analytics-documents-title">{{ $t('knowledge.stats.totalDocuments') }}</h4>
-          <p class="stat-value" aria-live="polite">{{ store.documentCount }}</p>
-          <p class="stat-change">
-            {{ $t('knowledge.stats.avgDocsPerCategoryValue', { count: avgDocsPerCategory }) }}
-          </p>
-        </div>
-      </BasePanel>
-
-      <BasePanel variant="elevated" size="sm" role="article" aria-labelledby="analytics-categories-title">
-        <div class="stat-icon categories" aria-hidden="true">
-          <Icon name="folder" />
-        </div>
-        <div class="stat-content">
-          <h4 id="analytics-categories-title">{{ $t('knowledge.stats.categories') }}</h4>
-          <p class="stat-value" aria-live="polite">{{ store.categoryCount }}</p>
-          <p class="stat-change">
-            {{ $t('knowledge.stats.avgDocsPerCategoryValue', { count: avgDocsPerCategory }) }}
-          </p>
-        </div>
-      </BasePanel>
-
-      <BasePanel variant="elevated" size="sm">
-        <div class="stat-icon tags">
-          <Icon name="tags" />
-        </div>
-        <div class="stat-content">
-          <h4>{{ $t('knowledge.stats.uniqueTags') }}</h4>
-          <p class="stat-value">{{ store.allTags.length }}</p>
-          <p class="stat-change">
-            {{ $t('knowledge.stats.avgTagsPerDoc', { count: avgTagsPerDoc }) }}
-          </p>
-        </div>
-      </BasePanel>
-
-      <BasePanel variant="elevated" size="sm">
-        <div class="stat-icon storage">
-          <Icon name="database" />
-        </div>
-        <div class="stat-content">
-          <h4>{{ $t('knowledge.stats.storageUsedTitle') }}</h4>
-          <p class="stat-value">{{ formatFileSize(totalStorageSize) }}</p>
-          <p class="stat-change">
-            {{ $t('knowledge.stats.avgPerDoc', { size: formatFileSize(avgDocSize) }) }}
-          </p>
-        </div>
-      </BasePanel>
-    </div>
+    <StatsOverviewCards
+      :document-count="store.documentCount"
+      :category-count="store.categoryCount"
+      :unique-tags-count="store.allTags.length"
+      :avg-docs-per-category="avgDocsPerCategory"
+      :avg-tags-per-doc="String(avgTagsPerDoc)"
+      :total-storage-size="totalStorageSize"
+      :avg-doc-size="avgDocSize"
+    />
 
     <!-- Charts Section -->
-    <div class="charts-section">
-      <!-- Documents by Category -->
-      <BasePanel variant="bordered" size="md">
-        <h4>{{ $t('knowledge.stats.docsByCategory') }}</h4>
-        <div class="bar-chart">
-          <div
-            v-for="category in topCategories"
-            :key="category.name"
-            class="bar-item"
-          >
-            <div class="bar-label">{{ category.name }}</div>
-            <div class="bar-wrapper">
-              <div
-                class="bar-fill"
-                :style="{
-                  width: `${(category.documentCount / maxCategoryCount) * 100}%`,
-                  backgroundColor: category.color || 'var(--color-info)'
-                }"
-              ></div>
-              <span class="bar-value">{{ category.documentCount }}</span>
-            </div>
-          </div>
-        </div>
-      </BasePanel>
-
-      <!-- Documents by Type -->
-      <BasePanel variant="bordered" size="md">
-        <h4>{{ $t('knowledge.stats.docsByType') }}</h4>
-        <div class="pie-chart">
-          <div class="type-stats">
-            <div v-for="(count, type) in documentsByType" :key="type" class="type-item">
-              <div class="type-color" :style="{ backgroundColor: getTypeColor(type) }"></div>
-              <span class="type-name">{{ capitalize(type) }}</span>
-              <span class="type-count">{{ count }}</span>
-              <span class="type-percentage">({{ getTypePercentage(count) }}%)</span>
-            </div>
-          </div>
-        </div>
-      </BasePanel>
-    </div>
+    <StatsChartsSection
+      :top-categories="topCategories"
+      :max-category-count="maxCategoryCount"
+      :documents-by-type="documentsByType"
+      :total-documents="store.documentCount"
+    />
 
     <!-- Recent Activity with Filter Chips -->
-    <BasePanel variant="bordered" size="md">
-      <div class="activity-header">
-        <h4>{{ $t('knowledge.stats.recentActivity') }}</h4>
-        <div class="feed-filter-chips" role="group" :aria-label="$t('knowledge.stats.recentActivity')">
-          <button
-            v-for="chip in feedChips"
-            :key="chip.value"
-            class="feed-chip"
-            :class="{ active: activeFeedFilter === chip.value }"
-            @click="activeFeedFilter = chip.value"
-          >
-            {{ $t(chip.labelKey) }}
-          </button>
-        </div>
-      </div>
-      <div class="activity-timeline">
-        <div v-for="activity in filteredActivities" :key="activity.id" class="activity-item">
-          <div class="activity-icon" :class="activity.type">
-            <Icon :name="getActivityIcon(activity.type)" />
-          </div>
-          <div class="activity-content">
-            <p class="activity-description">{{ activity.description }}</p>
-            <p class="activity-time">{{ formatTimeAgo(activity.timestamp) }}</p>
-          </div>
-        </div>
-        <EmptyState
-          v-if="filteredActivities.length === 0"
-          icon="clock"
-          :message="$t('knowledge.stats.noRecentActivity')"
-        />
-      </div>
-    </BasePanel>
+    <RecentActivityPanel :activities="recentActivities" />
 
     <!-- Tag Cloud -->
-    <BasePanel variant="bordered" size="md">
-      <h4>{{ $t('knowledge.stats.popularTags') }}</h4>
-      <div class="tag-cloud" role="list" :aria-label="$t('knowledge.stats.popularTagsAriaLabel')">
-        <span
-          v-for="tag in popularTags"
-          :key="tag.name"
-          class="tag-cloud-item"
-          :style="{ fontSize: `${tag.size}rem` }"
-          :title="$t('knowledge.health.tagDocCount', { count: tag.count })"
-          :aria-label="`${tag.name}: ${$t('knowledge.health.tagDocCount', { count: tag.count })}`"
-          role="listitem"
-        >
-          {{ tag.name }}
-        </span>
-      </div>
-    </BasePanel>
+    <TagCloudPanel :tags="popularTags" />
 
     <!-- Actions -->
-    <div class="stats-actions">
-      <button @click="exportStats" class="action-btn">
-        <Icon name="download" />
-        {{ $t('knowledge.stats.exportStats') }}
-      </button>
-      <button @click="generateReport" class="action-btn primary">
-        <Icon name="file-chart-line" />
-        {{ $t('knowledge.stats.generateReport') }}
-      </button>
-    </div>
+    <StatsActionsPanel
+      @export="exportStats"
+      @generate-report="generateReport"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useKnowledgeStore } from '@/stores/useKnowledgeStore'
-import { useVectorStats } from '@/composables/knowledge/useVectorStats'
 import type { KnowledgeDocument } from '@/stores/useKnowledgeStore'
 import { useKnowledgeStats } from '@/composables/knowledge/useKnowledgeStats'
 import { useKnowledgeController } from '@/models/controllers/index'
 import DocumentChangeFeed from '@/components/knowledge/DocumentChangeFeed.vue'
-import {
-  formatFileSize,
-  formatTimeAgo,
-  formatCategoryName
-} from '@/utils/formatHelpers'
-import EmptyState from '@/components/ui/EmptyState.vue'
-import BasePanel from '@/components/base/BasePanel.vue'
+import { formatFileSize } from '@/utils/formatHelpers'
 import { createLogger } from '@/utils/debugUtils'
 import { useTransientError } from '@/composables/useTransientError'
+import {
+  VectorStatsSection,
+  StatsOverviewCards,
+  StatsChartsSection,
+  RecentActivityPanel,
+  TagCloudPanel,
+  StatsActionsPanel
+} from '@/components/knowledge/stats'
 
 // Import shared document feed wrapper styles
 import '@/styles/document-feed-wrapper.css'
@@ -264,26 +111,11 @@ try {
 }
 
 // Composable: category facts fetching
-const { categoryFactCounts, refreshCategoryFacts } = useKnowledgeStats()
+const { refreshCategoryFacts } = useKnowledgeStats()
 
 // State
 const recentActivities = ref<Activity[]>([])
 const { message: errorMessage, show: showErrorNotification, clear: clearError } = useTransientError()
-
-// Vector stats for the category-distribution chart — computed over store.stats
-// so it stays in sync no matter which caller (shell loadVectorHealth or local
-// refreshStats) lands last (#11558)
-const { vectorStats } = useVectorStats()
-
-// Feed filter: 'all' | 'created' | 'updated'
-type FeedFilter = 'all' | 'created' | 'updated'
-const activeFeedFilter = ref<FeedFilter>('all')
-
-const feedChips: { value: FeedFilter; labelKey: string }[] = [
-  { value: 'all', labelKey: 'knowledge.health.feedAll' },
-  { value: 'created', labelKey: 'knowledge.health.feedCreated' },
-  { value: 'updated', labelKey: 'knowledge.health.feedUpdated' }
-]
 
 // Computed statistics
 const avgDocsPerCategory = computed(() => {
@@ -357,11 +189,6 @@ const recentDocsCount = computed(() => {
   return store.documents.filter(doc =>
     new Date(doc.createdAt) > oneWeekAgo
   ).length
-})
-
-const filteredActivities = computed(() => {
-  if (activeFeedFilter.value === 'all') return recentActivities.value
-  return recentActivities.value.filter(a => a.type === activeFeedFilter.value)
 })
 
 // Methods
@@ -479,53 +306,13 @@ const estimateTextSize = (text: string): number => {
   return text.length
 }
 
-const getTypeColor = (type: string): string => {
-  const colors: Record<string, string> = {
-    document: 'var(--color-info)',
-    webpage: 'var(--color-success)',
-    api: 'var(--color-warning)',
-    upload: 'var(--chart-purple)'
-  }
-  return colors[type] || 'var(--text-tertiary)'
-}
-
 const getTypePercentage = (count: number): number => {
   if (store.documentCount === 0) return 0
   return Math.round((count / store.documentCount) * 100)
 }
 
-const getActivityIcon = (type: string): IconName => {
-  const icons: Record<string, IconName> = {
-    created: 'plus-circle',
-    updated: 'edit'
-  }
-  return icons[type] || 'circle'
-}
-
 const capitalize = (str: string): string => {
   return str && str.length > 0 ? str.charAt(0).toUpperCase() + str.slice(1) : str || ''
-}
-
-const getCategoryFactCount = (category: string): number => {
-  return categoryFactCounts.value[category] || 0
-}
-
-const getCategoryPercentage = (category: string): number => {
-  const total = vectorStats.value?.total_facts || 1
-  const count = getCategoryFactCount(category)
-  return Math.round((count / total) * 100)
-}
-
-const getCategoryColor = (index: number): string => {
-  const colors = [
-    'var(--color-primary)',
-    'var(--color-success)',
-    'var(--color-warning)',
-    'var(--chart-purple)',
-    'var(--color-error)',
-    'var(--chart-cyan)'
-  ]
-  return colors[index % colors.length]
 }
 
 // Load stats on mount: unified refreshStats + refreshCategoryFacts
@@ -533,7 +320,7 @@ onMounted(async () => {
   // Fetch stats (controller + store) and populate recent activities
   await refreshStats()
 
-  // Fetch category fact counts for the distribution chart
+  // Fetch category fact counts for the distribution chart (owned by VectorStatsSection)
   const factsResult = await refreshCategoryFacts()
   if (factsResult === null) {
     logger.warn('Failed to fetch category facts, continuing with basic stats')
@@ -593,401 +380,5 @@ onMounted(async () => {
 
 .error-notification .close-btn:hover {
   opacity: 1;
-}
-
-/* Vector Chart Section */
-.vector-chart-section {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-xl);
-  padding: var(--spacing-6);
-}
-
-.vector-chart-section h4 {
-  color: var(--text-primary);
-  font-size: var(--text-lg);
-  font-weight: var(--font-semibold);
-  margin-bottom: var(--spacing-6);
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-}
-
-.vector-categories-chart {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-4);
-}
-
-.category-bar {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-2);
-}
-
-.category-info {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: var(--text-sm);
-}
-
-.category-name {
-  color: var(--text-primary);
-  font-weight: var(--font-medium);
-}
-
-.category-count {
-  color: var(--text-secondary);
-  font-size: var(--text-xs);
-}
-
-.category-progress {
-  height: 1.5rem;
-  background: var(--bg-primary);
-  border-radius: var(--radius-xl);
-  overflow: hidden;
-  position: relative;
-}
-
-.category-fill {
-  height: 100%;
-  border-radius: var(--radius-xl);
-  transition: width var(--duration-500) var(--ease-out);
-}
-
-/* Overview Cards */
-.stats-overview {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: var(--spacing-6);
-}
-
-.stat-icon {
-  width: 3.5rem;
-  height: 3.5rem;
-  border-radius: var(--radius-lg);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: var(--text-2xl);
-  color: var(--text-on-primary);
-}
-
-.stat-icon.documents {
-  background: var(--color-info);
-}
-
-.stat-icon.categories {
-  background: var(--color-success);
-}
-
-.stat-icon.tags {
-  background: var(--color-warning);
-}
-
-.stat-icon.storage {
-  background: var(--chart-purple);
-}
-
-.stat-content {
-  flex: 1;
-}
-
-.stat-content h4 {
-  font-size: var(--text-sm);
-  color: var(--text-secondary);
-  margin-bottom: var(--spacing-2);
-}
-
-.stat-value {
-  font-size: var(--text-3xl);
-  font-weight: var(--font-bold);
-  color: var(--text-primary);
-  margin-bottom: var(--spacing-1);
-}
-
-.stat-change {
-  font-size: var(--text-sm);
-  color: var(--text-secondary);
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-1);
-}
-
-/* Charts Section */
-.charts-section {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-  gap: var(--spacing-6);
-}
-
-.charts-section h4 {
-  font-weight: var(--font-semibold);
-  color: var(--text-primary);
-  margin-bottom: var(--spacing-4);
-}
-
-/* Bar Chart */
-.bar-chart {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-3);
-}
-
-.bar-item {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-4);
-}
-
-.bar-label {
-  width: 120px;
-  font-size: var(--text-sm);
-  color: var(--text-primary);
-}
-
-.bar-wrapper {
-  flex: 1;
-  height: 1.5rem;
-  background: var(--bg-secondary);
-  border-radius: var(--radius-md);
-  position: relative;
-  overflow: hidden;
-}
-
-.bar-fill {
-  height: 100%;
-  transition: width var(--duration-500) var(--ease-out);
-}
-
-.bar-value {
-  position: absolute;
-  right: var(--spacing-2);
-  top: 50%;
-  transform: translateY(-50%);
-  font-size: var(--text-xs);
-  font-weight: var(--font-medium);
-  color: var(--text-primary);
-}
-
-/* Type Stats */
-.type-stats {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-2);
-}
-
-.type-item {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-3);
-  padding: var(--spacing-2);
-  background: var(--bg-secondary);
-  border-radius: var(--radius-md);
-}
-
-.type-color {
-  width: 1rem;
-  height: 1rem;
-  border-radius: var(--radius-default);
-}
-
-.type-name {
-  flex: 1;
-  font-weight: var(--font-medium);
-  color: var(--text-primary);
-}
-
-.type-count {
-  font-weight: var(--font-semibold);
-  color: var(--text-primary);
-}
-
-.type-percentage {
-  font-size: var(--text-sm);
-  color: var(--text-secondary);
-}
-
-/* Activity Section */
-.activity-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: var(--spacing-4);
-  flex-wrap: wrap;
-  gap: var(--spacing-3);
-}
-
-.activity-header h4 {
-  font-weight: var(--font-semibold);
-  color: var(--text-primary);
-  margin: 0;
-}
-
-.feed-filter-chips {
-  display: flex;
-  gap: var(--spacing-2);
-  flex-wrap: wrap;
-}
-
-.feed-chip {
-  padding: var(--spacing-1) var(--spacing-3);
-  border-radius: var(--radius-full);
-  border: 1px solid var(--border-default);
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
-  font-size: var(--text-xs);
-  font-weight: var(--font-medium);
-  cursor: pointer;
-  transition: var(--transition-all);
-}
-
-.feed-chip:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-
-.feed-chip.active {
-  background: var(--color-primary);
-  color: var(--text-on-primary);
-  border-color: var(--color-primary);
-}
-
-.activity-timeline {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-4);
-  max-height: 300px;
-  overflow-y: auto;
-}
-
-.activity-item {
-  display: flex;
-  gap: var(--spacing-4);
-  padding: var(--spacing-3);
-  background: var(--bg-secondary);
-  border-radius: var(--radius-md);
-}
-
-.activity-icon {
-  width: 2rem;
-  height: 2rem;
-  border-radius: var(--radius-full);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-on-primary);
-  font-size: var(--text-sm);
-}
-
-.activity-icon.created {
-  background: var(--color-success);
-}
-
-.activity-icon.updated {
-  background: var(--color-info);
-}
-
-.activity-content {
-  flex: 1;
-}
-
-.activity-description {
-  font-size: var(--text-sm);
-  color: var(--text-primary);
-  margin-bottom: var(--spacing-1);
-}
-
-.activity-time {
-  font-size: var(--text-xs);
-  color: var(--text-secondary);
-}
-
-/* Tag Cloud */
-.tag-cloud {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--spacing-3);
-  align-items: center;
-}
-
-.tag-cloud-item {
-  color: var(--color-info);
-  transition: var(--transition-all);
-  padding: var(--spacing-1) var(--spacing-2);
-  border-radius: var(--radius-default);
-}
-
-.tag-cloud-item:hover {
-  color: var(--color-info-hover);
-  transform: scale(1.1);
-}
-
-/* Actions */
-.stats-actions {
-  display: flex;
-  justify-content: center;
-  gap: var(--spacing-4);
-  flex-wrap: wrap;
-}
-
-.action-btn {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  padding: var(--spacing-3) var(--spacing-6);
-  border: 1px solid var(--border-default);
-  background: var(--bg-primary);
-  border-radius: var(--radius-md);
-  font-weight: var(--font-medium);
-  color: var(--text-primary);
-  cursor: pointer;
-  transition: var(--transition-all);
-}
-
-.action-btn:hover {
-  background: var(--bg-secondary);
-}
-
-.action-btn.primary {
-  background: var(--color-info);
-  color: var(--text-on-primary);
-  border-color: var(--color-info);
-}
-
-.action-btn.primary:hover {
-  background: var(--color-info-hover);
-  border-color: var(--color-info-hover);
-}
-
-/* Responsive */
-@media (max-width: 768px) {
-  .stats-overview {
-    grid-template-columns: 1fr;
-  }
-
-  .charts-section {
-    grid-template-columns: 1fr;
-  }
-
-  .bar-label {
-    width: 80px;
-    font-size: var(--text-xs);
-  }
-
-  .stats-actions {
-    flex-direction: column;
-  }
-
-  .action-btn {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .activity-header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
 }
 </style>

--- a/autobot-frontend/src/components/knowledge/stats/RecentActivityPanel.vue
+++ b/autobot-frontend/src/components/knowledge/stats/RecentActivityPanel.vue
@@ -1,8 +1,21 @@
 <template>
   <BasePanel variant="bordered" size="md">
-    <h4>{{ $t('knowledge.stats.recentActivity.title') }}</h4>
+    <div class="activity-header">
+      <h4>{{ $t('knowledge.stats.recentActivity') }}</h4>
+      <div class="feed-filter-chips" role="group" :aria-label="$t('knowledge.stats.recentActivity')">
+        <button
+          v-for="chip in feedChips"
+          :key="chip.value"
+          class="feed-chip"
+          :class="{ active: activeFeedFilter === chip.value }"
+          @click="activeFeedFilter = chip.value"
+        >
+          {{ $t(chip.labelKey) }}
+        </button>
+      </div>
+    </div>
     <div class="activity-timeline">
-      <div v-for="activity in activities" :key="activity.id" class="activity-item">
+      <div v-for="activity in filteredActivities" :key="activity.id" class="activity-item">
         <div class="activity-icon" :class="activity.type">
           <Icon :name="getActivityIcon(activity.type)" />
         </div>
@@ -12,9 +25,9 @@
         </div>
       </div>
       <EmptyState
-        v-if="activities.length === 0"
+        v-if="filteredActivities.length === 0"
         icon="clock"
-        :message="$t('knowledge.stats.recentActivity.noActivity')"
+        :message="$t('knowledge.stats.noRecentActivity')"
       />
     </div>
   </BasePanel>
@@ -27,22 +40,22 @@
 /**
  * Recent Activity Panel Component
  *
- * Displays a timeline of recent knowledge base activities.
- * Extracted from the former KnowledgeStats.vue (#184); currently unmounted —
- * see orphaned-subpanels discovery issue.
+ * Displays a timeline of recent knowledge base activities with All/Created/Updated
+ * filter chips. Wired into KnowledgeHealthAnalytics.vue (#11562).
  *
  * Issue #184: Split oversized Vue components
+ * Issue #11562: Wire in orphaned stats subpanels
  */
 import type { IconName } from '@/components/ui/Icon.vue'
 import Icon from '@/components/ui/Icon.vue'
-
 import BasePanel from '@/components/base/BasePanel.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
+import { ref, computed } from 'vue'
 import { formatTimeAgo } from '@/utils/formatHelpers'
 
 interface Activity {
   id: string | number
-  type: 'created' | 'updated' | 'deleted' | 'imported'
+  type: 'created' | 'updated'
   description: string
   timestamp: Date | string
 }
@@ -51,14 +64,26 @@ interface Props {
   activities: Activity[]
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
+
+type FeedFilter = 'all' | 'created' | 'updated'
+const activeFeedFilter = ref<FeedFilter>('all')
+
+const feedChips: { value: FeedFilter; labelKey: string }[] = [
+  { value: 'all', labelKey: 'knowledge.health.feedAll' },
+  { value: 'created', labelKey: 'knowledge.health.feedCreated' },
+  { value: 'updated', labelKey: 'knowledge.health.feedUpdated' }
+]
+
+const filteredActivities = computed(() => {
+  if (activeFeedFilter.value === 'all') return props.activities
+  return props.activities.filter(a => a.type === activeFeedFilter.value)
+})
 
 const getActivityIcon = (type: string): IconName => {
   const icons: Record<string, IconName> = {
     created: 'plus-circle',
-    updated: 'edit',
-    deleted: 'trash',
-    imported: 'download'
+    updated: 'edit'
   }
   return icons[type] || 'circle'
 }
@@ -66,10 +91,48 @@ const getActivityIcon = (type: string): IconName => {
 
 <style scoped>
 /* Issue #704: Migrated to CSS design tokens */
-h4 {
+.activity-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-4);
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+}
+
+.activity-header h4 {
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin-bottom: var(--spacing-4);
+  margin: 0;
+}
+
+.feed-filter-chips {
+  display: flex;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.feed-chip {
+  padding: var(--spacing-1) var(--spacing-3);
+  border-radius: var(--radius-full);
+  border: 1px solid var(--border-default);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition: var(--transition-all);
+}
+
+.feed-chip:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.feed-chip.active {
+  background: var(--color-primary);
+  color: var(--text-on-primary);
+  border-color: var(--color-primary);
 }
 
 .activity-timeline {
@@ -91,7 +154,7 @@ h4 {
 .activity-icon {
   width: 2rem;
   height: 2rem;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -100,9 +163,7 @@ h4 {
 }
 
 .activity-icon.created { background: var(--color-success); }
-.activity-icon.updated { background: var(--color-primary); }
-.activity-icon.deleted { background: var(--color-error); }
-.activity-icon.imported { background: var(--chart-purple); }
+.activity-icon.updated { background: var(--color-info); }
 
 .activity-content { flex: 1; }
 
@@ -115,5 +176,12 @@ h4 {
 .activity-time {
   font-size: var(--text-xs);
   color: var(--text-secondary);
+}
+
+@media (max-width: 768px) {
+  .activity-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 </style>

--- a/autobot-frontend/src/components/knowledge/stats/StatsActionsPanel.vue
+++ b/autobot-frontend/src/components/knowledge/stats/StatsActionsPanel.vue
@@ -2,15 +2,11 @@
   <div class="stats-actions">
     <button @click="$emit('export')" class="action-btn">
       <Icon name="download" />
-      {{ $t('knowledge.stats.actions.exportStatistics') }}
-    </button>
-    <button @click="$emit('optimize')" class="action-btn">
-      <Icon name="compress" />
-      {{ $t('knowledge.stats.actions.optimizeDatabase') }}
+      {{ $t('knowledge.stats.exportStats') }}
     </button>
     <button @click="$emit('generate-report')" class="action-btn primary">
       <Icon name="file-chart-line" />
-      {{ $t('knowledge.stats.actions.generateReport') }}
+      {{ $t('knowledge.stats.generateReport') }}
     </button>
   </div>
 </template>
@@ -22,17 +18,16 @@
 /**
  * Stats Actions Panel Component
  *
- * Action buttons for exporting, optimizing, and reporting.
- * Extracted from the former KnowledgeStats.vue (#184); currently unmounted —
- * see orphaned-subpanels discovery issue.
+ * Action buttons for exporting stats and generating reports.
+ * Wired into KnowledgeHealthAnalytics.vue (#11562).
  *
  * Issue #184: Split oversized Vue components
+ * Issue #11562: Wire in orphaned stats subpanels
  */
 import Icon from '@/components/ui/Icon.vue'
 
 interface Emits {
   (e: 'export'): void
-  (e: 'optimize'): void
   (e: 'generate-report'): void
 }
 
@@ -59,7 +54,7 @@ defineEmits<Emits>()
   font-weight: var(--font-medium);
   color: var(--text-primary);
   cursor: pointer;
-  transition: all var(--duration-200) var(--ease-in-out);
+  transition: var(--transition-all);
 }
 
 .action-btn:hover {
@@ -67,14 +62,14 @@ defineEmits<Emits>()
 }
 
 .action-btn.primary {
-  background: var(--color-primary);
+  background: var(--color-info);
   color: var(--text-on-primary);
-  border-color: var(--color-primary);
+  border-color: var(--color-info);
 }
 
 .action-btn.primary:hover {
-  background: var(--color-primary-hover);
-  border-color: var(--color-primary-hover);
+  background: var(--color-info-hover);
+  border-color: var(--color-info-hover);
 }
 
 @media (max-width: 768px) {

--- a/autobot-frontend/src/components/knowledge/stats/StatsChartsSection.vue
+++ b/autobot-frontend/src/components/knowledge/stats/StatsChartsSection.vue
@@ -2,7 +2,7 @@
   <div class="charts-section">
     <!-- Documents by Category -->
     <BasePanel variant="bordered" size="md">
-      <h4>{{ $t('knowledge.stats.charts.documentsByCategory') }}</h4>
+      <h4>{{ $t('knowledge.stats.docsByCategory') }}</h4>
       <div class="bar-chart">
         <div
           v-for="category in topCategories"
@@ -15,7 +15,7 @@
               class="bar-fill"
               :style="{
                 width: `${(category.documentCount / maxCategoryCount) * 100}%`,
-                backgroundColor: category.color || '#3b82f6'
+                backgroundColor: category.color || 'var(--color-info)'
               }"
             ></div>
             <span class="bar-value">{{ category.documentCount }}</span>
@@ -26,7 +26,7 @@
 
     <!-- Documents by Type -->
     <BasePanel variant="bordered" size="md">
-      <h4>{{ $t('knowledge.stats.charts.documentsByType') }}</h4>
+      <h4>{{ $t('knowledge.stats.docsByType') }}</h4>
       <div class="pie-chart">
         <div class="type-stats">
           <div v-for="(count, type) in documentsByType" :key="type" class="type-item">
@@ -49,10 +49,10 @@
  * Stats Charts Section Component
  *
  * Displays chart visualizations for documents by category and type.
- * Extracted from the former KnowledgeStats.vue (#184); currently unmounted —
- * see orphaned-subpanels discovery issue.
+ * Wired into KnowledgeHealthAnalytics.vue (#11562).
  *
  * Issue #184: Split oversized Vue components
+ * Issue #11562: Wire in orphaned stats subpanels
  */
 
 import BasePanel from '@/components/base/BasePanel.vue'
@@ -74,12 +74,12 @@ const props = defineProps<Props>()
 
 const getTypeColor = (type: string): string => {
   const colors: Record<string, string> = {
-    document: '#3b82f6',
-    webpage: '#10b981',
-    api: '#f59e0b',
-    upload: '#8b5cf6'
+    document: 'var(--color-info)',
+    webpage: 'var(--color-success)',
+    api: 'var(--color-warning)',
+    upload: 'var(--chart-purple)'
   }
-  return colors[type] || '#6b7280'
+  return colors[type] || 'var(--text-tertiary)'
 }
 
 const getTypePercentage = (count: number): number => {
@@ -98,7 +98,6 @@ const capitalize = (str: string): string => {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
   gap: var(--spacing-6);
-  margin-bottom: var(--spacing-8);
 }
 
 .charts-section h4 {
@@ -123,7 +122,7 @@ const capitalize = (str: string): string => {
 .bar-label {
   width: 120px;
   font-size: var(--text-sm);
-  color: var(--text-secondary);
+  color: var(--text-primary);
 }
 
 .bar-wrapper {
@@ -137,7 +136,7 @@ const capitalize = (str: string): string => {
 
 .bar-fill {
   height: 100%;
-  transition: width var(--duration-500) var(--ease-in-out);
+  transition: width var(--duration-500) var(--ease-out);
 }
 
 .bar-value {
@@ -147,7 +146,7 @@ const capitalize = (str: string): string => {
   transform: translateY(-50%);
   font-size: var(--text-xs);
   font-weight: var(--font-medium);
-  color: var(--text-secondary);
+  color: var(--text-primary);
 }
 
 /* Type Stats */
@@ -162,20 +161,20 @@ const capitalize = (str: string): string => {
   align-items: center;
   gap: var(--spacing-3);
   padding: var(--spacing-2);
-  background: var(--bg-tertiary);
+  background: var(--bg-secondary);
   border-radius: var(--radius-md);
 }
 
 .type-color {
   width: 1rem;
   height: 1rem;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-default);
 }
 
 .type-name {
   flex: 1;
   font-weight: var(--font-medium);
-  color: var(--text-secondary);
+  color: var(--text-primary);
 }
 
 .type-count {
@@ -185,7 +184,7 @@ const capitalize = (str: string): string => {
 
 .type-percentage {
   font-size: var(--text-sm);
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
 }
 
 @media (max-width: 768px) {

--- a/autobot-frontend/src/components/knowledge/stats/StatsOverviewCards.vue
+++ b/autobot-frontend/src/components/knowledge/stats/StatsOverviewCards.vue
@@ -1,42 +1,27 @@
 <template>
-  <div class="stats-overview" role="region" :aria-label="$t('knowledge.stats.overview.ariaLabel')">
-    <BasePanel variant="elevated" size="sm" role="article" aria-labelledby="facts-title">
-      <div class="stat-icon facts" aria-hidden="true">
-        <Icon name="lightbulb" />
-      </div>
-      <div class="stat-content">
-        <h4 id="facts-title">{{ $t('knowledge.stats.overview.totalFacts') }}</h4>
-        <p class="stat-value" aria-live="polite">{{ totalFacts }}</p>
-        <p class="stat-change" :aria-label="$t('knowledge.stats.overview.factsAriaLabel')">
-          {{ $t('knowledge.stats.overview.factsDescription') }}
-        </p>
-      </div>
-    </BasePanel>
-
-    <BasePanel variant="elevated" size="sm" role="article" aria-labelledby="documents-title">
+  <div class="stats-overview" role="region" :aria-label="$t('knowledge.stats.overviewAriaLabel')">
+    <BasePanel variant="elevated" size="sm" role="article" aria-labelledby="analytics-documents-title">
       <div class="stat-icon documents" aria-hidden="true">
         <Icon name="file-alt" />
       </div>
       <div class="stat-content">
-        <h4 id="documents-title">{{ $t('knowledge.stats.overview.totalDocuments') }}</h4>
-        <p class="stat-value" aria-live="polite">{{ totalDocuments }}</p>
-        <p class="stat-change" :class="{ 'needs-vectorization': needsVectorization }"
-           :aria-label="needsVectorization ? $t('knowledge.stats.overview.notVectorizedAria') : $t('knowledge.stats.overview.vectorizedAria')">
-          <Icon name="exclamation-triangle" v-if="needsVectorization"  aria-hidden="true" />
-          {{ needsVectorization ? $t('knowledge.stats.overview.notVectorized') : $t('knowledge.stats.overview.vectorizedForRag') }}
+        <h4 id="analytics-documents-title">{{ $t('knowledge.stats.totalDocuments') }}</h4>
+        <p class="stat-value" aria-live="polite">{{ documentCount }}</p>
+        <p class="stat-change">
+          {{ $t('knowledge.stats.avgDocsPerCategoryValue', { count: avgDocsPerCategory }) }}
         </p>
       </div>
     </BasePanel>
 
-    <BasePanel variant="elevated" size="sm" role="article" aria-labelledby="categories-title">
+    <BasePanel variant="elevated" size="sm" role="article" aria-labelledby="analytics-categories-title">
       <div class="stat-icon categories" aria-hidden="true">
         <Icon name="folder" />
       </div>
       <div class="stat-content">
-        <h4 id="categories-title">{{ $t('knowledge.stats.overview.categories') }}</h4>
+        <h4 id="analytics-categories-title">{{ $t('knowledge.stats.categories') }}</h4>
         <p class="stat-value" aria-live="polite">{{ categoryCount }}</p>
-        <p class="stat-change" :aria-label="$t('knowledge.stats.overview.avgDocsPerCategoryAria')">
-          {{ $t('knowledge.stats.overview.avgDocsPerCategory', { count: avgDocsPerCategory }) }}
+        <p class="stat-change">
+          {{ $t('knowledge.stats.avgDocsPerCategoryValue', { count: avgDocsPerCategory }) }}
         </p>
       </div>
     </BasePanel>
@@ -46,10 +31,10 @@
         <Icon name="tags" />
       </div>
       <div class="stat-content">
-        <h4>{{ $t('knowledge.stats.overview.uniqueTags') }}</h4>
+        <h4>{{ $t('knowledge.stats.uniqueTags') }}</h4>
         <p class="stat-value">{{ uniqueTagsCount }}</p>
         <p class="stat-change">
-          {{ $t('knowledge.stats.overview.avgTagsPerDoc', { count: avgTagsPerDoc }) }}
+          {{ $t('knowledge.stats.avgTagsPerDoc', { count: avgTagsPerDoc }) }}
         </p>
       </div>
     </BasePanel>
@@ -59,10 +44,10 @@
         <Icon name="database" />
       </div>
       <div class="stat-content">
-        <h4>{{ $t('knowledge.stats.overview.storageUsed') }}</h4>
+        <h4>{{ $t('knowledge.stats.storageUsedTitle') }}</h4>
         <p class="stat-value">{{ formatFileSize(totalStorageSize) }}</p>
         <p class="stat-change">
-          {{ $t('knowledge.stats.overview.avgPerDoc', { size: formatFileSize(avgDocSize) }) }}
+          {{ $t('knowledge.stats.avgPerDoc', { size: formatFileSize(avgDocSize) }) }}
         </p>
       </div>
     </BasePanel>
@@ -76,11 +61,11 @@
 /**
  * Stats Overview Cards Component
  *
- * Displays overview statistics cards for knowledge base.
- * Extracted from the former KnowledgeStats.vue (#184); currently unmounted —
- * see orphaned-subpanels discovery issue.
+ * Displays overview statistics cards for knowledge base (4-card layout:
+ * documents, categories, tags, storage). Wired into KnowledgeHealthAnalytics.vue (#11562).
  *
  * Issue #184: Split oversized Vue components
+ * Issue #11562: Wire in orphaned stats subpanels
  */
 
 import Icon from '@/components/ui/Icon.vue'
@@ -88,15 +73,13 @@ import BasePanel from '@/components/base/BasePanel.vue'
 import { formatFileSize } from '@/utils/formatHelpers'
 
 interface Props {
-  totalFacts: number
-  totalDocuments: number
+  documentCount: number
   categoryCount: number
   uniqueTagsCount: number
   avgDocsPerCategory: number
   avgTagsPerDoc: string
   totalStorageSize: number
   avgDocSize: number
-  needsVectorization: boolean
 }
 
 defineProps<Props>()
@@ -106,15 +89,14 @@ defineProps<Props>()
 /* Issue #704: Migrated to CSS design tokens */
 .stats-overview {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: var(--spacing-6);
-  margin-bottom: var(--spacing-8);
-  contain: layout style;}
+}
 
 .stat-icon {
   width: 3.5rem;
   height: 3.5rem;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -122,8 +104,7 @@ defineProps<Props>()
   color: var(--text-on-primary);
 }
 
-.stat-icon.facts { background: var(--chart-pink); }
-.stat-icon.documents { background: var(--color-primary); }
+.stat-icon.documents { background: var(--color-info); }
 .stat-icon.categories { background: var(--color-success); }
 .stat-icon.tags { background: var(--color-warning); }
 .stat-icon.storage { background: var(--chart-purple); }
@@ -149,13 +130,6 @@ defineProps<Props>()
   display: flex;
   align-items: center;
   gap: var(--spacing-1);
-}
-
-.stat-change.positive { color: var(--color-success); }
-
-.stat-change.needs-vectorization {
-  color: var(--color-warning);
-  font-weight: var(--font-medium);
 }
 
 @media (max-width: 768px) {

--- a/autobot-frontend/src/components/knowledge/stats/TagCloudPanel.vue
+++ b/autobot-frontend/src/components/knowledge/stats/TagCloudPanel.vue
@@ -1,18 +1,15 @@
 <template>
   <BasePanel variant="bordered" size="md">
-    <h4>{{ $t('knowledge.stats.tagCloud.title') }}</h4>
-    <div class="tag-cloud" role="list" :aria-label="$t('knowledge.stats.tagCloud.ariaLabel')">
+    <h4>{{ $t('knowledge.stats.popularTags') }}</h4>
+    <div class="tag-cloud" role="list" :aria-label="$t('knowledge.stats.popularTagsAriaLabel')">
       <span
         v-for="tag in tags"
         :key="tag.name"
         class="tag-cloud-item"
         :style="{ fontSize: `${tag.size}rem` }"
-        :title="$t('knowledge.stats.tagCloud.documentsCount', { count: tag.count })"
-        :aria-label="$t('knowledge.stats.tagCloud.tagAriaLabel', { name: tag.name, count: tag.count })"
+        :title="$t('knowledge.health.tagDocCount', { count: tag.count })"
+        :aria-label="`${tag.name}: ${$t('knowledge.health.tagDocCount', { count: tag.count })}`"
         role="listitem"
-        tabindex="0"
-        @click="$emit('tag-click', tag.name)"
-        @keypress.enter="$emit('tag-click', tag.name)"
       >
         {{ tag.name }}
       </span>
@@ -28,10 +25,10 @@
  * Tag Cloud Panel Component
  *
  * Displays a cloud of popular tags with varying sizes.
- * Extracted from the former KnowledgeStats.vue (#184); currently unmounted —
- * see orphaned-subpanels discovery issue.
+ * Wired into KnowledgeHealthAnalytics.vue (#11562).
  *
  * Issue #184: Split oversized Vue components
+ * Issue #11562: Wire in orphaned stats subpanels
  */
 
 import BasePanel from '@/components/base/BasePanel.vue'
@@ -46,12 +43,7 @@ interface Props {
   tags: Tag[]
 }
 
-interface Emits {
-  (e: 'tag-click', tagName: string): void
-}
-
 defineProps<Props>()
-defineEmits<Emits>()
 </script>
 
 <style scoped>
@@ -70,26 +62,14 @@ h4 {
 }
 
 .tag-cloud-item {
-  color: var(--color-primary);
-  cursor: pointer;
-  transition: all var(--duration-200) var(--ease-in-out);
+  color: var(--color-info);
+  transition: var(--transition-all);
   padding: var(--spacing-1) var(--spacing-2);
-  border-radius: var(--radius-sm);
-  outline: none;
+  border-radius: var(--radius-default);
 }
 
-.tag-cloud-item:hover,
-.tag-cloud-item:focus {
-  color: var(--color-primary-hover);
+.tag-cloud-item:hover {
+  color: var(--color-info-hover);
   transform: scale(1.1);
-}
-
-.tag-cloud-item:focus {
-  box-shadow: var(--ring-primary);
-  background: var(--color-primary-bg);
-}
-.tag-cloud-item:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
 }
 </style>

--- a/autobot-frontend/src/components/knowledge/stats/VectorStatsSection.vue
+++ b/autobot-frontend/src/components/knowledge/stats/VectorStatsSection.vue
@@ -40,13 +40,27 @@
  * Issue #11562: Wire in orphaned stats subpanels
  */
 
+import { onMounted } from 'vue'
 import Icon from '@/components/ui/Icon.vue'
 import { useVectorStats } from '@/composables/knowledge/useVectorStats'
 import { useKnowledgeStats } from '@/composables/knowledge/useKnowledgeStats'
 import { formatCategoryName } from '@/utils/formatHelpers'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('VectorStatsSection')
 
 const { vectorStats } = useVectorStats()
-const { categoryFactCounts } = useKnowledgeStats()
+// useKnowledgeStats is per-instance state: the fetch must happen on the SAME
+// instance this section reads from (a parent-side refresh populates a
+// different ref and the chart renders 0% bars).
+const { categoryFactCounts, refreshCategoryFacts } = useKnowledgeStats()
+
+onMounted(async () => {
+  const result = await refreshCategoryFacts()
+  if (result === null) {
+    logger.warn('Failed to fetch category facts; distribution chart shows zero counts')
+  }
+})
 
 const getCategoryFactCount = (category: string): number => {
   return categoryFactCounts.value[category] || 0

--- a/autobot-frontend/src/components/knowledge/stats/VectorStatsSection.vue
+++ b/autobot-frontend/src/components/knowledge/stats/VectorStatsSection.vue
@@ -1,163 +1,24 @@
 <template>
-  <div v-if="stats" class="vector-stats-section">
-    <div class="section-header">
-      <h3><Icon name="project-diagram" /> {{ $t('knowledge.stats.vector.title') }}</h3>
-      <button @click="$emit('refresh')"
-              :disabled="loading"
-              class="refresh-btn"
-              :aria-label="$t('knowledge.stats.vector.refreshAriaLabel')">
-        <Icon name="sync" />
-        {{ $t('knowledge.stats.vector.refresh') }}
-      </button>
-    </div>
-
-    <div class="vector-overview-grid">
-      <BasePanel variant="elevated" size="md">
-        <div class="vector-stat-icon facts">
-          <Icon name="lightbulb" />
+  <div v-if="vectorStats" class="vector-chart-section">
+    <h4><Icon name="chart-pie" /> {{ $t('knowledge.stats.vectorDistribution') }}</h4>
+    <div class="vector-categories-chart">
+      <div
+        v-for="(category, idx) in vectorStats.categories"
+        :key="idx"
+        class="category-bar"
+      >
+        <div class="category-info">
+          <span class="category-name">{{ formatCategoryName(category) }}</span>
+          <span class="category-count">{{ $t('knowledge.stats.factsCount', { count: getCategoryFactCount(category) }) }}</span>
         </div>
-        <div class="vector-stat-content">
-          <h4>{{ $t('knowledge.stats.vector.totalFacts') }}</h4>
-          <p class="vector-stat-value">{{ stats.total_facts || 0 }}</p>
-          <p class="vector-stat-label">{{ $t('knowledge.stats.vector.knowledgeItemsStored') }}</p>
-        </div>
-      </BasePanel>
-
-      <BasePanel variant="elevated" size="md" :class="{ 'needs-attention': needsVectorization }">
-        <div class="vector-stat-icon vectors">
-          <Icon name="cubes" />
-        </div>
-        <div class="vector-stat-content">
-          <h4>{{ $t('knowledge.stats.vector.totalVectors') }}</h4>
-          <p class="vector-stat-value">{{ stats.total_vectors || 0 }}</p>
-          <p v-if="needsVectorization" class="vector-stat-label warning">
-            <Icon name="exclamation-triangle" /> {{ $t('knowledge.stats.vector.notVectorized') }}
-          </p>
-          <p v-else class="vector-stat-label">{{ $t('knowledge.stats.vector.embeddingsGenerated') }}</p>
-        </div>
-      </BasePanel>
-
-      <BasePanel variant="elevated" size="md">
-        <div class="vector-stat-icon database">
-          <Icon name="database" />
-        </div>
-        <div class="vector-stat-content">
-          <h4>{{ $t('knowledge.stats.vector.databaseSize') }}</h4>
-          <p class="vector-stat-value">{{ formatFileSize(stats.db_size || 0) }}</p>
-          <p class="vector-stat-label">{{ $t('knowledge.stats.vector.storageUsed') }}</p>
-        </div>
-      </BasePanel>
-
-      <BasePanel variant="elevated" size="md">
-        <div class="vector-stat-icon status">
-          <Icon name="check-circle" />
-        </div>
-        <div class="vector-stat-content">
-          <h4>{{ $t('knowledge.stats.vector.status') }}</h4>
-          <StatusBadge :variant="getStatusVariant(stats.status)" size="sm" class="vector-stat-value">
-            {{ stats.status || $t('knowledge.stats.vector.unknown') }}
-          </StatusBadge>
-          <p class="vector-stat-label">{{ $t('knowledge.stats.vector.rag') }}: {{ stats.rag_available ? $t('knowledge.stats.vector.available') : $t('knowledge.stats.vector.unavailable') }}</p>
-        </div>
-      </BasePanel>
-    </div>
-
-    <!-- Vectorization Notice -->
-    <div v-if="needsVectorization" class="vectorization-notice">
-      <div class="notice-icon">
-        <Icon name="info-circle" />
-      </div>
-      <div class="notice-content">
-        <h4>{{ $t('knowledge.stats.vector.embeddingsNotGenerated') }}</h4>
-        <p>
-          {{ $t('knowledge.stats.vector.embeddingsNotGeneratedDesc', { count: stats.total_facts }) }}
-        </p>
-        <p class="notice-hint">
-          <Icon name="lightbulb" />
-          {{ $t('knowledge.stats.vector.embeddingsHint') }}
-        </p>
-      </div>
-    </div>
-
-    <!-- Vector Categories Distribution Chart -->
-    <div class="vector-chart-section">
-      <h4><Icon name="chart-pie" /> {{ $t('knowledge.stats.vector.distributionByCategory') }}</h4>
-      <div class="vector-categories-chart">
-        <div
-          v-for="(category, idx) in stats.categories"
-          :key="idx"
-          class="category-bar"
-        >
-          <div class="category-info">
-            <span class="category-name">{{ formatCategoryName(category) }}</span>
-            <span class="category-count">{{ $t('knowledge.stats.vector.factsCount', { count: getCategoryFactCount(category) }) }}</span>
-          </div>
-          <div class="category-progress">
-            <div
-              class="category-fill"
-              :style="{
-                width: getCategoryPercentage(category) + '%',
-                backgroundColor: getCategoryColor(idx)
-              }"
-            ></div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Vector Index Health -->
-    <div class="vector-health-section">
-      <h4><Icon name="heartbeat" /> {{ $t('knowledge.stats.vector.indexHealth') }}</h4>
-      <div class="health-indicators">
-        <div class="health-item" :class="{ active: stats.initialized }">
-          <Icon name="check-circle" />
-          <span>{{ $t('knowledge.stats.vector.initialized') }}</span>
-        </div>
-        <div class="health-item" :class="{ active: stats.llama_index_configured }">
-          <Icon name="cube" />
-          <span>{{ $t('knowledge.stats.vector.llamaIndex') }}</span>
-        </div>
-        <div class="health-item" :class="{ active: stats.llama_index_configured }">
-          <Icon name="link" />
-          <span>{{ $t('knowledge.stats.vector.langChain') }}</span>
-        </div>
-        <div class="health-item" :class="{ active: stats.index_available }">
-          <Icon name="layer-group" />
-          <span>{{ $t('knowledge.stats.vector.indexAvailable') }}</span>
-        </div>
-        <div class="health-item" :class="{ active: stats.rag_available }">
-          <Icon name="brain" />
-          <span>{{ $t('knowledge.stats.vector.ragAvailable') }}</span>
-        </div>
-      </div>
-      <div class="health-details">
-        <div class="detail-item">
-          <label>{{ $t('knowledge.stats.vector.redisDb') }}:</label>
-          <span class="mono">{{ stats.redis_db }}</span>
-        </div>
-        <div class="detail-item">
-          <label>{{ $t('knowledge.stats.vector.indexName') }}:</label>
-          <span class="mono">{{ stats.index_name }}</span>
-        </div>
-        <div class="detail-item">
-          <label>{{ $t('knowledge.stats.vector.vectorFramework') }}:</label>
-          <span class="mono">LlamaIndex + LangChain</span>
-        </div>
-        <div class="detail-item">
-          <label>{{ $t('knowledge.stats.vector.embeddingModel') }}:</label>
-          <span class="mono">{{ embeddingModelDisplay }}</span>
-        </div>
-        <div class="detail-item">
-          <label>{{ $t('knowledge.stats.vector.textSplitter') }}:</label>
-          <span class="mono">LangChain RecursiveCharacterTextSplitter</span>
-        </div>
-        <div class="detail-item">
-          <label>{{ $t('knowledge.stats.vector.lastUpdated') }}:</label>
-          <span>{{ formatDateTime(stats.last_updated) }}</span>
-        </div>
-        <div class="detail-item">
-          <label>{{ $t('knowledge.stats.vector.indexedDocuments') }}:</label>
-          <span>{{ stats.indexed_documents || 0 }}</span>
+        <div class="category-progress">
+          <div
+            class="category-fill"
+            :style="{
+              width: getCategoryPercentage(category) + '%',
+              backgroundColor: getCategoryColor(idx)
+            }"
+          ></div>
         </div>
       </div>
     </div>
@@ -171,94 +32,33 @@
 /**
  * Vector Stats Section Component
  *
- * Displays vector database statistics including facts, vectors, health indicators.
- * Extracted from the former KnowledgeStats.vue (#184); currently unmounted —
- * see orphaned-subpanels discovery issue.
+ * Displays vector category distribution chart for KnowledgeHealthAnalytics.
+ * Self-contained: owns useVectorStats and useKnowledgeStats composables.
+ * Wired into KnowledgeHealthAnalytics.vue (#11562).
  *
  * Issue #184: Split oversized Vue components
+ * Issue #11562: Wire in orphaned stats subpanels
  */
 
 import Icon from '@/components/ui/Icon.vue'
-import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
-import BasePanel from '@/components/base/BasePanel.vue'
-import StatusBadge from '@/components/ui/StatusBadge.vue'
-import {
-  formatFileSize,
-  formatDateTime,
-  formatCategoryName
-} from '@/utils/formatHelpers'
+import { useVectorStats } from '@/composables/knowledge/useVectorStats'
+import { useKnowledgeStats } from '@/composables/knowledge/useKnowledgeStats'
+import { formatCategoryName } from '@/utils/formatHelpers'
 
-interface VectorStats {
-  total_facts: number
-  total_documents: number
-  total_vectors: number
-  indexed_documents: number
-  db_size: number
-  status: 'online' | 'offline' | 'unknown'
-  rag_available: boolean
-  initialized: boolean
-  llama_index_configured: boolean
-  index_available: boolean
-  redis_db: string | number
-  index_name: string
-  embedding_model?: string
-  embedding_dimensions?: number
-  last_updated?: string
-  categories?: string[]
-}
-
-interface Props {
-  stats: VectorStats | null
-  loading: boolean
-  categoryFactCounts: Record<string, number>
-}
-
-interface Emits {
-  (e: 'refresh'): void
-}
-
-const props = defineProps<Props>()
-defineEmits<Emits>()
-const { t } = useI18n()
-
-const needsVectorization = computed(() => {
-  if (!props.stats) return false
-  const totalFacts = props.stats.total_facts || 0
-  const totalVectors = props.stats.total_vectors || 0
-  return totalFacts > 0 && totalVectors === 0
-})
-
-const embeddingModelDisplay = computed(() => {
-  if (!props.stats) return t('knowledge.stats.vector.loading')
-  const model = props.stats.embedding_model
-  const dimensions = props.stats.embedding_dimensions
-  if (model && dimensions) return `${model} (${dimensions}-dim)`
-  if (model) return model
-  return t('knowledge.stats.vector.notConfigured')
-})
-
-const getStatusVariant = (status: string): 'success' | 'error' | 'secondary' => {
-  const variantMap: Record<string, 'success' | 'error' | 'secondary'> = {
-    'online': 'success',
-    'offline': 'error',
-    'unknown': 'secondary'
-  }
-  return variantMap[status] || 'secondary'
-}
+const { vectorStats } = useVectorStats()
+const { categoryFactCounts } = useKnowledgeStats()
 
 const getCategoryFactCount = (category: string): number => {
-  return props.categoryFactCounts[category] || 0
+  return categoryFactCounts.value[category] || 0
 }
 
 const getCategoryPercentage = (category: string): number => {
-  const total = props.stats?.total_facts || 1
+  const total = vectorStats.value?.total_facts || 1
   const count = getCategoryFactCount(category)
   return Math.round((count / total) * 100)
 }
 
 const getCategoryColor = (index: number): string => {
-  // Uses CSS custom property values for consistency with design tokens
   const colors = [
     'var(--color-primary)',
     'var(--color-success)',
@@ -273,186 +73,15 @@ const getCategoryColor = (index: number): string => {
 
 <style scoped>
 /* Issue #704: Migrated to CSS design tokens */
-.vector-stats-section {
-  background: var(--chart-purple);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-8);
-  margin-bottom: var(--spacing-8);
-  color: var(--text-on-primary);
-  box-shadow: var(--shadow-xl);
-}
-
-.section-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: var(--spacing-6);
-}
-
-.section-header h3 {
-  color: var(--text-on-primary);
-  font-size: var(--text-2xl);
-  font-weight: var(--font-bold);
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-3);
-}
-
-.refresh-btn {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  padding: var(--spacing-2) var(--spacing-4);
-  border: 1px solid var(--bg-primary-transparent-hover);
-  background: var(--bg-primary-transparent);
-  border-radius: var(--radius-md);
-  font-size: var(--text-sm);
-  color: var(--text-on-primary);
-  cursor: pointer;
-  transition: all var(--duration-200) var(--ease-in-out);
-}
-
-.refresh-btn:hover:not(:disabled) {
-  background: var(--bg-primary-transparent-hover);
-}
-
-.refresh-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.vector-overview-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: var(--spacing-6);
-  margin-bottom: var(--spacing-8);
-}
-
-.needs-attention {
-  border-color: var(--color-warning-border);
-  animation: pulse-card 2s ease-in-out infinite;
-}
-
-@keyframes pulse-card {
-  0%, 100% { border-color: var(--color-warning-border); opacity: 0.7; }
-  50% { border-color: var(--color-warning); opacity: 1; }
-}
-
-.vector-stat-icon {
-  width: 3.5rem;
-  height: 3.5rem;
-  border-radius: var(--radius-lg);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.75rem;
-  color: var(--text-on-primary);
-  flex-shrink: 0;
-}
-
-.vector-stat-icon.facts { background: var(--chart-pink); }
-.vector-stat-icon.vectors { background: var(--chart-cyan); }
-.vector-stat-icon.database { background: var(--color-success); }
-.vector-stat-icon.status { background: var(--chart-pink); }
-
-.vector-stat-content h4 {
-  font-size: var(--text-sm);
-  color: var(--text-tertiary);
-  margin-bottom: var(--spacing-2);
-  font-weight: var(--font-medium);
-}
-
-.vector-stat-value {
-  font-size: 2rem;
-  font-weight: var(--font-bold);
-  color: var(--text-primary);
-  margin-bottom: var(--spacing-1);
-  line-height: 1;
-}
-
-.vector-stat-label {
-  font-size: var(--text-xs);
-  color: var(--text-tertiary);
-}
-
-.vector-stat-label.warning {
-  color: var(--color-warning);
-  font-weight: var(--font-semibold);
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-1-5);
-}
-
-.vectorization-notice {
-  display: flex;
-  gap: var(--spacing-4);
-  background: var(--color-warning-bg-transparent);
-  border: 1px solid var(--color-warning-border);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-6);
-  margin-bottom: var(--spacing-8);
-  animation: pulse-warning 2s ease-in-out infinite;
-}
-
-@keyframes pulse-warning {
-  0%, 100% { box-shadow: 0 0 0 0 var(--color-warning-border); }
-  50% { box-shadow: 0 0 0 8px transparent; }
-}
-
-.notice-icon {
-  width: 3rem;
-  height: 3rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--color-warning-bg-transparent);
-  border-radius: 50%;
-  color: var(--color-warning);
-  font-size: var(--text-2xl);
-  flex-shrink: 0;
-}
-
-.notice-content h4 {
-  color: var(--text-on-primary);
-  font-size: var(--text-lg);
-  font-weight: var(--font-semibold);
-  margin-bottom: var(--spacing-3);
-}
-
-.notice-content p {
-  color: var(--text-on-primary-muted);
-  font-size: var(--text-sm);
-  line-height: 1.6;
-  margin-bottom: var(--spacing-2);
-}
-
-.notice-content strong { color: var(--color-warning); font-weight: var(--font-bold); }
-
-.notice-hint {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  padding: var(--spacing-3);
-  background: var(--bg-overlay);
-  border-radius: var(--radius-md);
-  margin-top: var(--spacing-3);
-  font-size: 0.8125rem;
-  color: var(--text-on-primary-muted);
-}
-
-.notice-hint i { color: var(--color-warning); }
-
 .vector-chart-section {
-  background: var(--bg-primary-transparent);
-  backdrop-filter: blur(10px);
-  border: 1px solid var(--bg-primary-transparent-hover);
-  border-radius: var(--radius-lg);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-xl);
   padding: var(--spacing-6);
-  margin-bottom: var(--spacing-8);
 }
 
 .vector-chart-section h4 {
-  color: var(--text-on-primary);
+  color: var(--text-primary);
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
   margin-bottom: var(--spacing-6);
@@ -480,98 +109,27 @@ const getCategoryColor = (index: number): string => {
   font-size: var(--text-sm);
 }
 
-.category-name { color: var(--text-on-primary); font-weight: var(--font-medium); }
-.category-count { color: var(--text-on-primary-muted); font-size: var(--text-xs); }
+.category-name {
+  color: var(--text-primary);
+  font-weight: var(--font-medium);
+}
+
+.category-count {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+}
 
 .category-progress {
   height: 1.5rem;
-  background: var(--bg-primary-transparent);
-  border-radius: var(--radius-lg);
+  background: var(--bg-primary);
+  border-radius: var(--radius-xl);
   overflow: hidden;
+  position: relative;
 }
 
 .category-fill {
   height: 100%;
-  border-radius: var(--radius-lg);
-  transition: width var(--duration-500) var(--ease-in-out);
-  box-shadow: var(--shadow-glow);
-}
-
-.vector-health-section {
-  background: var(--bg-primary-transparent);
-  backdrop-filter: blur(10px);
-  border: 1px solid var(--bg-primary-transparent-hover);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-6);
-}
-
-.vector-health-section h4 {
-  color: var(--text-on-primary);
-  font-size: var(--text-lg);
-  font-weight: var(--font-semibold);
-  margin-bottom: var(--spacing-6);
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-}
-
-.health-indicators {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: var(--spacing-4);
-  margin-bottom: var(--spacing-6);
-}
-
-.health-item {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  padding: var(--spacing-3) var(--spacing-4);
-  background: var(--bg-primary-transparent-light);
-  border: 1px solid var(--bg-primary-transparent);
-  border-radius: var(--radius-md);
-  color: var(--text-on-primary-muted);
-  font-size: var(--text-sm);
-  transition: all var(--duration-300) var(--ease-in-out);
-}
-
-.health-item.active {
-  background: var(--color-success-bg-transparent);
-  border-color: var(--color-success);
-  color: var(--text-on-primary);
-}
-
-.health-item.active i { color: var(--color-success); }
-
-.health-details {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: var(--spacing-4);
-  padding-top: var(--spacing-4);
-  border-top: 1px solid var(--bg-primary-transparent);
-}
-
-.detail-item {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-1);
-}
-
-.detail-item label {
-  font-size: var(--text-xs);
-  color: var(--text-on-primary-muted);
-  font-weight: var(--font-medium);
-}
-
-.detail-item span {
-  font-size: var(--text-sm);
-  color: var(--text-on-primary);
-}
-
-.detail-item .mono {
-  font-family: var(--font-mono);
-  background: var(--bg-overlay);
-  padding: var(--spacing-1) var(--spacing-2);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xl);
+  transition: width var(--duration-500) var(--ease-out);
 }
 </style>

--- a/autobot-frontend/src/components/knowledge/stats/index.ts
+++ b/autobot-frontend/src/components/knowledge/stats/index.ts
@@ -6,10 +6,11 @@
  * Knowledge Stats Sub-Components
  *
  * Barrel exports for knowledge stats sub-components (stats panels).
- * Extracted from the former KnowledgeStats.vue (#184); currently unmounted —
- * see orphaned-subpanels discovery issue.
+ * Extracted from the former KnowledgeStats.vue (#184); mounted into
+ * KnowledgeHealthAnalytics.vue (#11562).
  *
  * Issue #184: Split oversized Vue components
+ * Issue #11562: Wire in orphaned stats subpanels
  */
 
 export { default as VectorStatsSection } from './VectorStatsSection.vue'


### PR DESCRIPTION
Closes #11562

## Thinking Path

The six subpanels under `components/knowledge/stats/` were extracted from the old KnowledgeStats.vue (#184) but never mounted after the #11558 consolidation authored KnowledgeHealthAnalytics as a monolith. Owner decision: wire them in. Current Analytics behavior is canonical — each subpanel was updated to match it (facts card dropped, activity filter chips, i18n'd tooltips, display-only tags, token colors), then adopted.

## What Changed

- KnowledgeHealthAnalytics.vue: 993 → ~380 lines; now composes VectorStatsSection, StatsOverviewCards, StatsChartsSection, RecentActivityPanel, TagCloudPanel, StatsActionsPanel (DocumentChangeFeed section stays inline; error banner + data layer stay in the parent)
- Subpanels updated to canonical behavior; 5 hardcoded hex colors in StatsChartsSection replaced with existing tokens
- Review-found Critical fixed: `useKnowledgeStats` is per-instance state, so VectorStatsSection now fetches category facts on its own instance in `onMounted` (previously the parent fetched into a different instance → 0% bars); parent's duplicate fetch removed
- Barrel + header comments updated (no longer orphaned)

## Verification

- vue-tsc clean · vitest 1980 pass (138 files) · eslint+oxlint 0 problems · stylelint token guard 0 problems on all touched components
- Independent review traced all six sections against the pre-refactor monolith for render fidelity; the one Critical found was fixed and re-verified

## Model Used

Claude Fable 5 (controller) with Sonnet implementer/reviewer subagents.