### PR TITLE
docs(claude): retire one-issue-per-session; batch similar-scope issues per PR (#11622)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,5 +61,5 @@ Correctness → Speed → Maintainability. No wasted motion. No speculative work
 - **PR queue limit:** ≥5 open PRs → defer implementation and notify
 - **Codebase is source of truth:** never edit `/opt/autobot/` or `/var/log/autobot/`
 - **System updates (test AND prod):** ONLY via the builtin updater a user reaches at `/slm/maintenance/updates/code-sync` (code-sync API / self-update); if the builtin can't do it, fix that gap (issue + PR) — never side-channel via ad-hoc ansible/shell
-- **One issue per session** — don't auto-start others after completing one
+- **Batch similar-scope issues per PR:** one PR may close several similar-scope issues (`Closes #A, #B, …`) — each MUST be fully delivered (closure Gate 3: partial delivery never closes); genuinely independent or different-risk changes still get separate PRs
 - **Model tiers:** Haiku (`claude-haiku-4-5-20251001`) for status/labels/simple transitions; Sonnet for implementation and reviews


### PR DESCRIPTION
Closes #11622

## Thinking Path

Owner directive: one-issue-per-session is obsolete. The replacement rule folds in the existing batching feedback (one runner → many small PRs flood CI) and today's closure Gate 3 so bundling can never regress into partial closes (the #6828/#8082 failure mode).

## What Changed

- `CLAUDE.md` Workflow Quick Rules: "One issue per session" bullet replaced with "Batch similar-scope issues per PR" — `Closes #A, #B, …` allowed, each issue fully delivered per Gate 3; independent/different-risk changes still split.

Companion outside repo: `feedback_batch_issues_single_pr` memory updated with the superseding directive.

## Verification

`grep -c "One issue per session" CLAUDE.md` → 0; new bullet present at the same list position. Docs-only change.

## Model Used

Claude Fable 5