### PR TITLE
fix(test): make patch() effective by binding real-loaded service modules on the parent stub (#11532)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -860,27 +860,54 @@ def set_test_environment():
     os.environ.update(original_env)
 
 
-def pytest_configure(config):  # noqa: ANN001
-    """#11248: real-load lightweight service modules whose unit tests need the real
-    helpers, AFTER every module-level stub above is in place.
+def _real_load_service(name: str, rel_path: str) -> None:  # noqa: ANN001
+    """Real-load a services.* module by path, overwriting any existing stub.
 
-    ``services.llm_api_key_service`` imports ``autobot_shared.redis_client`` /
-    ``logging_manager`` / ``singleton_factory`` at module top — all stubbed/patched
-    during conftest import — so it can only be real-loaded once conftest import has
-    fully completed. pytest_configure runs after that and before collection, so the
-    real module (LLMApiKeyRecord, model_allowed, _parse_key_id_from_bearer, …) is in
-    place when tests/services/test_llm_api_key_service.py is imported. Overwrites the
-    services-package MagicMock stub; falls back to the stub if it can't load here.
+    Must be called from pytest_configure (after all module-level stubs are in
+    place but before collection imports test modules).  Falls back to the
+    existing stub silently if the real file can't be loaded in this env.
+
+    #11532 note: after inserting the real module into sys.modules we ALSO bind
+    it as an attribute on the parent package stub.  ``unittest.mock.patch``
+    resolves ``"services.foo.BAR"`` by calling ``__import__("services.foo")``
+    then ``getattr(services, "foo")``.  Without the setattr the parent stub's
+    ``__getattr__`` always returns a MagicMock singleton, so patch silently
+    patches the wrong object and the real module's globals are never updated.
     """
-    import importlib.util as _cfg_ilu
+    import importlib.util as _rl_ilu
 
-    _spec = _cfg_ilu.spec_from_file_location(
-        "services.llm_api_key_service", str(backend_root / "services" / "llm_api_key_service.py")
-    )
+    _spec = _rl_ilu.spec_from_file_location(name, str(backend_root / rel_path))
     if _spec and _spec.loader:
-        _mod = _cfg_ilu.module_from_spec(_spec)
-        sys.modules["services.llm_api_key_service"] = _mod
+        _mod = _rl_ilu.module_from_spec(_spec)
+        sys.modules[name] = _mod
         try:
             _spec.loader.exec_module(_mod)
         except Exception:
-            sys.modules["services.llm_api_key_service"] = _make_pkg_stub("services.llm_api_key_service")
+            sys.modules[name] = _make_pkg_stub(name)
+            return
+        # Bind on parent so patch() resolves via getattr(parent, child_name).
+        _parent, _, _child = name.rpartition(".")
+        if _parent and _parent in sys.modules:
+            setattr(sys.modules[_parent], _child, sys.modules[name])
+
+
+def pytest_configure(config):  # noqa: ANN001
+    """#11248/#11532: real-load lightweight service modules whose unit tests need the
+    real helpers, AFTER every module-level stub above is in place.
+
+    These modules import ``autobot_shared.redis_client`` / ``logging_manager`` /
+    ``singleton_factory`` at module top — all stubbed/patched during conftest import —
+    so they can only be real-loaded once conftest import has fully completed.
+    pytest_configure runs after that and before collection, so real symbols
+    (LLMApiKeyRecord, MODEL_PRICING, _check_pricing_staleness, …) are in place when
+    test modules are imported.  Each overwrites the services-package MagicMock stub.
+
+    #11532: ``services.llm_cost_tracker`` was stubbed at conftest-import time.
+    Tests that called ``patch("services.llm_cost_tracker.PRICING_VERSION", ...)``
+    were patching the *stub* module object while ``_check_pricing_staleness``
+    executed in the *real* module's globals — the patch was completely inert.
+    Real-loading here ensures ``sys.modules["services.llm_cost_tracker"]`` is the
+    same object as ``_check_pricing_staleness.__globals__`` so patch() is effective.
+    """
+    _real_load_service("services.llm_api_key_service", "services/llm_api_key_service.py")
+    _real_load_service("services.llm_cost_tracker", "services/llm_cost_tracker.py")


### PR DESCRIPTION
Closes #11532.

## Thinking Path
Discovered during #11519: `mock.patch("pkg.mod.name")` resolves its target through `sys.modules`, and conftest's stub machinery can leave `sys.modules["services.X"]` pointing at a MagicMock stub whose `__getattr__` returns a singleton — so `setattr` on it never touches the real module's function globals. The patch is inert; the test passes for the wrong reason (tests nothing).

## What Changed (test-infra only)
- `autobot-backend/conftest.py`: new `_real_load_service(name, rel_path)` helper that real-loads a module via `spec_from_file_location` AND binds it on the parent stub (`setattr(sys.modules["services"], "X", real_mod)`), so `patch("services.X.name")` resolves to the real module. Applied to `llm_cost_tracker` (new) and `llm_api_key_service` (retroactively — was silently affected).

## Audit
261 `patch(...)` calls examined across llm_shared/chat_workflow/services/agents/orchestration. **3 confirmed INERT and fixed** (all in `TestPricingStaleness`); the rest EFFECTIVE. 8 UNCERTAIN deferred to **#11618** (`test_hardware.py` — blocked by a separate `llm_shared.__path__` collection error). This corroborates the independent finding in #11557 (12 Slack Redis tests were patching a non-async symbol — same inert-patch class).

## Verification
- `pytest autobot-backend/tests/services/test_llm_cost_tracker.py` → **63 passed** (prior baseline: 31 failures in this file).
- **Sabotage proof (re-run independently):** forcing `_check_pricing_staleness` to a hardcoded stale date → **2 tests FAIL** (they genuinely reach the code now); revert → 63 pass. Proves the patches are effective, not inert.
- **Collection A/B:** full `autobot-backend/tests` collection = **131 errors with this conftest, 131 with origin's** — this change adds zero collection errors (131 is pre-existing base drift). flake8/black clean.

## Model Used
Claude (Fable 5) orchestrating + independent sabotage/collection verification; Sonnet audit agent.
