### PR TITLE
fix(slm-frontend): wire PromptsSettings to backend response shape — SLM prompt editor (#11555 step 4b)

### DIFF
--- a/autobot-slm-frontend/src/composables/useAutobotApi.ts
+++ b/autobot-slm-frontend/src/composables/useAutobotApi.ts
@@ -433,8 +433,21 @@ export function useAutobotApi() {
   // =============================================================================
 
   async function getPromptTemplates(): Promise<PromptTemplate[]> {
-    const response = await client.get<{ templates: PromptTemplate[] }>('/prompts')
-    return response.data.templates
+    // Backend GET /api/prompts returns { prompts: [...], defaults: {...} }
+    // where each prompt has { id, name, type, path, content } (Issue #11555)
+    const response = await client.get<{
+      prompts: Array<{ id: string; name: string; type: string; path: string; content: string }>
+      defaults: Record<string, string>
+    }>('/prompts')
+    const defaults = response.data.defaults ?? {}
+    return (response.data.prompts ?? []).map((p) => ({
+      id: p.id,
+      name: p.name,
+      content: p.content,
+      category: p.type,
+      is_default: Object.prototype.hasOwnProperty.call(defaults, p.id),
+      modified_at: '',
+    }))
   }
 
   async function getPromptTemplate(id: string): Promise<PromptTemplate> {
@@ -453,7 +466,8 @@ export function useAutobotApi() {
     id: string,
     data: Partial<PromptTemplate>
   ): Promise<PromptTemplate> {
-    const response = await client.patch<PromptTemplate>(`/prompts/${id}`, data)
+    // Backend exposes PUT /api/prompts/:id (also POST) — PATCH is not supported (Issue #11555)
+    const response = await client.put<PromptTemplate>(`/prompts/${id}`, data)
     return response.data
   }
 


### PR DESCRIPTION
## Thinking Path

Phase 1 investigation revealed that `/settings/admin/prompts` (PromptsSettings.vue), the route, nav entry, and backend RBAC were all already in place from a prior migration. Two bugs in `useAutobotApi` prevented it from working:

1. `getPromptTemplates()` read `response.data.templates` — backend returns `response.data.prompts` + a `defaults` dict
2. `updatePromptTemplate()` used `PATCH` — backend only defines `PUT` (and `POST`) for `/{prompt_id}`

## What Changed

**`autobot-slm-frontend/src/composables/useAutobotApi.ts`**
- `getPromptTemplates()`: read correct field (`prompts`), map `type→category`, derive `is_default` from the `defaults` dict, guard with `?? []`
- `updatePromptTemplate()`: switch `PATCH` → `PUT` to match the backend route

No backend changes — `check_admin_permission` is already on all three endpoints (`GET /api/prompts`, `PUT /api/prompts/:id`, `POST /api/prompts/:id/revert`).

No frontend route/nav/component changes — `/settings/admin/prompts` with `meta: { admin: true }` and the nav entry were already wired.

## Verification

- `vue-tsc --noEmit -p tsconfig.json` in `autobot-slm-frontend/` → **0 errors**
- API route map: `PromptsSettings.vue` calls `api.getPromptTemplates()` → `GET /autobot-api/prompts` → nginx proxy → user backend `GET /api/prompts ✓`; `api.updatePromptTemplate(id, {content})` → `PUT /autobot-api/prompts/:id ✓`; `api.revertPromptToDefault(id)` → `POST /autobot-api/prompts/:id/revert ✓`
- All three backend endpoints require `admin_check = Depends(check_admin_permission)` (Issue #744)
- SLM router guard: `meta.admin && !authStore.isAdmin → redirect fleet`

## Model Used

claude-sonnet-4-6

Closes #11555 step 4b