### PR TITLE
fix(test): real-load llm_shared.hardware so test_hardware patches are effective (#11618)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -397,7 +397,24 @@ if "llm_shared" not in sys.modules:
     if "llm_shared.optimization.model_inspector" not in sys.modules:
         _mi_stub = _make_pkg_stub("llm_shared.optimization.model_inspector")
         _mi_stub.inspect_model = MagicMock(return_value=None)  # type: ignore[attr-defined]
+        _mi_stub.ModelInfo = MagicMock()  # type: ignore[attr-defined]
         sys.modules["llm_shared.optimization.model_inspector"] = _mi_stub
+
+    # #11618: Real-load llm_shared.hardware so patch("llm_shared.hardware.X") in
+    # test_hardware.py targets the real module globals instead of the MagicMock
+    # package stub.  Deps: autobot_shared.logging_manager (already patched) and
+    # llm_shared.optimization.model_inspector (stubbed just above).
+    _load_real_mod("llm_shared.hardware", _llm_root / "hardware.py")
+    _hw_mod = sys.modules.get("llm_shared.hardware")
+    if _hw_mod is not None:
+        # Bind on parent stub so patch("llm_shared.hardware.X") resolves via
+        # getattr(sys.modules["llm_shared"], "hardware") rather than the stub's
+        # catch-all __getattr__ which always returns the same MagicMock.
+        setattr(_llm_stub, "hardware", _hw_mod)
+        if hasattr(_hw_mod, "HardwareDetector"):
+            _llm_stub.HardwareDetector = _hw_mod.HardwareDetector  # type: ignore[attr-defined]
+        if hasattr(_hw_mod, "TORCH_AVAILABLE"):
+            _llm_stub.TORCH_AVAILABLE = _hw_mod.TORCH_AVAILABLE  # type: ignore[attr-defined]
 
     # llm_shared.cache — provide symbols consumed by services.llm_service
     _cache_stub = sys.modules["llm_shared.cache"]


### PR DESCRIPTION
Closes #11618. Final piece of the #11532 mock.patch-inertness audit.

## Thinking Path
`tests/llm_interface_pkg/test_hardware.py` failed to COLLECT (`ModuleNotFoundError: No module named 'llm_shared.hardware'`) because `llm_shared` is a MagicMock package stub with empty `__path__`, so `@patch("llm_shared.hardware.TORCH_AVAILABLE"/"torch")` targets resolved to nothing — the 5 tests never ran. Same inert-patch / stub-shadow class as #11532; deferred there, fixed here with the established pattern.

## What Changed (conftest only, +17 lines)
- Stub `ModelInfo` on `llm_shared.optimization.model_inspector` (hardware.py imports `ModelInfo, inspect_model` from it).
- `_load_real_mod("llm_shared.hardware", ...)` (reusing the existing helper — no new one), inserted after its deps.
- Bind the real module on the parent stub (`setattr(llm_shared_stub, "hardware", real)`) so `patch("llm_shared.hardware.X")` resolves via `getattr` instead of the stub's catch-all `__getattr__`. Re-export `HardwareDetector`/`TORCH_AVAILABLE` for direct imports.

## Verification
- `pytest test_hardware.py` → **5 passed** (was a collection ERROR).
- **Sabotage-proven (re-run independently):** flipping the `if TORCH_AVAILABLE and torch.cuda.is_available()` branch in the real `hardware.py` → **2 tests FAIL** (they genuinely execute the patched globals now); revert → 5 pass.
- **Collection A/B:** full `autobot-backend/tests` = **130 errors with this conftest vs 131 with origin's** — removes exactly the test_hardware error, adds none. flake8/black clean.

## Model Used
Claude (Fable 5) orchestrating + independent sabotage/A/B verification; Sonnet implementation agent.
