### PR TITLE
feat(integrations): register STT adapter for every speech-registry language (#11617)

### DIFF
--- a/autobot-backend/integrations/capability_registry.py
+++ b/autobot-backend/integrations/capability_registry.py
@@ -144,9 +144,10 @@ def _register_stt_if_available(registry: CapabilityRegistry) -> None:
     Imports lazily so voice-processing heavy deps are not pulled in at module
     load time.  Skips silently when no provider is configured.
 
-    Enumerates ``ProviderRegistry._providers`` (language → priority-list) and
-    registers a ``SpeechProviderSTTAdapter`` for each language's highest-priority
-    provider, so every configured language is reachable via the STT capability.
+    Enumerates the speech registry's languages (via its public ``languages()``
+    accessor) and registers a ``SpeechProviderSTTAdapter`` for each language's
+    highest-priority provider, so every configured language is reachable via the
+    STT capability.
     """
     try:
         from integrations.stt_adapter import SpeechProviderSTTAdapter
@@ -157,7 +158,7 @@ def _register_stt_if_available(registry: CapabilityRegistry) -> None:
 
     try:
         speech_registry = get_speech_provider_registry()
-        languages = list(getattr(speech_registry, "_providers", {}).keys())
+        languages = list(speech_registry.languages())
         if not languages:
             logger.debug("No STT providers registered in speech registry — STT capability skipped")
             return

--- a/autobot-backend/integrations/capability_registry.py
+++ b/autobot-backend/integrations/capability_registry.py
@@ -139,10 +139,14 @@ def _populate_default_providers(registry: CapabilityRegistry) -> None:
 
 
 def _register_stt_if_available(registry: CapabilityRegistry) -> None:
-    """Credential-gate STT registration via SpeechProvider registry (#11559).
+    """Register one STT adapter per available language in the SpeechProvider registry (#11617).
 
     Imports lazily so voice-processing heavy deps are not pulled in at module
     load time.  Skips silently when no provider is configured.
+
+    Enumerates ``ProviderRegistry._providers`` (language → priority-list) and
+    registers a ``SpeechProviderSTTAdapter`` for each language's highest-priority
+    provider, so every configured language is reachable via the STT capability.
     """
     try:
         from integrations.stt_adapter import SpeechProviderSTTAdapter
@@ -153,18 +157,32 @@ def _register_stt_if_available(registry: CapabilityRegistry) -> None:
 
     try:
         speech_registry = get_speech_provider_registry()
-        # Use the first available provider from the speech registry.  The
-        # language-keyed registry exposes providers per-language; we surface a
-        # generic "en" provider as the default STT capability endpoint.
-        # Non-en language registration in the capability layer is tracked in #11617.
-        provider = speech_registry.get_provider("en")
-        if provider is None:
-            logger.debug("No STT provider registered for 'en' — STT capability skipped")
+        languages = list(getattr(speech_registry, "_providers", {}).keys())
+        if not languages:
+            logger.debug("No STT providers registered in speech registry — STT capability skipped")
             return
-        registry.register(STT, SpeechProviderSTTAdapter(provider))
-        logger.debug("Registered SpeechProviderSTTAdapter (%s) for capability=%s", provider.provider_name, STT)
+        for lang in languages:
+            _register_stt_language(registry, speech_registry, lang, SpeechProviderSTTAdapter)
     except Exception as exc:
         logger.warning("Failed to register STT capability: %s", exc)
+
+
+def _register_stt_language(registry: CapabilityRegistry, speech_registry, lang: str, adapter_cls) -> None:
+    """Register one STT adapter for *lang* if its highest-priority provider exists."""
+    try:
+        provider = speech_registry.get_provider(lang)
+        if provider is None:
+            logger.debug("No STT provider for language '%s' — skipped", lang)
+            return
+        registry.register(STT, adapter_cls(provider))
+        logger.debug(
+            "Registered SpeechProviderSTTAdapter (%s, lang=%s) for capability=%s",
+            provider.provider_name,
+            lang,
+            STT,
+        )
+    except Exception as exc:
+        logger.warning("Failed to register STT capability for language '%s': %s", lang, exc)
 
 
 def get_capability_registry() -> CapabilityRegistry:

--- a/autobot-backend/integrations/protocols_conformance_test.py
+++ b/autobot-backend/integrations/protocols_conformance_test.py
@@ -18,7 +18,7 @@ Tests:
 from __future__ import annotations
 
 import inspect
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -402,6 +402,10 @@ class _FakeSpeechRegistry:
             return None
         return entries[0][0]
 
+    def languages(self):
+        """Match the real ProviderRegistry.languages() public accessor (#11617)."""
+        return list(self._providers.keys())
+
 
 def _make_mock_provider(name: str):
     """Return a MagicMock SpeechProvider with provider_name set."""
@@ -414,14 +418,34 @@ class TestSTTMultiLanguageRegistration:
     """#11617 — every language in the speech registry must get an STT adapter."""
 
     def _run_register(self, fake_speech_registry):
-        """Run ``_register_stt_if_available`` with a fake speech registry injected."""
+        """Run ``_register_stt_language`` per language with a fake registry injected."""
         from integrations.capability_registry import _register_stt_language
 
         registry = CapabilityRegistry()
-        languages = list(getattr(fake_speech_registry, "_providers", {}).keys())
-        for lang in languages:
+        for lang in fake_speech_registry.languages():
             _register_stt_language(registry, fake_speech_registry, lang, SpeechProviderSTTAdapter)
         return registry
+
+    def test_register_stt_if_available_enumerates_via_languages(self):
+        """End-to-end: the production entry point enumerates via .languages() (#11617).
+
+        Drives the real ``_register_stt_if_available`` with the fake speech
+        registry injected, so the public-accessor enumeration path is covered —
+        not just the per-language helper.
+        """
+        import integrations.capability_registry as cr
+        from voice_processing import providers as vp
+
+        fake_reg = _FakeSpeechRegistry(
+            {"en": _make_mock_provider("whisper-en"), "lv": _make_mock_provider("whisper-lv")}
+        )
+        registry = CapabilityRegistry()
+        with patch.object(vp, "get_speech_provider_registry", return_value=fake_reg):
+            cr._register_stt_if_available(registry)
+
+        resolved = registry.resolve(STT)
+        assert len(resolved) == 2
+        assert all(isinstance(a, STTProtocol) for a in resolved)
 
     def test_single_language_registers_one_adapter(self):
         """A registry with one language produces exactly one STT adapter."""

--- a/autobot-backend/integrations/protocols_conformance_test.py
+++ b/autobot-backend/integrations/protocols_conformance_test.py
@@ -377,3 +377,131 @@ class TestSTTProtocolConformance:
         assert len(resolved) == 1
         assert isinstance(resolved[0], STTProtocol)
         assert isinstance(resolved[0], SpeechProviderSTTAdapter)
+
+
+# ---------------------------------------------------------------------------
+# 7. Multi-language STT registration (#11617)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSpeechRegistry:
+    """Minimal stand-in for ``voice_processing.providers.ProviderRegistry``.
+
+    Mirrors the real registry's ``_providers`` dict structure
+    (``{lang: [(provider, priority), ...]}``) and ``get_provider`` API.
+    """
+
+    def __init__(self, providers_by_lang: dict) -> None:
+        # providers_by_lang: {lang: SpeechProvider}
+        # Build the (provider, priority) tuple structure the real registry uses.
+        self._providers = {lang: [(provider, 0)] for lang, provider in providers_by_lang.items()}
+
+    def get_provider(self, language: str):
+        entries = self._providers.get(language)
+        if not entries:
+            return None
+        return entries[0][0]
+
+
+def _make_mock_provider(name: str):
+    """Return a MagicMock SpeechProvider with provider_name set."""
+    provider = MagicMock()
+    provider.provider_name = name
+    return provider
+
+
+class TestSTTMultiLanguageRegistration:
+    """#11617 — every language in the speech registry must get an STT adapter."""
+
+    def _run_register(self, fake_speech_registry):
+        """Run ``_register_stt_if_available`` with a fake speech registry injected."""
+        from integrations.capability_registry import _register_stt_language
+
+        registry = CapabilityRegistry()
+        languages = list(getattr(fake_speech_registry, "_providers", {}).keys())
+        for lang in languages:
+            _register_stt_language(registry, fake_speech_registry, lang, SpeechProviderSTTAdapter)
+        return registry
+
+    def test_single_language_registers_one_adapter(self):
+        """A registry with one language produces exactly one STT adapter."""
+        fake_reg = _FakeSpeechRegistry({"en": _make_mock_provider("whisper-en")})
+        registry = self._run_register(fake_reg)
+
+        resolved = registry.resolve(STT)
+        assert len(resolved) == 1
+        assert isinstance(resolved[0], STTProtocol)
+        assert isinstance(resolved[0], SpeechProviderSTTAdapter)
+
+    def test_multi_language_registers_one_adapter_per_language(self):
+        """Each language in the speech registry gets its own STT adapter (#11617)."""
+        fake_reg = _FakeSpeechRegistry(
+            {
+                "en": _make_mock_provider("whisper-en"),
+                "lv": _make_mock_provider("whisper-lv"),
+                "de": _make_mock_provider("whisper-de"),
+            }
+        )
+        registry = self._run_register(fake_reg)
+
+        resolved = registry.resolve(STT)
+        assert len(resolved) == 3
+        for adapter in resolved:
+            assert isinstance(adapter, STTProtocol)
+            assert isinstance(adapter, SpeechProviderSTTAdapter)
+
+    def test_en_provider_still_resolvable_alongside_others(self):
+        """Existing 'en' behaviour is preserved when other languages are present."""
+        en_provider = _make_mock_provider("whisper-en")
+        fake_reg = _FakeSpeechRegistry({"en": en_provider, "fr": _make_mock_provider("whisper-fr")})
+        registry = self._run_register(fake_reg)
+
+        resolved = registry.resolve(STT)
+        assert len(resolved) == 2
+        # The first registered language is 'en'; its adapter wraps en_provider.
+        assert resolved[0]._provider is en_provider
+
+    def test_empty_speech_registry_registers_no_adapters(self):
+        """An empty speech registry results in no STT capability entries."""
+        fake_reg = _FakeSpeechRegistry({})
+        registry = self._run_register(fake_reg)
+
+        assert registry.resolve(STT) == []
+
+    def test_language_with_no_provider_is_skipped(self):
+        """If get_provider returns None for a language, that language is skipped."""
+        from integrations.capability_registry import _register_stt_language
+
+        # Build a registry that has a language key but the provider returns None.
+        fake_reg = _FakeSpeechRegistry({"en": _make_mock_provider("whisper-en")})
+        # Patch get_provider to return None for 'en'.
+        fake_reg.get_provider = lambda lang: None
+
+        registry = CapabilityRegistry()
+        _register_stt_language(registry, fake_reg, "en", SpeechProviderSTTAdapter)
+
+        assert registry.resolve(STT) == []
+
+    def test_failing_language_does_not_block_others(self):
+        """A per-language registration failure is caught; other languages still register."""
+        from integrations.capability_registry import _register_stt_language
+
+        en_provider = _make_mock_provider("whisper-en")
+        fr_provider = _make_mock_provider("whisper-fr")
+
+        # Simulate 'lv' provider raising on construction.
+        def bad_adapter(provider):
+            if provider.provider_name == "whisper-lv":
+                raise RuntimeError("deps missing")
+            return SpeechProviderSTTAdapter(provider)
+
+        fake_reg = _FakeSpeechRegistry({"en": en_provider, "lv": _make_mock_provider("whisper-lv"), "fr": fr_provider})
+        registry = CapabilityRegistry()
+        for lang in ["en", "lv", "fr"]:
+            _register_stt_language(registry, fake_reg, lang, bad_adapter)
+
+        resolved = registry.resolve(STT)
+        # 'lv' failed — only 'en' and 'fr' should be registered.
+        assert len(resolved) == 2
+        provider_names = {a._provider.provider_name for a in resolved}
+        assert provider_names == {"whisper-en", "whisper-fr"}

--- a/autobot-backend/voice_processing/providers/__init__.py
+++ b/autobot-backend/voice_processing/providers/__init__.py
@@ -117,6 +117,10 @@ class ProviderRegistry:
         providers = self._providers.get(language, [])
         return [p for p, _ in providers]
 
+    def languages(self) -> List[str]:
+        """Return the language codes that have at least one registered provider."""
+        return list(self._providers.keys())
+
 
 # Global registry instance
 _registry = ProviderRegistry()


### PR DESCRIPTION
Closes #11617. Follow-up to #11559 (STT wiring).

## Thinking Path
`_register_stt_if_available` only wired the `en` SpeechProvider into the STT capability, so any non-en provider (lv/de/…) was silently unreachable through the capability layer — even though `ProviderRegistry` is language-keyed.

## What Changed
- **`voice_processing/providers/__init__.py`** — new public `ProviderRegistry.languages()` accessor (returns the registered language codes). Added because there was no public enumeration API; the STT registration would otherwise have to reach into the private `_providers` dict (canonical-coding: use/add a public seam, don't couple to internals).
- **`integrations/capability_registry.py`** — `_register_stt_if_available` now enumerates `speech_registry.languages()` and registers one `SpeechProviderSTTAdapter` per language via the extracted `_register_stt_language` helper. Chose approach (A) — one adapter per language — because `CapabilityRegistry` is a flat capability→list store (same shape as MESSAGING with multiple adapters). Same lazy-import + per-language try/except gating as before; en still resolvable.

## Verification
- `pytest protocols_conformance_test.py` → **42 passed** (7 new STT-multi-language tests incl. an **end-to-end test that drives the real `_register_stt_if_available` through `.languages()`** with an injected fake registry, plus single/multi/en-alongside/empty/None-skip/failure-isolation).
- Confirmed the 5 `voice_processing/` failures in the bare env are pre-existing (missing deps: deepgram/sentence-transformers; no providers self-register) — my change is purely additive (`languages()` method), removes nothing.
- flake8 `--config=.flake8` + black `-l 120` clean.

## Model Used
Claude (Fable 5) orchestrating + public-API refinement/test-coverage; Sonnet implementation agent.
