### PR TITLE
refactor(ui): useTabs composable — WAI-ARIA tab pattern shared across 6 components, 3 navs de-ARIA'd (#11571)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -359,13 +359,12 @@
 
     <!-- Issue #3436: Per-project sub-tab navigation and child route outlet -->
     <div v-if="route.params.sourceId" class="project-sub-tabs-container">
-      <nav class="project-sub-tabs" role="tablist" aria-label="Project analytics tabs">
+      <nav class="project-sub-tabs" :aria-label="$t('analytics.codebase.tabs.ariaLabel', 'Project analytics')">
         <router-link
           :to="`/analytics/codebase/${route.params.sourceId}`"
           class="project-sub-tab"
           :class="{ 'project-sub-tab-active': isOverviewTabActive }"
-          role="tab"
-          :aria-selected="isOverviewTabActive"
+          :aria-current="isOverviewTabActive ? 'page' : undefined"
         >
           <svg class="sub-tab-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
@@ -376,8 +375,7 @@
           :to="`/analytics/codebase/${route.params.sourceId}/code-quality`"
           class="project-sub-tab"
           :class="{ 'project-sub-tab-active': isCodeQualityTabActive }"
-          role="tab"
-          :aria-selected="isCodeQualityTabActive"
+          :aria-current="isCodeQualityTabActive ? 'page' : undefined"
         >
           <svg class="sub-tab-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -388,8 +386,7 @@
           :to="`/analytics/codebase/${route.params.sourceId}/code-review`"
           class="project-sub-tab"
           :class="{ 'project-sub-tab-active': isCodeReviewTabActive }"
-          role="tab"
-          :aria-selected="isCodeReviewTabActive"
+          :aria-current="isCodeReviewTabActive ? 'page' : undefined"
         >
           <svg class="sub-tab-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -401,8 +398,7 @@
           :to="`/analytics/codebase/${route.params.sourceId}/evolution`"
           class="project-sub-tab"
           :class="{ 'project-sub-tab-active': isEvolutionTabActive }"
-          role="tab"
-          :aria-selected="isEvolutionTabActive"
+          :aria-current="isEvolutionTabActive ? 'page' : undefined"
         >
           <svg class="sub-tab-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
@@ -413,8 +409,7 @@
           :to="`/analytics/codebase/${route.params.sourceId}/code-generation`"
           class="project-sub-tab"
           :class="{ 'project-sub-tab-active': isCodeGenerationTabActive }"
-          role="tab"
-          :aria-selected="isCodeGenerationTabActive"
+          :aria-current="isCodeGenerationTabActive ? 'page' : undefined"
         >
           <svg class="sub-tab-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />

--- a/autobot-frontend/src/components/canvas/CanvasSplitLayout.vue
+++ b/autobot-frontend/src/components/canvas/CanvasSplitLayout.vue
@@ -3,22 +3,22 @@
 <template>
   <!-- Mobile (≤390px): tabbed fallback -->
   <div v-if="isMobile" data-testid="canvas-tabbed-layout" class="flex flex-col h-full">
-    <div class="flex border-b border-border-default" role="tablist">
+    <div ref="mobileTablistRef" class="flex border-b border-border-default" role="tablist">
       <button
-        v-for="tab in tabs"
+        v-for="tab in CANVAS_TABS"
         :key="tab.id"
+        v-bind="tabAttrs(tab.id)"
         :class="['px-4 py-2 text-sm font-medium', activeTab === tab.id ? 'border-b-2 border-autobot-primary text-autobot-primary' : 'text-text-secondary']"
-        :aria-selected="activeTab === tab.id"
-        role="tab"
         @click="activeTab = tab.id"
+        @keydown="handleTabKeydown"
       >
         {{ tab.label }}
         <span v-if="tab.id === 'canvas' && agentContentBadge > 0" class="ml-1 text-xs bg-autobot-primary text-white rounded-full px-1.5">{{ agentContentBadge }}</span>
       </button>
     </div>
     <div class="flex-1 overflow-hidden">
-      <div v-show="activeTab === 'chat'" class="h-full" role="tabpanel"><slot name="chat" /></div>
-      <div v-show="activeTab === 'canvas'" class="h-full" role="tabpanel"><slot name="canvas" /></div>
+      <div v-show="activeTab === 'chat'" v-bind="panelAttrs('chat')" class="h-full"><slot name="chat" /></div>
+      <div v-show="activeTab === 'canvas'" v-bind="panelAttrs('canvas')" class="h-full"><slot name="canvas" /></div>
     </div>
   </div>
 
@@ -72,6 +72,7 @@
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import type { CanvasLayoutVariant } from '@/constants/canvas'
 import { CANVAS_GUTTER_HOT_ZONE_PX, CANVAS_MOBILE_BREAKPOINT_PX, CANVAS_SPLIT_DEFAULT } from '@/constants/canvas'
