### PR TITLE
feat(knowledge): wire orphan capabilities — system-docs route, browser category editing, health danger zone (#11555 step 4a)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -15,6 +15,7 @@
       @select="selectMainCategory"
       @populate="handlePopulate"
       @import="() => router.push('/knowledge/upload')"
+      @edit="handleEditCategory"
     />
 
     <!-- Header -->
@@ -118,6 +119,14 @@
         <Icon name="chevron-right" class="breadcrumb-sep" v-if="idx < breadcrumbParts.length - 1" />
       </span>
     </div>
+
+    <!-- Issue #11555: Category edit modal wired into the browser -->
+    <CategoryEditModal
+      v-model="showCategoryEditModal"
+      :category="categoryToEdit"
+      @updated="handleCategoryUpdated"
+      @deleted="handleCategoryDeleted"
+    />
 
     <!-- Split pane layout -->
     <div class="split-pane">
@@ -250,6 +259,8 @@ import AIDocumentEditor from '@/components/documents/AIDocumentEditor.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import KnowledgeMainCategories from './KnowledgeMainCategories.vue'
+import CategoryEditModal from './modals/CategoryEditModal.vue'
+import type { Category } from './modals/CategoryEditModal.vue'
 
 // Create scoped logger for KnowledgeBrowser
 const logger = createLogger('KnowledgeBrowser')
@@ -352,6 +363,10 @@ const populationStates = ref<Record<string, { isPopulating: boolean; progress: n
   'autobot-documentation': { isPopulating: false, progress: 0 },
   'system-knowledge': { isPopulating: false, progress: 0 }
 })
+
+// Issue #11555: category edit modal state
+const showCategoryEditModal = ref(false)
+const categoryToEdit = ref<Category | null>(null)
 
 // Search, document editor and branch state (Issue #11526)
 const search = useKnowledgeSearch(selectedCategory)
