### PR TITLE
fix(tests): repair 5 pre-existing tasks/ suite failures (#11606)

### DIFF
--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -167,6 +167,7 @@ import services.pricing_refresh  # noqa: F401
 
 # GH#4463: Mobile device tasks module
 import tasks.mobile_device_tasks  # noqa: F401
+from utils.celery_schedules import crontab_from_string  # noqa: E402
 
 # =========================================================================
 # Issue #4455: Periodic knowledge-base cleanup schedule
@@ -174,7 +175,6 @@ import tasks.mobile_device_tasks  # noqa: F401
 # importable when the test conftest stubs this module in sys.modules.
 # =========================================================================
 
-from utils.celery_schedules import crontab_from_string  # noqa: E402
 
 celery_app.conf.beat_schedule = {
     "knowledge-cleanup-orphan-documents": {

--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -170,49 +170,27 @@ import tasks.mobile_device_tasks  # noqa: F401
 
 # =========================================================================
 # Issue #4455: Periodic knowledge-base cleanup schedule
+# Issue #11606: cron parser extracted to utils.celery_schedules so it stays
+# importable when the test conftest stubs this module in sys.modules.
 # =========================================================================
 
-
-def _crontab_from_string(cron_expr: str) -> crontab:
-    """Parse a 5-field cron string ('m h dom mon dow') into a Celery crontab.
-
-    Falls back to a daily 03:00 UTC schedule if the expression is malformed,
-    logging a warning so misconfiguration does not prevent Beat from starting.
-    """
-
-    _log = _get_logger(__name__)
-    parts = cron_expr.strip().split()
-    if len(parts) != 5:
-        _log.warning(
-            "Invalid cron expression %r (expected 5 fields); falling back to '0 3 * * *'",
-            cron_expr,
-        )
-        parts = ["0", "3", "*", "*", "*"]
-    minute, hour, day_of_month, month_of_year, day_of_week = parts
-    return crontab(
-        minute=minute,
-        hour=hour,
-        day_of_month=day_of_month,
-        month_of_year=month_of_year,
-        day_of_week=day_of_week,
-    )
-
+from utils.celery_schedules import crontab_from_string  # noqa: E402
 
 celery_app.conf.beat_schedule = {
     "knowledge-cleanup-orphan-documents": {
         "task": "tasks.cleanup_orphan_documents",
-        "schedule": _crontab_from_string(ssot_config.knowledge_orphan_cleanup_schedule),
+        "schedule": crontab_from_string(ssot_config.knowledge_orphan_cleanup_schedule),
         "kwargs": {"dry_run": False},
     },
     "knowledge-cleanup-generated-files": {
         "task": "tasks.cleanup_generated_files",
-        "schedule": _crontab_from_string(ssot_config.knowledge_generated_files_cleanup_schedule),
+        "schedule": crontab_from_string(ssot_config.knowledge_generated_files_cleanup_schedule),
         "kwargs": {"dry_run": False},
     },
     # Issue #5081: prune expired entries from the doc_sync:queue:done zset
     "knowledge-sync-queue-prune": {
         "task": "tasks.prune_sync_queue_done",
-        "schedule": _crontab_from_string(ssot_config.knowledge_sync_queue_prune_schedule),
+        "schedule": crontab_from_string(ssot_config.knowledge_sync_queue_prune_schedule),
     },
     # GH#8224: detect expired active sprints and queue SPRINT_CLOSE approvals daily
     "llc-sprint-autoclose-daily": {
@@ -277,22 +255,22 @@ celery_app.conf.beat_schedule = {
     # Schedules are configurable via AUTOBOT_*_RETENTION_SCHEDULE env vars (5-field cron).
     "data-retention-chats-nightly": {
         "task": "tasks.cleanup_expired_chats",
-        "schedule": _crontab_from_string(getattr(ssot_config.misc, "chat_retention_schedule", None) or "0 1 * * *"),
+        "schedule": crontab_from_string(getattr(ssot_config.misc, "chat_retention_schedule", None) or "0 1 * * *"),
         "kwargs": {"dry_run": False},
     },
     "data-retention-files-nightly": {
         "task": "tasks.cleanup_expired_files",
-        "schedule": _crontab_from_string(getattr(ssot_config.misc, "file_retention_schedule", None) or "15 1 * * *"),
+        "schedule": crontab_from_string(getattr(ssot_config.misc, "file_retention_schedule", None) or "15 1 * * *"),
         "kwargs": {"dry_run": False},
     },
     "data-retention-audit-nightly": {
         "task": "tasks.cleanup_expired_audit_logs",
-        "schedule": _crontab_from_string(getattr(ssot_config.misc, "audit_retention_schedule", None) or "30 1 * * *"),
+        "schedule": crontab_from_string(getattr(ssot_config.misc, "audit_retention_schedule", None) or "30 1 * * *"),
         "kwargs": {"dry_run": False},
     },
     "data-retention-kb-nightly": {
         "task": "tasks.cleanup_expired_kb_entries",
-        "schedule": _crontab_from_string(getattr(ssot_config.misc, "kb_retention_schedule", None) or "45 1 * * *"),
+        "schedule": crontab_from_string(getattr(ssot_config.misc, "kb_retention_schedule", None) or "45 1 * * *"),
         "kwargs": {"dry_run": False},
     },
 }

--- a/autobot-backend/tasks/analytics_tasks_test.py
+++ b/autobot-backend/tasks/analytics_tasks_test.py
@@ -13,16 +13,32 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+_EAGER_CONF_KEYS = ("task_always_eager", "task_eager_propagates", "task_store_eager_result")
+
 
 @pytest.fixture(autouse=True)
-def celery_eager(monkeypatch):
-    """Force Celery to run tasks synchronously (no broker needed)."""
+def celery_eager():
+    """Force Celery to run tasks synchronously (no broker needed).
+
+    #11606: ``task_store_eager_result`` makes the terminal SUCCESS/FAILURE
+    state overwrite the intermediate PROGRESS meta that ``update_state``
+    writes to the shared ``cache+memory://`` backend — without it a fresh
+    ``AsyncResult(id)`` reads the stale PROGRESS meta and reports "running".
+    Teardown restores the prior config and wipes the backend cache so no
+    result state bleeds between tests.
+    """
     from celery_app import celery_app
 
+    previous = {key: getattr(celery_app.conf, key, False) for key in _EAGER_CONF_KEYS}
     celery_app.conf.task_always_eager = True
     celery_app.conf.task_eager_propagates = True
+    celery_app.conf.task_store_eager_result = True
     yield
-    celery_app.conf.task_always_eager = False
+    for key, value in previous.items():
+        setattr(celery_app.conf, key, value)
+    backend_cache = getattr(getattr(celery_app.backend, "client", None), "cache", None)
+    if backend_cache is not None:
+        backend_cache.clear()
 
 
 class TestRunDashboardAnalysis:

--- a/autobot-backend/tasks/conftest.py
+++ b/autobot-backend/tasks/conftest.py
@@ -21,6 +21,7 @@ register tasks on a lightweight in-process Celery app.
 
 from __future__ import annotations
 
+import importlib
 import sys
 import types
 from unittest.mock import MagicMock
@@ -78,3 +79,16 @@ _async_compat_stub.run_or_schedule = MagicMock()  # type: ignore[attr-defined]
 _type_defs = _ensure_stub("type_defs")
 _type_defs_common = _ensure_stub("type_defs.common")
 _type_defs_common.Metadata = dict  # type: ignore[attr-defined]
+
+# ---------------------------------------------------------------------------
+# 4. Real-load services.knowledge.doc_indexer (#11606).
+#    The root conftest replaces the ``services`` package with a stub whose
+#    catch-all ``__getattr__`` returns a MagicMock.  ``mock.patch`` resolves
+#    dotted targets via getattr() on the parent package, so
+#    ``patch("services.knowledge.doc_indexer.get_doc_indexer_service")``
+#    silently patched a MagicMock while the code under test imported (and
+#    called) the real module.  Importing the real module here binds it as an
+#    attribute on the parent stub, so patch() targets the real module.
+# ---------------------------------------------------------------------------
+
+importlib.import_module("services.knowledge.doc_indexer")

--- a/autobot-backend/tasks/knowledge_tasks_test.py
+++ b/autobot-backend/tasks/knowledge_tasks_test.py
@@ -8,7 +8,7 @@ Tests for knowledge-base cleanup Celery tasks (Issue #4455).
 Covers:
 - cleanup_orphan_documents: dry-run, orphan detection, batch deletion.
 - cleanup_generated_files: TTL filtering, dry-run, bytes_freed accounting.
-- _crontab_from_string: malformed cron fallback.
+- crontab_from_string: malformed cron fallback (utils.celery_schedules, #11606).
 """
 
 from __future__ import annotations
@@ -320,7 +320,9 @@ def test_cleanup_exclude_patterns_is_tuple():
 
 
 # ---------------------------------------------------------------------------
-# _crontab_from_string
+# crontab_from_string (#11606: extracted to utils.celery_schedules — the
+# celery_app module is replaced by a stub in sys.modules during tests, which
+# made the helper unimportable from there)
 # ---------------------------------------------------------------------------
 
 
@@ -339,9 +341,9 @@ def _have_real_celery() -> bool:
     reason="requires real celery package (test stub cannot parse cron expressions)",
 )
 def test_crontab_from_string_accepts_valid_expression():
-    from celery_app import _crontab_from_string
+    from utils.celery_schedules import crontab_from_string
 
-    cron = _crontab_from_string("30 4 * * *")
+    cron = crontab_from_string("30 4 * * *")
     # crontab stores minute/hour as sets of ints
     assert 30 in cron.minute
     assert 4 in cron.hour
@@ -352,8 +354,8 @@ def test_crontab_from_string_accepts_valid_expression():
     reason="requires real celery package",
 )
 def test_crontab_from_string_falls_back_on_malformed():
-    from celery_app import _crontab_from_string
+    from utils.celery_schedules import crontab_from_string
 
-    cron = _crontab_from_string("not a cron")
+    cron = crontab_from_string("not a cron")
     assert 0 in cron.minute
     assert 3 in cron.hour

--- a/autobot-backend/utils/celery_schedules.py
+++ b/autobot-backend/utils/celery_schedules.py
@@ -1,0 +1,40 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Lightweight Celery schedule helpers (#11606).
+
+Extracted from ``celery_app.py`` so the cron parser is importable without
+the celery_app Redis/config dependency chain — the test conftest replaces
+``celery_app`` in ``sys.modules`` with a stub app (issue #7766), which made
+the helper unreachable in any stubbed test run.
+"""
+
+import logging
+
+from celery.schedules import crontab
+
+logger = logging.getLogger(__name__)
+
+
+def crontab_from_string(cron_expr: str) -> crontab:
+    """Parse a 5-field cron string ('m h dom mon dow') into a Celery crontab.
+
+    Falls back to a daily 03:00 UTC schedule if the expression is malformed,
+    logging a warning so misconfiguration does not prevent Beat from starting.
+    """
+    parts = cron_expr.strip().split()
+    if len(parts) != 5:
+        logger.warning(
+            "Invalid cron expression %r (expected 5 fields); falling back to '0 3 * * *'",
+            cron_expr,
+        )
+        parts = ["0", "3", "*", "*", "*"]
+    minute, hour, day_of_month, month_of_year, day_of_week = parts
+    return crontab(
+        minute=minute,
+        hour=hour,
+        day_of_month=day_of_month,
+        month_of_year=month_of_year,
+        day_of_week=day_of_week,
+    )


### PR DESCRIPTION
Closes #11606.

## Thinking Path

Three distinct root causes behind the 5 failures — none were what the surface errors suggested:
1. `_crontab_from_string` lived in `celery_app.py`, which the root conftest replaces in `sys.modules` (#7766) — the helper was unreachable in every stubbed run. Real-loading celery_app is impossible (module-level Redis/config/autodiscover chain), so the pure parser moved to a light canonical module.
2. Analytics "state bleed" was actually within-test: eager runs never store terminal SUCCESS/FAILURE (`task_store_eager_result` defaults False), so a fresh `AsyncResult` read the stale PROGRESS meta.
3. The orphan dry-run failure was another #11532-class mock.patch landmine: the conftest's `services` package stub has a catch-all `__getattr__`, so `mock.patch("services.knowledge.doc_indexer....")` silently patched a MagicMock while the real function ran (30 s Redis retries). Sibling tests passed only by import-order accident.

## What Changed

- New `utils/celery_schedules.py::crontab_from_string` (imports only `celery.schedules` + logging); `celery_app.py` imports it at its 7 call sites — behavior identical incl. malformed-cron fallback
- `tasks/analytics_tasks_test.py`: fixture sets `task_store_eager_result=True` (restores conf on teardown) and wipes the cache backend between tests
- `tasks/conftest.py`: real-loads `services.knowledge.doc_indexer` at collection so `mock.patch` targets the real module (#11248 pattern)

## Verification

- `tasks/`: **78 passed, 0 failed** (was 5 failed/73 passed); runtime 46 s → ~6 s
- Regression: celery_priority, dead-letter health, celery reliability (18 passed); doc_indexer/code_indexer/knowledge_scrape suites — 4 pre-existing failures verified identical on untouched base
- `black --check` + `py_compile` clean; new module has production caller (celery_app.py, 7 sites)

## Discoveries

- #11643 — 4 pre-existing failures outside tasks/: `media/link/pipeline.py:88` py3.10 union-type import error (2 tests) and `code_indexer_test.py:299` asserting "ok" vs current "queued" contract (2 tests)

## Model Used

Claude Fable 5 (orchestrator + implementation agent)