+import { useTabs } from '@/composables/useTabs'
 
 const props = withDefaults(defineProps<{
   variant: CanvasLayoutVariant
@@ -87,13 +88,16 @@ const chatPercent = ref<number>(CANVAS_SPLIT_DEFAULT.chat)
 const dragging = ref(false)
 const dragStartX = ref(0)
 const dragStartPercent = ref<number>(CANVAS_SPLIT_DEFAULT.chat)
-const activeTab = ref<'chat' | 'canvas'>('chat')
 const isMobile = ref(false)
 
-const tabs = [
+const CANVAS_TAB_IDS = ['chat', 'canvas'] as const
+const CANVAS_TABS = [
   { id: 'chat' as const, label: 'Chat' },
   { id: 'canvas' as const, label: 'Canvas' },
 ]
+
+const { activeTab, tabAttrs, panelAttrs, handleKeydown: handleTabKeydown, tablistRef: mobileTablistRef } =
+  useTabs(CANVAS_TAB_IDS)
 
 const SNAP_PRESETS: CanvasLayoutVariant[] = ['canvas-focus', 'chat-focus', 'full-canvas', 'split']
 let snapIndex = 0

--- a/autobot-frontend/src/components/knowledge/KnowledgeHealth.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeHealth.vue
@@ -204,15 +204,11 @@
     <div ref="tablistRef" class="health-tabs" role="tablist" :aria-label="$t('knowledge.views.healthAriaLabel')">
       <button
         v-for="tab in tabs"
-        :id="`tab-${tab.id}`"
         :key="tab.id"
-        role="tab"
-        :aria-selected="activeTab === tab.id"
-        :aria-controls="`tabpanel-${tab.id}`"
-        :tabindex="activeTab === tab.id ? 0 : -1"
+        v-bind="tabAttrs(tab.id)"
         :class="['health-tab-btn', { active: activeTab === tab.id }]"
         @click="activeTab = tab.id"
-        @keydown="handleTabKeydown($event, tab.id)"
+        @keydown="handleTabKeydown"
       >
         <Icon :name="tab.icon" />
         {{ $t(tab.labelKey) }}
@@ -226,28 +222,13 @@
 
     <!-- Tab Bodies (v-if for lazy mount — each tab's onMounted fires on first open) -->
     <div class="health-tab-content">
-      <div
-        v-if="activeTab === 'analytics'"
-        id="tabpanel-analytics"
-        role="tabpanel"
-        aria-labelledby="tab-analytics"
-      >
+      <div v-if="activeTab === 'analytics'" v-bind="panelAttrs('analytics')">
         <KnowledgeHealthAnalytics />
       </div>
-      <div
-        v-if="activeTab === 'verification'"
-        id="tabpanel-verification"
-        role="tabpanel"
-        aria-labelledby="tab-verification"
-      >
+      <div v-if="activeTab === 'verification'" v-bind="panelAttrs('verification')">
         <KnowledgeVerificationQueue />
       </div>
-      <div
-        v-if="activeTab === 'tools'"
-        id="tabpanel-tools"
-        role="tabpanel"
-        aria-labelledby="tab-tools"
-      >
+      <div v-if="activeTab === 'tools'" v-bind="panelAttrs('tools')">
         <KnowledgeHealthTools @refresh-strip="loadHealthDashboard" />
       </div>
     </div>
@@ -257,8 +238,9 @@
 <script setup lang="ts">
 import Icon from '@/components/ui/Icon.vue'
 import type { IconName } from '@/components/ui/Icon.vue'
-import { ref, computed, onMounted, nextTick } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
+import { useTabs } from '@/composables/useTabs'
 import { formatFileSize, formatDateTime as formatDateTimeHelper } from '@/utils/formatHelpers'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { createLogger } from '@/utils/debugUtils'
@@ -297,21 +279,21 @@ const vectorStats = computed<VectorStats | null>(() =>
 // Tab state — initialized from the route at setup time so deep links
 // (?tab=verification|tools) mount the right tab on first render (#11558)
 type TabId = 'analytics' | 'verification' | 'tools'
-const VALID_TAB_IDS: TabId[] = ['analytics', 'verification', 'tools']
+const TAB_IDS = ['analytics', 'verification', 'tools'] as const satisfies readonly TabId[]
 const routeTab = route.query.tab
 const initialTab: TabId =
-  typeof routeTab === 'string' && (VALID_TAB_IDS as string[]).includes(routeTab)
+  typeof routeTab === 'string' && (TAB_IDS as readonly string[]).includes(routeTab)
     ? (routeTab as TabId)
     : 'analytics'
-const activeTab = ref<TabId>(initialTab)
+
+const { activeTab, tabAttrs, panelAttrs, handleKeydown: handleTabKeydown, tablistRef } =
+  useTabs(TAB_IDS, { initial: initialTab })
 
 const tabs: Array<{ id: TabId; labelKey: string; icon: IconName }> = [
   { id: 'analytics', labelKey: 'knowledge.health.tabAnalytics', icon: 'chart-bar' },
   { id: 'verification', labelKey: 'knowledge.health.tabVerification', icon: 'check-double' },
   { id: 'tools', labelKey: 'knowledge.health.tabTools', icon: 'cog' },
 ]
-
-const tablistRef = ref<HTMLElement | null>(null)
 
 // Computed
 const needsVectorization = computed(() => {
@@ -367,33 +349,6 @@ const getEmbeddingModelDisplay = (): string => {
     return model
   } else {
     return 'Not configured'
-  }
-}
-
-const handleTabKeydown = async (event: KeyboardEvent, currentId: TabId) => {
-  const tabIds = VALID_TAB_IDS
-  const currentIndex = tabIds.indexOf(currentId)
-  let newIndex: number | null = null
-
-  if (event.key === 'ArrowLeft') {
-    event.preventDefault()
-    newIndex = (currentIndex - 1 + tabIds.length) % tabIds.length
-  } else if (event.key === 'ArrowRight') {
-    event.preventDefault()
-    newIndex = (currentIndex + 1) % tabIds.length
-  } else if (event.key === 'Home') {
-    event.preventDefault()
-    newIndex = 0
-  } else if (event.key === 'End') {
-    event.preventDefault()
-    newIndex = tabIds.length - 1
-  }
-
-  if (newIndex !== null) {
-    activeTab.value = tabIds[newIndex]
-    await nextTick()
-    const tabBtns = tablistRef.value?.querySelectorAll<HTMLElement>('[role="tab"]')
-    tabBtns?.[newIndex]?.focus()
   }
 }
 

--- a/autobot-frontend/src/components/knowledge/WebResearchPanel.vue
+++ b/autobot-frontend/src/components/knowledge/WebResearchPanel.vue
@@ -4,8 +4,8 @@
 <!-- WebResearchPanel — 4-tab web research UI (MVA-344) -->
 
 <script setup lang="ts">
-import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useTabs } from '@/composables/useTabs'
 import ScrapeTab from '@/components/knowledge/web-research/ScrapeTab.vue'
 import CrawlTab from '@/components/knowledge/web-research/CrawlTab.vue'
 import SiteMapTab from '@/components/knowledge/web-research/SiteMapTab.vue'
@@ -13,9 +13,10 @@ import ExtractTab from '@/components/knowledge/web-research/ExtractTab.vue'
 
 const { t } = useI18n()
 
-type TabId = 'scrape' | 'crawl' | 'sitemap' | 'extract'
+const TAB_IDS = ['scrape', 'crawl', 'sitemap', 'extract'] as const
+type TabId = (typeof TAB_IDS)[number]
 
-const activeTab = ref<TabId>('scrape')
+const { activeTab, tabAttrs, panelAttrs, handleKeydown, tablistRef } = useTabs(TAB_IDS)
 
 interface Tab {
   id: TabId
@@ -64,27 +65,38 @@ const tabs: Tab[] = [
     </div>
 
     <!-- Tab bar -->
-    <div class="wrp-tabs" role="tablist" :aria-label="t('knowledge.webResearch.tabListAriaLabel')">
+    <div
+      ref="tablistRef"
+      class="wrp-tabs"
+      role="tablist"
+      :aria-label="t('knowledge.webResearch.tabListAriaLabel')"
+    >
       <button
         v-for="tab in tabs"
         :key="tab.id"
+        v-bind="tabAttrs(tab.id)"
         class="wrp-tab"
         :class="{ 'wrp-tab--active': activeTab === tab.id }"
-        role="tab"
-        :aria-selected="activeTab === tab.id"
         :aria-label="tab.ariaLabel"
         @click="activeTab = tab.id"
+        @keydown="handleKeydown"
       >
         {{ tab.label }}
       </button>
     </div>
 
-    <!-- Tab content -->
-    <div class="wrp-content" role="tabpanel">
-      <ScrapeTab v-if="activeTab === 'scrape'" />
-      <CrawlTab v-else-if="activeTab === 'crawl'" />
-      <SiteMapTab v-else-if="activeTab === 'sitemap'" />
-      <ExtractTab v-else-if="activeTab === 'extract'" />
+    <!-- Tab panels -->
+    <div v-if="activeTab === 'scrape'" v-bind="panelAttrs('scrape')" class="wrp-content">
+      <ScrapeTab />
+    </div>
+    <div v-else-if="activeTab === 'crawl'" v-bind="panelAttrs('crawl')" class="wrp-content">
+      <CrawlTab />
+    </div>
+    <div v-else-if="activeTab === 'sitemap'" v-bind="panelAttrs('sitemap')" class="wrp-content">
+      <SiteMapTab />
+    </div>
+    <div v-else-if="activeTab === 'extract'" v-bind="panelAttrs('extract')" class="wrp-content">
+      <ExtractTab />
     </div>
   </div>
 </template>

--- a/autobot-frontend/src/components/plugins/PluginInstallModal.vue
+++ b/autobot-frontend/src/components/plugins/PluginInstallModal.vue
@@ -29,22 +29,22 @@
             </button>
           </header>
 
-          <div class="modal-tabs" role="tablist">
+          <div ref="pluginTablistRef" class="modal-tabs" role="tablist">
             <button
+              v-bind="tabAttrs('zip')"
               class="modal-tab"
               :class="{ active: activeTab === 'zip' }"
-              role="tab"
-              :aria-selected="activeTab === 'zip'"
               @click="activeTab = 'zip'"
+              @keydown="handleTabKeydown"
             >
               {{ $t('views.plugins.install.zipTab') }}
             </button>
             <button
+              v-bind="tabAttrs('git')"
               class="modal-tab"
               :class="{ active: activeTab === 'git' }"
-              role="tab"
-              :aria-selected="activeTab === 'git'"
               @click="activeTab = 'git'"
+              @keydown="handleTabKeydown"
             >
               {{ $t('views.plugins.install.gitTab') }}
             </button>
@@ -52,7 +52,7 @@
 
           <div class="modal-body">
             <!-- ZIP tab -->
-            <div v-if="activeTab === 'zip'" class="tab-pane">
+            <div v-if="activeTab === 'zip'" v-bind="panelAttrs('zip')" class="tab-pane">
               <p class="hint">{{ $t('views.plugins.install.zipHint') }}</p>
               <label class="file-drop" :class="{ 'has-file': zipFile }">
                 <input
@@ -85,7 +85,7 @@
             </div>
 
             <!-- Git tab -->
-            <div v-if="activeTab === 'git'" class="tab-pane">
+            <div v-if="activeTab === 'git'" v-bind="panelAttrs('git')" class="tab-pane">
               <p class="hint">{{ $t('views.plugins.install.gitHint') }}</p>
               <label class="form-field">
                 <span class="form-label">{{ $t('views.plugins.install.gitUrlLabel') }}</span>
@@ -140,6 +140,7 @@
 import { computed, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { usePlugins } from '@/composables/usePlugins'
+import { useTabs } from '@/composables/useTabs'
 
 const props = defineProps<{ open: boolean }>()
 const emit = defineEmits<{
@@ -151,7 +152,9 @@ const { t } = useI18n()
 const { installFromZip, installFromGit, error: composableError } = usePlugins()
 let closeTimer: ReturnType<typeof setTimeout> | null = null
 
-const activeTab = ref<'zip' | 'git'>('zip')
+const PLUGIN_TAB_IDS = ['zip', 'git'] as const
+const { activeTab, tabAttrs, panelAttrs, handleKeydown: handleTabKeydown, tablistRef: pluginTablistRef } =
+  useTabs(PLUGIN_TAB_IDS)
 const zipFile = ref<File | null>(null)
 const gitUrl = ref('')
 const gitRef = ref('')

--- a/autobot-frontend/src/components/profile/ProfileModal.vue
+++ b/autobot-frontend/src/components/profile/ProfileModal.vue
@@ -21,17 +21,16 @@
       </div>
 
       <!-- Tab Bar -->
-      <div class="tab-bar" role="tablist">
+      <div ref="profileTablistRef" class="tab-bar" role="tablist">
         <button
           v-for="tab in tabs"
           :key="tab.key"
+          v-bind="tabAttrs(tab.key)"
           class="tab-btn"
           :class="{ active: activeTab === tab.key }"
-          role="tab"
-          :aria-selected="activeTab === tab.key"
-          :aria-controls="`panel-${tab.key}`"
           type="button"
           @click="activeTab = tab.key"
+          @keydown="handleTabKeydown"
         >
           <Icon :name="tab.icon" />
           {{ tab.label }}
@@ -40,7 +39,7 @@
 
       <div class="modal-body">
         <!-- General Tab -->
-        <div v-if="activeTab === 'general'" id="panel-general" role="tabpanel">
+        <div v-if="activeTab === 'general'" v-bind="panelAttrs('general')">
           <div class="profile-section">
             <h3>{{ $t('profile.accountInfo') }}</h3>
             <div class="info-grid">
@@ -125,7 +124,7 @@
         </div>
 
         <!-- Appearance & Voice Tab -->
-        <div v-if="activeTab === 'appearance'" id="panel-appearance" role="tabpanel">
+        <div v-if="activeTab === 'appearance'" v-bind="panelAttrs('appearance')">
           <div class="profile-section">
             <h3>{{ $t('profile.appearance') }}</h3>
             <PreferencesPanel />
@@ -162,12 +161,12 @@
         </div>
 
         <!-- Language Tab -->
-        <div v-if="activeTab === 'language'" id="panel-language" role="tabpanel">
+        <div v-if="activeTab === 'language'" v-bind="panelAttrs('language')">
           <LanguageSettingsPanel />
         </div>
 
         <!-- Security Tab -->
-        <div v-if="activeTab === 'security'" id="panel-security" role="tabpanel">
+        <div v-if="activeTab === 'security'" v-bind="panelAttrs('security')">
           <div class="profile-section">
             <h3>{{ $t('profile.changePassword') }}</h3>
             <div class="pw-form">
@@ -205,7 +204,7 @@
         </div>
 
         <!-- Devices Tab -->
-        <div v-if="activeTab === 'devices'" id="panel-devices" role="tabpanel">
+        <div v-if="activeTab === 'devices'" v-bind="panelAttrs('devices')">
           <DeviceManagementPanel />
         </div>
       </div>
@@ -238,6 +237,7 @@ import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
 import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
+import { useTabs } from '@/composables/useTabs'
 
 const props = defineProps<{
   isOpen: boolean
@@ -255,6 +255,12 @@ const emit = defineEmits<{
 }>()
 
 type TabKey = 'general' | 'appearance' | 'language' | 'security' | 'devices'
+const PROFILE_TAB_IDS = ['general', 'appearance', 'language', 'security', 'devices'] as const
+
+const { t } = useI18n()
+
+const { activeTab, tabAttrs, panelAttrs, handleKeydown: handleTabKeydown, tablistRef: profileTablistRef } =
+  useTabs(PROFILE_TAB_IDS)
 
 const tabs = computed<{ key: TabKey; label: string; icon: IconName }[]>(() => [
   { key: 'general', label: t('profile.tabGeneral'), icon: 'user' },
@@ -263,9 +269,6 @@ const tabs = computed<{ key: TabKey; label: string; icon: IconName }[]>(() => [
   { key: 'security', label: t('profile.tabSecurity'), icon: 'shield-alt' },
   { key: 'devices', label: t('profile.tabDevices'), icon: 'smartphone' }
 ])
-
-const { t } = useI18n()
-const activeTab = ref<TabKey>('general')
 
 const userStore = useUserStore()
 const { voiceDisplayMode, setVoiceDisplayMode } = usePreferences()

--- a/autobot-frontend/src/composables/__tests__/useTabs.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useTabs.test.ts
@@ -1,0 +1,201 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+/**
+ * Unit tests for useTabs composable (#11571).
+ *
+ * Covers:
+ *  - default initial value (first tab)
+ *  - opts.initial respected
+ *  - invalid opts.initial falls back to first tab
+ *  - selectTab updates activeTab
+ *  - isActive truth values
+ *  - tabAttrs shape (id, role, aria-selected, aria-controls, tabindex)
+ *  - panelAttrs shape (id, role, aria-labelledby)
+ *  - handleKeydown: ArrowRight wraps forward
+ *  - handleKeydown: ArrowLeft wraps backward
+ *  - handleKeydown: Home jumps to first
+ *  - handleKeydown: End jumps to last
+ *  - handleKeydown: unrelated keys are ignored (no state change)
+ *  - throws when tabIds is empty
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { nextTick } from 'vue'
+import { useTabs } from '../useTabs'
+
+// nextTick needs to flush properly inside tests
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+const TABS = ['alpha', 'beta', 'gamma'] as const
+type T = (typeof TABS)[number]
+
+function makeKeyEvent(key: string): KeyboardEvent {
+  return { key, preventDefault: vi.fn() } as unknown as KeyboardEvent
+}
+
+describe('useTabs — initialization', () => {
+  it('defaults to the first tab when no initial is provided', () => {
+    const { activeTab } = useTabs(TABS)
+    expect(activeTab.value).toBe('alpha')
+  })
+
+  it('respects opts.initial when it is a valid tab id', () => {
+    const { activeTab } = useTabs(TABS, { initial: 'gamma' })
+    expect(activeTab.value).toBe('gamma')
+  })
+
+  it('falls back to the first tab when opts.initial is not in tabIds', () => {
+    const { activeTab } = useTabs(TABS, { initial: 'nonexistent' as T })
+    expect(activeTab.value).toBe('alpha')
+  })
+
+  it('throws when tabIds is empty', () => {
+    expect(() => useTabs([])).toThrow('useTabs: tabIds must not be empty')
+  })
+
+  it('exposes tabIds', () => {
+    const { tabIds } = useTabs(TABS)
+    expect(tabIds).toEqual(TABS)
+  })
+})
+
+describe('useTabs — selectTab / isActive', () => {
+  it('selectTab changes the active tab', () => {
+    const { activeTab, selectTab } = useTabs(TABS)
+    selectTab('beta')
+    expect(activeTab.value).toBe('beta')
+  })
+
+  it('isActive returns true for the active tab', () => {
+    const { isActive, selectTab } = useTabs(TABS)
+    selectTab('gamma')
+    expect(isActive('gamma')).toBe(true)
+    expect(isActive('alpha')).toBe(false)
+    expect(isActive('beta')).toBe(false)
+  })
+})
+
+describe('useTabs — tabAttrs shape', () => {
+  it('produces correct attrs for the active tab', () => {
+    const { tabAttrs } = useTabs(TABS, { initial: 'beta' })
+    expect(tabAttrs('beta')).toEqual({
+      id: 'tab-beta',
+      role: 'tab',
+      'aria-selected': true,
+      'aria-controls': 'tabpanel-beta',
+      tabindex: 0,
+    })
+  })
+
+  it('produces correct attrs for an inactive tab', () => {
+    const { tabAttrs } = useTabs(TABS, { initial: 'beta' })
+    expect(tabAttrs('alpha')).toEqual({
+      id: 'tab-alpha',
+      role: 'tab',
+      'aria-selected': false,
+      'aria-controls': 'tabpanel-alpha',
+      tabindex: -1,
+    })
+  })
+})
+
+describe('useTabs — panelAttrs shape', () => {
+  it('produces correct panel attrs', () => {
+    const { panelAttrs } = useTabs(TABS)
+    expect(panelAttrs('gamma')).toEqual({
+      id: 'tabpanel-gamma',
+      role: 'tabpanel',
+      'aria-labelledby': 'tab-gamma',
+    })
+  })
+})
+
+describe('useTabs — handleKeydown', () => {
+  it('ArrowRight moves to the next tab', async () => {
+    const { activeTab, handleKeydown } = useTabs(TABS)
+    const evt = makeKeyEvent('ArrowRight')
+    await handleKeydown(evt)
+    await nextTick()
+    expect(activeTab.value).toBe('beta')
+    expect(evt.preventDefault).toHaveBeenCalled()
+  })
+
+  it('ArrowRight wraps from last to first', async () => {
+    const { activeTab, selectTab, handleKeydown } = useTabs(TABS)
+    selectTab('gamma')
+    const evt = makeKeyEvent('ArrowRight')
+    await handleKeydown(evt)
+    await nextTick()
+    expect(activeTab.value).toBe('alpha')
+  })
+
+  it('ArrowLeft moves to the previous tab', async () => {
+    const { activeTab, selectTab, handleKeydown } = useTabs(TABS)
+    selectTab('beta')
+    const evt = makeKeyEvent('ArrowLeft')
+    await handleKeydown(evt)
+    await nextTick()
+    expect(activeTab.value).toBe('alpha')
+  })
+
+  it('ArrowLeft wraps from first to last', async () => {
+    const { activeTab, handleKeydown } = useTabs(TABS)
+    // starts on alpha
+    const evt = makeKeyEvent('ArrowLeft')
+    await handleKeydown(evt)
+    await nextTick()
+    expect(activeTab.value).toBe('gamma')
+  })
+
+  it('Home jumps to the first tab', async () => {
+    const { activeTab, selectTab, handleKeydown } = useTabs(TABS)
+    selectTab('gamma')
+    const evt = makeKeyEvent('Home')
+    await handleKeydown(evt)
+    await nextTick()
+    expect(activeTab.value).toBe('alpha')
+  })
+
+  it('End jumps to the last tab', async () => {
+    const { activeTab, handleKeydown } = useTabs(TABS)
+    // starts on alpha
+    const evt = makeKeyEvent('End')
+    await handleKeydown(evt)
+    await nextTick()
+    expect(activeTab.value).toBe('gamma')
+  })
+
+  it('unrelated keys do not change active tab', async () => {
+    const { activeTab, handleKeydown } = useTabs(TABS)
+    const evt = makeKeyEvent('Enter')
+    await handleKeydown(evt)
+    expect(activeTab.value).toBe('alpha')
+    expect(evt.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('calls focus() on the newly selected tab button element', async () => {
+    const { handleKeydown, tablistRef, activeTab } = useTabs(TABS)
+
+    // Wire a mock DOM node so querySelector works
+    const mockFocus = vi.fn()
+    const mockTabBtns = [
+      { focus: vi.fn() },
+      { focus: mockFocus },
+      { focus: vi.fn() },
+    ]
+    tablistRef.value = {
+      querySelectorAll: (_sel: string) => mockTabBtns,
+    } as unknown as HTMLElement
+
+    await handleKeydown(makeKeyEvent('ArrowRight'))
+    await nextTick()
+
+    expect(activeTab.value).toBe('beta')
+    expect(mockTabBtns[1].focus).toHaveBeenCalled()
+  })
+})

--- a/autobot-frontend/src/composables/useTabs.ts
+++ b/autobot-frontend/src/composables/useTabs.ts
@@ -1,0 +1,152 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Author: mrveiss
+ *
+ * useTabs Composable (#11571)
+ *
+ * WAI-ARIA tab-bar pattern — roving tabindex, Arrow / Home / End keyboard
+ * navigation with focus-follow via nextTick, and attribute builders that
+ * produce correct id / aria-selected / aria-controls / tabindex / role
+ * values for both the tab button and the panel container.
+ *
+ * Consumer pattern:
+ *
+ *   const { activeTab, tabAttrs, panelAttrs, handleKeydown, tablistRef } =
+ *     useTabs(['a', 'b', 'c'] as const, { initial: 'b' })
+ *
+ *   <div ref="tablistRef" role="tablist">
+ *     <button v-for="id in tabIds" v-bind="tabAttrs(id)" @click="selectTab(id)">
+ *       {{ id }}
+ *     </button>
+ *   </div>
+ *   <div v-bind="panelAttrs('a')">…</div>
+ */
+
+import { ref, nextTick } from 'vue'
+import type { Ref } from 'vue'
+
+export interface UseTabsReturn<T extends string> {
+  /** Currently-active tab id. */
+  activeTab: Ref<T>
+  /** All tab ids in order — exposed so callers can iterate them. */
+  tabIds: readonly T[]
+  /** True when the given id is the active tab. */
+  isActive: (id: T) => boolean
+  /** Programmatically activate a tab. */
+  selectTab: (id: T) => void
+  /**
+   * Keyboard handler — attach to the tablist container element or to each
+   * individual tab button via `@keydown`.
+   * Handles: ArrowLeft / ArrowRight (wrap-around), Home, End.
+   * Focus follows selection after nextTick by querying [role="tab"] elements
+   * within `tablistRef`.
+   */
+  handleKeydown: (event: KeyboardEvent) => void
+  /**
+   * Attribute builder for a tab button.
+   * Returns: id, role, aria-selected, aria-controls, tabindex.
+   */
+  tabAttrs: (id: T) => {
+    id: string
+    role: 'tab'
+    'aria-selected': boolean
+    'aria-controls': string
+    tabindex: 0 | -1
+  }
+  /**
+   * Attribute builder for a panel container.
+   * Returns: id, role, aria-labelledby.
+   */
+  panelAttrs: (id: T) => {
+    id: string
+    role: 'tabpanel'
+    'aria-labelledby': string
+  }
+  /** Ref to attach to the element that wraps all tab buttons (role="tablist"). */
+  tablistRef: Ref<HTMLElement | null>
+}
+
+export interface UseTabsOptions<T extends string> {
+  /** The tab that should be active on first render. Defaults to `tabIds[0]`. */
+  initial?: T
+}
+
+/**
+ * WAI-ARIA tab-bar composable.
+ *
+ * @param tabIds — ordered tuple of string-literal tab identifiers
+ * @param opts   — optional initial tab; defaults to first entry
+ */
+export function useTabs<T extends string>(
+  tabIds: readonly T[],
+  opts?: UseTabsOptions<T>,
+): UseTabsReturn<T> {
+  if (tabIds.length === 0) throw new Error('useTabs: tabIds must not be empty')
+
+  const initial: T =
+    opts?.initial !== undefined && (tabIds as string[]).includes(opts.initial)
+      ? opts.initial
+      : tabIds[0]
+
+  const activeTab = ref<T>(initial) as Ref<T>
+  const tablistRef = ref<HTMLElement | null>(null)
+
+  const isActive = (id: T): boolean => activeTab.value === id
+
+  const selectTab = (id: T): void => {
+    activeTab.value = id
+  }
+
+  const handleKeydown = async (event: KeyboardEvent): Promise<void> => {
+    const { key } = event
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(key)) return
+    event.preventDefault()
+
+    const currentIndex = (tabIds as string[]).indexOf(activeTab.value)
+    let newIndex: number
+
+    if (key === 'ArrowLeft') {
+      newIndex = (currentIndex - 1 + tabIds.length) % tabIds.length
+    } else if (key === 'ArrowRight') {
+      newIndex = (currentIndex + 1) % tabIds.length
+    } else if (key === 'Home') {
+      newIndex = 0
+    } else {
+      // End
+      newIndex = tabIds.length - 1
+    }
+
+    activeTab.value = tabIds[newIndex]
+
+    await nextTick()
+    const tabBtns = tablistRef.value?.querySelectorAll<HTMLElement>('[role="tab"]')
+    tabBtns?.[newIndex]?.focus()
+  }
+
+  const tabAttrs = (id: T) => ({
+    id: `tab-${id}`,
+    role: 'tab' as const,
+    'aria-selected': isActive(id),
+    'aria-controls': `tabpanel-${id}`,
+    tabindex: (isActive(id) ? 0 : -1) as 0 | -1,
+  })
+
+  const panelAttrs = (id: T) => ({
+    id: `tabpanel-${id}`,
+    role: 'tabpanel' as const,
+    'aria-labelledby': `tab-${id}`,
+  })
+
+  return {
+    activeTab,
+    tabIds,
+    isActive,
+    selectTab,
+    handleKeydown,
+    tabAttrs,
+    panelAttrs,
+    tablistRef,
+  }
+}

--- a/autobot-frontend/src/composables/useTabs.ts
+++ b/autobot-frontend/src/composables/useTabs.ts
@@ -86,7 +86,7 @@ export function useTabs<T extends string>(
   if (tabIds.length === 0) throw new Error('useTabs: tabIds must not be empty')
 
   const initial: T =
-    opts?.initial !== undefined && (tabIds as string[]).includes(opts.initial)
+    opts?.initial !== undefined && (tabIds as readonly string[]).includes(opts.initial)
       ? opts.initial
       : tabIds[0]
 
@@ -104,7 +104,7 @@ export function useTabs<T extends string>(
     if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(key)) return
     event.preventDefault()
 
-    const currentIndex = (tabIds as string[]).indexOf(activeTab.value)
+    const currentIndex = (tabIds as readonly string[]).indexOf(activeTab.value)
     let newIndex: number
 
     if (key === 'ArrowLeft') {

--- a/autobot-frontend/src/composables/useTabs.ts
+++ b/autobot-frontend/src/composables/useTabs.ts
@@ -43,7 +43,7 @@ export interface UseTabsReturn<T extends string> {
    * Focus follows selection after nextTick by querying [role="tab"] elements
    * within `tablistRef`.
    */
-  handleKeydown: (event: KeyboardEvent) => void
+  handleKeydown: (event: KeyboardEvent) => Promise<void>
   /**
    * Attribute builder for a tab button.
    * Returns: id, role, aria-selected, aria-controls, tabindex.

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -1390,7 +1390,8 @@
         "codeReview": "Code Review",
         "evolution": "Evolution",
         "codeGeneration": "Code Generation",
-        "codeQuality": "Code Quality"
+        "codeQuality": "Code Quality",
+        "ariaLabel": "تحليلات المشروع"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -1390,7 +1390,8 @@
         "codeReview": "Code Review",
         "evolution": "Evolution",
         "codeGeneration": "Code Generation",
-        "codeQuality": "Code Quality"
+        "codeQuality": "Code Quality",
+        "ariaLabel": "Projektanalysen"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -1390,7 +1390,8 @@
         "codeQuality": "Code Quality",
         "codeReview": "Code Review",
         "evolution": "Evolution",
-        "overview": "Overview"
+        "overview": "Overview",
+        "ariaLabel": "Project analytics"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -1390,7 +1390,8 @@
         "codeReview": "Code Review",
         "evolution": "Evolution",
         "codeGeneration": "Code Generation",
-        "codeQuality": "Code Quality"
+        "codeQuality": "Code Quality",
+        "ariaLabel": "Analíticas del proyecto"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -797,7 +797,8 @@
         "overview": "Overview",
         "codeReview": "Code Review",
         "codeQuality": "Code Quality",
-        "codeGeneration": "Code Generation"
+        "codeGeneration": "Code Generation",
+        "ariaLabel": "تحلیل‌های پروژه"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -1390,7 +1390,8 @@
         "codeReview": "Code Review",
         "evolution": "Evolution",
         "codeGeneration": "Code Generation",
-        "codeQuality": "Code Quality"
+        "codeQuality": "Code Quality",
+        "ariaLabel": "Analyses du projet"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -797,7 +797,8 @@
         "overview": "Overview",
         "codeReview": "Code Review",
         "codeQuality": "Code Quality",
-        "codeGeneration": "Code Generation"
+        "codeGeneration": "Code Generation",
+        "ariaLabel": "ניתוחי פרויקט"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -1390,7 +1390,8 @@
         "codeReview": "Code Review",
         "evolution": "Evolution",
         "codeGeneration": "Code Generation",
-        "codeQuality": "Code Quality"
+        "codeQuality": "Code Quality",
+        "ariaLabel": "Projekta analītika"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -1390,7 +1390,8 @@
         "codeReview": "Code Review",
         "evolution": "Evolution",
         "codeGeneration": "Code Generation",
-        "codeQuality": "Code Quality"
+        "codeQuality": "Code Quality",
+        "ariaLabel": "Analityka projektu"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -1390,7 +1390,8 @@
         "codeReview": "Code Review",
         "evolution": "Evolution",
         "codeGeneration": "Code Generation",
-        "codeQuality": "Code Quality"
+        "codeQuality": "Code Quality",
+        "ariaLabel": "Análises do projeto"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -797,7 +797,8 @@
         "overview": "Overview",
         "codeReview": "Code Review",
         "codeQuality": "Code Quality",
-        "codeGeneration": "Code Generation"
+        "codeGeneration": "Code Generation",
+        "ariaLabel": "پروجیکٹ کے تجزیات"
       }
     },
     "patterns": {

--- a/autobot-frontend/src/views/AgentsLayout.vue
+++ b/autobot-frontend/src/views/AgentsLayout.vue
@@ -3,7 +3,6 @@
     <nav
       class="flex shrink-0 border-b border-autobot-border bg-autobot-bg-secondary px-4"
       :aria-label="$t('agent.nav.label')"
-      role="tablist"
     >
       <router-link
         v-for="tab in tabs"
@@ -13,8 +12,7 @@
           'px-4 py-3 text-sm font-medium border-b-2 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-autobot-primary',
           isActive(tab) ? activeClass : inactiveClass,
         ]"
-        role="tab"
-        :aria-selected="isActive(tab)"
+        :aria-current="isActive(tab) ? 'page' : undefined"
       >
         <i :class="['fas', tab.icon, 'mr-2']" aria-hidden="true"></i>
         {{ $t(tab.labelKey) }}

--- a/autobot-frontend/src/views/AnalyticsView.vue
+++ b/autobot-frontend/src/views/AnalyticsView.vue
@@ -11,7 +11,7 @@
 
       <!-- Sub-navigation Tabs - Issue #901 / TASK 14: overflow-aware tab bar -->
       <div class="analytics-nav">
-        <nav ref="tabsContainer" class="nav-tabs" role="tablist" :aria-label="$t('analytics.views.ariaLabel')">
+        <nav ref="tabsContainer" class="nav-tabs" :aria-label="$t('analytics.views.ariaLabel')">
           <router-link
             v-for="tab in visibleTabs"
             :key="tab.to"
@@ -19,8 +19,7 @@
             data-nav-item
             class="nav-tab"
             :class="{ 'nav-tab-active': isActive(tab) }"
-            role="tab"
-            :aria-selected="isActive(tab)"
+            :aria-current="isActive(tab) ? 'page' : undefined"
             :aria-label="$t(tab.aria)"
           >
             <Icon :name="tab.icon" class="tab-icon" aria-hidden="true" />

--- a/autobot-frontend/src/views/VisionAutomationView.vue
+++ b/autobot-frontend/src/views/VisionAutomationView.vue
@@ -13,6 +13,7 @@ import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
 import { useVisionAutomation } from '@/composables/useVisionAutomation'
 import Icon from '@/components/ui/Icon.vue'
+import { useTabs } from '@/composables/useTabs'
 
 const { t } = useI18n()
 const logger = createLogger('VisionAutomationView')
@@ -32,8 +33,10 @@ const {
   fetchOpportunities,
 } = useVisionAutomation()
 
-type Tab = 'analysis' | 'elements' | 'ocr' | 'opportunities'
-const activeTab = ref<Tab>('analysis')
+const VISION_TAB_IDS = ['analysis', 'elements', 'ocr', 'opportunities'] as const
+const { activeTab, tabAttrs, panelAttrs, handleKeydown: handleTabKeydown, tablistRef: visionTablistRef } =
+  useTabs(VISION_TAB_IDS)
+
 const sessionId = ref('')
 const elementTypeFilter = ref('')
 const minConfidence = ref(0.5)
@@ -141,39 +144,44 @@ onMounted(async () => {
     </div>
 
     <!-- Tabs -->
-    <nav class="tab-nav" role="tablist" :aria-label="t('vision.visionAutomation.tabsAriaLabel')">
+    <nav
+      ref="visionTablistRef"
+      class="tab-nav"
+      role="tablist"
+      :aria-label="t('vision.visionAutomation.tabsAriaLabel')"
+    >
       <button
-        role="tab"
-        :aria-selected="activeTab === 'analysis'"
+        v-bind="tabAttrs('analysis')"
         :class="['tab-btn', { active: activeTab === 'analysis' }]"
         @click="activeTab = 'analysis'"
+        @keydown="handleTabKeydown"
       >
         <Icon name="camera" aria-hidden="true" />
         {{ t('vision.visionAutomation.tabs.analysis') }}
       </button>
       <button
-        role="tab"
-        :aria-selected="activeTab === 'elements'"
+        v-bind="tabAttrs('elements')"
         :class="['tab-btn', { active: activeTab === 'elements' }]"
         @click="activeTab = 'elements'"
+        @keydown="handleTabKeydown"
       >
         <Icon name="th" aria-hidden="true" />
         {{ t('vision.visionAutomation.tabs.elements') }}
       </button>
       <button
-        role="tab"
-        :aria-selected="activeTab === 'ocr'"
+        v-bind="tabAttrs('ocr')"
         :class="['tab-btn', { active: activeTab === 'ocr' }]"
         @click="activeTab = 'ocr'"
+        @keydown="handleTabKeydown"
       >
         <Icon name="font" aria-hidden="true" />
         {{ t('vision.visionAutomation.tabs.ocr') }}
       </button>
       <button
-        role="tab"
-        :aria-selected="activeTab === 'opportunities'"
+        v-bind="tabAttrs('opportunities')"
         :class="['tab-btn', { active: activeTab === 'opportunities' }]"
         @click="activeTab = 'opportunities'"
+        @keydown="handleTabKeydown"
       >
         <Icon name="bolt" aria-hidden="true" />
         {{ t('vision.visionAutomation.tabs.opportunities') }}
@@ -183,7 +191,7 @@ onMounted(async () => {
     <!-- Tab panels -->
     <div class="tab-content">
       <!-- Screen Analysis -->
-      <div v-show="activeTab === 'analysis'" class="tab-panel">
+      <div v-show="activeTab === 'analysis'" v-bind="panelAttrs('analysis')" class="tab-panel">
         <div class="card">
           <div class="card-header">
             <span class="card-title">{{ t('vision.visionAutomation.analysis.cardTitle') }}</span>
@@ -257,7 +265,7 @@ onMounted(async () => {
       </div>
 
       <!-- Element Detection -->
-      <div v-show="activeTab === 'elements'" class="tab-panel">
+      <div v-show="activeTab === 'elements'" v-bind="panelAttrs('elements')" class="tab-panel">
         <div class="card">
           <div class="card-header">
             <span class="card-title">{{ t('vision.visionAutomation.elements.cardTitle') }}</span>
@@ -335,7 +343,7 @@ onMounted(async () => {
       </div>
 
       <!-- OCR -->
-      <div v-show="activeTab === 'ocr'" class="tab-panel">
+      <div v-show="activeTab === 'ocr'" v-bind="panelAttrs('ocr')" class="tab-panel">
         <div class="card">
           <div class="card-header">
             <span class="card-title">{{ t('vision.visionAutomation.ocr.cardTitle') }}</span>
@@ -383,7 +391,7 @@ onMounted(async () => {
       </div>
 
       <!-- Automation Opportunities -->
-      <div v-show="activeTab === 'opportunities'" class="tab-panel">
+      <div v-show="activeTab === 'opportunities'" v-bind="panelAttrs('opportunities')" class="tab-panel">
         <div class="card">
           <div class="card-header">
             <span class="card-title">{{ t('vision.visionAutomation.opportunities.cardTitle') }}</span>


### PR DESCRIPTION
Closes #11571

## Thinking Path

Item 3 of #11571 (items 1+2 merged in PR #11600). Nine components declared role="tablist" but only KnowledgeHealth (from #11558) implemented the full WAI-ARIA keyboard pattern. Extracting that reference implementation into a generic composable levels everything up — and review of the 9 call sites showed 3 were router-link navigation mislabeled as tab widgets, which per WAI-ARIA should be nav landmarks, not tablists.

## What Changed

- New `useTabs<T>()` composable: roving tabindex, Arrow wrap-around + Home/End with focus-follow, tabAttrs/panelAttrs producing the full matched id/aria-controls/aria-labelledby set; 18 unit tests
- Adopted in 6 real tab widgets: KnowledgeHealth (deep-link `?tab=` initial preserved; its 6 existing tests pass unchanged), WebResearchPanel (single panel split into 4 proper tabpanels), CanvasSplitLayout (mobile tablist), ProfileModal, PluginInstallModal (reset-on-open preserved), VisionAutomationView (v-show mounted-state panels)
- 3 router-link navs converted to proper semantics: AgentsLayout, AnalyticsView, CodebaseAnalytics — role=tablist/tab/aria-selected removed, `aria-current="page"` added, styling untouched
- Review minors fixed: `analytics.codebase.tabs.ariaLabel` registered in all 11 locales; handleKeydown return type corrected to Promise<void>

## Verification

- vue-tsc clean · vitest 1998 pass + 18 new (locale-parity 46/46) · eslint+oxlint 0 problems
- Independent review approved: composable semantics, all 6 adoption fidelity checks, all 3 nav conversions verified; KnowledgeUpload.spec/useModal.test flakes verified pre-existing (untouched by branch, pass isolated on base — discovery issue to follow)

## Model Used

Claude Fable 5 (controller) with Sonnet implementer/reviewer subagents.