### PR TITLE
fix(hardened): set AUTOBOT_LOGS_DIR=/app/logs for SLM — fixes EROFS crash on hardened overlay (#11574)

### DIFF
--- a/docker-compose.hardened.yml
+++ b/docker-compose.hardened.yml
@@ -129,7 +129,9 @@ services:
       - /var/run
       - /app/data/tmp:mode=1777
       - /app/autobot-slm-backend/config:mode=1777
-      # /app/logs is writable via slm_logs named volume in base compose
+      # /app/logs is writable via slm_logs named volume in base compose;
+      # AUTOBOT_LOGS_DIR=/app/logs in base compose ensures LoggingManager.mkdir()
+      # targets the volume, not the read-only image layer (#11574).
       # /app/data is writable via slm_data named volume; SLM_DATA_DIR=/app/data in base compose
       # ensures .slm_keys is written there, not to the image-layer /app/autobot-slm-backend/data
       # /app/autobot-slm-backend/config is tmpfs; config.py creates it on init

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -511,6 +511,10 @@ services:
       - SLM_POSTGRES_HOST=autobot-postgres
       - SLM_ADMIN_PASSWORD=${SLM_ADMIN_PASSWORD:-admin}
       - SLM_DATA_DIR=/app/data
+      # Point LoggingManager at the writable slm_logs volume so read_only: true
+      # in the hardened overlay doesn't fail with EROFS when mkdir("logs") is
+      # called relative to the /app/autobot-slm-backend working directory (#11574).
+      - AUTOBOT_LOGS_DIR=/app/logs
       # Surface each compose service container as a fleet node (#9761). Off by
       # default so production/Ansible VM fleets are unaffected; on for compose.
       - SLM_COMPOSE_NODES=${SLM_COMPOSE_NODES:-true}


### PR DESCRIPTION
## Thinking Path

`hardened-smoke-test` CI fails while plain `smoke-test` passes on the same commits.
Root cause hunt:
1. Read workflow: hardened overlay adds `read_only: true` to `autobot-slm`.
2. Downloaded failure artifact from run 29110336304.
3. Logs show repeated `OSError: [Errno 30] Read-only file system: 'logs'` in the SLM import probe and uvicorn.
4. Traced the call: `autobot_shared/logging_manager.py:130` → `Path(os.getenv("AUTOBOT_LOGS_DIR", "logs")).mkdir()`.
5. `AUTOBOT_LOGS_DIR` was never set for the SLM service → defaults to `"logs"` (relative).
6. SLM entrypoint does `cd /app/autobot-slm-backend` at line 16, so `Path("logs")` → `/app/autobot-slm-backend/logs` (image layer = read-only under hardened overlay).
7. The writable `slm_logs` named volume is mounted at `/app/logs`, NOT at `/app/autobot-slm-backend/logs` — hence the EROFS crash.
8. Fix: add `AUTOBOT_LOGS_DIR=/app/logs` to the SLM service environment in the base compose. Named volumes override `read_only: true`, so this path is always writable.

## What Changed

**`docker-compose.yml`** — `autobot-slm` environment block:
- Added `AUTOBOT_LOGS_DIR=/app/logs` (points LoggingManager at the `slm_logs` named volume).

**`docker-compose.hardened.yml`** — `autobot-slm` comment block:
- Updated comment to explain the AUTOBOT_LOGS_DIR linkage so the intent is self-documenting.

No code changes; no hardening weakened (no tmpfs added for the problem path; the env var redirects to the already-writable volume).

## Verification

- Static analysis: confirmed `logging_manager.py:128-130` reads `AUTOBOT_LOGS_DIR` with default `"logs"`, and SLM entrypoint cds to `/app/autobot-slm-backend`.
- CI artifact (`hardened-docker-compose-logs`, run 29110336304): confirmed `OSError: [Errno 30] Read-only file system: 'logs'` is the terminal failure.
- Fix is a one-line env var addition in the base compose — zero blast radius. Verification of the fix requires a CI run of `hardened-smoke-test`.

## Model Used

claude-sonnet-4-6

Closes #11574