### PR TITLE
fix(lifespan): shutdown symmetry — wire unreleased resources into cleanup_services (#11638)

### DIFF
--- a/autobot-backend/api/log_forwarding.py
+++ b/autobot-backend/api/log_forwarding.py
@@ -569,7 +569,8 @@ async def stop_forwarding(
         if not forwarder.running:
             return {"message": "Log forwarding service is not running"}
 
-        forwarder.stop()
+        # Off-loop: stop() drains the queue synchronously (#11638)
+        await asyncio.to_thread(forwarder.stop)
 
         return {"message": "Log forwarding service stopped"}
     except Exception as e:

--- a/autobot-backend/api/log_forwarding.py
+++ b/autobot-backend/api/log_forwarding.py
@@ -90,6 +90,19 @@ async def _get_forwarder() -> LogForwarder:
         return _forwarder
 
 
+async def stop_forwarder_if_running() -> bool:
+    """Stop the forwarder threads WITHOUT constructing one if never created.
+
+    ``LogForwarder.stop()`` drains the queue synchronously (``Queue.join()``
+    with no timeout) — run it off the event loop so a slow destination cannot
+    stall shutdown. Returns True if a forwarder was stopped. Issue #11638.
+    """
+    if _forwarder is None:
+        return False
+    await asyncio.to_thread(_forwarder.stop)
+    return True
+
+
 # Pydantic models for API
 
 

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -2018,13 +2018,16 @@ async def cleanup_services(app: FastAPI):
             from api.analytics import analytics_controller
 
             await analytics_controller.metrics_collector.stop_collection()
+            logger.info("✅ Metrics collection stopped")
+        except Exception as _mc_err:
+            logger.warning("Metrics collection stop failed: %s", _mc_err)
+        try:
             metrics_task = getattr(app.state, "metrics_collection_task", None)
             if metrics_task is not None and not metrics_task.done():
                 metrics_task.cancel()
                 await asyncio.gather(metrics_task, return_exceptions=True)
-            logger.info("✅ Metrics collection stopped")
-        except Exception as _mc_err:
-            logger.warning("Metrics collection shutdown failed: %s", _mc_err)
+        except Exception as _mt_err:
+            logger.warning("Metrics task cancel failed: %s", _mt_err)
 
         # Issue #11638: Shutdown orchestrator singleton (agent pools, memory)
         try:
@@ -2044,7 +2047,8 @@ async def cleanup_services(app: FastAPI):
         except Exception as _wr_err:
             logger.warning("WebResearcher shutdown failed: %s", _wr_err)
 
-        # Issue #11638: Close AI Stack client session and retry loop
+        # Issue #11638: Cancel AI Stack client retry loop (its HTTP session
+        # is the shared HTTPClientManager and is intentionally not closed)
         try:
             from services.ai_stack_client import close_ai_stack_client
 
@@ -2063,14 +2067,26 @@ async def cleanup_services(app: FastAPI):
             logger.warning("Skills engine shutdown failed: %s", _sk_err)
 
         # Issue #11638: Stop log forwarder threads if one was created
+        # (off-loop: LogForwarder.stop() drains its queue synchronously)
         try:
-            import api.log_forwarding as _log_fwd
+            from api.log_forwarding import stop_forwarder_if_running
 
-            if _log_fwd._forwarder is not None:
-                _log_fwd._forwarder.stop()
+            if await stop_forwarder_if_running():
                 logger.info("✅ Log forwarder stopped")
         except Exception as _lf_err:
             logger.warning("Log forwarder shutdown failed: %s", _lf_err)
+
+        # Issue #11638: Stop NPU worker manager health/failover/pulse tasks
+        # (started by get_worker_manager() during _wire_npu_task_queue; these
+        # loops touch Redis, so stop them BEFORE closing Redis pools)
+        try:
+            import services.npu_worker_manager as _npu_wm
+
+            if _npu_wm._worker_manager is not None:
+                await _npu_wm._worker_manager.stop_health_monitoring()
+                logger.info("✅ NPU worker manager monitoring stopped")
+        except Exception as _npu_err:
+            logger.warning("NPU worker manager shutdown failed: %s", _npu_err)
 
         # Issue #1233: Shutdown dedicated I/O thread pools
         shutdown_io_executors()
@@ -2139,8 +2155,7 @@ async def cleanup_services(app: FastAPI):
         #   pools closed above and per-call file handles.
         # - GraphRAGService / EntityExtractor / mesh components hold in-memory
         #   model state only; reclaimed at process exit.
-        # - NPUWorkerManager WebSocket subscriptions close with the server's
-        #   WebSocket shutdown; DocIndexerService / OperationIntegrationManager /
+        # - DocIndexerService / OperationIntegrationManager /
         #   ContentReachRegistry own no background tasks requiring cancellation.
         logger.info("✅ Cleanup completed successfully")
     except Exception as e:

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1114,12 +1114,13 @@ async def _init_slm_client():
         logger.warning("SLM client initialization failed (continuing without): %s", slm_error)
 
 
-async def _init_metrics_collection():
+async def _init_metrics_collection(app: FastAPI):
     """
     Initialize system metrics collection (NON-CRITICAL).
 
     Issue #876: Start metrics collection AFTER backend initialization completes.
     Previously started at module load time causing self-health-check deadlock.
+    Issue #11638: task stored on app.state so cleanup_services can cancel it.
     """
     logger.info("✅ [ 91%] Metrics Collection: Starting system metrics collection...")
     try:
@@ -1137,7 +1138,10 @@ async def _init_metrics_collection():
         if hasattr(collector, "_is_collecting") and not collector._is_collecting:
             import asyncio
 
-            asyncio.create_task(collector.start_collection())
+            app.state.metrics_collection_task = asyncio.create_task(
+                collector.start_collection(),
+                name="metrics_collection",
+            )
             logger.info("✅ [ 91%] Metrics Collection: Started successfully")
         else:
             logger.info("✅ [ 91%] Metrics Collection: Already running")
@@ -1801,7 +1805,7 @@ async def initialize_background_services(app: FastAPI):
         await _start_connector_scheduler()
         await _init_trigger_service(app)
         await _init_slm_reconciler(app)
-        await _init_metrics_collection()
+        await _init_metrics_collection(app)
         await _recover_index_queue()
         await _ensure_agent_memory_index()
         await _init_process_adapter(app)
@@ -2001,6 +2005,73 @@ async def cleanup_services(app: FastAPI):
             await app.state.process_adapter_service.stop()
             logger.info("✅ Process adapter stopped")
 
+        # Issue #11638: Stop autonomous improvement loop background task
+        try:
+            from workflow_scheduler import stop_autonomous_loop
+
+            await stop_autonomous_loop()
+        except Exception as _al_err:
+            logger.warning("Autonomous loop shutdown failed: %s", _al_err)
+
+        # Issue #11638: Stop metrics collection loop and cancel its task
+        try:
+            from api.analytics import analytics_controller
+
+            await analytics_controller.metrics_collector.stop_collection()
+            metrics_task = getattr(app.state, "metrics_collection_task", None)
+            if metrics_task is not None and not metrics_task.done():
+                metrics_task.cancel()
+                await asyncio.gather(metrics_task, return_exceptions=True)
+            logger.info("✅ Metrics collection stopped")
+        except Exception as _mc_err:
+            logger.warning("Metrics collection shutdown failed: %s", _mc_err)
+
+        # Issue #11638: Shutdown orchestrator singleton (agent pools, memory)
+        try:
+            from orchestrator import shutdown_orchestrator
+
+            await shutdown_orchestrator()
+            logger.info("✅ Orchestrator shutdown")
+        except Exception as _orch_err:
+            logger.warning("Orchestrator shutdown failed: %s", _orch_err)
+
+        # Issue #11638: Close WebResearcher browser resources
+        try:
+            web_researcher = getattr(app.state, "web_researcher", None)
+            if web_researcher is not None:
+                await web_researcher.close()
+                logger.info("✅ WebResearcher closed")
+        except Exception as _wr_err:
+            logger.warning("WebResearcher shutdown failed: %s", _wr_err)
+
+        # Issue #11638: Close AI Stack client session and retry loop
+        try:
+            from services.ai_stack_client import close_ai_stack_client
+
+            await close_ai_stack_client()
+            logger.info("✅ AI Stack client closed")
+        except Exception as _as_err:
+            logger.warning("AI Stack client shutdown failed: %s", _as_err)
+
+        # Issue #11638: Dispose skills DB engine
+        try:
+            from skills.db import close_skills_engine
+
+            await close_skills_engine()
+            logger.info("✅ Skills DB engine closed")
+        except Exception as _sk_err:
+            logger.warning("Skills engine shutdown failed: %s", _sk_err)
+
+        # Issue #11638: Stop log forwarder threads if one was created
+        try:
+            import api.log_forwarding as _log_fwd
+
+            if _log_fwd._forwarder is not None:
+                _log_fwd._forwarder.stop()
+                logger.info("✅ Log forwarder stopped")
+        except Exception as _lf_err:
+            logger.warning("Log forwarder shutdown failed: %s", _lf_err)
+
         # Issue #1233: Shutdown dedicated I/O thread pools
         shutdown_io_executors()
 
@@ -2044,7 +2115,33 @@ async def cleanup_services(app: FastAPI):
         except Exception as obs_err:
             logger.warning("LLM observer flush failed: %s", obs_err)
 
-        # Redis connections automatically managed by get_redis_client()
+        # Issue #11638: Dispose PostgreSQL async engine (was never disposed)
+        try:
+            from user_management.database import close_database
+
+            await close_database()
+        except Exception as _db_err:
+            logger.warning("Database engine dispose failed: %s", _db_err)
+
+        # Issue #11638: Close all Redis pools LAST — earlier shutdown steps
+        # above may still publish events or flush state through Redis.
+        try:
+            from autobot_shared.redis_client import close_all_redis_connections
+
+            await close_all_redis_connections()
+            logger.info("✅ Redis connections closed")
+        except Exception as _redis_err:
+            logger.warning("Redis close failed: %s", _redis_err)
+
+        # Issue #11638: Intentional no-ops (documented triage):
+        # - ChatHistoryManager / ConversationFileManager / ChatWorkflowManager
+        #   hold no owned connections — they operate through the shared Redis
+        #   pools closed above and per-call file handles.
+        # - GraphRAGService / EntityExtractor / mesh components hold in-memory
+        #   model state only; reclaimed at process exit.
+        # - NPUWorkerManager WebSocket subscriptions close with the server's
+        #   WebSocket shutdown; DocIndexerService / OperationIntegrationManager /
+        #   ContentReachRegistry own no background tasks requiring cancellation.
         logger.info("✅ Cleanup completed successfully")
     except Exception as e:
         logger.error("Error during shutdown: %s", e)

--- a/autobot-backend/tests/test_shutdown_symmetry.py
+++ b/autobot-backend/tests/test_shutdown_symmetry.py
@@ -1,0 +1,70 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Shutdown-symmetry unit tests (#11638).
+
+Pins the new lifespan cleanup helpers: PostgreSQL engine disposal and
+autonomous-loop task cancellation. Startup created these resources but
+shutdown never released them.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class TestCloseDatabase:
+    @pytest.mark.asyncio
+    async def test_dispose_called_and_state_reset(self, monkeypatch):
+        import user_management.database as db
+
+        fake_engine = AsyncMock()
+        monkeypatch.setattr(db, "_async_engine", fake_engine)
+        monkeypatch.setattr(db, "_async_session_factory", object())
+
+        await db.close_database()
+
+        fake_engine.dispose.assert_awaited_once()
+        assert db._async_engine is None
+        assert db._async_session_factory is None
+
+    @pytest.mark.asyncio
+    async def test_noop_when_engine_never_created(self, monkeypatch):
+        import user_management.database as db
+
+        monkeypatch.setattr(db, "_async_engine", None)
+        monkeypatch.setattr(db, "_async_session_factory", None)
+
+        await db.close_database()  # must not raise
+
+        assert db._async_engine is None
+
+
+class TestStopAutonomousLoop:
+    @pytest.mark.asyncio
+    async def test_cancels_running_task(self, monkeypatch):
+        import workflow_scheduler as ws
+
+        async def _forever():
+            while True:
+                await asyncio.sleep(3600)
+
+        task = asyncio.create_task(_forever())
+        monkeypatch.setattr(ws, "_autonomous_loop_task", task)
+
+        await ws.stop_autonomous_loop()
+
+        assert task.cancelled()
+        assert ws._autonomous_loop_task is None
+
+    @pytest.mark.asyncio
+    async def test_noop_when_never_started(self, monkeypatch):
+        import workflow_scheduler as ws
+
+        monkeypatch.setattr(ws, "_autonomous_loop_task", None)
+
+        await ws.stop_autonomous_loop()  # must not raise
+
+        assert ws._autonomous_loop_task is None

--- a/autobot-backend/workflow_scheduler.py
+++ b/autobot-backend/workflow_scheduler.py
@@ -1029,3 +1029,21 @@ def start_autonomous_loop(llm_service: Any) -> None:
         name="autonomous_loop_runner",
     )
     logger.info("AutonomousLoopRunner: task created")
+
+
+async def stop_autonomous_loop() -> None:
+    """Cancel the autonomous improvement loop background task.
+
+    Issue #11638: the task was created at startup but never tracked for
+    shutdown, so it survived lifespan cleanup. Call from application
+    lifespan cleanup; safe to call when the loop was never started.
+    """
+    global _autonomous_loop_task
+    if _autonomous_loop_task is not None and not _autonomous_loop_task.done():
+        _autonomous_loop_task.cancel()
+        try:
+            await _autonomous_loop_task
+        except asyncio.CancelledError:
+            pass
+        logger.info("AutonomousLoopRunner: task cancelled")
+    _autonomous_loop_task = None


### PR DESCRIPTION
Closes #11638. Part of umbrella #11634 (T4).

## Thinking Path

The lifecycle audit (#11634) found `cleanup_services()` closes many services but leaves resources created at startup unreleased. Investigation confirmed the gaps — and one canonical twist: `user_management/database.py` **already had** a correct `close_database()` that nothing ever called (unwired, not missing). The fix wires existing close APIs where they exist and adds the two genuinely missing pieces (autonomous-loop task tracking, metrics task tracking).

## What Changed

- `initialization/lifespan.py` `cleanup_services()` now:
  - stops the autonomous improvement loop (new `stop_autonomous_loop()` in `workflow_scheduler.py` — the task was previously untracked)
  - stops metrics collection and cancels its task (task now stored on `app.state.metrics_collection_task` by `_init_metrics_collection`)
  - shuts down the Orchestrator singleton (existing `shutdown_orchestrator()`, previously never called)
  - closes WebResearcher browser resources, AI Stack client (`close_ai_stack_client()`), skills DB engine (`close_skills_engine()`), and the log forwarder threads (module-global checked so shutdown doesn't construct one)
  - disposes the PostgreSQL async engine (wires the pre-existing `close_database()`)
  - closes all Redis pools LAST (`close_all_redis_connections()` — replaces the stale "automatically managed" comment); earlier steps may still flush through Redis
  - documents the intentional no-ops (chat managers operate through shared Redis pools; GraphRAG/EntityExtractor hold in-memory model state only)
- `workflow_scheduler.py` — `stop_autonomous_loop()` added (cancel + await, idempotent)
- `tests/test_shutdown_symmetry.py` — 4 tests: engine dispose + state reset, dispose no-op, loop-task cancellation, cancel no-op

## Verification

- `pytest tests/test_shutdown_symmetry.py -q` → **4 passed**
- `flake8` (repo config, 120 cols) clean on all touched files; AST parse clean
- Every new cleanup step is individually try/except-guarded — a failing step cannot abort the rest of shutdown

## Model Used

Claude Fable 5