@@ -624,6 +639,27 @@ const selectMainCategory = (mainCatId: string) => {
   selectedMainCategory.value = mainCatId
   // Filter subcategories based on main category
   // This will be handled by filteredTree computed property
+}
+
+// Issue #11555: open the category edit modal from the browser card
+const handleEditCategory = (cat: MainCategory) => {
+  categoryToEdit.value = cat as Category
+  showCategoryEditModal.value = true
+}
+
+const handleCategoryUpdated = (updated: Category) => {
+  const idx = mainCategories.value.findIndex(c => c.id === updated.id)
+  if (idx !== -1) {
+    mainCategories.value[idx] = { ...mainCategories.value[idx], ...updated }
+  }
+  showCategoryEditModal.value = false
+  categoryToEdit.value = null
+}
+
+const handleCategoryDeleted = (categoryId: string) => {
+  mainCategories.value = mainCategories.value.filter(c => c.id !== categoryId)
+  showCategoryEditModal.value = false
+  categoryToEdit.value = null
 }
 
 const loadMainCategories = async () => {

--- a/autobot-frontend/src/components/knowledge/KnowledgeHealthTools.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeHealthTools.vue
@@ -45,6 +45,38 @@
         </button>
       </div>
     </div>
+
+    <!-- Issue #11555: Danger zone — clear-all moved from KnowledgeAdvanced -->
+    <div class="tools-section danger-zone-section">
+      <h3 class="section-heading danger-heading">
+        <Icon name="exclamation-triangle" />
+        {{ $t('knowledge.health.dangerZone') }}
+      </h3>
+      <div class="danger-card">
+        <div class="danger-content">
+          <div class="danger-icon">
+            <Icon name="trash-alt" />
+          </div>
+          <div class="danger-text">
+            <h4>{{ $t('knowledge.advanced.clearAllKnowledge') }}</h4>
+            <p>
+              {{ $t('knowledge.advanced.clearAllDescription') }}
+              <strong>{{ $t('knowledge.advanced.clearAllWarning') }}</strong>
+            </p>
+            <small class="danger-meta">{{ $t('knowledge.advanced.clearAllMeta') }}</small>
+          </div>
+        </div>
+        <button
+          class="action-btn danger-btn"
+          :disabled="isClearing"
+          @click="clearAllKnowledge"
+        >
+          <Icon name="spinner" class="animate-spin" v-if="isClearing" />
+          <Icon name="exclamation-triangle" v-else />
+          {{ isClearing ? $t('knowledge.advanced.clearing') : $t('knowledge.advanced.clearAll') }}
+        </button>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -55,6 +87,8 @@ import Icon from '@/components/ui/Icon.vue'
 import { useConfirmDialog } from '@/composables/useConfirmDialog'
 import { useKnowledgeStore } from '@/stores/useKnowledgeStore'
 import { useKnowledgeController } from '@/models/controllers/index'
+import ApiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import DeduplicationManager from '@/components/knowledge/DeduplicationManager.vue'
 import SessionOrphanManager from '@/components/knowledge/SessionOrphanManager.vue'
 import CleanupStatistics from '@/components/knowledge/CleanupStatistics.vue'
@@ -96,6 +130,15 @@ try {
 }
 
 const isOptimizing = ref(false)
+// Issue #11555: clear-all danger zone state
+const isClearing = ref(false)
+
+// Shape of the clear_all endpoint response
+interface ClearAllResponse {
+  status?: string
+  message?: string
+  items_removed?: number
+}
 
 const refreshStats = async () => {
   try {
@@ -129,6 +172,35 @@ const optimizeKnowledge = async () => {
     logger.error('Failed to optimize knowledge base:', error)
   } finally {
     isOptimizing.value = false
+  }
+}
+
+// Issue #11555: clear-all danger zone — same flow as KnowledgeAdvanced
+const clearAllKnowledge = async () => {
+  if (isClearing.value) return
+
+  const firstConfirm = await confirm({ title: t('common.confirm'), message: t('knowledge.advanced.confirmClearAll') })
+  if (!firstConfirm) return
+
+  const secondConfirm = await confirm({ title: t('common.confirm'), message: t('knowledge.advanced.confirmClearFinal') })
+  if (!secondConfirm) return
+
+  const userInput = prompt(t('knowledge.advanced.promptDeleteAll'))
+  if (userInput !== 'DELETE ALL') return
+
+  isClearing.value = true
+  try {
+    const response = await ApiClient.post<ClearAllResponse>(`${getApiBase()}/knowledge_base/clear_all`, {})
+    if (response.status === 'success') {
+      await store.refreshStats()
+      logger.info(`Cleared knowledge base: ${response.items_removed ?? 0} entries removed`)
+    } else {
+      throw new Error(response.message || 'Failed to clear knowledge base')
+    }
+  } catch (error) {
+    logger.error('Failed to clear knowledge base:', error)
+  } finally {
+    isClearing.value = false
   }
 }
 </script>
@@ -190,6 +262,80 @@ const optimizeKnowledge = async () => {
 .action-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* Issue #11555: danger zone section */
+.danger-zone-section {
+  padding: var(--spacing-6);
+  border: 1px solid var(--color-error-light);
+  background: var(--color-error-bg);
+}
+
+.danger-heading {
+  color: var(--color-error-dark);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.danger-card {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+  flex-wrap: wrap;
+}
+
+.danger-content {
+  display: flex;
+  gap: var(--spacing-4);
+  align-items: flex-start;
+  flex: 1;
+  min-width: 0;
+}
+
+.danger-icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-xl);
+  background: var(--color-error-bg-hover);
+  color: var(--color-error);
+  flex-shrink: 0;
+}
+
+.danger-text h4 {
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 var(--spacing-1) 0;
+}
+
+.danger-text p {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  margin: 0 0 var(--spacing-1) 0;
+  line-height: 1.5;
+}
+
+.danger-meta {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+.danger-btn {
+  color: var(--color-error);
+  border-color: var(--color-error-light);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.danger-btn:hover:not(:disabled) {
+  background: var(--color-error-bg-hover);
+  border-color: var(--color-error);
 }
 
 @media (max-width: 1024px) {

--- a/autobot-frontend/src/components/knowledge/KnowledgeHealthTools.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeHealthTools.vue
@@ -1,5 +1,10 @@
 <template>
   <div class="tools-grid">
+    <!-- Transient notice (e.g. cancelled danger-zone confirmation) -->
+    <div v-if="noticeMessage" class="tools-notice" role="status" aria-live="polite">
+      {{ noticeMessage }}
+    </div>
+
     <!-- Deduplication Manager -->
     <div class="tools-section">
       <DeduplicationManager />
@@ -85,6 +90,7 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/ui/Icon.vue'
 import { useConfirmDialog } from '@/composables/useConfirmDialog'
+import { useTransientError } from '@/composables/useTransientError'
 import { useKnowledgeStore } from '@/stores/useKnowledgeStore'
 import { useKnowledgeController } from '@/models/controllers/index'
 import ApiClient from '@/utils/ApiClient'
@@ -108,6 +114,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const { confirm } = useConfirmDialog()
+const { message: noticeMessage, show: showNotice } = useTransientError()
 const store = useKnowledgeStore()
 
 interface KnowledgeController {
@@ -186,7 +193,10 @@ const clearAllKnowledge = async () => {
   if (!secondConfirm) return
 
   const userInput = prompt(t('knowledge.advanced.promptDeleteAll'))
-  if (userInput !== 'DELETE ALL') return
+  if (userInput !== 'DELETE ALL') {
+    showNotice(t('knowledge.advanced.clearCancelled'))
+    return
+  }
 
   isClearing.value = true
   try {
@@ -264,8 +274,19 @@ const clearAllKnowledge = async () => {
   cursor: not-allowed;
 }
 
+.tools-notice {
+  grid-column: 1 / -1;
+  padding: var(--spacing-3) var(--spacing-4);
+  border: 1px solid var(--color-warning);
+  border-radius: var(--radius-md);
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+  font-size: var(--text-sm);
+}
+
 /* Issue #11555: danger zone section */
 .danger-zone-section {
+  grid-column: 1 / -1;
   padding: var(--spacing-6);
   border: 1px solid var(--color-error-light);
   background: var(--color-error-bg);

--- a/autobot-frontend/src/components/knowledge/KnowledgeMainCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeMainCategories.vue
@@ -62,6 +62,15 @@
         :style="{ borderColor: mainCat.color }"
         @click="$emit('select', mainCat.id)"
       >
+        <!-- Issue #11555: per-card edit affordance -->
+        <button
+          class="category-edit-btn"
+          :title="$t('knowledge.browser.editCategory')"
+          :aria-label="$t('knowledge.browser.editCategory')"
+          @click.stop="$emit('edit', mainCat)"
+        >
+          <Icon name="pencil-alt" />
+        </button>
         <div class="category-icon" :style="{ backgroundColor: mainCat.color }">
           <Icon :name="categoryIcon(mainCat)" />
         </div>
@@ -158,6 +167,7 @@ interface Emits {
   (e: 'select', categoryId: string): void
   (e: 'populate', categoryId: string): void
   (e: 'import'): void
+  (e: 'edit', category: MainCategory): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -202,6 +212,33 @@ const showEmptyStateHint = computed(
   box-shadow: var(--shadow-sm);
   cursor: pointer;
   transition: all var(--duration-200) var(--ease-in-out);
+  position: relative;
+}
+
+/* Issue #11555: per-card edit button */
+.category-edit-btn {
+  position: absolute;
+  top: var(--spacing-3);
+  right: var(--spacing-3);
+  width: 1.75rem;
+  height: 1.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  transition: all var(--duration-150) var(--ease-in-out);
+  z-index: 1;
+}
+
+.category-edit-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--color-info);
+  border-color: var(--color-info);
 }
 
 .main-category-card:hover {

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -2915,7 +2915,8 @@
       "facts": "facts",
       "documentsSelected": "{count} document(s) selected",
       "backToRoot": "Back to root",
-      "filters": "عوامل التصفية"
+      "filters": "عوامل التصفية",
+      "editCategory": "تعديل الفئة"
     },
     "contentViewer": {
       "noFileSelected": "No file selected",

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -2591,6 +2591,8 @@
       "watchFoldersAriaLabel": "Watch Folders",
       "browser": "متصفح",
       "browserAriaLabel": "تصفح وبحث وتعديل مستندات المعرفة",
+      "systemDocs": "المستندات النظامية",
+      "systemDocsAriaLabel": "استعراض وتصدير وثائق نظام AutoBot",
       "health": "صحة المعرفة",
       "healthAriaLabel": "صحة المعرفة والتحليلات والتحقق والأدوات"
     },

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -2602,7 +2602,8 @@
       "tabTools": "الأدوات",
       "feedAll": "الكل",
       "feedCreated": "تم الإنشاء",
-      "feedUpdated": "تم التحديث"
+      "feedUpdated": "تم التحديث",
+      "dangerZone": "منطقة الخطر"
     },
     "backup": {
       "title": "Backup & Restore",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -2602,7 +2602,8 @@
       "tabTools": "Tools",
       "feedAll": "Alle",
       "feedCreated": "Erstellt",
-      "feedUpdated": "Aktualisiert"
+      "feedUpdated": "Aktualisiert",
+      "dangerZone": "Gefahrenzone"
     },
     "backup": {
       "title": "Sicherung & Wiederherstellung",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -2915,7 +2915,8 @@
       "facts": "Fakten",
       "documentsSelected": "{count} Dokument(e) ausgewählt",
       "backToRoot": "Zurück zum Stammverzeichnis",
-      "filters": "Filter"
+      "filters": "Filter",
+      "editCategory": "Kategorie bearbeiten"
     },
     "contentViewer": {
       "noFileSelected": "Keine Datei ausgewählt",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -2591,6 +2591,8 @@
       "watchFoldersAriaLabel": "Watch Folders",
       "browser": "Browser",
       "browserAriaLabel": "Wissensdokumente durchsuchen, suchen und bearbeiten",
+      "systemDocs": "Systemdokumentation",
+      "systemDocsAriaLabel": "AutoBot-Systemdokumentation durchsuchen und exportieren",
       "health": "Gesundheit",
       "healthAriaLabel": "Wissensdatenbank-Gesundheit, Analysen, Verifizierung und Tools"
     },

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -2665,7 +2665,8 @@
       "tabTools": "Tools",
       "feedAll": "All",
       "feedCreated": "Created",
-      "feedUpdated": "Updated"
+      "feedUpdated": "Updated",
+      "dangerZone": "Danger zone"
     },
     "backup": {
       "title": "Backup & Restore",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -2978,7 +2978,8 @@
       "facts": "facts",
       "documentsSelected": "{count} document(s) selected",
       "backToRoot": "Back to root",
-      "filters": "Filters"
+      "filters": "Filters",
+      "editCategory": "Edit category"
     },
     "contentViewer": {
       "noFileSelected": "No file selected",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -2654,6 +2654,8 @@
       "watchFoldersAriaLabel": "Watch Folders",
       "browser": "Browser",
       "browserAriaLabel": "Browse, search and edit knowledge documents",
+      "systemDocs": "System Docs",
+      "systemDocsAriaLabel": "Browse and export AutoBot system documentation",
       "health": "Health",
       "healthAriaLabel": "Knowledge health, analytics, verification and tools"
     },

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -2591,6 +2591,8 @@
       "watchFoldersAriaLabel": "Watch Folders",
       "browser": "Navegador",
       "browserAriaLabel": "Explorar, buscar y editar documentos de conocimiento",
+      "systemDocs": "Documentación del sistema",
+      "systemDocsAriaLabel": "Explorar y exportar la documentación del sistema AutoBot",
       "health": "Salud",
       "healthAriaLabel": "Salud del conocimiento, análisis, verificación y herramientas"
     },

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -2602,7 +2602,8 @@
       "tabTools": "Herramientas",
       "feedAll": "Todo",
       "feedCreated": "Creado",
-      "feedUpdated": "Actualizado"
+      "feedUpdated": "Actualizado",
+      "dangerZone": "Zona de peligro"
     },
     "backup": {
       "title": "Copia de seguridad y restauración",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -2915,7 +2915,8 @@
       "facts": "hechos",
       "documentsSelected": "{count} documento(s) seleccionado(s)",
       "backToRoot": "Volver a la raíz",
-      "filters": "Filtros"
+      "filters": "Filtros",
+      "editCategory": "Editar categoría"
     },
     "contentViewer": {
       "noFileSelected": "Ningún archivo seleccionado",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -2588,7 +2588,8 @@
       "loadingFileTree": "Loading file tree...",
       "closeFileViewer": "Close file viewer",
       "facts": "facts",
-      "status": "Status"
+      "status": "Status",
+      "editCategory": "ویرایش دسته‌بندی"
     },
     "entityGraph": {
       "viewGraph": "View Graph",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -2932,7 +2932,8 @@
       "tabTools": "ابزارها",
       "feedAll": "همه",
       "feedCreated": "ایجادشده",
-      "feedUpdated": "به‌روزشده"
+      "feedUpdated": "به‌روزشده",
+      "dangerZone": "منطقه خطر"
     },
     "upload": {
       "selectCategory": "Select category...",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -2920,6 +2920,8 @@
       "watchFoldersAriaLabel": "Watch Folders",
       "browser": "مرورگر",
       "browserAriaLabel": "مرور، جستجو و ویرایش اسناد دانش",
+      "systemDocs": "مستندات سیستم",
+      "systemDocsAriaLabel": "مرور و خروجی مستندات سیستم AutoBot",
       "health": "سلامت",
       "healthAriaLabel": "سلامت دانش، تحلیل‌ها، تأیید و ابزارها"
     },

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -2915,7 +2915,8 @@
       "facts": "faits",
       "documentsSelected": "{count} document(s) sélectionné(s)",
       "backToRoot": "Retour à la racine",
-      "filters": "Filtres"
+      "filters": "Filtres",
+      "editCategory": "Modifier la catégorie"
     },
     "contentViewer": {
       "noFileSelected": "Aucun fichier sélectionné",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -2591,6 +2591,8 @@
       "watchFoldersAriaLabel": "Watch Folders",
       "browser": "Navigateur",
       "browserAriaLabel": "Parcourir, rechercher et modifier les documents de connaissance",
+      "systemDocs": "Docs système",
+      "systemDocsAriaLabel": "Parcourir et exporter la documentation système AutoBot",
       "health": "Santé",
       "healthAriaLabel": "Santé des connaissances, analyses, vérification et outils"
     },

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -2602,7 +2602,8 @@
       "tabTools": "Outils",
       "feedAll": "Tout",
       "feedCreated": "Créé",
-      "feedUpdated": "Mis à jour"
+      "feedUpdated": "Mis à jour",
+      "dangerZone": "Zone de danger"
     },
     "backup": {
       "title": "Sauvegarde et restauration",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -2932,7 +2932,8 @@
       "tabTools": "כלים",
       "feedAll": "הכל",
       "feedCreated": "נוצר",
-      "feedUpdated": "עודכן"
+      "feedUpdated": "עודכן",
+      "dangerZone": "אזור סכנה"
     },
     "upload": {
       "selectCategory": "Select category...",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -2920,6 +2920,8 @@
       "watchFoldersAriaLabel": "Watch Folders",
       "browser": "דפדפן",
       "browserAriaLabel": "עיון, חיפוש ועריכת מסמכי ידע",
+      "systemDocs": "מסמכי מערכת",
+      "systemDocsAriaLabel": "עיון ויצוא תיעוד מערכת AutoBot",
       "health": "בריאות",
       "healthAriaLabel": "בריאות הידע, ניתוחים, אימות וכלים"
     },

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -2588,7 +2588,8 @@
       "loadingFileTree": "Loading file tree...",
       "closeFileViewer": "Close file viewer",
       "facts": "facts",
-      "status": "Status"
+      "status": "Status",
+      "editCategory": "ערוך קטגוריה"
     },
     "entityGraph": {
       "viewGraph": "View Graph",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -2591,6 +2591,8 @@
       "watchFoldersAriaLabel": "Watch Folders",
       "browser": "Pārlūks",
       "browserAriaLabel": "Pārlūkot, meklēt un rediģēt zināšanu dokumentus",
+      "systemDocs": "Sistēmas dokumentācija",
+      "systemDocsAriaLabel": "Pārlūkot un eksportēt AutoBot sistēmas dokumentāciju",
       "health": "Veselība",
       "healthAriaLabel": "Zināšanu veselība, analītika, verifikācija un rīki"
     },

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -2915,7 +2915,8 @@
       "facts": "fakti",
       "documentsSelected": "{count} dokuments(-i) atlasīts(-i)",
       "backToRoot": "Atpakaļ uz sakni",
-      "filters": "Filtri"
+      "filters": "Filtri",
+      "editCategory": "Rediģēt kategoriju"
     },
     "contentViewer": {
       "noFileSelected": "Nav atlasīts fails",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -2602,7 +2602,8 @@
       "tabTools": "Rīki",
       "feedAll": "Visi",
       "feedCreated": "Izveidots",
-      "feedUpdated": "Atjaunināts"
+      "feedUpdated": "Atjaunināts",
+      "dangerZone": "Bīstamā zona"
     },
     "backup": {
       "title": "Dublēšana un atjaunošana",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -2915,7 +2915,8 @@
       "facts": "faktów",
       "documentsSelected": "Zaznaczono {count} dokument(ów)",
       "backToRoot": "Powrót do katalogu głównego",
-      "filters": "Filtry"
+      "filters": "Filtry",
+      "editCategory": "Edytuj kategorię"
     },
     "contentViewer": {
       "noFileSelected": "Nie wybrano pliku",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -2591,6 +2591,8 @@
       "watchFoldersAriaLabel": "Watch Folders",
       "browser": "Przeglądarka",
       "browserAriaLabel": "Przeglądaj, wyszukuj i edytuj dokumenty wiedzy",
+      "systemDocs": "Dokumentacja systemowa",
+      "systemDocsAriaLabel": "Przeglądaj i eksportuj dokumentację systemu AutoBot",
       "health": "Kondycja",
       "healthAriaLabel": "Kondycja wiedzy, analityka, weryfikacja i narzędzia"
     },

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -2602,7 +2602,8 @@
       "tabTools": "Narzędzia",
       "feedAll": "Wszystkie",
       "feedCreated": "Utworzone",
