### PR TITLE
fix(celery): remove phantom deploy_host/provision_ssh_key/manage_service routes (#11608)

### DIFF
--- a/autobot-backend/api/infrastructure_integration_test.py
+++ b/autobot-backend/api/infrastructure_integration_test.py
@@ -127,7 +127,7 @@ def test_celery_worker_status():
             logs = f.read()
             if "ready" in logs and "autobot-worker" in logs:
                 print("✅ Test 9: Celery Worker - PASSED")  # noqa: print
-                print("   Worker is running with queues: deployments, provisioning, services")  # noqa: print
+                print("   Worker is running with queues: celery, deployments")  # noqa: print
                 return True
             else:
                 print("❌ Test 9: Celery Worker - FAILED")  # noqa: print

--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -109,10 +109,11 @@ celery_app.conf.update(
     task_queue_max_priority=_MAX_PRIORITY,
     task_default_priority=_PRIORITY_NORMAL,
     # Task routing - route tasks to appropriate queues
+    # #11608: phantom routes for tasks.deploy_host / tasks.provision_ssh_key /
+    # tasks.manage_service removed — those tasks moved to the SLM server (#729)
+    # and nothing sends those names to this broker anymore. The orphaned
+    # `provisioning` and `services` queues were dropped with them.
     task_routes={
-        "tasks.deploy_host": {"queue": "deployments"},
-        "tasks.provision_ssh_key": {"queue": "provisioning"},
-        "tasks.manage_service": {"queue": "services"},
         # Issue #687: RBAC initialization tasks
         "tasks.initialize_rbac": {"queue": "deployments"},
         # Issue #544: System update tasks

--- a/autobot-infrastructure/shared/scripts/start-celery-worker.sh
+++ b/autobot-infrastructure/shared/scripts/start-celery-worker.sh
@@ -89,7 +89,7 @@ echo "[4/4] Starting Celery worker..."
 echo ""
 echo "Worker Configuration:"
 echo "  - Concurrency: 4 workers"
-echo "  - Queues: deployments, provisioning, services"
+echo "  - Queues: deployments"
 echo "  - Max tasks per child: 50"
 echo "  - Time limit: 600s (10 minutes)"
 echo "  - Soft time limit: 540s (9 minutes)"
@@ -99,10 +99,12 @@ echo "=========================================="
 echo ""
 
 # Start Celery worker with appropriate configuration
+# provisioning/services queues removed — no tasks route to them since
+# deployment tasks moved to the SLM server (#729, cleanup #11608)
 exec celery -A backend.celery_app worker \
     --loglevel=info \
     --concurrency=4 \
-    --queues=deployments,provisioning,services \
+    --queues=deployments \
     --max-tasks-per-child=50 \
     --time-limit=600 \
     --soft-time-limit=540 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -325,7 +325,9 @@ services:
       - celery_app
       - worker
       - --loglevel=info
-      - --queues=celery,deployments,provisioning,services
+      # provisioning/services queues removed — no tasks route to them since
+      # deployment tasks moved to the SLM server (#729, cleanup #11608)
+      - --queues=celery,deployments
       - --concurrency=2
     working_dir: /app/autobot-backend
     env_file:

--- a/docs/how-to/distributed-execution-failover-redis-worker-nodes.md
+++ b/docs/how-to/distributed-execution-failover-redis-worker-nodes.md
@@ -179,9 +179,9 @@ For Celery-based distributed execution, tasks are routed by type:
 ```python
 # autobot-backend/celery_app.py
 task_routes = {
-    "tasks.deploy_host":       {"queue": "deployments"},
-    "tasks.provision_ssh_key": {"queue": "provisioning"},
-    "tasks.manage_service":    {"queue": "services"},
+    "tasks.initialize_rbac":         {"queue": "deployments"},
+    "tasks.run_system_update":       {"queue": "deployments"},
+    "tasks.check_available_updates": {"queue": "deployments"},
 }
 
 # Celery uses Redis as both broker and result backend:
@@ -193,7 +193,7 @@ Start workers per queue:
 
 ```bash
 celery -A celery_app worker -Q deployments -c 2 --loglevel=info
-celery -A celery_app worker -Q services    -c 4 --loglevel=info
+celery -A celery_app worker -Q memory      -c 4 --loglevel=info
 ```
 
 ## Architecture reference


### PR DESCRIPTION
Closes #11608.

## Thinking Path

`celery_app.py` routed three task names to `deployments`/`provisioning`/`services` queues, but the task definitions were moved to the SLM server (#729) and stubbed with NotImplementedError. The issue gated removal on verifying no external sender exists — verification done, routes are dead config.

## What Changed

- `celery_app.py`: removed the three phantom `task_routes` entries with a comment pointing at #729/#11608
- `docker-compose.yml` + `autobot-infrastructure/shared/scripts/start-celery-worker.sh`: dropped the now-orphaned `provisioning`/`services` queues from worker `--queues` lists (`deployments` kept — still serves initialize_rbac/run_system_update/check_available_updates)
- `docs/how-to/distributed-execution-failover-redis-worker-nodes.md`: routing examples updated to real routes
- `api/infrastructure_integration_test.py:130`: stale queue-list string updated

## Verification

- **Sender search (repo-wide)**: zero producers of the three names across autobot-slm-backend/, autobot-slm-agent/, autobot-npu-worker/, ansible/, scripts/, autobot_shared/. Only `send_task()` call site in the repo is `async_work/__init__.py:123`, whose callers pass `knowledge_tasks.rebuild_index` only. SLM side runs ansible-playbook directly.
- Git history: routes carried since restructure #926; `tasks/system_tasks.py:10` docstring confirms intentional move (#729)
- `tasks/test_task_registration.py` + `tests/integration/test_celery_reliability.py`: 12 passed; `py_compile`/`black --check`/`bash -n` clean; zero residual references

## Discoveries

- #11631 — compose `autobot-worker` consumes only `celery,deployments`; tasks routed to `memory`/`analytics` have no consumer in compose deployments (pre-existing)

## Model Used

Claude Fable 5 (orchestrator + implementation agent)