### PR TITLE
refactor(singletons): lock unlocked __new__ singletons; jina via shared HTTP client (#11637, #11641)

### DIFF
--- a/autobot-backend/llm_shared/adapters/registry.py
+++ b/autobot-backend/llm_shared/adapters/registry.py
@@ -11,6 +11,7 @@ and runtime adapter switching per agent/task.
 
 from __future__ import annotations
 
+import threading
 from typing import Dict, List
 
 from autobot_shared.logging_manager import get_logger
@@ -29,11 +30,17 @@ class AdapterRegistry:
     """
 
     _instance: "AdapterRegistry" | None = None
+    _instance_lock = threading.Lock()
 
     def __new__(cls) -> "AdapterRegistry":
+        # Issue #11637: double-checked locking — unlocked __new__ could
+        # construct two instances under concurrent first access.
         if cls._instance is None:
-            cls._instance = super().__new__(cls)
-            cls._instance._initialized = False
+            with cls._instance_lock:
+                if cls._instance is None:
+                    instance = super().__new__(cls)
+                    instance._initialized = False
+                    cls._instance = instance
         return cls._instance
 
     def __init__(self) -> None:

--- a/autobot-backend/media/link/pipeline.py
+++ b/autobot-backend/media/link/pipeline.py
@@ -32,7 +32,6 @@ None of these helpers are removed; they are kept here to preserve all call
 sites intact (see issue #7401 caller audit).
 """
 
-import asyncio
 import ipaddress
 import re
 import time
@@ -82,11 +81,8 @@ _JINA_FAILURE_WINDOW_SECONDS = 60.0
 _jina_cooldown_until: float = 0.0
 _jina_failures_in_window: List[float] = []
 
-# Pooled aiohttp session for Jina Reader (reused across calls for connection
-# pooling). Lazy-created under _jina_session_lock to serialize the first-
-# creation race. Close via close_jina_session() during app shutdown.
-_jina_session: "aiohttp.ClientSession" | None = None
-_jina_session_lock: asyncio.Lock | None = None
+# Jina Reader requests go through the shared HTTPClientManager session
+# (#11641) — no private session fork; see _get_jina_session().
 
 
 class LinkPipeline(BasePipeline):
@@ -451,27 +447,17 @@ async def process_url(url: str, render: str = "auto", timeout: float = 30.0) -> 
 
 
 async def _get_jina_session() -> "aiohttp.ClientSession":
-    """Return the shared Jina Reader aiohttp.ClientSession, creating on first call.
+    """Return the shared pooled aiohttp session.
 
-    Lazy-created under an asyncio.Lock so concurrent first calls don't each
-    create their own session. Closed at app shutdown via close_jina_session().
+    Issue #11641: the private module-level Jina session forked the concept
+    owned by ``autobot_shared.http_client.HTTPClientManager``. Delegates to
+    the canonical singleton (lifecycle managed there); the Jina-specific
+    timeout stays per-request via ``_JINA_TIMEOUT``. Kept as an indirection
+    point — tests patch this seam.
     """
-    global _jina_session, _jina_session_lock
-    if _jina_session_lock is None:
-        _jina_session_lock = asyncio.Lock()
-    if _jina_session is None or _jina_session.closed:
-        async with _jina_session_lock:
-            if _jina_session is None or _jina_session.closed:
-                _jina_session = aiohttp.ClientSession()
-    return _jina_session
+    from autobot_shared.http_client import get_http_client
 
-
-async def close_jina_session() -> None:
-    """Close the pooled Jina Reader session. Call from app shutdown hook."""
-    global _jina_session
-    if _jina_session is not None and not _jina_session.closed:
-        await _jina_session.close()
-    _jina_session = None
+    return await get_http_client().get_session()
 
 
 def _record_jina_failure() -> None:

--- a/autobot-backend/media/link/pipeline_test.py
+++ b/autobot-backend/media/link/pipeline_test.py
@@ -287,7 +287,7 @@ class TestLinkPipelineJina:
         pipe = LinkPipeline()
         mock_session = self._make_jina_mock_session(status=200, content="Title\n\nSome content text here.")
 
-        with patch("media.link.pipeline.aiohttp.ClientSession", return_value=mock_session):
+        with patch("media.link.pipeline._get_jina_session", new=AsyncMock(return_value=mock_session)):
             result = await pipe._try_jina("https://example.com")
 
         assert result == "Title\n\nSome content text here."
@@ -348,7 +348,7 @@ class TestLinkPipelineJina:
         bs4_result = {"type": "link_fetch", "confidence": 0.9, "url": "https://example.com"}
 
         with (
-            patch("media.link.pipeline.aiohttp.ClientSession", return_value=mock_session),
+            patch("media.link.pipeline._get_jina_session", new=AsyncMock(return_value=mock_session)),
             patch.object(pipe, "_parse_html", return_value=bs4_result),
         ):
             # _try_jina returns None on non-200, triggering BS4 fallback
@@ -547,12 +547,9 @@ def _reset_jina_state():
 
     pl._jina_cooldown_until = 0.0
     pl._jina_failures_in_window.clear()
-    # Force re-creation of pooled session on next use
-    pl._jina_session = None
     yield
     pl._jina_cooldown_until = 0.0
     pl._jina_failures_in_window.clear()
-    pl._jina_session = None
 
 
 class TestJinaCircuitBreaker:
@@ -645,13 +642,26 @@ class TestJinaCircuitBreaker:
 
 
 class TestJinaPooledSession:
-    """Pooled ClientSession is reused across sequential calls (#5022)."""
+    """Jina requests use the shared HTTPClientManager session (#11641)."""
 
     @pytest.mark.asyncio
-    async def test_pooled_session_reused_across_calls(self, _reset_jina_state):
-        """Two sequential _try_jina calls reuse the same _jina_session instance."""
+    async def test_delegates_to_shared_http_client(self, _reset_jina_state):
+        """_get_jina_session returns the canonical shared session."""
         from media.link import pipeline as pl
 
+        sentinel_session = MagicMock()
+        mock_manager = MagicMock()
+        mock_manager.get_session = AsyncMock(return_value=sentinel_session)
+
+        with patch("autobot_shared.http_client.get_http_client", return_value=mock_manager):
+            session = await pl._get_jina_session()
+
+        assert session is sentinel_session
+        mock_manager.get_session.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_shared_session_reused_across_calls(self, _reset_jina_state):
+        """Sequential _try_jina calls fetch through the same shared session."""
         pipe = LinkPipeline()
 
         mock_response = AsyncMock()
@@ -660,54 +670,16 @@ class TestJinaPooledSession:
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.__aexit__ = AsyncMock(return_value=False)
 
-        # Patch aiohttp.ClientSession to return a tracked MagicMock (not AsyncMock,
-        # so `.closed` is a truthy-free MagicMock attribute; we set it explicitly).
-        created_session = MagicMock()
-        created_session.closed = False
-        created_session.get = MagicMock(return_value=mock_response)
+        shared_session = MagicMock()
+        shared_session.get = MagicMock(return_value=mock_response)
+        mock_manager = MagicMock()
+        mock_manager.get_session = AsyncMock(return_value=shared_session)
 
-        call_count = MagicMock(return_value=created_session)
-
-        with patch("media.link.pipeline.aiohttp.ClientSession", call_count):
+        with patch("autobot_shared.http_client.get_http_client", return_value=mock_manager):
             await pipe._try_jina("https://example.com/1")
-            first_id = id(pl._jina_session)
             await pipe._try_jina("https://example.com/2")
-            second_id = id(pl._jina_session)
 
-        assert first_id == second_id, "Pooled session must be the same instance across calls"
-        # aiohttp.ClientSession() constructor should have been called exactly once
-        assert call_count.call_count == 1
-
-    @pytest.mark.asyncio
-    async def test_close_jina_session_allows_recreation(self, _reset_jina_state):
-        """close_jina_session() closes the pooled session; next call creates a new one."""
-        from media.link import pipeline as pl
-
-        pipe = LinkPipeline()
-
-        mock_response = AsyncMock()
-        mock_response.status = 200
-        mock_response.text = AsyncMock(return_value="ok")
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock(return_value=False)
-
-        session_a = MagicMock()
-        session_a.closed = False
-        session_a.get = MagicMock(return_value=mock_response)
-        session_a.close = AsyncMock()
-        session_b = MagicMock()
-        session_b.closed = False
-        session_b.get = MagicMock(return_value=mock_response)
-
-        with patch("media.link.pipeline.aiohttp.ClientSession", side_effect=[session_a, session_b]):
-            await pipe._try_jina("https://example.com/1")
-            assert pl._jina_session is session_a
-            await pl.close_jina_session()
-            assert pl._jina_session is None
-            await pipe._try_jina("https://example.com/2")
-            assert pl._jina_session is session_b
-
-        session_a.close.assert_awaited_once()
+        assert shared_session.get.call_count == 2, "Both fetches must use the shared session"
 
 
 class TestJinaTitleExtraction:

--- a/autobot-backend/plugin_sdk/extension_manifest.py
+++ b/autobot-backend/plugin_sdk/extension_manifest.py
@@ -1,0 +1,9 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Re-export shim — canonical home is ``autobot_shared.plugin_sdk.extension_manifest`` (#11637)."""
+
+from autobot_shared.plugin_sdk.extension_manifest import ExtensionManifest
+
+__all__ = ["ExtensionManifest"]

--- a/autobot-backend/plugin_sdk/loader.py
+++ b/autobot-backend/plugin_sdk/loader.py
@@ -4,9 +4,18 @@
 # Author: mrveiss
 """Re-export shim — canonical home is ``autobot_shared.plugin_sdk.loader`` (#11636)."""
 
-from autobot_shared.plugin_sdk.loader import PluginLoader, validate_plugin_config
+from autobot_shared.plugin_sdk.loader import (
+    PluginLoader,
+    _validate_config_against_schema,
+    _validate_config_schema,
+    validate_plugin_config,
+)
 
+# Private validators re-exported too (#11637): the canonical test suite
+# imports them via the bare path.
 __all__ = [
     "PluginLoader",
+    "_validate_config_against_schema",
+    "_validate_config_schema",
     "validate_plugin_config",
 ]

--- a/autobot-backend/plugin_sdk/manifest_contract.py
+++ b/autobot-backend/plugin_sdk/manifest_contract.py
@@ -1,0 +1,9 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Re-export shim — canonical home is ``autobot_shared.plugin_sdk.manifest_contract`` (#11637)."""
+
+from autobot_shared.plugin_sdk.manifest_contract import ManifestContract
+
+__all__ = ["ManifestContract"]

--- a/autobot-backend/plugin_sdk/plugin_manager.py
+++ b/autobot-backend/plugin_sdk/plugin_manager.py
@@ -1,0 +1,9 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Re-export shim — canonical home is ``autobot_shared.plugin_sdk.plugin_manager`` (#11637)."""
+
+from autobot_shared.plugin_sdk.plugin_manager import PluginManager
+
+__all__ = ["PluginManager"]

--- a/autobot-backend/plugin_sdk/registry.py
+++ b/autobot-backend/plugin_sdk/registry.py
@@ -1,0 +1,9 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Re-export shim — canonical home is ``autobot_shared.plugin_sdk.registry`` (#11637)."""
+
+from autobot_shared.plugin_sdk.registry import Registry, get_registry
+
+__all__ = ["Registry", "get_registry"]

--- a/autobot-backend/services/gateway/gateway.py
+++ b/autobot-backend/services/gateway/gateway.py
@@ -13,6 +13,7 @@ and channel adapters.
 from __future__ import annotations
 
 import asyncio
+import threading
 from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
@@ -40,11 +41,14 @@ class Gateway:
 
     _instance: "Gateway" | None = None
     _lock = asyncio.Lock()
+    _instance_lock = threading.Lock()
 
     def __new__(cls, *args, **kwargs):
-        """Singleton pattern for Gateway instance."""
+        """Singleton pattern for Gateway instance (double-checked, #11637)."""
         if cls._instance is None:
-            cls._instance = super().__new__(cls)
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
         return cls._instance
 
     def __init__(

--- a/autobot-backend/services/memory/external_provider_factory.py
+++ b/autobot-backend/services/memory/external_provider_factory.py
@@ -4,6 +4,7 @@
 # Author: mrveiss
 """External Provider Factory (Issue #4344)"""
 
+import threading
 from enum import Enum
 
 from autobot_shared.logging_manager import get_logger
@@ -23,12 +24,16 @@ class ExternalProviderFactory:
     """Factory for creating and managing external memory providers."""
 
     _instance = None
+    _instance_lock = threading.Lock()
     _external_provider = None
     _provider_type: ProviderType | None = None
 
     def __new__(cls):
+        # Issue #11637: double-checked locking for concurrent first access.
         if cls._instance is None:
-            cls._instance = super().__new__(cls)
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
         return cls._instance
 
     @classmethod

--- a/autobot-backend/tests/test_singleton_thread_safety.py
+++ b/autobot-backend/tests/test_singleton_thread_safety.py
@@ -115,3 +115,70 @@ class TestVisionGetScreenAnalyzerSingleton:
         assert len(results) == 10
         first = results[0]
         assert all(r is first for r in results), "get_screen_analyzer() must return the same instance from all threads"
+
+
+class TestLockedNewSingletons:
+    """__new__-based singletons gained double-checked locking in #11637.
+
+    Each class must construct exactly one instance under concurrent first
+    access (barrier-synchronized threads racing __new__).
+    """
+
+    @staticmethod
+    def _race(cls_factory, reset):
+        reset()
+        results = []
+        barrier = threading.Barrier(10)
+
+        def construct():
+            barrier.wait()
+            results.append(cls_factory())
+
+        threads = [threading.Thread(target=construct) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert len(results) == 10
+        assert all(r is results[0] for r in results)
+
+    def test_hook_registry_concurrent_new(self):
+        from autobot_shared.plugin_sdk.hooks import HookRegistry
+
+        self._race(HookRegistry, lambda: setattr(HookRegistry, "_instance", None))
+
+    def test_plugin_registry_concurrent_new(self):
+        from autobot_shared.plugin_sdk.base import PluginRegistry
+
+        self._race(PluginRegistry, lambda: setattr(PluginRegistry, "_instance", None))
+
+    def test_capability_checker_concurrent_new(self):
+        from autobot_shared.plugin_sdk.capabilities import CapabilityChecker
+
+        self._race(CapabilityChecker, lambda: setattr(CapabilityChecker, "_instance", None))
+
+    def test_adapter_registry_concurrent_new(self):
+        from llm_shared.adapters.registry import AdapterRegistry
+
+        self._race(AdapterRegistry, AdapterRegistry.reset)
+
+    def test_external_provider_factory_concurrent_new(self):
+        from services.memory.external_provider_factory import ExternalProviderFactory
+
+        self._race(
+            ExternalProviderFactory,
+            lambda: setattr(ExternalProviderFactory, "_instance", None),
+        )
+
+    def test_http_client_manager_concurrent_new(self):
+        from autobot_shared.http_client import HTTPClientManager
+
+        self._race(HTTPClientManager, lambda: setattr(HTTPClientManager, "_instance", None))
+
+    def test_http_client_reset_for_new_loop(self):
+        import autobot_shared.http_client as hc
+
+        first = hc.get_http_client()
+        hc.reset_http_client_for_new_loop()
+        second = hc.get_http_client()
+        assert first is not second, "reset must discard the loop-bound manager"

--- a/autobot-backend/tests/test_singleton_thread_safety.py
+++ b/autobot-backend/tests/test_singleton_thread_safety.py
@@ -182,3 +182,36 @@ class TestLockedNewSingletons:
         hc.reset_http_client_for_new_loop()
         second = hc.get_http_client()
         assert first is not second, "reset must discard the loop-bound manager"
+
+    def test_http_client_reset_rebinds_asyncio_lock(self):
+        """Reset must replace the class-level asyncio.Lock — a contended lock
+        stays bound to the loop that contended it (#11654 review M1)."""
+        import autobot_shared.http_client as hc
+
+        old_lock = hc.HTTPClientManager._lock
+        hc.reset_http_client_for_new_loop()
+        assert hc.HTTPClientManager._lock is not old_lock
+
+    def test_http_client_usable_across_loops_after_reset(self):
+        """Contend the lock in loop A, reset, then acquire it in loop B."""
+        import asyncio
+
+        import autobot_shared.http_client as hc
+
+        async def _contend():
+            lock = hc.HTTPClientManager._lock
+
+            async def hold():
+                async with lock:
+                    await asyncio.sleep(0.01)
+
+            await asyncio.gather(hold(), hold())  # forces the contended path
+
+        asyncio.run(_contend())
+        hc.reset_http_client_for_new_loop()
+
+        async def _acquire_in_new_loop():
+            async with hc.HTTPClientManager._lock:
+                return True
+
+        assert asyncio.run(_acquire_in_new_loop())

--- a/autobot-backend/tests/unit/chat_workflow/test_ceo_tool_execution_chain.py
+++ b/autobot-backend/tests/unit/chat_workflow/test_ceo_tool_execution_chain.py
@@ -38,8 +38,8 @@ def _mixin_instance():
 # tag omits the '>' (`</TOOL_CALL` + newline + more prose).
 _BOARD_OUTPUT = (
     "Creating the high priority task.\n\n"
-    "<TOOL_CALL name=\"create_task\" "
-    "params='{\"title\":\"Write the Q3 financial report\",\"priority\":\"high\"}'>"
+    '<TOOL_CALL name="create_task" '
+    'params=\'{"title":"Write the Q3 financial report","priority":"high"}\'>'
     "Create task</TOOL_CALL\n\nHigh priority task created."
 )
 

--- a/autobot_shared/http_client.py
+++ b/autobot_shared/http_client.py
@@ -408,6 +408,10 @@ def reset_http_client_for_new_loop() -> None:
     reused across loop boundaries. The old session is discarded, not closed;
     its connections are reclaimed by GC exactly as discarded Redis pools are.
 
+    Limitation (same as ``reset_async_redis_pools``): objects that cached the
+    manager instance at construction keep the old, loop-bound one — the reset
+    only affects future ``get_http_client()`` / ``HTTPClientManager()`` calls.
+
     Issue #11637.
     """
     global _http_client
@@ -415,7 +419,9 @@ def reset_http_client_for_new_loop() -> None:
         _http_client = None
         with HTTPClientManager._instance_lock:
             HTTPClientManager._instance = None
-            HTTPClientManager._session = None
+            # A contended asyncio.Lock binds permanently to the loop that
+            # contended it — rebind so the new loop gets a fresh lock.
+            HTTPClientManager._lock = asyncio.Lock()
 
 
 def sign_request(

--- a/autobot_shared/http_client.py
+++ b/autobot_shared/http_client.py
@@ -13,6 +13,7 @@ import asyncio
 import hashlib
 import hmac
 import logging
+import threading
 import time
 from typing import Any, Dict
 
@@ -31,13 +32,16 @@ class HTTPClientManager:
     """
 
     _instance: "HTTPClientManager" | None = None
+    _instance_lock = threading.Lock()
     _session: ClientSession | None = None
     _lock = asyncio.Lock()
 
     def __new__(cls):
-        """Create or return singleton HTTPClientManager instance."""
+        """Create or return singleton HTTPClientManager instance (double-checked, #11637)."""
         if cls._instance is None:
-            cls._instance = super(HTTPClientManager, cls).__new__(cls)
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = super(HTTPClientManager, cls).__new__(cls)
         return cls._instance
 
     def __init__(self) -> None:
@@ -365,7 +369,6 @@ class HTTPClientManager:
 
 
 # Global singleton instance (thread-safe)
-import threading
 
 _http_client: HTTPClientManager | None = None
 _http_client_lock = threading.Lock()
@@ -393,6 +396,26 @@ async def close_http_client() -> None:
     if _http_client:
         await _http_client.close()
         _http_client = None
+
+
+def reset_http_client_for_new_loop() -> None:
+    """Discard the loop-bound session/manager so the next call recreates them.
+
+    Mirror of ``autobot_shared.redis_client.reset_async_redis_pools`` (#10936):
+    call from synchronous code immediately before entering a NEW event loop
+    (e.g. a Celery ``worker_process_init`` handler) so the aiohttp
+    ``ClientSession`` — which is bound to the loop that created it — is never
+    reused across loop boundaries. The old session is discarded, not closed;
+    its connections are reclaimed by GC exactly as discarded Redis pools are.
+
+    Issue #11637.
+    """
+    global _http_client
+    with _http_client_lock:
+        _http_client = None
+        with HTTPClientManager._instance_lock:
+            HTTPClientManager._instance = None
+            HTTPClientManager._session = None
 
 
 def sign_request(

--- a/autobot_shared/plugin_sdk/base.py
+++ b/autobot_shared/plugin_sdk/base.py
@@ -16,8 +16,8 @@ Issue #9049 - Plugin capability manifest system.
 from __future__ import annotations
 
 import logging
-import threading
 import re
+import threading
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Dict, List

--- a/autobot_shared/plugin_sdk/base.py
+++ b/autobot_shared/plugin_sdk/base.py
@@ -16,6 +16,7 @@ Issue #9049 - Plugin capability manifest system.
 from __future__ import annotations
 
 import logging
+import threading
 import re
 from abc import ABC, abstractmethod
 from enum import Enum
@@ -231,12 +232,15 @@ class PluginRegistry:
     """
 
     _instance: "PluginRegistry" | None = None
+    _instance_lock = threading.Lock()
     _plugins: Dict[str, BasePlugin] = {}
 
     def __new__(cls):
-        """Singleton pattern."""
+        """Singleton pattern (double-checked locking, #11637)."""
         if cls._instance is None:
-            cls._instance = super().__new__(cls)
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
         return cls._instance
 
     def register(self, plugin: BasePlugin) -> None:

--- a/autobot_shared/plugin_sdk/capabilities.py
+++ b/autobot_shared/plugin_sdk/capabilities.py
@@ -12,6 +12,7 @@ Issue #9049 - Plugin capability manifest system.
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -117,13 +118,16 @@ class CapabilityChecker:
     """
 
     _instance: Optional[CapabilityChecker] = None
+    _instance_lock = threading.Lock()
 
     def __new__(cls) -> CapabilityChecker:
-        """Ensure singleton instance."""
+        """Ensure singleton instance (double-checked locking, #11637)."""
         if cls._instance is None:
-            cls._instance = super().__new__(cls)
-            cls._granted_capabilities: Dict[str, List[Capability]] = {}
-            cls._logger = get_logger(__name__)
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._granted_capabilities: Dict[str, List[Capability]] = {}
+                    cls._logger = get_logger(__name__)
+                    cls._instance = super().__new__(cls)
         return cls._instance
 
     def grant_capabilities(

--- a/autobot_shared/plugin_sdk/capabilities.py
+++ b/autobot_shared/plugin_sdk/capabilities.py
@@ -123,10 +123,13 @@ class CapabilityChecker:
     def __new__(cls) -> CapabilityChecker:
         """Ensure singleton instance (double-checked locking, #11637)."""
         if cls._instance is None:
+            # get_logger takes LoggingManager's lock — keep foreign locking
+            # outside our locked region (idempotent, safe to pre-compute).
+            logger_for_instance = get_logger(__name__)
             with cls._instance_lock:
                 if cls._instance is None:
                     cls._granted_capabilities: Dict[str, List[Capability]] = {}
-                    cls._logger = get_logger(__name__)
+                    cls._logger = logger_for_instance
                     cls._instance = super().__new__(cls)
         return cls._instance
 

--- a/autobot_shared/plugin_sdk/hooks.py
+++ b/autobot_shared/plugin_sdk/hooks.py
@@ -15,8 +15,8 @@ Issue #6970 - Hook registry with signatures and validation.
 from __future__ import annotations
 
 import asyncio
-import threading
 import logging
+import threading
 import warnings
 from enum import Enum
 from typing import Any, Callable, Dict, List

--- a/autobot_shared/plugin_sdk/hooks.py
+++ b/autobot_shared/plugin_sdk/hooks.py
@@ -15,6 +15,7 @@ Issue #6970 - Hook registry with signatures and validation.
 from __future__ import annotations
 
 import asyncio
+import threading
 import logging
 import warnings
 from enum import Enum
@@ -183,12 +184,15 @@ class HookRegistry:
     """
 
     _instance: "HookRegistry" | None = None
+    _instance_lock = threading.Lock()
     _hooks: Dict[str, List[Any]] = {}  # Each entry is a dict with callback and plugin_name keys
 
     def __new__(cls):
-        """Singleton pattern."""
+        """Singleton pattern (double-checked locking, #11637)."""
         if cls._instance is None:
-            cls._instance = super().__new__(cls)
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
         return cls._instance
 
     def register_hook(


### PR DESCRIPTION
Closes #11637, #11641. Part of umbrella #11634 (T3 + T7 — batched: same canonical-singleton scope, both fully delivered).

## Thinking Path

The #11634 audit found six `__new__` singletons with **no lock** (two threads racing first access can construct two instances) and `HTTPClientManager` with an unlocked `__new__` plus no seam to discard its loop-bound `ClientSession`. Rather than rewriting call sites, each class keeps its public `ClassName()` API and gains double-checked `threading.Lock` locking — the same shape the canonical `singleton_factory` primitives use. The private Jina session (#11641) was a fork of `HTTPClientManager`'s concept and is folded into it.

## What Changed

**T3 — locking (#11637):**
- Double-checked `threading.Lock` in `__new__`: `AdapterRegistry` (llm_shared/adapters/registry.py), `Gateway` (services/gateway/gateway.py), `ExternalProviderFactory` (services/memory/external_provider_factory.py), `HookRegistry` (autobot_shared/plugin_sdk/hooks.py), `PluginRegistry` (autobot_shared/plugin_sdk/base.py), `CapabilityChecker` (autobot_shared/plugin_sdk/capabilities.py), `HTTPClientManager` (autobot_shared/http_client.py). Where `__new__` initialises state (`_initialized`, `_granted_capabilities`), assignment to `cls._instance` happens LAST so no thread observes a half-built instance.
- `reset_http_client_for_new_loop()` — mirror of `reset_async_redis_pools()` (#10936): discards the loop-bound manager/session before entering a new event loop.
- `http_client.py`'s mid-file `import threading` moved to top (the class body now needs it).
- Completed the bare-path shim surface started in #11636: `plugin_sdk/{plugin_manager,registry,extension_manifest,manifest_contract}.py` re-export shims + private validators re-exported from the loader shim. The canonical `plugin_sdk_test.py` suite (which imports via the bare path) now collects and passes from repo root — it errored on base.

**T7 — Jina session (#11641):**
- `media/link/pipeline.py`: `_jina_session`/`_jina_session_lock` globals and `close_jina_session()` removed; `_get_jina_session()` kept as the (test-patchable) seam, now delegating to `get_http_client().get_session()`. Jina timeout stays per-request via `_JINA_TIMEOUT`. Circuit-breaker state untouched.
- Tests that patched the removed internals rewritten against the seam (one was silently making live network calls in the old form).

## Verification

- `tests/test_singleton_thread_safety.py` — 12 passed, incl. 6 new barrier-synchronized concurrent-`__new__` races (10 threads each, single construction asserted) + reset-for-new-loop semantics
- `media/link/pipeline_test.py` — 50 passed (incl. rewritten Jina delegation tests)
- `autobot_shared/plugin_sdk/plugin_sdk_test.py` + `manifest_contract_test.py` + `singleton_factory_test.py` — **111 passed** (plugin_sdk_test collected with an ImportError on base — fixed by the completed shim surface)
- flake8 clean on all touched files

## Model Used

Claude Fable 5
