### PR TITLE
fix(chat): sentinel-frame compose RPC so the script result is clean (#11613)

### DIFF
--- a/autobot-backend/chat_workflow/code_exec/protocol.py
+++ b/autobot-backend/chat_workflow/code_exec/protocol.py
@@ -1,0 +1,27 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Wire protocol constants shared between the shim, the broker pump, and tests.
+
+Code-execution mode multiplexes two logical streams over the sandbox's single
+stdout: the shim's JSON-RPC tool requests and the script's own output (prints
+and its final result). To keep them cleanly separable (GH#11613), every RPC
+request line the shim writes is prefixed with ``RPC_SENTINEL``; the executor
+pump routes only sentinel-prefixed lines to the broker and treats every other
+stdout line as the script's result.
+
+``\\x1e`` (ASCII Record Separator) is a control character that never appears in
+JSON or ordinary text output, so a script's own prints cannot be mistaken for
+RPC — and, conversely, RPC framing never pollutes the returned result.
+"""
+
+from __future__ import annotations
+
+#: Prefix marking a stdout line as a shim -> broker JSON-RPC request.
+RPC_SENTINEL: str = "\x1eCXRPC\x1e"
+
+#: Bytes form used by the executor pump before utf-8 decode.
+RPC_SENTINEL_BYTES: bytes = RPC_SENTINEL.encode("utf-8")
+
+__all__ = ["RPC_SENTINEL", "RPC_SENTINEL_BYTES"]

--- a/autobot-backend/chat_workflow/code_exec/shim_codegen.py
+++ b/autobot-backend/chat_workflow/code_exec/shim_codegen.py
@@ -11,6 +11,8 @@ per-call monotonic id so concurrent same-tool calls correlate their replies.
 
 import os
 
+from chat_workflow.code_exec.protocol import RPC_SENTINEL
+
 CODEEXEC_INJECTABLE_TOOLS: frozenset[str] = frozenset(
     os.environ.get(
         "AUTOBOT_CODEEXEC_INJECTABLE_TOOLS",
@@ -62,7 +64,11 @@ def _shim_for(tool: str) -> str:
 
 
 def _rpc_helper() -> str:
-    """Shared RPC helper: per-call monotonic id + reply correlation on that id."""
+    """Shared RPC helper: per-call monotonic id + reply correlation on that id.
+
+    RPC request lines are prefixed with ``RPC_SENTINEL`` so the executor pump can
+    tell them apart from the script's own stdout / final result (GH#11613).
+    """
     return (
         "_call_seq = 0\n"
         "_pending = {}\n\n"
@@ -73,7 +79,7 @@ def _rpc_helper() -> str:
         "async def _rpc_call(tool, params):\n"
         "    call_id = _next_id()\n"
         '    req = json.dumps({"id": call_id, "tool": tool, "params": params})\n'
-        '    sys.stdout.write(req + "\\n")\n'
+        '    sys.stdout.write(_RPC_SENTINEL + req + "\\n")\n'
         "    sys.stdout.flush()\n"
         "    while call_id not in _pending:\n"
         "        line = await asyncio.get_event_loop().run_in_executor(None, sys.stdin.readline)\n"
@@ -88,5 +94,9 @@ def _rpc_helper() -> str:
 
 def generate_shim_module(tools: list[str]) -> str:
     """Return Python source for the ``autobot_tools`` shim module."""
-    header = '"""autobot_tools — generated RPC shims. Do not edit."""\n' "import asyncio, json, sys\n\n"
+    header = (
+        '"""autobot_tools — generated RPC shims. Do not edit."""\n'
+        "import asyncio, json, sys\n\n"
+        f"_RPC_SENTINEL = {RPC_SENTINEL!r}\n\n"
+    )
     return header + _rpc_helper() + "\n".join(_shim_for(t) for t in tools)

--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -655,6 +655,8 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
             "via the `autobot_tools` module (e.g. `await autobot_tools.web_search(query=...)`). "
             "Scripts must only import from the allowlist (autobot_tools, asyncio, json, re, math). "
             "Do NOT use exec, eval, compile, or __import__.\n"
+            "Return your final answer by writing it to stdout (e.g. `print(json.dumps(result))`); "
+            "that printed output is what you receive back — tool-call plumbing is handled for you.\n"
         )
 
     def _build_conversation_context(self, session: WorkflowSession) -> str:

--- a/autobot-backend/secure_sandbox_executor.py
+++ b/autobot-backend/secure_sandbox_executor.py
@@ -458,12 +458,15 @@ class SecureSandboxExecutor:
             buf = buf[8 + size :]
         return out, buf
 
-    async def _pump_broker_io(self, container, broker: Any) -> None:
+    async def _pump_broker_io(self, container, broker: Any, script_out: "list[str]") -> None:
         """Drive the shim RPC loop: read stdout lines, reply on stdin (GH#11568).
 
         Reads Docker's multiplexed frames from the attach socket, demuxes stdout,
-        line-splits JSON-RPC requests, and writes the broker's reply to stdin.
-        Budget exhaustion aborts the container via teardown.
+        and line-splits it. Lines prefixed with ``RPC_SENTINEL`` are shim -> broker
+        JSON-RPC requests (reply written back to stdin); every other line is the
+        script's own output and is appended to *script_out* so the RPC framing
+        never pollutes the returned result (GH#11613). Budget exhaustion aborts
+        the container via teardown.
         """
         sock = container.attach_socket(params={"stdin": 1, "stdout": 1, "stream": 1})
         stream = getattr(sock, "_sock", sock)
@@ -476,16 +479,23 @@ class SecureSandboxExecutor:
             raw_buf += chunk
             decoded, raw_buf = self._demux_frames(raw_buf)
             line_buf += decoded
-            aborted = await self._drain_lines(stream, broker, line_buf, container)
-            line_buf = aborted[1]
-            if aborted[0]:
+            aborted, line_buf = await self._drain_lines(stream, broker, line_buf, container, script_out)
+            if aborted:
                 return
 
-    async def _drain_lines(self, stream, broker: Any, line_buf: bytes, container) -> "Tuple[bool, bytes]":
-        """Process complete JSON lines in *line_buf*; return (aborted, remaining)."""
+    async def _drain_lines(
+        self, stream, broker: Any, line_buf: bytes, container, script_out: "list[str]"
+    ) -> "Tuple[bool, bytes]":
+        """Route complete lines: sentinel -> broker RPC, others -> *script_out*."""
+        from chat_workflow.code_exec.protocol import RPC_SENTINEL_BYTES  # lazy
+
         while b"\n" in line_buf:
             raw, line_buf = line_buf.split(b"\n", 1)
-            reply = await broker.handle_line(raw.decode("utf-8", errors="replace"))
+            if not raw.startswith(RPC_SENTINEL_BYTES):
+                script_out.append(raw.decode("utf-8", errors="replace"))
+                continue
+            payload = raw[len(RPC_SENTINEL_BYTES) :].decode("utf-8", errors="replace")
+            reply = await broker.handle_line(payload)
             await asyncio.to_thread(stream.sendall, (reply + "\n").encode("utf-8"))
             if broker.budget_exhausted:
                 await asyncio.to_thread(container.kill)
@@ -534,8 +544,9 @@ class SecureSandboxExecutor:
             container = self.docker_client.containers.create(**cc)
             self.active_containers[container_id] = container.id
             container.start()
-            await self._pump_broker_io(container, broker)
-            return await self._collect_broker_results(container, container_id, cfg, start_time)
+            script_out: list[str] = []
+            await self._pump_broker_io(container, broker, script_out)
+            return await self._collect_broker_results(container, container_id, cfg, start_time, "\n".join(script_out))
         except Exception as e:  # noqa: BLE001
             self.logger.error("Broker script execution error: %s", e)
             return self._create_execution_error_result(e, start_time, container_id)
@@ -552,23 +563,25 @@ class SecureSandboxExecutor:
             pass
 
     async def _collect_broker_results(
-        self, container, container_id: str, cfg: "SandboxConfig", start_time: float
+        self, container, container_id: str, cfg: "SandboxConfig", start_time: float, script_stdout: str
     ) -> "SandboxResult":
         """Wait for an already-started broker container, then collect results (GH#11568 BLOCKER-2).
 
         Unlike ``_run_container_and_collect_results`` this never calls ``start()``
         again (the pump already started the container) — avoiding a 409 Conflict.
+        The result stdout is *script_stdout* — the non-RPC output the pump captured
+        live (GH#11613) — not ``container.logs()``, which interleaves the RPC frames.
         """
         try:
             exit_code = await asyncio.to_thread(lambda: container.wait(timeout=cfg.timeout)["StatusCode"])
         except Exception:  # noqa: BLE001
             await asyncio.to_thread(container.kill)
             exit_code = -9
-        logs = await asyncio.to_thread(lambda: container.logs(stdout=True, stderr=True, stream=False))
-        stdout_logs, stderr_logs = self._parse_logs(logs)
+        logs = await asyncio.to_thread(lambda: container.logs(stdout=False, stderr=True, stream=False))
+        _, stderr_logs = self._parse_logs(logs)
         security_events = await self._collect_security_events(container_id)
         result = self._build_sandbox_result(
-            exit_code, stdout_logs, stderr_logs, time.time() - start_time, container_id, security_events, {}, cfg
+            exit_code, script_stdout, stderr_logs, time.time() - start_time, container_id, security_events, {}, cfg
         )
         await self._log_execution_metrics(container_id, result)
         return result

--- a/autobot-backend/secure_sandbox_executor.py
+++ b/autobot-backend/secure_sandbox_executor.py
@@ -486,7 +486,14 @@ class SecureSandboxExecutor:
     async def _drain_lines(
         self, stream, broker: Any, line_buf: bytes, container, script_out: "list[str]"
     ) -> "Tuple[bool, bytes]":
-        """Route complete lines: sentinel -> broker RPC, others -> *script_out*."""
+        """Route complete lines: sentinel -> broker RPC, others -> *script_out*.
+
+        The sentinel is a MUX separator, not an auth token: a script CAN forge a
+        sentinel-prefixed line, but ``broker.handle_line`` re-validates every call
+        against the injectable allowlist + forbidden_work + per-run budget, so a
+        forged call is exactly equivalent to calling the shim it already has —
+        it gains nothing (GH#11613 security review).
+        """
         from chat_workflow.code_exec.protocol import RPC_SENTINEL_BYTES  # lazy
 
         while b"\n" in line_buf:
@@ -578,7 +585,10 @@ class SecureSandboxExecutor:
             await asyncio.to_thread(container.kill)
             exit_code = -9
         logs = await asyncio.to_thread(lambda: container.logs(stdout=False, stderr=True, stream=False))
-        _, stderr_logs = self._parse_logs(logs)
+        # logs holds stderr only (stdout=False); _parse_logs lumps all text into
+        # its first element, so that IS the stderr here (result stdout comes from
+        # the pump-captured script_stdout, not logs).
+        stderr_logs, _ = self._parse_logs(logs)
         security_events = await self._collect_security_events(container_id)
         result = self._build_sandbox_result(
             exit_code, script_stdout, stderr_logs, time.time() - start_time, container_id, security_events, {}, cfg

--- a/autobot-backend/tests/integration/test_codeexec_docker_smoke.py
+++ b/autobot-backend/tests/integration/test_codeexec_docker_smoke.py
@@ -96,9 +96,10 @@ async def test_smoke_two_readonly_tools_merge_in_one_dispatch():
     """A script calling two shim tools returns a merged result in ONE executor call.
 
     Asserts the broker dispatched exactly the two calls the script made and that
-    the script's final answer is cleanly retrievable — if the final-result
-    channel is polluted by the RPC stream (see discovery on result multiplexing),
-    this assertion fails loudly on-box, which is the point of the gate.
+    the script's final answer is cleanly retrievable. Since GH#11613 the RPC
+    stream is sentinel-framed and the pump captures only non-RPC stdout as the
+    result, so ``result.stdout`` holds the script's RESULT line with no RPC
+    transcript mixed in.
     """
 
     async def dispatch(tool, params):

--- a/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
@@ -782,3 +782,92 @@ async def test_broker_budget_no_overshoot_concurrent():
         replies = await asyncio.gather(*(b.handle_line(x) for x in lines))
     ok_count = sum(1 for r in replies if json.loads(r)["ok"])
     assert ok_count == 3  # never overshoots the cap
+
+
+# ---------------------------------------------------------------------------
+# GH#11613: RPC sentinel separates broker traffic from the script's result
+# ---------------------------------------------------------------------------
+
+
+def test_shim_rpc_lines_carry_sentinel_prefix():
+    """Generated shim writes RPC requests prefixed with RPC_SENTINEL."""
+    from chat_workflow.code_exec.protocol import RPC_SENTINEL
+    from chat_workflow.code_exec.shim_codegen import generate_shim_module
+
+    src = generate_shim_module(["web_search"])
+    assert repr(RPC_SENTINEL) in src
+    assert "_RPC_SENTINEL + req" in src
+
+
+@pytest.mark.asyncio
+async def test_drain_lines_routes_sentinel_to_broker_and_output_to_script():
+    """A sentinel line hits the broker; a plain script line goes to script_out (not the broker)."""
+    from chat_workflow.code_exec.protocol import RPC_SENTINEL
+    from secure_sandbox_executor import SecureSandboxExecutor
+
+    ex = object.__new__(SecureSandboxExecutor)
+    broker = MagicMock()
+    broker.handle_line = AsyncMock(return_value='{"id": 1, "ok": true, "result": {}}')
+    broker.budget_exhausted = False
+    stream = MagicMock()
+
+    rpc = (RPC_SENTINEL + json.dumps({"id": 1, "tool": "web_search", "params": {}})).encode("utf-8")
+    plain = b'RESULT {"answer": 42}'
+    line_buf = rpc + b"\n" + plain + b"\n"
+    script_out: list[str] = []
+
+    aborted, remaining = await ex._drain_lines(stream, broker, line_buf, MagicMock(), script_out)
+
+    assert aborted is False
+    # The broker saw ONLY the RPC payload, with the sentinel stripped.
+    broker.handle_line.assert_awaited_once()
+    handed = broker.handle_line.await_args[0][0]
+    assert not handed.startswith(RPC_SENTINEL)
+    assert json.loads(handed)["tool"] == "web_search"
+    # The script's own line was captured, never routed to the broker.
+    assert script_out == ['RESULT {"answer": 42}']
+
+
+@pytest.mark.asyncio
+async def test_drain_lines_script_print_is_not_a_bogus_tool_call():
+    """Regression for #11613: a bare print() must NOT reach broker.handle_line."""
+    from secure_sandbox_executor import SecureSandboxExecutor
+
+    ex = object.__new__(SecureSandboxExecutor)
+    broker = MagicMock()
+    broker.handle_line = AsyncMock()
+    broker.budget_exhausted = False
+
+    script_out: list[str] = []
+    line_buf = b"hello from the script\n" + json.dumps({"tool": "", "id": 0}).encode("utf-8") + b"\n"
+    await ex._drain_lines(MagicMock(), broker, line_buf, MagicMock(), script_out)
+
+    broker.handle_line.assert_not_awaited()
+    assert script_out == ["hello from the script", json.dumps({"tool": "", "id": 0})]
+
+
+@pytest.mark.asyncio
+async def test_collect_broker_results_uses_script_stdout_not_rpc_logs():
+    """#11613: result.stdout is the captured script output, not container.logs()."""
+    from secure_sandbox_executor import SandboxSecurityLevel, SecureSandboxExecutor
+
+    ex = object.__new__(SecureSandboxExecutor)
+    ex.logger = MagicMock()
+    container = MagicMock()
+    container.wait.return_value = {"StatusCode": 0}
+    # Simulate polluted logs: if the code used logs() for stdout, this RPC noise would leak.
+    container.logs.return_value = b'\x1eCXRPC\x1e{"id": 1}\nRESULT clean'
+    ex._parse_logs = SecureSandboxExecutor._parse_logs.__get__(ex)
+    ex._collect_security_events = AsyncMock(return_value=[])
+    ex._build_sandbox_result = SecureSandboxExecutor._build_sandbox_result.__get__(ex)
+    ex._log_execution_metrics = AsyncMock()
+
+    cfg = SecureSandboxExecutor._codeexec_config(ex, 30)
+    cfg.security_level = SandboxSecurityLevel.HIGH
+    result = await ex._collect_broker_results(container, "cid", cfg, 0.0, "RESULT clean")
+
+    assert result.stdout == "RESULT clean"
+    assert "CXRPC" not in result.stdout
+    # stdout must NOT have been sourced from container.logs (called with stdout=False).
+    _, kwargs = container.logs.call_args
+    assert kwargs.get("stdout") is False

--- a/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_code_exec.py
@@ -871,3 +871,6 @@ async def test_collect_broker_results_uses_script_stdout_not_rpc_logs():
     # stdout must NOT have been sourced from container.logs (called with stdout=False).
     _, kwargs = container.logs.call_args
     assert kwargs.get("stdout") is False
+    # stderr-only logs are surfaced (not silently dropped): _parse_logs lumps
+    # them into element 0, so the broker path reads them from there (#11613 review).
+    assert "RESULT clean" in result.stderr

--- a/docs/architecture/designs/CODE_EXECUTION_AGENT_MODE_DESIGN.md
+++ b/docs/architecture/designs/CODE_EXECUTION_AGENT_MODE_DESIGN.md
@@ -88,6 +88,14 @@ micro-calls is worse than what we have). Replacement controls:
 
 ## 4. Failure semantics
 
+- **Result channel (GH#11613):** the shim and the script share the sandbox's
+  single stdout, so RPC framing and the script's result must be separated or
+  the returned value is polluted by the tool-call transcript. RPC request lines
+  are prefixed with a control-char sentinel (`\x1e`, Record Separator — see
+  `code_exec/protocol.py`); the executor pump routes only sentinel lines to the
+  broker and captures every other stdout line as the script's result. The
+  script therefore returns its answer by printing to stdout normally (RPC is
+  transparent); `result.stdout` is that captured output, never `container.logs()`.
 - **Partial side effects:** v1 shims are read-only, so a mid-script abort
   loses only work, not consistency. This is the main reason v1 excludes
   mutating tools; compensation logic is deferred to v2 and must be designed


### PR DESCRIPTION
Closes #11613. Removes the first of the two gates blocking code-execution mode (#11568) from being enabled.

## Thinking Path
The compose script and the broker shared the sandbox's single stdout: the pump treated every stdout line as a JSON-RPC tool request, so (a) the script's final result came back polluted with RPC transcript and (b) a plain `print()` was consumed as a bogus tool call. Found while writing the #11596 smoke gate.

## What Changed
- **New `code_exec/protocol.py`** — `RPC_SENTINEL = "\x1eCXRPC\x1e"` (ASCII Record Separator — never appears in JSON via `json.dumps` or ordinary text), shared by the shim writer and the executor pump.
- **`shim_codegen.py`** — RPC request lines are written with the sentinel prefix.
- **`secure_sandbox_executor.py`** — `_drain_lines`/`_pump_broker_io` route ONLY sentinel-prefixed lines to `broker.handle_line` (sentinel stripped); every other stdout line is captured into `script_out` and returned as `result.stdout`. `_collect_broker_results` no longer sources stdout from `container.logs()` (which interleaved RPC frames); reads stderr-only logs and surfaces them (fixing an incidental stderr-loss the review caught).
- **Prompt teaching + design doc §4** — the script returns its answer by printing to stdout; RPC is transparent.
- **#11596 smoke** — the "fails by design until #11613" comment flipped; the result-retrieval assertion now describes the fixed behavior.

## Security
Adversarial security review: **APPROVE, no blockers.** Key finding, calibrated as not-a-vulnerability: a script CAN forge a sentinel line, but `broker.handle_line` re-validates every call against the injectable allowlist + forbidden_work + per-run budget regardless of source — a forged call is exactly equivalent to calling the shim it already has, and sensitive tools are unrepresentable. Documented in `_drain_lines`. Verified: no sentinel/JSON collision, correct byte-strip, cross-recv-chunk partial lines reassemble, per-broker budget (no cross-run exhaustion), flag-off zero-change.

## Verification
- `pytest test_code_exec.py` → **67 passed** (4 new incl. the regression: a script `print` must NOT reach `broker.handle_line`); regression `-k dispatch/tool_handler/delegat/compose/code_exec` → **129 passed**. flake8/black clean.
- Discovery filed: **#11629** (`_parse_logs` never splits stderr — pre-existing).

## Model Used
Claude (Fable 5) orchestrating + design; Sonnet security code-reviewer.