-      "feedUpdated": "Zaktualizowane"
+      "feedUpdated": "Zaktualizowane",
+      "dangerZone": "Strefa niebezpieczeństwa"
     },
     "backup": {
       "title": "Kopia zapasowa i przywracanie",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -2602,7 +2602,8 @@
       "tabTools": "Ferramentas",
       "feedAll": "Tudo",
       "feedCreated": "Criado",
-      "feedUpdated": "Atualizado"
+      "feedUpdated": "Atualizado",
+      "dangerZone": "Zona de perigo"
     },
     "backup": {
       "title": "Backup e restauração",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -2591,6 +2591,8 @@
       "watchFoldersAriaLabel": "Watch Folders",
       "browser": "Navegador",
       "browserAriaLabel": "Procurar, pesquisar e editar documentos de conhecimento",
+      "systemDocs": "Documentação do sistema",
+      "systemDocsAriaLabel": "Explorar e exportar documentação do sistema AutoBot",
       "health": "Saúde",
       "healthAriaLabel": "Saúde do conhecimento, análises, verificação e ferramentas"
     },

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -2915,7 +2915,8 @@
       "facts": "fatos",
       "documentsSelected": "{count} documento(s) selecionado(s)",
       "backToRoot": "Voltar à raiz",
-      "filters": "Filtros"
+      "filters": "Filtros",
+      "editCategory": "Editar categoria"
     },
     "contentViewer": {
       "noFileSelected": "Nenhum arquivo selecionado",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -2920,6 +2920,8 @@
       "watchFoldersAriaLabel": "Watch Folders",
       "browser": "براؤزر",
       "browserAriaLabel": "علمی دستاویزات کو دیکھیں، تلاش کیجیں اور ترمیم کیجیں",
+      "systemDocs": "سسٹم دستاویزات",
+      "systemDocsAriaLabel": "AutoBot سسٹم دستاویزات کو دیکھیں اور برآمد کریں",
       "health": "صحت",
       "healthAriaLabel": "علمی صحت، تجزیات، تصدیق اور اوزار"
     },

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -2588,7 +2588,8 @@
       "loadingFileTree": "Loading file tree...",
       "closeFileViewer": "Close file viewer",
       "facts": "facts",
