### PR TITLE
feat(llc): CEO chat renders replies like /chat + strips raw tool tags (#11501 T3)

### DIFF
--- a/autobot-frontend/src/views/llc/CeoChatView.vue
+++ b/autobot-frontend/src/views/llc/CeoChatView.vue
@@ -57,7 +57,7 @@
             >
               <div class="message-bubble" :class="msg.author_type === 'human' ? 'bubble-human' : 'bubble-system'">
                 <!-- #11501 T3: markdown links + DOMPurify sanitize + strip raw tool tags (same as /chat) -->
-                <div class="message-body" v-html="formatBody(msg.body)"></div>
+                <div class="message-body" v-html="formatBody(msg.body)" @click="handleEntityClick"></div>
                 <div v-if="msg.author_type === 'system' && activeThread.resolved_entity_type" class="entity-link">
                   {{ activeThread.resolved_entity_type }}
                   <template v-if="activeThread.resolved_entity_id">
@@ -117,17 +117,21 @@
 
 <script setup lang="ts">
 import { ref, computed, nextTick, onMounted } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
 import { formatDate as fmtDate, formatTime as fmtTime } from '@/utils/formatHelpers'
 import { useI18n } from 'vue-i18n'
 import { useNotificationBus } from '@/composables/useNotificationBus'
-import { renderMarkdownLinks } from '@/composables/chat/useEntityAnchors'
+import { createEntityAnchorClickHandler, renderMarkdownLinks } from '@/composables/chat/useEntityAnchors'
 import { sanitizeChatHtml } from '@/utils/sanitize'
 import { BaseModal } from '@autobot/ui'
 
 const logger = createLogger('CeoChatView')
+
+// #11501 T3: route entity-anchor links (#kind-id) via the router, same as
+// MessageItem in /chat, so board replies that reference work items navigate.
+const handleEntityClick = createEntityAnchorClickHandler(useRouter())
 
 // #11501 T3: render board replies with the same link + sanitize pipeline the
 // main /chat uses, and strip any raw <TOOL_CALL> fragments the model emits so

--- a/autobot-frontend/src/views/llc/CeoChatView.vue
+++ b/autobot-frontend/src/views/llc/CeoChatView.vue
@@ -56,7 +56,8 @@
               :class="msg.author_type === 'human' ? 'row-right' : 'row-left'"
             >
               <div class="message-bubble" :class="msg.author_type === 'human' ? 'bubble-human' : 'bubble-system'">
-                <div class="message-body">{{ msg.body }}</div>
+                <!-- #11501 T3: markdown links + DOMPurify sanitize + strip raw tool tags (same as /chat) -->
+                <div class="message-body" v-html="formatBody(msg.body)"></div>
                 <div v-if="msg.author_type === 'system' && activeThread.resolved_entity_type" class="entity-link">
                   {{ activeThread.resolved_entity_type }}
                   <template v-if="activeThread.resolved_entity_id">
@@ -122,9 +123,21 @@ import { createLogger } from '@/utils/debugUtils'
 import { formatDate as fmtDate, formatTime as fmtTime } from '@/utils/formatHelpers'
 import { useI18n } from 'vue-i18n'
 import { useNotificationBus } from '@/composables/useNotificationBus'
+import { renderMarkdownLinks } from '@/composables/chat/useEntityAnchors'
+import { sanitizeChatHtml } from '@/utils/sanitize'
 import { BaseModal } from '@autobot/ui'
 
 const logger = createLogger('CeoChatView')
+
+// #11501 T3: render board replies with the same link + sanitize pipeline the
+// main /chat uses, and strip any raw <TOOL_CALL> fragments the model emits so
+// tool syntax never renders to the user (until #11552 lands, the reply can
+// contain an unparsed tag; this keeps the UX clean regardless).
+const _TOOL_CALL_RE = /<tool_call\b[\s\S]*?(?:<\/tool_call\b\s*>?|$)/gi
+function formatBody(body: string): string {
+  const stripped = (body || '').replace(_TOOL_CALL_RE, '').trim()
+  return sanitizeChatHtml(renderMarkdownLinks(stripped))
+}
 const api = useApiClient()
 const route = useRoute()
 const { t } = useI18n()


### PR DESCRIPTION
## Thinking Path
CEO-chat #11501 T3 (frontend parity). `CeoChatView` rendered `msg.body` as raw plaintext, so markdown links showed unformatted and any unparsed `<TOOL_CALL>` fragment (the reply can carry one until #11552 lands) rendered verbatim. Bring it to `/chat` parity by reusing the main chat's render pipeline.

## What Changed
`views/llc/CeoChatView.vue`:
- `formatBody(body)` = strip `<TOOL_CALL>…</TOOL_CALL>` fragments (incl. missing-`>` and dangling/truncated variants) → `renderMarkdownLinks` (entity-anchor + external links, from the chat composable) → `sanitizeChatHtml` (DOMPurify; allows `a/href/target/rel/class`).
- Message body now renders via `v-html="formatBody(msg.body)"` instead of raw `{{ msg.body }}`.

## Verification
- `eslint` clean on the file.
- Strip regex verified: removes well-formed / missing-`>` / dangling tags, preserves clean prose + links.
- `sanitizeChatHtml` CHAT_SANITIZE_CONFIG confirmed to allow `<a>` + safe attrs.

## Notes
Frontend parity is independent of #11552 (tool execution) — this keeps the reply clean regardless. Full bold/list markdown (main chat's `marked` path) is a possible follow-up; this reuses the exported link+sanitize utils.

## Model Used
Claude Fable 5 (1M context)