-      "status": "Status"
+      "status": "Status",
+      "editCategory": "زمرہ ترمیم کریں"
     },
     "entityGraph": {
       "viewGraph": "View Graph",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -2932,7 +2932,8 @@
       "tabTools": "اوزار",
       "feedAll": "سب",
       "feedCreated": "تخلیق شدہ",
-      "feedUpdated": "تازہ کاری شدہ"
+      "feedUpdated": "تازہ کاری شدہ",
+      "dangerZone": "خطرناک علاقہ"
     },
     "upload": {
       "selectCategory": "Select category...",

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -194,6 +194,16 @@ export const routes: RouteRecordRaw[] = [
         }
       },
       {
+        // Issue #11555: System documentation viewer and exporter
+        path: 'system-docs',
+        name: 'knowledge-system-docs',
+        component: () => import('@/components/knowledge/KnowledgeSystemDocs.vue'),
+        meta: {
+          title: 'System Docs',
+          parent: 'knowledge'
+        }
+      },
+      {
         path: 'upload',
         redirect: '/knowledge/manage'
       },

--- a/autobot-frontend/src/views/KnowledgeView.vue
+++ b/autobot-frontend/src/views/KnowledgeView.vue
@@ -114,6 +114,19 @@
           <span>{{ $t('knowledge.views.browser') }}</span>
         </router-link>
 
+        <!-- Issue #11555: System Docs — browseable and exportable AutoBot system documentation -->
+        <router-link
+          to="/knowledge/system-docs"
+          class="category-item"
+          :class="{ active: $route.name === 'knowledge-system-docs' }"
+          :aria-label="$t('knowledge.views.systemDocsAriaLabel')"
+        >
+          <svg class="item-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
+          </svg>
+          <span>{{ $t('knowledge.views.systemDocs') }}</span>
+        </router-link>
+
         <router-link
           to="/knowledge/graph"
           class="category-item"


### PR DESCRIPTION
Closes #11555

> Note: merges target Dev_new_gui (non-default), so GitHub does not auto-close — #11555 is closed manually only after step 4c completes. This linkage line satisfies the branch/issue gate.



## Thinking Path

Before KnowledgeManager.vue and its orphaned tab components can be removed (owner condition: all functionality wired elsewhere), the three unique capabilities need routed homes. This PR wires them; 4b migrates the prompt editor to the SLM admin UI; 4c performs the removals.

## What Changed

- **/knowledge/system-docs**: new route + Browse-section sidebar entry for KnowledgeSystemDocs (docs tree, markdown preview, JSON/MD export); 2 i18n keys ×11 locales
- **Category editing in /knowledge/browser**: pencil affordance on the main-category cards (KnowledgeMainCategories emit) opening the same CategoryEditModal with the same persist/refresh paths KnowledgeCategories used; knowledge.browser.editCategory ×11
- **Danger zone in Health → Tools**: clear-all-knowledge moved from the orphaned KnowledgeAdvanced — identical double-confirm + typed 'DELETE ALL' flow and endpoint, disable-while-running, full-width destructive-token section; cancelled confirmations now surface a transient notice; knowledge.health.dangerZone ×11
- KnowledgeAdvanced.vue and KnowledgeCategories.vue intentionally untouched (removed in 4c)

## Verification

- vue-tsc clean · vitest 1980 pass · lint+oxlint 0 problems · stylelint 0 problems · locale JSON valid ×11
- Independent review approved; two cosmetic minors fixed post-review (grid span, cancelled notice); the pre-existing has_children/delete-button gap is shared with the code being removed in 4c

## Model Used

Claude Fable 5 (controller) with Sonnet implementer/reviewer subagents.